### PR TITLE
Add `spiffe` CA to `checkResourceConsistency`

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1058,7 +1058,7 @@ func checkResourceConsistency(ctx context.Context, keyStore *keystore.Manager, c
 			switch r.GetType() {
 			case types.HostCA, types.UserCA, types.OpenSSHCA:
 				_, signerErr = keyStore.GetSSHSigner(ctx, r)
-			case types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA:
+			case types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA, types.SPIFFECA:
 				_, _, signerErr = keyStore.GetTLSCertAndSigner(ctx, r)
 			case types.JWTSigner, types.OIDCIdPCA:
 				_, signerErr = keyStore.GetJWTSigner(ctx, r)


### PR DESCRIPTION
changelog: Fixes a bug that prevented CA import when a SPIFFE CA was present.

```
2024-03-28T12:50:15Z INFO [AUTH]      Applying 15 bootstrap resources (first initialization) auth/init.go:346

ERROR REPORT:
Original Error: *trace.BadParameterError unexpected cert_authority type spiffe for cluster gus-ca-test.teleportdemo.com
Stack Trace:
	github.com/gravitational/teleport/lib/auth/init.go:1001 github.com/gravitational/teleport/lib/auth.checkResourceConsistency
	github.com/gravitational/teleport/lib/auth/init.go:347 github.com/gravitational/teleport/lib/auth.initCluster
	github.com/gravitational/teleport/lib/auth/init.go:323 github.com/gravitational/teleport/lib/auth.Init.func1
	github.com/gravitational/teleport/lib/backend/helpers.go:222 github.com/gravitational/teleport/lib/backend.RunWhileLocked
	github.com/gravitational/teleport/lib/auth/init.go:314 github.com/gravitational/teleport/lib/auth.Init
	github.com/gravitational/teleport/lib/service/service.go:1831 github.com/gravitational/teleport/lib/service.(*TeleportProcess).initAuthService
	github.com/gravitational/teleport/lib/service/service.go:1143 github.com/gravitational/teleport/lib/service.NewTeleport
	github.com/gravitational/teleport/lib/service/service.go:693 github.com/gravitational/teleport/lib/service.newTeleportProcess
	github.com/gravitational/teleport/lib/service/service.go:703 github.com/gravitational/teleport/lib/service.Run
	github.com/gravitational/teleport/tool/teleport/common/teleport.go:637 github.com/gravitational/teleport/tool/teleport/common.OnStart
	github.com/gravitational/teleport/tool/teleport/common/teleport.go:548 github.com/gravitational/teleport/tool/teleport/common.Run
	github.com/gravitational/teleport/tool/teleport/main.go:33 main.main
	runtime/proc.go:267 runtime.main
	runtime/asm_amd64.s:1650 runtime.goexit
User Message: initialization failed
	refusing to bootstrap backend
		unexpected cert_authority type spiffe for cluster gus-ca-test.teleportdemo.com
```

Workaround: manually delete the SPIFFE CA resource when importing.