### PR TITLE
docs: Add instructions for buildboxes with new release branch

### DIFF
--- a/docs/postrelease.md
+++ b/docs/postrelease.md
@@ -22,3 +22,6 @@ is published, since the PR will include an update to the plugins version as well
 - [ ] Update the list of OCI images to monitor and rebuild nightly in
   [`monitor-teleport-oci-distroless.yml` on `master`](https://github.com/gravitational/teleport.e/blob/master/.github/workflows/monitor-teleport-oci-distroless.yml) and
   [`rebuild-teleport-oci-distroless-cron.yml` on `master`](https://github.com/gravitational/teleport.e/blob/master/.github/workflows/rebuild-teleport-oci-distroless-cron.yml)
+- [ ] Update `e/.github/workflows/build-buildboxes-cron.yaml` to bump the
+  branches on each job (two per job) and to comment out the final job that only
+  exists for the pre-release, and bump the versions for the next release.

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -11,5 +11,6 @@ This checklist is to be run prior to cutting the release branch.
 - [ ] Search code for DELETE IN and REMOVE IN comments and clean up if appropriate
 - [ ] Update docs/faq.mdx "Which version of Teleport is supported?" section with release date and support info
 - [ ] Update the CI buildbox image
-  - [ ] Update the `BUILDBOX_VERSION` in `build.assets/images.mk`
-  - [ ] Commit and merge. GitHub Actions should build new buildbox images and push to `ghcr.io`
+  - [ ] Update the `BUILDBOX_VERSION` in `build.assets/images.mk`. Commit and merge.
+  - [ ] Update `e/.github/workflows/build-buildboxes-cron.yaml` to uncomment final pre-release
+    job and ensure it has the correct branch names (two places). Commit and merge.


### PR DESCRIPTION
Update the preflight and postrelease docs for starting a new release
branch and after publishing that release for the first time to update
the GitHub Action the scheduled building of the buildboxes.