### PR TITLE
[v14] Disable session recording/audit to prevent tempdir flakiness in tbot tests

### DIFF
--- a/lib/tbot/testhelpers/srv.go
+++ b/lib/tbot/testhelpers/srv.go
@@ -95,9 +95,15 @@ func MakeAndRunTestAuthServer(t *testing.T, log utils.Logger, fc *config.FileCon
 	require.NoError(t, config.ApplyFileConfig(fc, cfg))
 	cfg.FileDescriptors = fds
 	cfg.Log = log
-
 	cfg.CachePolicy.Enabled = false
 	cfg.Proxy.DisableWebInterface = true
+
+	// Disable session recording to avoid flakiness caused by TempDir cleanup.
+	cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
+	// Disable audit log as we don't rely on this in our tests and it can cause
+	// flakiness due to TempDir cleanup.
+	cfg.Auth.NoAudit = true
+
 	auth, err = service.NewTeleport(cfg)
 	require.NoError(t, err)
 	require.NoError(t, auth.Start())


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/40253 to branch/v14