### PR TITLE
Expose `DiscoveryConfig.Status` through webapi

### DIFF
--- a/lib/web/discoveryconfig.go
+++ b/lib/web/discoveryconfig.go
@@ -109,7 +109,8 @@ func (h *Handler) discoveryconfigUpdate(w http.ResponseWriter, r *http.Request, 
 	dc.Spec.Kube = req.Kube
 	dc.Spec.AccessGraph = req.AccessGraph
 
-	if _, err := clt.DiscoveryConfigClient().UpdateDiscoveryConfig(r.Context(), dc); err != nil {
+	dc, err = clt.DiscoveryConfigClient().UpdateDiscoveryConfig(r.Context(), dc)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/web/discoveryconfig_test.go
+++ b/lib/web/discoveryconfig_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
@@ -124,7 +125,7 @@ func TestDiscoveryConfig(t *testing.T) {
 			require.Equal(t, "dc01", discoveryConfigResp.Name)
 		})
 
-		t.Run("Get one after status update", func(t *testing.T) {
+		t.Run("Read status after an update", func(t *testing.T) {
 			client, err := env.server.NewClient(auth.TestIdentity{
 				I: authz.BuiltinRole{
 					Role:     types.RoleDiscovery,
@@ -146,9 +147,9 @@ func TestDiscoveryConfig(t *testing.T) {
 			var discoveryConfigResp ui.DiscoveryConfig
 			err = json.Unmarshal(resp.Bytes(), &discoveryConfigResp)
 			require.NoError(t, err)
-			require.Equal(t, "dg01", discoveryConfigResp.DiscoveryGroup)
-			require.Equal(t, "dc01", discoveryConfigResp.Name)
-			require.Equal(t, status, discoveryConfigResp.Status)
+			assert.Equal(t, "dg01", discoveryConfigResp.DiscoveryGroup)
+			assert.Equal(t, "dc01", discoveryConfigResp.Name)
+			assert.Equal(t, status, discoveryConfigResp.Status)
 		})
 
 		t.Run("Update discovery config", func(t *testing.T) {

--- a/lib/web/discoveryconfig_test.go
+++ b/lib/web/discoveryconfig_test.go
@@ -29,7 +29,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
@@ -118,6 +122,33 @@ func TestDiscoveryConfig(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, "dg01", discoveryConfigResp.DiscoveryGroup)
 			require.Equal(t, "dc01", discoveryConfigResp.Name)
+		})
+
+		t.Run("Get one after status update", func(t *testing.T) {
+			client, err := env.server.NewClient(auth.TestIdentity{
+				I: authz.BuiltinRole{
+					Role:     types.RoleDiscovery,
+					Username: "disc",
+				},
+			})
+			require.NoError(t, err)
+			status := discoveryconfig.Status{
+				State:               discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_RUNNING.String(),
+				DiscoveredResources: 1,
+				LastSyncTime:        env.clock.Now().UTC(),
+			}
+			_, err = client.DiscoveryConfigClient().UpdateDiscoveryConfigStatus(ctx, "dc01", status)
+			require.NoError(t, err)
+			resp, err := pack.clt.Get(ctx, getDC01Endpoint, nil)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.Code())
+
+			var discoveryConfigResp ui.DiscoveryConfig
+			err = json.Unmarshal(resp.Bytes(), &discoveryConfigResp)
+			require.NoError(t, err)
+			require.Equal(t, "dg01", discoveryConfigResp.DiscoveryGroup)
+			require.Equal(t, "dc01", discoveryConfigResp.Name)
+			require.Equal(t, status, discoveryConfigResp.Status)
 		})
 
 		t.Run("Update discovery config", func(t *testing.T) {

--- a/lib/web/ui/discoveryconfig.go
+++ b/lib/web/ui/discoveryconfig.go
@@ -41,6 +41,8 @@ type DiscoveryConfig struct {
 	Kube []types.KubernetesMatcher `json:"kube,omitempty"`
 	// AccessGraph is the configuration for the Access Graph Cloud sync.
 	AccessGraph *types.AccessGraphSync `json:"accessGraph,omitempty"`
+	// Status is the status of the DiscoveryConfig.
+	Status discoveryconfig.Status `json:"status,omitempty"`
 }
 
 // CheckAndSetDefaults for the create request.
@@ -113,5 +115,6 @@ func MakeDiscoveryConfig(dc *discoveryconfig.DiscoveryConfig) DiscoveryConfig {
 		GCP:            dc.Spec.GCP,
 		Kube:           dc.Spec.Kube,
 		AccessGraph:    dc.Spec.AccessGraph,
+		Status:         dc.Status,
 	}
 }


### PR DESCRIPTION
This PR exposes `DiscoveryConfig.Status` field through webapi.