### PR TITLE
docs: correctly describe the behavior of host user creation

### DIFF
--- a/docs/pages/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/server-access/guides/host-user-creation.mdx
@@ -251,12 +251,11 @@ The Teleport SSH Service also creates a file in `/etc/sudoers.d` with the
 contents of the `host_sudoers` file written with one entry per line, each
 prefixed with the username of the user that has logged in.
 
-The session can then proceed as usual, however once the SSH session ends, the user
-will be automatically removed and their home directory will be deleted with
-`userdel --remove <username>`, as the
-matching role specified they should be dropped. Files owned by the deleted user,
-created outside the home directory, will remain in place. Groups that were created
-will remain on the system after the session ends.
+The session can then proceed as usual. When the SSH session ends, the user
+and their home directory will be kept on the machine. It is possible to remove the user
+by setting `create_host_user_mode` to `insecure-drop` in the role definition. However,
+the potential for a user id to be reused on the system opens up a number of potential security
+and privilege escalation cases, so we recommend using `keep` mode unless you have a specific need.
 
 Should a Teleport SSH instance be restarted while a session is in progress, the user
 will be cleaned up at the next Teleport restart.

--- a/docs/pages/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/server-access/guides/host-user-creation.mdx
@@ -254,8 +254,9 @@ prefixed with the username of the user that has logged in.
 The session can then proceed as usual. When the SSH session ends, the user
 and their home directory will be kept on the machine. It is possible to remove the user
 by setting `create_host_user_mode` to `insecure-drop` in the role definition. However,
-the potential for a user id to be reused on the system opens up a number of potential security
-and privilege escalation cases, so we recommend using `keep` mode unless you have a specific need.
+the potential for a user id to be reused on the system opens up a number of potential security risks,
+so we recommend using `keep` mode unless you have a specific need and understand
+the potential impacts.
 
 Should a Teleport SSH instance be restarted while a session is in progress, the user
 will be cleaned up at the next Teleport restart.


### PR DESCRIPTION
This guide currently states at the end that the user is removed, which used to be accurate for `create_user_host: on` but is no longer accurate for `create_user_host_mode: keep`. I think the end just didn't get updated when the guide was updated to use the new field. I included some great context on why we recommend `keep` from @jentfoo.