### PR TITLE
Configure the systemd unit file RestartSec value

### DIFF
--- a/examples/systemd/fips/teleport.service
+++ b/examples/systemd/fips/teleport.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
+RestartSec=5
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config /etc/teleport.yaml --fips --pid-file=/run/teleport.pid
 # systemd before 239 needs an absolute path

--- a/examples/systemd/production/auth/teleport.service
+++ b/examples/systemd/production/auth/teleport.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
+RestartSec=5
 # Set the nodes roles with the `--roles`
 # In most production environments you will not
 # want to run all three roles on a single host

--- a/examples/systemd/production/node/teleport.service
+++ b/examples/systemd/production/node/teleport.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
+RestartSec=5
 # Set the nodes roles with the `--roles`
 # In most production environments you will not
 # want to run all three roles on a single host

--- a/examples/systemd/production/proxy/teleport.service
+++ b/examples/systemd/production/proxy/teleport.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
+RestartSec=5
 # Set the nodes roles with the `--roles`
 # In most production environments you will not
 # want to run all three roles on a single host

--- a/examples/systemd/teleport.service
+++ b/examples/systemd/teleport.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
+RestartSec=5
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config /etc/teleport.yaml --pid-file=/run/teleport.pid
 # systemd before 239 needs an absolute path

--- a/lib/config/systemd.go
+++ b/lib/config/systemd.go
@@ -45,6 +45,7 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
+RestartSec=5
 EnvironmentFile=-{{ .EnvironmentFile }}
 ExecStart={{ .TeleportInstallationFile }} start --config {{ .TeleportConfigPath }} --pid-file={{ .PIDFile }}
 # systemd before 239 needs an absolute path

--- a/lib/config/testdata/TestWriteSystemdUnitFile.golden
+++ b/lib/config/testdata/TestWriteSystemdUnitFile.golden
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
+RestartSec=5
 EnvironmentFile=-/custom/env/dir/teleport
 ExecStart=/custom/install/dir/teleport start --config /etc/teleport.yaml --pid-file=/custom/pid/dir/teleport.pid
 # systemd before 239 needs an absolute path


### PR DESCRIPTION
This PR addresses https://github.com/gravitational/teleport/issues/40186

The RestartSec value on EC2 instances is set to 1sec. This results in the error `teleport.service: Start request repeated too quickly.` and the service stops attempting to restart.

changelog: Fix an issue that prevents the teleport service from restarting