### PR TITLE
[v13] Use dbcmd.WithPrintFormat only for preview of teleterm gateway command

### DIFF
--- a/gen/proto/go/teleport/lib/teleterm/v1/gateway.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/gateway.pb.go
@@ -168,8 +168,9 @@ func (x *Gateway) GetGatewayCliCommand() *GatewayCLICommand {
 	return nil
 }
 
-// GatewayCLICommand represents a command that the user can execute to connect to the gateway
-// resource. It is a direct translation of os.exec.Cmd.
+// GatewayCLICommand represents a command that the user can execute to connect to a gateway
+// resource. It is a combination of two different os/exec.Cmd structs, where path, args and env are
+// directly taken from one Cmd and the preview field is constructed from another Cmd.
 type GatewayCLICommand struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -179,10 +180,16 @@ type GatewayCLICommand struct {
 	Args []string `protobuf:"bytes,2,rep,name=args,proto3" json:"args,omitempty"`
 	Env  []string `protobuf:"bytes,3,rep,name=env,proto3" json:"env,omitempty"`
 	// preview is used to show the user what command will be executed before they decide to run it.
-	// It's like os.exec.Cmd.String with two exceptions:
+	// It can also be copied and then pasted into a terminal.
+	// It's like os/exec.Cmd.String with two exceptions:
 	//
 	// 1) It is prepended with Cmd.Env.
 	// 2) The command name is relative and not absolute.
+	// 3) It is taken from a different Cmd than the other fields in this message. This Cmd uses a
+	// special print format which makes the args suitable to be entered into a terminal, but not to
+	// directly spawn a process.
+	//
+	// Should not be used to execute the command in the shell. Instead, use path, args, and env.
 	Preview string `protobuf:"bytes,4,opt,name=preview,proto3" json:"preview,omitempty"`
 }
 

--- a/lib/client/db/dbcmd/dbcmd.go
+++ b/lib/client/db/dbcmd/dbcmd.go
@@ -855,7 +855,7 @@ func WithPassword(pass string) ConnectCommandFunc {
 // WithPrintFormat is known to be used for the following situations:
 // - tsh db config --format cmd <database>
 // - tsh proxy db --tunnel <database>
-// - Teleport Connect where the command is put into a terminal.
+// - Teleport Connect where the gateway command is shown in the UI.
 //
 // WithPrintFormat should NOT be used when the exec.Cmd gets executed by the
 // client application.

--- a/lib/client/db/dbcmd/dbcmd_test.go
+++ b/lib/client/db/dbcmd/dbcmd_test.go
@@ -570,6 +570,8 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			cmd:          nil,
 			wantErr:      true,
 		},
+		// If you find yourself changing this test so that generating a command for DynamoDB _doesn't_
+		// fail if WithPrintFormat() is not provided, please remember to update lib/teleterm/cmd/db.go.
 		{
 			name:         "dynamodb for exec is an error",
 			dbProtocol:   defaults.ProtocolDynamoDB,

--- a/lib/teleterm/cmd/cmds/cmds.go
+++ b/lib/teleterm/cmd/cmds/cmds.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmds
 
 import (
@@ -30,4 +31,3 @@ type Cmds struct {
 	// properly when the user copies and then pastes it into a terminal.
 	Preview *exec.Cmd
 }
-

--- a/lib/teleterm/cmd/cmds/cmds.go
+++ b/lib/teleterm/cmd/cmds/cmds.go
@@ -1,0 +1,33 @@
+// Copyright 2024 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmds
+
+import (
+	"os/exec"
+)
+
+// Cmds represents a single command in two variants – one that can be used to spawn a process and
+// one that can be copied and pasted into a terminal.
+//
+// Defined in a separate package to avoid cyclic imports. CLI commands got refactored in v15+ anyway.
+type Cmds struct {
+	// Exec is the command that should be used when directly executing a command for the given
+	// gateway.
+	Exec *exec.Cmd
+	// Preview is the command that should be used to display the command in the UI. Typically this
+	// means that Preview includes quotes around special characters, so that the command gets executed
+	// properly when the user copies and then pastes it into a terminal.
+	Preview *exec.Cmd
+}
+

--- a/lib/teleterm/gateway/gateway.go
+++ b/lib/teleterm/gateway/gateway.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -32,6 +31,7 @@ import (
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	alpn "github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
+	"github.com/gravitational/teleport/lib/teleterm/cmd/cmds"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -218,21 +218,21 @@ func (g *Gateway) LocalPortInt() int {
 
 // CLICommand returns a command which launches a CLI client pointed at the gateway.
 func (g *Gateway) CLICommand() (*api.GatewayCLICommand, error) {
-	cmd, err := g.cfg.CLICommandProvider.GetCommand(g)
+	cmds, err := g.cfg.CLICommandProvider.GetCommand(g)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	cmdString := strings.TrimSpace(
+	preview := strings.TrimSpace(
 		fmt.Sprintf("%s %s",
-			strings.Join(cmd.Env, " "),
-			strings.Join(cmd.Args, " ")))
+			strings.Join(cmds.Preview.Env, " "),
+			strings.Join(cmds.Preview.Args, " ")))
 
 	return &api.GatewayCLICommand{
-		Path:    cmd.Path,
-		Args:    cmd.Args,
-		Env:     cmd.Env,
-		Preview: cmdString,
+		Path:    cmds.Exec.Path,
+		Args:    cmds.Exec.Args,
+		Env:     cmds.Exec.Env,
+		Preview: preview,
 	}, nil
 }
 
@@ -300,7 +300,7 @@ type Gateway struct {
 
 // CLICommandProvider provides a CLI command for gateways which support CLI clients.
 type CLICommandProvider interface {
-	GetCommand(gateway *Gateway) (*exec.Cmd, error)
+	GetCommand(gateway *Gateway) (cmds.Cmds, error)
 }
 
 type TCPPortAllocator interface {

--- a/lib/teleterm/gateway/gateway_test.go
+++ b/lib/teleterm/gateway/gateway_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
+	"github.com/gravitational/teleport/lib/teleterm/cmd/cmds"
 	"github.com/gravitational/teleport/lib/teleterm/gatewaytest"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -148,10 +149,10 @@ func TestNewWithLocalPortReturnsErrorIfNewPortEqualsOldPort(t *testing.T) {
 
 type mockCLICommandProvider struct{}
 
-func (m mockCLICommandProvider) GetCommand(gateway *Gateway) (*exec.Cmd, error) {
+func (m mockCLICommandProvider) GetCommand(gateway *Gateway) (cmds.Cmds, error) {
 	absPath, err := filepath.Abs(gateway.Protocol())
 	if err != nil {
-		return nil, err
+		return cmds.Cmds{}, err
 	}
 	arg := fmt.Sprintf("%s/%s", gateway.TargetName(), gateway.TargetSubresourceName())
 	// Call exec.Command with a relative path so that cmd.Args[0] is a relative path.
@@ -164,7 +165,7 @@ func (m mockCLICommandProvider) GetCommand(gateway *Gateway) (*exec.Cmd, error) 
 	cmd := exec.Command(gateway.Protocol(), arg)
 	cmd.Path = absPath
 	cmd.Env = []string{"FOO=bar"}
-	return cmd, nil
+	return cmds.Cmds{Exec: cmd, Preview: cmd}, nil
 }
 
 func createAndServeGateway(t *testing.T, tcpPortAllocator TCPPortAllocator) *Gateway {

--- a/proto/teleport/lib/teleterm/v1/gateway.proto
+++ b/proto/teleport/lib/teleterm/v1/gateway.proto
@@ -55,16 +55,23 @@ message Gateway {
   GatewayCLICommand gateway_cli_command = 10;
 }
 
-// GatewayCLICommand represents a command that the user can execute to connect to the gateway
-// resource. It is a direct translation of os.exec.Cmd.
+// GatewayCLICommand represents a command that the user can execute to connect to a gateway
+// resource. It is a combination of two different os/exec.Cmd structs, where path, args and env are
+// directly taken from one Cmd and the preview field is constructed from another Cmd.
 message GatewayCLICommand {
   string path = 1;
   repeated string args = 2;
   repeated string env = 3;
   // preview is used to show the user what command will be executed before they decide to run it.
-  // It's like os.exec.Cmd.String with two exceptions:
+  // It can also be copied and then pasted into a terminal.
+  // It's like os/exec.Cmd.String with two exceptions:
   //
   // 1) It is prepended with Cmd.Env.
   // 2) The command name is relative and not absolute.
+  // 3) It is taken from a different Cmd than the other fields in this message. This Cmd uses a
+  // special print format which makes the args suitable to be entered into a terminal, but not to
+  // directly spawn a process.
+  //
+  // Should not be used to execute the command in the shell. Instead, use path, args, and env.
   string preview = 4;
 }


### PR DESCRIPTION
Backport #39906

changelog: Fixed "Invalid URI" error in Teleport Connect when starting mongosh from database connection tab

v15+ includes a lot refactors done around lib/teleterm's gateways, so I had to make a few adjustments. On top of that, v13 doesn't support kube proxies.