### PR TITLE
fix: Prevent passkey downgrades

### DIFF
--- a/lib/auth/webauthn/register.go
+++ b/lib/auth/webauthn/register.go
@@ -147,11 +147,15 @@ func (f *RegistrationFlow) Begin(ctx context.Context, user string, passwordless 
 		if dev.GetU2F() != nil {
 			continue
 		}
-		// Skip resident/non-resident keys depending on whether it's a passwordless
-		// registration.
-		// Letting users have both allows them to "swap" between key types in the
-		// same device.
-		if webDev := dev.GetWebauthn(); webDev != nil && webDev.ResidentKey != passwordless {
+
+		// Let "upgrades" from non-resident to resident happen, but prevent
+		// authenticator "downgrades".
+		//
+		// Modern passkey implementations will "disobey" our MFA registrations and
+		// actually create passkeys, silently replacing the old passkey with the new
+		// "MFA" key, which can make Teleport confused (for example, by letting the
+		// "MFA" key be deleted because Teleport thinks the passkey still exists).
+		if webDev := dev.GetWebauthn(); webDev != nil && !webDev.ResidentKey && passwordless {
 			continue
 		}
 

--- a/lib/auth/webauthn/register.go
+++ b/lib/auth/webauthn/register.go
@@ -148,8 +148,9 @@ func (f *RegistrationFlow) Begin(ctx context.Context, user string, passwordless 
 			continue
 		}
 
-		// Let "upgrades" from non-resident to resident happen, but prevent
-		// authenticator "downgrades".
+		// Let authenticator "upgrades" from non-resident (MFA) to resident
+		// (passwordless) happen, but prevent "downgrades" from resident to
+		// non-resident.
 		//
 		// Modern passkey implementations will "disobey" our MFA registrations and
 		// actually create passkeys, silently replacing the old passkey with the new


### PR DESCRIPTION
Prevent authenticators from "downgrading" passkeys to "MFA" keys by always adding passkeys to the registration credential exclude list.

Modern authenticators, like Touch ID on Chrome, will always create passkeys regardless of our registration parameters. This can lead to the following situation:

1. User registers a passkey using Chrome and Touch ID
2. User registers an "MFA" key using Chrome and Touch ID. The authenticator "ignores" our credential parameters and creates another passkey. Because that passkey has the same website and user as the original one, it replaces it.
3. Teleport now thinks the user has 2 distinct keys: a passkey and an MFA key
4. User deletes the MFA key in Teleport, which is allowed because Teleport thinks the original passkey still exists. The public key for the only existing key is removed from Teleport.
5. User is now locked out.

This PR stops 2) from happening: the browser will error with a message in the lines of "You already registered this device".

Related to #39521.

Changelog: Prevent accidental passkey "downgrades" to MFA