### PR TITLE
DiscoveryConfig: Update status after each run

### DIFF
--- a/api/client/discoveryconfig/discoveryconfig.go
+++ b/api/client/discoveryconfig/discoveryconfig.go
@@ -121,3 +121,16 @@ func (c *Client) DeleteAllDiscoveryConfigs(ctx context.Context) error {
 	_, err := c.grpcClient.DeleteAllDiscoveryConfigs(ctx, &discoveryconfigv1.DeleteAllDiscoveryConfigsRequest{})
 	return trace.Wrap(err)
 }
+
+// UpdateDiscoveryConfigStatus updates the DiscoveryConfig Status field.
+func (c *Client) UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error) {
+	resp, err := c.grpcClient.UpdateDiscoveryConfigStatus(ctx, &discoveryconfigv1.UpdateDiscoveryConfigStatusRequest{
+		Name:   name,
+		Status: conv.StatusToProto(status),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	dc, err := conv.FromProto(resp)
+	return dc, trace.Wrap(err)
+}

--- a/api/types/discoveryconfig/convert/v1/discoveryconfig.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig.go
@@ -119,16 +119,6 @@ func ToProto(discoveryConfig *discoveryconfig.DiscoveryConfig) *discoveryconfigv
 		kubeMatchers = append(kubeMatchers, &m)
 	}
 
-	var lastSyncTime *timestamppb.Timestamp
-	if !discoveryConfig.Status.LastSyncTime.IsZero() {
-		lastSyncTime = timestamppb.New(discoveryConfig.Status.LastSyncTime)
-	}
-	status := &discoveryconfigv1.DiscoveryConfigStatus{
-		State:               discoveryconfigv1.DiscoveryConfigState(discoveryconfigv1.DiscoveryConfigState_value[discoveryConfig.Status.State]),
-		ErrorMessage:        discoveryConfig.Status.ErrorMessage,
-		DiscoveredResources: discoveryConfig.Status.DiscoveredResources,
-		LastSyncTime:        lastSyncTime,
-	}
 	return &discoveryconfigv1.DiscoveryConfig{
 		Header: headerv1.ToResourceHeaderProto(discoveryConfig.ResourceHeader),
 		Spec: &discoveryconfigv1.DiscoveryConfigSpec{
@@ -139,6 +129,21 @@ func ToProto(discoveryConfig *discoveryconfig.DiscoveryConfig) *discoveryconfigv
 			Kube:           kubeMatchers,
 			AccessGraph:    discoveryConfig.Spec.AccessGraph,
 		},
-		Status: status,
+		Status: StatusToProto(discoveryConfig.Status),
+	}
+}
+
+// StatusToProto converts a discovery config status into the protobuf discovery config status object.
+func StatusToProto(status discoveryconfig.Status) *discoveryconfigv1.DiscoveryConfigStatus {
+	var lastSyncTime *timestamppb.Timestamp
+	if !status.LastSyncTime.IsZero() {
+		lastSyncTime = timestamppb.New(status.LastSyncTime)
+	}
+
+	return &discoveryconfigv1.DiscoveryConfigStatus{
+		State:               discoveryconfigv1.DiscoveryConfigState(discoveryconfigv1.DiscoveryConfigState_value[status.State]),
+		ErrorMessage:        status.ErrorMessage,
+		DiscoveredResources: status.DiscoveredResources,
+		LastSyncTime:        lastSyncTime,
 	}
 }

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -787,6 +787,9 @@ type DiscoveryAccessPoint interface {
 
 	// Ping gets basic info about the auth server.
 	Ping(context.Context) (proto.PingResponse, error)
+
+	// UpdateDiscoveryConfigStatus updates the status of a discovery config.
+	UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error)
 }
 
 // ReadOktaAccessPoint is a read only API interface to be
@@ -1379,6 +1382,11 @@ func (w *DiscoveryWrapper) EnrollEKSClusters(ctx context.Context, req *integrati
 // Ping gets basic info about the auth server.
 func (w *DiscoveryWrapper) Ping(ctx context.Context) (proto.PingResponse, error) {
 	return w.NoCache.Ping(ctx)
+}
+
+// UpdateDiscoveryConfigStatus updates the status of a discovery config.
+func (w *DiscoveryWrapper) UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error) {
+	return w.NoCache.UpdateDiscoveryConfigStatus(ctx, name, status)
 }
 
 // Close closes all associated resources

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -554,7 +554,7 @@ func (c *Client) UpsertUser(ctx context.Context, user types.User) (types.User, e
 }
 
 // DiscoveryConfigClient returns a client for managing the DiscoveryConfig resource.
-func (c *Client) DiscoveryConfigClient() services.DiscoveryConfigs {
+func (c *Client) DiscoveryConfigClient() services.DiscoveryConfigWithStatusUpdater {
 	return c.APIClient.DiscoveryConfigClient()
 }
 
@@ -1108,7 +1108,7 @@ type ClientI interface {
 	// Clients connecting to older Teleport versions, still get an DiscoveryConfig client
 	// when calling this method, but all RPCs will return "not implemented" errors
 	// (as per the default gRPC behavior).
-	DiscoveryConfigClient() services.DiscoveryConfigs
+	DiscoveryConfigClient() services.DiscoveryConfigWithStatusUpdater
 
 	// ResourceUsageClient returns a resource usage service client.
 	// Clients connecting to non-Enterprise clusters, or older Teleport versions,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -73,6 +73,7 @@ import (
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	transportpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/transport/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/aws"
@@ -2360,19 +2361,24 @@ type eksClustersEnroller interface {
 	EnrollEKSClusters(context.Context, *integrationpb.EnrollEKSClustersRequest, ...grpc.CallOption) (*integrationpb.EnrollEKSClustersResponse, error)
 }
 
+type discoveryConfigClient interface {
+	UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error)
+	services.DiscoveryConfigsGetter
+}
+
 // combinedDiscoveryClient is an auth.Client client with other, specific, services added to it.
 type combinedDiscoveryClient struct {
 	auth.ClientI
-	services.DiscoveryConfigsGetter
+	discoveryConfigClient
 	eksClustersEnroller
 }
 
 // newLocalCacheForDiscovery returns a new instance of access point for a discovery service.
 func (process *TeleportProcess) newLocalCacheForDiscovery(clt auth.ClientI, cacheName []string) (auth.DiscoveryAccessPoint, error) {
 	client := combinedDiscoveryClient{
-		ClientI:                clt,
-		DiscoveryConfigsGetter: clt.DiscoveryConfigClient(),
-		eksClustersEnroller:    clt.IntegrationAWSOIDCClient(),
+		ClientI:               clt,
+		discoveryConfigClient: clt.DiscoveryConfigClient(),
+		eksClustersEnroller:   clt.IntegrationAWSOIDCClient(),
 	}
 
 	// if caching is disabled, return access point

--- a/lib/services/discoveryconfig.go
+++ b/lib/services/discoveryconfig.go
@@ -43,6 +43,8 @@ type DiscoveryConfigs interface {
 	DeleteDiscoveryConfig(ctx context.Context, name string) error
 	// DeleteAllDiscoveryConfigs removes all DiscoveryConfigs.
 	DeleteAllDiscoveryConfigs(context.Context) error
+	// UpdateDiscoveryConfigStatus updates the status of the specified DiscoveryConfig resource.
+	UpdateDiscoveryConfigStatus(context.Context, string, discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error)
 }
 
 // DiscoveryConfigsGetter defines methods for List/Read operations on DiscoveryConfig Resources.

--- a/lib/services/discoveryconfig.go
+++ b/lib/services/discoveryconfig.go
@@ -43,6 +43,11 @@ type DiscoveryConfigs interface {
 	DeleteDiscoveryConfig(ctx context.Context, name string) error
 	// DeleteAllDiscoveryConfigs removes all DiscoveryConfigs.
 	DeleteAllDiscoveryConfigs(context.Context) error
+}
+
+// DiscoveryConfigWithStatusUpdater defines an interface for managing DiscoveryConfig resources including updating their status.
+type DiscoveryConfigWithStatusUpdater interface {
+	DiscoveryConfigs
 	// UpdateDiscoveryConfigStatus updates the status of the specified DiscoveryConfig resource.
 	UpdateDiscoveryConfigStatus(context.Context, string, discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error)
 }

--- a/lib/services/local/discoveryconfig.go
+++ b/lib/services/local/discoveryconfig.go
@@ -118,8 +118,3 @@ func (s *DiscoveryConfigService) DeleteDiscoveryConfig(ctx context.Context, name
 func (s *DiscoveryConfigService) DeleteAllDiscoveryConfigs(ctx context.Context) error {
 	return trace.Wrap(s.svc.DeleteAllResources(ctx))
 }
-
-// UpdateDiscoveryConfigStatus updates the status of the specified DiscoveryConfig resource.
-func (s *DiscoveryConfigService) UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error) {
-	return nil, trace.NotImplemented("not implemented")
-}

--- a/lib/services/local/discoveryconfig.go
+++ b/lib/services/local/discoveryconfig.go
@@ -118,3 +118,8 @@ func (s *DiscoveryConfigService) DeleteDiscoveryConfig(ctx context.Context, name
 func (s *DiscoveryConfigService) DeleteAllDiscoveryConfigs(ctx context.Context) error {
 	return trace.Wrap(s.svc.DeleteAllResources(ctx))
 }
+
+// UpdateDiscoveryConfigStatus updates the status of the specified DiscoveryConfig resource.
+func (s *DiscoveryConfigService) UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error) {
+	return nil, trace.NotImplemented("not implemented")
+}

--- a/lib/srv/discovery/access_graph.go
+++ b/lib/srv/discovery/access_graph.go
@@ -30,8 +30,10 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
 	"github.com/gravitational/teleport/lib/services"
 	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
@@ -65,6 +67,7 @@ func (s *Server) reconcileAccessGraph(ctx context.Context, currentTAGResources *
 		}
 		return trace.Wrap(errNoAccessGraphFetchers)
 	}
+	s.updateDiscoveryConfigStatus(allFetchers, nil, true /* preRun */)
 	resultsC := make(chan fetcherResult, len(allFetchers))
 	// Use a channel to limit the number of concurrent fetchers.
 	tokens := make(chan struct{}, 3)
@@ -102,6 +105,7 @@ func (s *Server) reconcileAccessGraph(ctx context.Context, currentTAGResources *
 	// Merge all results into a single result
 	upsert, toDel := aws_sync.ReconcileResults(currentTAGResources, result)
 	err = push(stream, upsert, toDel)
+	s.updateDiscoveryConfigStatus(allFetchers, err, false /* preRun */)
 	if err != nil {
 		s.Log.WithError(err).Error("Error pushing TAGs")
 		return nil
@@ -358,7 +362,7 @@ func grpcCredentials(config AccessGraphConfig, certs []tls.Certificate) (grpc.Di
 }
 
 func (s *Server) initAccessGraphWatchers(ctx context.Context, cfg *Config) error {
-	fetchers, err := s.accessGraphFetchersFromMatchers(ctx, cfg.Matchers)
+	fetchers, err := s.accessGraphFetchersFromMatchers(ctx, cfg.Matchers, "" /* discoveryConfigName */)
 	if err != nil {
 		s.Log.WithError(err).Error("Error initializing access graph fetchers")
 	}
@@ -402,7 +406,7 @@ func (s *Server) initAccessGraphWatchers(ctx context.Context, cfg *Config) error
 }
 
 // accessGraphFetchersFromMatchers converts Matchers into a set of AWS Sync Fetchers.
-func (s *Server) accessGraphFetchersFromMatchers(ctx context.Context, matchers Matchers) ([]aws_sync.AWSSync, error) {
+func (s *Server) accessGraphFetchersFromMatchers(ctx context.Context, matchers Matchers, discoveryConfigName string) ([]aws_sync.AWSSync, error) {
 	var fetchers []aws_sync.AWSSync
 	var errs []error
 	if matchers.AccessGraph == nil {
@@ -420,10 +424,11 @@ func (s *Server) accessGraphFetchersFromMatchers(ctx context.Context, matchers M
 		fetcher, err := aws_sync.NewAWSFetcher(
 			ctx,
 			aws_sync.Config{
-				CloudClients: s.CloudClients,
-				AssumeRole:   assumeRole,
-				Regions:      awsFetcher.Regions,
-				Integration:  awsFetcher.Integration,
+				CloudClients:        s.CloudClients,
+				AssumeRole:          assumeRole,
+				Regions:             awsFetcher.Regions,
+				Integration:         awsFetcher.Integration,
+				DiscoveryConfigName: discoveryConfigName,
 			},
 		)
 		if err != nil {
@@ -434,4 +439,47 @@ func (s *Server) accessGraphFetchersFromMatchers(ctx context.Context, matchers M
 	}
 
 	return fetchers, trace.NewAggregate(errs...)
+}
+
+func (s *Server) updateDiscoveryConfigStatus(fetchers []aws_sync.AWSSync, pushErr error, preRun bool) {
+	lastUpdate := s.clock.Now()
+	for _, fetcher := range fetchers {
+		// Only update the status for fetchers that are from the discovery config.
+		if !fetcher.IsFromDiscoveryConfig() {
+			continue
+		}
+
+		status := buildFetcherStatus(fetcher, pushErr, lastUpdate)
+		if preRun {
+			// If this is a pre-run, the status is syncing.
+			status.State = discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_SYNCING.String()
+		}
+		ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+		defer cancel()
+		_, err := s.AccessPoint.UpdateDiscoveryConfigStatus(ctx, fetcher.DiscoveryConfigName(), status)
+		switch {
+		case trace.IsNotImplemented(err):
+			s.Log.Warn("UpdateDiscoveryConfigStatus method is not implemented in Auth Server. Please upgrade it to a recent version.")
+		case err != nil:
+			s.Log.WithError(err).Infof("Error updating discovery config %q status", fetcher.DiscoveryConfigName())
+		}
+	}
+}
+
+func buildFetcherStatus(fetcher aws_sync.AWSSync, pushErr error, lastUpdate time.Time) discoveryconfig.Status {
+	count, err := fetcher.Status()
+	err = trace.NewAggregate(err, pushErr)
+	var errStr *string
+	state := discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_RUNNING
+	if err != nil {
+		errStr = new(string)
+		*errStr = err.Error()
+		state = discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_ERROR
+	}
+	return discoveryconfig.Status{
+		State:               state.String(),
+		ErrorMessage:        errStr,
+		LastSyncTime:        lastUpdate,
+		DiscoveredResources: count,
+	}
 }

--- a/lib/srv/discovery/access_graph_test.go
+++ b/lib/srv/discovery/access_graph_test.go
@@ -1,0 +1,178 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
+	var testErr = "test error"
+	clock := clockwork.NewFakeClock()
+	type args struct {
+		fetchers []aws_sync.AWSSync
+		pushErr  error
+		preRun   bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string][]discoveryconfig.Status
+	}{
+		{
+			name: "test updateDiscoveryConfigStatus",
+			args: args{
+				fetchers: []aws_sync.AWSSync{
+					&fakeFetcher{
+						count:               1,
+						discoveryConfigName: "test",
+					},
+				},
+			},
+			want: map[string][]discoveryconfig.Status{
+				"test": {
+					{
+						State:               "DISCOVERY_CONFIG_STATE_RUNNING",
+						ErrorMessage:        nil,
+						DiscoveredResources: 1,
+						LastSyncTime:        clock.Now(),
+					},
+				},
+			},
+		},
+
+		{
+			name: "test updateDiscoveryConfigStatus with pushError",
+			args: args{
+				fetchers: []aws_sync.AWSSync{
+					&fakeFetcher{
+						count:               1,
+						discoveryConfigName: "test",
+					},
+				},
+				pushErr: fmt.Errorf(testErr),
+			},
+			want: map[string][]discoveryconfig.Status{
+				"test": {
+					{
+						State:               "DISCOVERY_CONFIG_STATE_ERROR",
+						ErrorMessage:        &testErr,
+						DiscoveredResources: 1,
+						LastSyncTime:        clock.Now(),
+					},
+				},
+			},
+		},
+		{
+			name: "test updateDiscoveryConfigStatus with errpr",
+			args: args{
+				fetchers: []aws_sync.AWSSync{
+					&fakeFetcher{
+						count:               1,
+						discoveryConfigName: "test",
+						err:                 fmt.Errorf(testErr),
+					},
+				},
+			},
+			want: map[string][]discoveryconfig.Status{
+				"test": {
+					{
+						State:               "DISCOVERY_CONFIG_STATE_ERROR",
+						ErrorMessage:        &testErr,
+						DiscoveredResources: 1,
+						LastSyncTime:        clock.Now(),
+					},
+				},
+			},
+		},
+		{
+			name: "discar reports for non-discovery config results",
+			args: args{
+				fetchers: []aws_sync.AWSSync{
+					&fakeFetcher{
+						count: 1,
+					},
+				},
+			},
+			want: map[string][]discoveryconfig.Status{},
+		},
+		{
+			name: "test updateDiscoveryConfigStatus pre-run",
+			args: args{
+				fetchers: []aws_sync.AWSSync{
+					&fakeFetcher{
+						count:               1,
+						discoveryConfigName: "test",
+					},
+				},
+				preRun: true,
+			},
+			want: map[string][]discoveryconfig.Status{
+				"test": {
+					{
+						State:               "DISCOVERY_CONFIG_STATE_SYNCING",
+						ErrorMessage:        nil,
+						DiscoveredResources: 1,
+						LastSyncTime:        clock.Now(),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accessPoint := newFakeAccessPoint()
+			s := &Server{
+				ctx: context.Background(),
+				Config: &Config{
+					AccessPoint: accessPoint,
+					clock:       clock,
+				},
+			}
+			s.updateDiscoveryConfigStatus(tt.args.fetchers, tt.args.pushErr, tt.args.preRun)
+			require.Equal(t, tt.want, accessPoint.reports)
+		})
+	}
+}
+
+type fakeFetcher struct {
+	aws_sync.AWSSync
+	err                 error
+	count               uint64
+	discoveryConfigName string
+}
+
+func (f *fakeFetcher) Status() (uint64, error) {
+	return f.count, f.err
+}
+
+func (f *fakeFetcher) DiscoveryConfigName() string {
+	return f.discoveryConfigName
+}
+
+func (f *fakeFetcher) IsFromDiscoveryConfig() bool {
+	return f.discoveryConfigName != ""
+}

--- a/lib/srv/discovery/access_graph_test.go
+++ b/lib/srv/discovery/access_graph_test.go
@@ -23,10 +23,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/gravitational/teleport/api/types/discoveryconfig"
-	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
 )
 
 func TestServer_updateDiscoveryConfigStatus(t *testing.T) {

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -324,6 +324,8 @@ type Server struct {
 	dynamicKubeFetchers   map[string][]common.Fetcher
 	muDynamicKubeFetchers sync.RWMutex
 
+	dynamicDiscoveryConfig map[string]*discoveryconfig.DiscoveryConfig
+
 	// caRotationCh receives nodes that need to have their CAs rotated.
 	caRotationCh chan []types.Server
 	// reconciler periodically reconciles the labels of discovered instances
@@ -354,6 +356,7 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 		dynamicServerAzureFetchers: make(map[string][]server.Fetcher),
 		dynamicServerGCPFetchers:   make(map[string][]server.Fetcher),
 		dynamicTAGSyncFetchers:     make(map[string][]aws_sync.AWSSync),
+		dynamicDiscoveryConfig:     make(map[string]*discoveryconfig.DiscoveryConfig),
 	}
 	s.discardUnsupportedMatchers(&s.Matchers)
 
@@ -1374,6 +1377,7 @@ func (s *Server) loadExistingDynamicDiscoveryConfigs() error {
 				s.Log.WithError(err).Warnf("failed to update dynamic matchers for discovery config %q", dc.GetName())
 				continue
 			}
+			s.dynamicDiscoveryConfig[dc.GetName()] = dc
 		}
 		if respNextKey == "" {
 			break
@@ -1401,11 +1405,25 @@ func (s *Server) startDynamicWatcherUpdater() {
 				}
 
 				if dc.GetDiscoveryGroup() != s.DiscoveryGroup {
+					name := dc.GetName()
+					// If the DiscoveryConfig was never part part of this discovery service because the
+					// discovery group never matched, then it must be ignored.
+					if _, ok := s.dynamicDiscoveryConfig[name]; !ok {
+						continue
+					}
 					// Let's assume there's a DiscoveryConfig DC1 has DiscoveryGroup DG1, which this process is monitoring.
 					// If the user updates the DiscoveryGroup to DG2, then DC1 must be removed from the scope of this process.
 					// We blindly delete it, in the worst case, this is a no-op.
-					s.deleteDynamicFetchers(event.Resource.GetName())
+					s.deleteDynamicFetchers(name)
+					delete(s.dynamicDiscoveryConfig, name)
 					s.notifyDiscoveryConfigChanged()
+					continue
+				}
+
+				oldDiscoveryConfig := s.dynamicDiscoveryConfig[dc.GetName()]
+				// If the DiscoveryConfig spec didn't change, then there's no need to update the matchers.
+				// we can skip this event.
+				if oldDiscoveryConfig.Equal(dc) {
 					continue
 				}
 
@@ -1413,10 +1431,18 @@ func (s *Server) startDynamicWatcherUpdater() {
 					s.Log.WithError(err).Warnf("failed to update dynamic matchers for discovery config %q", dc.GetName())
 					continue
 				}
+				s.dynamicDiscoveryConfig[dc.GetName()] = dc
 				s.notifyDiscoveryConfigChanged()
 
 			case types.OpDelete:
-				s.deleteDynamicFetchers(event.Resource.GetName())
+				name := event.Resource.GetName()
+				// If the DiscoveryConfig was never part part of this discovery service because the
+				// discovery group never matched, then it must be ignored.
+				if _, ok := s.dynamicDiscoveryConfig[name]; !ok {
+					continue
+				}
+				s.deleteDynamicFetchers(name)
+				delete(s.dynamicDiscoveryConfig, name)
 				s.notifyDiscoveryConfigChanged()
 			default:
 				s.Log.Warnf("Skipping unknown event type %s", event.Type)
@@ -1520,7 +1546,7 @@ func (s *Server) upsertDynamicMatchers(ctx context.Context, dc *discoveryconfig.
 	s.muDynamicDatabaseFetchers.Unlock()
 
 	awsSyncMatchers, err := s.accessGraphFetchersFromMatchers(
-		ctx, matchers,
+		ctx, matchers, dc.GetName(),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -2735,11 +2735,18 @@ type fakeAccessPoint struct {
 	kube                types.KubeCluster
 	database            types.Database
 	upsertedServerInfos chan types.ServerInfo
+	reports             map[string][]discoveryconfig.Status
+}
+
+func (f *fakeAccessPoint) UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error) {
+	f.reports[name] = append(f.reports[name], status)
+	return nil, nil
 }
 
 func newFakeAccessPoint() *fakeAccessPoint {
 	return &fakeAccessPoint{
 		upsertedServerInfos: make(chan types.ServerInfo),
+		reports:             make(map[string][]discoveryconfig.Status),
 	}
 }
 

--- a/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
+++ b/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
@@ -131,10 +131,11 @@ func (r *Resources) count() int {
 	elem := reflect.ValueOf(r).Elem()
 	sum := 0
 	for i := 0; i < elem.NumField(); i++ {
-		if elem.Field(i).IsValid() {
-			switch elem.Field(i).Kind() {
+		field := elem.Field(i)
+		if field.IsValid() {
+			switch field.Kind() {
 			case reflect.Slice:
-				sum += elem.Field(i).Len()
+				sum += field.Len()
 			}
 		}
 	}

--- a/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
+++ b/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
@@ -20,6 +20,7 @@ package aws_sync
 
 import (
 	"context"
+	"reflect"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -47,6 +48,8 @@ type Config struct {
 	AssumeRole *AssumeRole
 	// Integration is the name of the AWS integration to use when fetching resources.
 	Integration string
+	// DiscoveryConfigName if set, will be used to report the Discovery Config Status to the Auth Server.
+	DiscoveryConfigName string
 }
 
 // AssumeRole is the configuration for assuming an AWS role.
@@ -60,12 +63,20 @@ type AssumeRole struct {
 // awsFetcher is a fetcher that fetches AWS resources.
 type awsFetcher struct {
 	Config
+	lastError               error
+	lastDiscoveredResources uint64
 }
 
 // AWSSync is the interface for fetching AWS resources.
 type AWSSync interface {
 	// Poll polls all AWS resources and returns the result.
 	Poll(context.Context, Features) (*Resources, error)
+	// Status reports the last known status of the fetcher.
+	Status() (uint64, error)
+	// DiscoveryConfigName returns the name of the Discovery Config.
+	DiscoveryConfigName() string
+	// IsFromDiscoveryConfig returns true if the fetcher is associated with a Discovery Config.
+	IsFromDiscoveryConfig() bool
 }
 
 // Resources is a collection of polled AWS resources.
@@ -112,6 +123,24 @@ type Resources struct {
 	RDSDatabases []*accessgraphv1alpha.AWSRDSDatabaseV1
 }
 
+func (r *Resources) count() int {
+	if r == nil {
+		return 0
+	}
+
+	elem := reflect.ValueOf(r).Elem()
+	sum := 0
+	for i := 0; i < elem.NumField(); i++ {
+		if elem.Field(i).IsValid() {
+			switch elem.Field(i).Kind() {
+			case reflect.Slice:
+				sum += elem.Field(i).Len()
+			}
+		}
+	}
+	return sum
+}
+
 // NewAWSFetcher creates a new AWS fetcher.
 func NewAWSFetcher(ctx context.Context, cfg Config) (AWSSync, error) {
 	a := &awsFetcher{
@@ -131,7 +160,16 @@ func NewAWSFetcher(ctx context.Context, cfg Config) (AWSSync, error) {
 // if some resources were fetched successfully and some were not.
 func (a *awsFetcher) Poll(ctx context.Context, features Features) (*Resources, error) {
 	result, err := a.poll(ctx, features)
+	a.storeReport(result, err)
 	return result, trace.Wrap(err)
+}
+
+func (a *awsFetcher) storeReport(rec *Resources, err error) {
+	a.lastError = err
+	if rec == nil {
+		return
+	}
+	a.lastDiscoveredResources = uint64(rec.count())
 }
 
 func (a *awsFetcher) poll(ctx context.Context, features Features) (*Resources, error) {
@@ -238,4 +276,16 @@ func (a *awsFetcher) getAccountId(ctx context.Context) (string, error) {
 	}
 
 	return aws.StringValue(req.Account), nil
+}
+
+func (a *awsFetcher) DiscoveryConfigName() string {
+	return a.Config.DiscoveryConfigName
+}
+
+func (a *awsFetcher) IsFromDiscoveryConfig() bool {
+	return a.Config.DiscoveryConfigName != ""
+}
+
+func (a *awsFetcher) Status() (uint64, error) {
+	return a.lastDiscoveredResources, a.lastError
 }

--- a/lib/srv/discovery/fetchers/aws-sync/merge_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/merge_test.go
@@ -48,3 +48,17 @@ func TestMergeResources(t *testing.T) {
 	}
 	require.Equal(t, &expected, result)
 }
+
+func TestCount(t *testing.T) {
+	_, users := generateUsers()
+	_, roles := generateRoles()
+	_, instances := generateEC2()
+	resources := Resources{
+		Users:     users,
+		Roles:     roles,
+		Instances: instances,
+	}
+
+	count := resources.count()
+	require.Equal(t, len(users)+len(roles)+len(instances), count)
+}


### PR DESCRIPTION
This PR adds the initial reporting of discovery config status when polling data from AWS APIs.

The status field is updated before start polling AWS APIS with `state=syncing` and once all pushes to access graph completed successfully with `state=running `