### PR TITLE
Fix kube-agent-updater default verbosity

### DIFF
--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -91,7 +91,7 @@ func main() {
 	)
 
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
The updater has been logging in debug by default; this is a mistake; this PR disables the Zap development mode.

The logging will be revamped in a future PR to eliminate zap.

Changelog: Fix a verbosity issue that caused the `teleport-kube-agent-updater` to output debug logs by default.