### PR TITLE
Fix missing shell error checking logic

### DIFF
--- a/lib/shell/shell.go
+++ b/lib/shell/shell.go
@@ -34,7 +34,7 @@ func GetLoginShell(username string) (string, error) {
 
 	shellcmd, err = getLoginShell(username)
 	if err != nil {
-		if !trace.IsNotFound(err) {
+		if trace.IsNotFound(err) {
 			logrus.Warnf("No shell specified for %v, using default %v.", username, DefaultShell)
 			return DefaultShell, nil
 		}

--- a/lib/shell/shell_test.go
+++ b/lib/shell/shell_test.go
@@ -29,9 +29,8 @@ func TestGetShell(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, shell == "/bin/bash" || shell == "/bin/sh")
 
-	shell, err = GetLoginShell("non-existent-user")
-	require.NoError(t, err)
-	require.Equal(t, DefaultShell, shell)
+	_, err = GetLoginShell("non-existent-user")
+	require.ErrorContains(t, err, "unknown user")
 
 	shell, err = GetLoginShell("nobody")
 	require.NoError(t, err)

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -871,8 +871,7 @@ func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pty *os.Fi
 	// Get the login shell for the user (or fallback to the default).
 	shellPath, err := shell.GetLoginShell(c.Login)
 	if err != nil {
-		log.Debugf("Failed to get login shell for %v: %v. Using default: %v.",
-			c.Login, err, shell.DefaultShell)
+		log.Debugf("Failed to get login shell for %v: %v.", c.Login, err)
 	}
 	if c.IsTestStub {
 		shellPath = "/bin/sh"


### PR DESCRIPTION
This PR fixes the logic that returns a default shell for os users that don't have a configured shell.