### PR TITLE
Dependabot: prevent terraform-plugin-go package upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -137,6 +137,8 @@ updates:
     ignore:
       # breaks compatibility
       - dependency-name: github.com/hashicorp/terraform-plugin-framework
+      # breaks compatibility
+      - dependency-name: github.com/hashicorp/terraform-plugin-go
     open-pull-requests-limit: 20
     groups:
       go:


### PR DESCRIPTION
The package `github.com/hashicorp/terraform-plugin-go` has breaking changes and we cant upgrade right now.

This PR ensures this package is ignored when Dependabot tries to update the go.mod packages.