### PR TITLE
[v14] Lower bcrypt cost when testing

### DIFF
--- a/lib/auth/assist/assistv1/test/service_test.go
+++ b/lib/auth/assist/assistv1/test/service_test.go
@@ -277,7 +277,7 @@ func initSvc(t *testing.T) (map[string]context.Context, *assistv1.Service) {
 	require.NoError(t, err)
 	trustSvc := local.NewCAService(backend)
 	roleSvc := local.NewAccessService(backend)
-	userSvc := local.NewIdentityService(backend)
+	userSvc := local.NewTestIdentityService(backend)
 
 	require.NoError(t, clusterConfigSvc.SetAuthPreference(ctx, types.DefaultAuthPreference()))
 	require.NoError(t, clusterConfigSvc.SetClusterAuditConfig(ctx, types.DefaultClusterAuditConfig()))

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -2989,7 +2989,7 @@ func newTestServices(t *testing.T) Services {
 		Trust:                   local.NewCAService(bk),
 		PresenceInternal:        local.NewPresenceService(bk),
 		Provisioner:             local.NewProvisioningService(bk),
-		Identity:                local.NewIdentityService(bk),
+		Identity:                local.NewTestIdentityService(bk),
 		Access:                  local.NewAccessService(bk),
 		DynamicAccessExt:        local.NewDynamicAccessService(bk),
 		ClusterConfiguration:    configService,

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service_test.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service_test.go
@@ -490,7 +490,7 @@ func initSvc(t *testing.T, clusterName string) (context.Context, localClient, *S
 
 	trustSvc := local.NewCAService(backend)
 	roleSvc := local.NewAccessService(backend)
-	userSvc := local.NewIdentityService(backend)
+	userSvc := local.NewTestIdentityService(backend)
 
 	clusterConfigSvc, err := local.NewClusterConfigurationService(backend)
 	require.NoError(t, err)

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -269,7 +269,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 	}
 
 	access := local.NewAccessService(srv.Backend)
-	identity := local.NewIdentityService(srv.Backend)
+	identity := local.NewTestIdentityService(srv.Backend)
 
 	emitter, err := events.NewCheckingEmitter(events.CheckingEmitterConfig{
 		Inner: srv.AuditLog,

--- a/lib/auth/integration/integrationv1/service_test.go
+++ b/lib/auth/integration/integrationv1/service_test.go
@@ -331,7 +331,7 @@ func initSvc(t *testing.T, ca types.CertAuthority, clusterName string, proxyPubl
 	require.NoError(t, err)
 	trustSvc := local.NewCAService(backend)
 	roleSvc := local.NewAccessService(backend)
-	userSvc := local.NewIdentityService(backend)
+	userSvc := local.NewTestIdentityService(backend)
 
 	require.NoError(t, clusterConfigSvc.SetAuthPreference(ctx, types.DefaultAuthPreference()))
 	require.NoError(t, clusterConfigSvc.SetClusterAuditConfig(ctx, types.DefaultClusterAuditConfig()))

--- a/lib/auth/kubewaitingcontainer/service_test.go
+++ b/lib/auth/kubewaitingcontainer/service_test.go
@@ -354,7 +354,7 @@ func initSvc(t *testing.T, authorizerFn func(t *testing.T, client localClient) a
 	require.NoError(t, err)
 
 	roleSvc := local.NewAccessService(backend)
-	userSvc := local.NewIdentityService(backend)
+	userSvc := local.NewTestIdentityService(backend)
 	clusterSrv, err := local.NewClusterConfigurationService(backend)
 	require.NoError(t, err)
 	caSrv := local.NewCAService(backend)

--- a/lib/auth/okta/service_test.go
+++ b/lib/auth/okta/service_test.go
@@ -169,7 +169,7 @@ func initSvc(t *testing.T, kind string) (context.Context, *Service) {
 	require.NoError(t, err)
 	trustSvc := local.NewCAService(backend)
 	roleSvc := local.NewAccessService(backend)
-	userSvc := local.NewIdentityService(backend)
+	userSvc := local.NewTestIdentityService(backend)
 
 	require.NoError(t, clusterConfigSvc.SetAuthPreference(ctx, types.DefaultAuthPreference()))
 	require.NoError(t, clusterConfigSvc.SetClusterAuditConfig(ctx, types.DefaultClusterAuditConfig()))

--- a/lib/auth/userloginstate/service_test.go
+++ b/lib/auth/userloginstate/service_test.go
@@ -203,7 +203,7 @@ func initSvc(t *testing.T) (userContext context.Context, noAccessContext context
 	require.NoError(t, err)
 	trustSvc := local.NewCAService(backend)
 	roleSvc := local.NewAccessService(backend)
-	userSvc := local.NewIdentityService(backend)
+	userSvc := local.NewTestIdentityService(backend)
 
 	require.NoError(t, clusterConfigSvc.SetAuthPreference(ctx, types.DefaultAuthPreference()))
 	require.NoError(t, clusterConfigSvc.SetClusterAuditConfig(ctx, types.DefaultClusterAuditConfig()))

--- a/lib/auth/userpreferences/userpreferencesv1/service_test.go
+++ b/lib/auth/userpreferences/userpreferencesv1/service_test.go
@@ -161,7 +161,7 @@ func initSvc(t *testing.T) (map[string]context.Context, *Service) {
 	require.NoError(t, err)
 	trustSvc := local.NewCAService(backend)
 	roleSvc := local.NewAccessService(backend)
-	userSvc := local.NewIdentityService(backend)
+	userSvc := local.NewTestIdentityService(backend)
 
 	require.NoError(t, clusterConfigSvc.SetAuthPreference(ctx, types.DefaultAuthPreference()))
 	require.NoError(t, clusterConfigSvc.SetClusterAuditConfig(ctx, types.DefaultClusterAuditConfig()))

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -764,7 +764,7 @@ func newTestResources(t *testing.T) (*testClient, *services.LockWatcher, Authori
 	require.NoError(t, err)
 	caSvc := local.NewCAService(backend)
 	accessSvc := local.NewAccessService(backend)
-	identitySvc := local.NewIdentityService(backend)
+	identitySvc := local.NewTestIdentityService(backend)
 	eventsSvc := local.NewEventsService(backend)
 
 	client := &testClient{

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -224,19 +224,21 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	idService := local.NewTestIdentityService(p.backend)
+
 	p.trustS = local.NewCAService(p.backend)
 	p.clusterConfigS = clusterConfig
 	p.provisionerS = local.NewProvisioningService(p.backend)
 	p.eventsS = newProxyEvents(local.NewEventsService(p.backend), cfg.ignoreKinds)
 	p.presenceS = local.NewPresenceService(p.backend)
-	p.usersS = local.NewIdentityService(p.backend)
+	p.usersS = idService
 	p.accessS = local.NewAccessService(p.backend)
 	p.dynamicAccessS = local.NewDynamicAccessService(p.backend)
-	p.appSessionS = local.NewIdentityService(p.backend)
-	p.webSessionS = local.NewIdentityService(p.backend).WebSessions()
-	p.snowflakeSessionS = local.NewIdentityService(p.backend)
-	p.samlIdPSessionsS = local.NewIdentityService(p.backend)
-	p.webTokenS = local.NewIdentityService(p.backend).WebTokens()
+	p.appSessionS = idService
+	p.webSessionS = idService.WebSessions()
+	p.snowflakeSessionS = idService
+	p.samlIdPSessionsS = idService
+	p.webTokenS = idService.WebTokens()
 	p.restrictions = local.NewRestrictionsService(p.backend)
 	p.apps = local.NewAppService(p.backend)
 	p.kubernetes = local.NewKubernetesService(p.backend)

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -83,7 +83,7 @@ func runUserResourceTest(
 	require.NoError(t, err)
 
 	// Check that dynamically created item is compatible with service
-	s := NewIdentityService(tt.bk)
+	s := NewTestIdentityService(tt.bk)
 	b, err := s.GetUser("bob", withSecrets)
 	require.NoError(t, err)
 	require.Equal(t, services.UsersEquals(bob, b), true, "dynamically inserted user does not match")
@@ -194,7 +194,7 @@ func TestGithubConnectorResource(t *testing.T) {
 	err := CreateResources(ctx, tt.bk, connector)
 	require.NoError(t, err)
 
-	s := NewIdentityService(tt.bk)
+	s := NewTestIdentityService(tt.bk)
 	_, err = s.GetGithubConnector(ctx, "github", true)
 	require.NoError(t, err)
 }

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -62,7 +62,7 @@ func setupServicesContext(ctx context.Context, t *testing.T) *servicesContext {
 		CAS:           NewCAService(tt.bk),
 		PresenceS:     presenceService,
 		ProvisioningS: NewProvisioningService(tt.bk),
-		WebS:          NewIdentityService(tt.bk),
+		WebS:          NewTestIdentityService(tt.bk),
 		Access:        NewAccessService(tt.bk),
 		EventsS:       eventsService,
 		ChangesC:      make(chan interface{}),

--- a/lib/services/local/session_test.go
+++ b/lib/services/local/session_test.go
@@ -38,7 +38,7 @@ func TestDeleteUserAppSessions(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	identity := NewIdentityService(backend)
+	identity := NewTestIdentityService(backend)
 	users := []string{"alice", "bob"}
 	ctx := context.Background()
 
@@ -90,7 +90,7 @@ func TestListAppSessions(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	identity := NewIdentityService(backend)
+	identity := NewTestIdentityService(backend)
 
 	users := []string{"alice", "bob"}
 	ctx := context.Background()
@@ -177,7 +177,7 @@ func TestDeleteUserSAMLIdPSessions(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	identity := NewIdentityService(backend)
+	identity := NewTestIdentityService(backend)
 	users := []string{"alice", "bob"}
 	ctx := context.Background()
 
@@ -229,7 +229,7 @@ func TestListSAMLIdPSessions(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	identity := NewIdentityService(backend)
+	identity := NewTestIdentityService(backend)
 
 	users := []string{"alice", "bob"}
 	ctx := context.Background()

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"sort"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -54,15 +55,30 @@ var GlobalSessionDataMaxEntries = 5000 // arbitrary
 // user accounts as well
 type IdentityService struct {
 	backend.Backend
-	log logrus.FieldLogger
+	log        logrus.FieldLogger
+	bcryptCost int
 }
 
 // NewIdentityService returns a new instance of IdentityService object
 func NewIdentityService(backend backend.Backend) *IdentityService {
 	return &IdentityService{
-		Backend: backend,
-		log:     logrus.WithField(trace.Component, "identity"),
+		Backend:    backend,
+		log:        logrus.WithField(trace.Component, "identity"),
+		bcryptCost: bcrypt.DefaultCost,
 	}
+}
+
+// NewTestIdentityService returns a new instance of IdentityService object to be
+// used in tests. It will use weaker cryptography to minimize the time it takes
+// to perform flakiness tests and decrease the probability of timeouts.
+func NewTestIdentityService(backend backend.Backend) *IdentityService {
+	if !testing.Testing() {
+		// Don't allow using weak cryptography in production.
+		panic("Attempted to create a test identity service outside of a test")
+	}
+	s := NewIdentityService(backend)
+	s.bcryptCost = bcrypt.MinCost
+	return s
 }
 
 // DeleteAllUsers deletes all users
@@ -591,7 +607,7 @@ func (s *IdentityService) UpsertPassword(user string, password []byte) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	hash, err := utils.BcryptFromPassword(password, bcrypt.DefaultCost)
+	hash, err := utils.BcryptFromPassword(password, s.bcryptCost)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -48,7 +48,7 @@ func newIdentityService(t *testing.T, clock clockwork.Clock) *local.IdentityServ
 		Clock:   clockwork.NewFakeClock(),
 	})
 	require.NoError(t, err)
-	return local.NewIdentityService(backend)
+	return local.NewTestIdentityService(backend)
 }
 
 func TestRecoveryCodesCRUD(t *testing.T) {


### PR DESCRIPTION
Backporting #40254 to v14.

Resolved manually:
- `lib/accessmonitoringrules/accessmonitoringrulesv1/service_test.go` (file doesn't exist in v14).
- `lib/auth/users/usersv1/service_test.go` (file doesn't exist in v14).
- `lib/auth/assist/assistv1/test/service_test.go`
-  `lib/services/local/resource_test.go`
- `lib/services/local/users.go`