### PR TITLE
Do not stringify log messages in the browser console

### DIFF
--- a/web/packages/teleterm/src/services/logger/loggerService.ts
+++ b/web/packages/teleterm/src/services/logger/loggerService.ts
@@ -232,9 +232,7 @@ function getBrowserConsoleTransport(opts: FileLoggerOptions) {
 function getRegularConsoleTransport(opts: FileLoggerOptions) {
   return new transports.Console({
     format: format.printf(({ level, message, context }) => {
-      const loggerName =
-        opts.loggerNameColor &&
-        `\x1b[${opts.loggerNameColor}m${opts.name.toUpperCase()}\x1b[0m`;
+      const loggerName = getLoggerName(opts);
 
       const text = stringifier(message as unknown as unknown[]);
       const logMessage = opts.passThroughMode

--- a/web/packages/teleterm/src/services/logger/loggerService.ts
+++ b/web/packages/teleterm/src/services/logger/loggerService.ts
@@ -210,7 +210,7 @@ type FileLoggerOptions = {
   omitTimestamp?: boolean;
 };
 
-/** Does not stringify messages and logs directly using `console.x` functions. */
+/** Does not stringify messages and logs directly using `console.*` functions. */
 function getBrowserConsoleTransport(opts: FileLoggerOptions) {
   return new transports.Console({
     log({ level, message, context }: Logform.TransformableInfo, next) {

--- a/web/packages/teleterm/src/services/logger/loggerService.ts
+++ b/web/packages/teleterm/src/services/logger/loggerService.ts
@@ -95,22 +95,7 @@ export function createFileLoggerService(
   });
 
   if (opts.dev) {
-    instance.add(
-      new transports.Console({
-        format: format.printf(({ level, message, context }) => {
-          const loggerName =
-            opts.loggerNameColor &&
-            `\x1b[${opts.loggerNameColor}m${opts.name.toUpperCase()}\x1b[0m`;
-
-          const text = stringifier(message as unknown as unknown[]);
-          const logMessage = opts.passThroughMode
-            ? text
-            : `[${context}] ${level}: ${text}`;
-
-          return [loggerName, logMessage].filter(Boolean).join(' ');
-        }),
-      })
-    );
+    instance.add(getRegularConsoleTransport(opts));
   }
 
   return {
@@ -217,3 +202,21 @@ type FileLoggerOptions = {
    * */
   omitTimestamp?: boolean;
 };
+
+/** Stringifies log messages and logs with winston's console transport. */
+function getRegularConsoleTransport(opts: FileLoggerOptions) {
+  return new transports.Console({
+    format: format.printf(({ level, message, context }) => {
+      const loggerName =
+        opts.loggerNameColor &&
+        `\x1b[${opts.loggerNameColor}m${opts.name.toUpperCase()}\x1b[0m`;
+
+      const text = stringifier(message as unknown as unknown[]);
+      const logMessage = opts.passThroughMode
+        ? text
+        : `[${context}] ${level}: ${text}`;
+
+      return [loggerName, logMessage].filter(Boolean).join(' ');
+    }),
+  });
+}

--- a/web/packages/teleterm/src/services/tshd/interceptors.test.ts
+++ b/web/packages/teleterm/src/services/tshd/interceptors.test.ts
@@ -40,7 +40,7 @@ it('do not log sensitive info like password', () => {
       service: { typeName: 'FooService' } as ServiceInfo,
     } as MethodInfo,
     {
-      passw: {},
+      password: {},
       userData: {
         login: 'admin',
         password: 'admin',
@@ -50,7 +50,7 @@ it('do not log sensitive info like password', () => {
   );
 
   expect(infoLogger).toHaveBeenCalledWith(expect.any(String), {
-    passw: '~FILTERED~',
+    password: '~FILTERED~',
     userData: { login: 'admin', password: '~FILTERED~' },
   });
 });

--- a/web/packages/teleterm/src/services/tshd/interceptors.ts
+++ b/web/packages/teleterm/src/services/tshd/interceptors.ts
@@ -22,7 +22,7 @@ import { isObject } from 'shared/utils/highbar';
 
 import Logger from 'teleterm/logger';
 
-const SENSITIVE_PROPERTIES = ['passw', 'authClusterId', 'pin'];
+const SENSITIVE_PROPERTIES = ['passw', 'password', 'authClusterId', 'pin'];
 
 export function loggingInterceptor(logger: Logger): RpcInterceptor {
   return {
@@ -109,7 +109,7 @@ export function filterSensitiveProperties(toFilter: object): object {
   const transformer = (result: object, value: any, key: any) => {
     if (
       SENSITIVE_PROPERTIES.some(
-        sensitiveProp => typeof key === 'string' && key.includes(sensitiveProp)
+        sensitiveProp => typeof key === 'string' && key === sensitiveProp
       )
     ) {
       result[key] = '~FILTERED~';

--- a/web/packages/teleterm/src/services/tshd/interceptors.ts
+++ b/web/packages/teleterm/src/services/tshd/interceptors.ts
@@ -22,7 +22,7 @@ import { isObject } from 'shared/utils/highbar';
 
 import Logger from 'teleterm/logger';
 
-const SENSITIVE_PROPERTIES = ['passw', 'password', 'authClusterId', 'pin'];
+const SENSITIVE_PROPERTIES = ['password', 'authClusterId', 'pin'];
 
 export function loggingInterceptor(logger: Logger): RpcInterceptor {
   return {


### PR DESCRIPTION
Currently, all log messages from Connect are stringified with `JSON.stringify` to allow logging complex values like objects or arrays (instead of printing `[object Object]`). This happens for both file loggers and dev loggers in consoles.

The only downside of this is that reading long log messages (like unified resources response) is quite hard.
To improve readability, we can stop stringifying the values for the browser. Instead, we can use `console.*` functions to present objects or arrays in a nice, expandable way.

Before:
<img width="501" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/8562d14d-1f2a-4f66-bb00-f9efd0807f79">


After:
<img width="501" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/8ca61fdc-14f2-42ed-9acd-d7f09faccdd9">

> [!IMPORTANT]
>This only affects dev logs in the browser, not file or dev logs in a non-browser console (main process).

I also fixed a bug introduced in https://github.com/gravitational/teleport/pull/39229, where `pinnedOnly` property started to be considered "sensitive". Instead of making partial matching on the key names, we can check the full name.