### PR TITLE
Fix JIRA issue type

### DIFF
--- a/integrations/access/jira/client.go
+++ b/integrations/access/jira/client.go
@@ -242,7 +242,7 @@ func (j *Jira) CreateIssue(ctx context.Context, reqID string, reqData RequestDat
 			},
 		},
 		Fields: IssueFieldsInput{
-			Type:        &IssueType{Name: "Task"},
+			Type:        &IssueType{Name: j.issueType},
 			Project:     &Project{Key: j.project},
 			Summary:     fmt.Sprintf("%s requested %s", reqData.User, strings.Join(reqData.Roles, ", ")),
 			Description: description,

--- a/integrations/access/jira/testlib/fake_jira.go
+++ b/integrations/access/jira/testlib/fake_jira.go
@@ -105,6 +105,7 @@ func NewFakeJira(author jira.UserDetails, concurrency int) *FakeJira {
 			Fields: jira.IssueFields{
 				Summary:     issueInput.Fields.Summary,
 				Description: issueInput.Fields.Description,
+				Type:        *issueInput.Fields.Type,
 			},
 			Properties: make(map[string]interface{}),
 		}

--- a/integrations/access/jira/testlib/suite.go
+++ b/integrations/access/jira/testlib/suite.go
@@ -195,6 +195,24 @@ func (s *JiraSuiteOSS) TestIssueCreationWithLargeRequestReason() {
 	s.SetReasonPadding(0)
 }
 
+// TestCustomIssueType tests that requests can use a custom issue type.
+func (s *JiraSuiteOSS) TestCustomIssueType() {
+	t := s.T()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	s.appConfig.Jira.IssueType = "Story"
+	s.startApp()
+
+	// Test setup: we create an access request
+	_ = s.CreateAccessRequest(ctx, integration.RequesterOSSUserName, nil)
+
+	// We validate that the issue was created using the Issue Type "Story"
+	newIssue, err := s.fakeJira.CheckNewIssue(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Story", newIssue.Fields.Type.Name)
+}
+
 // TestReviewComments tests that comments are posted for each access request
 // review.
 func (s *JiraSuiteEnterprise) TestReviewComments() {


### PR DESCRIPTION
During set up we ask for the Jira Issue Type, but then we always send the `Task` type.

This PR changes the field's value to match the configured one.

changelog: Allow other issue types when configuring JIRA plugin.