### PR TITLE
[v15] Mention in the documentation that we ignore "kube-system" and "kube-public" namespaces for kube app discovery

### DIFF
--- a/docs/pages/auto-discovery/kubernetes-applications/architecture.mdx
+++ b/docs/pages/auto-discovery/kubernetes-applications/architecture.mdx
@@ -16,7 +16,8 @@ Kubernetes application auto-discovery consists of two parts:
 
 The Discovery Service running in a Kubernetes cluster will periodically list services and filter them out
 according to the matchers specified in `kubernetes` filed of the service config. You can filter services based on
-types, namespaces and service labels. All services by default currently 
+types, namespaces and service labels. Services running in the `kube-system` and `kube-public` namespaces are
+ automatically ignored. All services by default currently
 are considered of an "app" type, but it can be changed for a service by Kubernetes annotation [`teleport.dev/discovery-type`](./reference.mdx#teleportdevdiscovery-type).
 If type of a service doesn't equal the one specified in the matcher, service is ignored.
 

--- a/docs/pages/reference/helm-reference/includes/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/includes/zz_generated.teleport-kube-agent.mdx
@@ -435,6 +435,10 @@ the agent to provide access to them. See [the Kubernetes App Discovery
 documentation](../../../auto-discovery/kubernetes-applications/architecture.mdx)
 for more details.
 
+<Admonition type="note">
+The Discovery mechanism ignores Kubernetes services running in the `kube-system` and
+`kube-public` namespaces.
+</Admonition>
 The default value will try to discover all apps running in Kubernetes.
 The discovery can be restricted through this value. For example:
 

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -384,9 +384,10 @@ databaseResources: []
 # documentation](../../../auto-discovery/kubernetes-applications/architecture.mdx)
 # for more details.
 #
-# NOTE: Discovery mechanism ignores Kubernetes services running in the "kube-system" and
-# "kube-public" namespaces.
-#
+# <Admonition type="note">
+# The Discovery mechanism ignores Kubernetes services running in the `kube-system` and
+# `kube-public` namespaces.
+# </Admonition>
 # The default value will try to discover all apps running in Kubernetes.
 # The discovery can be restricted through this value. For example:
 #

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -384,6 +384,9 @@ databaseResources: []
 # documentation](../../../auto-discovery/kubernetes-applications/architecture.mdx)
 # for more details.
 #
+# NOTE: Discovery mechanism ignores Kubernetes services running in the "kube-system" and
+# "kube-public" namespaces.
+#
 # The default value will try to discover all apps running in Kubernetes.
 # The discovery can be restricted through this value. For example:
 #


### PR DESCRIPTION
Backport #40529 to branch/v15