### PR TITLE
Handle access graph preferences being nil

### DIFF
--- a/lib/web/userpreferences.go
+++ b/lib/web/userpreferences.go
@@ -244,6 +244,12 @@ func onboardUserPreferencesResponse(resp *userpreferencesv1.OnboardUserPreferenc
 
 // accessGraphPreferencesResponse creates a JSON response for the access graph preferences.
 func accessGraphPreferencesResponse(resp *userpreferencesv1.AccessGraphUserPreferences) AccessGraphPreferencesResponse {
+	if resp == nil {
+		return AccessGraphPreferencesResponse{
+			HasBeenRedirected: false,
+		}
+	}
+
 	return AccessGraphPreferencesResponse{
 		HasBeenRedirected: resp.HasBeenRedirected,
 	}


### PR DESCRIPTION
The pointer to `userpreferences.AccessGraph` could be `nil` and cause a panic for those who have existing user preferences

```
2024-04-10T10:31:36-05:00 INFO  "http: panic serving 127.0.0.1:55811: runtime error: invalid memory address or nil pointer dereference\ngoroutine 3159 [running]:\nnet/http.(*conn).serve.func1()\n\tnet/http/server.go:1898 +0xb0\npanic({0x10cbb8120?, 0x112d46760?})\n\truntime/panic.go:770 +0x124\ngithub.com/gravitational/teleport/lib/web.accessGraphPreferencesResponse(...)\n\tgithub.com/gravitational/teleport/lib/web/userpreferences.go:248\ngithub.com/gravitational/teleport/lib/web.userPreferencesResponse(0x14003b65500)\n\tgithub.com/gravitational/teleport/lib/web/userpreferences.go:190 +0x2d0\ngithub.com/gravitational/teleport/lib/web.(*Handler).getUserPreferences(0x14002f34480?, {0x10def12f8?, 0x140036b84e0?}, 0x14003188c87?, {0x40?, 0x140037b18c0?, 0x14001076dc0?}, 0x108cf3c94?)\n\tgithub.com/gravitational/teleport/lib/web/userpreferences.go:124 +0xb4\ngithub.com/gravitational/teleport/lib/web.(*Handler).bindDefaultEndpoints.(*Handler).WithAuth.func140({0x10dee7190, 0x14002d17680}, 0x14002f34480, {0x0, 0x0, 0x0})\n\tgithub.com/gravitational/teleport/lib/web/apiserver.go:4218 +0xc4\ngithub.com/gravitational/teleport/lib/web.(*Handler).bindDefaultEndpoints.(*Handler).WithAuth.MakeHandler.MakeHandlerWithErrorWriter.func295({0x10dee7190, 0x14002d17680}, 0x14002f34480, {0x0, 0x0, 0x0})\n\tgithub.com/gravitational/teleport/lib/httplib/httplib.go:127 +0x8c\ngithub.com/julienschmidt/httprouter.(*Router).ServeHTTP(0x1400296af20, {0x10dee7190, 0x14002d17680}, 0x14002f34480)\n\tgithub.com/julienschmidt/httprouter@v1.3.0/router.go:399 +0x724\ngithub.com/gravitational/teleport/lib/web.NewHandler.func1.StripPrefix.1({0x10dee7190, 0x14002d17680}, 0x14002f34360)\n\tnet/http/server.go:2209 +0x228\nnet/http.HandlerFunc.ServeHTTP(0x140036b8420?, {0x10dee7190?, 0x14002d17680?}, 0x140036b8600?)\n\tnet/http/server.go:2166 +0x38\ngithub.com/gravitational/teleport/lib/web.NewHandler.func1({0x10dee7190, 0x14002d17680}, 0x14002f34360)\n\tgithub.com/gravitational/teleport/lib/web/apiserver.go:527 +0x700\nnet/http.HandlerFunc.ServeHTTP(0x10cb35ac0?, {0x10dee7190?, 0x14002d17680?}, 0x3?)\n\tnet/http/server.go:2166 +0x38\ngithub.com/julienschmidt/httprouter.(*Router).ServeHTTP(0x1400296af20, {0x10dee7190, 0x14002d17680}, 0x14002f34360)\n\tgithub.com/julienschmidt/httprouter@v1.3.0/router.go:460 +0x580\ngithub.com/gravitational/teleport/lib/web.(*APIHandler).ServeHTTP(0x14002bc27e0, {0x10dee7190, 0x14002d17680}, 0x14002f34360)\n\tgithub.com/gravitational/teleport/lib/web/apiserver.go:359 +0x114\ngithub.com/gravitational/oxy/ratelimit.(*TokenLimiter).ServeHTTP(0x140026efa00, {0x10dee7190, 0x14002d17680}, 0x14002f34360)\n\tgithub.com/gravitational/oxy@v0.0.0-20231219172753-f855322f2a6c/ratelimit/tokenlimiter.go:118 +0x1b4\ngithub.com/gravitational/oxy/connlimit.(*ConnLimiter).ServeHTTP(0x140033aede0, {0x10dee7190, 0x14002d17680}, 0x14002f34360)\n\tgithub.com/gravitational/oxy@v0.0.0-20231219172753-f855322f2a6c/connlimit/connlimit.go:75 +0x280\ngithub.com/gravitational/teleport/lib/httplib.MakeTracingHandler.func1({0x10dee7190, 0x14002d17680}, 0x14002f34360)\n\tgithub.com/gravitational/teleport/lib/httplib/httplib.go:104 +0x190\nnet/http.HandlerFunc.ServeHTTP(0x10def12f8?, {0x10dee7190?, 0x14002d17680?}, 0x10b7ed148?)\n\tnet/http/server.go:2166 +0x38\ngo.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*middleware).serveHTTP(0x14003b5a820, {0x10deca040, 0x1400346bce0}, 0x14002f34120, {0x10de29738, 0x14002b39e78})\n\tgo.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.50.0/handler.go:214 +0xf34\ngo.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewMiddleware.func1.1({0x10deca040?, 0x1400346bce0?}, 0x140036b8390?)\n\tgo.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.50.0/handler.go:72 +0x40\nnet/http.HandlerFunc.ServeHTTP(0x0?, {0x10deca040?, 0x1400346bce0?}, 0x140035b3b50?)\n\tnet/http/server.go:2166 +0x38\nnet/http.serverHandler.ServeHTTP({0x140036b8390?}, {0x10deca040?, 0x1400346bce0?}, 0x6?)\n\tnet/http/server.go:3137 +0xbc\nnet/http.(*conn).serve(0x140037a9170, {0x10def12f8, 0x140036b8330})\n\tnet/http/server.go:2039 +0x508\ncreated by net/http.(*Server).Serve in goroutine 1788\n\tnet/http/server.go:3285 +0x3f0"
```

This checks if it's `nil` and returns a default value