### PR TITLE
Include system annotations in audit event entries for access requests

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4839,11 +4839,11 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 	}
 
 	var annotations *apievents.Struct
-	if len(req.GetSystemAnnotations()) > 0 {
+	if sa := req.GetSystemAnnotations(); len(sa) > 0 {
 		var err error
-		annotations, err = apievents.EncodeMapStrings(req.GetSystemAnnotations())
+		annotations, err = apievents.EncodeMapStrings(sa)
 		if err != nil {
-			log.WithError(err).Debugf("Failed to encode access request annotations.")
+			log.WithError(err).Debug("Failed to encode access request annotations.")
 		}
 	}
 
@@ -4963,11 +4963,11 @@ func (a *Server) SetAccessRequestState(ctx context.Context, params types.AccessR
 		Roles:           params.Roles,
 		AssumeStartTime: params.AssumeStartTime,
 	}
-	if len(req.GetSystemAnnotations()) > 0 {
+	if sa := req.GetSystemAnnotations(); len(sa) > 0 {
 		var err error
-		event.Annotations, err = apievents.EncodeMapStrings(req.GetSystemAnnotations())
+		event.Annotations, err = apievents.EncodeMapStrings(sa)
 		if err != nil {
-			log.WithError(err).Debugf("Failed to encode access request annotations.")
+			log.WithError(err).Debug("Failed to encode access request annotations.")
 		}
 	}
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4837,6 +4837,16 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 	if _, err := a.Services.CreateAccessRequestV2(ctx, req); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	var annotations *apievents.Struct
+	if len(req.GetSystemAnnotations()) > 0 {
+		var err error
+		annotations, err = apievents.EncodeMapStrings(req.GetSystemAnnotations())
+		if err != nil {
+			log.WithError(err).Debugf("Failed to encode access request annotations.")
+		}
+	}
+
 	err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.AccessRequestCreate{
 		Metadata: apievents.Metadata{
 			Type: events.AccessRequestCreateEvent,
@@ -4852,6 +4862,7 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 		RequestState:         req.GetState().String(),
 		Reason:               req.GetRequestReason(),
 		MaxDuration:          req.GetMaxDuration(),
+		Annotations:          annotations,
 	})
 	if err != nil {
 		log.WithError(err).Warn("Failed to emit access request create event.")
@@ -4951,6 +4962,13 @@ func (a *Server) SetAccessRequestState(ctx context.Context, params types.AccessR
 		Reason:          params.Reason,
 		Roles:           params.Roles,
 		AssumeStartTime: params.AssumeStartTime,
+	}
+	if len(req.GetSystemAnnotations()) > 0 {
+		var err error
+		event.Annotations, err = apievents.EncodeMapStrings(req.GetSystemAnnotations())
+		if err != nil {
+			log.WithError(err).Debugf("Failed to encode access request annotations.")
+		}
 	}
 
 	if delegator := apiutils.GetDelegator(ctx); delegator != "" {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -3810,3 +3810,61 @@ func TestGetTokens(t *testing.T) {
 	_, err = s.a.GetTokens(ctx)
 	require.NoError(t, err)
 }
+
+func TestAccessRequestAuditLog(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	p, err := newTestPack(ctx, t.TempDir())
+	require.NoError(t, err)
+
+	requester, _, _ := createSessionTestUsers(t, p.a)
+
+	paymentsRole, err := types.NewRole("paymentsRole", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				Roles: []string{"requestRole"},
+				Annotations: map[string][]string{
+					"pagerduty_services": {"payments"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	requestRole, err := types.NewRole("requestRole", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	p.a.CreateRole(ctx, requestRole)
+	p.a.CreateRole(ctx, paymentsRole)
+
+	user, err := p.a.GetUser(ctx, requester, true)
+	require.NoError(t, err)
+	user.AddRole(paymentsRole.GetName())
+	_, err = p.a.UpsertUser(ctx, user)
+	require.NoError(t, err)
+
+	accessRequest, err := types.NewAccessRequest(uuid.NewString(), requester, "requestRole")
+	require.NoError(t, err)
+	req, err := p.a.CreateAccessRequestV2(ctx, accessRequest, TestUser(requester).I.GetIdentity())
+	require.NoError(t, err)
+
+	expectedAnnotations, err := apievents.EncodeMapStrings(paymentsRole.GetAccessRequestConditions(types.Allow).Annotations)
+	require.NoError(t, err)
+
+	arc, ok := p.mockEmitter.LastEvent().(*apievents.AccessRequestCreate)
+	require.True(t, ok)
+	require.Equal(t, expectedAnnotations, arc.Annotations)
+	require.Equal(t, "PENDING", arc.RequestState)
+
+	err = p.a.SetAccessRequestState(ctx, types.AccessRequestUpdate{
+		RequestID: req.GetName(),
+		State:     types.RequestState_APPROVED,
+	})
+	require.NoError(t, err)
+
+	arc, ok = p.mockEmitter.LastEvent().(*apievents.AccessRequestCreate)
+	require.True(t, ok)
+	require.Equal(t, expectedAnnotations, arc.Annotations)
+	require.Equal(t, "APPROVED", arc.RequestState)
+}


### PR DESCRIPTION
Example access request with this change:

```json
{
  "annotations": {
    "hello": [
      "hello"
    ]
  },
  "cluster_name": "localhost",
  "code": "T5000I",
  "ei": 0,
  "event": "access_request.create",
  "expires": "2024-03-31T01:18:59.523355715Z",
  "id": "018e8ba6-aac2-7edd-b97b-eba3ad0bb222",
  "max_duration": "2024-03-31T01:18:59.523355715Z",
  "roles": [
    "editor"
  ],
  "state": "PENDING",
  "time": "2024-03-29T19:18:59.552Z",
  "uid": "87c17476-6a64-4349-80c1-da618767723e",
  "user": "alex.mcgrath@goteleport.com",
  "user_kind": 1
}
```


Fix for #39747 

changelog: include system annotations in audit event entries for access requests