### PR TITLE
fix: Add license header to S3BucketWarningBanner.tsx

### DIFF
--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/S3BucketWarningBanner.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/S3BucketWarningBanner.tsx
@@ -1,3 +1,21 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { ButtonText, Box, Text, Flex, ButtonBorder } from 'design';
 import { OutlineWarn } from 'design/Alert/Alert';
 import { Notification } from 'design/Icon';


### PR DESCRIPTION
Fixes `make lint-license` breakage accidentally introduced by #40145.