### PR TITLE
Update slog json handler to output error text

### DIFF
--- a/lib/utils/log/formatter_test.go
+++ b/lib/utils/log/formatter_test.go
@@ -276,14 +276,14 @@ func TestOutput(t *testing.T) {
 				slogLogger := slog.New(NewSlogJSONHandler(&slogOutput, SlogJSONHandlerConfig{Level: test.slogLevel})).With(teleport.ComponentKey, "test")
 
 				// Add some fields and output the message at the desired log level via logrus.
-				l := entry.WithField("test", 123).WithField("animal", "llama").WithField("error", logErr)
+				l := entry.WithField("test", 123).WithField("animal", "llama").WithField("error", trace.Wrap(logErr))
 				logrusTestLogLineNumber := func() int {
 					l.WithField("diag_addr", &addr).Log(test.logrusLevel, message)
 					return getCallerLineNumber() - 1 // Get the line number of this call, and assume the log call is right above it
 				}()
 
 				// Add some fields and output the message at the desired log level via slog.
-				l2 := slogLogger.With("test", 123).With("animal", "llama").With("error", logErr)
+				l2 := slogLogger.With("test", 123).With("animal", "llama").With("error", trace.Wrap(logErr))
 				slogTestLogLineNumber := func() int {
 					l2.Log(context.Background(), test.slogLevel, message, "diag_addr", &addr)
 					return getCallerLineNumber() - 1 // Get the line number of this call, and assume the log call is right above it

--- a/lib/utils/log/slog_handler.go
+++ b/lib/utils/log/slog_handler.go
@@ -533,6 +533,16 @@ func NewSlogJSONHandler(w io.Writer, cfg SlogJSONHandlerConfig) *SlogJSONHandler
 					a = slog.String(CallerField, fmt.Sprintf("%s:%d", file, line))
 				}
 
+				// Convert any [slog.KindAny] values that are backed by errors to string
+				// so that only the message is output instead of a json object. The kind is
+				// first checked to avoid allocating an interface for the values stored inline
+				// in slog.Attr
+				if a.Value.Kind() == slog.KindAny {
+					if err, ok := a.Value.Any().(error); ok {
+						a.Value = slog.StringValue(err.Error())
+					}
+				}
+
 				return a
 			},
 		}),


### PR DESCRIPTION
The default slog json handler attempts to format attributes with json.Marshal instead of a string representation, which resulted in errors being output as json objects instead of just the message.

```json
"error":{"error":{"message":"Unable to communicate with the Teleport Auth Service"}}
```

In order to restore json output to contain only the error message instead of the entire object special handling is done in our slog handler wrapper that replaces the error object with the message.

```json
"error":"Unable to communicate with the Teleport Auth Service"
```