### PR TITLE
Dont show cluster dropdown for only one cluster

### DIFF
--- a/web/packages/shared/components/ClusterDropdown/ClusterDropdown.story.tsx
+++ b/web/packages/shared/components/ClusterDropdown/ClusterDropdown.story.tsx
@@ -83,6 +83,14 @@ export const Dropdown = () => {
             onError={() => null}
           />
         </Box>
+        <Box mb={4}>
+          <Text>1 cluster (shouldn't be displayed)</Text>
+          <ClusterDropdown
+            clusterId="cluster-2"
+            clusterLoader={{ clusters: oneCluster, fetchClusters }}
+            onError={() => null}
+          />
+        </Box>
       </ContextProvider>
     </MemoryRouter>
   );
@@ -96,6 +104,12 @@ const lotsOfClusters = new Array(500).fill(null).map(
       clusterId: `cluster-${i}`,
     }) as Cluster
 );
+
+const oneCluster = [
+  {
+    clusterId: `cluster-1`,
+  } as Cluster,
+];
 
 const twoClusters = new Array(2).fill(null).map(
   (_, i) =>

--- a/web/packages/shared/components/ClusterDropdown/ClusterDropdown.tsx
+++ b/web/packages/shared/components/ClusterDropdown/ClusterDropdown.tsx
@@ -129,7 +129,8 @@ export function ClusterDropdown({
     setAnchorEl(null);
   };
 
-  if (options.length < 1) {
+  // If only a single cluster is available, hide the dropdown
+  if (options.length < 2) {
     return null;
   }
 


### PR DESCRIPTION
The original intent of the new cluster dropdown was to hide if only one cluster exists. This fixes the conditional rendering check.

changelog: the cluster selector in the UI is now only visible when more than one cluster is available