### PR TITLE
Use AWS OIDC Integration for AWS App Access

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4161,6 +4161,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Proxy:            tsrv,
 			AuthServers:      cfg.AuthServerAddresses()[0],
 			DomainName:       cfg.Hostname,
+			DataDir:          cfg.DataDir,
 			ProxyClient:      conn.Client,
 			ProxySSHAddr:     proxySSHAddr,
 			ProxyWebAddr:     cfg.Proxy.WebAddr,

--- a/lib/srv/app/aws/handler.go
+++ b/lib/srv/app/aws/handler.go
@@ -173,6 +173,7 @@ func (s *signerHandler) serveCommonRequest(sessCtx *common.SessionContext, w htt
 			SessionName:   sessCtx.Identity.Username,
 			AWSRoleArn:    sessCtx.Identity.RouteToApp.AWSRoleARN,
 			AWSExternalID: sessCtx.App.GetAWSExternalID(),
+			Integration:   sessCtx.App.GetIntegration(),
 		})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/app/cloud.go
+++ b/lib/srv/app/cloud.go
@@ -63,8 +63,6 @@ type AWSSigninRequest struct {
 	// Integration is the Integration name to use to generate credentials.
 	// If empty, it will use ambient credentials
 	Integration string
-	// Region is the AWS region to used with the Integration to generate credentials.
-	Region string
 }
 
 // CheckAndSetDefaults validates the request.
@@ -172,7 +170,10 @@ func (c *cloud) getAWSSigninToken(ctx context.Context, req *AWSSigninRequest, en
 	// the AWS session is using temporary credentials. However, when the
 	// "SessionDuration" is not provided, the web console session duration will
 	// be bound to the duration used in the next AssumeRole call.
-	session, err := c.cfg.SessionGetter(ctx, req.Region, req.Integration)
+
+	// Sign In requests target IAM endpoints which don't require a region.
+	region := ""
+	session, err := c.cfg.SessionGetter(ctx, region, req.Integration)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -485,10 +485,11 @@ func (c *ConnectionsHandler) serveAWSWebConsole(w http.ResponseWriter, r *http.R
 	)
 
 	url, err := c.cfg.Cloud.GetAWSSigninURL(r.Context(), AWSSigninRequest{
-		Identity:   identity,
-		TargetURL:  app.GetURI(),
-		Issuer:     app.GetPublicAddr(),
-		ExternalID: app.GetAWSExternalID(),
+		Identity:    identity,
+		TargetURL:   app.GetURI(),
+		Issuer:      app.GetPublicAddr(),
+		ExternalID:  app.GetAWSExternalID(),
+		Integration: app.GetIntegration(),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -81,17 +81,20 @@ type Suite struct {
 	appServer    *Server
 	hostCertPool *x509.CertPool
 
-	hostUUID              string
-	closeContext          context.Context
-	closeFunc             context.CancelFunc
-	message               string
-	hostport              string
-	testhttp              *httptest.Server
-	clientCertificate     tls.Certificate
-	awsConsoleCertificate tls.Certificate
+	hostUUID     string
+	closeContext context.Context
+	closeFunc    context.CancelFunc
+	message      string
+	hostport     string
+	testhttp     *httptest.Server
 
-	appFoo *types.AppV3
-	appAWS *types.AppV3
+	clientCertificate                    tls.Certificate
+	awsConsoleCertificate                tls.Certificate
+	awsConsoleCertificateWithIntegration tls.Certificate
+
+	appFoo                *types.AppV3
+	appAWS                *types.AppV3
+	appAWSWithIntegration *types.AppV3
 
 	user       types.User
 	role       types.Role
@@ -287,6 +290,15 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		PublicAddr: "aws.example.com",
 	})
 	require.NoError(t, err)
+	s.appAWSWithIntegration, err = types.NewAppV3(types.Metadata{
+		Name:   "awsconsole-integration",
+		Labels: staticLabels,
+	}, types.AppSpecV3{
+		URI:         constants.AWSConsoleURL,
+		PublicAddr:  "aws-integration.example.com",
+		Integration: "my-integration",
+	})
+	require.NoError(t, err)
 
 	// Create a client with a machine role of RoleApp.
 	s.authClient, err = s.tlsServer.NewClient(auth.TestServerID(types.RoleApp, s.hostUUID))
@@ -308,6 +320,9 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	// Generate certificate for AWS console application.
 	s.awsConsoleCertificate = s.generateCertificate(t, s.user, "aws.example.com", "arn:aws:iam::123456789012:role/readonly")
 
+	// Generate certificate for AWS console application with integration
+	s.awsConsoleCertificateWithIntegration = s.generateCertificate(t, s.user, "aws-integration.example.com", "arn:aws:iam::123456789012:role/readonly")
+
 	lockWatcher, err := services.NewLockWatcher(s.closeContext, services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.ComponentApp,
@@ -326,7 +341,7 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		lockWatcher.Close()
 	})
 
-	apps := types.Apps{s.appFoo.Copy(), s.appAWS.Copy()}
+	apps := types.Apps{s.appFoo.Copy(), s.appAWS.Copy(), s.appAWSWithIntegration.Copy()}
 	if len(config.Apps) > 0 {
 		apps = config.Apps
 	}
@@ -414,6 +429,7 @@ func TestStart(t *testing.T) {
 	// check that the dynamic labels have been evaluated.
 	appFoo := s.appFoo.Copy()
 	appAWS := s.appAWS.Copy()
+	appAWSWithIntegration := s.appAWSWithIntegration.Copy()
 
 	appFoo.SetDynamicLabels(map[string]types.CommandLabel{
 		dynamicLabelName: &types.CommandLabelV2{
@@ -427,9 +443,11 @@ func TestStart(t *testing.T) {
 	require.NoError(t, err)
 	serverAWS, err := types.NewAppServerV3FromApp(appAWS, "test", s.hostUUID)
 	require.NoError(t, err)
+	serverAWSWithIntegration, err := types.NewAppServerV3FromApp(appAWSWithIntegration, "test", s.hostUUID)
+	require.NoError(t, err)
 
 	sort.Sort(types.AppServers(servers))
-	require.Empty(t, cmp.Diff([]types.AppServer{serverAWS, serverFoo}, servers,
+	require.Empty(t, cmp.Diff([]types.AppServer{serverAWS, serverAWSWithIntegration, serverFoo}, servers,
 		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision", "Expires")))
 
 	// Check the expiry time is correct.
@@ -980,7 +998,17 @@ func TestSessionClose(t *testing.T) {
 // TestAWSConsoleRedirect verifies AWS management console access.
 func TestAWSConsoleRedirect(t *testing.T) {
 	s := SetUpSuite(t)
+
+	// Using ambient credentials.
 	s.checkHTTPResponse(t, s.awsConsoleCertificate, func(resp *http.Response) {
+		require.Equal(t, http.StatusFound, resp.StatusCode)
+		location, err := resp.Location()
+		require.NoError(t, err)
+		require.Equal(t, "https://signin.aws.amazon.com", location.String())
+	})
+
+	// Using an Integration.
+	s.checkHTTPResponse(t, s.awsConsoleCertificateWithIntegration, func(resp *http.Response) {
 		require.Equal(t, http.StatusFound, resp.StatusCode)
 		location, err := resp.Location()
 		require.NoError(t, err)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -494,7 +494,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 		GetProxyIdentity: func() (*auth.Identity, error) {
 			return proxyIdentity, nil
 		},
-		DataDir: t.TempDir(),
+		IntegrationAppHandler: &mockIntegrationAppHandler{},
 	}
 
 	if handlerConfig.HealthCheckAppServer == nil {
@@ -8069,7 +8069,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		GetProxyIdentity: func() (*auth.Identity, error) {
 			return proxyIdentity, nil
 		},
-		DataDir: t.TempDir(),
+		IntegrationAppHandler: &mockIntegrationAppHandler{},
 	}, SetSessionStreamPollPeriod(200*time.Millisecond), SetClock(clock))
 	require.NoError(t, err)
 
@@ -8116,6 +8116,10 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		webURL:  *url,
 	}
 }
+
+type mockIntegrationAppHandler struct{}
+
+func (m *mockIntegrationAppHandler) HandleConnection(_ net.Conn) {}
 
 // webPack represents the state of a single web test.
 // It replicates most of the WebSuite and serves to gradually

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -459,6 +459,14 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	if cfg.ClusterFeatures != nil {
 		features = *cfg.ClusterFeatures
 	}
+	authID := auth.IdentityID{
+		Role:     types.RoleProxy,
+		HostUUID: proxyID,
+	}
+	dns := []string{"localhost", "127.0.0.1"}
+	proxyIdentity, err := auth.LocalRegister(authID, s.server.Auth(), nil, dns, "", nil)
+	require.NoError(t, err)
+
 	handlerConfig := Config{
 		ClusterFeatures:                 features,
 		Proxy:                           revTunServer,
@@ -483,6 +491,10 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 		UI:                   cfg.uiConfig,
 		OpenAIConfig:         cfg.OpenAIConfig,
 		PresenceChecker:      cfg.presenceChecker,
+		GetProxyIdentity: func() (*auth.Identity, error) {
+			return proxyIdentity, nil
+		},
+		DataDir: t.TempDir(),
 	}
 
 	if handlerConfig.HealthCheckAppServer == nil {
@@ -8025,6 +8037,14 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 
 	fs, err := newDebugFileSystem()
 	require.NoError(t, err)
+
+	authID := auth.IdentityID{
+		Role:     types.RoleProxy,
+		HostUUID: proxyID,
+	}
+	dns := []string{"localhost", "127.0.0.1"}
+	proxyIdentity, err := auth.LocalRegister(authID, authServer.Auth(), nil, dns, "", nil)
+	require.NoError(t, err)
 	handler, err := NewHandler(Config{
 		Proxy:            revTunServer,
 		AuthServers:      utils.FromAddr(authServer.Addr()),
@@ -8046,6 +8066,10 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		Router:                         router,
 		HealthCheckAppServer:           func(context.Context, string, string) error { return nil },
 		MinimalReverseTunnelRoutesOnly: cfg.minimalHandler,
+		GetProxyIdentity: func() (*auth.Identity, error) {
+			return proxyIdentity, nil
+		},
+		DataDir: t.TempDir(),
 	}, SetSessionStreamPollPeriod(200*time.Millisecond), SetClock(clock))
 	require.NoError(t, err)
 

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -30,20 +30,28 @@ import (
 	"net/url"
 	"path"
 
+	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/julienschmidt/httprouter"
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv"
+	srvapp "github.com/gravitational/teleport/lib/srv/app"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
 // HandlerConfig is the configuration for an application handler.
@@ -63,6 +71,14 @@ type HandlerConfig struct {
 	CipherSuites []uint16
 	// WebPublicAddr
 	WebPublicAddr string
+	// Emitter is event emitter
+	Emitter apievents.Emitter
+	// DataDir is the path to the data directory for the server.
+	DataDir string
+	// HostID is the id of the host where this application agent is running.
+	HostID string
+	// ProxyTLSConfig contains the current proxy's TLS config.
+	ProxyTLSConfig *tls.Config
 }
 
 // CheckAndSetDefaults validates configuration.
@@ -79,6 +95,18 @@ func (c *HandlerConfig) CheckAndSetDefaults() error {
 	}
 	if len(c.CipherSuites) == 0 {
 		return trace.BadParameter("ciphersuites missing")
+	}
+	if c.Emitter == nil {
+		return trace.BadParameter("event emitter missing")
+	}
+	if c.DataDir == "" {
+		return trace.BadParameter("datadir missing")
+	}
+	if c.HostID == "" {
+		return trace.BadParameter("hostid missing")
+	}
+	if c.ProxyTLSConfig == nil {
+		return trace.BadParameter("proxy tls config missing")
 	}
 
 	return nil
@@ -97,6 +125,9 @@ type Handler struct {
 	clusterName string
 
 	log *logrus.Entry
+
+	integrationsAppHandler *srvapp.ConnectionsHandler
+	awsSessionGetter       awsutils.AWSSessionProvider
 }
 
 // NewHandler returns a new application handler.
@@ -112,6 +143,13 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 		log: logrus.WithFields(logrus.Fields{
 			teleport.ComponentKey: teleport.ComponentAppProxy,
 		}),
+		awsSessionGetter: func(ctx context.Context, region, integration string) (*awssession.Session, error) {
+			if integration == "" {
+				return awsutils.SessionProviderUsingAmbientCredentials()(ctx, region, integration)
+			}
+
+			return awsoidc.NewSessionV1(ctx, c.AuthClient, region, integration)
+		},
 	}
 
 	// Create a new session cache, this holds sessions that can be used to
@@ -128,6 +166,61 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 	}
 	h.clusterName = cn.GetClusterName()
 
+	lockWatcher, err := services.NewLockWatcher(h.closeContext, services.LockWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentWebProxy,
+			Log:       h.log,
+			Client:    h.c.AuthClient,
+			Clock:     h.c.Clock,
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
+		ClusterName: h.clusterName,
+		AccessPoint: h.c.AccessPoint,
+		LockWatcher: lockWatcher,
+		Logger:      h.log,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	connMonitor, err := srv.NewConnectionMonitor(srv.ConnectionMonitorConfig{
+		AccessPoint:    h.c.AccessPoint,
+		LockWatcher:    lockWatcher,
+		Clock:          h.c.Clock,
+		ServerID:       h.c.HostID,
+		Emitter:        h.c.Emitter,
+		EmitterContext: h.closeContext,
+		Logger:         h.log,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	connectionsHandler, err := srvapp.NewConnectionsHandler(h.closeContext, &srvapp.ConnectionsHandlerConfig{
+		Clock:              h.c.Clock,
+		DataDir:            h.c.DataDir,
+		Emitter:            h.c.Emitter,
+		Authorizer:         authorizer,
+		HostID:             h.c.HostID,
+		AuthClient:         h.c.AuthClient,
+		AccessPoint:        h.c.AccessPoint,
+		TLSConfig:          h.c.ProxyTLSConfig,
+		ConnectionMonitor:  connMonitor,
+		CipherSuites:       h.c.CipherSuites,
+		ServiceComponent:   teleport.ComponentWebProxy,
+		AWSSessionProvider: h.awsSessionGetter,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	connectionsHandler.SetApplicationsProvider(h.appForPublicEndpoint)
+	h.integrationsAppHandler = connectionsHandler
+
 	// Create the application routes.
 	h.router = httprouter.New()
 	h.router.UseRawPath = true
@@ -143,6 +236,22 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 	h.router.NotFound = h.withAuth(h.handleHttp)
 
 	return h, nil
+}
+
+// appForPublicEndpoint returns an App given a public endpoint.
+// If no app is found for the given public endpoint, trace.NotFound is returned.
+func (h *Handler) appForPublicEndpoint(ctx context.Context, publicAddr string) (types.Application, error) {
+	allAppServers, err := h.c.AccessPoint.GetApplicationServers(ctx, defaults.Namespace)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	publicAddressMatcher := MatchPublicAddr(publicAddr)
+	for _, a := range allAppServers {
+		if publicAddressMatcher(ctx, a) {
+			return a.GetApp(), nil
+		}
+	}
+	return nil, trace.NotFound("no app found for endpoint %q", publicAddr)
 }
 
 // ServeHTTP hands the request to the request router.

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -245,9 +245,9 @@ func (h *Handler) appForPublicEndpoint(ctx context.Context, publicAddr string) (
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	publicAddressMatcher := MatchPublicAddr(publicAddr)
+	publicAddressMatches := MatchPublicAddr(publicAddr)
 	for _, a := range allAppServers {
-		if publicAddressMatcher(ctx, a) {
+		if publicAddressMatches(ctx, a) {
 			return a.GetApp(), nil
 		}
 	}

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -714,15 +714,12 @@ func TestHealthCheckAppServer(t *testing.T) {
 			}
 
 			appHandler, err := NewHandler(ctx, &HandlerConfig{
-				Clock:          fakeClock,
-				AuthClient:     authClient,
-				AccessPoint:    authClient,
-				ProxyClient:    tunnel,
-				CipherSuites:   utils.DefaultCipherSuites(),
-				DataDir:        t.TempDir(),
-				HostID:         uuid.NewString(),
-				Emitter:        authClient,
-				ProxyTLSConfig: utils.TLSConfig(utils.DefaultCipherSuites()),
+				Clock:                 fakeClock,
+				AuthClient:            authClient,
+				AccessPoint:           authClient,
+				ProxyClient:           tunnel,
+				CipherSuites:          utils.DefaultCipherSuites(),
+				IntegrationAppHandler: &mockIntegrationAppHandler{},
 			})
 			require.NoError(t, err)
 
@@ -739,16 +736,13 @@ type testServer struct {
 
 func setup(t *testing.T, clock clockwork.FakeClock, authClient auth.ClientI, proxyClient reversetunnelclient.Tunnel, proxyPublicAddrs []utils.NetAddr) *testServer {
 	appHandler, err := NewHandler(context.Background(), &HandlerConfig{
-		Clock:            clock,
-		AuthClient:       authClient,
-		AccessPoint:      authClient,
-		ProxyClient:      proxyClient,
-		CipherSuites:     utils.DefaultCipherSuites(),
-		ProxyPublicAddrs: proxyPublicAddrs,
-		DataDir:          t.TempDir(),
-		HostID:           uuid.NewString(),
-		Emitter:          authClient,
-		ProxyTLSConfig:   utils.TLSConfig(utils.DefaultCipherSuites()),
+		Clock:                 clock,
+		AuthClient:            authClient,
+		AccessPoint:           authClient,
+		ProxyClient:           proxyClient,
+		CipherSuites:          utils.DefaultCipherSuites(),
+		ProxyPublicAddrs:      proxyPublicAddrs,
+		IntegrationAppHandler: &mockIntegrationAppHandler{},
 	})
 	require.NoError(t, err)
 

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -108,6 +108,12 @@ func MatchHealthy(proxyClient reversetunnelclient.Tunnel, clusterName string) Ma
 			return true
 		}
 
+		// Apps that use the Integration should use its credentials which are obtained in Proxy.
+		// There's no need for an ApplicationService in this scenario.
+		if appServer.GetApp().GetIntegration() != "" {
+			return true
+		}
+
 		conn, err := dialAppServer(ctx, proxyClient, clusterName, appServer)
 		if err != nil {
 			return false

--- a/lib/web/app/session.go
+++ b/lib/web/app/session.go
@@ -92,7 +92,7 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 		servers:               servers,
 		ws:                    ws,
 		clusterName:           h.clusterName,
-		integrationAppHandler: h.integrationsAppHandler,
+		integrationAppHandler: h.c.IntegrationAppHandler,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/app/session.go
+++ b/lib/web/app/session.go
@@ -83,15 +83,16 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 
 	// Create a rewriting transport that will be used to forward requests.
 	transport, err := newTransport(&transportConfig{
-		log:          h.log,
-		clock:        h.c.Clock,
-		proxyClient:  h.c.ProxyClient,
-		accessPoint:  h.c.AccessPoint,
-		cipherSuites: h.c.CipherSuites,
-		identity:     identity,
-		servers:      servers,
-		ws:           ws,
-		clusterName:  h.clusterName,
+		log:                   h.log,
+		clock:                 h.c.Clock,
+		proxyClient:           h.c.ProxyClient,
+		accessPoint:           h.c.AccessPoint,
+		cipherSuites:          h.c.CipherSuites,
+		identity:              identity,
+		servers:               servers,
+		ws:                    ws,
+		clusterName:           h.clusterName,
+		integrationAppHandler: h.integrationsAppHandler,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -45,6 +45,13 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+// ServerHandler implements an interface which can handle a connection
+// (perform a handshake then process).
+type ServerHandler interface {
+	// HandleConnection performs a handshake then process the connection.
+	HandleConnection(conn net.Conn)
+}
+
 // transportConfig is configuration for a rewriting transport.
 type transportConfig struct {
 	proxyClient  reversetunnelclient.Tunnel
@@ -56,6 +63,10 @@ type transportConfig struct {
 	clusterName  string
 	log          logrus.FieldLogger
 	clock        clockwork.Clock
+
+	// integrationAppHandler is used to handle App proxy requests for Apps that are configured to use an Integration.
+	// Instead of proxying the connection to an AppService, the app is immediately proxied from the Proxy.
+	integrationAppHandler ServerHandler
 }
 
 // Check validates configuration.
@@ -80,6 +91,9 @@ func (c *transportConfig) Check() error {
 	}
 	if c.clusterName == "" {
 		return trace.BadParameter("cluster name missing")
+	}
+	if c.integrationAppHandler == nil {
+		return trace.BadParameter("integration app handler missing")
 	}
 	if c.log == nil {
 		c.log = logrus.New()
@@ -349,7 +363,14 @@ func (t *transport) DialContext(ctx context.Context, _, _ string) (conn net.Conn
 	var i int
 	for ; i < len(servers); i++ {
 		appServer := servers[i]
-		appServer.GetApp()
+
+		appIntegration := appServer.GetApp().GetIntegration()
+		if appIntegration != "" {
+			src, dst := net.Pipe()
+			go t.c.integrationAppHandler.HandleConnection(src)
+			return dst, nil
+		}
+
 		conn, err = dialAppServer(ctx, t.c.proxyClient, t.c.identity.RouteToApp.ClusterName, appServer)
 		if err != nil && isReverseTunnelDownError(err) {
 			t.c.log.WithFields(logrus.Fields{"app_server": appServer.GetName()}).

--- a/lib/web/app/transport_test.go
+++ b/lib/web/app/transport_test.go
@@ -27,10 +27,13 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -88,7 +91,8 @@ func Test_transport_rewriteRedirect(t *testing.T) {
 				caCert:      caCert,
 				clusterName: clusterName,
 			},
-			ws: createAppSession(t, clock, caKey, caCert, clusterName, clusterName),
+			ws:                    createAppSession(t, clock, caKey, caCert, clusterName, clusterName),
+			integrationAppHandler: &mockIntegrationAppHandler{},
 		}
 	}
 
@@ -231,9 +235,9 @@ func TestTransport_DialContextNoServersAvailable(t *testing.T) {
 			},
 			identity: &tlsca.Identity{},
 			servers: []types.AppServer{
-				&types.AppServerV3{},
-				&types.AppServerV3{},
-				&types.AppServerV3{},
+				&types.AppServerV3{Spec: types.AppServerSpecV3{App: &types.AppV3{}}},
+				&types.AppServerV3{Spec: types.AppServerSpecV3{App: &types.AppV3{}}},
+				&types.AppServerV3{Spec: types.AppServerSpecV3{App: &types.AppV3{}}},
 			},
 			log: utils.NewLoggerForTests(),
 		},
@@ -308,7 +312,8 @@ func Test_transport_rewriteRequest(t *testing.T) {
 			caCert:      caCert,
 			clusterName: rootCluster,
 		},
-		ws: appSession,
+		ws:                    appSession,
+		integrationAppHandler: &mockIntegrationAppHandler{},
 	})
 	require.NoError(t, err)
 
@@ -420,4 +425,93 @@ func Test_transport_rewriteRequest(t *testing.T) {
 			})
 		}
 	})
+}
+
+type mockIntegrationAppHandler struct {
+	mu   sync.Mutex
+	conn net.Conn
+}
+
+func (m *mockIntegrationAppHandler) HandleConnection(conn net.Conn) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.conn = conn
+}
+
+func (m *mockIntegrationAppHandler) getConnection() net.Conn {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.conn
+}
+
+func Test_transport_with_integration(t *testing.T) {
+	rootCluster := "root.teleport.example.com"
+
+	caKey, caCert, err := tlsca.GenerateSelfSignedCA(
+		pkix.Name{CommonName: rootCluster},
+		[]string{rootCluster, apiutils.EncodeClusterName(rootCluster)},
+		defaults.CATTL,
+	)
+	require.NoError(t, err)
+
+	appName := "awsconsole"
+	awsApp, err := types.NewAppV3(types.Metadata{Name: appName},
+		types.AppSpecV3{
+			PublicAddr:  fmt.Sprintf("%v.%v", appName, rootCluster),
+			URI:         fmt.Sprintf("https://%v.internal.example.com:8888", appName),
+			Cloud:       types.CloudAWS,
+			Integration: "my-integration",
+		},
+	)
+	require.NoError(t, err)
+
+	awsAppServer, err := types.NewAppServerV3FromApp(awsApp, rootCluster, "awsconsole-server")
+	require.NoError(t, err)
+
+	clock := clockwork.NewFakeClock()
+
+	integrationAppHandler := &mockIntegrationAppHandler{}
+
+	appSession := createAppSession(t, clock, caKey, caCert, rootCluster, rootCluster)
+	tr, err := newTransport(&transportConfig{
+		clock:       clock,
+		clusterName: rootCluster,
+		identity: &tlsca.Identity{
+			RouteToApp: tlsca.RouteToApp{
+				ClusterName: rootCluster,
+				AWSRoleARN:  "MyAWSRole",
+			},
+		},
+		servers:      []types.AppServer{awsAppServer},
+		cipherSuites: utils.DefaultCipherSuites(),
+		proxyClient:  &mockProxyClient{},
+		accessPoint: &mockAuthClient{
+			caKey:       caKey,
+			caCert:      caCert,
+			clusterName: rootCluster,
+		},
+		ws:                    appSession,
+		integrationAppHandler: integrationAppHandler,
+	})
+	require.NoError(t, err)
+
+	conn, err := tr.DialContext(context.Background(), "", "")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return integrationAppHandler.getConnection() != nil
+	}, 100*time.Millisecond, 10*time.Millisecond)
+
+	message := "hello world"
+	messageSize := len(message)
+
+	go func() {
+		io.WriteString(conn, message)
+	}()
+
+	bs := make([]byte, messageSize)
+	_, err = io.ReadAtLeast(integrationAppHandler.getConnection(), bs, messageSize)
+	require.NoError(t, err)
+
+	require.Equal(t, message, string(bs))
 }


### PR DESCRIPTION
Accessing the AWS Console requires an AppService.
That service is responsible for signing the AWS API requests using ambient credentials.

This PR adds a new flow for accessing AWS APIs (aws cli and aws web console).
This new flow uses the AWS OIDC credentials to sign the AWS API requests.
Given that we no longer need to use the ambient credentials, we no longer require a dedicated AppService.

This changes allows for any ProxyService to proxy AWS App Access requests directly.