### PR TITLE
Add a timeout to certain internal cluster requests

### DIFF
--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -760,7 +760,7 @@ type ReRegisterParams struct {
 }
 
 // ReRegister renews the certificates and private keys based on the client's existing identity.
-func ReRegister(params ReRegisterParams) (*Identity, error) {
+func ReRegister(ctx context.Context, params ReRegisterParams) (*Identity, error) {
 	var rotation *types.Rotation
 	if !params.Rotation.IsZero() {
 		// older auths didn't distinguish between empty and nil rotation
@@ -768,7 +768,7 @@ func ReRegister(params ReRegisterParams) (*Identity, error) {
 		// if it is truly non-empty.
 		rotation = &params.Rotation
 	}
-	certs, err := params.Client.GenerateHostCerts(context.Background(),
+	certs, err := params.Client.GenerateHostCerts(ctx,
 		&proto.HostCertsRequest{
 			HostID:               params.ID.HostID(),
 			NodeName:             params.ID.NodeName,

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib"
@@ -162,8 +163,10 @@ func (process *TeleportProcess) connectToAuthService(role types.SystemRole, opts
 	return connector, nil
 }
 
-type certOption func(*certOptions)
-type certOptions struct{}
+type (
+	certOption  func(*certOptions)
+	certOptions struct{}
+)
 
 func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOption) (conn *Connector, err error) {
 	var options certOptions
@@ -341,7 +344,9 @@ func (process *TeleportProcess) getCertAuthority(conn *Connector, id types.CertA
 	if conn.ClientIdentity.ID.Role == types.RoleAdmin || conn.ClientIdentity.ID.Role == types.RoleAuth {
 		return process.localAuth.GetCertAuthority(process.ExitContext(), id, loadPrivateKeys)
 	}
-	return conn.Client.GetCertAuthority(process.ExitContext(), id, loadPrivateKeys)
+	ctx, cancel := context.WithTimeout(process.ExitContext(), apidefaults.DefaultIOTimeout)
+	defer cancel()
+	return conn.Client.GetCertAuthority(ctx, id, loadPrivateKeys)
 }
 
 // reRegister receives new identity credentials for proxy, node and auth.
@@ -364,7 +369,9 @@ func (process *TeleportProcess) reRegister(conn *Connector, additionalPrincipals
 	if id.Role == types.RoleInstance {
 		systemRoles = process.getInstanceRoles()
 	}
-	identity, err := auth.ReRegister(auth.ReRegisterParams{
+	ctx, cancel := context.WithTimeout(process.ExitContext(), apidefaults.DefaultIOTimeout)
+	defer cancel()
+	identity, err := auth.ReRegister(ctx, auth.ReRegisterParams{
 		Client:               conn.Client,
 		ID:                   id,
 		AdditionalPrincipals: additionalPrincipals,
@@ -1156,7 +1163,9 @@ func (process *TeleportProcess) newClientThroughTunnel(tlsConfig *tls.Config, ss
 
 	// If connected, make sure the connector's client works by using
 	// a call that should succeed at all times (Ping).
-	resp, err := clt.Ping(process.ExitContext())
+	ctx, cancel := context.WithTimeout(process.ExitContext(), apidefaults.DefaultIOTimeout)
+	defer cancel()
+	resp, err := clt.Ping(ctx)
 	if err != nil {
 		return nil, nil, trace.NewAggregate(err, clt.Close())
 	}
@@ -1201,7 +1210,9 @@ func (process *TeleportProcess) newClientDirect(authServers []utils.NetAddr, tls
 
 	// If connected, make sure the connector's client works by using
 	// a call that should succeed at all times (Ping).
-	resp, err := clt.Ping(process.ExitContext())
+	ctx, cancel := context.WithTimeout(process.ExitContext(), apidefaults.DefaultIOTimeout)
+	defer cancel()
+	resp, err := clt.Ping(ctx)
 	if err != nil {
 		return nil, nil, trace.NewAggregate(err, clt.Close())
 	}


### PR DESCRIPTION
This PR sprinkles some timeouts on certain API requests that Teleport ends up using while connecting to the auth, running the agent pool loop (to spawn new reverse tunnel connections) and periodically for the CA rotation reconciler.

We'll say that this closes #37211, although it's still unclear whether or not the problem was actually in one of these unlimited-duration calls or if perhaps that specific hang was already fixed.