### PR TITLE
Update web_session_id description in DeviceMetadata

### DIFF
--- a/api/proto/teleport/legacy/types/events/events.proto
+++ b/api/proto/teleport/legacy/types/events/events.proto
@@ -3855,7 +3855,7 @@ message DeviceMetadata {
   // Only present in "device.authenticate" type events.
   bool web_authentication = 6 [(gogoproto.jsontag) = "web_authentication,omitempty"];
   // Web Session ID associated with the device.
-  // Only present if web_authentication is true.
+  // Present in events related to device web authentication.
   string web_session_id = 7 [(gogoproto.jsontag) = "web_session_id,omitempty"];
 }
 

--- a/api/types/events/events.pb.go
+++ b/api/types/events/events.pb.go
@@ -6571,7 +6571,7 @@ type DeviceMetadata struct {
 	// Only present in "device.authenticate" type events.
 	WebAuthentication bool `protobuf:"varint,6,opt,name=web_authentication,json=webAuthentication,proto3" json:"web_authentication,omitempty"`
 	// Web Session ID associated with the device.
-	// Only present if web_authentication is true.
+	// Present in events related to device web authentication.
 	WebSessionId         string   `protobuf:"bytes,7,opt,name=web_session_id,json=webSessionId,proto3" json:"web_session_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`


### PR DESCRIPTION
The web_session_id may be present in events that don't set web_authentication.

See https://github.com/gravitational/teleport.e/pull/3979.

https://github.com/gravitational/teleport.e/issues/3236