### PR TITLE
Allow dynamic AWS Session provider

### DIFF
--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1167,4 +1167,7 @@ type ClientI interface {
 
 	// GetClusterAccessGraphConfig retrieves the cluster Access Graph configuration from Auth server.
 	GetClusterAccessGraphConfig(ctx context.Context) (*clusterconfigpb.AccessGraphConfig, error)
+
+	// GenerateAppToken creates a JWT token with application access.
+	GenerateAppToken(ctx context.Context, req types.GenerateAppTokenRequest) (string, error)
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -146,6 +146,7 @@ import (
 	"github.com/gravitational/teleport/lib/system"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 	"github.com/gravitational/teleport/lib/utils/cert"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 	vc "github.com/gravitational/teleport/lib/versioncontrol"
@@ -5463,18 +5464,19 @@ func (process *TeleportProcess) initApps() {
 		}
 
 		connectionsHandler, err := app.NewConnectionsHandler(process.ExitContext(), &app.ConnectionsHandlerConfig{
-			Clock:             process.Config.Clock,
-			DataDir:           process.Config.DataDir,
-			AuthClient:        conn.Client,
-			AccessPoint:       accessPoint,
-			Authorizer:        authorizer,
-			TLSConfig:         tlsConfig,
-			CipherSuites:      process.Config.CipherSuites,
-			HostID:            process.Config.HostUUID,
-			Emitter:           asyncEmitter,
-			ConnectionMonitor: connMonitor,
-			ServiceComponent:  teleport.ComponentApp,
-			Logger:            logger,
+			Clock:              process.Config.Clock,
+			DataDir:            process.Config.DataDir,
+			AuthClient:         conn.Client,
+			AccessPoint:        accessPoint,
+			Authorizer:         authorizer,
+			TLSConfig:          tlsConfig,
+			CipherSuites:       process.Config.CipherSuites,
+			HostID:             process.Config.HostUUID,
+			Emitter:            asyncEmitter,
+			ConnectionMonitor:  connMonitor,
+			ServiceComponent:   teleport.ComponentApp,
+			Logger:             logger,
+			AWSSessionProvider: awsutils.SessionProviderUsingAmbientCredentials(),
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/app/aws/handler_test.go
+++ b/lib/srv/app/aws/handler_test.go
@@ -518,6 +518,7 @@ func createSuite(t *testing.T, mockAWSHandler http.HandlerFunc, app types.Applic
 	})
 
 	svc, err := awsutils.NewSigningService(awsutils.SigningServiceConfig{
+		SessionProvider:   awsutils.SessionProviderUsingAmbientCredentials(),
 		CredentialsGetter: awsutils.NewStaticCredentialsGetter(staticAWSCredentials),
 		Clock:             clock,
 	})

--- a/lib/srv/app/cloud.go
+++ b/lib/srv/app/cloud.go
@@ -19,6 +19,7 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -31,7 +32,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/ssocreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -39,7 +39,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/tlsca"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
@@ -48,7 +47,7 @@ import (
 // sign in URLs for management consoles.
 type Cloud interface {
 	// GetAWSSigninURL generates AWS management console federation sign-in URL.
-	GetAWSSigninURL(AWSSigninRequest) (*AWSSigninResponse, error)
+	GetAWSSigninURL(context.Context, AWSSigninRequest) (*AWSSigninResponse, error)
 }
 
 // AWSSigninRequest is a request to generate AWS console signin URL.
@@ -61,6 +60,11 @@ type AWSSigninRequest struct {
 	Issuer string
 	// ExternalID is the AWS external ID.
 	ExternalID string
+	// Integration is the Integration name to use to generate credentials.
+	// If empty, it will use ambient credentials
+	Integration string
+	// Region is the AWS region to used with the Integration to generate credentials.
+	Region string
 }
 
 // CheckAndSetDefaults validates the request.
@@ -89,29 +93,16 @@ type AWSSigninResponse struct {
 
 // CloudConfig is the configuration for cloud service.
 type CloudConfig struct {
-	// Session is AWS session.
-	Session *awssession.Session
+	// SessionGetter returns an AWS session.
+	SessionGetter awsutils.AWSSessionProvider
 	// Clock is used to override time in tests.
 	Clock clockwork.Clock
 }
 
 // CheckAndSetDefaults validates the config.
 func (c *CloudConfig) CheckAndSetDefaults() error {
-	if c.Session == nil {
-		useFIPSEndpoint := endpoints.FIPSEndpointStateUnset
-		if modules.GetModules().IsBoringBinary() {
-			useFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
-		}
-		session, err := awssession.NewSessionWithOptions(awssession.Options{
-			SharedConfigState: awssession.SharedConfigEnable,
-			Config: aws.Config{
-				UseFIPSEndpoint: useFIPSEndpoint,
-			},
-		})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		c.Session = session
+	if c.SessionGetter == nil {
+		return trace.BadParameter("missing session getter")
 	}
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()
@@ -138,14 +129,14 @@ func NewCloud(cfg CloudConfig) (Cloud, error) {
 // GetAWSSigninURL generates AWS management console federation sign-in URL.
 //
 // https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html
-func (c *cloud) GetAWSSigninURL(req AWSSigninRequest) (*AWSSigninResponse, error) {
+func (c *cloud) GetAWSSigninURL(ctx context.Context, req AWSSigninRequest) (*AWSSigninResponse, error) {
 	err := req.CheckAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	federationURL := getFederationURL(req.TargetURL)
-	signinToken, err := c.getAWSSigninToken(&req, federationURL)
+	signinToken, err := c.getAWSSigninToken(ctx, &req, federationURL)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -170,7 +161,7 @@ func (c *cloud) GetAWSSigninURL(req AWSSigninRequest) (*AWSSigninResponse, error
 // getAWSSigninToken gets the signin token required for the AWS sign in URL.
 //
 // https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html
-func (c *cloud) getAWSSigninToken(req *AWSSigninRequest, endpoint string, options ...func(*stscreds.AssumeRoleProvider)) (string, error) {
+func (c *cloud) getAWSSigninToken(ctx context.Context, req *AWSSigninRequest, endpoint string, options ...func(*stscreds.AssumeRoleProvider)) (string, error) {
 	// It is stated in the user guide linked above:
 	// When you use DurationSeconds in an AssumeRole* operation, you must call
 	// it as an IAM user with long-term credentials. Otherwise, the call to the
@@ -181,7 +172,12 @@ func (c *cloud) getAWSSigninToken(req *AWSSigninRequest, endpoint string, option
 	// the AWS session is using temporary credentials. However, when the
 	// "SessionDuration" is not provided, the web console session duration will
 	// be bound to the duration used in the next AssumeRole call.
-	temporarySession, err := isSessionUsingTemporaryCredentials(c.cfg.Session)
+	session, err := c.cfg.SessionGetter(ctx, req.Region, req.Integration)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	temporarySession, err := isSessionUsingTemporaryCredentials(session)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -215,7 +211,7 @@ func (c *cloud) getAWSSigninToken(req *AWSSigninRequest, endpoint string, option
 			creds.ExternalID = aws.String(req.ExternalID)
 		}
 	})
-	stsCredentials, err := stscreds.NewCredentials(c.cfg.Session, req.Identity.RouteToApp.AWSRoleARN, options...).Get()
+	stsCredentials, err := stscreds.NewCredentials(session, req.Identity.RouteToApp.AWSRoleARN, options...).Get()
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/srv/db/dynamodb/engine.go
+++ b/lib/srv/db/dynamodb/engine.go
@@ -146,7 +146,7 @@ func (e *Engine) HandleConnection(ctx context.Context, _ *common.Session) error 
 	}
 	signer, err := libaws.NewSigningService(libaws.SigningServiceConfig{
 		Clock:             e.Clock,
-		Session:           awsSession,
+		SessionProvider:   libaws.StaticAWSSessionProvider(awsSession),
 		CredentialsGetter: e.CredentialsGetter,
 	})
 	if err != nil {

--- a/lib/srv/db/opensearch/engine.go
+++ b/lib/srv/db/opensearch/engine.go
@@ -147,7 +147,7 @@ func (e *Engine) HandleConnection(ctx context.Context, _ *common.Session) error 
 	}
 	signer, err := libaws.NewSigningService(libaws.SigningServiceConfig{
 		Clock:             e.Clock,
-		Session:           awsSession,
+		SessionProvider:   libaws.StaticAWSSessionProvider(awsSession),
 		CredentialsGetter: e.CredentialsGetter,
 	})
 	if err != nil {

--- a/lib/utils/aws/credentials.go
+++ b/lib/utils/aws/credentials.go
@@ -28,11 +28,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -193,4 +196,45 @@ func (g *staticCredentialsGetter) Get(_ context.Context, _ GetCredentialsRequest
 		return nil, trace.NotFound("no credentials found")
 	}
 	return g.credentials, nil
+}
+
+// AWSSessionProvider defines a function that creates an AWS Session.
+// It must use ambient credentials if Integration is empty.
+// It must use Integration credentials otherwise.
+type AWSSessionProvider func(ctx context.Context, region string, integration string) (*session.Session, error)
+
+// StaticAWSSessionProvider is a helper method that returns a statis session.
+// Must not be used to provide sessions when using Integrations.
+func StaticAWSSessionProvider(awsSession *session.Session) AWSSessionProvider {
+	return func(ctx context.Context, region, integration string) (*session.Session, error) {
+		if integration != "" {
+			return nil, trace.BadParameter("integration %q is not allowed to use static sessions", integration)
+		}
+		return awsSession, nil
+	}
+}
+
+// SessionProviderUsingAmbientCredentials returns an AWS Session using ambient credentials.
+// This is in contrast with AWS Sessions that can be generated using an AWS OIDC Integration.
+func SessionProviderUsingAmbientCredentials() AWSSessionProvider {
+	return func(ctx context.Context, region, integration string) (*session.Session, error) {
+		if integration != "" {
+			return nil, trace.BadParameter("integration %q is not allowed to use ambient sessions", integration)
+		}
+		useFIPSEndpoint := endpoints.FIPSEndpointStateUnset
+		if modules.GetModules().IsBoringBinary() {
+			useFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+		}
+		session, err := session.NewSessionWithOptions(session.Options{
+			SharedConfigState: session.SharedConfigEnable,
+			Config: aws.Config{
+				UseFIPSEndpoint: useFIPSEndpoint,
+			},
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return session, nil
+	}
 }

--- a/lib/utils/aws/credentials.go
+++ b/lib/utils/aws/credentials.go
@@ -203,7 +203,7 @@ func (g *staticCredentialsGetter) Get(_ context.Context, _ GetCredentialsRequest
 // It must use Integration credentials otherwise.
 type AWSSessionProvider func(ctx context.Context, region string, integration string) (*session.Session, error)
 
-// StaticAWSSessionProvider is a helper method that returns a statis session.
+// StaticAWSSessionProvider is a helper method that returns a static session.
 // Must not be used to provide sessions when using Integrations.
 func StaticAWSSessionProvider(awsSession *session.Session) AWSSessionProvider {
 	return func(ctx context.Context, region, integration string) (*session.Session, error) {


### PR DESCRIPTION
Up until now, all the AWS Sessions used in App Access were generated using the ambient credentials.

This PRs changes this and allows for custom AWS Session Providers. This will allow the Session to be created from an Integration.

Another PR will be created where this is used to allow AWS OIDC to be used as an AWS Session Provider.