### PR TITLE
Introduce last import group for `terraform` and `event-handler` integrations.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,6 +81,7 @@ linters-settings:
       - standard # Standard section: captures all standard packages.
       - default # Default section: contains all imports that could not be matched to another section type.
       - prefix(github.com/gravitational/teleport) # Custom section: groups all imports with the specified Prefix.
+      - prefix(github.com/gravitational/teleport/integrations/terraform,github.com/gravitational/teleport/integrations/event-handler)
     skip-generated: true # Skip generated files.
     custom-order: true # Required for "sections" to take effect.
   misspell:

--- a/Makefile
+++ b/Makefile
@@ -1023,9 +1023,8 @@ fix-imports/host:
 		echo 'gci is not installed or is missing from PATH, consider installing it ("go install github.com/daixiang0/gci@latest") or use "make -C build.assets/ fix-imports"';\
 		exit 1;\
 	fi
-	gci write -s standard -s default -s 'prefix(github.com/gravitational/teleport)' --skip-generated .
+	gci write -s standard -s default  -s 'prefix(github.com/gravitational/teleport)' -s 'prefix(github.com/gravitational/teleport/integrations/terraform,github.com/gravitational/teleport/integrations/event-handler)' --skip-generated .
 
-.PHONY: lint-build-tooling
 lint-build-tooling: GO_LINT_FLAGS ?=
 lint-build-tooling:
 	cd build.assets/tooling && golangci-lint run -c ../../.golangci.yml $(GO_LINT_FLAGS)

--- a/integrations/event-handler/cli.go
+++ b/integrations/event-handler/cli.go
@@ -24,9 +24,10 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/integrations/event-handler/lib"
 	"github.com/gravitational/teleport/integrations/lib/logger"
 	"github.com/gravitational/teleport/integrations/lib/stringset"
+
+	"github.com/gravitational/teleport/integrations/event-handler/lib"
 )
 
 // FluentdConfig represents fluentd instance configuration

--- a/integrations/event-handler/state.go
+++ b/integrations/event-handler/state.go
@@ -27,8 +27,9 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/peterbourgon/diskv/v3"
 
-	"github.com/gravitational/teleport/integrations/event-handler/lib"
 	"github.com/gravitational/teleport/integrations/lib/logger"
+
+	"github.com/gravitational/teleport/integrations/event-handler/lib"
 )
 
 const (

--- a/integrations/event-handler/teleport_event_test.go
+++ b/integrations/event-handler/teleport_event_test.go
@@ -29,6 +29,7 @@ import (
 
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
 	"github.com/gravitational/teleport/api/types/events"
+
 	"github.com/gravitational/teleport/integrations/event-handler/lib"
 )
 

--- a/integrations/terraform/provider/resource_teleport_bot.go
+++ b/integrations/terraform/provider/resource_teleport_bot.go
@@ -29,6 +29,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/utils"
+
 	"github.com/gravitational/teleport/integrations/terraform/tfschema"
 )
 

--- a/integrations/terraform/test/main_test.go
+++ b/integrations/terraform/test/main_test.go
@@ -38,10 +38,11 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/testing/integration"
-	"github.com/gravitational/teleport/integrations/terraform/provider"
 	"github.com/gravitational/teleport/lib/auth"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/identityfile"
+
+	"github.com/gravitational/teleport/integrations/terraform/provider"
 )
 
 //go:embed fixtures/*


### PR DESCRIPTION
This PR adds a special group (last one) to match the `terraform` and `event-handler` integrations.

These two integrations aren't imported by teleport codebase but they import teleport packages. The issue arrises from the fact that they have their own module namespace. In order to distinguish their module namespace, this PR proposes moving them into a new (last) import group and keep Teleport into a separate group. Unfortunately, at the time of writing `gci` doesn't support skip directories which causes problems for our `lint` CI step as it will fail.

This results in the following structure for files within the two integrations:

- standard
- default
- teleport
- specific integration