### PR TITLE
Improve error message for SSO logins with hardware keys

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -38,6 +38,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
@@ -3420,16 +3421,19 @@ func (tc *TeleportClient) getSSHLoginFunc(pr *webclient.PingResponse) (SSHLoginF
 			return nil, trace.BadParameter("unsupported authentication connector type: %q", pr.Auth.Local.Name)
 		}
 	case constants.OIDC:
+		oidc := pr.Auth.OIDC
 		return func(ctx context.Context, priv *keys.PrivateKey) (*auth.SSHLoginResponse, error) {
-			return tc.ssoLogin(ctx, priv, pr.Auth.OIDC.Name, constants.OIDC)
+			return tc.ssoLogin(ctx, priv, oidc.Name, oidc.Display, constants.OIDC)
 		}, nil
 	case constants.SAML:
+		saml := pr.Auth.SAML
 		return func(ctx context.Context, priv *keys.PrivateKey) (*auth.SSHLoginResponse, error) {
-			return tc.ssoLogin(ctx, priv, pr.Auth.SAML.Name, constants.SAML)
+			return tc.ssoLogin(ctx, priv, saml.Name, saml.Display, constants.SAML)
 		}, nil
 	case constants.Github:
+		github := pr.Auth.Github
 		return func(ctx context.Context, priv *keys.PrivateKey) (*auth.SSHLoginResponse, error) {
-			return tc.ssoLogin(ctx, priv, pr.Auth.Github.Name, constants.Github)
+			return tc.ssoLogin(ctx, priv, github.Name, github.Display, constants.Github)
 		}, nil
 	default:
 		return nil, trace.BadParameter("unsupported authentication type: %q", pr.Auth.Type)
@@ -3902,8 +3906,22 @@ func (tc *TeleportClient) headlessLogin(ctx context.Context, priv *keys.PrivateK
 // SSOLoginFunc is a function used in tests to mock SSO logins.
 type SSOLoginFunc func(ctx context.Context, connectorID string, priv *keys.PrivateKey, protocol string) (*auth.SSHLoginResponse, error)
 
+// TODO(atburke): DELETE in v17.0.0
+func versionSupportsKeyPolicyMessage(proxyVersion *semver.Version) bool {
+	switch proxyVersion.Major {
+	case 15:
+		return !proxyVersion.LessThan(*semver.New("15.2.5"))
+	case 14:
+		return !proxyVersion.LessThan(*semver.New("14.3.17"))
+	case 13:
+		return !proxyVersion.LessThan(*semver.New("13.4.22"))
+	default:
+		return proxyVersion.Major > 15
+	}
+}
+
 // samlLogin opens browser window and uses OIDC or SAML redirect cycle with browser
-func (tc *TeleportClient) ssoLogin(ctx context.Context, priv *keys.PrivateKey, connectorID string, protocol string) (*auth.SSHLoginResponse, error) {
+func (tc *TeleportClient) ssoLogin(ctx context.Context, priv *keys.PrivateKey, connectorID, connectorName, protocol string) (*auth.SSHLoginResponse, error) {
 	if tc.MockSSOLogin != nil {
 		// sso login response is being mocked for testing purposes
 		return tc.MockSSOLogin(ctx, connectorID, priv, protocol)
@@ -3914,14 +3932,23 @@ func (tc *TeleportClient) ssoLogin(ctx context.Context, priv *keys.PrivateKey, c
 		return nil, trace.Wrap(err)
 	}
 
+	pr, err := tc.Ping(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	proxyVersion := semver.New(pr.ServerVersion)
+
 	// ask the CA (via proxy) to sign our public key:
 	response, err := SSHAgentSSOLogin(ctx, SSHLoginSSO{
-		SSHLogin:     sshLogin,
-		ConnectorID:  connectorID,
-		Protocol:     protocol,
-		BindAddr:     tc.BindAddr,
-		CallbackAddr: tc.CallbackAddr,
-		Browser:      tc.Browser,
+		SSHLogin:                      sshLogin,
+		ConnectorID:                   connectorID,
+		ConnectorName:                 connectorName,
+		Protocol:                      protocol,
+		BindAddr:                      tc.BindAddr,
+		CallbackAddr:                  tc.CallbackAddr,
+		Browser:                       tc.Browser,
+		PrivateKeyPolicy:              tc.PrivateKeyPolicy,
+		ProxySupportsKeyPolicyMessage: versionSupportsKeyPolicyMessage(proxyVersion),
 	}, nil)
 	return response, trace.Wrap(err)
 }

--- a/lib/client/redirect.go
+++ b/lib/client/redirect.go
@@ -31,6 +31,7 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/secret"
@@ -40,6 +41,11 @@ import (
 const (
 	// LoginSuccessRedirectURL is a redirect URL when login was successful without errors.
 	LoginSuccessRedirectURL = "/web/msg/info/login_success"
+
+	// LoginTerminalRedirectURL is a redirect URL when login requires extra
+	// action in the terminal, but was otherwise successful in the browser (ex.
+	// need a hardware key tap).
+	LoginTerminalRedirectURL = "/web/msg/info/login_terminal"
 
 	// LoginFailedRedirectURL is the default redirect URL when an SSO error was encountered.
 	LoginFailedRedirectURL = "/web/msg/error/login"
@@ -51,6 +57,12 @@ const (
 	// LoginFailedUnauthorizedRedirectURL is a redirect URL for when an SSO authenticates successfully,
 	// but the user has no matching roles in Teleport.
 	LoginFailedUnauthorizedRedirectURL = "/web/msg/error/login/auth"
+
+	// LoginClose is a redirect URL that will close the tab performing the SSO
+	// login. It's used when a second tab will be opened due to the first
+	// failing (such as an unmet hardware key policy) and the first should be
+	// ignored.
+	LoginClose = "/web/msg/info/login_close"
 )
 
 // Redirector handles SSH redirect flow with the Teleport server
@@ -301,11 +313,24 @@ func (rd *Redirector) Close() error {
 // wrapCallback is a helper wrapper method that wraps callback HTTP handler
 // and sends a result to the channel and redirect users to error page
 func (rd *Redirector) wrapCallback(fn func(http.ResponseWriter, *http.Request) (*auth.SSHLoginResponse, error)) http.Handler {
+	// Generate possible redirect URLs from the proxy URL.
 	clone := *rd.proxyURL
 	clone.Path = LoginFailedRedirectURL
 	errorURL := clone.String()
 	clone.Path = LoginSuccessRedirectURL
 	successURL := clone.String()
+	clone.Path = LoginClose
+	closeURL := clone.String()
+	clone.Path = LoginTerminalRedirectURL
+
+	connectorName := rd.ConnectorName
+	if connectorName == "" {
+		connectorName = rd.ConnectorID
+	}
+	query := clone.Query()
+	query.Set("auth", connectorName)
+	clone.RawQuery = query.Encode()
+	terminalRedirectURL := clone.String()
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Allow", "GET, OPTIONS, POST")
@@ -336,12 +361,36 @@ func (rd *Redirector) wrapCallback(fn func(http.ResponseWriter, *http.Request) (
 			case rd.errorC <- err:
 			case <-rd.context.Done():
 			}
-			http.Redirect(w, r, errorURL, http.StatusFound)
+			redirectURL := errorURL
+			// A second SSO login attempt will be initiated if a key policy requirement was not satisfied.
+			if requiredPolicy, err := keys.ParsePrivateKeyPolicyError(err); err == nil && rd.ProxySupportsKeyPolicyMessage {
+				switch requiredPolicy {
+				case keys.PrivateKeyPolicyHardwareKey, keys.PrivateKeyPolicyHardwareKeyTouch:
+					// No user interaction required.
+					redirectURL = closeURL
+				case keys.PrivateKeyPolicyHardwareKeyPIN, keys.PrivateKeyPolicyHardwareKeyTouchAndPIN:
+					// The user is prompted to enter their PIN in terminal.
+					redirectURL = terminalRedirectURL
+				}
+			}
+			http.Redirect(w, r, redirectURL, http.StatusFound)
 			return
 		}
 		select {
 		case rd.responseC <- response:
-			http.Redirect(w, r, successURL, http.StatusFound)
+			redirectURL := successURL
+			switch rd.PrivateKeyPolicy {
+			case keys.PrivateKeyPolicyHardwareKey:
+				// login should complete without user interaction, success.
+			case keys.PrivateKeyPolicyHardwareKeyPIN:
+				// The user is prompted to enter their PIN before this step,
+				// so we can go straight to success screen.
+			case keys.PrivateKeyPolicyHardwareKeyTouch, keys.PrivateKeyPolicyHardwareKeyTouchAndPIN:
+				// The user is prompted to touch their hardware key after
+				// this redirect, so display the terminal redirect screen.
+				redirectURL = terminalRedirectURL
+			}
+			http.Redirect(w, r, redirectURL, http.StatusFound)
 		case <-rd.context.Done():
 			http.Redirect(w, r, errorURL, http.StatusFound)
 		}

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -245,6 +245,8 @@ type SSHLoginSSO struct {
 	SSHLogin
 	// ConnectorID is the OIDC or SAML connector ID to use
 	ConnectorID string
+	// ConnectorName is the display name of the connector.
+	ConnectorName string
 	// Protocol is an optional protocol selection
 	Protocol string
 	// BindAddr is an optional host:port address to bind
@@ -257,6 +259,12 @@ type SSHLoginSSO struct {
 	// default (not currently implemented), or set to 'none' to suppress
 	// browser opening entirely.
 	Browser string
+	// PrivateKeyPolicy is a key policy to follow during login.
+	PrivateKeyPolicy keys.PrivateKeyPolicy
+	// ProxySupportsKeyPolicyMessage lets the tsh redirector give users more
+	// useful messages in the web UI if the proxy supports them.
+	// TODO(atburke): DELETE in v17.0.0
+	ProxySupportsKeyPolicyMessage bool
 }
 
 // SSHLoginDirect contains SSH login parameters for direct (user/pass/OTP)

--- a/web/packages/design/src/CardIcon/CardIcon.jsx
+++ b/web/packages/design/src/CardIcon/CardIcon.jsx
@@ -1,6 +1,6 @@
-/**
+/*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,8 +16,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Login } from './Login';
-export { LoginFailed } from './LoginFailed';
-export { LoginSuccess } from './LoginSuccess';
-export { LoginTerminalRedirect } from './LoginTerminalRedirect';
-export { LoginClose } from './LoginClose';
+import React from 'react';
+
+import Card from 'design/Card';
+import Text from 'design/Text';
+
+export default function CardIcon({ title, icon, children }) {
+  return (
+    <Card width="540px" p={7} my={4} mx="auto" textAlign="center">
+      {icon}
+      {title && (
+        <Text typography="h2" mb="4">
+          {title}
+        </Text>
+      )}
+      {children}
+    </Card>
+  );
+}

--- a/web/packages/design/src/CardIcon/CardIcon.story.jsx
+++ b/web/packages/design/src/CardIcon/CardIcon.story.jsx
@@ -1,6 +1,6 @@
-/**
+/*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,8 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Login } from './Login';
-export { LoginFailed } from './LoginFailed';
-export { LoginSuccess } from './LoginSuccess';
-export { LoginTerminalRedirect } from './LoginTerminalRedirect';
-export { LoginClose } from './LoginClose';
+import React from 'react';
+
+import CardIcon from './index';
+
+export default {
+  title: 'Design/Card/Icon',
+};
+
+export const Cards = () => <CardIcon />;

--- a/web/packages/design/src/CardIcon/CardIcon.test.jsx
+++ b/web/packages/design/src/CardIcon/CardIcon.test.jsx
@@ -1,6 +1,6 @@
-/**
+/*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,8 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Login } from './Login';
-export { LoginFailed } from './LoginFailed';
-export { LoginSuccess } from './LoginSuccess';
-export { LoginTerminalRedirect } from './LoginTerminalRedirect';
-export { LoginClose } from './LoginClose';
+import React from 'react';
+
+import { render } from 'design/utils/testing';
+
+import { Cards } from './CardIcon.story';
+
+test('rendering of CardIcon components', () => {
+  const { container } = render(<Cards />);
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/web/packages/design/src/CardIcon/__snapshots__/CardIcon.test.jsx.snap
+++ b/web/packages/design/src/CardIcon/__snapshots__/CardIcon.test.jsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rendering of CardIcon components 1`] = `
+.c0 {
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 24px;
+  margin-bottom: 24px;
+  padding: 48px;
+  width: 540px;
+  text-align: center;
+}
+
+.c1 {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
+  border-radius: 8px;
+  background-color: #222C59;
+}
+
+<div
+  class="c0 c1"
+  width="540px"
+/>
+`;

--- a/web/packages/design/src/CardIcon/index.js
+++ b/web/packages/design/src/CardIcon/index.js
@@ -1,6 +1,6 @@
-/**
+/*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,8 +16,5 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Login } from './Login';
-export { LoginFailed } from './LoginFailed';
-export { LoginSuccess } from './LoginSuccess';
-export { LoginTerminalRedirect } from './LoginTerminalRedirect';
-export { LoginClose } from './LoginClose';
+import CardIcon from './CardIcon';
+export default CardIcon;

--- a/web/packages/design/src/CardTerminal/CardTerminal.jsx
+++ b/web/packages/design/src/CardTerminal/CardTerminal.jsx
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -17,26 +17,33 @@
  */
 
 import React from 'react';
+import { useLocation } from 'react-router';
 
 import CardIcon from 'design/CardIcon';
-import { CircleCheck } from 'design/Icon';
+import { Terminal } from 'design/Icon';
 
-export default function CardSuccess({ title, children }) {
+export default function CardTerminal({ title, children }) {
   return (
     <CardIcon
       title={title}
-      icon={<CircleCheck mb={3} size={64} color="success.main" />}
+      icon={<Terminal mb={3} size={64} color="accent.main" />}
     >
       {children}
     </CardIcon>
   );
 }
 
-export function CardSuccessLogin() {
+export function CardTerminalLogin() {
+  const { search } = useLocation();
+  const queryParams = new URLSearchParams(search);
+  let provider = '';
+  if (queryParams.has('auth')) {
+    provider = ` by ${queryParams.get('auth')}`;
+  }
   return (
-    <CardSuccess title="Login Successful">
-      You have successfully signed into your account. <br /> You can close this
-      window and continue using the product.
-    </CardSuccess>
+    <CardTerminal title="Continue in Terminal">
+      You have been authenticated{provider}.<br />
+      You can close this window and finish logging in at your terminal.
+    </CardTerminal>
   );
 }

--- a/web/packages/design/src/CardTerminal/CardTerminal.story.jsx
+++ b/web/packages/design/src/CardTerminal/CardTerminal.story.jsx
@@ -1,6 +1,6 @@
-/**
+/*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,8 +16,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Login } from './Login';
-export { LoginFailed } from './LoginFailed';
-export { LoginSuccess } from './LoginSuccess';
-export { LoginTerminalRedirect } from './LoginTerminalRedirect';
-export { LoginClose } from './LoginClose';
+import React from 'react';
+
+import { MemoryRouter } from 'react-router';
+import { Route } from 'teleport/components/Router';
+
+import cfg from 'teleport/config';
+
+import CardTerminal, { CardTerminalLogin } from './index';
+
+export default {
+  title: 'Design/Card/Terminal',
+};
+
+export const Cards = () => (
+  <MemoryRouter initialEntries={[cfg.routes.loginTerminalRedirect]}>
+    <Route path={cfg.routes.loginTerminalRedirect + '?auth=MyAuth'}>
+      <CardTerminal />
+      <CardTerminalLogin />
+    </Route>
+  </MemoryRouter>
+);

--- a/web/packages/design/src/CardTerminal/CardTerminal.test.jsx
+++ b/web/packages/design/src/CardTerminal/CardTerminal.test.jsx
@@ -1,6 +1,6 @@
-/**
+/*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,8 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Login } from './Login';
-export { LoginFailed } from './LoginFailed';
-export { LoginSuccess } from './LoginSuccess';
-export { LoginTerminalRedirect } from './LoginTerminalRedirect';
-export { LoginClose } from './LoginClose';
+import React from 'react';
+
+import { render } from 'design/utils/testing';
+
+import { Cards } from './CardTerminal.story';
+
+test('rendering of CardTerminal components', () => {
+  const { container } = render(<Cards />);
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/web/packages/design/src/CardTerminal/__snapshots__/CardTerminal.test.jsx.snap
+++ b/web/packages/design/src/CardTerminal/__snapshots__/CardTerminal.test.jsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rendering of CardTerminal components 1`] = `null`;

--- a/web/packages/design/src/CardTerminal/index.js
+++ b/web/packages/design/src/CardTerminal/index.js
@@ -1,6 +1,6 @@
-/**
+/*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Login } from './Login';
-export { LoginFailed } from './LoginFailed';
-export { LoginSuccess } from './LoginSuccess';
-export { LoginTerminalRedirect } from './LoginTerminalRedirect';
-export { LoginClose } from './LoginClose';
+import CardTerminal, { CardTerminalLogin } from './CardTerminal';
+export default CardTerminal;
+export { CardTerminalLogin };

--- a/web/packages/teleport/src/Login/Login.story.tsx
+++ b/web/packages/teleport/src/Login/Login.story.tsx
@@ -18,7 +18,14 @@
 
 import React from 'react';
 
+import { MemoryRouter } from 'react-router';
+
+import { Route } from 'teleport/components/Router';
+
+import cfg from 'teleport/config';
+
 import { LoginSuccess } from './LoginSuccess';
+import { LoginTerminalRedirect } from './LoginTerminalRedirect';
 import { LoginFailedComponent as LoginFailed } from './LoginFailed';
 import { LoginComponent as Login } from './Login';
 import { State } from './useLogin';
@@ -33,6 +40,13 @@ export const Webauthn = () => <Login {...sample} auth2faType="webauthn" />;
 export const Optional = () => <Login {...sample} auth2faType="optional" />;
 export const On = () => <Login {...sample} auth2faType="on" />;
 export const Success = () => <LoginSuccess />;
+export const TerminalRedirect = () => (
+  <MemoryRouter initialEntries={[cfg.routes.loginTerminalRedirect]}>
+    <Route path={cfg.routes.loginTerminalRedirect + '?auth=MyAuth'}>
+      <LoginTerminalRedirect />
+    </Route>
+  </MemoryRouter>
+);
 export const FailedDefault = () => <LoginFailed />;
 export const FailedCustom = () => <LoginFailed message="custom message" />;
 

--- a/web/packages/teleport/src/Login/LoginClose.tsx
+++ b/web/packages/teleport/src/Login/LoginClose.tsx
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,8 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Login } from './Login';
-export { LoginFailed } from './LoginFailed';
-export { LoginSuccess } from './LoginSuccess';
-export { LoginTerminalRedirect } from './LoginTerminalRedirect';
-export { LoginClose } from './LoginClose';
+import React, { useEffect } from 'react';
+import { Card } from 'design';
+
+export function LoginClose() {
+  useEffect(() => {
+    window.close();
+  });
+  return (
+    <Card width="540px" p={7} my={4} mx="auto" textAlign="center">
+      This tab can be ignored and will close on its own.
+    </Card>
+  );
+}

--- a/web/packages/teleport/src/Login/LoginTerminalRedirect.test.tsx
+++ b/web/packages/teleport/src/Login/LoginTerminalRedirect.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,8 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Login } from './Login';
-export { LoginFailed } from './LoginFailed';
-export { LoginSuccess } from './LoginSuccess';
-export { LoginTerminalRedirect } from './LoginTerminalRedirect';
-export { LoginClose } from './LoginClose';
+import React from 'react';
+import { render } from 'design/utils/testing';
+
+import { TerminalRedirect } from './Login.story';
+
+test('renders', () => {
+  const { container } = render(<TerminalRedirect />);
+  expect(container).toMatchSnapshot();
+});

--- a/web/packages/teleport/src/Login/LoginTerminalRedirect.tsx
+++ b/web/packages/teleport/src/Login/LoginTerminalRedirect.tsx
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,8 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Login } from './Login';
-export { LoginFailed } from './LoginFailed';
-export { LoginSuccess } from './LoginSuccess';
-export { LoginTerminalRedirect } from './LoginTerminalRedirect';
-export { LoginClose } from './LoginClose';
+import React from 'react';
+import { CardTerminalLogin } from 'design/CardTerminal';
+
+import LogoHero from 'teleport/components/LogoHero';
+
+export function LoginTerminalRedirect() {
+  return (
+    <>
+      <LogoHero />
+      <CardTerminalLogin />
+    </>
+  );
+}

--- a/web/packages/teleport/src/Login/__snapshots__/LoginTerminalRedirect.test.tsx.snap
+++ b/web/packages/teleport/src/Login/__snapshots__/LoginTerminalRedirect.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders 1`] = `<div />`;

--- a/web/packages/teleport/src/Teleport.tsx
+++ b/web/packages/teleport/src/Teleport.tsx
@@ -35,6 +35,8 @@ import cfg from './config';
 import { AppLauncher } from './AppLauncher';
 import { LoginFailedComponent as LoginFailed } from './Login/LoginFailed';
 import { LoginSuccess } from './Login/LoginSuccess';
+import { LoginTerminalRedirect } from './Login/LoginTerminalRedirect';
+import { LoginClose } from './Login/LoginClose';
 import { Login } from './Login';
 import { Welcome } from './Welcome';
 
@@ -116,6 +118,18 @@ export function getSharedPublicRoutes() {
       title="Success"
       path={cfg.routes.loginSuccess}
       component={LoginSuccess}
+    />,
+    <Route
+      key="terminal"
+      title="Finish Login in Terminal"
+      path={cfg.routes.loginTerminalRedirect}
+      component={LoginTerminalRedirect}
+    />,
+    <Route
+      key="autoclose"
+      title="Working on SSO login"
+      path={cfg.routes.loginClose}
+      component={LoginClose}
     />,
     <Route
       key="invite"

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -142,6 +142,8 @@ const cfg = {
     player: '/web/cluster/:clusterId/session/:sid', // ?recordingType=ssh|desktop|k8s&durationMs=1234
     login: '/web/login',
     loginSuccess: '/web/msg/info/login_success',
+    loginTerminalRedirect: '/web/msg/info/login_terminal',
+    loginClose: '/web/msg/info/login_close',
     loginErrorLegacy: '/web/msg/error/login_failed',
     loginError: '/web/msg/error/login',
     loginErrorCallback: '/web/msg/error/login/callback',


### PR DESCRIPTION
This change updates the error message shown when a user logs in to `tsh` with SSO and required hardware key input. Previously, after SSO is complete `tsh` prompts the user to touch their hardware key, but the SSO redirect flow would leave them either at the login success or error page in the web UI. Now, the web UI correctly tells the user to return to `tsh` to finish logging in.

![Screenshot 2024-04-17 at 16-47-51 Design _ Card _ Terminal - Cards ⋅ Storybook](https://github.com/gravitational/teleport/assets/31974658/3414c4c0-e32e-45bb-a897-b1b4e67b92a9)

Changelog: Improved error message when performing an SSO login with a hardware key