### PR TITLE
[v15] docs: Add ssh verb to example tsh command in Machine ID SSH guide

### DIFF
--- a/docs/pages/machine-id/access-guides/ssh.mdx
+++ b/docs/pages/machine-id/access-guides/ssh.mdx
@@ -126,7 +126,7 @@ In this example, `tsh` is used to connect to a node called `my-host` via the
 proxy `example.teleport.sh:443` and to execute the command `hostname`:
 
 ```code
-$ tsh -i /opt/machine-id/identity --proxy example.teleport.sh:443 root@my-host hostname
+$ tsh -i /opt/machine-id/identity --proxy example.teleport.sh:443 ssh root@my-host hostname
 my-host
 ```
 


### PR DESCRIPTION
Backport #40577 to branch/v15