### PR TITLE
AWS OIDC: IAM set up for AWS App Access

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 var wildcard = "*"
@@ -138,13 +140,20 @@ func StatementForEC2InstanceConnectEndpoint() *Statement {
 }
 
 // StatementForAWSAppAccess returns the statement that allows AWS App Access.
+// Only IAM Roles with `teleport.dev/integration: Allowed` Tag can be used.
 func StatementForAWSAppAccess() *Statement {
+	requiredTag := types.TeleportNamespace + "/integration"
 	return &Statement{
 		Effect: EffectAllow,
 		Actions: []string{
 			"sts:AssumeRole",
 		},
 		Resources: allResources,
+		Conditions: map[string]map[string]SliceOrString{
+			"StringEquals": {
+				"iam:ResourceTag/" + requiredTag: SliceOrString{"Allowed"},
+			},
+		},
 	}
 }
 

--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -137,6 +137,17 @@ func StatementForEC2InstanceConnectEndpoint() *Statement {
 	}
 }
 
+// StatementForAWSAppAccess returns the statement that allows AWS App Access.
+func StatementForAWSAppAccess() *Statement {
+	return &Statement{
+		Effect: EffectAllow,
+		Actions: []string{
+			"sts:AssumeRole",
+		},
+		Resources: allResources,
+	}
+}
+
 // StatementForEKSAccess returns the statement that allows enrolling of EKS clusters into Teleport.
 func StatementForEKSAccess() *Statement {
 	return &Statement{

--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -151,7 +151,7 @@ func StatementForAWSAppAccess() *Statement {
 		Resources: allResources,
 		Conditions: map[string]map[string]SliceOrString{
 			"StringEquals": {
-				"iam:ResourceTag/" + requiredTag: SliceOrString{"Allowed"},
+				"iam:ResourceTag/" + requiredTag: SliceOrString{"true"},
 			},
 		},
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -277,8 +277,8 @@ type IntegrationConfEICEIAM struct {
 // IntegrationConfAWSAppAccessIAM contains the arguments of
 // `teleport integration configure aws-app-access-iam` command
 type IntegrationConfAWSAppAccessIAM struct {
-	// Role is the AWS Role associated with the Integration
-	Role string
+	// RoleName is the AWS Role associated with the Integration
+	RoleName string
 }
 
 // IntegrationConfEKSIAM contains the arguments of

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -214,6 +214,10 @@ type CommandLineFlags struct {
 	// `teleport integration configure eice-iam` command
 	IntegrationConfEICEIAMArguments IntegrationConfEICEIAM
 
+	// IntegrationConfAWSAppAccessIAMArguments contains the arguments of
+	// `teleport integration configure aws-app-access-iam` command
+	IntegrationConfAWSAppAccessIAMArguments IntegrationConfAWSAppAccessIAM
+
 	// IntegrationConfEKSIAMArguments contains the arguments of
 	// `teleport integration configure eks-iam` command
 	IntegrationConfEKSIAMArguments IntegrationConfEKSIAM
@@ -266,6 +270,13 @@ type IntegrationConfDeployServiceIAM struct {
 type IntegrationConfEICEIAM struct {
 	// Region is the AWS Region used to set up the client.
 	Region string
+	// Role is the AWS Role associated with the Integration
+	Role string
+}
+
+// IntegrationConfAWSAppAccessIAM contains the arguments of
+// `teleport integration configure aws-app-access-iam` command
+type IntegrationConfAWSAppAccessIAM struct {
 	// Role is the AWS Role associated with the Integration
 	Role string
 }

--- a/lib/integrations/awsoidc/aws_app_access_iam_config.go
+++ b/lib/integrations/awsoidc/aws_app_access_iam_config.go
@@ -72,7 +72,7 @@ type defaultAWSAppAccessConfigureClient struct {
 }
 
 // NewAWSAppAccessConfigureClient creates a new AWSAppAccessConfigureClient.
-func NewAWSAppAccessConfigureClient(ctx context.Context) (*defaultAWSAppAccessConfigureClient, error) {
+func NewAWSAppAccessConfigureClient(ctx context.Context) (AWSAppAccessConfigureClient, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/integrations/awsoidc/aws_app_access_iam_config.go
+++ b/lib/integrations/awsoidc/aws_app_access_iam_config.go
@@ -1,0 +1,124 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsoidc
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/gravitational/trace"
+
+	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+)
+
+const (
+	// defaultPolicyNameForAWSAppAccess is the default name for the Inline Policy added to the IntegrationRole.
+	defaultPolicyNameForAWSAppAccess = "AWSAppAccess"
+)
+
+// AWSAppAccessConfigureRequest is a request to configure the required Policies to use AWS App Access.
+type AWSAppAccessConfigureRequest struct {
+	// Region is the AWS Region.
+	// Used to set up the AWS SDK Client.
+	//Region string
+
+	// IntegrationRole is the Integration's AWS Role used to set up Teleport as an OIDC IdP.
+	IntegrationRole string
+
+	// IntegrationRoleAWSAppAccessPolicy is the Policy Name that is created to allow access to call AWS APIs.
+	// Defaults to AWSAppAccess
+	IntegrationRoleAWSAppAccessPolicy string
+}
+
+// CheckAndSetDefaults ensures the required fields are present.
+func (r *AWSAppAccessConfigureRequest) CheckAndSetDefaults() error {
+	if r.IntegrationRole == "" {
+		return trace.BadParameter("integration role is required")
+	}
+
+	if r.IntegrationRoleAWSAppAccessPolicy == "" {
+		r.IntegrationRoleAWSAppAccessPolicy = defaultPolicyNameForAWSAppAccess
+	}
+
+	return nil
+}
+
+// AWSAppAccessConfigureClient describes the required methods to create the IAM Policies required for AWS App Access.
+type AWSAppAccessConfigureClient interface {
+	// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
+	PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
+}
+
+type defaultAWSAppAccessConfigureClient struct {
+	*iam.Client
+}
+
+// NewAWSAppAccessConfigureClient creates a new AWSAppAccessConfigureClient.
+func NewAWSAppAccessConfigureClient(ctx context.Context) (AWSAppAccessConfigureClient, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if cfg.Region == "" {
+		// IAM Service does not support regions, however a value is required:
+		// https://github.com/aws/aws-sdk-go-v2/issues/1778#issuecomment-1210031692
+		// Providing an invalid region here, ensures the service uses the default AWS Partition.
+		cfg.Region = " "
+	}
+
+	return &defaultAWSAppAccessConfigureClient{
+		Client: iam.NewFromConfig(cfg),
+	}, nil
+}
+
+// ConfigureAWSAppAccess set ups the roles required for AWS App Access.
+// It creates an embedded policy with the following permissions:
+// - sts:AssumeRole
+//
+// The following actions must be allowed by the IAM Role assigned in the Client.
+//   - iam:PutRolePolicy
+func ConfigureAWSAppAccess(ctx context.Context, clt AWSAppAccessConfigureClient, req AWSAppAccessConfigureRequest) error {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	awsAppAccessPolicyDocument, err := awslib.NewPolicyDocument(
+		awslib.StatementForAWSAppAccess(),
+	).Marshal()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = clt.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		PolicyName:     &req.IntegrationRoleAWSAppAccessPolicy,
+		RoleName:       &req.IntegrationRole,
+		PolicyDocument: &awsAppAccessPolicyDocument,
+	})
+	if err != nil {
+		if trace.IsNotFound(awslib.ConvertIAMv2Error(err)) {
+			return trace.NotFound("role %q not found.", req.IntegrationRole)
+		}
+		return trace.Wrap(err)
+	}
+
+	slog.With("policy", req.IntegrationRoleAWSAppAccessPolicy).With("role", req.IntegrationRole).InfoContext(ctx, "IAM Inline Policy added to IAM Role.")
+	return nil
+}

--- a/lib/integrations/awsoidc/aws_app_access_iam_config.go
+++ b/lib/integrations/awsoidc/aws_app_access_iam_config.go
@@ -67,10 +67,6 @@ type AWSAppAccessConfigureClient interface {
 	PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
 }
 
-type defaultAWSAppAccessConfigureClient struct {
-	*iam.Client
-}
-
 // NewAWSAppAccessConfigureClient creates a new AWSAppAccessConfigureClient.
 func NewAWSAppAccessConfigureClient(ctx context.Context) (AWSAppAccessConfigureClient, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
@@ -84,9 +80,7 @@ func NewAWSAppAccessConfigureClient(ctx context.Context) (AWSAppAccessConfigureC
 		cfg.Region = " "
 	}
 
-	return &defaultAWSAppAccessConfigureClient{
-		Client: iam.NewFromConfig(cfg),
-	}, nil
+	return iam.NewFromConfig(cfg), nil
 }
 
 // ConfigureAWSAppAccess set ups the roles required for AWS App Access.

--- a/lib/integrations/awsoidc/aws_app_access_iam_config.go
+++ b/lib/integrations/awsoidc/aws_app_access_iam_config.go
@@ -37,6 +37,7 @@ const (
 )
 
 // AWSAppAccessConfigureRequest is a request to configure the required Policies to use AWS App Access.
+// Only IAM Roles with `teleport.dev/integration: Allowed` Tag can be used.
 type AWSAppAccessConfigureRequest struct {
 	// IntegrationRole is the Integration's AWS Role used to set up Teleport as an OIDC IdP.
 	IntegrationRole string

--- a/lib/integrations/awsoidc/aws_app_access_iam_config_test.go
+++ b/lib/integrations/awsoidc/aws_app_access_iam_config_test.go
@@ -1,0 +1,128 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsoidc
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAWSAppAccessConfigReqDefaults(t *testing.T) {
+	baseReq := func() AWSAppAccessConfigureRequest {
+		return AWSAppAccessConfigureRequest{
+			IntegrationRole: "integrationrole",
+		}
+	}
+
+	for _, tt := range []struct {
+		name     string
+		req      func() AWSAppAccessConfigureRequest
+		errCheck require.ErrorAssertionFunc
+		expected AWSAppAccessConfigureRequest
+	}{
+		{
+			name:     "set defaults",
+			req:      baseReq,
+			errCheck: require.NoError,
+			expected: AWSAppAccessConfigureRequest{
+				IntegrationRole:                   "integrationrole",
+				IntegrationRoleAWSAppAccessPolicy: "AWSAppAccess",
+			},
+		},
+		{
+			name: "missing integration role",
+			req: func() AWSAppAccessConfigureRequest {
+				req := baseReq()
+				req.IntegrationRole = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.req()
+			err := req.CheckAndSetDefaults()
+			tt.errCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Equal(t, tt.expected, req)
+		})
+	}
+}
+
+func TestAWSAppAccessConfig(t *testing.T) {
+	ctx := context.Background()
+	baseReq := func() AWSAppAccessConfigureRequest {
+		return AWSAppAccessConfigureRequest{
+			IntegrationRole: "integrationrole",
+		}
+	}
+
+	for _, tt := range []struct {
+		name              string
+		mockExistingRoles []string
+		req               func() AWSAppAccessConfigureRequest
+		errCheck          require.ErrorAssertionFunc
+	}{
+		{
+			name:              "valid",
+			req:               baseReq,
+			mockExistingRoles: []string{"integrationrole"},
+			errCheck:          require.NoError,
+		},
+		{
+			name:              "integration role does not exist",
+			mockExistingRoles: []string{},
+			req:               baseReq,
+			errCheck:          notFoundCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			clt := mockAWSAppAccessConfigClient{
+				existingRoles: tt.mockExistingRoles,
+			}
+
+			err := ConfigureAWSAppAccess(ctx, &clt, tt.req())
+			tt.errCheck(t, err)
+		})
+	}
+}
+
+type mockAWSAppAccessConfigClient struct {
+	existingRoles []string
+}
+
+// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
+func (m *mockAWSAppAccessConfigClient) PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error) {
+	if !slices.Contains(m.existingRoles, *params.RoleName) {
+		noSuchEntityMessage := fmt.Sprintf("role %q does not exist.", *params.RoleName)
+		return nil, &iamTypes.NoSuchEntityException{
+			Message: &noSuchEntityMessage,
+		}
+	}
+	return nil, nil
+}

--- a/lib/integrations/awsoidc/aws_app_access_iam_config_test.go
+++ b/lib/integrations/awsoidc/aws_app_access_iam_config_test.go
@@ -76,8 +76,8 @@ func TestAWSAppAccessConfigReqDefaults(t *testing.T) {
 
 func TestAWSAppAccessConfig(t *testing.T) {
 	ctx := context.Background()
-	baseReq := func() AWSAppAccessConfigureRequest {
-		return AWSAppAccessConfigureRequest{
+	baseReq := func() *AWSAppAccessConfigureRequest {
+		return &AWSAppAccessConfigureRequest{
 			IntegrationRole: "integrationrole",
 		}
 	}
@@ -85,7 +85,7 @@ func TestAWSAppAccessConfig(t *testing.T) {
 	for _, tt := range []struct {
 		name              string
 		mockExistingRoles []string
-		req               func() AWSAppAccessConfigureRequest
+		req               func() *AWSAppAccessConfigureRequest
 		errCheck          require.ErrorAssertionFunc
 	}{
 		{
@@ -102,11 +102,11 @@ func TestAWSAppAccessConfig(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			clt := mockAWSAppAccessConfigClient{
+			awsClient := &mockAWSAppAccessConfigClient{
 				existingRoles: tt.mockExistingRoles,
 			}
 
-			err := ConfigureAWSAppAccess(ctx, &clt, tt.req())
+			err := ConfigureAWSAppAccess(ctx, awsClient, tt.req())
 			tt.errCheck(t, err)
 		})
 	}
@@ -116,7 +116,6 @@ type mockAWSAppAccessConfigClient struct {
 	existingRoles []string
 }
 
-// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
 func (m *mockAWSAppAccessConfigClient) PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error) {
 	if !slices.Contains(m.existingRoles, *params.RoleName) {
 		noSuchEntityMessage := fmt.Sprintf("role %q does not exist.", *params.RoleName)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -916,6 +916,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/scripts/integrations/configure/eice-iam.sh", h.WithLimiter(h.awsOIDCConfigureEICEIAM))
 	h.GET("/webapi/scripts/integrations/configure/eks-iam.sh", h.WithLimiter(h.awsOIDCConfigureEKSIAM))
 	h.GET("/webapi/scripts/integrations/configure/access-graph-cloud-sync-iam.sh", h.WithLimiter(h.accessGraphCloudSyncOIDC))
+	h.GET("/webapi/scripts/integrations/configure/aws-app-access-iam.sh", h.WithLimiter(h.awsOIDCConfigureAWSAppAccessIAM))
 
 	// SAML IDP integration endpoints
 	h.GET("/webapi/scripts/integrations/configure/gcp-workforce-saml.sh", h.WithLimiter(h.gcpWorkforceConfigScript))

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -327,7 +327,7 @@ func (h *Handler) awsOIDCConfigureEICEIAM(w http.ResponseWriter, r *http.Request
 // awsOIDCConfigureAppAccessIAM returns a script that configures the required IAM permissions to enable App Access
 // using the AWS OIDC Credentials.
 // It receives the IAM Role from a query param "role".
-// The script is returned using the contente type "text/x-shellscript" and no ContentDisposition header is set.
+// The script is returned using the Content-Type "text/x-shellscript". No Content-Disposition header is set.
 func (h *Handler) awsOIDCConfigureAWSAppAccessIAM(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
 	queryParams := r.URL.Query()
 

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -326,6 +326,7 @@ func (h *Handler) awsOIDCConfigureEICEIAM(w http.ResponseWriter, r *http.Request
 
 // awsOIDCConfigureAppAccessIAM returns a script that configures the required IAM permissions to enable App Access
 // using the AWS OIDC Credentials.
+// Only IAM Roles with `teleport.dev/integration: Allowed` Tag can be used.
 // It receives the IAM Role from a query param "role".
 // The script is returned using the Content-Type "text/x-shellscript". No Content-Disposition header is set.
 func (h *Handler) awsOIDCConfigureAWSAppAccessIAM(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -324,8 +324,10 @@ func (h *Handler) awsOIDCConfigureEICEIAM(w http.ResponseWriter, r *http.Request
 	return nil, trace.Wrap(err)
 }
 
-// awsOIDCConfigureAppAccessIAM returns a script that configures the required IAM permissions to enable the usage of App Access
+// awsOIDCConfigureAppAccessIAM returns a script that configures the required IAM permissions to enable App Access
 // using the AWS OIDC Credentials.
+// It receives the IAM Role from a query param "role".
+// The script is returned using the contente type "text/x-shellscript" and no ContentDisposition header is set.
 func (h *Handler) awsOIDCConfigureAWSAppAccessIAM(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
 	queryParams := r.URL.Query()
 
@@ -349,8 +351,8 @@ func (h *Handler) awsOIDCConfigureAWSAppAccessIAM(w http.ResponseWriter, r *http
 	}
 
 	httplib.SetScriptHeaders(w.Header())
-	_, err = fmt.Fprint(w, script)
 
+	_, err = fmt.Fprint(w, script)
 	return nil, trace.Wrap(err)
 }
 

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -309,7 +309,6 @@ func TestBuildAWSAppAccessConfigureIAMScript(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			resp, err := anonymousHTTPClient.Get(ctx, endpoint, tc.reqQuery)
 			tc.errCheck(t, err)

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -248,6 +248,82 @@ func TestBuildEICEConfigureIAMScript(t *testing.T) {
 	}
 }
 
+func TestBuildAWSAppAccessConfigureIAMScript(t *testing.T) {
+	t.Parallel()
+	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
+		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	}
+
+	ctx := context.Background()
+	env := newWebPack(t, 1)
+
+	// Unauthenticated client for script downloading.
+	publicClt := env.proxies[0].newClient(t)
+	pathVars := []string{
+		"webapi",
+		"scripts",
+		"integrations",
+		"configure",
+		"aws-app-access-iam.sh",
+	}
+	endpoint := publicClt.Endpoint(pathVars...)
+
+	tests := []struct {
+		name                 string
+		reqRelativeURL       string
+		reqQuery             url.Values
+		errCheck             require.ErrorAssertionFunc
+		expectedTeleportArgs string
+	}{
+		{
+			name: "valid",
+			reqQuery: url.Values{
+				"awsRegion": []string{"us-east-1"},
+				"role":      []string{"myRole"},
+			},
+			errCheck: require.NoError,
+			expectedTeleportArgs: "integration configure aws-app-access-iam " +
+				"--role=myRole",
+		},
+		{
+			name: "valid with symbols in role",
+			reqQuery: url.Values{
+				"role": []string{"Test+1=2,3.4@5-6_7"},
+			},
+			errCheck: require.NoError,
+			expectedTeleportArgs: "integration configure aws-app-access-iam " +
+				"--role=Test\\+1=2,3.4\\@5-6_7",
+		},
+		{
+			name:     "missing role",
+			reqQuery: url.Values{},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "trying to inject escape sequence into query params",
+			reqQuery: url.Values{
+				"role": []string{"'; rm -rf /tmp/dir; echo '"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := publicClt.Get(ctx, endpoint, tc.reqQuery)
+			tc.errCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Contains(t, string(resp.Bytes()),
+				fmt.Sprintf("teleportArgs='%s'\n", tc.expectedTeleportArgs),
+			)
+		})
+	}
+}
+
 func TestBuildEKSConfigureIAMScript(t *testing.T) {
 	t.Parallel()
 	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -258,7 +258,7 @@ func TestBuildAWSAppAccessConfigureIAMScript(t *testing.T) {
 	env := newWebPack(t, 1)
 
 	// Unauthenticated client for script downloading.
-	publicClt := env.proxies[0].newClient(t)
+	anonymousHTTPClient := env.proxies[0].newClient(t)
 	pathVars := []string{
 		"webapi",
 		"scripts",
@@ -266,7 +266,7 @@ func TestBuildAWSAppAccessConfigureIAMScript(t *testing.T) {
 		"configure",
 		"aws-app-access-iam.sh",
 	}
-	endpoint := publicClt.Endpoint(pathVars...)
+	endpoint := anonymousHTTPClient.Endpoint(pathVars...)
 
 	tests := []struct {
 		name                 string
@@ -311,7 +311,7 @@ func TestBuildAWSAppAccessConfigureIAMScript(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			resp, err := publicClt.Get(ctx, endpoint, tc.reqQuery)
+			resp, err := anonymousHTTPClient.Get(ctx, endpoint, tc.reqQuery)
 			tc.errCheck(t, err)
 			if err != nil {
 				return

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -476,7 +476,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfEICECmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfEICEIAMArguments.Role)
 
 	integrationConfAWSAppAccessCmd := integrationConfigureCmd.Command("aws-app-access-iam", "Adds required IAM permissions to connect to AWS using App Access.")
-	integrationConfAWSAppAccessCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfAWSAppAccessIAMArguments.Role)
+	integrationConfAWSAppAccessCmd.Flag("role", "The AWS Role name used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfAWSAppAccessIAMArguments.RoleName)
 
 	integrationConfEKSCmd := integrationConfigureCmd.Command("eks-iam", "Adds required IAM permissions for enrollment of EKS clusters to Teleport.")
 	integrationConfEKSCmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfEKSIAMArguments.Region)
@@ -1033,7 +1033,7 @@ func onIntegrationConfAWSAppAccessIAM(ctx context.Context, params config.Integra
 	}
 
 	err = awsoidc.ConfigureAWSAppAccess(ctx, iamClient, &awsoidc.AWSAppAccessConfigureRequest{
-		IntegrationRole: params.Role,
+		IntegrationRole: params.RoleName,
 	})
 	return trace.Wrap(err)
 }


### PR DESCRIPTION
AWS App Access using AWS OIDC Integration requires a new policy in the AWS OIDC Role.
This PR adds a one-off script that executes the configuration command that adds said policy.

Demo:
```bash
$ teleport integration configure aws-app-access-iam --role=MarcoTestRoleOIDCProvider
2024-04-16T10:58:30+01:00 INFO  IAM Inline Policy added to IAM Role policy:AWSAppAccess role:MarcoTestRoleOIDCProvider awsoidc/aws_app_access_iam_config.go:121
```

![image](https://github.com/gravitational/teleport/assets/689271/dd79a3b5-8324-4000-be45-5d3a629a0331)

