### PR TITLE
Convert WithRootClusterClient to use ClusterClient

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1540,6 +1540,8 @@ func (tc *TeleportClient) NewWatcher(ctx context.Context, watch types.Watch) (ty
 
 // WithRootClusterClient provides a functional interface for making calls
 // against the root cluster's auth server.
+// Deprecated: Prefer reusing auth clients instead of creating at worst two
+// clients for a single function.
 func (tc *TeleportClient) WithRootClusterClient(ctx context.Context, do func(clt auth.ClientI) error) error {
 	ctx, span := tc.Tracer.Start(
 		ctx,
@@ -1548,14 +1550,13 @@ func (tc *TeleportClient) WithRootClusterClient(ctx context.Context, do func(clt
 	)
 	defer span.End()
 
-	//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
-	proxyClient, err := tc.ConnectToProxy(ctx)
+	clusterClient, err := tc.ConnectToCluster(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer proxyClient.Close()
+	defer clusterClient.Close()
 
-	clt, err := proxyClient.ConnectToRootCluster(ctx)
+	clt, err := clusterClient.ConnectToRootCluster(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Replaces the deprecated SSH connection mechanism to the cluster in favor of using the gRPC mechanism. The WithRootClusterClient has also been deprecated as it requires at worst two dials to a Teleport cluster for a single function. Callers should instead explicitly create and reuse clients where possible so that no extraneous dialing is required for each action being performed against a cluster.