### PR TITLE
Update slog json handler to prefer fmt.Stringer over json marshaling

### DIFF
--- a/lib/utils/log/formatter_test.go
+++ b/lib/utils/log/formatter_test.go
@@ -278,7 +278,7 @@ func TestOutput(t *testing.T) {
 				// Add some fields and output the message at the desired log level via logrus.
 				l := entry.WithField("test", 123).WithField("animal", "llama").WithField("error", trace.Wrap(logErr))
 				logrusTestLogLineNumber := func() int {
-					l.WithField("diag_addr", &addr).Log(test.logrusLevel, message)
+					l.WithField("diag_addr", addr.String()).Log(test.logrusLevel, message)
 					return getCallerLineNumber() - 1 // Get the line number of this call, and assume the log call is right above it
 				}()
 

--- a/lib/utils/log/slog_handler.go
+++ b/lib/utils/log/slog_handler.go
@@ -533,13 +533,17 @@ func NewSlogJSONHandler(w io.Writer, cfg SlogJSONHandlerConfig) *SlogJSONHandler
 					a = slog.String(CallerField, fmt.Sprintf("%s:%d", file, line))
 				}
 
-				// Convert any [slog.KindAny] values that are backed by errors to string
-				// so that only the message is output instead of a json object. The kind is
+				// Convert [slog.KindAny] values that are backed by an [error] or [fmt.Stringer]
+				// to strings so that only the message is output instead of a json object. The kind is
 				// first checked to avoid allocating an interface for the values stored inline
-				// in slog.Attr
+				// in [slog.Attr].
 				if a.Value.Kind() == slog.KindAny {
 					if err, ok := a.Value.Any().(error); ok {
 						a.Value = slog.StringValue(err.Error())
+					}
+
+					if stringer, ok := a.Value.Any().(fmt.Stringer); ok {
+						a.Value = slog.StringValue(stringer.String())
 					}
 				}
 


### PR DESCRIPTION
Builds on https://github.com/gravitational/teleport/pull/39974 to prefer writing a single string instead of a json object to logs. This more closely follows the behavior of the text formatter which will output strings. The primary motivation is to ensure that no secrets or unwanted items of a struct make it into json logs because it is converting an object differently than the text handler.

There are two other options to avoid this, but both rely on doing the right thing when adding an attribute, which may be overlooked or forgotten and ultimately not noticed because only text ouput was tested with.

1) Call .String() directly on the attribute, but this goes against
 the performance guidance in the slog docs.

2) Wrap the attribute in a logutils.StringerAttr which follows the
 recomendations in the slog docs:

> If you want to avoid eagerly paying the cost of the String call
> without causing the handler to potentially inspect the structure
> of the value, wrap the value in a fmt.Stringer implementation
> that hides its Marshal methods.