### PR TITLE
Implement the /webapi/devices/webconfirm handler

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -839,6 +839,11 @@ func (h *Handler) bindDefaultEndpoints() {
 	// TODO(bl-nero): DELETE IN 17.0.0
 	h.POST("/webapi/mfa/authenticatechallenge/password", h.WithAuth(h.createAuthenticateChallengeWithPassword))
 
+	// Device Trust.
+	// Do not enforce bearer token for /webconfirm, it is called from outside the
+	// Web UI.
+	h.GET("/webapi/devices/webconfirm", h.WithAuthCookieAndCSRF(h.deviceWebConfirm))
+
 	// trusted clusters
 	h.POST("/webapi/trustedclusters/validate", h.WithUnauthenticatedLimiter(h.validateTrustedCluster))
 

--- a/lib/web/device_trust.go
+++ b/lib/web/device_trust.go
@@ -1,0 +1,82 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package web
+
+import (
+	"net/http"
+
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	"github.com/gravitational/teleport/lib/web/app"
+)
+
+// deviceWebConfirm is the last step in device web authentication, where the
+// "authenticator process" (aka Connect) forwards the DeviceConfirmationToken
+// back to the Auth Server, via the Proxy.
+//
+// GET /webapi/devices/webconfirm?id=a&token=b
+//
+// - id: ID of the confirmation token.
+// - token: raw confirmation token.
+//
+// The result of this call is a redirect to "/web", regardless of the outcome of
+// the ConfirmDeviceWebAuthentication RPC.
+func (h *Handler) deviceWebConfirm(w http.ResponseWriter, r *http.Request, _ httprouter.Params, sessionCtx *SessionContext) (interface{}, error) {
+	query := r.URL.Query()
+
+	// Read input parameters.
+	confirmToken := &devicepb.DeviceConfirmationToken{}
+	confirmToken.Id = query.Get("id")
+	confirmToken.Token = query.Get("token")
+	switch {
+	case confirmToken.Id == "":
+		return nil, trace.BadParameter("parameter id required")
+	case confirmToken.Token == "":
+		return nil, trace.BadParameter("parameter token required")
+	}
+
+	// Use the Proxy identity for this call. Only the Proxy is allowed to do it.
+	devicesClient := h.GetProxyClient().DevicesClient()
+	ctx := r.Context()
+
+	_, err := devicesClient.ConfirmDeviceWebAuthentication(ctx, &devicepb.ConfirmDeviceWebAuthenticationRequest{
+		ConfirmationToken:   confirmToken,
+		CurrentWebSessionId: sessionCtx.GetSessionID(),
+	})
+	switch {
+	case err != nil:
+		h.log.
+			WithError(err).
+			WithField("user", sessionCtx.GetUser()).
+			Warn("Device web authentication confirm failed")
+		// err swallowed on purpose.
+	default:
+		// Preemptively release session from cache, as its certificates are now
+		// updated.
+		// The WebSession watcher takes care of this in other proxy instances
+		// (see [sessionCache.watchWebSessions]).
+		h.auth.releaseResources(sessionCtx.GetUser(), sessionCtx.GetSessionID())
+	}
+
+	// Always redirect back to the dashboard, regardless of outcome.
+	app.SetRedirectPageHeaders(w.Header(), "" /* nonce */)
+	http.Redirect(w, r, "/web", http.StatusSeeOther)
+
+	return nil, nil
+}

--- a/lib/web/device_trust_test.go
+++ b/lib/web/device_trust_test.go
@@ -1,0 +1,146 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package web
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+)
+
+func TestHandler_DeviceWebConfirm(t *testing.T) {
+	t.Parallel()
+
+	fakeDevices := &fakeDevicesClient{}
+	wPack := newWebPack(
+		t,
+		1, /* numProxies */
+		withDevicesClientOverride(fakeDevices),
+	)
+
+	proxy := wPack.proxies[0]
+	aPack := proxy.authPack(t, "llama", nil /* roles */)
+	webClient := aPack.clt
+
+	ctx := context.Background()
+
+	t.Run("ok", func(t *testing.T) {
+		query := make(url.Values)
+		query.Set("id", "my-token-id")
+		query.Set("token", "my-token-token")
+
+		// Detect client redirects.
+		var redirected bool
+		httpClient := webClient.HTTPClient()
+		httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			// Ignore any subsequent redirects that may happen.
+			if redirected {
+				return nil
+			}
+
+			redirected = true
+			if !assert.Len(t, via, 1, "CheckRedirect param via has an unexpected length") {
+				return nil
+			}
+			src := via[0]
+
+			// Host didn't change, ie redirect is within the same Proxy.
+			assert.Equal(t, src.URL.Host, req.URL.Host, "CheckRedirect Host mismatch")
+			// Redirect target is as expected.
+			assert.Equal(t, "/web", req.URL.Path, "CheckRedirect dest Path mismatch")
+			// Redirect source is as expected.
+			assert.Regexp(t, "/webapi/devices/webconfirm$", src.URL.Path, "CheckRedirect src Path mismatch")
+
+			return nil
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "GET", webClient.Endpoint("webapi", "devices", "webconfirm"), nil /* body */)
+		require.NoError(t, err, "NewRequestWithContext failed")
+		req.URL.RawQuery = query.Encode()
+
+		// Request using the httpClient, this shows we don't need the bearer token
+		// logic from webclient.
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err, "GET /webapi/devices/webconfirm failed")
+		// Always drain and close the body.
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		// Verify redirect and response status.
+		assert.True(t, redirected, "GET /webapi/devices/webconfirm didn't cause a redirect")
+		assert.Equal(t, 200, resp.StatusCode, "GET /webapi/devices/webconfirm code mismatch")
+
+		// Verify RPC call.
+		got := fakeDevices.resetConfirmRequests()
+		want := []*devicepb.ConfirmDeviceWebAuthenticationRequest{
+			{
+				ConfirmationToken: &devicepb.DeviceConfirmationToken{
+					Id:    "my-token-id",
+					Token: "my-token-token",
+				},
+			},
+		}
+		// Copy WebSessionID from got to want.
+		if len(got) > 0 {
+			webSessionID := got[0].CurrentWebSessionId
+			assert.NotEmpty(t, webSessionID, "ConfirmDeviceWebAuthentication called with empty WebSessionID")
+			want[0].CurrentWebSessionId = webSessionID
+		}
+		if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+			t.Errorf("ConfirmDeviceWebAuthentication requests mismatch (-want +got)\n%s", diff)
+		}
+	})
+}
+
+type fakeDevicesClient struct {
+	devicepb.DeviceTrustServiceClient // used only to "implement" the interface, typically left nil
+
+	mu                    sync.Mutex
+	confirmDeviceRequests []*devicepb.ConfirmDeviceWebAuthenticationRequest
+}
+
+func (f *fakeDevicesClient) ConfirmDeviceWebAuthentication(ctx context.Context, req *devicepb.ConfirmDeviceWebAuthenticationRequest, opts ...grpc.CallOption) (*devicepb.ConfirmDeviceWebAuthenticationResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Save request for later inspection.
+	f.confirmDeviceRequests = append(f.confirmDeviceRequests, req)
+
+	// Successful response.
+	return &devicepb.ConfirmDeviceWebAuthenticationResponse{}, nil
+}
+
+func (f *fakeDevicesClient) resetConfirmRequests() []*devicepb.ConfirmDeviceWebAuthenticationRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	reqs := f.confirmDeviceRequests
+	f.confirmDeviceRequests = nil
+
+	return reqs
+}


### PR DESCRIPTION
The "/webconfirm" handler forwards a DeviceConfirmationToken to Auth, along with the current session ID. This is the last step in the [token move check][1], and the last step of device web authentication.

I've changed the RFD path from "/webapi/**device**/webconfirm" to "/webapi/**devices**/webconfirm". Plural seems more appropriate.

https://github.com/gravitational/teleport.e/issues/3236

[1]: https://github.com/gravitational/teleport.e/blob/master/rfd/0009e-device-trust-web-support.md#the-token-move-check