### PR TITLE
[v15] player: fix seeking during dead time

### DIFF
--- a/lib/player/player.go
+++ b/lib/player/player.go
@@ -58,7 +58,7 @@ type Player struct {
 	advanceTo atomic.Int64
 
 	emit chan events.AuditEvent
-	wake chan struct{}
+	wake chan int64
 	done chan struct{}
 
 	// playPause holds a channel to be closed when
@@ -120,7 +120,7 @@ func New(cfg *Config) (*Player, error) {
 		streamer:  cfg.Streamer,
 		emit:      make(chan events.AuditEvent, 1024),
 		playPause: make(chan chan struct{}, 1),
-		wake:      make(chan struct{}),
+		wake:      make(chan int64),
 		done:      make(chan struct{}),
 	}
 
@@ -209,7 +209,13 @@ func (p *Player) stream() {
 						// time we were advanced to
 						lastDelay = adv
 					}
-					if err := p.applyDelay(time.Duration(currentDelay-lastDelay) * time.Millisecond); err != nil {
+
+					switch err := p.applyDelay(lastDelay, currentDelay); {
+					case err == errSeekWhilePaused:
+						p.log.Debug("seeked during pause, will restart stream")
+						go p.stream()
+						return
+					case err != nil:
 						close(p.emit)
 						return
 					}
@@ -279,27 +285,88 @@ func (p *Player) SetPos(d time.Duration) error {
 
 	// try to wake up the player if it's waiting to emit an event
 	select {
-	case p.wake <- struct{}{}:
+	case p.wake <- d.Milliseconds():
 	default:
 	}
 
 	return nil
 }
 
-// applyDelay "sleeps" for d in a manner that
-// can be canceled
-func (p *Player) applyDelay(d time.Duration) error {
-	scaled := float64(d) / p.speed.Load().(float64)
+// applyDelay applies the timing delay between the last emitted event
+// (lastDelay) and the event that will be emitted next (currentDelay).
+//
+// The delay can be interrupted by:
+// 1. The player being closed.
+// 2. The user pausing playback.
+// 3. The user seeking to a new position in the playback (SetPos)
+//
+// A nil return value indicates that the delay has elapsed and that
+// the next even can be emitted.
+func (p *Player) applyDelay(lastDelay, currentDelay int64) error {
+loop:
+	for {
+		// TODO(zmb3): changing play speed during a long sleep
+		// will not apply until after the sleep completes
+		speed := p.speed.Load().(float64)
+		scaled := float64(currentDelay-lastDelay) / speed
 
-	select {
-	case <-p.done:
-		return errClosed
-	case <-p.wake:
-		return nil
-	case <-p.clock.After(time.Duration(scaled)):
-		return nil
+		timer := p.clock.NewTimer(time.Duration(scaled) * time.Millisecond)
+		defer timer.Stop()
+
+		start := time.Now()
+
+		select {
+		case <-p.done:
+			return errClosed
+		case newPos := <-p.wake:
+			// the sleep was interrupted due to the user changing playback controls
+			switch {
+			case newPos == interruptForPause:
+				// the user paused playback while we were waiting to emit the next event:
+				// 1) figure out much of the sleep we completed
+				dur := float64(time.Since(start).Milliseconds()) * speed
+
+				// 2) wait here until the user resumes playback
+				if err := p.waitWhilePaused(); err == errSeekWhilePaused {
+					// the user changed the playback position, so consider the delay
+					// applied and let the player pick up from the new position
+
+					return errSeekWhilePaused
+				}
+
+				// now that we're playing again, update our delay to account
+				// for the portion that was already satisfied and apply the
+				// remaining delay
+				lastDelay += int64(dur)
+				timer.Stop()
+				continue loop
+			case newPos > currentDelay:
+				// the user scrubbed forward in time past the current event,
+				// so we can return as if the delay has elapsed naturally
+				return nil
+			case newPos < 0:
+				// the user has rewinded playback, which means we need to restart
+				// the stream and can consider this delay as having elapsed naturally
+				return nil
+			case newPos < currentDelay:
+				// the user has scrubbed forward in time, but not enough to
+				// emit the next event - we need to delay more
+				lastDelay = newPos
+				timer.Stop()
+				continue loop
+			default:
+				return nil
+			}
+
+		case <-timer.Chan():
+			return nil
+		}
 	}
 }
+
+// interruptForPause is a special value used to interrupt the player's
+// sleep due to the user pausing playback.
+const interruptForPause = math.MaxInt64
 
 func (p *Player) setPlaying(play bool) {
 	ch := <-p.playPause
@@ -307,6 +374,13 @@ func (p *Player) setPlaying(play bool) {
 
 	if alreadyPlaying && !play {
 		ch = make(chan struct{})
+
+		// try to wake up the player if it's waiting to emit an event
+		select {
+		case p.wake <- interruptForPause:
+		default:
+		}
+
 	} else if !alreadyPlaying && play {
 		// signal waiters who are paused that it's time to resume playing
 		close(ch)
@@ -316,20 +390,34 @@ func (p *Player) setPlaying(play bool) {
 	p.playPause <- ch
 }
 
+var errSeekWhilePaused = errors.New("player seeked during pause")
+
 // waitWhilePaused blocks while the player is in a paused state.
 // It returns immediately if the player is currently playing.
 func (p *Player) waitWhilePaused() error {
-	ch := <-p.playPause
-	p.playPause <- ch
+	seeked := false
+	for {
+		ch := <-p.playPause
+		p.playPause <- ch
 
-	if alreadyPlaying := ch == nil; !alreadyPlaying {
-		select {
-		case <-p.done:
-			return errClosed
-		case <-ch:
+		if alreadyPlaying := ch == nil; !alreadyPlaying {
+			select {
+			case <-p.done:
+				return errClosed
+			case <-p.wake:
+				// seek while paused, this can happen an unlimited number of times,
+				// we just keep waiting until we're unpaused
+				seeked = true
+				continue
+			case <-ch:
+				// we have been unpaused
+			}
 		}
+		if seeked {
+			return errSeekWhilePaused
+		}
+		return nil
 	}
-	return nil
 }
 
 // LastPlayed returns the time of the last played event,

--- a/lib/player/player.go
+++ b/lib/player/player.go
@@ -211,7 +211,7 @@ func (p *Player) stream() {
 					}
 
 					switch err := p.applyDelay(lastDelay, currentDelay); {
-					case err == errSeekWhilePaused:
+					case errors.Is(err, errSeekWhilePaused):
 						p.log.Debug("seeked during pause, will restart stream")
 						go p.stream()
 						return
@@ -331,7 +331,7 @@ loop:
 				dur := float64(time.Since(start).Milliseconds()) * speed
 
 				// 2) wait here until the user resumes playback
-				if err := p.waitWhilePaused(); err == errSeekWhilePaused {
+				if err := p.waitWhilePaused(); errors.Is(err, errSeekWhilePaused) {
 					// the user changed the playback position, so consider the delay
 					// applied and let the player pick up from the new position
 					return errSeekWhilePaused

--- a/lib/player/player.go
+++ b/lib/player/player.go
@@ -277,8 +277,12 @@ func (p *Player) Play() error {
 // from the beginning. A duration greater than the length of the session
 // will cause playback to rapidly advance to the end of the recording.
 func (p *Player) SetPos(d time.Duration) error {
+	// we use a negative value to indicate rewinding, which means we can't
+	// rewind to position 0 (there is no negative 0)
+	if d == 0 {
+		d = 1 * time.Millisecond
+	}
 	if d.Milliseconds() < p.lastPlayed.Load() {
-		// if we're rewinding we store a negative value
 		d = -1 * d
 	}
 	p.advanceTo.Store(d.Milliseconds())
@@ -330,7 +334,6 @@ loop:
 				if err := p.waitWhilePaused(); err == errSeekWhilePaused {
 					// the user changed the playback position, so consider the delay
 					// applied and let the player pick up from the new position
-
 					return errSeekWhilePaused
 				}
 

--- a/lib/player/player_test.go
+++ b/lib/player/player_test.go
@@ -258,8 +258,8 @@ func TestSeekForwardTwice(t *testing.T) {
 	clk.Advance(51 * time.Millisecond)
 	select {
 	case <-p.C():
-	case <-time.After(1 * time.Second):
-		require.FailNow(t, "event not ready in time %#v", clk)
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "event not ready in time", "clock %#v", clk)
 	}
 }
 

--- a/lib/player/player_test.go
+++ b/lib/player/player_test.go
@@ -258,7 +258,7 @@ func TestSeekForwardTwice(t *testing.T) {
 	clk.Advance(51 * time.Millisecond)
 	select {
 	case <-p.C():
-	case <-time.After(3 * time.Second):
+	case <-time.After(5 * time.Second):
 		require.FailNow(t, "event not ready in time", "clock %#v", clk)
 	}
 }

--- a/lib/web/tty_playback.go
+++ b/lib/web/tty_playback.go
@@ -221,6 +221,8 @@ func (h *Handler) ttyPlaybackHandle(
 						return
 					}
 
+				case *events.SessionLeave: // do nothing
+
 				default:
 					h.log.Debugf("unexpected event type %T", evt)
 				}

--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -122,8 +122,8 @@ export const DesktopPlayer = ({
           onRestart={reload}
           onStartMove={() => playerClient.suspendTimeUpdates()}
           move={pos => {
-            playerClient.seekTo(pos);
             playerClient.resumeTimeUpdates();
+            playerClient.seekTo(pos);
           }}
           onPlaySpeedChange={s => playerClient.setPlaySpeed(s)}
           toggle={() => playerClient.togglePlayPause()}

--- a/web/packages/teleport/src/Player/SshPlayer.tsx
+++ b/web/packages/teleport/src/Player/SshPlayer.tsx
@@ -70,8 +70,8 @@ export default function Player({ sid, clusterId, durationMs }) {
         onRestart={() => window.location.reload()}
         onStartMove={() => tty.suspendTimeUpdates()}
         move={pos => {
-          tty.move(pos);
           tty.resumeTimeUpdates();
+          tty.move(pos);
         }}
         toggle={() => {
           isPlaying ? tty.stop() : tty.play();

--- a/web/packages/teleport/src/lib/tdp/playerClient.ts
+++ b/web/packages/teleport/src/lib/tdp/playerClient.ts
@@ -44,9 +44,12 @@ export class PlayerClient extends Client {
 
   private speed = 1.0;
   private paused = false;
+
   private lastPlayedTimestamp = 0;
+  private skipTimeUpdatesUntil = null;
+  private lastTimestamp = 0;
   private sendTimeUpdates = true;
-  private lastUpdate = 0;
+  private lastUpdateTime = 0;
   private timeout = null;
 
   constructor({ url, setTime, setPlayerStatus, setStatusText }) {
@@ -62,6 +65,8 @@ export class PlayerClient extends Client {
       if (this.sendTimeUpdates) {
         this._setTime(t);
       }
+      this.lastTimestamp = t;
+      this.lastUpdateTime = Date.now();
     }, PROGRESS_UPDATE_INTERVAL_MS);
   }
 
@@ -73,11 +78,11 @@ export class PlayerClient extends Client {
 
   scheduleNextUpdate(current: number) {
     this.timeout = setTimeout(() => {
-      const delta = Date.now() - this.lastUpdate;
+      const delta = Date.now() - this.lastUpdateTime;
       const next = current + delta * this.speed;
 
       this.setTime(next);
-      this.lastUpdate = Date.now();
+      this.lastUpdateTime = Date.now();
 
       this.scheduleNextUpdate(next);
     }, PROGRESS_UPDATE_INTERVAL_MS);
@@ -101,11 +106,21 @@ export class PlayerClient extends Client {
   // togglePlayPause toggles the playback system between "playing" and "paused" states.
   togglePlayPause() {
     this.paused = !this.paused;
-    this.send(JSON.stringify({ action: Action.TOGGLE_PLAY_PAUSE }));
+    this.setPlayerStatus(this.paused ? StatusEnum.PAUSED : StatusEnum.PLAYING);
     if (this.paused) {
       this.cancelTimeUpdate();
     }
-    this.setPlayerStatus(this.paused ? StatusEnum.PAUSED : StatusEnum.PLAYING);
+
+    this.lastUpdateTime = Date.now();
+
+    if (this.isSeekingForward()) {
+      const next = Math.max(this.skipTimeUpdatesUntil, this.lastTimestamp);
+      this.scheduleNextUpdate(next);
+    } else {
+      this.scheduleNextUpdate(this.lastTimestamp);
+    }
+
+    this.send(JSON.stringify({ action: Action.TOGGLE_PLAY_PAUSE }));
   }
 
   // setPlaySpeed sets the playback speed of the recording.
@@ -126,12 +141,29 @@ export class PlayerClient extends Client {
     } else {
       this.cancelTimeUpdate();
       this.lastPlayedTimestamp = json.ms;
-      this.lastUpdate = Date.now();
+      this.lastUpdateTime = Date.now();
       this.setTime(json.ms);
 
-      // schedule the next time update (in case this
-      // part of the recording is dead time)
-      if (!this.paused) {
+      // clear seek state if we caught up to the seek point
+      if (
+        this.skipTimeUpdatesUntil !== null &&
+        this.lastPlayedTimestamp >= this.skipTimeUpdatesUntil
+      ) {
+        this.skipTimeUpdatesUntil = null;
+      }
+
+      if (!this.isSeekingForward()) {
+        this.cancelTimeUpdate();
+      }
+
+      // schedule the next time update, which ensures that
+      // the progress bar continues to update even if this
+      // section of the recording is idle time
+      //
+      // note: we don't schedule an update if we're currently
+      // seeking forward in time, as we're trying to get there
+      // as quickly as possible
+      if (!this.paused && !this.isSeekingForward()) {
         this.scheduleNextUpdate(json.ms);
       }
 
@@ -144,14 +176,22 @@ export class PlayerClient extends Client {
 
     this.send(JSON.stringify({ action: Action.SEEK, pos }));
 
+    this._setTime(pos);
+    this.lastUpdateTime = Date.now();
+    this.skipTimeUpdatesUntil = pos;
+
     if (pos < this.lastPlayedTimestamp) {
       // TODO: clear canvas
-    } else if (this.paused) {
-      // if we're paused, we want the scrubber to "stick" at the new
-      // time until we press play (rather than waiting for us to click
-      // play and start receiving new data)
-      this._setTime(pos);
+    } else if (!this.paused) {
+      this.scheduleNextUpdate(pos);
     }
+  }
+
+  isSeekingForward(): boolean {
+    return (
+      this.skipTimeUpdatesUntil !== null &&
+      this.skipTimeUpdatesUntil > this.lastPlayedTimestamp
+    );
   }
 
   // Overrides Client implementation.

--- a/web/packages/teleport/src/lib/term/ttyPlayer.js
+++ b/web/packages/teleport/src/lib/term/ttyPlayer.js
@@ -218,12 +218,13 @@ export default class TtyPlayer extends Tty {
       logger.error('error seeking', e);
     }
 
+    this._setTime(newPos);
+    this._lastUpdateTime = Date.now();
+    this._skipTimeUpdatesUntil = newPos;
+
     if (newPos < this._lastPlayedTimestamp) {
       this.emit(TermEvent.RESET);
     } else {
-      this._skipTimeUpdatesUntil = newPos;
-      this._setTime(newPos);
-      this._lastUpdateTime = Date.now();
       if (!this._paused) {
         this.scheduleNextUpdate(newPos);
       }

--- a/web/packages/teleport/src/lib/term/ttyPlayer.js
+++ b/web/packages/teleport/src/lib/term/ttyPlayer.js
@@ -50,10 +50,12 @@ export default class TtyPlayer extends Tty {
 
     this._paused = false;
     this._lastPlayedTimestamp = 0;
+    this._skipTimeUpdatesUntil = null;
 
     this._sendTimeUpdates = true;
     this._setTime = throttle(t => setTime(t), PROGRESS_UPDATE_INTERVAL_MS);
-    this._lastUpdate = 0;
+    this._lastUpdateTime = 0;
+    this._lastTimestamp = 0;
     this._timeout = null;
   }
 
@@ -97,6 +99,9 @@ export default class TtyPlayer extends Tty {
     if (this._sendTimeUpdates) {
       this._setTime(t);
     }
+
+    this._lastTimestamp = t;
+    this._lastUpdateTime = Date.now();
   }
 
   disconnect(closeCode = WebsocketCloseCode.NORMAL) {
@@ -108,10 +113,11 @@ export default class TtyPlayer extends Tty {
 
   scheduleNextUpdate(current) {
     this._timeout = setTimeout(() => {
-      const delta = Date.now() - this._lastUpdate;
+      const delta = Date.now() - this._lastUpdateTime;
       const next = current + delta;
+
       this.setTime(next);
-      this._lastUpdate = Date.now();
+      this._lastUpdateTime = Date.now();
 
       this.scheduleNextUpdate(next);
     }, PROGRESS_UPDATE_INTERVAL_MS);
@@ -133,8 +139,6 @@ export default class TtyPlayer extends Tty {
       // see lib/web/tty_playback.go for details on this protocol
       switch (typ) {
         case messageTypePty:
-          this.cancelTimeUpdate();
-
           const delay = Number(dv.getBigUint64(3));
           const data = dv.buffer.slice(
             dv.byteOffset + 11,
@@ -143,13 +147,29 @@ export default class TtyPlayer extends Tty {
 
           this.emit(TermEvent.DATA, data);
           this._lastPlayedTimestamp = delay;
-
-          this._lastUpdate = Date.now();
+          this._lastUpdateTime = Date.now();
           this.setTime(delay);
 
-          // schedule the next time update (in case this
-          // part of the recording is dead time)
-          if (!this._paused) {
+          // clear seek state if we caught up to the seek point
+          if (
+            this._skipTimeUpdatesUntil !== null &&
+            this._lastPlayedTimestamp >= this._skipTimeUpdatesUntil
+          ) {
+            this._skipTimeUpdatesUntil = null;
+          }
+
+          if (!this.isSeekingForward()) {
+            this.cancelTimeUpdate();
+          }
+
+          // schedule the next time update, which ensures that
+          // the progress bar continues to update even if this
+          // section of the recording is idle time
+          //
+          // note: we don't schedule an update if we're currently
+          // seeking forward in time, as we're trying to get there
+          // as quickly as possible
+          if (!this._paused && !this.isSeekingForward()) {
             this.scheduleNextUpdate(delay);
           }
           break;
@@ -187,7 +207,6 @@ export default class TtyPlayer extends Tty {
 
   move(newPos) {
     this.cancelTimeUpdate();
-
     try {
       const buffer = new ArrayBuffer(11);
       const dv = new DataView(buffer);
@@ -201,12 +220,21 @@ export default class TtyPlayer extends Tty {
 
     if (newPos < this._lastPlayedTimestamp) {
       this.emit(TermEvent.RESET);
-    } else if (this._paused) {
-      // if we're paused, we want the scrubber to "stick" at the new
-      // time until we press play (rather than waiting for us to click
-      // play and start receiving new data)
+    } else {
+      this._skipTimeUpdatesUntil = newPos;
       this._setTime(newPos);
+      this._lastUpdateTime = Date.now();
+      if (!this._paused) {
+        this.scheduleNextUpdate(newPos);
+      }
     }
+  }
+
+  isSeekingForward() {
+    return (
+      this._skipTimeUpdatesUntil !== null &&
+      this._skipTimeUpdatesUntil > this._lastPlayedTimestamp
+    );
   }
 
   stop() {
@@ -225,6 +253,15 @@ export default class TtyPlayer extends Tty {
   play() {
     this._paused = false;
     this._setPlayerStatus(StatusEnum.PLAYING);
+
+    this._lastUpdateTime = Date.now();
+
+    if (this.isSeekingForward()) {
+      const next = Math.max(this._skipTimeUpdatesUntil, this._lastTimestamp);
+      this.scheduleNextUpdate(next);
+    } else {
+      this.scheduleNextUpdate(this._lastTimestamp);
+    }
 
     // the very first play call happens before we've even
     // connected - we only need to send the websocket message


### PR DESCRIPTION
Backport #38914 to branch/v15

changelog: Improved the responsiveness of the session player during long periods of idle time.
