### PR TITLE
[v14] Add missing `HostUUID` to TestAuthServer

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -292,6 +292,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 			},
 		},
 		EmbeddingRetriever: ai.NewSimpleRetriever(),
+		HostUUID:           uuid.New().String(),
 	},
 		WithClock(cfg.Clock),
 		WithEmbedder(cfg.Embedder),


### PR DESCRIPTION
Backport #40008 to branch/v14