### PR TITLE
[v15] docs: Always use curl.exe on Windows with explicit failure if URL is incorrect

### DIFF
--- a/docs/pages/desktop-access/active-directory-manual.mdx
+++ b/docs/pages/desktop-access/active-directory-manual.mdx
@@ -226,7 +226,7 @@ To export the Teleport user CA certificate:
    command and replacing `teleport.example.com` with the address of your Teleport cluster:
 
    ```code
-   $ curl -o user-ca.cer https://<Var name="teleport.example.com"/>/webapi/auth/export?type=windows
+   $ curl.exe -fo user-ca.cer https://<Var name="teleport.example.com"/>/webapi/auth/export?type=windows
    ```
 
 1. Take note of the path to the `user-ca.cer` file for use in a later step.

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -43,7 +43,7 @@ To prepare a Windows computer:
 2. Export the Teleport user certificate authority by running the following command using your Teleport cluster address:
 
    ```code
-   $ curl -o teleport.cer <Var name="https://teleport.example.com"/>/webapi/auth/export?type=windows
+   $ curl.exe -fo teleport.cer <Var name="https://teleport.example.com"/>/webapi/auth/export?type=windows
    ```
 
 <Tabs>
@@ -52,7 +52,7 @@ To prepare a Windows computer:
 3. Download the Teleport Windows Auth setup program:
 
 ```code
-$ curl -o teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe
+$ curl.exe -fo teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe
 ```
 
 </TabItem>
@@ -61,7 +61,7 @@ $ curl -o teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe https://cd
 3. Download the Teleport Windows Auth setup program:
 
 ```code
-$ curl -o teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe
+$ curl.exe -fo teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe
 ```
 
 </TabItem>

--- a/docs/pages/desktop-access/troubleshooting.mdx
+++ b/docs/pages/desktop-access/troubleshooting.mdx
@@ -62,7 +62,7 @@ fetch the new CA using the following command, replacing <Var name="teleport.exam
 with the address of your Teleport cluster:
 
 ```code
-$ curl -o user-ca.cer https://<Var name="teleport.example.com"/>/webapi/auth/export?type=windows
+$ curl.exe -fo user-ca.cer https://<Var name="teleport.example.com"/>/webapi/auth/export?type=windows
 ```
 
 If that doesn't help, log into the target host directly, open PowerShell and


### PR DESCRIPTION
Backport #40352 to branch/v15