### PR TITLE
[v14] Add ability to re-exec into shell when using `tsh proxy kube`.

### DIFF
--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -102,8 +102,8 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	rexecIntoShell := cf.Headless || c.exec
-	if rexecIntoShell {
+
+	if cf.Headless {
 		tc.AllowHeadless = true
 	}
 
@@ -135,7 +135,10 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 		return trace.Wrap(cf.RunCommand(cmd))
 	}
 
-	if rexecIntoShell {
+	// re-exec into a new shell with $KUBECONFIG already pointed to our config file
+	// if --exec flag is set or headless mode is enabled.
+	reexecIntoShell := cf.Headless || c.exec
+	if reexecIntoShell {
 		// If headless, run proxy in the background and reexec into a new shell with $KUBECONFIG already pointed to
 		// our config file
 		return trace.Wrap(runHeadlessKubeProxy(cf, localProxy))

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -118,7 +119,10 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 	}
 	defer localProxy.Close()
 
-	if err := c.printTemplate(cf, localProxy); err != nil {
+	// re-exec into a new shell with $KUBECONFIG already pointed to our config file
+	// if --exec flag is set or headless mode is enabled.
+	reexecIntoShell := cf.Headless || c.exec
+	if err := c.printTemplate(cf.Stdout(), reexecIntoShell, localProxy); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -135,9 +139,6 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 		return trace.Wrap(cf.RunCommand(cmd))
 	}
 
-	// re-exec into a new shell with $KUBECONFIG already pointed to our config file
-	// if --exec flag is set or headless mode is enabled.
-	reexecIntoShell := cf.Headless || c.exec
 	if reexecIntoShell {
 		// If headless, run proxy in the background and reexec into a new shell with $KUBECONFIG already pointed to
 		// our config file
@@ -264,13 +265,13 @@ func (c *proxyKubeCommand) printPrepare(cf *CLIConf, title string, clusters kube
 	fmt.Fprintln(cf.Stdout(), table.AsBuffer().String())
 }
 
-func (c *proxyKubeCommand) printTemplate(cf *CLIConf, localProxy *kubeLocalProxy) error {
-	if cf.Headless {
-		return trace.Wrap(proxyKubeHeadlessTemplate.Execute(cf.Stdout(), map[string]interface{}{
+func (c *proxyKubeCommand) printTemplate(w io.Writer, isReexec bool, localProxy *kubeLocalProxy) error {
+	if isReexec {
+		return trace.Wrap(proxyKubeHeadlessTemplate.Execute(w, map[string]interface{}{
 			"multipleContexts": len(localProxy.kubeconfig.Contexts) > 1,
 		}))
 	}
-	return trace.Wrap(proxyKubeTemplate.Execute(cf.Stdout(), map[string]interface{}{
+	return trace.Wrap(proxyKubeTemplate.Execute(w, map[string]interface{}{
 		"addr":           localProxy.GetAddr(),
 		"format":         c.format,
 		"randomPort":     c.port == "",


### PR DESCRIPTION
Backport #40246 to branch/v14

changelog: Added `tsh proxy kube --exec` mode that spawns kube proxy in the background, re-executes user shell with the appropriate kubeconfig.
