### PR TITLE
[v15] Correctly propagate windows desktop logins in GetUnifiedResourcePage

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3916,7 +3916,7 @@ func convertEnrichedResource(resource *proto.PaginatedResource) (*types.Enriched
 	} else if r := resource.GetAppServerOrSAMLIdPServiceProvider(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r}, nil
 	} else if r := resource.GetWindowsDesktop(); r != nil {
-		return &types.EnrichedResource{ResourceWithLabels: r}, nil
+		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins}, nil
 	} else if r := resource.GetWindowsDesktopService(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r}, nil
 	} else if r := resource.GetKubeCluster(); r != nil {

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -668,3 +668,54 @@ func TestGetResourcesWithFilters(t *testing.T) {
 		})
 	}
 }
+
+type fakeUnifiedResourcesClient struct {
+	resp *proto.ListUnifiedResourcesResponse
+	err  error
+}
+
+func (f fakeUnifiedResourcesClient) ListUnifiedResources(ctx context.Context, req *proto.ListUnifiedResourcesRequest) (*proto.ListUnifiedResourcesResponse, error) {
+	return f.resp, f.err
+}
+
+// TestGetUnifiedResourcesWithLogins validates that any logins provided
+// in a [proto.PaginatedResource] are correctly parsed and applied to
+// the corresponding [types.EnrichedResource].
+func TestGetUnifiedResourcesWithLogins(t *testing.T) {
+	ctx := context.Background()
+
+	clt := fakeUnifiedResourcesClient{
+		resp: &proto.ListUnifiedResourcesResponse{
+			Resources: []*proto.PaginatedResource{
+				{
+					Resource: &proto.PaginatedResource_Node{Node: &types.ServerV2{}},
+					Logins:   []string{"alice", "bob"},
+				},
+				{
+					Resource: &proto.PaginatedResource_WindowsDesktop{WindowsDesktop: &types.WindowsDesktopV3{}},
+					Logins:   []string{"llama"},
+				},
+			},
+		},
+	}
+
+	resources, _, err := GetUnifiedResourcePage(ctx, clt, &proto.ListUnifiedResourcesRequest{
+		SortBy: types.SortBy{
+			IsDesc: false,
+			Field:  types.ResourceSpecHostname,
+		},
+		IncludeLogins: true,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, resources, len(clt.resp.Resources))
+
+	for _, enriched := range resources {
+		switch enriched.ResourceWithLabels.(type) {
+		case *types.ServerV2:
+			assert.Equal(t, enriched.Logins, clt.resp.Resources[0].Logins)
+		case *types.WindowsDesktopV3:
+			assert.Equal(t, enriched.Logins, clt.resp.Resources[1].Logins)
+		}
+	}
+}


### PR DESCRIPTION
Backport #40359 to branch/v15

changelog: Fixes a bug that prevented the available logins for windows desktops in leaf clusters that were being accessed via the root cluster web ui.
