### PR TITLE
Clean up TypeScript types related to tsh daemon

### DIFF
--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -49,8 +49,7 @@ import { getAssetPath } from 'teleterm/mainProcess/runtimeSettings';
 import { RootClusterUri } from 'teleterm/ui/uri';
 import Logger from 'teleterm/logger';
 import * as grpcCreds from 'teleterm/services/grpcCredentials';
-import { createTshdClient } from 'teleterm/services/tshd/createClient';
-import { TshdClient } from 'teleterm/services/tshd/types';
+import { createTshdClient, TshdClient } from 'teleterm/services/tshd';
 import { loggingInterceptor } from 'teleterm/services/tshd/interceptors';
 
 import {

--- a/web/packages/teleterm/src/mainProcess/rootClusterProxyHostAllowList.ts
+++ b/web/packages/teleterm/src/mainProcess/rootClusterProxyHostAllowList.ts
@@ -21,7 +21,7 @@ import { ipcMain } from 'electron';
 import { isAbortError } from 'shared/utils/abortError';
 
 import { proxyHostToBrowserProxyHost } from 'teleterm/services/tshd/cluster';
-import { TshdClient } from 'teleterm/services/tshd/types';
+import { TshdClient } from 'teleterm/services/tshd';
 import { Logger } from 'teleterm/types';
 import { MainProcessIpc } from 'teleterm/mainProcess/types';
 import * as tshd from 'teleterm/services/tshd/types';

--- a/web/packages/teleterm/src/preload.ts
+++ b/web/packages/teleterm/src/preload.ts
@@ -20,10 +20,7 @@ import { contextBridge } from 'electron';
 import { ChannelCredentials, ServerCredentials } from '@grpc/grpc-js';
 import { GrpcTransport } from '@protobuf-ts/grpc-transport';
 
-import {
-  createTshdClient,
-  createVnetClient,
-} from 'teleterm/services/tshd/createClient';
+import { createTshdClient, createVnetClient } from 'teleterm/services/tshd';
 import { loggingInterceptor } from 'teleterm/services/tshd/interceptors';
 import createMainProcessClient from 'teleterm/mainProcess/mainProcessClient';
 import { createFileLoggerService } from 'teleterm/services/logger';

--- a/web/packages/teleterm/src/services/tshd/createClient.ts
+++ b/web/packages/teleterm/src/services/tshd/createClient.ts
@@ -25,9 +25,12 @@ import * as vnetServiceProtobuf from 'gen-proto-ts/teleport/lib/teleterm/vnet/v1
 
 import { CloneableClient, cloneClient } from './cloneableClient';
 
+// Creating the client type based on the interface (ITerminalServiceClient) and not the class
+// (TerminalServiceClient) lets us omit a bunch of properties when mocking a client.
 export type TshdClient = CloneableClient<ITerminalServiceClient>;
 
-export type VnetClient = CloneableClient<vnetServiceProtobuf.VnetServiceClient>;
+export type VnetClient =
+  CloneableClient<vnetServiceProtobuf.IVnetServiceClient>;
 
 export function createTshdClient(transport: GrpcTransport): TshdClient {
   return cloneClient(new TerminalServiceClient(transport));

--- a/web/packages/teleterm/src/services/tshd/createClient.ts
+++ b/web/packages/teleterm/src/services/tshd/createClient.ts
@@ -17,19 +17,23 @@
  */
 
 import { GrpcTransport } from '@protobuf-ts/grpc-transport';
-import { TerminalServiceClient } from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb.client';
+import {
+  ITerminalServiceClient,
+  TerminalServiceClient,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb.client';
 import * as vnetServiceProtobuf from 'gen-proto-ts/teleport/lib/teleterm/vnet/v1/vnet_service_pb.client';
 
 import { CloneableClient, cloneClient } from './cloneableClient';
-import * as types from './types';
 
-export function createTshdClient(transport: GrpcTransport): types.TshdClient {
+export type TshdClient = CloneableClient<ITerminalServiceClient>;
+
+export type VnetServiceClient =
+  CloneableClient<vnetServiceProtobuf.VnetServiceClient>;
+
+export function createTshdClient(transport: GrpcTransport): TshdClient {
   return cloneClient(new TerminalServiceClient(transport));
 }
 
 export function createVnetClient(transport: GrpcTransport): VnetServiceClient {
   return cloneClient(new vnetServiceProtobuf.VnetServiceClient(transport));
 }
-
-export type VnetServiceClient =
-  CloneableClient<vnetServiceProtobuf.VnetServiceClient>;

--- a/web/packages/teleterm/src/services/tshd/createClient.ts
+++ b/web/packages/teleterm/src/services/tshd/createClient.ts
@@ -27,13 +27,12 @@ import { CloneableClient, cloneClient } from './cloneableClient';
 
 export type TshdClient = CloneableClient<ITerminalServiceClient>;
 
-export type VnetServiceClient =
-  CloneableClient<vnetServiceProtobuf.VnetServiceClient>;
+export type VnetClient = CloneableClient<vnetServiceProtobuf.VnetServiceClient>;
 
 export function createTshdClient(transport: GrpcTransport): TshdClient {
   return cloneClient(new TerminalServiceClient(transport));
 }
 
-export function createVnetClient(transport: GrpcTransport): VnetServiceClient {
+export function createVnetClient(transport: GrpcTransport): VnetClient {
   return cloneClient(new vnetServiceProtobuf.VnetServiceClient(transport));
 }

--- a/web/packages/teleterm/src/services/tshd/createClient.ts
+++ b/web/packages/teleterm/src/services/tshd/createClient.ts
@@ -21,7 +21,10 @@ import {
   ITerminalServiceClient,
   TerminalServiceClient,
 } from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb.client';
-import * as vnetServiceProtobuf from 'gen-proto-ts/teleport/lib/teleterm/vnet/v1/vnet_service_pb.client';
+import {
+  IVnetServiceClient,
+  VnetServiceClient,
+} from 'gen-proto-ts/teleport/lib/teleterm/vnet/v1/vnet_service_pb.client';
 
 import { CloneableClient, cloneClient } from './cloneableClient';
 
@@ -29,13 +32,12 @@ import { CloneableClient, cloneClient } from './cloneableClient';
 // (TerminalServiceClient) lets us omit a bunch of properties when mocking a client.
 export type TshdClient = CloneableClient<ITerminalServiceClient>;
 
-export type VnetClient =
-  CloneableClient<vnetServiceProtobuf.IVnetServiceClient>;
+export type VnetClient = CloneableClient<IVnetServiceClient>;
 
 export function createTshdClient(transport: GrpcTransport): TshdClient {
   return cloneClient(new TerminalServiceClient(transport));
 }
 
 export function createVnetClient(transport: GrpcTransport): VnetClient {
-  return cloneClient(new vnetServiceProtobuf.VnetServiceClient(transport));
+  return cloneClient(new VnetServiceClient(transport));
 }

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -116,9 +116,6 @@ export class MockTshClient implements TshdClient {
 }
 
 export class MockVnetClient implements VnetClient {
-  typeName: never;
-  methods: never;
-  options: never;
   start = () => new MockedUnaryCall({});
   stop = () => new MockedUnaryCall({});
 }

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -21,7 +21,7 @@ import {
   makeAppGateway,
 } from 'teleterm/services/tshd/testHelpers';
 
-import { VnetServiceClient, TshdClient } from '../createClient';
+import { VnetClient, TshdClient } from '../createClient';
 import { MockedUnaryCall } from '../cloneableClient';
 
 export class MockTshClient implements TshdClient {
@@ -115,7 +115,7 @@ export class MockTshClient implements TshdClient {
   authenticateWebDevice = () => new MockedUnaryCall({});
 }
 
-export class MockVnetClient implements VnetServiceClient {
+export class MockVnetClient implements VnetClient {
   typeName: never;
   methods: never;
   options: never;

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -21,11 +21,10 @@ import {
   makeAppGateway,
 } from 'teleterm/services/tshd/testHelpers';
 
-import * as types from '../types';
-import { VnetServiceClient } from '../createClient';
+import { VnetServiceClient, TshdClient } from '../createClient';
 import { MockedUnaryCall } from '../cloneableClient';
 
-export class MockTshClient implements types.TshdClient {
+export class MockTshClient implements TshdClient {
   listRootClusters = () => new MockedUnaryCall({ clusters: [] });
   listLeafClusters = () => new MockedUnaryCall({ clusters: [] });
   getKubes = () =>

--- a/web/packages/teleterm/src/services/tshd/index.ts
+++ b/web/packages/teleterm/src/services/tshd/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from './createClient';
+export { cloneAbortSignal, isTshdRpcError } from './cloneableClient';
+export type { CloneableAbortSignal } from './cloneableClient';

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -110,13 +110,6 @@ export {
  */
 export * from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb';
 
-export type {
-  /**
-   * @deprecated Import directly from tshd instead.
-   */
-  CloneableAbortSignal,
-} from './cloneableClient';
-
 /**
  * Available types are listed here:
  * https://github.com/gravitational/teleport/blob/v9.0.3/lib/defaults/defaults.go#L513-L530

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -16,11 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ITerminalServiceClient } from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb.client';
-
 import { SortType } from 'design/DataTable/types';
-
-import { CloneableClient } from './cloneableClient';
 
 import type * as uri from 'teleterm/ui/uri';
 
@@ -42,8 +38,6 @@ export type {
   CloneableRpcOptions,
   CloneableClient,
 } from './cloneableClient';
-
-export type TshdClient = CloneableClient<ITerminalServiceClient>;
 
 /**
  * Available types are listed here:

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -20,23 +20,101 @@ import { SortType } from 'design/DataTable/types';
 
 import type * as uri from 'teleterm/ui/uri';
 
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/database_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/gateway_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/server_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/kube_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/app_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/label_pb';
+/*
+ *
+ * Do not add new imports to this file, we're trying to get rid of types.ts files.
+ *
+ */
+
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  Cluster,
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  LoggedInUser,
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  LoggedInUser_UserType,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  Database,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/database_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  Gateway,
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  GatewayCLICommand,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/gateway_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  Server,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/server_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  Kube,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/kube_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  App,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/app_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  Label,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/label_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  AuthSettings,
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  AuthProvider,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/auth_settings_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  AccessRequest,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  AccessList,
+} from 'gen-proto-ts/teleport/accesslist/v1/accesslist_pb';
+
+// There's too many re-exports from this file to list them individually.
+// A @deprecated annotation like this Unfortunately has no effect on the language server.
+/**
+ * @deprecated Import directly from gen-proto-ts instead.
+ */
 export * from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/auth_settings_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/usage_events_pb';
-export * from 'gen-proto-ts/teleport/accesslist/v1/accesslist_pb';
 
 export type {
+  /**
+   * @deprecated Import directly from tshd instead.
+   */
   CloneableAbortSignal,
-  CloneableRpcOptions,
-  CloneableClient,
 } from './cloneableClient';
 
 /**

--- a/web/packages/teleterm/src/types.ts
+++ b/web/packages/teleterm/src/types.ts
@@ -24,10 +24,7 @@ import { Logger, LoggerService } from 'teleterm/services/logger/types';
 import { FileStorage } from 'teleterm/services/fileStorage';
 import { MainProcessClient, RuntimeSettings } from 'teleterm/mainProcess/types';
 import { PtyServiceClient } from 'teleterm/services/pty';
-import {
-  VnetServiceClient,
-  TshdClient,
-} from 'teleterm/services/tshd';
+import { VnetClient, TshdClient } from 'teleterm/services/tshd/createClient';
 
 export type {
   Logger,
@@ -109,7 +106,7 @@ export type ExtractResponseType<T> =
 export type ElectronGlobals = {
   readonly mainProcessClient: MainProcessClient;
   readonly tshClient: TshdClient;
-  readonly vnetClient: VnetServiceClient;
+  readonly vnetClient: VnetClient;
   readonly ptyServiceClient: PtyServiceClient;
   readonly setupTshdEventContextBridgeService: (
     listener: TshdEventContextBridgeService

--- a/web/packages/teleterm/src/types.ts
+++ b/web/packages/teleterm/src/types.ts
@@ -24,8 +24,10 @@ import { Logger, LoggerService } from 'teleterm/services/logger/types';
 import { FileStorage } from 'teleterm/services/fileStorage';
 import { MainProcessClient, RuntimeSettings } from 'teleterm/mainProcess/types';
 import { PtyServiceClient } from 'teleterm/services/pty';
-import { TshdClient } from 'teleterm/services/tshd/types';
-import { VnetServiceClient } from 'teleterm/services/tshd/createClient';
+import {
+  VnetServiceClient,
+  TshdClient,
+} from 'teleterm/services/tshd';
 
 export type {
   Logger,

--- a/web/packages/teleterm/src/ui/appContext.ts
+++ b/web/packages/teleterm/src/ui/appContext.ts
@@ -40,10 +40,7 @@ import { UsageService } from 'teleterm/ui/services/usage';
 import { ResourcesService } from 'teleterm/ui/services/resources';
 import { ConnectMyComputerService } from 'teleterm/ui/services/connectMyComputer';
 import { ConfigService } from 'teleterm/services/config';
-import {
-  TshdClient,
-  VnetServiceClient,
-} from 'teleterm/services/tshd';
+import { TshdClient, VnetClient } from 'teleterm/services/tshd/createClient';
 import { IAppContext } from 'teleterm/ui/types';
 import { DeepLinksService } from 'teleterm/ui/services/deepLinks';
 import { parseDeepLink } from 'teleterm/deepLinks';
@@ -66,7 +63,7 @@ export default class AppContext implements IAppContext {
   fileTransferService: FileTransferService;
   resourcesService: ResourcesService;
   tshd: TshdClient;
-  vnet: VnetServiceClient;
+  vnet: VnetClient;
   /**
    * setupTshdEventContextBridgeService adds a context-bridge-compatible version of a gRPC service
    * that's going to be called every time a client makes a particular RPC to the tshd events

--- a/web/packages/teleterm/src/ui/appContext.ts
+++ b/web/packages/teleterm/src/ui/appContext.ts
@@ -40,11 +40,13 @@ import { UsageService } from 'teleterm/ui/services/usage';
 import { ResourcesService } from 'teleterm/ui/services/resources';
 import { ConnectMyComputerService } from 'teleterm/ui/services/connectMyComputer';
 import { ConfigService } from 'teleterm/services/config';
-import { TshdClient } from 'teleterm/services/tshd/types';
+import {
+  TshdClient,
+  VnetServiceClient,
+} from 'teleterm/services/tshd';
 import { IAppContext } from 'teleterm/ui/types';
 import { DeepLinksService } from 'teleterm/ui/services/deepLinks';
 import { parseDeepLink } from 'teleterm/deepLinks';
-import { VnetServiceClient } from 'teleterm/services/tshd/createClient';
 
 import { CommandLauncher } from './commandLauncher';
 import { createTshdEventsContextBridgeService } from './tshdEvents';

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
@@ -30,7 +30,7 @@ import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 import { ClustersService } from './clustersService';
 
 import type * as uri from 'teleterm/ui/uri';
-import type * as tsh from 'teleterm/services/tshd/types';
+import type { TshdClient } from 'teleterm/services/tshd';
 
 jest.mock('teleterm/ui/services/notifications');
 jest.mock('teleterm/ui/services/usage');
@@ -58,9 +58,9 @@ const NotificationsServiceMock = NotificationsService as jest.MockedClass<
 >;
 const UsageServiceMock = UsageService as jest.MockedClass<typeof UsageService>;
 
-function createService(client: Partial<tsh.TshdClient>): ClustersService {
+function createService(client: Partial<TshdClient>): ClustersService {
   return new ClustersService(
-    client as tsh.TshdClient,
+    client as TshdClient,
     {
       removeKubeConfig: jest.fn().mockResolvedValueOnce(undefined),
     } as unknown as MainProcessClient,
@@ -69,7 +69,7 @@ function createService(client: Partial<tsh.TshdClient>): ClustersService {
   );
 }
 
-function getClientMocks(): Partial<tsh.TshdClient> {
+function getClientMocks(): Partial<TshdClient> {
   return {
     login: jest.fn().mockReturnValueOnce(new MockedUnaryCall({})),
     logout: jest.fn().mockReturnValueOnce(new MockedUnaryCall({})),

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -41,6 +41,7 @@ import { UsageService } from 'teleterm/ui/services/usage';
 import { ImmutableStore } from '../immutableStore';
 
 import type * as types from './types';
+import type { TshdClient, CloneableAbortSignal } from 'teleterm/services/tshd';
 import type * as tsh from 'teleterm/services/tshd/types';
 
 const { routing } = uri;
@@ -56,7 +57,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
   state: types.ClustersServiceState = createClusterServiceState();
 
   constructor(
-    public client: tsh.TshdClient,
+    public client: TshdClient,
     private mainProcessClient: MainProcessClient,
     private notificationsService: NotificationsService,
     private usageService: UsageService
@@ -101,7 +102,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
 
   async loginLocal(
     params: types.LoginLocalParams,
-    abortSignal: tsh.CloneableAbortSignal
+    abortSignal: CloneableAbortSignal
   ) {
     await this.client.login(
       {
@@ -126,7 +127,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
 
   async loginSso(
     params: types.LoginSsoParams,
-    abortSignal: tsh.CloneableAbortSignal
+    abortSignal: CloneableAbortSignal
   ) {
     await this.client.login(
       {
@@ -147,7 +148,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
 
   async loginPasswordless(
     params: types.LoginPasswordlessParams,
-    abortSignal: tsh.CloneableAbortSignal
+    abortSignal: CloneableAbortSignal
   ) {
     await new Promise<void>((resolve, reject) => {
       const stream = this.client.loginPasswordless({

--- a/web/packages/teleterm/src/ui/services/connectMyComputer/connectMyComputerService.ts
+++ b/web/packages/teleterm/src/ui/services/connectMyComputer/connectMyComputerService.ts
@@ -21,9 +21,8 @@ import {
   Cluster,
   CreateConnectMyComputerRoleResponse,
   Server,
-  CloneableAbortSignal,
-  TshdClient,
 } from 'teleterm/services/tshd/types';
+import { TshdClient, CloneableAbortSignal } from 'teleterm/services/tshd';
 
 import type * as uri from 'teleterm/ui/uri';
 

--- a/web/packages/teleterm/src/ui/services/fileTransferClient/fileTransferService.ts
+++ b/web/packages/teleterm/src/ui/services/fileTransferClient/fileTransferService.ts
@@ -20,7 +20,8 @@ import { FileTransferListeners } from 'shared/components/FileTransfer';
 
 import { FileTransferDirection } from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb';
 
-import { FileTransferRequest, TshdClient } from 'teleterm/services/tshd/types';
+import { FileTransferRequest } from 'teleterm/services/tshd/types';
+import { TshdClient } from 'teleterm/services/tshd';
 import { UsageService } from 'teleterm/ui/services/usage';
 import { cloneAbortSignal } from 'teleterm/services/tshd/cloneableClient';
 

--- a/web/packages/teleterm/src/ui/services/headlessAuthn/headlessAuthnService.ts
+++ b/web/packages/teleterm/src/ui/services/headlessAuthn/headlessAuthnService.ts
@@ -21,13 +21,14 @@ import { MainProcessClient } from 'teleterm/types';
 import { ModalsService } from 'teleterm/ui/services/modals';
 import { ConfigService } from 'teleterm/services/config';
 
+import type { TshdClient, CloneableAbortSignal } from 'teleterm/services/tshd';
 import type * as types from 'teleterm/services/tshd/types';
 
 export class HeadlessAuthenticationService {
   constructor(
     private mainProcessClient: MainProcessClient,
     private modalsService: ModalsService,
-    private tshClient: types.TshdClient,
+    private tshClient: TshdClient,
     private configService: ConfigService
   ) {}
 
@@ -60,7 +61,7 @@ export class HeadlessAuthenticationService {
 
   async updateHeadlessAuthenticationState(
     params: types.UpdateHeadlessAuthenticationStateRequest,
-    abortSignal: types.CloneableAbortSignal
+    abortSignal: CloneableAbortSignal
   ): Promise<void> {
     await this.tshClient.updateHeadlessAuthenticationState(params, {
       abort: abortSignal,

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
@@ -30,6 +30,7 @@ import {
   ResourcesService,
 } from './resourcesService';
 
+import type { TshdClient } from 'teleterm/services/tshd';
 import type * as tsh from 'teleterm/services/tshd/types';
 
 describe('getServerByHostname', () => {
@@ -37,7 +38,7 @@ describe('getServerByHostname', () => {
   const getServerByHostnameTests: Array<
     {
       name: string;
-      getServersMockedValue: ReturnType<tsh.TshdClient['getServers']>;
+      getServersMockedValue: ReturnType<TshdClient['getServers']>;
     } & (
       | { expectedServer: tsh.Server; expectedErr?: never }
       | { expectedErr: any; expectedServer?: never }
@@ -74,10 +75,10 @@ describe('getServerByHostname', () => {
   test.each(getServerByHostnameTests)(
     '$name',
     async ({ getServersMockedValue, expectedServer, expectedErr }) => {
-      const tshClient: Partial<tsh.TshdClient> = {
+      const tshClient: Partial<TshdClient> = {
         getServers: jest.fn().mockResolvedValueOnce(getServersMockedValue),
       };
-      const service = new ResourcesService(tshClient as tsh.TshdClient);
+      const service = new ResourcesService(tshClient as TshdClient);
 
       const promise = service.getServerByHostname('/clusters/bar', 'foo');
 
@@ -110,7 +111,7 @@ describe('searchResources', () => {
     const kube = makeKube();
     const app = makeApp();
 
-    const tshClient: Partial<tsh.TshdClient> = {
+    const tshClient: Partial<TshdClient> = {
       getServers: jest.fn().mockResolvedValueOnce(
         new MockedUnaryCall({
           agents: [server],
@@ -140,7 +141,7 @@ describe('searchResources', () => {
         })
       ),
     };
-    const service = new ResourcesService(tshClient as tsh.TshdClient);
+    const service = new ResourcesService(tshClient as TshdClient);
 
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',
@@ -172,7 +173,7 @@ describe('searchResources', () => {
 
   it('returns a single item if a filter is supplied', async () => {
     const server = makeServer();
-    const tshClient: Partial<tsh.TshdClient> = {
+    const tshClient: Partial<TshdClient> = {
       getServers: jest.fn().mockResolvedValueOnce(
         new MockedUnaryCall({
           agents: [server],
@@ -181,7 +182,7 @@ describe('searchResources', () => {
         })
       ),
     };
-    const service = new ResourcesService(tshClient as tsh.TshdClient);
+    const service = new ResourcesService(tshClient as TshdClient);
 
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',
@@ -200,13 +201,13 @@ describe('searchResources', () => {
 
   it('returns a custom error pointing at resource kind and cluster when an underlying promise gets rejected', async () => {
     const expectedCause = new Error('oops');
-    const tshClient: Partial<tsh.TshdClient> = {
+    const tshClient: Partial<TshdClient> = {
       getServers: jest.fn().mockRejectedValueOnce(expectedCause),
       getDatabases: jest.fn().mockRejectedValueOnce(expectedCause),
       getKubes: jest.fn().mockRejectedValueOnce(expectedCause),
       getApps: jest.fn().mockRejectedValueOnce(expectedCause),
     };
-    const service = new ResourcesService(tshClient as tsh.TshdClient);
+    const service = new ResourcesService(tshClient as TshdClient);
 
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -34,6 +34,7 @@ import {
 
 import Logger from 'teleterm/logger';
 
+import type { TshdClient } from 'teleterm/services/tshd';
 import type * as types from 'teleterm/services/tshd/types';
 import type * as uri from 'teleterm/ui/uri';
 import type { ResourceTypeFilter } from 'teleterm/ui/Search/searchResult';
@@ -41,7 +42,7 @@ import type { ResourceTypeFilter } from 'teleterm/ui/Search/searchResult';
 export class ResourcesService {
   private logger = new Logger('ResourcesService');
 
-  constructor(private tshClient: types.TshdClient) {}
+  constructor(private tshClient: TshdClient) {}
 
   async fetchServers(params: types.GetResourcesParams) {
     const { response } = await this.tshClient.getServers(

--- a/web/packages/teleterm/src/ui/services/usage/usageService.ts
+++ b/web/packages/teleterm/src/ui/services/usage/usageService.ts
@@ -21,7 +21,8 @@ import { SubmitConnectEventRequest } from 'gen-proto-ts/prehog/v1alpha/connect_p
 import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
 
 import { ClusterOrResourceUri, ClusterUri, routing } from 'teleterm/ui/uri';
-import { Cluster, TshdClient } from 'teleterm/services/tshd/types';
+import { Cluster } from 'teleterm/services/tshd/types';
+import { TshdClient } from 'teleterm/services/tshd';
 import { RuntimeSettings } from 'teleterm/mainProcess/types';
 import { ConfigService } from 'teleterm/services/config';
 import Logger from 'teleterm/logger';

--- a/web/packages/teleterm/src/ui/types.ts
+++ b/web/packages/teleterm/src/ui/types.ts
@@ -37,8 +37,7 @@ import { UsageService } from 'teleterm/ui/services/usage';
 import { ConfigService } from 'teleterm/services/config';
 import { ConnectMyComputerService } from 'teleterm/ui/services/connectMyComputer';
 import { HeadlessAuthenticationService } from 'teleterm/ui/services/headlessAuthn/headlessAuthnService';
-import { TshdClient } from 'teleterm/services/tshd/types';
-import { VnetServiceClient } from 'teleterm/services/tshd/createClient';
+import { TshdClient, VnetServiceClient } from 'teleterm/services/tshd';
 
 export interface IAppContext {
   clustersService: ClustersService;

--- a/web/packages/teleterm/src/ui/types.ts
+++ b/web/packages/teleterm/src/ui/types.ts
@@ -37,7 +37,7 @@ import { UsageService } from 'teleterm/ui/services/usage';
 import { ConfigService } from 'teleterm/services/config';
 import { ConnectMyComputerService } from 'teleterm/ui/services/connectMyComputer';
 import { HeadlessAuthenticationService } from 'teleterm/ui/services/headlessAuthn/headlessAuthnService';
-import { TshdClient, VnetServiceClient } from 'teleterm/services/tshd';
+import { TshdClient, VnetClient } from 'teleterm/services/tshd';
 
 export interface IAppContext {
   clustersService: ClustersService;
@@ -62,7 +62,7 @@ export interface IAppContext {
   connectMyComputerService: ConnectMyComputerService;
   headlessAuthenticationService: HeadlessAuthenticationService;
   tshd: TshdClient;
-  vnet: VnetServiceClient;
+  vnet: VnetClient;
 
   pullInitialState(): Promise<void>;
 }


### PR DESCRIPTION
* `VnetServiceClient` is now `VnetClient`.
* `TshdClient`, `VnetClient` and everything else needed by the outside world is exported from `web/packages/teleterm/src/services/tshd/index.ts`.
* `tshd/types.ts` is deprecated in favor of importing directly from `gen-proto-ts` and moving types to files centered around concepts and data structures, rather than having a dedicated `types.ts` file.

I'll have to manually backport this as v15 doesn't know and won't know about VNet.