### PR TITLE
Clarify environment vars in the teleport unit file

### DIFF
--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -61,7 +61,11 @@ specified hosts/netmasks/ports.
 
 By default, Teleport installations based on package managers (such as `apt` and
 `yum`) configure The `teleport` systemd unit to read environment variables from
-the file `/etc/default/teleport`. 
+the file `/etc/default/teleport` by using the `EnvironmentFile` field:
+
+```ini
+(!/examples/systemd/teleport.service!)
+```
 
 To configure HTTP CONNECT tunneling, you can assign these environment variables
 within `/etc/default/teleport` on machines that run Teleport binaries. Use the


### PR DESCRIPTION
Closes #38824

In the Networking reference, the discussion of environment variables didn't make it sufficiently clear that `/etc/default/teleport` is the environment file specified in the Teleport unit file.

This change includes the unit file to make it more explicit how the file uses `/etc/default/teleport`.