### PR TITLE
fix: Restore component key value

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -71,7 +71,7 @@ const (
 const (
 	// ComponentKey is a field that represents a component - e.g. service or
 	// function
-	ComponentKey = "teleport.ComponentKey"
+	ComponentKey = "trace.component"
 	// ComponentFields is a fields component
 	ComponentFields = "trace.fields"
 


### PR DESCRIPTION
When converting from using constants in trace to equivalents defined in teleport the trace.component value was accidentally replaced.