### PR TITLE
[v15] Disable session recording/audit to prevent tempdir flakiness in tbot tests

### DIFF
--- a/lib/tbot/testhelpers/srv.go
+++ b/lib/tbot/testhelpers/srv.go
@@ -99,9 +99,15 @@ func MakeAndRunTestAuthServer(t *testing.T, log utils.Logger, fc *config.FileCon
 	require.NoError(t, config.ApplyFileConfig(fc, cfg))
 	cfg.FileDescriptors = fds
 	cfg.Log = log
-
 	cfg.CachePolicy.Enabled = false
 	cfg.Proxy.DisableWebInterface = true
+
+	// Disable session recording to avoid flakiness caused by TempDir cleanup.
+	cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
+	// Disable audit log as we don't rely on this in our tests and it can cause
+	// flakiness due to TempDir cleanup.
+	cfg.Auth.NoAudit = true
+
 	auth, err = service.NewTeleport(cfg)
 	require.NoError(t, err)
 	require.NoError(t, auth.Start())

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1878,7 +1878,7 @@ version: v2
 	var expected types.SessionRecordingConfigV2
 	require.NoError(t, yaml.Unmarshal([]byte(srcYAML), &expected))
 
-	require.Equal(t, types.RecordAtNode, initial.GetMode())
+	require.Equal(t, types.RecordOff, initial.GetMode())
 	require.Equal(t, types.RecordAtProxy, expected.GetMode())
 
 	// Explicitly change the revision and try creating the src with and without


### PR DESCRIPTION
Backport #40253 to branch/v15