### PR TITLE
Add a vale rule for subjective terms

### DIFF
--- a/.github/vale-styles/messaging/subjective-terms.yml
+++ b/.github/vale-styles/messaging/subjective-terms.yml
@@ -1,0 +1,14 @@
+extends: existence
+link: "https://github.com/gravitational/docs/blob/main/docs-contributors/style-guide.md#voice"
+message: "Avoid using '%s' as a qualifier, since it is subject to interpretation. Use more technically precise terms instead."
+level: error
+ignorecase: true
+tokens:
+  - "powerful(ly)?"
+  - "seamless(ly)?"
+  - "simpl(e|ly)"
+  - "smooth(ly)?"
+  - "quick(ly)?"
+  - "fast"
+  - "eas(y|ily)"
+  - "rich(ly)?"


### PR DESCRIPTION
Enforce a standard that minimizes terms that require a personal point of view and promote technical precision. Add a vale rule that flags terms like "simple" and "seamless".