### PR TITLE
Modify lib/devicetrust/authn to return the DeviceConfirmationToken

### DIFF
--- a/lib/devicetrust/authn/authn.go
+++ b/lib/devicetrust/authn/authn.go
@@ -72,44 +72,63 @@ func (c *Ceremony) Run(
 		return nil, trace.BadParameter("certs required")
 	}
 
-	newCerts, err := c.run(ctx, devicesClient, &devicepb.AuthenticateDeviceInit{
+	resp, err := c.run(ctx, devicesClient, &devicepb.AuthenticateDeviceInit{
 		UserCertificates: &devicepb.UserCertificates{
 			// Forward only the SSH certificate, the TLS identity is part of the
 			// connection.
 			SshAuthorizedKey: certs.SshAuthorizedKey,
 		},
 	})
-	return newCerts, trace.Wrap(err)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	newCerts := resp.GetUserCertificates()
+	if newCerts == nil {
+		return nil, trace.BadParameter("unexpected payload from server, expected UserCertificates: %T", resp.Payload)
+	}
+
+	return newCerts, nil
 }
 
 // RunWeb performs on-behalf-of device authentication. It exchanges a webToken
 // issued for the Web UI for a device authentication attempt.
 //
-// On success the WebSession certificates, for the session associated to
-// webToken, are augmented with device extensions.
+// On success a [devicepb.DeviceConfirmationToken] is issued. To complete
+// authentication the browser that originated the attempt must forward the token
+// to the /webapi/device/webconfirm endpoint.
 func (c *Ceremony) RunWeb(
 	ctx context.Context,
 	devicesClient devicepb.DeviceTrustServiceClient,
 	webToken *devicepb.DeviceWebToken,
-) error {
+) (*devicepb.DeviceConfirmationToken, error) {
 	switch {
 	case devicesClient == nil:
-		return trace.BadParameter("devicesClient required")
+		return nil, trace.BadParameter("devicesClient required")
 	case webToken == nil:
-		return trace.BadParameter("webToken required")
+		return nil, trace.BadParameter("webToken required")
 	}
 
-	_, err := c.run(ctx, devicesClient, &devicepb.AuthenticateDeviceInit{
+	resp, err := c.run(ctx, devicesClient, &devicepb.AuthenticateDeviceInit{
 		DeviceWebToken: webToken,
 	})
-	return trace.Wrap(err)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	confirmToken := resp.GetConfirmationToken()
+	if confirmToken == nil {
+		return nil, trace.BadParameter("unexpected payload from server, expected ConfirmationToken: %T", resp.Payload)
+	}
+
+	return confirmToken, trace.Wrap(err)
 }
 
 func (c *Ceremony) run(
 	ctx context.Context,
 	devicesClient devicepb.DeviceTrustServiceClient,
 	init *devicepb.AuthenticateDeviceInit,
-) (*devicepb.UserCertificates, error) {
+) (*devicepb.AuthenticateDeviceResponse, error) {
 	// Fetch device data early, this automatically excludes unsupported platforms
 	// and unenrolled devices.
 	cred, err := c.GetDeviceCredential()
@@ -160,17 +179,9 @@ func (c *Ceremony) run(
 		return nil, trace.Wrap(err)
 	}
 
+	// 3. Success (either UserCertificates or DeviceConfirmationToken).
 	resp, err = stream.Recv()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// 3. User certificates.
-	newCerts := resp.GetUserCertificates()
-	if newCerts == nil {
-		return nil, trace.BadParameter("unexpected payload from server, expected UserCertificates: %T", resp.Payload)
-	}
-	return newCerts, nil
+	return resp, trace.Wrap(err)
 }
 
 func (c *Ceremony) authenticateDeviceMacOS(

--- a/lib/devicetrust/authn/authn_test.go
+++ b/lib/devicetrust/authn/authn_test.go
@@ -122,7 +122,7 @@ func TestCeremony_RunWeb(t *testing.T) {
 	runError := func(t *testing.T, wantErr string, dev testenv.FakeDevice, webToken *devicepb.DeviceWebToken) {
 		t.Helper()
 
-		err := newAuthnCeremony(dev).RunWeb(ctx, devicesClient, webToken)
+		_, err := newAuthnCeremony(dev).RunWeb(ctx, devicesClient, webToken)
 		assert.ErrorContains(t, err, wantErr, "RunWeb expected to fail")
 	}
 
@@ -178,10 +178,9 @@ func TestCeremony_RunWeb(t *testing.T) {
 		})
 		require.NoError(t, err, "CreateDeviceWebTokenForTesting failed")
 
-		err = newAuthnCeremony(dev).RunWeb(ctx, devicesClient, webToken)
-
-		// Absence of errors is good enough here.
-		assert.NoError(t, err, "RunWeb failed")
+		confirmToken, err := newAuthnCeremony(dev).RunWeb(ctx, devicesClient, webToken)
+		require.NoError(t, err, "RunWeb failed")
+		assert.NoError(t, fakeService.VerifyConfirmationToken(confirmToken))
 	})
 }
 

--- a/lib/devicetrust/authn/authn_test.go
+++ b/lib/devicetrust/authn/authn_test.go
@@ -133,10 +133,16 @@ func TestCeremony_RunWeb(t *testing.T) {
 		devID := macOSDev1.Id
 		dev := macOSFakeDev1
 
-		webToken1, err := fakeService.CreateDeviceWebTokenForTesting(devID)
+		webToken1, err := fakeService.CreateDeviceWebTokenForTesting(testenv.CreateDeviceWebTokenParams{
+			ExpectedDeviceID: devID,
+			WebSessionID:     "my-web-session-1",
+		})
 		require.NoError(t, err, "CreateDeviceWebTokenForTesting failed")
 
-		invalidDeviceToken, err := fakeService.CreateDeviceWebTokenForTesting("I'm a llama not a device ID")
+		invalidDeviceToken, err := fakeService.CreateDeviceWebTokenForTesting(testenv.CreateDeviceWebTokenParams{
+			ExpectedDeviceID: "I'm a llama not a device ID",
+			WebSessionID:     "my-web-session-2",
+		})
 		require.NoError(t, err, "CreateDeviceWebTokenForTesting failed")
 
 		const wantErr = "invalid device web token"
@@ -166,7 +172,10 @@ func TestCeremony_RunWeb(t *testing.T) {
 
 		// Create a fake DeviceWebToken. This and a previous enrollment is all the
 		// fake service requires.
-		webToken, err := fakeService.CreateDeviceWebTokenForTesting(devID)
+		webToken, err := fakeService.CreateDeviceWebTokenForTesting(testenv.CreateDeviceWebTokenParams{
+			ExpectedDeviceID: devID,
+			WebSessionID:     "my-web-session-ok",
+		})
 		require.NoError(t, err, "CreateDeviceWebTokenForTesting failed")
 
 		err = newAuthnCeremony(dev).RunWeb(ctx, devicesClient, webToken)

--- a/lib/devicetrust/testenv/fake_device_service.go
+++ b/lib/devicetrust/testenv/fake_device_service.go
@@ -25,6 +25,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -111,6 +112,23 @@ func (s *FakeDeviceService) CreateDeviceWebTokenForTesting(params CreateDeviceWe
 		Id:    id,
 		Token: webToken,
 	}, nil
+}
+
+// VerifyConfirmationToken verifies that the token is valid within this
+// FakeDeviceService.
+//
+// This is a test support method, it doesn't spend the token.
+func (s *FakeDeviceService) VerifyConfirmationToken(token *devicepb.DeviceConfirmationToken) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, attempt := range s.deviceAuthnAttempts {
+		if attempt.id == token.Id && attempt.confirmToken == token.Token {
+			return nil
+		}
+	}
+
+	return errors.New("token not issued by FakeDeviceService")
 }
 
 // SetDevicesLimitReached simulates a server where the devices limit was already

--- a/lib/devicetrust/testenv/fake_device_service.go
+++ b/lib/devicetrust/testenv/fake_device_service.go
@@ -26,7 +26,6 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"fmt"
-	"slices"
 	"sync"
 
 	"github.com/google/uuid"
@@ -46,9 +45,13 @@ type storedDevice struct {
 	enrollToken string // stored separately from the device
 }
 
-type storedWebToken struct {
-	expectedDeviceID string
-	id, token        string
+// storedDeviceAuthnAttempt is the underlying entity behind
+// [devicepb.DeviceWebToken] and [devicepb.DeviceConfirmationToken].
+type storedDeviceAuthnAttempt struct {
+	id                     string
+	webSessionID           string
+	expectedDeviceID       string
+	webToken, confirmToken string
 }
 
 type FakeDeviceService struct {
@@ -56,46 +59,57 @@ type FakeDeviceService struct {
 
 	autoCreateDevice bool
 
-	// mu guards devices and devicesLimitReached.
+	// mu guards the fields below it.
 	// As a rule of thumb we lock entire methods, so we can work with pointers to
 	// the contents of devices without worry.
 	mu                  sync.Mutex
 	devices             []storedDevice
 	devicesLimitReached bool
-	deviceWebTokens     []storedWebToken
+	deviceAuthnAttempts []*storedDeviceAuthnAttempt
 }
 
 func newFakeDeviceService() *FakeDeviceService {
 	return &FakeDeviceService{}
 }
 
+// CreateDeviceWebTokenParams are the parameters for
+// [CreateDeviceWebTokenForTesting].
+type CreateDeviceWebTokenParams struct {
+	ExpectedDeviceID string
+	WebSessionID     string
+}
+
 // CreateDeviceWebTokenForTesting creates a fake [devicepb.DeviceWebToken] for
 // testing.
 // The returned token can be used for a successful [AuthenticateDevice] call.
-func (s *FakeDeviceService) CreateDeviceWebTokenForTesting(expectedDeviceID string) (*devicepb.DeviceWebToken, error) {
+func (s *FakeDeviceService) CreateDeviceWebTokenForTesting(params CreateDeviceWebTokenParams) (*devicepb.DeviceWebToken, error) {
 	// "True" device web token creation requires quite a bit more and calculates
 	// the expected device itself.
 	// For the purposes of this fake this is good enough to give us confidence
 	// that the client-side ceremony is passing all the right inputs.
-	if expectedDeviceID == "" {
-		return nil, trace.BadParameter("expectedDeviceID required")
+	switch {
+	case params.ExpectedDeviceID == "":
+		return nil, trace.BadParameter("param ExpectedDeviceID required")
+	case params.WebSessionID == "":
+		return nil, trace.BadParameter("param WebSessionID required")
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	id := uuid.NewString()
-	token := uuid.NewString()
+	webToken := uuid.NewString()
 
-	s.deviceWebTokens = append(s.deviceWebTokens, storedWebToken{
-		expectedDeviceID: expectedDeviceID,
+	s.deviceAuthnAttempts = append(s.deviceAuthnAttempts, &storedDeviceAuthnAttempt{
 		id:               id,
-		token:            token,
+		expectedDeviceID: params.ExpectedDeviceID,
+		webSessionID:     params.WebSessionID,
+		webToken:         webToken,
 	})
 
 	return &devicepb.DeviceWebToken{
 		Id:    id,
-		Token: token,
+		Token: webToken,
 	}, nil
 }
 
@@ -484,12 +498,13 @@ func (s *FakeDeviceService) AuthenticateDevice(stream devicepb.DeviceTrustServic
 	}
 
 	// Validate/spent the device web token, if present.
-	hasWebToken := false
+	var confirmToken *devicepb.DeviceConfirmationToken
 	if webToken := initReq.DeviceWebToken; webToken != nil {
-		if err := s.spendDeviceWebToken(webToken, dev); err != nil {
+		var err error
+		confirmToken, err = s.spendDeviceWebToken(webToken, dev)
+		if err != nil {
 			return trace.Wrap(err)
 		}
-		hasWebToken = true
 	}
 
 	switch dev.pb.OsType {
@@ -504,44 +519,59 @@ func (s *FakeDeviceService) AuthenticateDevice(stream devicepb.DeviceTrustServic
 		return trace.Wrap(err)
 	}
 
-	newCerts := &devicepb.UserCertificates{}
-	if !hasWebToken {
-		newCerts.X509Der = []byte("<insert augmented X.509 cert here")
-		newCerts.SshAuthorizedKey = []byte("<insert augmented SSH cert here")
+	// Standalone device authentication.
+	if confirmToken == nil {
+		return trace.Wrap(stream.Send(&devicepb.AuthenticateDeviceResponse{
+			Payload: &devicepb.AuthenticateDeviceResponse_UserCertificates{
+				UserCertificates: &devicepb.UserCertificates{
+					X509Der:          []byte("<insert augmented X.509 cert here"),
+					SshAuthorizedKey: []byte("<insert augmented SSH cert here"),
+				},
+			},
+		}))
 	}
 
-	err = stream.Send(&devicepb.AuthenticateDeviceResponse{
-		Payload: &devicepb.AuthenticateDeviceResponse_UserCertificates{
-			UserCertificates: newCerts,
+	// Web authentication.
+	return trace.Wrap(stream.Send(&devicepb.AuthenticateDeviceResponse{
+		Payload: &devicepb.AuthenticateDeviceResponse_ConfirmationToken{
+			ConfirmationToken: confirmToken,
 		},
-	})
-	return trace.Wrap(err)
+	}))
 }
 
-func (s *FakeDeviceService) spendDeviceWebToken(webToken *devicepb.DeviceWebToken, dev *storedDevice) error {
+func (s *FakeDeviceService) spendDeviceWebToken(webToken *devicepb.DeviceWebToken, dev *storedDevice) (*devicepb.DeviceConfirmationToken, error) {
 	const invalidWebTokenMessage = "invalid device web token"
 
-	for i, token := range s.deviceWebTokens {
-		if token.id != webToken.Id {
+	for _, attempt := range s.deviceAuthnAttempts {
+		if attempt.id != webToken.Id {
 			continue
 		}
 
-		// Spend token regardless of outcome.
-		s.deviceWebTokens = slices.Delete(s.deviceWebTokens, i, i+1)
+		storedToken := attempt.webToken
 
-		// Validate token info.
+		// Spend token regardless of outcome.
+		attempt.webToken = ""
+
 		switch {
-		case token.token != webToken.Token:
-			return trace.AccessDenied(invalidWebTokenMessage)
-		case token.expectedDeviceID != dev.pb.Id:
-			return trace.AccessDenied(invalidWebTokenMessage)
+		case storedToken == "": // Invalid attempt state or token already spent.
+			return nil, trace.AccessDenied(invalidWebTokenMessage)
+		case storedToken != webToken.Token: // Bad token
+			return nil, trace.AccessDenied(invalidWebTokenMessage)
+		case attempt.expectedDeviceID != dev.pb.Id: // Failed expected device check.
+			return nil, trace.AccessDenied(invalidWebTokenMessage)
 		}
 
-		return nil // Valid token.
+		// Issue a new confirmation token.
+		attempt.confirmToken = uuid.NewString()
+
+		return &devicepb.DeviceConfirmationToken{
+			Id:    attempt.id,
+			Token: attempt.confirmToken,
+		}, nil
 	}
 
 	// Token ID not found.
-	return trace.AccessDenied(invalidWebTokenMessage)
+	return nil, trace.AccessDenied(invalidWebTokenMessage)
 }
 
 func authenticateDeviceMacOS(dev *storedDevice, stream devicepb.DeviceTrustService_AuthenticateDeviceServer) error {


### PR DESCRIPTION
Modify lib/devicetrust/authn.Ceremony.RunWeb according to recent RPC changes (#40097), so it now looks for and returns the DeviceConfirmationToken.

https://github.com/gravitational/teleport.e/issues/3236