### PR TITLE
Prepare teleport access plugin enterprise test suite

### DIFF
--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -129,11 +129,10 @@ func (a *App) run(ctx context.Context) error {
 	for {
 		select {
 		case <-timer.Chan():
-			timer.Reset(jitter(reminderInterval))
-
 			if err := a.remindIfNecessary(ctx); err != nil {
 				return trace.Wrap(err)
 			}
+			timer.Reset(jitter(reminderInterval))
 		case <-ctx.Done():
 			log.Info("Access list monitor is finished")
 			return nil

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -129,11 +129,11 @@ func (a *App) run(ctx context.Context) error {
 	for {
 		select {
 		case <-timer.Chan():
+			timer.Reset(jitter(reminderInterval))
+
 			if err := a.remindIfNecessary(ctx); err != nil {
 				return trace.Wrap(err)
 			}
-
-			timer.Reset(jitter(reminderInterval))
 		case <-ctx.Done():
 			log.Info("Access list monitor is finished")
 			return nil

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -20,6 +20,7 @@ package accesslist
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,6 +41,7 @@ import (
 type mockMessagingBot struct {
 	lastReminderRecipients []common.Recipient
 	recipients             map[string]*common.Recipient
+	mutex                  sync.Mutex
 }
 
 func (m *mockMessagingBot) CheckHealth(ctx context.Context) error {
@@ -47,11 +49,27 @@ func (m *mockMessagingBot) CheckHealth(ctx context.Context) error {
 }
 
 func (m *mockMessagingBot) SendReviewReminders(ctx context.Context, recipient common.Recipient, accessList *accesslist.AccessList) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	m.lastReminderRecipients = append(m.lastReminderRecipients, recipient)
 	return nil
 }
 
+func (m *mockMessagingBot) getLastRecipients() []common.Recipient {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.lastReminderRecipients
+}
+
+func (m *mockMessagingBot) resetLastRecipients() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.lastReminderRecipients = make([]common.Recipient, 0)
+}
+
 func (m *mockMessagingBot) FetchRecipient(ctx context.Context, recipient string) (*common.Recipient, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	fetchedRecipient, ok := m.recipients[recipient]
 	if !ok {
 		return nil, trace.NotFound("recipient %s not found", recipient)
@@ -255,14 +273,13 @@ func advanceAndLookForRecipients(t *testing.T,
 	advance time.Duration,
 	accessList *accesslist.AccessList,
 	recipients ...string) {
-	t.Helper()
 
 	ctx := context.Background()
 
 	_, err := alSvc.UpsertAccessList(ctx, accessList)
 	require.NoError(t, err)
 
-	bot.lastReminderRecipients = nil
+	bot.resetLastRecipients()
 
 	var expectedRecipients []common.Recipient
 	if len(recipients) > 0 {
@@ -274,5 +291,5 @@ func advanceAndLookForRecipients(t *testing.T,
 	clock.Advance(advance)
 	clock.BlockUntil(1)
 
-	require.ElementsMatch(t, expectedRecipients, bot.lastReminderRecipients)
+	require.ElementsMatch(t, expectedRecipients, bot.getLastRecipients())
 }

--- a/integrations/access/discord/testlib/helpers.go
+++ b/integrations/access/discord/testlib/helpers.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gravitational/teleport/integrations/access/discord"
 )
 
-func (s *DiscordSuite) checkPluginData(ctx context.Context, reqID string, cond func(accessrequest.PluginData) bool) accessrequest.PluginData {
+func (s *DiscordBaseSuite) checkPluginData(ctx context.Context, reqID string, cond func(accessrequest.PluginData) bool) accessrequest.PluginData {
 	t := s.T()
 	t.Helper()
 

--- a/integrations/access/discord/testlib/oss_integration_test.go
+++ b/integrations/access/discord/testlib/oss_integration_test.go
@@ -27,9 +27,11 @@ import (
 )
 
 func TestDiscordPluginOSS(t *testing.T) {
-	discordSuite := &DiscordSuite{
-		AccessRequestSuite: &integration.AccessRequestSuite{
-			AuthHelper: &integration.OSSAuthHelper{},
+	discordSuite := &DiscordSuiteOSS{
+		DiscordBaseSuite: DiscordBaseSuite{
+			AccessRequestSuite: &integration.AccessRequestSuite{
+				AuthHelper: &integration.MinimalAuthHelper{},
+			},
 		},
 	}
 	suite.Run(t, discordSuite)

--- a/integrations/access/discord/testlib/suite.go
+++ b/integrations/access/discord/testlib/suite.go
@@ -45,9 +45,9 @@ import (
 var msgFieldRegexp = regexp.MustCompile(`(?im)^\*([a-zA-Z ]+)\*: (.+)$`)
 var requestReasonRegexp = regexp.MustCompile("(?im)^\\*Reason\\*:\\ ```\\n(.*?)```(.*?)$")
 
-// DiscordSuite is the discord access plugin test suite.
+// DiscordBaseSuite is the discord access plugin test suite.
 // It implements the testify.TestingSuite interface.
-type DiscordSuite struct {
+type DiscordBaseSuite struct {
 	*integration.AccessRequestSuite
 	appConfig   *discord.Config
 	raceNumber  int
@@ -56,7 +56,7 @@ type DiscordSuite struct {
 
 // SetupTest starts a fake discord and generates the plugin configuration.
 // It is run for each test.
-func (s *DiscordSuite) SetupTest() {
+func (s *DiscordBaseSuite) SetupTest() {
 	t := s.T()
 
 	err := logger.Setup(logger.Config{Severity: "debug"})
@@ -75,7 +75,7 @@ func (s *DiscordSuite) SetupTest() {
 }
 
 // startApp starts the discord plugin, waits for it to become ready and returns,
-func (s *DiscordSuite) startApp() {
+func (s *DiscordBaseSuite) startApp() {
 	t := s.T()
 	t.Helper()
 
@@ -83,10 +83,30 @@ func (s *DiscordSuite) startApp() {
 	integration.RunAndWaitReady(t, app)
 }
 
+// DiscordSuiteOSS contains all tests that support running against a Teleport
+// OSS Server.
+type DiscordSuiteOSS struct {
+	DiscordBaseSuite
+}
+
+// DiscordSuiteEnterprise contains all tests that require a Teleport Enterprise
+// to run.
+type DiscordSuiteEnterprise struct {
+	DiscordBaseSuite
+}
+
+// SetupTest overrides DiscordBaseSuite.SetupTest to check the Teleport features
+// before each test.
+func (s *DiscordSuiteEnterprise) SetupTest() {
+	t := s.T()
+	s.RequireAdvancedWorkflow(t)
+	s.DiscordBaseSuite.SetupTest()
+}
+
 // TestMessagePosting validates that a message is sent to each recipient
 // specified in the plugin's configuration. It also checks that the message
 // content is correct.
-func (s *DiscordSuite) TestMessagePosting() {
+func (s *DiscordSuiteOSS) TestMessagePosting() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -151,7 +171,7 @@ func (s *DiscordSuite) TestMessagePosting() {
 
 // TestApproval tests that when a request is approved, its corresponding message
 // is updated to reflect the new request state.
-func (s *DiscordSuite) TestApproval() {
+func (s *DiscordSuiteOSS) TestApproval() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -189,7 +209,7 @@ func (s *DiscordSuite) TestApproval() {
 
 // TestDenial tests that when a request is denied, its corresponding message
 // is updated to reflect the new request state.
-func (s *DiscordSuite) TestDenial() {
+func (s *DiscordSuiteOSS) TestDenial() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -228,14 +248,10 @@ func (s *DiscordSuite) TestDenial() {
 
 // TestReviewUpdates tests that the message is updated after the access request
 // is reviewed. Each review should be reflected in the original message.
-func (s *DiscordSuite) TestReviewUpdates() {
+func (s *DiscordSuiteEnterprise) TestReviewUpdates() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.appConfig.Recipients = common.RawRecipientsMap{
 		"editor": []string{
@@ -295,14 +311,10 @@ func (s *DiscordSuite) TestReviewUpdates() {
 
 // TestApprovalByReview tests that the message is updated after the access request
 // is reviewed and approved.
-func (s *DiscordSuite) TestApprovalByReview() {
+func (s *DiscordSuiteEnterprise) TestApprovalByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.appConfig.Recipients = common.RawRecipientsMap{
 		"editor": []string{
@@ -363,14 +375,10 @@ func (s *DiscordSuite) TestApprovalByReview() {
 
 // TestDenialByReview tests that the message is updated after the access request
 // is reviewed and denied.
-func (s *DiscordSuite) TestDenialByReview() {
+func (s *DiscordSuiteEnterprise) TestDenialByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.appConfig.Recipients = common.RawRecipientsMap{
 		"editor": []string{
@@ -431,7 +439,7 @@ func (s *DiscordSuite) TestDenialByReview() {
 
 // TestExpiration tests that when a request expires, its corresponding message
 // is updated to reflect the new request state.
-func (s *DiscordSuite) TestExpiration() {
+func (s *DiscordSuiteOSS) TestExpiration() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -475,14 +483,10 @@ func (s *DiscordSuite) TestExpiration() {
 // TestRace validates that the plugin behaves properly and performs all the
 // message updates when a lot of access requests are sent and reviewed in a very
 // short time frame.
-func (s *DiscordSuite) TestRace() {
+func (s *DiscordSuiteEnterprise) TestRace() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	err := logger.Setup(logger.Config{Severity: "info"}) // Turn off noisy debug logging
 	require.NoError(t, err)

--- a/integrations/access/email/testlib/helpers.go
+++ b/integrations/access/email/testlib/helpers.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/teleport/integrations/access/email"
 )
 
-func (s *EmailSuite) checkPluginData(ctx context.Context, reqID string, cond func(email.PluginData) bool) email.PluginData {
+func (s *EmailBaseSuite) checkPluginData(ctx context.Context, reqID string, cond func(email.PluginData) bool) email.PluginData {
 	t := s.T()
 	t.Helper()
 
@@ -40,7 +40,7 @@ func (s *EmailSuite) checkPluginData(ctx context.Context, reqID string, cond fun
 }
 
 // skipEmails ensures that emails were received, but dumps the contents
-func (s *EmailSuite) skipMessages(ctx context.Context, t *testing.T, n int) {
+func (s *EmailBaseSuite) skipMessages(ctx context.Context, t *testing.T, n int) {
 	for i := 0; i < n; i++ {
 		_, err := s.mockMailgun.GetMessage(ctx)
 		require.NoError(t, err)
@@ -48,7 +48,7 @@ func (s *EmailSuite) skipMessages(ctx context.Context, t *testing.T, n int) {
 }
 
 // getMessages returns next n email messages
-func (s *EmailSuite) getMessages(ctx context.Context, t *testing.T, n int) []mockMailgunMessage {
+func (s *EmailBaseSuite) getMessages(ctx context.Context, t *testing.T, n int) []mockMailgunMessage {
 	messages := make([]mockMailgunMessage, n)
 	for i := 0; i < n; i++ {
 		m, err := s.mockMailgun.GetMessage(ctx)
@@ -60,7 +60,7 @@ func (s *EmailSuite) getMessages(ctx context.Context, t *testing.T, n int) []moc
 }
 
 // extractRequestID extracts request id from a subject
-func (s *EmailSuite) extractRequestID(subject string) string {
+func (s *EmailBaseSuite) extractRequestID(subject string) string {
 	idx := strings.Index(subject, subjectIDSubstring)
 	return subject[idx+len(subjectIDSubstring):]
 }

--- a/integrations/access/email/testlib/oss_integration_test.go
+++ b/integrations/access/email/testlib/oss_integration_test.go
@@ -27,9 +27,11 @@ import (
 )
 
 func TestEmailPluginOSS(t *testing.T) {
-	emailSuite := &EmailSuite{
-		AccessRequestSuite: &integration.AccessRequestSuite{
-			AuthHelper: &integration.OSSAuthHelper{},
+	emailSuite := &EmailSuiteOSS{
+		EmailBaseSuite{
+			AccessRequestSuite: &integration.AccessRequestSuite{
+				AuthHelper: &integration.MinimalAuthHelper{},
+			},
 		},
 	}
 	suite.Run(t, emailSuite)

--- a/integrations/access/email/testlib/suite.go
+++ b/integrations/access/email/testlib/suite.go
@@ -59,11 +59,11 @@ const (
 	messageCountPerThread = newMessageCount + reviewMessageCount + resolveMessageCount
 )
 
-// EmailSuite implements the test suite for the email access plugin.
+// EmailBaseSuite implements the test suite for the email access plugin.
 // As some plugin features require Teleport Enterprise but the plugin code and
 // tests live in the Teleport OSS repo, the test suite can be run both from the
 // OSS and the enterprise repo.
-type EmailSuite struct {
+type EmailBaseSuite struct {
 	*integration.AccessRequestSuite
 	appConfig   email.Config
 	mockMailgun *mockMailgunServer
@@ -72,7 +72,7 @@ type EmailSuite struct {
 
 // SetupTest starts a fake Mailgun, generates the plugin configuration, and
 // also starts the plugin. It runs for each test.
-func (s *EmailSuite) SetupTest() {
+func (s *EmailBaseSuite) SetupTest() {
 	t := s.T()
 
 	err := logger.Setup(logger.Config{Severity: "debug"})
@@ -101,7 +101,7 @@ func (s *EmailSuite) SetupTest() {
 }
 
 // startApp starts the email plugin, waits for it to become ready and returns.
-func (s *EmailSuite) startApp() {
+func (s *EmailBaseSuite) startApp() {
 	t := s.T()
 	t.Helper()
 
@@ -110,9 +110,29 @@ func (s *EmailSuite) startApp() {
 	integration.RunAndWaitReady(t, app)
 }
 
+// EmailSuiteOSS contains all tests that support running against a Teleport
+// OSS Server.
+type EmailSuiteOSS struct {
+	EmailBaseSuite
+}
+
+// EmailSuiteEnterprise contains all tests that require a Teleport Enterprise
+// to run.
+type EmailSuiteEnterprise struct {
+	EmailBaseSuite
+}
+
+// SetupTest overrides EmailBaseSuite.SetupTest to check the Teleport features
+// before each test.
+func (s *EmailSuiteEnterprise) SetupTest() {
+	t := s.T()
+	s.RequireAdvancedWorkflow(t)
+	s.EmailBaseSuite.SetupTest()
+}
+
 // TestNewThreads tests that the plugin starts new email threads when it
 // receives a new access request.
-func (s *EmailSuite) TestNewThreads() {
+func (s *EmailSuiteOSS) TestNewThreads() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -157,7 +177,7 @@ func (s *EmailSuite) TestNewThreads() {
 
 // TestApproval tests that when a request is approved, a followup email is sent
 // in the existing thread to notify that the request was approved.
-func (s *EmailSuite) TestApproval() {
+func (s *EmailSuiteOSS) TestApproval() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -185,7 +205,7 @@ func (s *EmailSuite) TestApproval() {
 
 // TestDenial tests that when a request is denied, a followup email is sent
 // in the existing thread to notify that the request was approved.
-func (s *EmailSuite) TestDenial() {
+func (s *EmailSuiteOSS) TestDenial() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -213,14 +233,10 @@ func (s *EmailSuite) TestDenial() {
 
 // TestReviewReplies tests that a followup email is sent after the access request
 // is reviewed.
-func (s *EmailSuite) TestReviewReplies() {
+func (s *EmailSuiteEnterprise) TestReviewReplies() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	// Test setup: create an access request and wait for its emails
 	userName := integration.Requester1UserName
@@ -266,14 +282,10 @@ func (s *EmailSuite) TestReviewReplies() {
 
 // TestApprovalByReview tests that followup emails are sent when an access
 // request reaches its approval threshold.
-func (s *EmailSuite) TestApprovalByReview() {
+func (s *EmailSuiteEnterprise) TestApprovalByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	// Test setup: create an access request and wait for its emails
 	userName := integration.Requester1UserName
@@ -313,14 +325,10 @@ func (s *EmailSuite) TestApprovalByReview() {
 
 // TestDenialByReview tests that followup emails are sent when an access
 // request reaches its denial threshold.
-func (s *EmailSuite) TestDenialByReview() {
+func (s *EmailSuiteEnterprise) TestDenialByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	// Test setup: create an access request and wait for its emails
 	userName := integration.Requester1UserName
@@ -360,7 +368,7 @@ func (s *EmailSuite) TestDenialByReview() {
 
 // TestExpiration tests that when a request expires, a followup email is sent
 // in the existing thread to notify that the request has expired.
-func (s *EmailSuite) TestExpiration() {
+func (s *EmailSuiteOSS) TestExpiration() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -386,14 +394,10 @@ func (s *EmailSuite) TestExpiration() {
 // TestRace validates that the plugin behaves properly and performs all the
 // message updates when a lot of access requests are sent and reviewed in a very
 // short time frame.
-func (s *EmailSuite) TestRace() {
+func (s *EmailSuiteEnterprise) TestRace() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	err := logger.Setup(logger.Config{Severity: "info"}) // Turn off noisy debug logging
 	require.NoError(t, err)

--- a/integrations/access/jira/testlib/helpers.go
+++ b/integrations/access/jira/testlib/helpers.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport/integrations/access/jira"
 )
 
-func (s *JiraSuite) checkPluginData(ctx context.Context, reqID string, cond func(jira.PluginData) bool) jira.PluginData {
+func (s *JiraBaseSuite) checkPluginData(ctx context.Context, reqID string, cond func(jira.PluginData) bool) jira.PluginData {
 	t := s.T()
 	t.Helper()
 
@@ -43,7 +43,7 @@ func (s *JiraSuite) checkPluginData(ctx context.Context, reqID string, cond func
 	}
 }
 
-func (s *JiraSuite) postWebhook(ctx context.Context, url, issueID, status string) (*http.Response, error) {
+func (s *JiraBaseSuite) postWebhook(ctx context.Context, url, issueID, status string) (*http.Response, error) {
 	var buf bytes.Buffer
 	wh := jira.Webhook{
 		WebhookEvent:       "jira:issue_updated",
@@ -72,7 +72,7 @@ func (s *JiraSuite) postWebhook(ctx context.Context, url, issueID, status string
 	return response, trace.Wrap(err)
 }
 
-func (s *JiraSuite) postWebhookAndCheck(ctx context.Context, url, issueID, status string) {
+func (s *JiraBaseSuite) postWebhookAndCheck(ctx context.Context, url, issueID, status string) {
 	t := s.T()
 	t.Helper()
 

--- a/integrations/access/jira/testlib/oss_integration_test.go
+++ b/integrations/access/jira/testlib/oss_integration_test.go
@@ -27,9 +27,11 @@ import (
 )
 
 func TestJiraPluginOSS(t *testing.T) {
-	jiraSuite := &JiraSuite{
-		AccessRequestSuite: &integration.AccessRequestSuite{
-			AuthHelper: &integration.OSSAuthHelper{},
+	jiraSuite := &JiraSuiteOSS{
+		JiraBaseSuite: JiraBaseSuite{
+			AccessRequestSuite: &integration.AccessRequestSuite{
+				AuthHelper: &integration.MinimalAuthHelper{},
+			},
 		},
 	}
 	suite.Run(t, jiraSuite)

--- a/integrations/access/jira/testlib/suite.go
+++ b/integrations/access/jira/testlib/suite.go
@@ -41,9 +41,9 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/testing/integration"
 )
 
-// JiraSuite is the Jira access plugin test suite.
+// JiraBaseSuite is the Jira access plugin test suite.
 // It implements the testify.TestingSuite interface.
-type JiraSuite struct {
+type JiraBaseSuite struct {
 	*integration.AccessRequestSuite
 	appConfig  jira.Config
 	raceNumber int
@@ -60,7 +60,7 @@ type JiraSuite struct {
 
 // SetupTest starts a fake discord and generates the plugin configuration.
 // It is run for each test.
-func (s *JiraSuite) SetupTest() {
+func (s *JiraBaseSuite) SetupTest() {
 	t := s.T()
 
 	err := logger.Setup(logger.Config{Severity: "debug"})
@@ -88,7 +88,7 @@ func (s *JiraSuite) SetupTest() {
 }
 
 // startApp starts the discord plugin, waits for it to become ready and returns,
-func (s *JiraSuite) startApp() {
+func (s *JiraBaseSuite) startApp() {
 	t := s.T()
 	t.Helper()
 
@@ -98,9 +98,29 @@ func (s *JiraSuite) startApp() {
 	s.webhookURL = app.PublicURL()
 }
 
+// JiraSuiteOSS contains all tests that support running against a Teleport
+// OSS Server.
+type JiraSuiteOSS struct {
+	JiraBaseSuite
+}
+
+// JiraSuiteEnterprise contains all tests that require a Teleport Enterprise
+// to run.
+type JiraSuiteEnterprise struct {
+	JiraBaseSuite
+}
+
+// SetupTest overrides JiraBaseSuite.SetupTest to check the Teleport features
+// before each test.
+func (s *JiraSuiteEnterprise) SetupTest() {
+	t := s.T()
+	s.RequireAdvancedWorkflow(t)
+	s.JiraBaseSuite.SetupTest()
+}
+
 // TestIssueCreation validates that an issue is created when a new access
 // request is created. It also checks that the issue content is correct.
-func (s *JiraSuite) TestIssueCreation() {
+func (s *JiraSuiteOSS) TestIssueCreation() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -124,7 +144,7 @@ func (s *JiraSuite) TestIssueCreation() {
 // TestIssueCreationWithRequestReason validates that an issue is created when
 // a new access request is created. It also checks that the issue content
 // reflects the access request reason.
-func (s *JiraSuite) TestIssueCreationWithRequestReason() {
+func (s *JiraSuiteOSS) TestIssueCreationWithRequestReason() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -147,7 +167,7 @@ func (s *JiraSuite) TestIssueCreationWithRequestReason() {
 
 // TestIssueCreationWithLargeRequestReason validates that an issue is created
 // when a new access request with a large reason is created.
-func (s *JiraSuite) TestIssueCreationWithLargeRequestReason() {
+func (s *JiraSuiteOSS) TestIssueCreationWithLargeRequestReason() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -177,14 +197,10 @@ func (s *JiraSuite) TestIssueCreationWithLargeRequestReason() {
 
 // TestReviewComments tests that comments are posted for each access request
 // review.
-func (s *JiraSuite) TestReviewComments() {
+func (s *JiraSuiteEnterprise) TestReviewComments() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -230,14 +246,10 @@ func (s *JiraSuite) TestReviewComments() {
 
 // TestReviewerApproval tests that comments are posted for each review, and the
 // issue transitions to the approved state once it gets approved.
-func (s *JiraSuite) TestReviewerApproval() {
+func (s *JiraSuiteEnterprise) TestReviewerApproval() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -301,14 +313,10 @@ func (s *JiraSuite) TestReviewerApproval() {
 
 // TestReviewerDenial tests that comments are posted for each review, and the
 // issue transitions to the denied state once it gets denied.
-func (s *JiraSuite) TestReviewerDenial() {
+func (s *JiraSuiteEnterprise) TestReviewerDenial() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -372,7 +380,7 @@ func (s *JiraSuite) TestReviewerDenial() {
 
 // TestWebhookApproval tests that the access request plugin can approve
 // requests based on Jira webhooks.
-func (s *JiraSuite) TestWebhookApproval() {
+func (s *JiraSuiteOSS) TestWebhookApproval() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -420,7 +428,7 @@ func (s *JiraSuite) TestWebhookApproval() {
 
 // TestWebhookDenial tests that the access request plugin can deny requests
 // based on Jira webhooks.
-func (s *JiraSuite) TestWebhookDenial() {
+func (s *JiraSuiteOSS) TestWebhookDenial() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -468,7 +476,7 @@ func (s *JiraSuite) TestWebhookDenial() {
 
 // TestWebhookApprovalWithReason tests that the access request plugin can approve
 // requests and specify the approval reason based on Jira webhooks and comments.
-func (s *JiraSuite) TestWebhookApprovalWithReason() {
+func (s *JiraSuiteOSS) TestWebhookApprovalWithReason() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -524,7 +532,7 @@ func (s *JiraSuite) TestWebhookApprovalWithReason() {
 // requests and specify the denial reason based on Jira webhooks and comments.
 // This test has extra cases to validate that the reason is picked from the
 // correct Jira comment.
-func (s *JiraSuite) TestWebhookDenialWithReason() {
+func (s *JiraSuiteOSS) TestWebhookDenialWithReason() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -597,7 +605,7 @@ func (s *JiraSuite) TestWebhookDenialWithReason() {
 
 // TestExpiration tests that when a request expires, its corresponding issue
 // is updated to reflect the new request state.
-func (s *JiraSuite) TestExpiration() {
+func (s *JiraSuiteOSS) TestExpiration() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -635,7 +643,7 @@ func (s *JiraSuite) TestExpiration() {
 // TestRace validates that the plugin behaves properly, sends all the comments
 // and performs all the resolutions when a lot of access requests are sent and
 // reviewed in a very short time frame.
-func (s *JiraSuite) TestRace() {
+func (s *JiraSuiteOSS) TestRace() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(cancel)

--- a/integrations/access/mattermost/testlib/helpers.go
+++ b/integrations/access/mattermost/testlib/helpers.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gravitational/teleport/integrations/access/mattermost"
 )
 
-func (s *MattermostSuite) checkPluginData(ctx context.Context, reqID string, cond func(accessrequest.PluginData) bool) accessrequest.PluginData {
+func (s *MattermostBaseSuite) checkPluginData(ctx context.Context, reqID string, cond func(accessrequest.PluginData) bool) accessrequest.PluginData {
 	t := s.T()
 	t.Helper()
 

--- a/integrations/access/mattermost/testlib/oss_integration_test.go
+++ b/integrations/access/mattermost/testlib/oss_integration_test.go
@@ -27,9 +27,11 @@ import (
 )
 
 func TestMattermostPluginOSS(t *testing.T) {
-	mattermostSuite := &MattermostSuite{
-		AccessRequestSuite: &integration.AccessRequestSuite{
-			AuthHelper: &integration.OSSAuthHelper{},
+	mattermostSuite := &MattermostSuiteOSS{
+		MattermostBaseSuite: MattermostBaseSuite{
+			AccessRequestSuite: &integration.AccessRequestSuite{
+				AuthHelper: &integration.MinimalAuthHelper{},
+			},
 		},
 	}
 	suite.Run(t, mattermostSuite)

--- a/integrations/access/mattermost/testlib/suite.go
+++ b/integrations/access/mattermost/testlib/suite.go
@@ -46,9 +46,9 @@ var msgFieldRegexp = regexp.MustCompile(`(?im)^\*\*([a-zA-Z ]+)\*\*:\ +(.+)$`)
 var requestReasonRegexp = regexp.MustCompile("(?im)^\\*\\*Reason\\*\\*:\\ ```\\n(.*?)```(.*?)$")
 var resolutionReasonRegexp = regexp.MustCompile("(?im)^\\*\\*Resolution reason\\*\\*:\\ ```\\n(.*?)```(.*?)$")
 
-// MattermostSuite is the Mattermost access plugin test suite.
+// MattermostBaseSuite is the Mattermost access plugin test suite.
 // It implements the testify.TestingSuite interface.
-type MattermostSuite struct {
+type MattermostBaseSuite struct {
 	*integration.AccessRequestSuite
 	appConfig      *mattermost.Config
 	raceNumber     int
@@ -62,7 +62,7 @@ type MattermostSuite struct {
 
 // SetupTest starts a fake Mattermost and generates the plugin configuration.
 // It is run for each test.
-func (s *MattermostSuite) SetupTest() {
+func (s *MattermostBaseSuite) SetupTest() {
 	t := s.T()
 
 	err := logger.Setup(logger.Config{Severity: "debug"})
@@ -89,7 +89,7 @@ func (s *MattermostSuite) SetupTest() {
 }
 
 // startApp starts the Mattermost plugin, waits for it to become ready and returns,
-func (s *MattermostSuite) startApp() {
+func (s *MattermostBaseSuite) startApp() {
 	t := s.T()
 	t.Helper()
 
@@ -97,11 +97,31 @@ func (s *MattermostSuite) startApp() {
 	integration.RunAndWaitReady(t, app)
 }
 
+// MattermostSuiteOSS contains all tests that support running against a Teleport
+// OSS Server.
+type MattermostSuiteOSS struct {
+	MattermostBaseSuite
+}
+
+// MattermostSuiteEnterprise contains all tests that require a Teleport Enterprise
+// to run.
+type MattermostSuiteEnterprise struct {
+	MattermostBaseSuite
+}
+
+// SetupTest overrides MattermostBaseSuite.SetupTest to check the Teleport features
+// before each test.
+func (s *MattermostSuiteEnterprise) SetupTest() {
+	t := s.T()
+	s.RequireAdvancedWorkflow(t)
+	s.MattermostBaseSuite.SetupTest()
+}
+
 // TestMattermostMessagePosting validates that a message is sent to each recipient
 // specified in the plugin's configuration and optional reviewers.
 // It also checks that the message content is correct, even when the reason
 // is too large.
-func (s *MattermostSuite) TestMattermostMessagePosting() {
+func (s *MattermostSuiteOSS) TestMattermostMessagePosting() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -176,7 +196,7 @@ func (s *MattermostSuite) TestMattermostMessagePosting() {
 
 // TestApproval tests that when a request is approved, its corresponding message
 // is updated to reflect the new request state.
-func (s *MattermostSuite) TestApproval() {
+func (s *MattermostSuiteOSS) TestApproval() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -215,7 +235,7 @@ func (s *MattermostSuite) TestApproval() {
 
 // TestDenial tests that when a request is denied, its corresponding message
 // is updated to reflect the new request state.
-func (s *MattermostSuite) TestDenial() {
+func (s *MattermostSuiteOSS) TestDenial() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -254,14 +274,10 @@ func (s *MattermostSuite) TestDenial() {
 
 // TestReviewComments tests that that update messages are sent after the access
 // request is reviewed. Each review should trigger a new message.
-func (s *MattermostSuite) TestReviewComments() {
+func (s *MattermostSuiteEnterprise) TestReviewComments() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	directChannelID := s.fakeMattermost.GetDirectChannelFor(s.fakeMattermost.GetBotUser(), s.reviewer1MattermostUser).ID
 
@@ -316,14 +332,10 @@ func (s *MattermostSuite) TestReviewComments() {
 
 // TestApprovalByReview tests that the message is updated after the access request
 // is reviewed and approved.
-func (s *MattermostSuite) TestApprovalByReview() {
+func (s *MattermostSuiteEnterprise) TestApprovalByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -388,14 +400,10 @@ func (s *MattermostSuite) TestApprovalByReview() {
 
 // TestDenialByReview tests that the message is updated after the access request
 // is reviewed and denied.
-func (s *MattermostSuite) TestDenialByReview() {
+func (s *MattermostSuiteEnterprise) TestDenialByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -460,7 +468,7 @@ func (s *MattermostSuite) TestDenialByReview() {
 
 // TestExpiration tests that when a request expires, its corresponding message
 // is updated to reflect the new request state.
-func (s *MattermostSuite) TestExpiration() {
+func (s *MattermostSuiteOSS) TestExpiration() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -497,14 +505,10 @@ func (s *MattermostSuite) TestExpiration() {
 // TestRace validates that the plugin behaves properly and performs all the
 // message updates when a lot of access requests are sent and reviewed in a very
 // short time frame.
-func (s *MattermostSuite) TestRace() {
+func (s *MattermostSuiteEnterprise) TestRace() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	err := logger.Setup(logger.Config{Severity: "info"}) // Turn off noisy debug logging
 	require.NoError(t, err)
@@ -648,7 +652,7 @@ func (s *MattermostSuite) TestRace() {
 	})
 }
 
-func (s *MattermostSuite) TestRecipientsConfig() {
+func (s *MattermostSuiteOSS) TestRecipientsConfig() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)

--- a/integrations/access/msteams/testlib/helpers.go
+++ b/integrations/access/msteams/testlib/helpers.go
@@ -24,7 +24,7 @@ import (
 	"github.com/gravitational/teleport/integrations/access/msteams"
 )
 
-func (s *MsTeamsSuite) checkPluginData(ctx context.Context, reqID string, cond func(msteams.PluginData) bool) msteams.PluginData {
+func (s *MsTeamsBaseSuite) checkPluginData(ctx context.Context, reqID string, cond func(msteams.PluginData) bool) msteams.PluginData {
 	t := s.T()
 	t.Helper()
 
@@ -39,7 +39,7 @@ func (s *MsTeamsSuite) checkPluginData(ctx context.Context, reqID string, cond f
 	}
 }
 
-func (s *MsTeamsSuite) getNewMessages(ctx context.Context, n int) (MsgSlice, error) {
+func (s *MsTeamsBaseSuite) getNewMessages(ctx context.Context, n int) (MsgSlice, error) {
 	msgs := MsgSlice{}
 	for i := 0; i < 2; i++ {
 		msg, err := s.fakeTeams.CheckNewMessage(ctx)

--- a/integrations/access/msteams/testlib/oss_integration_test.go
+++ b/integrations/access/msteams/testlib/oss_integration_test.go
@@ -23,9 +23,11 @@ import (
 )
 
 func TestMsTeamsPluginOSS(t *testing.T) {
-	teamsSuite := &MsTeamsSuite{
-		AccessRequestSuite: &integration.AccessRequestSuite{
-			AuthHelper: &integration.OSSAuthHelper{},
+	teamsSuite := &MsTeamsSuiteOSS{
+		MsTeamsBaseSuite: MsTeamsBaseSuite{
+			AccessRequestSuite: &integration.AccessRequestSuite{
+				AuthHelper: &integration.MinimalAuthHelper{},
+			},
 		},
 	}
 	suite.Run(t, teamsSuite)

--- a/integrations/access/msteams/testlib/suite.go
+++ b/integrations/access/msteams/testlib/suite.go
@@ -37,9 +37,9 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/testing/integration"
 )
 
-// MsTeamsSuite is the Slack access plugin test suite.
+// MsTeamsBaseSuite is the Slack access plugin test suite.
 // It implements the testify.TestingSuite interface.
-type MsTeamsSuite struct {
+type MsTeamsBaseSuite struct {
 	*integration.AccessRequestSuite
 	appConfig             *msteams.Config
 	raceNumber            int
@@ -53,7 +53,7 @@ type MsTeamsSuite struct {
 
 // SetupTest starts a fake Slack, generates the plugin configuration, and loads
 // the fixtures in Slack. It runs for each test.
-func (s *MsTeamsSuite) SetupTest() {
+func (s *MsTeamsBaseSuite) SetupTest() {
 	t := s.T()
 
 	err := logger.Setup(logger.Config{Severity: "debug"})
@@ -81,7 +81,7 @@ func (s *MsTeamsSuite) SetupTest() {
 }
 
 // startApp starts the Slack plugin, waits for it to become ready and returns.
-func (s *MsTeamsSuite) startApp() {
+func (s *MsTeamsBaseSuite) startApp() {
 	t := s.T()
 	t.Helper()
 
@@ -90,7 +90,27 @@ func (s *MsTeamsSuite) startApp() {
 	integration.RunAndWaitReady(t, app)
 }
 
-func (s *MsTeamsSuite) TestMessagePosting() {
+// MsTeamsSuiteOSS contains all tests that support running against a Teleport
+// OSS Server.
+type MsTeamsSuiteOSS struct {
+	MsTeamsBaseSuite
+}
+
+// MsTeamsSuiteEnterprise contains all tests that require a Teleport Enterprise
+// to run.
+type MsTeamsSuiteEnterprise struct {
+	MsTeamsBaseSuite
+}
+
+// SetupTest overrides MsTeamsBaseSuite.SetupTest to check the Teleport features
+// before each test.
+func (s *MsTeamsSuiteEnterprise) SetupTest() {
+	t := s.T()
+	s.RequireAdvancedWorkflow(t)
+	s.MsTeamsBaseSuite.SetupTest()
+}
+
+func (s *MsTeamsSuiteOSS) TestMessagePosting() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -120,7 +140,7 @@ func (s *MsTeamsSuite) TestMessagePosting() {
 	require.Equal(t, msgs[1].RecipientID, s.reviewer2TeamsUser.ID)
 }
 
-func (s *MsTeamsSuite) TestRecipientsConfig() {
+func (s *MsTeamsSuiteOSS) TestRecipientsConfig() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -153,7 +173,7 @@ func (s *MsTeamsSuite) TestRecipientsConfig() {
 	require.Equal(t, msgs[1].RecipientID, s.reviewer2TeamsUser.ID)
 }
 
-func (s *MsTeamsSuite) TestApproval() {
+func (s *MsTeamsSuiteOSS) TestApproval() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -181,7 +201,7 @@ func (s *MsTeamsSuite) TestApproval() {
 	body.checkStatusApproved(t, reason)
 }
 
-func (s *MsTeamsSuite) TestDenial() {
+func (s *MsTeamsSuiteOSS) TestDenial() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -209,14 +229,10 @@ func (s *MsTeamsSuite) TestDenial() {
 	body.checkStatusDenied(t, reason)
 }
 
-func (s *MsTeamsSuite) TestReviewReplies() {
+func (s *MsTeamsSuiteEnterprise) TestReviewReplies() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -263,14 +279,10 @@ func (s *MsTeamsSuite) TestReviewReplies() {
 	body.checkReview(t, 1, false /* approved */, "not okay", integration.Reviewer2UserName)
 }
 
-func (s *MsTeamsSuite) TestApprovalByReview() {
+func (s *MsTeamsSuiteEnterprise) TestApprovalByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -318,14 +330,10 @@ func (s *MsTeamsSuite) TestApprovalByReview() {
 	body.checkStatusApproved(t, "finally okay")
 }
 
-func (s *MsTeamsSuite) TestDenialByReview() {
+func (s *MsTeamsSuiteEnterprise) TestDenialByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -373,7 +381,7 @@ func (s *MsTeamsSuite) TestDenialByReview() {
 	body.checkStatusDenied(t, "finally not okay")
 }
 
-func (s *MsTeamsSuite) TestExpiration() {
+func (s *MsTeamsSuiteOSS) TestExpiration() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -401,14 +409,10 @@ func (s *MsTeamsSuite) TestExpiration() {
 	require.NoError(t, json.Unmarshal([]byte(msgUpdate.Body), &body))
 	body.checkStatusExpired(t)
 }
-func (s *MsTeamsSuite) TestRace() {
+func (s *MsTeamsSuiteEnterprise) TestRace() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	err := logger.Setup(logger.Config{Severity: "info"}) // Turn off noisy debug logging
 	require.NoError(t, err)

--- a/integrations/access/opsgenie/testlib/helpers.go
+++ b/integrations/access/opsgenie/testlib/helpers.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/teleport/integrations/access/opsgenie"
 )
 
-func (s *OpsgenieSuite) checkPluginData(ctx context.Context, reqID string, cond func(opsgenie.PluginData) bool) opsgenie.PluginData {
+func (s *OpsgenieBaseSuite) checkPluginData(ctx context.Context, reqID string, cond func(opsgenie.PluginData) bool) opsgenie.PluginData {
 	t := s.T()
 	t.Helper()
 

--- a/integrations/access/opsgenie/testlib/oss_integration_test.go
+++ b/integrations/access/opsgenie/testlib/oss_integration_test.go
@@ -27,9 +27,11 @@ import (
 )
 
 func TestOpsgeniePluginOSS(t *testing.T) {
-	opsgenieSuite := &OpsgenieSuite{
-		AccessRequestSuite: &integration.AccessRequestSuite{
-			AuthHelper: &integration.OSSAuthHelper{},
+	opsgenieSuite := &OpsgenieSuiteOSS{
+		OpsgenieBaseSuite: OpsgenieBaseSuite{
+			AccessRequestSuite: &integration.AccessRequestSuite{
+				AuthHelper: &integration.MinimalAuthHelper{},
+			},
 		},
 	}
 	suite.Run(t, opsgenieSuite)

--- a/integrations/access/opsgenie/testlib/suite.go
+++ b/integrations/access/opsgenie/testlib/suite.go
@@ -37,13 +37,11 @@ const (
 	NotifyScheduleAnnotation   = types.TeleportNamespace + types.ReqAnnotationNotifySchedulesLabel
 	ApprovalScheduleName       = "Teleport Approval"
 	ApprovalScheduleAnnotation = types.TeleportNamespace + types.ReqAnnotationApproveSchedulesLabel
-	ResponderName1             = "Responder 1"
-	ResponderName2             = "Responder 2"
 )
 
-// OpsgenieSuite is the OpsGenie access plugin test suite.
+// OpsgenieBaseSuite is the OpsGenie access plugin test suite.
 // It implements the testify.TestingSuite interface.
-type OpsgenieSuite struct {
+type OpsgenieBaseSuite struct {
 	*integration.AccessRequestSuite
 	appConfig    opsgenie.Config
 	raceNumber   int
@@ -58,7 +56,7 @@ type OpsgenieSuite struct {
 // It also configures the role notifications for OpsGenie notifications and
 // automatic approval.
 // It is run for each test.
-func (s *OpsgenieSuite) SetupTest() {
+func (s *OpsgenieBaseSuite) SetupTest() {
 	t := s.T()
 	ctx := context.Background()
 
@@ -98,7 +96,7 @@ func (s *OpsgenieSuite) SetupTest() {
 }
 
 // startApp starts the OpsGenie plugin, waits for it to become ready and returns.
-func (s *OpsgenieSuite) startApp() {
+func (s *OpsgenieBaseSuite) startApp() {
 	t := s.T()
 	t.Helper()
 
@@ -107,9 +105,29 @@ func (s *OpsgenieSuite) startApp() {
 	integration.RunAndWaitReady(t, app)
 }
 
+// OpsgenieSuiteOSS contains all tests that support running against a Teleport
+// OSS Server.
+type OpsgenieSuiteOSS struct {
+	OpsgenieBaseSuite
+}
+
+// OpsgenieSuiteEnterprise contains all tests that require a Teleport Enterprise
+// to run.
+type OpsgenieSuiteEnterprise struct {
+	OpsgenieBaseSuite
+}
+
+// SetupTest overrides OpsgenieBaseSuite.SetupTest to check the Teleport features
+// before each test.
+func (s *OpsgenieSuiteEnterprise) SetupTest() {
+	t := s.T()
+	s.RequireAdvancedWorkflow(t)
+	s.OpsgenieBaseSuite.SetupTest()
+}
+
 // TestAlertCreation validates that an alert is created to the service
 // specified in the role's annotation.
-func (s *OpsgenieSuite) TestAlertCreation() {
+func (s *OpsgenieSuiteOSS) TestAlertCreation() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -133,7 +151,7 @@ func (s *OpsgenieSuite) TestAlertCreation() {
 
 // TestApproval tests that when a request is approved, its corresponding alert
 // is updated to reflect the new request state and a note is added to the alert.
-func (s *OpsgenieSuite) TestApproval() {
+func (s *OpsgenieSuiteOSS) TestApproval() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -165,7 +183,7 @@ func (s *OpsgenieSuite) TestApproval() {
 
 // TestDenial tests that when a request is denied, its corresponding alert
 // is updated to reflect the new request state and a note is added to the alert.
-func (s *OpsgenieSuite) TestDenial() {
+func (s *OpsgenieSuiteOSS) TestDenial() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -197,14 +215,10 @@ func (s *OpsgenieSuite) TestDenial() {
 
 // TestReviewNotes tests that alert notes are sent after the access request
 // is reviewed. Each review should create a new note.
-func (s *OpsgenieSuite) TestReviewNotes() {
+func (s *OpsgenieSuiteEnterprise) TestReviewNotes() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -250,14 +264,10 @@ func (s *OpsgenieSuite) TestReviewNotes() {
 
 // TestApprovalByReview tests that the alert is annotated and resolved after the
 // access request approval threshold is reached.
-func (s *OpsgenieSuite) TestApprovalByReview() {
+func (s *OpsgenieSuiteEnterprise) TestApprovalByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -314,14 +324,10 @@ func (s *OpsgenieSuite) TestApprovalByReview() {
 
 // TestDenialByReview tests that the alert is annotated and resolved after the
 // access request denial threshold is reached.
-func (s *OpsgenieSuite) TestDenialByReview() {
+func (s *OpsgenieSuiteEnterprise) TestDenialByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -378,14 +384,10 @@ func (s *OpsgenieSuite) TestDenialByReview() {
 
 // TestAutoApprovalWhenNotOnCall tests that access requests are not automatically
 // approved when the user is not on-call.
-func (s *OpsgenieSuite) TestAutoApprovalWhenNotOnCall() {
+func (s *OpsgenieSuiteEnterprise) TestAutoApprovalWhenNotOnCall() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	// Test setup: create an on-call schedule with a non-Teleport user in it.
 	s.fakeOpsgenie.StoreSchedule(ApprovalScheduleName, s.ogResponder2)
@@ -418,14 +420,10 @@ func (s *OpsgenieSuite) TestAutoApprovalWhenNotOnCall() {
 
 // TestAutoApprovalWhenOnCall tests that access requests are automatically
 // approved when the user is not on-call.
-func (s *OpsgenieSuite) TestAutoApprovalWhenOnCall() {
+func (s *OpsgenieSuiteEnterprise) TestAutoApprovalWhenOnCall() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	// Test setup: create an on-call schedule with a non-Teleport user in it.
 	s.fakeOpsgenie.StoreSchedule(ApprovalScheduleName, s.ogResponder1, s.ogResponder2)

--- a/integrations/access/pagerduty/testlib/helper.go
+++ b/integrations/access/pagerduty/testlib/helper.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/teleport/integrations/access/pagerduty"
 )
 
-func (s *PagerdutySuite) checkPluginData(ctx context.Context, reqID string, cond func(pagerduty.PluginData) bool) pagerduty.PluginData {
+func (s *PagerdutyBaseSuite) checkPluginData(ctx context.Context, reqID string, cond func(pagerduty.PluginData) bool) pagerduty.PluginData {
 	t := s.T()
 	t.Helper()
 

--- a/integrations/access/pagerduty/testlib/oss_integration_test.go
+++ b/integrations/access/pagerduty/testlib/oss_integration_test.go
@@ -27,9 +27,11 @@ import (
 )
 
 func TestPagerdutyPluginOSS(t *testing.T) {
-	pagerdutySuite := &PagerdutySuite{
-		AccessRequestSuite: &integration.AccessRequestSuite{
-			AuthHelper: &integration.OSSAuthHelper{},
+	pagerdutySuite := &PagerdutySuiteOSS{
+		PagerdutyBaseSuite: PagerdutyBaseSuite{
+			AccessRequestSuite: &integration.AccessRequestSuite{
+				AuthHelper: &integration.MinimalAuthHelper{},
+			},
 		},
 	}
 	suite.Run(t, pagerdutySuite)

--- a/integrations/access/pagerduty/testlib/suite.go
+++ b/integrations/access/pagerduty/testlib/suite.go
@@ -49,9 +49,9 @@ const (
 	ServiceName3        = "Service 3"
 )
 
-// PagerdutySuite is the Pagerduty access plugin test suite.
+// PagerdutyBaseSuite is the Pagerduty access plugin test suite.
 // It implements the testify.TestingSuite interface.
-type PagerdutySuite struct {
+type PagerdutyBaseSuite struct {
 	*integration.AccessRequestSuite
 	appConfig     pagerduty.Config
 	raceNumber    int
@@ -67,7 +67,7 @@ type PagerdutySuite struct {
 // It also configures the role notifications for Pagerduty notifications and
 // automatic approval.
 // It is run for each test.
-func (s *PagerdutySuite) SetupTest() {
+func (s *PagerdutyBaseSuite) SetupTest() {
 	t := s.T()
 	ctx := context.Background()
 
@@ -122,7 +122,7 @@ func (s *PagerdutySuite) SetupTest() {
 }
 
 // startApp starts the Pagerduty plugin, waits for it to become ready and returns.
-func (s *PagerdutySuite) startApp() {
+func (s *PagerdutyBaseSuite) startApp() {
 	t := s.T()
 	t.Helper()
 
@@ -131,9 +131,29 @@ func (s *PagerdutySuite) startApp() {
 	integration.RunAndWaitReady(t, app)
 }
 
+// PagerdutySuiteOSS contains all tests that support running against a Teleport
+// OSS Server.
+type PagerdutySuiteOSS struct {
+	PagerdutyBaseSuite
+}
+
+// PagerdutySuiteEnterprise contains all tests that require a Teleport Enterprise
+// to run.
+type PagerdutySuiteEnterprise struct {
+	PagerdutyBaseSuite
+}
+
+// SetupTest overrides PagerdutyBaseSuite.SetupTest to check the Teleport features
+// before each test.
+func (s *PagerdutySuiteEnterprise) SetupTest() {
+	t := s.T()
+	s.RequireAdvancedWorkflow(t)
+	s.PagerdutyBaseSuite.SetupTest()
+}
+
 // TestIncidentCreation validates that an incident is created to the service
 // specified in the role's annotation.
-func (s *PagerdutySuite) TestIncidentCreation() {
+func (s *PagerdutySuiteOSS) TestIncidentCreation() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -161,7 +181,7 @@ func (s *PagerdutySuite) TestIncidentCreation() {
 
 // TestApproval tests that when a request is approved, its corresponding incident
 // is updated to reflect the new request state and a note is added to the incident.
-func (s *PagerdutySuite) TestApproval() {
+func (s *PagerdutySuiteOSS) TestApproval() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -193,7 +213,7 @@ func (s *PagerdutySuite) TestApproval() {
 
 // TestDenial tests that when a request is denied, its corresponding incident
 // is updated to reflect the new request state and a note is added to the incident.
-func (s *PagerdutySuite) TestDenial() {
+func (s *PagerdutySuiteOSS) TestDenial() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -225,14 +245,10 @@ func (s *PagerdutySuite) TestDenial() {
 
 // TestReviewNotes tests that incident notes are sent after the access request
 // is reviewed. Each review should create a new note.
-func (s *PagerdutySuite) TestReviewNotes() {
+func (s *PagerdutySuiteEnterprise) TestReviewNotes() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -278,14 +294,10 @@ func (s *PagerdutySuite) TestReviewNotes() {
 
 // TestApprovalByReview tests that the incident is annotated and resolved after the
 // access request approval threshold is reached.
-func (s *PagerdutySuite) TestApprovalByReview() {
+func (s *PagerdutySuiteEnterprise) TestApprovalByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -342,14 +354,10 @@ func (s *PagerdutySuite) TestApprovalByReview() {
 
 // TestDenialByReview tests that the incident is annotated and resolved after the
 // access request denial threshold is reached.
-func (s *PagerdutySuite) TestDenialByReview() {
+func (s *PagerdutySuiteEnterprise) TestDenialByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -404,7 +412,7 @@ func (s *PagerdutySuite) TestDenialByReview() {
 	assert.Equal(t, "resolved", incidentUpdate.Status)
 }
 
-func (s *PagerdutySuite) assertNewEvent(ctx context.Context, watcher types.Watcher, opType types.OpType, resourceKind, resourceName string) types.Event {
+func (s *PagerdutyBaseSuite) assertNewEvent(ctx context.Context, watcher types.Watcher, opType types.OpType, resourceKind, resourceName string) types.Event {
 	t := s.T()
 	t.Helper()
 
@@ -429,7 +437,7 @@ func (s *PagerdutySuite) assertNewEvent(ctx context.Context, watcher types.Watch
 	return ev
 }
 
-func (s *PagerdutySuite) assertNoNewEvents(ctx context.Context, watcher types.Watcher) {
+func (s *PagerdutyBaseSuite) assertNoNewEvents(ctx context.Context, watcher types.Watcher) {
 	t := s.T()
 	t.Helper()
 
@@ -442,7 +450,7 @@ func (s *PagerdutySuite) assertNoNewEvents(ctx context.Context, watcher types.Wa
 	}
 }
 
-func (s *PagerdutySuite) assertReviewSubmitted(ctx context.Context, userName string) {
+func (s *PagerdutyBaseSuite) assertReviewSubmitted(ctx context.Context, userName string) {
 	t := s.T()
 	t.Helper()
 
@@ -472,7 +480,7 @@ func (s *PagerdutySuite) assertReviewSubmitted(ctx context.Context, userName str
 	assert.Equal(t, integration.PluginUserName, reqReviews[0].Author)
 }
 
-func (s *PagerdutySuite) assertNoReviewSubmitted(ctx context.Context, userName string) {
+func (s *PagerdutyBaseSuite) assertNoReviewSubmitted(ctx context.Context, userName string) {
 	t := s.T()
 	t.Helper()
 
@@ -504,14 +512,10 @@ func (s *PagerdutySuite) assertNoReviewSubmitted(ctx context.Context, userName s
 
 // TestAutoApprovalWhenNotOnCall tests that access requests are not automatically
 // approved when the user is not on-call.
-func (s *PagerdutySuite) TestAutoApprovalWhenNotOnCall() {
+func (s *PagerdutySuiteEnterprise) TestAutoApprovalWhenNotOnCall() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	// We use the OSS user for this advanced workflow test because their role
 	// doesn't have a threshold
@@ -526,14 +530,10 @@ func (s *PagerdutySuite) TestAutoApprovalWhenNotOnCall() {
 
 // TestAutoApprovalWhenOnCall tests that access requests are automatically
 // approved when the user is on-call.
-func (s *PagerdutySuite) TestAutoApprovalWhenOnCall() {
+func (s *PagerdutySuiteEnterprise) TestAutoApprovalWhenOnCall() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	// We use the OSS user for this advanced workflow test because their role
 	// doesn't have a threshold
@@ -553,14 +553,10 @@ func (s *PagerdutySuite) TestAutoApprovalWhenOnCall() {
 // TestAutoApprovalWhenOnCallInSecondPolicy tests that access requests are
 // automatically approved when the user is not on-call for the first service
 // escalation policy but is on-call for the second service.
-func (s *PagerdutySuite) TestAutoApprovalWhenOnCallInSecondPolicy() {
+func (s *PagerdutySuiteEnterprise) TestAutoApprovalWhenOnCallInSecondPolicy() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	// We use the OSS user for this advanced workflow test because their role
 	// doesn't have a threshold
@@ -581,14 +577,10 @@ func (s *PagerdutySuite) TestAutoApprovalWhenOnCallInSecondPolicy() {
 // not automatically approved when the user is not on-call for a service
 // specified in the role annotations, but is on-call for a third unrelated\
 // service.
-func (s *PagerdutySuite) TestAutoApprovalWhenOnCallInSomeOtherPolicy() {
+func (s *PagerdutySuiteEnterprise) TestAutoApprovalWhenOnCallInSomeOtherPolicy() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	// We use the OSS user for this advanced workflow test because their role
 	// doesn't have a threshold
@@ -607,7 +599,7 @@ func (s *PagerdutySuite) TestAutoApprovalWhenOnCallInSomeOtherPolicy() {
 
 // TestExpiration tests that when a request expires, its corresponding incident
 // is updated to reflect the new request state and a note is added to the incident.
-func (s *PagerdutySuite) TestExpiration() {
+func (s *PagerdutySuiteOSS) TestExpiration() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -645,14 +637,10 @@ func (s *PagerdutySuite) TestExpiration() {
 // TestRace validates that the plugin behaves properly and performs all the
 // message updates when a lot of access requests are sent and reviewed in a very
 // short time frame.
-func (s *PagerdutySuite) TestRace() {
+func (s *PagerdutySuiteEnterprise) TestRace() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	err := logger.Setup(logger.Config{Severity: "info"}) // Turn off noisy debug logging
 	require.NoError(t, err)

--- a/integrations/access/servicenow/testlib/helpers.go
+++ b/integrations/access/servicenow/testlib/helpers.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/teleport/integrations/access/servicenow"
 )
 
-func (s *ServiceNowSuite) checkPluginData(ctx context.Context, reqID string, cond func(servicenow.PluginData) bool) servicenow.PluginData {
+func (s *ServiceNowBaseSuite) checkPluginData(ctx context.Context, reqID string, cond func(servicenow.PluginData) bool) servicenow.PluginData {
 	t := s.T()
 	t.Helper()
 

--- a/integrations/access/servicenow/testlib/oss_integration_test.go
+++ b/integrations/access/servicenow/testlib/oss_integration_test.go
@@ -27,9 +27,11 @@ import (
 )
 
 func TestServiceNowPluginOSS(t *testing.T) {
-	servicenowSuite := &ServiceNowSuite{
-		AccessRequestSuite: &integration.AccessRequestSuite{
-			AuthHelper: &integration.OSSAuthHelper{},
+	servicenowSuite := &ServiceNowSuiteOSS{
+		ServiceNowBaseSuite: ServiceNowBaseSuite{
+			AccessRequestSuite: &integration.AccessRequestSuite{
+				AuthHelper: &integration.MinimalAuthHelper{},
+			},
 		},
 	}
 	suite.Run(t, servicenowSuite)

--- a/integrations/access/servicenow/testlib/suite.go
+++ b/integrations/access/servicenow/testlib/suite.go
@@ -34,9 +34,9 @@ import (
 
 const snowOnCallRotationName = "important-rotation"
 
-// ServiceNowSuite is the ServiceNow access plugin test suite.
+// ServiceNowBaseSuite is the ServiceNow access plugin test suite.
 // It implements the testify.TestingSuite interface.
-type ServiceNowSuite struct {
+type ServiceNowBaseSuite struct {
 	*integration.AccessRequestSuite
 	appConfig      servicenow.Config
 	raceNumber     int
@@ -50,7 +50,7 @@ type ServiceNowSuite struct {
 // It also configures the role notifications for ServiceNow notifications and
 // automatic approval.
 // It is run for each test.
-func (s *ServiceNowSuite) SetupTest() {
+func (s *ServiceNowBaseSuite) SetupTest() {
 	t := s.T()
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -82,7 +82,7 @@ func (s *ServiceNowSuite) SetupTest() {
 }
 
 // startApp starts the ServiceNow plugin, waits for it to become ready and returns.
-func (s *ServiceNowSuite) startApp() {
+func (s *ServiceNowBaseSuite) startApp() {
 	t := s.T()
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -93,9 +93,29 @@ func (s *ServiceNowSuite) startApp() {
 	integration.RunAndWaitReady(t, app)
 }
 
+// ServiceNowSuiteOSS contains all tests that support running against a Teleport
+// OSS Server.
+type ServiceNowSuiteOSS struct {
+	ServiceNowBaseSuite
+}
+
+// ServiceNowSuiteEnterprise contains all tests that require a Teleport Enterprise
+// to run.
+type ServiceNowSuiteEnterprise struct {
+	ServiceNowBaseSuite
+}
+
+// SetupTest overrides ServiceNowBaseSuite.SetupTest to check the Teleport features
+// before each test.
+func (s *ServiceNowSuiteEnterprise) SetupTest() {
+	t := s.T()
+	s.RequireAdvancedWorkflow(t)
+	s.ServiceNowBaseSuite.SetupTest()
+}
+
 // TestIncidentCreation validates that a new access request triggers an
 // incident creation.
-func (s *ServiceNowSuite) TestIncidentCreation() {
+func (s *ServiceNowSuiteOSS) TestIncidentCreation() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -117,7 +137,7 @@ func (s *ServiceNowSuite) TestIncidentCreation() {
 
 // TestApproval tests that when a request is approved, its corresponding incident
 // is updated to reflect the new request state and a note is added to the incident.
-func (s *ServiceNowSuite) TestApproval() {
+func (s *ServiceNowSuiteOSS) TestApproval() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -146,7 +166,7 @@ func (s *ServiceNowSuite) TestApproval() {
 
 // TestDenial tests that when a request is denied, its corresponding incident
 // is updated to reflect the new request state and a note is added to the incident.
-func (s *ServiceNowSuite) TestDenial() {
+func (s *ServiceNowSuiteOSS) TestDenial() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -176,14 +196,10 @@ func (s *ServiceNowSuite) TestDenial() {
 
 // TestReviewNotes tests that incident notes are sent after the access request
 // is reviewed. Each review should create a new note.
-func (s *ServiceNowSuite) TestReviewNotes() {
+func (s *ServiceNowSuiteEnterprise) TestReviewNotes() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -227,14 +243,10 @@ func (s *ServiceNowSuite) TestReviewNotes() {
 
 // TestApprovalByReview tests that the incident is annotated and resolved after the
 // access request approval threshold is reached.
-func (s *ServiceNowSuite) TestApprovalByReview() {
+func (s *ServiceNowSuiteEnterprise) TestApprovalByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -287,14 +299,10 @@ func (s *ServiceNowSuite) TestApprovalByReview() {
 
 // TestDenialByReview tests that the incident is annotated and resolved after the
 // access request denial threshold is reached.
-func (s *ServiceNowSuite) TestDenialByReview() {
+func (s *ServiceNowSuiteEnterprise) TestDenialByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -347,14 +355,10 @@ func (s *ServiceNowSuite) TestDenialByReview() {
 
 // TestAutoApproval tests that access requests are automatically
 // approved when the user is on-call.
-func (s *ServiceNowSuite) TestAutoApproval() {
+func (s *ServiceNowSuiteEnterprise) TestAutoApproval() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 

--- a/integrations/access/slack/testlib/helpers.go
+++ b/integrations/access/slack/testlib/helpers.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/teleport/integrations/access/slack"
 )
 
-func (s *SlackSuite) checkPluginData(ctx context.Context, reqID string, cond func(accessrequest.PluginData) bool) accessrequest.PluginData {
+func (s *SlackBaseSuite) checkPluginData(ctx context.Context, reqID string, cond func(accessrequest.PluginData) bool) accessrequest.PluginData {
 	t := s.T()
 	t.Helper()
 
@@ -114,12 +114,12 @@ func matchByThreadTs(matchAgainst, newMsg slack.Message) bool {
 // checkMsgTestFn is a test function to run on a new message after it has been matched.
 type checkMsgTestFn func(*testing.T, slack.Message)
 
-func (s *SlackSuite) checkNewMessages(t *testing.T, ctx context.Context, matchMessages []slack.Message, matchBy matchFn, testFns ...checkMsgTestFn) []slack.Message {
+func (s *SlackBaseSuite) checkNewMessages(t *testing.T, ctx context.Context, matchMessages []slack.Message, matchBy matchFn, testFns ...checkMsgTestFn) []slack.Message {
 	t.Helper()
 	return s.matchAndCallFn(t, ctx, matchMessages, matchBy, testFns, s.fakeSlack.CheckNewMessage)
 }
 
-func (s *SlackSuite) checkNewMessageUpdateByAPI(t *testing.T, ctx context.Context, matchMessages []slack.Message, matchBy matchFn, testFns ...checkMsgTestFn) []slack.Message {
+func (s *SlackBaseSuite) checkNewMessageUpdateByAPI(t *testing.T, ctx context.Context, matchMessages []slack.Message, matchBy matchFn, testFns ...checkMsgTestFn) []slack.Message {
 	t.Helper()
 	return s.matchAndCallFn(t, ctx, matchMessages, matchBy, testFns, s.fakeSlack.CheckMessageUpdateByAPI)
 }
@@ -134,7 +134,7 @@ func channelsToMessages(channels ...string) (messages []slack.Message) {
 
 type slackCheckMessage func(context.Context) (slack.Message, error)
 
-func (s *SlackSuite) matchAndCallFn(t *testing.T, ctx context.Context, matchMessages []slack.Message, matchBy matchFn, testFns []checkMsgTestFn, slackCall slackCheckMessage) []slack.Message {
+func (s *SlackBaseSuite) matchAndCallFn(t *testing.T, ctx context.Context, matchMessages []slack.Message, matchBy matchFn, testFns []checkMsgTestFn, slackCall slackCheckMessage) []slack.Message {
 	matchingTimestamps := map[string]slack.Message{}
 
 	for _, matchMessage := range matchMessages {

--- a/integrations/access/slack/testlib/oss_integration_test.go
+++ b/integrations/access/slack/testlib/oss_integration_test.go
@@ -27,9 +27,11 @@ import (
 )
 
 func TestSlackPluginOSS(t *testing.T) {
-	slackSuite := &SlackSuite{
-		AccessRequestSuite: &integration.AccessRequestSuite{
-			AuthHelper: &integration.OSSAuthHelper{},
+	slackSuite := &SlackSuiteOSS{
+		SlackBaseSuite: SlackBaseSuite{
+			AccessRequestSuite: &integration.AccessRequestSuite{
+				AuthHelper: &integration.MinimalAuthHelper{},
+			},
 		},
 	}
 	suite.Run(t, slackSuite)

--- a/integrations/access/slack/testlib/suite.go
+++ b/integrations/access/slack/testlib/suite.go
@@ -46,9 +46,9 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/testing/integration"
 )
 
-// SlackSuite is the Slack access plugin test suite.
+// SlackBaseSuite is the Slack access plugin test suite.
 // It implements the testify.TestingSuite interface.
-type SlackSuite struct {
+type SlackBaseSuite struct {
 	*integration.AccessRequestSuite
 	appConfig             *slack.Config
 	raceNumber            int
@@ -62,7 +62,7 @@ type SlackSuite struct {
 
 // SetupTest starts a fake Slack, generates the plugin configuration, and loads
 // the fixtures in Slack. It runs for each test.
-func (s *SlackSuite) SetupTest() {
+func (s *SlackBaseSuite) SetupTest() {
 	t := s.T()
 
 	err := logger.Setup(logger.Config{Severity: "debug"})
@@ -92,7 +92,7 @@ func (s *SlackSuite) SetupTest() {
 }
 
 // startApp starts the Slack plugin, waits for it to become ready and returns.
-func (s *SlackSuite) startApp() {
+func (s *SlackBaseSuite) startApp() {
 	t := s.T()
 	t.Helper()
 
@@ -100,10 +100,30 @@ func (s *SlackSuite) startApp() {
 	integration.RunAndWaitReady(t, app)
 }
 
+// SlackSuiteOSS contains all tests that support running against a Teleport
+// OSS Server.
+type SlackSuiteOSS struct {
+	SlackBaseSuite
+}
+
+// SlackSuiteEnterprise contains all tests that require a Teleport Enterprise
+// to run.
+type SlackSuiteEnterprise struct {
+	SlackBaseSuite
+}
+
+// SetupTest overrides SlackBaseSuite.SetupTest to check the Teleport features
+// before each test.
+func (s *SlackSuiteEnterprise) SetupTest() {
+	t := s.T()
+	s.RequireAdvancedWorkflow(t)
+	s.SlackBaseSuite.SetupTest()
+}
+
 // TestMessagePosting validates that a message is sent to each recipient
 // specified in the suggested reviewers. It also checks that the message
 // content is correct.
-func (s *SlackSuite) TestMessagePosting() {
+func (s *SlackSuiteOSS) TestMessagePosting() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -172,7 +192,7 @@ func (s *SlackSuite) TestMessagePosting() {
 
 // TestRecipientsConfig checks that the recipient configuration accepts both
 // referencing users by their email, or their slack user ID.
-func (s *SlackSuite) TestRecipientsConfig() {
+func (s *SlackSuiteOSS) TestRecipientsConfig() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -222,7 +242,7 @@ func (s *SlackSuite) TestRecipientsConfig() {
 
 // TestApproval tests that when a request is approved, its corresponding message
 // is updated to reflect the new request state.
-func (s *SlackSuite) TestApproval() {
+func (s *SlackSuiteOSS) TestApproval() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -248,7 +268,7 @@ func (s *SlackSuite) TestApproval() {
 
 // TestDenial tests that when a request is denied, its corresponding message
 // is updated to reflect the new request state.
-func (s *SlackSuite) TestDenial() {
+func (s *SlackSuiteOSS) TestDenial() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -275,14 +295,10 @@ func (s *SlackSuite) TestDenial() {
 
 // TestReviewReplies tests that a reply is sent after the access request
 // is reviewed. Each review should be reflected in the original message.
-func (s *SlackSuite) TestReviewReplies() {
+func (s *SlackSuiteEnterprise) TestReviewReplies() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -328,14 +344,10 @@ func (s *SlackSuite) TestReviewReplies() {
 
 // TestApprovalByReview tests that the message is updated after the access request
 // is reviewed and approved.
-func (s *SlackSuite) TestApprovalByReview() {
+func (s *SlackSuiteEnterprise) TestApprovalByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -386,14 +398,10 @@ func (s *SlackSuite) TestApprovalByReview() {
 
 // TestDenialByReview tests that the message is updated after the access request
 // is reviewed and denied.
-func (s *SlackSuite) TestDenialByReview() {
+func (s *SlackSuiteEnterprise) TestDenialByReview() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	s.startApp()
 
@@ -444,7 +452,7 @@ func (s *SlackSuite) TestDenialByReview() {
 
 // TestExpiration tests that when a request expires, its corresponding message
 // is updated to reflect the new request state.
-func (s *SlackSuite) TestExpiration() {
+func (s *SlackSuiteOSS) TestExpiration() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -475,14 +483,10 @@ func (s *SlackSuite) TestExpiration() {
 // TestRace validates that the plugin behaves properly and performs all the
 // message updates when a lot of access requests are sent and reviewed in a very
 // short time frame.
-func (s *SlackSuite) TestRace() {
+func (s *SlackSuiteEnterprise) TestRace() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	err := logger.Setup(logger.Config{Severity: "info"}) // Turn off noisy debug logging
 	require.NoError(t, err)
@@ -621,14 +625,10 @@ func (s *SlackSuite) TestRace() {
 
 // TestAccessListReminder validates that Access List reminders are sent before
 // the Access List expires.
-func (s *SlackSuite) TestAccessListReminder() {
+func (s *SlackSuiteEnterprise) TestAccessListReminder() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
-
-	if !s.TeleportFeatures().AdvancedAccessWorkflows {
-		t.Skip("Doesn't work in OSS version")
-	}
 
 	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
 	s.appConfig.Clock = clock
@@ -675,7 +675,7 @@ func (s *SlackSuite) TestAccessListReminder() {
 	s.requireReminderMsgEqual(ctx, s.reviewer1SlackUser.ID, "Access List *simple title* is 7 day(s) past due for a review! Please review it.")
 }
 
-func (s *SlackSuite) requireReminderMsgEqual(ctx context.Context, id, text string) {
+func (s *SlackBaseSuite) requireReminderMsgEqual(ctx context.Context, id, text string) {
 	t := s.T()
 
 	msg, err := s.fakeSlack.CheckNewMessage(ctx)

--- a/integrations/access/slack/testlib/suite.go
+++ b/integrations/access/slack/testlib/suite.go
@@ -656,21 +656,25 @@ func (s *SlackSuiteEnterprise) TestAccessListReminder() {
 
 	// Test execution: move the clock to 2 weeks before expiry
 	// This should trigger a reminder.
+	clock.BlockUntil(1)
 	clock.Advance(45 * 24 * time.Hour)
 	s.requireReminderMsgEqual(ctx, s.reviewer1SlackUser.ID, "Access List *simple title* is due for a review by 2023-03-01. Please review it soon!")
 
 	// Test execution: move the clock to 1 week before expiry
 	// This should trigger a reminder.
+	clock.BlockUntil(1)
 	clock.Advance(7 * 24 * time.Hour)
 	s.requireReminderMsgEqual(ctx, s.reviewer1SlackUser.ID, "Access List *simple title* is due for a review by 2023-03-01. Please review it soon!")
 
 	// Test execution: move the clock to the expiry day
 	// This should trigger a reminder.
+	clock.BlockUntil(1)
 	clock.Advance(7 * 24 * time.Hour)
 	s.requireReminderMsgEqual(ctx, s.reviewer1SlackUser.ID, "Access List *simple title* is due for a review by 2023-03-01. Please review it soon!")
 
 	// Test execution: move the clock after the expiry day
 	// This should trigger a reminder.
+	clock.BlockUntil(1)
 	clock.Advance(7 * 24 * time.Hour)
 	s.requireReminderMsgEqual(ctx, s.reviewer1SlackUser.ID, "Access List *simple title* is 7 day(s) past due for a review! Please review it.")
 }

--- a/integrations/event-handler/event_handler_test.go
+++ b/integrations/event-handler/event_handler_test.go
@@ -45,7 +45,7 @@ type EventHandlerSuite struct {
 
 func TestEventHandler(t *testing.T) {
 	suite.Run(t, &EventHandlerSuite{
-		AuthHelper: &integration.OSSAuthHelper{},
+		AuthHelper: &integration.MinimalAuthHelper{},
 	})
 }
 

--- a/integrations/lib/testing/integration/accessrequestsuite.go
+++ b/integrations/lib/testing/integration/accessrequestsuite.go
@@ -21,6 +21,7 @@ package integration
 import (
 	"context"
 	"strings"
+	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -383,5 +384,11 @@ func (s *AccessRequestSuite) AnnotateRequesterRoleAccessRequests(ctx context.Con
 		role.SetAccessRequestConditions(types.Allow, conditions)
 		_, err = adminClient.UpdateRole(ctx, role)
 		require.NoError(t, err)
+	}
+}
+
+func (s *AccessRequestSuite) RequireAdvancedWorkflow(t *testing.T) {
+	if !s.TeleportFeatures().GetAdvancedAccessWorkflows() {
+		require.Fail(t, "This test requires AdvancedAccessWorkflows (Teleport enterprise)")
 	}
 }

--- a/integrations/lib/testing/integration/authhelper.go
+++ b/integrations/lib/testing/integration/authhelper.go
@@ -37,23 +37,25 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	libauth "github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/plugin"
 )
 
-// OSSAuthHelper implements the AuthHelper interface.
-// It starts an OSS Auth server and exposes the functions required for plugin
-// integration tests to build teleport clients for each user/plugin/bot.
-type OSSAuthHelper struct {
+// MinimalAuthHelper implements the AuthHelper interface.
+// It starts an Auth server and a TLS server. This is not a full-featured
+// Teleport process.
+type MinimalAuthHelper struct {
 	server *libauth.TestTLSServer
 	// dir is where we put identity files, and start the auth server
 	// (unless AuthConfig.Dir is manually set).
-	dir        string
-	AuthConfig libauth.TestAuthServerConfig
+	dir            string
+	AuthConfig     libauth.TestAuthServerConfig
+	PluginRegistry plugin.Registry
 }
 
 // StartServer implements the AuthHelper interface.
 // The function takes care of registering client and server close function
 // on the t.Cleanup() stack.
-func (a *OSSAuthHelper) StartServer(t *testing.T) *client.Client {
+func (a *MinimalAuthHelper) StartServer(t *testing.T) *client.Client {
 	a.dir = t.TempDir()
 	if a.AuthConfig.Dir == "" {
 		a.AuthConfig.Dir = a.dir
@@ -67,10 +69,11 @@ func (a *OSSAuthHelper) StartServer(t *testing.T) *client.Client {
 
 	server, err := libauth.NewTestTLSServer(libauth.TestTLSServerConfig{
 		APIConfig: &libauth.APIConfig{
-			AuthServer: authServer.AuthServer,
-			Authorizer: authServer.Authorizer,
-			AuditLog:   authServer.AuditLog,
-			Emitter:    authServer.AuditLog,
+			AuthServer:     authServer.AuthServer,
+			Authorizer:     authServer.Authorizer,
+			AuditLog:       authServer.AuditLog,
+			Emitter:        authServer.AuditLog,
+			PluginRegistry: a.PluginRegistry,
 		},
 		AuthServer:    authServer,
 		AcceptedUsage: authServer.AcceptedUsage,
@@ -94,7 +97,7 @@ func (a *OSSAuthHelper) StartServer(t *testing.T) *client.Client {
 // ServerAddr implements the AuthHelper interface.
 // It returns the server address, including the port.
 // For example, "192.0.2.1:25" or "[2001:db8::1]:80"
-func (a *OSSAuthHelper) ServerAddr() string {
+func (a *MinimalAuthHelper) ServerAddr() string {
 	return a.server.Addr().String()
 }
 
@@ -112,7 +115,7 @@ type userCerts struct {
 // - the PEM-encoded private key
 // - the Authorized-key formatted SSH cert
 // - the PEM-encoded TLS cert
-func (a *OSSAuthHelper) getUserCerts(t *testing.T, user types.User) userCerts {
+func (a *MinimalAuthHelper) getUserCerts(t *testing.T, user types.User) userCerts {
 	auth := a.server.Auth()
 
 	clusterName, err := auth.GetClusterName()
@@ -145,7 +148,7 @@ func (a *OSSAuthHelper) getUserCerts(t *testing.T, user types.User) userCerts {
 
 // CredentialsForUser implements the AuthHelper interface.
 // It builds TLS client credentials for the given user.
-func (a *OSSAuthHelper) CredentialsForUser(t *testing.T, ctx context.Context, user types.User) client.Credentials {
+func (a *MinimalAuthHelper) CredentialsForUser(t *testing.T, ctx context.Context, user types.User) client.Credentials {
 	auth := a.server.Auth()
 	clusterName, err := auth.GetClusterName()
 	require.NoError(t, err)
@@ -176,7 +179,7 @@ func (a *OSSAuthHelper) CredentialsForUser(t *testing.T, ctx context.Context, us
 
 // SignIdentityForUser implements the AuthHelper interface.
 // It signs an identity, write it to a temporary directory, and returns its path.
-func (a *OSSAuthHelper) SignIdentityForUser(t *testing.T, ctx context.Context, user types.User) string {
+func (a *MinimalAuthHelper) SignIdentityForUser(t *testing.T, ctx context.Context, user types.User) string {
 	auth := a.server.Auth()
 	clusterName, err := auth.GetClusterName()
 	require.NoError(t, err)
@@ -215,4 +218,8 @@ func (a *OSSAuthHelper) SignIdentityForUser(t *testing.T, ctx context.Context, u
 	path := fmt.Sprintf("%s/%s-identity.pem", a.dir, user.GetName())
 	require.NoError(t, identityfile.Write(id, path))
 	return path
+}
+
+func (a *MinimalAuthHelper) Auth() *libauth.Server {
+	return a.server.Auth()
 }

--- a/integrations/lib/testing/integration/interfaces.go
+++ b/integrations/lib/testing/integration/interfaces.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
+	libauth "github.com/gravitational/teleport/lib/auth"
 )
 
 // AuthHelper is the interface one must implement to run the AccessRequestSuite.
@@ -34,6 +35,7 @@ type AuthHelper interface {
 	ServerAddr() string
 	CredentialsForUser(t *testing.T, ctx context.Context, user types.User) client.Credentials
 	SignIdentityForUser(t *testing.T, ctx context.Context, user types.User) string
+	Auth() *libauth.Server
 }
 
 // NewAccessRequestClient returns a new integration.Client.

--- a/integrations/terraform/provider/provider.go
+++ b/integrations/terraform/provider/provider.go
@@ -29,8 +29,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -38,6 +36,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
+
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/integrations/lib"
 )
 
 const (

--- a/integrations/terraform/provider/resource_teleport_bot.go
+++ b/integrations/terraform/provider/resource_teleport_bot.go
@@ -20,15 +20,15 @@ import (
 	"context"
 	"fmt"
 
-	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
-	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
-	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/integrations/terraform/tfschema"
 )
 

--- a/integrations/terraform/test/access_list_test.go
+++ b/integrations/terraform/test/access_list_test.go
@@ -18,7 +18,6 @@ package test
 
 import (
 	"context"
-	"github.com/gravitational/teleport/api/client"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -26,6 +25,8 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/gravitational/teleport/api/client"
 )
 
 type nextAuditDateComparer struct {

--- a/integrations/terraform/test/app_test.go
+++ b/integrations/terraform/test/app_test.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func (s *TerraformSuite) TestApp() {

--- a/integrations/terraform/test/auth_preference_test.go
+++ b/integrations/terraform/test/auth_preference_test.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func (s *TerraformSuite) TestAuthPreference() {

--- a/integrations/terraform/test/bot_test.go
+++ b/integrations/terraform/test/bot_test.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"context"
+
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/integrations/terraform/test/cluster_networking_config_test.go
+++ b/integrations/terraform/test/cluster_networking_config_test.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func (s *TerraformSuite) TestClusterNetworkingConfig() {

--- a/integrations/terraform/test/database_test.go
+++ b/integrations/terraform/test/database_test.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func (s *TerraformSuite) TestDatabase() {

--- a/integrations/terraform/test/device_trust_test.go
+++ b/integrations/terraform/test/device_trust_test.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"fmt"
 
-	// devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	// devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	"github.com/gravitational/teleport/api/types"
 )
 
 func (s *TerraformSuite) TestTrustedDevices() {

--- a/integrations/terraform/test/github_connector_test.go
+++ b/integrations/terraform/test/github_connector_test.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"regexp"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func (s *TerraformSuite) TestGithubConnector() {

--- a/integrations/terraform/test/loginrule_test.go
+++ b/integrations/terraform/test/loginrule_test.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"fmt"
 
-	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
+	"github.com/gravitational/teleport/api/types"
 )
 
 func (s *TerraformSuite) TestLoginRule() {

--- a/integrations/terraform/test/main_test.go
+++ b/integrations/terraform/test/main_test.go
@@ -20,28 +20,28 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/constants"
-	"github.com/gravitational/teleport/lib/auth"
-	libclient "github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/client/identityfile"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/integrations/lib"
-	"github.com/gravitational/teleport/integrations/lib/testing/integration"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/integrations/lib"
+	"github.com/gravitational/teleport/integrations/lib/testing/integration"
 	"github.com/gravitational/teleport/integrations/terraform/provider"
+	"github.com/gravitational/teleport/lib/auth"
+	libclient "github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/client/identityfile"
 )
 
 //go:embed fixtures/*
@@ -76,7 +76,7 @@ type TerraformSuite struct {
 func TestTerraform(t *testing.T) {
 	suite.Run(t, &TerraformSuite{
 		TerraformBaseSuite: TerraformBaseSuite{
-			AuthHelper: &integration.OSSAuthHelper{},
+			AuthHelper: &integration.MinimalAuthHelper{},
 		},
 	})
 }
@@ -84,7 +84,7 @@ func TestTerraform(t *testing.T) {
 func TestTerraformWithCache(t *testing.T) {
 	suite.Run(t, &TerraformSuiteWithCache{
 		TerraformBaseSuite: TerraformBaseSuite{
-			AuthHelper: &integration.OSSAuthHelper{
+			AuthHelper: &integration.MinimalAuthHelper{
 				AuthConfig: auth.TestAuthServerConfig{CacheEnabled: true},
 			},
 		},

--- a/integrations/terraform/test/oidc_connector_test.go
+++ b/integrations/terraform/test/oidc_connector_test.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/wrappers"
 )
 
 func (s *TerraformSuite) TestOIDCConnector() {

--- a/integrations/terraform/test/okta_import_rule_test.go
+++ b/integrations/terraform/test/okta_import_rule_test.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func (s *TerraformSuite) TestOktaImportRule() {

--- a/integrations/terraform/test/provision_token_test.go
+++ b/integrations/terraform/test/provision_token_test.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func (s *TerraformSuite) TestProvisionToken() {

--- a/integrations/terraform/test/role_test.go
+++ b/integrations/terraform/test/role_test.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func (s *TerraformSuite) TestRole() {

--- a/integrations/terraform/test/saml_connector_test.go
+++ b/integrations/terraform/test/saml_connector_test.go
@@ -23,11 +23,12 @@ import (
 	"net/http/httptest"
 	"regexp"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func (s *TerraformSuite) TestSAMLConnector() {

--- a/integrations/terraform/test/server_test.go
+++ b/integrations/terraform/test/server_test.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport/api/defaults"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
 )
 
 func (s *TerraformSuite) TestOpenSSHServer() {

--- a/integrations/terraform/test/session_recording_config_test.go
+++ b/integrations/terraform/test/session_recording_config_test.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func (s *TerraformSuite) TestSessionRecordingConfig() {

--- a/integrations/terraform/test/user_test.go
+++ b/integrations/terraform/test/user_test.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"context"
+
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/integrations/terraform/tfschema/custom_types.go
+++ b/integrations/terraform/tfschema/custom_types.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	fmt "fmt"
 
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/wrappers"
-	"github.com/gravitational/teleport/api/utils"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/wrappers"
+	"github.com/gravitational/teleport/api/utils"
 )
 
 // GenSchemaBoolOptions returns Terraform schema for BoolOption type

--- a/integrations/terraform/tfschema/custom_types_test.go
+++ b/integrations/terraform/tfschema/custom_types_test.go
@@ -19,11 +19,12 @@ package tfschema
 import (
 	"testing"
 
-	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/wrappers"
 )
 
 func TestStringsCopyTo(t *testing.T) {


### PR DESCRIPTION
This PR lays the groundwork for running enterprise tests for access plugins in telepeort.e.

It does 3 changes:
- make the OSSAuthHelper into a MinimalAuthHelper that supports starting enterprise plugins (avoid Auth Helper duplication in teleport.e)
- split OSS and enterprise access plugin suite (so teleport.e don't have to run the OSS tests again)
- Fail instead of skipping if running enterprise tests against a non-enterprise instance (avoids silent failure)