### PR TITLE
Add equivalent of `(ProxyClient) IssueUserCertsWithMFA` to ClusterClient

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1421,14 +1421,13 @@ func (tc *TeleportClient) IssueUserCertsWithMFA(ctx context.Context, params Reis
 	)
 	defer span.End()
 
-	//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
-	proxyClient, err := tc.ConnectToProxy(ctx)
+	clusterClient, err := tc.ConnectToCluster(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer proxyClient.Close()
+	defer clusterClient.Close()
 
-	key, err := proxyClient.IssueUserCertsWithMFA(ctx, params, tc.NewMFAPrompt(mfaPromptOpts...))
+	key, _, err := clusterClient.IssueUserCertsWithMFA(ctx, params, tc.NewMFAPrompt(mfaPromptOpts...))
 	return key, trace.Wrap(err)
 }
 

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -152,6 +152,20 @@ func (c *ClusterClient) ReissueUserCerts(ctx context.Context, cachePolicy CertCa
 	)
 	defer span.End()
 
+	key, err := c.generateUserCerts(ctx, cachePolicy, params)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if cachePolicy == CertCacheDrop {
+		c.tc.localAgent.DeleteUserCerts("", WithAllCerts...)
+	}
+
+	// save the cert to the local storage (~/.tsh usually):
+	return trace.Wrap(c.tc.localAgent.AddKey(key))
+}
+
+func (c *ClusterClient) generateUserCerts(ctx context.Context, cachePolicy CertCachePolicy, params ReissueParams) (*Key, error) {
 	if params.RouteToCluster == "" {
 		params.RouteToCluster = c.cluster
 	}
@@ -172,24 +186,24 @@ func (c *ClusterClient) ReissueUserCerts(ctx context.Context, cachePolicy CertCa
 
 		key, err = c.tc.localAgent.GetKey(params.RouteToCluster, certOptions...)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
 
 	req, err := c.prepareUserCertsRequest(params, key)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	rootClient, err := c.ConnectToRootCluster(ctx)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	defer rootClient.Close()
 
 	certs, err := rootClient.GenerateUserCerts(ctx, *req)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	key.ClusterName = params.RouteToCluster
@@ -211,7 +225,7 @@ func (c *ClusterClient) ReissueUserCerts(ctx context.Context, cachePolicy CertCa
 	case proto.UserCertsRequest_Database:
 		dbCert, err := makeDatabaseClientPEM(params.RouteToDatabase.Protocol, certs.TLS, key)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 		key.DBTLSCerts[params.RouteToDatabase.ServiceName] = dbCert
 	case proto.UserCertsRequest_Kubernetes:
@@ -220,12 +234,7 @@ func (c *ClusterClient) ReissueUserCerts(ctx context.Context, cachePolicy CertCa
 		key.WindowsDesktopCerts[params.RouteToWindowsDesktop.WindowsDesktop] = certs.TLS
 	}
 
-	if cachePolicy == CertCacheDrop {
-		c.tc.localAgent.DeleteUserCerts("", WithAllCerts...)
-	}
-
-	// save the cert to the local storage (~/.tsh usually):
-	return trace.Wrap(c.tc.localAgent.AddKey(key))
+	return key, nil
 }
 
 // SessionSSHConfig returns the [ssh.ClientConfig] that should be used to connected to the
@@ -280,13 +289,15 @@ func (c *ClusterClient) SessionSSHConfig(ctx context.Context, user string, targe
 	}
 
 	log.Debug("Attempting to issue a single-use user certificate with an MFA check.")
-	key, err = c.performMFACeremony(ctx, mfaClt,
+	key, err = c.performMFACeremony(ctx,
+		mfaClt,
 		ReissueParams{
 			NodeName:       nodeName(targetNode{addr: target.Addr}),
 			RouteToCluster: target.Cluster,
 			MFACheck:       target.MFACheck,
 		},
 		key,
+		c.tc.NewMFAPrompt(),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -344,7 +355,7 @@ func (c *ClusterClient) prepareUserCertsRequest(params ReissueParams, key *Key) 
 
 // performMFACeremony runs the mfa ceremony to completion.
 // If successful the returned [Key] will be authorized to connect to the target.
-func (c *ClusterClient) performMFACeremony(ctx context.Context, rootClient *ClusterClient, params ReissueParams, key *Key) (*Key, error) {
+func (c *ClusterClient) performMFACeremony(ctx context.Context, rootClient *ClusterClient, params ReissueParams, key *Key, mfaPrompt mfa.Prompt) (*Key, error) {
 	certsReq, err := rootClient.prepareUserCertsRequest(params, key)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -353,7 +364,7 @@ func (c *ClusterClient) performMFACeremony(ctx context.Context, rootClient *Clus
 	key, _, err = PerformMFACeremony(ctx, PerformMFACeremonyParams{
 		CurrentAuthClient: c.AuthClient,
 		RootAuthClient:    rootClient.AuthClient,
-		MFAPrompt:         c.tc.NewMFAPrompt(),
+		MFAPrompt:         mfaPrompt,
 		MFAAgainstRoot:    c.cluster == rootClient.cluster,
 		MFARequiredReq:    params.isMFARequiredRequest(c.tc.HostLogin),
 		ChallengeExtensions: mfav1.ChallengeExtensions{
@@ -363,6 +374,113 @@ func (c *ClusterClient) performMFACeremony(ctx context.Context, rootClient *Clus
 		Key:      key,
 	})
 	return key, trace.Wrap(err)
+}
+
+// IssueUserCertsWithMFA generates a single-use certificate for the user. If MFA is required
+// to access the resource the provided [mfa.Prompt] will be used to perform the MFA ceremony.
+func (c *ClusterClient) IssueUserCertsWithMFA(ctx context.Context, params ReissueParams, mfaPrompt mfa.Prompt) (*Key, proto.MFARequired, error) {
+	ctx, span := c.Tracer.Start(
+		ctx,
+		"ClusterClient/IssueUserCertsWithMFA",
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			attribute.String("cluster", c.tc.SiteName),
+		),
+	)
+	defer span.End()
+
+	if params.RouteToCluster == "" {
+		params.RouteToCluster = c.tc.SiteName
+	}
+
+	key := params.ExistingCreds
+	if key == nil {
+		var err error
+		key, err = c.tc.localAgent.GetKey(params.RouteToCluster, WithAllCerts...)
+		if err != nil {
+			return nil, proto.MFARequired_MFA_REQUIRED_UNSPECIFIED, trace.Wrap(err)
+		}
+	}
+
+	certClient := c
+	var mfaRequired bool
+	if params.MFACheck == nil {
+		var err error
+		authClient := params.AuthClient
+		if authClient == nil {
+			authClient, err = c.ConnectToCluster(ctx, params.RouteToCluster)
+			if err != nil {
+				return nil, proto.MFARequired_MFA_REQUIRED_UNSPECIFIED, trace.Wrap(err)
+			}
+		}
+
+		resp, err := authClient.IsMFARequired(ctx, params.isMFARequiredRequest(c.tc.HostLogin))
+		if err != nil {
+			return nil, proto.MFARequired_MFA_REQUIRED_UNSPECIFIED, trace.Wrap(err)
+		}
+		mfaRequired = resp.Required
+
+		// If connected to the root cluster, store the client so that it
+		// can be reused below.
+		if params.RouteToCluster == c.root {
+			certClient = &ClusterClient{
+				tc:          c.tc,
+				ProxyClient: c.ProxyClient,
+				AuthClient:  authClient,
+				Tracer:      c.Tracer,
+				cluster:     c.root,
+				root:        c.root,
+			}
+		}
+
+		// only close the new auth client and not the copied cluster client.
+		defer authClient.Close()
+	} else {
+		mfaRequired = params.MFACheck.Required
+	}
+
+	// SSH certs can be used without embedding the node name.
+	if !mfaRequired && params.usage() == proto.UserCertsRequest_SSH && key.Cert != nil {
+		return key, proto.MFARequired_MFA_REQUIRED_NO, nil
+	}
+
+	// At this point, a connection to the root cluster is required to generate
+	// an MFA verified certificate OR to issue certificates with the target
+	// embedded in them for routing.
+	if params.RouteToCluster != certClient.root {
+		authClient, err := c.ConnectToRootCluster(ctx)
+		if err != nil {
+			return nil, proto.MFARequired_MFA_REQUIRED_UNSPECIFIED, trace.Wrap(err)
+		}
+
+		certClient = &ClusterClient{
+			tc:          c.tc,
+			ProxyClient: c.ProxyClient,
+			AuthClient:  authClient,
+			Tracer:      c.Tracer,
+			cluster:     c.root,
+			root:        c.root,
+		}
+		// only close the new auth client and not the copied cluster client.
+		defer authClient.Close()
+	}
+
+	// MFA is not required, but the user requires a new certificate with the
+	// target included in it for routing.
+	if !mfaRequired {
+		log.Debug("MFA not required for access.")
+		key, err := certClient.generateUserCerts(ctx, CertCacheKeep, params)
+		return key, proto.MFARequired_MFA_REQUIRED_NO, trace.Wrap(err)
+	}
+
+	// Perform the MFA ceremony and retrieve a new key.
+	key, err := c.performMFACeremony(ctx, certClient, params, key, mfaPrompt)
+	if err != nil {
+		return nil, proto.MFARequired_MFA_REQUIRED_YES, trace.Wrap(err)
+	}
+
+	log.Debug("Issued single-use user certificate after an MFA check.")
+	return key, proto.MFARequired_MFA_REQUIRED_YES, nil
 }
 
 // PerformMFARootClient is a subset of Auth methods required for MFA.

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -1,0 +1,377 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/client/proxy"
+	"github.com/gravitational/teleport/api/mfa"
+	webauthnpb "github.com/gravitational/teleport/api/types/webauthn"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/observability/tracing"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+type fakeAuthClient struct {
+	auth.ClientI
+
+	isMFARequired     func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error)
+	generateUserCerts func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error)
+}
+
+func (f fakeAuthClient) Close() error {
+	return nil
+}
+
+func (f fakeAuthClient) IsMFARequired(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
+	if f.isMFARequired == nil {
+		return nil, trace.NotImplemented("isMFARequired was not set")
+	}
+
+	return f.isMFARequired(ctx, req)
+}
+
+func (f fakeAuthClient) GenerateUserCerts(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+	if f.generateUserCerts == nil {
+		return nil, trace.NotImplemented("generateUserCerts was not set")
+	}
+
+	return f.generateUserCerts(ctx, req)
+}
+
+func (f fakeAuthClient) CreateAuthenticateChallenge(ctx context.Context, req *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error) {
+	return &proto.MFAAuthenticateChallenge{WebauthnChallenge: &webauthnpb.CredentialAssertion{}}, nil
+}
+
+type fakePrompt struct {
+	mfa.Prompt
+
+	err error
+}
+
+func (f fakePrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	return &proto.MFAAuthenticateResponse{
+		Response: &proto.MFAAuthenticateResponse_Webauthn{Webauthn: &webauthnpb.CredentialAssertionResponse{}},
+	}, nil
+}
+
+func TestIssueUserCertsWithMFA(t *testing.T) {
+	ca := newTestAuthority(t)
+	clock := clockwork.NewFakeClock()
+
+	agent, err := NewLocalAgent(LocalAgentConfig{
+		ClientStore: NewMemClientStore(),
+		ProxyHost:   "test",
+		Username:    "alice",
+		Insecure:    true,
+		Site:        "test",
+		LoadAllCAs:  false,
+	})
+	require.NoError(t, err)
+
+	key := ca.makeSignedKey(t, KeyIndex{
+		ProxyHost:   "test",
+		ClusterName: "test",
+		Username:    "alice",
+	}, false)
+
+	require.NoError(t, agent.clientStore.AddKey(key))
+
+	leafKey := ca.makeSignedKey(t, KeyIndex{
+		ProxyHost:   "test",
+		ClusterName: "leaf",
+		Username:    "alice",
+	}, false)
+
+	require.NoError(t, agent.clientStore.AddKey(leafKey))
+
+	pemBytes, ok := fixtures.PEMBytes["rsa"]
+	require.True(t, ok, "RSA key not found in fixtures")
+
+	caSigner, err := ssh.ParsePrivateKey(pemBytes)
+	require.NoError(t, err)
+
+	failedPrompt := fakePrompt{err: errors.New("prompt failed intentionally")}
+
+	tests := []struct {
+		name        string
+		mfaRequired proto.MFARequired
+		agent       *LocalKeyAgent
+		params      ReissueParams
+		prompt      fakePrompt
+		assertion   func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error)
+	}{
+		{
+			name:        "ssh no mfa",
+			mfaRequired: proto.MFARequired_MFA_REQUIRED_NO,
+			params:      ReissueParams{NodeName: "test"},
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_NO, mfaRequired)
+			},
+		},
+		{
+			name:        "ssh mfa success",
+			mfaRequired: proto.MFARequired_MFA_REQUIRED_YES,
+			params:      ReissueParams{NodeName: "test"},
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, mfaRequired)
+			},
+		},
+		{
+			name:        "ssh mfa fail",
+			mfaRequired: proto.MFARequired_MFA_REQUIRED_YES,
+			params:      ReissueParams{NodeName: "test"},
+			prompt:      failedPrompt,
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.Error(t, err)
+				require.Nil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, mfaRequired)
+			},
+		},
+		{
+			name:        "kube no mfa",
+			mfaRequired: proto.MFARequired_MFA_REQUIRED_NO,
+			params:      ReissueParams{KubernetesCluster: "test"},
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_NO, mfaRequired)
+			},
+		},
+		{
+			name:        "kube mfa success",
+			mfaRequired: proto.MFARequired_MFA_REQUIRED_YES,
+			params:      ReissueParams{KubernetesCluster: "test"},
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, mfaRequired)
+			},
+		},
+		{
+			name:        "kube mfa fail",
+			mfaRequired: proto.MFARequired_MFA_REQUIRED_YES,
+			params:      ReissueParams{KubernetesCluster: "test"},
+			prompt:      failedPrompt,
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.Error(t, err)
+				require.Nil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, mfaRequired)
+			},
+		}, {
+			name:        "db no mfa",
+			mfaRequired: proto.MFARequired_MFA_REQUIRED_NO,
+			params: ReissueParams{
+				RouteToDatabase: proto.RouteToDatabase{
+					Username: "test",
+					Database: "test",
+				},
+			},
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_NO, mfaRequired)
+			},
+		},
+		{
+			name:        "db mfa success",
+			mfaRequired: proto.MFARequired_MFA_REQUIRED_YES,
+			params: ReissueParams{
+				RouteToDatabase: proto.RouteToDatabase{
+					Username: "test",
+					Database: "test",
+				},
+			},
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, mfaRequired)
+			},
+		},
+		{
+			name:        "db mfa fail",
+			mfaRequired: proto.MFARequired_MFA_REQUIRED_YES,
+			params: ReissueParams{
+				RouteToDatabase: proto.RouteToDatabase{
+					Username: "test",
+					Database: "test",
+				},
+			},
+			prompt: failedPrompt,
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.Error(t, err)
+				require.Nil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, mfaRequired)
+			},
+		},
+		{
+			name: "no keys loaded",
+			agent: &LocalKeyAgent{
+				clientStore: NewMemClientStore(),
+			},
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.Error(t, err)
+				require.Nil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_UNSPECIFIED, mfaRequired)
+			},
+		},
+		{
+			name:   "existing credentials used",
+			params: ReissueParams{NodeName: "test", ExistingCreds: key},
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.Error(t, err)
+				require.Nil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_UNSPECIFIED, mfaRequired)
+			},
+		},
+		{
+			name:        "mfa unknown",
+			mfaRequired: proto.MFARequired_MFA_REQUIRED_UNSPECIFIED,
+			params:      ReissueParams{NodeName: "test"},
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.Error(t, err)
+				require.Nil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_UNSPECIFIED, mfaRequired)
+			},
+		},
+		{
+			name:        "ssh leaf cluster no mfa",
+			mfaRequired: proto.MFARequired_MFA_REQUIRED_NO,
+			params: ReissueParams{
+				NodeName:       "test",
+				RouteToCluster: "leaf",
+				AuthClient: fakeAuthClient{
+					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
+						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_NO, Required: false}, nil
+					},
+				},
+			},
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_NO, mfaRequired)
+			},
+		},
+		{
+			name:        "ssh leaf cluster mfa",
+			mfaRequired: proto.MFARequired_MFA_REQUIRED_YES,
+			params: ReissueParams{
+				NodeName:       "test",
+				RouteToCluster: "leaf",
+				AuthClient: fakeAuthClient{
+					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
+						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
+					},
+				},
+			},
+			assertion: func(t *testing.T, key *Key, mfaRequired proto.MFARequired, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, key)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, mfaRequired)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			agent := agent
+			if test.agent != nil {
+				agent = test.agent
+			}
+
+			clt := &ClusterClient{
+				tc: &TeleportClient{
+					localAgent: agent,
+					Config:     Config{SiteName: "test"},
+				},
+				ProxyClient: &proxy.Client{},
+				AuthClient: fakeAuthClient{
+					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
+						switch test.mfaRequired {
+						case proto.MFARequired_MFA_REQUIRED_YES:
+							return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
+						case proto.MFARequired_MFA_REQUIRED_NO:
+							return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_NO, Required: false}, nil
+						default:
+							return nil, trace.NotImplemented("mfa unknown")
+						}
+					},
+					generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+						cert, err := ca.keygen.GenerateUserCert(services.UserCertParams{
+							CASigner:          caSigner,
+							PublicUserKey:     req.PublicKey,
+							TTL:               req.Expires.Sub(clock.Now()),
+							Username:          req.Username,
+							CertificateFormat: req.Format,
+							RouteToCluster:    req.RouteToCluster,
+						})
+						if err != nil {
+							return nil, trace.Wrap(err)
+						}
+
+						priv, err := ca.keygen.GeneratePrivateKey()
+						require.NoError(t, err)
+
+						identity := tlsca.Identity{
+							Username: req.Username,
+							Groups:   []string{"groups"},
+						}
+						subject, err := identity.Subject()
+						require.NoError(t, err)
+
+						tlsCert, err := ca.tlsCA.GenerateCertificate(tlsca.CertificateRequest{
+							Clock:     clock,
+							PublicKey: priv.Public(),
+							Subject:   subject,
+							NotAfter:  req.Expires,
+						})
+						require.NoError(t, err)
+
+						return &proto.Certs{SSH: cert, TLS: tlsCert}, nil
+					},
+				},
+				Tracer:  tracing.NoopTracer("test"),
+				cluster: "test",
+				root:    "test",
+			}
+
+			ctx := context.Background()
+
+			key, mfaRequired, err := clt.IssueUserCertsWithMFA(ctx, test.params, test.prompt)
+			test.assertion(t, key, mfaRequired, err)
+		})
+	}
+}


### PR DESCRIPTION
Updates the ClusterClient to support issuing user certificates, possibly with MFA, for all protocols. This should be the last bit of functionality required to allow Connect to convert to using the ClusterClient. Once that is done the deprecated ProxyClient should be one step closer to deletion.

Updates #38239