### PR TITLE
[v15] Clean up TypeScript types related to tsh daemon

### DIFF
--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -49,8 +49,7 @@ import { getAssetPath } from 'teleterm/mainProcess/runtimeSettings';
 import { RootClusterUri } from 'teleterm/ui/uri';
 import Logger from 'teleterm/logger';
 import * as grpcCreds from 'teleterm/services/grpcCredentials';
-import { createTshdClient } from 'teleterm/services/tshd/createClient';
-import { TshdClient } from 'teleterm/services/tshd/types';
+import { createTshdClient, TshdClient } from 'teleterm/services/tshd';
 import { loggingInterceptor } from 'teleterm/services/tshd/interceptors';
 
 import {

--- a/web/packages/teleterm/src/mainProcess/rootClusterProxyHostAllowList.ts
+++ b/web/packages/teleterm/src/mainProcess/rootClusterProxyHostAllowList.ts
@@ -21,7 +21,7 @@ import { ipcMain } from 'electron';
 import { isAbortError } from 'shared/utils/abortError';
 
 import { proxyHostToBrowserProxyHost } from 'teleterm/services/tshd/cluster';
-import { TshdClient } from 'teleterm/services/tshd/types';
+import { TshdClient } from 'teleterm/services/tshd';
 import { Logger } from 'teleterm/types';
 import { MainProcessIpc } from 'teleterm/mainProcess/types';
 import * as tshd from 'teleterm/services/tshd/types';

--- a/web/packages/teleterm/src/preload.ts
+++ b/web/packages/teleterm/src/preload.ts
@@ -18,8 +18,10 @@
 
 import { contextBridge } from 'electron';
 import { ChannelCredentials, ServerCredentials } from '@grpc/grpc-js';
+import { GrpcTransport } from '@protobuf-ts/grpc-transport';
 
 import { createTshdClient } from 'teleterm/services/tshd/createClient';
+import { loggingInterceptor } from 'teleterm/services/tshd/interceptors';
 import createMainProcessClient from 'teleterm/mainProcess/mainProcessClient';
 import { createFileLoggerService } from 'teleterm/services/logger';
 import Logger from 'teleterm/logger';
@@ -60,7 +62,12 @@ async function getElectronGlobals(): Promise<ElectronGlobals> {
     mainProcessClient.getResolvedChildProcessAddresses(),
     createGrpcCredentials(runtimeSettings),
   ]);
-  const tshClient = createTshdClient(addresses.tsh, credentials.tshd);
+  const tshdTransport = new GrpcTransport({
+    host: addresses.tsh,
+    channelCredentials: credentials.tshd,
+    interceptors: [loggingInterceptor(new Logger('tshd'))],
+  });
+  const tshClient = createTshdClient(tshdTransport);
   const ptyServiceClient = createPtyService(
     addresses.shared,
     credentials.shared,

--- a/web/packages/teleterm/src/services/tshd/createClient.ts
+++ b/web/packages/teleterm/src/services/tshd/createClient.ts
@@ -16,25 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import grpc from '@grpc/grpc-js';
 import { GrpcTransport } from '@protobuf-ts/grpc-transport';
 import { TerminalServiceClient } from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb.client';
 
-import Logger from 'teleterm/logger';
-
 import { cloneClient } from './cloneableClient';
 import * as types from './types';
-import { loggingInterceptor } from './interceptors';
 
-export function createTshdClient(
-  addr: string,
-  credentials: grpc.ChannelCredentials
-): types.TshdClient {
-  const logger = new Logger('tshd');
-  const transport = new GrpcTransport({
-    host: addr,
-    channelCredentials: credentials,
-    interceptors: [loggingInterceptor(logger)],
-  });
+export function createTshdClient(transport: GrpcTransport): types.TshdClient {
   return cloneClient(new TerminalServiceClient(transport));
 }

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -20,11 +20,11 @@ import {
   makeRootCluster,
   makeAppGateway,
 } from 'teleterm/services/tshd/testHelpers';
-import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 
-import * as types from '../types';
+import { TshdClient } from '../createClient';
+import { MockedUnaryCall } from '../cloneableClient';
 
-export class MockTshClient implements types.TshdClient {
+export class MockTshClient implements TshdClient {
   listRootClusters = () => new MockedUnaryCall({ clusters: [] });
   listLeafClusters = () => new MockedUnaryCall({ clusters: [] });
   getKubes = () =>

--- a/web/packages/teleterm/src/services/tshd/index.ts
+++ b/web/packages/teleterm/src/services/tshd/index.ts
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024 Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,18 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { GrpcTransport } from '@protobuf-ts/grpc-transport';
-import {
-  ITerminalServiceClient,
-  TerminalServiceClient,
-} from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb.client';
-
-import { CloneableClient, cloneClient } from './cloneableClient';
-
-// Creating the client type based on the interface (ITerminalServiceClient) and not the class
-// (TerminalServiceClient) lets us omit a bunch of properties when mocking a client.
-export type TshdClient = CloneableClient<ITerminalServiceClient>;
-
-export function createTshdClient(transport: GrpcTransport): TshdClient {
-  return cloneClient(new TerminalServiceClient(transport));
-}
+export * from './createClient';
+export { cloneAbortSignal, isTshdRpcError } from './cloneableClient';
+export type { CloneableAbortSignal } from './cloneableClient';

--- a/web/packages/teleterm/src/services/tshd/types.test.ts
+++ b/web/packages/teleterm/src/services/tshd/types.test.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { GrpcTransport } from '@protobuf-ts/grpc-transport';
+
 import { createInsecureClientCredentials } from 'teleterm/services/grpcCredentials';
 
 import { createTshdClient } from './createClient';
@@ -24,6 +26,11 @@ import { createTshdClient } from './createClient';
 // Dependencies must be provided as `--path` values to `buf generate` in build.assets/genproto.sh.
 test('generated protos import necessary dependencies', () => {
   expect(() => {
-    createTshdClient('localhost:0', createInsecureClientCredentials());
+    createTshdClient(
+      new GrpcTransport({
+        host: 'localhost:1337',
+        channelCredentials: createInsecureClientCredentials(),
+      })
+    );
   }).not.toThrow();
 });

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -16,34 +16,99 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ITerminalServiceClient } from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb.client';
-
 import { SortType } from 'design/DataTable/types';
-
-import { CloneableClient } from './cloneableClient';
 
 import type * as uri from 'teleterm/ui/uri';
 
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/database_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/gateway_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/server_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/kube_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/app_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/label_pb';
+/*
+ *
+ * Do not add new imports to this file, we're trying to get rid of types.ts files.
+ *
+ */
+
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  Cluster,
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  LoggedInUser,
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  LoggedInUser_UserType,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  Database,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/database_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  Gateway,
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  GatewayCLICommand,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/gateway_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  Server,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/server_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  Kube,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/kube_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  App,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/app_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  Label,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/label_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  AuthSettings,
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  AuthProvider,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/auth_settings_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  AccessRequest,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
+export {
+  /**
+   * @deprecated Import directly from gen-proto-ts instead.
+   */
+  AccessList,
+} from 'gen-proto-ts/teleport/accesslist/v1/accesslist_pb';
+
+// There's too many re-exports from this file to list them individually.
+// A @deprecated annotation like this Unfortunately has no effect on the language server.
+/**
+ * @deprecated Import directly from gen-proto-ts instead.
+ */
 export * from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/auth_settings_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
-export * from 'gen-proto-ts/teleport/lib/teleterm/v1/usage_events_pb';
-export * from 'gen-proto-ts/teleport/accesslist/v1/accesslist_pb';
-
-export type {
-  CloneableAbortSignal,
-  CloneableRpcOptions,
-  CloneableClient,
-} from './cloneableClient';
-
-export type TshdClient = CloneableClient<ITerminalServiceClient>;
 
 /**
  * Available types are listed here:

--- a/web/packages/teleterm/src/types.ts
+++ b/web/packages/teleterm/src/types.ts
@@ -24,7 +24,7 @@ import { Logger, LoggerService } from 'teleterm/services/logger/types';
 import { FileStorage } from 'teleterm/services/fileStorage';
 import { MainProcessClient, RuntimeSettings } from 'teleterm/mainProcess/types';
 import { PtyServiceClient } from 'teleterm/services/pty';
-import { TshdClient } from 'teleterm/services/tshd/types';
+import { TshdClient } from 'teleterm/services/tshd/createClient';
 
 export type {
   Logger,

--- a/web/packages/teleterm/src/ui/appContext.ts
+++ b/web/packages/teleterm/src/ui/appContext.ts
@@ -40,7 +40,7 @@ import { UsageService } from 'teleterm/ui/services/usage';
 import { ResourcesService } from 'teleterm/ui/services/resources';
 import { ConnectMyComputerService } from 'teleterm/ui/services/connectMyComputer';
 import { ConfigService } from 'teleterm/services/config';
-import { TshdClient } from 'teleterm/services/tshd/types';
+import { TshdClient } from 'teleterm/services/tshd/createClient';
 import { IAppContext } from 'teleterm/ui/types';
 import { DeepLinksService } from 'teleterm/ui/services/deepLinks';
 import { parseDeepLink } from 'teleterm/deepLinks';

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
@@ -30,7 +30,7 @@ import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 import { ClustersService } from './clustersService';
 
 import type * as uri from 'teleterm/ui/uri';
-import type * as tsh from 'teleterm/services/tshd/types';
+import type { TshdClient } from 'teleterm/services/tshd';
 
 jest.mock('teleterm/ui/services/notifications');
 jest.mock('teleterm/ui/services/usage');
@@ -58,9 +58,9 @@ const NotificationsServiceMock = NotificationsService as jest.MockedClass<
 >;
 const UsageServiceMock = UsageService as jest.MockedClass<typeof UsageService>;
 
-function createService(client: Partial<tsh.TshdClient>): ClustersService {
+function createService(client: Partial<TshdClient>): ClustersService {
   return new ClustersService(
-    client as tsh.TshdClient,
+    client as TshdClient,
     {
       removeKubeConfig: jest.fn().mockResolvedValueOnce(undefined),
     } as unknown as MainProcessClient,
@@ -69,7 +69,7 @@ function createService(client: Partial<tsh.TshdClient>): ClustersService {
   );
 }
 
-function getClientMocks(): Partial<tsh.TshdClient> {
+function getClientMocks(): Partial<TshdClient> {
   return {
     login: jest.fn().mockReturnValueOnce(new MockedUnaryCall({})),
     logout: jest.fn().mockReturnValueOnce(new MockedUnaryCall({})),

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -41,6 +41,7 @@ import { UsageService } from 'teleterm/ui/services/usage';
 import { ImmutableStore } from '../immutableStore';
 
 import type * as types from './types';
+import type { TshdClient, CloneableAbortSignal } from 'teleterm/services/tshd';
 import type * as tsh from 'teleterm/services/tshd/types';
 
 const { routing } = uri;
@@ -56,7 +57,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
   state: types.ClustersServiceState = createClusterServiceState();
 
   constructor(
-    public client: tsh.TshdClient,
+    public client: TshdClient,
     private mainProcessClient: MainProcessClient,
     private notificationsService: NotificationsService,
     private usageService: UsageService
@@ -101,7 +102,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
 
   async loginLocal(
     params: types.LoginLocalParams,
-    abortSignal: tsh.CloneableAbortSignal
+    abortSignal: CloneableAbortSignal
   ) {
     await this.client.login(
       {
@@ -126,7 +127,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
 
   async loginSso(
     params: types.LoginSsoParams,
-    abortSignal: tsh.CloneableAbortSignal
+    abortSignal: CloneableAbortSignal
   ) {
     await this.client.login(
       {
@@ -147,7 +148,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
 
   async loginPasswordless(
     params: types.LoginPasswordlessParams,
-    abortSignal: tsh.CloneableAbortSignal
+    abortSignal: CloneableAbortSignal
   ) {
     await new Promise<void>((resolve, reject) => {
       const stream = this.client.loginPasswordless({

--- a/web/packages/teleterm/src/ui/services/connectMyComputer/connectMyComputerService.ts
+++ b/web/packages/teleterm/src/ui/services/connectMyComputer/connectMyComputerService.ts
@@ -21,9 +21,8 @@ import {
   Cluster,
   CreateConnectMyComputerRoleResponse,
   Server,
-  CloneableAbortSignal,
-  TshdClient,
 } from 'teleterm/services/tshd/types';
+import { TshdClient, CloneableAbortSignal } from 'teleterm/services/tshd';
 
 import type * as uri from 'teleterm/ui/uri';
 

--- a/web/packages/teleterm/src/ui/services/fileTransferClient/fileTransferService.ts
+++ b/web/packages/teleterm/src/ui/services/fileTransferClient/fileTransferService.ts
@@ -20,7 +20,8 @@ import { FileTransferListeners } from 'shared/components/FileTransfer';
 
 import { FileTransferDirection } from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb';
 
-import { FileTransferRequest, TshdClient } from 'teleterm/services/tshd/types';
+import { FileTransferRequest } from 'teleterm/services/tshd/types';
+import { TshdClient } from 'teleterm/services/tshd';
 import { UsageService } from 'teleterm/ui/services/usage';
 import { cloneAbortSignal } from 'teleterm/services/tshd/cloneableClient';
 

--- a/web/packages/teleterm/src/ui/services/headlessAuthn/headlessAuthnService.ts
+++ b/web/packages/teleterm/src/ui/services/headlessAuthn/headlessAuthnService.ts
@@ -21,13 +21,14 @@ import { MainProcessClient } from 'teleterm/types';
 import { ModalsService } from 'teleterm/ui/services/modals';
 import { ConfigService } from 'teleterm/services/config';
 
+import type { TshdClient, CloneableAbortSignal } from 'teleterm/services/tshd';
 import type * as types from 'teleterm/services/tshd/types';
 
 export class HeadlessAuthenticationService {
   constructor(
     private mainProcessClient: MainProcessClient,
     private modalsService: ModalsService,
-    private tshClient: types.TshdClient,
+    private tshClient: TshdClient,
     private configService: ConfigService
   ) {}
 
@@ -60,7 +61,7 @@ export class HeadlessAuthenticationService {
 
   async updateHeadlessAuthenticationState(
     params: types.UpdateHeadlessAuthenticationStateRequest,
-    abortSignal: types.CloneableAbortSignal
+    abortSignal: CloneableAbortSignal
   ): Promise<void> {
     await this.tshClient.updateHeadlessAuthenticationState(params, {
       abort: abortSignal,

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
@@ -30,6 +30,7 @@ import {
   ResourcesService,
 } from './resourcesService';
 
+import type { TshdClient } from 'teleterm/services/tshd';
 import type * as tsh from 'teleterm/services/tshd/types';
 
 describe('getServerByHostname', () => {
@@ -37,7 +38,7 @@ describe('getServerByHostname', () => {
   const getServerByHostnameTests: Array<
     {
       name: string;
-      getServersMockedValue: ReturnType<tsh.TshdClient['getServers']>;
+      getServersMockedValue: ReturnType<TshdClient['getServers']>;
     } & (
       | { expectedServer: tsh.Server; expectedErr?: never }
       | { expectedErr: any; expectedServer?: never }
@@ -74,10 +75,10 @@ describe('getServerByHostname', () => {
   test.each(getServerByHostnameTests)(
     '$name',
     async ({ getServersMockedValue, expectedServer, expectedErr }) => {
-      const tshClient: Partial<tsh.TshdClient> = {
+      const tshClient: Partial<TshdClient> = {
         getServers: jest.fn().mockResolvedValueOnce(getServersMockedValue),
       };
-      const service = new ResourcesService(tshClient as tsh.TshdClient);
+      const service = new ResourcesService(tshClient as TshdClient);
 
       const promise = service.getServerByHostname('/clusters/bar', 'foo');
 
@@ -110,7 +111,7 @@ describe('searchResources', () => {
     const kube = makeKube();
     const app = makeApp();
 
-    const tshClient: Partial<tsh.TshdClient> = {
+    const tshClient: Partial<TshdClient> = {
       getServers: jest.fn().mockResolvedValueOnce(
         new MockedUnaryCall({
           agents: [server],
@@ -140,7 +141,7 @@ describe('searchResources', () => {
         })
       ),
     };
-    const service = new ResourcesService(tshClient as tsh.TshdClient);
+    const service = new ResourcesService(tshClient as TshdClient);
 
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',
@@ -172,7 +173,7 @@ describe('searchResources', () => {
 
   it('returns a single item if a filter is supplied', async () => {
     const server = makeServer();
-    const tshClient: Partial<tsh.TshdClient> = {
+    const tshClient: Partial<TshdClient> = {
       getServers: jest.fn().mockResolvedValueOnce(
         new MockedUnaryCall({
           agents: [server],
@@ -181,7 +182,7 @@ describe('searchResources', () => {
         })
       ),
     };
-    const service = new ResourcesService(tshClient as tsh.TshdClient);
+    const service = new ResourcesService(tshClient as TshdClient);
 
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',
@@ -200,13 +201,13 @@ describe('searchResources', () => {
 
   it('returns a custom error pointing at resource kind and cluster when an underlying promise gets rejected', async () => {
     const expectedCause = new Error('oops');
-    const tshClient: Partial<tsh.TshdClient> = {
+    const tshClient: Partial<TshdClient> = {
       getServers: jest.fn().mockRejectedValueOnce(expectedCause),
       getDatabases: jest.fn().mockRejectedValueOnce(expectedCause),
       getKubes: jest.fn().mockRejectedValueOnce(expectedCause),
       getApps: jest.fn().mockRejectedValueOnce(expectedCause),
     };
-    const service = new ResourcesService(tshClient as tsh.TshdClient);
+    const service = new ResourcesService(tshClient as TshdClient);
 
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -34,6 +34,7 @@ import {
 
 import Logger from 'teleterm/logger';
 
+import type { TshdClient } from 'teleterm/services/tshd';
 import type * as types from 'teleterm/services/tshd/types';
 import type * as uri from 'teleterm/ui/uri';
 import type { ResourceTypeFilter } from 'teleterm/ui/Search/searchResult';
@@ -41,7 +42,7 @@ import type { ResourceTypeFilter } from 'teleterm/ui/Search/searchResult';
 export class ResourcesService {
   private logger = new Logger('ResourcesService');
 
-  constructor(private tshClient: types.TshdClient) {}
+  constructor(private tshClient: TshdClient) {}
 
   async fetchServers(params: types.GetResourcesParams) {
     const { response } = await this.tshClient.getServers(

--- a/web/packages/teleterm/src/ui/services/usage/usageService.ts
+++ b/web/packages/teleterm/src/ui/services/usage/usageService.ts
@@ -21,7 +21,8 @@ import { SubmitConnectEventRequest } from 'gen-proto-ts/prehog/v1alpha/connect_p
 import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
 
 import { ClusterOrResourceUri, ClusterUri, routing } from 'teleterm/ui/uri';
-import { Cluster, TshdClient } from 'teleterm/services/tshd/types';
+import { Cluster } from 'teleterm/services/tshd/types';
+import { TshdClient } from 'teleterm/services/tshd';
 import { RuntimeSettings } from 'teleterm/mainProcess/types';
 import { ConfigService } from 'teleterm/services/config';
 import Logger from 'teleterm/logger';

--- a/web/packages/teleterm/src/ui/types.ts
+++ b/web/packages/teleterm/src/ui/types.ts
@@ -37,7 +37,7 @@ import { UsageService } from 'teleterm/ui/services/usage';
 import { ConfigService } from 'teleterm/services/config';
 import { ConnectMyComputerService } from 'teleterm/ui/services/connectMyComputer';
 import { HeadlessAuthenticationService } from 'teleterm/ui/services/headlessAuthn/headlessAuthnService';
-import { TshdClient } from 'teleterm/services/tshd/types';
+import { TshdClient } from 'teleterm/services/tshd';
 
 export interface IAppContext {
   clustersService: ClustersService;


### PR DESCRIPTION
Backport #40017.

This backport also includes two commits from #39826, c407c0680112efb22eb12e5328e53c1dceb88043 and 0b1d15e0a21f7d48ce4351e87750928151819037, mostly so that the API to create gRPC clients is the same. v15 doesn't have VNet, so that PR wasn't backported to v15.