### PR TITLE
RFD 0169: Automatic Updates for Agents

### DIFF
--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -54,25 +54,16 @@ Whether the updater querying the endpoint is instructed to upgrade (via `agent_a
 To ensure that the updater is always able to retrieve the desired version, instructions to the updater are delivered via unauthenticated requests to the `/v1/webapi/find`.
 Teleport proxies use their access to heartbeat data to drive the rollout and modulate the `/v1/webapi/find` response given the host UUID.
 
-Rollouts are specified as interdependent groups of hosts, selected by SSH resource or instance label query.
-A host is eligible to upgrade if the seleciton query returns true.
-Instance labels are a new feature introduced by this RFD that may be used when SSH service is not running or it is undesirable to reuse SSH labels:
+Rollouts are specified as interdependent groups of hosts, selected by upgrade group identifier.
+A host is eligible to upgrade if the upgrade group identifier matches, set in teleport.yaml:
 
 ```
 teleport:
-  labels:
-    environment: staging
-  commands:
-    # this command will add a label 'arch=x86_64' to an instance
-    - name: arch
-      command: ['/bin/uname', '-p']
-      period: 1h0m0s
+  upgrade_group: staging
 ```
 
-Only static and command-based and labels may be used.
-
-At the start of a group rollout, the Teleport proxy marks a desired group of hosts to update in the backend.
-An arbitrary but UUID-deterministic fixed number of hosts (`max_in_flight % x total`) are instructed to upgrade at the same time via `/v1/webapi/find`.
+At the start of a group rollout, the Teleport auth server captures the desired group of hosts to update in the backend.
+An fixed number of hosts (`max_in_flight % x total`) are instructed to upgrade at the same time via `/v1/webapi/find`.
 Additional hosts are instructed to update as earlier updates complete, timeout, or fail, never exceeding `max_in_flight`.
 The group rollout is halted if timeouts or failures exceed their specified thresholds.
 Group rollouts may be retried with `tctl autoupdate run`.
@@ -81,29 +72,41 @@ Group rollouts may be retried with `tctl autoupdate run`.
 
 Instance heartbeats will now be cached at both the auth server and the proxy.
 
-All rollout logic is trigger by instance heartbeat backend writes, as changes can only occur on these events.
+The rollout logic is progressed by instance heartbeat backend writes, as changes can only occur on these events.
+
 The following data related to the rollout are stored in each instance heartbeat:
 - `agent_upgrade_start_time`: timestamp of individual agent's upgrade time
-- `agent_upgrade_group_schedule`: schedule type of group (e.g., critical)
-- `agent_upgrade_group_name`: name of group (e.g., staging)
-- `agent_upgrade_group_start_time`: timestamp of current window start time
-- `agent_upgrade_group_end_time`: timestamp of current window start time
+- `agent_upgrade_group_name`: name of auto-update group
 
-At the start of the window, all queried instance heartbeats are marked with updated values for the `agent_upgrade_group_*` fields.
-Instance heartbeats are included in the current window if all three fields match the window defined in `cluster_maintenance_config`.
+At the start of the upgrade window, auth servers attempt to write an update rollout plan to the backend under a single key.
+This plan is protected by optimistic locking, and contains the following data:
+
+Data key: `[name of group]@[scheduled type]` (e.g., `staging@critical`)
+
+Data value JSON:
+- `group_start_time`: timestamp of current window start time
+- `group_end_time`: timestamp of current window start time
+- `host_order`: list of UUIDs in randomized order
+
+At a fixed interval, auth servers will check the plan to determine if a new plan is needed by comparing `group_start_time` to the current time and the desired window.
+If a new plan is needed, auth servers will query their cache of instance heartbeats and attempt to write the new plan.
+The first auth server to write the plan wins; others will be rejected by the optimistic lock.
+Auth servers will only write the plan if their instance heartbeat cache is initialized and recently updated.
 
 On each instance heartbeat write, the auth server looks at instance heartbeats in cache and determines if additional agents should be upgrading.
 If they should, additional instance heartbeats are marked as upgrading by setting `agent_upgrade_start_time` to the current time.
 When `agent_upgrade_start_time` is in the group's window, the proxy serves `agent_auto_upgrade: true` when queried via `/v1/webapi/find`.
 
-To avoid synchronization issues between auth servers, the rollout order is deterministically sorted by UUID.
-Two concurrent writes to different auth servers may temporarily result in fewer upgrading instances than desired, but this should be resolved on the next write.
+
+The predetermined ordering of hosts avoids cache synchronization issues between auth servers.
+Two concurrent heartbeat writes to by auth servers may temporarily result in fewer upgrading instances than desired, but this should be resolved on the next write.
 
 Upgrading all agents generates the following write load:
-- One write of `agent_upgrade_group_*` fields per agent
-- One write of `agent_upgrade_start_time` field per agent
+- One write of plan.
+- One write of `agent_upgrade_start_time` field per agent.
 
 All reads are from cache.
+Each instance heartbeat write will trigger an eventually consistent cache update on all auth servers and proxies, but not agents.
 If the cache is unhealthy, `agent_auto_update` is still served based on the last available value in cache.
 This is safe because `agent_upgrade_start_time` is only written once during the upgrade.
 However, this means that timeout thresholds should account for possible cache init time if initialization occurs right after `agent_upgrade_start_time` is written.
@@ -142,15 +145,8 @@ spec:
   agent_auto_update_groups:
     # schedule is "regular" or "critical"
     regular:
+      # name of the group
     - name: staging-group
-      # agents defines which agents are included in the group.
-      agents:
-        # node_labels_expression selects agents by SSH resource query.
-        #  default: all connected agents
-        node_labels_expression: 'labels["environment"]=="staging"'
-        # instance_labels_expression selects agents by instance query.
-        #  default: all connected agents
-        instance_labels_expression: 'labels["environment"]=="staging"'
       # days specifies the days of the week when the group may be upgraded.
       #  default: ["*"] (all days)
       days: [“Sun”, “Mon”, ... | "*"]
@@ -186,7 +182,7 @@ spec:
   # ...
 ```
 
-Note that cycles and dependency chains longer than a week will be rejected.
+Cycles and dependency chains longer than a week will be rejected.
 Otherwise, updates could take up to 7 weeks to propagate.
 
 Changing the version or schedule completely resets progress.
@@ -284,6 +280,21 @@ Automatic updates configuration has been updated.
 
 Notes:
 - These two resources are separate so that Cloud customers can be restricted from updating `autoupdate_version`, while maintaining control over the rollout.
+
+### Version Promotion
+
+Maintaining the version of different groups of agents is out-of-scope for this RFD.
+This means that groups which employ auto-scaling or ephemeral resources will slowly converge to the latest Teleport version.
+This could lead to a production outage, as the latest Teleport version may not receive any validation before it is advertised to newly provisioned resources in production.
+
+To solve this in the future, we can add an additional `--group` flag to `teleport-update`:
+```shell
+$ teleport-update enable --proxy example.teleport.sh --group staging
+```
+
+This group name could be provided as a parameter to `/v1/webapi/find`, so that newly added resources may install at the group's designated version.
+
+This will require tracking the desired version of groups in the backend, which will add additional complexity to the rollout logic.
 
 ## Details - Linux Agents
 
@@ -437,6 +448,8 @@ To ensure that SELinux permissions do not prevent the `teleport-updater` binary 
 
 To ensure that `teleport` package removal does not interfere with `teleport-updater`, package removal will run `apt purge` (or `yum` equivalent) while ensuring that `/etc/teleport.yaml` and `/var/lib/teleport` are not purged.
 Failure to do this could result in `/etc/teleport.yaml` being removed when an operator runs `apt purge` at a later date.
+
+To ensure that `teleport` package removal does not lead to a hard restart of Teleport, the updater will ensure that the package is removed without triggering needrestart or similar services.
 
 To ensure that backups are consistent, the updater will use the [SQLite backup API](https://www.sqlite.org/backup.html) to perform the backup.
 

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -104,6 +104,9 @@ Upgrading all agents generates the following write load:
 - One write of `agent_upgrade_start_time` field per agent
 
 All reads are from cache.
+If the cache is unhealthy, `agent_auto_update` is still served based on the last available value in cache.
+This is safe because `agent_upgrade_start_time` is only written once during the upgrade.
+However, this means that timeout thresholds should account for possible cache init time if initialization occurs right after `agent_upgrade_start_time` is written.
 
 ### Endpoints
 

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -393,7 +393,7 @@ The `enable` subcommand will:
 1. Query the `/v1/webapi/find` endpoint.
 2. If the current updater-managed version of Teleport is the latest, and teleport package is not installed, jump to (16).
 3. If the current updater-managed version of Teleport is the latest, but the teleport package is installed, jump to (13).
-4. Ensure there is enough free disk space to upgrade Teleport via `df .`.
+4. Ensure there is enough free disk space to upgrade Teleport via `df .` and `content-length` header from `HEAD` request.
 5. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
 6. Download and verify the checksum (tarball URL suffixed with `.sha256`).
 7. Extract the tarball to `/var/lib/teleport/versions/VERSION` and write the SHA to `/var/lib/teleport/versions/VERSION/sha256`.
@@ -416,7 +416,7 @@ When `update` subcommand is otherwise executed, it will:
 3. Check that `agent_auto_updates` is true, quit otherwise.
 4. If the current version of Teleport is the latest, quit.
 5. Wait `random(0, agent_update_jitter_seconds)` seconds.
-6. Ensure there is enough free disk space to upgrade Teleport via `df .`.
+6. Ensure there is enough free disk space to upgrade Teleport via `df .` and `content-length` header from `HEAD` request.
 7. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
 8. Download and verify the checksum (tarball URL suffixed with `.sha256`).
 9. Extract the tarball to `/var/lib/teleport/versions/VERSION` and write the SHA to `/var/lib/teleport/versions/VERSION/sha256`.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -393,7 +393,7 @@ The `enable` subcommand will:
 1. Query the `/v1/webapi/find` endpoint.
 2. If the current updater-managed version of Teleport is the latest, and teleport package is not installed, jump to (16).
 3. If the current updater-managed version of Teleport is the latest, but the teleport package is installed, jump to (13).
-4. Ensure there is enough free disk space to upgrade Teleport.
+4. Ensure there is enough free disk space to upgrade Teleport via `df .`.
 5. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
 6. Download and verify the checksum (tarball URL suffixed with `.sha256`).
 7. Extract the tarball to `/var/lib/teleport/versions/VERSION` and write the SHA to `/var/lib/teleport/versions/VERSION/sha256`.
@@ -416,7 +416,7 @@ When `update` subcommand is otherwise executed, it will:
 3. Check that `agent_auto_updates` is true, quit otherwise.
 4. If the current version of Teleport is the latest, quit.
 5. Wait `random(0, agent_update_jitter_seconds)` seconds.
-6. Ensure there is enough free disk space to upgrade Teleport.
+6. Ensure there is enough free disk space to upgrade Teleport via `df .`.
 7. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
 8. Download and verify the checksum (tarball URL suffixed with `.sha256`).
 9. Extract the tarball to `/var/lib/teleport/versions/VERSION` and write the SHA to `/var/lib/teleport/versions/VERSION/sha256`.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -93,7 +93,10 @@ If a new plan is needed, auth servers will query their cache of instance heartbe
 The first auth server to write the plan wins; others will be rejected by the optimistic lock.
 Auth servers will only write the plan if their instance heartbeat cache is healthy.
 
-If the list is greater than 100,000 UUIDs, auth servers will first write pages with a randomly generated suffix, in a linked-link, before the atomic non-suffixed write.
+If the resource size is greater than 100 KiB, auth servers will divide the resource into pages no greater than 100 KiB each.
+Each page will duplicate all values besides `hosts`, which will be different for each page.
+All pages besides the first page will be suffixed with a randomly generated number.
+Pages will be written in reverse order, in a linked-link, before the final atomic non-suffixed write of the first page.
 If the non-suffixed write fails, the auth server is responsible for cleaning up the unusable pages.
 If cleanup fails, the unusable pages will expire after 2 weeks.
 

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -58,7 +58,7 @@ Rollouts are specified as interdependent groups of hosts, selected by resource l
 A host is eligible to upgrade if the label is present on any of its connected resources.
 
 At the start of a group rollout, the Teleport proxy marks a desired group of hosts to update in the backend.
-A fixed number of hosts (`max_in_flight`) are instructed to upgrade via `/v1/webapi/find`.
+An arbitrarily selected fixed number of hosts (`max_in_flight x total`) are instructed to upgrade at the same time via `/v1/webapi/find`.
 Additional hosts are instructed to update as earlier updates complete, timeout, or fail, never exceeding `max_in_flight`.
 The group rollout is halted if timeouts or failures exceed their specified thresholds.
 Group rollouts may be retried with `tctl autoupdate run`.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -292,7 +292,7 @@ It will be distributed as a separate package from Teleport, and manage the insta
 It will read the unauthenticated `/v1/webapi/find` endpoint from the Teleport proxy, parse new fields on that endpoint, and install the specified agent version according to the specified upgrade plan.
 It will download the correct version of Teleport as a tarball, unpack it in `/var/lib/teleport`, and ensure it is symlinked from `/usr/local/bin`.
 
-Source code for the updater will live in `integrations/updater`.
+Source code for the updater will live in the main Teleport repository, with the updater binary built from `tools/teleport-update`.
 
 ### Installation
 

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -256,6 +256,9 @@ The `/usr/local/bin/teleport-updater` symlink will take precedence to avoid reex
 
 To ensure that SELinux permissions do not prevent the `teleport-updater` binary from installing/removing Teleport versions, the updater package will configure SELinux contexts to allow changes to all required paths.
 
+To ensure that `teleport` package removal does not interfere with `teleport-updater`, package removal will run `apt purge` (or `yum` equivalent) while ensuring that `/etc/teleport.yaml` and `/var/lib/teleport` are not purged.
+Failure to do this could result in `/etc/teleport.yaml` being removed when an operator runs `apt purge` at a later date.
+
 #### Failure Conditions
 
 If the new version of Teleport fails to start, the installation of Teleport is reverted as described above.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -213,6 +213,8 @@ If the proxy address is not provided with `--proxy`, the current proxy address f
 The `enable` subcommand will change the behavior of `teleport-update update` to update teleport and restart the existing agent, if running.
 It will also run update teleport immediately, to ensure that subsequent executions succeed.
 
+Both `update` and `enable` will maintain a shared lock file preventing any re-entrant executions.
+
 The `enable` subcommand will:
 1. Query the `/v1/webapi/find` endpoint.
 2. If the current updater-managed version of Teleport is the latest, and teleport package is not installed, jump to (16).

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -410,6 +410,13 @@ are signed.
 
 The Upgrade Framework (TUF) will be used to implement secure updates in the future.
 
+## Logging
+
+All installation steps will be logged locally, such that they are viewable with `journalctl`.
+Care will be taken to ensure that updater logs are sharable with Teleport Support for debugging and auditing purposes.
+
+When TUF is added, that events related to supply chain security may be sent to the Teleport cluster via the Teleport Agent.
+
 ## Execution Plan
 
 1. Implement new auto-updater in Go.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -214,22 +214,22 @@ The `enable` subcommand will change the behavior of `teleport-update update` to 
 It will also run update teleport immediately, to ensure that subsequent executions succeed.
 
 The `enable` subcommand will:
-1. Configure `updates.yaml` with the current proxy address and set `enabled` to true.
-2. Query the `/v1/webapi/find` endpoint.
-3. If the current updater-managed version of Teleport is the latest, and teleport package is not installed, quit.
-4. If the current updater-managed version of Teleport is the latest, but the teleport package is installed, jump to (14).
-5. Ensure there is enough free disk space to upgrade Teleport.
-6. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
-7. Download and verify the checksum (tarball URL suffixed with `.sha256`).
-8. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
-9. Replace any existing binaries or symlinks with symlinks to the current version.
-10. Backup `/var/lib/teleport/proc/sqlite.db` into `/var/lib/teleport/versions/OLD-VERSION/backup/sqlite.db` and create `backup.yaml`.
-11. Restart the agent if the systemd service is already enabled.
-12. Set `active_version` in `updates.yaml` if successful or not enabled.
-13. Replace the symlinks/binaries and `/var/lib/teleport/proc/sqlite.db` and quit (exit 1) if unsuccessful.
-14. Remove any `teleport` package if installed.
-15. Verify the symlinks to the active version still exists.
-16. Remove all stored versions of the agent except the current version and last working version.
+1. Query the `/v1/webapi/find` endpoint.
+2. If the current updater-managed version of Teleport is the latest, and teleport package is not installed, jump to (16).
+3. If the current updater-managed version of Teleport is the latest, but the teleport package is installed, jump to (13).
+4. Ensure there is enough free disk space to upgrade Teleport.
+5. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
+6. Download and verify the checksum (tarball URL suffixed with `.sha256`).
+7. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
+8. Replace any existing binaries or symlinks with symlinks to the current version.
+9. Backup `/var/lib/teleport/proc/sqlite.db` into `/var/lib/teleport/versions/OLD-VERSION/backup/sqlite.db` and create `backup.yaml`.
+10. Restart the agent if the systemd service is already enabled.
+11. Set `active_version` in `updates.yaml` if successful or not enabled.
+12. Replace the symlinks/binaries and `/var/lib/teleport/proc/sqlite.db` and quit (exit 1) if unsuccessful.
+13. Remove and purge any `teleport` package if installed.
+14. Verify the symlinks to the active version still exists.
+15. Remove all stored versions of the agent except the current version and last working version.
+16. Configure `updates.yaml` with the current proxy address and set `enabled` to true.
 
 The `disable` subcommand will:
 1. Configure `updates.yaml` to set `enabled` to false.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -9,7 +9,7 @@ state: draft
 
 * Engineering: @russjones && @bernardjkim
 * Product: @klizhentas || @xinding33 
-* Security: Vendor TBD
+* Security: Doyensec
 
 ## What
 
@@ -234,7 +234,7 @@ The `enable` subcommand will:
 4. Ensure there is enough free disk space to upgrade Teleport.
 5. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
 6. Download and verify the checksum (tarball URL suffixed with `.sha256`).
-7. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
+7. Extract the tarball to `/var/lib/teleport/versions/VERSION` and write the SHA to `/var/lib/teleport/versions/VERSION/sha256`.
 8. Replace any existing binaries or symlinks with symlinks to the current version.
 9. Backup `/var/lib/teleport/proc/sqlite.db` into `/var/lib/teleport/versions/OLD-VERSION/backup/sqlite.db` and create `backup.yaml`.
 10. Restart the agent if the systemd service is already enabled.
@@ -257,7 +257,7 @@ When `update` subcommand is otherwise executed, it will:
 6. Ensure there is enough free disk space to upgrade Teleport.
 7. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
 8. Download and verify the checksum (tarball URL suffixed with `.sha256`).
-9. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
+9. Extract the tarball to `/var/lib/teleport/versions/VERSION` and write the SHA to `/var/lib/teleport/versions/VERSION/sha256`.
 10. Update symlinks to point at the new version.
 11. Backup `/var/lib/teleport/proc/sqlite.db` into `/var/lib/teleport/versions/OLD-VERSION/backup/sqlite.db` and create `backup.yaml`.
 12. Restart the agent if the systemd service is already enabled.
@@ -314,6 +314,9 @@ When Teleport is downgraded to a previous version that has a backup of `sqlite.d
 
 Downgrades are applied with `teleport-updater update`, just like upgrades.
 The above steps modulate the standard workflow in the section above.
+If the downgraded version is already present, the uncompressed version is used to ensure fast recovery of the exact state before the failed upgrade.
+To ensure that the target version is was not corrupted by incomplete extraction, the downgrade checks for the existance of `/var/lib/teleport/versions/TARGET-VERSION/sha256` before downgrading.
+To ensure that the DB backup was not corrupted by incomplete copying, the downgrade checks for the existance of `/var/lib/teleport/versions/TARGET-VERSION/backup/backup.yaml` before restoring.
 
 Teleport must be fully-stopped to safely replace `sqlite.db`.
 When restarting the agent during an upgrade, `SIGHUP` is used.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -93,9 +93,6 @@ spec:
   agent_auto_update: true|false
   # agent_update_hour sets the hour in UTC at which clients should update their agents.
   agent_update_hour: 0-23
-  # agent_update_now overrides agent_update_hour and serves the new version immediately.
-  # This is useful for rolling out critical security updates and bug fixes.
-  agent_update_now: on|off
   # agent_update_jitter_seconds sets a duration in which the upgrade will occur after the hour.
   # The agent upgrader will pick a random time within this duration to wait to upgrade.
   agent_update_jitter_seconds: 0-3600
@@ -107,12 +104,17 @@ $ tctl autoupdate update --set-agent-auto-update=off
 Automatic updates configuration has been updated.
 $ tctl autoupdate update --set-agent-update-hour=3
 Automatic updates configuration has been updated.
-$ tctl autoupdate update --set-agent-update-now=true
-Automatic updates configuration has been updated.
 $ tctl autoupdate update --set-agent-update-jitter-seconds=600
 Automatic updates configuration has been updated.
 $ tctl autoupdate reset
 Automatic updates configuration has been reset to defaults.
+$ tctl autoupdate status
+Status: disabled
+Current: v1.2.3
+Desired: v1.2.4 (critical)
+Window: 3
+Jitter: 600s
+
 ```
 
 ```yaml
@@ -120,6 +122,10 @@ kind: autoupdate_version
 spec:
   # agent_version is the version of the agent the cluster will advertise.
   agent_version: X.Y.Z
+  # agent_critical makes the version as critical.
+  # This overrides agent_update_hour in cluster_maintenance_config and serves the version immediately.
+  # This is useful for rolling out critical security updates and bug fixes.
+  agent_critical: true|false
 
   [...]
 ```

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -132,6 +132,8 @@ spec:
 ```
 $ tctl autoupdate update --set-agent-version=15.1.1
 Automatic updates configuration has been updated.
+$ tctl autoupdate update --set-agent-version=15.1.2 --critical
+Automatic updates configuration has been updated.
 ```
 
 Notes:

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -265,6 +265,8 @@ To ensure that SELinux permissions do not prevent the `teleport-updater` binary 
 To ensure that `teleport` package removal does not interfere with `teleport-updater`, package removal will run `apt purge` (or `yum` equivalent) while ensuring that `/etc/teleport.yaml` and `/var/lib/teleport` are not purged.
 Failure to do this could result in `/etc/teleport.yaml` being removed when an operator runs `apt purge` at a later date.
 
+To ensure that backups are consistent, the updater will use the [SQLite backup API](https://www.sqlite.org/backup.html) to perform the backup.
+
 #### Failure Conditions
 
 If the new version of Teleport fails to start, the installation of Teleport is reverted as described above.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -51,6 +51,8 @@ It will be distributed as a separate package from Teleport, and manage the insta
 It will read the unauthenticated `/v1/webapi/find` endpoint from the Teleport proxy, parse new fields on that endpoint, and install the specified agent version according to the specified upgrade plan.
 It will download the correct version of Teleport as a tarball, unpack it in `/var/lib/teleport`, and ensure it is symlinked from `/usr/local/bin`.
 
+Source code for the updater will live in `integrations/updater`.
+
 ### Installation
 
 ```shell

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -109,6 +109,8 @@ $ tctl autoupdate update --set-agent-update-now=true
 Automatic updates configuration has been updated.
 $ tctl autoupdate update --set-agent-update-jitter-seconds=600
 Automatic updates configuration has been updated.
+$ tctl autoupdate reset
+Automatic updates configuration has been reset to defaults.
 ```
 
 ```yaml

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -268,11 +268,11 @@ $ tctl autoupdate get
 ### Installers
 
 The following install scripts will be updated to install the latest updater and run `teleport-updater enable` with the proxy address:
-- https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/api/types/installers/agentless-installer.sh.tmpl
-- https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/api/types/installers/installer.sh.tmpl
-- https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/lib/web/scripts/oneoff/oneoff.sh
-- https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/lib/web/scripts/node-join/install.sh
-- https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/assets/aws/files/install-hardened.sh
+- [/api/types/installers/agentless-installer.sh.tmpl](https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/api/types/installers/agentless-installer.sh.tmpl)
+- [/api/types/installers/installer.sh.tmpl](https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/api/types/installers/installer.sh.tmpl)
+- [/lib/web/scripts/oneoff/oneoff.sh](https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/lib/web/scripts/oneoff/oneoff.sh)
+- [/lib/web/scripts/node-join/install.sh](https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/lib/web/scripts/node-join/install.sh)
+- [/assets/aws/files/install-hardened.sh](https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/assets/aws/files/install-hardened.sh)
 
 Eventually, additional logic from the scripts could be added to `teleport-updater`, such that `teleport-updater` can configure teleport.
 

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -227,7 +227,8 @@ The `/usr/local/bin/teleport-upgrader` symlink will take precedence to avoid ree
 
 ### Manual Workflow
 
-For use cases that fall outside of the functionality provided by `teleport-updater`, such as JamF or ansible-controlled updates, we provide an alternative manual workflow using the `/v1/webapi/ping` endpoint.
+For use cases that fall outside of the functionality provided by `teleport-updater`, we provide an alternative manual workflow using the `/v1/webapi/ping` endpoint.
+This workflow supports customers that cannot use the auto-update mechanism provided by `teleport-updater` because they use their own automation for updates (e.g., JamF or ansible).
 
 Cluster administrators that want to self-manage agent updates will be
 able to get and watch for changes to agent versions which can then be
@@ -235,15 +236,15 @@ used to trigger other integrations to update the installed version of agents.
 
 ```shell
 $ tctl autoupdate watch
-{"agent_version": "1.0.0"}
-{"agent_version": "1.0.1"}
-{"agent_version": "2.0.0"}
+{"agent_version": "1.0.0", ... }
+{"agent_version": "1.0.1, ... }
+{"agent_version": "2.0.0", ... }
 [...]
 ```
 
 ```shell
 $ tctl autoupdate get
-{"agent_version": "2.0.0"}
+{"agent_version": "2.0.0", ... }
 ```
 
 ### Scripts

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -160,9 +160,14 @@ $ ls -l /usr/local/lib/systemd/system/teleport.service
 updates.yaml:
 ```
 version: v1
-proxy: mytenant.teleport.sh
-enabled: true
-active_version: 15.1.1
+kind: agent_versions
+spec:
+  # proxy specifies the Teleport proxy address to retrieve the agent version and update configuration from.
+  proxy: mytenant.teleport.sh
+  # enabled specifies whether auto-updates are enabled, i.e., whether teleport-updater update is allowed to update the agent.
+  enabled: true
+  # active_version specifies the active (symlinked) deployment of the telepport agent.
+  active_version: 15.1.1
 ```
 
 ### Runtime

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -123,10 +123,6 @@ Automatic updates configuration has been updated.
 Notes:
 - These two resources are separate so that Cloud customers can be restricted from updating `autoupdate_version`, while maintaining control over the rollout.
 
-Questions:
-- Should we use a time-only format for specifying the update hour? E.g., `agent_update_time: "18:00:00.000+01`
-  This would allow users to set an exact time via the CLI, instead of restricting to hours.
-
 ### Filesystem
 
 ```

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -224,7 +224,7 @@ The `/usr/local/bin/teleport-upgrader` symlink will take precedence to avoid ree
 
 For use cases that fall outside of the functionality provided by `teleport-updater`, such as JamF or ansible-controlled updates, we provide an alternative manual workflow using the `/v1/webapi/ping` endpoint.
 
-Cluster administrators that want to self-manage client tools updates will be
+Cluster administrators that want to self-manage agent updates will be
 able to get and watch for changes to agent versions which can then be
 used to trigger other integrations to update the installed version of agents.
 

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -282,6 +282,21 @@ Eventually, additional logic from the scripts could be added to `teleport-update
 
 Moving additional logic into the upgrader is out-of-scope for this proposal.
 
+To create pre-baked VM or container images that reduce the complexity of the cluster joining operation, two workflows are permitted:
+- Install the `teleport-updater` package and defer `teleport-updater enable`, Teleport configuration, and `systemctl enable teleport` to cloud-init scripts.
+  This allows both the proxy address and token to be injected at VM initialization. The VM image may be used with any Teleport cluster.
+  Installers scripts will continue to function, as the package install operation will no-op.
+- Install the `teleport-updater` package and run `teleport-updater enable` before the image is baked, but defer final Teleport configuration and `systemctl enable teleport` to cloud-init scripts.
+  This allows the proxy address to be pre-set in the image. `teleport.yaml` can be partially configured during image creation. At minimum, the token must be injected via cloud-init scripts.
+  Installers scripts would be skipped in favor of the `teleport configure` command.
+
+It is possible for a VM or container image to be created with a baked-in join token.
+We should recommend against this workflow for security reasons, since a long-lived token improperly stored in an image could be leaked.
+
+Alternatively, users may prefer to skip pre-baked agent configuration, and run one of the script-based installers to join VMs to the cluster after the VM is started.
+
+Documentation should be created covering the above workflows.
+
 ### Documentation
 
 The following documentation will need to be updated to cover the new upgrader workflow:

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -284,6 +284,8 @@ To retrieve known information about agent upgrades, the `status` subcommand will
 ### Downgrades
 
 Downgrades may be necessary in cases where we have rolled out a bug or security vulnerability with critical impact.
+To initiate a downgrade, `agent_version` is set to an older version than it was previously set to.
+
 Downgrades are challenging, because `sqlite.db` used by newer version of Teleport may not be valid for older versions of Teleport.
 
 When Teleport is downgraded to a previous version that has a backup of `sqlite.db` present in `/var/lib/teleport/versions/OLD-VERSION/backup/`:
@@ -291,10 +293,12 @@ When Teleport is downgraded to a previous version that has a backup of `sqlite.d
 2. If the backup is valid, Teleport is fully stopped, the backup is restored along with symlinks, and the downgraded version of Teleport is started.
 3. If the backup is invalid, we refuse to downgrade.
 
-Downgrades are still applied with `teleport-updater update`.
+Downgrades are applied with `teleport-updater update`, just like upgrades.
 The above steps modulate the standard workflow in the section above.
 
-Downgrades lead to downtime, as Teleport must be fully-stopped to safely replace `sqlite.db`.
+Teleport must be fully-stopped to safely replace `sqlite.db`.
+When restarting the agent during an upgrade, `SIGHUP` is used.
+When restarting the agent during a downgrade, `systemd stop/start` are used before/after the downgrade.
 
 Teleport CA certificate rotations will break rollbacks.
 This may be addressed in the future by additional validation of the agent's client certificate issuer fingerprints.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -1,0 +1,271 @@
+---
+authors: Stephen Levine (stephen.levine@goteleport.com)
+state: draft
+---
+
+# RFD 0169 - Automatic Updates for Linux Agents
+
+## Required Approvers
+
+* Engineering: @rjones && @bernardjkim
+* Security: @reed
+
+## What
+
+This RFD proposes a new mechanism for Teleport agents installed on Linux servers to automatically update to a version set by an operator via tctl.
+
+The following anti-goals are out-of-scope for this proposal, but will be addressed in future RFDs:
+- Analogous adjustments for Teleport agents installed on Kubernetes
+- Phased rollouts of new agent versions for agents connected to an existing cluster
+- Signing of agent artifacts via TUF
+- Teleport Cloud APIs for updating agents
+
+This RFD proposes a specific implementation of several sections in https://github.com/gravitational/teleport/pull/39217.
+
+Additionally, this RFD parallels the auto-update functionality for client tools proposed in https://github.com/gravitational/teleport/pull/39805.
+
+## Why
+
+The existing mechanism for automatic agent updates does not provide a hands-off experience for all Teleport users.
+
+1. The use of system package management leads to interactions with `apt upgrade`, `yum upgrade`, etc. that can result in unintentional upgrades or confusing command output.
+2. The use of system package management requires complex logic for each target distribution.
+3. The installation mechanism requires 4-5 commands, includes manually installing multiple packages, and varies depending on your version and edition of Teleport.
+4. The use of bash to implement the updater makes changes difficult and prone to error.
+5. The existing auto-updater has limited automated testing.
+6. The use of GPG keys in system package managers has key management implications that we would prefer to solve with TUF in the future.
+7. The desired agent version cannot be set via Teleport's operator-targeted CLI (tctl).
+8. The rollout plan for the new agent version is not fully-configurable using tctl.
+9. Agent installation logic is spread between the auto-updater script, install script, auto-discovery script, and documentation.
+10. Teleport contains logic that is specific to Teleport Cloud upgrade workflows.
+11. The existing auto-updater is not self-updating.
+12. It is difficult and undocumented to automate agent upgrades with custom automation (e.g., with JamF). 
+
+We must provide a seamless, hands-off experience for auto-updates that is easy to maintain.
+
+## Details
+
+We will ship a new auto-updater package written in Go that does not interface with the system package manager.
+It will be versioned separately from Teleport, and manage the installation of the correct Teleport agent version manually. 
+It will read the unauthenticated `/v1/webapi/ping` endpoint from the Teleport proxy, parse new fields on that endpoint, and install the specified agent version according to the specified upgrade plan.
+It will download the correct version of Teleport as a tarball, unpack it in `/var/lib/teleport`, and ensure it is symlinked from `/usr/local/bin`.
+
+### Installation
+
+```shell
+$ apt-get install teleport-ent-updater
+$ teleport-update enable --proxy example.teleport.sh
+
+# if not enabled already, configure teleport and:
+$ systemctl enable teleport
+```
+
+### API
+
+#### Endpoints
+
+`/v1/webapi/ping`
+```json
+{
+  "agent_version": "15.1.1",
+  "agent_auto_update": true,
+  "agent_update_after": "2024-04-23T18:00:00.000Z",
+  "agent_update_jitter": 10,
+}
+```
+Notes:
+- Critical updates are achieved by serving `agent_update_after` with the current time.
+- The Teleport proxy translates upgrade hours (below) into a specific time after which all agents should be upgraded.
+- If an agent misses an upgrade window, it will always update immediately.
+
+#### Teleport Resources
+
+```yaml
+kind: cluster_maintenance_config
+spec:
+  # agent_auto_update allows turning agent updates on or off at the
+  # cluster level. Only turn agent automatic updates off if self-managed
+  # agent updates are in place.
+  agent_auto_update: on|off
+  # agent_update_hour sets the hour in UTC at which clients should update their agents.
+  # The value -1 will set the upgrade time to the current time, resulting in immediate upgrades.
+  agent_update_hour: -1-23
+  # agent_update_jitter sets a duration in which the upgrade will occur after the hour.
+  # The agent upgrader will pick a random time within this duration in which to upgrade.
+  agent_update_jitter: 0-MAXINT64
+  
+  [...]
+```
+```
+$ tctl autoupdate update --set-agent-auto-update=off
+Automatic updates configuration has been updated.
+$ tctl autoupdate update --set-agent-update-hour=3
+Automatic updates configuration has been updated.
+$ tctl autoupdate update --set-agent-update-jitterr=600
+Automatic updates configuration has been updated.
+```
+
+```yaml
+kind: autoupdate_version
+spec:
+  # agent_version is the version of the agent the cluster will advertise.
+  # Can be auto (match the version of the proxy) or an exact semver formatted
+  # version.
+  agent_version: auto|X.Y.Z
+
+  [...]
+```
+```
+$ tctl autoupdate update --set-agent-version=15.1.1
+Automatic updates configuration has been updated.
+```
+
+Notes:
+- These two resources are separate so that Cloud customers can be restricted from updating `autoupdate_version`, while maintaining control over the rollout.
+
+Questions:
+- Should we use a time-only format for specifying the update hour? E.g., `agent_update_time: "18:00:00.000+01`
+  This would allow users to set an exact time via the CLI, instead of restricting to hours.
+
+### Filesystem
+
+```
+$ tree /var/lib/teleport
+/var/lib/teleport
+└── versions
+   ├── 15.0.0
+   │  ├── bin
+   │  │  ├── ...
+   │  │  ├── teleport-updater
+   │  │  └── teleport
+   │  └── etc
+   │     ├── ...
+   │     └── systemd
+   │        └── teleport.service
+   ├── 15.1.1
+   │  ├── bin
+   │  │  ├── ...
+   │  │  ├── teleport-updater
+   │  │  └── teleport
+   │  └── etc
+   │     ├── ...
+   │     └── systemd
+   │        └── teleport.service
+   └── updates.yaml
+$ ls -l /usr/local/bin/teleport
+/usr/local/bin/teleport -> /var/lib/teleport/versions/15.0.0/bin/teleport
+$ ls -l /usr/local/bin/teleport
+/usr/local/bin/teleport-updater -> /var/lib/teleport/versions/15.0.0/bin/teleport-updater
+$ ls -l /usr/local/lib/systemd/system/teleport.service
+/usr/local/lib/systemd/system/teleport.service -> /var/lib/teleport/versions/15.0.0/etc/systemd/teleport.service
+```
+
+updates.yaml:
+```
+version: v1
+proxy: mytenant.teleport.sh
+enabled: true
+active_version: 15.1.1
+```
+
+### Runtime
+
+The agent-updater will run as a periodically executing systemd service which runs every 10 minutes.
+The systemd service will run:
+```shell
+$ teleport-updater update
+```
+
+After it is installed, the `update` subcommand will no-op when executed until configured with the `teleport-updater` command:
+```shell
+$ teleport-updater enable --proxy mytenant.teleport.sh
+```
+
+If the proxy address is not provided with `--proxy`, the current proxy address from `teleport.yaml` is used.
+
+On servers without Teleport installed already, the `enable` subcommand will change the behavior of `teleport-update update` to update teleport and restart the existing agent, if running.
+It will also run update teleport immediately, to ensure that subsequent executions succeed.
+
+The `enable` subcommand will:
+1. Configure `updates.yaml` with the current proxy address and set `enabled` to true.
+2. Query the `/v1/webapi/ping` endpoint.
+3. If the current updater-managed version of Teleport is the latest, and teleport package is not installed, quit.
+4. If the current updater-managed version of Teleport is the latest, but the teleport package is installed, jump to (12).
+5. Download the desired Teleport tarball specified by `agent_version`.
+6. Verify the checksum.
+7. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
+8. Replace any existing binaries or symlinks with symlinks to the current version.
+9. Restart the agent if the systemd service is already enabled.
+10. Set `active_version` in `updates.yaml` if successful or not enabled.
+11. Replace the old symlinks or binaries and quit (exit 1) if unsuccessful.
+12. Remove any `teleport` package if installed.
+13. Verify the symlinks to the active version still exists.
+14. Remove all stored versions of the agent except the current version and last working version.
+
+The `disable` subcommand will:
+1. Configure `updates.yaml` to set `enabled` to false.
+
+When `update` subcommand is otherwise executed, it will:
+1. Check `updates.yaml`, and quit (exit 0) if `enabled` is false, or quit (exit 1) if `enabled` is true and no proxy address is set.
+2. Query the `/v1/webapi/ping` endpoint.
+3. Check if the current time is after the time advertised in `agent_update_after`, and that `agent_auto_updates` is true.
+4. If the current version of Teleport is the latest, quit.
+5. Wait `random(0, agent_update_jitter)` seconds.
+6. Download the desired Teleport tarball specified by `agent_version`.
+7. Verify the checksum.
+8. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
+9. Update symlinks to point at the new version.
+10. Restart the agent if the systemd service is already enabled.
+11. Set `active_version` in `updates.yaml` if successful or not enabled.
+12. Replace the old symlink or binary and quit (exit 1) if unsuccessful.
+13. Remove all stored versions of the agent except the current version and last working version.
+
+To enable auto-updates of the updater itself, all commands will first check for an `active_version`, and reexec using the `teleport-updater` at that version if present and different.
+The `/usr/local/bin/teleport-upgrader` symlink will take precedence to avoid reexec in most scenarios.
+
+### Manual Workflow
+
+For use cases that fall outside of the functionality provided by `teleport-updater`, such as JamF or ansible-controlled updates, we provide an alternative manual workflow using the `/v1/webapi/ping` endpoint.
+
+Cluster administrators that want to self-manage client tools updates will be
+able to get and watch for changes to agent versions which can then be
+used to trigger other integrations to update the installed version of agents.
+
+```shell
+$ tctl autoupdate watch
+{"agent_version": "1.0.0"}
+{"agent_version": "1.0.1"}
+{"agent_version": "2.0.0"}
+[...]
+```
+
+```shell
+$ tctl autoupdate get
+{"agent_version": "2.0.0"}
+```
+
+### Scripts
+
+All scripts will install the latest updater and run `teleport-updater enable` with the proxy address.
+
+Eventually, additional logic from the scripts could be added to `teleport-updater`, such that `teleport-updater` can configure teleport.
+
+This is out-of-scope for this proposal.
+
+## Security
+
+The initial version of automatic updates will rely on TLS to establish
+connection authenticity to the Teleport download server. The authenticity of
+assets served from the download server is out of scope for this RFD. Cluster
+administrators concerned with the authenticity of assets served from the
+download server can use self-managed updates with system package managers which
+are signed.
+
+The Upgrade Framework (TUF) will be used to implement secure updates in the future.
+
+## Execution Plan
+
+1. Implement new auto-updater in Go.
+2. Prep documentation changes.
+3. Release new updater via teleport-ent-updater package.
+4. Release documentation changes.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -213,7 +213,7 @@ $ teleport-updater enable --proxy mytenant.teleport.sh
 
 If the proxy address is not provided with `--proxy`, the current proxy address from `teleport.yaml` is used.
 
-On servers without Teleport installed already, the `enable` subcommand will change the behavior of `teleport-update update` to update teleport and restart the existing agent, if running.
+The `enable` subcommand will change the behavior of `teleport-update update` to update teleport and restart the existing agent, if running.
 It will also run update teleport immediately, to ensure that subsequent executions succeed.
 
 The `enable` subcommand will:
@@ -377,6 +377,9 @@ The Upgrade Framework (TUF) will be used to implement secure updates in the futu
 ## Execution Plan
 
 1. Implement new auto-updater in Go.
-2. Prep documentation changes.
-3. Release new updater via teleport-ent-updater package.
-4. Release documentation changes.
+2. Test extensively on all supported Linux distributions.
+3. Prep documentation changes.
+4. Release new updater via teleport-ent-updater package.
+5. Release documentation changes.
+6. Communicate to select Cloud customers that they must update their updater, starting with lower ARR customers.
+7. Communicate to all Cloud customers that they must update their updater.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -138,11 +138,12 @@ $ tree /var/lib/teleport
 └── versions
    ├── 15.0.0
    │  ├── bin
-   │  │  ├── ...
+   │  │  ├── tsh
+   │  │  ├── tbot
+   │  │  ├── ... # other binaries
    │  │  ├── teleport-updater
    │  │  └── teleport
    │  ├── etc
-   │  │  ├── ...
    │  │  └── systemd
    │  │     └── teleport.service
    │  └── backup
@@ -150,14 +151,19 @@ $ tree /var/lib/teleport
    │     └── backup.yaml
    ├── 15.1.1
    │  ├── bin
-   │  │  ├── ...
+   │  │  ├── tsh
+   │  │  ├── tbot
+   │  │  ├── ... # other binaries
    │  │  ├── teleport-updater
    │  │  └── teleport
    │  └── etc
-   │     ├── ...
    │     └── systemd
    │        └── teleport.service
    └── updates.yaml
+$ ls -l /usr/local/bin/tsh
+/usr/local/bin/tsh -> /var/lib/teleport/versions/15.0.0/bin/tsh
+$ ls -l /usr/local/bin/tbot
+/usr/local/bin/tbot -> /var/lib/teleport/versions/15.0.0/bin/tbot
 $ ls -l /usr/local/bin/teleport
 /usr/local/bin/teleport -> /var/lib/teleport/versions/15.0.0/bin/teleport
 $ ls -l /usr/local/bin/teleport-updater
@@ -216,13 +222,13 @@ The `enable` subcommand will:
 3. If the current updater-managed version of Teleport is the latest, and teleport package is not installed, quit.
 4. If the current updater-managed version of Teleport is the latest, but the teleport package is installed, jump to (12).
 5. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
-6. Verify the checksum.
+6. Download and verify the checksum.
 7. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
 8. Replace any existing binaries or symlinks with symlinks to the current version.
 9. Backup /var/lib/teleport into `/var/lib/teleport/versions/OLD-VERSION/backup/teleport`
 10. Restart the agent if the systemd service is already enabled.
 11. Set `active_version` in `updates.yaml` if successful or not enabled.
-12. Replace the symlink/binary and `/var/lib/teleport` and quit (exit 1) if unsuccessful.
+12. Replace the symlinks/binaries and `/var/lib/teleport` and quit (exit 1) if unsuccessful.
 13. Remove any `teleport` package if installed.
 14. Verify the symlinks to the active version still exists.
 15. Remove all stored versions of the agent except the current version and last working version.
@@ -237,17 +243,19 @@ When `update` subcommand is otherwise executed, it will:
 4. If the current version of Teleport is the latest, quit.
 5. Wait `random(0, agent_update_jitter_seconds)` seconds.
 6. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
-7. Verify the checksum.
+7. Download and verify the checksum.
 8. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
 9. Update symlinks to point at the new version.
 10. Backup /var/lib/teleport into `/var/lib/teleport/versions/OLD-VERSION/backup/teleport`.
 11. Restart the agent if the systemd service is already enabled.
 12. Set `active_version` in `updates.yaml` if successful or not enabled.
-13. Replace the old symlink/binary and `/var/lib/teleport` and quit (exit 1) if unsuccessful.
+13. Replace the old symlinks/binaries and `/var/lib/teleport` and quit (exit 1) if unsuccessful.
 14. Remove all stored versions of the agent except the current version and last working version.
 
 To enable auto-updates of the updater itself, all commands will first check for an `active_version`, and reexec using the `teleport-updater` at that version if present and different.
 The `/usr/local/bin/teleport-upgrader` symlink will take precedence to avoid reexec in most scenarios.
+
+If `teleport-updater` fails with an error, and an older version of `teleport-updater` is available, the upgrade will retry with the older version.
 
 To retrieve known information about agent upgrades, the `status` subcommand will return the following:
 ```json

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -265,13 +265,29 @@ $ tctl autoupdate get
 {"agent_version": "2.0.0", "agent_edition": "enterprise", ... }
 ```
 
-### Scripts
+### Installers
 
-All scripts will install the latest updater and run `teleport-updater enable` with the proxy address.
+The following install scripts will install the latest updater and run `teleport-updater enable` with the proxy address:
+
+- https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/api/types/installers/agentless-installer.sh.tmpl
+- https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/api/types/installers/installer.sh.tmpl
+- https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/lib/web/scripts/oneoff/oneoff.sh
+- https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/lib/web/scripts/node-join/install.sh
+- https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/assets/aws/files/install-hardened.sh
 
 Eventually, additional logic from the scripts could be added to `teleport-updater`, such that `teleport-updater` can configure teleport.
 
-This is out-of-scope for this proposal.
+Moving additional logic into the upgrader is out-of-scope for this proposal.
+
+### Documentation
+
+The following documentation will need to be updated to cover the new upgrader workflow:
+- https://goteleport.com/docs/choose-an-edition/teleport-cloud/downloads
+- https://goteleport.com/docs/installation
+- https://goteleport.com/docs/upgrading/self-hosted-linux
+- https://goteleport.com/docs/upgrading/self-hosted-automatic-agent-updates
+
+Additionally, the Cloud dashboard tenants downloads tab will need to be updated to reference the new instructions.
 
 ## Security
 

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -70,7 +70,7 @@ $ systemctl enable teleport
   "agent_version": "15.1.1",
   "agent_auto_update": true,
   "agent_update_after": "2024-04-23T18:00:00.000Z",
-  "agent_update_jitter": 10,
+  "agent_update_jitter_seconds": 10,
 }
 ```
 Notes:
@@ -90,9 +90,9 @@ spec:
   # agent_update_hour sets the hour in UTC at which clients should update their agents.
   # The value -1 will set the upgrade time to the current time, resulting in immediate upgrades.
   agent_update_hour: -1-23
-  # agent_update_jitter sets a duration in which the upgrade will occur after the hour.
+  # agent_update_jitter_seconds sets a duration in which the upgrade will occur after the hour.
   # The agent upgrader will pick a random time within this duration in which to upgrade.
-  agent_update_jitter: 0-MAXINT64
+  agent_update_jitter_seconds: 0-MAXINT64
   
   [...]
 ```
@@ -101,7 +101,7 @@ $ tctl autoupdate update --set-agent-auto-update=off
 Automatic updates configuration has been updated.
 $ tctl autoupdate update --set-agent-update-hour=3
 Automatic updates configuration has been updated.
-$ tctl autoupdate update --set-agent-update-jitterr=600
+$ tctl autoupdate update --set-agent-update-jitter-seconds=600
 Automatic updates configuration has been updated.
 ```
 
@@ -210,7 +210,7 @@ When `update` subcommand is otherwise executed, it will:
 2. Query the `/v1/webapi/ping` endpoint.
 3. Check if the current time is after the time advertised in `agent_update_after`, and that `agent_auto_updates` is true.
 4. If the current version of Teleport is the latest, quit.
-5. Wait `random(0, agent_update_jitter)` seconds.
+5. Wait `random(0, agent_update_jitter_seconds)` seconds.
 6. Download the desired Teleport tarball specified by `agent_version`.
 7. Verify the checksum.
 8. Extract the tarball to `/var/lib/teleport/versions/VERSION`.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -7,7 +7,7 @@ state: draft
 
 ## Required Approvers
 
-* Engineering: @rjones && @bernardjkim
+* Engineering: @russjones && @bernardjkim
 * Security: @reed
 
 ## What

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -8,7 +8,7 @@ state: draft
 ## Required Approvers
 
 * Engineering: @russjones && @bernardjkim
-* Security: @reed
+* Security: @reedloden
 
 ## What
 

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -68,6 +68,7 @@ $ systemctl enable teleport
 `/v1/webapi/ping`
 ```json
 {
+  "server_edition": "enterprise",
   "agent_version": "15.1.1",
   "agent_auto_update": true,
   "agent_update_after": "2024-04-23T18:00:00.000Z",
@@ -78,6 +79,7 @@ Notes:
 - Critical updates are achieved by serving `agent_update_after` with the current time.
 - The Teleport proxy translates upgrade hours (below) into a specific time after which all agents should be upgraded.
 - If an agent misses an upgrade window, it will always update immediately.
+- The edition served is the cluster edition (enterprise, enterprise-fips, or oss), and cannot be configured.
 
 #### Teleport Resources
 
@@ -193,7 +195,7 @@ The `enable` subcommand will:
 2. Query the `/v1/webapi/ping` endpoint.
 3. If the current updater-managed version of Teleport is the latest, and teleport package is not installed, quit.
 4. If the current updater-managed version of Teleport is the latest, but the teleport package is installed, jump to (12).
-5. Download the desired Teleport tarball specified by `agent_version`.
+5. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
 6. Verify the checksum.
 7. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
 8. Replace any existing binaries or symlinks with symlinks to the current version.
@@ -213,7 +215,7 @@ When `update` subcommand is otherwise executed, it will:
 3. Check if the current time is after the time advertised in `agent_update_after`, and that `agent_auto_updates` is true.
 4. If the current version of Teleport is the latest, quit.
 5. Wait `random(0, agent_update_jitter_seconds)` seconds.
-6. Download the desired Teleport tarball specified by `agent_version`.
+6. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
 7. Verify the checksum.
 8. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
 9. Update symlinks to point at the new version.
@@ -231,10 +233,13 @@ To retrieve known information about agent upgrades, the `status` subcommand will
   "agent_version_installed": "15.1.1",
   "agent_version_desired": "15.1.2",
   "agent_version_previous": "15.1.0",
-  "update_time_next": "2020-12-09T16:09:53+00:00",
-  "update_time_last": "2020-12-10T16:00:00+00:00",
-  "update_time_jitter": 600,
-  "updates_enabled": true
+  "agent_edition_installed": "enterprise",
+  "agent_edition_desired": "enterprise",
+  "agent_edition_previous": "enterprise",
+  "agent_update_time_next": "2020-12-09T16:09:53+00:00",
+  "agent_update_time_last": "2020-12-10T16:00:00+00:00",
+  "agent_update_time_jitter": 600,
+  "agent_updates_enabled": true
 }
 ```
 
@@ -249,15 +254,15 @@ used to trigger other integrations to update the installed version of agents.
 
 ```shell
 $ tctl autoupdate watch
-{"agent_version": "1.0.0", ... }
-{"agent_version": "1.0.1, ... }
-{"agent_version": "2.0.0", ... }
+{"agent_version": "1.0.0", "agent_edition": "enterprise", ... }
+{"agent_version": "1.0.1, "agent_edition": "enterprise", ... }
+{"agent_version": "2.0.0", "agent_edition": "enterprise", ... }
 [...]
 ```
 
 ```shell
 $ tctl autoupdate get
-{"agent_version": "2.0.0", ... }
+{"agent_version": "2.0.0", "agent_edition": "enterprise", ... }
 ```
 
 ### Scripts

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -220,18 +220,19 @@ The `enable` subcommand will:
 1. Configure `updates.yaml` with the current proxy address and set `enabled` to true.
 2. Query the `/v1/webapi/ping` endpoint.
 3. If the current updater-managed version of Teleport is the latest, and teleport package is not installed, quit.
-4. If the current updater-managed version of Teleport is the latest, but the teleport package is installed, jump to (12).
-5. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
-6. Download and verify the checksum.
-7. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
-8. Replace any existing binaries or symlinks with symlinks to the current version.
-9. Backup /var/lib/teleport into `/var/lib/teleport/versions/OLD-VERSION/backup/teleport`
-10. Restart the agent if the systemd service is already enabled.
-11. Set `active_version` in `updates.yaml` if successful or not enabled.
-12. Replace the symlinks/binaries and `/var/lib/teleport` and quit (exit 1) if unsuccessful.
-13. Remove any `teleport` package if installed.
-14. Verify the symlinks to the active version still exists.
-15. Remove all stored versions of the agent except the current version.
+4. If the current updater-managed version of Teleport is the latest, but the teleport package is installed, jump to (14).
+5. Ensure there is enough free disk space to upgrade Teleport.
+6. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
+7. Download and verify the checksum (tarball URL suffixed with `.sha256`).
+8. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
+9. Replace any existing binaries or symlinks with symlinks to the current version.
+10. Backup /var/lib/teleport into `/var/lib/teleport/versions/OLD-VERSION/backup/teleport`
+11. Restart the agent if the systemd service is already enabled.
+12. Set `active_version` in `updates.yaml` if successful or not enabled.
+13. Replace the symlinks/binaries and `/var/lib/teleport` and quit (exit 1) if unsuccessful.
+14. Remove any `teleport` package if installed.
+15. Verify the symlinks to the active version still exists.
+16. Remove all stored versions of the agent except the current version.
 
 The `disable` subcommand will:
 1. Configure `updates.yaml` to set `enabled` to false.
@@ -242,15 +243,16 @@ When `update` subcommand is otherwise executed, it will:
 3. Check if the current time is after the time advertised in `agent_update_after`, and that `agent_auto_updates` is true.
 4. If the current version of Teleport is the latest, quit.
 5. Wait `random(0, agent_update_jitter_seconds)` seconds.
-6. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
-7. Download and verify the checksum.
-8. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
-9. Update symlinks to point at the new version.
-10. Backup /var/lib/teleport into `/var/lib/teleport/versions/OLD-VERSION/backup/teleport`.
-11. Restart the agent if the systemd service is already enabled.
-12. Set `active_version` in `updates.yaml` if successful or not enabled.
-13. Replace the old symlinks/binaries and `/var/lib/teleport` and quit (exit 1) if unsuccessful.
-14. Remove all stored versions of the agent except the current version.
+6. Ensure there is enough free disk space to upgrade Teleport.
+7. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
+8. Download and verify the checksum (tarball URL suffixed with `.sha256`).
+9. Extract the tarball to `/var/lib/teleport/versions/VERSION`.
+10. Update symlinks to point at the new version.
+11. Backup /var/lib/teleport into `/var/lib/teleport/versions/OLD-VERSION/backup/teleport`.
+12. Restart the agent if the systemd service is already enabled.
+13. Set `active_version` in `updates.yaml` if successful or not enabled.
+14. Replace the old symlinks/binaries and `/var/lib/teleport` and quit (exit 1) if unsuccessful.
+15. Remove all stored versions of the agent except the current version.
 
 To enable auto-updates of the updater itself, all commands will first check for an `active_version`, and reexec using the `teleport-updater` at that version if present and different.
 The `/usr/local/bin/teleport-upgrader` symlink will take precedence to avoid reexec in most scenarios.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -231,7 +231,7 @@ The `enable` subcommand will:
 12. Replace the symlinks/binaries and `/var/lib/teleport` and quit (exit 1) if unsuccessful.
 13. Remove any `teleport` package if installed.
 14. Verify the symlinks to the active version still exists.
-15. Remove all stored versions of the agent except the current version and last working version.
+15. Remove all stored versions of the agent except the current version.
 
 The `disable` subcommand will:
 1. Configure `updates.yaml` to set `enabled` to false.
@@ -250,7 +250,7 @@ When `update` subcommand is otherwise executed, it will:
 11. Restart the agent if the systemd service is already enabled.
 12. Set `active_version` in `updates.yaml` if successful or not enabled.
 13. Replace the old symlinks/binaries and `/var/lib/teleport` and quit (exit 1) if unsuccessful.
-14. Remove all stored versions of the agent except the current version and last working version.
+14. Remove all stored versions of the agent except the current version.
 
 To enable auto-updates of the updater itself, all commands will first check for an `active_version`, and reexec using the `teleport-updater` at that version if present and different.
 The `/usr/local/bin/teleport-upgrader` symlink will take precedence to avoid reexec in most scenarios.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -91,8 +91,10 @@ spec:
   # agent updates are in place.
   agent_auto_update: on|off
   # agent_update_hour sets the hour in UTC at which clients should update their agents.
-  # The value -1 will set the upgrade time to the current time, resulting in immediate upgrades.
-  agent_update_hour: -1-23
+  agent_update_hour: 0-23
+  # agent_update_now overrides agent_update_hour and sets agent update time to the current time.
+  # This is useful for rolling out critical security updates and bug fixes.
+  agent_update_now: on|off
   # agent_update_jitter_seconds sets a duration in which the upgrade will occur after the hour.
   # The agent upgrader will pick a random time within this duration in which to upgrade.
   agent_update_jitter_seconds: 0-MAXINT64
@@ -103,6 +105,8 @@ spec:
 $ tctl autoupdate update --set-agent-auto-update=off
 Automatic updates configuration has been updated.
 $ tctl autoupdate update --set-agent-update-hour=3
+Automatic updates configuration has been updated.
+$ tctl autoupdate update --set-agent-update-now=true
 Automatic updates configuration has been updated.
 $ tctl autoupdate update --set-agent-update-jitter-seconds=600
 Automatic updates configuration has been updated.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -255,7 +255,15 @@ When `update` subcommand is otherwise executed, it will:
 To enable auto-updates of the updater itself, all commands will first check for an `active_version`, and reexec using the `teleport-updater` at that version if present and different.
 The `/usr/local/bin/teleport-upgrader` symlink will take precedence to avoid reexec in most scenarios.
 
-If `teleport-updater` fails with an error, and an older version of `teleport-updater` is available, the upgrade will retry with the older version.
+#### Failure Conditions
+
+If the new version of Teleport fails to start, the installation of Teleport is reverted as described above.
+
+If `teleport-updater` itself fails with an error, and an older version of `teleport-updater` is available, the upgrade will retry with the older version.
+
+Known failure conditions caused by intentional configuration (e.g., upgrades disabled) will not trigger retry logic.
+
+#### Status
 
 To retrieve known information about agent upgrades, the `status` subcommand will return the following:
 ```json

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -267,8 +267,7 @@ $ tctl autoupdate get
 
 ### Installers
 
-The following install scripts will install the latest updater and run `teleport-updater enable` with the proxy address:
-
+The following install scripts will be updated to install the latest updater and run `teleport-updater enable` with the proxy address:
 - https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/api/types/installers/agentless-installer.sh.tmpl
 - https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/api/types/installers/installer.sh.tmpl
 - https://github.com/gravitational/teleport/blob/d0a68fd82412b48cb54f664ae8500f625fb91e48/lib/web/scripts/oneoff/oneoff.sh

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -225,6 +225,19 @@ When `update` subcommand is otherwise executed, it will:
 To enable auto-updates of the updater itself, all commands will first check for an `active_version`, and reexec using the `teleport-updater` at that version if present and different.
 The `/usr/local/bin/teleport-upgrader` symlink will take precedence to avoid reexec in most scenarios.
 
+To retrieve known information about agent upgrades, the `status` subcommand will return the following:
+```json
+{
+  "agent_version_installed": "15.1.1",
+  "agent_version_desired": "15.1.2",
+  "agent_version_previous": "15.1.0",
+  "update_time_next": "2020-12-09T16:09:53+00:00",
+  "update_time_last": "2020-12-10T16:00:00+00:00",
+  "update_time_jitter": 600,
+  "updates_enabled": true
+}
+```
+
 ### Manual Workflow
 
 For use cases that fall outside of the functionality provided by `teleport-updater`, we provide an alternative manual workflow using the `/v1/webapi/ping` endpoint.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -8,6 +8,7 @@ state: draft
 ## Required Approvers
 
 * Engineering: @russjones && @bernardjkim
+* Product: @klizhentas || @xinding33 
 * Security: @reedloden
 
 ## What

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -255,7 +255,7 @@ used to trigger other integrations to update the installed version of agents.
 ```shell
 $ tctl autoupdate watch
 {"agent_version": "1.0.0", "agent_edition": "enterprise", ... }
-{"agent_version": "1.0.1, "agent_edition": "enterprise", ... }
+{"agent_version": "1.0.1", "agent_edition": "enterprise", ... }
 {"agent_version": "2.0.0", "agent_edition": "enterprise", ... }
 [...]
 ```

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -255,7 +255,7 @@ When `update` subcommand is otherwise executed, it will:
 15. Remove all stored versions of the agent except the current version.
 
 To enable auto-updates of the updater itself, all commands will first check for an `active_version`, and reexec using the `teleport-updater` at that version if present and different.
-The `/usr/local/bin/teleport-upgrader` symlink will take precedence to avoid reexec in most scenarios.
+The `/usr/local/bin/teleport-updater` symlink will take precedence to avoid reexec in most scenarios.
 
 #### Failure Conditions
 
@@ -293,7 +293,7 @@ When Teleport is downgraded to a previous version that has a backup of `/var/lib
 2. If the backup is valid, Teleport is fully stopped, the backup is restored along with symlinks, and the downgraded version of Teleport is started.
 3. If the backup is invalid, we refuse to downgrade.
 
-Downgrades are still applied with `teleport-upgrader update`.
+Downgrades are still applied with `teleport-updater update`.
 The above steps modulate the standard workflow in the section above.
 
 Notes:

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -151,7 +151,7 @@ $ tree /var/lib/teleport
    └── updates.yaml
 $ ls -l /usr/local/bin/teleport
 /usr/local/bin/teleport -> /var/lib/teleport/versions/15.0.0/bin/teleport
-$ ls -l /usr/local/bin/teleport
+$ ls -l /usr/local/bin/teleport-updater
 /usr/local/bin/teleport-updater -> /var/lib/teleport/versions/15.0.0/bin/teleport-updater
 $ ls -l /usr/local/lib/systemd/system/teleport.service
 /usr/local/lib/systemd/system/teleport.service -> /var/lib/teleport/versions/15.0.0/etc/systemd/teleport.service

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -92,7 +92,7 @@ The cache will be kept up-to-date when the auth server receives updates.
 At the start of the upgrade window, auth servers attempt to write an update rollout plan to the backend.
 This plan is protected by optimistic locking, and contains the following data:
 
-Data key: `/autoupdate/[name of group](/[auth ID]/page[number])` (e.g., `/autoupdate/staging/58526ba2-c12d-4a49-b5a4-1b694b82bf56/page1`)
+Data key: `/autoupdate/[name of group](/[auth ID]/[number])` (e.g., `/autoupdate/staging/58526ba2-c12d-4a49-b5a4-1b694b82bf56/1`)
 
 Data value JSON:
 - `start_time`: timestamp of current window start time
@@ -120,16 +120,16 @@ If cleanup fails, the unusable pages will expire from the backend after 2 weeks.
 
 ```
 Winning auth:
-  WRITE: /autoupdate/staging/58526ba2-c12d-4a49-b5a4-1b694b82bf56/page2
-  WRITE: /autoupdate/staging/58526ba2-c12d-4a49-b5a4-1b694b82bf56/page1
+  WRITE: /autoupdate/staging/58526ba2-c12d-4a49-b5a4-1b694b82bf56/2
+  WRITE: /autoupdate/staging/58526ba2-c12d-4a49-b5a4-1b694b82bf56/1
   WRITE: /autoupdate/staging | auth_id: 58526ba2-c12d-4a49-b5a4-1b694b82bf56
 
 Losing auth:
-  WRITE: /autoupdate/staging/dd850e65-d2b2-4557-8ffb-def893c52530/page2
-  WRITE: /autoupdate/staging/dd850e65-d2b2-4557-8ffb-def893c52530/page1
+  WRITE: /autoupdate/staging/dd850e65-d2b2-4557-8ffb-def893c52530/2
+  WRITE: /autoupdate/staging/dd850e65-d2b2-4557-8ffb-def893c52530/1
   WRITE CONFLICT: /autoupdate/staging | auth_id: dd850e65-d2b2-4557-8ffb-def893c52530
-  DELETE: /autoupdate/staging/dd850e65-d2b2-4557-8ffb-def893c52530/page1
-  DELETE: /autoupdate/staging/dd850e65-d2b2-4557-8ffb-def893c52530/page2
+  DELETE: /autoupdate/staging/dd850e65-d2b2-4557-8ffb-def893c52530/1
+  DELETE: /autoupdate/staging/dd850e65-d2b2-4557-8ffb-def893c52530/2
 ```
 
 To read all pages, auth servers read the first page, get the auth server ID from the `auth_id` field, and then range-read the remaining pages.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -223,8 +223,8 @@ tctl autoupdate agent new-rollout v3
 # created new rollout from v2 to v3
 ```
 
-TODO(sclevine): What about `update` or `target` instead of `new-rollout`?
-  `new-rollout` seems like we're creating a new resource, not changing target version.
+[TODO(sclevine): What about `update` or `target` instead of `new-rollout`?
+  `new-rollout` seems like we're creating a new resource, not changing target version.]
 
 <details>
 <summary>After</summary>
@@ -1114,8 +1114,8 @@ However, any changes to `agent_schedules` that occur while a group is active wil
 
 Releasing new agent versions multiple times a week has the potential to starve dependent groups from updates.
 
-Note that the `default` schedule applies to agents that do not specify a group name.
-[TODO: It seems we removed the default bool, So we have a mandatory default group? Can we pick the last one instead?]
+Note that the `default` group applies to agents that do not specify a group name.
+If a `default` group is not present, the last group is treated as the default.
 
 ### Updater APIs
 
@@ -1156,10 +1156,10 @@ Notes:
 
 - Agents will only update if `agent_autoupdate` is `true`, but new installations will use `agent_version` regardless of
   the value in `agent_autoupdate`.
-- The edition served is the cluster edition (enterprise, enterprise-fips, or oss), and cannot be configured.
+- The edition served is the cluster edition (enterprise, enterprise-fips, or oss) and cannot be configured.
 - The group name is read from `/var/lib/teleport/versions/update.yaml` by the updater.
 - The UUID is read from `/tmp/teleport_update_uuid`, which `teleport-update` regenerates when missing.
-- the jitter is served by the teleport cluster and depends on the rollout strategy (60 sec by default, 10sec when using
+- the jitter is served by the teleport cluster and depends on the rollout strategy (60s by default, 10s when using
   the backpressure strategy).
 
 Let `v1` be the previous version and `v2` the target version, the response matrix is the following:
@@ -1192,7 +1192,7 @@ Let `v1` be the previous version and `v2` the target version, the response matri
 
 #### Updater status reporting
 
-Instance heartbeats will be extended to incorporate and send data that is written to `/var/lib/teleport/versions/update.yaml` by the `teleport-update` binary.
+Instance heartbeats will be extended to incorporate and send data that is written to `/var/lib/teleport/versions/update.yaml` and `/tmp/teleport_update_uuid` by the `teleport-update` binary.
 
 The following data related to the rollout are stored in each instance heartbeat:
 - `agent_update_start_time`: timestamp of individual agent's upgrade time
@@ -1627,7 +1627,7 @@ Making the update boolean instruction available via the `/webapi/find` TLS endpo
 3. Implement changes to Kubernetes auto-updater.
 4. Test extensively on all supported Linux distributions.
 5. Prep documentation changes.
-6. Release via `teleport` package and script for packageless install.
+6. Release via `teleport` package and script for package-less installation.
 7. Release documentation changes.
 8. Communicate to users that they should update to the new system.
 9. Begin deprecation of old auto-updater resources, packages, and endpoints.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -855,13 +855,13 @@ message AgentAutoUpdateGroup {
   // start_hour to initiate update
   int32 start_hour = 3;
   // wait_days after last group succeeds before this group can run
-  int32 wait_days = 4;
-  // jitter_seconds to introduce before update as rand([0, jitter_seconds])
-  int32 jitter_seconds = 5;
-  // canary_count of agents to use in the canary deployment.
-  int32 canary_count = 6;
+  int64 wait_days = 4;
   // alert_after_hours specifies the number of hours to wait before alerting that the rollout is not complete.
-  int32 alert_after_hours = 7; 
+  int64 alert_after_hours = 5;
+  // jitter_seconds to introduce before update as rand([0, jitter_seconds])
+  int64 jitter_seconds = 6;
+  // canary_count of agents to use in the canary deployment.
+  int64 canary_count = 7;
   // max_in_flight specifies agents that can be updated at the same time, by percent.
   string max_in_flight = 8;
 }
@@ -964,17 +964,54 @@ enum Strategy {
 
 // AutoUpdateAgentPlanStatus is the status for the AutoUpdateAgentPlan.
 message AutoUpdateAgentPlanStatus {
-  // version targetted by the rollout
-  string version = 2;
+  // name of the group
+  string name = 0;
   // start_time of the rollout
   google.protobuf.Timestamp start_time = 1;
-  // last_active_host_index specifies the index of the last host that may be updated.
-  int64 last_active_host_index = 1;
-  // failed_host_count specifies the number of failed hosts.
-  int64 failed_host_count = 2;
-  // timeout_host_count specifies the number of timed-out hosts.
-  int64 timeout_host_count = 3;
+  // initial_count is the number of connected agents at the start of the window.
+  int64 initial_count = 2;
+  // present_count is the current number of connected agents.
+  int64 present_count = 3;
+  // failed_count specifies the number of failed agents.
+  int64 failed_count = 4;
+  // canaries is a list of canary agents.
+  repeated Canary canaries = 5;
+  // progress is the current progress through the rollout.
+  float64 progress = 6;
+  // state is the current state of the rollout.
+  State state = 7;
+  // last_update_time is the time of the previous update for this group.
+  google.protobuf.Timestamp last_update_time = 8;
+  // last_update_reason is the trigger for the last update
+  string last_update_reason = 9;
 }
+
+// Canary agent
+message Canary {
+  // update_uuid of the canary agent
+  string update_uuid = 0;
+  // host_uuid of the canary agent
+  string host_uuid = 1;
+  // hostname of the canary agent
+  string hostname = 2;
+}
+
+// State of the rollout
+enum State {
+  // UNSPECIFIED state
+  STATE_UNSPECIFIED = 0;
+  // UNSTARTED state
+  STATE_UNSTARTED = 1;
+  // CANARY state
+  STATE_CANARY = 2;
+  // ACTIVE state
+  STATE_ACTIVE = 3;
+  // DONE state
+  STATE_DONE = 4;
+  // ROLLEDBACK state
+  STATE_ROLLEDBACK = 5;
+}
+
 ```
 
 ## Alternatives

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -921,13 +921,14 @@ message AutoupdateVersionSpec {
 
 // Schedule type for the rollout
 enum Schedule {
-  Schedule_UNSPECIFIED = 0;
+  // UNSPECIFIED update schedule
+  SCHEDULE_UNSPECIFIED = 0;
   // REGULAR update schedule
-  Schedule_REGULAR = 1;
+  SCHEDULE_REGULAR = 1;
   // CRITICAL update schedule for critical bugs and vulnerabilities
-  Schedule_CRITICAL = 2;
+  SCHEDULE_CRITICAL = 2;
   // IMMEDIATE update schedule for updating all agents immediately
-  Schedule_IMMEDIATE = 3;
+  SCHEDULE_IMMEDIATE = 3;
 }
 
 // GetAgentRolloutPlanRequest requests an agent_rollout_plan.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -921,12 +921,13 @@ message AutoupdateVersionSpec {
 
 // Schedule type for the rollout
 enum Schedule {
+  Schedule_UNSPECIFIED = 0;
   // REGULAR update schedule
-  REGULAR = 0;
+  Schedule_REGULAR = 1;
   // CRITICAL update schedule for critical bugs and vulnerabilities
-  CRITICAL = 1;
+  Schedule_CRITICAL = 2;
   // IMMEDIATE update schedule for updating all agents immediately
-  IMMEDIATE = 2;
+  Schedule_IMMEDIATE = 3;
 }
 
 // GetAgentRolloutPlanRequest requests an agent_rollout_plan.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -515,6 +515,71 @@ tctl auto-update agent status
 ```
 </details>
 
+#### As a Teleport user, I want to install a new agent automatically updated
+
+The manual way:
+
+```bash
+wget https://cdn.teleport.dev/teleport-updater-<os>-<arch>
+chmod +x teleport-updater
+./teleport-updater enable example.teleport.sh --group production
+# Detecting the Teleport version and edition used by cluster "example.teleport.sh"
+# Installing the following teleport version:
+#   Version: 16.2.1
+#   Edition: Enterprise
+#   OS: Linux
+#   Architecture: x86
+# Teleport installed
+# Enabling automatic updates, the agent is part of the "production" update group.
+# You can now configure the teleport agent with `teleport configure` or by writing your own `teleport.yaml`.
+# When the configuration is done, enable and start teleport by running:
+# `systemctl start teleport && systemctl enable teleport`
+```
+
+The one-liner:
+
+```
+curl https://cdn.teleport.dev/auto-install | bash -s example.teleport.sh
+# Downloading the teleport updater
+# Detecting the Teleport version and edition used by cluster "example.teleport.sh"
+# Installing the following teleport version:
+#   Version: 16.2.1
+#   Edition: Enterprise
+#   OS: Linux
+#   Architecture: x86
+# Teleport installed
+# Enabling automatic updates, the agent is part of the "default" update group.
+# You can now configure the teleport agent with `teleport configure` or by writing your own `teleport.yaml`.
+# When the configuration is finished, enable and start teleport by running:
+# `systemctl start teleport && systemctl enable teleport`
+```
+
+I can also install teleport using the package manager, then enroll the agent into AUs. See the section below:
+
+#### As a Teleport user I want to enroll my existing agent into AUs
+
+I have an agent, installed from a package manager or by manually unpacking the tarball.
+I have the teleport updater installed and available in my path.
+I run:
+
+```shell
+teleport-updater enable --group production
+# Detecting the Teleport version and edition used by cluster "example.teleport.sh"
+# Installing the following teleport version:
+#   Version: 16.2.1
+#   Edition: Enterprise
+#   OS: Linux
+#   Architecture: x86
+# Teleport installed, reloading the service.
+# Enabling automatic updates, the agent is part of the "production" update group.
+```
+
+> [!NOTE]
+> The updater saw the teleport unit running and the existing teleport configuration.
+> It used the configuration to pick the right proxy address. As teleport is already running, the teleport service is
+> reloaded to use the new binary.
+
+
 ### Teleport Resources
 
 #### Autoupdate Config
@@ -1058,14 +1123,7 @@ minute will be considered in these formulas.
 
 ### Manually interacting with the rollout
 
-
-#### RPCs
-Users and administrators can interact with the rollout plan using the following RPCs:
-
-```protobuf
-```
-
-#### CLI
+[TODO add cli commands]
 
 ### Editing the plan
 
@@ -1082,51 +1140,6 @@ Releasing new agent versions multiple times a week has the potential to starve d
 
 Note that the `default` schedule applies to agents that do not specify a group name.
 [TODO: It seems we removed the default bool, So we have a mandatory default group? Can we pick the last one instead?]
-
-```shell
-# configuration
-# TODO: "tctl autoudpate update" is bad UX, especially as this doen't even trigger agent update but updates the AU resource.
-#       We should chose a user-friendly signature
-$ tctl autoupdate update --set-agent-auto-update=off
-Automatic updates configuration has been updated.
-$ tctl autoupdate update --group staging --set-start-hour=3
-Automatic updates configuration has been updated.
-$ tctl autoupdate update --group staging --set-jitter-seconds=60
-Automatic updates configuration has been updated.
-$ tctl autoupdate update --group default --set-jitter-seconds=60
-Automatic updates configuration has been updated.
-$ tctl autoupdate reset
-Automatic updates configuration has been reset to defaults.
-
-# status
-$ tctl autoupdate status
-Status: disabled
-Version: v1.2.4
-Schedule: regular
-
-Groups:
-staging: succeeded at 2024-01-03 23:43:22 UTC
-prod: scheduled for 2024-01-03 23:43:22 UTC (depends on prod)
-other: failed at 2024-01-05 22:53:22 UTC
-
-$ tctl autoupdate status --group staging
-Status: succeeded
-Date: 2024-01-03 23:43:22 UTC
-Requires: (none)
-
-Updated: 230 (95%)
-Unchanged: 10 (2%)
-Failed: 15 (3%)
-Timed-out: 0
-
-# re-running failed group
-$ tctl autoupdate run --group staging
-Executing auto-update for group 'staging' immediately.
-```
-
-Notes:
-- `autoupdate_agent_plan` is separate from `autoupdate_config` so that Cloud customers can be restricted from updating
-  `autoupdate_agent_plan`, while maintaining control over the rollout.
 
 ### Updater APIs
 

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -57,7 +57,7 @@ The version and edition served from that endpoint will be configured using new `
 
 Whether the Teleport updater querying the endpoint is instructed to upgrade (via the `agent_autoupdate` field) is dependent on:
 - The `host=[uuid]` parameter sent to `/v1/webapi/find`
-- The schedule defined in the new `cluster_autoupdate_config` resource
+- The schedule defined in the new `autoupdate_config` resource
 - The status of past agent upgrades for the given version
 
 To ensure that the updater is always able to retrieve the desired version, instructions to the updater are delivered via unauthenticated requests to `/v1/webapi/find`.
@@ -195,7 +195,7 @@ Notes:
 #### Scheduling
 
 ```yaml
-kind: cluster_autoupdate_config
+kind: autoupdate_config
 spec:
   # agent_autoupdate allows turning agent updates on or off at the
   # cluster level. Only turn agent automatic updates off if self-managed
@@ -260,7 +260,7 @@ Note the MVP version of this resource will not support host UUIDs, groups, or ba
 This field will remain indefinitely to cover connected agents that are not matched to a group.
 
 ```yaml
-kind: cluster_autoupdate_config
+kind: autoupdate_config
 spec:
   # agent_autoupdate allows turning agent updates on or off at the
   # cluster level. Only turn agent automatic updates off if self-managed
@@ -354,7 +354,7 @@ Automatic updates configuration has been updated.
 ```
 
 Notes:
-- `autoupdate_version` is separate from `cluster_autoupdate_config` so that Cloud customers can be restricted from updating `autoupdate_version`, while maintaining control over the rollout.
+- `autoupdate_version` is separate from `autoupdate_config` so that Cloud customers can be restricted from updating `autoupdate_version`, while maintaining control over the rollout.
 
 #### Rollout
 
@@ -707,54 +707,66 @@ When TUF is added, that events related to supply chain security may be sent to t
 
 Note: all updates use revisions to prevent data loss in case of concurrent access.
 
-### clusterconfig/v1
+### autoupdate/v1
 
 ```protobuf
 syntax = "proto3";
 
-package teleport.clusterconfig.v1;
+package teleport.autoupdate.v1;
 
-option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1;clusterconfigv1";
+option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1;autoupdatev1";
 
-// ClusterConfigService provides methods to manage cluster configuration resources.
-service ClusterConfigService {
-  // ...
+// AutoupdateService serves agent and client automatic version updates.
+service AutoupdateService {
+  // GetAutoupdateConfig updates the autoupdate config.
+  rpc GetAutoupdateConfig(GetAutoupdateConfigRequest) returns (AutoupdateConfig);
+  // CreateAutoupdateConfig creates the autoupdate config.
+  rpc CreateAutoupdateConfig(CreateAutoupdateConfigRequest) returns (AutoupdateConfig);
+  // UpdateAutoupdateConfig updates the autoupdate config.
+  rpc UpdateAutoupdateConfig(UpdateAutoupdateConfigRequest) returns (AutoupdateConfig);
+  // UpsertAutoupdateConfig overwrites the autoupdate config.
+  rpc UpsertAutoupdateConfig(UpsertAutoupdateConfigRequest) returns (AutoupdateConfig);
+  // ResetAutoupdateConfig restores the autoupdate config to default values.
+  rpc ResetAutoupdateConfig(ResetAutoupdateConfigRequest) returns (AutoupdateConfig);
 
-  // GetClusterAutoupdateConfig updates the cluster autoupdate config.
-  rpc GetClusterAutoupdateConfig(GetClusterAutoupdateConfigRequest) returns (ClusterAutoupdateConfig);
-  // CreateClusterAutoupdateConfig creates the cluster autoupdate config.
-  rpc CreateClusterAutoupdateConfig(CreateClusterAutoupdateConfigRequest) returns (ClusterAutoupdateConfig);
-  // UpdateClusterAutoupdateConfig updates the cluster autoupdate config.
-  rpc UpdateClusterAutoupdateConfig(UpdateClusterAutoupdateConfigRequest) returns (ClusterAutoupdateConfig);
-  // UpsertClusterAutoupdateConfig overwrites the cluster autoupdate config.
-  rpc UpsertClusterAutoupdateConfig(UpsertClusterAutoupdateConfigRequest) returns (ClusterAutoupdateConfig);
-  // ResetClusterAutoupdateConfig restores the cluster autoupdate config to default values.
-  rpc ResetClusterAutoupdateConfig(ResetClusterAutoupdateConfigRequest) returns (ClusterAutoupdateConfig);
+  // GetAutoupdateVersion returns the autoupdate version.
+  rpc GetAutoupdateVersion(GetAutoupdateVersionRequest) returns (AutoupdateVersion);
+  // CreateAutoupdateVersion creates the autoupdate version.
+  rpc CreateAutoupdateVersion(CreateAutoupdateVersionRequest) returns (AutoupdateVersion);
+  // UpdateAutoupdateVersion updates the autoupdate version.
+  rpc UpdateAutoupdateVersion(UpdateAutoupdateVersionRequest) returns (AutoupdateVersion);
+  // UpsertAutoupdateVersion overwrites the autoupdate version.
+  rpc UpsertAutoupdateVersion(UpsertAutoupdateVersionRequest) returns (AutoupdateVersion);
+
+  // GetAgentRolloutPlan returns the agent rollout plan and current progress.
+  rpc GetAgentRolloutPlan(GetAgentRolloutPlanRequest) returns (AgentRolloutPlan);
+  // GetAutoupdateVersion streams the agent rollout plan's list of all hosts.
+  rpc GetAgentRolloutPlanHosts(GetAgentRolloutPlanHostsRequest) returns (stream AgentRolloutPlanHost);
 }
 
-// GetClusterAutoupdateConfigRequest requests the contents of the ClusterAutoupdateConfig.
-message GetClusterAutoupdateConfigRequest {}
+// GetAutoupdateConfigRequest requests the contents of the AutoupdateConfig.
+message GetAutoupdateConfigRequest {}
 
-// CreateClusterAutoupdateConfigRequest requests creation of the the ClusterAutoupdateConfig.
-message CreateClusterAutoupdateConfigRequest {
-  ClusterAutoupdateConfig cluster_autoupdate_config = 1;
+// CreateAutoupdateConfigRequest requests creation of the the AutoupdateConfig.
+message CreateAutoupdateConfigRequest {
+  AutoupdateConfig autoupdate_config = 1;
 }
 
-// UpdateClusterAutoupdateConfigRequest requests an update of the the ClusterAutoupdateConfig.
-message UpdateClusterAutoupdateConfigRequest {
-  ClusterAutoupdateConfig cluster_autoupdate_config = 1;
+// UpdateAutoupdateConfigRequest requests an update of the the AutoupdateConfig.
+message UpdateAutoupdateConfigRequest {
+  AutoupdateConfig autoupdate_config = 1;
 }
 
-// UpsertClusterAutoupdateConfigRequest requests an upsert of the the ClusterAutoupdateConfig.
-message UpsertClusterAutoupdateConfigRequest {
-  ClusterAutoupdateConfig cluster_autoupdate_config = 1;
+// UpsertAutoupdateConfigRequest requests an upsert of the the AutoupdateConfig.
+message UpsertAutoupdateConfigRequest {
+  AutoupdateConfig autoupdate_config = 1;
 }
 
-// ResetClusterAutoupdateConfigRequest requests a reset of the the ClusterAutoupdateConfig to default values.
-message ResetClusterAutoupdateConfigRequest {}
+// ResetAutoupdateConfigRequest requests a reset of the the AutoupdateConfig to default values.
+message ResetAutoupdateConfigRequest {}
 
-// ClusterAutoupdateConfig holds dynamic configuration settings for cluster maintenance activities.
-message ClusterAutoupdateConfig {
+// AutoupdateConfig holds dynamic configuration settings for automatic updates.
+message AutoupdateConfig {
   // kind is the kind of the resource.
   string kind = 1;
   // sub_kind is the sub kind of the resource.
@@ -764,11 +776,11 @@ message ClusterAutoupdateConfig {
   // metadata is the metadata of the resource.
   teleport.header.v1.Metadata metadata = 4;
   // spec is the spec of the resource.
-  ClusterAutoupdateConfigSpec spec = 7;
+  AutoupdateConfigSpec spec = 7;
 }
 
-// ClusterAutoupdateConfigSpec is the spec for the cluster autoupdate config.
-message ClusterAutoupdateConfigSpec {
+// AutoupdateConfigSpec is the spec for the autoupdate config.
+message AutoupdateConfigSpec {
   // agent_autoupdate specifies whether agent autoupdates are enabled.
   bool agent_autoupdate = 1;
   // agent_default_schedules specifies schedules for upgrades of agents.
@@ -848,33 +860,6 @@ enum Day {
   DAY_FRIDAY = 7;
   DAY_SATURDAY = 8;
 }
-```
-
-### autoupdate/v1
-
-```protobuf
-syntax = "proto3";
-
-package teleport.autoupdate.v1;
-
-option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1;autoupdatev1";
-
-// AutoupdateService serves agent and client automatic version updates.
-service AutoupdateService {
-  // GetAutoupdateVersion returns the autoupdate version.
-  rpc GetAutoupdateVersion(GetAutoupdateVersionRequest) returns (AutoupdateVersion);
-  // CreateAutoupdateVersion creates the autoupdate version.
-  rpc CreateAutoupdateVersion(CreateAutoupdateVersionRequest) returns (AutoupdateVersion);
-  // UpdateAutoupdateVersion updates the autoupdate version.
-  rpc UpdateAutoupdateVersion(UpdateAutoupdateVersionRequest) returns (AutoupdateVersion);
-  // UpsertAutoupdateVersion overwrites the autoupdate version.
-  rpc UpsertAutoupdateVersion(UpsertAutoupdateVersionRequest) returns (AutoupdateVersion);
-
-  // GetAgentRolloutPlan returns the agent rollout plan and current progress.
-  rpc GetAgentRolloutPlan(GetAgentRolloutPlanRequest) returns (AgentRolloutPlan);
-  // GetAutoupdateVersion streams the agent rollout plan's list of all hosts.
-  rpc GetAgentRolloutPlanHosts(GetAgentRolloutPlanHostsRequest) returns (stream AgentRolloutPlanHost);
-}
 
 // GetAutoupdateVersionRequest requests the autoupdate_version singleton resource.
 message GetAutoupdateVersionRequest {}
@@ -908,7 +893,7 @@ message AutoupdateVersion {
   // metadata is the metadata of the resource.
   teleport.header.v1.Metadata metadata = 4;
   // spec is the spec of the resource.
-  AutoupdateVersionSpec spec = 6;
+  AutoupdateVersionSpec spec = 5;
 }
 
 // AutoupdateVersionSpec is the spec for the autoupdate version.
@@ -959,7 +944,7 @@ message AgentRolloutPlan {
   AgentRolloutPlanStatus status = 6;
 }
 
-// AutoupdateVersionSpec is the spec for the autoupdate version.
+// AutoupdateVersionSpec is the spec for the AgentRolloutPlan.
 message AgentRolloutPlanSpec {
   // start_time of the rollout
   google.protobuf.Timestamp start_time = 1;
@@ -971,7 +956,7 @@ message AgentRolloutPlanSpec {
   int64 host_count = 4;
 }
 
-// AutoupdateVersionSpec is the spec for the autoupdate version.
+// AutoupdateVersionStatus is the status for the AgentRolloutPlan.
 message AgentRolloutPlanStatus {
   // last_active_host_index specifies the index of the last host that may be updated.
   int64 last_active_host_index = 1;

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -385,6 +385,7 @@ For air-gapped Teleport installs, the agent may be configured with a custom tarb
 ```shell
 $ teleport-update enable --proxy example.teleport.sh --template 'https://example.com/teleport-{{ .Edition }}-{{ .Version }}-{{ .Arch }}.tgz'
 ```
+(Checksum will use template path + `.sha256`)
 
 ### Filesystem
 

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -481,7 +481,7 @@ The `enable` subcommand will:
 1. Query the `/v1/webapi/find` endpoint.
 2. If the current updater-managed version of Teleport is the latest, and teleport package is not installed, jump to (16).
 3. If the current updater-managed version of Teleport is the latest, but the teleport package is installed, jump to (13).
-4. Ensure there is enough free disk space to update Teleport via `df .` and `content-length` header from `HEAD` request.
+4. Ensure there is enough free disk space to update Teleport via `unix.Statfs()` and `content-length` header from `HEAD` request.
 5. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
 6. Download and verify the checksum (tarball URL suffixed with `.sha256`).
 7. Extract the tarball to `/var/lib/teleport/versions/VERSION` and write the SHA to `/var/lib/teleport/versions/VERSION/sha256`.
@@ -504,7 +504,7 @@ When `update` subcommand is otherwise executed, it will:
 3. Check that `agent_autoupdates` is true, quit otherwise.
 4. If the current version of Teleport is the latest, quit.
 5. Wait `random(0, agent_update_jitter_seconds)` seconds.
-6. Ensure there is enough free disk space to update Teleport via `df .` and `content-length` header from `HEAD` request.
+6. Ensure there is enough free disk space to update Teleport via `unix.Statfs()` and `content-length` header from `HEAD` request.
 7. Download the desired Teleport tarball specified by `agent_version` and `server_edition`.
 8. Download and verify the checksum (tarball URL suffixed with `.sha256`).
 9. Extract the tarball to `/var/lib/teleport/versions/VERSION` and write the SHA to `/var/lib/teleport/versions/VERSION/sha256`.

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -65,15 +65,15 @@ kind: autoupdate_config
 spec:
   # agent_autoupdate allows turning agent updates on or off at the
   # cluster level. Only turn agent automatic updates off if self-managed
-  # agent updates are in place. Setting this to pause will halt the rollout.
+  # agent updates are in place. Setting this to pause will temporarily halt the rollout.
   agent_autoupdate: disable|enable|pause
 
   # agent_schedules specifies version rollout schedules for agents.
   # The schedule used is determined by the schedule associated
-  # with the version in the rollout_plan resource.
-  # For now, only the "regular" strategy is configurable.
+  # with the version in the autoupdate_agent_plan resource.
+  # For now, only the "regular" schedule is configurable.
   agent_schedules:
-    # rollout strategy must be "regular" for now
+    # rollout schedule must be "regular" for now
     regular:
         # name of the group. Must only contain valid backend / resource name characters.
       - name: staging
@@ -93,7 +93,7 @@ spec:
         # canary_count specifies the desired number of canaries to update before any other agents
         # are updated.
         #  default: 5
-        canaries: 0-10
+        canary_count: 0-10
         # max_in_flight specifies the maximum number of agents that may be updated at the same time.
         # Only valid for the backpressure strategy.
         #  default: 20%
@@ -117,6 +117,7 @@ spec:
       days: ["*"]
       start_hour: 0
       jitter_seconds: 5
+      canary_count: 5
       max_in_flight: 20%
       alert_after: 4h
 ```
@@ -143,9 +144,9 @@ Note that the `default` schedule applies to agents that do not specify a group n
 # configuration
 $ tctl autoupdate update --set-agent-auto-update=off
 Automatic updates configuration has been updated.
-$ tctl autoupdate update --group staging-group --set-start-hour=3
+$ tctl autoupdate update --group staging --set-start-hour=3
 Automatic updates configuration has been updated.
-$ tctl autoupdate update --group staging-group --set-jitter-seconds=60
+$ tctl autoupdate update --group staging --set-jitter-seconds=60
 Automatic updates configuration has been updated.
 $ tctl autoupdate update --group default --set-jitter-seconds=60
 Automatic updates configuration has been updated.
@@ -159,11 +160,11 @@ Version: v1.2.4
 Schedule: regular
 
 Groups:
-staging-group: succeeded at 2024-01-03 23:43:22 UTC
-prod-group: scheduled for 2024-01-03 23:43:22 UTC (depends on prod-group)
-other-group: failed at 2024-01-05 22:53:22 UTC
+staging: succeeded at 2024-01-03 23:43:22 UTC
+prod: scheduled for 2024-01-03 23:43:22 UTC (depends on prod)
+other: failed at 2024-01-05 22:53:22 UTC
 
-$ tctl autoupdate status --group staging-group
+$ tctl autoupdate status --group staging
 Status: succeeded
 Date: 2024-01-03 23:43:22 UTC
 Requires: (none)
@@ -174,8 +175,8 @@ Failed: 15 (3%)
 Timed-out: 0
 
 # re-running failed group
-$ tctl autoupdate run --group staging-group
-Executing auto-update for group 'staging-group' immediately.
+$ tctl autoupdate run --group staging
+Executing auto-update for group 'staging' immediately.
 ```
 
 Notes:

--- a/rfd/0169-auto-updates-linux-agents.md
+++ b/rfd/0169-auto-updates-linux-agents.md
@@ -838,14 +838,15 @@ message AgentAutoupdateGroup {
 
 // Day of the week
 enum Day {
-  ALL = 0;
-  SUNDAY = 1;
-  MONDAY = 2;
-  TUESDAY = 3;
-  WEDNESDAY = 4;
-  THURSDAY = 5;
-  FRIDAY = 6;
-  SATURDAY = 7;
+  DAY_UNSPECIFIED = 0;
+  DAY_ALL = 1;
+  DAY_SUNDAY = 2;
+  DAY_MONDAY = 3;
+  DAY_TUESDAY = 4;
+  DAY_WEDNESDAY = 5;
+  DAY_THURSDAY = 6;
+  DAY_FRIDAY = 7;
+  DAY_SATURDAY = 8;
 }
 ```
 


### PR DESCRIPTION
This RFD proposes a new mechanism for Teleport agents to automatically update to a version set by an operator via tctl.

[Readable](https://github.com/gravitational/teleport/blob/rfd/0169-auto-updates-linux-agents/rfd/0169-auto-updates-linux-agents.md)