### PR TITLE
Fix licensing protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-async"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
 dependencies = [
  "bytes",
  "ironrdp-connector",
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
 dependencies = [
  "bitflags 2.5.0",
  "ironrdp-pdu",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-connector"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
 dependencies = [
  "ironrdp-error",
  "ironrdp-pdu",
@@ -1263,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-dvc"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
 dependencies = [
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -1274,12 +1274,12 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
 
 [[package]]
 name = "ironrdp-graphics"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
 dependencies = [
  "bit_field",
  "bitflags 2.5.0",
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-pdu"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
 dependencies = [
  "bit_field",
  "bitflags 2.5.0",
@@ -1318,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
 dependencies = [
  "bitflags 2.5.0",
  "ironrdp-error",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpsnd"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
 dependencies = [
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -1339,7 +1339,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-session"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
 dependencies = [
  "ironrdp-connector",
  "ironrdp-dvc",
@@ -1353,7 +1353,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-svc"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
 dependencies = [
  "bitflags 2.5.0",
  "ironrdp-pdu",
@@ -1362,7 +1362,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tls"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
 dependencies = [
  "tokio",
  "tokio-rustls",
@@ -1372,7 +1372,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tokio"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
 dependencies = [
  "bytes",
  "ironrdp-async",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-async"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c0031d34eb4b956162862aeadcde195c0d2835ee#c0031d34eb4b956162862aeadcde195c0d2835ee"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
 dependencies = [
  "bytes",
  "ironrdp-connector",
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c0031d34eb4b956162862aeadcde195c0d2835ee#c0031d34eb4b956162862aeadcde195c0d2835ee"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
 dependencies = [
  "bitflags 2.5.0",
  "ironrdp-pdu",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-connector"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c0031d34eb4b956162862aeadcde195c0d2835ee#c0031d34eb4b956162862aeadcde195c0d2835ee"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
 dependencies = [
  "ironrdp-error",
  "ironrdp-pdu",
@@ -1263,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-dvc"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c0031d34eb4b956162862aeadcde195c0d2835ee#c0031d34eb4b956162862aeadcde195c0d2835ee"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
 dependencies = [
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -1274,12 +1274,12 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c0031d34eb4b956162862aeadcde195c0d2835ee#c0031d34eb4b956162862aeadcde195c0d2835ee"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
 
 [[package]]
 name = "ironrdp-graphics"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c0031d34eb4b956162862aeadcde195c0d2835ee#c0031d34eb4b956162862aeadcde195c0d2835ee"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
 dependencies = [
  "bit_field",
  "bitflags 2.5.0",
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-pdu"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c0031d34eb4b956162862aeadcde195c0d2835ee#c0031d34eb4b956162862aeadcde195c0d2835ee"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
 dependencies = [
  "bit_field",
  "bitflags 2.5.0",
@@ -1318,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c0031d34eb4b956162862aeadcde195c0d2835ee#c0031d34eb4b956162862aeadcde195c0d2835ee"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
 dependencies = [
  "bitflags 2.5.0",
  "ironrdp-error",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpsnd"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c0031d34eb4b956162862aeadcde195c0d2835ee#c0031d34eb4b956162862aeadcde195c0d2835ee"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
 dependencies = [
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -1339,7 +1339,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-session"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c0031d34eb4b956162862aeadcde195c0d2835ee#c0031d34eb4b956162862aeadcde195c0d2835ee"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
 dependencies = [
  "ironrdp-connector",
  "ironrdp-dvc",
@@ -1353,7 +1353,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-svc"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c0031d34eb4b956162862aeadcde195c0d2835ee#c0031d34eb4b956162862aeadcde195c0d2835ee"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
 dependencies = [
  "bitflags 2.5.0",
  "ironrdp-pdu",
@@ -1362,7 +1362,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tls"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c0031d34eb4b956162862aeadcde195c0d2835ee#c0031d34eb4b956162862aeadcde195c0d2835ee"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
 dependencies = [
  "tokio",
  "tokio-rustls",
@@ -1372,7 +1372,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tokio"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c0031d34eb4b956162862aeadcde195c0d2835ee#c0031d34eb4b956162862aeadcde195c0d2835ee"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e#e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e"
 dependencies = [
  "bytes",
  "ironrdp-async",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-async"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e5bd2beab54bee2cf173cc110a804df2e709a1ac#e5bd2beab54bee2cf173cc110a804df2e709a1ac"
 dependencies = [
  "bytes",
  "ironrdp-connector",
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e5bd2beab54bee2cf173cc110a804df2e709a1ac#e5bd2beab54bee2cf173cc110a804df2e709a1ac"
 dependencies = [
  "bitflags 2.5.0",
  "ironrdp-pdu",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-connector"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e5bd2beab54bee2cf173cc110a804df2e709a1ac#e5bd2beab54bee2cf173cc110a804df2e709a1ac"
 dependencies = [
  "ironrdp-error",
  "ironrdp-pdu",
@@ -1263,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-dvc"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e5bd2beab54bee2cf173cc110a804df2e709a1ac#e5bd2beab54bee2cf173cc110a804df2e709a1ac"
 dependencies = [
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -1274,12 +1274,12 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e5bd2beab54bee2cf173cc110a804df2e709a1ac#e5bd2beab54bee2cf173cc110a804df2e709a1ac"
 
 [[package]]
 name = "ironrdp-graphics"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e5bd2beab54bee2cf173cc110a804df2e709a1ac#e5bd2beab54bee2cf173cc110a804df2e709a1ac"
 dependencies = [
  "bit_field",
  "bitflags 2.5.0",
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-pdu"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e5bd2beab54bee2cf173cc110a804df2e709a1ac#e5bd2beab54bee2cf173cc110a804df2e709a1ac"
 dependencies = [
  "bit_field",
  "bitflags 2.5.0",
@@ -1318,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e5bd2beab54bee2cf173cc110a804df2e709a1ac#e5bd2beab54bee2cf173cc110a804df2e709a1ac"
 dependencies = [
  "bitflags 2.5.0",
  "ironrdp-error",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpsnd"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e5bd2beab54bee2cf173cc110a804df2e709a1ac#e5bd2beab54bee2cf173cc110a804df2e709a1ac"
 dependencies = [
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -1339,7 +1339,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-session"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e5bd2beab54bee2cf173cc110a804df2e709a1ac#e5bd2beab54bee2cf173cc110a804df2e709a1ac"
 dependencies = [
  "ironrdp-connector",
  "ironrdp-dvc",
@@ -1353,7 +1353,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-svc"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e5bd2beab54bee2cf173cc110a804df2e709a1ac#e5bd2beab54bee2cf173cc110a804df2e709a1ac"
 dependencies = [
  "bitflags 2.5.0",
  "ironrdp-pdu",
@@ -1362,7 +1362,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tls"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e5bd2beab54bee2cf173cc110a804df2e709a1ac#e5bd2beab54bee2cf173cc110a804df2e709a1ac"
 dependencies = [
  "tokio",
  "tokio-rustls",
@@ -1372,7 +1372,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tokio"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=a494270c247ffd62162352886304a3d7504be8b0#a494270c247ffd62162352886304a3d7504be8b0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=e5bd2beab54bee2cf173cc110a804df2e709a1ac#e5bd2beab54bee2cf173cc110a804df2e709a1ac"
 dependencies = [
  "bytes",
  "ironrdp-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ codegen-units = 1
 # Note: To use a local IronRDP repository as a crate (for example, ironrdp-cliprdr), define the dependency as follows:
 # ironrdp-cliprdr = { path = "/path/to/local/IronRDP/crates/ironrdp-cliprdr" }
 # This rev hash corresponds to https://github.com/Devolutions/IronRDP/pull/436 and should be changed before merging
-ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
-ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
-ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
-ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
-ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
-ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
-ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
-ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e", features = ["rustls"]}
-ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
+ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
+ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
+ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
+ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
+ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
+ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
+ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
+ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0", features = ["rustls"]}
+ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,14 @@ codegen-units = 1
 [workspace.dependencies]
 # Note: To use a local IronRDP repository as a crate (for example, ironrdp-cliprdr), define the dependency as follows:
 # ironrdp-cliprdr = { path = "/path/to/local/IronRDP/crates/ironrdp-cliprdr" }
-ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "c0031d34eb4b956162862aeadcde195c0d2835ee" }
-ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "c0031d34eb4b956162862aeadcde195c0d2835ee" }
-ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "c0031d34eb4b956162862aeadcde195c0d2835ee" }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "c0031d34eb4b956162862aeadcde195c0d2835ee" }
-ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "c0031d34eb4b956162862aeadcde195c0d2835ee" }
-ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "c0031d34eb4b956162862aeadcde195c0d2835ee" }
-ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "c0031d34eb4b956162862aeadcde195c0d2835ee" }
-ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "c0031d34eb4b956162862aeadcde195c0d2835ee" }
-ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "c0031d34eb4b956162862aeadcde195c0d2835ee", features = ["rustls"]}
-ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "c0031d34eb4b956162862aeadcde195c0d2835ee" }
+# This rev hash corresponds to https://github.com/Devolutions/IronRDP/pull/436 and should be changed before merging
+ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
+ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
+ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
+ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
+ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
+ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
+ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }
+ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e", features = ["rustls"]}
+ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "e9b2f3a1db9e8b04e9b06bf2ae6599ee98cfb02e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,16 @@ codegen-units = 1
 [workspace.dependencies]
 # Note: To use a local IronRDP repository as a crate (for example, ironrdp-cliprdr), define the dependency as follows:
 # ironrdp-cliprdr = { path = "/path/to/local/IronRDP/crates/ironrdp-cliprdr" }
-# This rev hash corresponds to https://github.com/Devolutions/IronRDP/pull/436 and should be changed before merging
-ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
-ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
-ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
-ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
-ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
-ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
-ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
-ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0", features = ["rustls"]}
-ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "a494270c247ffd62162352886304a3d7504be8b0" }
+# This rev hash corresponds to https://github.com/Devolutions/IronRDP/pull/436. It is being merged while that PR is
+# still open in IronRDP in order to get these changes into a release, however it should be updated once that PR is
+# merged. In the meantime, no other IronRDP hash's (without these changes) should be used.
+ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "e5bd2beab54bee2cf173cc110a804df2e709a1ac" }
+ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "e5bd2beab54bee2cf173cc110a804df2e709a1ac" }
+ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "e5bd2beab54bee2cf173cc110a804df2e709a1ac" }
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "e5bd2beab54bee2cf173cc110a804df2e709a1ac" }
+ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "e5bd2beab54bee2cf173cc110a804df2e709a1ac" }
+ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "e5bd2beab54bee2cf173cc110a804df2e709a1ac" }
+ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "e5bd2beab54bee2cf173cc110a804df2e709a1ac" }
+ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "e5bd2beab54bee2cf173cc110a804df2e709a1ac" }
+ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "e5bd2beab54bee2cf173cc110a804df2e709a1ac", features = ["rustls"]}
+ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "e5bd2beab54bee2cf173cc110a804df2e709a1ac" }


### PR DESCRIPTION
Updates Teleport to use the IronRDP hash with licensing protocol fixes. Of note is the note I left for myself:

```
# This rev hash corresponds to https://github.com/Devolutions/IronRDP/pull/436. It is being merged while that PR is
# still open in IronRDP in order to get these changes into a release, however it should be updated once that PR is
# merged. In the meantime, no other IronRDP hash's (without these changes) should be used.
```

changelog: Fixes RDP licensing.