### PR TITLE
[v15] Use dbcmd.WithPrintFormat only for preview of teleterm gateway command

### DIFF
--- a/gen/proto/go/teleport/lib/teleterm/v1/gateway.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/gateway.pb.go
@@ -171,8 +171,9 @@ func (x *Gateway) GetGatewayCliCommand() *GatewayCLICommand {
 	return nil
 }
 
-// GatewayCLICommand represents a command that the user can execute to connect to the gateway
-// resource. It is a direct translation of os.exec.Cmd.
+// GatewayCLICommand represents a command that the user can execute to connect to a gateway
+// resource. It is a combination of two different os/exec.Cmd structs, where path, args and env are
+// directly taken from one Cmd and the preview field is constructed from another Cmd.
 type GatewayCLICommand struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -182,10 +183,14 @@ type GatewayCLICommand struct {
 	Args []string `protobuf:"bytes,2,rep,name=args,proto3" json:"args,omitempty"`
 	Env  []string `protobuf:"bytes,3,rep,name=env,proto3" json:"env,omitempty"`
 	// preview is used to show the user what command will be executed before they decide to run it.
-	// It's like os.exec.Cmd.String with two exceptions:
+	// It can also be copied and then pasted into a terminal.
+	// It's like os/exec.Cmd.String with two exceptions:
 	//
 	// 1) It is prepended with Cmd.Env.
 	// 2) The command name is relative and not absolute.
+	// 3) It is taken from a different Cmd than the other fields in this message. This Cmd uses a
+	// special print format which makes the args suitable to be entered into a terminal, but not to
+	// directly spawn a process.
 	Preview string `protobuf:"bytes,4,opt,name=preview,proto3" json:"preview,omitempty"`
 }
 

--- a/gen/proto/ts/teleport/lib/teleterm/v1/gateway_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/gateway_pb.ts
@@ -105,8 +105,9 @@ export interface Gateway {
     gatewayCliCommand?: GatewayCLICommand;
 }
 /**
- * GatewayCLICommand represents a command that the user can execute to connect to the gateway
- * resource. It is a direct translation of os.exec.Cmd.
+ * GatewayCLICommand represents a command that the user can execute to connect to a gateway
+ * resource. It is a combination of two different os/exec.Cmd structs, where path, args and env are
+ * directly taken from one Cmd and the preview field is constructed from another Cmd.
  *
  * @generated from protobuf message teleport.lib.teleterm.v1.GatewayCLICommand
  */
@@ -125,10 +126,14 @@ export interface GatewayCLICommand {
     env: string[];
     /**
      * preview is used to show the user what command will be executed before they decide to run it.
-     * It's like os.exec.Cmd.String with two exceptions:
+     * It can also be copied and then pasted into a terminal.
+     * It's like os/exec.Cmd.String with two exceptions:
      *
      * 1) It is prepended with Cmd.Env.
      * 2) The command name is relative and not absolute.
+     * 3) It is taken from a different Cmd than the other fields in this message. This Cmd uses a
+     * special print format which makes the args suitable to be entered into a terminal, but not to
+     * directly spawn a process.
      *
      * @generated from protobuf field: string preview = 4;
      */

--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -515,9 +515,10 @@ func testKubeGatewayCertRenewal(ctx context.Context, t *testing.T, params kubeGa
 func checkKubeconfigPathInCommandEnv(t *testing.T, daemonService *daemon.Service, gw gateway.Gateway, wantKubeconfigPath string) {
 	t.Helper()
 
-	cmd, err := daemonService.GetGatewayCLICommand(gw)
+	cmds, err := daemonService.GetGatewayCLICommand(gw)
 	require.NoError(t, err)
-	require.Equal(t, []string{"KUBECONFIG=" + wantKubeconfigPath}, cmd.Env)
+	require.Equal(t, []string{"KUBECONFIG=" + wantKubeconfigPath}, cmds.Exec.Env)
+	require.Equal(t, []string{"KUBECONFIG=" + wantKubeconfigPath}, cmds.Preview.Env)
 }
 
 // setupUserMFA upserts role so that it requires per-session MFA and configures the user account to

--- a/lib/client/db/dbcmd/dbcmd.go
+++ b/lib/client/db/dbcmd/dbcmd.go
@@ -861,7 +861,7 @@ func WithPassword(pass string) ConnectCommandFunc {
 // WithPrintFormat is known to be used for the following situations:
 // - tsh db config --format cmd <database>
 // - tsh proxy db --tunnel <database>
-// - Teleport Connect where the command is put into a terminal.
+// - Teleport Connect where the gateway command is shown in the UI.
 //
 // WithPrintFormat should NOT be used when the exec.Cmd gets executed by the
 // client application.

--- a/lib/client/db/dbcmd/dbcmd_test.go
+++ b/lib/client/db/dbcmd/dbcmd_test.go
@@ -574,6 +574,8 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			cmd:          nil,
 			wantErr:      true,
 		},
+		// If you find yourself changing this test so that generating a command for DynamoDB _doesn't_
+		// fail if WithPrintFormat() is not provided, please remember to update lib/teleterm/cmd/db.go.
 		{
 			name:         "dynamodb for exec is an error",
 			dbProtocol:   defaults.ProtocolDynamoDB,

--- a/lib/teleterm/apiserver/handler/handler_gateways_test.go
+++ b/lib/teleterm/apiserver/handler/handler_gateways_test.go
@@ -26,29 +26,30 @@ import (
 	"github.com/stretchr/testify/require"
 
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
+	"github.com/gravitational/teleport/lib/teleterm/cmd"
 )
 
 func Test_makeGatewayCLICommand(t *testing.T) {
 	absPath, err := filepath.Abs("test-binary")
 	require.NoError(t, err)
 
-	// Call exec.Command with a relative path so that cmd.Args[0] is a relative path.
-	// Then replace cmd.Path with an absolute path to simulate binary being resolved to
+	// Call exec.Command with a relative path so that command.Args[0] is a relative path.
+	// Then replace command.Path with an absolute path to simulate binary being resolved to
 	// an absolute path. This way we can later verify that gateway.CLICommand doesn't use the absolute
 	// path.
 	//
 	// This also ensures that exec.Command behaves the same way on different devices, no matter
 	// whether a command like postgres is installed on the system or not.
-	cmd := exec.Command("test-binary", "arg1", "arg2")
-	cmd.Path = absPath
-	cmd.Env = []string{"FOO=bar"}
+	command := exec.Command("test-binary", "arg1", "arg2")
+	command.Path = absPath
+	command.Env = []string{"FOO=bar"}
 
-	command := makeGatewayCLICommand(cmd)
+	gatewayCmd := makeGatewayCLICommand(cmd.Cmds{Exec: command, Preview: command})
 
 	require.Equal(t, &api.GatewayCLICommand{
 		Path:    absPath,
 		Args:    []string{"test-binary", "arg1", "arg2"},
 		Env:     []string{"FOO=bar"},
 		Preview: "FOO=bar test-binary arg1 arg2",
-	}, command)
+	}, gatewayCmd)
 }

--- a/lib/teleterm/cmd/db.go
+++ b/lib/teleterm/cmd/db.go
@@ -24,18 +24,31 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/client/db/dbcmd"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 	"github.com/gravitational/teleport/lib/teleterm/gateway"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
-// NewDBCLICommand creates CLI commands for database gateway.
-func NewDBCLICommand(cluster *clusters.Cluster, gateway gateway.Gateway) (*exec.Cmd, error) {
-	cmd, err := newDBCLICommandWithExecer(cluster, gateway, dbcmd.SystemExecer{})
-	return cmd, trace.Wrap(err)
+// Cmds represents a single command in two variants – one that can be used to spawn a process and
+// one that can be copied and pasted into a terminal.
+type Cmds struct {
+	// Exec is the command that should be used when directly executing a command for the given
+	// gateway.
+	Exec *exec.Cmd
+	// Preview is the command that should be used to display the command in the UI. Typically this
+	// means that Preview includes quotes around special characters, so that the command gets executed
+	// properly when the user copies and then pastes it into a terminal.
+	Preview *exec.Cmd
 }
 
-func newDBCLICommandWithExecer(cluster *clusters.Cluster, gateway gateway.Gateway, execer dbcmd.Execer) (*exec.Cmd, error) {
+// NewDBCLICommand creates CLI commands for database gateway.
+func NewDBCLICommand(cluster *clusters.Cluster, gateway gateway.Gateway) (Cmds, error) {
+	cmds, err := newDBCLICommandWithExecer(cluster, gateway, dbcmd.SystemExecer{})
+	return cmds, trace.Wrap(err)
+}
+
+func newDBCLICommandWithExecer(cluster *clusters.Cluster, gateway gateway.Gateway, execer dbcmd.Execer) (Cmds, error) {
 	routeToDb := tlsca.RouteToDatabase{
 		ServiceName: gateway.TargetName(),
 		Protocol:    gateway.Protocol(),
@@ -43,17 +56,35 @@ func newDBCLICommandWithExecer(cluster *clusters.Cluster, gateway gateway.Gatewa
 		Database:    gateway.TargetSubresourceName(),
 	}
 
-	cmd, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb,
+	opts := []dbcmd.ConnectCommandFunc{
 		dbcmd.WithLogger(gateway.Log()),
 		dbcmd.WithLocalProxy(gateway.LocalAddress(), gateway.LocalPortInt(), ""),
 		dbcmd.WithNoTLS(),
-		dbcmd.WithPrintFormat(),
 		dbcmd.WithTolerateMissingCLIClient(),
 		dbcmd.WithExecer(execer),
-	).GetConnectCommand()
-	if err != nil {
-		return nil, trace.Wrap(err)
 	}
 
-	return cmd, nil
+	// DynamoDB doesn't support non-print-format use.
+	if gateway.Protocol() == defaults.ProtocolDynamoDB {
+		opts = append(opts, dbcmd.WithPrintFormat())
+	}
+
+	previewOpts := append(opts, dbcmd.WithPrintFormat())
+
+	execCmd, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, opts...).GetConnectCommand()
+	if err != nil {
+		return Cmds{}, trace.Wrap(err)
+	}
+
+	previewCmd, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, previewOpts...).GetConnectCommand()
+	if err != nil {
+		return Cmds{}, trace.Wrap(err)
+	}
+
+	cmds := Cmds{
+		Exec:    execCmd,
+		Preview: previewCmd,
+	}
+
+	return cmds, nil
 }

--- a/lib/teleterm/cmd/db_test.go
+++ b/lib/teleterm/cmd/db_test.go
@@ -115,10 +115,13 @@ func TestNewDBCLICommand(t *testing.T) {
 }
 
 func checkMongoCmds(t *testing.T, gw fakeDatabaseGateway, cmds Cmds) {
-	execConnString := cmds.Exec.Args[1]
-	previewConnString := cmds.Preview.Args[1]
+	t.Helper()
 	require.Len(t, cmds.Exec.Args, 2)
 	require.Len(t, cmds.Preview.Args, 2)
+
+	execConnString := cmds.Exec.Args[1]
+	previewConnString := cmds.Preview.Args[1]
+
 	require.Contains(t, execConnString, gw.TargetSubresourceName())
 	require.Contains(t, previewConnString, gw.TargetSubresourceName())
 	require.Contains(t, execConnString, gw.LocalPort())
@@ -131,6 +134,7 @@ func checkMongoCmds(t *testing.T, gw fakeDatabaseGateway, cmds Cmds) {
 }
 
 func checkArgsNotEmpty(t *testing.T, gw fakeDatabaseGateway, cmds Cmds) {
+	t.Helper()
 	require.NotEmpty(t, cmds.Exec.Args)
 	require.NotEmpty(t, cmds.Preview.Args)
 }

--- a/lib/teleterm/cmd/db_test.go
+++ b/lib/teleterm/cmd/db_test.go
@@ -19,6 +19,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -52,13 +53,14 @@ type fakeDatabaseGateway struct {
 	gateway.Database
 	targetURI       uri.ResourceURI
 	subresourceName string
+	protocol        string
 }
 
 func (m fakeDatabaseGateway) TargetURI() uri.ResourceURI    { return m.targetURI }
 func (m fakeDatabaseGateway) TargetName() string            { return m.targetURI.GetDbName() }
 func (m fakeDatabaseGateway) TargetUser() string            { return "alice" }
 func (m fakeDatabaseGateway) TargetSubresourceName() string { return m.subresourceName }
-func (m fakeDatabaseGateway) Protocol() string              { return defaults.ProtocolMongoDB }
+func (m fakeDatabaseGateway) Protocol() string              { return m.protocol }
 func (m fakeDatabaseGateway) Log() *logrus.Entry            { return nil }
 func (m fakeDatabaseGateway) LocalAddress() string          { return "localhost" }
 func (m fakeDatabaseGateway) LocalPortInt() int             { return 8888 }
@@ -68,14 +70,27 @@ func TestNewDBCLICommand(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		targetSubresourceName string
+		argsCount             int
+		protocol              string
+		checkCmds             func(*testing.T, fakeDatabaseGateway, Cmds)
 	}{
 		{
 			name:                  "empty name",
+			protocol:              defaults.ProtocolMongoDB,
 			targetSubresourceName: "",
+			checkCmds:             checkMongoCmds,
 		},
 		{
 			name:                  "with name",
+			protocol:              defaults.ProtocolMongoDB,
 			targetSubresourceName: "bar",
+			checkCmds:             checkMongoCmds,
+		},
+		{
+			name:                  "custom handling of DynamoDB does not blow up",
+			targetSubresourceName: "bar",
+			protocol:              defaults.ProtocolDynamoDB,
+			checkCmds:             checkArgsNotEmpty,
 		},
 	}
 
@@ -88,14 +103,34 @@ func TestNewDBCLICommand(t *testing.T) {
 			mockGateway := fakeDatabaseGateway{
 				targetURI:       cluster.URI.AppendDB("foo"),
 				subresourceName: tc.targetSubresourceName,
+				protocol:        tc.protocol,
 			}
 
-			command, err := newDBCLICommandWithExecer(&cluster, mockGateway, fakeExec{})
-
+			cmds, err := newDBCLICommandWithExecer(&cluster, mockGateway, fakeExec{})
 			require.NoError(t, err)
-			require.Len(t, command.Args, 2)
-			require.Contains(t, command.Args[1], tc.targetSubresourceName)
-			require.Contains(t, command.Args[1], mockGateway.LocalPort())
+
+			tc.checkCmds(t, mockGateway, cmds)
 		})
 	}
+}
+
+func checkMongoCmds(t *testing.T, gw fakeDatabaseGateway, cmds Cmds) {
+	execConnString := cmds.Exec.Args[1]
+	previewConnString := cmds.Preview.Args[1]
+	require.Len(t, cmds.Exec.Args, 2)
+	require.Len(t, cmds.Preview.Args, 2)
+	require.Contains(t, execConnString, gw.TargetSubresourceName())
+	require.Contains(t, previewConnString, gw.TargetSubresourceName())
+	require.Contains(t, execConnString, gw.LocalPort())
+	require.Contains(t, previewConnString, gw.LocalPort())
+
+	// Verify that the preview cmd has exec cmd conn string wrapped in quotes.
+	require.NotContains(t, execConnString, "\"")
+	expectedPreviewConnString := fmt.Sprintf("%q", execConnString)
+	require.Equal(t, expectedPreviewConnString, previewConnString)
+}
+
+func checkArgsNotEmpty(t *testing.T, gw fakeDatabaseGateway, cmds Cmds) {
+	require.NotEmpty(t, cmds.Exec.Args)
+	require.NotEmpty(t, cmds.Preview.Args)
 }

--- a/lib/teleterm/cmd/kube.go
+++ b/lib/teleterm/cmd/kube.go
@@ -29,14 +29,14 @@ import (
 )
 
 // NewKubeCLICommand creates CLI commands for kube gateways.
-func NewKubeCLICommand(g gateway.Gateway) (*exec.Cmd, error) {
+func NewKubeCLICommand(g gateway.Gateway) (Cmds, error) {
 	kube, err := gateway.AsKube(g)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return Cmds{}, trace.Wrap(err)
 	}
 
 	// Use kubectl version as placeholders. Only env should be used.
 	cmd := exec.Command("kubectl", "version")
 	cmd.Env = []string{fmt.Sprintf("%v=%v", teleport.EnvKubeConfig, kube.KubeconfigPath())}
-	return cmd, nil
+	return Cmds{Exec: cmd, Preview: cmd}, nil
 }

--- a/lib/teleterm/cmd/kube_test.go
+++ b/lib/teleterm/cmd/kube_test.go
@@ -35,5 +35,5 @@ func (m fakeKubeGateway) KubeconfigPath() string { return "test.kubeconfig" }
 func TestNewKubeCLICommand(t *testing.T) {
 	cmd, err := NewKubeCLICommand(fakeKubeGateway{})
 	require.NoError(t, err)
-	require.Equal(t, []string{"KUBECONFIG=test.kubeconfig"}, cmd.Env)
+	require.Equal(t, []string{"KUBECONFIG=test.kubeconfig"}, cmd.Exec.Env)
 }

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -462,27 +462,28 @@ func (s *Service) ListGateways() []gateway.Gateway {
 }
 
 // GetGatewayCLICommand creates the CLI command used for the provided gateway.
-func (s *Service) GetGatewayCLICommand(gateway gateway.Gateway) (*exec.Cmd, error) {
+func (s *Service) GetGatewayCLICommand(gateway gateway.Gateway) (cmd.Cmds, error) {
 	targetURI := gateway.TargetURI()
 	switch {
 	case targetURI.IsDB():
 		cluster, _, err := s.cfg.Storage.GetByResourceURI(targetURI)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return cmd.Cmds{}, trace.Wrap(err)
 		}
 
-		cmd, err := cmd.NewDBCLICommand(cluster, gateway)
-		return cmd, trace.Wrap(err)
+		cmds, err := cmd.NewDBCLICommand(cluster, gateway)
+		return cmds, trace.Wrap(err)
 
 	case targetURI.IsKube():
-		cmd, err := cmd.NewKubeCLICommand(gateway)
-		return cmd, trace.Wrap(err)
+		cmds, err := cmd.NewKubeCLICommand(gateway)
+		return cmds, trace.Wrap(err)
 
 	case targetURI.IsApp():
-		return exec.Command(""), nil
+		blankCmd := exec.Command("")
+		return cmd.Cmds{Exec: blankCmd, Preview: blankCmd}, nil
 
 	default:
-		return nil, trace.NotImplemented("gateway not supported for %v", targetURI)
+		return cmd.Cmds{}, trace.NotImplemented("gateway not supported for %v", targetURI)
 	}
 }
 

--- a/lib/teleterm/daemon/daemon_test.go
+++ b/lib/teleterm/daemon/daemon_test.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os/exec"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -43,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
+	"github.com/gravitational/teleport/lib/teleterm/cmd"
 	"github.com/gravitational/teleport/lib/teleterm/gateway"
 	"github.com/gravitational/teleport/lib/teleterm/gatewaytest"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -666,7 +666,7 @@ func TestGetGatewayCLICommand(t *testing.T) {
 		name         string
 		inputGateway gateway.Gateway
 		checkError   require.ErrorAssertionFunc
-		checkCmd     func(*testing.T, *exec.Cmd)
+		checkCmds    func(*testing.T, cmd.Cmds)
 	}{
 		{
 			name: "unsupported gateway",
@@ -674,7 +674,7 @@ func TestGetGatewayCLICommand(t *testing.T) {
 				targetURI: uri.NewClusterURI("profile").AppendServer("server"),
 			},
 			checkError: require.Error,
-			checkCmd:   func(*testing.T, *exec.Cmd) {},
+			checkCmds:  func(*testing.T, cmd.Cmds) {},
 		},
 		{
 			name: "database gateway",
@@ -683,10 +683,12 @@ func TestGetGatewayCLICommand(t *testing.T) {
 				subresourceName: "subresource-name",
 			},
 			checkError: require.NoError,
-			checkCmd: func(t *testing.T, cmd *exec.Cmd) {
+			checkCmds: func(t *testing.T, cmds cmd.Cmds) {
 				t.Helper()
-				require.Len(t, cmd.Args, 2)
-				require.Contains(t, cmd.Args[1], "subresource-name")
+				require.Len(t, cmds.Exec.Args, 2)
+				require.Contains(t, cmds.Exec.Args[1], "subresource-name")
+				require.Len(t, cmds.Preview.Args, 2)
+				require.Contains(t, cmds.Preview.Args[1], "subresource-name")
 			},
 		},
 		{
@@ -695,18 +697,19 @@ func TestGetGatewayCLICommand(t *testing.T) {
 				targetURI: uri.NewClusterURI("profile").AppendKube("kube"),
 			},
 			checkError: require.NoError,
-			checkCmd: func(t *testing.T, cmd *exec.Cmd) {
+			checkCmds: func(t *testing.T, cmds cmd.Cmds) {
 				t.Helper()
-				require.Equal(t, []string{"KUBECONFIG=test.kubeconfig"}, cmd.Env)
+				require.Equal(t, []string{"KUBECONFIG=test.kubeconfig"}, cmds.Exec.Env)
+				require.Equal(t, []string{"KUBECONFIG=test.kubeconfig"}, cmds.Preview.Env)
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd, err := daemon.GetGatewayCLICommand(test.inputGateway)
+			cmds, err := daemon.GetGatewayCLICommand(test.inputGateway)
 			test.checkError(t, err)
-			test.checkCmd(t, cmd)
+			test.checkCmds(t, cmds)
 		})
 	}
 }

--- a/proto/teleport/lib/teleterm/v1/gateway.proto
+++ b/proto/teleport/lib/teleterm/v1/gateway.proto
@@ -59,16 +59,21 @@ message Gateway {
   GatewayCLICommand gateway_cli_command = 10;
 }
 
-// GatewayCLICommand represents a command that the user can execute to connect to the gateway
-// resource. It is a direct translation of os.exec.Cmd.
+// GatewayCLICommand represents a command that the user can execute to connect to a gateway
+// resource. It is a combination of two different os/exec.Cmd structs, where path, args and env are
+// directly taken from one Cmd and the preview field is constructed from another Cmd.
 message GatewayCLICommand {
   string path = 1;
   repeated string args = 2;
   repeated string env = 3;
   // preview is used to show the user what command will be executed before they decide to run it.
-  // It's like os.exec.Cmd.String with two exceptions:
+  // It can also be copied and then pasted into a terminal.
+  // It's like os/exec.Cmd.String with two exceptions:
   //
   // 1) It is prepended with Cmd.Env.
   // 2) The command name is relative and not absolute.
+  // 3) It is taken from a different Cmd than the other fields in this message. This Cmd uses a
+  // special print format which makes the args suitable to be entered into a terminal, but not to
+  // directly spawn a process.
   string preview = 4;
 }


### PR DESCRIPTION
Backport #39906 to branch/v15

changelog: Fixed "Invalid URI" error in Teleport Connect when starting mongosh from database connection tab

🙏  https://github.com/gravitational/teleport/pull/40027
