### PR TITLE
[v13] build: Use buildx and caching for buildboxes, push to ghcr.io

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -124,8 +124,7 @@ build-binaries-fips: buildbox-centos7-fips webassets
 #
 .PHONY:buildbox
 buildbox:
-	$(call PULL_ON_CI,$(BUILDBOX))
-	DOCKER_BUILDKIT=1 docker build --platform=linux/$(RUNTIME_ARCH) \
+	docker buildx build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
@@ -139,7 +138,9 @@ buildbox:
 		--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \
 		--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \
 		--build-arg PROTOC_VER=$(PROTOC_VER) \
+		--cache-to type=inline \
 		--cache-from $(BUILDBOX) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX) .
 
 # Builds a Docker buildbox for FIPS
@@ -155,8 +156,7 @@ buildbox-fips: buildbox-centos7-fips
 .PHONY:buildbox-centos7
 buildbox-centos7:
 	$(REQUIRE_HOST_ARCH)
-	$(call PULL_ON_CI,$(BUILDBOX_CENTOS7))
-	DOCKER_BUILDKIT=1 docker build \
+	docker buildx build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
@@ -166,7 +166,9 @@ buildbox-centos7:
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--build-arg LIBPCSCLITE_VERSION=$(LIBPCSCLITE_VERSION) \
+		--cache-to type=inline \
 		--cache-from $(BUILDBOX_CENTOS7) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_CENTOS7) -f Dockerfile-centos7 .
 
 #
@@ -174,8 +176,7 @@ buildbox-centos7:
 #
 .PHONY:buildbox-centos7-fips
 buildbox-centos7-fips:
-	$(call PULL_ON_CI,$(BUILDBOX_CENTOS7_FIPS))
-	docker build \
+	docker buildx build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
@@ -184,7 +185,9 @@ buildbox-centos7-fips:
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
+		--cache-to type=inline \
 		--cache-from $(BUILDBOX_CENTOS7_FIPS) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_CENTOS7_FIPS) -f Dockerfile-centos7-fips .
 
 #
@@ -194,11 +197,12 @@ buildbox-centos7-fips:
 #
 .PHONY:buildbox-arm
 buildbox-arm: buildbox
-	$(call PULL_ON_CI,$(BUILDBOX_ARM))
-	docker build \
+	docker buildx build \
 		--build-arg BUILDBOX_VERSION=$(BUILDBOX_VERSION) \
+		--cache-to type=inline \
 		--cache-from $(BUILDBOX) \
 		--cache-from $(BUILDBOX_ARM) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_ARM) -f Dockerfile-arm .
 
 CONNECT_VERSION ?= $(VERSION)
@@ -212,12 +216,13 @@ endif
 #
 .PHONY:buildbox-node
 buildbox-node:
-	$(call PULL_ON_CI,$(BUILDBOX_NODE))
-	DOCKER_BUILDKIT=1 docker build \
+	docker buildx build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
+		--cache-to type=inline \
 		--cache-from $(BUILDBOX_NODE) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_NODE) -f Dockerfile-node .
 
 #

--- a/build.assets/images.mk
+++ b/build.assets/images.mk
@@ -1,7 +1,7 @@
 # Those variables are extracted from build.assets/Makefile so they can be imported
 # by other Makefiles
 BUILDBOX_VERSION ?= teleport13
-BUILDBOX_BASE_NAME ?= public.ecr.aws/gravitational/teleport-buildbox
+BUILDBOX_BASE_NAME ?= ghcr.io/gravitational/teleport-buildbox
 
 BUILDBOX = $(BUILDBOX_BASE_NAME):$(BUILDBOX_VERSION)
 BUILDBOX_CENTOS7 = $(BUILDBOX_BASE_NAME)-centos7:$(BUILDBOX_VERSION)


### PR DESCRIPTION
Use the `docker buildx` `--cache-to type=inline` to put the build cache
in the buildbox image, to with with the existing `--cache-from`
parameter. To do this we need to use `docker buildx`, and to ensure that
a buildbox image is available locally if a container builder is being
used, ensure `--load` is used if we are not pushing to a remote
registry, based on the `PUSH` make variable.

This rolls up a number of changes made on master that are intertwined
with other changes we do not want to backport. This smaller set of
changes aligns the way the buildboxes are built, cached and pushed
across the branches without bringing across the larger scale changes for
PIC/PIE builds and ARM64 FIPS builds.

This also allows us to remove the `PULL_ON_CI` make "macro" since docker
will effectively do the same with `--cache-from` when those images have
an inline cache.

Backport: https://github.com/gravitational/teleport/pull/34950 (partial)
Backport: https://github.com/gravitational/teleport/pull/37559 (partial)
Issue: https://github.com/gravitational/teleport/issues/34281
Test-run: https://github.com/gravitational/teleport.e/actions/runs/8564099366 (build)
Test-run: https://github.com/gravitational/teleport.e/actions/runs/8564648023 (cached)