### PR TITLE
Reduce flakiness of `TestBotDatabaseTunnel`

### DIFF
--- a/lib/tbot/config/service_database_tunnel.go
+++ b/lib/tbot/config/service_database_tunnel.go
@@ -19,6 +19,7 @@
 package config
 
 import (
+	"net"
 	"net/url"
 
 	"github.com/gravitational/trace"
@@ -44,6 +45,10 @@ type DatabaseTunnelService struct {
 	Database string `yaml:"database"`
 	// Username is the database username to proxy as.
 	Username string `yaml:"username"`
+
+	// Listener overrides "listen" and directly provides an opened listener to
+	// use.
+	Listener net.Listener `yaml:"-"`
 }
 
 func (s *DatabaseTunnelService) Type() string {
@@ -66,7 +71,7 @@ func (s *DatabaseTunnelService) UnmarshalYAML(node *yaml.Node) error {
 
 func (s *DatabaseTunnelService) CheckAndSetDefaults() error {
 	switch {
-	case s.Listen == "":
+	case s.Listen == "" && s.Listener == nil:
 		return trace.BadParameter("listen: should not be empty")
 	case s.Service == "":
 		return trace.BadParameter("service: should not be empty")


### PR DESCRIPTION
This may not fix the flakiness but I can't reproduce it locally, this should give us a better chance to work out what's wrong.

Changes:
- Allow more time for the listener to be ready to proxy connections (5s vs 10s)
- Fixes a case where the failure of the Bot to start would not be properly reported (this will let us figure out the root cause if there is one)