### PR TITLE
[v15] Improve CRD display in kubectl

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_openssheiceserversv2.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_openssheiceserversv2.yaml
@@ -15,7 +15,20 @@ spec:
     singular: teleportopenssheiceserverv2
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Server hostname
+      jsonPath: .spec.hostname
+      name: Hostname
+      type: string
+    - description: Server address, with SSH port.
+      jsonPath: .spec.addr
+      name: Address
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpenSSHEICEServerV2 is the Schema for the openssheiceserversv2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_opensshserversv2.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_opensshserversv2.yaml
@@ -15,7 +15,20 @@ spec:
     singular: teleportopensshserverv2
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Server hostname
+      jsonPath: .spec.hostname
+      name: Hostname
+      type: string
+    - description: Server address, with SSH port.
+      jsonPath: .spec.addr
+      name: Address
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpenSSHServerV2 is the Schema for the opensshserversv2 API

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_provisiontokens.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_provisiontokens.yaml
@@ -15,7 +15,20 @@ spec:
     singular: teleportprovisiontoken
   scope: Namespaced
   versions:
-  - name: v2
+  - additionalPrinterColumns:
+    - description: Token join method.
+      jsonPath: .spec.join_method
+      name: Join Method
+      type: string
+    - description: System roles granted by this token.
+      jsonPath: .spec.roles
+      name: System Roles
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v2
     schema:
       openAPIV3Schema:
         description: ProvisionToken is the Schema for the provisiontokens API

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_users.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_users.yaml
@@ -15,7 +15,16 @@ spec:
     singular: teleportuser
   scope: Namespaced
   versions:
-  - name: v2
+  - additionalPrinterColumns:
+    - description: List of Teleport roles granted to the user.
+      jsonPath: .spec.roles
+      name: Roles
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v2
     schema:
       openAPIV3Schema:
         description: User is the Schema for the users API

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_openssheiceserversv2.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_openssheiceserversv2.yaml
@@ -15,7 +15,20 @@ spec:
     singular: teleportopenssheiceserverv2
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Server hostname
+      jsonPath: .spec.hostname
+      name: Hostname
+      type: string
+    - description: Server address, with SSH port.
+      jsonPath: .spec.addr
+      name: Address
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpenSSHEICEServerV2 is the Schema for the openssheiceserversv2

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_opensshserversv2.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_opensshserversv2.yaml
@@ -15,7 +15,20 @@ spec:
     singular: teleportopensshserverv2
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Server hostname
+      jsonPath: .spec.hostname
+      name: Hostname
+      type: string
+    - description: Server address, with SSH port.
+      jsonPath: .spec.addr
+      name: Address
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpenSSHServerV2 is the Schema for the opensshserversv2 API

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_provisiontokens.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_provisiontokens.yaml
@@ -15,7 +15,20 @@ spec:
     singular: teleportprovisiontoken
   scope: Namespaced
   versions:
-  - name: v2
+  - additionalPrinterColumns:
+    - description: Token join method.
+      jsonPath: .spec.join_method
+      name: Join Method
+      type: string
+    - description: System roles granted by this token.
+      jsonPath: .spec.roles
+      name: System Roles
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v2
     schema:
       openAPIV3Schema:
         description: ProvisionToken is the Schema for the provisiontokens API

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_users.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_users.yaml
@@ -15,7 +15,16 @@ spec:
     singular: teleportuser
   scope: Namespaced
   versions:
-  - name: v2
+  - additionalPrinterColumns:
+    - description: List of Teleport roles granted to the user.
+      jsonPath: .spec.roles
+      name: Roles
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v2
     schema:
       openAPIV3Schema:
         description: User is the Schema for the users API

--- a/integrations/operator/crdgen/handlerequest.go
+++ b/integrations/operator/crdgen/handlerequest.go
@@ -20,7 +20,6 @@ package main
 
 import (
 	"fmt"
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"os"
 
 	gogodesc "github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
@@ -29,6 +28,7 @@ import (
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/pluginpb"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport/api/types"

--- a/integrations/operator/crdgen/handlerequest.go
+++ b/integrations/operator/crdgen/handlerequest.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"fmt"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"os"
 
 	gogodesc "github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
@@ -107,11 +108,55 @@ type resource struct {
 	opts []resourceSchemaOption
 }
 
+var userColumns = []apiextv1.CustomResourceColumnDefinition{
+	{
+		Name:        "Roles",
+		Type:        "string",
+		Description: "List of Teleport roles granted to the user.",
+		Priority:    0,
+		JSONPath:    ".spec.roles",
+	},
+}
+
+var serverColumns = []apiextv1.CustomResourceColumnDefinition{
+	{
+		Name:        "Hostname",
+		Type:        "string",
+		Description: "Server hostname",
+		Priority:    0,
+		JSONPath:    ".spec.hostname",
+	},
+	{
+		Name:        "Address",
+		Type:        "string",
+		Description: "Server address, with SSH port.",
+		Priority:    0,
+		JSONPath:    ".spec.addr",
+	},
+}
+
+var tokenColumns = []apiextv1.CustomResourceColumnDefinition{
+	{
+		Name:        "Join Method",
+		Type:        "string",
+		Description: "Token join method.",
+		Priority:    0,
+		JSONPath:    ".spec.join_method",
+	},
+	{
+		Name:        "System Roles",
+		Type:        "string",
+		Description: "System roles granted by this token.",
+		Priority:    0,
+		JSONPath:    ".spec.roles",
+	},
+}
+
 func generateSchema(file *File, groupName string, resp *gogoplugin.CodeGeneratorResponse) error {
 	generator := NewSchemaGenerator(groupName)
 
 	resources := []resource{
-		{name: "UserV2"},
+		{name: "UserV2", opts: []resourceSchemaOption{withAdditionalColumns(userColumns)}},
 		// Role V5 is using the RoleV6 message
 		{name: "RoleV6", opts: []resourceSchemaOption{withVersionOverride(types.V5)}},
 		// For backward compatibility in v15, it actually creates v5 roles though.
@@ -133,7 +178,7 @@ func generateSchema(file *File, groupName string, resp *gogoplugin.CodeGenerator
 				withCustomSpecFields([]string{"priority", "traits_expression", "traits_map"}),
 			},
 		},
-		{name: "ProvisionTokenV2"},
+		{name: "ProvisionTokenV2", opts: []resourceSchemaOption{withAdditionalColumns(tokenColumns)}},
 		{name: "OktaImportRuleV1"},
 		{
 			name: "AccessList",
@@ -146,6 +191,7 @@ func generateSchema(file *File, groupName string, resp *gogoplugin.CodeGenerator
 			opts: []resourceSchemaOption{
 				withVersionInKindOverride(),
 				withNameOverride("OpenSSHServer"),
+				withAdditionalColumns(serverColumns),
 			},
 		},
 		{
@@ -153,6 +199,7 @@ func generateSchema(file *File, groupName string, resp *gogoplugin.CodeGenerator
 			opts: []resourceSchemaOption{
 				withVersionInKindOverride(),
 				withNameOverride("OpenSSHEICEServer"),
+				withAdditionalColumns(serverColumns),
 			},
 		},
 	}

--- a/integrations/operator/crdgen/schemagen.go
+++ b/integrations/operator/crdgen/schemagen.go
@@ -76,8 +76,9 @@ type SchemaVersion struct {
 	// Teleport resource, this is equal to the Teleport resource Version for
 	// compatibility purposes. For multi-version resource, the value is always
 	// "v1" as the version is already in the CR kind.
-	Version string
-	Schema  *Schema
+	Version           string
+	Schema            *Schema
+	additionalColumns []apiextv1.CustomResourceColumnDefinition
 }
 
 // Schema is a set of object properties.
@@ -113,6 +114,7 @@ type resourceSchemaConfig struct {
 	versionOverride     string
 	customSpecFields    []string
 	kindContainsVersion bool
+	additionalColumns   []apiextv1.CustomResourceColumnDefinition
 }
 
 type resourceSchemaOption func(*resourceSchemaConfig)
@@ -142,6 +144,24 @@ func withCustomSpecFields(customSpecFields []string) resourceSchemaOption {
 	}
 }
 
+var ageColumn = apiextv1.CustomResourceColumnDefinition{
+	Name:        "Age",
+	Type:        "date",
+	Description: "The age of this resource",
+	JSONPath:    ".metadata.creationTimestamp",
+}
+
+func withAdditionalColumns(additionalColumns []apiextv1.CustomResourceColumnDefinition) resourceSchemaOption {
+	// We add the age column back (it's removed if we set additional columns for the CRD).
+	// See https://github.com/kubernetes/kubectl/issues/903#issuecomment-669244656.
+	columns := make([]apiextv1.CustomResourceColumnDefinition, len(additionalColumns)+1)
+	copy(columns, additionalColumns)
+	columns[len(additionalColumns)] = ageColumn
+
+	return func(cfg *resourceSchemaConfig) {
+		cfg.additionalColumns = columns
+	}
+}
 func (generator *SchemaGenerator) addResource(file *File, name string, opts ...resourceSchemaOption) error {
 	var cfg resourceSchemaConfig
 	for _, opt := range opts {
@@ -231,8 +251,9 @@ func (generator *SchemaGenerator) addResource(file *File, name string, opts ...r
 		kubernetesVersion = "v1"
 	}
 	root.versions = append(root.versions, SchemaVersion{
-		Version: kubernetesVersion,
-		Schema:  schema,
+		Version:           kubernetesVersion,
+		Schema:            schema,
+		additionalColumns: cfg.additionalColumns,
 	})
 
 	return nil
@@ -513,6 +534,7 @@ func (root RootSchema) CustomResourceDefinition() (apiextv1.CustomResourceDefini
 					},
 				},
 			},
+			AdditionalPrinterColumns: schemaVersion.additionalColumns,
 		})
 	}
 	return crd, nil

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_openssheiceserversv2.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_openssheiceserversv2.yaml
@@ -15,7 +15,20 @@ spec:
     singular: teleportopenssheiceserverv2
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Server hostname
+      jsonPath: .spec.hostname
+      name: Hostname
+      type: string
+    - description: Server address, with SSH port.
+      jsonPath: .spec.addr
+      name: Address
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpenSSHEICEServerV2 is the Schema for the openssheiceserversv2

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_opensshserversv2.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_opensshserversv2.yaml
@@ -15,7 +15,20 @@ spec:
     singular: teleportopensshserverv2
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Server hostname
+      jsonPath: .spec.hostname
+      name: Hostname
+      type: string
+    - description: Server address, with SSH port.
+      jsonPath: .spec.addr
+      name: Address
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpenSSHServerV2 is the Schema for the opensshserversv2 API

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_provisiontokens.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_provisiontokens.yaml
@@ -15,7 +15,20 @@ spec:
     singular: teleportprovisiontoken
   scope: Namespaced
   versions:
-  - name: v2
+  - additionalPrinterColumns:
+    - description: Token join method.
+      jsonPath: .spec.join_method
+      name: Join Method
+      type: string
+    - description: System roles granted by this token.
+      jsonPath: .spec.roles
+      name: System Roles
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v2
     schema:
       openAPIV3Schema:
         description: ProvisionToken is the Schema for the provisiontokens API

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_users.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_users.yaml
@@ -15,7 +15,16 @@ spec:
     singular: teleportuser
   scope: Namespaced
   versions:
-  - name: v2
+  - additionalPrinterColumns:
+    - description: List of Teleport roles granted to the user.
+      jsonPath: .spec.roles
+      name: Roles
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v2
     schema:
       openAPIV3Schema:
         description: User is the Schema for the users API


### PR DESCRIPTION
Backport #39985 to branch/v15

changelog: The role, server and token Teleport operator CRs now display additional information when listed with `kubectl get`.
