### PR TITLE
[v15] Set CommonName to first DNS SAN when issuing X509 SVIDs

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -925,7 +925,8 @@
     "SVIDs",
     "Ghostunnel",
     "Linkerd",
-    "Istio"
+    "Istio",
+    "mydb"
   ],
   "flagWords": [
     "hte"

--- a/docs/pages/machine-id/workload-identity/best-practices.mdx
+++ b/docs/pages/machine-id/workload-identity/best-practices.mdx
@@ -115,4 +115,23 @@ yourself.
 
 One such proxy is [Ghostunnel](https://github.com/ghostunnel/ghostunnel).
 
+## X509 SVID Subject
 
+When the X509 SVIDs are issued by Teleport Workload Identity, the subject
+distinguished name of the certificate is determined by the following criteria:
+
+- If no DNS SANs have been requested, the subject is unset.
+- If DNS SANs have been requested, the first DNS SAN is set as the subject
+  common name.
+
+This behavior exists to support interoperability with legacy systems which are
+not able to parse DNS SANs or which are not SPIFFE aware.
+
+An example of one such legacy system is Postgres. Postgres supports client
+authentication using certificates, but only allows the common name to be used
+to determine which database user access should be granted to. To integrate
+Teleport Workload Identity with Postgres, you can issue X509 SVIDs with a DNS
+SAN which can then be mapped to database user. For example, you could issue
+a certificate with a DNS SAN of `myuser.mydb.db-access.example.com`. The
+behavior described above will then set the common name to this DNS SAN, and you
+can then configure Postgres to map this common name to `myuser`.

--- a/lib/auth/machineid/machineidv1/workload_identity_service.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service.go
@@ -170,7 +170,7 @@ func signx509SVID(
 		IPAddresses: ipSANS,
 	}
 
-	// For legacy compatability, we set the subject common name to the first
+	// For legacy compatibility, we set the subject common name to the first
 	// DNS SAN. This allows interoperability with non-SPIFFE aware clients that
 	// trust the CA, or interoperability with servers like Postgres which can
 	// only inspect the common name when making authz/authn decisions.

--- a/lib/auth/machineid/machineidv1/workload_identity_service.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service.go
@@ -170,6 +170,15 @@ func signx509SVID(
 		IPAddresses: ipSANS,
 	}
 
+	// For legacy compatability, we set the subject common name to the first
+	// DNS SAN. This allows interoperability with non-SPIFFE aware clients that
+	// trust the CA, or interoperability with servers like Postgres which can
+	// only inspect the common name when making authz/authn decisions.
+	// Eventually, we may wish to make this behavior more configurable.
+	if len(dnsSANs) > 0 {
+		template.Subject.CommonName = dnsSANs[0]
+	}
+
 	certBytes, err := x509.CreateCertificate(
 		rand.Reader, template, ca.Cert, pubKey, ca.Signer,
 	)


### PR DESCRIPTION
Backport #40150 to branch/v15

changelog: Sets the subject common name of issued X509 SVIDs to the first requested DNS SAN to support interoperability with legacy software.
