### PR TITLE
lib/teleterm: Log ping response

### DIFF
--- a/lib/teleterm/clusters/cluster_auth.go
+++ b/lib/teleterm/clusters/cluster_auth.go
@@ -20,6 +20,7 @@ package clusters
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sort"
 
@@ -40,9 +41,15 @@ import (
 
 // SyncAuthPreference fetches Teleport auth preferences and stores it in the cluster profile
 func (c *Cluster) SyncAuthPreference(ctx context.Context) (*webclient.WebConfigAuthSettings, error) {
-	_, err := c.clusterClient.Ping(ctx)
+	pingResponse, err := c.clusterClient.Ping(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+	pingResponseJSON, err := json.Marshal(pingResponse)
+	if err != nil {
+		c.Log.WithError(err).Debugln("Could not marshal ping response to JSON")
+	} else {
+		c.Log.WithField("response", string(pingResponseJSON)).Debugln("Got ping response")
 	}
 
 	if err := c.clusterClient.SaveProfile(false); err != nil {

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -20,6 +20,7 @@ package clusters
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 
 	"github.com/gravitational/trace"
@@ -169,6 +170,15 @@ func (s *Storage) addCluster(ctx context.Context, dir, webProxyAddress string) (
 		return nil, nil, trace.Wrap(err)
 	}
 
+	clusterLog := s.Log.WithField("cluster", clusterURI)
+
+	pingResponseJSON, err := json.Marshal(pingResponse)
+	if err != nil {
+		clusterLog.WithError(err).Debugln("Could not marshal ping response to JSON")
+	} else {
+		clusterLog.WithField("response", string(pingResponseJSON)).Debugln("Got ping response")
+	}
+
 	if err := clusterClient.SaveProfile(false); err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -182,7 +192,7 @@ func (s *Storage) addCluster(ctx context.Context, dir, webProxyAddress string) (
 		clusterClient: clusterClient,
 		dir:           s.Dir,
 		clock:         s.Clock,
-		Log:           s.Log.WithField("cluster", clusterURI),
+		Log:           clusterLog,
 	}, clusterClient, nil
 }
 


### PR DESCRIPTION
Sometimes customers have clusters available only through their company network. Having access to the ping response provides a lot of value, especially early on when trying to triage an issue. Here's [a recent example](https://gravitational.slack.com/archives/C03FJA391M3/p1711706788070359) where the ping response directly impacts the saved yaml file — without knowing how exactly the ping response looks like it's hard to decipher what's going on.

This PR adds the ping response to debug logs which can be turned on by [supplying the `--connect-debug` flag to Connect](https://goteleport.com/docs/connect-your-client/teleport-connect/#submitting-an-issue).

I know about the migration to slog, I have [another PR in the works](https://github.com/gravitational/teleport/pull/39956) which migrates lib/teleterm to slog.