### PR TITLE
Mention that DB per-session MFA works with `tsh proxy db --tunnel`

### DIFF
--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -262,7 +262,7 @@ Current limitations for this feature are:
 - For SSH connections besides the Web UI, the `tsh` or Teleport Connect client must be used for per-session MFA.
   (The OpenSSH `ssh` client does not work with per-session MFA).
 - Only `kubectl` supports per-session WebAuthn authentication for Kubernetes.
-- Database access with per-session MFA only works with `tsh db connect` or `tsh proxy db --tunnel`
+- Database access with per-session MFA only works with `tsh db connect` or `tsh proxy db --tunnel`.
   Per-session MFA for databases is not supported in Teleport Connect.
 - Application access clients don't support per-session MFA
   authentication yet, although cluster and role configuration applies to them.

--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -262,7 +262,7 @@ Current limitations for this feature are:
 - For SSH connections besides the Web UI, the `tsh` or Teleport Connect client must be used for per-session MFA.
   (The OpenSSH `ssh` client does not work with per-session MFA).
 - Only `kubectl` supports per-session WebAuthn authentication for Kubernetes.
-- Database access with per-session MFA only works with `tsh db connect`.
+- Database access with per-session MFA only works with `tsh db connect` or `tsh proxy db --tunnel`
   Per-session MFA for databases is not supported in Teleport Connect.
 - Application access clients don't support per-session MFA
   authentication yet, although cluster and role configuration applies to them.


### PR DESCRIPTION
### Summary

Documentation states that `tsh db connect` is the only way to use DB per-Session MFA. However, `tsh proxy db --tunnel` works as well.

> Database access with per-session MFA **only works** with `tsh db connect`


RFD:
- https://github.com/gravitational/teleport/blob/master/rfd/0090-db-mfa-sessions.md#why