### PR TITLE
[v15] Add ability to re-exec into shell when using `tsh proxy kube`.

### DIFF
--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -105,8 +105,8 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	rexecIntoShell := cf.Headless || c.exec
-	if rexecIntoShell {
+
+	if cf.Headless {
 		tc.AllowHeadless = true
 	}
 
@@ -138,7 +138,10 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 		return trace.Wrap(cf.RunCommand(cmd))
 	}
 
-	if rexecIntoShell {
+	// re-exec into a new shell with $KUBECONFIG already pointed to our config file
+	// if --exec flag is set or headless mode is enabled.
+	reexecIntoShell := cf.Headless || c.exec
+	if reexecIntoShell {
 		// If headless, run proxy in the background and reexec into a new shell with $KUBECONFIG already pointed to
 		// our config file
 		return trace.Wrap(runHeadlessKubeProxy(cf, localProxy))

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -62,6 +62,7 @@ type proxyKubeCommand struct {
 
 	labels              string
 	predicateExpression string
+	exec                bool
 }
 
 func newProxyKubeCommand(parent *kingpin.CmdClause) *proxyKubeCommand {
@@ -84,6 +85,7 @@ func newProxyKubeCommand(parent *kingpin.CmdClause) *proxyKubeCommand {
 		// This works as an hint to the user that the context name can be customized.
 		Default(kubeconfig.ContextName("{{.ClusterName}}", "{{.KubeName}}")).
 		StringVar(&c.overrideContextName)
+	c.Flag("exec", "Run the proxy in the background and reexec into a new shell with $KUBECONFIG already pointed to our config file.").BoolVar(&c.exec)
 	return c
 }
 
@@ -103,7 +105,8 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if cf.Headless {
+	rexecIntoShell := cf.Headless || c.exec
+	if rexecIntoShell {
 		tc.AllowHeadless = true
 	}
 
@@ -135,7 +138,7 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 		return trace.Wrap(cf.RunCommand(cmd))
 	}
 
-	if cf.Headless {
+	if rexecIntoShell {
 		// If headless, run proxy in the background and reexec into a new shell with $KUBECONFIG already pointed to
 		// our config file
 		return trace.Wrap(runHeadlessKubeProxy(cf, localProxy))


### PR DESCRIPTION
Backport #40246 to branch/v15

changelog: Added `tsh proxy kube --exec` mode that spawns kube proxy in the background, re-executes user shell with the appropriate kubeconfig.
