### PR TITLE
[v14] build: Simplify darwin-signing and add new GHA environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -505,7 +505,6 @@ release-darwin-unsigned: full build-archive
 
 .PHONY: release-darwin
 ifneq ($(ARCH),universal)
-release-darwin: ABSOLUTE_BINARY_PATHS:=$(addprefix $(CURDIR)/,$(BINARIES))
 release-darwin: release-darwin-unsigned
 	$(NOTARIZE_BINARIES)
 	$(MAKE) build-archive
@@ -594,9 +593,6 @@ release-windows: release-windows-unsigned
 # It is used only for MacOS releases. Windows releases do not use this
 # Makefile. Linux uses the `teleterm` target in build.assets/Makefile.
 #
-# Only export the CSC_NAME (developer key ID) when the recipe is run, so
-# that we do not shell out and run the `security` command if not necessary.
-#
 # Either CONNECT_TSH_BIN_PATH or CONNECT_TSH_APP_PATH environment variable
 # should be defined for the `yarn package-term` command to succeed. CI sets
 # this appropriately depending on whether a push build is running, or a
@@ -606,7 +602,6 @@ release-windows: release-windows-unsigned
 
 .PHONY: release-connect
 release-connect: | $(RELEASE_DIR)
-	$(eval export CSC_NAME)
 	yarn install --frozen-lockfile
 	yarn build-term
 	yarn package-term -c.extraMetadata.version=$(VERSION) --$(ELECTRON_BUILDER_ARCH)
@@ -1417,7 +1412,6 @@ endif
 # build .pkg
 .PHONY: pkg
 pkg: | $(RELEASE_DIR)
-	$(eval export DEVELOPER_ID_APPLICATION DEVELOPER_ID_INSTALLER)
 	mkdir -p $(BUILDDIR)/
 	cp ./build.assets/build-package.sh ./build.assets/build-common.sh $(BUILDDIR)/
 	chmod +x $(BUILDDIR)/build-package.sh
@@ -1430,7 +1424,6 @@ pkg: | $(RELEASE_DIR)
 # build tsh client-only .pkg
 .PHONY: pkg-tsh
 pkg-tsh: | $(RELEASE_DIR)
-	$(eval export DEVELOPER_ID_APPLICATION DEVELOPER_ID_INSTALLER)
 	./build.assets/build-pkg-tsh.sh -t oss -v $(VERSION) -b $(TSH_BUNDLEID) -a $(ARCH) $(TARBALL_PATH_SECTION)
 	mkdir -p $(BUILDDIR)/
 	mv tsh*.pkg* $(BUILDDIR)/

--- a/build.assets/build-pkg-tsh.sh
+++ b/build.assets/build-pkg-tsh.sh
@@ -106,14 +106,14 @@ password created by APPLE_USERNAME"
   if [[ -z "${DEVELOPER_ID_APPLICATION}" ]]; then
     echo "\
 The DEVELOPER_ID_APPLICATION environment variable needs to be set to the hash\
-of the key to sign applications"
+or name of the key to sign applications"
     exit 1
   fi
 
   if [[ -z "${DEVELOPER_ID_INSTALLER}" ]]; then
     echo "\
 The DEVELOPER_ID_INSTALLER environment variable needs to be set to the hash\
-of the key to sign packages"
+or name of the key to sign packages"
     exit 1
   fi
 

--- a/darwin-signing.mk
+++ b/darwin-signing.mk
@@ -17,33 +17,17 @@ ENVIRONMENT_NAME ?= promote
 # TEAMID is an Apple-assigned identifier for a developer. It has two keys,
 # one for signing binaries (application) and one for signing packages/images
 # (installer). The keys are identified by name per-environment which we use
-# to extract the key IDs. Key names can be view by running `security find-identity`.
-#
-# NOTE: If you need to export the DEVELOPER_ID_{APPLICATION,INSTALLER}
-# variables to the environment for a command, it should be done within the
-# recipe containing the command using $(eval export DEVELOPER_ID_APPLICATION ...).
-# This is so the `security` shell command is only run to extract the key ID
-# if necessary. If exported at the top level, it will run every time `make`
-# is run.
-#
-# e.g.
-# pkg:
-#         $(eval export DEVELOPER_ID_APPLICATION DEVELOPER_ID_INSTALLER)
-#         ./build.assets/build-package.sh ...
-#
+# to sign binaries and packages. We do not use the hash. Key names can be
+# view by running `security find-identity`.
+
 TEAMID = $(TEAMID_$(ENVIRONMENT_NAME))
-DEVELOPER_ID_APPLICATION = $(call get_key_id,$(DEVELOPER_KEY_NAME_$(ENVIRONMENT_NAME)))
-DEVELOPER_ID_INSTALLER = $(call get_key_id,$(INSTALLER_KEY_NAME_$(ENVIRONMENT_NAME)))
+DEVELOPER_ID_APPLICATION = $(DEVELOPER_KEY_NAME_$(ENVIRONMENT_NAME))
+DEVELOPER_ID_INSTALLER = $(INSTALLER_KEY_NAME_$(ENVIRONMENT_NAME))
 
 # CSC_NAME is the key ID for signing used by electron-builder for signing
-# Teleport Connect.
-CSC_NAME = $(DEVELOPER_ID_APPLICATION)
-
-# Don't export DEVELOPER_ID_APPLICATION, DEVELOPER_ID_INSTALLER or CSC_NAME as
-# it causes them to be evaluated, which shells out to the `security` command.
-# They should only be evaluated if used. Any variables below that reference
-# these are also unexported for the same reason.
-unexport CSC_NAME DEVELOPER_ID_APPLICATION DEVELOPER_ID_INSTALLER
+# Teleport Connect. electron-builder does not want the "Developer ID Application: "
+# prefix on the key so strip it off
+CSC_NAME = $(subst Developer ID Application: ,,$(DEVELOPER_ID_APPLICATION))
 
 # Bundle IDs identify packages/images. We use different bundle IDs for
 # release and development.
@@ -70,58 +54,36 @@ TELEPORT_BUNDLEID_build = com.goteleport.dev
 TSH_BUNDLEID_build = $(TEAMID).com.goteleport.tshdev
 TSH_SKELETON_build = tshdev
 
-# --- utility
-# Extract application/installer key ID from keychain. This looks at all
-# keychains in the search path. It should be used with $(call ...).
-# e.g. $(call get_key_id,Key Name goes here)
-get_key_id = $(or $(word 2,$(shell $(get_key_id_cmd))), $(missing_key_error))
-get_key_id_cmd = security find-identity -v -s codesigning | grep --fixed-strings --max-count=1 "$(1)"
-missing_key_error = $(error Could not find key named "$(1)" in keychain)
-
-# Dont export missing_key_error or get_key_id as it evaluates them
-unexport missing_key_error get_key_id
-
 # SHOULD_NOTARIZE evalutes to "true" if we should sign and notarize binaries,
 # and the empty string if not. We only notarize if APPLE_USERNAME and
 # APPLE_PASSWORD are set in the environment.
 SHOULD_NOTARIZE = $(if $(and $(APPLE_USERNAME),$(APPLE_PASSWORD)),true)
 
-# NOTARIZE_BINARIES runs the notarize-apple-binaries tool. It is expected that
-# the current working directory is the root of the OSS Teleport repo, so to call
-# from the enterprise repo, invoke it as:
-#     cd .. && $(NOTARIZE_BINARIES)
+# NOTARIZE_BINARIES signs and notarizes $(BINARIES).
 # It will not run the command if $APPLE_USERNAME or $APPLE_PASSWORD are empty.
-# It uses the make $(if ...) construct instead of doing it in the shell so as
-# to not evaluate its arguments (DEVELOPER_ID_APPLICATION) if we are not
-# goint to use them, preventing a missing key error defined above.
 NOTARIZE_BINARIES = $(if $(SHOULD_NOTARIZE),$(notarize_binaries_cmd),$(not_notarizing_cmd))
-unexport NOTARIZE_BINARIES
 
 not_notarizing_cmd = echo Not notarizing binaries. APPLE_USERNAME or APPLE_PASSWORD not set.
 
 notary_dir = $(BUILDDIR)/notarize
 notary_file = $(BUILDDIR)/notarize.zip
 
-# notarize_binaries_cmd must be a single command - multiple commands must be
-# joined with "&& \". This is so the command can be prefixed with "cd .. &&"
-# for the enterprise invocation.
 define notarize_binaries_cmd
 	codesign \
-		--sign $(DEVELOPER_ID_APPLICATION) \
+		--sign '$(DEVELOPER_ID_APPLICATION)' \
 		--force \
 		--verbose \
 		--timestamp \
 		--options runtime \
-		$(ABSOLUTE_BINARY_PATHS) && \
-	rm -rf $(notary_dir) && \
-	mkdir $(notary_dir) && \
-	ditto $(ABSOLUTE_BINARY_PATHS) $(notary_dir) && \
-	ditto -c -k $(notary_dir) $(notary_file) && \
+		$(BINARIES)
+	rm -rf $(notary_dir)
+	mkdir $(notary_dir)
+	ditto $(BINARIES) $(notary_dir)
+	ditto -c -k $(notary_dir) $(notary_file)
 	xcrun notarytool submit $(notary_file) \
 		--team-id="$(TEAMID)" \
 		--apple-id="$(APPLE_USERNAME)" \
 		--password="$(APPLE_PASSWORD)" \
-		--wait && \
+		--wait
 	rm -rf $(notary_dir) $(notary_file)
 endef
-unexport notarize_binaries_cmd

--- a/darwin-signing.mk
+++ b/darwin-signing.mk
@@ -1,28 +1,40 @@
 # MacOS/Darwin variables for packaging, signing and notarizing.
 #
-# These are parameterized per environment, with `promote` for official
-# releases and `build` for development testing. These environment names
-# come from our configuration in GitHub Actions.
+# These are parameterized per environment, with `build-prod` for official
+# releases and `build-stage` for development testing. These environment names
+# come from our configuration in GitHub Actions. These parameters may be
+# moved to the GitHub Actions environments, however we'll always keep the
+# development testing variables defined here so as to be able to run the
+# signing locally for development purposes.
+#
+# A new set of signing parameters would also require a new provisioning
+# profile alongside build.assets/macos/*/*.provisioningprofile. We also need
+# to update these profiles if the keys are changed/rotated.
 
-# Default environment name if not specified. This is currently for Drone
-# which does not set `ENVIRONMENT_NAME`. Once migrated fully to GitHub
-# actions, we should change this to `build` as the default.
-ENVIRONMENT_NAME ?= promote
+# Default environment name if not specified. This is currently for running
+# locally instead of from GitHub Actions, where ENVIRONMENT_NAME would not be
+# set.
+ENVIRONMENT_NAME ?= build-stage
 
-# Variables defined here are defined with the environment name suffix
-# to specify the appropriate value for that environment. The unsuffixed
-# names select the appropriate value based on `ENVIRONMENT_NAME`
+# CLEAN_ENV_NAME replaces hyphens with underscores as hyphens are not valid in
+# environment variable names (make is ok with them, but they get exported, and
+# we want that to be clean).
+CLEAN_ENV_NAME = $(subst -,_,$(ENVIRONMENT_NAME))
+
+# Variables defined below are defined with the clean environment name suffix to
+# specify the appropriate value for that environment. The unsuffixed names
+# select the appropriate value based on `CLEAN_ENV_NAME`
 
 # Developer "team" and keys.
-# TEAMID is an Apple-assigned identifier for a developer. It has two keys,
-# one for signing binaries (application) and one for signing packages/images
-# (installer). The keys are identified by name per-environment which we use
-# to sign binaries and packages. We do not use the hash. Key names can be
-# view by running `security find-identity`.
-
-TEAMID = $(TEAMID_$(ENVIRONMENT_NAME))
-DEVELOPER_ID_APPLICATION = $(DEVELOPER_KEY_NAME_$(ENVIRONMENT_NAME))
-DEVELOPER_ID_INSTALLER = $(INSTALLER_KEY_NAME_$(ENVIRONMENT_NAME))
+#
+# TEAMID is an Apple-assigned identifier for a developer. It has two keys, one
+# for signing binaries (application) and one for signing packages/images
+# (installer). The keys are identified by name per-environment which we use to
+# sign binaries and packages. We do not use the hash. Key names can be view by
+# running `security find-identity`.
+TEAMID = $(TEAMID_$(CLEAN_ENV_NAME))
+DEVELOPER_ID_APPLICATION = $(DEVELOPER_KEY_NAME_$(CLEAN_ENV_NAME))
+DEVELOPER_ID_INSTALLER = $(INSTALLER_KEY_NAME_$(CLEAN_ENV_NAME))
 
 # CSC_NAME is the key ID for signing used by electron-builder for signing
 # Teleport Connect. electron-builder does not want the "Developer ID Application: "
@@ -31,28 +43,42 @@ CSC_NAME = $(subst Developer ID Application: ,,$(DEVELOPER_ID_APPLICATION))
 
 # Bundle IDs identify packages/images. We use different bundle IDs for
 # release and development.
-TELEPORT_BUNDLEID = $(TELEPORT_BUNDLEID_$(ENVIRONMENT_NAME))
-TSH_BUNDLEID = $(TSH_BUNDLEID_$(ENVIRONMENT_NAME))
+TELEPORT_BUNDLEID = $(TELEPORT_BUNDLEID_$(CLEAN_ENV_NAME))
+TSH_BUNDLEID = $(TSH_BUNDLEID_$(CLEAN_ENV_NAME))
 
 # TSH_SKELETON is a directory name relative to build.assets/macos/
-TSH_SKELETON = $(TSH_SKELETON_$(ENVIRONMENT_NAME))
+TSH_SKELETON = $(TSH_SKELETON_$(CLEAN_ENV_NAME))
 
-# --- promote environment
+# --- build-prod environment (promote is the old name and will be removed)
 # Key names can be found on https://goteleport.com/security
-TEAMID_promote = QH8AA5B8UP
-DEVELOPER_KEY_NAME_promote = Developer ID Application: Gravitational Inc.
-INSTALLER_KEY_NAME_promote = Developer ID Installer: Gravitational Inc.
-TELEPORT_BUNDLEID_promote = com.gravitational.teleport
-TSH_BUNDLEID_promote = $(TEAMID).com.gravitational.teleport.tsh
-TSH_SKELETON_promote = tsh
+TEAMID_build_prod = QH8AA5B8UP
+DEVELOPER_KEY_NAME_build_prod = Developer ID Application: Gravitational Inc.
+INSTALLER_KEY_NAME_build_prod = Developer ID Installer: Gravitational Inc.
+TELEPORT_BUNDLEID_build_prod = com.gravitational.teleport
+TSH_BUNDLEID_build_prod = $(TEAMID).com.gravitational.teleport.tsh
+TSH_SKELETON_build_prod = tsh
 
-# --- build environment
-TEAMID_build = K497G57PDJ
-DEVELOPER_KEY_NAME_build = Developer ID Application: Ada Lin
-INSTALLER_KEY_NAME_build = Developer ID Installer: Ada Lin
-TELEPORT_BUNDLEID_build = com.goteleport.dev
-TSH_BUNDLEID_build = $(TEAMID).com.goteleport.tshdev
-TSH_SKELETON_build = tshdev
+TEAMID_promote = $(TEAMID_build_prod)
+DEVELOPER_KEY_NAME_promote = $(DEVELOPER_KEY_NAME_build_prod)
+INSTALLER_KEY_NAME_promote = $(DEVELOPER_KEY_NAME_build_prod)
+TELEPORT_BUNDLEID_promote = $(TELEPORT_BUNDLEID_build_prod)
+TSH_BUNDLEID_promote = $(TSH_BUNDLEID_build_prod)
+TSH_SKELETON_promote = $(TSH_SKELETON_build_prod)
+
+# --- build-stage environment (build is the old name and will be removed)
+TEAMID_build_stage = K497G57PDJ
+DEVELOPER_KEY_NAME_build_stage = Developer ID Application: Ada Lin
+INSTALLER_KEY_NAME_build_stage = Developer ID Installer: Ada Lin
+TELEPORT_BUNDLEID_build_stage = com.goteleport.dev
+TSH_BUNDLEID_build_stage = $(TEAMID).com.goteleport.tshdev
+TSH_SKELETON_build_stage = tshdev
+
+TEAMID_build = $(TEAMID_build_stage)
+DEVELOPER_KEY_NAME_build = $(DEVELOPER_KEY_NAME_build_stage)
+INSTALLER_KEY_NAME_build = $(DEVELOPER_KEY_NAME_build_stage)
+TELEPORT_BUNDLEID_build = $(TELEPORT_BUNDLEID_build_stage)
+TSH_BUNDLEID_build = $(TSH_BUNDLEID_build_stage)
+TSH_SKELETON_build = $(TSH_SKELETON_build_stage)
 
 # SHOULD_NOTARIZE evalutes to "true" if we should sign and notarize binaries,
 # and the empty string if not. We only notarize if APPLE_USERNAME and
@@ -87,3 +113,17 @@ define notarize_binaries_cmd
 		--wait
 	rm -rf $(notary_dir) $(notary_file)
 endef
+
+echo_var = @echo $(1)=\''$($(1))'\'
+
+.PHONY: print-darwin-signing-vars
+print-darwin-signing-vars:
+	$(call echo_var,ENVIRONMENT_NAME)
+	$(call echo_var,CLEAN_ENV_NAME)
+	$(call echo_var,TEAMID)
+	$(call echo_var,DEVELOPER_ID_APPLICATION)
+	$(call echo_var,DEVELOPER_ID_INSTALLER)
+	$(call echo_var,CSC_NAME)
+	$(call echo_var,TELEPORT_BUNDLEID)
+	$(call echo_var,TSH_BUNDLEID)
+	$(call echo_var,TSH_SKELETON)


### PR DESCRIPTION
Simplify darwin-signing to sign by key name instead of key hash, as we
just look up the key hash from the name anyway, and all the signing
options take the key name as well as the hash. This cleans up a bit of
fragility around exported make variables where care needed to be taken
to ensure the key hash lookup commands we not run when not needed.

Update the signing variables to accept `build-prod` and `build-stage` as
environment names and deprecate the old `promote` and `build`
environment names.

Backport: https://github.com/gravitational/teleport/pull/40304
Companion: https://github.com/gravitational/teleport.e/pull/3926

---

Prior to merging this PR, but after approval, I will add a commit
to update the e ref to bring in the changes from the companion PR.