### PR TITLE
Add tctl sso configure and tctl sso test support for OIDC and SAML

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3506,6 +3506,13 @@ func (a *ServerWithRoles) GetOIDCConnectors(ctx context.Context, withSecrets boo
 }
 
 func (a *ServerWithRoles) CreateOIDCAuthRequest(ctx context.Context, req types.OIDCAuthRequest) (*types.OIDCAuthRequest, error) {
+	if !modules.GetModules().Features().OIDC {
+		// TODO(zmb3): ideally we would wrap ErrRequiresEnterprise here, but
+		// we can't currently propagate wrapped errors across the gRPC boundary,
+		// and we want tctl to display a clean user-facing message in this case
+		return nil, trace.AccessDenied("OIDC is only available in Teleport Enterprise")
+	}
+
 	if err := a.action(apidefaults.Namespace, types.KindOIDCRequest, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3660,6 +3667,10 @@ func (a *ServerWithRoles) GetSAMLConnectors(ctx context.Context, withSecrets boo
 }
 
 func (a *ServerWithRoles) CreateSAMLAuthRequest(ctx context.Context, req types.SAMLAuthRequest) (*types.SAMLAuthRequest, error) {
+	if !modules.GetModules().Features().SAML {
+		return nil, trace.Wrap(ErrSAMLRequiresEnterprise)
+	}
+
 	if err := a.action(apidefaults.Namespace, types.KindSAMLRequest, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -37,7 +37,7 @@ import (
 // TODO(zmb3): ideally we would wrap ErrRequiresEnterprise here, but
 // we can't currently propagate wrapped errors across the gRPC boundary,
 // and we want tctl to display a clean user-facing message in this case
-var ErrSAMLRequiresEnterprise = trace.AccessDenied("SAML is only available in Teleport Enterprise")
+var ErrSAMLRequiresEnterprise = &trace.AccessDeniedError{Message: "SAML is only available in Teleport Enterprise"}
 
 // SAMLService are the methods that the auth server delegates to a plugin for
 // implementing the SAML connector. These are the core functions of SAML

--- a/tool/tctl/sso/configure/command.go
+++ b/tool/tctl/sso/configure/command.go
@@ -54,7 +54,7 @@ func (cmd *SSOConfigureCommand) Initialize(app *kingpin.Application, cfg *servic
 
 	sso := app.Command("sso", "A family of commands for configuring and testing auth connectors (SSO).")
 	cmd.ConfigureCmd = sso.Command("configure", "Create auth connector configuration.")
-	cmd.AuthCommands = []*AuthKindCommand{addGithubCommand(cmd)}
+	cmd.AuthCommands = []*AuthKindCommand{addGithubCommand(cmd), addSAMLCommand(cmd), addOIDCCommand(cmd)}
 }
 
 // TryRun is executed after the CLI parsing is done. The command must

--- a/tool/tctl/sso/configure/flags/attributes_to_roles.go
+++ b/tool/tctl/sso/configure/flags/attributes_to_roles.go
@@ -1,0 +1,52 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// attributesToRolesParser parsers 'name,value,role1,role2,...' values into types.AttributeMapping entries. Cumulative, can handle multiple entries.
+type attributesToRolesParser struct {
+	mappings *[]types.AttributeMapping
+}
+
+func (a *attributesToRolesParser) String() string {
+	return fmt.Sprintf("%v", a.mappings)
+}
+
+func (a *attributesToRolesParser) Set(s string) error {
+	splits := strings.Split(s, ",")
+
+	if len(splits) < 3 {
+		return trace.BadParameter("Too few elements separated with comma. use syntax: 'name,value,role1,role2,...'.")
+	}
+
+	name := splits[0]
+	value := splits[1]
+	roles := splits[2:]
+
+	mapping := types.AttributeMapping{
+		Name:  name,
+		Value: value,
+		Roles: roles,
+	}
+
+	*a.mappings = append(*a.mappings, mapping)
+
+	return nil
+}
+
+// IsCumulative returns true if flag is repeatable. This is checked by kingpin library.
+func (a *attributesToRolesParser) IsCumulative() bool {
+	return true
+}
+
+// NewAttributesToRolesParser returns new parser, which can parse strings such as 'name,value,role1,role2,...' into types.AttributeMapping entries. It can be called multiple times, making the flag repeatable.
+func NewAttributesToRolesParser(field *[]types.AttributeMapping) kingpin.Value {
+	return &attributesToRolesParser{mappings: field}
+}

--- a/tool/tctl/sso/configure/flags/attributes_to_roles.go
+++ b/tool/tctl/sso/configure/flags/attributes_to_roles.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package flags
 
 import (

--- a/tool/tctl/sso/configure/flags/attributes_to_roles_test.go
+++ b/tool/tctl/sso/configure/flags/attributes_to_roles_test.go
@@ -1,0 +1,73 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func Test_attributesToRolesParser_Set(t *testing.T) {
+	tests := []struct {
+		name       string
+		parser     attributesToRolesParser
+		arg        string
+		wantErr    bool
+		wantParser attributesToRolesParser
+	}{
+		{
+			name:   "one set of correct args",
+			parser: attributesToRolesParser{mappings: &[]types.AttributeMapping{}},
+			arg:    "foo,bar,baz",
+			wantParser: attributesToRolesParser{mappings: &[]types.AttributeMapping{
+				{
+					Name:  "foo",
+					Value: "bar",
+					Roles: []string{"baz"},
+				}}},
+			wantErr: false,
+		},
+		{
+			name: "two sets of correct args",
+			parser: attributesToRolesParser{mappings: &[]types.AttributeMapping{
+				{
+					Name:  "foo",
+					Value: "bar",
+					Roles: []string{"baz"},
+				}}},
+			arg: "aaa,bbb,ccc,ddd",
+			wantParser: attributesToRolesParser{mappings: &[]types.AttributeMapping{
+				{
+					Name:  "foo",
+					Value: "bar",
+					Roles: []string{"baz"},
+				},
+				{
+					Name:  "aaa",
+					Value: "bbb",
+					Roles: []string{"ccc", "ddd"},
+				}}},
+			wantErr: false,
+		},
+		{
+			name:       "one set of incorrect args",
+			parser:     attributesToRolesParser{mappings: &[]types.AttributeMapping{}},
+			arg:        "abracadabra",
+			wantParser: attributesToRolesParser{mappings: &[]types.AttributeMapping{}},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.parser.Set(tt.arg)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantParser, tt.parser)
+			}
+		})
+	}
+}

--- a/tool/tctl/sso/configure/flags/attributes_to_roles_test.go
+++ b/tool/tctl/sso/configure/flags/attributes_to_roles_test.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package flags
 
 import (

--- a/tool/tctl/sso/configure/flags/claims_to_roles.go
+++ b/tool/tctl/sso/configure/flags/claims_to_roles.go
@@ -1,0 +1,52 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// claimsToRolesParser parsers 'claim,value,role1,role2,...' values into types.ClaimMapping entries. Cumulative, can handle multiple entries.
+type claimsToRolesParser struct {
+	mappings *[]types.ClaimMapping
+}
+
+func (a *claimsToRolesParser) String() string {
+	return fmt.Sprintf("%v", a.mappings)
+}
+
+func (a *claimsToRolesParser) Set(s string) error {
+	splits := strings.Split(s, ",")
+
+	if len(splits) < 3 {
+		return trace.BadParameter("Too few elements separated with comma. Syntax: 'claim,value,role1,role2,...'.")
+	}
+
+	claim := splits[0]
+	value := splits[1]
+	roles := splits[2:]
+
+	mapping := types.ClaimMapping{
+		Claim: claim,
+		Value: value,
+		Roles: roles,
+	}
+
+	*a.mappings = append(*a.mappings, mapping)
+
+	return nil
+}
+
+// IsCumulative returns true if flag is repeatable. This is checked by kingpin library.
+func (a *claimsToRolesParser) IsCumulative() bool {
+	return true
+}
+
+// NewClaimsToRolesParser returns new parser, which can parse strings such as 'claim,value,role1,role2,...' into types.ClaimMapping entries. It can be called multiple times, making the flag repeatable.
+func NewClaimsToRolesParser(field *[]types.ClaimMapping) kingpin.Value {
+	return &claimsToRolesParser{mappings: field}
+}

--- a/tool/tctl/sso/configure/flags/claims_to_roles.go
+++ b/tool/tctl/sso/configure/flags/claims_to_roles.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package flags
 
 import (

--- a/tool/tctl/sso/configure/flags/claims_to_roles_test.go
+++ b/tool/tctl/sso/configure/flags/claims_to_roles_test.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package flags
 
 import (

--- a/tool/tctl/sso/configure/flags/claims_to_roles_test.go
+++ b/tool/tctl/sso/configure/flags/claims_to_roles_test.go
@@ -1,0 +1,72 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func Test_claimsToRolesParser_Set(t *testing.T) {
+	tests := []struct {
+		name       string
+		parser     claimsToRolesParser
+		arg        string
+		wantErr    bool
+		wantParser claimsToRolesParser
+	}{
+		{
+			name:   "one set of correct args",
+			parser: claimsToRolesParser{mappings: &[]types.ClaimMapping{}},
+			arg:    "foo,bar,baz",
+			wantParser: claimsToRolesParser{mappings: &[]types.ClaimMapping{
+				{
+					Claim: "foo",
+					Value: "bar",
+					Roles: []string{"baz"},
+				}}},
+			wantErr: false,
+		},
+		{
+			name: "two sets of correct args",
+			parser: claimsToRolesParser{mappings: &[]types.ClaimMapping{
+				{
+					Claim: "foo",
+					Value: "bar",
+					Roles: []string{"baz"},
+				}}},
+			arg: "aaa,bbb,ccc,ddd",
+			wantParser: claimsToRolesParser{mappings: &[]types.ClaimMapping{
+				{
+					Claim: "foo",
+					Value: "bar",
+					Roles: []string{"baz"},
+				},
+				{
+					Claim: "aaa",
+					Value: "bbb",
+					Roles: []string{"ccc", "ddd"},
+				}}},
+			wantErr: false,
+		},
+		{
+			name:       "one set of incorrect args",
+			parser:     claimsToRolesParser{mappings: &[]types.ClaimMapping{}},
+			arg:        "abracadabra",
+			wantParser: claimsToRolesParser{mappings: &[]types.ClaimMapping{}},
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.parser.Set(tt.arg)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantParser, tt.parser)
+			}
+		})
+	}
+}

--- a/tool/tctl/sso/configure/flags/file_reader.go
+++ b/tool/tctl/sso/configure/flags/file_reader.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package flags
 
 import (

--- a/tool/tctl/sso/configure/flags/file_reader.go
+++ b/tool/tctl/sso/configure/flags/file_reader.go
@@ -1,0 +1,33 @@
+package flags
+
+import (
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+// flagFileReader implements kingpin.Value.
+type flagFileReader struct {
+	bytes []byte
+	field *string
+}
+
+func (reader *flagFileReader) String() string {
+	return string(reader.bytes)
+}
+
+func (reader *flagFileReader) Set(filename string) error {
+	bytes, err := os.ReadFile(filename)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	reader.bytes = bytes
+	*reader.field = string(bytes)
+	return nil
+}
+
+// NewFileReader returns a file which will read the provided file and store the contents into provided field.
+func NewFileReader(field *string) kingpin.Value {
+	return &flagFileReader{field: field}
+}

--- a/tool/tctl/sso/configure/flags/file_reader_test.go
+++ b/tool/tctl/sso/configure/flags/file_reader_test.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package flags
 
 import (

--- a/tool/tctl/sso/configure/flags/file_reader_test.go
+++ b/tool/tctl/sso/configure/flags/file_reader_test.go
@@ -1,0 +1,47 @@
+package flags
+
+import (
+	"math/rand"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileReader(t *testing.T) {
+	out := "initial"
+	reader := NewFileReader(&out)
+
+	tmp := t.TempDir()
+
+	// running against non-existing file returns error, does not change the stored value
+	fn := path.Join(tmp, "does-not-exist.txt")
+	err := reader.Set(fn)
+	require.Error(t, err)
+	require.Equal(t, "initial", out)
+
+	// lots of ones...
+	fn = path.Join(tmp, "ones.txt")
+	ones := strings.Repeat("1", 1024*1024)
+	err = os.WriteFile(fn, []byte(ones), 0777)
+	require.NoError(t, err)
+	err = reader.Set(fn)
+	require.NoError(t, err)
+	require.Equal(t, ones, out)
+
+	// random string
+	fn = path.Join(tmp, "random.txt")
+	src := rand.NewSource(time.Now().UnixNano())
+	buf := make([]byte, 1024*1024)
+	for ix := range buf {
+		buf[ix] = byte(src.Int63())
+	}
+	err = os.WriteFile(fn, buf, 0777)
+	require.NoError(t, err)
+	err = reader.Set(fn)
+	require.NoError(t, err)
+	require.Equal(t, buf, []byte(out))
+}

--- a/tool/tctl/sso/configure/oidc.go
+++ b/tool/tctl/sso/configure/oidc.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package configure
 
 import (

--- a/tool/tctl/sso/configure/oidc.go
+++ b/tool/tctl/sso/configure/oidc.go
@@ -1,0 +1,336 @@
+package configure
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/coreos/go-oidc/oidc"
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/tool/tctl/sso/configure/flags"
+	"github.com/gravitational/teleport/tool/tctl/sso/tester"
+)
+
+type oidcPreset struct {
+	name        string
+	description string
+	display     string
+	issuerURL   string
+	modifySpec  func(logger *logrus.Entry, spec *types.OIDCConnectorSpecV3) error
+}
+
+type oidcPresetList []oidcPreset
+
+func (lst oidcPresetList) getNames() []string {
+	var names []string
+	for _, p := range lst {
+		names = append(names, p.name)
+	}
+	return names
+}
+
+func (lst oidcPresetList) getPreset(name string) *oidcPreset {
+	for _, p := range lst {
+		if p.name == name {
+			return &p
+		}
+	}
+	return nil
+}
+
+const presetGoogle = "google"
+
+var oidcPresets = oidcPresetList([]oidcPreset{
+	{
+		name:        presetGoogle,
+		description: "Google Workspace",
+		display:     "Google",
+		issuerURL:   "https://accounts.google.com",
+		modifySpec: func(logger *logrus.Entry, spec *types.OIDCConnectorSpecV3) error {
+			if !strings.HasSuffix(spec.ClientID, ".apps.googleusercontent.com") {
+				return trace.BadParameter(`For Google Workspace the client ID have to use format "<GOOGLE_WORKSPACE_CLIENT_ID>.apps.googleusercontent.com", got %q instead. Set full value with --id=... or shorthand with --google-id=...`, spec.ClientID)
+			}
+
+			if spec.GoogleServiceAccount == "" && spec.GoogleServiceAccountURI == "" {
+				return trace.BadParameter("Provide Google service account credentials file with --google-acc-uri=file://<path> or --google-acc=...")
+			}
+
+			if spec.GoogleAdminEmail == "" {
+				return trace.BadParameter("Provide Google admin email address with --google-admin=...")
+			}
+
+			return nil
+		},
+	},
+
+	{
+		name:        "gitlab",
+		description: "GitLab",
+		display:     "GitLab",
+		issuerURL:   "https://gitlab.com",
+		modifySpec: func(logger *logrus.Entry, spec *types.OIDCConnectorSpecV3) error {
+			switch spec.Prompt {
+			case "none":
+				break
+			case "":
+				spec.Prompt = "none"
+			default:
+				logger.Warnf("GitLab requires the 'prompt' parameter to be set to 'none', but %q found", spec.Prompt)
+			}
+
+			return nil
+		},
+	},
+
+	{
+		name:        "okta",
+		description: "Okta",
+		display:     "Okta",
+		issuerURL:   "https://oktaice.okta.com",
+		modifySpec: func(logger *logrus.Entry, spec *types.OIDCConnectorSpecV3) error {
+			if spec.Provider == "" {
+				spec.Provider = teleport.Okta
+			}
+
+			if spec.Provider != teleport.Okta {
+				logger.Warnf("Okta requires %q provider, but %q found.", teleport.Okta, spec.Provider)
+			}
+
+			return nil
+		},
+	},
+})
+
+type oidcExtraFlags struct {
+	chosenPreset       string
+	connectorName      string
+	googleID           string
+	googleLegacy       bool
+	ignoreMissingRoles bool
+}
+
+func addOIDCCommand(cmd *SSOConfigureCommand) *AuthKindCommand {
+	spec := types.OIDCConnectorSpecV3{}
+
+	pTable := asciitable.MakeTable([]string{"Name", "Description", "Display", "Issuer URL"})
+	for _, preset := range oidcPresets {
+		pTable.AddRow([]string{preset.name, preset.description, preset.display, preset.issuerURL})
+	}
+	presets := tester.Indent(pTable.AsBuffer().String(), 2)
+
+	extra := &oidcExtraFlags{}
+
+	sub := cmd.ConfigureCmd.Command("oidc", fmt.Sprintf("Configure OIDC auth connector, optionally using a preset. Available presets: %v.", oidcPresets.getNames()))
+	// commonly used flags
+	sub.Flag("preset", fmt.Sprintf("Preset. One of: %v", oidcPresets.getNames())).Short('p').EnumVar(&extra.chosenPreset, oidcPresets.getNames()...)
+	sub.Flag("name", "Connector name. Required, unless implied from preset.").Short('n').StringVar(&extra.connectorName)
+	sub.Flag("claims-to-roles", "Sets claim-to-roles mapping using format 'claim_name,claim_value,role1,role2,...'. Repeatable.").Short('r').Required().PlaceHolder("name,value,role1,role2,...").SetValue(flags.NewClaimsToRolesParser(&spec.ClaimsToRoles))
+	sub.Flag("display", "Sets the connector display name.").StringVar(&spec.Display)
+	sub.Flag("id", "OIDC app client ID.").PlaceHolder("ID").StringVar(&spec.ClientID)
+	sub.Flag("secret", "OIDC app client secret.").Required().PlaceHolder("SECRET").StringVar(&spec.ClientSecret)
+	sub.Flag("issuer-url", "Issuer URL.").PlaceHolder("URL").StringVar(&spec.IssuerURL)
+
+	// auto
+	sub.Flag("redirect-url", "Authorization callback URL(s). Each repetition of the flag declares one redirectURL.").PlaceHolder("https://<proxy>/v1/webapi/oidc/callback").StringsVar((*[]string)(&spec.RedirectURLs))
+
+	// rarely used
+	sub.Flag("prompt", "Optional OIDC prompt. Example values: none, select_account, login, consent.").StringVar(&spec.Prompt)
+	sub.Flag("scope", "Scope specifies additional scopes set by provider. Each repetition of the flag declares one scope. Examples: email, groups, openid.").StringsVar(&spec.Scope)
+	sub.Flag("acr", "Authentication Context Class Reference values.").StringVar(&spec.ACR)
+	sub.Flag("provider", "Sets the external identity provider type to enable IdP specific workarounds. Examples: ping, adfs, netiq, okta.").StringVar(&spec.Provider)
+
+	// google only.
+	sub.Flag("google-acc-uri", "Google only. URI pointing at service account credentials. Example: file:///var/lib/teleport/gworkspace-creds.json.").StringVar(&spec.GoogleServiceAccountURI)
+	sub.Flag("google-acc", "Google only. String containing Google service account credentials.").StringVar(&spec.GoogleServiceAccount)
+	sub.Flag("google-admin", "Google only. Email of a Google admin to impersonate.").StringVar(&spec.GoogleAdminEmail)
+	sub.Flag("google-legacy", "Google only. Flag to select groups with direct membership filtered by domain (legacy behavior). Disabled by default. More info: https://goteleport.com/docs/enterprise/sso/google-workspace/#how-teleport-uses-google-workspace-apis").BoolVar(&extra.googleLegacy)
+
+	sub.Flag("google-id", "Shorthand for setting the --id flag to <GOOGLE_WORKSPACE_CLIENT_ID>.apps.googleusercontent.com").PlaceHolder("GOOGLE_WORKSPACE_CLIENT_ID").StringVar(&extra.googleID)
+
+	// ignores
+	ignoreMissingRoles := false
+	sub.Flag("ignore-missing-roles", "Ignore missing roles referenced in --claims-to-roles.").BoolVar(&ignoreMissingRoles)
+
+	sub.Alias(fmt.Sprintf(`
+Presets:
+
+%v
+Examples:
+
+  > tctl sso configure oidc -n myauth -r groups,admin,access,editor,auditor -r group,developer,access --secret IDP_SECRET --id CLIENT_ID --issuer-url https://idp.example.com
+
+  Generate OIDC auth connector configuration called 'myauth'. Two mappings from OIDC claims to roles are defined: 
+    - members of 'admin' group will receive 'access', 'editor' and 'auditor' roles.
+    - members of 'developer' group will receive 'access' role.
+
+  The values for --secret, --id and --issuer-url are provided by IdP.
+  
+  > tctl sso configure oidc --preset okta --scope groups -r groups,okta-admin,access,editor,auditor --secret IDP_SECRET --id CLIENT_ID --issuer-url dev-123456.oktapreview.com
+
+  Generate OIDC auth connector with Okta preset, enabled 'groups' scope, mapping group 'okta-admin' to roles 'access', 'editor', 'auditor'.
+  Issuer URL is set to match custom Okta domain.
+
+  > tctl sso configure oidc --preset google -r groups,mygroup@mydomain.example.com,access --secret SECRET --google-id GOOGLE_ID --google-acc-uri /var/lib/teleport/gacc.json --google-admin admin@mydomain.example.com
+
+  Generate OIDC auth connector with Google preset. Service account credentials are set to be loaded from /var/lib/teleport/gacc.json with --google-acc-uri.
+
+  > tctl sso configure oidc ... | tctl sso test
+  
+  Generate the configuration and immediately test it using "tctl sso test" command.`, presets))
+
+	preset := &AuthKindCommand{
+		Run: func(ctx context.Context, clt *auth.Client) error { return oidcRunFunc(ctx, cmd, &spec, extra, clt) },
+	}
+
+	sub.Action(func(ctx *kingpin.ParseContext) error {
+		preset.Parsed = true
+		return nil
+	})
+
+	return preset
+}
+
+func oidcRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.OIDCConnectorSpecV3, flags *oidcExtraFlags, clt *auth.Client) error {
+	if flags.googleID != "" {
+		if spec.ClientID != "" {
+			return trace.BadParameter("Conflicting flags: --id and --google-id. Provide only one.")
+		}
+		spec.ClientID = flags.googleID + ".apps.googleusercontent.com"
+	}
+
+	if spec.GoogleServiceAccountURI != "" {
+		_, err := apiutils.ParseSessionsURI(spec.GoogleServiceAccountURI)
+		if err != nil {
+			return trace.BadParameter("Failed to parse --google-acc-uri: %v", err)
+		}
+	}
+
+	// automatically switch to 'google' preset if google-specific flags are set.
+	if flags.chosenPreset == "" {
+		if spec.GoogleAdminEmail != "" || spec.GoogleServiceAccount != "" || spec.GoogleServiceAccountURI != "" {
+			cmd.Logger.Infof("Google-specific flags detected, enabling preset %q.", presetGoogle)
+			flags.chosenPreset = presetGoogle
+		}
+	}
+
+	// apply preset, if chosen
+	p := oidcPresets.getPreset(flags.chosenPreset)
+	if p != nil {
+		if spec.Display == "" {
+			spec.Display = p.display
+		}
+
+		if spec.IssuerURL == "" {
+			spec.IssuerURL = p.issuerURL
+		}
+
+		if flags.connectorName == "" {
+			flags.connectorName = p.name
+		}
+
+		if p.modifySpec != nil {
+			if err := p.modifySpec(cmd.Logger, spec); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+
+	// check ClientID *after* applying presets. This is because 'google' preset will validate the value of spec.ClientID.
+	if spec.ClientID == "" {
+		return trace.BadParameter("Missing client ID. Provide with --id.")
+	}
+
+	if spec.IssuerURL == "" {
+		return trace.BadParameter("Missing issuer URL. Provide with --issuer-url or choose a preset with one.")
+	}
+	parse, err := url.Parse(spec.IssuerURL)
+	if err != nil {
+		return trace.Wrap(err, "Invalid issuer URL.")
+	}
+
+	switch strings.ToLower(parse.Scheme) {
+	case "":
+		spec.IssuerURL = "https://" + spec.IssuerURL
+		cmd.Logger.Infof("Missing scheme for issuer URL. Defaulting to %q. New value: %q", "https://", spec.IssuerURL)
+	case "https":
+		break
+	default:
+		return trace.BadParameter("Bad scheme for issuer URL %q. Expected %q got %q.", spec.IssuerURL, "https", parse.Scheme)
+	}
+
+	// verify .well-known/openid-configuration is reachable
+	err = checkOpenidConfiguration(spec.IssuerURL)
+	if err != nil {
+		if cmd.Config.Debug {
+			cmd.Logger.WithError(err).Warnf("Failed to load .well-known/openid-configuration for issuer URL %q", spec.IssuerURL)
+		}
+		return trace.BadParameter("Failed to load .well-known/openid-configuration for issuer URL %q. Check expected --issuer-url against IdP configuration. Rerun with --debug to see the error.", spec.IssuerURL)
+	}
+
+	if flags.connectorName == "" {
+		return trace.BadParameter("Connector name must be set, either by choosing --preset or explicitly via --name")
+	}
+
+	allRoles, err := clt.GetRoles(ctx)
+	if err != nil {
+		cmd.Logger.WithError(err).Warn("unable to get roles list. Skipping attributes_to_roles sanity checks.")
+	} else {
+		roleMap := map[string]bool{}
+		var roleNames []string
+		for _, role := range allRoles {
+			roleMap[role.GetName()] = true
+			roleNames = append(roleNames, role.GetName())
+		}
+
+		for _, mapping := range spec.ClaimsToRoles {
+			for _, role := range mapping.Roles {
+				_, found := roleMap[role]
+				if !found {
+					if flags.ignoreMissingRoles {
+						cmd.Logger.Warnf("claims-to-roles references non-existing role: %q. Available roles: %v.", role, roleNames)
+					} else {
+						return trace.BadParameter("claims-to-roles references non-existing role: %v. Correct the mapping, or add --ignore-missing-roles to ignore this error. Available roles: %v.", role, roleNames)
+					}
+				}
+			}
+		}
+	}
+
+	if len(spec.RedirectURLs) == 0 {
+		spec.RedirectURLs = []string{ResolveCallbackURL(cmd.Logger, clt, "RedirectURLs", "https://%v/v1/webapi/oidc/callback")}
+	}
+
+	connector, err := types.NewOIDCConnector(flags.connectorName, *spec)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if flags.googleLegacy {
+		// The Google Workspace groups fetcher follows the legacy behavior when the version of the OIDCConnector is v2.
+		if cv3, ok := connector.(*types.OIDCConnectorV3); ok {
+			cv3.Version = types.V2
+		} else {
+			return trace.BadParameter("Unable to set connector version to %q, bad type: %v", types.V2, connector)
+		}
+	}
+
+	return trace.Wrap(utils.WriteYAML(os.Stdout, connector))
+}
+
+func checkOpenidConfiguration(issuerURL string) error {
+	r := oidc.NewHTTPProviderConfigGetter(http.DefaultClient, issuerURL)
+	_, err := r.Get()
+	return trace.Wrap(err)
+}

--- a/tool/tctl/sso/configure/saml.go
+++ b/tool/tctl/sso/configure/saml.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package configure
 
 import (

--- a/tool/tctl/sso/configure/saml.go
+++ b/tool/tctl/sso/configure/saml.go
@@ -1,0 +1,331 @@
+package configure
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/tool/tctl/sso/configure/flags"
+	"github.com/gravitational/teleport/tool/tctl/sso/tester"
+)
+
+type samlPreset struct {
+	name        string
+	description string
+	display     string
+	modifySpec  func(spec *types.SAMLConnectorSpecV2) error
+}
+
+type samlPresetList []samlPreset
+
+func (lst samlPresetList) getNames() []string {
+	var names []string
+	for _, p := range lst {
+		names = append(names, p.name)
+	}
+	return names
+}
+
+func (lst samlPresetList) getPreset(name string) *samlPreset {
+	for _, p := range lst {
+		if p.name == name {
+			return &p
+		}
+	}
+	return nil
+}
+
+var samlPresets = samlPresetList([]samlPreset{
+	{name: "okta", description: "Okta", display: "Okta"},
+	{name: "onelogin", description: "OneLogin", display: "OneLogin"},
+	{name: "ad", description: "Azure Active Directory", display: "Microsoft"},
+	{name: "adfs", description: "Active Directory Federation Services", display: "ADFS", modifySpec: func(spec *types.SAMLConnectorSpecV2) error {
+		spec.Provider = teleport.ADFS
+		return nil
+	}},
+})
+
+type samlExtraFlags struct {
+	chosenPreset         string
+	connectorName        string
+	ignoreMissingRoles   bool
+	entityDescriptorFlag string
+	signingKeyPair       types.AsymmetricKeyPair
+	encryptionKeyPair    types.AsymmetricKeyPair
+}
+
+func addSAMLCommand(cmd *SSOConfigureCommand) *AuthKindCommand {
+	spec := types.SAMLConnectorSpecV2{}
+
+	pTable := asciitable.MakeTable([]string{"Name", "Description", "Display"})
+	for _, preset := range samlPresets {
+		pTable.AddRow([]string{preset.name, preset.description, preset.display})
+	}
+	presets := tester.Indent(pTable.AsBuffer().String(), 2)
+
+	sub := cmd.ConfigureCmd.Command("saml", fmt.Sprintf("Configure SAML auth connector, optionally using a preset. Available presets: %v.", samlPresets.getNames()))
+
+	saml := &samlExtraFlags{}
+
+	// commonly used flags
+	sub.Flag("preset", fmt.Sprintf("Preset. One of: %v", samlPresets.getNames())).Short('p').EnumVar(&saml.chosenPreset, samlPresets.getNames()...)
+	sub.Flag("name", "Connector name. Required, unless implied from preset.").Short('n').StringVar(&saml.connectorName)
+	sub.Flag("entity-descriptor", "Set the Entity Descriptor. Valid values: file, URL, XML content. Supplies configuration parameters as single XML instead of individual elements.").Short('e').StringVar(&saml.entityDescriptorFlag)
+	sub.Flag("attributes-to-roles", "Sets attribute-to-role mapping using format 'attr_name,attr_value,role1,role2,...'. Repeatable.").Short('r').Required().SetValue(flags.NewAttributesToRolesParser(&spec.AttributesToRoles))
+	sub.Flag("display", "Sets the connector display name.").StringVar(&spec.Display)
+	sub.Flag("allow-idp-initiated", "Allow the IdP to initiate the SSO flow.").BoolVar(&spec.AllowIDPInitiated)
+
+	// alternatives to --entity-descriptor:
+	sub.Flag("issuer", "Issuer is the identity provider issuer.").StringVar(&spec.Issuer)
+	sub.Flag("sso", "SSO is the URL of the identity provider's SSO service.").StringVar(&spec.SSO)
+	sub.Flag("cert", "Cert file with with the IdP certificate PEM. IdP signs <Response> responses using this certificate.").SetValue(flags.NewFileReader(&spec.Cert))
+
+	// provided for completeness, but typically omitted.
+	sub.Flag("acs", "AssertionConsumerService is a URL for assertion consumer service on the service provider (Teleport's side).").StringVar(&spec.AssertionConsumerService)
+	sub.Flag("audience", "Audience uniquely identifies our service provider.").StringVar(&spec.Audience)
+	sub.Flag("service-provider-issuer", "ServiceProviderIssuer is the issuer of the service provider (Teleport).").StringVar(&spec.ServiceProviderIssuer)
+	sub.Flag("signing-key-file", "A file with request signing key. Must be used together with --signing-cert-file.").SetValue(flags.NewFileReader(&saml.signingKeyPair.PrivateKey))
+	sub.Flag("signing-cert-file", "A file with request certificate. Must be used together with --signing-key-file.").SetValue(flags.NewFileReader(&saml.signingKeyPair.Cert))
+
+	// advanced feature: assertion encryption
+	sub.Flag("assertion-key-file", "A file with key used for securing SAML assertions. Must be used together with --assertion-cert-file.").SetValue(flags.NewFileReader(&saml.encryptionKeyPair.PrivateKey))
+	sub.Flag("assertion-cert-file", "A file with cert used for securing SAML assertions. Must be used together with --assertion-key-file.").SetValue(flags.NewFileReader(&saml.encryptionKeyPair.Cert))
+
+	// niche: required for particular providers.
+	sub.Flag("provider", "Sets the external identity provider type. Examples: ping, adfs.").StringVar(&spec.Provider)
+
+	// ignore warnings;
+	sub.Flag("ignore-missing-roles", "Ignore missing roles referenced in --attributes-to-roles.").BoolVar(&saml.ignoreMissingRoles)
+
+	sub.Alias(fmt.Sprintf(`
+Presets:
+
+%v
+
+Examples:
+
+  > tctl sso configure saml -n myauth -r groups,admin,access,editor,auditor -r groups,developer,access -e entity-desc.xml  
+
+  Generate SAML auth connector configuration called 'myauth'. Two mappings from SAML attributes to roles are defined: 
+    - members of 'admin' group will receive 'access', 'editor' and 'auditor' roles.
+    - members of 'developer' group will receive 'access' role.
+  The IdP metadata will be read from 'entity-desc.xml' file.
+
+
+  > tctl sso configure saml -p okta -r group,dev,access -e https://dev-123456.oktapreview.com/app/ex30h8/sso/saml/metadata
+
+  Generate SAML auth connector configuration using 'okta' preset. The choice of preset affects default name, display attribute and may apply IdP-specific tweaks.
+  Instead of XML file, a URL was provided to -e flag, which will be fetched by Teleport during runtime.
+
+
+  > tctl sso configure saml -p okta -r groups,developer,access -e entity-desc.xml | tctl sso test
+  
+  Generate the configuration and immediately test it using "tctl sso test" command.
+
+`, presets))
+
+	preset := &AuthKindCommand{
+		Run: func(ctx context.Context, clt *auth.Client) error { return samlRunFunc(ctx, cmd, &spec, saml, clt) },
+	}
+
+	sub.Action(func(ctx *kingpin.ParseContext) error {
+		preset.Parsed = true
+		return nil
+	})
+
+	return preset
+}
+
+func samlRunFunc(
+	ctx context.Context,
+	cmd *SSOConfigureCommand,
+	spec *types.SAMLConnectorSpecV2,
+	flags *samlExtraFlags,
+	clt *auth.Client,
+) error {
+	// apply preset, if chosen
+	p := samlPresets.getPreset(flags.chosenPreset)
+	if p != nil {
+		if spec.Display == "" {
+			spec.Display = p.display
+		}
+
+		if flags.connectorName == "" {
+			flags.connectorName = p.name
+		}
+
+		if p.modifySpec != nil {
+			if err := p.modifySpec(spec); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+
+	if flags.connectorName == "" {
+		return trace.BadParameter("Connector name must be set, either by choosing --preset or explicitly via --name")
+	}
+
+	allRoles, err := clt.GetRoles(ctx)
+	if err != nil {
+		cmd.Logger.WithError(err).Warn("unable to get roles list. Skipping attributes-to-roles sanity checks.")
+	} else {
+		roleMap := map[string]bool{}
+		var roleNames []string
+		for _, role := range allRoles {
+			roleMap[role.GetName()] = true
+			roleNames = append(roleNames, role.GetName())
+		}
+
+		for _, attrMapping := range spec.AttributesToRoles {
+			for _, role := range attrMapping.Roles {
+				_, found := roleMap[role]
+				if !found {
+					if flags.ignoreMissingRoles {
+						cmd.Logger.Warnf("attributes-to-roles references non-existing role: %q. Available roles: %v.", role, roleNames)
+					} else {
+						return trace.BadParameter("attributes-to-roles references non-existing role: %v. Correct the mapping, or add --ignore-missing-roles to ignore this error. Available roles: %v.", role, roleNames)
+					}
+				}
+			}
+		}
+	}
+
+	spec.SigningKeyPair = keyPairFromFlags(flags.signingKeyPair)
+	if spec.SigningKeyPair != nil {
+		if spec.SigningKeyPair.PrivateKey == "" {
+			return trace.BadParameter("Signing key pair was set, but key is empty. Provide the key with --signing-key-file.")
+		}
+		if spec.SigningKeyPair.Cert == "" {
+			return trace.BadParameter("Signing key pair was set, but cert is empty. Provide the cert with --signing-cert-file.")
+		}
+	}
+
+	spec.EncryptionKeyPair = keyPairFromFlags(flags.encryptionKeyPair)
+	if spec.EncryptionKeyPair != nil {
+		if spec.EncryptionKeyPair.PrivateKey == "" {
+			return trace.BadParameter("Assertion key pair was set, but key is empty. Provide the key with --assertion-key-file.")
+		}
+		if spec.EncryptionKeyPair.Cert == "" {
+			return trace.BadParameter("Assertion key pair was set, but cert is empty. Provide the cert with --assertion-cert-file.")
+		}
+	}
+
+	if spec.AssertionConsumerService == "" {
+		spec.AssertionConsumerService = ResolveCallbackURL(cmd.Logger, clt, "ACS", "https://%v/v1/webapi/saml/acs/"+flags.connectorName)
+	}
+
+	// figure out the actual meaning of entityDescriptorFlag. Can be: URL, file, plain XML.
+	if flags.entityDescriptorFlag != "" {
+		if err = processEntityDescriptorFlag(spec, flags.entityDescriptorFlag, cmd.Logger); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	if spec.Cert != "" {
+		if err = validateCert(spec.Cert); err != nil {
+			return trace.Wrap(err, "invalid certificate provided with --cert.")
+		}
+	}
+
+	if spec.EntityDescriptorURL == "" && spec.EntityDescriptor == "" && (spec.Issuer == "" || spec.SSO == "" || spec.Cert == "") {
+		return trace.BadParameter("missing one or more: issuer, sso, cert. Provide missing values using corresponding flags or with Entity Descriptor -e FILE/URL/XML.")
+	}
+
+	connector, err := types.NewSAMLConnector(flags.connectorName, *spec)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(utils.WriteYAML(os.Stdout, connector))
+}
+
+// keyPairFromFlags is a helper func to set key pair if appropriate flags were given.
+func keyPairFromFlags(flags types.AsymmetricKeyPair) *types.AsymmetricKeyPair {
+	if flags.PrivateKey == "" && flags.Cert == "" {
+		return nil
+	}
+
+	return &flags
+}
+
+func processEntityDescriptorFlag(spec *types.SAMLConnectorSpecV2, entityDescriptorFlag string, log *logrus.Entry) error {
+	var err error
+
+	// case: URL
+	var parsedURL *url.URL
+	if parsedURL, err = url.Parse(entityDescriptorFlag); err == nil && parsedURL.Scheme != "" {
+		spec.EntityDescriptorURL = entityDescriptorFlag
+		log.Infof("Entity descriptor looks like URL, entity_descriptor_url set to %q.", spec.EntityDescriptorURL)
+		return nil
+	}
+	if parsedURL.Scheme == "" {
+		log.Infof("Cannot parse entity descriptor as URL, missing scheme: %q.", entityDescriptorFlag)
+	} else {
+		log.WithError(err).Infof("Cannot parse entity descriptor as URL: %q.", entityDescriptorFlag)
+	}
+
+	// case: file
+	var bytes []byte
+	if bytes, err = os.ReadFile(entityDescriptorFlag); err == nil {
+		if err = validateEntityDescriptor(bytes, spec.Cert); err != nil {
+			return trace.WrapWithMessage(err, "Validating entity descriptor from file %q failed. Check that XML is valid or download the file directly.", entityDescriptorFlag)
+		}
+		spec.EntityDescriptor = string(bytes)
+		log.Infof("Entity descriptor read from file %q.", entityDescriptorFlag)
+		return nil
+	}
+	log.WithError(err).Infof("Cannot read entity descriptor from file: %q.", entityDescriptorFlag)
+
+	// case: verbatim XML
+	if err = validateEntityDescriptor([]byte(entityDescriptorFlag), spec.Cert); err == nil {
+		spec.EntityDescriptor = entityDescriptorFlag
+		log.Infof("Entity descriptor is valid XML, EntityDescriptor set to flag value.")
+		return nil
+	}
+	log.WithError(trace.Unwrap(err)).Infof("Cannot parse entity descriptor as verbatim XML: %q.", entityDescriptorFlag)
+
+	return trace.Errorf("failed to process -e/--entity-descriptor flag. Valid values: XML file, URL, verbatim XML")
+}
+
+func validateCert(certString string) error {
+	_, err := tlsca.ParseCertificatePEM([]byte(certString))
+	if err != nil {
+		return trace.Wrap(err, "failed to parse certificate")
+	}
+	return nil
+}
+
+func validateEntityDescriptor(entityDescriptorXML []byte, specCert string) error {
+	certificates, err := services.CheckSAMLEntityDescriptor(string(entityDescriptorXML))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// ensure we have at least one root.
+	if len(certificates) > 0 {
+		return nil
+	}
+
+	if specCert == "" {
+		return trace.BadParameter("no certificates in entity descriptor and none provided with --cert.")
+	}
+
+	err = validateCert(specCert)
+	if err != nil {
+		return trace.Wrap(err, "no certificates in entity descriptor and invalid certificate provided with --cert.")
+	}
+
+	return nil
+}

--- a/tool/tctl/sso/configure/saml_test.go
+++ b/tool/tctl/sso/configure/saml_test.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package configure
 
 import (

--- a/tool/tctl/sso/configure/saml_test.go
+++ b/tool/tctl/sso/configure/saml_test.go
@@ -1,0 +1,274 @@
+package configure
+
+import (
+	"io"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func Test_processEntityDescriptorFlag(t *testing.T) {
+
+	edOk := `<?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exk14fxcpjuKMcor30h8" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDpDCCAoygAwIBAgIGAX4zyofpMA0GCSqGSIb3DQEBCwUAMIGSMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+MBIGA1UECwwLU1NPUHJvdmlkZXIxEzARBgNVBAMMCmRldi04MTMzNTQxHDAaBgkqhkiG9w0BCQEW
+DWluZm9Ab2t0YS5jb20wHhcNMjIwMTA3MDkwNTU4WhcNMzIwMTA3MDkwNjU4WjCBkjELMAkGA1UE
+BhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNV
+BAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRMwEQYDVQQDDApkZXYtODEzMzU0MRwwGgYJ
+KoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+xQz+tLD5cNlOBfdohHvqNWIfC13OCSnUAe20qA0K8y+jtZrpwjtjjLX8iRuCx8dYc/nd6zYOhhSq
+2sLmrRa09wUXXTgnLGcj50gePTaroYLyF4FNgQWLvPHJk0FGcx6JvD6L+V5RzYwH87Fhg8niP4LZ
+EBw3iZnsIJN9KOuLuQeXTW0PIlMFzpCwT9aUCHCoLepe5Ou8oi8XcOCmsOESHPchV2RC/xQDIqRP
+Lp1Sf7NNJ6mTmP2gOoLwsz95beOLrEI+PI/GgZBqM3OutWA0L9mAbJK9T5dPAvhnwCV+SK2HvicJ
+T8c6uJxuKmoWv1t3SyaN0cIbmw6vj9CIf4DTwQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCWGgLL
+f3tgUZRGjmR5iiKeOeaEWG/eaF1nfenVfSaWT9ckimcXyLCY/P7CXEBiioVrxjky07iceJpi4rVE
+RcVZ8SGXCa0NroESmIFlIHez6vRTrqUsfDmidxsSCwY02eaBq+9gK5iXV5WeXMKbn0yeGwF+3PkU
+RAH1HuypwMH0FJRLIdW36pw7FCrGrXpk3UC6mEumXC9FptjSK1FlW+ZckgDprePOoUpypEygr2UC
+XXOsqT0dwBUUttdOQMZHqIiXS5VPJ8zhYPHBGYI8WGk5FWVuXIXhgRm7LN/EyXIvCOFmDH0tVnQL
+V115UGOwvjOOxmOFbYBn865SHgMndFtr</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://dev-813354.oktapreview.com/app/dev-813354_krzysztofssodev_1/exk14fxcpjuKMcor30h8/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://dev-813354.oktapreview.com/app/dev-813354_krzysztofssodev_1/exk14fxcpjuKMcor30h8/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>`
+
+	dir := t.TempDir()
+
+	edBadFile := path.Join(dir, "entity_descriptor_bad.xml")
+	require.NoError(t, os.WriteFile(edBadFile, []byte("foo bar baz"), 0777))
+
+	edGoodFile := path.Join(dir, "entity_descriptor_good.xml")
+	require.NoError(t, os.WriteFile(edGoodFile, []byte(edOk), 0777))
+
+	tests := []struct {
+		name             string
+		entityDescriptor string
+		log              *logrus.Entry
+
+		wantErr bool
+		want    types.SAMLConnectorSpecV2
+	}{
+		{
+			name:             "URL",
+			entityDescriptor: "https://my-idp.com/entity_descriptor.xml",
+			wantErr:          false,
+			want:             types.SAMLConnectorSpecV2{EntityDescriptorURL: "https://my-idp.com/entity_descriptor.xml"},
+		},
+		{
+			name:             "bad file",
+			entityDescriptor: edBadFile,
+			wantErr:          true,
+		},
+		{
+			name:             "good file",
+			entityDescriptor: edGoodFile,
+			wantErr:          false,
+			want:             types.SAMLConnectorSpecV2{EntityDescriptor: edOk},
+		},
+		{
+			name:             "verbatim XML",
+			entityDescriptor: edOk,
+			wantErr:          false,
+			want:             types.SAMLConnectorSpecV2{EntityDescriptor: edOk},
+		},
+		{
+			name:             "error",
+			entityDescriptor: "does_not_exist.xml",
+			wantErr:          true,
+		},
+		{
+			name:             "empty",
+			entityDescriptor: "",
+			wantErr:          true,
+		},
+	}
+
+	log := logrus.New()
+	log.Out = io.Discard
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := types.SAMLConnectorSpecV2{}
+			err := processEntityDescriptorFlag(&spec, tt.entityDescriptor, logrus.NewEntry(log))
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, spec)
+			}
+		})
+	}
+}
+
+func Test_validateEntityDescriptor(t *testing.T) {
+	edMalformed := `    <md:EntityDescriptor entityID="http://www.okta.com/exk14fxcpjuKMcor30h8" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">
+      <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:KeyDescriptor use="signing">
+          <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+              <ds:X509Certificate>
+							nonBase64Cert
+							</ds:X509Certificate>
+            </ds:X509Data>
+          </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://dev-813354.oktapreview.com/app/dev-813354_krzysztofssodev_1/exk14fxcpjuKMcor30h8/sso/saml"/>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://dev-813354.oktapreview.com/app/dev-813354_krzysztofssodev_1/exk14fxcpjuKMcor30h8/sso/saml"/>
+      </md:IDPSSODescriptor>
+    </md:EntityDescriptor>`
+
+	edOk := `<?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exk14fxcpjuKMcor30h8" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDpDCCAoygAwIBAgIGAX4zyofpMA0GCSqGSIb3DQEBCwUAMIGSMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+MBIGA1UECwwLU1NPUHJvdmlkZXIxEzARBgNVBAMMCmRldi04MTMzNTQxHDAaBgkqhkiG9w0BCQEW
+DWluZm9Ab2t0YS5jb20wHhcNMjIwMTA3MDkwNTU4WhcNMzIwMTA3MDkwNjU4WjCBkjELMAkGA1UE
+BhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNV
+BAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRMwEQYDVQQDDApkZXYtODEzMzU0MRwwGgYJ
+KoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+xQz+tLD5cNlOBfdohHvqNWIfC13OCSnUAe20qA0K8y+jtZrpwjtjjLX8iRuCx8dYc/nd6zYOhhSq
+2sLmrRa09wUXXTgnLGcj50gePTaroYLyF4FNgQWLvPHJk0FGcx6JvD6L+V5RzYwH87Fhg8niP4LZ
+EBw3iZnsIJN9KOuLuQeXTW0PIlMFzpCwT9aUCHCoLepe5Ou8oi8XcOCmsOESHPchV2RC/xQDIqRP
+Lp1Sf7NNJ6mTmP2gOoLwsz95beOLrEI+PI/GgZBqM3OutWA0L9mAbJK9T5dPAvhnwCV+SK2HvicJ
+T8c6uJxuKmoWv1t3SyaN0cIbmw6vj9CIf4DTwQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCWGgLL
+f3tgUZRGjmR5iiKeOeaEWG/eaF1nfenVfSaWT9ckimcXyLCY/P7CXEBiioVrxjky07iceJpi4rVE
+RcVZ8SGXCa0NroESmIFlIHez6vRTrqUsfDmidxsSCwY02eaBq+9gK5iXV5WeXMKbn0yeGwF+3PkU
+RAH1HuypwMH0FJRLIdW36pw7FCrGrXpk3UC6mEumXC9FptjSK1FlW+ZckgDprePOoUpypEygr2UC
+XXOsqT0dwBUUttdOQMZHqIiXS5VPJ8zhYPHBGYI8WGk5FWVuXIXhgRm7LN/EyXIvCOFmDH0tVnQL
+V115UGOwvjOOxmOFbYBn865SHgMndFtr</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://dev-813354.oktapreview.com/app/dev-813354_krzysztofssodev_1/exk14fxcpjuKMcor30h8/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://dev-813354.oktapreview.com/app/dev-813354_krzysztofssodev_1/exk14fxcpjuKMcor30h8/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>`
+
+	edNoCerts := `<?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exk14fxcpjuKMcor30h8" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://dev-813354.oktapreview.com/app/dev-813354_krzysztofssodev_1/exk14fxcpjuKMcor30h8/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://dev-813354.oktapreview.com/app/dev-813354_krzysztofssodev_1/exk14fxcpjuKMcor30h8/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>`
+
+	certFromFlag := `-----BEGIN CERTIFICATE-----
+MIIDpDCCAoygAwIBAgIGAX4zyofpMA0GCSqGSIb3DQEBCwUAMIGSMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+MBIGA1UECwwLU1NPUHJvdmlkZXIxEzARBgNVBAMMCmRldi04MTMzNTQxHDAaBgkqhkiG9w0BCQEW
+DWluZm9Ab2t0YS5jb20wHhcNMjIwMTA3MDkwNTU4WhcNMzIwMTA3MDkwNjU4WjCBkjELMAkGA1UE
+BhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNV
+BAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRMwEQYDVQQDDApkZXYtODEzMzU0MRwwGgYJ
+KoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+xQz+tLD5cNlOBfdohHvqNWIfC13OCSnUAe20qA0K8y+jtZrpwjtjjLX8iRuCx8dYc/nd6zYOhhSq
+2sLmrRa09wUXXTgnLGcj50gePTaroYLyF4FNgQWLvPHJk0FGcx6JvD6L+V5RzYwH87Fhg8niP4LZ
+EBw3iZnsIJN9KOuLuQeXTW0PIlMFzpCwT9aUCHCoLepe5Ou8oi8XcOCmsOESHPchV2RC/xQDIqRP
+Lp1Sf7NNJ6mTmP2gOoLwsz95beOLrEI+PI/GgZBqM3OutWA0L9mAbJK9T5dPAvhnwCV+SK2HvicJ
+T8c6uJxuKmoWv1t3SyaN0cIbmw6vj9CIf4DTwQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCWGgLL
+f3tgUZRGjmR5iiKeOeaEWG/eaF1nfenVfSaWT9ckimcXyLCY/P7CXEBiioVrxjky07iceJpi4rVE
+RcVZ8SGXCa0NroESmIFlIHez6vRTrqUsfDmidxsSCwY02eaBq+9gK5iXV5WeXMKbn0yeGwF+3PkU
+RAH1HuypwMH0FJRLIdW36pw7FCrGrXpk3UC6mEumXC9FptjSK1FlW+ZckgDprePOoUpypEygr2UC
+XXOsqT0dwBUUttdOQMZHqIiXS5VPJ8zhYPHBGYI8WGk5FWVuXIXhgRm7LN/EyXIvCOFmDH0tVnQL
+V115UGOwvjOOxmOFbYBn865SHgMndFtr
+-----END CERTIFICATE-----`
+
+	tests := []struct {
+		name                string
+		entityDescriptorXML string
+		certificate         string
+		wantErr             bool
+	}{
+		{
+			name:                "empty ed fails",
+			entityDescriptorXML: "",
+			certificate:         "",
+			wantErr:             true,
+		},
+		{
+			name:                "random data ed fails",
+			entityDescriptorXML: `lkzjlkasdjamsdn,mnczkladjiwd,zdnqoiwlkdnaldskalkjalskdjalksdj,.mzxc.,mqwe`,
+			certificate:         "",
+			wantErr:             true,
+		},
+		{
+			name:                "malformed ed fails",
+			entityDescriptorXML: edMalformed,
+			wantErr:             true,
+		},
+		{
+			name:                "malformed ed with good cert still fails",
+			entityDescriptorXML: edMalformed,
+			certificate:         certFromFlag,
+			wantErr:             true,
+		},
+		{
+			name:                "good ed works",
+			entityDescriptorXML: edOk,
+			certificate:         "",
+			wantErr:             false,
+		},
+		{
+			name:                "ed without certs fails",
+			entityDescriptorXML: edNoCerts,
+			certificate:         "",
+			wantErr:             true,
+		},
+		{
+			name:                "ed without certs with cert from flag works",
+			entityDescriptorXML: edNoCerts,
+			certificate:         certFromFlag,
+			wantErr:             false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateEntityDescriptor([]byte(tt.entityDescriptorXML), tt.certificate)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_validateCert(t *testing.T) {
+	cert := `-----BEGIN CERTIFICATE-----
+MIIDpDCCAoygAwIBAgIGAX4zyofpMA0GCSqGSIb3DQEBCwUAMIGSMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+MBIGA1UECwwLU1NPUHJvdmlkZXIxEzARBgNVBAMMCmRldi04MTMzNTQxHDAaBgkqhkiG9w0BCQEW
+DWluZm9Ab2t0YS5jb20wHhcNMjIwMTA3MDkwNTU4WhcNMzIwMTA3MDkwNjU4WjCBkjELMAkGA1UE
+BhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNV
+BAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRMwEQYDVQQDDApkZXYtODEzMzU0MRwwGgYJ
+KoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+xQz+tLD5cNlOBfdohHvqNWIfC13OCSnUAe20qA0K8y+jtZrpwjtjjLX8iRuCx8dYc/nd6zYOhhSq
+2sLmrRa09wUXXTgnLGcj50gePTaroYLyF4FNgQWLvPHJk0FGcx6JvD6L+V5RzYwH87Fhg8niP4LZ
+EBw3iZnsIJN9KOuLuQeXTW0PIlMFzpCwT9aUCHCoLepe5Ou8oi8XcOCmsOESHPchV2RC/xQDIqRP
+Lp1Sf7NNJ6mTmP2gOoLwsz95beOLrEI+PI/GgZBqM3OutWA0L9mAbJK9T5dPAvhnwCV+SK2HvicJ
+T8c6uJxuKmoWv1t3SyaN0cIbmw6vj9CIf4DTwQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCWGgLL
+f3tgUZRGjmR5iiKeOeaEWG/eaF1nfenVfSaWT9ckimcXyLCY/P7CXEBiioVrxjky07iceJpi4rVE
+RcVZ8SGXCa0NroESmIFlIHez6vRTrqUsfDmidxsSCwY02eaBq+9gK5iXV5WeXMKbn0yeGwF+3PkU
+RAH1HuypwMH0FJRLIdW36pw7FCrGrXpk3UC6mEumXC9FptjSK1FlW+ZckgDprePOoUpypEygr2UC
+XXOsqT0dwBUUttdOQMZHqIiXS5VPJ8zhYPHBGYI8WGk5FWVuXIXhgRm7LN/EyXIvCOFmDH0tVnQL
+V115UGOwvjOOxmOFbYBn865SHgMndFtr
+-----END CERTIFICATE-----`
+
+	tests := []struct {
+		name       string
+		certString string
+		wantErr    bool
+	}{
+		{
+			name:       "empty cert fails",
+			certString: "",
+			wantErr:    true,
+		},
+		{
+			name:       "random string fails",
+			certString: "akjldsjlkadsjalkdsjalkdsjqiowkadsdjlkasdjiqwdalksdj,mzncxkladjiqowkajshd",
+			wantErr:    true,
+		},
+		{
+			name:       "good cert works",
+			certString: cert,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCert(tt.certString)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/tool/tctl/sso/tester/command.go
+++ b/tool/tctl/sso/tester/command.go
@@ -82,10 +82,14 @@ Examples:
 
 	cmd.Handlers = map[string]func(c *auth.Client, connBytes []byte) (*AuthRequestInfo, error){
 		types.KindGithubConnector: handleGithubConnector,
+		types.KindSAMLConnector:   handleSAMLConnector,
+		types.KindOIDCConnector:   handleOIDCConnector,
 	}
 
 	cmd.GetDiagInfoFields = map[string]func(diag *types.SSODiagnosticInfo, debug bool) []string{
 		types.KindGithubConnector: getGithubDiagInfoFields,
+		types.KindSAMLConnector:   getInfoFieldsSAML,
+		types.KindOIDCConnector:   getInfoFieldsOIDC,
 	}
 }
 

--- a/tool/tctl/sso/tester/format.go
+++ b/tool/tctl/sso/tester/format.go
@@ -21,6 +21,7 @@ package tester
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/ghodss/yaml"
 
@@ -65,4 +66,16 @@ func formatUserDetails(description string, info *types.CreateUserParams) string 
 
 func formatError(fieldDesc string, err error) string {
 	return fmt.Sprintf("%v: error rendering field: %v\n", fieldDesc, err)
+}
+
+func formatSSOWarnings(description string, info *types.SSOWarnings) string {
+	if info == nil {
+		return ""
+	}
+
+	if len(info.Warnings) > 0 {
+		return fmt.Sprintf("%v: %v. Warnings:\n%v\n", description, info.Message, Indent(strings.Join(info.Warnings, "\n"), 2))
+	}
+
+	return fmt.Sprintf("%v: %v\n", description, info.Message)
 }

--- a/tool/tctl/sso/tester/format_test.go
+++ b/tool/tctl/sso/tester/format_test.go
@@ -260,3 +260,40 @@ func Test_formatError(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatSSOWarnings(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		info        *types.SSOWarnings
+		want        string
+	}{
+		{
+			name:        "empty",
+			description: "",
+			info:        nil,
+			want:        "",
+		},
+		{
+			name:        "message, no individual warnings",
+			description: "my field",
+			info:        &types.SSOWarnings{Message: "blah blah"},
+			want:        "my field: blah blah\n",
+		},
+		{
+			name:        "message and warnings",
+			description: "my field",
+			info: &types.SSOWarnings{
+				Message:  "blah blah",
+				Warnings: []string{"foo", "bar", "baz"},
+			},
+			want: "my field: blah blah. Warnings:\n  foo\n  bar\n  baz\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatSSOWarnings(tt.description, tt.info)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/tool/tctl/sso/tester/oidc.go
+++ b/tool/tctl/sso/tester/oidc.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package tester
 
 import (

--- a/tool/tctl/sso/tester/oidc.go
+++ b/tool/tctl/sso/tester/oidc.go
@@ -1,0 +1,104 @@
+package tester
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+func handleOIDCConnector(c *auth.Client, connBytes []byte) (*AuthRequestInfo, error) {
+	conn, err := services.UnmarshalOIDCConnector(connBytes)
+	if err != nil {
+		return nil, trace.Wrap(err, "Unable to load OIDC connector. Correct the definition and try again.")
+	}
+	requestInfo, err := oidcTest(c, conn)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return requestInfo, nil
+}
+
+func oidcTest(c *auth.Client, connector types.OIDCConnector) (*AuthRequestInfo, error) {
+	ctx := context.Background()
+	// get connector spec
+	var spec types.OIDCConnectorSpecV3
+	switch oidcConnector := connector.(type) {
+	case *types.OIDCConnectorV3:
+		spec = oidcConnector.Spec
+	default:
+		return nil, trace.BadParameter("Unrecognized oidc connector version: %T. Provide supported connector version.", oidcConnector)
+	}
+
+	requestInfo := &AuthRequestInfo{}
+
+	makeRequest := func(req client.SSOLoginConsoleReq) (*client.SSOLoginConsoleResponse, error) {
+		oidcRequest := types.OIDCAuthRequest{
+			ConnectorID:       req.ConnectorID + "-" + connector.GetName(),
+			Type:              constants.OIDC,
+			CheckUser:         false,
+			PublicKey:         req.PublicKey,
+			CertTTL:           defaults.OIDCAuthRequestTTL,
+			CreateWebSession:  false,
+			ClientRedirectURL: req.RedirectURL,
+			RouteToCluster:    req.RouteToCluster,
+			SSOTestFlow:       true,
+			ConnectorSpec:     &spec,
+		}
+
+		request, err := c.CreateOIDCAuthRequest(ctx, oidcRequest)
+		if request != nil {
+			requestInfo.RequestID = request.StateToken
+		}
+		requestInfo.RequestCreateErr = err
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return &client.SSOLoginConsoleResponse{RedirectURL: request.RedirectURL}, nil
+	}
+
+	requestInfo.Config = &client.RedirectorConfig{SSOLoginConsoleRequestFn: makeRequest}
+	return requestInfo, nil
+}
+
+func getInfoFieldsOIDC(diag *types.SSODiagnosticInfo, debug bool) []string {
+	return []string{
+		GetDiagMessage(
+			diag.OIDCClaims != nil,
+			true,
+			FormatJSON("[OIDC] Claims", diag.OIDCClaims)),
+		GetDiagMessage(
+			diag.OIDCClaimsToRoles != nil,
+			true,
+			FormatYAML("[OIDC] Claims to roles", diag.OIDCClaimsToRoles),
+		),
+		GetDiagMessage(
+			diag.OIDCClaimsToRolesWarnings != nil,
+			true,
+			formatSSOWarnings("[OIDC] Claims to roles warnings", diag.OIDCClaimsToRolesWarnings),
+		),
+		GetDiagMessage(
+			diag.OIDCTraitsFromClaims != nil,
+			debug,
+			FormatJSON("[OIDC] Calculated user traits", diag.OIDCTraitsFromClaims),
+		),
+		GetDiagMessage(
+			diag.OIDCIdentity != nil,
+			true,
+			FormatJSON("[OIDC] Calculated identity", diag.OIDCIdentity),
+		),
+		GetDiagMessage(
+			diag.OIDCConnectorTraitMapping != nil,
+			debug,
+			FormatYAML("[OIDC] Connector trait mapping", diag.OIDCConnectorTraitMapping),
+		),
+	}
+}

--- a/tool/tctl/sso/tester/saml.go
+++ b/tool/tctl/sso/tester/saml.go
@@ -1,0 +1,105 @@
+package tester
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+func handleSAMLConnector(c *auth.Client, connBytes []byte) (*AuthRequestInfo, error) {
+	conn, err := services.UnmarshalSAMLConnector(connBytes)
+	if err != nil {
+		return nil, trace.Wrap(err, "Unable to load SAML connector. Correct the definition and try again.")
+	}
+	requestInfo, err := samlTest(c, conn)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return requestInfo, nil
+}
+
+func samlTest(c *auth.Client, samlConnector types.SAMLConnector) (*AuthRequestInfo, error) {
+	ctx := context.Background()
+	// get connector spec
+	var spec types.SAMLConnectorSpecV2
+	switch samlConnector := samlConnector.(type) {
+	case *types.SAMLConnectorV2:
+		spec = samlConnector.Spec
+	default:
+		return nil, trace.BadParameter("Unrecognized SAML connector version: %T. Provide supported connector version.", samlConnector)
+	}
+
+	requestInfo := &AuthRequestInfo{}
+
+	makeRequest := func(req client.SSOLoginConsoleReq) (*client.SSOLoginConsoleResponse, error) {
+		samlRequest := types.SAMLAuthRequest{
+			ConnectorID:       req.ConnectorID + "-" + samlConnector.GetName(),
+			Type:              constants.SAML,
+			CheckUser:         false,
+			PublicKey:         req.PublicKey,
+			CertTTL:           defaults.SAMLAuthRequestTTL,
+			CreateWebSession:  false,
+			ClientRedirectURL: req.RedirectURL,
+			RouteToCluster:    req.RouteToCluster,
+			SSOTestFlow:       true,
+			ConnectorSpec:     &spec,
+		}
+
+		request, err := c.CreateSAMLAuthRequest(ctx, samlRequest)
+		if request != nil {
+			requestInfo.RequestID = request.ID
+		}
+		requestInfo.RequestCreateErr = err
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return &client.SSOLoginConsoleResponse{RedirectURL: request.RedirectURL}, nil
+	}
+
+	requestInfo.Config = &client.RedirectorConfig{SSOLoginConsoleRequestFn: makeRequest}
+	return requestInfo, nil
+}
+
+func getInfoFieldsSAML(diag *types.SSODiagnosticInfo, debug bool) []string {
+	return []string{
+		GetDiagMessage(
+			diag.SAMLAttributesToRoles != nil,
+			true,
+			FormatYAML("[SAML] Attributes to roles", diag.SAMLAttributesToRoles),
+		),
+		GetDiagMessage(
+			diag.SAMLAttributesToRolesWarnings != nil,
+			true,
+			formatSSOWarnings("[SAML] Attributes mapping warning", diag.SAMLAttributesToRolesWarnings),
+		),
+		GetDiagMessage(
+			diag.SAMLAttributeStatements != nil,
+			true,
+			FormatYAML("[SAML] Attributes statements", diag.SAMLAttributeStatements),
+		),
+		GetDiagMessage(
+			diag.SAMLAssertionInfo != nil,
+			debug,
+			FormatJSON("[SAML] Assertion info", diag.SAMLAssertionInfo),
+		),
+		GetDiagMessage(
+			diag.SAMLTraitsFromAssertions != nil,
+			debug,
+			FormatJSON("[SAML] Calculated user traits", diag.SAMLTraitsFromAssertions),
+		),
+		GetDiagMessage(
+			diag.SAMLConnectorTraitMapping != nil,
+			debug,
+			FormatYAML("[SAML] Connector trait mapping", diag.SAMLConnectorTraitMapping),
+		),
+	}
+}

--- a/tool/tctl/sso/tester/saml.go
+++ b/tool/tctl/sso/tester/saml.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package tester
 
 import (


### PR DESCRIPTION
Migrates the tctl sso configure and tctl sso test commands for SAML and OIDC connectors from tctl enterprise to OSS. This will allow the enterprise tctl binary to be removed.