### PR TITLE
API for creating AppServer that uses AWS OIDC Integration

### DIFF
--- a/api/types/appserver.go
+++ b/api/types/appserver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/utils"
 )
 
@@ -80,6 +81,22 @@ func NewAppServerV3FromApp(app *AppV3, hostname, hostID string) (*AppServerV3, e
 		Hostname: hostname,
 		HostID:   hostID,
 		App:      app,
+	})
+}
+
+// NewAppServerForAWSOIDCIntegration creates a new AppServer that will be used to grant AWS App Access
+// using the AWSOIDC credentials.
+func NewAppServerForAWSOIDCIntegration(integrationName string, hostID string) (*AppServerV3, error) {
+	return NewAppServerV3(Metadata{
+		Name: integrationName,
+	}, AppServerSpecV3{
+		HostID: hostID,
+		App: &AppV3{Metadata: Metadata{
+			Name: integrationName,
+		}, Spec: AppSpecV3{
+			URI:         constants.AWSConsoleURL,
+			Integration: integrationName,
+		}},
 	})
 }
 

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -174,6 +174,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindAccessGraph, RW()),
 					types.NewRule(types.KindServerInfo, RW()),
 					types.NewRule(types.KindAccessMonitoringRule, RW()),
+					types.NewRule(types.KindAppServer, RW()),
 				},
 			},
 		},

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2742,6 +2742,7 @@ func calculateDesktopLogins(loginGetter loginGetter, r types.ResourceWithLabels,
 
 // getUserGroupLookup is a generator to retrieve UserGroupLookup on first call and return it again in subsequent calls.
 // If we encounter an error, we log it once and return an empty UserGroupLookup for the current and subsequent calls.
+// The returned function is not thread safe.
 func (h *Handler) getUserGroupLookup(ctx context.Context, clt apiclient.GetResourcesClient) func() map[string]types.UserGroup {
 	userGroupLookup := make(map[string]types.UserGroup)
 	var gotUserGroupLookup bool

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -924,6 +924,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/scripts/integrations/configure/eks-iam.sh", h.WithLimiter(h.awsOIDCConfigureEKSIAM))
 	h.GET("/webapi/scripts/integrations/configure/access-graph-cloud-sync-iam.sh", h.WithLimiter(h.accessGraphCloudSyncOIDC))
 	h.GET("/webapi/scripts/integrations/configure/aws-app-access-iam.sh", h.WithLimiter(h.awsOIDCConfigureAWSAppAccessIAM))
+	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/aws-app-access", h.WithClusterAuth(h.awsOIDCCreateAWSAppAccess))
 
 	// SAML IDP integration endpoints
 	h.GET("/webapi/scripts/integrations/configure/gcp-workforce-saml.sh", h.WithLimiter(h.gcpWorkforceConfigScript))

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -898,11 +898,25 @@ func (h *Handler) awsOIDCCreateAWSAppAccess(w http.ResponseWriter, r *http.Reque
 		return nil, trace.BadParameter("only aws oidc integrations are supported")
 	}
 
+	identity, err := sctx.GetIdentity()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	getUserGroupLookup := h.getUserGroupLookup(r.Context(), clt)
+
 	if _, err := clt.UpsertApplicationServer(ctx, appServer); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return nil, nil
+	return ui.MakeApp(appServer.GetApp(), ui.MakeAppsConfig{
+		LocalClusterName:  h.auth.clusterName,
+		LocalProxyDNSName: h.proxyDNSName(),
+		AppClusterName:    site.GetName(),
+		Identity:          identity,
+		UserGroupLookup:   getUserGroupLookup(),
+		Logger:            h.log,
+	}), nil
 }
 
 // awsOIDCConfigureIdP returns a script that configures AWS OIDC Integration

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -880,11 +880,6 @@ func (h *Handler) awsOIDCCreateAWSAppAccess(w http.ResponseWriter, r *http.Reque
 		return nil, trace.BadParameter("an integration name is required")
 	}
 
-	appServer, err := types.NewAppServerForAWSOIDCIntegration(integrationName, h.cfg.HostUUID)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	clt, err := sctx.GetUserClient(ctx, site)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -904,6 +899,11 @@ func (h *Handler) awsOIDCCreateAWSAppAccess(w http.ResponseWriter, r *http.Reque
 	}
 
 	getUserGroupLookup := h.getUserGroupLookup(r.Context(), clt)
+
+	appServer, err := types.NewAppServerForAWSOIDCIntegration(integrationName, h.cfg.HostUUID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	if _, err := clt.UpsertApplicationServer(ctx, appServer); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -851,6 +851,7 @@ func TestAWSOIDCAppAccessAppServerCreation(t *testing.T) {
 			Rules: []types.Rule{
 				types.NewRule(types.KindIntegration, []string{types.VerbRead}),
 				types.NewRule(types.KindAppServer, []string{types.VerbCreate, types.VerbUpdate}),
+				types.NewRule(types.KindUserGroup, []string{types.VerbList, types.VerbRead}),
 			},
 		},
 	})
@@ -871,8 +872,10 @@ func TestAWSOIDCAppAccessAppServerCreation(t *testing.T) {
 
 	// Create the AWS App Access for the current integration.
 	endpoint := pack.clt.Endpoint("webapi", "sites", "localhost", "integrations", "aws-oidc", "my-integration", "aws-app-access")
-	_, err = pack.clt.PostJSON(context.Background(), endpoint, nil)
+	x, err := pack.clt.PostJSON(context.Background(), endpoint, nil)
 	require.NoError(t, err)
+
+	t.Log(x)
 
 	// Ensure the AppServer was correctly created.
 	appServers, err := env.server.Auth().GetApplicationServers(context.Background(), "default")

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -133,6 +133,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *servicec
 		types.KindLock:                     rc.createLock,
 		types.KindNetworkRestrictions:      rc.createNetworkRestrictions,
 		types.KindApp:                      rc.createApp,
+		types.KindAppServer:                rc.createAppServer,
 		types.KindDatabase:                 rc.createDatabase,
 		types.KindKubernetesCluster:        rc.createKubeCluster,
 		types.KindToken:                    rc.createToken,
@@ -864,6 +865,21 @@ func (rc *ResourceCommand) createWindowsDesktop(ctx context.Context, client *aut
 	}
 
 	fmt.Printf("windows desktop %q has been updated\n", wd.GetName())
+	return nil
+}
+
+func (rc *ResourceCommand) createAppServer(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+	appServer, err := services.UnmarshalAppServer(raw.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if appServer.GetApp().GetIntegration() == "" {
+		return trace.BadParameter("only applications that use an integration can be created")
+	}
+	if _, err := client.UpsertApplicationServer(ctx, appServer); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("application server %q has been upserted\n", appServer.GetName())
 	return nil
 }
 

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1394,6 +1394,10 @@ func TestCreateResources(t *testing.T) {
 			kind:   types.KindSessionRecordingConfig,
 			create: testCreateSessionRecordingConfig,
 		},
+		{
+			kind:   types.KindAppServer,
+			create: testCreateAppServer,
+		},
 	}
 
 	for _, test := range tests {
@@ -1883,6 +1887,66 @@ version: v2
 
 	_, err = runResourceCommand(t, fc, []string{"create", "-f", srcYAMLPath})
 	require.NoError(t, err)
+}
+
+func testCreateAppServer(t *testing.T, fc *config.FileConfig) {
+	const appServerWithIntegrationYAML = `---
+kind: app_server
+metadata:
+  name: my-integration
+spec:
+  app:
+    kind: app
+    metadata:
+      name: my-integration
+    spec:
+      uri: https://console.aws.amazon.com
+      integration: my-integration
+    version: v3
+  host_id: c6cfe5c2-653f-4e5d-a914-bfac5a7baf38
+version: v3
+`
+
+	const appServerWithoutIntegrationYAML = `---
+kind: app_server
+metadata:
+  name: my-integration
+spec:
+  app:
+    kind: app
+    metadata:
+      name: my-integration
+    spec:
+      uri: https://console.aws.amazon.com
+    version: v3
+  host_id: c6cfe5c2-653f-4e5d-a914-bfac5a7baf38
+version: v3
+`
+
+	// Creating an AppServer with integration is valid.
+	srcYAMLPath := filepath.Join(t.TempDir(), "appServerWithIntegrationYAML.yaml")
+	require.NoError(t, os.WriteFile(srcYAMLPath, []byte(appServerWithIntegrationYAML), 0644))
+	_, err := runResourceCommand(t, fc, []string{"create", srcYAMLPath})
+	require.NoError(t, err)
+
+	// Creating an AppServer without integration is invalid.
+	srcYAMLPath = filepath.Join(t.TempDir(), "appServerWithoutIntegrationYAML.yaml")
+	require.NoError(t, os.WriteFile(srcYAMLPath, []byte(appServerWithoutIntegrationYAML), 0644))
+	_, err = runResourceCommand(t, fc, []string{"create", srcYAMLPath})
+	require.ErrorContains(t, err, "integration")
+
+	buf, err := runResourceCommand(t, fc, []string{"get", types.KindAppServer, "--format=json"})
+	require.NoError(t, err)
+	appServers := mustDecodeJSON[[]*types.AppServerV3](t, buf)
+	require.Len(t, appServers, 1)
+
+	expectedAppServer, err := types.NewAppServerForAWSOIDCIntegration("my-integration", "c6cfe5c2-653f-4e5d-a914-bfac5a7baf38")
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(
+		expectedAppServer,
+		appServers[0],
+		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision", "Namespace"),
+	))
 }
 
 func testCreateDatabaseObject(t *testing.T, fc *config.FileConfig) {


### PR DESCRIPTION
This PR adds two new APIs:
- web api endpoint
- `tctl create` for AppServers

This allows the client to create AppServer which use the integration credentials.

This also updates the `editor` role so that they are able to upsert the AppServer.