### PR TITLE
Lint Terraform and Event-Handler

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -102,6 +102,20 @@ jobs:
           working-directory: build.assets/tooling
           args: --out-format=colored-line-number
           skip-cache: true
+      - name: golangci-lint (integrations/terraform)
+        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          working-directory: integrations/terraform
+          args: --out-format=colored-line-number
+          skip-cache: true
+      - name: golangci-lint (integrations/event-handler)
+        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          working-directory: integrations/event-handler
+          args: --out-format=colored-line-number
+          skip-cache: true
 
       - uses: bufbuild/buf-setup-action@9990c72db080fa39cf561230b8d2d7b736681f85 # v1.30.1
         with:

--- a/Makefile
+++ b/Makefile
@@ -1008,6 +1008,8 @@ endif
 lint-go: GO_LINT_FLAGS ?=
 lint-go:
 	golangci-lint run -c .golangci.yml --build-tags='$(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_LINT_TAG)' $(GO_LINT_FLAGS)
+	$(MAKE) -C integrations/terraform lint
+	$(MAKE) -C integrations/event-handler lint
 
 .PHONY: fix-imports
 fix-imports:

--- a/integrations/event-handler/Makefile
+++ b/integrations/event-handler/Makefile
@@ -123,7 +123,6 @@ gen-example-mtls:
 	openssl req -config example/ssl.conf -subj "/CN=client" -key example/keys/client.key -new -out example/keys/client.csr
 	openssl x509 -req -in example/keys/client.csr -CA example/keys/ca.crt -CAkey example/keys/ca.key -CAcreateserial -days 365 -out example/keys/client.crt -extfile example/ssl.conf -extensions client_cert
 
-
 .PHONY: lint
 lint:
 	golangci-lint run -c ../../.golangci.yml

--- a/integrations/event-handler/Makefile
+++ b/integrations/event-handler/Makefile
@@ -124,3 +124,6 @@ gen-example-mtls:
 	openssl x509 -req -in example/keys/client.csr -CA example/keys/ca.crt -CAkey example/keys/ca.key -CAcreateserial -days 365 -out example/keys/client.crt -extfile example/ssl.conf -extensions client_cert
 
 
+.PHONY: lint
+lint:
+	golangci-lint run -c ../../.golangci.yml

--- a/integrations/terraform/Makefile
+++ b/integrations/terraform/Makefile
@@ -130,3 +130,7 @@ reapply:
 .PHONY: destroy
 destroy:
 	terraform -chdir=$(TFDIR) destroy -auto-approve
+
+.PHONY: lint
+lint:
+	golangci-lint run -c ../../.golangci.yml

--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"slices"
 	"sort"
 	"strings"
 	"text/template"
@@ -31,7 +32,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/olekukonko/tablewriter"
-	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/teleport/integrations/terraform/provider"
 	"github.com/gravitational/teleport/integrations/terraform/tfschema"

--- a/integrations/terraform/test/app_test.go
+++ b/integrations/terraform/test/app_test.go
@@ -115,8 +115,8 @@ func (s *TerraformSuite) TestImportApp() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], "app")
-					require.Equal(s.T(), state[0].Attributes["spec.uri"], "localhost:3000/test")
+					require.Equal(s.T(), "app", state[0].Attributes["kind"])
+					require.Equal(s.T(), "localhost:3000/test", state[0].Attributes["spec.uri"])
 
 					return nil
 				},

--- a/integrations/terraform/test/auth_preference_test.go
+++ b/integrations/terraform/test/auth_preference_test.go
@@ -102,8 +102,8 @@ func (s *TerraformSuite) TestImportAuthPreference() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], "cluster_auth_preference")
-					require.Equal(s.T(), state[0].Attributes["spec.disconnect_expired_cert"], "true")
+					require.Equal(s.T(), "cluster_auth_preference", state[0].Attributes["kind"])
+					require.Equal(s.T(), "true", state[0].Attributes["spec.disconnect_expired_cert"])
 
 					return nil
 				},

--- a/integrations/terraform/test/cluster_networking_config_test.go
+++ b/integrations/terraform/test/cluster_networking_config_test.go
@@ -103,8 +103,8 @@ func (s *TerraformSuite) TestImportClusterNetworkingConfig() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], "cluster_networking_config")
-					require.Equal(s.T(), state[0].Attributes["spec.client_idle_timeout"], "30s")
+					require.Equal(s.T(), "cluster_networking_config", state[0].Attributes["kind"])
+					require.Equal(s.T(), "30s", state[0].Attributes["spec.client_idle_timeout"])
 
 					return nil
 				},

--- a/integrations/terraform/test/configuration_test.go
+++ b/integrations/terraform/test/configuration_test.go
@@ -25,10 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (s *TerraformSuite) getTLSCerts() {
-
-}
-
 func (s *TerraformSuite) TestConfigureAuthBase64() {
 	name := "teleport_app.test_auth_b64"
 

--- a/integrations/terraform/test/database_test.go
+++ b/integrations/terraform/test/database_test.go
@@ -118,9 +118,9 @@ func (s *TerraformSuite) TestImportDatabase() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], "db")
-					require.Equal(s.T(), state[0].Attributes["spec.uri"], "localhost:3000/test")
-					require.Equal(s.T(), state[0].Attributes["spec.protocol"], "postgres")
+					require.Equal(s.T(), "db", state[0].Attributes["kind"])
+					require.Equal(s.T(), "localhost:3000/test", state[0].Attributes["spec.uri"])
+					require.Equal(s.T(), "postgres", state[0].Attributes["spec.protocol"])
 
 					return nil
 				},

--- a/integrations/terraform/test/device_trust_test.go
+++ b/integrations/terraform/test/device_trust_test.go
@@ -125,11 +125,11 @@ func (s *TerraformSuite) TestImportTrustedDevices() {
 				ImportState:   true,
 				ImportStateId: deviceID,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					s.Require().Equal(state[0].Attributes["metadata.name"], deviceID)
-					s.Require().Equal(state[0].Attributes["kind"], "device")
-					s.Require().Equal(state[0].Attributes["spec.asset_tag"], "DEVICE1")
-					s.Require().Equal(state[0].Attributes["spec.os_type"], "macos")
-					s.Require().Equal(state[0].Attributes["spec.enroll_status"], "not_enrolled")
+					s.Require().Equal(deviceID, state[0].Attributes["metadata.name"])
+					s.Require().Equal("device", state[0].Attributes["kind"])
+					s.Require().Equal("DEVICE1", state[0].Attributes["spec.asset_tag"])
+					s.Require().Equal("macos", state[0].Attributes["spec.os_type"])
+					s.Require().Equal("not_enrolled", state[0].Attributes["spec.enroll_status"])
 					return nil
 				},
 			},

--- a/integrations/terraform/test/github_connector_test.go
+++ b/integrations/terraform/test/github_connector_test.go
@@ -121,11 +121,11 @@ func (s *TerraformSuite) TestImportGithubConnector() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], "github")
-					require.Equal(s.T(), state[0].Attributes["spec.client_id"], "Iv1.3386eee92ff932a4")
-					require.Equal(s.T(), state[0].Attributes["spec.teams_to_logins.0.organization"], "evilmartians")
-					require.Equal(s.T(), state[0].Attributes["spec.teams_to_logins.0.team"], "devs")
-					require.Equal(s.T(), state[0].Attributes["spec.teams_to_logins.0.logins.0"], "terraform")
+					require.Equal(s.T(), "github", state[0].Attributes["kind"])
+					require.Equal(s.T(), "Iv1.3386eee92ff932a4", state[0].Attributes["spec.client_id"])
+					require.Equal(s.T(), "evilmartians", state[0].Attributes["spec.teams_to_logins.0.organization"])
+					require.Equal(s.T(), "devs", state[0].Attributes["spec.teams_to_logins.0.team"])
+					require.Equal(s.T(), "terraform", state[0].Attributes["spec.teams_to_logins.0.logins.0"])
 
 					return nil
 				},

--- a/integrations/terraform/test/loginrule_test.go
+++ b/integrations/terraform/test/loginrule_test.go
@@ -135,9 +135,9 @@ func (s *TerraformSuite) TestImportLoginRule() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					s.Require().Equal(state[0].Attributes["metadata.name"], id)
-					s.Require().Equal(state[0].Attributes["priority"], "1")
-					s.Require().Equal(state[0].Attributes["traits_expression"], rule.TraitsExpression)
+					s.Require().Equal(id, state[0].Attributes["metadata.name"])
+					s.Require().Equal("1", state[0].Attributes["priority"])
+					s.Require().Equal(rule.TraitsExpression, state[0].Attributes["traits_expression"])
 					return nil
 				},
 			},

--- a/integrations/terraform/test/main_test.go
+++ b/integrations/terraform/test/main_test.go
@@ -57,8 +57,6 @@ type TerraformBaseSuite struct {
 	teleportConfig lib.TeleportConfig
 	// teleportFeatures represents enabled Teleport feature flags
 	teleportFeatures *proto.Features
-	// plugin represents plugin user name
-	plugin string
 	// terraformConfig represents Terraform provider configuration
 	terraformConfig string
 	// terraformProvider represents an instance of a Terraform provider
@@ -142,6 +140,7 @@ func (s *TerraformBaseSuite) SetupSuite() {
 	require.NoError(t, err)
 	tfUser.SetRoles([]string{tfRole.GetName()})
 	tfUser, err = s.client.CreateUser(ctx, tfUser)
+	require.NoError(t, err)
 
 	// Sign an identity for the access plugin and generate its configuration
 	s.teleportConfig.Addr = s.AuthHelper.ServerAddr()

--- a/integrations/terraform/test/oidc_connector_test.go
+++ b/integrations/terraform/test/oidc_connector_test.go
@@ -132,11 +132,11 @@ func (s *TerraformSuite) TestImportOIDCConnector() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], "oidc")
-					require.Equal(s.T(), state[0].Attributes["spec.client_id"], "Iv1.3386eee92ff932a4")
-					require.Equal(s.T(), state[0].Attributes["spec.claims_to_roles.0.claim"], "test")
-					require.Equal(s.T(), state[0].Attributes["spec.claims_to_roles.0.roles.0"], "terraform")
-					require.Equal(s.T(), state[0].Attributes["spec.max_age"], "5m0s")
+					require.Equal(s.T(), "oidc", state[0].Attributes["kind"])
+					require.Equal(s.T(), "Iv1.3386eee92ff932a4", state[0].Attributes["spec.client_id"])
+					require.Equal(s.T(), "test", state[0].Attributes["spec.claims_to_roles.0.claim"])
+					require.Equal(s.T(), "terraform", state[0].Attributes["spec.claims_to_roles.0.roles.0"])
+					require.Equal(s.T(), "5m0s", state[0].Attributes["spec.max_age"])
 
 					return nil
 				},
@@ -234,11 +234,11 @@ func (s *TerraformSuite) TestImportOIDCConnectorWithoutMaxAge() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], "oidc")
-					require.Equal(s.T(), state[0].Attributes["spec.client_id"], "Iv1.3386eee92ff932a4")
-					require.Equal(s.T(), state[0].Attributes["spec.claims_to_roles.0.claim"], "test")
-					require.Equal(s.T(), state[0].Attributes["spec.claims_to_roles.0.roles.0"], "terraform")
-					require.NotContains(s.T(), state[0].Attributes, "spec.max_age")
+					require.Equal(s.T(), "oidc", state[0].Attributes["kind"])
+					require.Equal(s.T(), "Iv1.3386eee92ff932a4", state[0].Attributes["spec.client_id"])
+					require.Equal(s.T(), "test", state[0].Attributes["spec.claims_to_roles.0.claim"])
+					require.Equal(s.T(), "terraform", state[0].Attributes["spec.claims_to_roles.0.roles.0"])
+					require.NotContains(s.T(), "spec.max_age", state[0].Attributes)
 
 					return nil
 				},

--- a/integrations/terraform/test/okta_import_rule_test.go
+++ b/integrations/terraform/test/okta_import_rule_test.go
@@ -159,7 +159,7 @@ func (s *TerraformSuite) TestImportOktaImportRule() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], "okta_import_rule")
+					require.Equal(s.T(), "okta_import_rule", state[0].Attributes["kind"])
 
 					return nil
 				},

--- a/integrations/terraform/test/provision_token_test.go
+++ b/integrations/terraform/test/provision_token_test.go
@@ -178,8 +178,8 @@ func (s *TerraformSuite) TestImportProvisionToken() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], "token")
-					require.Equal(s.T(), state[0].Attributes["metadata.name"], "test_import")
+					require.Equal(s.T(), "token", state[0].Attributes["kind"])
+					require.Equal(s.T(), "test_import", state[0].Attributes["metadata.name"])
 
 					return nil
 				},

--- a/integrations/terraform/test/role_test.go
+++ b/integrations/terraform/test/role_test.go
@@ -252,14 +252,16 @@ func (s *TerraformSuite) TestRoleLoginsSplitBrain() {
 }
 
 func (s *TerraformSuite) TestRoleVersionUpgrade() {
-	s.T().Skip("Test temporarily disabled until v16")
-	ctx, cancel := context.WithCancel(context.Background())
-	s.T().Cleanup(cancel)
-
+	// TODO(hugoShaka) Re-enable this test when we fix the role defaults in v16
 	// We had a bug in v14 and below that caused the defaults to be badly computed.
 	// We tried to fix this bug in v15 but it was too aggressive (forcing replacement is too destructive).
 	// In v16 we'll push a new plan modifier to fix this issue, this might be a
 	// breaking change for users who relied on the bug.
+	s.T().Skip("Test temporarily disabled until v16")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
 	checkDestroyed := func(state *terraform.State) error {
 		_, err := s.client.GetRole(ctx, "upgrade")
 		if trace.IsNotFound(err) {

--- a/integrations/terraform/test/role_test.go
+++ b/integrations/terraform/test/role_test.go
@@ -186,8 +186,8 @@ func (s *TerraformSuite) TestImportRole() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], "role")
-					require.Equal(s.T(), state[0].Attributes["metadata.name"], "test_import")
+					require.Equal(s.T(), "role", state[0].Attributes["kind"])
+					require.Equal(s.T(), "test_import", state[0].Attributes["metadata.name"])
 
 					return nil
 				},
@@ -252,6 +252,7 @@ func (s *TerraformSuite) TestRoleLoginsSplitBrain() {
 }
 
 func (s *TerraformSuite) TestRoleVersionUpgrade() {
+	s.T().Skip("Test temporarily disabled until v16")
 	ctx, cancel := context.WithCancel(context.Background())
 	s.T().Cleanup(cancel)
 
@@ -259,7 +260,6 @@ func (s *TerraformSuite) TestRoleVersionUpgrade() {
 	// We tried to fix this bug in v15 but it was too aggressive (forcing replacement is too destructive).
 	// In v16 we'll push a new plan modifier to fix this issue, this might be a
 	// breaking change for users who relied on the bug.
-	s.T().Skip("Test temporarily disabled until v16")
 	checkDestroyed := func(state *terraform.State) error {
 		_, err := s.client.GetRole(ctx, "upgrade")
 		if trace.IsNotFound(err) {

--- a/integrations/terraform/test/saml_connector_test.go
+++ b/integrations/terraform/test/saml_connector_test.go
@@ -153,8 +153,8 @@ func (s *TerraformSuite) TestImportSAMLConnector() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], "saml")
-					require.Equal(s.T(), state[0].Attributes["spec.acs"], "https://example.com/v1/webapi/saml/acs")
+					require.Equal(s.T(), "saml", state[0].Attributes["kind"])
+					require.Equal(s.T(), "https://example.com/v1/webapi/saml/acs", state[0].Attributes["spec.acs"])
 
 					return nil
 				},

--- a/integrations/terraform/test/server_test.go
+++ b/integrations/terraform/test/server_test.go
@@ -176,10 +176,10 @@ func (s *TerraformSuite) TestImportOpenSSHServer() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], types.KindNode)
-					require.Equal(s.T(), state[0].Attributes["sub_kind"], types.SubKindOpenSSHNode)
-					require.Equal(s.T(), state[0].Attributes["spec.addr"], "127.0.0.1:22")
-					require.Equal(s.T(), state[0].Attributes["spec.hostname"], "foobar")
+					require.Equal(s.T(), types.KindNode, state[0].Attributes["kind"])
+					require.Equal(s.T(), types.SubKindOpenSSHNode, state[0].Attributes["sub_kind"])
+					require.Equal(s.T(), "127.0.0.1:22", state[0].Attributes["spec.addr"])
+					require.Equal(s.T(), "foobar", state[0].Attributes["spec.hostname"])
 
 					return nil
 				},
@@ -305,16 +305,16 @@ func (s *TerraformSuite) TestImportOpenSSHEICEServer() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], types.KindNode)
-					require.Equal(s.T(), state[0].Attributes["sub_kind"], types.SubKindOpenSSHEICENode)
-					require.Equal(s.T(), state[0].Attributes["spec.addr"], "127.0.0.1:22")
-					require.Equal(s.T(), state[0].Attributes["spec.hostname"], "foobar")
-					require.Equal(s.T(), state[0].Attributes["spec.cloud_metadata.aws.account_id"], "123")
-					require.Equal(s.T(), state[0].Attributes["spec.cloud_metadata.aws.instance_id"], "123")
-					require.Equal(s.T(), state[0].Attributes["spec.cloud_metadata.aws.region"], "us-east-1")
-					require.Equal(s.T(), state[0].Attributes["spec.cloud_metadata.aws.vpc_id"], "123")
-					require.Equal(s.T(), state[0].Attributes["spec.cloud_metadata.aws.integration"], "foo")
-					require.Equal(s.T(), state[0].Attributes["spec.cloud_metadata.aws.subnet_id"], "123")
+					require.Equal(s.T(), types.KindNode, state[0].Attributes["kind"])
+					require.Equal(s.T(), types.SubKindOpenSSHEICENode, state[0].Attributes["sub_kind"])
+					require.Equal(s.T(), "127.0.0.1:22", state[0].Attributes["spec.addr"])
+					require.Equal(s.T(), "foobar", state[0].Attributes["spec.hostname"])
+					require.Equal(s.T(), "123", state[0].Attributes["spec.cloud_metadata.aws.account_id"])
+					require.Equal(s.T(), "123", state[0].Attributes["spec.cloud_metadata.aws.instance_id"])
+					require.Equal(s.T(), "us-east-1", state[0].Attributes["spec.cloud_metadata.aws.region"])
+					require.Equal(s.T(), "123", state[0].Attributes["spec.cloud_metadata.aws.vpc_id"])
+					require.Equal(s.T(), "foo", state[0].Attributes["spec.cloud_metadata.aws.integration"])
+					require.Equal(s.T(), "123", state[0].Attributes["spec.cloud_metadata.aws.subnet_id"])
 					return nil
 				},
 			},

--- a/integrations/terraform/test/session_recording_config_test.go
+++ b/integrations/terraform/test/session_recording_config_test.go
@@ -99,8 +99,8 @@ func (s *TerraformSuite) TestImportSessionRecordingConfig() {
 				ImportState:   true,
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
-					require.Equal(s.T(), state[0].Attributes["kind"], "session_recording_config")
-					require.Equal(s.T(), state[0].Attributes["spec.mode"], "off")
+					require.Equal(s.T(), "session_recording_config", state[0].Attributes["kind"])
+					require.Equal(s.T(), "off", state[0].Attributes["spec.mode"])
 
 					return nil
 				},


### PR DESCRIPTION
This PR adds lint jobs in CI for Terraform and event handler. Those were ignored before as they are living in separate go modules.