### PR TITLE
Make VNet connection item behave like other items

### DIFF
--- a/web/packages/design/src/StepSlider/StepSlider.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.tsx
@@ -323,12 +323,18 @@ type Props<T> = {
 };
 
 export type StepComponentProps = {
-  // refCallback is a func that is called after component mounts.
-  // Required to calculate dimensions of the component for height animations.
+  /**
+   * refCallback is a func that is called after component mounts.
+   * Required to calculate dimensions of the component for height animations.
+   */
   refCallback(node: HTMLElement): void;
-  // next goes to the next step in the flow.
+  /**
+   * next goes to the next step in the flow.
+   */
   next(): void;
-  // prev goes back a step in the flow.
+  /**
+   * prev goes back a step in the flow.
+   */
   prev(): void;
   hasTransitionEnded: boolean;
   stepIndex: number;

--- a/web/packages/shared/libs/mergeRefs.test.tsx
+++ b/web/packages/shared/libs/mergeRefs.test.tsx
@@ -1,0 +1,68 @@
+/* MIT License
+
+Copyright (c) 2020 Greg Bergé
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. */
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import { mergeRefs } from './mergeRefs';
+
+test('mergeRefs', () => {
+  const Dummy = React.forwardRef(function Dummy(_, ref) {
+    React.useImperativeHandle(ref, () => 'refValue');
+    return null;
+  });
+  const refAsFunc = jest.fn();
+  const refAsObj = { current: undefined };
+  const Example: React.FC<{ visible: boolean }> = ({ visible }) => {
+    return visible ? <Dummy ref={mergeRefs([refAsObj, refAsFunc])} /> : null;
+  };
+  const { rerender } = render(<Example visible />);
+  expect(refAsFunc).toHaveBeenCalledTimes(1);
+  expect(refAsFunc).toHaveBeenCalledWith('refValue');
+  expect(refAsObj.current).toBe('refValue');
+  rerender(<Example visible={false} />);
+  expect(refAsFunc).toHaveBeenCalledTimes(2);
+  expect(refAsFunc).toHaveBeenCalledWith(null);
+  expect(refAsObj.current).toBe(null);
+});
+
+test('mergeRefs with undefined and null refs', () => {
+  const Dummy = React.forwardRef(function Dummy(_, ref) {
+    React.useImperativeHandle(ref, () => 'refValue');
+    return null;
+  });
+  const refAsFunc = jest.fn();
+  const refAsObj = { current: undefined };
+  const Example: React.FC<{ visible: boolean }> = ({ visible }) => {
+    return visible ? (
+      <Dummy ref={mergeRefs([null, undefined, refAsFunc, refAsObj])} />
+    ) : null;
+  };
+  const { rerender } = render(<Example visible />);
+  expect(refAsFunc).toHaveBeenCalledTimes(1);
+  expect(refAsFunc).toHaveBeenCalledWith('refValue');
+  expect(refAsObj.current).toBe('refValue');
+  rerender(<Example visible={false} />);
+  expect(refAsFunc).toHaveBeenCalledTimes(2);
+  expect(refAsFunc).toHaveBeenCalledWith(null);
+  expect(refAsObj.current).toBe(null);
+});

--- a/web/packages/shared/libs/mergeRefs.ts
+++ b/web/packages/shared/libs/mergeRefs.ts
@@ -1,0 +1,45 @@
+/* MIT License
+
+Copyright (c) 2020 Greg Bergé
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. */
+
+/**
+ * Combines multiple refs into one that can be passed to a component.
+ *
+ * https://github.com/gregberge/react-merge-refs/tree/v2.1.1
+ * @example
+ * const Example = React.forwardRef(function Example(props, ref) {
+ *   const localRef = React.useRef();
+ *   return <div ref={mergeRefs([localRef, ref])} />;
+ * });
+ */
+export function mergeRefs<T = any>(
+  refs: Array<React.MutableRefObject<T> | React.LegacyRef<T> | undefined | null>
+): React.RefCallback<T> {
+  return value => {
+    refs.forEach(ref => {
+      if (typeof ref === 'function') {
+        ref(value);
+      } else if (ref != null) {
+        (ref as React.MutableRefObject<T | null>).current = value;
+      }
+    });
+  };
+}

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -33,6 +33,7 @@ export class MockMainProcessClient implements MainProcessClient {
       jsonSchemaFile: createMockFileStorage(),
       platform: this.getRuntimeSettings().platform,
     });
+    this.configService.set('feature.vnet', true);
   }
 
   subscribeToNativeThemeUpdate() {

--- a/web/packages/teleterm/src/ui/TopBar/Connections/Connections.test.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/Connections.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, screen, userEvent } from 'design/utils/testing';
+
+import Logger, { NullService } from 'teleterm/logger';
+import { VnetContextProvider } from 'teleterm/ui/Vnet';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+
+import { Workspace } from 'teleterm/ui/services/workspacesService';
+
+import { Connections } from './Connections';
+
+beforeAll(() => {
+  Logger.init(new NullService());
+});
+
+describe('opening VNet panel', () => {
+  const tests: Array<{
+    name: string;
+    open: (user: ReturnType<typeof userEvent.setup>) => Promise<void>;
+  }> = [
+    {
+      name: 'with keyboard shortcuts',
+      open: user => user.keyboard('{ArrowDown}{Enter}'),
+    },
+    {
+      name: 'with clicks',
+      open: user => user.click(screen.getByTitle(/Open VNet/)),
+    },
+    {
+      name: 'through search',
+      open: user => user.keyboard('vnet{Enter}'),
+    },
+  ];
+  test.each(tests)('$name', async ({ open }) => {
+    const user = userEvent.setup();
+
+    render(
+      <MockAppContextProvider>
+        <VnetContextProvider>
+          <Connections />
+        </VnetContextProvider>
+      </MockAppContextProvider>
+    );
+
+    await user.click(screen.getByTitle(/Open Connections/));
+
+    expect(
+      screen.queryByTitle('Open VNet documentation')
+    ).not.toBeInTheDocument();
+
+    await open(user);
+
+    expect(
+      await screen.findByTitle('Open VNet documentation')
+    ).toBeInTheDocument();
+  });
+});
+
+describe('opening a connection', () => {
+  const tests: Array<{
+    name: string;
+    open: (user: ReturnType<typeof userEvent.setup>) => Promise<void>;
+  }> = [
+    {
+      name: 'with clicks',
+      open: user => user.click(screen.getByText('alice@foo')),
+    },
+    {
+      name: 'with keyboard',
+      open: user => user.keyboard('{ArrowDown}{ArrowDown}{Enter}'),
+    },
+    {
+      name: 'with search',
+      open: async user => user.keyboard('foo{Enter}'),
+    },
+  ];
+  test.each(tests)('$name', async ({ open }) => {
+    const user = userEvent.setup();
+    const appContext = new MockAppContext();
+    const cluster = makeRootCluster();
+    appContext.clustersService.setState(draft => {
+      draft.clusters.set(cluster.uri, cluster);
+    });
+    const doc = {
+      kind: 'doc.terminal_tsh_node',
+      origin: 'search_bar',
+      rootClusterId: cluster.name,
+      serverUri: `${cluster.uri}/servers/foo`,
+      serverId: 'foo',
+      login: 'alice',
+      title: 'alice@foo',
+      uri: '/docs/123',
+    };
+    appContext.workspacesService.setState(draft => {
+      draft.workspaces[cluster.uri] = {
+        documents: [doc],
+        location: undefined,
+      } as Workspace;
+    });
+
+    render(
+      <MockAppContextProvider appContext={appContext}>
+        <VnetContextProvider>
+          <Connections />
+        </VnetContextProvider>
+      </MockAppContextProvider>
+    );
+
+    await user.click(screen.getByTitle(/Open Connections/));
+
+    await open(user);
+
+    // The popover got closed.
+    expect(screen.queryByText('alice@foo')).not.toBeInTheDocument();
+    // Doc with the connection got opened
+    const workspace = appContext.workspacesService.getWorkspace(cluster.uri);
+    expect(workspace.location).toEqual(doc.uri);
+  });
+});

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionsFilterableList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionsFilterableList.tsx
@@ -39,39 +39,39 @@ export function ConnectionsFilterableList(props: {
     return <Text color="text.muted">No Connections</Text>;
   } // With VNet being supported, there's always at least one item to show – the VNet item.
 
+  let items: Array<ExtendedTrackedConnection | VnetConnection> = props.items;
+
+  if (isVnetSupported) {
+    items = [{ kind: 'vnet', title: 'VNet' }, ...items];
+  }
+
   return (
-    <FilterableList<ExtendedTrackedConnection>
-      items={props.items}
+    <FilterableList<ExtendedTrackedConnection | VnetConnection>
+      items={items}
       filterBy="title"
       placeholder="Search Connections"
       onFilterChange={value =>
         value.length ? setActiveIndex(0) : setActiveIndex(-1)
       }
-      Node={({ item, index }) => (
-        <ConnectionItem
-          item={item}
-          index={index}
-          onActivate={() => props.onActivateItem(item.id)}
-          onRemove={() => props.onRemoveItem(item.id)}
-          onDisconnect={() => props.onDisconnectItem(item.id)}
-        />
-      )}
-    >
-      {/*
-        TODO(ravicious): Change the type of FilterableList above to something like
-        FilterableList<ExtendedTrackedConnection | Vnet> and render a different component in Node
-        depending on the item type. This way VNet will have tighter integration with the connection
-        list, i.e. be searchable and selectable through keyboard.
-
-        We don't want to put VNet into ExtendedTrackedConnection because these are two fundamentally
-        different things.
-      */}
-      {isVnetSupported && (
-        <VnetConnectionItem
-          onClick={props.slideToVnet}
-          title="Open VNet panel"
-        />
-      )}
-    </FilterableList>
+      Node={({ item, index }) =>
+        item.kind === 'vnet' ? (
+          <VnetConnectionItem
+            openVnetPanel={props.slideToVnet}
+            title="Open VNet panel"
+            index={index}
+          />
+        ) : (
+          <ConnectionItem
+            item={item}
+            index={index}
+            onActivate={() => props.onActivateItem(item.id)}
+            onRemove={() => props.onRemoveItem(item.id)}
+            onDisconnect={() => props.onDisconnectItem(item.id)}
+          />
+        )
+      }
+    />
   );
 }
+
+type VnetConnection = { kind: 'vnet'; title: 'VNet' };

--- a/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { render, screen, userEvent } from 'design/utils/testing';
+import { wait } from 'shared/utils/wait';
+
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
+
+import { VnetContextProvider } from './vnetContext';
+import { VnetSliderStepHeader } from './VnetConnectionItem';
+
+describe('VnetSliderStepHeader', () => {
+  it('allows to tab through the header itself as well as the buttons', async () => {
+    const user = userEvent.setup();
+    render(
+      <MockAppContextProvider>
+        <VnetContextProvider>
+          <VnetSliderStepHeader goBack={() => {}} />
+        </VnetContextProvider>
+      </MockAppContextProvider>
+    );
+
+    const listItem = screen.getByTitle('Go back to Connections');
+    const openDocumentationButton = screen.getByTitle(
+      'Open VNet documentation'
+    );
+    const toggleButton = screen.getByTitle('Start VNet');
+    expect(document.body).toHaveFocus();
+
+    await user.tab();
+    expect(listItem).toHaveFocus();
+
+    await user.tab();
+    expect(openDocumentationButton).toHaveFocus();
+
+    await user.tab();
+    expect(toggleButton).toHaveFocus();
+  });
+
+  it('maintains focus on start/stop toggle when transitioning between states', async () => {
+    const appContext = new MockAppContext();
+    jest.spyOn(appContext.vnet, 'start').mockImplementation(async () => {
+      // An artificial delay so that the test is able to find an element with "Starting VNet" title.
+      await wait(50);
+      return new MockedUnaryCall({});
+    });
+    jest.spyOn(appContext.vnet, 'stop').mockImplementation(async () => {
+      await wait(50);
+      return new MockedUnaryCall({});
+    });
+    const user = userEvent.setup();
+    render(
+      <MockAppContextProvider appContext={appContext}>
+        <VnetContextProvider>
+          <VnetSliderStepHeader goBack={() => {}} />
+        </VnetContextProvider>
+      </MockAppContextProvider>
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await user.tab();
+    await user.tab();
+    await user.tab();
+    expect(await screen.findByTitle('Start VNet')).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+
+    expect(await screen.findByTitle('Starting VNet')).toHaveFocus();
+    expect(await screen.findByTitle('Stop VNet')).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+
+    expect(await screen.findByTitle('Stopping VNet')).toHaveFocus();
+    expect(await screen.findByTitle('Start VNet')).toHaveFocus();
+  });
+});

--- a/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
@@ -82,6 +82,9 @@ const VnetConnectionItemBase = forwardRef(
     ref
   ) => {
     const { status, start, stop, startAttempt, stopAttempt } = useVnetContext();
+    const isProcessing =
+      startAttempt.status === 'processing' ||
+      stopAttempt.status === 'processing';
     const indicatorStatus =
       startAttempt.status === 'error' || stopAttempt.status === 'error'
         ? 'error'
@@ -169,41 +172,57 @@ const VnetConnectionItemBase = forwardRef(
               </ButtonIcon>
             )}
 
-            {startAttempt.status === 'processing' ||
-            stopAttempt.status === 'processing' ? (
-              <icons.Spinner
-                css={`
-                  width: 32px;
-                  height: 32px;
-                  animation: ${rotate360} 1.5s infinite linear;
-                `}
-                size={18}
-              />
-            ) : (
-              <>
-                {status === 'running' && (
-                  <ButtonIcon
-                    title="Stop VNet"
-                    onClick={e => {
-                      e.stopPropagation();
-                      stop();
-                    }}
-                  >
-                    <icons.BroadcastSlash size={18} />
-                  </ButtonIcon>
-                )}
-                {status === 'stopped' && (
-                  <ButtonIcon
-                    title="Start VNet"
-                    onClick={e => {
-                      e.stopPropagation();
-                      start();
-                    }}
-                  >
-                    <icons.Broadcast size={18} />
-                  </ButtonIcon>
-                )}
-              </>
+            {/* The conditions for the buttons below could be written in a more concise way.
+                However, what's important for us here is that React keeps focus on the same
+                "logical" button when this component transitions between different states.
+                As a result, we cannot e.g. use a fragment to group two different states together.
+
+                There's a test which checks whether the focus is kept between state transitions.
+            */}
+
+            {isProcessing && (
+              // This button cannot be disabled, otherwise the focus will be lost between
+              // transitions and the test won't be able to catch this.
+              <ButtonIcon
+                key="vnet-toggle"
+                title={status === 'stopped' ? 'Starting VNet' : 'Stopping VNet'}
+                onClick={e => {
+                  e.stopPropagation();
+                }}
+              >
+                <icons.Spinner
+                  css={`
+                    width: 32px;
+                    height: 32px;
+                    animation: ${rotate360} 1.5s infinite linear;
+                  `}
+                  size={18}
+                />
+              </ButtonIcon>
+            )}
+            {!isProcessing && status === 'running' && (
+              <ButtonIcon
+                key="vnet-toggle"
+                title="Stop VNet"
+                onClick={e => {
+                  e.stopPropagation();
+                  stop();
+                }}
+              >
+                <icons.BroadcastSlash size={18} />
+              </ButtonIcon>
+            )}
+            {!isProcessing && status === 'stopped' && (
+              <ButtonIcon
+                key="vnet-toggle"
+                title="Start VNet"
+                onClick={e => {
+                  e.stopPropagation();
+                  start();
+                }}
+              >
+                <icons.Broadcast size={18} />
+              </ButtonIcon>
             )}
           </Flex>
         </Flex>

--- a/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import React, { forwardRef, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { Text, ButtonIcon, Flex, rotate360 } from 'design';
 import * as icons from 'design/Icon';
@@ -23,131 +24,193 @@ import { copyToClipboard } from 'design/utils/copyToClipboard';
 
 import { ConnectionStatusIndicator } from 'teleterm/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator';
 import { ListItem, StaticListItem } from 'teleterm/ui/components/ListItem';
+import { useKeyboardArrowsNavigation } from 'teleterm/ui/components/KeyboardArrowsNavigation';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 
 import { useVnetContext } from './vnetContext';
 
 /**
- * VnetConnection is the VNet entry in Connections. Also used as the topmost item in VnetSliderStep.
+ * VnetConnectionItem is the VNet entry in Connections.
  */
 export const VnetConnectionItem = (props: {
-  onClick: () => void;
+  openVnetPanel: () => void;
+  index: number;
   title: string;
-  showBackButton?: boolean;
-  showHelpButton?: boolean;
 }) => {
-  const { status, start, stop, startAttempt, stopAttempt } = useVnetContext();
-  const indicatorStatus =
-    startAttempt.status === 'error' || stopAttempt.status === 'error'
-      ? 'error'
-      : status === 'running'
-        ? 'on'
-        : 'off';
+  const { isActive, scrollIntoViewIfActive } = useKeyboardArrowsNavigation({
+    index: props.index,
+    onRun: props.openVnetPanel,
+  });
+
+  const ref = useRef<HTMLElement>();
+
+  useEffect(() => {
+    scrollIntoViewIfActive(ref.current);
+  }, [scrollIntoViewIfActive]);
 
   return (
-    <ListItem
-      css={`
-        padding: 6px 8px;
-        height: unset;
-      `}
-      onClick={props.onClick}
-      title={props.title}
-    >
-      {props.showBackButton ? (
-        <icons.ArrowBack size="small" mr={2} />
-      ) : (
-        <ConnectionStatusIndicator
-          mr={3}
-          css={`
-            flex-shrink: 0;
-          `}
-          status={indicatorStatus}
-        />
-      )}
-      <Flex
-        alignItems="center"
-        justifyContent="space-between"
-        flex="1"
-        minWidth="0"
-      >
-        <div
-          css={`
-            min-width: 0;
-          `}
-        >
-          <Text
-            typography="body1"
-            bold
-            color="text.main"
-            css={`
-              line-height: 16px;
-            `}
-          >
-            VNet
-          </Text>
-          <Text color="text.slightlyMuted" typography="body2">
-            Virtual Network Emulation
-          </Text>
-        </div>
-
-        {/* Buttons to the right. Negative margin to match buttons of other connections. */}
-        <Flex gap={1} mr="-3px">
-          {props.showHelpButton && (
-            <ButtonIcon
-              as="a"
-              title="Open VNet documentation"
-              href="https://goteleport.com/docs/connect-your-client/teleport-connect/#vnet"
-              target="_blank"
-              onClick={e => {
-                // Don't trigger ListItem's onClick.
-                e.stopPropagation();
-              }}
-            >
-              <icons.Question size={18} />
-            </ButtonIcon>
-          )}
-
-          {startAttempt.status === 'processing' ||
-          stopAttempt.status === 'processing' ? (
-            <icons.Spinner
-              css={`
-                width: 32px;
-                height: 32px;
-                animation: ${rotate360} 1.5s infinite linear;
-              `}
-              size={18}
-            />
-          ) : (
-            <>
-              {status === 'running' && (
-                <ButtonIcon
-                  title="Stop VNet"
-                  onClick={e => {
-                    e.stopPropagation();
-                    stop();
-                  }}
-                >
-                  <icons.BroadcastSlash size={18} />
-                </ButtonIcon>
-              )}
-              {status === 'stopped' && (
-                <ButtonIcon
-                  title="Start VNet"
-                  onClick={e => {
-                    e.stopPropagation();
-                    start();
-                  }}
-                >
-                  <icons.Broadcast size={18} />
-                </ButtonIcon>
-              )}
-            </>
-          )}
-        </Flex>
-      </Flex>
-    </ListItem>
+    <VnetConnectionItemBase
+      title="Open VNet panel"
+      onClick={props.openVnetPanel}
+      isActive={isActive}
+      ref={ref}
+    />
   );
 };
+
+export const VnetSliderStepHeader = (props: { goBack: () => void }) => (
+  <VnetConnectionItemBase
+    title="Go back to Connections"
+    onClick={props.goBack}
+    showBackButton
+    showHelpButton
+    // Make the element focusable.
+    tabIndex={0}
+  />
+);
+
+const VnetConnectionItemBase = forwardRef(
+  (
+    props: {
+      onClick: () => void;
+      title: string;
+      showBackButton?: boolean;
+      showHelpButton?: boolean;
+      isActive?: boolean;
+      tabIndex?: number;
+    },
+    ref
+  ) => {
+    const { status, start, stop, startAttempt, stopAttempt } = useVnetContext();
+    const indicatorStatus =
+      startAttempt.status === 'error' || stopAttempt.status === 'error'
+        ? 'error'
+        : status === 'running'
+          ? 'on'
+          : 'off';
+
+    const onEnterPress = (event: React.KeyboardEvent) => {
+      if (
+        event.key !== 'Enter' ||
+        // onKeyDown propagates from children too.
+        // Ignore those events, handle only keypresses on ListItem.
+        event.target !== event.currentTarget
+      ) {
+        return;
+      }
+
+      props.onClick();
+    };
+
+    return (
+      <ListItem
+        ref={ref}
+        css={`
+          padding: 6px 8px;
+          height: unset;
+        `}
+        isActive={props.isActive}
+        title={props.title}
+        onClick={props.onClick}
+        onKeyDown={onEnterPress}
+        tabIndex={props.tabIndex}
+      >
+        {props.showBackButton ? (
+          <icons.ArrowBack size="small" mr={2} />
+        ) : (
+          <ConnectionStatusIndicator
+            mr={3}
+            css={`
+              flex-shrink: 0;
+            `}
+            status={indicatorStatus}
+          />
+        )}
+        <Flex
+          alignItems="center"
+          justifyContent="space-between"
+          flex="1"
+          minWidth="0"
+        >
+          <div
+            css={`
+              min-width: 0;
+            `}
+          >
+            <Text
+              typography="body1"
+              bold
+              color="text.main"
+              css={`
+                line-height: 16px;
+              `}
+            >
+              VNet
+            </Text>
+            <Text color="text.slightlyMuted" typography="body2">
+              Virtual Network Emulation
+            </Text>
+          </div>
+
+          {/* Buttons to the right. Negative margin to match buttons of other connections. */}
+          <Flex gap={1} mr="-3px">
+            {props.showHelpButton && (
+              <ButtonIcon
+                as="a"
+                title="Open VNet documentation"
+                href="https://goteleport.com/docs/connect-your-client/teleport-connect/#vnet"
+                target="_blank"
+                onClick={e => {
+                  // Don't trigger ListItem's onClick.
+                  e.stopPropagation();
+                }}
+              >
+                <icons.Question size={18} />
+              </ButtonIcon>
+            )}
+
+            {startAttempt.status === 'processing' ||
+            stopAttempt.status === 'processing' ? (
+              <icons.Spinner
+                css={`
+                  width: 32px;
+                  height: 32px;
+                  animation: ${rotate360} 1.5s infinite linear;
+                `}
+                size={18}
+              />
+            ) : (
+              <>
+                {status === 'running' && (
+                  <ButtonIcon
+                    title="Stop VNet"
+                    onClick={e => {
+                      e.stopPropagation();
+                      stop();
+                    }}
+                  >
+                    <icons.BroadcastSlash size={18} />
+                  </ButtonIcon>
+                )}
+                {status === 'stopped' && (
+                  <ButtonIcon
+                    title="Start VNet"
+                    onClick={e => {
+                      e.stopPropagation();
+                      start();
+                    }}
+                  >
+                    <icons.Broadcast size={18} />
+                  </ButtonIcon>
+                )}
+              </>
+            )}
+          </Flex>
+        </Flex>
+      </ListItem>
+    );
+  }
+);
 
 /**
  * AppConnectionItem is an individual connection to an app made through VNet, shown in

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -18,26 +18,36 @@
 
 import { StepComponentProps } from 'design/StepSlider';
 import { Box, Flex, Text } from 'design';
+import { mergeRefs } from 'shared/libs/mergeRefs';
+import { useRefAutoFocus } from 'shared/hooks';
 
 import { useVnetContext } from './vnetContext';
-import { VnetConnectionItem, AppConnectionItem } from './VnetConnectionItem';
+import { VnetSliderStepHeader, AppConnectionItem } from './VnetConnectionItem';
 
 /**
  * VnetSliderStep is the second step of StepSlider used in TopBar/Connections. It is shown after
  * selecting VnetConnectionItem from ConnectionsFilterableList.
  */
 export const VnetSliderStep = (props: StepComponentProps) => {
+  const visible = props.stepIndex === 1 && props.hasTransitionEnded;
   const { status, startAttempt, stopAttempt } = useVnetContext();
+  const autoFocusRef = useRefAutoFocus<HTMLElement>({
+    shouldFocus: visible,
+  });
 
   return (
     // Padding needs to align with the padding of the previous slider step.
-    <Box p={2} ref={props.refCallback}>
-      <VnetConnectionItem
-        onClick={props.prev}
-        title="Go back to Connections"
-        showBackButton
-        showHelpButton
-      />
+    <Box
+      p={2}
+      ref={mergeRefs([props.refCallback, autoFocusRef])}
+      tabIndex={visible ? 0 : -1}
+      css={`
+        // Do not show the outline when focused. This element cannot be interacted with and we focus
+        // it only so that the next tab press is going to focus the VNet header button instead.
+        outline: none;
+      `}
+    >
+      <VnetSliderStepHeader goBack={props.prev} />
       <Flex
         p={textSpacing}
         gap={1}

--- a/web/packages/teleterm/src/ui/components/FilterableList/FilterableList.tsx
+++ b/web/packages/teleterm/src/ui/components/FilterableList/FilterableList.tsx
@@ -30,9 +30,7 @@ interface FilterableListProps<T> {
   onFilterChange?(filter: string): void;
 }
 
-export function FilterableList<T>(
-  props: React.PropsWithChildren<FilterableListProps<T>>
-) {
+export function FilterableList<T>(props: FilterableListProps<T>) {
   const { items } = props;
   const [searchValue, setSearchValue] = useState<string>();
 
@@ -54,7 +52,6 @@ export function FilterableList<T>(
         autoFocus={true}
       />
       <UnorderedList>
-        {props.children}
         {filteredItems.map((item, index) => (
           <Fragment key={index}>{props.Node({ item, index })}</Fragment>
         ))}

--- a/web/packages/teleterm/src/ui/components/FilterableList/FilterableList.tsx
+++ b/web/packages/teleterm/src/ui/components/FilterableList/FilterableList.tsx
@@ -68,11 +68,13 @@ function filterItems<T>(
   items: T[],
   filterBy: keyof T
 ): T[] {
-  const trimmed = searchValue?.trim();
+  const trimmed = searchValue?.trim().toLocaleLowerCase();
   if (!trimmed) {
     return items;
   }
-  return items.filter(item => item[filterBy].toString().includes(trimmed));
+  return items.filter(item =>
+    item[filterBy].toString().toLocaleLowerCase().includes(trimmed)
+  );
 }
 
 const UnorderedList = styled.ul`


### PR DESCRIPTION
VNet was already displayed in the connection list, however it couldn't be selected with a keyboard nor included/excluded from search within the connection list. This PR makes it so that it behaves like any other item.

I also made sure that keyboard navigation works good enough. After you select VNet from the main list, the outermost div of the VNet panel becomes focused, so you can press tab just once to tab through VNet controls.

This is not perfect, there are two issues that I decided to not address for now, but if you feel strongly about them I'd be inclined to fix them:

1. _Tabbing_ from the main list to the VNet toggle button and pressing enter doesn't work. That's because `KeyboardArrowsNavigation` steals all key down events and dispatches to them only if there's an active item selected with _arrows_.
   * This could be potentially fixed by making sure that the key down events are stolen only if they originate exactly from the element which calls `useKeyboardArrowsNavigation`. This would require keeping track of a list of refs.
2. Once you go to the VNet panel, you can only use the tab to switch focus, arrows do nothing. I think a typical user would expect that up/down arrow in the VNet panel selects the VNet header. But if we use `KeyboardArrowsNavigation` there, then you cannot press enter on the buttons because of the issue described above.

I also vendored in [react-merge-refs](https://www.npmjs.com/package/react-merge-refs) because I needed it in one place. It's a small lib with two files (one for implementation, one for tests) and types. I figured if we ever need to update it because of React changes, then it'll be easy because of the types and tests.

> [!IMPORTANT]
> To see the UI for VNet, you need to set `feature.vnet` to `true` in [your app config](https://goteleport.com/docs/connect-your-client/teleport-connect/#configuration). For the dev version of the app it's `~/Library/Application\ Support/Electron/app_config.json`.

https://github.com/gravitational/teleport/assets/27113/d22e6f3b-7128-4e1d-97f0-89693c25569c

