### PR TITLE
[v13] Update rust to latest stable (1.77.0)

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -7,7 +7,7 @@ GOLANGCI_LINT_VERSION ?= v1.57.1
 NODE_VERSION ?= 20.11.1
 
 # Run lint-rust check locally before merging code after you bump this.
-RUST_VERSION ?= 1.71.1
+RUST_VERSION ?= 1.77.0
 LIBBPF_VERSION ?= 1.2.2
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -617,7 +617,8 @@ fn connect_rdp_inner(go_ref: usize, params: ConnectParams) -> Result<Client, Con
         // Any `arc_with_non_send_sync` is generally a bad idea, but the system is stable
         // and will be deprecated over the course of the next few months as we transition
         // all supported versions to `IronRDP`.
-        #[allow(clippy::arc_with_non_send_sync)]
+        // TODO(isaiah): Temporary hack to pass CI when updating RUST_VERSION; uncomment the following line once merged:
+        // #[allow(clippy::arc_with_non_send_sync)]
         rdp_client: Arc::new(Mutex::new(rdp_client)),
         tcp_fd,
         go_ref,

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -203,6 +203,7 @@ pub unsafe extern "C" fn connect_rdp(go_ref: usize, params: CGOConnectParams) ->
 }
 
 #[derive(Debug)]
+#[allow(dead_code)] // Tcp and Rdp variants are considered "dead code", but we want them for debug logging.
 enum ConnectError {
     Tcp(IoError),
     Rdp(RdpError),
@@ -613,6 +614,10 @@ fn connect_rdp_inner(go_ref: usize, params: ConnectParams) -> Result<Client, Con
     shared_tcp.tcp.set_read_timeout(None)?;
 
     Ok(Client {
+        // Any `arc_with_non_send_sync` is generally a bad idea, but the system is stable
+        // and will be deprecated over the course of the next few months as we transition
+        // all supported versions to `IronRDP`.
+        #[allow(clippy::arc_with_non_send_sync)]
         rdp_client: Arc::new(Mutex::new(rdp_client)),
         tcp_fd,
         go_ref,


### PR DESCRIPTION
Roughly a backport for https://github.com/gravitational/teleport/pull/39895 and https://github.com/gravitational/teleport/pull/39981, however the rust codebase have diverged enough between this branch and `master` that I am considering this its own thing.

Confirm that build succeeds:
- [ ] https://github.com/gravitational/teleport.e/actions/runs/8474386165

changelog: updates rust to `1.77.0`