### PR TITLE
tls handshake perf improvements

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -928,6 +928,13 @@ type AccessCache interface {
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
 }
 
+// AccessCacheWithEvents extends the AccessCache interface with events. Useful for trust-related components
+// that need to watch for changes.
+type AccessCacheWithEvents interface {
+	AccessCache
+	types.Events
+}
+
 // Cache is a subset of the auth interface handling
 // access to the discovery API and static tokens
 type Cache interface {

--- a/lib/auth/client_tls_config_generator.go
+++ b/lib/auth/client_tls_config_generator.go
@@ -68,7 +68,7 @@ func (cfg *ClientTLSConfigGeneratorConfig) CheckAndSetDefaults() error {
 }
 
 // ClientTLSConfigGenerator is a helper type used to implement fast & efficient client tls config specialization based upon
-// the target cluster specified in the client tls hello. this type keeps per-cluster client tls configs pre-generated and
+// the target cluster specified in the client TLS hello. This type keeps per-cluster client TLS configs pre-generated and
 // refreshes them periodically and/or when ca modification events are observed. The GetConfigForClient method of this type
 // is intended to be slotted into the GetConfigForClient field of tls.Config.
 type ClientTLSConfigGenerator struct {

--- a/lib/auth/client_tls_config_generator.go
+++ b/lib/auth/client_tls_config_generator.go
@@ -1,0 +1,263 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"log/slog"
+	"math"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/genmap"
+)
+
+// ClientTLSConfigGeneratorConfig holds parameters for ClientTLSConfigGenerator setup.
+type ClientTLSConfigGeneratorConfig struct {
+	// TLS is the upstream TLS config that per-cluster configs are generated from.
+	TLS *tls.Config
+	// ClusterName is the name of the current cluster.
+	ClusterName string
+	// PermiteRemoteClusters must be true for non-local cluster CAs to be used. Most usecases
+	// want this to be true, but it defaults to false to help avoid accidentally expanding the
+	// CA pool in cases where remote cluster CA usage is inappropriate.
+	PermitRemoteClusters bool
+	// AccessPoint is the upstream data source used to lookup cert authorities
+	// and watch for changes.
+	AccessPoint AccessCacheWithEvents
+}
+
+// CheckAndSetDefaults checks that required parameters were supplied and
+// sets default values as needed.
+func (cfg *ClientTLSConfigGeneratorConfig) CheckAndSetDefaults() error {
+	if cfg.TLS == nil {
+		return trace.BadParameter("missing required parameter 'TLS' for client tls config generator")
+	}
+
+	if cfg.ClusterName == "" {
+		return trace.BadParameter("missing required parameter 'ClusterName' for client tls config generator")
+	}
+
+	if cfg.AccessPoint == nil {
+		return trace.BadParameter("missing required parameter 'AccessPoint' for client tls config generator")
+	}
+
+	return nil
+}
+
+// ClientTLSConfigGenerator is a helper type used to implement fast & efficient client tls config specialization based upon
+// the target cluster specified in the client tls hello. this type keeps per-cluster client tls configs pre-generated and
+// refreshes them periodically and/or when ca modification events are observed. The GetConfigForClient method of this type
+// is intended to be slotted into the GetConfigForClient field of tls.Config.
+type ClientTLSConfigGenerator struct {
+	// cfg holds the config parameters for this generator.
+	cfg ClientTLSConfigGeneratorConfig
+	// clientTLSConfigs is a specialized cache that stores tls configs
+	// by cluster name.
+	clientTLSConfigs *genmap.GenMap[string, *tls.Config]
+	// cancel terminates the above close context.
+	cancel context.CancelFunc
+}
+
+// NewClientTLSConfigGenerator sets up a new generator based on the supplied parameters.
+func NewClientTLSConfigGenerator(cfg ClientTLSConfigGeneratorConfig) (*ClientTLSConfigGenerator, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := &ClientTLSConfigGenerator{
+		cfg:    cfg,
+		cancel: cancel,
+	}
+
+	var err error
+	c.clientTLSConfigs, err = genmap.New(genmap.Config[string, *tls.Config]{
+		Generator: c.generator,
+	})
+
+	if err != nil {
+		cancel()
+		return nil, trace.Wrap(err)
+	}
+
+	go c.refreshClientTLSConfigs(ctx)
+
+	return c, nil
+}
+
+// GetConfigForClient is intended to be slotted into the GetConfigForClient field of tls.Config.
+func (c *ClientTLSConfigGenerator) GetConfigForClient(info *tls.ClientHelloInfo) (*tls.Config, error) {
+	var clusterName string
+	var err error
+	switch info.ServerName {
+	case "":
+		// Client does not use SNI, will validate against all known CAs.
+	default:
+		clusterName, err = apiutils.DecodeClusterName(info.ServerName)
+		if err != nil {
+			if !trace.IsNotFound(err) {
+				slog.WarnContext(context.Background(), "ignoring unsupported cluster name in client hello", "cluster_name", info.ServerName)
+				clusterName = ""
+			}
+		}
+	}
+
+	cfg, err := c.clientTLSConfigs.Get(context.Background(), clusterName)
+	return cfg, trace.Wrap(err)
+}
+
+var errNonLocalCluster = errors.New("non-local cluster specified in client hello")
+
+// generator is the underlying lookup function used to resolve the tls config that should be used for a
+// given cluster. this method is used by the underlying genmap to load/refresh values as-needed.
+func (c *ClientTLSConfigGenerator) generator(ctx context.Context, clusterName string) (*tls.Config, error) {
+	if !c.cfg.PermitRemoteClusters && clusterName != c.cfg.ClusterName {
+		if clusterName != "" {
+			slog.WarnContext(ctx, "refusing to set up client cert pool for non-local cluster", "cluster_name", clusterName)
+			return nil, trace.Wrap(errNonLocalCluster)
+		}
+		// unsepcified cluster name should be treated as a request for local cluster CAs
+		clusterName = c.cfg.ClusterName
+	}
+
+	// update client certificate pool based on currently trusted TLS
+	// certificate authorities.
+	pool, totalSubjectsLen, err := DefaultClientCertPool(c.cfg.AccessPoint, clusterName)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to retrieve client cert pool for target cluster", "cluster_name", clusterName, "error", err)
+		// this falls back to the default config
+		return nil, nil
+	}
+
+	// Per https://tools.ietf.org/html/rfc5246#section-7.4.4 the total size of
+	// the known CA subjects sent to the client can't exceed 2^16-1 (due to
+	// 2-byte length encoding). The crypto/tls stack will panic if this
+	// happens.
+	//
+	// This usually happens on the root cluster with a very large (>500) number
+	// of leaf clusters. In these cases, the client cert will be signed by the
+	// current (root) cluster.
+	//
+	// If the number of CAs turns out too large for the handshake, drop all but
+	// the current cluster CA. In the unlikely case where it's wrong, the
+	// client will be rejected.
+	if totalSubjectsLen >= int64(math.MaxUint16) {
+		slog.WarnContext(ctx, "cluster subject name set too large for TLS handshake, falling back to using local cluster CAs only")
+		pool, _, err = DefaultClientCertPool(c.cfg.AccessPoint, c.cfg.ClusterName)
+		if err != nil {
+			slog.ErrorContext(ctx, "failed to retrieve client cert pool for current cluster", "cluster_name", c.cfg.ClusterName, "error", err)
+			// this falls back to the default config
+			return nil, nil
+		}
+	}
+
+	tlsCopy := c.cfg.TLS.Clone()
+	tlsCopy.ClientCAs = pool
+	return tlsCopy, nil
+}
+
+// refreshClientTLSConfigs is the top-level loop for client TLS config regen. note that it
+// has a fairly aggressive retry since this is a server-side singleton.
+func (c *ClientTLSConfigGenerator) refreshClientTLSConfigs(ctx context.Context) {
+	var lastWarning time.Time
+	for {
+		err := c.watchForCAChanges(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+
+		if lastWarning.IsZero() || time.Since(lastWarning) > time.Second*30 {
+			slog.WarnContext(ctx, "cert authority watch loop for client TLS config generator failed", "error", err)
+			lastWarning = time.Now()
+		}
+
+		select {
+		case <-time.After(utils.FullJitter(time.Second * 3)):
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// watchForCAChanges sets up a cert authority watcher and triggers regeneration of client
+// tls configs for a given cluster whenever a CA associated with that cluster is modified.
+// note that this function errs on the side of regenerating more often than might be
+// strictly necessary.
+func (c *ClientTLSConfigGenerator) watchForCAChanges(ctx context.Context) error {
+	watcher, err := c.cfg.AccessPoint.NewWatcher(ctx, types.Watch{
+		Name: "client-tls-config-generator",
+		Kinds: []types.WatchKind{
+			{Kind: types.KindCertAuthority, LoadSecrets: false},
+		},
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer watcher.Close()
+
+	select {
+	case <-watcher.Done():
+		return trace.Errorf("ca watcher exited while waiting for init: %v", watcher.Error())
+	case event := <-watcher.Events():
+		if event.Type != types.OpInit {
+			return trace.BadParameter("expected init event from ca watcher, got %v instead", event.Type)
+		}
+	case <-time.After(time.Second * 30):
+		return trace.Errorf("timeout waiting for ca watcher init")
+	case <-ctx.Done():
+		return nil
+	}
+
+	c.clientTLSConfigs.RegenAll()
+
+	for {
+		select {
+		case <-watcher.Done():
+			return trace.Errorf("ca watcher exited with: %v", watcher.Error())
+		case event := <-watcher.Events():
+			if event.Type == types.OpDelete {
+				c.clientTLSConfigs.Terminate(event.Resource.GetName())
+			} else {
+				if !c.cfg.PermitRemoteClusters && event.Resource.GetName() != c.cfg.ClusterName {
+					// ignore non-local cluster CA events when we aren't configured to support them
+					continue
+				}
+				// trigger regen of client tls configs for the associated cluster.
+				c.clientTLSConfigs.Generate(event.Resource.GetName())
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+// Close terminates background ca load/refresh operations.
+func (c *ClientTLSConfigGenerator) Close() error {
+	c.clientTLSConfigs.Close()
+	c.cancel()
+	return nil
+}

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"math"
 	"net"
 	"net/http"
 	"os"
@@ -46,7 +45,6 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
-	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -77,7 +75,7 @@ type TLSServerConfig struct {
 	// LimiterConfig is limiter config
 	LimiterConfig limiter.Config
 	// AccessPoint is a caching access point
-	AccessPoint AccessCache
+	AccessPoint AccessCacheWithEvents
 	// Component is used for debugging purposes
 	Component string
 	// AcceptedUsage restricts authentication
@@ -140,6 +138,9 @@ type TLSServer struct {
 	// mux is a listener that multiplexes HTTP/2 and HTTP/1.1
 	// on different listeners
 	mux *multiplexer.TLSListener
+	// clientTLSConfigGenerator pre-generates and caches specialized per-cluster
+	// client TLS configs.
+	clientTLSConfigGenerator *ClientTLSConfigGenerator
 }
 
 // NewTLSServer returns new unstarted TLS server
@@ -213,7 +214,18 @@ func NewTLSServer(ctx context.Context, cfg TLSServerConfig) (*TLSServer, error) 
 			teleport.ComponentKey: cfg.Component,
 		}),
 	}
-	server.cfg.TLS.GetConfigForClient = server.GetConfigForClient
+
+	server.clientTLSConfigGenerator, err = NewClientTLSConfigGenerator(ClientTLSConfigGeneratorConfig{
+		TLS:                  server.cfg.TLS,
+		ClusterName:          localClusterName.GetClusterName(),
+		PermitRemoteClusters: true,
+		AccessPoint:          server.cfg.AccessPoint,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	server.cfg.TLS.GetConfigForClient = server.clientTLSConfigGenerator.GetConfigForClient
 
 	server.grpcServer, err = NewGRPCServer(GRPCServerConfig{
 		TLS:                server.cfg.TLS,
@@ -258,6 +270,7 @@ func (t *TLSServer) Close() error {
 		errors = append(errors, <-errC)
 	}
 	errors = append(errors, t.mux.Close())
+	errors = append(errors, t.clientTLSConfigGenerator.Close())
 	return trace.NewAggregate(errors...)
 }
 
@@ -296,62 +309,6 @@ func (t *TLSServer) Serve() error {
 		errors = append(errors, <-errC)
 	}
 	return trace.NewAggregate(errors...)
-}
-
-// GetConfigForClient is getting called on every connection
-// and server's GetConfigForClient reloads the list of trusted
-// local and remote certificate authorities
-func (t *TLSServer) GetConfigForClient(info *tls.ClientHelloInfo) (*tls.Config, error) {
-	var clusterName string
-	var err error
-	switch info.ServerName {
-	case "":
-		// Client does not use SNI, will validate against all known CAs.
-	default:
-		clusterName, err = apiutils.DecodeClusterName(info.ServerName)
-		if err != nil {
-			if !trace.IsNotFound(err) {
-				t.log.Warningf("Client sent unsupported cluster name %q, what resulted in error %v.", info.ServerName, err)
-				return nil, trace.AccessDenied("access is denied")
-			}
-		}
-	}
-
-	// update client certificate pool based on currently trusted TLS
-	// certificate authorities.
-	// TODO(klizhentas) drop connections of the TLS cert authorities
-	// that are not trusted
-	pool, totalSubjectsLen, err := DefaultClientCertPool(t.cfg.AccessPoint, clusterName)
-	if err != nil {
-		var ourClusterName string
-		if clusterName, err := t.cfg.AccessPoint.GetClusterName(); err == nil {
-			ourClusterName = clusterName.GetClusterName()
-		}
-		t.log.Errorf("Failed to retrieve client pool for client %v, client cluster %v, target cluster %v, error:  %v.",
-			info.Conn.RemoteAddr().String(), clusterName, ourClusterName, trace.DebugReport(err))
-		// this falls back to the default config
-		return nil, nil
-	}
-
-	// Per https://tools.ietf.org/html/rfc5246#section-7.4.4 the total size of
-	// the known CA subjects sent to the client can't exceed 2^16-1 (due to
-	// 2-byte length encoding). The crypto/tls stack will panic if this
-	// happens. To make the error less cryptic, catch this condition and return
-	// a better error.
-	//
-	// This may happen with a very large (>500) number of trusted clusters, if
-	// the client doesn't send the correct ServerName in its ClientHelloInfo
-	// (see the switch at the top of this func).
-	if totalSubjectsLen >= int64(math.MaxUint16) {
-		return nil, trace.BadParameter("number of CAs in client cert pool is too large and cannot be encoded in a TLS handshake; this is due to a large number of trusted clusters; try updating tsh to the latest version; if that doesn't help, remove some trusted clusters")
-	}
-
-	tlsCopy := t.cfg.TLS.Clone()
-	tlsCopy.ClientCAs = pool
-	for _, cert := range tlsCopy.Certificates {
-		t.log.Debugf("Server certificate %v.", TLSCertInfo(&cert))
-	}
-	return tlsCopy, nil
 }
 
 // Middleware is authentication middleware checking every request

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -475,15 +475,16 @@ func TestAutoRotation(t *testing.T) {
 	require.Equal(t, types.RotationPhaseStandby, ca.GetRotation().Phase)
 	require.NoError(t, err)
 
-	// old clients should no longer work
-	// new client has to be created here to force re-create the new
-	// connection instead of re-using the one from pool
-	// this is not going to be a problem in real teleport
+	// old clients should no longer work as soon as backend modification event propagates.
+	// new client has to be created here to force re-create the new connection instead of
+	// re-using the one from pool this is not going to be a problem in real teleport
 	// as it reloads the full server after reload
-	_, err = testSrv.CloneClient(t, proxy).GetNodes(ctx, apidefaults.Namespace)
-	// TODO(rosstimothy, espadolini, jakule): figure out how to consistently
-	// match a certificate error and not other errors
-	require.Error(t, err)
+	require.Eventually(t, func() bool {
+		_, err = testSrv.CloneClient(t, proxy).GetNodes(ctx, apidefaults.Namespace)
+		// TODO(rosstimothy, espadolini, jakule): figure out how to consistently
+		// match a certificate error and not other errors
+		return err != nil
+	}, time.Second*15, time.Millisecond*200)
 
 	// new clients work
 	_, err = testSrv.CloneClient(t, newProxy).GetNodes(ctx, apidefaults.Namespace)
@@ -650,13 +651,14 @@ func TestManualRotation(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// old clients should no longer work
-	// new client has to be created here to force re-create the new
-	// connection instead of re-using the one from pool
-	// this is not going to be a problem in real teleport
+	// old clients should no longer work as soon as backend modification event propagates.
+	// new client has to be created here to force re-create the new connection instead of
+	// re-using the one from pool this is not going to be a problem in real teleport
 	// as it reloads the full server after reload
-	_, err = testSrv.CloneClient(t, proxy).GetNodes(ctx, apidefaults.Namespace)
-	require.Error(t, err)
+	require.Eventually(t, func() bool {
+		_, err = testSrv.CloneClient(t, proxy).GetNodes(ctx, apidefaults.Namespace)
+		return err != nil
+	}, time.Second*15, time.Millisecond*200)
 
 	// new clients work
 	_, err = testSrv.CloneClient(t, newProxy).GetNodes(ctx, apidefaults.Namespace)
@@ -749,9 +751,11 @@ func TestRollback(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// clients with new creds will no longer work
-	_, err = testSrv.CloneClient(t, newProxy).GetNodes(ctx, apidefaults.Namespace)
-	require.Error(t, err)
+	// clients with new creds will no longer work as soon as backend modification event propagates.
+	require.Eventually(t, func() bool {
+		_, err := testSrv.CloneClient(t, newProxy).GetNodes(ctx, apidefaults.Namespace)
+		return err != nil
+	}, time.Second*15, time.Millisecond*200)
 
 	grpcClientOld := testSrv.CloneClient(t, proxy)
 	t.Cleanup(func() {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4378,7 +4378,19 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		tlscfg.InsecureSkipVerify = true
 		tlscfg.ClientAuth = tls.RequireAnyClientCert
 	}
-	tlscfg.GetConfigForClient = auth.WithClusterCAs(tlscfg, accessPoint, clusterName, process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)))
+
+	// clientTLSConfigGenerator pre-generates specialized per-cluster client TLS config values
+	clientTLSConfigGenerator, err := auth.NewClientTLSConfigGenerator(auth.ClientTLSConfigGeneratorConfig{
+		TLS:                  tlscfg,
+		ClusterName:          clusterName,
+		PermitRemoteClusters: true,
+		AccessPoint:          accessPoint,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	tlscfg.GetConfigForClient = clientTLSConfigGenerator.GetConfigForClient
 
 	creds, err := auth.NewTransportCredentials(auth.TransportCredentialsConfig{
 		TransportCredentials: credentials.NewTLS(tlscfg),
@@ -4765,7 +4777,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			return trace.Wrap(err)
 		}
 
-		alpnTLSConfigForWeb := process.setupALPNTLSConfigForWeb(serverTLSConfig, accessPoint, clusterName)
+		alpnTLSConfigForWeb, err := process.setupALPNTLSConfigForWeb(serverTLSConfig, accessPoint, clusterName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		alpnHandlerForWeb.Set(alpnServer.MakeConnectionHandler(alpnTLSConfigForWeb))
 
 		process.RegisterCriticalFunc("proxy.tls.alpn.sni.proxy", func() error {
@@ -4840,6 +4855,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			if reverseTunnelALPNServer != nil {
 				warnOnErr(process.ExitContext(), reverseTunnelALPNServer.Close(), logger)
 			}
+
+			if clientTLSConfigGenerator != nil {
+				clientTLSConfigGenerator.Close()
+			}
 		} else {
 			logger.InfoContext(process.ExitContext(), "Shutting down gracefully.")
 			ctx := payloadContext(payload)
@@ -4891,6 +4910,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 						logger.DebugContext(ctx, "Failed to delete heartbeat.", "error", err)
 					}
 				}
+			}
+
+			if clientTLSConfigGenerator != nil {
+				clientTLSConfigGenerator.Close()
 			}
 		}
 		warnOnErr(process.ExitContext(), asyncEmitter.Close(), logger)
@@ -5050,7 +5073,9 @@ func (process *TeleportProcess) setupProxyTLSConfig(conn *Connector, tsrv revers
 	}
 
 	setupTLSConfigALPNProtocols(tlsConfig)
-	setupTLSConfigClientCAsForCluster(tlsConfig, accessPoint, clusterName)
+	if err := process.setupTLSConfigClientCAGeneratorForCluster(tlsConfig, accessPoint, clusterName); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	return tlsConfig, nil
 }
 
@@ -5060,41 +5085,55 @@ func setupTLSConfigALPNProtocols(tlsConfig *tls.Config) {
 	tlsConfig.NextProtos = apiutils.Deduplicate(append(tlsConfig.NextProtos, alpncommon.ProtocolsToString(alpncommon.SupportedProtocols)...))
 }
 
-func setupTLSConfigClientCAsForCluster(tlsConfig *tls.Config, accessPoint auth.ReadProxyAccessPoint, clusterName string) {
-	tlsConfig.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
-		tlsClone := tlsConfig.Clone()
+func (process *TeleportProcess) setupTLSConfigClientCAGeneratorForCluster(tlsConfig *tls.Config, accessPoint auth.ReadProxyAccessPoint, clusterName string) error {
+	// create a local copy of the TLS config so we can change some settings that are only
+	// relevant to the config returned by GetConfigForClient.
+	tlsClone := tlsConfig.Clone()
 
-		// Set client auth to "verify client cert if given" to support
-		// app access CLI flow.
-		//
-		// Clients (like curl) connecting to the web proxy endpoint will
-		// present a client certificate signed by the cluster's user CA.
-		//
-		// Browser connections to web UI and other clients (like database
-		// access) connecting to web proxy won't be affected since they
-		// don't present a certificate.
-		tlsClone.ClientAuth = tls.VerifyClientCertIfGiven
+	// Set client auth to "verify client cert if given" to support
+	// app access CLI flow.
+	//
+	// Clients (like curl) connecting to the web proxy endpoint will
+	// present a client certificate signed by the cluster's user CA.
+	//
+	// Browser connections to web UI and other clients (like database
+	// access) connecting to web proxy won't be affected since they
+	// don't present a certificate.
+	tlsClone.ClientAuth = tls.VerifyClientCertIfGiven
 
-		// Build the client CA pool containing the cluster's user CA in
-		// order to be able to validate certificates provided by app
-		// access CLI clients.
-		var err error
-		tlsClone.ClientCAs, _, err = auth.DefaultClientCertPool(accessPoint, clusterName)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		return tlsClone, nil
+	// Set up the client CA generator containing for the local cluster's CAs in
+	// order to be able to validate certificates provided by app access CLI clients.
+	generator, err := auth.NewClientTLSConfigGenerator(auth.ClientTLSConfigGeneratorConfig{
+		TLS:                  tlsClone,
+		ClusterName:          clusterName,
+		PermitRemoteClusters: false,
+		AccessPoint:          accessPoint,
+	})
+	if err != nil {
+		return trace.Wrap(err)
 	}
+
+	process.OnExit("closer", func(payload interface{}) {
+		generator.Close()
+	})
+
+	// set getter on the original TLS config.
+	tlsConfig.GetConfigForClient = generator.GetConfigForClient
+
+	// note: generator will be closed via the passed in context, rather than an explicit call to Close.
+	return nil
 }
 
-func (process *TeleportProcess) setupALPNTLSConfigForWeb(serverTLSConfig *tls.Config, accessPoint auth.ReadProxyAccessPoint, clusterName string) *tls.Config {
+func (process *TeleportProcess) setupALPNTLSConfigForWeb(serverTLSConfig *tls.Config, accessPoint auth.ReadProxyAccessPoint, clusterName string) (*tls.Config, error) {
 	tlsConfig := utils.TLSConfig(process.Config.CipherSuites)
 	tlsConfig.Certificates = serverTLSConfig.Certificates
 
 	setupTLSConfigALPNProtocols(tlsConfig)
-	setupTLSConfigClientCAsForCluster(tlsConfig, accessPoint, clusterName)
-	return tlsConfig
+	if err := process.setupTLSConfigClientCAGeneratorForCluster(tlsConfig, accessPoint, clusterName); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return tlsConfig, nil
 }
 
 func setupALPNRouter(listeners *proxyListeners, serverTLSConfig *tls.Config, cfg *servicecfg.Config) (router, rtRouter *alpnproxy.Router) {

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -766,6 +766,11 @@ type mockAccessPoint struct {
 	auth.ProxyAccessPoint
 }
 
+// NewWatcher needs to be defined so that we can test proxy TLS config setup without panicing.
+func (m *mockAccessPoint) NewWatcher(_ context.Context, _ types.Watch) (types.Watcher, error) {
+	return nil, trace.NotImplemented("mock access point does not produce events")
+}
+
 type mockReverseTunnelServer struct {
 	reversetunnelclient.Server
 }


### PR DESCRIPTION
Implements tls client config caching for some of the more frequently used TLS listener configs.

Historically, teleport has built client cert pools from scratch for each incoming TLS connection.  The reasoning for this is that in order to support trusted clusters and rotations we need to have the most up to date CA set at all times.  This PR solves that issue by instead rebuilding tls configs whenever a relevant backend event is detected, and on a periodic as fallback, so that even in the event of event system issues the TLS configs can't fall more than a handful of seconds out of date.

We've been eyeing this as a potential change for a while now as we regularly see non-trivial amounts of memory devoted to redundant tls configs (and more specifically certificates) when running large scale tests.  Based on scaling tests done with this PR, it looks like we get a roughly 5-6% reduction in memory usage at 10k nodes.  I anticipate that percentage being slightly higher in larger clusters.

We also have some past evidence that the tls config setup step could take up to 50ms in some clusters under high load.  Those conditions proved hard to replicate so I don't have hard confirmation that this change fixes that issue, but I'm reasonably confident that it does.  I do know that in local benchmarks of `GetConfigForClient`, this caching method is roughly 60x faster than the old implementation, but that isn't saying much since the old implementation rarely takes more than a couple ms at most to complete on a fast machine.  It's likely that the actual raw speed increase will be negligible outside of extreme load cases.

Closes #22903