### PR TITLE
[v15] Add `spiffe` CA to `checkResourceConsistency`

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1061,7 +1061,7 @@ func checkResourceConsistency(ctx context.Context, keyStore *keystore.Manager, c
 			switch r.GetType() {
 			case types.HostCA, types.UserCA, types.OpenSSHCA:
 				_, signerErr = keyStore.GetSSHSigner(ctx, r)
-			case types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA:
+			case types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA, types.SPIFFECA:
 				_, _, signerErr = keyStore.GetTLSCertAndSigner(ctx, r)
 			case types.JWTSigner, types.OIDCIdPCA:
 				_, signerErr = keyStore.GetJWTSigner(ctx, r)


### PR DESCRIPTION
Backport #39949 to branch/v15

changelog: Fixes a bug that prevented CA import when a SPIFFE CA was present.
