### PR TITLE
Remove extraneous App Session watch logic

### DIFF
--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -340,18 +340,6 @@ func (a *Server) CreateAppSession(ctx context.Context, req *proto.CreateAppSessi
 	return session, nil
 }
 
-// WaitForAppSession will block until the requested application session shows up in the
-// cache or a timeout occurs.
-func WaitForAppSession(ctx context.Context, sessionID, user string, ap ReadProxyAccessPoint) error {
-	req := waitForWebSessionReq{
-		newWatcherFn: ap.NewWatcher,
-		getSessionFn: func(ctx context.Context, sessionID string) (types.WebSession, error) {
-			return ap.GetAppSession(ctx, types.GetAppSessionRequest{SessionID: sessionID})
-		},
-	}
-	return trace.Wrap(waitForWebSession(ctx, sessionID, user, types.KindAppSession, req))
-}
-
 // WaitForSnowflakeSession waits until the requested Snowflake session shows up int the cache
 // or a timeout occurs.
 func WaitForSnowflakeSession(ctx context.Context, sessionID, user string, ap SnowflakeSessionWatcher) error {

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
@@ -36,7 +35,6 @@ import (
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -338,72 +336,6 @@ func (a *Server) CreateAppSession(ctx context.Context, req *proto.CreateAppSessi
 	log.Debugf("Generated application web session for %v with TTL %v.", req.Username, ttl)
 	UserLoginCount.Inc()
 	return session, nil
-}
-
-// WaitForSnowflakeSession waits until the requested Snowflake session shows up int the cache
-// or a timeout occurs.
-func WaitForSnowflakeSession(ctx context.Context, sessionID, user string, ap SnowflakeSessionWatcher) error {
-	req := waitForWebSessionReq{
-		newWatcherFn: ap.NewWatcher,
-		getSessionFn: func(ctx context.Context, sessionID string) (types.WebSession, error) {
-			return ap.GetSnowflakeSession(ctx, types.GetSnowflakeSessionRequest{SessionID: sessionID})
-		},
-	}
-	return trace.Wrap(waitForWebSession(ctx, sessionID, user, types.KindSnowflakeSession, req))
-}
-
-// waitForWebSessionReq is a request to wait for web session to be populated in the application cache.
-type waitForWebSessionReq struct {
-	// newWatcherFn is a function that returns new event watcher.
-	newWatcherFn func(ctx context.Context, watch types.Watch) (types.Watcher, error)
-	// getSessionFn is a function that returns web session by given ID.
-	getSessionFn func(ctx context.Context, sessionID string) (types.WebSession, error)
-}
-
-// waitForWebSession is an implementation for web session wait functions.
-func waitForWebSession(ctx context.Context, sessionID, user string, evenSubKind string, req waitForWebSessionReq) error {
-	_, err := req.getSessionFn(ctx, sessionID)
-	if err == nil {
-		return nil
-	}
-	logger := log.WithField("session", sessionID)
-	if !trace.IsNotFound(err) {
-		logger.WithError(err).Debug("Failed to query web session.")
-	}
-	// Establish a watch on application session.
-	watcher, err := req.newWatcherFn(ctx, types.Watch{
-		Name: teleport.ComponentAppProxy,
-		Kinds: []types.WatchKind{
-			{
-				Kind:    types.KindWebSession,
-				SubKind: evenSubKind,
-				Filter:  (&types.WebSessionFilter{User: user}).IntoMap(),
-			},
-		},
-		MetricComponent: teleport.ComponentAppProxy,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer watcher.Close()
-	matchEvent := func(event types.Event) (types.Resource, error) {
-		if event.Type == types.OpPut &&
-			event.Resource.GetKind() == types.KindWebSession &&
-			event.Resource.GetSubKind() == evenSubKind &&
-			event.Resource.GetName() == sessionID {
-			return event.Resource, nil
-		}
-		return nil, trace.CompareFailed("no match")
-	}
-	_, err = local.WaitForEvent(ctx, watcher, local.EventMatcherFunc(matchEvent), clockwork.NewRealClock())
-	if err != nil {
-		logger.WithError(err).Warn("Failed to wait for web session.")
-		// See again if we maybe missed the event but the session was actually created.
-		if _, err := req.getSessionFn(ctx, sessionID); err == nil {
-			return nil
-		}
-	}
-	return trace.Wrap(err)
 }
 
 // generateAppToken generates an JWT token that will be passed along with every

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -2380,7 +2380,7 @@ func (c *Cache) GetAppSession(ctx context.Context, req types.GetAppSessionReques
 		// fallback is sane because method is never used
 		// in construction of derivative caches.
 		if sess, err := c.Config.AppSession.GetAppSession(ctx, req); err == nil {
-			c.Logger.Warnf("Cache was forced to load session %v/%v from upstream. Frequent occurrence may indicate sync/perf issues.", sess.GetSubKind(), sess.GetName())
+			c.Logger.Debugf("Cache was forced to load session %v/%v from upstream.", sess.GetSubKind(), sess.GetName())
 			return sess, nil
 		}
 	}
@@ -2419,7 +2419,7 @@ func (c *Cache) GetSnowflakeSession(ctx context.Context, req types.GetSnowflakeS
 		// fallback is sane because method is never used
 		// in construction of derivative caches.
 		if sess, err := c.Config.SnowflakeSession.GetSnowflakeSession(ctx, req); err == nil {
-			c.Logger.Warnf("Cache was forced to load session %v/%v from upstream. Frequent occurrence may indicate sync/perf issues.", sess.GetSubKind(), sess.GetName())
+			c.Logger.Debugf("Cache was forced to load session %v/%v from upstream.", sess.GetSubKind(), sess.GetName())
 			return sess, nil
 		}
 	}
@@ -2445,7 +2445,7 @@ func (c *Cache) GetSAMLIdPSession(ctx context.Context, req types.GetSAMLIdPSessi
 		// fallback is sane because method is never used
 		// in construction of derivative caches.
 		if sess, err := c.Config.SAMLIdPSession.GetSAMLIdPSession(ctx, req); err == nil {
-			c.Logger.Warnf("Cache was forced to load session %v/%v from upstream. Frequent occurrence may indicate sync/perf issues.", sess.GetSubKind(), sess.GetName())
+			c.Logger.Debugf("Cache was forced to load session %v/%v from upstream.", sess.GetSubKind(), sess.GetName())
 			return sess, nil
 		}
 	}
@@ -2511,7 +2511,7 @@ func (c *Cache) GetWebSession(ctx context.Context, req types.GetWebSessionReques
 		// fallback is sane because method is never used
 		// in construction of derivative caches.
 		if sess, err := c.Config.WebSession.Get(ctx, req); err == nil {
-			c.Logger.Warnf("Cache was forced to load session %v/%v from upstream. Frequent occurrence may indicate sync/perf issues.", sess.GetSubKind(), sess.GetName())
+			c.Logger.Debugf("Cache was forced to load session %v/%v from upstream.", sess.GetSubKind(), sess.GetName())
 			return sess, nil
 		}
 	}

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2528,10 +2528,6 @@ func (tc *TeleportClient) CreateAppSession(ctx context.Context, req *proto.Creat
 		return nil, trace.Wrap(err)
 	}
 
-	err = auth.WaitForAppSession(ctx, ws.GetName(), ws.GetUser(), rootAuthClient)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	return ws, nil
 }
 

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -803,10 +803,6 @@ func (proxy *ProxyClient) CreateAppSession(ctx context.Context, req *proto.Creat
 	}
 	defer accessPoint.Close()
 
-	err = auth.WaitForAppSession(ctx, ws.GetName(), ws.GetUser(), accessPoint)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	return ws, nil
 }
 

--- a/lib/srv/db/snowflake/engine.go
+++ b/lib/srv/db/snowflake/engine.go
@@ -38,7 +38,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/role"
@@ -563,11 +562,6 @@ func (e *Engine) getSnowflakeToken(ctx context.Context, sessionToken string) (st
 	snowflakeToken := e.tokens.getToken(sessionToken)
 	if snowflakeToken != "" {
 		return snowflakeToken, nil
-	}
-
-	// Fetch the token from the auth server if not found in the local cache.
-	if err := auth.WaitForSnowflakeSession(ctx, sessionToken, e.sessionCtx.Identity.Username, e.AuthClient); err != nil {
-		return "", trace.Wrap(err)
 	}
 
 	snowflakeSession, err := e.AuthClient.GetSnowflakeSession(ctx, types.GetSnowflakeSessionRequest{SessionID: sessionToken})

--- a/lib/tbot/service_outputs.go
+++ b/lib/tbot/service_outputs.go
@@ -448,11 +448,6 @@ func (s *outputsService) getRouteToApp(ctx context.Context, botIdentity *identit
 		return proto.RouteToApp{}, trace.Wrap(err)
 	}
 
-	err = auth.WaitForAppSession(ctx, ws.GetName(), ws.GetUser(), client)
-	if err != nil {
-		return proto.RouteToApp{}, trace.Wrap(err)
-	}
-
 	return proto.RouteToApp{
 		Name:        app.GetName(),
 		SessionID:   ws.GetName(),

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -34,7 +34,6 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
-	"github.com/gravitational/teleport/lib/auth"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
@@ -254,14 +253,6 @@ func (h *Handler) createAppSession(w http.ResponseWriter, r *http.Request, p htt
 		return nil, trace.Wrap(err)
 	}
 
-	// Block and wait a few seconds for the session that was created to show up
-	// in the cache. If this request is not blocked here, it can get stuck in a
-	// racy session creation loop.
-	err = h.waitForAppSession(r.Context(), ws.GetName(), ctx.GetUser())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	// Extract the identity of the user.
 	certificate, err := tlsca.ParseCertificatePEM(ws.GetTLSCert())
 	if err != nil {
@@ -313,12 +304,6 @@ func (h *Handler) createAppSession(w http.ResponseWriter, r *http.Request, p htt
 		SubjectCookieValue: ws.GetBearerToken(),
 		FQDN:               result.FQDN,
 	}, nil
-}
-
-// waitForAppSession will block until the requested application session shows up in the
-// cache or a timeout occurs.
-func (h *Handler) waitForAppSession(ctx context.Context, sessionID, user string) error {
-	return auth.WaitForAppSession(ctx, sessionID, user, h.cfg.AccessPoint)
 }
 
 type ResolveAppParams struct {


### PR DESCRIPTION
Changelog: Improve efficiency of App Access session creation

This PR removes extraneous App Session and Snowflake Session client-side watcher logic.

In the original App Access implementation, it was possible for an App session to be created without it propagating to the Proxy's cache before the user attempted to use it. This race condition was handled with an Auth client watcher immediately after calling `CreateAppSession`. IIUC, the logic here was that if the app session propagated to the client watcher, it should have propagated to the proxy cache shortly before, thus avoiding the race condition.

This racy condition is no longer possible with the introduction of the [cache fallback mechanism for web session](https://github.com/gravitational/teleport/pull/36364) in v15. The Proxy will simply check Auth itself if it doesn't find the web session in the cache.

In fact, in v15 this watcher wasn't even doing anything since the `GetAppSession` call at the start of `WaitForAppSession` would immediately fall back to the auth cache, and then the auth backend. 

Note: as the above fix wasn't added until v15, this change will not be backported to avoid compatibility issues with old Proxy and Snowflake DB services.