### PR TITLE
[v15] Introduce role friendly name labels and frontend utilities.

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -971,6 +971,9 @@ const (
 
 	// OktaGroupDescriptionLabel is the individual group description label.
 	OktaGroupDescriptionLabel = TeleportInternalLabelPrefix + "okta-group-description"
+
+	// OktaRoleNameLabel is the human readable name for a role sourced from Okta.
+	OktaRoleNameLabel = TeleportInternalLabelPrefix + "okta-role-name"
 )
 
 const (

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -692,6 +692,8 @@ func FriendlyName(resource ResourceWithLabels) string {
 			return appName
 		} else if groupName, ok := resource.GetLabel(OktaGroupNameLabel); ok {
 			return groupName
+		} else if roleName, ok := resource.GetLabel(OktaRoleNameLabel); ok {
+			return roleName
 		}
 		return resource.GetMetadata().Description
 	}

--- a/api/types/resource_test.go
+++ b/api/types/resource_test.go
@@ -528,6 +528,15 @@ func TestFriendlyName(t *testing.T) {
 		return group
 	}
 
+	newRole := func(t *testing.T, name string, labels map[string]string) Role {
+		role, err := NewRole(name, RoleSpecV6{})
+		require.NoError(t, err)
+		metadata := role.GetMetadata()
+		metadata.Labels = labels
+		role.SetMetadata(metadata)
+		return role
+	}
+
 	node, err := NewServer("node", KindNode, ServerSpecV2{
 		Hostname: "friendly hostname",
 	})
@@ -570,6 +579,14 @@ func TestFriendlyName(t *testing.T) {
 			resource: newGroup(t, "friendly", "friendly name", map[string]string{
 				OriginLabel:        OriginOkta,
 				OktaGroupNameLabel: "label friendly name",
+			}),
+			expected: "label friendly name",
+		},
+		{
+			name: "friendly role name (uses label)",
+			resource: newRole(t, "friendly", map[string]string{
+				OriginLabel:       OriginOkta,
+				OktaRoleNameLabel: "label friendly name",
 			}),
 			expected: "label friendly name",
 		},


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/40113 to branch/v15.

Note: This is manual due to a small conflict in `api/types/constants.go`.

changelog: Introduce friendly role names for Okta sourced roles. These will be displayed in access list and access request pages in the UI.