### PR TITLE
Add `tpm` package with Attestation/Validation functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-containerregistry v0.19.1
 	github.com/google/go-querystring v1.1.0
+	github.com/google/go-tpm v0.9.0
 	github.com/google/go-tpm-tools v0.4.4
 	github.com/google/renameio/v2 v2.0.0
 	github.com/google/safetext v0.0.0-20240104143208-7a7d9b3d812f
@@ -352,7 +353,6 @@ require (
 	github.com/google/flatbuffers v24.3.7+incompatible // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
 	github.com/google/go-configfs-tsm v0.2.2 // indirect
-	github.com/google/go-tpm v0.9.0 // indirect
 	github.com/google/go-tspi v0.3.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect

--- a/lib/tpm/proto.go
+++ b/lib/tpm/proto.go
@@ -1,0 +1,74 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tpm
+
+import (
+	"github.com/google/go-attestation/attest"
+
+	"github.com/gravitational/teleport/api/client/proto"
+)
+
+// AttestationParametersToProto converts an attest.AttestationParameters to
+// its protobuf representation.
+func AttestationParametersToProto(in attest.AttestationParameters) *proto.TPMAttestationParameters {
+	return &proto.TPMAttestationParameters{
+		Public:            in.Public,
+		CreateData:        in.CreateData,
+		CreateAttestation: in.CreateAttestation,
+		CreateSignature:   in.CreateSignature,
+	}
+}
+
+// AttestationParametersFromProto extracts an attest.AttestationParameters from
+// its protobuf representation.
+func AttestationParametersFromProto(in *proto.TPMAttestationParameters) attest.AttestationParameters {
+	if in == nil {
+		return attest.AttestationParameters{}
+	}
+	return attest.AttestationParameters{
+		Public:            in.Public,
+		CreateData:        in.CreateData,
+		CreateAttestation: in.CreateAttestation,
+		CreateSignature:   in.CreateSignature,
+	}
+}
+
+// EncryptedCredentialToProto converts an attest.EncryptedCredential to
+// its protobuf representation.
+func EncryptedCredentialToProto(in *attest.EncryptedCredential) *proto.TPMEncryptedCredential {
+	if in == nil {
+		return nil
+	}
+	return &proto.TPMEncryptedCredential{
+		CredentialBlob: in.Credential,
+		Secret:         in.Secret,
+	}
+}
+
+// EncryptedCredentialFromProto extracts an attest.EncryptedCredential from
+// its protobuf representation.
+func EncryptedCredentialFromProto(in *proto.TPMEncryptedCredential) *attest.EncryptedCredential {
+	if in == nil {
+		return nil
+	}
+	return &attest.EncryptedCredential{
+		Credential: in.CredentialBlob,
+		Secret:     in.Secret,
+	}
+}

--- a/lib/tpm/proto_test.go
+++ b/lib/tpm/proto_test.go
@@ -1,0 +1,52 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tpm
+
+import (
+	"testing"
+
+	"github.com/google/go-attestation/attest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/utils"
+)
+
+func TestAttestationParametersProto(t *testing.T) {
+	want := attest.AttestationParameters{
+		Public:            []byte("public"),
+		CreateData:        []byte("create_data"),
+		CreateAttestation: []byte("create_attestation"),
+		CreateSignature:   []byte("create_signature"),
+	}
+	pb := AttestationParametersToProto(want)
+	clonedPb := utils.CloneProtoMsg(pb)
+	got := AttestationParametersFromProto(clonedPb)
+	require.Equal(t, want, got)
+}
+
+func TestEncryptedCredentialProto(t *testing.T) {
+	want := &attest.EncryptedCredential{
+		Credential: []byte("encrypted_credential"),
+		Secret:     []byte("secret"),
+	}
+	pb := EncryptedCredentialToProto(want)
+	clonedPb := utils.CloneProtoMsg(pb)
+	got := EncryptedCredentialFromProto(clonedPb)
+	require.Equal(t, want, got)
+}

--- a/lib/tpm/tpm.go
+++ b/lib/tpm/tpm.go
@@ -148,7 +148,7 @@ func queryWithTPM(
 	return data, nil
 }
 
-// Attest provides the information necessary to perform a tpm join to a Teleport
+// Attest provides the information necessary to perform a TPM join to a Teleport
 // cluster. It returns a solve function which should be called when the
 // encrypted credential challenge is received from the server.
 // The Close function must be called if Attest returns in a non-error state.

--- a/lib/tpm/tpm.go
+++ b/lib/tpm/tpm.go
@@ -53,7 +53,7 @@ func serialString(serial *big.Int) string {
 	return out.String()
 }
 
-// hashEKPub hashes the public part of an EK key. The key is first marshalled
+// hashEKPub hashes the public part of an EK key. The key is first marshaled
 // in PKIX format and then hashed with SHA256.
 func hashEKPub(key crypto.PublicKey) (string, error) {
 	marshaled, err := x509.MarshalPKIXPublicKey(key)
@@ -66,9 +66,9 @@ func hashEKPub(key crypto.PublicKey) (string, error) {
 
 // QueryRes is the result of the TPM query performed by Query.
 type QueryRes struct {
-	// EKPub is the PKIX marshalled public part of the EK.
+	// EKPub is the PKIX marshaled public part of the EK.
 	EKPub []byte
-	// EKPubHash is the SHA256 hash of the PKIX marshalled EKPub.
+	// EKPubHash is the SHA256 hash of the PKIX marshaled EKPub.
 	EKPubHash string
 	// EKCertPresent is true if an EK cert is present in the TPM.
 	EKCertPresent bool

--- a/lib/tpm/tpm.go
+++ b/lib/tpm/tpm.go
@@ -115,16 +115,7 @@ func QueryWithTPM(
 
 	eks, err := tpm.EKs()
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if len(eks) == 0 {
-		// This is a pretty unusual case, `go-attestation` will attempt to
-		// create an EK if no EK Certs are present in the NVRAM of the TPM.
-		// Either way, it lets us catch this early in case `go-attestation`
-		// misbehaves.
-		return nil, trace.BadParameter(
-			"no endorsement keys found in tpm",
-		)
+		return nil, trace.Wrap(err, "querying EKs")
 	}
 
 	// The first EK returned by `go-attestation` will be an RSA based EK key or

--- a/lib/tpm/tpm.go
+++ b/lib/tpm/tpm.go
@@ -123,6 +123,7 @@ func query(
 
 	if eks[0].Certificate != nil {
 		data.EKCert = eks[0].Certificate.Raw
+		data.EKCertSerial = serialString(eks[0].Certificate.SerialNumber)
 	}
 	log.DebugContext(ctx, "Successfully queried TPM", "data", data)
 	return data, nil

--- a/lib/tpm/tpm.go
+++ b/lib/tpm/tpm.go
@@ -145,6 +145,17 @@ func Attest(ctx context.Context, log *slog.Logger) (
 	if err != nil {
 		return nil, nil, nil, nil, trace.Wrap(err)
 	}
+	return attestWithTPM(ctx, log, tpm)
+
+}
+
+func attestWithTPM(ctx context.Context, log *slog.Logger, tpm *attest.TPM) (
+	data *QueryRes,
+	attestParams *attest.AttestationParameters,
+	solve func(ec *attest.EncryptedCredential) ([]byte, error),
+	close func() error,
+	err error,
+) {
 	defer func() {
 		if err != nil {
 			if err := tpm.Close(); err != nil {

--- a/lib/tpm/tpm.go
+++ b/lib/tpm/tpm.go
@@ -1,0 +1,176 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tpm
+
+import (
+	"context"
+	"crypto"
+	"crypto/sha256"
+	"crypto/x509"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"strings"
+
+	"github.com/google/go-attestation/attest"
+	"github.com/gravitational/trace"
+)
+
+// serialString converts a serial number into a readable colon-delimited hex
+// string thats user-readable e.g ab:ab:ab:ff:ff:ff
+func serialString(serial *big.Int) string {
+	hex := serial.Text(16)
+	if len(hex)%2 == 1 {
+		hex = "0" + hex
+	}
+
+	out := strings.Builder{}
+	for i := 0; i < len(hex); i += 2 {
+		if i != 0 {
+			out.WriteString(":")
+		}
+		out.WriteString(hex[i : i+2])
+	}
+	return out.String()
+}
+
+func hashEKPub(key crypto.PublicKey) (string, error) {
+	marshaled, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	hashed := sha256.Sum256(marshaled)
+	return fmt.Sprintf("%x", hashed), nil
+}
+
+type QueryRes struct {
+	// EKPub is the PKIX marshalled public part of the EK.
+	EKPub []byte
+	// EKPubHash is the SHA256 hash of the PKIX marshalled EKPub.
+	EKPubHash string
+	// EKCertPresent is true if an EK cert is present in the TPM.
+	EKCertPresent bool
+	// EKCert is the ASN.1 DER encoded EK cert.
+	EKCert []byte
+	// EKCertSerial is the serial number of the EK cert represented as a colon
+	// delimited hex string.
+	EKCertSerial string
+}
+
+// Query returns information about the TPM on a system, including the
+// EKPubHash and EKCertSerial which are needed to configure TPM joining.
+func Query(ctx context.Context, log *slog.Logger) (*QueryRes, error) {
+	tpm, err := attest.OpenTPM(&attest.OpenConfig{
+		TPMVersion: attest.TPMVersion20,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer func() {
+		if err := tpm.Close(); err != nil {
+			log.ErrorContext(ctx, "Failed to close TPM", slog.Any("error", err))
+		}
+	}()
+	return query(ctx, log, tpm)
+}
+
+func query(
+	ctx context.Context, log *slog.Logger, tpm *attest.TPM,
+) (*QueryRes, error) {
+	data := &QueryRes{}
+
+	eks, err := tpm.EKs()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if len(eks) == 0 {
+		// This is a pretty unusual case, `go-attestation` will attempt to
+		// create an EK if no EK Certs are present in the NVRAM of the TPM.
+		// Either way, it lets us catch this early in case `go-attestation`
+		// misbehaves.
+		return nil, trace.BadParameter("no endorsement keys found in tpm")
+	}
+
+	// The first EK returned by `go-attestation` will be an RSA based EK key or
+	// EK cert. On Windows, ECC certs may also be returned following this. At
+	// this time, we are only interested in RSA certs, so we just consider the
+	// first thing returned.
+	ekPub, err := x509.MarshalPKIXPublicKey(eks[0].Public)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	data.EKPub = ekPub
+	data.EKPubHash, err = hashEKPub(eks[0].Public)
+	if err != nil {
+		return nil, trace.Wrap(err, "hashing ekpub")
+	}
+
+	if eks[0].Certificate != nil {
+		data.EKCert = eks[0].Certificate.Raw
+	}
+	log.DebugContext(ctx, "Successfully queried TPM", "data", data)
+	return data, nil
+}
+
+// Attest provides the information necessary to perform a tpm join to a Teleport
+// cluster. It returns a solve function which should be called when the
+// encrypted credential challenge is received from the server.
+// The Close function must be called if Attest returns in a non-error state.
+func Attest(ctx context.Context, log *slog.Logger) (
+	data *QueryRes,
+	attestParams *attest.AttestationParameters,
+	solve func(ec *attest.EncryptedCredential) ([]byte, error),
+	close func() error,
+	err error,
+) {
+	tpm, err := attest.OpenTPM(&attest.OpenConfig{
+		TPMVersion: attest.TPMVersion20,
+	})
+	if err != nil {
+		return nil, nil, nil, nil, trace.Wrap(err)
+	}
+	defer func() {
+		if err != nil {
+			if err := tpm.Close(); err != nil {
+				log.ErrorContext(ctx, "Failed to close TPM", slog.Any("error", err))
+			}
+		}
+	}()
+
+	queryData, err := query(ctx, log, tpm)
+	if err != nil {
+		return nil, nil, nil, nil, trace.Wrap(err, "querying TPM")
+	}
+
+	// Create AK and calculate attestation parameters.
+	ak, err := tpm.NewAK(&attest.AKConfig{})
+	if err != nil {
+		return nil, nil, nil, nil, trace.Wrap(err, "creating ak")
+	}
+	log.DebugContext(ctx, "Successfully generated AK for TPM")
+	attParams := ak.AttestationParameters()
+	solve = func(ec *attest.EncryptedCredential) ([]byte, error) {
+		log.DebugContext(ctx, "Solving credential challenge")
+		return ak.ActivateCredential(tpm, *ec)
+	}
+	close = func() error {
+		return tpm.Close()
+	}
+	return queryData, &attParams, solve, close, nil
+}

--- a/lib/tpm/tpm.go
+++ b/lib/tpm/tpm.go
@@ -101,13 +101,14 @@ func Query(ctx context.Context, log *slog.Logger) (*QueryRes, error) {
 			)
 		}
 	}()
-	return queryWithTPM(ctx, log, tpm)
+	return QueryWithTPM(ctx, log, tpm)
 }
 
-func queryWithTPM(
+// QueryWithTPM is similar to Query, but accepts an already opened TPM.
+func QueryWithTPM(
 	ctx context.Context, log *slog.Logger, tpm *attest.TPM,
 ) (*QueryRes, error) {
-	ctx, span := tracer.Start(ctx, "queryWithTPM")
+	ctx, span := tracer.Start(ctx, "QueryWithTPM")
 	defer span.End()
 
 	data := &QueryRes{}
@@ -181,7 +182,7 @@ func Attest(ctx context.Context, log *slog.Logger) (
 		}
 	}()
 
-	data, attestParams, solve, err = attestWithTPM(ctx, log, tpm)
+	data, attestParams, solve, err = AttestWithTPM(ctx, log, tpm)
 	if err != nil {
 		return nil, nil, nil, nil, trace.Wrap(err, "attesting with TPM")
 	}
@@ -190,16 +191,17 @@ func Attest(ctx context.Context, log *slog.Logger) (
 
 }
 
-func attestWithTPM(ctx context.Context, log *slog.Logger, tpm *attest.TPM) (
+// AttestWithTPM is similar to Attest, but accepts an already opened TPM.
+func AttestWithTPM(ctx context.Context, log *slog.Logger, tpm *attest.TPM) (
 	data *QueryRes,
 	attestParams *attest.AttestationParameters,
 	solve func(ec *attest.EncryptedCredential) ([]byte, error),
 	err error,
 ) {
-	ctx, span := tracer.Start(ctx, "attestWithTPM")
+	ctx, span := tracer.Start(ctx, "AttestWithTPM")
 	defer span.End()
 
-	queryData, err := queryWithTPM(ctx, log, tpm)
+	queryData, err := QueryWithTPM(ctx, log, tpm)
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err, "querying TPM")
 	}

--- a/lib/tpm/tpm.go
+++ b/lib/tpm/tpm.go
@@ -54,7 +54,7 @@ func serialString(serial *big.Int) string {
 }
 
 // hashEKPub hashes the public part of an EK key. The key is first marshaled
-// in PKIX format and then hashed with SHA256.
+// in PKIX format, hashed with SHA256, and returned as a hexadecimal string.
 func hashEKPub(key crypto.PublicKey) (string, error) {
 	marshaled, err := x509.MarshalPKIXPublicKey(key)
 	if err != nil {

--- a/lib/tpm/tpm.go
+++ b/lib/tpm/tpm.go
@@ -39,11 +39,17 @@ var tracer = otel.Tracer("github.com/gravitational/teleport/lib/tpm")
 // string thats user-readable e.g ab:ab:ab:ff:ff:ff
 func serialString(serial *big.Int) string {
 	hex := serial.Text(16)
-	if len(hex)%2 == 1 {
-		hex = "0" + hex
-	}
 
 	out := strings.Builder{}
+	// Handle odd-sized strings.
+	if len(hex)%2 == 1 {
+		out.WriteRune('0')
+		out.WriteRune(rune(hex[0]))
+		if len(hex) > 1 {
+			out.WriteRune(':')
+		}
+		hex = hex[1:]
+	}
 	for i := 0; i < len(hex); i += 2 {
 		if i != 0 {
 			out.WriteString(":")

--- a/lib/tpm/tpm.go
+++ b/lib/tpm/tpm.go
@@ -20,7 +20,6 @@ package tpm
 
 import (
 	"context"
-	"crypto"
 	"crypto/sha256"
 	"crypto/x509"
 	"fmt"
@@ -59,14 +58,10 @@ func serialString(serial *big.Int) string {
 	return out.String()
 }
 
-// hashEKPub hashes the public part of an EK key. The key is first marshaled
-// in PKIX format, hashed with SHA256, and returned as a hexadecimal string.
-func hashEKPub(key crypto.PublicKey) (string, error) {
-	marshaled, err := x509.MarshalPKIXPublicKey(key)
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-	hashed := sha256.Sum256(marshaled)
+// hashEKPub hashes the public part of an EK key. The key is hashed with SHA256,
+// and returned as a hexadecimal string.
+func hashEKPub(pkixPublicKey []byte) (string, error) {
+	hashed := sha256.Sum256(pkixPublicKey)
 	return fmt.Sprintf("%x", hashed), nil
 }
 
@@ -138,7 +133,7 @@ func QueryWithTPM(
 		return nil, trace.Wrap(err)
 	}
 	data.EKPub = ekPub
-	data.EKPubHash, err = hashEKPub(eks[0].Public)
+	data.EKPubHash, err = hashEKPub(ekPub)
 	if err != nil {
 		return nil, trace.Wrap(err, "hashing ekpub")
 	}

--- a/lib/tpm/tpm.go
+++ b/lib/tpm/tpm.go
@@ -93,7 +93,11 @@ func Query(ctx context.Context, log *slog.Logger) (*QueryRes, error) {
 	}
 	defer func() {
 		if err := tpm.Close(); err != nil {
-			log.ErrorContext(ctx, "Failed to close TPM", slog.Any("error", err))
+			log.ErrorContext(
+				ctx,
+				"Failed to close TPM",
+				slog.String("error", err.Error()),
+			)
 		}
 	}()
 	return queryWithTPM(ctx, log, tpm)
@@ -116,7 +120,9 @@ func queryWithTPM(
 		// create an EK if no EK Certs are present in the NVRAM of the TPM.
 		// Either way, it lets us catch this early in case `go-attestation`
 		// misbehaves.
-		return nil, trace.BadParameter("no endorsement keys found in tpm")
+		return nil, trace.BadParameter(
+			"no endorsement keys found in tpm",
+		)
 	}
 
 	// The first EK returned by `go-attestation` will be an RSA based EK key or
@@ -178,7 +184,11 @@ func attestWithTPM(ctx context.Context, log *slog.Logger, tpm *attest.TPM) (
 	defer func() {
 		if err != nil {
 			if err := tpm.Close(); err != nil {
-				log.ErrorContext(ctx, "Failed to close TPM", slog.Any("error", err))
+				log.ErrorContext(
+					ctx,
+					"Failed to close TPM",
+					slog.String("error", err.Error()),
+				)
 			}
 		}
 	}()

--- a/lib/tpm/tpm.go
+++ b/lib/tpm/tpm.go
@@ -68,7 +68,8 @@ func hashEKPub(key crypto.PublicKey) (string, error) {
 type QueryRes struct {
 	// EKPub is the PKIX marshaled public part of the EK.
 	EKPub []byte
-	// EKPubHash is the SHA256 hash of the PKIX marshaled EKPub.
+	// EKPubHash is the SHA256 hash of the PKIX marshaled EKPub in hexadecimal
+	// format.
 	EKPubHash string
 	// EKCertPresent is true if an EK cert is present in the TPM.
 	EKCertPresent bool

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -1,5 +1,23 @@
 //go:build tpmsimulator
 
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package tpm
 
 import (

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -1,4 +1,4 @@
-//go:build tpmsimulator
+//go:build tpmsimulator_test
 
 /*
  * Teleport
@@ -129,7 +129,7 @@ func TestWithSimulator(t *testing.T) {
 	})
 
 	t.Run("Without EKCert", func(t *testing.T) {
-		queryRes, attParams, solve, err := attestWithTPM(ctx, log, attestTPM)
+		queryRes, attParams, solve, err := AttestWithTPM(ctx, log, attestTPM)
 		require.NoError(t, err)
 
 		// Check QueryRes looks right.
@@ -180,7 +180,7 @@ func TestWithSimulator(t *testing.T) {
 	writeEKCertToTPM(t, sim, fakeEKBytes)
 
 	t.Run("With EKCert", func(t *testing.T) {
-		queryRes, attParams, solve, err := attestWithTPM(ctx, log, attestTPM)
+		queryRes, attParams, solve, err := AttestWithTPM(ctx, log, attestTPM)
 		require.NoError(t, err)
 
 		// Check queryRes looks right.

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -185,7 +185,7 @@ func TestWithSimulator(t *testing.T) {
 		require.Equal(t, wantEKPubHash, queryRes.EKPubHash)
 		require.NotEmpty(t, queryRes.EKPub)
 		require.True(t, queryRes.EKCertPresent)
-		require.Equal(t, "04:c0:1d:b4:00:b0:c9", queryRes.EKCertSerial)
+		require.Equal(t, ekCertSerialHex, queryRes.EKCertSerial)
 		require.NotEmpty(t, queryRes.EKCert)
 
 		// Now attempt a validation that should succeed without verifying the
@@ -199,7 +199,7 @@ func TestWithSimulator(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, wantEKPubHash, validated.EKPubHash)
 		require.False(t, validated.EKCertVerified)
-		require.Equal(t, "04:c0:1d:b4:00:b0:c9", validated.EKCertSerial)
+		require.Equal(t, ekCertSerialHex, validated.EKCertSerial)
 
 		// Now attempt a validation that should succeed with verifying the
 		// against a CA.
@@ -213,7 +213,7 @@ func TestWithSimulator(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, wantEKPubHash, validated.EKPubHash)
 		require.True(t, validated.EKCertVerified)
-		require.Equal(t, "04:c0:1d:b4:00:b0:c9", validated.EKCertSerial)
+		require.Equal(t, ekCertSerialHex, validated.EKCertSerial)
 
 		// Now attempt a validation that should fail because the allowed CA does
 		// not match the EKCert.

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -164,8 +164,10 @@ func TestWithSimulator(t *testing.T) {
 	// Write fake EKCert to the TPM
 	origEK, err := attestTPM.EKs()
 	require.NoError(t, err)
+	const ekCertSerialNum = 1337133713371337
+	const ekCertSerialHex = "04:c0:1d:b4:00:b0:c9"
 	fakeEKCert := &x509.Certificate{
-		SerialNumber: big.NewInt(1337133713371337),
+		SerialNumber: big.NewInt(ekCertSerialNum),
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(time.Hour),
 	}

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -7,16 +7,20 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/pem"
 	"io"
 	"log/slog"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/google/go-attestation/attest"
 	tpmsimulator "github.com/google/go-tpm-tools/simulator"
 	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/fixtures"
 )
 
 // To include tests based on this simulator, use the `tpmsimulator` build tag.
@@ -33,20 +37,63 @@ type fakeCmdChannel struct {
 	io.ReadWriteCloser
 }
 
-// https://github.com/mrcdb/tpm2_ek_cert_generator/blob/master/generate_ek_cert.sh
-
 // MeasurementLog implements CommandChannelTPM20.
 func (cc *fakeCmdChannel) MeasurementLog() ([]byte, error) {
 	// Return nil, we inject an event log in handleEnrollStream
 	return nil, nil
 }
 
+func writeEKCertToTPM(t *testing.T, sim *tpmsimulator.Simulator, data []byte) {
+	const nvramRSAEKCertIndex = 0x1c00002
+	err := tpm2.NVDefineSpace(
+		sim,
+		tpm2.HandlePlatform, // Using Platform Authorization.
+		nvramRSAEKCertIndex,
+		"", // As this is the simulator, there isn't a password for Platform Authorization.
+		"", // We do not configure a password for this index. This allows it to be read using the NV index as the auth handle.
+		nil,
+		tpm2.AttrPPWrite| // Allows this NV index to be written with platform authorization.
+			tpm2.AttrPPRead| // Allows this NV index to be read with platform authorization.
+			tpm2.AttrPlatformCreate| // Marks this index as created by the Platform
+			tpm2.AttrAuthRead, // Allows the nv index to be used as an auth handle to read itself.
+
+		uint16(len(data)),
+	)
+	require.NoError(t, err)
+
+	err = tpm2.NVWrite(
+		sim,
+		tpm2.HandlePlatform,
+		nvramRSAEKCertIndex,
+		"",
+		data,
+		0,
+	)
+	require.NoError(t, err)
+}
+
 func TestWithSimulator(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
+	log := slog.Default()
+
+	ca := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+	}
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(t, err)
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	require.NoError(t, err)
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caBytes})
 
 	sim, err := tpmsimulator.GetWithFixedSeedInsecure(0)
 	require.NoError(t, err)
+	// This is the EKPubHash that results from the EK generated with the seed 0.
+	wantEKPubHash := "1b5bbe2e96054f7bc34ebe7ba9a4a9eac5611c6879285ceff6094fa556af485c"
 
 	attestTPM, err := attest.OpenTPM(&attest.OpenConfig{
 		TPMVersion:     attest.TPMVersion20,
@@ -57,69 +104,103 @@ func TestWithSimulator(t *testing.T) {
 		assert.NoError(t, attestTPM.Close())
 	})
 
+	t.Run("Without EKCert", func(t *testing.T) {
+		queryRes, attParams, solve, _, err := attestWithTPM(ctx, log, attestTPM)
+		require.NoError(t, err)
+
+		// Check QueryRes looks right.
+		require.Equal(t, wantEKPubHash, queryRes.EKPubHash)
+		require.NotEmpty(t, queryRes.EKPub)
+		require.False(t, queryRes.EKCertPresent)
+		require.Empty(t, queryRes.EKCertSerial)
+		require.Empty(t, queryRes.EKCert)
+
+		// Now attempt a validation that should succeed
+		validated, err := Validate(ctx, log, ValidateParams{
+			EKKey:        queryRes.EKPub,
+			EKCert:       nil,
+			AttestParams: *attParams,
+			Solve:        solve,
+			AllowedCAs:   []string{},
+		})
+		require.NoError(t, err)
+		require.Equal(t, wantEKPubHash, validated.EKPubHash)
+		require.False(t, validated.EKCertVerified)
+		require.Empty(t, validated.EKCertSerial)
+
+		// Attempt a validation which should fail because there's no EKCert and
+		// AllowedCAs is configured.
+		_, err = Validate(ctx, log, ValidateParams{
+			EKKey:        queryRes.EKPub,
+			EKCert:       nil,
+			AttestParams: *attParams,
+			Solve:        solve,
+			AllowedCAs:   []string{string(caPEM)},
+		})
+		require.ErrorContains(t, err, "tpm did not provide an EKCert to validate against allowed CAs")
+	})
+
+	// Write fake EKCert to the TPM
 	origEK, err := attestTPM.EKs()
 	require.NoError(t, err)
-
-	ca := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
-	require.NoError(t, err)
-	_, err = x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
-	require.NoError(t, err)
-
 	fakeEKCert := &x509.Certificate{
-		SerialNumber: big.NewInt(1337),
+		SerialNumber: big.NewInt(1337133713371337),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
 	}
 	fakeEKBytes, err := x509.CreateCertificate(rand.Reader, fakeEKCert, ca, origEK[0].Public, caPrivKey)
 	require.NoError(t, err)
+	writeEKCertToTPM(t, sim, fakeEKBytes)
 
-	const nvramRSACertIndex = 0x1c00002
-	err = tpm2.NVDefineSpace(
-		sim,
-		tpm2.HandlePlatform, // We act as the platform when creating this index.
-		nvramRSACertIndex,
-		"", // As this is the simulator, there isn't a password on the platform authorization.
-		"", // We do not configure a password for this index. This allows it to be read using the NV index as the auth handle.
-		nil,
-		tpm2.AttrPPWrite| // Allows this NV index to be written with platform authorization.
-			tpm2.AttrPPRead| // Allows this NV index to be read with platform authorization.
-			tpm2.AttrPlatformCreate| // Marks this index as created by the Platform
-			tpm2.AttrAuthRead, // Allows the nv index to be used as an auth handle to read itself.
-
-		uint16(len(fakeEKBytes)),
-	)
-	require.NoError(t, err)
-
-	err = tpm2.NVWrite(
-		sim,
-		tpm2.HandlePlatform,
-		nvramRSACertIndex,
-		"",
-		fakeEKBytes,
-		0,
-	)
-	require.NoError(t, err)
-
-	read, err := tpm2.NVReadEx(
-		sim,
-		nvramRSACertIndex, // The index we want to read.
-		nvramRSACertIndex, // Weird case: we act as the index itself when reading from it.
-		"",                // The password for the NV index auth handle - left empty in NVDefineSpace
-		0,
-	)
-	require.NoError(t, err)
-	require.NotEmpty(t, read)
-
-	t.Run("query", func(t *testing.T) {
-		res, err := query(ctx, slog.Default(), attestTPM)
+	t.Run("With EKCert", func(t *testing.T) {
+		queryRes, attParams, solve, _, err := attestWithTPM(ctx, log, attestTPM)
 		require.NoError(t, err)
-		assert.NotEmpty(t, res.EKPub)
-		assert.NotEmpty(t, res.EKCertSerial)
+
+		// Check queryRes looks right.
+		require.Equal(t, wantEKPubHash, queryRes.EKPubHash)
+		require.NotEmpty(t, queryRes.EKPub)
+		require.True(t, queryRes.EKCertPresent)
+		require.Equal(t, "04:c0:1d:b4:00:b0:c9", queryRes.EKCertSerial)
+		require.NotEmpty(t, queryRes.EKCert)
+
+		// Now attempt a validation that should succeed without verifying the
+		// EKCert.
+		validated, err := Validate(ctx, log, ValidateParams{
+			EKKey:        queryRes.EKPub,
+			EKCert:       queryRes.EKCert,
+			AttestParams: *attParams,
+			Solve:        solve,
+			AllowedCAs:   []string{},
+		})
+		require.NoError(t, err)
+		require.Equal(t, wantEKPubHash, validated.EKPubHash)
+		require.False(t, validated.EKCertVerified)
+		require.Equal(t, "04:c0:1d:b4:00:b0:c9", validated.EKCertSerial)
+
+		// Now attempt a validation that should succeed with verifying the
+		// against a CA.
+		validated, err = Validate(ctx, log, ValidateParams{
+			EKKey:        queryRes.EKPub,
+			EKCert:       queryRes.EKCert,
+			AttestParams: *attParams,
+			Solve:        solve,
+			AllowedCAs:   []string{string(caPEM)},
+		})
+		require.NoError(t, err)
+		require.Equal(t, wantEKPubHash, validated.EKPubHash)
+		require.True(t, validated.EKCertVerified)
+		require.Equal(t, "04:c0:1d:b4:00:b0:c9", validated.EKCertSerial)
+
+		// Now attempt a validation that should fail because the allowed CA does
+		// not match the EKCert.
+		validated, err = Validate(ctx, log, ValidateParams{
+			EKKey:        queryRes.EKPub,
+			EKCert:       queryRes.EKCert,
+			AttestParams: *attParams,
+			Solve:        solve,
+			// Some random CA that won't match the EKCert.
+			AllowedCAs: []string{fixtures.TLSCACertPEM},
+		})
+		require.ErrorContains(t, err, "certificate signed by unknown authority")
 	})
-
-	// TODO: Create fake EKCert and write it to the TPM!
-
 }

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -23,14 +23,6 @@ import (
 	"github.com/gravitational/teleport/api/fixtures"
 )
 
-// To include tests based on this simulator, use the `tpmsimulator` build tag.
-// This requires openssl libraries to be installed on the machine and findable
-// by the compiler. On macOS:
-// brew install openssl
-// export C_INCLUDE_PATH="$(brew --prefix openssl)/include"
-// export LIBRARY_PATH="$(brew --prefix openssl)/lib"
-// go test ./e/lib/devicetrust/devicetrustv1 -run TestService_EnrollDevice -tags tpmsimulator
-
 // fakeCmdChannel is used to inject the TPM simulator into `go-attestation`'s
 // TPM wrapper.
 type fakeCmdChannel struct {
@@ -71,6 +63,14 @@ func writeEKCertToTPM(t *testing.T, sim *tpmsimulator.Simulator, data []byte) {
 	)
 	require.NoError(t, err)
 }
+
+// To include tests based on this simulator, use the `tpmsimulator` build tag.
+// This requires openssl libraries to be installed on the machine and findable
+// by the compiler. On macOS:
+// brew install openssl
+// export C_INCLUDE_PATH="$(brew --prefix openssl)/include"
+// export LIBRARY_PATH="$(brew --prefix openssl)/lib"
+// go test ./lib/tpm -run TestWithSimulator -tags tpmsimulator
 
 func TestWithSimulator(t *testing.T) {
 	t.Parallel()

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -143,7 +143,6 @@ func TestWithSimulator(t *testing.T) {
 			EKCert:       nil,
 			AttestParams: *attParams,
 			Solve:        solve,
-			AllowedCAs:   []string{},
 		})
 		require.NoError(t, err)
 		require.Equal(t, wantEKPubHash, validated.EKPubHash)

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -86,9 +86,13 @@ func TestWithSimulator(t *testing.T) {
 	}
 	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
 	require.NoError(t, err)
-	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	caBytes, err := x509.CreateCertificate(
+		rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey,
+	)
 	require.NoError(t, err)
-	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caBytes})
+	caPEM := pem.EncodeToMemory(
+		&pem.Block{Type: "CERTIFICATE", Bytes: caBytes},
+	)
 
 	sim, err := tpmsimulator.GetWithFixedSeedInsecure(0)
 	require.NoError(t, err)
@@ -148,7 +152,9 @@ func TestWithSimulator(t *testing.T) {
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(time.Hour),
 	}
-	fakeEKBytes, err := x509.CreateCertificate(rand.Reader, fakeEKCert, ca, origEK[0].Public, caPrivKey)
+	fakeEKBytes, err := x509.CreateCertificate(
+		rand.Reader, fakeEKCert, ca, origEK[0].Public, caPrivKey,
+	)
 	require.NoError(t, err)
 	writeEKCertToTPM(t, sim, fakeEKBytes)
 

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -117,7 +117,7 @@ func TestWithSimulator(t *testing.T) {
 	sim, err := tpmsimulator.GetWithFixedSeedInsecure(0)
 	require.NoError(t, err)
 	// This is the EKPubHash that results from the EK generated with the seed 0.
-	wantEKPubHash := "1b5bbe2e96054f7bc34ebe7ba9a4a9eac5611c6879285ceff6094fa556af485c"
+	const wantEKPubHash = "1b5bbe2e96054f7bc34ebe7ba9a4a9eac5611c6879285ceff6094fa556af485c"
 
 	attestTPM, err := attest.OpenTPM(&attest.OpenConfig{
 		TPMVersion:     attest.TPMVersion20,

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -193,7 +193,6 @@ func TestWithSimulator(t *testing.T) {
 			EKCert:       queryRes.EKCert,
 			AttestParams: *attParams,
 			Solve:        solve,
-			AllowedCAs:   []string{},
 		})
 		require.NoError(t, err)
 		require.Equal(t, wantEKPubHash, validated.EKPubHash)

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -88,11 +88,19 @@ func TestWithSimulator(t *testing.T) {
 			tpm2.AttrPPRead| // Allows this NV index to be read with platform authorization.
 			tpm2.AttrPlatformCreate| // Marks this index as created by the Platform
 			tpm2.AttrAuthRead, // Allows the nv index to be used as an auth handle to read itself.
+
 		uint16(len(fakeEKBytes)),
 	)
 	require.NoError(t, err)
 
-	err = tpm2.NVWrite(sim, tpm2.HandlePlatform, nvramRSACertIndex, "", fakeEKBytes, 0)
+	err = tpm2.NVWrite(
+		sim,
+		tpm2.HandlePlatform,
+		nvramRSACertIndex,
+		"",
+		fakeEKBytes,
+		0,
+	)
 	require.NoError(t, err)
 
 	read, err := tpm2.NVReadEx(

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -127,7 +127,7 @@ func TestWithSimulator(t *testing.T) {
 	})
 
 	t.Run("Without EKCert", func(t *testing.T) {
-		queryRes, attParams, solve, _, err := attestWithTPM(ctx, log, attestTPM)
+		queryRes, attParams, solve, err := attestWithTPM(ctx, log, attestTPM)
 		require.NoError(t, err)
 
 		// Check QueryRes looks right.
@@ -178,7 +178,7 @@ func TestWithSimulator(t *testing.T) {
 	writeEKCertToTPM(t, sim, fakeEKBytes)
 
 	t.Run("With EKCert", func(t *testing.T) {
-		queryRes, attParams, solve, _, err := attestWithTPM(ctx, log, attestTPM)
+		queryRes, attParams, solve, err := attestWithTPM(ctx, log, attestTPM)
 		require.NoError(t, err)
 
 		// Check queryRes looks right.

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -31,7 +31,7 @@ type fakeCmdChannel struct {
 
 // MeasurementLog implements CommandChannelTPM20.
 func (cc *fakeCmdChannel) MeasurementLog() ([]byte, error) {
-	// Return nil, we inject an event log in handleEnrollStream
+	// Nothing to do here - we don't use the measurement log for tpm joining.
 	return nil, nil
 }
 

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -123,7 +123,7 @@ func TestWithSimulator(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		assert.NoError(t, attestTPM.Close())
+		assert.NoError(t, attestTPM.Close(), "TPM simulator close errored")
 	})
 
 	t.Run("Without EKCert", func(t *testing.T) {

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -54,6 +54,8 @@ func (cc *fakeCmdChannel) MeasurementLog() ([]byte, error) {
 }
 
 func writeEKCertToTPM(t *testing.T, sim *tpmsimulator.Simulator, data []byte) {
+	// As per TCG Credential Profile EK for TPM 2.0, 2.2.1.4, the RSA 2048
+	// EK certificate is stored in the TPM's NV index 0x1c00002.
 	const nvramRSAEKCertIndex = 0x1c00002
 	err := tpm2.NVDefineSpace(
 		sim,

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -1,0 +1,58 @@
+//go:build tpmsimulator
+
+package tpm
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/google/go-attestation/attest"
+	tpmsimulator "github.com/google/go-tpm-tools/simulator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// To include tests based on this simulator, use the `tpmsimulator` build tag.
+// This requires openssl libraries to be installed on the machine and findable
+// by the compiler. On macOS:
+// brew install openssl
+// export C_INCLUDE_PATH="$(brew --prefix openssl)/include"
+// export LIBRARY_PATH="$(brew --prefix openssl)/lib"
+// go test ./e/lib/devicetrust/devicetrustv1 -run TestService_EnrollDevice -tags tpmsimulator
+
+// fakeCmdChannel is used to inject the TPM simulator into `go-attestation`'s
+// TPM wrapper.
+type fakeCmdChannel struct {
+	io.ReadWriteCloser
+}
+
+// MeasurementLog implements CommandChannelTPM20.
+func (cc *fakeCmdChannel) MeasurementLog() ([]byte, error) {
+	// Return nil, we inject an event log in handleEnrollStream
+	return nil, nil
+}
+
+func TestWithSimulator(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	sim, err := tpmsimulator.GetWithFixedSeedInsecure(0)
+	require.NoError(t, err)
+
+	attestTPM, err := attest.OpenTPM(&attest.OpenConfig{
+		TPMVersion:     attest.TPMVersion20,
+		CommandChannel: &fakeCmdChannel{ReadWriteCloser: sim},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, attestTPM.Close())
+	})
+
+	t.Run("query", func(t *testing.T) {
+		res, err := query(ctx, slog.Default(), attestTPM)
+		require.NoError(t, err)
+		assert.NotEmpty(t, res.EKPub)
+	})
+}

--- a/lib/tpm/validate.go
+++ b/lib/tpm/validate.go
@@ -54,7 +54,7 @@ type ValidateParams struct {
 // ValidatedTPM is returned by Validate and contains the validated information
 // about the remote TPM.
 type ValidatedTPM struct {
-	// EKPubHash is the SHA256 hash of the PKIX marshalled EKPub.
+	// EKPubHash is the SHA256 hash of the PKIX marshaled EKPub.
 	EKPubHash string `json:"ek_pub_hash"`
 	// EKCertSerial is the serial number of the EK cert represented as a colon
 	// delimited hex string. If there is no EKCert, this field will be empty.
@@ -158,7 +158,7 @@ func Validate(
 func parseEK(
 	ctx context.Context, params ValidateParams,
 ) (*x509.Certificate, crypto.PublicKey, error) {
-	ctx, span := tracer.Start(ctx, "parseEK")
+	_, span := tracer.Start(ctx, "parseEK")
 	defer span.End()
 
 	ekCertPresent := len(params.EKCert) > 0
@@ -186,7 +186,7 @@ func verifyEKCert(
 	allowedCAs []string,
 	ekCert *x509.Certificate,
 ) error {
-	ctx, span := tracer.Start(ctx, "verifyEKCert")
+	_, span := tracer.Start(ctx, "verifyEKCert")
 	defer span.End()
 
 	if ekCert == nil {

--- a/lib/tpm/validate.go
+++ b/lib/tpm/validate.go
@@ -53,7 +53,7 @@ type ValidateParams struct {
 // ValidatedTPM is returned by Validate and contains the validated information
 // about the remote TPM.
 type ValidatedTPM struct {
-	// EKPubHash is the SHA256 hash of the PKIX marshaled EKPub.
+	// EKPubHash is the SHA256 hash of the PKIX marshaled EKPub in hex format.
 	EKPubHash string `json:"ek_pub_hash"`
 	// EKCertSerial is the serial number of the EK cert represented as a colon
 	// delimited hex string. If there is no EKCert, this field will be empty.

--- a/lib/tpm/validate.go
+++ b/lib/tpm/validate.go
@@ -98,7 +98,11 @@ func Validate(
 	}
 
 	validated := &ValidatedTPM{}
-	validated.EKPubHash, err = hashEKPub(ekPub)
+	ekPubPKIX, err := x509.MarshalPKIXPublicKey(ekPub)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	validated.EKPubHash, err = hashEKPub(ekPubPKIX)
 	if err != nil {
 		return validated, trace.Wrap(err, "hashing EK public key")
 	}

--- a/lib/tpm/validate.go
+++ b/lib/tpm/validate.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/google/go-attestation/attest"
 	"github.com/gravitational/trace"
-	"github.com/mitchellh/mapstructure"
 )
 
 // ValidateParams are the parameters required to validate a TPM.
@@ -68,10 +67,10 @@ type ValidatedTPM struct {
 // audit events related to a specific join.
 func (c *ValidatedTPM) JoinAuditAttributes() (map[string]interface{}, error) {
 	return map[string]interface{}{
-		"ek_pub_hash": c.EKPubHash,
-		"ek_cert_serial": c.EKCertSerial,
+		"ek_pub_hash":      c.EKPubHash,
+		"ek_cert_serial":   c.EKCertSerial,
 		"ek_cert_verified": c.EKCertVerified,
-	}
+	}, nil
 }
 
 // Validate takes the parameters from a remote TPM and performs the necessary

--- a/lib/tpm/validate.go
+++ b/lib/tpm/validate.go
@@ -84,6 +84,14 @@ func Validate(
 	ctx, span := tracer.Start(ctx, "Validate")
 	defer span.End()
 
+	// Validate params
+	switch {
+	case params.Solve == nil:
+		return nil, trace.BadParameter("solve must be non-nil")
+	case params.EKCert == nil && params.EKKey == nil:
+		return nil, trace.BadParameter("at least one of EKCert or EKKey must be provided")
+	}
+
 	ekCert, ekPub, err := parseEK(ctx, params)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/tpm/validate.go
+++ b/lib/tpm/validate.go
@@ -146,7 +146,6 @@ func Validate(
 		log.ErrorContext(
 			ctx,
 			"TPM Credential Activation solution did not match expected solution.",
-			"error", err,
 			"tpm", validated,
 		)
 		return validated, trace.BadParameter("invalid credential activation solution")

--- a/lib/tpm/validate.go
+++ b/lib/tpm/validate.go
@@ -67,19 +67,11 @@ type ValidatedTPM struct {
 // JoinAuditAttributes returns a series of attributes that can be inserted into
 // audit events related to a specific join.
 func (c *ValidatedTPM) JoinAuditAttributes() (map[string]interface{}, error) {
-	res := map[string]interface{}{}
-	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		TagName: "json",
-		Result:  &res,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
+	return map[string]interface{}{
+		"ek_pub_hash": c.EKPubHash,
+		"ek_cert_serial": c.EKCertSerial,
+		"ek_cert_verified": c.EKCertVerified,
 	}
-
-	if err := d.Decode(c); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return res, nil
 }
 
 // Validate takes the parameters from a remote TPM and performs the necessary

--- a/lib/tpm/validate.go
+++ b/lib/tpm/validate.go
@@ -1,0 +1,188 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tpm
+
+import (
+	"context"
+	"crypto"
+	"crypto/subtle"
+	"crypto/x509"
+	"log/slog"
+
+	"github.com/google/go-attestation/attest"
+	"github.com/gravitational/trace"
+	"github.com/mitchellh/mapstructure"
+)
+
+type ValidateParams struct {
+	EKCert       []byte
+	EKKey        []byte
+	AttestParams attest.AttestationParameters
+	Solve        func(ec *attest.EncryptedCredential) ([]byte, error)
+	AllowedCAs   []string
+}
+
+type ValidatedTPM struct {
+	EKPubHash      string `json:"ek_pub_hash"`
+	EKCertSerial   string `json:"ek_cert_serial,omitempty"`
+	EKCertVerified bool   `json:"ek_cert_verified"`
+}
+
+// JoinAuditAttributes returns a series of attributes that can be inserted into
+// audit events related to a specific join.
+func (c *ValidatedTPM) JoinAuditAttributes() (map[string]interface{}, error) {
+	res := map[string]interface{}{}
+	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  &res,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := d.Decode(c); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return res, nil
+}
+
+func Validate(
+	ctx context.Context, log *slog.Logger, params ValidateParams,
+) (*ValidatedTPM, error) {
+	ekCert, ekPub, err := parseEK(ctx, log, params)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	validated := &ValidatedTPM{}
+	validated.EKPubHash, err = hashEKPub(ekPub)
+	if err != nil {
+		return validated, trace.Wrap(err, "hashing EK public key")
+	}
+	if ekCert != nil {
+		validated.EKCertSerial = serialString(ekCert.SerialNumber)
+	}
+
+	if len(params.AllowedCAs) > 0 {
+		if err := verifyEKCert(ctx, log, params.AllowedCAs, ekCert); err != nil {
+			log.ErrorContext(
+				ctx,
+				"EKCert CA verification failed",
+				"error", err,
+				"tpm", validated,
+			)
+			return validated, trace.Wrap(err)
+		}
+		validated.EKCertVerified = true
+	}
+
+	activationParameters := attest.ActivationParameters{
+		TPMVersion: attest.TPMVersion20,
+		AK:         params.AttestParams,
+		EK:         ekPub,
+	}
+	// The generate method completes initial validation that provides the
+	// following assurances:
+	// - The attestation key is of a secure length
+	// - The attestation key is marked as created within a TPM
+	// - The attestation key is marked as restricted (e.g cannot be used to
+	//   sign or decrypt external data)
+	// When the returned challenge is solved by the TPM using ActivateCredential
+	// the following additional assurance is given:
+	// - The attestation key resides in the same TPM as the endorsement key
+	solution, encryptedCredential, err := activationParameters.Generate()
+	if err != nil {
+		return validated, trace.Wrap(err, "generating credential activation challenge")
+	}
+	clientSolution, err := params.Solve(encryptedCredential)
+	if err != nil {
+		return validated, trace.Wrap(err, "asking client to perform credential activation")
+	}
+	if subtle.ConstantTimeCompare(clientSolution, solution) == 0 {
+		log.ErrorContext(
+			ctx,
+			"TPM Credential Activation solution did not match expected solution.",
+			"error", err,
+			"tpm", validated,
+		)
+		return validated, trace.BadParameter("invalid credential activation solution")
+	}
+
+	return validated, nil
+}
+
+func parseEK(
+	ctx context.Context, log *slog.Logger, params ValidateParams,
+) (*x509.Certificate, crypto.PublicKey, error) {
+	ekCertPresent := len(params.EKCert) > 0
+	ekKeyPresent := len(params.EKKey) > 0
+	switch {
+	case ekCertPresent:
+		ekCert, err := attest.ParseEKCertificate(params.EKCert)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		ekPub, err := x509.MarshalPKIXPublicKey(ekCert.PublicKey)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		return ekCert, ekPub, nil
+	case ekKeyPresent:
+		ekPub, err := x509.ParsePKIXPublicKey(params.EKKey)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		return nil, ekPub, nil
+	default:
+		return nil, nil, trace.BadParameter("either EK cert or EK key must be provided")
+	}
+}
+
+func verifyEKCert(
+	ctx context.Context,
+	log *slog.Logger,
+	allowedCAs []string,
+	ekCert *x509.Certificate,
+) error {
+	if ekCert == nil {
+		return trace.BadParameter("tpm did not provide an EKCert to validate against allowed CAs")
+	}
+
+	// Collect CAs into a pool to use for validation
+	caPool := x509.NewCertPool()
+	for _, caPEM := range allowedCAs {
+		if !caPool.AppendCertsFromPEM([]byte(caPEM)) {
+			return trace.BadParameter("invalid CA PEM")
+		}
+	}
+	// Validate EKCert against CA pool
+	_, err := ekCert.Verify(x509.VerifyOptions{
+		Roots: caPool,
+		KeyUsages: []x509.ExtKeyUsage{
+			// Go's x509 Verification doesn't support the EK certificate
+			// ExtKeyUsage (http://oid-info.com/get/2.23.133.8.1), so we
+			// allow any.
+			x509.ExtKeyUsageAny,
+		},
+	})
+	if err != nil {
+		return trace.Wrap(err, "verifying ekcert")
+	}
+	return nil
+}

--- a/lib/tpm/validate.go
+++ b/lib/tpm/validate.go
@@ -139,7 +139,7 @@ func Validate(
 	if err != nil {
 		return validated, trace.Wrap(err, "asking client to perform credential activation")
 	}
-	if subtle.ConstantTimeCompare(clientSolution, solution) == 0 {
+	if subtle.ConstantTimeCompare(clientSolution, solution) != 1 {
 		return validated, trace.BadParameter("invalid credential activation solution")
 	}
 


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/38558

As per RFD https://github.com/gravitational/teleport/pull/38613

This is the foundational package for the new TPM joining functionality. It adds the client side element of attestation and the server side which can verify that attestation.