### PR TITLE
Uniform equal function names to `IsEqual`

### DIFF
--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -28,9 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 )
 
-var (
-	_ compare.IsEqual[*AccessListMember] = (*AccessListMember)(nil)
-)
+var _ compare.IsEqual[*AccessListMember] = (*AccessListMember)(nil)
 
 // AccessListMember is an access list member resource.
 type AccessListMember struct {

--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -22,9 +22,14 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/compare"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/header/convert/legacy"
 	"github.com/gravitational/teleport/api/utils"
+)
+
+var (
+	_ compare.IsEqual[*AccessListMember] = (*AccessListMember)(nil)
 )
 
 // AccessListMember is an access list member resource.

--- a/api/types/app.go
+++ b/api/types/app.go
@@ -29,9 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 )
 
-var (
-	_ compare.IsEqual[Application] = (*AppV3)(nil)
-)
+var _ compare.IsEqual[Application] = (*AppV3)(nil)
 
 // Application represents a web, TCP or cloud console application.
 type Application interface {

--- a/api/types/app.go
+++ b/api/types/app.go
@@ -25,7 +25,12 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types/compare"
 	"github.com/gravitational/teleport/api/utils"
+)
+
+var (
+	_ compare.IsEqual[Application] = (*AppV3)(nil)
 )
 
 // Application represents a web, TCP or cloud console application.

--- a/api/types/compare/equal.go
+++ b/api/types/compare/equal.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Gravitational, Inc.
+Copyright 2024 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/api/types/compare/equal.go
+++ b/api/types/compare/equal.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compare
+
+// IsEqual[T] will be used instead of cmp.Equal if a resource implements it.
+type IsEqual[T any] interface {
+	IsEqual(T) bool
+}

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -27,10 +27,15 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/types/compare"
 	"github.com/gravitational/teleport/api/utils"
 	atlasutils "github.com/gravitational/teleport/api/utils/atlas"
 	awsutils "github.com/gravitational/teleport/api/utils/aws"
 	azureutils "github.com/gravitational/teleport/api/utils/azure"
+)
+
+var (
+	_ compare.IsEqual[Database] = (*DatabaseV3)(nil)
 )
 
 // Database represents a single database proxied by a database server.

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -34,9 +34,7 @@ import (
 	azureutils "github.com/gravitational/teleport/api/utils/azure"
 )
 
-var (
-	_ compare.IsEqual[Database] = (*DatabaseV3)(nil)
-)
+var _ compare.IsEqual[Database] = (*DatabaseV3)(nil)
 
 // Database represents a single database proxied by a database server.
 type Database interface {

--- a/api/types/desktop.go
+++ b/api/types/desktop.go
@@ -31,9 +31,7 @@ const (
 	MaxRDPScreenHeight = 8192
 )
 
-var (
-	_ compare.IsEqual[WindowsDesktop] = (*WindowsDesktopV3)(nil)
-)
+var _ compare.IsEqual[WindowsDesktop] = (*WindowsDesktopV3)(nil)
 
 // WindowsDesktopService represents a Windows desktop service instance.
 type WindowsDesktopService interface {

--- a/api/types/desktop.go
+++ b/api/types/desktop.go
@@ -22,12 +22,17 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/types/compare"
 	"github.com/gravitational/teleport/api/utils"
 )
 
 const (
 	MaxRDPScreenWidth  = 8192
 	MaxRDPScreenHeight = 8192
+)
+
+var (
+	_ compare.IsEqual[WindowsDesktop] = (*WindowsDesktopV3)(nil)
 )
 
 // WindowsDesktopService represents a Windows desktop service instance.

--- a/api/types/discoveryconfig/discoveryconfig.go
+++ b/api/types/discoveryconfig/discoveryconfig.go
@@ -28,9 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 )
 
-var (
-	_ compare.IsEqual[*DiscoveryConfig] = (*DiscoveryConfig)(nil)
-)
+var _ compare.IsEqual[*DiscoveryConfig] = (*DiscoveryConfig)(nil)
 
 // DiscoveryConfig describes extra discovery matchers that are added to DiscoveryServices that share the same Discovery Group.
 type DiscoveryConfig struct {

--- a/api/types/discoveryconfig/discoveryconfig.go
+++ b/api/types/discoveryconfig/discoveryconfig.go
@@ -22,9 +22,14 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/compare"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/header/convert/legacy"
 	"github.com/gravitational/teleport/api/utils"
+)
+
+var (
+	_ compare.IsEqual[*DiscoveryConfig] = (*DiscoveryConfig)(nil)
 )
 
 // DiscoveryConfig describes extra discovery matchers that are added to DiscoveryServices that share the same Discovery Group.
@@ -58,7 +63,7 @@ type Spec struct {
 }
 
 // Equal checks if the discovery config is equal to another.
-func (m *DiscoveryConfig) Equal(n *DiscoveryConfig) bool {
+func (m *DiscoveryConfig) IsEqual(n *DiscoveryConfig) bool {
 	return deriveTeleportEqualDiscoveryConfig(m, n)
 }
 

--- a/api/types/discoveryconfig/discoveryconfig.go
+++ b/api/types/discoveryconfig/discoveryconfig.go
@@ -61,6 +61,12 @@ type Spec struct {
 }
 
 // Equal checks if the discovery config is equal to another.
+// Deprecated: use IsEqual.
+func (m *DiscoveryConfig) Equal(n *DiscoveryConfig) bool {
+	return m.IsEqual(n)
+}
+
+// IsEqual checks if the discovery config is equal to another.
 func (m *DiscoveryConfig) IsEqual(n *DiscoveryConfig) bool {
 	return deriveTeleportEqualDiscoveryConfig(m, n)
 }

--- a/api/types/header/header.go
+++ b/api/types/header/header.go
@@ -23,7 +23,13 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types/common"
+	"github.com/gravitational/teleport/api/types/compare"
 	"github.com/gravitational/teleport/api/utils"
+)
+
+var (
+	_ compare.IsEqual[*ResourceHeader] = (*ResourceHeader)(nil)
+	_ compare.IsEqual[*Metadata]       = (*Metadata)(nil)
 )
 
 func ResourceHeaderFromMetadata(metadata Metadata) ResourceHeader {

--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -29,9 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 )
 
-var (
-	_ compare.IsEqual[KubeCluster] = (*KubernetesClusterV3)(nil)
-)
+var _ compare.IsEqual[KubeCluster] = (*KubernetesClusterV3)(nil)
 
 // KubeCluster represents a kubernetes cluster.
 type KubeCluster interface {

--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -25,7 +25,12 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/types/compare"
 	"github.com/gravitational/teleport/api/utils"
+)
+
+var (
+	_ compare.IsEqual[KubeCluster] = (*KubernetesClusterV3)(nil)
 )
 
 // KubeCluster represents a kubernetes cluster.

--- a/api/types/kubernetes_server.go
+++ b/api/types/kubernetes_server.go
@@ -28,9 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 )
 
-var (
-	_ compare.IsEqual[KubeServer] = (*KubernetesServerV3)(nil)
-)
+var _ compare.IsEqual[KubeServer] = (*KubernetesServerV3)(nil)
 
 // KubeServer represents a single Kubernetes server.
 type KubeServer interface {

--- a/api/types/kubernetes_server.go
+++ b/api/types/kubernetes_server.go
@@ -24,7 +24,12 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api"
+	"github.com/gravitational/teleport/api/types/compare"
 	"github.com/gravitational/teleport/api/utils"
+)
+
+var (
+	_ compare.IsEqual[KubeServer] = (*KubernetesServerV3)(nil)
 )
 
 // KubeServer represents a single Kubernetes server.

--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -23,7 +23,12 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types/compare"
 	"github.com/gravitational/teleport/api/utils"
+)
+
+var (
+	_ compare.IsEqual[OktaAssignment] = (*OktaAssignmentV1)(nil)
 )
 
 // OktaImportRule specifies a rule for importing and labeling Okta applications and groups.

--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -27,9 +27,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 )
 
-var (
-	_ compare.IsEqual[OktaAssignment] = (*OktaAssignmentV1)(nil)
-)
+var _ compare.IsEqual[OktaAssignment] = (*OktaAssignmentV1)(nil)
 
 // OktaImportRule specifies a rule for importing and labeling Okta applications and groups.
 type OktaImportRule interface {

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -27,7 +27,13 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types/common"
+	"github.com/gravitational/teleport/api/types/compare"
 	"github.com/gravitational/teleport/api/utils"
+)
+
+var (
+	_ compare.IsEqual[*ResourceHeader] = (*ResourceHeader)(nil)
+	_ compare.IsEqual[*Metadata]       = (*Metadata)(nil)
 )
 
 // Resource represents common properties for all resources.

--- a/api/types/usergroup.go
+++ b/api/types/usergroup.go
@@ -23,7 +23,12 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/types/compare"
 	"github.com/gravitational/teleport/api/utils"
+)
+
+var (
+	_ compare.IsEqual[UserGroup] = (*UserGroupV1)(nil)
 )
 
 // UserGroup specifies an externally sourced group.

--- a/api/types/usergroup.go
+++ b/api/types/usergroup.go
@@ -27,9 +27,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 )
 
-var (
-	_ compare.IsEqual[UserGroup] = (*UserGroupV1)(nil)
-)
+var _ compare.IsEqual[UserGroup] = (*UserGroupV1)(nil)
 
 // UserGroup specifies an externally sourced group.
 type UserGroup interface {

--- a/lib/services/compare.go
+++ b/lib/services/compare.go
@@ -27,17 +27,13 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/compare"
 )
-
-// IsEqual[T] will be used instead of cmp.Equal if a resource implements it.
-type IsEqual[T any] interface {
-	IsEqual(T) bool
-}
 
 // CompareResources compares two resources by all significant fields.
 func CompareResources[T any](resA, resB T) int {
 	var equal bool
-	if hasEqual, ok := any(resA).(IsEqual[T]); ok {
+	if hasEqual, ok := any(resA).(compare.IsEqual[T]); ok {
 		equal = hasEqual.IsEqual(resB)
 	} else {
 		equal = cmp.Equal(resA, resB,

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1423,7 +1423,7 @@ func (s *Server) startDynamicWatcherUpdater() {
 				oldDiscoveryConfig := s.dynamicDiscoveryConfig[dc.GetName()]
 				// If the DiscoveryConfig spec didn't change, then there's no need to update the matchers.
 				// we can skip this event.
-				if oldDiscoveryConfig.Equal(dc) {
+				if oldDiscoveryConfig.IsEqual(dc) {
 					continue
 				}
 


### PR DESCRIPTION
Our API doesn't define any naming or characteristics for object comparison functions like `IsEqual`. Checks rely on using `services.CompareResources` that has some coverage but doesn't cover all resources otherwise it fallback to expensive `cmp.Equal` comparison.

This PR moves the `IsEqual` interface to `api` so we can ensure objects satisfy the same interface required by `services.CompareResources`.