### PR TITLE
Add support for exact matching on an element in a delimited label

### DIFF
--- a/docs/pages/reference/predicate-language.mdx
+++ b/docs/pages/reference/predicate-language.mdx
@@ -62,13 +62,15 @@ The language supports the following operators:
 
 The language also supports the following functions:
 
-| Functions (with examples)             | Description                                                |
-|---------------------------------------|------------------------------------------------------------|
-| `equals(labels["env"], "prod")`       | resources with label key `env` equal to label value `prod` |
-| `exists(labels["env"])`               | resources with a label key `env`; label value unchecked    |
-| `!exists(labels["env"])`              | resources without a label key `env`; label value unchecked |
-| `search("foo", "bar", "some phrase")` | fuzzy match against common resource fields                 |
-| `hasPrefix(name, "foo")`              | resources with a name that starts with the prefix `foo`    |
+| Functions (with examples)                    | Description                                                |
+|----------------------------------------------|------------------------------------------------------------|
+| `equals(labels["env"], "prod")`              | resources with label key `env` equal to label value `prod` |
+| `exists(labels["env"])`                      | resources with a label key `env`; label value unchecked    |
+| `!exists(labels["env"])`                     | resources without a label key `env`; label value unchecked |
+| `search("foo", "bar", "some phrase")`        | fuzzy match against common resource fields                 |
+| `hasPrefix(name, "foo")`                     | resources with a name that starts with the prefix `foo`    |
+| `split(labels["foo"], ",")`                  | converts a delimited string into a list                    |
+| `contains(split(labels["foo"], ","), "bar")` | determines if a value exists in a list                     |
 
 See some [examples](cli.mdx#filter-examples) of the different ways you can filter resources.
 

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -21,6 +21,7 @@ package services
 import (
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"time"
 
@@ -778,6 +779,12 @@ func NewResourceExpression(expression string) (typical.Expression[types.Resource
 			}),
 			"exists": typical.UnaryFunction[types.ResourceWithLabels](func(value string) (bool, error) {
 				return value != "", nil
+			}),
+			"split": typical.BinaryFunction[types.ResourceWithLabels](func(value string, delimiter string) ([]string, error) {
+				return strings.Split(value, delimiter), nil
+			}),
+			"contains": typical.BinaryFunction[types.ResourceWithLabels](func(list []string, value string) (bool, error) {
+				return slices.Contains(list, value), nil
 			}),
 		},
 		GetUnknownIdentifier: func(env types.ResourceWithLabels, fields []string) (any, error) {


### PR DESCRIPTION
Updates the resource parser with two new functions: `contains` and `split`. When used together they provide the ability to search for resources that have labels with multiple values in a delimited list. For example, if a resource has label `foo=bar,baz,bang` then `split(labels[foo], ",")` would transform the comma label value from a string into a list: ["bar", "baz", "bang"] The list could then be fed to `contains` to determine if bar exists in the list: `contains(split(labels[foo], ","), bar)`.


Changelog: Add new resource filtering predicates to allow exact matches on a single item of a delimited list stored in a label value. For example, if given the following label containing a string separated list of values `foo=bar,baz,bang`, it is now possible to match on any resources with a label `foo` that contains the element `bar` via `contains(split(labels[foo], ","), bar)`.