### PR TITLE
Add DeviceTrustWeb passthrough component

### DIFF
--- a/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.story.tsx
+++ b/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.story.tsx
@@ -1,0 +1,41 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { getPlatform } from 'design/platform';
+import { MemoryRouter } from 'react-router';
+
+import { getConnectDownloadLinks } from '../DownloadConnect/DownloadConnect';
+
+import { DeviceTrustConnectPassthrough } from './AuthorizeDeviceWeb';
+
+export default {
+  title: 'Shared/AuthorizeDeviceWeb',
+};
+
+export function AuthorizeDeviceWeb() {
+  const platform = getPlatform();
+  const downloadLinks = getConnectDownloadLinks(platform, '15.2.2');
+  return (
+    <MemoryRouter>
+      <DeviceTrustConnectPassthrough
+        authorizeWebDeviceDeepLink={'blank'}
+        downloadLinks={downloadLinks}
+      />
+    </MemoryRouter>
+  );
+}

--- a/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.tsx
+++ b/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.tsx
@@ -1,0 +1,110 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+import { Box, Flex, ButtonPrimary, Text, ButtonLink } from 'design';
+import { Link } from 'react-router-dom';
+
+import cfg from 'teleport/config';
+
+import {
+  DownloadConnect,
+  DownloadLink,
+} from 'shared/components/DownloadConnect/DownloadConnect';
+
+export const DeviceTrustConnectPassthrough = ({
+  authorizeWebDeviceDeepLink,
+  downloadLinks,
+}: {
+  authorizeWebDeviceDeepLink: string;
+  downloadLinks: Array<DownloadLink>;
+}) => {
+  return (
+    <Wrapper>
+      <Flex flexDirection="column">
+        <Text fontWeight={300} fontSize={7} mb={7}>
+          Click <BoldText>Open Teleport Connect</BoldText> on the dialog shown
+          by your browser
+        </Text>
+        <Text fontSize={7} mb={10} fontWeight={300}>
+          If you don't see a dialog, click{' '}
+          <BoldText>Launch Teleport Connect</BoldText> below
+        </Text>
+        <Flex justifyContent="center" mb={9}>
+          <ButtonPrimary
+            textTransform="none"
+            width="280px"
+            as="a"
+            href={authorizeWebDeviceDeepLink}
+          >
+            Launch Teleport Connect
+          </ButtonPrimary>
+        </Flex>
+        <Box>
+          <Text fontSize={3}>
+            Don't have Teleport Connect?{' '}
+            {downloadLinks.length === 1 ? (
+              <DownloadButton as="a" href={downloadLinks[0].url}>
+                Download it now
+              </DownloadButton>
+            ) : (
+              <DownloadConnect downloadLinks={downloadLinks} />
+            )}
+          </Text>
+        </Box>
+        <SkipAuthNotice>
+          <Text>
+            You can{' '}
+            <Link
+              css={`
+                text-decoration: none;
+              `}
+              to={cfg.routes.root}
+            >
+              continue without device trust{' '}
+            </Link>
+            but you will not be able to connect to resources that require Device
+            Trust.
+          </Text>
+        </SkipAuthNotice>
+      </Flex>
+    </Wrapper>
+  );
+};
+
+const SkipAuthNotice = styled(Box)`
+  text-align: center;
+  width: 100%;
+  position: absolute;
+  bottom: 24px;
+`;
+
+const DownloadButton = styled(ButtonLink)`
+  text-decoration: none;
+  font-size: 16px;
+  color: ${props => props.theme.colors.brand};
+`;
+
+const BoldText = styled.span`
+  font-weight: 700;
+`;
+
+const Wrapper = styled(Box)`
+  text-align: center;
+  line-height: 32px;
+`;

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -133,74 +133,76 @@ export function TopBar({ CustomLogo, assistProps }: TopBarProps) {
       {!feature?.hideNavigation && (
         <>
           <TeleportLogo CustomLogo={CustomLogo} />
-          <Flex
-            height="100%"
-            css={`
-              margin-left: auto;
-              @media screen and (min-width: ${p =>
-                  p.theme.breakpoints.medium}px) {
-                margin-left: 0;
-                margin-right: auto;
-              }
-            `}
-          >
-            {cfg.isDashboard ? (
+          {!feature?.logoOnlyTopbar && (
+            <Flex
+              height="100%"
+              css={`
+                margin-left: auto;
+                @media screen and (min-width: ${p =>
+                    p.theme.breakpoints.medium}px) {
+                  margin-left: 0;
+                  margin-right: auto;
+                }
+              `}
+            >
+              {cfg.isDashboard ? (
+                <MainNavItem
+                  name="Downloads"
+                  to={cfg.routes.downloadCenter}
+                  isSelected={downloadTabSelected}
+                  size={iconSize}
+                  Icon={Download}
+                />
+              ) : (
+                <MainNavItem
+                  name="Resources"
+                  to={cfg.getUnifiedResourcesRoute(clusterId)}
+                  isSelected={resourceTabSelected}
+                  size={iconSize}
+                  Icon={Server}
+                />
+              )}
               <MainNavItem
-                name="Downloads"
-                to={cfg.routes.downloadCenter}
-                isSelected={downloadTabSelected}
+                name="Access Management"
+                to={
+                  previousManagementRoute ||
+                  getFirstRouteForCategory(
+                    features,
+                    NavigationCategory.Management
+                  )
+                }
                 size={iconSize}
-                Icon={Download}
+                isSelected={managementTabSelected}
+                Icon={SlidersVertical}
               />
-            ) : (
-              <MainNavItem
-                name="Resources"
-                to={cfg.getUnifiedResourcesRoute(clusterId)}
-                isSelected={resourceTabSelected}
-                size={iconSize}
-                Icon={Server}
-              />
-            )}
-            <MainNavItem
-              name="Access Management"
-              to={
-                previousManagementRoute ||
-                getFirstRouteForCategory(
-                  features,
-                  NavigationCategory.Management
-                )
-              }
-              size={iconSize}
-              isSelected={managementTabSelected}
-              Icon={SlidersVertical}
-            />
 
-            {topBarLinks.map(({ topMenuItem, navigationItem }) => {
-              const link = navigationItem.getLink(clusterId);
-              const currentPath = history.location.pathname;
-              const selected =
-                navigationItem.isSelected?.(clusterId, currentPath) ||
-                history.location.pathname.includes(link);
-              return (
-                <NavigationButton
-                  key={topMenuItem.title}
-                  to={topMenuItem.getLink(clusterId)}
-                  selected={selected}
-                  title={topMenuItem.title}
-                  css={`
-                    &:hover {
-                      color: red;
-                    }
-                  `}
-                >
-                  <topMenuItem.icon
-                    color={selected ? 'text.main' : 'text.muted'}
-                    size={iconSize}
-                  />
-                </NavigationButton>
-              );
-            })}
-          </Flex>
+              {topBarLinks.map(({ topMenuItem, navigationItem }) => {
+                const link = navigationItem.getLink(clusterId);
+                const currentPath = history.location.pathname;
+                const selected =
+                  navigationItem.isSelected?.(clusterId, currentPath) ||
+                  history.location.pathname.includes(link);
+                return (
+                  <NavigationButton
+                    key={topMenuItem.title}
+                    to={topMenuItem.getLink(clusterId)}
+                    selected={selected}
+                    title={topMenuItem.title}
+                    css={`
+                      &:hover {
+                        color: red;
+                      }
+                    `}
+                  >
+                    <topMenuItem.icon
+                      color={selected ? 'text.main' : 'text.muted'}
+                      size={iconSize}
+                    />
+                  </NavigationButton>
+                );
+              })}
+            </Flex>
+          )}
         </>
       )}
       {feature?.hideNavigation && (

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -109,6 +109,10 @@ export interface TeleportFeature {
   category?: NavigationCategory;
   section?: ManagementSection;
   hasAccess(flags: FeatureFlags): boolean;
+  // logoOnlyTopbar is used to optionally hide the elements in the topbar from view except for the logo.
+  // The features that use this are supposed to be "full page" features where navigation
+  // is either blocked, or done explicitly through the page (such as device trust authorize)
+  logoOnlyTopbar?: boolean;
   hideFromNavigation?: boolean;
   // route defines react router Route fields.
   // This field can be left undefined to indicate


### PR DESCRIPTION


[figma link](https://www.figma.com/file/JKd0Bgs30AnNfNCLUuzzc2/Unified-Resources?type=design&node-id=2841-227&mode=design&t=SkWnnlZCzpK142HT-4)

This PR adds the "passthrough page" component for the device trust web authentication piece. This page will be what users see after logging into the web UI and a device trust token is returned in the response.

The final PR will be actually creating the route/feature that implements this component in e and passes it off to Connect but that will come together once this PR, https://github.com/gravitational/teleport/pull/40438, and https://github.com/gravitational/teleport/pull/40420 are in

Also, i snuck a prop update to our TopBar into this PR. the topbar will be displayed but with no components besides the logo so I added an optional prop to hide everything in the top bar but the Logo. that way, the logo functions the same way on this page as any other page (responsiveness and what not)

https://github.com/gravitational/teleport.e/issues/3236

<img width="878" alt="Screenshot 2024-04-17 at 5 37 20 AM" src="https://github.com/gravitational/teleport/assets/5201977/97b0c779-ca98-4b99-9cd4-de002a27a5a4">