### PR TITLE
Fix flaky test `TestProxySSHJumpHost`

### DIFF
--- a/api/utils/grpc/stream/stream.go
+++ b/api/utils/grpc/stream/stream.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // MaxChunkSize is the maximum number of bytes to send in a single data message.
@@ -70,9 +72,10 @@ func (c *ReadWriter) Read(b []byte) (n int, err error) {
 
 	if len(c.rBytes) == 0 {
 		data, err := c.source.Recv()
-		if errors.Is(err, io.EOF) {
+		if errors.Is(err, io.EOF) || status.Code(err) == codes.Canceled {
 			return 0, io.EOF
 		}
+
 		if err != nil {
 			return 0, trace.ConnectionProblem(trace.Wrap(err), "failed to receive from source: %v", err)
 		}

--- a/tool/teleport/testenv/test_server.go
+++ b/tool/teleport/testenv/test_server.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/breaker"
@@ -353,10 +354,10 @@ func SetupTrustedCluster(ctx context.Context, t *testing.T, rootServer, leafServ
 	_, err = leafServer.GetAuthServer().UpsertTrustedCluster(ctx, tc)
 	require.NoError(t, err)
 
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		rt, err := rootServer.GetAuthServer().GetTunnelConnections("leaf")
-		require.NoError(t, err)
-		return len(rt) == 1
+		assert.NoError(t, err)
+		assert.Len(t, rt, 1)
 	}, time.Second*10, time.Second)
 }
 

--- a/tool/tsh/common/app_aws_test.go
+++ b/tool/tsh/common/app_aws_test.go
@@ -196,6 +196,7 @@ func makeUserWithAWSRole(t *testing.T) (types.User, types.Role) {
 	return alice, awsRole
 }
 
+// deprecated: Use `tools/teleport/testenv.MakeTestServer` instead.
 func makeTestApplicationServer(t *testing.T, proxy *service.TeleportProcess, apps ...servicecfg.App) *service.TeleportProcess {
 	// Proxy uses self-signed certificates in tests.
 	lib.SetInsecureDevMode(true)

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -62,6 +62,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/tlsca"
+	testserver "github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
 // TestSSH verifies "tsh ssh" command.
@@ -558,101 +559,103 @@ func TestProxySSH(t *testing.T) {
 
 // TestProxySSHJumpHost verifies "tsh proxy ssh -J" functionality.
 func TestProxySSHJumpHost(t *testing.T) {
+	ctx := context.Background()
+
 	lib.SetInsecureDevMode(true)
 	t.Cleanup(func() { lib.SetInsecureDevMode(false) })
 
 	createAgent(t)
 
-	tests := []struct {
-		name string
-		opts []testSuiteOptionFunc
-	}{
-		{
-			name: "TLS routing enabled for root and leaf",
-			opts: []testSuiteOptionFunc{
-				withRootConfigFunc(func(cfg *servicecfg.Config) {
-					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
-					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
-				}),
-				withLeafConfigFunc(func(cfg *servicecfg.Config) {
-					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
-					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
-				}),
-			},
-		},
-		{
-			name: "TLS routing enabled for root and disabled for leaf",
-			opts: []testSuiteOptionFunc{
-				withRootConfigFunc(func(cfg *servicecfg.Config) {
-					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
-					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
-				}),
-				withLeafConfigFunc(func(cfg *servicecfg.Config) {
-					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Separate)
-					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
-				}),
-			},
-		},
-		{
-			name: "TLS routing disabled for root and enabled for leaf",
-			opts: []testSuiteOptionFunc{
-				withRootConfigFunc(func(cfg *servicecfg.Config) {
-					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Separate)
-					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
-				}),
-				withLeafConfigFunc(func(cfg *servicecfg.Config) {
-					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
-					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
-				}),
-			},
-		},
-		{
-			name: "TLS routing disabled for root and leaf",
-			opts: []testSuiteOptionFunc{
-				withRootConfigFunc(func(cfg *servicecfg.Config) {
-					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Separate)
-					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
-				}),
-				withLeafConfigFunc(func(cfg *servicecfg.Config) {
-					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Separate)
-					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
-				}),
-			},
-		},
+	listenerModes := []types.ProxyListenerMode{
+		types.ProxyListenerMode_Multiplex,
+		types.ProxyListenerMode_Separate,
 	}
 
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+	for _, rootListenerMode := range listenerModes {
+		for _, leafListenerMode := range listenerModes {
+			rootListenerMode := rootListenerMode
+			leafListenerMode := leafListenerMode
+			t.Run(fmt.Sprintf("Proxy listener mode %s for root and %s for leaf", rootListenerMode, leafListenerMode), func(t *testing.T) {
+				t.Parallel()
 
-			s := newTestSuite(t, tc.opts...)
+				accessUser, err := types.NewUser("access")
+				require.NoError(t, err)
+				accessUser.SetRoles([]string{"access"})
 
-			runProxySSHJump := func(opts ...CliOption) error {
-				proxyRequest := fmt.Sprintf("%s:%d",
-					s.leaf.Config.Proxy.SSHAddr.Host(),
-					s.leaf.Config.SSH.Addr.Port(defaults.SSHServerListenPort))
-				return Run(context.Background(), []string{
-					"--insecure", "proxy", "ssh", "-J", s.leaf.Config.Proxy.WebAddr.Addr, proxyRequest,
-				}, opts...)
-			}
+				connector := mockConnector(t)
+				rootServerOpts := []testserver.TestServerOptFunc{
+					testserver.WithBootstrap(connector, accessUser),
+					testserver.WithHostname("node01"),
+					testserver.WithClusterName(t, "root"),
+					testserver.WithAuthConfig(
+						func(cfg *servicecfg.AuthConfig) {
+							cfg.NetworkingConfig.SetProxyListenerMode(rootListenerMode)
+							// Disable session recording to prevent writing to disk after the test concludes.
+							cfg.SessionRecordingConfig.SetMode(types.RecordOff)
+						},
+					),
+				}
+				rootServer := testserver.MakeTestServer(t, rootServerOpts...)
 
-			// login to root
-			tshHome, _ := mustLogin(t, s, s.root.Config.Auth.ClusterName.GetClusterName())
+				leafServerOpts := []testserver.TestServerOptFunc{
+					testserver.WithBootstrap(accessUser),
+					testserver.WithHostname("node02"),
+					testserver.WithClusterName(t, "leaf"),
+					testserver.WithAuthConfig(
+						func(cfg *servicecfg.AuthConfig) {
+							cfg.NetworkingConfig.SetProxyListenerMode(leafListenerMode)
+							// Disable session recording to prevent writing to disk after the test concludes.
+							cfg.SessionRecordingConfig.SetMode(types.RecordOff)
+						},
+					),
+				}
+				leafServer := testserver.MakeTestServer(t, leafServerOpts...)
+				testserver.SetupTrustedCluster(ctx, t, rootServer, leafServer)
 
-			// Connect to leaf node though proxy jump host. This should automatically
-			// reissue leaf certs from the root without explicility switching clusters.
-			err := runProxySSHJump(setHomePath(tshHome))
-			require.NoError(t, err)
+				rootProxyAddr, err := rootServer.ProxyWebAddr()
+				require.NoError(t, err)
+				leafProxyAddr, err := leafServer.ProxyWebAddr()
+				require.NoError(t, err)
+				leafNodeAddr, err := leafServer.NodeSSHAddr()
+				require.NoError(t, err)
 
-			// Terminate root cluster.
-			err = s.root.Close()
-			require.NoError(t, err)
+				// login to root
+				tshHome := t.TempDir()
+				err = Run(ctx, []string{
+					"--insecure",
+					"login",
+					"--proxy", rootProxyAddr.String(),
+				}, setHomePath(tshHome), setMockSSOLogin(rootServer.GetAuthServer(), accessUser, connector.GetName()))
+				require.NoError(t, err)
 
-			// Since we've already retrieved valid leaf certs, we should be able to connect without root.
-			err = runProxySSHJump(setHomePath(tshHome))
-			require.NoError(t, err)
-		})
+				// Connect to leaf node though proxy jump host. This should automatically
+				// reissue leaf certs from the root without explicility switching clusters.
+				err = Run(context.Background(), []string{
+					"--insecure",
+					"--debug",
+					"proxy",
+					"ssh",
+					"-J", leafProxyAddr.String(),
+					leafNodeAddr.String(),
+				}, setHomePath(tshHome))
+				require.NoError(t, err)
+
+				// Terminate root cluster.
+				err = rootServer.Close()
+				require.NoError(t, err)
+
+				// Since we've already retrieved valid leaf certs, we should be able to connect without root.
+				err = Run(context.Background(), []string{
+					"--insecure",
+					"--debug",
+					"proxy",
+					"ssh",
+					"-J", leafProxyAddr.String(),
+					leafNodeAddr.String(),
+				}, setHomePath(tshHome))
+				require.NoError(t, err)
+			})
+		}
 	}
 }
 

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -582,6 +582,10 @@ func TestProxySSHJumpHost(t *testing.T) {
 				require.NoError(t, err)
 				accessUser.SetRoles([]string{"access"})
 
+				user, err := user.Current()
+				require.NoError(t, err)
+				accessUser.SetLogins([]string{user.Name})
+
 				connector := mockConnector(t)
 				rootServerOpts := []testserver.TestServerOptFunc{
 					testserver.WithBootstrap(connector, accessUser),
@@ -592,6 +596,8 @@ func TestProxySSHJumpHost(t *testing.T) {
 							cfg.NetworkingConfig.SetProxyListenerMode(rootListenerMode)
 							// Disable session recording to prevent writing to disk after the test concludes.
 							cfg.SessionRecordingConfig.SetMode(types.RecordOff)
+							// Load all CAs on login so that leaf CA is trusted by clients.
+							cfg.LoadAllCAs = true
 						},
 					),
 				}
@@ -616,8 +622,6 @@ func TestProxySSHJumpHost(t *testing.T) {
 				require.NoError(t, err)
 				leafProxyAddr, err := leafServer.ProxyWebAddr()
 				require.NoError(t, err)
-				leafNodeAddr, err := leafServer.NodeSSHAddr()
-				require.NoError(t, err)
 
 				// login to root
 				tshHome := t.TempDir()
@@ -628,15 +632,14 @@ func TestProxySSHJumpHost(t *testing.T) {
 				}, setHomePath(tshHome), setMockSSOLogin(rootServer.GetAuthServer(), accessUser, connector.GetName()))
 				require.NoError(t, err)
 
-				// Connect to leaf node though proxy jump host. This should automatically
-				// reissue leaf certs from the root without explicility switching clusters.
-				err = Run(context.Background(), []string{
-					"--insecure",
+				// Connect through the leaf proxy jumphost.
+				err = Run(ctx, []string{
 					"--debug",
 					"proxy",
 					"ssh",
+					"--no-resume",
 					"-J", leafProxyAddr.String(),
-					leafNodeAddr.String(),
+					"node02",
 				}, setHomePath(tshHome))
 				require.NoError(t, err)
 
@@ -644,14 +647,15 @@ func TestProxySSHJumpHost(t *testing.T) {
 				err = rootServer.Close()
 				require.NoError(t, err)
 
-				// Since we've already retrieved valid leaf certs, we should be able to connect without root.
-				err = Run(context.Background(), []string{
-					"--insecure",
+				// We should be able to connect without root online.
+				err = Run(ctx, []string{
 					"--debug",
+					"--insecure",
 					"proxy",
 					"ssh",
+					"--no-resume",
 					"-J", leafProxyAddr.String(),
-					leafNodeAddr.String(),
+					"node02",
 				}, setHomePath(tshHome))
 				require.NoError(t, err)
 			})

--- a/tool/tsh/common/tsh_helper_test.go
+++ b/tool/tsh/common/tsh_helper_test.go
@@ -267,6 +267,7 @@ func withValidationFunc(f func(*suite) bool) testSuiteOptionFunc {
 	}
 }
 
+// deprecated: Use `tools/teleport/testenv.MakeTestServer` instead.
 func newTestSuite(t *testing.T, opts ...testSuiteOptionFunc) *suite {
 	var options testSuiteOptions
 	for _, opt := range opts {

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -3389,6 +3389,7 @@ func withSSHLabel(key, value string) testServerOptFunc {
 	})
 }
 
+// deprecated: Use `tools/teleport/testenv.MakeTestServer` instead.
 func makeTestSSHNode(t *testing.T, authAddr *utils.NetAddr, opts ...testServerOptFunc) *service.TeleportProcess {
 	var options testServersOpts
 	for _, opt := range opts {
@@ -3418,6 +3419,7 @@ func makeTestSSHNode(t *testing.T, authAddr *utils.NetAddr, opts ...testServerOp
 	return runTeleport(t, cfg)
 }
 
+// deprecated: Use `tools/teleport/testenv.MakeTestServer` instead.
 func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.TeleportProcess, proxy *service.TeleportProcess) {
 	t.Helper()
 


### PR DESCRIPTION
Attempt to fix https://github.com/gravitational/teleport/issues/39578

I turned of SSH connection resumption as it seems like that was causing the flake.

I also switch to `testserver.MakeTestServer` because `newTestSuite` was having issues in parallel runs, likely because the file descriptors for listeners are handled differently. This also improved the test speed from 9 to 8 seconds, so maybe it will have an impact.

The test was also outdated as it was testing if we issued a valid leaf certificate for `tsh proxy ssh -J`. This functionality was removed in favor of using `load_all_cas` since the leaf trusts the root cert and we just need the leaf CA.