### PR TITLE
Use slog in lib/teleterm

### DIFF
--- a/lib/teleterm/clusters/cluster.go
+++ b/lib/teleterm/clusters/cluster.go
@@ -20,10 +20,10 @@ package clusters
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -47,7 +47,7 @@ type Cluster struct {
 	// ProfileName is the name of the tsh profile
 	ProfileName string
 	// Log is a component logger
-	Log *logrus.Entry
+	Log *slog.Logger
 	// dir is the directory where cluster certificates are stored
 	dir string
 	// Status is the cluster status

--- a/lib/teleterm/clusters/config.go
+++ b/lib/teleterm/clusters/config.go
@@ -19,9 +19,10 @@
 package clusters
 
 import (
+	"log/slog"
+
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/client"
@@ -36,7 +37,7 @@ type Config struct {
 	// InsecureSkipVerify is an option to skip TLS cert check
 	InsecureSkipVerify bool
 	// Log is a component logger
-	Log *logrus.Entry
+	Log *slog.Logger
 	// WebauthnLogin allows tests to override the Webauthn Login func.
 	// Defaults to wancli.Login.
 	WebauthnLogin client.WebauthnLoginFunc
@@ -53,7 +54,7 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if c.Log == nil {
-		c.Log = logrus.WithField(teleport.ComponentKey, "conn:storage")
+		c.Log = slog.With(teleport.ComponentKey, "storage")
 	}
 
 	return nil

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -182,7 +182,7 @@ func (s *Storage) addCluster(ctx context.Context, dir, webProxyAddress string) (
 		clusterClient: clusterClient,
 		dir:           s.Dir,
 		clock:         s.Clock,
-		Log:           s.Log.WithField("cluster", clusterURI),
+		Log:           s.Log.With("cluster", clusterURI),
 	}, clusterClient, nil
 }
 
@@ -226,7 +226,7 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, *c
 		dir:           s.Dir,
 		clock:         s.Clock,
 		status:        *status,
-		Log:           s.Log.WithField("cluster", clusterURI),
+		Log:           s.Log.With("cluster", clusterURI),
 	}, clusterClient, nil
 }
 
@@ -237,7 +237,7 @@ func (s *Storage) loadProfileStatusAndClusterKey(clusterClient *client.TeleportC
 	_, err := clusterClient.LocalAgent().GetKey(clusterNameForKey)
 	if err != nil {
 		if trace.IsNotFound(err) {
-			s.Log.Infof("No keys found for cluster %v.", clusterNameForKey)
+			s.Log.InfoContext(context.Background(), "No keys found for cluster", "cluster", clusterNameForKey)
 		} else {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/teleterm/teleterm.go
+++ b/lib/teleterm/teleterm.go
@@ -20,6 +20,7 @@ package teleterm
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -27,7 +28,6 @@ import (
 	"syscall"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -90,9 +90,9 @@ func Serve(ctx context.Context, cfg Config) error {
 
 		select {
 		case <-ctx.Done():
-			log.Info("Context closed, stopping service.")
+			slog.InfoContext(ctx, "Context closed, stopping service")
 		case sig := <-c:
-			log.Infof("Captured %s, stopping service.", sig)
+			slog.InfoContext(ctx, "Captured signal, stopping service", "signal", sig)
 		}
 
 		daemonService.Stop()


### PR DESCRIPTION
I think almost all of lib/teleterm uses a single logger that's passed down from the outermost layer. This PR so far changed that outermost callsite, so what's left is just following compiler errors.