### PR TITLE
DiscoveryConfig: Implement `UpdateDiscoveryConfigStatus` handler

### DIFF
--- a/api/types/discoveryconfig/convert/v1/discoveryconfig_test.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig_test.go
@@ -18,10 +18,12 @@ package v1
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/header"
@@ -68,5 +70,11 @@ func newDiscoveryConfig(t *testing.T, name string) *discoveryconfig.DiscoveryCon
 		},
 	)
 	require.NoError(t, err)
+	discoveryConfig.Status.State = discoveryconfigv1.DiscoveryConfigState_name[int32(discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_RUNNING)]
+	discoveryConfig.Status.DiscoveredResources = 42
+	now := time.Now()
+	discoveryConfig.Status.LastSyncTime = now
+	errMsg := "error message"
+	discoveryConfig.Status.ErrorMessage = &errMsg
 	return discoveryConfig
 }

--- a/api/types/discoveryconfig/discoveryconfig.go
+++ b/api/types/discoveryconfig/discoveryconfig.go
@@ -17,6 +17,8 @@ limitations under the License.
 package discoveryconfig
 
 import (
+	"time"
+
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
@@ -32,6 +34,9 @@ type DiscoveryConfig struct {
 
 	// Spec is the specification for the discovery config.
 	Spec Spec `json:"spec" yaml:"spec"`
+
+	// Status is the status for the discovery config.
+	Status Status `json:"status" yaml:"status"`
 }
 
 // Spec is the specification for a discovery config.
@@ -50,6 +55,19 @@ type Spec struct {
 	Kube []types.KubernetesMatcher `json:"kube,omitempty" yaml:"kube"`
 	// AccessGraph is the configuration for the Access Graph Cloud sync.
 	AccessGraph *types.AccessGraphSync `json:"access_graph,omitempty" yaml:"access_graph"`
+}
+
+// Status holds dynamic information about the discovery configuration
+// running status such as errors, state and count of the resources.
+type Status struct {
+	// State is the current state of the discovery config.
+	State string `json:"state" yaml:"state"`
+	// ErrorMessage holds the error message when state is DISCOVERY_CONFIG_STATE_ERROR.
+	ErrorMessage *string `json:"error_message,omitempty" yaml:"error_message,omitempty"`
+	// DiscoveredResources holds the count of the discovered resources in the previous iteration.
+	DiscoveredResources uint64 `json:"discovered_resources" yaml:"discovered_resources"`
+	// LastSyncTime is the timestamp when the Discovery Config was last sync.
+	LastSyncTime time.Time `json:"last_sync_time,omitempty" yaml:"last_sync_time,omitempty"`
 }
 
 // NewDiscoveryConfig will create a new discovery config.

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport"
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	conv "github.com/gravitational/teleport/api/types/discoveryconfig/convert/v1"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/services"
@@ -157,6 +158,10 @@ func (s *Service) CreateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 		return nil, trace.Wrap(err)
 	}
 
+	// Set the status to an empty struct to clear any status that may have been set
+	// in the request.
+	dc.Status = discoveryconfig.Status{}
+
 	resp, err := s.backend.CreateDiscoveryConfig(ctx, dc)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -181,6 +186,13 @@ func (s *Service) UpdateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 		return nil, trace.Wrap(err)
 	}
 
+	// Set the status to the existing status to ensure it is not cleared.
+	oldAccessList, err := s.backend.GetDiscoveryConfig(ctx, dc.GetName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	dc.Status = oldAccessList.Status
+
 	resp, err := s.backend.UpdateDiscoveryConfig(ctx, dc)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -204,6 +216,10 @@ func (s *Service) UpsertDiscoveryConfig(ctx context.Context, req *discoveryconfi
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	// Set the status to an empty struct to clear any status that may have been set
+	// in the request.
+	dc.Status = discoveryconfig.Status{}
 
 	resp, err := s.backend.UpsertDiscoveryConfig(ctx, dc)
 	if err != nil {
@@ -247,4 +263,37 @@ func (s *Service) DeleteAllDiscoveryConfigs(ctx context.Context, _ *discoverycon
 	}
 
 	return &emptypb.Empty{}, nil
+}
+
+// UpdateDiscoveryConfigStatus updates the status of a DiscoveryConfig.
+func (s *Service) UpdateDiscoveryConfigStatus(ctx context.Context, req *discoveryconfigv1.UpdateDiscoveryConfigStatusRequest) (*discoveryconfigv1.DiscoveryConfig, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authCtx, string(types.RoleDiscovery)) {
+		return nil, trace.AccessDenied("UpdateDiscoveryConfigStatus request can be only executed by a Discovery Service")
+	}
+
+	for {
+		dc, err := s.backend.GetDiscoveryConfig(ctx, req.GetName())
+		switch {
+		case trace.IsNotFound(err):
+			return nil, trace.NotFound("discovery config %q not found", req.GetName())
+		case err != nil:
+			return nil, trace.Wrap(err)
+		}
+
+		dc.Status = conv.StatusFromProto(req.GetStatus())
+		resp, err := s.backend.UpdateDiscoveryConfig(ctx, dc)
+		if err != nil {
+			if trace.IsCompareFailed(err) {
+				continue
+			}
+			return nil, trace.Wrap(err)
+		}
+
+		return conv.ToProto(resp), nil
+	}
 }

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service.go
@@ -187,11 +187,11 @@ func (s *Service) UpdateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 	}
 
 	// Set the status to the existing status to ensure it is not cleared.
-	oldAccessList, err := s.backend.GetDiscoveryConfig(ctx, dc.GetName())
+	oldDiscoveryConfig, err := s.backend.GetDiscoveryConfig(ctx, dc.GetName())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	dc.Status = oldAccessList.Status
+	dc.Status = oldDiscoveryConfig.Status
 
 	resp, err := s.backend.UpdateDiscoveryConfig(ctx, dc)
 	if err != nil {

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -3332,6 +3332,7 @@ func newDiscoveryConfig(t *testing.T, name string) *discoveryconfig.DiscoveryCon
 		},
 	)
 	require.NoError(t, err)
+	discoveryConfig.Status.State = "DISCOVERY_CONFIG_STATE_UNSPECIFIED"
 	return discoveryConfig
 }
 


### PR DESCRIPTION
This PR implements
`/teleport.discoveryconfig.v1.DiscoveryConfigService/UpdateDiscoveryConfigStatus` grpc method with conditional updates.

To prevent multiple agents to run against each other, we still need lock the discovery group.