### PR TITLE
Add AuthenticateWebService deeplink in Connect

### DIFF
--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
@@ -23,7 +23,7 @@ import { ButtonSecondary } from 'design/Button';
 import { getPlatform } from 'design/platform';
 import { Text, Flex } from 'design';
 import * as Icons from 'design/Icon';
-import { Path, makeDeepLinkWithSafeInput } from 'shared/deepLinks';
+import { makeDeepLinkWithSafeInput } from 'shared/deepLinks';
 import * as connectMyComputer from 'shared/connectMyComputer';
 import {
   DownloadConnect,
@@ -67,7 +67,8 @@ export function SetupConnect(
   const connectMyComputerDeepLink = makeDeepLinkWithSafeInput({
     proxyHost: cluster.publicURL,
     username,
-    path: Path.ConnectMyComputer,
+    path: '/connect_my_computer',
+    searchParams: {},
   });
   const [showHint, setShowHint] = useState(false);
 

--- a/web/packages/teleterm/src/deepLinks.test.ts
+++ b/web/packages/teleterm/src/deepLinks.test.ts
@@ -16,13 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Path, makeDeepLinkWithSafeInput } from 'shared/deepLinks';
+import { DeepURL, makeDeepLinkWithSafeInput } from 'shared/deepLinks';
 
 import {
   DeepLinkParseResult,
   DeepLinkParseResultSuccess,
   parseDeepLink,
-  DeepURL,
 } from './deepLinks';
 
 describe('parseDeepLink', () => {
@@ -39,6 +38,22 @@ describe('parseDeepLink', () => {
           port: '',
           pathname: '/connect_my_computer',
           username: '',
+          searchParams: {},
+        },
+      },
+      {
+        input:
+          'teleport://cluster.example.com/authenticate_web_device?id=123&token=234',
+        expectedURL: {
+          host: 'cluster.example.com',
+          hostname: 'cluster.example.com',
+          port: '',
+          pathname: '/authenticate_web_device',
+          username: '',
+          searchParams: {
+            id: '123',
+            token: '234',
+          },
         },
       },
       {
@@ -49,6 +64,7 @@ describe('parseDeepLink', () => {
           port: '',
           pathname: '/connect_my_computer',
           username: 'alice',
+          searchParams: {},
         },
       },
       {
@@ -60,6 +76,7 @@ describe('parseDeepLink', () => {
           port: '1337',
           pathname: '/connect_my_computer',
           username: 'alice.bobson@example.com',
+          searchParams: {},
         },
       },
       // The example below is a bit contrived, usernames in URL should be percent-encoded. However,
@@ -74,6 +91,7 @@ describe('parseDeepLink', () => {
           port: '',
           pathname: '/connect_my_computer',
           username: 'alice.bobson@example.com',
+          searchParams: {},
         },
       },
     ];
@@ -100,21 +118,21 @@ describe('parseDeepLink', () => {
         input: 'teleport:///clusters/foo',
         output: {
           status: 'error',
-          reason: 'unsupported-uri',
+          reason: 'unsupported-url',
         },
       },
       {
         input: 'teleport://cluster.example.com/foo',
         output: {
           status: 'error',
-          reason: 'unsupported-uri',
+          reason: 'unsupported-url',
         },
       },
       {
         input: 'teleport:///foo/bar',
         output: {
           status: 'error',
-          reason: 'unsupported-uri',
+          reason: 'unsupported-url',
         },
       },
       {
@@ -123,6 +141,16 @@ describe('parseDeepLink', () => {
           status: 'error',
           reason: 'unknown-protocol',
           protocol: 'foobar:',
+        },
+      },
+      {
+        input: 'teleport://cluster.example.com/authenticate_web_device',
+        output: {
+          error: new TypeError(
+            'id and token must be included in the deep link for authenticating a web device'
+          ),
+          status: 'error',
+          reason: 'malformed-url',
         },
       },
     ];
@@ -138,18 +166,30 @@ describe('makeDeepLinkWithSafeInput followed by parseDeepLink gives the same res
   const inputs: Array<Parameters<typeof makeDeepLinkWithSafeInput>[0]> = [
     {
       proxyHost: 'cluster.example.com',
-      path: Path.ConnectMyComputer,
+      path: '/connect_my_computer',
       username: undefined,
+      searchParams: {},
     },
     {
       proxyHost: 'cluster.example.com',
-      path: Path.ConnectMyComputer,
+      path: '/connect_my_computer',
       username: 'alice',
+      searchParams: {},
     },
     {
       proxyHost: 'cluster.example.com:1337',
-      path: Path.ConnectMyComputer,
+      path: '/connect_my_computer',
       username: 'alice.bobson@example.com',
+      searchParams: {},
+    },
+    {
+      proxyHost: 'cluster.example.com:1337',
+      path: '/authenticate_web_device',
+      username: 'alice.bobson@example.com',
+      searchParams: {
+        token: '123',
+        id: '123',
+      },
     },
   ];
 
@@ -160,8 +200,9 @@ describe('makeDeepLinkWithSafeInput followed by parseDeepLink gives the same res
       status: 'success',
       url: {
         host: input.proxyHost,
-        pathname: '/' + input.path,
+        pathname: input.path,
         username: input.username === undefined ? '' : input.username,
+        searchParams: input.searchParams,
       },
     });
   });
@@ -180,8 +221,30 @@ describe('parseDeepLink followed by makeDeepLinkWithSafeInput gives the same res
     const { url } = parseResult as DeepLinkParseResultSuccess;
     const deepLink = makeDeepLinkWithSafeInput({
       proxyHost: url.host,
-      path: url.pathname.substring(1) as Path, // Remove the leading slash.
+      path: url.pathname,
       username: url.username,
+      searchParams: {},
+    });
+    expect(deepLink).toEqual(input);
+  });
+});
+
+describe('"parseDeepLink followed by makeDeepLinkWithSafeInput gives the same result"', () => {
+  const inputs: string[] = [
+    'teleport://cluster.example.com/connect_my_computer',
+    'teleport://alice@cluster.example.com/connect_my_computer',
+    'teleport://alice@cluster.example.com/authenticate_web_device?id=123&token=234',
+  ];
+
+  test.each(inputs)('%s', input => {
+    const parseResult = parseDeepLink(input);
+    expect(parseResult).toMatchObject({ status: 'success' });
+    const { url } = parseResult as DeepLinkParseResultSuccess;
+    const deepLink = makeDeepLinkWithSafeInput({
+      proxyHost: url.host,
+      path: url.pathname,
+      username: url.username,
+      searchParams: url.searchParams,
     });
     expect(deepLink).toEqual(input);
   });

--- a/web/packages/teleterm/src/deepLinks.ts
+++ b/web/packages/teleterm/src/deepLinks.ts
@@ -17,7 +17,13 @@
  */
 
 import * as whatwg from 'whatwg-url';
-import { CUSTOM_PROTOCOL, Path } from 'shared/deepLinks';
+import {
+  CUSTOM_PROTOCOL,
+  Path,
+  DeepURL,
+  ConnectMyComputerDeepURL,
+  AuthenticateWebDeviceDeepURL,
+} from 'shared/deepLinks';
 
 export type DeepLinkParseResult =
   // Just having a field like `ok: true` for success and `status: 'error'` for errors would be much more
@@ -26,9 +32,12 @@ export type DeepLinkParseResult =
   | DeepLinkParseResultSuccess
   | ParseError<'malformed-url', { error: TypeError }>
   | ParseError<'unknown-protocol', { protocol: string }>
-  | ParseError<'unsupported-uri'>;
+  | ParseError<'unsupported-url'>;
 
-export type DeepLinkParseResultSuccess = { status: 'success'; url: DeepURL };
+export type DeepLinkParseResultSuccess = {
+  status: 'success';
+  url: DeepURL;
+};
 
 type ParseError<Reason, AdditionalData = void> = AdditionalData extends void
   ? {
@@ -41,38 +50,9 @@ type ParseError<Reason, AdditionalData = void> = AdditionalData extends void
     } & AdditionalData;
 
 /**
- *
- * DeepURL is a parsed version of an URL.
- *
- * Since DeepLinkParseResult goes through IPC in Electron [1], anything included in it is subject to
- * Structured Clone Algorithm [2]. As such, getters and setters are dropped which means were not
- * able to pass whatwg.URL without casting it to an object.
- *
- * [1] https://www.electronjs.org/docs/latest/tutorial/ipc
- * [2] https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+ * pathname is the path from the URL with the leading slash included, e.g. if the URL is
+ * "teleport://example.com/connect_my_computer", the pathname is "/connect_my_computer"
  */
-export type DeepURL = {
-  /**
-   * host is the hostname plus the port.
-   */
-  host: string;
-  /**
-   * hostname is the host without the port, e.g. if the host is "example.com:4321", the hostname is
-   * "example.com".
-   */
-  hostname: string;
-  port: string;
-  /**
-   * username is percent-decoded username from the URL. whatwg-url encodes usernames found in URLs.
-   * parseDeepLink decodes them so that other parts of the app don't have to deal with this.
-   */
-  username: string;
-  /**
-   * pathname is the path from the URL with the leading slash included, e.g. if the URL is
-   * "teleport://example.com/connect_my_computer", the pathname is "/connect_my_computer"
-   */
-  pathname: `/${Path}`;
-};
 
 /**
  * parseDeepLink receives a full URL of a deep link passed to Connect, e.g.
@@ -104,20 +84,51 @@ export function parseDeepLink(rawUrl: string): DeepLinkParseResult {
     };
   }
 
-  if (whatwgURL.pathname !== '/connect_my_computer') {
-    return { status: 'error', reason: 'unsupported-uri' };
-  }
-
-  const { host, hostname, port, username, pathname } = whatwgURL;
-  const url: DeepURL = {
+  // TODO (avatus): remove when authenticate web device case is implemented
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { host, hostname, port, username, pathname, searchParams } = whatwgURL;
+  const baseUrl = {
     host,
     hostname,
     port,
     // whatwg-url percent-encodes usernames. We decode them here so that the rest of the app doesn't
     // have to do this. https://url.spec.whatwg.org/#set-the-username
     username: decodeURIComponent(username),
-    pathname,
   };
 
-  return { status: 'success', url };
+  switch (pathname as Path) {
+    case '/connect_my_computer': {
+      const url: ConnectMyComputerDeepURL = {
+        ...baseUrl,
+        pathname: '/connect_my_computer',
+        searchParams: {},
+      };
+      return { status: 'success', url };
+    }
+    case '/authenticate_web_device': {
+      const id = searchParams.get('id');
+      const token = searchParams.get('token');
+      if (!(id && token)) {
+        return {
+          status: 'error',
+          reason: 'malformed-url',
+          error: new TypeError(
+            'id and token must be included in the deep link for authenticating a web device'
+          ),
+        };
+      }
+
+      const url: AuthenticateWebDeviceDeepURL = {
+        ...baseUrl,
+        pathname: '/authenticate_web_device',
+        searchParams: {
+          id,
+          token,
+        },
+      };
+      return { status: 'success', url };
+    }
+    default:
+      return { status: 'error', reason: 'unsupported-url' };
+  }
 }

--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -401,8 +401,8 @@ function launchDeepLink(
         reason = `unknown protocol of the deep link ("${result.protocol}")`;
         break;
       }
-      case 'unsupported-uri': {
-        reason = 'unsupported URI received';
+      case 'unsupported-url': {
+        reason = 'unsupported URL received';
         break;
       }
       case 'malformed-url': {

--- a/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.test.ts
+++ b/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.test.ts
@@ -35,7 +35,7 @@ describe('parse errors', () => {
       error: new TypeError('whoops'),
     },
     { status: 'error', reason: 'unknown-protocol', protocol: 'foo:' },
-    { status: 'error', reason: 'unsupported-uri' },
+    { status: 'error', reason: 'unsupported-url' },
   ];
 
   test.each(tests)(
@@ -88,6 +88,7 @@ const successResult: DeepLinkParseResult = {
     port: '1234',
     pathname: '/connect_my_computer',
     username: 'alice',
+    searchParams: {},
   },
 };
 

--- a/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.ts
+++ b/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.ts
@@ -16,7 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { DeepLinkParseResult, DeepURL } from 'teleterm/deepLinks';
+import { DeepURL } from 'shared/deepLinks';
+
+import { DeepLinkParseResult } from 'teleterm/deepLinks';
 import { routing } from 'teleterm/ui/uri';
 import { assertUnreachable } from 'teleterm/ui/utils';
 import { RuntimeSettings } from 'teleterm/types';
@@ -50,14 +52,14 @@ export class DeepLinksService {
           reason = `The URL of the link is of an unknown protocol.`;
           break;
         }
-        case 'unsupported-uri': {
+        case 'unsupported-url': {
           reason =
             'The received link does not point at a resource or an action that can be launched from a link. ' +
             'Either this version of Teleport Connect does not support it or the link is incorrect.';
           break;
         }
         case 'malformed-url': {
-          reason = `The URL of the link appears to be malformed.`;
+          reason = `The URL of the link appears to be malformed. ${result.error.message}`;
           break;
         }
         default: {
@@ -83,6 +85,12 @@ export class DeepLinksService {
     switch (result.url.pathname) {
       case '/connect_my_computer': {
         await this.launchConnectMyComputer(result.url);
+        break;
+      }
+      case '/authenticate_web_device': {
+        // TODO (avatus): add authenticate device web confirmation dialog
+        // this case is a stub and will not be reached
+        break;
       }
     }
   }


### PR DESCRIPTION
This PR adds a handler stub for the upcoming device trust web deeplink. The main purpose of this PR is to have a discussion around the use of query params in the deeplink and a proposed implementation to hopefully provide type safety. 

The goal afterwards is to PR the change that implements the confirmation dialog to authenticate the request so I left some stubs in here

https://github.com/gravitational/teleport.e/issues/3236