### PR TITLE
[v14] Discovery: Reuse `conn.Client` instead of `process.getInstanceClient`

### DIFF
--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -77,7 +77,7 @@ func (process *TeleportProcess) initDiscoveryService() error {
 	accessGraphCfg, err := buildAccessGraphFromTAGOrFallbackToAuth(
 		process.ExitContext(),
 		process.Config,
-		process.getInstanceClient(),
+		conn.Client,
 		log,
 	)
 	if err != nil {


### PR DESCRIPTION
Backport #40484  to branch/v14