### PR TITLE
DiscoveryService: prevent EICE Node duplication

### DIFF
--- a/api/types/semaphore.go
+++ b/api/types/semaphore.go
@@ -48,7 +48,7 @@ const SemaphoreKindAccessMonitoringLimiter = "access_monitoring_limiter"
 
 // SemaphoreKindDiscoveryServiceGroup is the semaphore kind used by
 // the DiscoveryService to ensure that only one DiscoveryService with
-// discovery group DG1 can run at the same time.
+// the same discovery group can run at the same time.
 const SemaphoreKindDiscoveryServiceGroup = "discovery_service_group"
 
 // Semaphore represents distributed semaphore concept

--- a/api/types/semaphore.go
+++ b/api/types/semaphore.go
@@ -46,6 +46,11 @@ const SemaphoreKindHostUserModification = "host_user_modification"
 // the Access Monitoring feature during handling user queries.
 const SemaphoreKindAccessMonitoringLimiter = "access_monitoring_limiter"
 
+// SemaphoreKindDiscoveryServiceGroup is the semaphore kind used by
+// the DiscoveryService to ensure that only one DiscoveryService with
+// discovery group DG1 can run at the same time.
+const SemaphoreKindDiscoveryServiceGroup = "discovery_service_group"
+
 // Semaphore represents distributed semaphore concept
 type Semaphore interface {
 	// Resource contains common resource values

--- a/api/types/semaphore.go
+++ b/api/types/semaphore.go
@@ -46,11 +46,6 @@ const SemaphoreKindHostUserModification = "host_user_modification"
 // the Access Monitoring feature during handling user queries.
 const SemaphoreKindAccessMonitoringLimiter = "access_monitoring_limiter"
 
-// SemaphoreKindDiscoveryServiceGroup is the semaphore kind used by
-// the DiscoveryService to ensure that only one DiscoveryService with
-// the same discovery group can run at the same time.
-const SemaphoreKindDiscoveryServiceGroup = "discovery_service_group"
-
 // Semaphore represents distributed semaphore concept
 type Semaphore interface {
 	// Resource contains common resource values

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -524,6 +524,7 @@ func (s *ServerV2) CheckAndSetDefaults() error {
 		switch s.SubKind {
 		case SubKindOpenSSHEICENode:
 			// For EICE nodes, use a deterministic name.
+			// This name must comply with the expected format for EC2 Nodes as defined here: api/utils/aws.IsEC2NodeID
 			eiceNodeName := serverNameForEICE(s)
 			if eiceNodeName == "" {
 				return trace.BadParameter("missing account id or instance id in %s node", SubKindOpenSSHEICENode)

--- a/api/types/server_test.go
+++ b/api/types/server_test.go
@@ -440,7 +440,6 @@ func TestServerCheckAndSetDefaults(t *testing.T) {
 				SubKind: SubKindOpenSSHEICENode,
 				Version: V2,
 				Metadata: Metadata{
-					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
 					Namespace: defaults.Namespace,
 				},
 				Spec: ServerSpecV2{
@@ -467,7 +466,6 @@ func TestServerCheckAndSetDefaults(t *testing.T) {
 				SubKind: SubKindOpenSSHEICENode,
 				Version: V2,
 				Metadata: Metadata{
-					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
 					Namespace: defaults.Namespace,
 				},
 				Spec: ServerSpecV2{
@@ -522,6 +520,63 @@ func TestServerCheckAndSetDefaults(t *testing.T) {
 				require.True(t, aws.IsEC2NodeID(s.GetName()),
 					"expected an EC2 Node ID format (<accid>-<instanceid>), got %s", s.GetName(),
 				)
+			},
+		},
+		{
+			name: "already existing OpenSSHEC2InstanceConnectEndpoint nodes use UUID and that must be accepted",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHEICENode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "f043b730-8fdd-4f9a-81e4-45f5a9ea23a7",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:     "example:22",
+					Hostname: "openssh-node",
+					CloudMetadata: &CloudMetadata{
+						AWS: &AWSInfo{
+							AccountID:   "123456789012",
+							InstanceID:  "i-123456789012",
+							Region:      "us-east-1",
+							Integration: "teleportdev",
+							VPCID:       "some-vpc",
+							SubnetID:    "some-subnet",
+						},
+					},
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "OpenSSHEC2InstanceConnectEndpoint nodes with invalid account id or instance id must be rejected",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHEICENode,
+				Version: V2,
+				Metadata: Metadata{
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:     "example:22",
+					Hostname: "openssh-node",
+					CloudMetadata: &CloudMetadata{
+						AWS: &AWSInfo{
+							AccountID:   "abcd",
+							InstanceID:  "i-defg",
+							Region:      "us-east-1",
+							Integration: "teleportdev",
+							VPCID:       "some-vpc",
+							SubnetID:    "some-subnet",
+						},
+					},
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.ErrorContains(t, err, `invalid account "abcd" or instance id "i-defg"`)
 			},
 		},
 	}

--- a/api/types/server_test.go
+++ b/api/types/server_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/utils/aws"
 )
 
 func getTestVal(isTestField bool, testVal string) string {
@@ -112,7 +113,6 @@ func TestServerCheckAndSetDefaults(t *testing.T) {
 			SubKind: SubKindOpenSSHEICENode,
 			Version: V2,
 			Metadata: Metadata{
-				Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
 				Namespace: defaults.Namespace,
 			},
 			Spec: ServerSpecV2{
@@ -394,7 +394,7 @@ func TestServerCheckAndSetDefaults(t *testing.T) {
 				s.Spec.CloudMetadata = nil
 			}),
 			assertion: func(t *testing.T, s *ServerV2, err error) {
-				require.ErrorContains(t, err, "missing AWS CloudMetadata")
+				require.ErrorContains(t, err, "missing account id or instance id in openssh-ec2-ice node")
 			},
 		},
 		{
@@ -403,7 +403,7 @@ func TestServerCheckAndSetDefaults(t *testing.T) {
 				s.Spec.CloudMetadata.AWS = nil
 			}),
 			assertion: func(t *testing.T, s *ServerV2, err error) {
-				require.ErrorContains(t, err, "missing AWS CloudMetadata")
+				require.ErrorContains(t, err, "missing account id or instance id in openssh-ec2-ice node")
 			},
 		},
 		{
@@ -412,7 +412,7 @@ func TestServerCheckAndSetDefaults(t *testing.T) {
 				s.Spec.CloudMetadata.AWS.AccountID = ""
 			}),
 			assertion: func(t *testing.T, s *ServerV2, err error) {
-				require.ErrorContains(t, err, "missing AWS Account ID")
+				require.ErrorContains(t, err, "missing account id or instance id in openssh-ec2-ice node")
 			},
 		},
 		{
@@ -421,7 +421,7 @@ func TestServerCheckAndSetDefaults(t *testing.T) {
 				s.Spec.CloudMetadata.AWS.InstanceID = ""
 			}),
 			assertion: func(t *testing.T, s *ServerV2, err error) {
-				require.ErrorContains(t, err, "missing AWS InstanceID")
+				require.ErrorContains(t, err, "missing account id or instance id in openssh-ec2-ice node")
 			},
 		},
 		{
@@ -497,7 +497,7 @@ func TestServerCheckAndSetDefaults(t *testing.T) {
 					SubKind: SubKindOpenSSHEICENode,
 					Version: V2,
 					Metadata: Metadata{
-						Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+						Name:      "123456789012-i-123456789012",
 						Namespace: defaults.Namespace,
 					},
 					Spec: ServerSpecV2{
@@ -518,6 +518,10 @@ func TestServerCheckAndSetDefaults(t *testing.T) {
 				assert.Equal(t, expectedServer, s)
 
 				require.True(t, s.IsOpenSSHNode(), "IsOpenSSHNode must be true for this node")
+
+				require.True(t, aws.IsEC2NodeID(s.GetName()),
+					"expected an EC2 Node ID format (<accid>-<instanceid>), got %s", s.GetName(),
+				)
 			},
 		},
 	}

--- a/lib/integrations/awsoidc/listec2_test.go
+++ b/lib/integrations/awsoidc/listec2_test.go
@@ -109,7 +109,7 @@ func TestListEC2(t *testing.T) {
 		for i := 0; i < totalEC2s; i++ {
 			allInstances = append(allInstances, ec2Types.Instance{
 				PrivateDnsName:   aws.String("my-private-dns.compute.aws"),
-				InstanceId:       aws.String(fmt.Sprintf("i-%d", i)),
+				InstanceId:       aws.String(fmt.Sprintf("i-12345678%d", i)),
 				VpcId:            aws.String("vpc-abcd"),
 				SubnetId:         aws.String("subnet-123"),
 				PrivateIpAddress: aws.String("172.31.1.1"),
@@ -132,7 +132,7 @@ func TestListEC2(t *testing.T) {
 		require.NotEmpty(t, resp.NextToken)
 		require.Len(t, resp.Servers, pageSize)
 		nextPageToken := resp.NextToken
-		require.Equal(t, "i-0", resp.Servers[0].GetCloudMetadata().AWS.InstanceID)
+		require.Equal(t, "i-123456780", resp.Servers[0].GetCloudMetadata().AWS.InstanceID)
 
 		// Second page must return pageSize number of Servers
 		resp, err = ListEC2(ctx, mockListClient, ListEC2Request{
@@ -144,7 +144,7 @@ func TestListEC2(t *testing.T) {
 		require.NotEmpty(t, resp.NextToken)
 		require.Len(t, resp.Servers, pageSize)
 		nextPageToken = resp.NextToken
-		require.Equal(t, "i-100", resp.Servers[0].GetCloudMetadata().AWS.InstanceID)
+		require.Equal(t, "i-12345678100", resp.Servers[0].GetCloudMetadata().AWS.InstanceID)
 
 		// Third page must return only the remaining Servers and an empty nextToken
 		resp, err = ListEC2(ctx, mockListClient, ListEC2Request{
@@ -155,7 +155,7 @@ func TestListEC2(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, resp.NextToken)
 		require.Len(t, resp.Servers, 3)
-		require.Equal(t, "i-200", resp.Servers[0].GetCloudMetadata().AWS.InstanceID)
+		require.Equal(t, "i-12345678200", resp.Servers[0].GetCloudMetadata().AWS.InstanceID)
 	})
 
 	for _, tt := range []struct {

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -28,7 +28,6 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	ec2v1 "github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -457,9 +456,7 @@ func NewAWSNodeFromEC2Instance(instance ec2types.Instance, awsCloudMetadata *typ
 	// We use the default port for the OpenSSH daemon.
 	addr := net.JoinHostPort(aws.ToString(instance.PrivateIpAddress), defaultSSHPort)
 
-	server, err := types.NewNode(
-		uuid.NewString(),
-		types.SubKindOpenSSHEICENode,
+	server, err := types.NewEICENode(
 		types.ServerSpecV2{
 			Hostname: aws.ToString(instance.PrivateDnsName),
 			Addr:     addr,

--- a/lib/services/server_test.go
+++ b/lib/services/server_test.go
@@ -66,7 +66,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 			name:        "valid",
 			ec2Instance: makeEC2Instance(func(i *ec2types.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Region:      "us-east-1",
 				Integration: "myintegration",
 			},
@@ -77,11 +77,11 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 				SubKind: "openssh-ec2-ice",
 				Metadata: types.Metadata{
 					Labels: map[string]string{
-						"account-id":               "1234567889012",
+						"account-id":               "123456789012",
 						"region":                   "us-east-1",
 						"MyTag":                    "MyTagValue",
 						"teleport.dev/instance-id": "i-123456789abcedf",
-						"teleport.dev/account-id":  "1234567889012",
+						"teleport.dev/account-id":  "123456789012",
 					},
 					Namespace: "default",
 				},
@@ -90,7 +90,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 					Hostname: "my-private-dns.compute.aws",
 					CloudMetadata: &types.CloudMetadata{
 						AWS: &types.AWSInfo{
-							AccountID:   "1234567889012",
+							AccountID:   "123456789012",
 							InstanceID:  "i-123456789abcedf",
 							Region:      "us-east-1",
 							VPCID:       "vpc-abcd",
@@ -114,7 +114,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 				})
 			}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Region:      "us-east-1",
 				Integration: "myintegration",
 			},
@@ -125,11 +125,11 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 				SubKind: "openssh-ec2-ice",
 				Metadata: types.Metadata{
 					Labels: map[string]string{
-						"account-id":               "1234567889012",
+						"account-id":               "123456789012",
 						"region":                   "us-east-1",
 						"MyTag":                    "MyTagValue",
 						"teleport.dev/instance-id": "i-123456789abcedf",
-						"teleport.dev/account-id":  "1234567889012",
+						"teleport.dev/account-id":  "123456789012",
 					},
 					Namespace: "default",
 				},
@@ -138,7 +138,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 					Hostname: "my-private-dns.compute.aws",
 					CloudMetadata: &types.CloudMetadata{
 						AWS: &types.AWSInfo{
-							AccountID:   "1234567889012",
+							AccountID:   "123456789012",
 							InstanceID:  "i-123456789abcedf",
 							Region:      "us-east-1",
 							VPCID:       "vpc-abcd",
@@ -155,7 +155,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 				i.PrivateDnsName = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Region:      "us-east-1",
 				Integration: "myintegration",
 			},
@@ -167,7 +167,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 				i.InstanceId = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Region:      "us-east-1",
 				Integration: "myintegration",
 			},
@@ -179,7 +179,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 				i.VpcId = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Region:      "us-east-1",
 				Integration: "myintegration",
 			},
@@ -191,7 +191,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 				i.PrivateDnsName = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Region:      "us-east-1",
 				Integration: "myintegration",
 			},
@@ -210,7 +210,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 			name:        "missing region",
 			ec2Instance: makeEC2Instance(func(i *ec2types.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Integration: "myintegration",
 			},
 			errCheck: isBadParameterErr,
@@ -219,7 +219,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 			name:        "missing integration name",
 			ec2Instance: makeEC2Instance(func(i *ec2types.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID: "1234567889012",
+				AccountID: "123456789012",
 				Region:    "us-east-1",
 			},
 			errCheck: isBadParameterErr,
@@ -271,7 +271,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 			name:        "valid",
 			ec2Instance: makeEC2Instance(func(i *ec2v1.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Region:      "us-east-1",
 				Integration: "myintegration",
 			},
@@ -282,11 +282,11 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 				SubKind: "openssh-ec2-ice",
 				Metadata: types.Metadata{
 					Labels: map[string]string{
-						"account-id":               "1234567889012",
+						"account-id":               "123456789012",
 						"region":                   "us-east-1",
 						"MyTag":                    "MyTagValue",
 						"teleport.dev/instance-id": "i-123456789abcedf",
-						"teleport.dev/account-id":  "1234567889012",
+						"teleport.dev/account-id":  "123456789012",
 					},
 					Namespace: "default",
 				},
@@ -295,7 +295,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 					Hostname: "my-private-dns.compute.aws",
 					CloudMetadata: &types.CloudMetadata{
 						AWS: &types.AWSInfo{
-							AccountID:   "1234567889012",
+							AccountID:   "123456789012",
 							InstanceID:  "i-123456789abcedf",
 							Region:      "us-east-1",
 							VPCID:       "vpc-abcd",
@@ -319,7 +319,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 				})
 			}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Region:      "us-east-1",
 				Integration: "myintegration",
 			},
@@ -330,11 +330,11 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 				SubKind: "openssh-ec2-ice",
 				Metadata: types.Metadata{
 					Labels: map[string]string{
-						"account-id":               "1234567889012",
+						"account-id":               "123456789012",
 						"region":                   "us-east-1",
 						"MyTag":                    "MyTagValue",
 						"teleport.dev/instance-id": "i-123456789abcedf",
-						"teleport.dev/account-id":  "1234567889012",
+						"teleport.dev/account-id":  "123456789012",
 					},
 					Namespace: "default",
 				},
@@ -343,7 +343,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 					Hostname: "my-private-dns.compute.aws",
 					CloudMetadata: &types.CloudMetadata{
 						AWS: &types.AWSInfo{
-							AccountID:   "1234567889012",
+							AccountID:   "123456789012",
 							InstanceID:  "i-123456789abcedf",
 							Region:      "us-east-1",
 							VPCID:       "vpc-abcd",
@@ -360,7 +360,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 				i.PrivateDnsName = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Region:      "us-east-1",
 				Integration: "myintegration",
 			},
@@ -372,7 +372,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 				i.InstanceId = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Region:      "us-east-1",
 				Integration: "myintegration",
 			},
@@ -384,7 +384,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 				i.VpcId = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Region:      "us-east-1",
 				Integration: "myintegration",
 			},
@@ -396,7 +396,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 				i.PrivateDnsName = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Region:      "us-east-1",
 				Integration: "myintegration",
 			},
@@ -415,7 +415,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 			name:        "missing region",
 			ec2Instance: makeEC2Instance(func(i *ec2v1.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID:   "1234567889012",
+				AccountID:   "123456789012",
 				Integration: "myintegration",
 			},
 			errCheck: isBadParameterErr,
@@ -424,7 +424,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 			name:        "missing integration name",
 			ec2Instance: makeEC2Instance(func(i *ec2v1.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
-				AccountID: "1234567889012",
+				AccountID: "123456789012",
 				Region:    "us-east-1",
 			},
 			errCheck: isBadParameterErr,

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1775,6 +1775,22 @@ func (n *nodeCollector) GetNodes(ctx context.Context, fn func(n Node) bool) []ty
 	return matched
 }
 
+// GetNode allows callers to retrieve a node based on its name. The
+// returned server are a copy and can be safely modified.
+func (n *nodeCollector) GetNode(ctx context.Context, name string) (types.Server, error) {
+	// Attempt to freshen our data first.
+	n.refreshStaleNodes(ctx)
+
+	n.rw.RLock()
+	defer n.rw.RUnlock()
+
+	server, found := n.current[name]
+	if !found {
+		return nil, trace.NotFound("server does not exist")
+	}
+	return server.DeepCopy(), nil
+}
+
 // refreshStaleNodes attempts to reload nodes from the NodeGetter if
 // the collecter is stale. This ensures that no matter the health of
 // the collecter callers will be returned the most up to date node

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -865,19 +865,20 @@ func (s *Server) heartbeatEICEInstance(instances *server.EC2Instances) {
 		}
 
 		// EICE Node's Name are deterministic (based on the Account and Instance ID).
-		if existingNode != nil {
-			// To reduce load, nodes are skipped if
-			// - they didn't change and
-			// - their expiration is far away in the future (at least 2 Poll iterations before the Node expires)
-			//
-			// As an example, and using the default PollInterval (5 minutes),
-			// nodes that didn't change and have their expiration greater than now+15m will be skipped.
-			// This gives at least another two iterations of the DiscoveryService before the node is actually removed.
-			// Note: heartbeats set an expiration of 90 minutes.
-			if existingNode.Expiry().After(s.clock.Now().Add(3*s.PollInterval)) &&
-				services.CompareServers(existingNode, eiceNode) == services.OnlyTimestampsDifferent {
-				continue
-			}
+		//
+		// To reduce load, nodes are skipped if
+		// - they didn't change and
+		// - their expiration is far away in the future (at least 2 Poll iterations before the Node expires)
+		//
+		// As an example, and using the default PollInterval (5 minutes),
+		// nodes that didn't change and have their expiration greater than now+15m will be skipped.
+		// This gives at least another two iterations of the DiscoveryService before the node is actually removed.
+		// Note: heartbeats set an expiration of 90 minutes.
+		if existingNode != nil &&
+			existingNode.Expiry().After(s.clock.Now().Add(3*s.PollInterval)) &&
+			services.CompareServers(existingNode, eiceNode) == services.OnlyTimestampsDifferent {
+
+			continue
 		}
 
 		eiceNodeExpiration := s.clock.Now().Add(s.jitter(serverExpirationDuration))

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -619,15 +619,15 @@ func TestDiscoveryServerConcurrency(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Start both servers, but only one should be executing at the same time
+	// Start both servers.
 	go server1.Start()
 	t.Cleanup(server1.Stop)
 
-	// Server must not start because lock exists.
 	go server2.Start()
 	t.Cleanup(server2.Stop)
 
-	// We should get only one instance.
+	// We must get only one EC2 EICE Node.
+	// Even when two servers are discovering the same EC2 Instance, they will use the same name when converting to EICE Node.
 	require.Eventually(t, func() bool {
 		allNodes, err := tlsServer.Auth().GetNodes(ctx, "default")
 		require.NoError(t, err)

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -559,9 +559,9 @@ func TestDiscoveryServerConcurrency(t *testing.T) {
 	testCloudClients := &cloud.TestCloudClients{
 		EC2: &mockEC2Client{output: &ec2.DescribeInstancesOutput{
 			Reservations: []*ec2.Reservation{{
-				OwnerId: aws.String("owner"),
+				OwnerId: aws.String("123456789012"),
 				Instances: []*ec2.Instance{{
-					InstanceId: aws.String("instance-id-1"),
+					InstanceId: aws.String("i-123456789012"),
 					Tags: []*ec2.Tag{{
 						Key:   aws.String("env"),
 						Value: aws.String("dev"),

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -534,6 +534,116 @@ func TestDiscoveryServer(t *testing.T) {
 	}
 }
 
+func TestDiscoveryServerConcurrency(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := logrus.New()
+
+	defaultDiscoveryGroup := "dg01"
+	staticMatcher := Matchers{
+		AWS: []types.AWSMatcher{{
+			Types:       []string{"ec2"},
+			Regions:     []string{"eu-central-1"},
+			Tags:        map[string]utils.Strings{"teleport": {"yes"}},
+			Integration: "my-integration",
+			SSM:         &types.AWSSSM{DocumentName: "document"},
+		}},
+	}
+
+	emitter := &mockEmitter{
+		eventHandler: func(t *testing.T, ae events.AuditEvent, server *Server) {
+			t.Helper()
+		},
+	}
+
+	testCloudClients := &cloud.TestCloudClients{
+		EC2: &mockEC2Client{output: &ec2.DescribeInstancesOutput{
+			Reservations: []*ec2.Reservation{{
+				OwnerId: aws.String("owner"),
+				Instances: []*ec2.Instance{{
+					InstanceId: aws.String("instance-id-1"),
+					Tags: []*ec2.Tag{{
+						Key:   aws.String("env"),
+						Value: aws.String("dev"),
+					}},
+					PrivateIpAddress: aws.String("172.0.1.2"),
+					VpcId:            aws.String("vpcId"),
+					SubnetId:         aws.String("subnetId"),
+					PrivateDnsName:   aws.String("privateDnsName"),
+					State:            &ec2.InstanceState{Name: aws.String(ec2.InstanceStateNameRunning)},
+				}},
+			}},
+		}},
+	}
+
+	// Create and start test auth server.
+	testAuthServer, err := auth.NewTestAuthServer(auth.TestAuthServerConfig{
+		Dir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testAuthServer.Close()) })
+
+	tlsServer, err := testAuthServer.NewTestTLSServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+	// Auth client for discovery service.
+	identity := auth.TestServerID(types.RoleDiscovery, "hostID")
+	authClient, err := tlsServer.NewClient(identity)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authClient.Close()) })
+
+	// Create Server1
+	server1, err := New(authz.ContextWithUser(ctx, identity.I), &Config{
+		CloudClients:     testCloudClients,
+		ClusterFeatures:  func() proto.Features { return proto.Features{} },
+		KubernetesClient: fake.NewSimpleClientset(),
+		AccessPoint:      getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
+		Matchers:         staticMatcher,
+		Emitter:          emitter,
+		Log:              logger,
+		DiscoveryGroup:   defaultDiscoveryGroup,
+	})
+	require.NoError(t, err)
+
+	// Create Server2
+	server2, err := New(authz.ContextWithUser(ctx, identity.I), &Config{
+		CloudClients:     testCloudClients,
+		ClusterFeatures:  func() proto.Features { return proto.Features{} },
+		KubernetesClient: fake.NewSimpleClientset(),
+		AccessPoint:      getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
+		Matchers:         staticMatcher,
+		Emitter:          emitter,
+		Log:              logger,
+		DiscoveryGroup:   defaultDiscoveryGroup,
+	})
+	require.NoError(t, err)
+
+	// Start both servers, but only one should be executing at the same time
+	go server1.Start()
+	t.Cleanup(server1.Stop)
+
+	// Server must not start because lock exists.
+	go server2.Start()
+	t.Cleanup(server2.Stop)
+
+	// We should get only one instance.
+	require.Eventually(t, func() bool {
+		allNodes, err := tlsServer.Auth().GetNodes(ctx, "default")
+		require.NoError(t, err)
+
+		return len(allNodes) == 1
+	}, 1*time.Second, 50*time.Millisecond)
+
+	// We should never get a duplicate instance.
+	require.Never(t, func() bool {
+		allNodes, err := tlsServer.Auth().GetNodes(ctx, "default")
+		require.NoError(t, err)
+
+		return len(allNodes) != 1
+	}, 2*time.Second, 50*time.Millisecond)
+}
+
 func newMockKubeService(name, namespace, externalName string, labels, annotations map[string]string, ports []corev1.ServicePort) *corev1.Service {
 	serviceType := corev1.ServiceTypeClusterIP
 	if externalName != "" {


### PR DESCRIPTION
This PR ensures does a couple of things to prevent duplicated nodes.

### Run only one DiscoveryService per DiscoveryGroup
This should prevent any duplicate API calls and also prevent duplicate resources on Teleport side.

### Deterministic name for EICE Nodes
Instead of using a random UUID, we are now building the Node's Name based on the account id and instance ID of the EC2 instance.

This reduces the load because we can now use the NodeWatcher's internal Map for quicker access (instead of always listing and filtering all the Nodes).

Given the name is deterministic, it also ensures we don't get duplicate nodes.
