### PR TITLE
Reset `tlsConfig.ServerName` field before dialing to TAG

### DIFF
--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -71,6 +71,10 @@ func (process *TeleportProcess) initDiscoveryService() error {
 		return trace.Wrap(err)
 	}
 
+	if tlsConfig != nil {
+		tlsConfig.ServerName = "" /* empty the server name to avoid SNI collisions with access graph addr */
+	}
+
 	accessGraphCfg, err := buildAccessGraphFromTAGOrFallbackToAuth(
 		process.ExitContext(),
 		process.Config,


### PR DESCRIPTION
Drop `tlsConfig.ServerName` default value to avoid SNI dial problems to access graph service.

 Teleport identities encode the clustername into the ServerName property which cause failures when dialing to other hosts where the certificate isn't issued for that `*.teleport.cluster` cert.