### PR TITLE
[v15] Add missing `HostUUID` to TestAuthServer

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -294,6 +294,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 			},
 		},
 		EmbeddingRetriever: ai.NewSimpleRetriever(),
+		HostUUID:           uuid.New().String(),
 	},
 		WithClock(cfg.Clock),
 		WithEmbedder(cfg.Embedder),


### PR DESCRIPTION
Backport #40008 to branch/v15