### PR TITLE
Add a way to configure the `RunWhileLocked.RunWhileLockedRetryInteral` for tests

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -1135,7 +1135,7 @@ type Cache interface {
 	// implicit member list and the underlying implementation does not have
 	// enough information to compute the dynamic member list.
 	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
-	// ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
+	// ListAllAccessListMembers returns a paginated list of all members of all access lists.
 	ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// GetAccessListMember returns the specified access list member resource.
 	// May return a DynamicAccessListError if the requested access list has an

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -73,38 +73,45 @@ type AccessListService struct {
 var _ services.AccessLists = (*AccessListService)(nil)
 
 // NewAccessListService creates a new AccessListService.
-func NewAccessListService(backend backend.Backend, clock clockwork.Clock) (*AccessListService, error) {
+func NewAccessListService(backend backend.Backend, clock clockwork.Clock, opts ...ServiceOption) (*AccessListService, error) {
+	var opt serviceOptions
+	for _, o := range opts {
+		o(&opt)
+	}
 	service, err := generic.NewService(&generic.ServiceConfig[*accesslist.AccessList]{
-		Backend:       backend,
-		PageLimit:     accessListMaxPageSize,
-		ResourceKind:  types.KindAccessList,
-		BackendPrefix: accessListPrefix,
-		MarshalFunc:   services.MarshalAccessList,
-		UnmarshalFunc: services.UnmarshalAccessList,
+		Backend:                     backend,
+		PageLimit:                   accessListMaxPageSize,
+		ResourceKind:                types.KindAccessList,
+		BackendPrefix:               accessListPrefix,
+		MarshalFunc:                 services.MarshalAccessList,
+		UnmarshalFunc:               services.UnmarshalAccessList,
+		RunWhileLockedRetryInterval: opt.runWhileLockedRetryInterval,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	memberService, err := generic.NewService(&generic.ServiceConfig[*accesslist.AccessListMember]{
-		Backend:       backend,
-		PageLimit:     accessListMemberMaxPageSize,
-		ResourceKind:  types.KindAccessListMember,
-		BackendPrefix: accessListMemberPrefix,
-		MarshalFunc:   services.MarshalAccessListMember,
-		UnmarshalFunc: services.UnmarshalAccessListMember,
+		Backend:                     backend,
+		PageLimit:                   accessListMemberMaxPageSize,
+		ResourceKind:                types.KindAccessListMember,
+		BackendPrefix:               accessListMemberPrefix,
+		MarshalFunc:                 services.MarshalAccessListMember,
+		UnmarshalFunc:               services.UnmarshalAccessListMember,
+		RunWhileLockedRetryInterval: opt.runWhileLockedRetryInterval,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	reviewService, err := generic.NewService(&generic.ServiceConfig[*accesslist.Review]{
-		Backend:       backend,
-		PageLimit:     accessListReviewMaxPageSize,
-		ResourceKind:  types.KindAccessListReview,
-		BackendPrefix: accessListReviewPrefix,
-		MarshalFunc:   services.MarshalAccessListReview,
-		UnmarshalFunc: services.UnmarshalAccessListReview,
+		Backend:                     backend,
+		PageLimit:                   accessListReviewMaxPageSize,
+		ResourceKind:                types.KindAccessListReview,
+		BackendPrefix:               accessListReviewPrefix,
+		MarshalFunc:                 services.MarshalAccessListReview,
+		UnmarshalFunc:               services.UnmarshalAccessListReview,
+		RunWhileLockedRetryInterval: opt.runWhileLockedRetryInterval,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -21,7 +21,6 @@ package generic
 import (
 	"context"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -54,6 +53,7 @@ type ServiceConfig[T Resource] struct {
 	UnmarshalFunc UnmarshalFunc[T]
 	// RunWhileLockedRetryInterval is the interval to retry the RunWhileLocked function.
 	// If set to 0, the default interval of 250ms will be used.
+	// WARNING: If set to a negative value, the RunWhileLocked function will retry immediately.
 	RunWhileLockedRetryInterval time.Duration
 }
 
@@ -77,10 +77,6 @@ func (c *ServiceConfig[T]) CheckAndSetDefaults() error {
 	}
 	if c.UnmarshalFunc == nil {
 		return trace.BadParameter("unmarshal func is missing")
-	}
-
-	if c.RunWhileLockedRetryInterval < 0 && !testing.Testing() {
-		return trace.BadParameter("run while locked retry interval must be greater than or equal to 0")
 	}
 
 	return nil

--- a/lib/services/local/options.go
+++ b/lib/services/local/options.go
@@ -1,0 +1,36 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package local
+
+import "time"
+
+// ServiceOption is a functional option for configuring the service.
+// TODO(tigrato): Add support for other services besides the access list service.
+type ServiceOption func(*serviceOptions)
+
+type serviceOptions struct {
+	runWhileLockedRetryInterval time.Duration
+}
+
+// WithRunWhileLockedRetryInterval sets the retry interval for the RunWhileLocked function.
+func WithRunWhileLockedRetryInterval(interval time.Duration) ServiceOption {
+	return func(o *serviceOptions) {
+		o.runWhileLockedRetryInterval = interval
+	}
+}


### PR DESCRIPTION
This PR adds a way to bypass the
`cfg.Backend.Clock().After(cfg.RetryInterval)` call within `backend.AcquireLock` when using the fake clock.

When multiple parallel calls try to acquire the same lock, `backend.AcquireLock` tries to sleep before retrying. When using the fake clock this operation isn't reliable enough when using `clock.Advance` so we are adding a way to configure it with negative values - i.e. retry immediately - for testing purposes.