### PR TITLE
Add Hugo as a reviewer to dependabot / and /api PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,7 @@ updates:
       - codingllama
       - rosstimothy
       - zmb3
+      - hugoshaka
     labels:
       - "dependencies"
       - "go"
@@ -52,6 +53,7 @@ updates:
       - codingllama
       - rosstimothy
       - zmb3
+      - hugoshaka
     labels:
       - "dependencies"
       - "go"


### PR DESCRIPTION
The introduction of the ./integrations/event-handler and ./integrations/terraform modules means a constant need to tidy those module for root PRs to pass CI.

This means:
- Root module PRs now often cause changes in those modules
- We could use the additional help in keeping up with the bots

Because of that, Hugo is now summoned to be take part in those reviews. ;)