### PR TITLE
docs: Always use curl.exe on Windows with explicit failure if URL is incorrect

### DIFF
--- a/docs/pages/desktop-access/active-directory-manual.mdx
+++ b/docs/pages/desktop-access/active-directory-manual.mdx
@@ -226,7 +226,7 @@ To export the Teleport user CA certificate:
    command and replacing `teleport.example.com` with the address of your Teleport cluster:
 
    ```code
-   $ curl -o user-ca.cer https://<Var name="teleport.example.com"/>/webapi/auth/export?type=windows
+   $ curl.exe -fo user-ca.cer https://<Var name="teleport.example.com"/>/webapi/auth/export?type=windows
    ```
 
 1. Take note of the path to the `user-ca.cer` file for use in a later step.

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -43,7 +43,7 @@ To prepare a Windows computer:
 2. Export the Teleport user certificate authority by running the following command using your Teleport cluster address:
 
    ```code
-   $ curl -o teleport.cer <Var name="https://teleport.example.com"/>/webapi/auth/export?type=windows
+   $ curl.exe -fo teleport.cer <Var name="https://teleport.example.com"/>/webapi/auth/export?type=windows
    ```
 
 <Tabs>
@@ -52,7 +52,7 @@ To prepare a Windows computer:
 3. Download the Teleport Windows Auth setup program:
 
 ```code
-$ curl -o teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe
+$ curl.exe -fo teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe
 ```
 
 </TabItem>
@@ -61,7 +61,7 @@ $ curl -o teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe https://cd
 3. Download the Teleport Windows Auth setup program:
 
 ```code
-$ curl -o teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe
+$ curl.exe -fo teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe
 ```
 
 </TabItem>

--- a/docs/pages/desktop-access/troubleshooting.mdx
+++ b/docs/pages/desktop-access/troubleshooting.mdx
@@ -62,7 +62,7 @@ fetch the new CA using the following command, replacing <Var name="teleport.exam
 with the address of your Teleport cluster:
 
 ```code
-$ curl -o user-ca.cer https://<Var name="teleport.example.com"/>/webapi/auth/export?type=windows
+$ curl.exe -fo user-ca.cer https://<Var name="teleport.example.com"/>/webapi/auth/export?type=windows
 ```
 
 If that doesn't help, log into the target host directly, open PowerShell and


### PR DESCRIPTION
I've seen 3 or 4 folks now get bitten by the error described here: https://github.com/gravitational/teleport/discussions/40292#discussioncomment-9032393

It seems people aren't always great at trimming excess slashes from their URL requests, an issue probably exacerbated by the fact that web browsers will remove them for you and handle `/webapi//auth/export` just the same as `/webapi/auth/export` - but `curl` definitely won't.

This PR changes all invocations of `curl` intended for use on Windows to:
- always call `curl.exe` explicitly (rather than using `curl` as an alias for `Invoke-WebRequest` if run in PowerShell)
- add the `-f` parameter so the request fails with a visible warning and doesn't write the file if the URL 404s

Before:
```
PS C:\Users\gus> curl -o user-ca.cer https://gus.teleportdemo.com/webapi//auth/export?type=windows
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    19  100    19    0     0     23      0 --:--:-- --:--:-- --:--:--    25
PS C:\Users\gus> dir user-ca.cer


    Directory: C:\Users\gus


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----          4/9/2024  10:23 AM             19 user-ca.cer
```

After:
```
PS C:\Users\gus> curl.exe -fo user-ca.cer https://gus.teleportdemo.com/webapi//auth/export?type=windows
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0    19    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
PS C:\Users\gus> dir user-ca.cer
dir : Cannot find path 'C:\Users\gus\user-ca.cer' because it does not exist.
At line:1 char:1
+ dir user-ca.cer
+ ~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\gus\user-ca.cer:String) [Get-ChildItem], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetChildItemCommand
```

This should help avoid folks getting tripped up by inadvertently adding extra slashes to their commands. It also serves as a nice reminder that you should be running the commands listed on a Windows machine, because `curl.exe` won't work on Linux or MacOS.