### PR TITLE
Introduce role friendly name labels and frontend utilities.

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -974,6 +974,9 @@ const (
 	// OktaGroupDescriptionLabel is the individual group description label.
 	OktaGroupDescriptionLabel = TeleportInternalLabelPrefix + "okta-group-description"
 
+	// OktaRoleNameLabel is the human readable name for a role sourced from Okta.
+	OktaRoleNameLabel = TeleportInternalLabelPrefix + "okta-role-name"
+
 	// PluginGenerationLabel is the label for the current generation of the plugin.
 	PluginGenerationLabel = TeleportInternalLabelPrefix + "plugin-generation"
 )

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -692,6 +692,8 @@ func FriendlyName(resource ResourceWithLabels) string {
 			return appName
 		} else if groupName, ok := resource.GetLabel(OktaGroupNameLabel); ok {
 			return groupName
+		} else if roleName, ok := resource.GetLabel(OktaRoleNameLabel); ok {
+			return roleName
 		}
 		return resource.GetMetadata().Description
 	}

--- a/api/types/resource_test.go
+++ b/api/types/resource_test.go
@@ -528,6 +528,15 @@ func TestFriendlyName(t *testing.T) {
 		return group
 	}
 
+	newRole := func(t *testing.T, name string, labels map[string]string) Role {
+		role, err := NewRole(name, RoleSpecV6{})
+		require.NoError(t, err)
+		metadata := role.GetMetadata()
+		metadata.Labels = labels
+		role.SetMetadata(metadata)
+		return role
+	}
+
 	node, err := NewServer("node", KindNode, ServerSpecV2{
 		Hostname: "friendly hostname",
 	})
@@ -570,6 +579,14 @@ func TestFriendlyName(t *testing.T) {
 			resource: newGroup(t, "friendly", "friendly name", map[string]string{
 				OriginLabel:        OriginOkta,
 				OktaGroupNameLabel: "label friendly name",
+			}),
+			expected: "label friendly name",
+		},
+		{
+			name: "friendly role name (uses label)",
+			resource: newRole(t, "friendly", map[string]string{
+				OriginLabel:       OriginOkta,
+				OktaRoleNameLabel: "label friendly name",
 			}),
 			expected: "label friendly name",
 		},

--- a/web/packages/teleport/src/lib/util.ts
+++ b/web/packages/teleport/src/lib/util.ts
@@ -93,39 +93,3 @@ export function compareByString(a: string, b: string) {
   }
   return 0;
 }
-
-// sortRolesAndFriendlyNames supports roles and their friendly names
-// in the same order.
-export function sortRolesAndFriendlyNames(
-  roles: string[],
-  friendlyNames: string[]
-) {
-  if (roles.length != friendlyNames.length) {
-    let sortedRoles = roles.sort();
-    // If the lengths don't match, we'll just return the regular roles as both.
-    return { roles: sortedRoles, friendlyNames: sortedRoles };
-  }
-
-  let rolesAndFriendlyNames = [];
-  for (let i = 0; i < roles.length; i++) {
-    rolesAndFriendlyNames.push({
-      role: roles[i],
-      friendlyName: friendlyNames[i],
-    });
-  }
-
-  rolesAndFriendlyNames.sort(function (item1, item2) {
-    if (item1.friendlyName < item2.friendlyName) {
-      return -1;
-    }
-    if (item1.friendlyName == item2.friendlyName) {
-      return 0;
-    }
-    return 1;
-  });
-
-  return {
-    roles: rolesAndFriendlyNames.map(r => r.role),
-    friendlyNames: rolesAndFriendlyNames.map(r => r.friendlyName),
-  };
-}

--- a/web/packages/teleport/src/lib/util.ts
+++ b/web/packages/teleport/src/lib/util.ts
@@ -93,3 +93,39 @@ export function compareByString(a: string, b: string) {
   }
   return 0;
 }
+
+// sortRolesAndFriendlyNames supports roles and their friendly names
+// in the same order.
+export function sortRolesAndFriendlyNames(
+  roles: string[],
+  friendlyNames: string[]
+) {
+  if (roles.length != friendlyNames.length) {
+    let sortedRoles = roles.sort();
+    // If the lengths don't match, we'll just return the regular roles as both.
+    return { roles: sortedRoles, friendlyNames: sortedRoles };
+  }
+
+  let rolesAndFriendlyNames = [];
+  for (let i = 0; i < roles.length; i++) {
+    rolesAndFriendlyNames.push({
+      role: roles[i],
+      friendlyName: friendlyNames[i],
+    });
+  }
+
+  rolesAndFriendlyNames.sort(function (item1, item2) {
+    if (item1.friendlyName < item2.friendlyName) {
+      return -1;
+    }
+    if (item1.friendlyName == item2.friendlyName) {
+      return 0;
+    }
+    return 1;
+  });
+
+  return {
+    roles: rolesAndFriendlyNames.map(r => r.role),
+    friendlyNames: rolesAndFriendlyNames.map(r => r.friendlyName),
+  };
+}


### PR DESCRIPTION
Role friendly name labels and frontend utilities have been introduced.

changelog: Introduce friendly role names for Okta sourced roles. These will be displayed in access list and access request pages in the UI.