### PR TITLE
docs: update docs cert validity period descriptions

### DIFF
--- a/docs/pages/database-access/guides/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/guides/oracle-self-hosted.mdx
@@ -67,7 +67,7 @@ Follow the instructions below to generate TLS credentials for your database.
 
 ```code
 # Export Teleport's certificate authority and a generated certificate/key pair
-# for host db.example.com with a 1-year validity period.
+# for host db.example.com with a 3-month validity period.
 $ tctl auth sign --format=oracle --host=db.example.com --out=server --ttl=2190h
 ```
 

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -45,7 +45,7 @@ Create the secrets:
 
 ```code
 # Export Teleport's certificate authority and a generate certificate/key pair
-# for host db.example.com with a 1-year validity period.
+# for host db.example.com with a 3-month validity period.
 $ tctl auth sign --format=db --host=db.example.com --out=server --ttl=2190h
 ```
 

--- a/docs/pages/database-access/troubleshooting.mdx
+++ b/docs/pages/database-access/troubleshooting.mdx
@@ -24,7 +24,7 @@ to create a certificate for PostgreSQL, the command looks like this:
 
 ```bash
 # Export Teleport's certificate authority and a generate certificate/key pair
-# for host db.example.com with a 1-year validity period.
+# for host db.example.com with a 3-month validity period.
 
 $ tctl auth sign --format=db --host=db.example.com --out=server --ttl=2190h
 ```


### PR DESCRIPTION
The description did not match the period for the certs being made.