### PR TITLE
Add `node:rw` to RoleDiscovery to allow EICE

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1107,7 +1107,7 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindCertAuthority, services.ReadNoSecrets()),
 						types.NewRule(types.KindClusterName, services.RO()),
 						types.NewRule(types.KindNamespace, services.RO()),
-						types.NewRule(types.KindNode, services.RO()),
+						types.NewRule(types.KindNode, services.RW()),
 						types.NewRule(types.KindKubeServer, services.RO()),
 						types.NewRule(types.KindKubernetesCluster, services.RW()),
 						types.NewRule(types.KindDatabase, services.RW()),


### PR DESCRIPTION
This PR adds a missing permission to the RoleDiscovery so that it can create nodes of EICE kind.
These nodes are the only ones created by the DiscoveryService. Teleport Nodes are created when the teleport process joins the cluster Agentless Nodes are either created via `tclt` or `teleport join` command