### PR TITLE
Discovery: Reuse `conn.Client` instead of `process.getInstanceClient`

### DIFF
--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -78,7 +78,7 @@ func (process *TeleportProcess) initDiscoveryService() error {
 	accessGraphCfg, err := buildAccessGraphFromTAGOrFallbackToAuth(
 		process.ExitContext(),
 		process.Config,
-		process.getInstanceClient(),
+		conn.Client,
 		logger,
 	)
 	if err != nil {


### PR DESCRIPTION
This PR replaces the usage of `process.getInstanceClient` client when dialing to Auth Server to pull AccessGraph config with the `conn.Client`.
