### PR TITLE
docs: warn about unprivileged access to KMS credentials

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -86,6 +86,7 @@
     "Hqlo",
     "IAMR",
     "IDAQAB",
+    "IMDS",
     "INSYNC",
     "IQMHY",
     "IRSA",

--- a/docs/pages/choose-an-edition/teleport-enterprise/aws-kms.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/aws-kms.mdx
@@ -123,6 +123,23 @@ $ aws iam attach-role-policy --role-name <IAM role> --policy-arn <policy ARN>
 
 (!docs/pages/includes/aws-credentials.mdx service="the Teleport Auth Service"!)
 
+<Admonition type="warning">
+Be aware that anyone with access to this IAM role will be able create signatures
+as if they are the Teleport CA.
+It should be considered a highly privileged role and should be restricted as
+much as possible.
+
+If you provide AWS credentials to the Teleport Auth Service via the Instance
+Metadata Service, be aware that any user with access to the instance could use
+those credentials.
+You may wish to use the following iptables rule to restrict IMDS access to the
+root user only:
+
+```sh
+$ iptables -A OUTPUT -m owner ! --uid-owner 0 -d 169.254.169.254 -j REJECT
+```
+</Admonition>
+
 ## Step 2/5. Configure your Auth Service to use KMS keys
 
 CA key parameters are statically configured in the `teleport.yaml` configuration

--- a/docs/pages/choose-an-edition/teleport-enterprise/gcp-kms.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/gcp-kms.mdx
@@ -123,6 +123,13 @@ $ gcloud kms keyrings add-iam-policy-binding <Var name="teleport-keyring"/> \
     --role "${IAM_ROLE}"
 ```
 
+<Admonition type="warning">
+Be aware that anyone with access to this service account will be able to create
+signatures as if they are the Teleport CA.
+It should be considered highly privileged and access should be restricted as
+much as possible.
+</Admonition>
+
 ## Step 3/5. Provide the service account credentials to your Auth Server
 
 The Teleport Auth Server will use Application Default Credentials to make

--- a/docs/pages/includes/aws-credentials.mdx
+++ b/docs/pages/includes/aws-credentials.mdx
@@ -1,7 +1,7 @@
 {{ service="your Teleport instance" }}
 
 Grant {{ service }} access to credentials that it can use to authenticate to
-AWS. If you are running {{ service }} on an EC2 instance, you should use the EC2
+AWS. If you are running {{ service }} on an EC2 instance, you may use the EC2
 Instance Metadata Service method. Otherwise, you must use environment variables:
 
 <Tabs>
@@ -48,7 +48,7 @@ order:
 
 While you can provide AWS credentials via a shared credentials file or shared
 configuration file, you will need to run {{ service }} with the `AWS_PROFILE`
-environment variable assigned to the name of your profile of choice. 
+environment variable assigned to the name of your profile of choice.
 
 If you have a specific use case that the instructions above do not account for,
 consult the documentation for the [AWS SDK for
@@ -56,4 +56,3 @@ Go](https://docs.aws.amazon.com/sdk-for-go/api/aws/session/) for a detailed
 description of credential loading behavior.
 
 </Details>
-


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport-private/issues/1458 by warning users about unprivileged access to KMS credentials and suggesting an iptables rule that would allow IMDS access to the root user only.