### PR TITLE
[v14] AWS OIDC: only auth, proxy and discovery can generate tokens

### DIFF
--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -36,11 +36,13 @@ func (s *Service) GenerateAWSOIDCToken(ctx context.Context, req *integrationpb.G
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbUse); err != nil {
-		return nil, trace.Wrap(err)
+	for _, allowedRole := range []types.SystemRole{types.RoleDiscovery, types.RoleAuth, types.RoleProxy} {
+		if authz.HasBuiltinRole(*authCtx, string(allowedRole)) {
+			return s.generateAWSOIDCTokenWithoutAuthZ(ctx, req.Integration)
+		}
 	}
 
-	return s.generateAWSOIDCTokenWithoutAuthZ(ctx, req.Integration)
+	return nil, trace.AccessDenied("token generation is only available to auth, proxy or discovery services")
 }
 
 // generateAWSOIDCTokenWithoutAuthZ generates a token to be used when executing an AWS OIDC Integration action.

--- a/lib/auth/integration/integrationv1/awsoidc_test.go
+++ b/lib/auth/integration/integrationv1/awsoidc_test.go
@@ -24,9 +24,11 @@ import (
 
 	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/jwt"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -69,6 +71,42 @@ func TestGenerateAWSOIDCToken(t *testing.T) {
 			{Resources: []string{types.KindIntegration}, Verbs: []string{types.VerbUse}},
 		}},
 	}, localClient)
+
+	t.Run("requesting with an user should return access denied", func(t *testing.T) {
+		ctx = authorizerForDummyUser(t, ctx, types.RoleSpecV6{
+			Allow: types.RoleConditions{Rules: []types.Rule{
+				{Resources: []string{types.KindIntegration}, Verbs: []string{types.VerbUse}},
+			}},
+		}, localClient)
+
+		_, err := resourceSvc.GenerateAWSOIDCToken(ctx, &integrationv1.GenerateAWSOIDCTokenRequest{})
+		require.True(t, trace.IsAccessDenied(err), "expected AccessDenied error, got %T", err)
+	})
+
+	t.Run("auth, discovery and proxy can request tokens", func(t *testing.T) {
+		for _, allowedRole := range []types.SystemRole{types.RoleAuth, types.RoleDiscovery, types.RoleProxy} {
+			ctx = authz.ContextWithUser(ctx, authz.BuiltinRole{
+				Role:                  types.RoleInstance,
+				AdditionalSystemRoles: []types.SystemRole{allowedRole},
+				Username:              string(allowedRole),
+				Identity: tlsca.Identity{
+					Username: string(allowedRole),
+				},
+			})
+
+			_, err := resourceSvc.GenerateAWSOIDCToken(ctx, &integrationv1.GenerateAWSOIDCTokenRequest{})
+			require.NoError(t, err)
+		}
+	})
+
+	ctx = authz.ContextWithUser(ctx, authz.BuiltinRole{
+		Role:                  types.RoleInstance,
+		AdditionalSystemRoles: []types.SystemRole{types.RoleDiscovery},
+		Username:              string(types.RoleDiscovery),
+		Identity: tlsca.Identity{
+			Username: string(types.RoleDiscovery),
+		},
+	})
 
 	// Get Public Key
 	require.NotEmpty(t, ca.GetActiveKeys().JWT)

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -944,15 +944,11 @@ func TestOIDCIdPTokenRotation(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+
 	_, err = clt.CreateIntegration(ctx, ig)
 	require.NoError(t, err)
 
-	user1, _, err := CreateUserAndRole(clt, "user1", nil, []types.Rule{
-		types.NewRule(types.KindIntegration, []string{types.VerbUse}),
-	})
-	require.NoError(t, err)
-
-	client, err := testSrv.NewClient(TestUser(user1.GetName()))
+	client, err := testSrv.NewClient(TestBuiltin(types.RoleDiscovery))
 	require.NoError(t, err)
 
 	// Create a JWT using the current CA, this will become the "old" CA during


### PR DESCRIPTION
Backport #39146 to branch/v14