### PR TITLE
Update docs to use insecure-drop instead of insecure_drop and drop

### DIFF
--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -69,7 +69,7 @@ user:
 | `desktop_clipboard` | Allow clipboard sharing for desktop sessions | Logical "AND" i.e. evaluates to "yes" if all roles enable clipboard sharing |
 | `pin_source_ip` | Enable source IP pinning for SSH certificates. | Logical "OR" i.e. evaluates to "yes" if at least one role requires session termination |
 | `cert_extensions` | Specifies extensions to be included in SSH certificates | |
-| `create_host_user_mode` | Allow users to be automatically created on a host |  Logical "AND" i.e. if all roles matching a server specify host user creation (`off`, `drop`, `keep`), it will evaluate to the option specified by all of the roles. If some roles specify both `drop` or `keep` it will evaluate to `keep`|
+| `create_host_user_mode` | Allow users to be automatically created on a host |  Logical "AND" i.e. if all roles matching a server specify host user creation (`off`, `keep`, `insecure-drop`), it will evaluate to the option specified by all of the roles. If some roles specify both `insecure-drop` or `keep` it will evaluate to `keep`|
 | `create_db_user_mode` | Allow [database user auto provisioning](../database-access/auto-user-provisioning.mdx). Options: `off` (disable database user auto-provisioning), `keep` (disables the user at session end, removing the roles and locking it), and `best_effort_drop` (try to drop the user at session end, if it doesn't succeed, fallback to disabling it). | Logical "OR" i.e. if any role allows database user auto-provisioning, it's allowed |
 
 ## Preset roles

--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -97,9 +97,9 @@ spec:
        name: login@github.com
        value: "{{ external.github_login }}"
     # Controls whether this role supports auto provisioning of SSH users.
-    # Options: drop (remove user on session end), keep (keep users at session end)
+    # Options: keep (keep users at session end), insecure-drop (remove user on session end),
     #          and off (disable host user creation)
-    create_host_user_mode: drop
+    create_host_user_mode: insecure-drop
     # Controls whether this role requires automatic database user provisioning.
     # Options: off (disable database user auto-provisioning), keep (disables the
     # user at session end, removing the roles and locking it), and

--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -99,7 +99,7 @@ spec:
     # Controls whether this role supports auto provisioning of SSH users.
     # Options: keep (keep users at session end), insecure-drop (remove user on session end),
     #          and off (disable host user creation)
-    create_host_user_mode: insecure-drop
+    create_host_user_mode: keep
     # Controls whether this role requires automatic database user provisioning.
     # Options: off (disable database user auto-provisioning), keep (disables the
     # user at session end, removing the roles and locking it), and

--- a/docs/pages/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/server-access/guides/host-user-creation.mdx
@@ -149,7 +149,7 @@ ssh_service:
 ```
 
 In low-security environments, you can also set `create_host_user_mode` to
-`insecure_drop`, which deletes users once the session ends. However, in this
+`insecure-drop`, which deletes users once the session ends. However, in this
 mode it is possible for a created user to get the same UID as a previously
 deleted user, which would give the new user access to all of the old user's
 files if they are not deleted. Use `keep` mode unless you really need users to

--- a/docs/pages/server-access/rbac.mdx
+++ b/docs/pages/server-access/rbac.mdx
@@ -128,9 +128,9 @@ spec:
     #....
   options:
     # Controls whether this role supports auto provisioning of users.
-    # Options: drop (remove user on session end), keep (keep users at session end)
+    # Options: keep (keep users at session end), insecure-drop (remove user on session end),
     #          and off (disable host user creation)
-    create_host_user_mode: drop
+    create_host_user_mode: keep
     # forward_agent controls whether SSH agent forwarding is allowed
     forward_agent: true
     # port_forwarding controls whether TCP port forwarding is allowed for SSH


### PR DESCRIPTION
It turns out that the correct value is `insecure-drop`, not `insecure_drop`. A few pages were still using `drop` as well.