### PR TITLE
build: Simplify darwin-signing and add new GHA environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -508,7 +508,6 @@ release-darwin-unsigned: full build-archive
 
 .PHONY: release-darwin
 ifneq ($(ARCH),universal)
-release-darwin: ABSOLUTE_BINARY_PATHS:=$(addprefix $(CURDIR)/,$(BINARIES))
 release-darwin: release-darwin-unsigned
 	$(NOTARIZE_BINARIES)
 	$(MAKE) build-archive
@@ -597,9 +596,6 @@ release-windows: release-windows-unsigned
 # It is used only for MacOS releases. Windows releases do not use this
 # Makefile. Linux uses the `teleterm` target in build.assets/Makefile.
 #
-# Only export the CSC_NAME (developer key ID) when the recipe is run, so
-# that we do not shell out and run the `security` command if not necessary.
-#
 # Either CONNECT_TSH_BIN_PATH or CONNECT_TSH_APP_PATH environment variable
 # should be defined for the `yarn package-term` command to succeed. CI sets
 # this appropriately depending on whether a push build is running, or a
@@ -609,7 +605,6 @@ release-windows: release-windows-unsigned
 
 .PHONY: release-connect
 release-connect: | $(RELEASE_DIR)
-	$(eval export CSC_NAME)
 	yarn install --frozen-lockfile
 	yarn build-term
 	yarn package-term -c.extraMetadata.version=$(VERSION) --$(ELECTRON_BUILDER_ARCH)
@@ -1448,7 +1443,6 @@ endif
 # build .pkg
 .PHONY: pkg
 pkg: | $(RELEASE_DIR)
-	$(eval export DEVELOPER_ID_APPLICATION DEVELOPER_ID_INSTALLER)
 	mkdir -p $(BUILDDIR)/
 	cp ./build.assets/build-package.sh ./build.assets/build-common.sh $(BUILDDIR)/
 	chmod +x $(BUILDDIR)/build-package.sh
@@ -1461,7 +1455,6 @@ pkg: | $(RELEASE_DIR)
 # build tsh client-only .pkg
 .PHONY: pkg-tsh
 pkg-tsh: | $(RELEASE_DIR)
-	$(eval export DEVELOPER_ID_APPLICATION DEVELOPER_ID_INSTALLER)
 	./build.assets/build-pkg-tsh.sh -t oss -v $(VERSION) -b $(TSH_BUNDLEID) -a $(ARCH) $(TARBALL_PATH_SECTION)
 	mkdir -p $(BUILDDIR)/
 	mv tsh*.pkg* $(BUILDDIR)/

--- a/build.assets/build-pkg-tsh.sh
+++ b/build.assets/build-pkg-tsh.sh
@@ -106,14 +106,14 @@ password created by APPLE_USERNAME"
   if [[ -z "${DEVELOPER_ID_APPLICATION}" ]]; then
     echo "\
 The DEVELOPER_ID_APPLICATION environment variable needs to be set to the hash\
-of the key to sign applications"
+or name of the key to sign applications"
     exit 1
   fi
 
   if [[ -z "${DEVELOPER_ID_INSTALLER}" ]]; then
     echo "\
 The DEVELOPER_ID_INSTALLER environment variable needs to be set to the hash\
-of the key to sign packages"
+or name of the key to sign packages"
     exit 1
   fi
 

--- a/darwin-signing.mk
+++ b/darwin-signing.mk
@@ -17,33 +17,17 @@ ENVIRONMENT_NAME ?= promote
 # TEAMID is an Apple-assigned identifier for a developer. It has two keys,
 # one for signing binaries (application) and one for signing packages/images
 # (installer). The keys are identified by name per-environment which we use
-# to extract the key IDs. Key names can be view by running `security find-identity`.
-#
-# NOTE: If you need to export the DEVELOPER_ID_{APPLICATION,INSTALLER}
-# variables to the environment for a command, it should be done within the
-# recipe containing the command using $(eval export DEVELOPER_ID_APPLICATION ...).
-# This is so the `security` shell command is only run to extract the key ID
-# if necessary. If exported at the top level, it will run every time `make`
-# is run.
-#
-# e.g.
-# pkg:
-#         $(eval export DEVELOPER_ID_APPLICATION DEVELOPER_ID_INSTALLER)
-#         ./build.assets/build-package.sh ...
-#
+# to sign binaries and packages. We do not use the hash. Key names can be
+# view by running `security find-identity`.
+
 TEAMID = $(TEAMID_$(ENVIRONMENT_NAME))
-DEVELOPER_ID_APPLICATION = $(call get_key_id,$(DEVELOPER_KEY_NAME_$(ENVIRONMENT_NAME)))
-DEVELOPER_ID_INSTALLER = $(call get_key_id,$(INSTALLER_KEY_NAME_$(ENVIRONMENT_NAME)))
+DEVELOPER_ID_APPLICATION = $(DEVELOPER_KEY_NAME_$(ENVIRONMENT_NAME))
+DEVELOPER_ID_INSTALLER = $(INSTALLER_KEY_NAME_$(ENVIRONMENT_NAME))
 
 # CSC_NAME is the key ID for signing used by electron-builder for signing
-# Teleport Connect.
-CSC_NAME = $(DEVELOPER_ID_APPLICATION)
-
-# Don't export DEVELOPER_ID_APPLICATION, DEVELOPER_ID_INSTALLER or CSC_NAME as
-# it causes them to be evaluated, which shells out to the `security` command.
-# They should only be evaluated if used. Any variables below that reference
-# these are also unexported for the same reason.
-unexport CSC_NAME DEVELOPER_ID_APPLICATION DEVELOPER_ID_INSTALLER
+# Teleport Connect. electron-builder does not want the "Developer ID Application: "
+# prefix on the key so strip it off
+CSC_NAME = $(subst Developer ID Application: ,,$(DEVELOPER_ID_APPLICATION))
 
 # Bundle IDs identify packages/images. We use different bundle IDs for
 # release and development.
@@ -70,58 +54,36 @@ TELEPORT_BUNDLEID_build = com.goteleport.dev
 TSH_BUNDLEID_build = $(TEAMID).com.goteleport.tshdev
 TSH_SKELETON_build = tshdev
 
-# --- utility
-# Extract application/installer key ID from keychain. This looks at all
-# keychains in the search path. It should be used with $(call ...).
-# e.g. $(call get_key_id,Key Name goes here)
-get_key_id = $(or $(word 2,$(shell $(get_key_id_cmd))), $(missing_key_error))
-get_key_id_cmd = security find-identity -v -s codesigning | grep --fixed-strings --max-count=1 "$(1)"
-missing_key_error = $(error Could not find key named "$(1)" in keychain)
-
-# Dont export missing_key_error or get_key_id as it evaluates them
-unexport missing_key_error get_key_id
-
 # SHOULD_NOTARIZE evalutes to "true" if we should sign and notarize binaries,
 # and the empty string if not. We only notarize if APPLE_USERNAME and
 # APPLE_PASSWORD are set in the environment.
 SHOULD_NOTARIZE = $(if $(and $(APPLE_USERNAME),$(APPLE_PASSWORD)),true)
 
-# NOTARIZE_BINARIES runs the notarize-apple-binaries tool. It is expected that
-# the current working directory is the root of the OSS Teleport repo, so to call
-# from the enterprise repo, invoke it as:
-#     cd .. && $(NOTARIZE_BINARIES)
+# NOTARIZE_BINARIES signs and notarizes $(BINARIES).
 # It will not run the command if $APPLE_USERNAME or $APPLE_PASSWORD are empty.
-# It uses the make $(if ...) construct instead of doing it in the shell so as
-# to not evaluate its arguments (DEVELOPER_ID_APPLICATION) if we are not
-# goint to use them, preventing a missing key error defined above.
 NOTARIZE_BINARIES = $(if $(SHOULD_NOTARIZE),$(notarize_binaries_cmd),$(not_notarizing_cmd))
-unexport NOTARIZE_BINARIES
 
 not_notarizing_cmd = echo Not notarizing binaries. APPLE_USERNAME or APPLE_PASSWORD not set.
 
 notary_dir = $(BUILDDIR)/notarize
 notary_file = $(BUILDDIR)/notarize.zip
 
-# notarize_binaries_cmd must be a single command - multiple commands must be
-# joined with "&& \". This is so the command can be prefixed with "cd .. &&"
-# for the enterprise invocation.
 define notarize_binaries_cmd
 	codesign \
-		--sign $(DEVELOPER_ID_APPLICATION) \
+		--sign '$(DEVELOPER_ID_APPLICATION)' \
 		--force \
 		--verbose \
 		--timestamp \
 		--options runtime \
-		$(ABSOLUTE_BINARY_PATHS) && \
-	rm -rf $(notary_dir) && \
-	mkdir $(notary_dir) && \
-	ditto $(ABSOLUTE_BINARY_PATHS) $(notary_dir) && \
-	ditto -c -k $(notary_dir) $(notary_file) && \
+		$(BINARIES)
+	rm -rf $(notary_dir)
+	mkdir $(notary_dir)
+	ditto $(BINARIES) $(notary_dir)
+	ditto -c -k $(notary_dir) $(notary_file)
 	xcrun notarytool submit $(notary_file) \
 		--team-id="$(TEAMID)" \
 		--apple-id="$(APPLE_USERNAME)" \
 		--password="$(APPLE_PASSWORD)" \
-		--wait && \
+		--wait
 	rm -rf $(notary_dir) $(notary_file)
 endef
-unexport notarize_binaries_cmd


### PR DESCRIPTION
Simplify darwin-signing to sign by key name instead of key hash, as we
just look up the key hash from the name anyway, and all the signing
options take the key name as well as the hash. This cleans up a bit of
fragility around exported make variables where care needed to be taken
to ensure the key hash lookup commands we not run when not needed.

Update the signing variables to accept `build-prod` and `build-stage` as
environment names and deprecate the old `promote` and `build`
environment names.

Companion: https://github.com/gravitational/teleport.e/pull/3908
