### PR TITLE
Add reissuing user certificates to the ClusterClient

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1392,16 +1392,14 @@ func (tc *TeleportClient) ReissueUserCerts(ctx context.Context, cachePolicy Cert
 	)
 	defer span.End()
 
-	//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
-	proxyClient, err := tc.ConnectToProxy(ctx)
+	clusterClient, err := tc.ConnectToCluster(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer proxyClient.Close()
+	defer clusterClient.Close()
 
 	err = RetryWithRelogin(ctx, tc, func() error {
-		err := proxyClient.ReissueUserCerts(ctx, cachePolicy, params)
-		return trace.Wrap(err)
+		return trace.Wrap(clusterClient.ReissueUserCerts(ctx, cachePolicy, params))
 	})
 	return trace.Wrap(err)
 }


### PR DESCRIPTION
Updating the ClusterClient to support generating new user certs covers some of the exiting missing functionality that is required by some components to migrate fully off of the deprecated ProxyClient. The ClusterClient implementation is almost a verbatim copy from the ProxyClient.

The ProxyClient method was not removed because Connect does not use the ClusterClient yet. That will be addressed after the ClusterClient has complete feature parity with the ProxyClient.

Updates #38239.