### PR TITLE
[v14] Fix JIRA issue type

### DIFF
--- a/integrations/access/jira/client.go
+++ b/integrations/access/jira/client.go
@@ -239,7 +239,7 @@ func (j *Jira) CreateIssue(ctx context.Context, reqID string, reqData RequestDat
 			},
 		},
 		Fields: IssueFieldsInput{
-			Type:        &IssueType{Name: "Task"},
+			Type:        &IssueType{Name: j.issueType},
 			Project:     &Project{Key: j.project},
 			Summary:     fmt.Sprintf("%s requested %s", reqData.User, strings.Join(reqData.Roles, ", ")),
 			Description: description,

--- a/integrations/access/jira/fake_jira_test.go
+++ b/integrations/access/jira/fake_jira_test.go
@@ -101,6 +101,7 @@ func NewFakeJira(author UserDetails, concurrency int) *FakeJira {
 			Fields: IssueFields{
 				Summary:     issueInput.Fields.Summary,
 				Description: issueInput.Fields.Description,
+				Type:        *issueInput.Fields.Type,
 			},
 			Properties: make(map[string]interface{}),
 		}

--- a/integrations/access/jira/jira_test.go
+++ b/integrations/access/jira/jira_test.go
@@ -852,3 +852,21 @@ func (s *JiraSuite) TestRace() {
 	})
 	assert.Equal(t, s.raceNumber, count)
 }
+
+// TestCustomIssueType tests that requests can use a custom issue type.
+func (s *JiraSuite) TestCustomIssueType() {
+	t := s.T()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	s.appConfig.Jira.IssueType = "Story"
+	s.startApp()
+
+	// Test setup: we create an access request
+	_ = s.createAccessRequest()
+
+	// We validate that the issue was created using the Issue Type "Story"
+	newIssue, err := s.fakeJira.CheckNewIssue(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Story", newIssue.Fields.Type.Name)
+}


### PR DESCRIPTION
Backport #40587 to v14

changelog: Allow other issue types when configuring JIRA plugin.