### PR TITLE
[v13] Add missing `HostUUID` to TestAuthServer

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -284,6 +284,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 			},
 		},
 		EmbeddingRetriever: ai.NewSimpleRetriever(),
+		HostUUID:           uuid.New().String(),
 	},
 		WithClock(cfg.Clock),
 		WithEmbedder(cfg.Embedder),


### PR DESCRIPTION
Backport #40008 to branch/v13