### PR TITLE
[v14] Mention in the documentation that we ignore "kube-system" and "kube-public" namespaces for kube app discovery

### DIFF
--- a/docs/pages/application-access/enroll-kubernetes-applications/architecture.mdx
+++ b/docs/pages/application-access/enroll-kubernetes-applications/architecture.mdx
@@ -16,7 +16,8 @@ Kubernetes application auto-discovery consists of two parts:
 
 The Discovery Service running in a Kubernetes cluster will periodically list services and filter them out
 according to the matchers specified in `kubernetes` filed of the service config. You can filter services based on
-types, namespaces and service labels. All services by default currently 
+types, namespaces and service labels. Services running in the `kube-system` and `kube-public` namespaces are
+automatically ignored. All services by default currently
 are considered of an "app" type, but it can be changed for a service by Kubernetes annotation [`teleport.dev/discovery-type`](./reference.mdx#teleportdevdiscovery-type).
 If type of a service doesn't equal the one specified in the matcher, service is ignored.
 

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -105,8 +105,9 @@ databaseResources: []
 
 # kubernetesDiscovery controls configuration for discovery service if it's enabled.
 # discovery service is enabled when the agent `roles` contains "discovery".
-# Default value will try to discovery all apps, use needs to override it to limit
-# scope of the discovered apps.
+# Default value will try to discovery all apps, except for those running in the
+# "kube-system" and "kube-public" namespaces, which are automatically ignored.
+# User needs to override it to limit the scope of the discovered apps.
 kubernetesDiscovery:
   - types: ["app"]
     namespaces: ["*"]


### PR DESCRIPTION
Backport #40529 to branch/v14.