### PR TITLE
[v14] AWS OIDC: use ACL for S3 objects during IdP set up

### DIFF
--- a/lib/integrations/awsoidc/idp_iam_config.go
+++ b/lib/integrations/awsoidc/idp_iam_config.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -194,12 +195,6 @@ type IdPIAMConfigureClient interface {
 	// HeadBucket checks if a bucket exists and if you have permission to access it.
 	HeadBucket(ctx context.Context, params *s3.HeadBucketInput, optFns ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
 
-	// GetBucketPolicy returns the policy of a specified bucket
-	GetBucketPolicy(ctx context.Context, params *s3.GetBucketPolicyInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error)
-
-	// PutBucketPolicy applies an Amazon S3 bucket policy to an Amazon S3 bucket.
-	PutBucketPolicy(ctx context.Context, params *s3.PutBucketPolicyInput, optFns ...func(*s3.Options)) (*s3.PutBucketPolicyOutput, error)
-
 	// DeletePublicAccessBlock removes the PublicAccessBlock configuration for an Amazon S3 bucket.
 	DeletePublicAccessBlock(ctx context.Context, params *s3.DeletePublicAccessBlockInput, optFns ...func(*s3.Options)) (*s3.DeletePublicAccessBlockOutput, error)
 }
@@ -315,8 +310,6 @@ func NewIdPIAMConfigureClient(ctx context.Context) (IdPIAMConfigureClient, error
 //
 // If it's using the S3 bucket flow, the following are required as well:
 //   - s3:CreateBucket
-//   - s3:GetBucketPolicy
-//   - s3:PutBucketPolicy
 //   - s3:PutBucketPublicAccessBlock (used for s3:DeletePublicAccessBlock)
 //   - s3:ListBuckets (used for s3:HeadBucket)
 //   - s3:PutObject
@@ -358,8 +351,12 @@ func ConfigureIdPIAM(ctx context.Context, clt IdPIAMConfigureClient, req IdPIAMC
 		return trace.Wrap(err)
 	}
 
-	log.Info("Setting public access.")
-	if err := ensureBucketPoliciesIdPIAM(ctx, clt, req); err != nil {
+	log.Info(`Removing "Block all public access".`)
+	_, err := clt.DeletePublicAccessBlock(ctx, &s3.DeletePublicAccessBlockInput{
+		Bucket:              &req.s3Bucket,
+		ExpectedBucketOwner: &req.AccountID,
+	})
+	if err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -438,61 +435,12 @@ func ensureBucketIdPIAM(ctx context.Context, clt IdPIAMConfigureClient, req IdPI
 		_, err := clt.CreateBucket(ctx, &s3.CreateBucketInput{
 			Bucket:                    &req.s3Bucket,
 			CreateBucketConfiguration: awsutil.CreateBucketConfiguration(clt.RegionForCreateBucket()),
+			ObjectOwnership:           s3types.ObjectOwnershipBucketOwnerPreferred,
 		})
 		return trace.Wrap(err)
 	}
 
 	return trace.Wrap(awsErr)
-}
-
-func ensureBucketPoliciesIdPIAM(ctx context.Context, clt IdPIAMConfigureClient, req IdPIAMConfigureRequest) error {
-	_, err := clt.DeletePublicAccessBlock(ctx, &s3.DeletePublicAccessBlockInput{
-		Bucket:              &req.s3Bucket,
-		ExpectedBucketOwner: &req.AccountID,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	bucketPolicyDoc := awslib.NewPolicyDocument()
-	bucketPolicyResp, err := clt.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
-		Bucket:              &req.s3Bucket,
-		ExpectedBucketOwner: &req.AccountID,
-	})
-	if err != nil {
-		// TODO(marco): this is an S3 error, not an IAM Error
-		awsErr := awslib.ConvertIAMv2Error(err)
-		// If no policy is defined yet, it will return a NotFound.
-		// Any other error, should be returned.
-		if !trace.IsNotFound(awsErr) {
-			return trace.Wrap(err)
-		}
-	} else {
-		bucketPolicyDoc, err = awslib.ParsePolicyDocument(aws.ToString(bucketPolicyResp.Policy))
-		if err != nil {
-			return trace.Wrap(err)
-		}
-	}
-
-	policyS3PublicRead := awslib.StatementForS3BucketPublicRead(req.s3Bucket, req.s3BucketPrefix)
-	for _, existingStatement := range bucketPolicyDoc.Statements {
-		if existingStatement.EqualStatement(policyS3PublicRead) {
-			return nil
-		}
-	}
-
-	bucketPolicyDoc.Statements = append(bucketPolicyDoc.Statements, policyS3PublicRead)
-	newPolicyDocPublicRead, err := bucketPolicyDoc.Marshal()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	_, err = clt.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{
-		Bucket: &req.s3Bucket,
-		Policy: &newPolicyDocPublicRead,
-	})
-
-	return trace.Wrap(err)
 }
 
 func uploadOpenIDPublicFiles(ctx context.Context, clt IdPIAMConfigureClient, req IdPIAMConfigureRequest) error {
@@ -511,6 +459,7 @@ func uploadOpenIDPublicFiles(ctx context.Context, clt IdPIAMConfigureClient, req
 		Bucket: &req.s3Bucket,
 		Key:    &openidConfigPath,
 		Body:   bytes.NewReader(openIDConfigJSON),
+		ACL:    s3types.ObjectCannedACLPublicRead,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -520,6 +469,7 @@ func uploadOpenIDPublicFiles(ctx context.Context, clt IdPIAMConfigureClient, req
 		Bucket: &req.s3Bucket,
 		Key:    &jwksBucketPath,
 		Body:   bytes.NewReader(req.jwksFileContents),
+		ACL:    s3types.ObjectCannedACLPublicRead,
 	})
 	return trace.Wrap(err)
 }

--- a/lib/integrations/awsoidc/idp_iam_config_test.go
+++ b/lib/integrations/awsoidc/idp_iam_config_test.go
@@ -227,15 +227,6 @@ func assumeRoleStatementJSON(issuer string) string {
 }`, issuer, issuer)
 }
 
-func policyStatementS3PublicAccessJSON(bucket, prefix string) string {
-	return fmt.Sprintf(`{
-    "Effect": "Allow",
-    "Principal": "*",
-    "Action": "s3:GetObject",
-    "Resource": "arn:aws:s3:::%s/%s/*"
-}`, bucket, prefix)
-}
-
 func TestConfigureIdPIAMUsingProxyURL(t *testing.T) {
 	ctx := context.Background()
 
@@ -432,11 +423,15 @@ func TestConfigureIdPIAMUsingProxyURL(t *testing.T) {
 					bucket := mipc.existingBuckets["bucket-1"]
 					require.Equal(t, "my-region", bucket.region)
 					require.False(t, bucket.publicAccessIsBlocked)
-					expectedBucketPolicyDoc := policyDocWithStatementsJSON(
-						policyStatementS3PublicAccessJSON("bucket-1", "prefix-2"),
-					)
-					require.JSONEq(t, *expectedBucketPolicyDoc, *bucket.policyDoc)
+					require.Equal(t, "BucketOwnerPreferred", bucket.ownership)
 
+					jwksKey := "bucket-1/prefix-2/.well-known/jwks"
+					require.Contains(t, mipc.existingObjects, jwksKey)
+					require.Equal(t, "public-read", mipc.existingObjects[jwksKey].acl)
+
+					openidconfigKey := "bucket-1/prefix-2/.well-known/openid-configuration"
+					require.Contains(t, mipc.existingObjects, openidconfigKey)
+					require.Equal(t, "public-read", mipc.existingObjects[openidconfigKey].acl)
 				},
 			},
 			{
@@ -477,10 +472,7 @@ func TestConfigureIdPIAMUsingProxyURL(t *testing.T) {
 					bucket := mipc.existingBuckets["bucket-1"]
 					require.Equal(t, "my-region", bucket.region)
 					require.False(t, bucket.publicAccessIsBlocked)
-					expectedBucketPolicyDoc := policyDocWithStatementsJSON(
-						policyStatementS3PublicAccessJSON("bucket-1", "prefix-2"),
-					)
-					require.JSONEq(t, *expectedBucketPolicyDoc, *bucket.policyDoc)
+					require.Equal(t, "BucketOwnerPreferred", bucket.ownership)
 				},
 			},
 			{
@@ -493,6 +485,7 @@ func TestConfigureIdPIAMUsingProxyURL(t *testing.T) {
 					"bucket-1": {
 						region:                "another-region",
 						publicAccessIsBlocked: true,
+						ownership:             "BucketOwnerPreferred",
 					},
 				},
 				mockClientRegion: "my-region",
@@ -512,52 +505,10 @@ func TestConfigureIdPIAMUsingProxyURL(t *testing.T) {
 					require.Contains(t, mipc.existingBuckets, "bucket-1")
 					bucket := mipc.existingBuckets["bucket-1"]
 					require.False(t, bucket.publicAccessIsBlocked)
-					expectedBucketPolicyDoc := policyDocWithStatementsJSON(
-						policyStatementS3PublicAccessJSON("bucket-1", "prefix-2"),
-					)
-					require.JSONEq(t, *expectedBucketPolicyDoc, *bucket.policyDoc)
+					require.Equal(t, "BucketOwnerPreferred", bucket.ownership)
 
 					// The last configured region must be the existing bucket's region.
 					require.Equal(t, "another-region", mipc.clientRegion)
-				},
-			},
-			{
-				name:               "bucket already exists and already has a policy",
-				mockAccountID:      "123456789012",
-				req:                baseIdPIAMConfigReqWithS3Bucket,
-				mockExistingIdPUrl: []string{},
-				mockExistingRoles:  map[string]mockRole{},
-				mockExistingBuckets: map[string]mockBucket{
-					"bucket-1": {
-						region:                "my-region",
-						publicAccessIsBlocked: true,
-						policyDoc: policyDocWithStatementsJSON(
-							policyStatementS3PublicAccessJSON("bucket-2", "prefix-2"),
-						),
-					},
-				},
-				mockClientRegion: "my-region",
-				errCheck:         require.NoError,
-				externalStateCheck: func(t *testing.T, mipc mockIdPIAMConfigClient) {
-					// Check IdP creation
-					require.Contains(t, mipc.existingIDPUrl, expectedIssuerURL)
-
-					// Check Role creation
-					role := mipc.existingRoles["integrationrole"]
-					expectedAssumeRolePolicyDoc := policyDocWithStatementsJSON(
-						assumeRoleStatementJSON(expectedIssuer),
-					)
-					require.JSONEq(t, *expectedAssumeRolePolicyDoc, aws.ToString(role.assumeRolePolicyDoc))
-
-					// Check Bucket creation
-					require.Contains(t, mipc.existingBuckets, "bucket-1")
-					bucket := mipc.existingBuckets["bucket-1"]
-					require.False(t, bucket.publicAccessIsBlocked)
-					expectedBucketPolicyDoc := policyDocWithStatementsJSON(
-						policyStatementS3PublicAccessJSON("bucket-2", "prefix-2"),
-						policyStatementS3PublicAccessJSON("bucket-1", "prefix-2"),
-					)
-					require.JSONEq(t, *expectedBucketPolicyDoc, *bucket.policyDoc)
 				},
 			},
 			{
@@ -581,9 +532,6 @@ func TestConfigureIdPIAMUsingProxyURL(t *testing.T) {
 					"bucket-1": {
 						region:                "my-region",
 						publicAccessIsBlocked: true,
-						policyDoc: policyDocWithStatementsJSON(
-							policyStatementS3PublicAccessJSON("bucket-1", "prefix-2"),
-						),
 					},
 				},
 				mockClientRegion: "my-region",
@@ -603,10 +551,6 @@ func TestConfigureIdPIAMUsingProxyURL(t *testing.T) {
 					require.Contains(t, mipc.existingBuckets, "bucket-1")
 					bucket := mipc.existingBuckets["bucket-1"]
 					require.False(t, bucket.publicAccessIsBlocked)
-					expectedBucketPolicyDoc := policyDocWithStatementsJSON(
-						policyStatementS3PublicAccessJSON("bucket-1", "prefix-2"),
-					)
-					require.JSONEq(t, *expectedBucketPolicyDoc, *bucket.policyDoc)
 				},
 			},
 		} {
@@ -633,12 +577,16 @@ func TestConfigureIdPIAMUsingProxyURL(t *testing.T) {
 type mockBucket struct {
 	region                string
 	publicAccessIsBlocked bool
-	policyDoc             *string
+	ownership             string
 }
 
 type mockRole struct {
 	assumeRolePolicyDoc *string
 	tags                []iamTypes.Tag
+}
+
+type mockObject struct {
+	acl string
 }
 type mockIdPIAMConfigClient struct {
 	clientRegion    string
@@ -646,6 +594,7 @@ type mockIdPIAMConfigClient struct {
 	existingIDPUrl  []string
 	existingRoles   map[string]mockRole
 	existingBuckets map[string]mockBucket
+	existingObjects map[string]mockObject
 }
 
 // GetCallerIdentity returns information about the caller identity.
@@ -724,12 +673,22 @@ func (m *mockIdPIAMConfigClient) CreateBucket(ctx context.Context, params *s3.Cr
 	m.existingBuckets[*params.Bucket] = mockBucket{
 		publicAccessIsBlocked: true,
 		region:                m.clientRegion,
+		ownership:             string(params.ObjectOwnership),
 	}
 	return nil, nil
 }
 
 // PutObject adds an object to a bucket.
 func (m *mockIdPIAMConfigClient) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if m.existingObjects == nil {
+		m.existingObjects = map[string]mockObject{}
+	}
+
+	objectKey := fmt.Sprintf("%s/%s", *params.Bucket, *params.Key)
+
+	m.existingObjects[objectKey] = mockObject{
+		acl: string(params.ACL),
+	}
 	return nil, nil
 }
 
@@ -755,19 +714,6 @@ func (m *mockIdPIAMConfigClient) SetAWSRegion(awsRegion string) {
 	m.clientRegion = awsRegion
 }
 
-// PutBucketPolicy applies an Amazon S3 bucket policy to an Amazon S3 bucket.
-func (m *mockIdPIAMConfigClient) PutBucketPolicy(ctx context.Context, params *s3.PutBucketPolicyInput, optFns ...func(*s3.Options)) (*s3.PutBucketPolicyOutput, error) {
-	bucket, found := m.existingBuckets[*params.Bucket]
-	if !found {
-		return nil, trace.NotFound("bucket does not exist")
-	}
-
-	bucket.policyDoc = params.Policy
-	m.existingBuckets[*params.Bucket] = bucket
-
-	return &s3.PutBucketPolicyOutput{}, nil
-}
-
 // DeletePublicAccessBlock  removes the PublicAccessBlock configuration for an Amazon S3 bucket.
 func (m *mockIdPIAMConfigClient) DeletePublicAccessBlock(ctx context.Context, params *s3.DeletePublicAccessBlockInput, optFns ...func(*s3.Options)) (*s3.DeletePublicAccessBlockOutput, error) {
 	bucket, found := m.existingBuckets[*params.Bucket]
@@ -779,22 +725,6 @@ func (m *mockIdPIAMConfigClient) DeletePublicAccessBlock(ctx context.Context, pa
 	m.existingBuckets[*params.Bucket] = bucket
 
 	return &s3.DeletePublicAccessBlockOutput{}, nil
-}
-
-// GetBucketPolicy returns the policy of a specified bucket
-func (m *mockIdPIAMConfigClient) GetBucketPolicy(ctx context.Context, params *s3.GetBucketPolicyInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error) {
-	bucket, found := m.existingBuckets[*params.Bucket]
-	if !found {
-		return nil, trace.NotFound("bucket does not exist")
-	}
-
-	if bucket.policyDoc == nil {
-		return nil, trace.NotFound("policy not set yet")
-	}
-
-	return &s3.GetBucketPolicyOutput{
-		Policy: bucket.policyDoc,
-	}, nil
 }
 
 // HTTPHead does an HEAD HTTP Request to the target URL.


### PR DESCRIPTION
This PR changes the method to expose the public keys and openid config.
Instead of using Bucket Policy, it uses ACLs.

When listing buckets in AWS S3 Console, instead of showing up as `Public`, it will show up as 
`Objects can be public`.

Demo:
![image](https://github.com/gravitational/teleport/assets/689271/6e80834e-b85f-460a-9d77-a3c54bf85666)

![image](https://github.com/gravitational/teleport/assets/689271/56fef5f6-2c88-417f-ad2a-f6163dbd7f2c)


Backports #40171