### PR TITLE
chore: rename NewExternalAuditStorageServiceFallible to NewExternalAuditStorageService

### DIFF
--- a/lib/auth/integration/integrationv1/service_test.go
+++ b/lib/auth/integration/integrationv1/service_test.go
@@ -397,7 +397,7 @@ func initSvc(t *testing.T, ca types.CertAuthority, clusterName string, proxyPubl
 	trustSvc := local.NewCAService(backend)
 	roleSvc := local.NewAccessService(backend)
 	userSvc := local.NewTestIdentityService(backend)
-	easSvc, err := local.NewExternalAuditStorageServiceFallible(backend)
+	easSvc, err := local.NewExternalAuditStorageService(backend)
 	require.NoError(t, err)
 
 	_, err = clusterConfigSvc.UpsertAuthPreference(ctx, types.DefaultAuthPreference())

--- a/lib/integrations/externalauditstorage/configurator_test.go
+++ b/lib/integrations/externalauditstorage/configurator_test.go
@@ -153,7 +153,7 @@ func TestConfiguratorIsUsed(t *testing.T) {
 			_, err = integrationSvc.CreateIntegration(ctx, testOIDCIntegration(t))
 			require.NoError(t, err)
 
-			ecaSvc, err := local.NewExternalAuditStorageServiceFallible(mem)
+			ecaSvc, err := local.NewExternalAuditStorageService(mem)
 			require.NoError(t, err)
 			if tt.resourceServiceFn != nil {
 				tt.resourceServiceFn(t, ecaSvc)
@@ -196,7 +196,7 @@ func TestCredentialsCache(t *testing.T) {
 
 	// Pre-req: existing cluster ExternalAuditStorage configuration
 	draftConfig := testDraftExternalAuditStorage(t)
-	svc, err := local.NewExternalAuditStorageServiceFallible(mem)
+	svc, err := local.NewExternalAuditStorageService(mem)
 	require.NoError(t, err)
 	_, err = svc.UpsertDraftExternalAuditStorage(ctx, draftConfig)
 	require.NoError(t, err)
@@ -335,7 +335,7 @@ func TestDraftConfigurator(t *testing.T) {
 
 	// Pre-req: existing draft ExternalAuditStorage configuration
 	draftConfig := testDraftExternalAuditStorage(t)
-	svc, err := local.NewExternalAuditStorageServiceFallible(mem)
+	svc, err := local.NewExternalAuditStorageService(mem)
 	require.NoError(t, err)
 	_, err = svc.UpsertDraftExternalAuditStorage(ctx, draftConfig)
 	require.NoError(t, err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6181,7 +6181,7 @@ func (process *TeleportProcess) newExternalAuditStorageConfigurator() (*external
 	// watcher initialized.
 	watcher.WaitInit(process.GracefulExitContext())
 
-	easSvc, err := local.NewExternalAuditStorageServiceFallible(process.backend)
+	easSvc, err := local.NewExternalAuditStorageService(process.backend)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -504,7 +504,7 @@ func TestAthenaAuditLogSetup(t *testing.T) {
 	_, err = integrationSvc.CreateIntegration(ctx, oidcIntegration)
 	require.NoError(t, err)
 
-	easSvc, err := local.NewExternalAuditStorageServiceFallible(backend, local.WithIntegrationsService(integrationSvc))
+	easSvc, err := local.NewExternalAuditStorageService(backend, local.WithIntegrationsService(integrationSvc))
 	require.NoError(t, err)
 	_, err = easSvc.GenerateDraftExternalAuditStorage(ctx, "aws-integration-1", "us-west-2")
 	require.NoError(t, err)

--- a/lib/services/local/externalauditstorage.go
+++ b/lib/services/local/externalauditstorage.go
@@ -49,9 +49,7 @@ var (
 type ExternalAuditStorageService struct {
 	backend         backend.Backend
 	integrationsSvc *IntegrationsService
-	// TODO(nklaassen): delete this once teleport.e is updated
-	skipOIDCIntegrationCheck bool
-	logger                   *logrus.Entry
+	logger          *logrus.Entry
 }
 
 // ExternalAuditStorageServiceOption is a functional configuration option for the ExternalAuditStorageService.
@@ -64,9 +62,8 @@ func WithIntegrationsService(integrationsSvc *IntegrationsService) func(svc *Ext
 	}
 }
 
-// NewExternalAuditStorageServiceFallible returns a new *ExternalAuditStorageService or an error if it fails.
-// TODO(nklaassen): once teleport.e is updated unify this with NewExternalAuditStorage.
-func NewExternalAuditStorageServiceFallible(backend backend.Backend, opts ...ExternalAuditStorageServiceOption) (*ExternalAuditStorageService, error) {
+// NewExternalAuditStorageService returns a new *ExternalAuditStorageService or an error if it fails.
+func NewExternalAuditStorageService(backend backend.Backend, opts ...ExternalAuditStorageServiceOption) (*ExternalAuditStorageService, error) {
 	svc := &ExternalAuditStorageService{
 		backend: backend,
 		logger:  logrus.WithField(teleport.ComponentKey, "ExternalAuditStorage.backend"),
@@ -84,15 +81,9 @@ func NewExternalAuditStorageServiceFallible(backend backend.Backend, opts ...Ext
 	return svc, nil
 }
 
-// NewExternalAuditStorageServiceFallible returns a new *ExternalAuditStorageService.
-// TODO(nklaassen): once teleport.e is updated unify this with NewExternalAuditStorageServiceFallible.
-func NewExternalAuditStorageService(backend backend.Backend, opts ...ExternalAuditStorageServiceOption) *ExternalAuditStorageService {
-	svc, err := NewExternalAuditStorageServiceFallible(backend, opts...)
-	if err != nil {
-		panic(err)
-	}
-	svc.skipOIDCIntegrationCheck = true
-	return svc
+// TODO(nklaassen): delete this after teleport.e is updated to use NewExternalAuditStorageService.
+func NewExternalAuditStorageServiceFallible(backend backend.Backend) (*ExternalAuditStorageService, error) {
+	return NewExternalAuditStorageService(backend)
 }
 
 // GetDraftExternalAuditStorage returns the draft External Audit Storage resource.
@@ -293,10 +284,6 @@ func (s *ExternalAuditStorageService) DisableClusterExternalAuditStorage(ctx con
 }
 
 func (s *ExternalAuditStorageService) checkOIDCIntegration(ctx context.Context, integrationName string) error {
-	// TODO(nklaassen): delete this once teleport.e is updated.
-	if s.skipOIDCIntegrationCheck {
-		return nil
-	}
 	integration, err := s.integrationsSvc.GetIntegration(ctx, integrationName)
 	if err != nil {
 		return trace.Wrap(err, "getting integration")

--- a/lib/services/local/externalauditstorage_test.go
+++ b/lib/services/local/externalauditstorage_test.go
@@ -48,7 +48,7 @@ func TestExternalAuditStorageService(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service, err := NewExternalAuditStorageServiceFallible(backend.NewSanitizer(mem))
+	service, err := NewExternalAuditStorageService(backend.NewSanitizer(mem))
 	require.NoError(t, err)
 
 	sessRecURL1 := "s3://bucket1/ses-rec-v1"

--- a/lib/services/local/externalauditstorage_watcher_test.go
+++ b/lib/services/local/externalauditstorage_watcher_test.go
@@ -42,7 +42,7 @@ func TestClusterExternalAuditWatcher(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	svc, err := NewExternalAuditStorageServiceFallible(bk)
+	svc, err := NewExternalAuditStorageService(bk)
 	require.NoError(t, err)
 
 	integrationsSvc, err := NewIntegrationsService(bk)
@@ -154,7 +154,7 @@ func TestClusterExternalAuditWatcher_WatcherClosed(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	svc, err := NewExternalAuditStorageServiceFallible(bk)
+	svc, err := NewExternalAuditStorageService(bk)
 	require.NoError(t, err)
 
 	integrationsSvc, err := NewIntegrationsService(bk)

--- a/lib/services/local/integrations.go
+++ b/lib/services/local/integrations.go
@@ -83,7 +83,7 @@ func NewIntegrationsService(backend backend.Backend, opts ...IntegrationsService
 		opt(integrationsSvc)
 	}
 	if integrationsSvc.easSvc == nil {
-		integrationsSvc.easSvc, err = NewExternalAuditStorageServiceFallible(backend, WithIntegrationsService(integrationsSvc))
+		integrationsSvc.easSvc, err = NewExternalAuditStorageService(backend, WithIntegrationsService(integrationsSvc))
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}


### PR DESCRIPTION
This is a followup to https://github.com/gravitational/teleport/pull/40630 and https://github.com/gravitational/teleport.e/pull/3978 which uses the original, more ergonomic name for the EAS service constructor now that teleport.e is not referencing the original.