### PR TITLE
[v15] Fix kube-agent-updater default verbosity

### DIFF
--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -91,7 +91,7 @@ func main() {
 	)
 
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Backport #39923 to branch/v15

changelog: Fix a verbosity issue that caused the `teleport-kube-agent-updater` to output debug logs by default.
