### PR TITLE
Fixes rust linting errors 

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
@@ -1647,6 +1647,7 @@ impl Iterator for FileCacheObject {
 
 /// A generic error type for the FilesystemBackend that can contain any arbitrary error message.
 #[derive(Debug)]
+#[allow(dead_code)] // The internal `String` is "dead code" according to the compiler, but we want it for debugging purposes.
 struct FilesystemBackendError(pub String);
 
 impl std::fmt::Display for FilesystemBackendError {

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
@@ -694,6 +694,7 @@ const TIMEOUT_IMMEDIATE: u32 = 0;
 
 /// A generic error type for the SmartcardBackend that can contain any arbitrary error message.
 #[derive(Debug)]
+#[allow(dead_code)] // The internal `String` is "dead code" according to the compiler, but we want it for debugging purposes.
 struct SmartcardBackendError(pub String);
 
 impl std::fmt::Display for SmartcardBackendError {

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
@@ -578,6 +578,10 @@ pub enum FileType {
     Directory = 1,
 }
 
+/// CGOData is a wrapper around data that needs to be passed to Go.
+///
+/// See [`CGOWithData`] for more information.
+#[allow(dead_code)] // Dead code is required to ensure that the data is available in Go. See [`CGOWithData`].
 enum CGOData {
     CString(CString),
     VecU8(Vec<u8>),


### PR DESCRIPTION
These showed up due to the recent rust version update from 1.71.1 to 1.77.0 in https://github.com/gravitational/teleport/pull/39895