### PR TITLE
Add a linter for `[Resource] Access`

### DIFF
--- a/.github/vale-styles/messaging/protocol-products.yml
+++ b/.github/vale-styles/messaging/protocol-products.yml
@@ -1,0 +1,12 @@
+extends: existence
+message: Avoid the impression that Teleport consists of multiple products for secure access, e.g., "Database Access" or "Server Access". Instead, talk about enrolling resources in your Teleport cluster, protecting resources with Teleport, or the ability for Teleport to proxy various protocols.
+level: error
+ignorecase: false
+tokens:
+  - 'Server Access'
+  - 'Application Access'
+  - 'Kubernetes Access'
+  - 'Desktop Access'
+  # Ignore "Database Access Controls" since it's a Teleport feature, but catch
+  # "Database Access" without "Controls".
+  - 'Database Access(?!\s*Controls)'


### PR DESCRIPTION
This is a legacy convention for describing Teleport features. This change ports the linter for `[Resource] Access` usage from `gravitational/docs` to a vale style (we'll need to remove the linter from `gravitational/docs` separately). It also excludes "Database Access Controls" from the linter, since Database Access Controls is a current Teleport feature.