### PR TITLE
Fix context usage in DiscoveryService initialization

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -360,7 +360,7 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 	}
 	s.discardUnsupportedMatchers(&s.Matchers)
 
-	if err := s.startDynamicMatchersWatcher(ctx); err != nil {
+	if err := s.startDynamicMatchersWatcher(s.ctx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -374,11 +374,11 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.initAzureWatchers(ctx, cfg.Matchers.Azure); err != nil {
+	if err := s.initAzureWatchers(s.ctx, cfg.Matchers.Azure); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.initGCPWatchers(ctx, cfg.Matchers.GCP); err != nil {
+	if err := s.initGCPWatchers(s.ctx, cfg.Matchers.GCP); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -392,7 +392,7 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.initAccessGraphWatchers(ctx, cfg); err != nil {
+	if err := s.initAccessGraphWatchers(s.ctx, cfg); err != nil {
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
The created context is the one that should be used for context propagation.

Most of this doesn't change anything, except for the AccessGraph, where we span a goroutine using the received context.
It was using the initial one (`process.ExitContext`), but now it will use the wrapped context which respects the `s.cancelFn`.