### PR TITLE
Thread `context.Context` through `auth.Register` and add OTel Tracing

### DIFF
--- a/api/observability/tracing/tracing.go
+++ b/api/observability/tracing/tracing.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
@@ -52,4 +53,24 @@ func DefaultProvider() oteltrace.TracerProvider {
 // [oteltrace.TracerProvider] with the provided name.
 func NewTracer(name string) oteltrace.Tracer {
 	return DefaultProvider().Tracer(name)
+}
+
+// EndSpan ends the given span and if an error has occurred, set's the span's
+// status to error and additionally records the error.
+//
+// Example usage:
+//
+//	func myFunc() (err error) {
+//	  ctx, span := tracer.NewSpan(ctx, "myFunc")
+//	  defer func() {
+//	    tracing.EndSpan(span, err)
+//	  }()
+//	  ...
+//	}
+func EndSpan(span oteltrace.Span, err error) {
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	}
+	span.End()
 }

--- a/api/observability/tracing/tracing.go
+++ b/api/observability/tracing/tracing.go
@@ -17,6 +17,7 @@ package tracing
 import (
 	"context"
 
+	"github.com/gravitational/trace"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
@@ -70,7 +71,7 @@ func NewTracer(name string) oteltrace.Tracer {
 func EndSpan(span oteltrace.Span, err error) {
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		span.RecordError(err)
+		span.RecordError(trace.Unwrap(err))
 	}
 	span.End()
 }

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -663,7 +663,7 @@ func mustRegisterUsingIAMMethod(t *testing.T, proxyAddr utils.NetAddr, token str
 	require.NoError(t, err)
 
 	node := uuid.NewString()
-	_, err = auth.Register(auth.RegisterParams{
+	_, err = auth.Register(context.TODO(), auth.RegisterParams{
 		Token: token,
 		ID: auth.IdentityID{
 			Role:     types.RoleNode,

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -54,6 +54,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/exp/maps"
@@ -152,6 +153,8 @@ const (
 		"This is not recommended due to the volatitily of dynamic/ labels and is not allowed for new roles. " +
 		"(hint: use 'tctl get roles' to find roles that need updating)"
 )
+
+var tracer = otel.Tracer("github.com/gravitational/teleport/lib/auth")
 
 var ErrRequiresEnterprise = services.ErrRequiresEnterprise
 

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -116,7 +116,7 @@ func TestRegisterBotCertificateGenerationCheck(t *testing.T) {
 	tlsPublicKey, err := tlsca.MarshalPublicKeyFromPrivateKeyPEM(sshPrivateKey)
 	require.NoError(t, err)
 
-	certs, err := Register(RegisterParams{
+	certs, err := Register(ctx, RegisterParams{
 		Token: token.GetName(),
 		ID: IdentityID{
 			Role: types.RoleBot,
@@ -189,7 +189,7 @@ func TestRegisterBotCertificateGenerationStolen(t *testing.T) {
 	tlsPublicKey, err := tlsca.MarshalPublicKeyFromPrivateKeyPEM(sshPrivateKey)
 	require.NoError(t, err)
 
-	certs, err := Register(RegisterParams{
+	certs, err := Register(ctx, RegisterParams{
 		Token: token.GetName(),
 		ID: IdentityID{
 			Role: types.RoleBot,
@@ -265,7 +265,7 @@ func TestRegisterBotCertificateExtensions(t *testing.T) {
 	tlsPublicKey, err := tlsca.MarshalPublicKeyFromPrivateKeyPEM(sshPrivateKey)
 	require.NoError(t, err)
 
-	certs, err := Register(RegisterParams{
+	certs, err := Register(ctx, RegisterParams{
 		Token: token.GetName(),
 		ID: IdentityID{
 			Role: types.RoleBot,

--- a/lib/auth/join_test.go
+++ b/lib/auth/join_test.go
@@ -370,7 +370,7 @@ func TestRegister_Bot(t *testing.T) {
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			start := srv.Clock().Now()
-			certs, err := Register(RegisterParams{
+			certs, err := Register(ctx, RegisterParams{
 				Token: test.token.GetName(),
 				ID: IdentityID{
 					Role: types.RoleBot,
@@ -473,7 +473,7 @@ func TestRegister_Bot_Expiry(t *testing.T) {
 			tok := newBotToken(t, t.Name(), botName, types.RoleBot, srv.Clock().Now().Add(time.Hour))
 			require.NoError(t, srv.Auth().UpsertToken(ctx, tok))
 
-			certs, err := Register(RegisterParams{
+			certs, err := Register(ctx, RegisterParams{
 				Token: tok.GetName(),
 				ID: IdentityID{
 					Role: types.RoleBot,

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -3387,7 +3387,7 @@ func TestRegisterCAPin(t *testing.T) {
 	caPin := caPins[0]
 
 	// Attempt to register with valid CA pin, should work.
-	_, err = Register(RegisterParams{
+	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
 		ID: IdentityID{
@@ -3405,7 +3405,7 @@ func TestRegisterCAPin(t *testing.T) {
 
 	// Attempt to register with multiple CA pins where the auth server only
 	// matches one, should work.
-	_, err = Register(RegisterParams{
+	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
 		ID: IdentityID{
@@ -3422,7 +3422,7 @@ func TestRegisterCAPin(t *testing.T) {
 	require.NoError(t, err)
 
 	// Attempt to register with invalid CA pin, should fail.
-	_, err = Register(RegisterParams{
+	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
 		ID: IdentityID{
@@ -3439,7 +3439,7 @@ func TestRegisterCAPin(t *testing.T) {
 	require.Error(t, err)
 
 	// Attempt to register with multiple invalid CA pins, should fail.
-	_, err = Register(RegisterParams{
+	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
 		ID: IdentityID{
@@ -3475,7 +3475,7 @@ func TestRegisterCAPin(t *testing.T) {
 	require.Len(t, caPins, 2)
 
 	// Attempt to register with multiple CA pins, should work
-	_, err = Register(RegisterParams{
+	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
 		ID: IdentityID{
@@ -3520,7 +3520,7 @@ func TestRegisterCAPath(t *testing.T) {
 	require.NoError(t, err)
 
 	// Attempt to register with nothing at the CA path, should work.
-	_, err = Register(RegisterParams{
+	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
 		ID: IdentityID{
@@ -3549,7 +3549,7 @@ func TestRegisterCAPath(t *testing.T) {
 	require.NoError(t, err)
 
 	// Attempt to register with valid CA path, should work.
-	_, err = Register(RegisterParams{
+	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
 		ID: IdentityID{

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -463,7 +463,7 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 			}
 		}
 
-		certs, err := auth.Register(registerParams)
+		certs, err := auth.Register(process.ExitContext(), registerParams)
 		if err != nil {
 			if utils.IsUntrustedCertErr(err) {
 				return nil, trace.WrapWithMessage(err, utils.SelfSignedCertsMsg)

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -435,7 +435,7 @@ func botIdentityFromToken(ctx context.Context, log logrus.FieldLogger, cfg *conf
 		}
 	}
 
-	certs, err := auth.Register(params)
+	certs, err := auth.Register(ctx, params)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
P much does what it says on the tin with this one.

CC: @rosstimothy - I've added an "EndSpan" function to our `tracing` lib, curious on your thoughts on this.