### PR TITLE
[v14] docs: remove team version reference in terraform guide

### DIFF
--- a/docs/pages/agents/deploy-agents-terraform.mdx
+++ b/docs/pages/agents/deploy-agents-terraform.mdx
@@ -191,7 +191,7 @@ Edit the `module "teleport"` block in `main.tf` as follows:
    </Notice>
 
 1. Make sure `teleport_edition` matches your Teleport edition. Assign this to
-   `oss`, `cloud`, `enterprise`, or `team`. The default is `oss`.
+   `oss`, `cloud`, or `enterprise`. The default is `oss`.
 
 1. If needed, change the value of `teleport_version` to the version of Teleport
    you want to run on your agents. It must be either the same major version as


### PR DESCRIPTION
Backport #40600 to branch/v14