### PR TITLE
[v14] Fix kube-agent-updater default verbosity

### DIFF
--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -82,7 +82,7 @@ func main() {
 	flag.StringVar(&baseImageName, "base-image", "public.ecr.aws/gravitational/teleport", "Image reference containing registry and repository.")
 
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Backport #39923 to branch/v14

changelog: Fix a verbosity issue that caused the `teleport-kube-agent-updater` to output debug logs by default.
