### PR TITLE
chore: Bump golangci-lint to v1.57.2

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.22.1
-GOLANGCI_LINT_VERSION ?= v1.57.1
+GOLANGCI_LINT_VERSION ?= v1.57.2
 
 NODE_VERSION ?= 20.11.1
 

--- a/lib/srv/desktop/rdp/rdpclient/client_nop.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_nop.go
@@ -36,8 +36,9 @@ type Client struct {
 }
 
 // New creates and connects a new Client based on opts.
+//
+//nolint:staticcheck // SA4023. False positive, depends on build tags.
 func New(cfg Config) (*Client, error) {
-	//nolint:staticcheck // SA4023. False positive, depends on build tags.
 	return nil, errors.New("the real rdpclient.Client implementation was not included in this build")
 }
 


### PR DESCRIPTION
Update to the latest release.

* https://github.com/golangci/golangci-lint/releases/tag/v1.57.2
