### PR TITLE
Update github SSO doc to clarify incorrect guidance about org slug

### DIFF
--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -72,7 +72,7 @@ $ tctl sso configure github \
 > github.yaml
 ```
 <Admonition type="tip">
-  GitHub organizations and teams should be referred to by their slug, not display name.
+  GitHub teams should be referred to by their slug, not display name.
   To create the slug, GitHub replaces special characters in the name string, changes all words to lowercase,
   and replaces spaces with a `-` separator. For example, `My TEam Näme` would become `my-team-name`.
   You can confirm the slug in GitHub Web application URLs or via the GitHub API.

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -72,9 +72,10 @@ $ tctl sso configure github \
 > github.yaml
 ```
 <Admonition type="tip">
-  GitHub teams should be referred to by their slug, not display name.
-  To create the slug, GitHub replaces special characters in the name string, changes all words to lowercase,
+  GitHub organizations and teams should be referred to by their slug, not display name.
+  To create the team slug, GitHub replaces special characters in the name string, changes all words to lowercase,
   and replaces spaces with a `-` separator. For example, `My TEam Näme` would become `my-team-name`.
+  The organization slug is treated the same except the organization is not changed to lowercase.
   You can confirm the slug in GitHub Web application URLs or via the GitHub API.
   Example: navigate to the team `My Team` in the GitHub web application.
   The URL `https://github.com/orgs/org-name/teams/my-team`


### PR DESCRIPTION
based on multiple user feedback, the Organization slug is not lowercased and does not follow the same rules as the team slug.  If following the admonition for organisations, it will not work

~~~
  teams_to_logins:
  - logins:
    - admin organization: Teleport-Training-1 team: admin 
~~~

~~~
  "attributes": {
    "Teleport-Training-1": [ "admin", "test-caps-and-spaces" ] }, 
"cluster_name": "ip-172-31-36-239-ec2-internal", 
"code": "T1001I", 
"ei": 0, 
"event": "user.login", 
"method": "github", 
"success": true,
~~~