### PR TITLE
[v15] Reset `tlsConfig.ServerName` field before dialing to TAG

### DIFF
--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -71,6 +71,10 @@ func (process *TeleportProcess) initDiscoveryService() error {
 		return trace.Wrap(err)
 	}
 
+	if tlsConfig != nil {
+		tlsConfig.ServerName = "" /* empty the server name to avoid SNI collisions with access graph addr */
+	}
+
 	accessGraphCfg, err := buildAccessGraphFromTAGOrFallbackToAuth(
 		process.ExitContext(),
 		process.Config,


### PR DESCRIPTION
Backport #40298 to branch/v15