### PR TITLE
Fix EAS token generation used for AWS APIs

### DIFF
--- a/lib/integrations/awsoidc/token_generator.go
+++ b/lib/integrations/awsoidc/token_generator.go
@@ -1,0 +1,165 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsoidc
+
+import (
+	"context"
+	"crypto"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/jwt"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils/oidc"
+)
+
+// Cache is the subset of the cached resources that the AWS OIDC Token Generation queries.
+type Cache interface {
+	// GetIntegration returns the specified integration resources.
+	GetIntegration(ctx context.Context, name string) (types.Integration, error)
+
+	// GetClusterName returns local cluster name of the current auth server
+	GetClusterName(...services.MarshalOption) (types.ClusterName, error)
+
+	// GetCertAuthority returns cert authority by id
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)
+
+	// GetProxies returns a list of registered proxies.
+	GetProxies() ([]types.Server, error)
+}
+
+// KeyStoreManager defines methods to get signers using the server's keystore.
+type KeyStoreManager interface {
+	// GetJWTSigner selects a usable JWT keypair from the given keySet and returns a [crypto.Signer].
+	GetJWTSigner(ctx context.Context, ca types.CertAuthority) (crypto.Signer, error)
+}
+
+// GenerateAWSOIDCTokenRequest contains the required elements to generate an AWS OIDC Token (JWT).
+type GenerateAWSOIDCTokenRequest struct {
+	// Integration is the AWS OIDC Integration name.
+	Integration string
+	// Username is the JWT Username (on behalf of claim)
+	Username string
+	// Subject is the JWT Subject (subject claim)
+	Subject string
+	// Clock is used to mock time
+	Clock clockwork.Clock
+}
+
+// CheckAndSetDefaults checks the request params.
+func (g *GenerateAWSOIDCTokenRequest) CheckAndSetDefaults() error {
+	if g.Username == "" {
+		return trace.BadParameter("username missing")
+	}
+	if g.Subject == "" {
+		return trace.BadParameter("missing subject")
+	}
+	if g.Clock == nil {
+		g.Clock = clockwork.NewRealClock()
+	}
+
+	return nil
+}
+
+// GenerateAWSOIDCToken generates a token to be used when executing an AWS OIDC Integration action.
+func GenerateAWSOIDCToken(ctx context.Context, cacheClt Cache, keyStoreManager KeyStoreManager, req GenerateAWSOIDCTokenRequest) (string, error) {
+	var integration types.Integration
+	var err error
+	var issuer string
+
+	// Clients in v15 or lower might not send the Integration
+	// All v16+ clients will send the Integration
+	// For V17.0, if the Integration is empty, an error must be returned.
+	// TODO(marco) DELETE IN v17.0
+	if req.Integration != "" {
+		integration, err = cacheClt.GetIntegration(ctx, req.Integration)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		if integration.GetSubKind() != types.IntegrationSubKindAWSOIDC {
+			return "", trace.BadParameter("integration subkind (%s) mismatch", integration.GetSubKind())
+		}
+
+		if integration.GetAWSOIDCIntegrationSpec() == nil {
+			return "", trace.BadParameter("missing spec fields for %q (%q) integration", integration.GetName(), integration.GetSubKind())
+		}
+
+		issuerS3URI := integration.GetAWSOIDCIntegrationSpec().IssuerS3URI
+		if issuerS3URI != "" {
+			issuerS3URL, err := url.Parse(issuerS3URI)
+			if err != nil {
+				return "", trace.Wrap(err)
+			}
+			prefix := strings.TrimLeft(issuerS3URL.Path, "/")
+			issuer = fmt.Sprintf("https://%s.s3.amazonaws.com/%s", issuerS3URL.Host, prefix)
+		}
+	}
+
+	if issuer == "" {
+		issuer, err = oidc.IssuerForCluster(ctx, cacheClt)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+	}
+
+	clusterName, err := cacheClt.GetClusterName()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	ca, err := cacheClt.GetCertAuthority(ctx, types.CertAuthID{
+		Type:       types.OIDCIdPCA,
+		DomainName: clusterName.GetClusterName(),
+	}, true /*loadKeys*/)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	signer, err := keyStoreManager.GetJWTSigner(ctx, ca)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	privateKey, err := services.GetJWTSigner(signer, ca.GetClusterName(), req.Clock)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	token, err := privateKey.SignAWSOIDC(jwt.SignParams{
+		Username: req.Username,
+		Audience: types.IntegrationAWSOIDCAudience,
+		Subject:  req.Subject,
+		Issuer:   issuer,
+		// Token expiration is not controlled by the Expires property.
+		// It is defined by assumed IAM Role's "Maximum session duration" (usually 1h).
+		Expires: req.Clock.Now().Add(time.Hour),
+	})
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return token, nil
+}

--- a/lib/integrations/externalauditstorage/configurator_test.go
+++ b/lib/integrations/externalauditstorage/configurator_test.go
@@ -212,7 +212,7 @@ func TestCredentialsCache(t *testing.T) {
 	require.True(t, c.IsUsed())
 
 	// Set the GenerateOIDCTokenFn to a dumb faked function.
-	c.SetGenerateOIDCTokenFn(func(ctx context.Context) (string, error) {
+	c.SetGenerateOIDCTokenFn(func(ctx context.Context, integration string) (string, error) {
 		return uuid.NewString(), nil
 	})
 
@@ -348,7 +348,7 @@ func TestDraftConfigurator(t *testing.T) {
 	require.True(t, c.IsUsed())
 
 	// Set the GenerateOIDCTokenFn to a faked function for the test.
-	c.SetGenerateOIDCTokenFn(func(ctx context.Context) (string, error) {
+	c.SetGenerateOIDCTokenFn(func(ctx context.Context, integration string) (string, error) {
 		// Can sleep here to confirm that WaitForFirstCredentials works.
 		// time.Sleep(time.Second)
 		return uuid.NewString(), nil


### PR DESCRIPTION
In the latest release, we added support for S3 bucket as OIDC Provider URL.
There are two places were the Token is generated.
One used in Discover Wizard, EICE access and Auto-Discover. Another one for the External Audit Storage.

The first was updated to include the S3 Bucket as possible Issuer. EAS flow was not updated.

This PR merges both flows.

Fixes https://github.com/gravitational/teleport/issues/40125