### PR TITLE
AppService: split connection handler and service

### DIFF
--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -1,0 +1,817 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package app runs the application proxy process. It keeps dynamic labels
+// updated, heart beats its presence, checks access controls, and forwards
+// connections between the tunnel and the target host.
+package app
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/events"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv"
+	appaws "github.com/gravitational/teleport/lib/srv/app/aws"
+	appazure "github.com/gravitational/teleport/lib/srv/app/azure"
+	"github.com/gravitational/teleport/lib/srv/app/common"
+	appgcp "github.com/gravitational/teleport/lib/srv/app/gcp"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+)
+
+// ConnMonitor monitors authorized connections and terminates them when
+// session controls dictate so.
+type ConnMonitor interface {
+	MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, net.Conn, error)
+}
+
+// ConnectionsHandlerConfig is the configuration for a ConnectionsHandler.
+type ConnectionsHandlerConfig struct {
+	// Clock is used to control time.
+	Clock clockwork.Clock
+
+	// DataDir is the path to the data directory for the server.
+	DataDir string
+
+	// Emitter is an event emitter.
+	Emitter events.Emitter
+
+	// Authorizer is used to authorize requests.
+	Authorizer authz.Authorizer
+
+	// HostID is the id of the host where this application agent is running.
+	HostID string
+
+	// AuthClient is a client directly connected to the Auth server.
+	AuthClient *auth.Client
+
+	// AccessPoint is a caching client connected to the Auth Server.
+	AccessPoint auth.AppsAccessPoint
+
+	// Cloud provides cloud provider access related functionality.
+	Cloud Cloud
+
+	// TLSConfig is the *tls.Config for this server.
+	TLSConfig *tls.Config
+
+	// ConnectionMonitor monitors connections and terminates any if
+	// any session controls prevent them.
+	ConnectionMonitor ConnMonitor
+
+	// CipherSuites is the list of TLS cipher suites that have been configured
+	// for this process.
+	CipherSuites []uint16
+
+	// ServiceComponent is the Teleport Component identifier used for tracing and logging.
+	// Must be one of teleport.Component* values.
+	// Eg, teleport.ComponentApp
+	ServiceComponent string
+
+	// Logger is the slog.Logger.
+	Logger *slog.Logger
+}
+
+// CheckAndSetDefaults validates the config values and sets defaults.
+func (c *ConnectionsHandlerConfig) CheckAndSetDefaults() error {
+	if c.Clock == nil {
+		c.Clock = clockwork.NewRealClock()
+	}
+	if c.DataDir == "" {
+		return trace.BadParameter("data dir missing")
+	}
+	if c.HostID == "" {
+		return trace.BadParameter("host id missing")
+	}
+	if c.AuthClient == nil {
+		return trace.BadParameter("auth client missing")
+	}
+	if c.AccessPoint == nil {
+		return trace.BadParameter("access point missing")
+	}
+	if c.Emitter == nil {
+		return trace.BadParameter("emitter missing")
+	}
+	if c.Authorizer == nil {
+		return trace.BadParameter("authorizer missing")
+	}
+	if c.TLSConfig == nil {
+		return trace.BadParameter("tls config missing")
+	}
+	if c.Cloud == nil {
+		cloud, err := NewCloud(CloudConfig{
+			Clock: c.Clock,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.Cloud = cloud
+	}
+	if len(c.CipherSuites) == 0 {
+		return trace.BadParameter("ciphersuites missing")
+	}
+	if c.ServiceComponent == "" {
+		return trace.BadParameter("service component missing")
+	}
+	if c.Logger == nil {
+		c.Logger = slog.Default().With(teleport.ComponentKey, teleport.Component(c.ServiceComponent))
+	}
+	return nil
+}
+
+// ConnectionsHandler handles Connections for the ApplicationService.
+// It authenticates requests from the web proxy and forwards them to internal applications.
+type ConnectionsHandler struct {
+	cfg *ConnectionsHandlerConfig
+	log *slog.Logger
+
+	// TODO(marco): convert everything to log/slog
+	legacyLogger *logrus.Entry
+
+	closeContext context.Context
+
+	httpServer *http.Server
+	tlsConfig  *tls.Config
+	tcpServer  *tcpServer
+
+	// cache holds sessionChunk objects for in-flight app sessions.
+	cache *utils.FnCache
+	// cacheCloseWg prevents closing the app server until all app
+	// sessions have been removed from the cache and closed.
+	cacheCloseWg sync.WaitGroup
+
+	connAuthMu sync.Mutex
+	// connAuth is used to map an initial failure of authorization to a connection.
+	// This will force the HTTP server to serve an error and close the connection.
+	connAuth map[net.Conn]error
+
+	awsHandler   http.Handler
+	azureHandler http.Handler
+	gcpHandler   http.Handler
+
+	// authMiddleware allows wrapping connections with identity information.
+	authMiddleware *auth.Middleware
+
+	proxyPort string
+
+	// getAppByPublicAddress returns a types.Application using the public address as matcher.
+	getAppByPublicAddress func(context.Context, string) (types.Application, error)
+}
+
+// NewConnectionsHandler returns a new ConnectionsHandler.
+func NewConnectionsHandler(closeContext context.Context, cfg *ConnectionsHandlerConfig) (*ConnectionsHandler, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	awsSigner, err := awsutils.NewSigningService(awsutils.SigningServiceConfig{
+		Clock: cfg.Clock,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	awsHandler, err := appaws.NewAWSSignerHandler(closeContext, appaws.SignerHandlerConfig{
+		SigningService: awsSigner,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	azureHandler, err := appazure.NewAzureHandler(closeContext, appazure.HandlerConfig{
+		Logger: cfg.Logger.With(teleport.ComponentKey, appazure.ComponentKey),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	gcpHandler, err := appgcp.NewGCPHandler(closeContext, appgcp.HandlerConfig{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	c := &ConnectionsHandler{
+		cfg:          cfg,
+		closeContext: closeContext,
+		awsHandler:   awsHandler,
+		azureHandler: azureHandler,
+		gcpHandler:   gcpHandler,
+		connAuth:     make(map[net.Conn]error),
+		log:          slog.With(teleport.ComponentKey, cfg.ServiceComponent),
+		legacyLogger: logrus.WithFields(logrus.Fields{teleport.ComponentKey: cfg.ServiceComponent}),
+		getAppByPublicAddress: func(ctx context.Context, s string) (types.Application, error) {
+			return nil, trace.NotFound("no applications are being proxied")
+		},
+	}
+
+	// Create a new session cache, this holds sessions that can be used to
+	// forward requests.
+	c.cache, err = utils.NewFnCache(utils.FnCacheConfig{
+		TTL:             5 * time.Minute,
+		Context:         c.closeContext,
+		Clock:           c.cfg.Clock,
+		CleanupInterval: time.Second,
+		OnExpiry:        c.onSessionExpired,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	go c.expireSessions()
+
+	clustername, err := c.cfg.AccessPoint.GetClusterName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Create and configure HTTP server with authorizing middleware.
+	c.httpServer = c.newHTTPServer(clustername.GetClusterName())
+
+	// TCP server will handle TCP applications.
+	tcpServer, err := c.newTCPServer()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	c.tcpServer = tcpServer
+
+	// Make copy of server's TLS configuration and update it with the specific
+	// functionality this server needs, like requiring client certificates.
+	c.tlsConfig = CopyAndConfigureTLS(c.legacyLogger, c.cfg.AccessPoint, c.cfg.TLSConfig)
+
+	// Figure out the port the proxy is running on.
+	c.proxyPort = c.getProxyPort()
+
+	return c, nil
+}
+
+// SetApplicationsProvider sets the internal state for the monitored applications.
+// This method must be called before the ConnectionsHandler is able to handle connections.
+func (c *ConnectionsHandler) SetApplicationsProvider(fn func(context.Context, string) (types.Application, error)) {
+	c.getAppByPublicAddress = fn
+}
+
+func (c *ConnectionsHandler) expireSessions() {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			c.cache.RemoveExpired()
+		case <-c.closeContext.Done():
+			return
+		}
+	}
+}
+
+// HandleConnection takes a connection and wraps it in a listener, so it can
+// be passed to http.Serve to process as a HTTP request.
+func (c *ConnectionsHandler) HandleConnection(conn net.Conn) {
+	ctx := context.Background()
+
+	// Wrap conn in a CloserConn to detect when it is closed.
+	// Returning early will close conn before it has been serviced.
+	// httpServer will initiate the close call.
+	closerConn := utils.NewCloserConn(conn)
+
+	cleanup, err := c.handleConnection(closerConn)
+	// Make sure that the cleanup function is run
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	if err != nil {
+		if !utils.IsOKNetworkError(err) {
+			c.log.WarnContext(ctx, "Failed to handle client connection.", "error", err)
+		}
+		if err := conn.Close(); err != nil && !utils.IsOKNetworkError(err) {
+			c.log.WarnContext(ctx, "Failed to close client connection.", "error", err)
+		}
+		return
+	}
+
+	// Wait for connection to close.
+	closerConn.Wait()
+}
+
+// serveSession finds the app session and forwards the request.
+func (c *ConnectionsHandler) serveSession(w http.ResponseWriter, r *http.Request, identity *tlsca.Identity, app types.Application, opts ...sessionOpt) error {
+	// Fetch a cached request forwarder (or create one) that lives about 5
+	// minutes. Used to stream session chunks to the Audit Log.
+	ttl := min(identity.Expires.Sub(c.cfg.Clock.Now()), 5*time.Minute)
+	session, err := utils.FnCacheGetWithTTL(r.Context(), c.cache, identity.RouteToApp.SessionID, ttl, func(ctx context.Context) (*sessionChunk, error) {
+		session, err := c.newSessionChunk(ctx, identity, app, c.sessionStartTime(r.Context()), opts...)
+		return session, trace.Wrap(err)
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := session.acquire(); err != nil {
+		return trace.Wrap(err)
+	}
+	defer session.release()
+
+	// Create session context.
+	sessionCtx := &common.SessionContext{
+		Identity: identity,
+		App:      app,
+		ChunkID:  session.id,
+		Audit:    session.audit,
+	}
+
+	// Forward request to the target application.
+	session.handler.ServeHTTP(w, common.WithSessionContext(r, sessionCtx))
+	return nil
+}
+
+// sessionStartTime fetches the session start time based on the the certificate
+// valid date.
+func (c *ConnectionsHandler) sessionStartTime(ctx context.Context) time.Time {
+	if userCert, err := authz.UserCertificateFromContext(ctx); err == nil {
+		return userCert.NotBefore
+	}
+
+	c.log.WarnContext(ctx, "Unable to retrieve session start time from certificate.")
+	return time.Time{}
+}
+
+// newTCPServer creates a server that proxies TCP applications.
+func (c *ConnectionsHandler) newTCPServer() (*tcpServer, error) {
+	return &tcpServer{
+		newAudit: func(ctx context.Context, sessionID string) (common.Audit, error) {
+			// Audit stream is using server context, not session context,
+			// to make sure that session is uploaded even after it is closed.
+			rec, err := c.newSessionRecorder(c.closeContext, c.sessionStartTime(ctx), sessionID)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			audit, err := common.NewAudit(common.AuditConfig{
+				Emitter:  c.cfg.Emitter,
+				Recorder: rec,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			return audit, nil
+		},
+		hostID: c.cfg.HostID,
+		log:    c.log,
+	}, nil
+}
+
+// Close performs a graceful shutdown.
+func (c *ConnectionsHandler) Close(ctx context.Context) []error {
+	var errs []error
+	// Stop HTTP server.
+	if err := c.httpServer.Close(); err != nil {
+		errs = append(errs, err)
+	}
+
+	// Close the session cache and its remaining sessions.
+	c.cache.Shutdown(c.closeContext)
+	// Any sessions still in the cache during shutdown are closed in
+	// background goroutines. We must wait for sessions to finish closing
+	// before proceeding any further.
+	c.cacheCloseWg.Wait()
+
+	return errs
+}
+
+func (c *ConnectionsHandler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
+	// Extract the identity and application being requested from the certificate
+	// and check if the caller has access.
+	authCtx, app, err := c.authorizeContext(r.Context())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	identity := authCtx.Identity.GetIdentity()
+	switch {
+	case app.IsAWSConsole():
+		// Requests from AWS applications are signed by AWS Signature Version 4
+		// algorithm. AWS CLI and AWS SDKs automatically use SigV4 for all
+		// services that support it (All services expect Amazon SimpleDB but
+		// this AWS service has been deprecated)
+		//
+		// Also check header common.TeleportAWSAssumedRole which is added by
+		// the local proxy for AWS requests signed by assumed roles.
+		if awsutils.IsSignedByAWSSigV4(r) || r.Header.Get(common.TeleportAWSAssumedRole) != "" {
+			return c.serveSession(w, r, &identity, app, c.withAWSSigner)
+		}
+
+		// Request for AWS console access originated from Teleport Proxy WebUI
+		// is not signed by SigV4.
+		return c.serveAWSWebConsole(w, r, &identity, app)
+
+	case app.IsAzureCloud():
+		return c.serveSession(w, r, &identity, app, c.withAzureHandler)
+
+	case app.IsGCP():
+		return c.serveSession(w, r, &identity, app, c.withGCPHandler)
+
+	default:
+		return c.serveSession(w, r, &identity, app, c.withJWTTokenForwarder)
+	}
+}
+
+// getProxyPort tries to figure out the address the proxy is running at.
+func (c *ConnectionsHandler) getProxyPort() string {
+	servers, err := c.cfg.AccessPoint.GetProxies()
+	if err != nil {
+		return strconv.Itoa(defaults.HTTPListenPort)
+	}
+	if len(servers) == 0 {
+		return strconv.Itoa(defaults.HTTPListenPort)
+	}
+	_, port, err := net.SplitHostPort(servers[0].GetPublicAddr())
+	if err != nil {
+		return strconv.Itoa(defaults.HTTPListenPort)
+	}
+	return port
+}
+
+// serveAWSWebConsole generates a sign-in URL for AWS management console and
+// redirects the user to it.
+func (c *ConnectionsHandler) serveAWSWebConsole(w http.ResponseWriter, r *http.Request, identity *tlsca.Identity, app types.Application) error {
+	c.log.DebugContext(c.closeContext, "Redirect to AWS management console.",
+		"username", identity.Username,
+		"aws_role_arn", identity.RouteToApp.AWSRoleARN,
+	)
+
+	url, err := c.cfg.Cloud.GetAWSSigninURL(AWSSigninRequest{
+		Identity:   identity,
+		TargetURL:  app.GetURI(),
+		Issuer:     app.GetPublicAddr(),
+		ExternalID: app.GetAWSExternalID(),
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	http.Redirect(w, r, url.SigninURL, http.StatusFound)
+	return nil
+}
+
+// authorizeContext will check if the context carries identity information and
+// runs authorization checks on it.
+func (c *ConnectionsHandler) authorizeContext(ctx context.Context) (*authz.Context, types.Application, error) {
+	// Only allow local and remote identities to proxy to an application.
+	userType, err := authz.UserFromContext(ctx)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	switch userType.(type) {
+	case authz.LocalUser, authz.RemoteUser:
+	default:
+		return nil, nil, trace.BadParameter("invalid identity: %T", userType)
+	}
+
+	// Extract authorizing context and identity of the user from the request.
+	authContext, err := c.cfg.Authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	identity := authContext.Identity.GetIdentity()
+
+	// Fetch the application and check if the identity has access.
+	app, err := c.getAppByPublicAddress(ctx, identity.RouteToApp.PublicAddr)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	authPref, err := c.cfg.AccessPoint.GetAuthPreference(ctx)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	// When accessing AWS management console, check permissions to assume
+	// requested IAM role as well.
+	var matchers []services.RoleMatcher
+	if app.IsAWSConsole() {
+		matchers = append(matchers, &services.AWSRoleARNMatcher{
+			RoleARN: identity.RouteToApp.AWSRoleARN,
+		})
+	}
+
+	// When accessing Azure API, check permissions to assume
+	// requested Azure identity as well.
+	if app.IsAzureCloud() {
+		matchers = append(matchers, &services.AzureIdentityMatcher{
+			Identity: identity.RouteToApp.AzureIdentity,
+		})
+	}
+
+	// When accessing GCP API, check permissions to assume
+	// requested GCP service account as well.
+	if app.IsGCP() {
+		matchers = append(matchers, &services.GCPServiceAccountMatcher{
+			ServiceAccount: identity.RouteToApp.GCPServiceAccount,
+		})
+	}
+
+	state := authContext.GetAccessState(authPref)
+	switch err := authContext.Checker.CheckAccess(
+		app,
+		state,
+		matchers...); {
+	case errors.Is(err, services.ErrTrustedDeviceRequired):
+		// Let the trusted device error through for clarity.
+		return nil, nil, trace.Wrap(services.ErrTrustedDeviceRequired)
+	case err != nil:
+		c.log.WarnContext(c.closeContext, "Access denied to application.",
+			"app", app.GetName(),
+			"error", err,
+		)
+		return nil, nil, utils.OpaqueAccessDenied(err)
+	}
+
+	return authContext, app, nil
+}
+
+func (c *ConnectionsHandler) handleConnection(conn net.Conn) (func(), error) {
+	ctx, cancel := context.WithCancelCause(c.closeContext)
+	tc, err := srv.NewTrackingReadConn(srv.TrackingReadConnConfig{
+		Conn:    conn,
+		Clock:   c.cfg.Clock,
+		Context: ctx,
+		Cancel:  cancel,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Proxy sends a X.509 client certificate to pass identity information,
+	// extract it and run authorization checks on it.
+	tlsConn, user, app, err := c.getConnectionInfo(c.closeContext, tc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ctx = authz.ContextWithUser(ctx, user)
+	ctx = authz.ContextWithClientSrcAddr(ctx, conn.RemoteAddr())
+	authCtx, _, err := c.authorizeContext(ctx)
+
+	// The behavior here is a little hard to track. To be clear here, if authorization fails
+	// the following will occur:
+	// 1. If the application is a TCP application, error out immediately as expected.
+	// 2. If the application is an HTTP application, store the error and let the HTTP handler
+	//    serve the error directly so that it's properly converted to an HTTP status code.
+	//    This will ensure users will get a 403 when authorization fails.
+	if err != nil {
+		if !app.IsTCP() {
+			c.setConnAuth(tlsConn, err)
+		} else {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		// Monitor the connection an update the context.
+		ctx, _, err = c.cfg.ConnectionMonitor.MonitorConn(ctx, authCtx, tc)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	// Add user certificate into the context after the monitor connection
+	// initialization to ensure value is present on the context.
+	ctx = authz.ContextWithUserCertificate(ctx, leafCertFromConn(tlsConn))
+
+	// Application access supports plain TCP connections which are handled
+	// differently than HTTP requests from web apps.
+	if app.IsTCP() {
+		identity := authCtx.Identity.GetIdentity()
+		defer cancel(nil)
+		return nil, trace.Wrap(c.handleTCPApp(ctx, tlsConn, &identity, app))
+	}
+
+	cleanup := func() {
+		cancel(nil)
+		c.deleteConnAuth(tlsConn)
+	}
+	return cleanup, trace.Wrap(c.handleHTTPApp(ctx, tlsConn))
+}
+
+// handleHTTPApp handles connection for an HTTP application.
+func (c *ConnectionsHandler) handleHTTPApp(ctx context.Context, conn net.Conn) error {
+	// Wrap a TLS authorizing conn in a single-use listener.
+	listener := newListener(ctx, conn)
+
+	// Serve will return as soon as tlsConn is running in its own goroutine
+	err := c.httpServer.Serve(listener)
+	if err != nil && !errors.Is(err, errListenerConnServed) {
+		// okay to ignore errListenerConnServed; it is a signal that our
+		// single-use listener has passed the connection to http.Serve
+		// and conn is being served. See listener.Accept for details.
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// handleTCPApp handles connection for a TCP application.
+func (c *ConnectionsHandler) handleTCPApp(ctx context.Context, conn net.Conn, identity *tlsca.Identity, app types.Application) error {
+	err := c.tcpServer.handleConnection(ctx, conn, identity, app)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// newHTTPServer creates an *http.Server that can authorize and forward
+// requests to a target application.
+func (c *ConnectionsHandler) newHTTPServer(clusterName string) *http.Server {
+	// Reuse the auth.Middleware to authorize requests but only accept
+	// certificates that were specifically generated for applications.
+
+	c.authMiddleware = &auth.Middleware{
+		ClusterName:   clusterName,
+		AcceptedUsage: []string{teleport.UsageAppsOnly},
+	}
+	c.authMiddleware.Wrap(c)
+
+	return &http.Server{
+		// Note: read/write timeouts *should not* be set here because it will
+		// break application access.
+		Handler:           httplib.MakeTracingHandler(c.authMiddleware, c.cfg.ServiceComponent),
+		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+		IdleTimeout:       apidefaults.DefaultIdleTimeout,
+		ErrorLog:          utils.NewStdlogger(c.legacyLogger.Error, c.cfg.ServiceComponent),
+		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+			return context.WithValue(ctx, connContextKey, c)
+		},
+	}
+}
+
+// ServeHTTP will forward the *http.Request to the target application.
+func (c *ConnectionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// See if the initial auth failed. If it didn't, serve the HTTP regularly, which
+	// will include subsequent auth attempts to prevent race-type conditions.
+	conn, ok := r.Context().Value(connContextKey).(net.Conn)
+	if !ok {
+		c.log.ErrorContext(c.closeContext, "Unable to extract connection from context.")
+	}
+	err := c.getAndDeleteConnAuth(conn)
+	if err == nil {
+		err = c.serveHTTP(w, r)
+	}
+	if err != nil {
+		c.log.WarnContext(c.closeContext, "Failed to serve request", "error", err)
+
+		// Covert trace error type to HTTP and write response, make sure we close the
+		// connection afterwards so that the monitor is recreated if needed.
+		code := trace.ErrorToCode(err)
+
+		var text string
+		if errors.Is(err, services.ErrTrustedDeviceRequired) {
+			// Return a nicer error message for device trust errors.
+			text = `Access to this app requires a trusted device.
+
+See https://goteleport.com/docs/access-controls/device-trust/device-management/#troubleshooting for help.
+`
+		} else {
+			text = http.StatusText(code)
+		}
+
+		w.Header().Set("Connection", "close")
+		http.Error(w, text, code)
+	}
+}
+
+// getConnectionInfo extracts identity information from the provided
+// connection and runs authorization checks on it.
+//
+// The connection comes from the reverse tunnel and is expected to be TLS and
+// carry identity in the client certificate.
+func (c *ConnectionsHandler) getConnectionInfo(ctx context.Context, conn net.Conn) (*tls.Conn, authz.IdentityGetter, types.Application, error) {
+	tlsConn := tls.Server(conn, c.tlsConfig)
+	if err := tlsConn.Handshake(); err != nil {
+		return nil, nil, nil, trace.Wrap(err, "TLS handshake failed")
+	}
+
+	user, err := c.authMiddleware.GetUser(tlsConn.ConnectionState())
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
+
+	app, err := c.getAppByPublicAddress(ctx, user.GetIdentity().RouteToApp.PublicAddr)
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
+
+	return tlsConn, user, app, nil
+}
+
+func (c *ConnectionsHandler) getAndDeleteConnAuth(conn net.Conn) error {
+	c.connAuthMu.Lock()
+	defer c.connAuthMu.Unlock()
+	err := c.connAuth[conn]
+	delete(c.connAuth, conn)
+	return err
+}
+
+func (c *ConnectionsHandler) setConnAuth(conn net.Conn, err error) {
+	c.connAuthMu.Lock()
+	defer c.connAuthMu.Unlock()
+	c.connAuth[conn] = err
+}
+
+func (c *ConnectionsHandler) deleteConnAuth(conn net.Conn) {
+	c.connAuthMu.Lock()
+	defer c.connAuthMu.Unlock()
+	delete(c.connAuth, conn)
+}
+
+// CopyAndConfigureTLS can be used to copy and modify an existing *tls.Config
+// for Teleport application proxy servers.
+func CopyAndConfigureTLS(log logrus.FieldLogger, client auth.AccessCache, config *tls.Config) *tls.Config {
+	tlsConfig := config.Clone()
+
+	// Require clients to present a certificate
+	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+
+	// Configure function that will be used to fetch the CA that signed the
+	// client's certificate to verify the chain presented. If the client does not
+	// pass in the cluster name, this functions pulls back all CA to try and
+	// match the certificate presented against any CA.
+	tlsConfig.GetConfigForClient = newGetConfigForClientFn(log, client, tlsConfig)
+
+	return tlsConfig
+}
+
+func newGetConfigForClientFn(log logrus.FieldLogger, client auth.AccessCache, tlsConfig *tls.Config) func(*tls.ClientHelloInfo) (*tls.Config, error) {
+	return func(info *tls.ClientHelloInfo) (*tls.Config, error) {
+		var clusterName string
+		var err error
+
+		// Try and extract the name of the cluster that signed the client's certificate.
+		if info.ServerName != "" {
+			clusterName, err = apiutils.DecodeClusterName(info.ServerName)
+			if err != nil {
+				if !trace.IsNotFound(err) {
+					log.Debugf("Ignoring unsupported cluster name %q.", info.ServerName)
+				}
+			}
+		}
+
+		// Fetch list of CAs that could have signed this certificate. If clusterName
+		// is empty, all CAs that this cluster knows about are returned.
+		pool, _, err := auth.DefaultClientCertPool(client, clusterName)
+		if err != nil {
+			// If this request fails, return nil and fallback to the default ClientCAs.
+
+			log.Debugf("Failed to retrieve client pool: %v.", trace.DebugReport(err))
+			return nil, nil
+		}
+
+		// Don't modify the server's *tls.Config, create one per connection because
+		// the requests could be coming from different clusters.
+		tlsCopy := tlsConfig.Clone()
+		tlsCopy.ClientCAs = pool
+		return tlsCopy, nil
+	}
+}
+
+// leafCertFromConn returns the leaf certificate from the connection.
+func leafCertFromConn(tlsConn *tls.Conn) *x509.Certificate {
+	state := tlsConn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		return nil
+	}
+
+	return state.PeerCertificates[0]
+}

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -23,13 +23,7 @@ package app
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"errors"
-	"log/slog"
 	"net"
-	"net/http"
-	"strconv"
 	"sync"
 	"time"
 
@@ -40,23 +34,13 @@ import (
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/events"
-	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv"
-	appaws "github.com/gravitational/teleport/lib/srv/app/aws"
-	appazure "github.com/gravitational/teleport/lib/srv/app/azure"
-	"github.com/gravitational/teleport/lib/srv/app/common"
-	appgcp "github.com/gravitational/teleport/lib/srv/app/gcp"
-	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
-	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
 type appServerContextKey string
@@ -65,19 +49,10 @@ const (
 	connContextKey appServerContextKey = "teleport-connContextKey"
 )
 
-// ConnMonitor monitors authorized connections and terminates them when
-// session controls dictate so.
-type ConnMonitor interface {
-	MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, net.Conn, error)
-}
-
 // Config is the configuration for an application server.
 type Config struct {
 	// Clock is used to control time.
 	Clock clockwork.Clock
-
-	// DataDir is the path to the data directory for the server.
-	DataDir string
 
 	// AuthClient is a client directly connected to the Auth server.
 	AuthClient *auth.Client
@@ -85,21 +60,11 @@ type Config struct {
 	// AccessPoint is a caching client connected to the Auth Server.
 	AccessPoint auth.AppsAccessPoint
 
-	// TLSConfig is the *tls.Config for this server.
-	TLSConfig *tls.Config
-
-	// CipherSuites is the list of TLS cipher suites that have been configured
-	// for this process.
-	CipherSuites []uint16
-
 	// Hostname is the hostname where this application agent is running.
 	Hostname string
 
 	// HostID is the id of the host where this application agent is running.
 	HostID string
-
-	// Authorizer is used to authorize requests.
-	Authorizer authz.Authorizer
 
 	// GetRotation returns the certificate rotation state.
 	GetRotation services.RotationGetter
@@ -114,9 +79,6 @@ type Config struct {
 	// OnHeartbeat is called after every heartbeat. Used to update process state.
 	OnHeartbeat func(error)
 
-	// Cloud provides cloud provider access related functionality.
-	Cloud Cloud
-
 	// ResourceMatchers is a list of app resource matchers.
 	ResourceMatchers []services.ResourceMatcher
 
@@ -126,15 +88,8 @@ type Config struct {
 	// ConnectedProxyGetter gets the proxies teleport is connected to.
 	ConnectedProxyGetter *reversetunnel.ConnectedProxyGetter
 
-	// Emitter is an event emitter.
-	Emitter events.Emitter
-
-	// ConnectionMonitor monitors connections and terminates any if
-	// any session controls prevent them.
-	ConnectionMonitor ConnMonitor
-
-	// Logger is the slog.Logger.
-	Logger *slog.Logger
+	// ConnectionsHandler handles the HTTP/TCP App proxy connections.
+	ConnectionsHandler *ConnectionsHandler
 }
 
 // CheckAndSetDefaults makes sure the configuration has the minimum required
@@ -143,21 +98,11 @@ func (c *Config) CheckAndSetDefaults() error {
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()
 	}
-
-	if c.DataDir == "" {
-		return trace.BadParameter("data dir missing")
-	}
 	if c.AuthClient == nil {
 		return trace.BadParameter("auth client log missing")
 	}
 	if c.AccessPoint == nil {
 		return trace.BadParameter("access point missing")
-	}
-	if c.TLSConfig == nil {
-		return trace.BadParameter("tls config missing")
-	}
-	if len(c.CipherSuites) == 0 {
-		return trace.BadParameter("ciphersuites missing")
 	}
 	if c.Hostname == "" {
 		return trace.BadParameter("hostname missing")
@@ -165,34 +110,23 @@ func (c *Config) CheckAndSetDefaults() error {
 	if c.HostID == "" {
 		return trace.BadParameter("host id missing")
 	}
-	if c.Authorizer == nil {
-		return trace.BadParameter("authorizer missing")
-	}
 	if c.GetRotation == nil {
 		return trace.BadParameter("rotation getter missing")
 	}
 	if c.OnHeartbeat == nil {
 		return trace.BadParameter("heartbeat missing")
 	}
-	if c.Cloud == nil {
-		cloud, err := NewCloud(CloudConfig{})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		c.Cloud = cloud
+	if c.ConnectionsHandler == nil {
+		return trace.BadParameter("connections handler missing")
 	}
 	if c.ConnectedProxyGetter == nil {
 		c.ConnectedProxyGetter = reversetunnel.NewConnectedProxyGetter()
 	}
-	if c.Logger == nil {
-		c.Logger = slog.Default().With(teleport.ComponentKey, teleport.Component(teleport.ComponentApp))
-	}
-
 	return nil
 }
 
 // Server is an application server. It authenticates requests from the web
-// proxy and forwards them to internal applications.
+// proxy and forwards th to internal applications.
 type Server struct {
 	c   *Config
 	log *logrus.Entry
@@ -200,18 +134,9 @@ type Server struct {
 	closeContext context.Context
 	closeFunc    context.CancelFunc
 
-	httpServer *http.Server
-	tcpServer  *tcpServer
-	tlsConfig  *tls.Config
-
 	mu            sync.RWMutex
 	heartbeats    map[string]*srv.Heartbeat
 	dynamicLabels map[string]*labels.Dynamic
-
-	connAuthMu sync.Mutex
-	// connAuth is used to map an initial failure of authorization to a connection.
-	// This will force the HTTP server to serve an error and close the connection.
-	connAuth map[net.Conn]error
 
 	// apps are all apps this server currently proxies. Proxied apps are
 	// reconciled against monitoredApps below.
@@ -222,23 +147,8 @@ type Server struct {
 	// reconcileCh triggers reconciliation of proxied apps.
 	reconcileCh chan struct{}
 
-	proxyPort string
-
-	// cache holds sessionChunk objects for in-flight app sessions.
-	cache *utils.FnCache
-	// cacheCloseWg prevents closing the app server until all app
-	// sessions have been removed from the cache and closed.
-	cacheCloseWg sync.WaitGroup
-
-	awsHandler   http.Handler
-	azureHandler http.Handler
-	gcpHandler   http.Handler
-
 	// watcher monitors changes to application resources.
 	watcher *services.AppWatcher
-
-	// authMiddleware allows wrapping connections with identity information.
-	authMiddleware *auth.Middleware
 }
 
 // monitoredApps is a collection of applications from different sources
@@ -283,31 +193,6 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 		}
 	}()
 
-	awsSigner, err := awsutils.NewSigningService(awsutils.SigningServiceConfig{
-		Clock: c.Clock,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	awsHandler, err := appaws.NewAWSSignerHandler(closeContext, appaws.SignerHandlerConfig{
-		SigningService: awsSigner,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	azureHandler, err := appazure.NewAzureHandler(closeContext, appazure.HandlerConfig{
-		Logger: c.Logger.With(teleport.ComponentKey, appazure.ComponentKey),
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	gcpHandler, err := appgcp.NewGCPHandler(closeContext, appgcp.HandlerConfig{})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	s := &Server{
 		c: c,
 		// TODO(greedy52) replace with slog from Config.Logger.
@@ -317,10 +202,6 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 		heartbeats:    make(map[string]*srv.Heartbeat),
 		dynamicLabels: make(map[string]*labels.Dynamic),
 		apps:          make(map[string]types.Application),
-		connAuth:      make(map[net.Conn]error),
-		awsHandler:    awsHandler,
-		azureHandler:  azureHandler,
-		gcpHandler:    gcpHandler,
 		monitoredApps: monitoredApps{
 			static: c.Apps,
 		},
@@ -329,62 +210,10 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 		closeContext: closeContext,
 	}
 
-	// Make copy of server's TLS configuration and update it with the specific
-	// functionality this server needs, like requiring client certificates.
-	s.tlsConfig = CopyAndConfigureTLS(s.log, s.c.AccessPoint, s.c.TLSConfig)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	clustername, err := s.c.AccessPoint.GetClusterName()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Create and configure HTTP server with authorizing middleware.
-	s.httpServer = s.newHTTPServer(clustername.GetClusterName())
-
-	// TCP server will handle TCP applications.
-	tcpServer, err := s.newTCPServer()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	s.tcpServer = tcpServer
-
-	// Create a new session cache, this holds sessions that can be used to
-	// forward requests.
-	s.cache, err = utils.NewFnCache(utils.FnCacheConfig{
-		TTL:             5 * time.Minute,
-		Context:         s.closeContext,
-		Clock:           s.c.Clock,
-		CleanupInterval: time.Second,
-		OnExpiry:        s.onSessionExpired,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	go s.expireSessions()
-
-	// Figure out the port the proxy is running on.
-	s.proxyPort = s.getProxyPort()
+	s.c.ConnectionsHandler.SetApplicationsProvider(s.GetAppByPublicAddress)
 
 	callClose = false
 	return s, nil
-}
-
-func (s *Server) expireSessions() {
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			s.cache.RemoveExpired()
-		case <-s.closeContext.Done():
-			return
-		}
-	}
 }
 
 // startApp registers the specified application.
@@ -652,17 +481,8 @@ func (s *Server) close(ctx context.Context) error {
 		}
 	}
 
-	// Stop HTTP server.
-	if err := s.httpServer.Close(); err != nil {
-		errs = append(errs, err)
-	}
-
-	// Close the session cache and its remaining sessions.
-	s.cache.Shutdown(s.closeContext)
-	// Any sessions still in the cache during shutdown are closed in
-	// background goroutines. We must wait for sessions to finish closing
-	// before proceeding any further.
-	s.cacheCloseWg.Wait()
+	connectionHandlerClosingErrs := s.c.ConnectionsHandler.Close(ctx)
+	errs = append(errs, connectionHandlerClosingErrs...)
 
 	// Signal to any blocking go routine that it should exit.
 	s.closeFunc()
@@ -694,367 +514,18 @@ func (s *Server) ForceHeartbeat() error {
 	return nil
 }
 
-func (s *Server) getAndDeleteConnAuth(conn net.Conn) error {
-	s.connAuthMu.Lock()
-	defer s.connAuthMu.Unlock()
-	err := s.connAuth[conn]
-	delete(s.connAuth, conn)
-	return err
-}
-
-func (s *Server) setConnAuth(conn net.Conn, err error) {
-	s.connAuthMu.Lock()
-	defer s.connAuthMu.Unlock()
-	s.connAuth[conn] = err
-}
-
-func (s *Server) deleteConnAuth(conn net.Conn) {
-	s.connAuthMu.Lock()
-	defer s.connAuthMu.Unlock()
-	delete(s.connAuth, conn)
-}
-
 // HandleConnection takes a connection and wraps it in a listener, so it can
 // be passed to http.Serve to process as a HTTP request.
 func (s *Server) HandleConnection(conn net.Conn) {
-	// Wrap conn in a CloserConn to detect when it is closed.
-	// Returning early will close conn before it has been serviced.
-	// httpServer will initiate the close call.
-	closerConn := utils.NewCloserConn(conn)
-
-	cleanup, err := s.handleConnection(closerConn)
-	// Make sure that the cleanup function is run
-	if cleanup != nil {
-		defer cleanup()
-	}
-
-	if err != nil {
-		if !utils.IsOKNetworkError(err) {
-			s.log.WithError(err).Warn("Failed to handle client connection.")
-		}
-		if err := conn.Close(); err != nil && !utils.IsOKNetworkError(err) {
-			s.log.WithError(err).Warn("Failed to close client connection.")
-		}
-		return
-	}
-
-	// Wait for connection to close.
-	closerConn.Wait()
+	s.c.ConnectionsHandler.HandleConnection(conn)
 }
 
-func (s *Server) handleConnection(conn net.Conn) (func(), error) {
-	ctx, cancel := context.WithCancelCause(s.closeContext)
-	tc, err := srv.NewTrackingReadConn(srv.TrackingReadConnConfig{
-		Conn:    conn,
-		Clock:   s.c.Clock,
-		Context: ctx,
-		Cancel:  cancel,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Proxy sends a X.509 client certificate to pass identity information,
-	// extract it and run authorization checks on it.
-	tlsConn, user, app, err := s.getConnectionInfo(s.closeContext, tc)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	ctx = authz.ContextWithUser(ctx, user)
-	ctx = authz.ContextWithClientSrcAddr(ctx, conn.RemoteAddr())
-	authCtx, _, err := s.authorizeContext(ctx)
-
-	// The behavior here is a little hard to track. To be clear here, if authorization fails
-	// the following will occur:
-	// 1. If the application is a TCP application, error out immediately as expected.
-	// 2. If the application is an HTTP application, store the error and let the HTTP handler
-	//    serve the error directly so that it's properly converted to an HTTP status code.
-	//    This will ensure users will get a 403 when authorization fails.
-	if err != nil {
-		if !app.IsTCP() {
-			s.setConnAuth(tlsConn, err)
-		} else {
-			return nil, trace.Wrap(err)
-		}
-	} else {
-		// Monitor the connection an update the context.
-		ctx, _, err = s.c.ConnectionMonitor.MonitorConn(ctx, authCtx, tc)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
-	// Add user certificate into the context after the monitor connection
-	// initialization to ensure value is present on the context.
-	ctx = authz.ContextWithUserCertificate(ctx, leafCertFromConn(tlsConn))
-
-	// Application access supports plain TCP connections which are handled
-	// differently than HTTP requests from web apps.
-	if app.IsTCP() {
-		identity := authCtx.Identity.GetIdentity()
-		defer cancel(nil)
-		return nil, trace.Wrap(s.handleTCPApp(ctx, tlsConn, &identity, app))
-	}
-
-	cleanup := func() {
-		cancel(nil)
-		s.deleteConnAuth(tlsConn)
-	}
-	return cleanup, trace.Wrap(s.handleHTTPApp(ctx, tlsConn))
-}
-
-// handleTCPApp handles connection for a TCP application.
-func (s *Server) handleTCPApp(ctx context.Context, conn net.Conn, identity *tlsca.Identity, app types.Application) error {
-	err := s.tcpServer.handleConnection(ctx, conn, identity, app)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
-}
-
-// handleHTTPApp handles connection for an HTTP application.
-func (s *Server) handleHTTPApp(ctx context.Context, conn net.Conn) error {
-	// Wrap a TLS authorizing conn in a single-use listener.
-	listener := newListener(ctx, conn)
-
-	// Serve will return as soon as tlsConn is running in its own goroutine
-	err := s.httpServer.Serve(listener)
-	if err != nil && !errors.Is(err, errListenerConnServed) {
-		// okay to ignore errListenerConnServed; it is a signal that our
-		// single-use listener has passed the connection to http.Serve
-		// and conn is being served. See listener.Accept for details.
-		return trace.Wrap(err)
-	}
-
-	return nil
-}
-
-// ServeHTTP will forward the *http.Request to the target application.
-func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// See if the initial auth failed. If it didn't, serve the HTTP regularly, which
-	// will include subsequent auth attempts to prevent race-type conditions.
-	conn, ok := r.Context().Value(connContextKey).(net.Conn)
-	if !ok {
-		s.log.Errorf("unable to extract connection from context")
-	}
-	err := s.getAndDeleteConnAuth(conn)
-	if err == nil {
-		err = s.serveHTTP(w, r)
-	}
-	if err != nil {
-		s.log.WithError(err).Warnf("Failed to serve request")
-
-		// Covert trace error type to HTTP and write response, make sure we close the
-		// connection afterwards so that the monitor is recreated if needed.
-		code := trace.ErrorToCode(err)
-
-		var text string
-		if errors.Is(err, services.ErrTrustedDeviceRequired) {
-			// Return a nicer error message for device trust errors.
-			text = `Access to this app requires a trusted device.
-
-See https://goteleport.com/docs/access-controls/device-trust/device-management/#troubleshooting for help.
-`
-		} else {
-			text = http.StatusText(code)
-		}
-
-		w.Header().Set("Connection", "close")
-		http.Error(w, text, code)
-	}
-}
-
-func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) error {
-	// Extract the identity and application being requested from the certificate
-	// and check if the caller has access.
-	authCtx, app, err := s.authorizeContext(r.Context())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	identity := authCtx.Identity.GetIdentity()
-	switch {
-	case app.IsAWSConsole():
-		// Requests from AWS applications are signed by AWS Signature Version 4
-		// algorithm. AWS CLI and AWS SDKs automatically use SigV4 for all
-		// services that support it (All services expect Amazon SimpleDB but
-		// this AWS service has been deprecated)
-		//
-		// Also check header common.TeleportAWSAssumedRole which is added by
-		// the local proxy for AWS requests signed by assumed roles.
-		if awsutils.IsSignedByAWSSigV4(r) || r.Header.Get(common.TeleportAWSAssumedRole) != "" {
-			return s.serveSession(w, r, &identity, app, s.withAWSSigner)
-		}
-
-		// Request for AWS console access originated from Teleport Proxy WebUI
-		// is not signed by SigV4.
-		return s.serveAWSWebConsole(w, r, &identity, app)
-
-	case app.IsAzureCloud():
-		return s.serveSession(w, r, &identity, app, s.withAzureHandler)
-
-	case app.IsGCP():
-		return s.serveSession(w, r, &identity, app, s.withGCPHandler)
-
-	default:
-		return s.serveSession(w, r, &identity, app, s.withJWTTokenForwarder)
-	}
-}
-
-// serveAWSWebConsole generates a sign-in URL for AWS management console and
-// redirects the user to it.
-func (s *Server) serveAWSWebConsole(w http.ResponseWriter, r *http.Request, identity *tlsca.Identity, app types.Application) error {
-	s.log.Debugf("Redirecting %v to AWS management console with role %v.",
-		identity.Username, identity.RouteToApp.AWSRoleARN)
-
-	url, err := s.c.Cloud.GetAWSSigninURL(AWSSigninRequest{
-		Identity:   identity,
-		TargetURL:  app.GetURI(),
-		Issuer:     app.GetPublicAddr(),
-		ExternalID: app.GetAWSExternalID(),
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	http.Redirect(w, r, url.SigninURL, http.StatusFound)
-	return nil
-}
-
-// serveSession finds the app session and forwards the request.
-func (s *Server) serveSession(w http.ResponseWriter, r *http.Request, identity *tlsca.Identity, app types.Application, opts ...sessionOpt) error {
-	// Fetch a cached request forwarder (or create one) that lives about 5
-	// minutes. Used to stream session chunks to the Audit Log.
-	ttl := min(identity.Expires.Sub(s.c.Clock.Now()), 5*time.Minute)
-	session, err := utils.FnCacheGetWithTTL(r.Context(), s.cache, identity.RouteToApp.SessionID, ttl, func(ctx context.Context) (*sessionChunk, error) {
-		session, err := s.newSessionChunk(ctx, identity, app, s.sessionStartTime(r.Context()), opts...)
-		return session, trace.Wrap(err)
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	if err := session.acquire(); err != nil {
-		return trace.Wrap(err)
-	}
-	defer session.release()
-
-	// Create session context.
-	sessionCtx := &common.SessionContext{
-		Identity: identity,
-		App:      app,
-		ChunkID:  session.id,
-		Audit:    session.audit,
-	}
-
-	// Forward request to the target application.
-	session.handler.ServeHTTP(w, common.WithSessionContext(r, sessionCtx))
-	return nil
-}
-
-// getConnectionInfo extracts identity information from the provided
-// connection and runs authorization checks on it.
-//
-// The connection comes from the reverse tunnel and is expected to be TLS and
-// carry identity in the client certificate.
-func (s *Server) getConnectionInfo(ctx context.Context, conn net.Conn) (*tls.Conn, authz.IdentityGetter, types.Application, error) {
-	tlsConn := tls.Server(conn, s.tlsConfig)
-	if err := tlsConn.Handshake(); err != nil {
-		return nil, nil, nil, trace.Wrap(err, "TLS handshake failed")
-	}
-
-	user, err := s.authMiddleware.GetUser(tlsConn.ConnectionState())
-	if err != nil {
-		return nil, nil, nil, trace.Wrap(err)
-	}
-
-	app, err := s.getApp(ctx, user.GetIdentity().RouteToApp.PublicAddr)
-	if err != nil {
-		return nil, nil, nil, trace.Wrap(err)
-	}
-
-	return tlsConn, user, app, nil
-}
-
-// authorizeContext will check if the context carries identity information and
-// runs authorization checks on it.
-func (s *Server) authorizeContext(ctx context.Context) (*authz.Context, types.Application, error) {
-	// Only allow local and remote identities to proxy to an application.
-	userType, err := authz.UserFromContext(ctx)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	switch userType.(type) {
-	case authz.LocalUser, authz.RemoteUser:
-	default:
-		return nil, nil, trace.BadParameter("invalid identity: %T", userType)
-	}
-
-	// Extract authorizing context and identity of the user from the request.
-	authContext, err := s.c.Authorizer.Authorize(ctx)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	identity := authContext.Identity.GetIdentity()
-
-	// Fetch the application and check if the identity has access.
-	app, err := s.getApp(ctx, identity.RouteToApp.PublicAddr)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	authPref, err := s.c.AccessPoint.GetAuthPreference(ctx)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	// When accessing AWS management console, check permissions to assume
-	// requested IAM role as well.
-	var matchers []services.RoleMatcher
-	if app.IsAWSConsole() {
-		matchers = append(matchers, &services.AWSRoleARNMatcher{
-			RoleARN: identity.RouteToApp.AWSRoleARN,
-		})
-	}
-
-	// When accessing Azure API, check permissions to assume
-	// requested Azure identity as well.
-	if app.IsAzureCloud() {
-		matchers = append(matchers, &services.AzureIdentityMatcher{
-			Identity: identity.RouteToApp.AzureIdentity,
-		})
-	}
-
-	// When accessing GCP API, check permissions to assume
-	// requested GCP service account as well.
-	if app.IsGCP() {
-		matchers = append(matchers, &services.GCPServiceAccountMatcher{
-			ServiceAccount: identity.RouteToApp.GCPServiceAccount,
-		})
-	}
-
-	state := authContext.GetAccessState(authPref)
-	switch err := authContext.Checker.CheckAccess(
-		app,
-		state,
-		matchers...); {
-	case errors.Is(err, services.ErrTrustedDeviceRequired):
-		// Let the trusted device error through for clarity.
-		return nil, nil, trace.Wrap(services.ErrTrustedDeviceRequired)
-	case err != nil:
-		s.log.WithError(err).Warnf("access denied to application %v", app.GetName())
-		return nil, nil, utils.OpaqueAccessDenied(err)
-	}
-
-	return authContext, app, nil
-}
-
-// getApp returns an application matching the public address. If multiple
+// GetAppByPublicAddress returns an application matching the public address. If multiple
 // matching applications exist, the first one is returned. Random selection
 // (or round robin) does not need to occur here because they will all point
 // to the same target address. Random selection (or round robin) occurs at the
 // web proxy to load balance requests to the application service.
-func (s *Server) getApp(ctx context.Context, publicAddr string) (types.Application, error) {
+func (s *Server) GetAppByPublicAddress(ctx context.Context, publicAddr string) (types.Application, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	// don't call s.getApps() as this will call RLock and potentially deadlock.
@@ -1086,140 +557,4 @@ func (s *Server) appWithUpdatedLabelsLocked(app types.Application) *types.AppV3 
 	}
 
 	return copy
-}
-
-// newHTTPServer creates an *http.Server that can authorize and forward
-// requests to a target application.
-func (s *Server) newHTTPServer(clusterName string) *http.Server {
-	// Reuse the auth.Middleware to authorize requests but only accept
-	// certificates that were specifically generated for applications.
-
-	s.authMiddleware = &auth.Middleware{
-		ClusterName:   clusterName,
-		AcceptedUsage: []string{teleport.UsageAppsOnly},
-	}
-	s.authMiddleware.Wrap(s)
-
-	return &http.Server{
-		// Note: read/write timeouts *should not* be set here because it will
-		// break application access.
-		Handler:           httplib.MakeTracingHandler(s.authMiddleware, teleport.ComponentApp),
-		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
-		IdleTimeout:       apidefaults.DefaultIdleTimeout,
-		ErrorLog:          utils.NewStdlogger(s.log.Error, teleport.ComponentApp),
-		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
-			return context.WithValue(ctx, connContextKey, c)
-		},
-	}
-}
-
-// newTCPServer creates a server that proxies TCP applications.
-func (s *Server) newTCPServer() (*tcpServer, error) {
-	return &tcpServer{
-		newAudit: func(ctx context.Context, sessionID string) (common.Audit, error) {
-			// Audit stream is using server context, not session context,
-			// to make sure that session is uploaded even after it is closed.
-			rec, err := s.newSessionRecorder(s.closeContext, s.sessionStartTime(ctx), sessionID)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			audit, err := common.NewAudit(common.AuditConfig{
-				Emitter:  s.c.Emitter,
-				Recorder: rec,
-			})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			return audit, nil
-		},
-		hostID: s.c.HostID,
-		log:    s.log,
-	}, nil
-}
-
-// getProxyPort tries to figure out the address the proxy is running at.
-func (s *Server) getProxyPort() string {
-	servers, err := s.c.AccessPoint.GetProxies()
-	if err != nil {
-		return strconv.Itoa(defaults.HTTPListenPort)
-	}
-	if len(servers) == 0 {
-		return strconv.Itoa(defaults.HTTPListenPort)
-	}
-	_, port, err := net.SplitHostPort(servers[0].GetPublicAddr())
-	if err != nil {
-		return strconv.Itoa(defaults.HTTPListenPort)
-	}
-	return port
-}
-
-// sessionStartTime fetches the session start time based on the the certificate
-// valid date.
-func (s *Server) sessionStartTime(ctx context.Context) time.Time {
-	if userCert, err := authz.UserCertificateFromContext(ctx); err == nil {
-		return userCert.NotBefore
-	}
-
-	s.log.Warn("Unable to retrieve session start time from certificate.")
-	return time.Time{}
-}
-
-// CopyAndConfigureTLS can be used to copy and modify an existing *tls.Config
-// for Teleport application proxy servers.
-func CopyAndConfigureTLS(log logrus.FieldLogger, client auth.AccessCache, config *tls.Config) *tls.Config {
-	tlsConfig := config.Clone()
-
-	// Require clients to present a certificate
-	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-
-	// Configure function that will be used to fetch the CA that signed the
-	// client's certificate to verify the chain presented. If the client does not
-	// pass in the cluster name, this functions pulls back all CA to try and
-	// match the certificate presented against any CA.
-	tlsConfig.GetConfigForClient = newGetConfigForClientFn(log, client, tlsConfig)
-
-	return tlsConfig
-}
-
-func newGetConfigForClientFn(log logrus.FieldLogger, client auth.AccessCache, tlsConfig *tls.Config) func(*tls.ClientHelloInfo) (*tls.Config, error) {
-	return func(info *tls.ClientHelloInfo) (*tls.Config, error) {
-		var clusterName string
-		var err error
-
-		// Try and extract the name of the cluster that signed the client's certificate.
-		if info.ServerName != "" {
-			clusterName, err = apiutils.DecodeClusterName(info.ServerName)
-			if err != nil {
-				if !trace.IsNotFound(err) {
-					log.Debugf("Ignoring unsupported cluster name %q.", info.ServerName)
-				}
-			}
-		}
-
-		// Fetch list of CAs that could have signed this certificate. If clusterName
-		// is empty, all CAs that this cluster knows about are returned.
-		pool, _, err := auth.DefaultClientCertPool(client, clusterName)
-		if err != nil {
-			// If this request fails, return nil and fallback to the default ClientCAs.
-			log.Debugf("Failed to retrieve client pool: %v.", trace.DebugReport(err))
-			return nil, nil
-		}
-
-		// Don't modify the server's *tls.Config, create one per connection because
-		// the requests could be coming from different clusters.
-		tlsCopy := tlsConfig.Clone()
-		tlsCopy.ClientCAs = pool
-		return tlsCopy, nil
-	}
-}
-
-// leafCertFromConn returns the leaf certificate from the connection.
-func leafCertFromConn(tlsConn *tls.Conn) *x509.Certificate {
-	state := tlsConn.ConnectionState()
-	if len(state.PeerCertificates) == 0 {
-		return nil
-	}
-
-	return state.PeerCertificates[0]
 }

--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -92,34 +92,34 @@ type sessionOpt func(context.Context, *sessionChunk, *tlsca.Identity, types.Appl
 // The session chunk is created with inflight=1,
 // and as such expects `release()` to eventually be called
 // by the caller of this function.
-func (s *Server) newSessionChunk(ctx context.Context, identity *tlsca.Identity, app types.Application, startTime time.Time, opts ...sessionOpt) (*sessionChunk, error) {
+func (c *ConnectionsHandler) newSessionChunk(ctx context.Context, identity *tlsca.Identity, app types.Application, startTime time.Time, opts ...sessionOpt) (*sessionChunk, error) {
 	sess := &sessionChunk{
 		id:           uuid.New().String(),
 		closeC:       make(chan struct{}),
 		inflightCond: sync.NewCond(&sync.Mutex{}),
 		closeTimeout: sessionChunkCloseTimeout,
-		log:          s.log,
+		log:          c.legacyLogger,
 	}
 
 	sess.log.Debugf("Creating app session chunk %s", sess.id)
 
 	// Create a session tracker so that other services, such as the
 	// session upload completer, can track the session chunk's lifetime.
-	if err := s.createTracker(sess, identity, app.GetName()); err != nil {
+	if err := c.createTracker(sess, identity, app.GetName()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Create the stream writer that will write this chunk to the audit log.
 	// Audit stream is using server context, not session context,
 	// to make sure that session is uploaded even after it is closed.
-	rec, err := s.newSessionRecorder(s.closeContext, startTime, sess.id)
+	rec, err := c.newSessionRecorder(c.closeContext, startTime, sess.id)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	sess.streamCloser = rec
 
 	audit, err := common.NewAudit(common.AuditConfig{
-		Emitter:  s.c.Emitter,
+		Emitter:  c.cfg.Emitter,
 		Recorder: rec,
 	})
 	if err != nil {
@@ -134,7 +134,7 @@ func (s *Server) newSessionChunk(ctx context.Context, identity *tlsca.Identity, 
 	}
 
 	// only emit a session chunk if we didn't get an error making the new session chunk
-	if err := sess.audit.OnSessionChunk(ctx, s.c.HostID, sess.id, identity, app); err != nil {
+	if err := sess.audit.OnSessionChunk(ctx, c.cfg.HostID, sess.id, identity, app); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -144,7 +144,7 @@ func (s *Server) newSessionChunk(ctx context.Context, identity *tlsca.Identity, 
 
 // withJWTTokenForwarder is a sessionOpt that creates a forwarder that attaches
 // a generated JWT token to all requests.
-func (s *Server) withJWTTokenForwarder(ctx context.Context, sess *sessionChunk, identity *tlsca.Identity, app types.Application) error {
+func (c *ConnectionsHandler) withJWTTokenForwarder(ctx context.Context, sess *sessionChunk, identity *tlsca.Identity, app types.Application) error {
 	rewrite := app.GetRewrite()
 	traits := identity.Traits
 	roles := identity.Groups
@@ -162,7 +162,7 @@ func (s *Server) withJWTTokenForwarder(ctx context.Context, sess *sessionChunk, 
 	}
 
 	// Request a JWT token that will be attached to all requests.
-	jwt, err := s.c.AuthClient.GenerateAppToken(ctx, types.GenerateAppTokenRequest{
+	jwt, err := c.cfg.AuthClient.GenerateAppToken(ctx, types.GenerateAppTokenRequest{
 		Username: identity.Username,
 		Roles:    roles,
 		Traits:   traits,
@@ -180,14 +180,14 @@ func (s *Server) withJWTTokenForwarder(ctx context.Context, sess *sessionChunk, 
 	traits[teleport.TraitJWT] = []string{jwt}
 
 	// Create a rewriting transport that will be used to forward requests.
-	transport, err := newTransport(s.closeContext,
+	transport, err := newTransport(c.closeContext,
 		&transportConfig{
 			app:          app,
-			publicPort:   s.proxyPort,
-			cipherSuites: s.c.CipherSuites,
+			publicPort:   c.proxyPort,
+			cipherSuites: c.cfg.CipherSuites,
 			jwt:          jwt,
 			traits:       traits,
-			log:          s.log,
+			log:          c.legacyLogger,
 		})
 	if err != nil {
 		return trace.Wrap(err)
@@ -208,18 +208,18 @@ func (s *Server) withJWTTokenForwarder(ctx context.Context, sess *sessionChunk, 
 }
 
 // withAWSSigner is a sessionOpt that uses an AWS signing service handler.
-func (s *Server) withAWSSigner(_ context.Context, sess *sessionChunk, _ *tlsca.Identity, _ types.Application) error {
-	sess.handler = s.awsHandler
+func (c *ConnectionsHandler) withAWSSigner(_ context.Context, sess *sessionChunk, _ *tlsca.Identity, _ types.Application) error {
+	sess.handler = c.awsHandler
 	return nil
 }
 
-func (s *Server) withAzureHandler(ctx context.Context, sess *sessionChunk, identity *tlsca.Identity, app types.Application) error {
-	sess.handler = s.azureHandler
+func (c *ConnectionsHandler) withAzureHandler(ctx context.Context, sess *sessionChunk, identity *tlsca.Identity, app types.Application) error {
+	sess.handler = c.azureHandler
 	return nil
 }
 
-func (s *Server) withGCPHandler(ctx context.Context, sess *sessionChunk, identity *tlsca.Identity, app types.Application) error {
-	sess.handler = s.gcpHandler
+func (c *ConnectionsHandler) withGCPHandler(ctx context.Context, sess *sessionChunk, identity *tlsca.Identity, app types.Application) error {
+	sess.handler = c.gcpHandler
 	return nil
 }
 
@@ -274,7 +274,7 @@ func (s *sessionChunk) close(ctx context.Context) error {
 	return trace.Wrap(s.streamCloser.Close(ctx))
 }
 
-func (s *Server) onSessionExpired(ctx context.Context, key, expired any) {
+func (c *ConnectionsHandler) onSessionExpired(ctx context.Context, key, expired any) {
 	sess, ok := expired.(*sessionChunk)
 	if !ok {
 		return
@@ -283,11 +283,11 @@ func (s *Server) onSessionExpired(ctx context.Context, key, expired any) {
 	// Closing the session stream writer may trigger a flush operation which could
 	// be time-consuming. Launch in another goroutine to prevent interfering with
 	// cache operations.
-	s.cacheCloseWg.Add(1)
+	c.cacheCloseWg.Add(1)
 	go func() {
-		defer s.cacheCloseWg.Done()
+		defer c.cacheCloseWg.Done()
 		if err := sess.close(ctx); err != nil {
-			s.log.WithError(err).Debugf("Error closing session %v", sess.id)
+			c.log.DebugContext(ctx, "Error closing session", "session_id", sess.id, "error", err)
 		}
 	}()
 }
@@ -295,26 +295,26 @@ func (s *Server) onSessionExpired(ctx context.Context, key, expired any) {
 // newSessionRecorder creates a session stream that will be used to record
 // requests that occur within this session chunk and upload the recording
 // to the Auth server.
-func (s *Server) newSessionRecorder(ctx context.Context, startTime time.Time, chunkID string) (events.SessionPreparerRecorder, error) {
-	recConfig, err := s.c.AccessPoint.GetSessionRecordingConfig(ctx)
+func (c *ConnectionsHandler) newSessionRecorder(ctx context.Context, startTime time.Time, chunkID string) (events.SessionPreparerRecorder, error) {
+	recConfig, err := c.cfg.AccessPoint.GetSessionRecordingConfig(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	clusterName, err := s.c.AccessPoint.GetClusterName()
+	clusterName, err := c.cfg.AccessPoint.GetClusterName()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	rec, err := recorder.New(recorder.Config{
 		SessionID:    rsession.ID(chunkID),
-		ServerID:     s.c.HostID,
+		ServerID:     c.cfg.HostID,
 		Namespace:    apidefaults.Namespace,
-		Clock:        s.c.Clock,
+		Clock:        c.cfg.Clock,
 		ClusterName:  clusterName.GetClusterName(),
 		RecordingCfg: recConfig,
-		SyncStreamer: s.c.AuthClient,
-		DataDir:      s.c.DataDir,
+		SyncStreamer: c.cfg.AuthClient,
+		DataDir:      c.cfg.DataDir,
 		Component:    teleport.Component(teleport.ComponentSession, teleport.ComponentApp),
 		Context:      ctx,
 		StartTime:    startTime,
@@ -327,34 +327,34 @@ func (s *Server) newSessionRecorder(ctx context.Context, startTime time.Time, ch
 }
 
 // createTracker creates a new session tracker for the session chunk.
-func (s *Server) createTracker(sess *sessionChunk, identity *tlsca.Identity, appName string) error {
+func (c *ConnectionsHandler) createTracker(sess *sessionChunk, identity *tlsca.Identity, appName string) error {
 	trackerSpec := types.SessionTrackerSpecV1{
 		SessionID:   sess.id,
 		Kind:        string(types.AppSessionKind),
 		State:       types.SessionState_SessionStateRunning,
-		Hostname:    s.c.HostID,
+		Hostname:    c.cfg.HostID,
 		ClusterName: identity.RouteToApp.ClusterName,
 		Login:       identity.GetUserMetadata().Login,
 		Participants: []types.Participant{{
 			User: identity.Username,
 		}},
 		HostUser:     identity.Username,
-		Created:      s.c.Clock.Now(),
+		Created:      c.cfg.Clock.Now(),
 		AppName:      appName, // app name is only present in RouteToApp for CLI sessions
 		AppSessionID: identity.RouteToApp.SessionID,
-		HostID:       s.c.HostID,
+		HostID:       c.cfg.HostID,
 	}
 
-	s.log.Debugf("Creating tracker for session chunk %v", sess.id)
-	tracker, err := srv.NewSessionTracker(s.closeContext, trackerSpec, s.c.AuthClient)
+	c.log.DebugContext(c.closeContext, "Creating tracker for session chunk", "session", sess.id)
+	tracker, err := srv.NewSessionTracker(c.closeContext, trackerSpec, c.cfg.AuthClient)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	go func() {
 		<-sess.closeC
-		if err := tracker.Close(s.closeContext); err != nil {
-			s.log.WithError(err).Debugf("Failed to close session tracker for session chunk %v", sess.id)
+		if err := tracker.Close(c.closeContext); err != nil {
+			c.log.DebugContext(c.closeContext, "Failed to close session tracker for session chunk", "session", sess.id, "error", err)
 		}
 	}()
 

--- a/lib/srv/app/tcpserver.go
+++ b/lib/srv/app/tcpserver.go
@@ -20,10 +20,10 @@ package app
 
 import (
 	"context"
+	"log/slog"
 	"net"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	apitypes "github.com/gravitational/teleport/api/types"
@@ -35,7 +35,7 @@ import (
 type tcpServer struct {
 	newAudit func(ctx context.Context, sessionID string) (common.Audit, error)
 	hostID   string
-	log      logrus.FieldLogger
+	log      *slog.Logger
 }
 
 // handleConnection handles connection from a TCP application.
@@ -64,7 +64,7 @@ func (s *tcpServer) handleConnection(ctx context.Context, clientConn net.Conn, i
 	}
 	defer func() {
 		if err := audit.OnSessionEnd(ctx, s.hostID, identity, app); err != nil {
-			s.log.WithError(err).Warnf("Failed to emit session end event for app %v.", app.GetName())
+			s.log.WarnContext(ctx, "Failed to emit session end event for app.", "app", app.GetName(), "error", err)
 		}
 	}()
 	err = utils.ProxyConn(ctx, clientConn, serverConn)


### PR DESCRIPTION
This PR splits the AppService into two:
- app service: handles service state and heartbeats
- connections handler: handles incoming connections for app access proxy requests

We'll create a new feature where users can access their AWS account (webconsole or aws cli) using their AWS OIDC Integration.

This new access flow will use only the ProxyService because we don't need to deploy an AppService with AWS access using the ambient credentials.
This way, users only need the ProxyService in order to access their AWS infrastructure.


Related: https://github.com/gravitational/teleport/issues/30150