### PR TITLE
Open VNet panel when launching TCP app from Connect

### DIFF
--- a/gen/proto/go/teleport/lib/teleterm/v1/app.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/app.pb.go
@@ -43,7 +43,7 @@ type App struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// uri is the cluster resource URI.
+	// uri uniquely identifies an app within Teleport Connect.
 	Uri string `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty"`
 	// name is the name of the app.
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
@@ -55,9 +55,20 @@ type App struct {
 	// aws_console is true if this app is AWS management console.
 	AwsConsole bool `protobuf:"varint,5,opt,name=aws_console,json=awsConsole,proto3" json:"aws_console,omitempty"`
 	// public_addr is the public address the application is accessible at.
-	// By default, it is a subdomain of the cluster (e.g., dumper.example.com).
-	// Optionally, it can be overridden (by the 'public_addr' field in the app config)
-	// with an address available on the internet.
+	//
+	// If the app resource has its public_addr field set, this field returns the value of public_addr
+	// from the app resource.
+	//
+	// If the app resource does not have public_addr field set, this field returns the name of the app
+	// under the proxy hostname of the cluster to which the app belongs, e.g.,
+	// dumper.root-cluster.com, example-app.leaf-cluster.org.
+	//
+	// In both cases public_addr does not include a port number. An app resource cannot include a port
+	// number in its public_addr, as the backend will (wrongly) reject such resource with an error
+	// saying "public_addr "example.com:1337" can not contain a port, applications will be available
+	// on the same port as the web proxy". This is obviously not the case for custom public addresses.
+	// Ultimately, it means that public_addr alone is not enough to access the app, unless either the
+	// cluster or the custom domain use the default port of 443.
 	//
 	// Always empty for SAML applications.
 	PublicAddr string `protobuf:"bytes,6,opt,name=public_addr,json=publicAddr,proto3" json:"public_addr,omitempty"`
@@ -70,13 +81,14 @@ type App struct {
 	SamlApp bool `protobuf:"varint,8,opt,name=saml_app,json=samlApp,proto3" json:"saml_app,omitempty"`
 	// labels is a list of labels for the app.
 	Labels []*Label `protobuf:"bytes,9,rep,name=labels,proto3" json:"labels,omitempty"`
-	// fqdn is the hostname under which the app is accessible within the root cluster. It doesn't
-	// include the port number. It is used by the Web UI to route the requests to /web/launch to the
-	// correct app.
+	// fqdn is the hostname under which the app is accessible within the root cluster. It is used by
+	// the Web UI to route the requests from the /web/launch URL to the correct app. fqdn by itself
+	// does not include the port number, so fqdn alone cannot be used to launch an app, hence why it's
+	// incorporated into the /web/launch URL.
 	//
-	// If the app belongs to a root cluster, fqdn is equal to public_addr or <name>.<root cluster
-	// proxy hostname> if public_addr is not present.
-	// If the app belongs to a leaf cluster, fqdn is equal to <name>.<root cluster proxy hostname>.
+	// If the app belongs to a root cluster, fqdn is equal to public_addr or [name].[root cluster
+	// proxy hostname] if public_addr is not present.
+	// If the app belongs to a leaf cluster, fqdn is equal to [name].[root cluster proxy hostname].
 	//
 	// fqdn is not present for SAML applications.
 	Fqdn string `protobuf:"bytes,10,opt,name=fqdn,proto3" json:"fqdn,omitempty"`

--- a/gen/proto/ts/teleport/lib/teleterm/v1/app_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/app_pb.ts
@@ -38,7 +38,7 @@ import { Label } from "./label_pb";
  */
 export interface App {
     /**
-     * uri is the cluster resource URI.
+     * uri uniquely identifies an app within Teleport Connect.
      *
      * @generated from protobuf field: string uri = 1;
      */
@@ -70,9 +70,20 @@ export interface App {
     awsConsole: boolean;
     /**
      * public_addr is the public address the application is accessible at.
-     * By default, it is a subdomain of the cluster (e.g., dumper.example.com).
-     * Optionally, it can be overridden (by the 'public_addr' field in the app config)
-     * with an address available on the internet.
+     *
+     * If the app resource has its public_addr field set, this field returns the value of public_addr
+     * from the app resource.
+     *
+     * If the app resource does not have public_addr field set, this field returns the name of the app
+     * under the proxy hostname of the cluster to which the app belongs, e.g.,
+     * dumper.root-cluster.com, example-app.leaf-cluster.org.
+     *
+     * In both cases public_addr does not include a port number. An app resource cannot include a port
+     * number in its public_addr, as the backend will (wrongly) reject such resource with an error
+     * saying "public_addr "example.com:1337" can not contain a port, applications will be available
+     * on the same port as the web proxy". This is obviously not the case for custom public addresses.
+     * Ultimately, it means that public_addr alone is not enough to access the app, unless either the
+     * cluster or the custom domain use the default port of 443.
      *
      * Always empty for SAML applications.
      *
@@ -101,13 +112,14 @@ export interface App {
      */
     labels: Label[];
     /**
-     * fqdn is the hostname under which the app is accessible within the root cluster. It doesn't
-     * include the port number. It is used by the Web UI to route the requests to /web/launch to the
-     * correct app.
+     * fqdn is the hostname under which the app is accessible within the root cluster. It is used by
+     * the Web UI to route the requests from the /web/launch URL to the correct app. fqdn by itself
+     * does not include the port number, so fqdn alone cannot be used to launch an app, hence why it's
+     * incorporated into the /web/launch URL.
      *
-     * If the app belongs to a root cluster, fqdn is equal to public_addr or <name>.<root cluster
-     * proxy hostname> if public_addr is not present.
-     * If the app belongs to a leaf cluster, fqdn is equal to <name>.<root cluster proxy hostname>.
+     * If the app belongs to a root cluster, fqdn is equal to public_addr or [name].[root cluster
+     * proxy hostname] if public_addr is not present.
+     * If the app belongs to a leaf cluster, fqdn is equal to [name].[root cluster proxy hostname].
      *
      * fqdn is not present for SAML applications.
      *

--- a/proto/teleport/lib/teleterm/v1/app.proto
+++ b/proto/teleport/lib/teleterm/v1/app.proto
@@ -26,7 +26,7 @@ option go_package = "github.com/gravitational/teleport/gen/proto/go/teleport/lib
 
 // App describes an app resource.
 message App {
-  // uri is the cluster resource URI.
+  // uri uniquely identifies an app within Teleport Connect.
   string uri = 1;
   // name is the name of the app.
   string name = 2;
@@ -38,9 +38,20 @@ message App {
   // aws_console is true if this app is AWS management console.
   bool aws_console = 5;
   // public_addr is the public address the application is accessible at.
-  // By default, it is a subdomain of the cluster (e.g., dumper.example.com).
-  // Optionally, it can be overridden (by the 'public_addr' field in the app config)
-  // with an address available on the internet.
+  //
+  // If the app resource has its public_addr field set, this field returns the value of public_addr
+  // from the app resource.
+  //
+  // If the app resource does not have public_addr field set, this field returns the name of the app
+  // under the proxy hostname of the cluster to which the app belongs, e.g.,
+  // dumper.root-cluster.com, example-app.leaf-cluster.org.
+  //
+  // In both cases public_addr does not include a port number. An app resource cannot include a port
+  // number in its public_addr, as the backend will (wrongly) reject such resource with an error
+  // saying "public_addr "example.com:1337" can not contain a port, applications will be available
+  // on the same port as the web proxy". This is obviously not the case for custom public addresses.
+  // Ultimately, it means that public_addr alone is not enough to access the app, unless either the
+  // cluster or the custom domain use the default port of 443.
   //
   // Always empty for SAML applications.
   string public_addr = 6;
@@ -53,13 +64,14 @@ message App {
   bool saml_app = 8;
   // labels is a list of labels for the app.
   repeated Label labels = 9;
-  // fqdn is the hostname under which the app is accessible within the root cluster. It doesn't
-  // include the port number. It is used by the Web UI to route the requests to /web/launch to the
-  // correct app.
+  // fqdn is the hostname under which the app is accessible within the root cluster. It is used by
+  // the Web UI to route the requests from the /web/launch URL to the correct app. fqdn by itself
+  // does not include the port number, so fqdn alone cannot be used to launch an app, hence why it's
+  // incorporated into the /web/launch URL.
   //
-  // If the app belongs to a root cluster, fqdn is equal to public_addr or <name>.<root cluster
-  // proxy hostname> if public_addr is not present.
-  // If the app belongs to a leaf cluster, fqdn is equal to <name>.<root cluster proxy hostname>.
+  // If the app belongs to a root cluster, fqdn is equal to public_addr or [name].[root cluster
+  // proxy hostname] if public_addr is not present.
+  // If the app belongs to a leaf cluster, fqdn is equal to [name].[root cluster proxy hostname].
   //
   // fqdn is not present for SAML applications.
   string fqdn = 10;

--- a/web/packages/design/src/StepSlider/StepSlider.story.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.story.tsx
@@ -29,19 +29,26 @@ export default {
 };
 
 const singleFlow = { default: [Body1, Body2] };
-export const SingleFlowInPlaceSlider = () => {
+export const SingleFlowInPlaceSlider = (props: {
+  defaultStepIndex?: number;
+}) => {
   return (
     <Card my="5" mx="auto" width={464}>
-      <Text typography="h3" pt={5} textAlign="center" color="text.main">
+      <Text typography="h1" pt={5} textAlign="center" color="text.main">
         Static Title
       </Text>
       <StepSlider<typeof singleFlow>
         flows={singleFlow}
         currFlow={'default'}
         testProp="I'm that test prop"
+        defaultStepIndex={props.defaultStepIndex}
       />
     </Card>
   );
+};
+
+export const SingleFlowWithDefaultStepIndex = () => {
+  return <SingleFlowInPlaceSlider defaultStepIndex={1} />;
 };
 
 type MultiFlow = 'primary' | 'secondary';
@@ -52,7 +59,7 @@ const multiflows = {
   primary: [MainStep1, MainStep2, FinalStep],
   secondary: [OtherStep1, FinalStep],
 };
-export const MultiFlowWheelSlider = () => {
+export const MultiFlowWheelSlider = (props: { defaultStepIndex?: number }) => {
   const [flow, setFlow] = useState<MultiFlow>('primary');
   const [newFlow, setNewFlow] = useState<NewFlow<MultiFlow>>();
 
@@ -71,6 +78,7 @@ export const MultiFlowWheelSlider = () => {
       onSwitchFlow={onSwitchFlow}
       newFlow={newFlow}
       changeFlow={onNewFlow}
+      defaultStepIndex={props.defaultStepIndex}
     />
   );
 };
@@ -110,7 +118,7 @@ function MainStep1({ next, refCallback, changeFlow }: ViewProps) {
   );
 }
 
-function MainStep2({ next, prev, refCallback }: ViewProps) {
+function MainStep2({ next, prev, refCallback, changeFlow }: ViewProps) {
   return (
     <OnboardCard ref={refCallback} data-testid="multi-primary2">
       <Text typography="h2" mb={3} textAlign="center" color="text.main" bold>
@@ -157,6 +165,14 @@ function MainStep2({ next, prev, refCallback }: ViewProps) {
           }}
         >
           Go Back
+        </ButtonLink>
+        <ButtonLink
+          onClick={e => {
+            e.preventDefault();
+            changeFlow({ flow: 'secondary' });
+          }}
+        >
+          Switch Secondary Flow
         </ButtonLink>
       </Box>
     </OnboardCard>
@@ -236,6 +252,9 @@ function Body1({
 }: StepComponentProps & { testProp: string }) {
   return (
     <Box p={6} ref={refCallback} data-testid="single-body1">
+      <Text typography="h2" mb={3}>
+        Step 1
+      </Text>
       <Text mb={3}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua.
@@ -273,6 +292,9 @@ function Body2({
 }: StepComponentProps & { testProp: string }) {
   return (
     <Box p={6} ref={refCallback} data-testid="single-body2">
+      <Text typography="h2" mb={3}>
+        Step 2
+      </Text>
       <Text mb={3}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim

--- a/web/packages/design/src/StepSlider/StepSlider.test.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.test.tsx
@@ -29,25 +29,25 @@ test('single flow', () => {
   render(<SingleFlowInPlaceSlider />);
 
   // Test initial render.
-  expect(screen.getByTestId('single-body1')).toBeVisible();
+  expect(screen.getByText('Step 1')).toBeVisible();
 
   // Test going back when already at the beginning of array.
   // Should do nothing as expected.
   fireEvent.click(screen.getByText(/back1/i));
-  expect(screen.getByTestId('single-body1')).toBeVisible();
+  expect(screen.getByText('Step 1')).toBeVisible();
 
   // Test next.
   fireEvent.click(screen.getByText(/next1/i));
-  expect(screen.getByTestId('single-body2')).toBeVisible();
+  expect(screen.getByText('Step 2')).toBeVisible();
 
   // Test going next when at the end of array.
   // Should do nothing.
   fireEvent.click(screen.getByText(/next2/i));
-  expect(screen.getByTestId('single-body2')).toBeVisible();
+  expect(screen.getByText('Step 2')).toBeVisible();
 
   // Test going back.
   fireEvent.click(screen.getByText(/back2/i));
-  expect(screen.getByTestId('single-body1')).toBeVisible();
+  expect(screen.getByText('Step 1')).toBeVisible();
 });
 
 test('switching between multi flow', () => {
@@ -63,4 +63,26 @@ test('switching between multi flow', () => {
   // Test switching back to primary flow.
   fireEvent.click(screen.getByText(/primary flow/i));
   expect(screen.getByTestId('multi-primary1')).toBeVisible();
+});
+
+test('setting default step index', () => {
+  render(<SingleFlowInPlaceSlider defaultStepIndex={1} />);
+
+  expect(screen.getByText('Step 2')).toBeVisible();
+
+  fireEvent.click(screen.getByText(/back2/i));
+  expect(screen.getByText('Step 1')).toBeVisible();
+
+  fireEvent.click(screen.getByText(/next1/i));
+  expect(screen.getByText('Step 2')).toBeVisible();
+});
+
+test('setting default step index for multi flow', () => {
+  render(<MultiFlowWheelSlider defaultStepIndex={1} />);
+
+  expect(screen.getByTestId('multi-primary2')).toBeVisible();
+
+  // Changing flows should reset the step to 0, not to the provided defaultStepIndex.
+  fireEvent.click(screen.getByText(/secondary flow/i));
+  expect(screen.getByTestId('multi-secondary1')).toBeVisible();
 });

--- a/web/packages/design/src/StepSlider/StepSlider.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.tsx
@@ -52,6 +52,7 @@ export function StepSlider<Flows>(props: Props<Flows>) {
     currFlow,
     onSwitchFlow,
     newFlow,
+    defaultStepIndex = 0,
     tDuration = 500,
     // extraProps are the props required by our step components defined in our flows.
     ...extraProps
@@ -60,7 +61,7 @@ export function StepSlider<Flows>(props: Props<Flows>) {
   const [hasTransitionEnded, setHasTransitionEnded] = useState<boolean>(false);
 
   // step defines the current step we are in the current flow.
-  const [step, setStep] = useState(0);
+  const [step, setStep] = useState(defaultStepIndex);
   // animationDirectionPrefix defines the prefix of the class name that contains
   // the animations to apply when transitioning.
   const [animationDirectionPrefix, setAnimationDirectionPrefix] = useState<
@@ -328,6 +329,14 @@ type Props<Flows> =
          * Optional if there is only one flow.
          */
         onSwitchFlow?(flow: keyof Flows): void;
+        /**
+         * defaultStepIndex is the step that will be shown on the first render, similar to
+         * defaultValue passed to the input tag.
+         *
+         * Since this value is used only for the initial render, it won't be persisted when
+         * switching flows – this will result in the current step index being reset to 0.
+         */
+        defaultStepIndex?: number;
       } & ExtraProps // Extra props that are passed to each step component. Each step of each flow needs to accept the same set of extra props.
     : never;
 

--- a/web/packages/teleterm/src/ui/App.tsx
+++ b/web/packages/teleterm/src/ui/App.tsx
@@ -28,6 +28,7 @@ import AppContextProvider from './appContextProvider';
 import AppContext from './appContext';
 import { ThemeProvider } from './ThemeProvider';
 import { VnetContextProvider } from './Vnet/vnetContext';
+import { ConnectionsContextProvider } from './TopBar/Connections/connectionsContext';
 
 export const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
   return (
@@ -35,11 +36,13 @@ export const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
       <StyledApp>
         <DndProvider backend={HTML5Backend}>
           <AppContextProvider value={ctx}>
-            <VnetContextProvider>
-              <ThemeProvider>
-                <AppInitializer />
-              </ThemeProvider>
-            </VnetContextProvider>
+            <ConnectionsContextProvider>
+              <VnetContextProvider>
+                <ThemeProvider>
+                  <AppInitializer />
+                </ThemeProvider>
+              </VnetContextProvider>
+            </ConnectionsContextProvider>
           </AppContextProvider>
         </DndProvider>
       </StyledApp>

--- a/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
@@ -30,8 +30,9 @@ import {
   makeRootCluster,
   makeRetryableError,
 } from 'teleterm/services/tshd/testHelpers';
-
 import { ClusterUri } from 'teleterm/ui/uri';
+import { VnetContextProvider } from 'teleterm/ui/Vnet';
+import { ConnectionsContextProvider } from 'teleterm/ui/TopBar/Connections/connectionsContext';
 
 import { SearchAction } from './actions';
 
@@ -89,7 +90,11 @@ it('does not display empty results copy after selecting two filters', () => {
 
   render(
     <MockAppContextProvider appContext={appContext}>
-      <SearchBarConnected />
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <SearchBarConnected />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </MockAppContextProvider>
   );
 
@@ -119,7 +124,11 @@ it('displays empty results copy after providing search query for which there is 
 
   render(
     <MockAppContextProvider appContext={appContext}>
-      <SearchBarConnected />
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <SearchBarConnected />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </MockAppContextProvider>
   );
 
@@ -153,7 +162,11 @@ it('includes offline cluster names in the empty results copy', () => {
 
   render(
     <MockAppContextProvider appContext={appContext}>
-      <SearchBarConnected />
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <SearchBarConnected />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </MockAppContextProvider>
   );
 
@@ -198,7 +211,11 @@ it('notifies about resource search errors and allows to display details', () => 
 
   render(
     <MockAppContextProvider appContext={appContext}>
-      <SearchBarConnected />
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <SearchBarConnected />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </MockAppContextProvider>
   );
 
@@ -246,8 +263,12 @@ it('maintains focus on the search input after closing a resource search error mo
 
   render(
     <MockAppContextProvider appContext={appContext}>
-      <SearchBarConnected />
-      <ModalsHost />
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <SearchBarConnected />
+          <ModalsHost />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </MockAppContextProvider>
   );
 
@@ -305,8 +326,12 @@ it('shows a login modal when a request to a cluster from the current workspace f
 
   render(
     <MockAppContextProvider appContext={appContext}>
-      <SearchBarConnected />
-      <ModalsHost />
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <SearchBarConnected />
+          <ModalsHost />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </MockAppContextProvider>
   );
 
@@ -346,8 +371,12 @@ it('closes on a click on an unfocusable element outside of the search bar', asyn
 
   render(
     <MockAppContextProvider appContext={appContext}>
-      <SearchBarConnected />
-      <p data-testid="unfocusable-element">Lorem ipsum</p>
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <SearchBarConnected />
+          <p data-testid="unfocusable-element">Lorem ipsum</p>
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </MockAppContextProvider>
   );
 

--- a/web/packages/teleterm/src/ui/Search/actions.tsx
+++ b/web/packages/teleterm/src/ui/Search/actions.tsx
@@ -70,6 +70,7 @@ export type SearchAction = SimpleAction | ParametrizedAction;
 
 export function mapToAction(
   ctx: IAppContext,
+  launchVnet: () => Promise<[void, Error]>,
   searchContext: SearchContext,
   result: SearchResult
 ): SearchAction {
@@ -136,6 +137,7 @@ export function mapToAction(
           perform: parameter =>
             connectToApp(
               ctx,
+              launchVnet,
               result.resource,
               {
                 origin: 'search_bar',
@@ -148,14 +150,9 @@ export function mapToAction(
         type: 'simple-action',
         searchResult: result,
         perform: () =>
-          connectToApp(
-            ctx,
-            result.resource,
-            {
-              origin: 'search_bar',
-            },
-            { launchInBrowserIfWebApp: true }
-          ),
+          connectToApp(ctx, launchVnet, result.resource, {
+            origin: 'search_bar',
+          }),
       };
     }
     case 'database': {

--- a/web/packages/teleterm/src/ui/Search/pickers/useActionAttempts.ts
+++ b/web/packages/teleterm/src/ui/Search/pickers/useActionAttempts.ts
@@ -37,6 +37,7 @@ import { useSearchContext } from 'teleterm/ui/Search/SearchContext';
 import { SearchFilter } from 'teleterm/ui/Search/searchResult';
 import { routing } from 'teleterm/ui/uri';
 import { isRetryable } from 'teleterm/ui/utils/retryWithRelogin';
+import { useVnetContext, useVnetLauncher } from 'teleterm/ui/Vnet';
 
 import { useDisplayResults } from './useDisplayResults';
 
@@ -45,6 +46,9 @@ export function useActionAttempts() {
   const { modalsService, workspacesService } = ctx;
   const searchContext = useSearchContext();
   const { inputValue, filters, pauseUserInteraction } = searchContext;
+  const { isSupported: isVnetSupported } = useVnetContext();
+  const vnetLauncher = useVnetLauncher();
+  const launchVnet = isVnetSupported ? vnetLauncher : undefined;
 
   const [resourceSearchAttempt, runResourceSearch, setResourceSearchAttempt] =
     useAsync(useResourceSearch());
@@ -123,10 +127,10 @@ export function useActionAttempts() {
     () =>
       mapAttempt(resourceSearchAttempt, ({ results, search }) =>
         rankResults(results, search).map(result =>
-          mapToAction(ctx, searchContext, result)
+          mapToAction(ctx, launchVnet, searchContext, result)
         )
       ),
-    [ctx, resourceSearchAttempt, searchContext]
+    [ctx, resourceSearchAttempt, searchContext, launchVnet]
   );
 
   const runFilterSearch = useFilterSearch();
@@ -134,13 +138,14 @@ export function useActionAttempts() {
     () =>
       // TODO(gzdunek): filters are sorted inline, should be done here to align with resource search
       runFilterSearch(inputValue, filters).map(result =>
-        mapToAction(ctx, searchContext, result)
+        mapToAction(ctx, launchVnet, searchContext, result)
       ),
-    [runFilterSearch, inputValue, filters, ctx, searchContext]
+    [runFilterSearch, inputValue, filters, ctx, searchContext, launchVnet]
   );
 
   const displayResultsAction = mapToAction(
     ctx,
+    launchVnet,
     searchContext,
     useDisplayResults({
       inputValue,

--- a/web/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
@@ -26,6 +26,7 @@ import { VnetContextProvider } from 'teleterm/ui/Vnet';
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 
 import { Connections } from './Connections';
+import { ConnectionsContextProvider } from './connectionsContext';
 
 export default {
   title: 'Teleterm/TopBar/Connections',
@@ -46,9 +47,11 @@ export function Story() {
 
   return (
     <AppContextProvider value={appContext}>
-      <VnetContextProvider>
-        <Connections />
-      </VnetContextProvider>
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <Connections />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </AppContextProvider>
   );
 }
@@ -97,9 +100,11 @@ export function JustVnet() {
 
   return (
     <AppContextProvider value={appContext}>
-      <VnetContextProvider>
-        <Connections />
-      </VnetContextProvider>
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <Connections />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </AppContextProvider>
   );
 }
@@ -131,9 +136,11 @@ export function WithScroll() {
       maxWidth="600px"
     >
       <AppContextProvider value={appContext}>
-        <VnetContextProvider>
-          <Connections />
-        </VnetContextProvider>
+        <ConnectionsContextProvider>
+          <VnetContextProvider>
+            <Connections />
+          </VnetContextProvider>
+        </ConnectionsContextProvider>
       </AppContextProvider>
       <Text
         css={`
@@ -152,9 +159,11 @@ export function WithoutVnet() {
 
   return (
     <AppContextProvider value={appContext}>
-      <VnetContextProvider>
-        <Connections />
-      </VnetContextProvider>
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <Connections />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </AppContextProvider>
   );
 }
@@ -164,9 +173,11 @@ export function EmptyWithoutVnet() {
 
   return (
     <AppContextProvider value={appContext}>
-      <VnetContextProvider>
-        <Connections />
-      </VnetContextProvider>
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <Connections />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </AppContextProvider>
   );
 }

--- a/web/packages/teleterm/src/ui/TopBar/Connections/Connections.test.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/Connections.test.tsx
@@ -32,6 +32,7 @@ import { routing } from 'teleterm/ui/uri';
 import { unique } from 'teleterm/ui/utils';
 
 import { Connections } from './Connections';
+import { ConnectionsContextProvider } from './connectionsContext';
 
 beforeAll(() => {
   Logger.init(new NullService());
@@ -60,9 +61,11 @@ describe('opening VNet panel', () => {
 
     render(
       <MockAppContextProvider>
-        <VnetContextProvider>
-          <Connections />
-        </VnetContextProvider>
+        <ConnectionsContextProvider>
+          <VnetContextProvider>
+            <Connections />
+          </VnetContextProvider>
+        </ConnectionsContextProvider>
       </MockAppContextProvider>
     );
 
@@ -124,9 +127,11 @@ describe('opening a connection', () => {
 
     render(
       <MockAppContextProvider appContext={appContext}>
-        <VnetContextProvider>
-          <Connections />
-        </VnetContextProvider>
+        <ConnectionsContextProvider>
+          <VnetContextProvider>
+            <Connections />
+          </VnetContextProvider>
+        </ConnectionsContextProvider>
       </MockAppContextProvider>
     );
 
@@ -170,9 +175,11 @@ test('adding a new conn while the list is open puts the new conn at the top', as
 
   render(
     <MockAppContextProvider appContext={appContext}>
-      <VnetContextProvider>
-        <Connections />
-      </VnetContextProvider>
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <Connections />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </MockAppContextProvider>
   );
 
@@ -246,9 +253,11 @@ test('disconnecting a conn does not update its position in the list', async () =
 
   render(
     <MockAppContextProvider appContext={appContext}>
-      <VnetContextProvider>
-        <Connections />
-      </VnetContextProvider>
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <Connections />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </MockAppContextProvider>
   );
 

--- a/web/packages/teleterm/src/ui/TopBar/Connections/Connections.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/Connections.tsx
@@ -26,13 +26,13 @@ import { useAppContext } from 'teleterm/ui/appContextProvider';
 
 import { ConnectionsIcon } from './ConnectionsIcon/ConnectionsIcon';
 import { ConnectionsSliderStep } from './ConnectionsSliderStep';
-import { useConnectionsContext } from './connectionsContext';
+import { Step, useConnectionsContext } from './connectionsContext';
 
 export function Connections() {
   const { connectionTracker } = useAppContext();
   connectionTracker.useState();
   const iconRef = useRef();
-  const { isOpen, toggle, close } = useConnectionsContext();
+  const { isOpen, toggle, close, stepToOpen } = useConnectionsContext();
   const { status: vnetStatus } = useVnetContext();
   const isAnyConnectionActive =
     connectionTracker.getConnections().some(c => c.connected) ||
@@ -74,7 +74,11 @@ export function Connections() {
           padding (so 24px on both sides) and ConnectionsFilterableList had 300px of width.
         */}
         <Box width="324px" bg="levels.elevated">
-          <StepSlider currFlow="default" flows={stepSliderFlows} />
+          <StepSlider
+            currFlow="default"
+            flows={stepSliderFlows}
+            defaultStepIndex={stepToIndex(stepToOpen)}
+          />
         </Box>
       </Popover>
     </>
@@ -82,3 +86,15 @@ export function Connections() {
 }
 
 const stepSliderFlows = { default: [ConnectionsSliderStep, VnetSliderStep] };
+
+const stepToIndex = (step: Step): number => {
+  switch (step) {
+    case 'connections':
+      return 0;
+    case 'vnet':
+      return 1;
+    default:
+      step satisfies never;
+      return 0;
+  }
+};

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsSliderStep.tsx
@@ -24,12 +24,12 @@ import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { KeyboardArrowsNavigation } from 'teleterm/ui/components/KeyboardArrowsNavigation';
 
 import { ConnectionsFilterableList } from './ConnectionsFilterableList/ConnectionsFilterableList';
+import { useConnectionsContext } from './connectionsContext';
 
-export const ConnectionsSliderStep = (
-  props: StepComponentProps & { closeConnectionList: () => void }
-) => {
+export const ConnectionsSliderStep = (props: StepComponentProps) => {
   const { connectionTracker } = useAppContext();
   connectionTracker.useState();
+  const { close: closeConnectionList } = useConnectionsContext();
 
   const items = connectionTracker.getConnections();
   const [sortedIds, setSortedIds] = useState<string[]>(null);
@@ -68,7 +68,7 @@ export const ConnectionsSliderStep = (
   const disconnectItem =
     connectionTracker.disconnectItem.bind(connectionTracker);
   const activateItem = (id: string) => {
-    props.closeConnectionList();
+    closeConnectionList();
     connectionTracker.activateItem(id, { origin: 'connection_list' });
   };
 

--- a/web/packages/teleterm/src/ui/TopBar/Connections/connectionsContext.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/connectionsContext.tsx
@@ -1,0 +1,67 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  FC,
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+} from 'react';
+
+/**
+ * ConnectionsContext allows other parts of the app to control the connection list.
+ */
+export type ConnectionsContext = {
+  isOpen: boolean;
+  close: () => void;
+  toggle: () => void;
+};
+
+export const ConnectionsContext = createContext<ConnectionsContext>(null);
+
+export const ConnectionsContextProvider: FC<PropsWithChildren> = props => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggle = useCallback(() => {
+    setIsOpen(wasOpen => !wasOpen);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return (
+    <ConnectionsContext.Provider value={{ isOpen, toggle, close }}>
+      {props.children}
+    </ConnectionsContext.Provider>
+  );
+};
+
+export const useConnectionsContext = () => {
+  const context = useContext(ConnectionsContext);
+
+  if (!context) {
+    throw new Error(
+      'useConnectionsContext must be used within a ConnectionsContextProvider'
+    );
+  }
+
+  return context;
+};

--- a/web/packages/teleterm/src/ui/TopBar/Connections/connectionsContext.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/connectionsContext.tsx
@@ -30,25 +30,48 @@ import {
  */
 export type ConnectionsContext = {
   isOpen: boolean;
+  open: (step?: Step) => void;
   close: () => void;
   toggle: () => void;
+  /**
+   * stepToOpen is the step that will be shown when the connection list gets opened.
+   * It doesn't control the current stop beyond the initial render.
+   */
+  stepToOpen: Step;
 };
+
+export type Step = 'connections' | 'vnet';
+
+const defaultStep: Step = 'connections';
 
 export const ConnectionsContext = createContext<ConnectionsContext>(null);
 
 export const ConnectionsContextProvider: FC<PropsWithChildren> = props => {
   const [isOpen, setIsOpen] = useState(false);
+  const [stepToOpen, setStepToOpen] = useState<Step>('connections');
 
   const toggle = useCallback(() => {
     setIsOpen(wasOpen => !wasOpen);
-  }, []);
+
+    if (isOpen) {
+      setStepToOpen(defaultStep);
+    }
+  }, [isOpen]);
 
   const close = useCallback(() => {
     setIsOpen(false);
+    setStepToOpen(defaultStep);
+  }, []);
+
+  const open = useCallback((step: Step = defaultStep) => {
+    setIsOpen(true);
+    setStepToOpen(step);
   }, []);
 
   return (
-    <ConnectionsContext.Provider value={{ isOpen, toggle, close }}>
+    <ConnectionsContext.Provider
+      value={{ isOpen, toggle, close, open, stepToOpen }}
+    >
       {props.children}
     </ConnectionsContext.Provider>
   );

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -28,9 +28,7 @@ import { VnetSliderStepHeader, AppConnectionItem } from './VnetConnectionItem';
  * VnetSliderStep is the second step of StepSlider used in TopBar/Connections. It is shown after
  * selecting VnetConnectionItem from ConnectionsFilterableList.
  */
-export const VnetSliderStep = (
-  props: StepComponentProps & { closeConnectionList: () => void }
-) => {
+export const VnetSliderStep = (props: StepComponentProps) => {
   const visible = props.stepIndex === 1 && props.hasTransitionEnded;
   const { status, startAttempt, stopAttempt } = useVnetContext();
   const autoFocusRef = useRefAutoFocus<HTMLElement>({

--- a/web/packages/teleterm/src/ui/Vnet/useVnetLauncher.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/useVnetLauncher.tsx
@@ -16,7 +16,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export * from './VnetSliderStep';
-export * from './vnetContext';
-export { VnetConnectionItem } from './VnetConnectionItem';
-export * from './useVnetLauncher';
+import { useCallback } from 'react';
+
+import { useConnectionsContext } from 'teleterm/ui/TopBar/Connections/connectionsContext';
+
+import { useVnetContext } from './vnetContext';
+
+export const useVnetLauncher = (): (() => Promise<[void, Error]>) => {
+  const { start, status, startAttempt } = useVnetContext();
+  const { open } = useConnectionsContext();
+
+  return useCallback(() => {
+    if (status === 'running' || startAttempt.status === 'processing') {
+      return Promise.resolve([undefined, undefined]);
+    }
+
+    open('vnet');
+
+    return start();
+  }, [status, startAttempt.status, open, start]);
+};

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -40,9 +40,9 @@ export type VnetContext = {
    */
   isSupported: boolean;
   status: VnetStatus;
-  start: () => void;
+  start: () => Promise<[void, Error]>;
   startAttempt: Attempt<void>;
-  stop: () => void;
+  stop: () => Promise<[void, Error]>;
   stopAttempt: Attempt<void>;
 };
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.test.ts
@@ -16,108 +16,143 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { connectToApp } from 'teleterm/ui/services/workspacesService';
+import {
+  connectToApp,
+  setUpAppGateway,
+} from 'teleterm/ui/services/workspacesService';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { makeApp, makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 import { IAppContext } from 'teleterm/ui/types';
 
-describe('launching an app in the browser for', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  test('web app (if requested)', async () => {
-    jest.spyOn(window, 'open').mockImplementation();
-    const appContext = new MockAppContext();
-    setTestCluster(appContext);
-    const app = makeApp({
-      endpointUri: 'http://localhost:3000',
+describe('connectToApp', () => {
+  describe('launching an app in the browser for', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
     });
 
-    await connectToApp(
-      appContext,
-      app,
-      { origin: 'resource_table' },
-      {
-        launchInBrowserIfWebApp: true,
-      }
-    );
-    expect(window.open).toHaveBeenCalledWith(
-      'https://teleport-local:3080/web/launch/local-app.example.com:3000/teleport-local/local-app.example.com:3000',
-      '_blank',
-      'noreferrer,noopener'
-    );
+    test('web app', async () => {
+      jest.spyOn(window, 'open').mockImplementation();
+      const appContext = new MockAppContext();
+      setTestCluster(appContext);
+      const app = makeApp({
+        endpointUri: 'http://localhost:3000',
+      });
+
+      await connectToApp(appContext, launchVnet, app, {
+        origin: 'resource_table',
+      });
+      expect(window.open).toHaveBeenCalledWith(
+        'https://teleport-local:3080/web/launch/local-app.example.com:3000/teleport-local/local-app.example.com:3000',
+        '_blank',
+        'noreferrer,noopener'
+      );
+    });
+
+    test('saml app', async () => {
+      jest.spyOn(window, 'open').mockImplementation();
+      const appContext = new MockAppContext();
+      setTestCluster(appContext);
+      const app = makeApp({ samlApp: true });
+
+      await connectToApp(appContext, launchVnet, app, {
+        origin: 'resource_table',
+      });
+
+      expect(window.open).toHaveBeenCalledWith(
+        'https://teleport-local:3080/enterprise/saml-idp/login/foo',
+        '_blank',
+        'noreferrer,noopener'
+      );
+    });
+
+    test('aws app', async () => {
+      jest.spyOn(window, 'open').mockImplementation();
+      const appContext = new MockAppContext();
+      setTestCluster(appContext);
+      const app = makeApp({ awsConsole: true });
+
+      await connectToApp(
+        appContext,
+        launchVnet,
+        app,
+        { origin: 'resource_table' },
+        { arnForAwsApp: 'foo-arn' }
+      );
+      expect(window.open).toHaveBeenCalledWith(
+        'https://teleport-local:3080/web/launch/local-app.example.com:3000/teleport-local/local-app.example.com:3000/foo-arn',
+        '_blank',
+        'noreferrer,noopener'
+      );
+    });
   });
 
-  test('saml app', async () => {
-    jest.spyOn(window, 'open').mockImplementation();
+  test('setting up a gateway for TCP app when VNet is not supported', async () => {
+    const app = makeApp({
+      endpointUri: 'tcp://localhost:3000',
+    });
+
     const appContext = new MockAppContext();
     setTestCluster(appContext);
-    const app = makeApp({ samlApp: true });
 
-    await connectToApp(appContext, app, { origin: 'resource_table' });
-
-    expect(window.open).toHaveBeenCalledWith(
-      'https://teleport-local:3080/enterprise/saml-idp/login/foo',
-      '_blank',
-      'noreferrer,noopener'
-    );
-  });
-
-  test('aws app', async () => {
-    jest.spyOn(window, 'open').mockImplementation();
-    const appContext = new MockAppContext();
-    setTestCluster(appContext);
-    const app = makeApp({ awsConsole: true });
-
-    await connectToApp(
-      appContext,
-      app,
-      { origin: 'resource_table' },
-      { launchInBrowserIfWebApp: true, arnForAwsApp: 'foo-arn' }
-    );
-    expect(window.open).toHaveBeenCalledWith(
-      'https://teleport-local:3080/web/launch/local-app.example.com:3000/teleport-local/local-app.example.com:3000/foo-arn',
-      '_blank',
-      'noreferrer,noopener'
-    );
+    await connectToApp(appContext, undefined, app, {
+      origin: 'resource_table',
+    });
+    const documents = appContext.workspacesService
+      .getActiveWorkspaceDocumentService()
+      .getGatewayDocuments();
+    expect(documents).toHaveLength(1);
+    expect(documents[0]).toEqual({
+      gatewayUri: undefined,
+      kind: 'doc.gateway',
+      origin: 'resource_table',
+      port: undefined,
+      status: '',
+      targetName: 'foo',
+      targetSubresourceName: undefined,
+      targetUri: '/clusters/teleport-local/apps/foo',
+      targetUser: '',
+      title: 'foo',
+      uri: expect.any(String),
+    });
   });
 });
 
-test.each([
-  {
-    name: 'creates tunnel for a tcp app',
-    app: makeApp({
-      endpointUri: 'tcp://localhost:3000',
-    }),
-  },
-  {
-    name: 'creates tunnel for a web app by default',
-    app: makeApp({
-      endpointUri: 'http://localhost:3000',
-    }),
-  },
-])('$name', async ({ app }) => {
-  const appContext = new MockAppContext();
-  setTestCluster(appContext);
+describe('setUpAppGateway', () => {
+  test.each([
+    {
+      name: 'creates tunnel for a tcp app',
+      app: makeApp({
+        endpointUri: 'tcp://localhost:3000',
+      }),
+    },
+    {
+      name: 'creates tunnel for a web app',
+      app: makeApp({
+        endpointUri: 'http://localhost:3000',
+      }),
+    },
+  ])('$name', async ({ app }) => {
+    const appContext = new MockAppContext();
+    setTestCluster(appContext);
 
-  await connectToApp(appContext, app, { origin: 'resource_table' });
-  const documents = appContext.workspacesService
-    .getActiveWorkspaceDocumentService()
-    .getGatewayDocuments();
-  expect(documents).toHaveLength(1);
-  expect(documents[0]).toEqual({
-    gatewayUri: undefined,
-    kind: 'doc.gateway',
-    origin: 'resource_table',
-    port: undefined,
-    status: '',
-    targetName: 'foo',
-    targetSubresourceName: undefined,
-    targetUri: '/clusters/teleport-local/apps/foo',
-    targetUser: '',
-    title: 'foo',
-    uri: expect.any(String),
+    await setUpAppGateway(appContext, app, { origin: 'resource_table' });
+    const documents = appContext.workspacesService
+      .getActiveWorkspaceDocumentService()
+      .getGatewayDocuments();
+    expect(documents).toHaveLength(1);
+    expect(documents[0]).toEqual({
+      gatewayUri: undefined,
+      kind: 'doc.gateway',
+      origin: 'resource_table',
+      port: undefined,
+      status: '',
+      targetName: 'foo',
+      targetSubresourceName: undefined,
+      targetUri: '/clusters/teleport-local/apps/foo',
+      targetUser: '',
+      title: 'foo',
+      uri: expect.any(String),
+    });
   });
 });
 
@@ -129,7 +164,7 @@ test('cloud app triggers alert', async () => {
     endpointUri: 'cloud://localhost:3000',
   });
 
-  await connectToApp(appContext, app, { origin: 'resource_table' });
+  await connectToApp(appContext, launchVnet, app, { origin: 'resource_table' });
   expect(window.alert).toHaveBeenCalledWith(
     'Cloud apps are supported only in tsh.'
   );
@@ -144,3 +179,6 @@ function setTestCluster(appContext: IAppContext): void {
     d.clusters.set(testCluster.uri, testCluster);
   });
 }
+
+const launchVnet = () =>
+  Promise.resolve([undefined, undefined] as [void, Error]);

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.ts
@@ -16,10 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { copyToClipboard } from 'design/utils/copyToClipboard';
+import { App } from 'gen-proto-ts/teleport/lib/teleterm/v1/app_pb';
+import { Cluster } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
+
 import { routing } from 'teleterm/ui/uri';
 import { IAppContext } from 'teleterm/ui/types';
 
-import { App } from 'teleterm/services/tshd/types';
 import {
   getWebAppLaunchUrl,
   isWebApp,
@@ -29,12 +32,25 @@ import {
 
 import { DocumentOrigin } from './types';
 
+/**
+ * connectToApp launches an app in the browser, with the exception of TCP apps, for which it either
+ * sets up an app gateway or launches VNet if supported.
+ *
+ * Unlike other connectTo* functions, connectToApp is oriented towards the search bar. In other
+ * contexts outside of the search bar, you typically want to open apps in the browser. In that case,
+ * you don't need connectToApp – you can just use a regular link instead. In the search bar you
+ * select a div, so there's no href you can add.
+ */
 export async function connectToApp(
   ctx: IAppContext,
+  /**
+   * launchVnet is supposed to be provided if VNet is supported. If so, connectToApp is going to use
+   * this function when targeting a TCP app. Otherwise it'll create an app gateway.
+   */
+  launchVnet: null | (() => Promise<[void, Error]>),
   target: App,
   telemetry: { origin: DocumentOrigin },
   options?: {
-    launchInBrowserIfWebApp?: boolean;
     arnForAwsApp?: string;
   }
 ): Promise<void> {
@@ -75,7 +91,7 @@ export async function connectToApp(
     return;
   }
 
-  if (isWebApp(target) && options?.launchInBrowserIfWebApp) {
+  if (isWebApp(target)) {
     launchAppInBrowser(
       ctx,
       target,
@@ -88,6 +104,22 @@ export async function connectToApp(
     );
     return;
   }
+
+  // TCP app
+  if (launchVnet) {
+    await connectToAppWithVnet(ctx, launchVnet, target);
+    return;
+  }
+
+  await setUpAppGateway(ctx, target, telemetry);
+}
+
+export async function setUpAppGateway(
+  ctx: IAppContext,
+  target: App,
+  telemetry: { origin: DocumentOrigin }
+) {
+  const rootClusterUri = routing.ensureRootClusterUri(target.uri);
 
   const documentsService =
     ctx.workspacesService.getWorkspaceDocumentService(rootClusterUri);
@@ -110,6 +142,46 @@ export async function connectToApp(
     documentsService.open(doc.uri);
   }
 }
+
+export async function connectToAppWithVnet(
+  ctx: IAppContext,
+  launchVnet: () => Promise<[void, Error]>,
+  target: App
+) {
+  const cluster = ctx.clustersService.findClusterByResource(target.uri);
+
+  const [, err] = await launchVnet();
+  if (err) {
+    return;
+  }
+
+  const addrToCopy = getVnetAddr(cluster, target);
+  await copyToClipboard(addrToCopy);
+
+  ctx.notificationsService.notifyInfo(`Copied ${addrToCopy} to clipboard`);
+}
+
+// TODO(ravicious): For apps from a root cluster, the copied address needs to be:
+// * publicAddr if the domain from the public addr is configured as a DNS zone.
+// * fqdn if the domain from the public addr is not configured as a DNS zone.
+//
+// For apps from a leaf cluster, it needs to be:
+// * publicAddr if the domain from the public addr is configured as a DNS zone.
+// * <app name>.<leaf cluster proxy host> if the domain from the public addr is not configured as
+// a DNS zone.
+//
+// For now, it can be just fqdn for root apps and the latter form for leaf apps.
+const getVnetAddr = (cluster: Cluster, target: App): string => {
+  if (!cluster.leaf) {
+    return target.fqdn;
+  }
+
+  // Strip port number from proxyHost.
+  const { hostname: leafProxyHostname } = new URL(
+    `https://${cluster.proxyHost}`
+  );
+  return `${target.name}.${leafProxyHostname}`;
+};
 
 /**
  * When the app is opened outside Connect,


### PR DESCRIPTION
This PR makes it so that when the user clicks on "Connect" next to a TCP app or selects a TCP app from the search bar, VNet gets launched and the app opens the VNet panel. On a successful launch, it copies the address of the app to clipboard. If VNet is already running, then only the address is copied.

This is described in the [Guiding the user towards VNet](https://github.com/gravitational/teleport/blob/rfd/0163-vnet/rfd/0163-vnet.md#guiding-the-user-towards-vnet) section of the RFD.

https://github.com/gravitational/teleport/assets/27113/09d9b3fd-6147-4803-9f8a-defe21f8a97f

To do this, I had to first make a couple of changes:

* Management of the state of the connection list popover had to be moved to a context. This way any place in the app can open the popover.
* StepSlider now supports `defaultStepIndex` so that we can pick the right step on the first render. This is because the VNet panel is the second step of the StepSlider used in the connection list.
* `connectToApp` needs to account for VNet.

Best reviewed commit-by-commit, as usual. Remember to enable `feature.vnet` in you app config if you want to test this out.

### A side note about `AppContext` and React contexts

<details>
<summary>Side note</summary>

The changes to `connectToApp` is are a bit convoluted without having a context (hehe) of how Connect was developed over time.

Connect was originally built using services, such as `ClustersService`, which are all collected in `AppContext`. To compare that to React contexts, when a callsite has access to `AppContext`, it has access to any service in the app. This is obviously not possible with React contexts which depend on the "DOM" hierarchy and allow multiple contexts of the same type.

Over time, we started using React contexts more and more. Contexts pretty much force you to use hooks. But hooks are fundamentally different than the services that we have – there's no "rules", once someone hands you `AppContext` you can just use whatever is there.

So we ended up with a bunch of places which receive `AppContext` as an argument and then they can pluck out whatever they want from there. But what if there's a callsite that needs access to some data from a service provided by `AppContext` and some data from a React context?

Well, `connectToApp` is a good example. It now needs to be able to launch VNet, which is a bit of functionality that I implemented through a React context. The answer is… we just need to pass more stuff as function arguments.

Until we migrate away from services towards contexts, I don't think there's a way around it. Basically, any function that does `ctx.clustersService.foo` will have to do `const clusters = useClusters(); clusters.foo` instead. Once that's done, the semantics of those functions change and as a result we don't have to pass as much stuff as arguments since everything gets done by hooks.
</details>