### PR TITLE
[Web] Add support for enterprise-only notifications

### DIFF
--- a/web/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
+++ b/web/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
@@ -1,21 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`render clusters 1`] = `
-.c16 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.c19 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: rgba(255,255,255,0.72);
-  margin-left: 8px;
-  margin-right: -8px;
-}
-
 .c0 {
   box-sizing: border-box;
   padding-left: 40px;
@@ -68,6 +53,21 @@ exports[`render clusters 1`] = `
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
+}
+
+.c16 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.c19 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255,255,255,0.72);
+  margin-left: 8px;
+  margin-right: -8px;
 }
 
 .c6 {

--- a/web/packages/teleport/src/Notifications/Notification.story.tsx
+++ b/web/packages/teleport/src/Notifications/Notification.story.tsx
@@ -18,30 +18,21 @@
 
 import React from 'react';
 import { MemoryRouter } from 'react-router';
-import {
-  subSeconds,
-  subMinutes,
-  subHours,
-  subDays,
-  subWeeks,
-  subMonths,
-} from 'date-fns';
+import { subSeconds, subMinutes, subHours, subDays } from 'date-fns';
 import { initialize, mswLoader } from 'msw-storybook-addon';
 import { rest } from 'msw';
 
 import { Flex } from 'design';
 
-import {
-  NotificationSubKind,
-  Notification as NotificationType,
-} from 'teleport/services/notifications';
+import { NotificationSubKind } from 'teleport/services/notifications';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import cfg from 'teleport/config';
 
 import { ContextProvider } from '..';
 
 import { Notification } from './Notification';
-import { Notifications as NotificationsComponent } from './Notifications';
+import { Notifications as NotificationsListComponent } from './Notifications';
+import { notifications as mockNotifications } from './fixtures';
 
 export default {
   title: 'Teleport/Notifications',
@@ -50,149 +41,33 @@ export default {
 
 initialize();
 
-export const Notifications = () => {
+export const NotificationTypes = () => {
+  const ctx = createTeleportContext();
+
   return (
-    <Flex
-      css={`
-        background: ${props => props.theme.colors.levels.surface};
-        padding: 24px;
-        width: fit-content;
-        height: fit-content;
-        flex-direction: column;
-        gap: 24px;
-      `}
-    >
-      {mockNotifications.map(notification => {
-        return (
-          <Notification notification={notification} key={notification.id} />
-        );
-      })}
-    </Flex>
+    <ContextProvider ctx={ctx}>
+      Enterprise notifications can be viewed in the
+      "TeleportE/Notifications/Notification Types E" story.
+      <Flex
+        mt={4}
+        p={4}
+        gap={4}
+        css={`
+          background: ${props => props.theme.colors.levels.surface};
+          width: fit-content;
+          height: fit-content;
+          flex-direction: column;
+        `}
+      >
+        {mockNotifications.map(notification => {
+          return (
+            <Notification notification={notification} key={notification.id} />
+          );
+        })}
+      </Flex>
+    </ContextProvider>
   );
 };
-
-const mockNotifications: NotificationType[] = [
-  {
-    id: '1',
-    title: 'joe approved your access request for 5 resources.',
-    subKind: NotificationSubKind.AccessRequestApproved,
-    createdDate: subSeconds(Date.now(), 30), // 30 seconds ago
-    clicked: false,
-    labels: [
-      {
-        name: 'request-id',
-        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
-      },
-    ],
-  },
-  {
-    id: '2',
-    title: `joe approved your access request for the 'auditor' role,`,
-    subKind: NotificationSubKind.AccessRequestApproved,
-    createdDate: subMinutes(Date.now(), 4), // 4 minutes ago
-    clicked: false,
-    labels: [
-      {
-        name: 'request-id',
-        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
-      },
-    ],
-  },
-  {
-    id: '3',
-    title: `joe denied your access request for the 'auditor' role,`,
-    subKind: NotificationSubKind.AccessRequestDenied,
-    createdDate: subMinutes(Date.now(), 15), // 15 minutes ago
-    clicked: false,
-    labels: [
-      {
-        name: 'request-id',
-        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
-      },
-    ],
-  },
-  {
-    id: '4',
-    title: 'bob requested access to 2 resources.',
-    subKind: NotificationSubKind.AccessRequestPending,
-    createdDate: subHours(Date.now(), 3), // 3 hours ago
-    clicked: true,
-    labels: [
-      {
-        name: 'request-id',
-        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
-      },
-    ],
-  },
-  {
-    id: '5',
-    title: `bob requested access to the 'intern' role.`,
-    subKind: NotificationSubKind.AccessRequestPending,
-    createdDate: subHours(Date.now(), 15), // 15 hours ago
-    clicked: true,
-    labels: [
-      {
-        name: 'request-id',
-        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
-      },
-    ],
-  },
-  {
-    id: '6',
-    title: `2 resources are now available to access.`,
-    subKind: NotificationSubKind.AccessRequestNowAssumable,
-    createdDate: subDays(Date.now(), 1), // 1 day ago
-    clicked: true,
-    labels: [
-      {
-        name: 'request-id',
-        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
-      },
-      { name: 'request-type', value: 'resource' },
-    ],
-  },
-  {
-    id: '7',
-    title: `"node-5" is now available to access.`,
-    subKind: NotificationSubKind.AccessRequestNowAssumable,
-    createdDate: subDays(Date.now(), 3), // 3 days ago
-    clicked: false,
-    labels: [
-      {
-        name: 'request-id',
-        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
-      },
-      { name: 'request-type', value: 'resource' },
-    ],
-  },
-  {
-    id: '8',
-    title: `"auditor" is now ready to assume.`,
-    subKind: NotificationSubKind.AccessRequestNowAssumable,
-    createdDate: subWeeks(Date.now(), 2), // 2 weeks ago
-    clicked: true,
-    labels: [
-      {
-        name: 'request-id',
-        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
-      },
-      { name: 'request-type', value: 'role' },
-    ],
-  },
-  {
-    id: '9',
-    title: 'This is an example user-created warning notification',
-    subKind: NotificationSubKind.UserCreatedWarning,
-    createdDate: subMonths(Date.now(), 3), // 3 months ago
-    clicked: true,
-    labels: [
-      {
-        name: 'text-content',
-        value: 'This is the text content of a warning notification.',
-      },
-    ],
-  },
-];
 
 export const NotificationsList = () => <ListComponent />;
 NotificationsList.parameters = {
@@ -255,7 +130,7 @@ const ListComponent = () => {
             height: ${p => p.theme.topBarHeight[2]}px;
           `}
         >
-          <NotificationsComponent />
+          <NotificationsListComponent />
         </Flex>
       </ContextProvider>
     </MemoryRouter>

--- a/web/packages/teleport/src/Notifications/Notification.tsx
+++ b/web/packages/teleport/src/Notifications/Notification.tsx
@@ -36,17 +36,23 @@ import { Theme } from 'design/theme/themes/types';
 
 import { Notification as NotificationType } from 'teleport/services/notifications';
 
-import {
-  NotificationContent,
-  notificationContentFactory,
-} from './notificationContentFactory';
+import { useTeleport } from '..';
+
+import { NotificationContent } from './notificationContentFactory';
 
 export function Notification({
   notification,
 }: {
   notification: NotificationType;
 }) {
-  const content = notificationContentFactory(notification);
+  const ctx = useTeleport();
+
+  const content = ctx.notificationContentFactory(notification);
+
+  // If the notification is unsupported, it should not be shown.
+  if (!content) {
+    return null;
+  }
 
   // Whether to show the text content dialog. This is only ever used for user-created notifications which only contain informational text
   // and don't redirect to any page.

--- a/web/packages/teleport/src/Notifications/fixtures.ts
+++ b/web/packages/teleport/src/Notifications/fixtures.ts
@@ -1,0 +1,152 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  subSeconds,
+  subMinutes,
+  subHours,
+  subDays,
+  subWeeks,
+  subMonths,
+} from 'date-fns';
+
+import { NotificationSubKind } from 'teleport/services/notifications';
+import { Notification } from 'teleport/services/notifications';
+
+export const notifications: Notification[] = [
+  {
+    id: '1',
+    title: 'joe approved your access request for 5 resources.',
+    subKind: NotificationSubKind.AccessRequestApproved,
+    createdDate: subSeconds(Date.now(), 30), // 30 seconds ago
+    clicked: false,
+    labels: [
+      {
+        name: 'request-id',
+        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
+      },
+    ],
+  },
+  {
+    id: '2',
+    title: `joe approved your access request for the 'auditor' role,`,
+    subKind: NotificationSubKind.AccessRequestApproved,
+    createdDate: subMinutes(Date.now(), 4), // 4 minutes ago
+    clicked: false,
+    labels: [
+      {
+        name: 'request-id',
+        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
+      },
+    ],
+  },
+  {
+    id: '3',
+    title: `joe denied your access request for the 'auditor' role,`,
+    subKind: NotificationSubKind.AccessRequestDenied,
+    createdDate: subMinutes(Date.now(), 15), // 15 minutes ago
+    clicked: false,
+    labels: [
+      {
+        name: 'request-id',
+        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
+      },
+    ],
+  },
+  {
+    id: '4',
+    title: 'bob requested access to 2 resources.',
+    subKind: NotificationSubKind.AccessRequestPending,
+    createdDate: subHours(Date.now(), 3), // 3 hours ago
+    clicked: true,
+    labels: [
+      {
+        name: 'request-id',
+        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
+      },
+    ],
+  },
+  {
+    id: '5',
+    title: `bob requested access to the 'intern' role.`,
+    subKind: NotificationSubKind.AccessRequestPending,
+    createdDate: subHours(Date.now(), 15), // 15 hours ago
+    clicked: true,
+    labels: [
+      {
+        name: 'request-id',
+        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
+      },
+    ],
+  },
+  {
+    id: '6',
+    title: `2 resources are now available to access.`,
+    subKind: NotificationSubKind.AccessRequestNowAssumable,
+    createdDate: subDays(Date.now(), 1), // 1 day ago
+    clicked: true,
+    labels: [
+      {
+        name: 'request-id',
+        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
+      },
+      { name: 'request-type', value: 'resource' },
+    ],
+  },
+  {
+    id: '7',
+    title: `"node-5" is now available to access.`,
+    subKind: NotificationSubKind.AccessRequestNowAssumable,
+    createdDate: subDays(Date.now(), 3), // 3 days ago
+    clicked: false,
+    labels: [
+      {
+        name: 'request-id',
+        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
+      },
+      { name: 'request-type', value: 'resource' },
+    ],
+  },
+  {
+    id: '8',
+    title: `"auditor" is now ready to assume.`,
+    subKind: NotificationSubKind.AccessRequestNowAssumable,
+    createdDate: subWeeks(Date.now(), 2), // 2 weeks ago
+    clicked: true,
+    labels: [
+      {
+        name: 'request-id',
+        value: '3bd7d71f-64ad-588a-988c-22f3853910fa',
+      },
+      { name: 'request-type', value: 'role' },
+    ],
+  },
+  {
+    id: '9',
+    title: 'This is an example user-created warning notification',
+    subKind: NotificationSubKind.UserCreatedWarning,
+    createdDate: subMonths(Date.now(), 3), // 3 months ago
+    clicked: true,
+    labels: [
+      {
+        name: 'text-content',
+        value: 'This is the text content of a warning notification.',
+      },
+    ],
+  },
+];

--- a/web/packages/teleport/src/Notifications/index.ts
+++ b/web/packages/teleport/src/Notifications/index.ts
@@ -17,3 +17,4 @@
  */
 
 export { Notifications } from './Notifications';
+export { notificationContentFactory } from './notificationContentFactory';

--- a/web/packages/teleport/src/Notifications/notificationContentFactory.tsx
+++ b/web/packages/teleport/src/Notifications/notificationContentFactory.tsx
@@ -26,6 +26,9 @@ import {
 } from 'teleport/services/notifications';
 import { Label } from 'teleport/types';
 
+/**
+ notificationContentFactory produces the content for notifications for OSS features.
+*/
 export function notificationContentFactory({
   subKind,
   labels,
@@ -59,68 +62,8 @@ export function notificationContentFactory({
       };
       break;
     }
-
-    case NotificationSubKind.AccessRequestApproved: {
-      notificationContent = {
-        kind: 'redirect',
-        title: notification.title,
-        type: 'success',
-        icon: Icons.Users,
-        redirectRoute: '/', //TODO: rudream - handle enterprise routes
-        quickAction: {
-          onClick: () => null, //TODO: rudream - handle assuming roles from quick action button
-          buttonText: 'Assume Roles',
-        },
-      };
-      break;
-    }
-
-    case NotificationSubKind.AccessRequestDenied: {
-      notificationContent = {
-        kind: 'redirect',
-        title: notification.title,
-        type: 'failure',
-        icon: Icons.Users,
-        redirectRoute: '/', //TODO: rudream - handle enterprise routes
-      };
-      break;
-    }
-
-    case NotificationSubKind.AccessRequestPending: {
-      notificationContent = {
-        kind: 'redirect',
-        title: notification.title,
-        type: 'informational',
-        icon: Icons.UserList,
-        redirectRoute: '/', //TODO: rudream - handle enterprise routes
-      };
-      break;
-    }
-
-    case NotificationSubKind.AccessRequestNowAssumable: {
-      let buttonText;
-
-      const accessRequestType = getLabelValue(labels, 'request-type');
-
-      if (accessRequestType === 'resource') {
-        buttonText = 'Access Now';
-      } else {
-        buttonText = 'Assume Role';
-      }
-
-      notificationContent = {
-        kind: 'redirect',
-        title: notification.title,
-        type: 'success-alt',
-        icon: Icons.Users,
-        redirectRoute: '/', //TODO: rudream - handle enterprise routes
-        quickAction: {
-          onClick: () => null, //TODO: rudream - handle assuming roles from quick action button
-          buttonText: buttonText,
-        },
-      };
-      break;
-    }
+    default:
+      return null;
   }
 
   return notificationContent;
@@ -160,7 +103,7 @@ export type NotificationContent =
   | NotificationContentText;
 
 // getLabelValue returns the value of a label for a given key.
-function getLabelValue(labels: Label[], key: string): string {
+export function getLabelValue(labels: Label[], key: string): string {
   const label = labels.find(label => {
     return label.name === key;
   });

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -39,6 +39,7 @@ import { agentService } from './services/agents';
 import { storageService } from './services/storageService';
 import ClustersService from './services/clusters/clusters';
 import { NotificationService } from './services/notifications';
+import { notificationContentFactory } from './Notifications';
 
 class TeleportContext implements types.Context {
   // stores
@@ -62,6 +63,8 @@ class TeleportContext implements types.Context {
   userGroupService = userGroupService;
   mfaService = new MfaService();
   notificationService = new NotificationService();
+
+  notificationContentFactory = notificationContentFactory;
 
   isEnterprise = cfg.isEnterprise;
   isCloud = cfg.isCloud;


### PR DESCRIPTION
## Purpose

Part of #37704 

Adds support for enterprise-only notifications. This is so that we can configure notifications to redirect to enterprise-only routes.

For example, clicking an access request notification should take you to the access request's page, however this route isn't available in OSS, so it needs to be defined in `e`.

This PR is based on changes from:
- #40263 

## Implementation

The `TeleportContext` has a `notificationsContentFactory` method which will by default be the base OSS `notificationsContentFactory`, however if the user is running enterprise, this method in the context will be overwritten by `notificationsContentFactoryE` which adds support for enterprise notifications. 

The `NotificationTypes` story in the OSS Storybook will only display OSS notifications, while the `NotificationTypesE` story will support all notification types. I considered only having the `Notification Types E` story, but I thought it might be useful to have the OSS one as well in case an open-source contributor would like to add a new notification type to Teleport. 
