### PR TITLE
[v13] Include system annotations in audit event entries for access requests

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4238,11 +4238,11 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 	}
 
 	var annotations *apievents.Struct
-	if len(req.GetSystemAnnotations()) > 0 {
+	if sa := req.GetSystemAnnotations(); len(sa) > 0 {
 		var err error
-		annotations, err = apievents.EncodeMapStrings(req.GetSystemAnnotations())
+		annotations, err = apievents.EncodeMapStrings(sa)
 		if err != nil {
-			log.WithError(err).Debugf("Failed to encode access request annotations.")
+			log.WithError(err).Debug("Failed to encode access request annotations.")
 		}
 	}
 
@@ -4361,11 +4361,11 @@ func (a *Server) SetAccessRequestState(ctx context.Context, params types.AccessR
 		Reason:       params.Reason,
 		Roles:        params.Roles,
 	}
-	if len(req.GetSystemAnnotations()) > 0 {
+	if sa := req.GetSystemAnnotations(); len(sa) > 0 {
 		var err error
-		event.Annotations, err = apievents.EncodeMapStrings(req.GetSystemAnnotations())
+		event.Annotations, err = apievents.EncodeMapStrings(sa)
 		if err != nil {
-			log.WithError(err).Debugf("Failed to encode access request annotations.")
+			log.WithError(err).Debug("Failed to encode access request annotations.")
 		}
 	}
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/40045 to branch/v13

changelog: Include system annotations in audit event entries for access requests