### PR TITLE
Support Azure CLI Access on AKS with workload identity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -653,6 +653,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNL
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2/go.mod h1:FbdwsQ2EzwvXxOPcMFYO8ogEc9uMMIj3YkmCdXdAFmk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0 h1:z4YeiSXxnUI+PqB46Yj6MZA3nwb1CcJIkEMDrzUd8Cs=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0/go.mod h1:rko9SzMxcMk0NJsNAxALEGaTYyy79bNRwxgJfrH0Spw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0 h1:dhywcZH9yPDIje9aTqwy6psZSPzI6CJLYEprDahIBSQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0/go.mod h1:6z3b+JdBLH0eMzfBex/cvEIoEFVEwXuB0wbgdfN11iM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0 h1:3jDMffAwnvs6qmOqhjNVHB29AKxs6brnzJeo65E1YwM=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v1.2.0 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -624,6 +624,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNL
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2/go.mod h1:FbdwsQ2EzwvXxOPcMFYO8ogEc9uMMIj3YkmCdXdAFmk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0 h1:z4YeiSXxnUI+PqB46Yj6MZA3nwb1CcJIkEMDrzUd8Cs=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0/go.mod h1:rko9SzMxcMk0NJsNAxALEGaTYyy79bNRwxgJfrH0Spw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0 h1:dhywcZH9yPDIje9aTqwy6psZSPzI6CJLYEprDahIBSQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0/go.mod h1:6z3b+JdBLH0eMzfBex/cvEIoEFVEwXuB0wbgdfN11iM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0 h1:3jDMffAwnvs6qmOqhjNVHB29AKxs6brnzJeo65E1YwM=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v1.2.0 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -631,6 +631,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNL
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2/go.mod h1:FbdwsQ2EzwvXxOPcMFYO8ogEc9uMMIj3YkmCdXdAFmk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0 h1:z4YeiSXxnUI+PqB46Yj6MZA3nwb1CcJIkEMDrzUd8Cs=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0/go.mod h1:rko9SzMxcMk0NJsNAxALEGaTYyy79bNRwxgJfrH0Spw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0 h1:dhywcZH9yPDIje9aTqwy6psZSPzI6CJLYEprDahIBSQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0/go.mod h1:6z3b+JdBLH0eMzfBex/cvEIoEFVEwXuB0wbgdfN11iM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0 h1:3jDMffAwnvs6qmOqhjNVHB29AKxs6brnzJeo65E1YwM=

--- a/lib/cloud/azure/mocks.go
+++ b/lib/cloud/azure/mocks.go
@@ -20,12 +20,15 @@ package azure
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql"
@@ -663,4 +666,49 @@ func (m *ARMPostgresFlexServerMock) NewListByResourceGroupPager(group string, _ 
 			},
 		}, nil
 	})
+}
+
+type ARMUserAssignedIdentitiesMock struct {
+	identitiesMap map[string]armmsi.Identity
+}
+
+func NewARMUserAssignedIdentitiesMock(identities ...armmsi.Identity) *ARMUserAssignedIdentitiesMock {
+	identitiesMap := make(map[string]armmsi.Identity)
+	for _, identity := range identities {
+		id, err := arm.ParseResourceID(*identity.ID)
+		if err == nil {
+			identitiesMap[id.ResourceGroupName+"+"+id.Name] = identity
+		} else {
+			slog.With("error", err).Warn("Failed to add identity to mock.")
+		}
+	}
+	return &ARMUserAssignedIdentitiesMock{
+		identitiesMap: identitiesMap,
+	}
+}
+
+func (m *ARMUserAssignedIdentitiesMock) Get(ctx context.Context, resourceGroupName, resourceName string, options *armmsi.UserAssignedIdentitiesClientGetOptions) (armmsi.UserAssignedIdentitiesClientGetResponse, error) {
+	if m.identitiesMap == nil {
+		return armmsi.UserAssignedIdentitiesClientGetResponse{}, trace.AccessDenied("access denied")
+	}
+
+	identity, found := m.identitiesMap[resourceGroupName+"+"+resourceName]
+	if !found {
+		return armmsi.UserAssignedIdentitiesClientGetResponse{}, trace.NotFound("%s of group %s not found", resourceName, resourceGroupName)
+	}
+	return armmsi.UserAssignedIdentitiesClientGetResponse{
+		Identity: identity,
+	}, nil
+}
+
+// NewUserAssignedIdentity creates an armmsi.Identity.
+func NewUserAssignedIdentity(subscription, resourceGroupName, resourceName, clientID string) armmsi.Identity {
+	id := fmt.Sprintf("/subscriptions/%s/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", subscription, resourceGroupName, resourceName)
+	return armmsi.Identity{
+		ID:   &id,
+		Name: &resourceName,
+		Properties: &armmsi.UserAssignedIdentityProperties{
+			ClientID: &clientID,
+		},
+	}
 }

--- a/lib/cloud/azure/mocks.go
+++ b/lib/cloud/azure/mocks.go
@@ -679,7 +679,7 @@ func NewARMUserAssignedIdentitiesMock(identities ...armmsi.Identity) *ARMUserAss
 		if err == nil {
 			identitiesMap[id.ResourceGroupName+"+"+id.Name] = identity
 		} else {
-			slog.With("error", err).Warn("Failed to add identity to mock.")
+			slog.With("error", err).WarnContext(context.Background(), "Failed to add identity to mock.")
 		}
 	}
 	return &ARMUserAssignedIdentitiesMock{

--- a/lib/cloud/azure/mocks.go
+++ b/lib/cloud/azure/mocks.go
@@ -668,10 +668,12 @@ func (m *ARMPostgresFlexServerMock) NewListByResourceGroupPager(group string, _ 
 	})
 }
 
+// ARMUserAssignedIdentitiesMock implements ARMUserAssignedIdentities.
 type ARMUserAssignedIdentitiesMock struct {
 	identitiesMap map[string]armmsi.Identity
 }
 
+// NewARMUserAssignedIdentitiesMock creates a new ARMUserAssignedIdentitiesMock.
 func NewARMUserAssignedIdentitiesMock(identities ...armmsi.Identity) *ARMUserAssignedIdentitiesMock {
 	identitiesMap := make(map[string]armmsi.Identity)
 	for _, identity := range identities {
@@ -688,7 +690,7 @@ func NewARMUserAssignedIdentitiesMock(identities ...armmsi.Identity) *ARMUserAss
 }
 
 func (m *ARMUserAssignedIdentitiesMock) Get(ctx context.Context, resourceGroupName, resourceName string, options *armmsi.UserAssignedIdentitiesClientGetOptions) (armmsi.UserAssignedIdentitiesClientGetResponse, error) {
-	if m.identitiesMap == nil {
+	if m == nil || m.identitiesMap == nil {
 		return armmsi.UserAssignedIdentitiesClientGetResponse{}, trace.AccessDenied("access denied")
 	}
 

--- a/lib/cloud/azure/user_identities.go
+++ b/lib/cloud/azure/user_identities.go
@@ -1,0 +1,71 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package azure
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
+	"github.com/gravitational/trace"
+)
+
+// ARMUserAssignedIdentities provides an interface for armmsi.UserAssignedIdentitiesClient
+type ARMUserAssignedIdentities interface {
+	Get(ctx context.Context, resourceGroupName, resourceName string, options *armmsi.UserAssignedIdentitiesClientGetOptions) (armmsi.UserAssignedIdentitiesClientGetResponse, error)
+}
+
+// UserAssignedIdentitiesClient wraps the armmsi.UserAssignedIdentitiesClient to fetch
+// identity info.
+type UserAssignedIdentitiesClient struct {
+	api ARMUserAssignedIdentities
+}
+
+// NewUserAssignedIdentitiesClient creates a new UserAssignedIdentitiesClient
+// by subscription and credential.
+func NewUserAssignedIdentitiesClient(subscription string, cred azcore.TokenCredential, options *arm.ClientOptions) (*UserAssignedIdentitiesClient, error) {
+	api, err := armmsi.NewUserAssignedIdentitiesClient(subscription, cred, options)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return NewUserAssignedIdentitiesClientByAPI(api), nil
+}
+
+// NewUserAssignedIdentitiesClientByAPI creates a new
+// UserAssignedIdentitiesClient by ARMUserAssignedIdentities interface.
+func NewUserAssignedIdentitiesClientByAPI(api ARMUserAssignedIdentities) *UserAssignedIdentitiesClient {
+	return &UserAssignedIdentitiesClient{
+		api: api,
+	}
+}
+
+// GetClientID returns the client ID for the provided identity.
+func (c *UserAssignedIdentitiesClient) GetClientID(ctx context.Context, resourceGroupName, resourceName string) (string, error) {
+	identity, err := c.api.Get(ctx, resourceGroupName, resourceName, nil)
+	if err != nil {
+		return "", trace.Wrap(ConvertResponseError(err))
+	}
+
+	if identity.Properties == nil || identity.Properties.ClientID == nil {
+		return "", trace.BadParameter("cannot find ClientID from identity %s", resourceName)
+	}
+
+	return *identity.Properties.ClientID, nil
+}

--- a/lib/cloud/azure/user_identities.go
+++ b/lib/cloud/azure/user_identities.go
@@ -27,7 +27,8 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// ARMUserAssignedIdentities provides an interface for armmsi.UserAssignedIdentitiesClient
+// ARMUserAssignedIdentities provides an interface for
+// armmsi.UserAssignedIdentitiesClient.
 type ARMUserAssignedIdentities interface {
 	Get(ctx context.Context, resourceGroupName, resourceName string, options *armmsi.UserAssignedIdentitiesClientGetOptions) (armmsi.UserAssignedIdentitiesClientGetResponse, error)
 }

--- a/lib/cloud/azure/user_identities_test.go
+++ b/lib/cloud/azure/user_identities_test.go
@@ -1,0 +1,67 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package azure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserAssignedIdentitiesClient(t *testing.T) {
+	t.Parallel()
+
+	bot1 := NewUserAssignedIdentity("my-sub", "my-group", "bot1", "bot1-id")
+	mockAPI := NewARMUserAssignedIdentitiesMock(bot1)
+
+	tests := []struct {
+		name                   string
+		inputResourceGroupName string
+		inputUserName          string
+		wantError              bool
+		wantClientID           string
+	}{
+		{
+			name:                   "success",
+			inputResourceGroupName: "my-group",
+			inputUserName:          "bot1",
+			wantClientID:           "bot1-id",
+		},
+		{
+			name:                   "not found",
+			inputResourceGroupName: "my-group",
+			inputUserName:          "bot5",
+			wantError:              true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := NewUserAssignedIdentitiesClientByAPI(mockAPI)
+			actualClientID, err := client.GetClientID(context.Background(), test.inputResourceGroupName, test.inputUserName)
+			if test.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.wantClientID, actualClientID)
+		})
+	}
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5480,6 +5480,7 @@ func (process *TeleportProcess) initApps() {
 			ConnectedProxyGetter: proxyGetter,
 			Emitter:              asyncEmitter,
 			ConnectionMonitor:    connMonitor,
+			Logger:               logger,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/app/azure/credential.go
+++ b/lib/srv/app/azure/credential.go
@@ -1,0 +1,190 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package azure
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/gravitational/trace"
+
+	cloudazure "github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// credentialProvider defines an interface that manages a particular type of
+// credential.
+type credentialProvider interface {
+	// MakeCredential creates an azcore.TokenCredential for provided identity.
+	MakeCredential(ctx context.Context, userRequestedIdentity string) (azcore.TokenCredential, error)
+	// MapScope maps the input scope if necessary.
+	MapScope(scope string) string
+}
+
+func getAccessTokenFromCredentialProvider(credProvider credentialProvider) getAccessTokenFunc {
+	return func(ctx context.Context, userRequestedIdentity string, scope string) (*azcore.AccessToken, error) {
+		credential, err := credProvider.MakeCredential(ctx, userRequestedIdentity)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		opts := policy.TokenRequestOptions{
+			Scopes: []string{credProvider.MapScope(scope)},
+		}
+		token, err := credential.GetToken(ctx, opts)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &token, nil
+	}
+}
+
+func findDefaultCredentialProvider(ctx context.Context) (credentialProvider, error) {
+	// Check if default workload identity is available: the clientID/tenantID
+	// for the default workload identity and the token file path are required
+	// from environment variables.
+	defaultAgentIdentity, err := azidentity.NewWorkloadIdentityCredential(nil)
+	if err == nil {
+		slog.InfoContext(ctx, "Using workload identity.")
+		credProvider, err := newWorloadIdentityCredentialProvider(ctx, defaultAgentIdentity)
+		return credProvider, trace.Wrap(err)
+	} else {
+		slog.With("error", err).DebugContext(ctx, "Failed to load worload identity.")
+	}
+
+	slog.InfoContext(ctx, "Using managed identity.")
+	return managedIdentityCredentialProvider{}, nil
+
+}
+
+// managedIdentityCredentialProvider implements credentialProvider for using
+// managed identities assigned to the host machine. Identities are usually
+// checked against the IMDS service available in local network.
+type managedIdentityCredentialProvider struct {
+}
+
+func (m managedIdentityCredentialProvider) MakeCredential(ctx context.Context, userRequestedIdentity string) (azcore.TokenCredential, error) {
+	credenial, err := azidentity.NewManagedIdentityCredential(&azidentity.ManagedIdentityCredentialOptions{
+		ID: azidentity.ResourceID(userRequestedIdentity),
+	})
+	return credenial, trace.Wrap(err)
+}
+
+func (m managedIdentityCredentialProvider) MapScope(scope string) string {
+	// No scope needs to be mapped.
+	return scope
+}
+
+// workloadIdentityCredentialProvider implements credentialProvider for using
+// workload identities assigned to host machine.
+//
+// https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview
+//
+// When running on AKS, multiple workload identities can be associated to the
+// same service account attached to the pod. Assuming a oorkload identity
+// requires a Client ID of that identity but only the default Client ID is
+// provided through environment variable. We assume that the default workload
+// identity (mapped by the default Client ID) is the app-service identity with
+// msi permissions so the client IDs for other user-requested identity can be
+// retrieved using the default idenitty.
+type workloadIdentityCredentialProvider struct {
+	cache                *utils.FnCache
+	defaultAgentIdentity azcore.TokenCredential
+
+	// newClient defaults to cloudazure.NewUserAssignedIdentitiesClient. Can be
+	// overridden for test.
+	newClient func(string, azcore.TokenCredential, *arm.ClientOptions) (*cloudazure.UserAssignedIdentitiesClient, error)
+	// newCredential defaults to newWorkloadIdentityCredentialForClientID. Can
+	// be overridden for test.
+	newCredential func(string) (azcore.TokenCredential, error)
+}
+
+func newWorloadIdentityCredentialProvider(ctx context.Context, defaultAgentIdentity azcore.TokenCredential) (*workloadIdentityCredentialProvider, error) {
+	cache, err := utils.NewFnCache(utils.FnCacheConfig{
+		Context:     ctx,
+		TTL:         clientIDCacheTTL,
+		ReloadOnErr: true,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &workloadIdentityCredentialProvider{
+		cache:                cache,
+		defaultAgentIdentity: defaultAgentIdentity,
+		newClient:            cloudazure.NewUserAssignedIdentitiesClient,
+		newCredential:        newWorkloadIdentityCredentialForClientID,
+	}, nil
+}
+
+func newWorkloadIdentityCredentialForClientID(clientID string) (azcore.TokenCredential, error) {
+	cred, err := azidentity.NewWorkloadIdentityCredential(&azidentity.WorkloadIdentityCredentialOptions{
+		ClientID: clientID,
+	})
+	return cred, trace.Wrap(err)
+}
+
+func (w *workloadIdentityCredentialProvider) MakeCredential(ctx context.Context, userRequestedIdentity string) (azcore.TokenCredential, error) {
+	clientID, err := w.getClientID(ctx, userRequestedIdentity)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	credential, err := w.newCredential(clientID)
+	return credential, trace.Wrap(err)
+}
+
+func (w *workloadIdentityCredentialProvider) MapScope(scope string) string {
+	// This scope ("https://management.core.windows.net/") from `az` CLI tool
+	// will fail for worload identity as worload identity is only expected to
+	// be used with compatible SDKs, whereas the SDK adds ".default" to the
+	// scope:
+	//
+	// https://github.com/Azure/azure-sdk-for-go/blob/9e78ee2b86f0f4989098dd7e545b73841fc8df47/sdk/azcore/arm/runtime/pipeline.go#L35
+	if scope == "https://management.core.windows.net/" {
+		return scope + ".default"
+	}
+	return scope
+}
+
+func (w *workloadIdentityCredentialProvider) getClientID(ctx context.Context, identityResourceID string) (string, error) {
+	clientID, err := utils.FnCacheGet(ctx, w.cache, identityResourceID, func(ctx context.Context) (string, error) {
+		resourceID, err := arm.ParseResourceID(identityResourceID)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		client, err := w.newClient(resourceID.SubscriptionID, w.defaultAgentIdentity, nil)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		clientID, err := client.GetClientID(ctx, resourceID.ResourceGroupName, resourceID.Name)
+		return clientID, trace.Wrap(err)
+	})
+	return clientID, trace.Wrap(err)
+}
+
+// clientIDCacheTTL defines how long client IDs should be cached. ClientID
+// should never change for an identity so use a longer cache TTL.
+var clientIDCacheTTL = 30 * time.Minute

--- a/lib/srv/app/azure/credential_test.go
+++ b/lib/srv/app/azure/credential_test.go
@@ -1,0 +1,129 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package azure
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	cloudazure "github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTokenCredential struct {
+	lastSeenScope string
+}
+
+func (f *fakeTokenCredential) GetToken(_ context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	if len(opts.Scopes) != 1 {
+		return azcore.AccessToken{}, trace.BadParameter("expect one scope but got %v", opts.Scopes)
+	}
+
+	f.lastSeenScope = opts.Scopes[0]
+	return azcore.AccessToken{
+		Token:     "fake-token",
+		ExpiresOn: time.Now().Add(time.Hour),
+	}, nil
+}
+
+type fakeCredentialProvider struct {
+	cred             fakeTokenCredential
+	lastSeenIdentity string
+}
+
+func (f *fakeCredentialProvider) MakeCredential(_ context.Context, userRequestedIdentity string) (azcore.TokenCredential, error) {
+	f.lastSeenIdentity = userRequestedIdentity
+	return &f.cred, nil
+}
+
+func (f *fakeCredentialProvider) MapScope(scope string) string {
+	return scope + ".mapped"
+}
+
+func Test_getAccessTokenFromCredentialProvider(t *testing.T) {
+	fakeCredProvider := &fakeCredentialProvider{}
+	userRequestedIdentity := "/subscriptions/my-sub/resourcegroups/my-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-name"
+	ctx := context.Background()
+
+	token, err := getAccessTokenFromCredentialProvider(fakeCredProvider)(ctx, userRequestedIdentity, "test-scope")
+	require.NoError(t, err)
+	require.Equal(t, "fake-token", token.Token)
+	require.Equal(t, userRequestedIdentity, fakeCredProvider.lastSeenIdentity)
+	require.Equal(t, "test-scope.mapped", fakeCredProvider.cred.lastSeenScope)
+}
+
+func Test_workloadIdentityCredentialProvider(t *testing.T) {
+	ctx := context.Background()
+	fakeAgentIdentity := &fakeTokenCredential{}
+	credProvider, err := newWorloadIdentityCredentialProvider(ctx, fakeAgentIdentity)
+	require.NoError(t, err)
+
+	// Hook up more mocks.
+	fakeWorkloadIdentityCredential := &fakeTokenCredential{}
+	userRequestedIdentity := cloudazure.NewUserAssignedIdentity("my-sub", "my-group", "my-name", "my-client-id")
+	mockAPI := cloudazure.NewARMUserAssignedIdentitiesMock(userRequestedIdentity)
+	credProvider.newClient = func(string, azcore.TokenCredential, *arm.ClientOptions) (*cloudazure.UserAssignedIdentitiesClient, error) {
+		return cloudazure.NewUserAssignedIdentitiesClientByAPI(mockAPI), nil
+	}
+	credProvider.newCredential = func(clientID string) (azcore.TokenCredential, error) {
+		if clientID != "my-client-id" {
+			return nil, trace.BadParameter("expect my-client-id but got %s", clientID)
+		}
+		return fakeWorkloadIdentityCredential, nil
+	}
+
+	t.Run("MakeCredential", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			actualCredential, err := credProvider.MakeCredential(ctx, *userRequestedIdentity.ID)
+			require.NoError(t, err)
+			require.Same(t, fakeWorkloadIdentityCredential, actualCredential)
+		})
+		t.Run("fail to get client ID", func(t *testing.T) {
+			notFoundIdentity := "/subscriptions/my-sub/resourcegroups/my-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/not-my-name"
+			_, err := credProvider.MakeCredential(ctx, notFoundIdentity)
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("MapScope", func(t *testing.T) {
+		tests := []struct {
+			inputScope  string
+			outputScope string
+		}{
+			{
+				inputScope:  "https://management.core.windows.net/",
+				outputScope: "https://management.core.windows.net/.default",
+			},
+			{
+				inputScope:  "some-other-scope",
+				outputScope: "some-other-scope",
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.inputScope, func(t *testing.T) {
+				require.Equal(t, test.outputScope, credProvider.MapScope(test.inputScope))
+			})
+		}
+	})
+}

--- a/lib/srv/app/azure/credential_test.go
+++ b/lib/srv/app/azure/credential_test.go
@@ -26,9 +26,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	cloudazure "github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	cloudazure "github.com/gravitational/teleport/lib/cloud/azure"
 )
 
 type fakeTokenCredential struct {


### PR DESCRIPTION
Implements #39532:
- #39532 

changelog: added Azure CLI access support on AKS with Entra Workload ID

Why:
Azure CLI app access is implemented with `azidentity.NewManagedIdentityCredential`. This works fine for regular VMs, and Azure AKS with [Entra pod identity](https://learn.microsoft.com/en-us/azure/aks/use-azure-ad-pod-identity). However, the Entra pod identity is a Preview feature that will be deprecated soon. The **Official** way to do pod-level identity on AKS is [Azure Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview). We also advertise Azure Workload Identity in our own [Azure AKS guide](https://goteleport.com/docs/deploy-a-cluster/helm-deployments/azure/#prerequisites).

How it works:
- Workload Identity requires `azidentity.NewWorkloadIdentityCredential`, plus the client ID of the Azure user-assigned identity in order to be assumed. Multiple workload identities can be assigned to the single service account assigned to the AKS pod. 
- On the Pod though, there is only one "default" client ID available to the App service. we assume the "default" client ID/assigned identity is the **app-agent** identity with `Microsoft.ManagedIdentity/userAssignedIdentities/read` permission. 
- When user sends in requests from `tsh`, the app agent makes API calls to fetch client IDs for the **user-requested** identities, then use the fetched client ID for `azidentity.NewWorkloadIdentityCredential`.

Setup:
(TODO make a proper doc change)
1. AKS
   1.  Follow [Official Workload ID guide](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster) to setup AKS, user identity, service account, OIDC mapping, etc.
   1. IMPORTANT! When following this guide, we create a new  **app-agent** identity say `teleport-azure-app-aks-agent` for "USER_ASSIGNED_IDENTITY_NAME".  Create a role for this identity with `Microsoft.ManagedIdentity/userAssignedIdentities/read` action permission, and assign it to the role. Note that the client ID for this **app-agent** will be used for service account's `azure.workload.identity/client-id`
1. Deploy Teleport App Service with an azure app (`cloud: "Azure"`) and use the service account created in the previous step for this pod in this AKS cluster. 
1. For each end-user access user assigned identities
   1. Create a user assigned identity for end-user access, say `teleport-user-reader`, and grant it relevant permissions. 
   1. Repeat the "Establish federated identity credential" from the above guide, but use the end-user identity and assign it to the same service account (e.g: `az identity federated-credential create --name federated-teleport-user-reader --identity-name teleport-user-reader --resource-group "${RESOURCE_GROUP}" --issuer "${AKS_OIDC_ISSUER}" --subject system:serviceaccount:"${SERVICE_ACCOUNT_NAMESPACE}":"${SERVICE_ACCOUNT_NAME}" --audience api://AzureADTokenExchange`)
   1. Grant this identity to the Teleport role or user traits.
1. Use `tsh apps login <azure-on-aks>` and `tsh az` as usual 

Testing
- [x] AKS
- [x] Azure VM (for existing "direct" managed identity credential)