### PR TITLE
[v15] Add `node:rw` to RoleDiscovery to allow EICE

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1107,7 +1107,7 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindCertAuthority, services.ReadNoSecrets()),
 						types.NewRule(types.KindClusterName, services.RO()),
 						types.NewRule(types.KindNamespace, services.RO()),
-						types.NewRule(types.KindNode, services.RO()),
+						types.NewRule(types.KindNode, services.RW()),
 						types.NewRule(types.KindKubeServer, services.RO()),
 						types.NewRule(types.KindKubernetesCluster, services.RW()),
 						types.NewRule(types.KindDatabase, services.RW()),


### PR DESCRIPTION
Backport #40194 to branch/v15