### PR TITLE
docs: add access monitoring notice for external audit storage

### DIFF
--- a/docs/pages/access-controls/access-monitoring.mdx
+++ b/docs/pages/access-controls/access-monitoring.mdx
@@ -15,6 +15,12 @@ or database sessions without MFA) and provides users with recommendations on sug
 
 Users are able to write their own custom access monitoring queries by querying the audit log.
 
+<Admonition type="notice">
+  Access Monitoring is not currently supported with External Audit Storage
+  in Teleport Cloud. A upcoming version will support Access Monitoring in
+  that configuration.
+</Admonition>
+
 ## Prerequisites
 - Teleport v14 or later.
 - For self-hosted Teleport the [AWS Athena Backend](../reference/backends.mdx#athena) is required.

--- a/docs/pages/access-controls/access-monitoring.mdx
+++ b/docs/pages/access-controls/access-monitoring.mdx
@@ -17,8 +17,8 @@ Users are able to write their own custom access monitoring queries by querying t
 
 <Admonition type="notice">
   Access Monitoring is not currently supported with External Audit Storage
-  in Teleport Enterprise (cloud-hosted). A upcoming version will support Access Monitoring in
-  that configuration.
+  in Teleport Enterprise (cloud-hosted). This functionality will be
+  enabled in a future Teleport release.
 </Admonition>
 
 ## Prerequisites

--- a/docs/pages/access-controls/access-monitoring.mdx
+++ b/docs/pages/access-controls/access-monitoring.mdx
@@ -304,7 +304,7 @@ WHERE
 
 ### Query Examples with Assist AI
 
-The query editor also integrates with Teleport Assist, allowing to generate queries with a human-readable description of the data you want to retrieve.
+The query editor also integrates with Teleport Assist, allowing you to to generate queries with a human-readable description of the data you want to retrieve.
 
 ![assist query](../../img/access-monitoring/assist_query_1.png)
 

--- a/docs/pages/access-controls/access-monitoring.mdx
+++ b/docs/pages/access-controls/access-monitoring.mdx
@@ -17,7 +17,7 @@ Users are able to write their own custom access monitoring queries by querying t
 
 <Admonition type="notice">
   Access Monitoring is not currently supported with External Audit Storage
-  in Teleport Cloud. A upcoming version will support Access Monitoring in
+  in Teleport Enterprise (cloud-hosted). A upcoming version will support Access Monitoring in
   that configuration.
 </Admonition>
 
@@ -29,9 +29,9 @@ Users are able to write their own custom access monitoring queries by querying t
 ### Configuration
 
 <Tabs>
-<TabItem scope={["cloud","team"]} label="Teleport Cloud">
+<TabItem scope={["cloud","team"]} label="Teleport Enterprise (cloud-hosted)">
 
-Teleport Access Monitoring is enabled by default for all Teleport Cloud users.
+Teleport Access Monitoring is enabled by default for all Teleport Enterprise (cloud-hosted) accounts.
 
 </TabItem>
 <TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
@@ -304,7 +304,7 @@ WHERE
 
 ### Query Examples with Assist AI
 
-The query editor also integrates with Teleport Assist, making it easy to generate queries with a human-readable description of the data you want to retrieve.
+The query editor also integrates with Teleport Assist, allowing to generate queries with a human-readable description of the data you want to retrieve.
 
 ![assist query](../../img/access-monitoring/assist_query_1.png)
 


### PR DESCRIPTION
We've seen some issues raised where folks are seeing that External Audit Storage does not allow to use Access Monitoring in Teleport Cloud.  Adding this notice until it is supported.