### PR TITLE
[v14] allow agents to dial to `GetClusterAccessGraphConfig`

### DIFF
--- a/lib/auth/clusterconfig/clusterconfigv1/service_test.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service_test.go
@@ -89,15 +89,9 @@ func TestGetAccessGraphConfig(t *testing.T) {
 		responseAssertion *clusterconfigpb.GetClusterAccessGraphConfigResponse
 	}{
 		{
-			name: "unauthorized",
-			role: types.RoleKube,
-			errorAssertion: func(t require.TestingT, err error, _ ...any) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to be prevented from getting auth preferences", err)
-			},
-		},
-		{
 			name:              "authorized proxy with non empty access graph config; Policy module is disabled",
 			role:              types.RoleProxy,
+			testSetup:         func(t *testing.T) {},
 			accessGraphConfig: cfgEnabled,
 			errorAssertion:    require.NoError,
 			responseAssertion: &clusterconfigpb.GetClusterAccessGraphConfigResponse{
@@ -158,9 +152,8 @@ func TestGetAccessGraphConfig(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			if test.testSetup != nil {
-				test.testSetup(t)
-			}
+			test.testSetup(t)
+
 			authRoleContext, err := authz.ContextForBuiltinRole(authz.BuiltinRole{
 				Role:     test.role,
 				Username: string(test.role),
@@ -176,7 +169,6 @@ func TestGetAccessGraphConfig(t *testing.T) {
 			test.errorAssertion(t, err)
 
 			require.Empty(t, cmp.Diff(test.responseAssertion, got, protocmp.Transform()))
-
 		})
 	}
 }

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -4731,7 +4731,8 @@ func TestGetAccessGraphConfig(t *testing.T) {
 			Address: "addr",
 		}),
 	)
-
+	user, _, err := CreateUserAndRole(server.Auth(), "test", []string{"role"}, nil)
+	require.NoError(t, err)
 	positiveResponse := &clusterconfigpb.AccessGraphConfig{
 		Enabled: true,
 		Ca:      []byte("ca"),
@@ -4740,24 +4741,32 @@ func TestGetAccessGraphConfig(t *testing.T) {
 
 	tests := []struct {
 		desc      string
-		role      types.SystemRole
+		identity  authz.IdentityGetter
 		assertErr require.ErrorAssertionFunc
 		expected  *clusterconfigpb.AccessGraphConfig
 	}{
 		{
-			desc:      "admin role can't pull the access graph config",
-			role:      types.RoleAdmin,
+			desc: "users can't pull the access graph config",
+			identity: authz.LocalUser{
+				Username: user.GetName(),
+			},
 			assertErr: require.Error,
 		},
 		{
-			desc:      "proxy can pull access graph config",
-			role:      types.RoleProxy,
+			desc: "proxy can pull access graph config",
+			identity: authz.BuiltinRole{
+				Role:     types.RoleProxy,
+				Username: server.ClusterName(),
+			},
 			assertErr: require.NoError,
 			expected:  positiveResponse,
 		},
 		{
-			desc:      "discovery can pull access graph config",
-			role:      types.RoleDiscovery,
+			desc: "discovery can pull access graph config",
+			identity: authz.BuiltinRole{
+				Role:     types.RoleDiscovery,
+				Username: server.ClusterName(),
+			},
 			assertErr: require.NoError,
 			expected:  positiveResponse,
 		},
@@ -4766,10 +4775,7 @@ func TestGetAccessGraphConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			client, err := server.NewClient(TestIdentity{
-				I: authz.BuiltinRole{
-					Role:     test.role,
-					Username: server.ClusterName(),
-				},
+				I: test.identity,
 			})
 			require.NoError(t, err)
 			rsp, err := client.GetClusterAccessGraphConfig(context.Background())

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -4748,7 +4748,6 @@ func newTestTLSServer(t testing.TB, opts ...testTLSServerOption) *TestTLSServer 
 		Dir:          t.TempDir(),
 		Clock:        clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC()),
 		CacheEnabled: options.cacheEnabled,
-		//AccessGraphConfig: options.accessGraph,
 	})
 	require.NoError(t, err)
 	var tlsServerOpts []TestTLSServerOption


### PR DESCRIPTION
This PR backports a commit that wasn't picked during backport.