### PR TITLE
[v14] Web: Make s3 fields optional (#40145)

### DIFF
--- a/web/packages/design/src/Alert/Alert.jsx
+++ b/web/packages/design/src/Alert/Alert.jsx
@@ -44,10 +44,26 @@ const kind = props => {
         background: theme.colors.success.main,
         color: theme.colors.text.primaryInverse,
       };
+    case 'outline-danger':
+      return {
+        background: fade(theme.colors.error.main, 0.1),
+        border: `${theme.borders[2]} ${theme.colors.error.main}`,
+        borderRadius: `${theme.radii[3]}px`,
+        boxShadow: 'none',
+        justifyContent: 'normal',
+      };
     case 'outline-info':
       return {
-        background: fade(theme.colors.link, 0.1),
-        border: `${theme.radii[1]}px solid ${theme.colors.link}`,
+        background: fade(theme.colors.accent.main, 0.1),
+        border: `${theme.borders[2]} ${theme.colors.accent.main}`,
+        borderRadius: `${theme.radii[3]}px`,
+        boxShadow: 'none',
+        justifyContent: 'normal',
+      };
+    case 'outline-warn':
+      return {
+        background: fade(theme.colors.warning.main, 0.1),
+        border: `${theme.borders[2]} ${theme.colors.warning.main}`,
         borderRadius: `${theme.radii[3]}px`,
         boxShadow: 'none',
         justifyContent: 'normal',
@@ -89,6 +105,7 @@ Alert.propTypes = {
     'warning',
     'success',
     'outline-info',
+    'outline-warn',
   ]),
   ...color.propTypes,
   ...space.propTypes,
@@ -107,3 +124,4 @@ export const Info = props => <Alert kind="info" {...props} />;
 export const Warning = props => <Alert kind="warning" {...props} />;
 export const Success = props => <Alert kind="success" {...props} />;
 export const OutlineInfo = props => <Alert kind="outline-info" {...props} />;
+export const OutlineWarn = props => <Alert kind="outline-warn" {...props} />;

--- a/web/packages/design/src/Alert/Alert.story.js
+++ b/web/packages/design/src/Alert/Alert.story.js
@@ -31,5 +31,7 @@ export const Alerts = () => (
     <Alert kind="info">Some informational message</Alert>
     <Alert kind="success">This is success</Alert>
     <Alert kind="outline-info">Text align it yourself</Alert>
+    <Alert kind="outline-warn">Text align it yourself</Alert>
+    <Alert kind="outline-danger">Text align it yourself</Alert>
   </Box>
 );

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.tsx
@@ -43,6 +43,7 @@ import {
 } from 'teleport/services/discovery';
 import useTeleport from 'teleport/useTeleport';
 import { Tabs } from 'teleport/components/Tabs';
+import { splitAwsIamArn } from 'teleport/services/integrations/aws';
 
 import { ActionButtons, Header, Mark, StyledBox } from '../../Shared';
 
@@ -215,13 +216,11 @@ export function EnrollRdsDatabase() {
     if (!requiredVpcsAndSubnets) {
       try {
         const { spec, name: integrationName } = agentMeta.awsIntegration;
-        const accountId = spec.roleArn
-          .split('arn:aws:iam::')[1]
-          .substring(0, 12);
+        const { awsAccountId } = splitAwsIamArn(spec.roleArn);
         requiredVpcsAndSubnets =
           await integrationService.fetchAwsRdsRequiredVpcs(integrationName, {
             region: tableData.currRegion,
-            accountId,
+            accountId: awsAccountId,
           });
 
         setRequiredVpcs(requiredVpcsAndSubnets);

--- a/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.test.tsx
+++ b/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.test.tsx
@@ -15,7 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { render, screen, fireEvent } from 'design/utils/testing';
+import { render, screen, fireEvent, waitFor } from 'design/utils/testing';
+import userEvent from '@testing-library/user-event';
 
 import {
   Integration,
@@ -25,11 +26,84 @@ import {
 
 import { EditAwsOidcIntegrationDialog } from './EditAwsOidcIntegrationDialog';
 
-test('edit without s3 fields', async () => {
+test('user acknowledging script was ran when s3 bucket fields are edited', async () => {
   render(
     <EditAwsOidcIntegrationDialog
       close={() => null}
       edit={() => null}
+      integration={{
+        resourceType: 'integration',
+        kind: IntegrationKind.AwsOidc,
+        name: 'some-integration-name',
+        spec: {
+          roleArn: 'arn:aws:iam::123456789012:role/johndoe',
+          issuerS3Bucket: 'test-value',
+          issuerS3Prefix: '',
+        },
+        statusCode: IntegrationStatusCode.Running,
+      }}
+    />
+  );
+
+  // Initial state.
+  expect(screen.queryByTestId('scriptbox')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('checkbox')).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: /generate command/i })
+  ).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+
+  // Fill in the s3 prefix field.
+  fireEvent.change(screen.getByPlaceholderText(/prefix/i), {
+    target: { value: 'test-value' },
+  });
+  await waitFor(() =>
+    expect(
+      screen.getByRole('button', { name: /generate command/i })
+    ).toBeEnabled()
+  );
+  // When clicking on generate command:
+  //  - script rendered
+  //  - checkbox to confirm user has ran command
+  //  - edit button replaces generate command button
+  //  - save button still disabled
+  userEvent.click(screen.getByRole('button', { name: /generate command/i }));
+  await screen.findByRole('button', { name: /edit/i });
+  expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  expect(
+    screen.queryByRole('button', { name: /generate command/i })
+  ).not.toBeInTheDocument();
+  expect(screen.getByTestId('checkbox')).toBeInTheDocument();
+  expect(screen.getByTestId('scriptbox')).toBeInTheDocument();
+
+  // Click on checkbox should enable save button and disable edit button.
+  userEvent.click(screen.getByRole('checkbox'));
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
+  );
+  expect(screen.getByRole('button', { name: /edit/i })).toBeDisabled();
+
+  // Unchecking the checkbox should disable save button.
+  userEvent.click(screen.getByRole('checkbox'));
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()
+  );
+
+  // Click on edit, should replace it with generate command
+  userEvent.click(screen.getByRole('button', { name: /edit/i }));
+  await waitFor(() =>
+    expect(
+      screen.getByRole('button', { name: /generate command/i })
+    ).toBeEnabled()
+  );
+});
+
+test('render warning on save when leaving s3 fields empty', async () => {
+  const edit = jest.fn(() => Promise.resolve());
+  render(
+    <EditAwsOidcIntegrationDialog
+      close={() => null}
+      edit={edit}
       integration={{
         resourceType: 'integration',
         kind: IntegrationKind.AwsOidc,
@@ -45,74 +119,111 @@ test('edit without s3 fields', async () => {
   );
 
   // Initial state.
-  expect(screen.getByText(/required/i)).toBeInTheDocument();
   expect(screen.queryByTestId('scriptbox')).not.toBeInTheDocument();
   expect(screen.queryByTestId('checkbox')).not.toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
-
-  // Click on generate command:
-  //  - script rendered
-  //  - checkbox to confirm user has ran command
-  //  - edit button replaces generate command button
-  //  - save button still disabled
-  fireEvent.click(screen.getByRole('button', { name: /generate command/i }));
-  screen.getByRole('button', { name: /edit/i });
   expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
   expect(
     screen.queryByRole('button', { name: /generate command/i })
   ).not.toBeInTheDocument();
-  expect(screen.getByTestId('checkbox')).toBeInTheDocument();
-  expect(screen.getByTestId('scriptbox')).toBeInTheDocument();
 
-  // Click on checkbox should enable save button and disable edit button.
-  fireEvent.click(screen.getByRole('checkbox'));
-  expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
-  expect(screen.getByRole('button', { name: /edit/i })).toBeDisabled();
+  // Enable the generate command button by changing a field.
+  fireEvent.change(screen.getByPlaceholderText(/arn:aws:iam:/i), {
+    target: { value: 'arn:aws:iam::123456789012:role/someonelse' },
+  });
+  await waitFor(() =>
+    expect(
+      screen.getByRole('button', { name: /generate command/i })
+    ).toBeEnabled()
+  );
 
-  // Unchecking the checkbox should disable save button.
-  fireEvent.click(screen.getByRole('checkbox'));
+  expect(screen.queryByTestId('checkbox')).not.toBeInTheDocument();
   expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
 
-  // Click on edit, should replace it with generate command
-  fireEvent.click(screen.getByRole('button', { name: /edit/i }));
-  expect(
-    screen.getByRole('button', { name: /generate command/i })
-  ).toBeEnabled();
+  userEvent.click(screen.getByRole('button', { name: /generate command/i }));
+  await screen.findByRole('button', { name: /edit/i });
+  expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+
+  userEvent.click(screen.getByTestId('checkbox'));
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
+  );
+
+  // Clicking on save without defining s3 fields, should render
+  // a warning.
+  userEvent.click(screen.getByRole('button', { name: /save/i }));
+  await screen.findByText(/recommended to use an S3 bucket/i);
+  expect(edit).not.toHaveBeenCalled();
+
+  // Canceling and saving should re-render the warning.
+  userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+  await screen.findByRole('button', { name: /save/i });
+
+  userEvent.click(screen.getByRole('button', { name: /save/i }));
+  await screen.findByText(/recommended to use an S3 bucket/i);
+
+  userEvent.click(screen.getByRole('button', { name: /continue/i }));
+  await waitFor(() => expect(edit).toHaveBeenCalledTimes(1));
 });
 
-test('edit with s3 fields', async () => {
+test('render warning on save when deleting existing s3 fields', async () => {
+  const edit = jest.fn(() => Promise.resolve());
   render(
     <EditAwsOidcIntegrationDialog
       close={() => null}
-      edit={() => null}
-      integration={integration}
+      edit={edit}
+      integration={{
+        resourceType: 'integration',
+        kind: IntegrationKind.AwsOidc,
+        name: 'some-integration-name',
+        spec: {
+          roleArn: 'arn:aws:iam::123456789012:role/johndoe',
+          issuerS3Bucket: 'delete-me',
+          issuerS3Prefix: 'delete-me',
+        },
+        statusCode: IntegrationStatusCode.Running,
+      }}
     />
   );
 
-  // Initial state.
-  expect(screen.queryByText(/required/i)).not.toBeInTheDocument();
-  expect(screen.queryByTestId('scriptbox')).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: /generate command/i })
+  ).not.toBeInTheDocument();
+
+  // Delete the s3 fields.
+  fireEvent.change(screen.getByPlaceholderText(/bucket/i), {
+    target: { value: '' },
+  });
+  fireEvent.change(screen.getByPlaceholderText(/prefix/i), {
+    target: { value: '' },
+  });
+  await waitFor(() =>
+    expect(
+      screen.getByRole('button', { name: /generate command/i })
+    ).toBeEnabled()
+  );
+
   expect(screen.queryByTestId('checkbox')).not.toBeInTheDocument();
   expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
-  expect(
-    screen.queryByRole('button', { name: /generate command/i })
-  ).not.toBeInTheDocument();
 
-  // Changing role arn should not render generate command.
-  fireEvent.change(screen.getByPlaceholderText(/arn:aws:iam:/i), {
-    target: { value: 'something else' },
-  });
-  expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
-  expect(
-    screen.queryByRole('button', { name: /generate command/i })
-  ).not.toBeInTheDocument();
-
-  // Changing the s3 fields should render generate command.
-  fireEvent.change(screen.getByPlaceholderText(/bucket/i), {
-    target: { value: 's3-bucket-something' },
-  });
-  fireEvent.click(screen.getByRole('button', { name: /generate command/i }));
+  userEvent.click(screen.getByRole('button', { name: /generate command/i }));
+  await screen.findByRole('button', { name: /edit/i });
   expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+
+  userEvent.click(screen.getByTestId('checkbox'));
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
+  );
+
+  // Test for warning render.
+  userEvent.click(screen.getByRole('button', { name: /save/i }));
+  await screen.findByText(/recommended to use an S3 bucket/i);
+  expect(edit).not.toHaveBeenCalled();
+  expect(
+    screen.getByText(/recommended to use an S3 bucket/i)
+  ).toBeInTheDocument();
+
+  userEvent.click(screen.getByRole('button', { name: /continue/i }));
+  await waitFor(() => expect(edit).toHaveBeenCalledTimes(1));
 });
 
 test('edit invalid fields', async () => {
@@ -131,22 +242,18 @@ test('edit invalid fields', async () => {
     target: { value: 'role something else' },
   });
 
-  fireEvent.click(screen.getByRole('button', { name: /save/i }));
-  expect(screen.getByText(/invalid role ARN format/i)).toBeInTheDocument();
+  await waitFor(() =>
+    expect(
+      screen.getByRole('button', { name: /generate command/i })
+    ).toBeEnabled()
+  );
 
-  // invalid s3 fields
-  fireEvent.change(screen.getByPlaceholderText(/bucket/i), {
-    target: { value: '' },
-  });
-  fireEvent.change(screen.getByPlaceholderText(/prefix/i), {
-    target: { value: '' },
-  });
-  fireEvent.click(screen.getByRole('button', { name: /generate command/i }));
-  expect(screen.queryAllByText(/required/i)).toHaveLength(2);
+  userEvent.click(screen.getByRole('button', { name: /generate command/i }));
+  await screen.findByText(/invalid role ARN format/i);
 });
 
-test('edit submit', async () => {
-  const mockEditFn = jest.fn();
+test('edit submit called with proper fields', async () => {
+  const mockEditFn = jest.fn(() => Promise.resolve());
   render(
     <EditAwsOidcIntegrationDialog
       close={() => null}
@@ -170,9 +277,21 @@ test('edit submit', async () => {
     target: { value: 'other-prefix' },
   });
 
-  fireEvent.click(screen.getByRole('button', { name: /generate command/i }));
-  fireEvent.click(screen.getByRole('checkbox'));
-  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+  await waitFor(() =>
+    expect(
+      screen.getByRole('button', { name: /generate command/i })
+    ).toBeEnabled()
+  );
+
+  userEvent.click(screen.getByRole('button', { name: /generate command/i }));
+  await screen.findByRole('button', { name: /edit/i });
+
+  userEvent.click(screen.getByTestId('checkbox'));
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
+  );
+  userEvent.click(screen.getByRole('button', { name: /save/i }));
+  await waitFor(() => expect(mockEditFn).toHaveBeenCalledTimes(1));
 
   expect(mockEditFn).toHaveBeenCalledWith({
     roleArn: 'arn:aws:iam::123456789011:role/other',

--- a/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.tsx
+++ b/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.tsx
@@ -25,7 +25,6 @@ import {
   Alert,
   Text,
   Box,
-  Flex,
   Link,
 } from 'design';
 import Dialog, {
@@ -38,19 +37,16 @@ import useAttempt from 'shared/hooks/useAttemptNext';
 import FieldInput from 'shared/components/FieldInput';
 import Validation, { Validator } from 'shared/components/Validation';
 import { requiredRoleArn } from 'shared/components/Validation/rules';
-import { ToolTipInfo } from 'shared/components/ToolTip';
 import { CheckboxInput } from 'design/Checkbox';
 
 import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
 import { Integration } from 'teleport/services/integrations';
 import cfg from 'teleport/config';
+import { splitAwsIamArn } from 'teleport/services/integrations/aws';
 
 import { EditableIntegrationFields } from './Operations/useIntegrationOperation';
 import { S3BucketConfiguration } from './Enroll/AwsOidc/S3BucketConfiguration';
-import {
-  getDefaultS3BucketName,
-  getDefaultS3PrefixName,
-} from './Enroll/AwsOidc/Shared/utils';
+import { S3BucketWarningBanner } from './Enroll/AwsOidc/S3BucketWarningBanner';
 
 type Props = {
   close(): void;
@@ -62,14 +58,13 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
   const { close, edit, integration } = props;
   const { attempt, run } = useAttempt();
 
+  const [showS3BucketWarning, setShowS3BucketWarning] = useState(false);
   const [roleArn, setRoleArn] = useState(integration.spec.roleArn);
   const [s3Bucket, setS3Bucket] = useState(
-    () => integration.spec.issuerS3Bucket || getDefaultS3BucketName()
+    () => integration.spec.issuerS3Bucket
   );
   const [s3Prefix, setS3Prefix] = useState(
-    () =>
-      integration.spec.issuerS3Prefix ||
-      getDefaultS3PrefixName(integration.spec.roleArn.split(':role/')[1])
+    () => integration.spec.issuerS3Prefix
   );
 
   const [scriptUrl, setScriptUrl] = useState('');
@@ -90,10 +85,12 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
 
     validator.reset();
 
-    const roleName = roleArn.split(':role/')[1];
+    const { arnResourceName } = splitAwsIamArn(
+      roleArn || props.integration.spec.roleArn
+    );
     const newScriptUrl = cfg.getAwsOidcConfigureIdpScriptUrl({
       integrationName: integration.name,
-      roleName,
+      roleName: arnResourceName,
       s3Bucket: s3Bucket,
       s3Prefix: s3Prefix,
     });
@@ -102,17 +99,29 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
   }
 
   const isProcessing = attempt.status === 'processing';
-  const requiresS3 =
-    !integration.spec.issuerS3Bucket || !integration.spec.issuerS3Prefix;
+  const requiresS3BucketWarning = !s3Bucket && !s3Prefix;
   const showGenerateCommand =
-    requiresS3 ||
     integration.spec.issuerS3Bucket !== s3Bucket ||
-    integration.spec.issuerS3Prefix !== s3Prefix;
+    integration.spec.issuerS3Prefix !== s3Prefix ||
+    integration.spec.roleArn !== roleArn;
+
+  const changeDetected =
+    integration.spec.issuerS3Bucket !== s3Bucket ||
+    integration.spec.issuerS3Prefix !== s3Prefix ||
+    integration.spec.roleArn !== roleArn;
 
   return (
     <Validation>
       {({ validator }) => (
-        <Dialog disableEscapeKeyDown={false} onClose={close} open={true}>
+        <Dialog
+          disableEscapeKeyDown={false}
+          onClose={close}
+          open={true}
+          dialogCss={() => ({
+            maxWidth: '650px',
+            width: '100%',
+          })}
+        >
           <DialogHeader>
             <DialogTitle>Edit Integration</DialogTitle>
           </DialogHeader>
@@ -125,30 +134,22 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
               value={integration.name}
               readonly={true}
             />
-            <FieldInput
-              autoFocus
-              label="Role ARN"
-              rule={requiredRoleArn}
-              value={roleArn}
-              onChange={e => setRoleArn(e.target.value)}
-              placeholder="arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>"
-              toolTipContent={
-                <Text>
-                  Role ARN can be found in the format: <br />
-                  {`arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>`}
-                </Text>
-              }
-              disabled={scriptUrl}
-            />
-            <S3BucketBox requiresS3={requiresS3} px={3} pt={2}>
-              {requiresS3 && (
-                <Flex alignItems="center" gap={1} mb={2}>
-                  <Text bold>Required</Text>
-                  <ToolTipInfo>
-                    This integration does not have Amazon S3 configured
-                  </ToolTipInfo>
-                </Flex>
-              )}
+            <EditableBox px={3} pt={2}>
+              <FieldInput
+                autoFocus
+                label="Role ARN"
+                rule={requiredRoleArn}
+                value={roleArn}
+                onChange={e => setRoleArn(e.target.value)}
+                placeholder="arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>"
+                toolTipContent={
+                  <Text>
+                    Role ARN can be found in the format: <br />
+                    {`arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>`}
+                  </Text>
+                }
+                disabled={scriptUrl}
+              />
               <S3BucketConfiguration
                 s3Bucket={s3Bucket}
                 setS3Bucket={setS3Bucket}
@@ -194,12 +195,15 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
                 <ButtonBorder
                   mb={3}
                   onClick={() => generateAwsOidcConfigIdpScript(validator)}
-                  disabled={!s3Bucket || !s3Prefix || !roleArn}
+                  disabled={
+                    (!requiresS3BucketWarning && (!s3Bucket || !s3Prefix)) ||
+                    !roleArn
+                  }
                 >
                   Generate Command
                 </ButtonBorder>
               )}
-            </S3BucketBox>
+            </EditableBox>
           </DialogContent>
           <DialogFooter>
             {showGenerateCommand && scriptUrl && (
@@ -217,22 +221,40 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
                 I have ran the command
               </Box>
             )}
-            <ButtonPrimary
-              mr="3"
-              disabled={
-                isProcessing ||
-                (showGenerateCommand && !confirmed) ||
-                (roleArn === integration.spec.roleArn &&
-                  s3Bucket === integration.spec.issuerS3Bucket &&
-                  s3Prefix === integration.spec.issuerS3Prefix)
-              }
-              onClick={() => handleEdit(validator)}
-            >
-              Save
-            </ButtonPrimary>
-            <ButtonSecondary disabled={isProcessing} onClick={close}>
-              Cancel
-            </ButtonSecondary>
+
+            {requiresS3BucketWarning && showS3BucketWarning ? (
+              <S3BucketWarningBanner
+                onClose={() => setShowS3BucketWarning(false)}
+                onContinue={() => {
+                  setShowS3BucketWarning(false);
+                  handleEdit(validator);
+                }}
+                btnFlexWrap={true}
+              />
+            ) : (
+              <>
+                <ButtonPrimary
+                  mr="3"
+                  disabled={
+                    isProcessing ||
+                    (showGenerateCommand && !confirmed) ||
+                    !changeDetected
+                  }
+                  onClick={() => {
+                    if (requiresS3BucketWarning) {
+                      setShowS3BucketWarning(true);
+                    } else {
+                      handleEdit(validator);
+                    }
+                  }}
+                >
+                  Save
+                </ButtonPrimary>
+                <ButtonSecondary disabled={isProcessing} onClick={close}>
+                  Cancel
+                </ButtonSecondary>
+              </>
+            )}
           </DialogFooter>
         </Dialog>
       )}
@@ -240,19 +262,8 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
   );
 }
 
-const S3BucketBox = styled(Box)`
+const EditableBox = styled(Box)`
   border-radius: ${p => p.theme.space[1]}px;
-  border: 2px solid
-    ${p => {
-      if (p.requiresS3) {
-        return p.theme.colors.warning.main;
-      }
-      return p.theme.colors.spotBackground[1];
-    }};
-  background-color: ${p => {
-    if (p.requiresS3) {
-      return p.theme.colors.interactive.tonal.alert[0];
-    }
-    return p.theme.colors.spotBackground[0];
-  }};
+  border: 2px solid ${p => p.theme.colors.spotBackground[1]};
+  background-color: ${p => p.theme.colors.spotBackground[0]};
 `;

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.story.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.story.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { AwsOidc } from './AwsOidc';
+import { S3BucketWarningBanner } from './S3BucketWarningBanner';
 
 export default {
   title: 'Teleport/Integrations/Enroll/AwsOidc',
@@ -27,4 +28,16 @@ export const Flow = () => (
   <MemoryRouter>
     <AwsOidc />
   </MemoryRouter>
+);
+
+export const SBucketWarning = () => (
+  <S3BucketWarningBanner onClose={() => null} onContinue={() => null} />
+);
+
+export const SBucketWarningWithReview = () => (
+  <S3BucketWarningBanner
+    onClose={() => null}
+    onContinue={() => null}
+    reviewing={true}
+  />
 );

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.tsx
@@ -18,7 +18,15 @@ import React, { useEffect, useState } from 'react';
 import { Link as InternalRouteLink } from 'react-router-dom';
 import { useLocation } from 'react-router';
 import styled from 'styled-components';
-import { Box, ButtonSecondary, Text, Link, Flex, ButtonPrimary } from 'design';
+import {
+  Box,
+  ButtonSecondary,
+  Text,
+  Link,
+  Flex,
+  ButtonPrimary,
+  ButtonText,
+} from 'design';
 import * as Icons from 'design/Icon';
 import FieldInput from 'shared/components/FieldInput';
 import { requiredIamRoleName } from 'shared/components/Validation/rules';
@@ -49,6 +57,7 @@ import {
   requiredPrefixName,
   validPrefixNameToolTipContent,
 } from './Shared/utils';
+import { S3BucketWarningBanner } from './S3BucketWarningBanner';
 
 export function AwsOidc() {
   const [integrationName, setIntegrationName] = useState('');
@@ -57,6 +66,9 @@ export function AwsOidc() {
   const [scriptUrl, setScriptUrl] = useState('');
   const [s3Bucket, setS3Bucket] = useState(() => getDefaultS3BucketName());
   const [s3Prefix, setS3Prefix] = useState('');
+  const [showS3BucketWarning, setShowS3BucketWarning] = useState(false);
+  const [confirmedS3BucketWarning, setConfirmedS3BucketWarning] =
+    useState(false);
   const [createdIntegration, setCreatedIntegration] = useState<Integration>();
   const { attempt, run } = useAttempt('');
 
@@ -66,6 +78,8 @@ export function AwsOidc() {
     id: crypto.randomUUID(),
     kind: IntegrationEnrollKind.AwsOidc,
   });
+
+  const requiresS3BucketWarning = !s3Bucket && !s3Prefix;
 
   useEffect(() => {
     // If a user came from the discover wizard,
@@ -164,10 +178,9 @@ export function AwsOidc() {
           <>
             <Container mb={5}>
               <Text bold>Step 1</Text>
-
               <Box width="600px">
                 <FieldInput
-                  rule={requiredPrefixName}
+                  rule={requiredPrefixName(true)}
                   autoFocus={true}
                   value={integrationName}
                   label="Give this AWS integration a name"
@@ -175,6 +188,9 @@ export function AwsOidc() {
                   onChange={e => setIntegrationName(e.target.value)}
                   disabled={!!scriptUrl}
                   onBlur={() => {
+                    // s3Bucket by default is defined.
+                    // If empty user intentionally cleared it.
+                    if (!integrationName || (!s3Bucket && !s3Prefix)) return;
                     // Help come up with a default prefix name for user.
                     if (!s3Prefix) {
                       setS3Prefix(`${integrationName}-oidc-idp`);
@@ -198,14 +214,49 @@ export function AwsOidc() {
                   disabled={!!scriptUrl}
                 />
               </Box>
-              {scriptUrl ? (
-                <ButtonSecondary mb={3} onClick={() => setScriptUrl('')}>
+              {confirmedS3BucketWarning && (
+                <Box>
+                  <ButtonText
+                    pl={0}
+                    gap={2}
+                    onClick={() => setShowS3BucketWarning(true)}
+                    alignItems="center"
+                  >
+                    <Icons.Warning size="small" color="warning.main" />
+                    <Text fontSize={1}>Click to view S3 Bucket Warning</Text>
+                  </ButtonText>
+                </Box>
+              )}
+              {showS3BucketWarning ? (
+                <S3BucketWarningBanner
+                  onClose={() => setShowS3BucketWarning(false)}
+                  onContinue={() => {
+                    setShowS3BucketWarning(false);
+                    setConfirmedS3BucketWarning(true);
+                    generateAwsOidcConfigIdpScript(validator);
+                  }}
+                  reviewing={confirmedS3BucketWarning}
+                />
+              ) : scriptUrl ? (
+                <ButtonSecondary
+                  mb={3}
+                  onClick={() => {
+                    setScriptUrl('');
+                    setConfirmedS3BucketWarning(false);
+                  }}
+                >
                   Edit
                 </ButtonSecondary>
               ) : (
                 <ButtonSecondary
                   mb={3}
-                  onClick={() => generateAwsOidcConfigIdpScript(validator)}
+                  onClick={() => {
+                    if (requiresS3BucketWarning) {
+                      setShowS3BucketWarning(true);
+                    } else {
+                      generateAwsOidcConfigIdpScript(validator);
+                    }
+                  }}
                 >
                   Generate Command
                 </ButtonSecondary>
@@ -215,7 +266,6 @@ export function AwsOidc() {
               <>
                 <Container mb={5}>
                   <Text bold>Step 2</Text>
-                  Configure the required permission in your AWS account.
                   <Text mb={2}>
                     Open{' '}
                     <Link

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/S3BucketConfiguration.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/S3BucketConfiguration.tsx
@@ -52,7 +52,7 @@ export function S3BucketConfiguration({
       </Flex>
       <Flex gap={3}>
         <FieldInput
-          rule={requiredBucketName}
+          rule={requiredBucketName(Boolean(s3Bucket || s3Prefix))}
           value={s3Bucket}
           placeholder="bucket"
           label="Bucket Name"
@@ -67,7 +67,7 @@ export function S3BucketConfiguration({
           }
         />
         <FieldInput
-          rule={requiredPrefixName}
+          rule={requiredPrefixName(Boolean(s3Bucket || s3Prefix))}
           value={s3Prefix}
           placeholder="prefix"
           label="Bucket's Prefix Name"

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/S3BucketWarningBanner.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/S3BucketWarningBanner.tsx
@@ -1,0 +1,67 @@
+import { ButtonText, Box, Text, Flex, ButtonBorder } from 'design';
+import { OutlineWarn } from 'design/Alert/Alert';
+import { Notification } from 'design/Icon';
+import styled from 'styled-components';
+
+export const S3BucketWarningBanner = ({
+  onClose,
+  onContinue,
+  reviewing = false,
+  btnFlexWrap = false,
+}: {
+  onClose(): void;
+  onContinue(): void;
+  reviewing?: boolean;
+  btnFlexWrap?: boolean;
+}) => {
+  return (
+    <OutlineWarn css={{ justifyContent: 'normal', margin: 0 }}>
+      <Box>
+        <BellIcon size={18} />
+      </Box>
+      <Flex gap={2}>
+        <Box>
+          <Text mb={2}>
+            It is recommended to use an S3 bucket to host the public keys.
+          </Text>
+          <Text>
+            Without an S3 bucket, you will be required to append the new
+            certificate's thumbprint in the AWS IAM/Identity Provider section
+            after you have renewed and started using the new certificate.
+          </Text>
+        </Box>
+        <Flex
+          gap={3}
+          alignItems="center"
+          css={
+            btnFlexWrap ? { justifyContent: 'center', flexWrap: 'wrap' } : ``
+          }
+        >
+          {reviewing ? (
+            <ButtonBorder onClick={onClose} width="80px">
+              Ok
+            </ButtonBorder>
+          ) : (
+            <>
+              <ButtonBorder onClick={onContinue} width="130px">
+                Continue
+              </ButtonBorder>
+              <ButtonText onClick={onClose} width="100px">
+                Cancel
+              </ButtonText>
+            </>
+          )}
+        </Flex>
+      </Flex>
+    </OutlineWarn>
+  );
+};
+
+const BellIcon = styled(Notification)`
+  background-color: ${p => p.theme.colors.warning.hover};
+  border-radius: 100px;
+  height: 32px;
+  width: 32px;
+  color: ${p => p.theme.colors.text.primaryInverse};
+  margin-right: ${p => p.theme.space[3]}px;
+`;

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/S3BucketWarningBanner.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/S3BucketWarningBanner.tsx
@@ -1,3 +1,21 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { ButtonText, Box, Text, Flex, ButtonBorder } from 'design';
 import { OutlineWarn } from 'design/Alert/Alert';
 import { Notification } from 'design/Icon';

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/Shared/utils.test.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/Shared/utils.test.ts
@@ -48,6 +48,7 @@ test('getDefaultS3PrefixName', () => {
 });
 
 describe('requiredPrefixName', () => {
+  const requiredField = true;
   test.each`
     input                         | valid
     ${''}                         | ${false}
@@ -61,8 +62,13 @@ describe('requiredPrefixName', () => {
     ${'sdlfkjs/dfsd'}             | ${false}
     ${'Asd09f-_.sdfDFs1'}         | ${true}
   `('validity of input($input) should be ($valid)', ({ input, valid }) => {
-    const result = requiredPrefixName(input)();
+    const result = requiredPrefixName(requiredField)(input)();
     expect(result.valid).toEqual(valid);
+  });
+
+  test('empty prefix name is valid if not a required field', () => {
+    const requiredField = false;
+    expect(requiredPrefixName(requiredField)('')().valid).toBeTruthy();
   });
 });
 
@@ -83,7 +89,13 @@ describe('requiredBucketName', () => {
     ${'Asd09f-sdfDFs1'}           | ${false}
     ${'sdf0-dfs0'}                | ${true}
   `('validity of input($input) should be ($valid)', ({ input, valid }) => {
-    const result = requiredBucketName(input)();
+    const requiredField = true;
+    const result = requiredBucketName(requiredField)(input)();
     expect(result.valid).toEqual(valid);
+  });
+
+  test('empty bucket name is valid if not a required field', () => {
+    const requiredField = false;
+    expect(requiredBucketName(requiredField)('')().valid).toBeTruthy();
   });
 });

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/Shared/utils.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/Shared/utils.ts
@@ -23,98 +23,104 @@ import cfg from 'teleport/config';
 // Must start and end with lowercase letters or numbers.
 // Can have hyphens in between start and end.
 const bucketNameRegex = new RegExp(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
-export const requiredBucketName: Rule = inputVal => () => {
-  if (!inputVal) {
-    return {
-      valid: false,
-      message: 'required',
-    };
-  }
+export const requiredBucketName =
+  (required): Rule =>
+  inputVal =>
+  () => {
+    if (!inputVal) {
+      return {
+        valid: !required,
+        message: required ? 'required' : '',
+      };
+    }
 
-  if (inputVal.length < 3 || inputVal.length > 63) {
-    return {
-      valid: false,
-      message: 'name should be 3-63 characters',
-    };
-  }
+    if (inputVal.length < 3 || inputVal.length > 63) {
+      return {
+        valid: false,
+        message: 'name should be 3-63 characters',
+      };
+    }
 
-  if (!bucketNameRegex.test(inputVal)) {
-    return {
-      valid: false,
-      message: 'name is in a invalid format',
-    };
-  }
+    if (!bucketNameRegex.test(inputVal)) {
+      return {
+        valid: false,
+        message: 'name is in a invalid format',
+      };
+    }
 
-  if (inputVal.startsWith('xn--')) {
-    return {
-      valid: false,
-      message: 'cannot start with "xn--"',
-    };
-  }
+    if (inputVal.startsWith('xn--')) {
+      return {
+        valid: false,
+        message: 'cannot start with "xn--"',
+      };
+    }
 
-  if (inputVal.startsWith('sthree-')) {
-    return {
-      valid: false,
-      message: 'cannot start with "sthree-"',
-    };
-  }
+    if (inputVal.startsWith('sthree-')) {
+      return {
+        valid: false,
+        message: 'cannot start with "sthree-"',
+      };
+    }
 
-  if (inputVal.startsWith('sthree-configurator')) {
-    return {
-      valid: false,
-      message: 'cannot start with "sthree-configurator"',
-    };
-  }
+    if (inputVal.startsWith('sthree-configurator')) {
+      return {
+        valid: false,
+        message: 'cannot start with "sthree-configurator"',
+      };
+    }
 
-  if (inputVal.endsWith('-s3alias')) {
-    return {
-      valid: false,
-      message: 'cannot end with "-s3alias"',
-    };
-  }
+    if (inputVal.endsWith('-s3alias')) {
+      return {
+        valid: false,
+        message: 'cannot end with "-s3alias"',
+      };
+    }
 
-  if (inputVal.endsWith('--ol-s3')) {
-    return {
-      valid: false,
-      message: 'cannot end with "--ol-s3"',
-    };
-  }
+    if (inputVal.endsWith('--ol-s3')) {
+      return {
+        valid: false,
+        message: 'cannot end with "--ol-s3"',
+      };
+    }
 
-  return {
-    valid: true,
+    return {
+      valid: true,
+    };
   };
-};
 
 // Must start and end with letters or numbers.
 // Can have hyphens, underscores, and periods in between start and end.
 const prefixNameRegex = new RegExp(/^[a-zA-Z0-9][a-zA-Z0-9-_.]*[a-zA-Z0-9]$/);
-export const requiredPrefixName: Rule = inputVal => () => {
-  if (!inputVal) {
-    return {
-      valid: false,
-      message: 'required',
-    };
-  }
+export const requiredPrefixName =
+  (required): Rule =>
+  inputVal =>
+  () => {
+    if (!inputVal) {
+      return {
+        valid: !required,
+        message: required ? 'required' : '',
+      };
+    }
 
-  // Just a random hard cap.
-  if (inputVal.length > 63) {
-    return {
-      valid: false,
-      message: 'name can be max 63 characters long',
-    };
-  }
+    // Just a random hard cap.
+    if (inputVal.length > 63) {
+      return {
+        valid: false,
+        message: 'name can be max 63 characters long',
+      };
+    }
 
-  if (!prefixNameRegex.test(inputVal)) {
-    return {
-      valid: false,
-      message: 'name is in a invalid format',
-    };
-  }
+    if (!prefixNameRegex.test(inputVal)) {
+      return {
+        valid: false,
+        message: 'name is in a invalid format',
+      };
+    }
 
-  return {
-    valid: true,
+    return {
+      valid: true,
+    };
   };
-};
 
 export function getDefaultS3BucketName() {
   const modifiedClusterName = cfg.proxyCluster.replaceAll('.', '-');

--- a/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, screen, userEvent } from 'design/utils/testing';
+
+import {
+  IntegrationKind,
+  integrationService,
+  IntegrationStatusCode,
+} from 'teleport/services/integrations';
+
+import { IntegrationList } from './IntegrationList';
+
+test('aws oidc row without s3 fields should render tooltip', async () => {
+  jest
+    .spyOn(integrationService, 'fetchThumbprint')
+    .mockResolvedValue('some-thumbprint');
+
+  render(
+    <IntegrationList
+      list={[
+        {
+          resourceType: 'integration',
+          name: 'aws',
+          kind: IntegrationKind.AwsOidc,
+          statusCode: IntegrationStatusCode.Running,
+          spec: { roleArn: '', issuerS3Prefix: '', issuerS3Bucket: '' },
+        },
+      ]}
+    />
+  );
+
+  expect(screen.getByText('aws')).toBeInTheDocument();
+  expect(screen.getByText(/running/i)).toBeInTheDocument();
+  await userEvent.hover(screen.getByRole('icon'));
+  expect(screen.queryByTestId('btn-copy')).not.toBeInTheDocument();
+
+  await userEvent.click(screen.getByText(/generate a new thumbprint/i));
+  expect(screen.getByText(/some-thumbprint/i)).toBeInTheDocument();
+});
+
+test('aws oidc row with s3 fields should NOT render tooltip', async () => {
+  jest
+    .spyOn(integrationService, 'fetchThumbprint')
+    .mockResolvedValue('some-thumbprint');
+
+  render(
+    <IntegrationList
+      list={[
+        {
+          resourceType: 'integration',
+          name: 'aws',
+          kind: IntegrationKind.AwsOidc,
+          statusCode: IntegrationStatusCode.Running,
+          spec: {
+            roleArn: 'some-role-arn',
+            issuerS3Prefix: 'some-prefix',
+            issuerS3Bucket: 'some-bucket',
+          },
+        },
+      ]}
+    />
+  );
+
+  expect(screen.getByText('aws')).toBeInTheDocument();
+  expect(screen.getByText(/running/i)).toBeInTheDocument();
+  expect(screen.queryByRole('icon')).not.toBeInTheDocument();
+});

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
+import { Link as InternalRouteLink } from 'react-router-dom';
 
 import { Box, Flex, Image } from 'design';
 import { AWSIcon } from 'design/SVGIcon';
@@ -48,6 +48,7 @@ import {
 import cfg from 'teleport/config';
 
 import { ExternalAuditStorageOpType } from './Operations/useIntegrationOperation';
+import { UpdateAwsOidcThumbprint } from './UpdateAwsOidcThumbprint';
 
 type Props<IntegrationLike> = {
   list: IntegrationLike[];
@@ -136,7 +137,7 @@ export function IntegrationList(props: Props<IntegrationLike>) {
                 <Cell align="right">
                   <MenuButton>
                     <MenuItem
-                      as={Link}
+                      as={InternalRouteLink}
                       to={{
                         pathname: cfg.getIntegrationEnrollRoute(
                           IntegrationKind.ExternalAuditStorage
@@ -181,6 +182,8 @@ export function IntegrationList(props: Props<IntegrationLike>) {
 }
 
 const StatusCell = ({ item }: { item: IntegrationLike }) => {
+  const status = getStatus(item);
+
   if (
     item.resourceType === 'integration' &&
     item.kind === IntegrationKind.AwsOidc &&
@@ -189,21 +192,16 @@ const StatusCell = ({ item }: { item: IntegrationLike }) => {
     return (
       <Cell>
         <Flex alignItems="center">
-          <StatusLight status={Status.Warning} />
-          Integration needs updating
+          <StatusLight status={status} />
+          {getStatusCodeTitle(item.statusCode)}
           <Box mx="1">
-            <ToolTipInfo>
-              Requires setting up a Amazon S3 Bucket. Click on 'OPTIONS' and
-              'Edit...' and fill out the 'S3 Location' input fields.
-            </ToolTipInfo>
+            <UpdateAwsOidcThumbprint integration={item} />
           </Box>
         </Flex>
       </Cell>
     );
   }
-  const status = getStatus(item);
   const statusDescription = getStatusCodeDescription(item.statusCode);
-
   return (
     <Cell>
       <Flex alignItems="center">

--- a/web/packages/teleport/src/Integrations/Integrations.story.tsx
+++ b/web/packages/teleport/src/Integrations/Integrations.story.tsx
@@ -24,6 +24,7 @@ import {
 import { IntegrationList } from './IntegrationList';
 import { DeleteIntegrationDialog } from './RemoveIntegrationDialog';
 import { EditAwsOidcIntegrationDialog } from './EditAwsOidcIntegrationDialog';
+import { UpdateAwsOidcThumbprint } from './UpdateAwsOidcThumbprint';
 import { plugins, integrations } from './fixtures';
 
 export default {
@@ -32,6 +33,20 @@ export default {
 
 export function List() {
   return <IntegrationList list={[...plugins, ...integrations]} />;
+}
+
+export function UpdateAwsOidcThumbprintHoverTooltip() {
+  return (
+    <UpdateAwsOidcThumbprint
+      integration={{
+        resourceType: 'integration',
+        name: 'aws',
+        kind: IntegrationKind.AwsOidc,
+        statusCode: IntegrationStatusCode.Running,
+        spec: { roleArn: '', issuerS3Prefix: '', issuerS3Bucket: '' },
+      }}
+    />
+  );
 }
 
 export function DeleteDialog() {

--- a/web/packages/teleport/src/Integrations/UpdateAwsOidcThumbprint.tsx
+++ b/web/packages/teleport/src/Integrations/UpdateAwsOidcThumbprint.tsx
@@ -1,0 +1,123 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState } from 'react';
+import styled from 'styled-components';
+import { Text, Link as ExternalLink, Flex, Box, ButtonPrimary } from 'design';
+import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
+import { ToolTipInfo } from 'shared/components/ToolTip';
+import useAttempt from 'shared/hooks/useAttemptNext';
+import * as Icons from 'design/Icon';
+
+import { Mark } from 'teleport/Discover/Shared';
+import {
+  Integration,
+  integrationService,
+} from 'teleport/services/integrations';
+import { splitAwsIamArn } from 'teleport/services/integrations/aws';
+import cfg from 'teleport/config';
+
+export function UpdateAwsOidcThumbprint({
+  integration,
+}: {
+  integration: Integration;
+}) {
+  const { attempt, run } = useAttempt();
+
+  const [thumbprint, setThumbprint] = useState('');
+
+  function getThumbprint() {
+    run(() => integrationService.fetchThumbprint().then(setThumbprint));
+  }
+
+  const { awsAccountId, arnStartingPart } = splitAwsIamArn(
+    integration.spec.roleArn
+  );
+
+  const encodedOidcProviderArn = encodeURIComponent(
+    `${arnStartingPart}${awsAccountId}:oidc-provider/${cfg.proxyCluster}`
+  );
+
+  return (
+    <ToolTipInfo sticky={true}>
+      <Box py={1}>
+        <Flex gap={2} flexDirection="column" mb={2}>
+          <Text>
+            This integration has no S3 bucket configured. When renewing your
+            HTTPS certificate, if it has a different CA, a manual update of this
+            integration's thumbprint is required.
+          </Text>
+          <Text>You may run into issues when the thumbprint is stale.</Text>
+        </Flex>
+        <Box mb={3} mt={1}>
+          <ButtonPrimary
+            onClick={getThumbprint}
+            size="medium"
+            width="100%"
+            disabled={attempt.status === 'processing'}
+          >
+            Generate a New Thumbprint
+          </ButtonPrimary>
+          <Box mt={2}>
+            {thumbprint && (
+              <TextSelectCopyMulti
+                bash={false}
+                lines={[
+                  {
+                    text: thumbprint,
+                  },
+                ]}
+              />
+            )}
+            {attempt.status === 'failed' && (
+              <Flex mt={1}>
+                <Icons.Warning size="small" color="error.main" mr={1} /> Error
+                fetching thumbprint: some kind of error
+              </Flex>
+            )}
+          </Box>
+        </Box>
+
+        <Ul>
+          <Text bold>To update thumbprint:</Text>
+          <li>
+            - Go to your{' '}
+            <ExternalLink
+              target="_blank"
+              href={`https://console.aws.amazon.com/iam/home#/identity_providers/details/OPENID/${encodedOidcProviderArn}`}
+            >
+              IAM Identity Provider
+            </ExternalLink>{' '}
+            dashboard
+          </li>
+          <li>
+            - On <Mark>Thumbprints</Mark> section click on <Mark>Manage</Mark>{' '}
+            then click on <Mark>Add Thumbprint</Mark>
+          </li>
+          <li>- Copy and paste the generated thumbprint</li>
+        </Ul>
+      </Box>
+    </ToolTipInfo>
+  );
+}
+
+const Ul = styled.ul`
+  margin-left: 0;
+  padding-left: 0;
+  list-style: none;
+`;

--- a/web/packages/teleport/src/Integrations/UpdateAwsOidcThumbprint.tsx
+++ b/web/packages/teleport/src/Integrations/UpdateAwsOidcThumbprint.tsx
@@ -19,7 +19,6 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { Text, Link as ExternalLink, Flex, Box, ButtonPrimary } from 'design';
-import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
 import { ToolTipInfo } from 'shared/components/ToolTip';
 import useAttempt from 'shared/hooks/useAttemptNext';
 import * as Icons from 'design/Icon';
@@ -31,6 +30,7 @@ import {
 } from 'teleport/services/integrations';
 import { splitAwsIamArn } from 'teleport/services/integrations/aws';
 import cfg from 'teleport/config';
+import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
 
 export function UpdateAwsOidcThumbprint({
   integration,

--- a/web/packages/teleport/src/config.test.ts
+++ b/web/packages/teleport/src/config.test.ts
@@ -34,7 +34,7 @@ test('getDeployServiceIamConfigureScriptPath formatting', async () => {
   );
 });
 
-test('getAwsOidcConfigureIdpScriptUrl formatting', async () => {
+test('getAwsOidcConfigureIdpScriptUrl formatting with s3 fields', async () => {
   const params: UrlAwsOidcConfigureIdp = {
     integrationName: 'int-name',
     roleName: 'role-arn',
@@ -44,6 +44,19 @@ test('getAwsOidcConfigureIdpScriptUrl formatting', async () => {
   const base =
     'http://localhost/webapi/scripts/integrations/configure/awsoidc-idp.sh?';
   const expected = `integrationName=int-name&role=role-arn&s3Bucket=s3-bucket&s3Prefix=s3-prefix`;
+  expect(cfg.getAwsOidcConfigureIdpScriptUrl(params)).toBe(
+    `${base}${expected}`
+  );
+});
+
+test('getAwsOidcConfigureIdpScriptUrl formatting, without s3 fields', async () => {
+  const params: UrlAwsOidcConfigureIdp = {
+    integrationName: 'int-name',
+    roleName: 'role-arn',
+  };
+  const base =
+    'http://localhost/webapi/scripts/integrations/configure/awsoidc-idp.sh?';
+  const expected = `integrationName=int-name&role=role-arn`;
   expect(cfg.getAwsOidcConfigureIdpScriptUrl(params)).toBe(
     `${base}${expected}`
   );

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -263,7 +263,7 @@ const cfg = {
     thumbprintPath: '/v1/webapi/thumbprint',
 
     awsConfigureIamScriptOidcIdpPath:
-      '/webapi/scripts/integrations/configure/awsoidc-idp.sh?integrationName=:integrationName&role=:roleName&s3Bucket=:s3Bucket&s3Prefix=:s3Prefix',
+      '/webapi/scripts/integrations/configure/awsoidc-idp.sh?integrationName=:integrationName&role=:roleName',
     awsConfigureIamScriptDeployServicePath:
       '/webapi/scripts/integrations/configure/deployservice-iam.sh?integrationName=:integrationName&awsRegion=:region&role=:awsOidcRoleArn&taskRole=:taskRoleArn',
     awsConfigureIamScriptListDatabasesPath:
@@ -437,10 +437,11 @@ const cfg = {
   },
 
   getAwsOidcConfigureIdpScriptUrl(p: UrlAwsOidcConfigureIdp) {
-    return (
-      cfg.baseUrl +
-      generatePath(cfg.api.awsConfigureIamScriptOidcIdpPath, { ...p })
-    );
+    let path = cfg.api.awsConfigureIamScriptOidcIdpPath;
+    if (p.s3Bucket && p.s3Prefix) {
+      path += '&s3Bucket=:s3Bucket&s3Prefix=:s3Prefix';
+    }
+    return cfg.baseUrl + generatePath(path, { ...p });
   },
 
   getDbScriptUrl(token: string) {
@@ -1075,8 +1076,8 @@ export interface UrlDeployServiceIamConfigureScriptParams {
 export interface UrlAwsOidcConfigureIdp {
   integrationName: string;
   roleName: string;
-  s3Bucket: string;
-  s3Prefix: string;
+  s3Bucket?: string;
+  s3Prefix?: string;
 }
 
 export interface UrlAwsConfigureIamScriptParams {

--- a/web/packages/teleport/src/services/integrations/aws.test.ts
+++ b/web/packages/teleport/src/services/integrations/aws.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { splitAwsIamArn } from './aws';
+
+describe('splitAwsIamArn', () => {
+  it.each([
+    {
+      name: 'with default partition',
+      arn: 'arn:aws:iam::123456789012:role/johndoe',
+      expected: {
+        awsAccountId: '123456789012',
+        arnStartingPart: 'arn:aws:iam::',
+        arnResourceName: 'johndoe',
+      },
+    },
+    {
+      name: 'with china partition',
+      arn: 'arn:aws-cn:iam::123456789012:role/johndoe',
+      expected: {
+        awsAccountId: '123456789012',
+        arnStartingPart: 'arn:aws-cn:iam::',
+        arnResourceName: 'johndoe',
+      },
+    },
+    {
+      name: 'with us gov partition',
+      arn: 'arn:aws-us-gov:iam::123456789012:role/johndoe',
+      expected: {
+        awsAccountId: '123456789012',
+        arnStartingPart: 'arn:aws-us-gov:iam::',
+        arnResourceName: 'johndoe',
+      },
+    },
+  ])('$name', ({ arn, expected }) => {
+    const result = splitAwsIamArn(arn);
+
+    expect(result).toStrictEqual(expected);
+  });
+});

--- a/web/packages/teleport/src/services/integrations/aws.ts
+++ b/web/packages/teleport/src/services/integrations/aws.ts
@@ -1,0 +1,66 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export const AWS_IAM_ARN_DEFAULT_PARTITION = 'arn:aws:iam::';
+export const AWS_IAM_ARN_CHINA_PARTITION = 'arn:aws-cn:iam::';
+export const AWS_IAM_ARN_USGOV_PARTITION = 'arn:aws-us-gov:iam::';
+
+/**
+ * @returns
+ *   - awsAccountId: the 12 digit aws account Id
+ *   - arnStartingPart: starting part is returned in the format
+ *    "arn:\<partition\>:iam::"
+ *   - arnResourceName: is the resource name in the resource part
+ *     of arn: <resource-type>/<this-user-defined-resource-name>
+ */
+export function splitAwsIamArn(arn: string): {
+  awsAccountId: string;
+  arnStartingPart: string;
+  arnResourceName: string;
+} {
+  if (!arn) {
+    return {
+      awsAccountId: '',
+      arnStartingPart: '',
+      arnResourceName: '',
+    };
+  }
+
+  let awsAccountId: string;
+  let arnStartingPart: string;
+  let splitted: string[] = [];
+
+  if (arn.startsWith(AWS_IAM_ARN_DEFAULT_PARTITION)) {
+    arnStartingPart = AWS_IAM_ARN_DEFAULT_PARTITION;
+    splitted = arn.split(AWS_IAM_ARN_DEFAULT_PARTITION);
+  } else if (arn.startsWith(AWS_IAM_ARN_CHINA_PARTITION)) {
+    arnStartingPart = AWS_IAM_ARN_CHINA_PARTITION;
+    splitted = arn.split(AWS_IAM_ARN_CHINA_PARTITION);
+  } else if (arn.startsWith(AWS_IAM_ARN_USGOV_PARTITION)) {
+    arnStartingPart = AWS_IAM_ARN_USGOV_PARTITION;
+    splitted = arn.split(AWS_IAM_ARN_USGOV_PARTITION);
+  }
+
+  awsAccountId = splitted[1]?.substring(0, 12) ?? '';
+
+  return {
+    awsAccountId,
+    arnStartingPart,
+    arnResourceName: splitted[1]?.substring(12).replace(/^(:role\/)/, ''),
+  };
+}


### PR DESCRIPTION
backport of #40145 to branch/v14

manual because conflict with `Alert.jsx` (missing backport for one of banner style) and a conflict with a import line

changelog: Amazon S3 fields are now optional when creating or editing AWS OIDC integration on the web UI