### PR TITLE
Improve performance of resource filtering via predicate expressions

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1358,31 +1358,18 @@ func (a *ServerWithRoles) checkUnifiedAccess(resource types.ResourceWithLabels, 
 
 // ListUnifiedResources returns a paginated list of unified resources filtered by user access.
 func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.ListUnifiedResourcesRequest) (*proto.ListUnifiedResourcesResponse, error) {
-	// Fetch full list of resources in the backend.
-	var (
-		unifiedResources types.ResourcesWithLabels
-		nextKey          string
-	)
-
 	filter := services.MatchResourceFilter{
-		Labels:              req.Labels,
-		SearchKeywords:      req.SearchKeywords,
-		PredicateExpression: req.PredicateExpression,
-		Kinds:               req.Kinds,
+		Labels:         req.Labels,
+		SearchKeywords: req.SearchKeywords,
+		Kinds:          req.Kinds,
 	}
 
-	// If a predicate expression was provided, evaluate it with an empty
-	// server to determine if the expression is valid before attempting
-	// to do any listing.
-	if filter.PredicateExpression != "" {
-		parser, err := services.NewResourceParser(&types.ServerV2{})
+	if req.PredicateExpression != "" {
+		expression, err := services.NewResourceExpression(req.PredicateExpression)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		if _, err := parser.EvalBoolPredicate(filter.PredicateExpression); err != nil {
-			return nil, trace.BadParameter("failed to parse predicate expression: %s", err.Error())
-		}
+		filter.PredicateExpression = expression
 	}
 
 	// Populate resourceAccessMap with any access errors the user has for each possible
@@ -1448,6 +1435,11 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 		return nil, trace.Wrap(err)
 	}
 
+	// Fetch full list of resources in the backend.
+	var (
+		unifiedResources types.ResourcesWithLabels
+		nextKey          string
+	)
 	if req.PinnedOnly {
 		prefs, err := a.authServer.GetUserPreferences(ctx, a.context.User.GetName())
 		if err != nil {
@@ -1736,11 +1728,19 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 	// `ListResources`) to ensure that it will be applied only to resources
 	// the user has access to.
 	filter := services.MatchResourceFilter{
-		ResourceKind:        req.ResourceType,
-		Labels:              req.Labels,
-		SearchKeywords:      req.SearchKeywords,
-		PredicateExpression: req.PredicateExpression,
+		ResourceKind:   req.ResourceType,
+		Labels:         req.Labels,
+		SearchKeywords: req.SearchKeywords,
 	}
+
+	if req.PredicateExpression != "" {
+		expression, err := services.NewResourceExpression(req.PredicateExpression)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		filter.PredicateExpression = expression
+	}
+
 	req.Labels = nil
 	req.SearchKeywords = nil
 	req.PredicateExpression = ""
@@ -2019,14 +2019,12 @@ func (a *ServerWithRoles) listResourcesWithSort(ctx context.Context, req proto.L
 		return nil, trace.NotImplemented("resource type %q is not supported for listResourcesWithSort", req.ResourceType)
 	}
 
-	// Apply request filters and get pagination info.
-	resp, err := local.FakePaginate(resources, local.FakePaginateParams{
-		ResourceType:        req.ResourceType,
-		Limit:               req.Limit,
-		Labels:              req.Labels,
-		SearchKeywords:      req.SearchKeywords,
-		PredicateExpression: req.PredicateExpression,
-		StartKey:            req.StartKey,
+	params := local.FakePaginateParams{
+		ResourceType:   req.ResourceType,
+		Limit:          req.Limit,
+		Labels:         req.Labels,
+		SearchKeywords: req.SearchKeywords,
+		StartKey:       req.StartKey,
 		EnrichResourceFn: func(r types.ResourceWithLabels) (types.ResourceWithLabels, error) {
 			if req.IncludeLogins && (r.GetKind() == types.KindNode || r.GetKind() == types.KindWindowsDesktop) {
 				resourceChecker, err := a.newResourceAccessChecker(req.ResourceType)
@@ -2044,7 +2042,18 @@ func (a *ServerWithRoles) listResourcesWithSort(ctx context.Context, req proto.L
 
 			return r, nil
 		},
-	})
+	}
+
+	if req.PredicateExpression != "" {
+		expression, err := services.NewResourceExpression(req.PredicateExpression)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		params.PredicateExpression = expression
+	}
+
+	// Apply request filters and get pagination info.
+	resp, err := local.FakePaginate(resources, params)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -3084,14 +3084,23 @@ func (c *Cache) ListResources(ctx context.Context, req proto.ListResourcesReques
 				return nil, trace.Wrap(err)
 			}
 
-			return local.FakePaginate(servers.AsResources(), local.FakePaginateParams{
-				ResourceType:        req.ResourceType,
-				Limit:               req.Limit,
-				Labels:              req.Labels,
-				SearchKeywords:      req.SearchKeywords,
-				PredicateExpression: req.PredicateExpression,
-				StartKey:            req.StartKey,
-			})
+			params := local.FakePaginateParams{
+				ResourceType:   req.ResourceType,
+				Limit:          req.Limit,
+				Labels:         req.Labels,
+				SearchKeywords: req.SearchKeywords,
+				StartKey:       req.StartKey,
+			}
+
+			if req.PredicateExpression != "" {
+				expression, err := services.NewResourceExpression(req.PredicateExpression)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+				params.PredicateExpression = expression
+			}
+
+			return local.FakePaginate(servers.AsResources(), params)
 		}
 	}
 

--- a/lib/services/fuzz_test.go
+++ b/lib/services/fuzz_test.go
@@ -113,11 +113,13 @@ func FuzzParserEvalBoolPredicate(f *testing.F) {
 		})
 		require.NoError(t, err)
 
-		parser, err := NewResourceParser(resource)
-		require.NoError(t, err)
-
 		require.NotPanics(t, func() {
-			parser.EvalBoolPredicate(expr)
+			parser, err := NewResourceExpression(expr)
+			if err != nil {
+				return
+			}
+
+			parser.Evaluate(resource)
 		})
 	})
 }

--- a/lib/services/local/desktops.go
+++ b/lib/services/local/desktops.go
@@ -182,10 +182,17 @@ func (s *WindowsDesktopService) ListWindowsDesktops(ctx context.Context, req typ
 	rangeStart := backend.Key(windowsDesktopsPrefix, req.StartKey)
 	rangeEnd := backend.RangeEnd(backend.ExactKey(windowsDesktopsPrefix))
 	filter := services.MatchResourceFilter{
-		ResourceKind:        types.KindWindowsDesktop,
-		Labels:              req.Labels,
-		SearchKeywords:      req.SearchKeywords,
-		PredicateExpression: req.PredicateExpression,
+		ResourceKind:   types.KindWindowsDesktop,
+		Labels:         req.Labels,
+		SearchKeywords: req.SearchKeywords,
+	}
+
+	if req.PredicateExpression != "" {
+		expression, err := services.NewResourceExpression(req.PredicateExpression)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		filter.PredicateExpression = expression
 	}
 
 	// Get most limit+1 results to determine if there will be a next key.
@@ -247,10 +254,17 @@ func (s *WindowsDesktopService) ListWindowsDesktopServices(ctx context.Context, 
 	rangeStart := backend.Key(windowsDesktopServicesPrefix, req.StartKey)
 	rangeEnd := backend.RangeEnd(backend.ExactKey(windowsDesktopServicesPrefix))
 	filter := services.MatchResourceFilter{
-		ResourceKind:        types.KindWindowsDesktopService,
-		Labels:              req.Labels,
-		SearchKeywords:      req.SearchKeywords,
-		PredicateExpression: req.PredicateExpression,
+		ResourceKind:   types.KindWindowsDesktopService,
+		Labels:         req.Labels,
+		SearchKeywords: req.SearchKeywords,
+	}
+
+	if req.PredicateExpression != "" {
+		expression, err := services.NewResourceExpression(req.PredicateExpression)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		filter.PredicateExpression = expression
 	}
 
 	// Get most limit+1 results to determine if there will be a next key.

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -996,12 +996,11 @@ func TestListResources_Helpers(t *testing.T) {
 				require.NoError(t, err)
 
 				return FakePaginate(types.Servers(nodes).AsResources(), FakePaginateParams{
-					ResourceType:        req.ResourceType,
-					Limit:               req.Limit,
-					Labels:              req.Labels,
-					SearchKeywords:      req.SearchKeywords,
-					PredicateExpression: req.PredicateExpression,
-					StartKey:            req.StartKey,
+					ResourceType:   req.ResourceType,
+					Limit:          req.Limit,
+					Labels:         req.Labels,
+					SearchKeywords: req.SearchKeywords,
+					StartKey:       req.StartKey,
 				})
 			},
 		},

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
 // RuleContext specifies context passed to the
@@ -731,136 +732,69 @@ func newParserForIdentifierSubcondition(ctx RuleContext, identifier string) (pre
 	})
 }
 
-// NewResourceParser returns a parser made for boolean expressions based on a
-// json-serialiable resource. Customized to allow short identifiers common in all
+// NewResourceExpression returns a [typical.Expression] that is to be evaluated against a
+// [types.ResourceWithLabels]. It is customized to allow short identifiers common in all
 // resources:
-//   - shorthand `name` refers to `resource.spec.hostname` for node resources or it refers
+//   - shorthand `name` refers to `resource.spec.hostname` for node resources, or it refers
 //     to `resource.metadata.name` for all other resources eg: `name == "app-name-jenkins"`
 //   - shorthand `labels` refers to resource `resource.metadata.labels + resource.spec.dynamic_labels`
 //     eg: `labels.env == "prod"`
 //
 // All other fields can be referenced by starting expression with identifier `resource`
 // followed by the names of the json fields ie: `resource.spec.public_addr`.
-func NewResourceParser(resource types.ResourceWithLabels) (BoolPredicateParser, error) {
-	predEquals := func(a interface{}, b interface{}) predicate.BoolPredicate {
-		switch aval := a.(type) {
-		case label:
-			bval, ok := b.(string)
-			return func() bool {
-				return ok && aval.value == bval
-			}
-		default:
-			return predicate.Equals(a, b)
-		}
-	}
-	predPrefix := func(a interface{}, prefix string) predicate.BoolPredicate {
-		switch aval := a.(type) {
-		case label:
-			return func() bool {
-				return strings.HasPrefix(aval.value, prefix)
-			}
-		case string:
-			return func() bool {
-				return strings.HasPrefix(aval, prefix)
-			}
-		default:
-			return func() bool {
-				return false
-			}
-		}
-	}
-
-	p, err := predicate.NewParser(predicate.Def{
-		Operators: predicate.Operators{
-			AND: predicate.And,
-			OR:  predicate.Or,
-			NOT: predicate.Not,
-			EQ:  predEquals,
-			NEQ: func(a interface{}, b interface{}) predicate.BoolPredicate {
-				return predicate.Not(predEquals(a, b))
-			},
-		},
-		Functions: map[string]interface{}{
-			"hasPrefix": predPrefix,
-			"equals":    predEquals,
-			// search allows fuzzy matching against select field values.
-			"search": func(searchVals ...string) predicate.BoolPredicate {
-				return func() bool {
-					return resource.MatchSearch(searchVals)
-				}
-			},
-			// exists checks for an existence of a label by checking
-			// if a key exists. Label value are unchecked.
-			"exists": func(l label) predicate.BoolPredicate {
-				return func() bool {
-					return len(l.key) > 0
-				}
-			},
-		},
-		GetIdentifier: func(fields []string) (interface{}, error) {
-			switch fields[0] {
-			case ResourceLabelsIdentifier:
-				switch {
-				// Field length of 1 means the user is using
-				// an index expression ie: labels["env"], which the
-				// parser will expect a map for lookup in `GetProperty`.
-				case len(fields) == 1:
-					return resource, nil
-				case len(fields) > 2:
-					return nil, trace.BadParameter("only two fields are supported with identifier %q, got %d: %v", ResourceLabelsIdentifier, len(fields), fields)
-				default:
-					key := fields[1]
-					val, ok := resource.GetLabel(key)
-					if ok {
-						return label{key: key, value: val}, nil
-					}
-					return label{}, nil
-				}
-
-			case ResourceNameIdentifier:
-				if len(fields) > 1 {
-					return nil, trace.BadParameter("only one field are supported with identifier %q, got %d: %v", ResourceNameIdentifier, len(fields), fields)
-				}
-
+func NewResourceExpression(expression string) (typical.Expression[types.ResourceWithLabels, bool], error) {
+	parser, err := typical.NewParser[types.ResourceWithLabels, bool](typical.ParserSpec[types.ResourceWithLabels]{
+		Variables: map[string]typical.Variable{
+			"resource.metadata.labels": typical.DynamicVariable(func(r types.ResourceWithLabels) (map[string]string, error) {
+				return r.GetStaticLabels(), nil
+			}),
+			"resource.metadata.name": typical.DynamicVariable(func(r types.ResourceWithLabels) (string, error) {
+				return r.GetName(), nil
+			}),
+			"labels": typical.DynamicMapFunction(func(r types.ResourceWithLabels, key string) (string, error) {
+				val, _ := r.GetLabel(key)
+				return val, nil
+			}),
+			"name": typical.DynamicVariable(func(r types.ResourceWithLabels) (string, error) {
 				// For nodes, the resource "name" that user expects is the
-				// nodes hostname, not its UUID. Currently for other resources,
+				// nodes hostname, not its UUID. Currently, for other resources,
 				// the metadata.name returns the name as expected.
-				if server, ok := resource.(types.Server); ok {
+				if server, ok := r.(types.Server); ok {
 					return server.GetHostname(), nil
 				}
 
-				return resource.GetName(), nil
-			case ResourceIdentifier:
-				return predicate.GetFieldByTag(resource, teleport.JSON, fields[1:])
-			default:
-				return nil, trace.NotFound("identifier %q is not defined", strings.Join(fields, "."))
-			}
+				return r.GetName(), nil
+			}),
 		},
-		GetProperty: func(mapVal, keyVal interface{}) (interface{}, error) {
-			r, ok := mapVal.(types.ResourceWithLabels)
-			if !ok {
-				return GetStringMapValue(mapVal, keyVal)
+		Functions: map[string]typical.Function{
+			"hasPrefix": typical.BinaryFunction[types.ResourceWithLabels](func(s, suffix string) (bool, error) {
+				return strings.HasPrefix(s, suffix), nil
+			}),
+			"equals": typical.BinaryFunction[types.ResourceWithLabels](func(a, b string) (bool, error) {
+				return strings.Compare(a, b) == 0, nil
+			}),
+			"search": typical.UnaryVariadicFunctionWithEnv(func(r types.ResourceWithLabels, v ...string) (bool, error) {
+				return r.MatchSearch(v), nil
+			}),
+			"exists": typical.UnaryFunction[types.ResourceWithLabels](func(value string) (bool, error) {
+				return value != "", nil
+			}),
+		},
+		GetUnknownIdentifier: func(env types.ResourceWithLabels, fields []string) (any, error) {
+			if fields[0] == ResourceIdentifier {
+				if f, err := predicate.GetFieldByTag(env, teleport.JSON, fields[1:]); err == nil {
+					return f, nil
+				}
 			}
 
-			key, ok := keyVal.(string)
-			if !ok {
-				return nil, trace.BadParameter("only string keys are supported")
-			}
-
-			val, ok := r.GetLabel(key)
-			if ok {
-				return label{key: key, value: val}, nil
-			}
-			return label{}, nil
+			identifier := strings.Join(fields, ".")
+			return nil, trace.BadParameter("identifier %s is not defined", identifier)
 		},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return boolPredicateParser{Parser: p}, nil
-}
-
-type label struct {
-	key, value string
+	expr, err := parser.Parse(expression)
+	return expr, trace.Wrap(err)
 }

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -158,7 +158,7 @@ func TestParserForIdentifierSubcondition(t *testing.T) {
 			}}))
 }
 
-func TestNewResourceParser(t *testing.T) {
+func TestNewResourceExpression(t *testing.T) {
 	t.Parallel()
 	resource, err := types.NewServerWithLabels("test-name", types.KindNode, types.ServerSpecV2{
 		Hostname: "test-hostname",
@@ -172,9 +172,6 @@ func TestNewResourceParser(t *testing.T) {
 		"env": "prod",
 		"os":  "mac",
 	})
-	require.NoError(t, err)
-
-	parser, err := NewResourceParser(resource)
 	require.NoError(t, err)
 
 	t.Run("matching expressions", func(t *testing.T) {
@@ -220,7 +217,10 @@ func TestNewResourceParser(t *testing.T) {
 		}
 		for _, expr := range exprs {
 			t.Run(expr, func(t *testing.T) {
-				match, err := parser.EvalBoolPredicate(expr)
+				parser, err := NewResourceExpression(expr)
+				require.NoError(t, err)
+
+				match, err := parser.Evaluate(resource)
 				require.NoError(t, err)
 				require.True(t, match)
 			})
@@ -245,18 +245,19 @@ func TestNewResourceParser(t *testing.T) {
 		}
 		for _, expr := range exprs {
 			t.Run(expr, func(t *testing.T) {
-				match, err := parser.EvalBoolPredicate(expr)
+				parser, err := NewResourceExpression(expr)
+				require.NoError(t, err)
+
+				match, err := parser.Evaluate(resource)
 				require.NoError(t, err)
 				require.False(t, match)
 			})
 		}
 	})
 
-	t.Run("error in expressions", func(t *testing.T) {
+	t.Run("fail to parse", func(t *testing.T) {
 		t.Parallel()
 		exprs := []string{
-			`name.toomanyfield`,
-			`labels.env.toomanyfield`,
 			`!name`,
 			`name ==`,
 			`name &`,
@@ -269,7 +270,6 @@ func TestNewResourceParser(t *testing.T) {
 			`|`,
 			`&`,
 			`.`,
-			`equals(resource.incorrect.selector, "_")`,
 			`equals(invalidIdentifier)`,
 			`equals(labels.env)`,
 			`equals(labels.env, "too", "many")`,
@@ -286,7 +286,26 @@ func TestNewResourceParser(t *testing.T) {
 		}
 		for _, expr := range exprs {
 			t.Run(expr, func(t *testing.T) {
-				match, err := parser.EvalBoolPredicate(expr)
+				expression, err := NewResourceExpression(expr)
+				require.Error(t, err)
+				require.Nil(t, expression)
+			})
+		}
+	})
+
+	t.Run("fail to evaluate", func(t *testing.T) {
+		t.Parallel()
+		exprs := []string{
+			`name.toomanyfield`,
+			`labels.env.toomanyfield`,
+			`equals(resource.incorrect.selector, "_")`,
+		}
+		for _, expr := range exprs {
+			t.Run(expr, func(t *testing.T) {
+				parser, err := NewResourceExpression(expr)
+				require.NoError(t, err)
+
+				match, err := parser.Evaluate(resource)
 				require.Error(t, err)
 				require.False(t, match)
 			})
@@ -294,7 +313,7 @@ func TestNewResourceParser(t *testing.T) {
 	})
 }
 
-func TestResourceParser_NameIdentifier(t *testing.T) {
+func TestResourceExpression_NameIdentifier(t *testing.T) {
 	t.Parallel()
 
 	// Server resource should use hostname when using name identifier.
@@ -303,9 +322,10 @@ func TestResourceParser_NameIdentifier(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	parser, err := NewResourceParser(server)
+	parser, err := NewResourceExpression(`name == "server-hostname"`)
 	require.NoError(t, err)
-	match, err := parser.EvalBoolPredicate(`name == "server-hostname"`)
+
+	match, err := parser.Evaluate(server)
 	require.NoError(t, err)
 	require.True(t, match)
 
@@ -315,9 +335,10 @@ func TestResourceParser_NameIdentifier(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	parser, err = NewResourceParser(desktop)
+	parser, err = NewResourceExpression(`name == "desktop-name"`)
 	require.NoError(t, err)
-	match, err = parser.EvalBoolPredicate(`name == "desktop-name"`)
+
+	match, err = parser.Evaluate(desktop)
 	require.NoError(t, err)
 	require.True(t, match)
 }


### PR DESCRIPTION
The existing resource parser was converted to use typical under the hood. Aside from the type safety improvements making the switch allows a single predicate expression to be parsed once and evaluated per resource. The previous parser worked backwards, it created a parser per resource with the same expression which lead to elevated memory consumption and poor performance.

An additional bug was fixed that prevented predicate filtering from working properly with the unified resource API due to applying predicates prior to filtering by kind. This resulted in queriers for server specific things (resource.spec.hostname) to fail even when only the server resource was specified in the resource kinds.

Benchmark results for the changes in this commit compared to master show a 75% reduction in the test time and a 96% reduction in allocations during the tests.

```bash

$ benchstat e77e5e080b1848da830a9030d43c38be55a5b8d5.txt 8eff752a93dfe96225a71431af829015e83400fa.txt
goos: darwin
goarch: arm64
pkg: github.com/gravitational/teleport/lib/auth
                                              │ e77e5e080b1848da830a9030d43c38be55a5b8d5.txt │ 8eff752a93dfe96225a71431af829015e83400fa.txt │
                                              │                    sec/op                    │        sec/op         vs base                │
ListUnifiedResourcesFilter/labels-12                                            73.88m ±  1%            64.74m ± 6%  -12.37% (p=0.000 n=10)
ListUnifiedResourcesFilter/predicate_path-12                                   294.06m ± 20%            74.83m ± 5%  -74.55% (p=0.000 n=10)
ListUnifiedResourcesFilter/predicate_index-12                                  307.63m ±  4%            76.32m ± 4%  -75.19% (p=0.000 n=10)
ListUnifiedResourcesFilter/search_lower-12                                      130.7m ±  5%            130.5m ± 4%        ~ (p=0.971 n=10)
ListUnifiedResourcesFilter/search_upper-12                                      147.4m ±  5%            138.7m ± 2%   -5.87% (p=0.003 n=10)
ListUnifiedResources/simple_labels-12                                            1.748 ±  2%             1.744 ± 2%        ~ (p=0.631 n=10)
geomean                                                                         246.6m                  150.6m       -38.93%

                                              │ e77e5e080b1848da830a9030d43c38be55a5b8d5.txt │ 8eff752a93dfe96225a71431af829015e83400fa.txt │
                                              │                     B/op                     │         B/op          vs base                │
ListUnifiedResourcesFilter/labels-12                                            735.2Ki ± 0%           724.6Ki ± 1%   -1.44% (p=0.000 n=10)
ListUnifiedResourcesFilter/predicate_path-12                                  238.873Mi ± 0%           7.585Mi ± 0%  -96.82% (p=0.000 n=10)
ListUnifiedResourcesFilter/predicate_index-12                                 238.869Mi ± 0%           7.587Mi ± 0%  -96.82% (p=0.000 n=10)
ListUnifiedResourcesFilter/search_lower-12                                      16.77Mi ± 0%           16.77Mi ± 0%        ~ (p=0.436 n=10)
ListUnifiedResourcesFilter/search_upper-12                                      16.78Mi ± 0%           16.76Mi ± 0%        ~ (p=0.052 n=10)
ListUnifiedResources/simple_labels-12                                           1.272Gi ± 0%           1.273Gi ± 0%        ~ (p=0.739 n=10)
geomean                                                                         49.67Mi                15.69Mi       -68.41%

                                              │ e77e5e080b1848da830a9030d43c38be55a5b8d5.txt │ 8eff752a93dfe96225a71431af829015e83400fa.txt │
                                              │                  allocs/op                   │      allocs/op        vs base                │
ListUnifiedResourcesFilter/labels-12                                             11.45k ± 0%            11.41k ± 0%   -0.37% (p=0.000 n=10)
ListUnifiedResourcesFilter/predicate_path-12                                    4962.0k ± 0%            161.5k ± 0%  -96.75% (p=0.000 n=10)
ListUnifiedResourcesFilter/predicate_index-12                                   4812.0k ± 0%            161.5k ± 0%  -96.64% (p=0.000 n=10)
ListUnifiedResourcesFilter/search_lower-12                                       161.6k ± 0%            161.6k ± 0%        ~ (p=0.419 n=10)
ListUnifiedResourcesFilter/search_upper-12                                       161.7k ± 0%            161.6k ± 0%        ~ (p=0.116 n=10)
ListUnifiedResources/simple_labels-12                                            23.70M ± 0%            23.70M ± 0%   +0.01% (p=0.019 n=10)
geomean                                                                          743.7k                 238.5k       -67.93%
```

Changelog: Improve performance of filtering resources via predicate expressions