### PR TITLE
Add clientside elements of TPM joining

### DIFF
--- a/api/client/joinservice.go
+++ b/api/client/joinservice.go
@@ -173,7 +173,7 @@ func (c *JoinServiceClient) RegisterUsingTPMMethod(
 
 	solution, err := solveChallenge(challenge.ChallengeRequest)
 	if err != nil {
-		return nil, trace.Wrap(err, "calling solveChallenge")
+		return nil, trace.Wrap(err, "solving challenge")
 	}
 
 	err = tpmJoinClient.Send(&proto.RegisterUsingTPMMethodRequest{

--- a/api/client/joinservice_test.go
+++ b/api/client/joinservice_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package client
 
 import (

--- a/api/client/joinservice_test.go
+++ b/api/client/joinservice_test.go
@@ -1,0 +1,110 @@
+package client
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+)
+
+type mockJoinServiceServer struct {
+	*proto.UnimplementedJoinServiceServer
+	registerUsingTPMMethod func(srv proto.JoinService_RegisterUsingTPMMethodServer) error
+}
+
+func (m *mockJoinServiceServer) RegisterUsingTPMMethod(srv proto.JoinService_RegisterUsingTPMMethodServer) error {
+	return m.registerUsingTPMMethod(srv)
+}
+
+func TestJoinServiceClient_RegisterUsingTPMMethod(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	lis := bufconn.Listen(100)
+	t.Cleanup(func() {
+		assert.NoError(t, lis.Close())
+	})
+
+	mockInitReq := &proto.RegisterUsingTPMMethodInitialRequest{
+		JoinRequest: &types.RegisterUsingTokenRequest{
+			Token: "token",
+		},
+	}
+	mockChallenge := &proto.TPMEncryptedCredential{
+		CredentialBlob: []byte("cred-blob"),
+		Secret:         []byte("secret"),
+	}
+	mockChallengeResp := &proto.RegisterUsingTPMMethodChallengeResponse{
+		Solution: []byte("solution"),
+	}
+	mockCerts := &proto.Certs{
+		TLS: []byte("cert"),
+	}
+	mockService := &mockJoinServiceServer{
+		registerUsingTPMMethod: func(srv proto.JoinService_RegisterUsingTPMMethodServer) error {
+			req, err := srv.Recv()
+			require.NoError(t, err)
+			assert.Empty(t, cmp.Diff(req.GetInit(), mockInitReq))
+
+			err = srv.Send(&proto.RegisterUsingTPMMethodResponse{
+				Payload: &proto.RegisterUsingTPMMethodResponse_ChallengeRequest{
+					ChallengeRequest: mockChallenge,
+				},
+			})
+			require.NoError(t, err)
+
+			req, err = srv.Recv()
+			require.NoError(t, err)
+			assert.Empty(t, cmp.Diff(req.GetChallengeResponse(), mockChallengeResp))
+
+			err = srv.Send(&proto.RegisterUsingTPMMethodResponse{
+				Payload: &proto.RegisterUsingTPMMethodResponse_Certs{
+					Certs: mockCerts,
+				},
+			})
+			require.NoError(t, err)
+			return nil
+		},
+	}
+	srv := grpc.NewServer()
+	t.Cleanup(func() {
+		srv.Stop()
+	})
+	proto.RegisterJoinServiceServer(srv, mockService)
+
+	go func() {
+		err := srv.Serve(lis)
+		assert.NotErrorIs(t, err, grpc.ErrServerStopped)
+		cancel()
+	}()
+
+	c, err := grpc.NewClient("example.com", grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	joinClient := NewJoinServiceClient(proto.NewJoinServiceClient(c))
+
+	certs, err := joinClient.RegisterUsingTPMMethod(
+		ctx,
+		mockInitReq,
+		func(challenge *proto.TPMEncryptedCredential) (*proto.RegisterUsingTPMMethodChallengeResponse, error) {
+			assert.Empty(t, cmp.Diff(mockChallenge, challenge))
+			return mockChallengeResp, nil
+		},
+	)
+	if assert.NoError(t, err) {
+		assert.Empty(t, cmp.Diff(mockCerts, certs))
+	}
+}

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -342,7 +342,7 @@ func (p *ProvisionTokenV2) CheckAndSetDefaults() error {
 				JoinMethodTPM,
 			)
 		}
-		if err := providerCfg.checkAndSetDefaults(); err != nil {
+		if err := providerCfg.validate(); err != nil {
 			return trace.Wrap(err, "spec.tpm: failed validation")
 		}
 	default:
@@ -772,7 +772,7 @@ func (a *ProvisionTokenSpecV2Spacelift) checkAndSetDefaults() error {
 	return nil
 }
 
-func (a *ProvisionTokenSpecV2TPM) checkAndSetDefaults() error {
+func (a *ProvisionTokenSpecV2TPM) validate() error {
 	for i, caData := range a.EKCertAllowedCAs {
 		p, _ := pem.Decode([]byte(caData))
 		if p == nil {

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -17,6 +17,8 @@ limitations under the License.
 package types
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"slices"
 	"strings"
@@ -66,6 +68,9 @@ const (
 	// method. Documentation regarding implementation of this can be found in
 	// lib/spacelift.
 	JoinMethodSpacelift JoinMethod = "spacelift"
+	// JoinMethodTPM indicates that the node will join with the TPM join method.
+	// The core implementation of this join method can be found in lib/tpm.
+	JoinMethodTPM JoinMethod = "tpm"
 )
 
 var JoinMethods = []JoinMethod{
@@ -79,6 +84,7 @@ var JoinMethods = []JoinMethod{
 	JoinMethodKubernetes,
 	JoinMethodSpacelift,
 	JoinMethodToken,
+	JoinMethodTPM,
 }
 
 func ValidateJoinMethod(method JoinMethod) error {
@@ -327,6 +333,17 @@ func (p *ProvisionTokenV2) CheckAndSetDefaults() error {
 		}
 		if err := providerCfg.checkAndSetDefaults(); err != nil {
 			return trace.Wrap(err, "spec.spacelift: failed validation")
+		}
+	case JoinMethodTPM:
+		providerCfg := p.Spec.TPM
+		if providerCfg == nil {
+			return trace.BadParameter(
+				`spec.tpm: must be configured for the join method %q`,
+				JoinMethodTPM,
+			)
+		}
+		if err := providerCfg.checkAndSetDefaults(); err != nil {
+			return trace.Wrap(err, "spec.tpm: failed validation")
 		}
 	default:
 		return trace.BadParameter("unknown join method %q", p.Spec.JoinMethod)
@@ -748,6 +765,47 @@ func (a *ProvisionTokenSpecV2Spacelift) checkAndSetDefaults() error {
 		if allowRule.SpaceID == "" && allowRule.CallerID == "" {
 			return trace.BadParameter(
 				"allow[%d]: at least one of ['space_id', 'caller_id'] must be set",
+				i,
+			)
+		}
+	}
+	return nil
+}
+
+func (a *ProvisionTokenSpecV2TPM) checkAndSetDefaults() error {
+	for i, caData := range a.EKCertAllowedCAs {
+		p, _ := pem.Decode([]byte(caData))
+		if p == nil {
+			return trace.BadParameter(
+				"ekcert_allowed_cas[%d]: no pem block found",
+				i,
+			)
+		}
+		if p.Type != "CERTIFICATE" {
+			return trace.BadParameter(
+				"ekcert_allowed_cas[%d]: pem block is not 'CERTIFICATE' type",
+				i,
+			)
+		}
+		if _, err := x509.ParseCertificate(p.Bytes); err != nil {
+			return trace.Wrap(
+				err,
+				"ekcert_allowed_cas[%d]: parsing certificate",
+				i,
+			)
+
+		}
+	}
+
+	if len(a.Allow) == 0 {
+		return trace.BadParameter(
+			"allow: at least one rule must be set",
+		)
+	}
+	for i, allowRule := range a.Allow {
+		if len(allowRule.EKPublicHash) == 0 && len(allowRule.EKCertificateSerial) == 0 {
+			return trace.BadParameter(
+				"allow[%d]: at least one of ['ek_public_hash', 'ek_certificate_serial'] must be set",
 				i,
 			)
 		}

--- a/api/types/provisioning_test.go
+++ b/api/types/provisioning_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/fixtures"
 )
 
 func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
@@ -894,6 +895,123 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 						Allow: []*ProvisionTokenSpecV2GCP_Rule{
 							{
 								Locations: []string{"us-west1-b"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "tpm success with CA",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: JoinMethodTPM,
+					TPM: &ProvisionTokenSpecV2TPM{
+						EKCertAllowedCAs: []string{fixtures.TLSCACertPEM},
+						Allow: []*ProvisionTokenSpecV2TPM_Rule{
+							{
+								Description:  "my description",
+								EKPublicHash: "d4b45864d9d6fabfc568d74f26c35ababde2105337d7af9a6605e1c56c891aa6",
+							},
+							{
+								EKCertificateSerial: "73:df:dc:bd:af:ef:8a:d8:15:2e:96:71:7a:3e:7f:a4",
+							},
+							{
+								EKPublicHash:        "d4b45864d9d6fabfc568d74f26c35ababde2105337d7af9a6605e1c56c891aa6",
+								EKCertificateSerial: "73:df:dc:bd:af:ef:8a:d8:15:2e:96:71:7a:3e:7f:a4",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			desc: "tpm success without CA",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: JoinMethodTPM,
+					TPM: &ProvisionTokenSpecV2TPM{
+						Allow: []*ProvisionTokenSpecV2TPM_Rule{
+							{
+								Description:  "my description",
+								EKPublicHash: "d4b45864d9d6fabfc568d74f26c35ababde2105337d7af9a6605e1c56c891aa6",
+							},
+							{
+								EKCertificateSerial: "73:df:dc:bd:af:ef:8a:d8:15:2e:96:71:7a:3e:7f:a4",
+							},
+							{
+								EKPublicHash:        "d4b45864d9d6fabfc568d74f26c35ababde2105337d7af9a6605e1c56c891aa6",
+								EKCertificateSerial: "73:df:dc:bd:af:ef:8a:d8:15:2e:96:71:7a:3e:7f:a4",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			desc: "tpm corrupt CA",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: JoinMethodTPM,
+					TPM: &ProvisionTokenSpecV2TPM{
+						EKCertAllowedCAs: []string{"corrupt"},
+						Allow: []*ProvisionTokenSpecV2TPM_Rule{
+							{
+								Description:  "my description",
+								EKPublicHash: "d4b45864d9d6fabfc568d74f26c35ababde2105337d7af9a6605e1c56c891aa6",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "tpm missing rules",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: JoinMethodTPM,
+					TPM: &ProvisionTokenSpecV2TPM{
+						EKCertAllowedCAs: []string{},
+						Allow:            []*ProvisionTokenSpecV2TPM_Rule{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "tpm rule without ekpubhash or ekcertserial",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: JoinMethodTPM,
+					TPM: &ProvisionTokenSpecV2TPM{
+						EKCertAllowedCAs: []string{},
+						Allow: []*ProvisionTokenSpecV2TPM_Rule{
+							{
+								Description: "my description",
 							},
 						},
 					},

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -807,7 +807,7 @@ func registerUsingTPMMethod(
 		log.DebugContext(
 			ctx,
 			"Using EKKey for TPM registration",
-			slog.String("ekpub_hash", attestation.Data.EKPubHash),
+			"ekpub_hash", attestation.Data.EKPubHash,
 		)
 		initReq.Ek = &proto.RegisterUsingTPMMethodInitialRequest_EkKey{
 			EkKey: attestation.Data.EKPub,

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"log/slog"
 	"os"
 	"slices"
 	"time"
@@ -53,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/lib/spacelift"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/tpm"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -332,7 +334,7 @@ func registerThroughProxy(
 	}()
 
 	switch params.JoinMethod {
-	case types.JoinMethodIAM, types.JoinMethodAzure:
+	case types.JoinMethodIAM, types.JoinMethodAzure, types.JoinMethodTPM:
 		// IAM and Azure join methods require gRPC client
 		conn, err := proxyJoinServiceConn(ctx, params, params.Insecure)
 		if err != nil {
@@ -341,10 +343,13 @@ func registerThroughProxy(
 		defer conn.Close()
 
 		joinServiceClient := client.NewJoinServiceClient(proto.NewJoinServiceClient(conn))
-		if params.JoinMethod == types.JoinMethodIAM {
+		switch params.JoinMethod {
+		case types.JoinMethodIAM:
 			certs, err = registerUsingIAMMethod(ctx, joinServiceClient, token, params)
-		} else {
+		case types.JoinMethodAzure:
 			certs, err = registerUsingAzureMethod(ctx, joinServiceClient, token, params)
+		case types.JoinMethodTPM:
+			certs, err = registerUsingTPMMethod(ctx, joinServiceClient, token, params)
 		}
 
 		if err != nil {
@@ -424,6 +429,8 @@ func registerThroughAuth(
 		certs, err = registerUsingIAMMethod(ctx, client, token, params)
 	case types.JoinMethodAzure:
 		certs, err = registerUsingAzureMethod(ctx, client, token, params)
+	case types.JoinMethodTPM:
+		certs, err = registerUsingTPMMethod(ctx, client, token, params)
 	default:
 		// non-IAM join methods use HTTP endpoint
 		// Get the SSH and X509 certificates for a node.
@@ -676,6 +683,25 @@ func caPathRegisterClient(params RegisterParams) (*Client, error) {
 type joinServiceClient interface {
 	RegisterUsingIAMMethod(ctx context.Context, challengeResponse client.RegisterIAMChallengeResponseFunc) (*proto.Certs, error)
 	RegisterUsingAzureMethod(ctx context.Context, challengeResponse client.RegisterAzureChallengeResponseFunc) (*proto.Certs, error)
+	RegisterUsingTPMMethod(
+		ctx context.Context,
+		initReq *proto.RegisterUsingTPMMethodInitialRequest,
+		solveChallenge client.RegisterTPMChallengeResponseFunc,
+	) (*proto.Certs, error)
+}
+
+func registerUsingTokenRequestForParams(token string, params RegisterParams) *types.RegisterUsingTokenRequest {
+	return &types.RegisterUsingTokenRequest{
+		Token:                token,
+		HostID:               params.ID.HostUUID,
+		NodeName:             params.ID.NodeName,
+		Role:                 params.ID.Role,
+		AdditionalPrincipals: params.AdditionalPrincipals,
+		DNSNames:             params.DNSNames,
+		PublicTLSKey:         params.PublicTLSKey,
+		PublicSSHKey:         params.PublicSSHKey,
+		Expires:              params.Expires,
+	}
 }
 
 // registerUsingIAMMethod is used to register using the IAM join method. It is
@@ -697,18 +723,8 @@ func registerUsingIAMMethod(
 
 		// send the register request including the challenge response
 		return &proto.RegisterUsingIAMMethodRequest{
-			RegisterUsingTokenRequest: &types.RegisterUsingTokenRequest{
-				Token:                token,
-				HostID:               params.ID.HostUUID,
-				NodeName:             params.ID.NodeName,
-				Role:                 params.ID.Role,
-				AdditionalPrincipals: params.AdditionalPrincipals,
-				DNSNames:             params.DNSNames,
-				PublicTLSKey:         params.PublicTLSKey,
-				PublicSSHKey:         params.PublicSSHKey,
-				Expires:              params.Expires,
-			},
-			StsIdentityRequest: signedRequest,
+			RegisterUsingTokenRequest: registerUsingTokenRequestForParams(token, params),
+			StsIdentityRequest:        signedRequest,
 		}, nil
 	})
 	if err != nil {
@@ -740,20 +756,86 @@ func registerUsingAzureMethod(
 		}
 
 		return &proto.RegisterUsingAzureMethodRequest{
-			RegisterUsingTokenRequest: &types.RegisterUsingTokenRequest{
-				Token:                token,
-				HostID:               params.ID.HostUUID,
-				NodeName:             params.ID.NodeName,
-				Role:                 params.ID.Role,
-				AdditionalPrincipals: params.AdditionalPrincipals,
-				DNSNames:             params.DNSNames,
-				PublicTLSKey:         params.PublicTLSKey,
-				PublicSSHKey:         params.PublicSSHKey,
-			},
-			AttestedData: ad,
-			AccessToken:  accessToken,
+			RegisterUsingTokenRequest: registerUsingTokenRequestForParams(token, params),
+			AttestedData:              ad,
+			AccessToken:               accessToken,
 		}, nil
 	})
+	return certs, trace.Wrap(err)
+}
+
+// registerUsingTPMMethod is used to register using the TPM join method. It
+// is able to register through a proxy or through the auth server directly.
+func registerUsingTPMMethod(
+	ctx context.Context,
+	client joinServiceClient,
+	token string,
+	params RegisterParams,
+) (*proto.Certs, error) {
+	log := slog.Default()
+
+	initReq := &proto.RegisterUsingTPMMethodInitialRequest{
+		JoinRequest: registerUsingTokenRequestForParams(token, params),
+	}
+
+	attestation, close, err := tpm.Attest(ctx, log)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer func() {
+		if err := close(); err != nil {
+			log.WarnContext(ctx, "Failed to close TPM", "error", err)
+		}
+	}()
+
+	initReq.AttestationParams = tpm.AttestationParametersToProto(
+		attestation.AttestParams,
+	)
+	// Get the EKKey or EKCert. We want to prefer the EKCert if it is available
+	// as this is signed by the manufacturer.
+	switch {
+	case attestation.Data.EKCert != nil:
+		log.DebugContext(
+			ctx,
+			"Using EKCert for TPM registration",
+			slog.String("ekcert_serial", attestation.Data.EKCert.SerialNumber),
+		)
+		initReq.Ek = &proto.RegisterUsingTPMMethodInitialRequest_EkCert{
+			EkCert: attestation.Data.EKCert.Raw,
+		}
+	case attestation.Data.EKPub != nil:
+		log.DebugContext(
+			ctx,
+			"Using EKKey for TPM registration",
+			slog.String("ekpub_hash", attestation.Data.EKPubHash),
+		)
+		initReq.Ek = &proto.RegisterUsingTPMMethodInitialRequest_EkKey{
+			EkKey: attestation.Data.EKPub,
+		}
+	default:
+		return nil, trace.BadParameter("tpm has neither ekkey or ekcert")
+	}
+
+	// Submit initial request to the Auth Server.
+	certs, err := client.RegisterUsingTPMMethod(
+		ctx,
+		initReq,
+		func(
+			challenge *proto.TPMEncryptedCredential,
+		) (*proto.RegisterUsingTPMMethodChallengeResponse, error) {
+			// Solve the encrypted credential with our AK to prove possession
+			// and obtain the solution we need to complete the ceremony.
+			solution, err := attestation.Solve(tpm.EncryptedCredentialFromProto(
+				challenge,
+			))
+			if err != nil {
+				return nil, trace.Wrap(err, "activating credential")
+			}
+			return &proto.RegisterUsingTPMMethodChallengeResponse{
+				Solution: solution,
+			}, nil
+		},
+	)
 	return certs, trace.Wrap(err)
 }
 

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -798,7 +798,7 @@ func registerUsingTPMMethod(
 		log.DebugContext(
 			ctx,
 			"Using EKCert for TPM registration",
-			slog.String("ekcert_serial", attestation.Data.EKCert.SerialNumber),
+			"ekcert_serial", attestation.Data.EKCert.SerialNumber,
 		)
 		initReq.Ek = &proto.RegisterUsingTPMMethodInitialRequest_EkCert{
 			EkCert: attestation.Data.EKCert.Raw,

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -350,6 +350,8 @@ func registerThroughProxy(
 			certs, err = registerUsingAzureMethod(ctx, joinServiceClient, token, params)
 		case types.JoinMethodTPM:
 			certs, err = registerUsingTPMMethod(ctx, joinServiceClient, token, params)
+		default:
+			return nil, trace.BadParameter("unhandled join method %q", params.JoinMethod)
 		}
 
 		if err != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5897,7 +5897,8 @@ func readOrGenerateHostID(ctx context.Context, cfg *servicecfg.Config, kubeBacke
 				types.JoinMethodGitHub,
 				types.JoinMethodGitLab,
 				types.JoinMethodAzure,
-				types.JoinMethodGCP:
+				types.JoinMethodGCP,
+				types.JoinMethodTPM:
 				// Checking error instead of the usual uuid.New() in case uuid generation
 				// fails due to not enough randomness. It's been known to happen happen when
 				// Teleport starts very early in the node initialization cycle and /dev/urandom

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -57,6 +57,7 @@ var SupportedJoinMethods = []string{
 	string(types.JoinMethodKubernetes),
 	string(types.JoinMethodSpacelift),
 	string(types.JoinMethodToken),
+	string(types.JoinMethodTPM),
 }
 
 var log = logrus.WithFields(logrus.Fields{

--- a/lib/tpm/testdata/TestPrintQuery/ekcert.golden
+++ b/lib/tpm/testdata/TestPrintQuery/ekcert.golden
@@ -1,4 +1,4 @@
 TPM Information
-EKPub Hash: aabbaabbcc
-EKCert Detected: true
-EKCert Serial: aa:bb:cc
+EK Public Hash: aabbaabbcc
+EK Certificate Detected: true
+EK Certificate Serial: aa:bb:cc

--- a/lib/tpm/testdata/TestPrintQuery/ekcert_debug.golden
+++ b/lib/tpm/testdata/TestPrintQuery/ekcert_debug.golden
@@ -1,12 +1,12 @@
 TPM Information
-EKPub Hash: aabbaabbcc
-EKCert Detected: true
-EKCert Serial: aa:bb:cc
-EKPub:
+EK Public Hash: aabbaabbcc
+EK Certificate Detected: true
+EK Certificate Serial: aa:bb:cc
+EK Public:
 -----BEGIN PUBLIC KEY-----
 ZWtwdWI=
 -----END PUBLIC KEY-----
-EKCert:
+EK Certificate:
 -----BEGIN CERTIFICATE-----
 ZWtjZXJ0
 -----END CERTIFICATE-----

--- a/lib/tpm/testdata/TestPrintQuery/ekpub.golden
+++ b/lib/tpm/testdata/TestPrintQuery/ekpub.golden
@@ -1,3 +1,3 @@
 TPM Information
-EKPub Hash: aabbaabbcc
-EKCert Detected: false
+EK Public Hash: aabbaabbcc
+EK Certificate Detected: false

--- a/lib/tpm/testdata/TestPrintQuery/ekpub_debug.golden
+++ b/lib/tpm/testdata/TestPrintQuery/ekpub_debug.golden
@@ -1,7 +1,7 @@
 TPM Information
-EKPub Hash: aabbaabbcc
-EKCert Detected: false
-EKPub:
+EK Public Hash: aabbaabbcc
+EK Certificate Detected: false
+EK Public:
 -----BEGIN PUBLIC KEY-----
 ZWtwdWI=
 -----END PUBLIC KEY-----

--- a/lib/tpm/tpm.go
+++ b/lib/tpm/tpm.go
@@ -236,18 +236,18 @@ func AttestWithTPM(ctx context.Context, log *slog.Logger, tpm *attest.TPM) (
 // specified io.Writer.
 func PrintQuery(data *QueryRes, debug bool, w io.Writer) {
 	_, _ = fmt.Fprintf(w, "TPM Information\n")
-	_, _ = fmt.Fprintf(w, "EKPub Hash: %s\n", data.EKPubHash)
-	_, _ = fmt.Fprintf(w, "EKCert Detected: %t\n", data.EKCert != nil)
+	_, _ = fmt.Fprintf(w, "EK Public Hash: %s\n", data.EKPubHash)
+	_, _ = fmt.Fprintf(w, "EK Certificate Detected: %t\n", data.EKCert != nil)
 	if data.EKCert != nil {
-		_, _ = fmt.Fprintf(w, "EKCert Serial: %s\n", data.EKCert.SerialNumber)
+		_, _ = fmt.Fprintf(w, "EK Certificate Serial: %s\n", data.EKCert.SerialNumber)
 	}
 	if debug {
-		_, _ = fmt.Fprintf(w, "EKPub:\n%s", pem.EncodeToMemory(&pem.Block{
+		_, _ = fmt.Fprintf(w, "EK Public:\n%s", pem.EncodeToMemory(&pem.Block{
 			Type:  "PUBLIC KEY",
 			Bytes: data.EKPub,
 		}))
 		if data.EKCert != nil {
-			_, _ = fmt.Fprintf(w, "EKCert:\n%s", pem.EncodeToMemory(&pem.Block{
+			_, _ = fmt.Fprintf(w, "EK Certificate:\n%s", pem.EncodeToMemory(&pem.Block{
 				Type:  "CERTIFICATE",
 				Bytes: data.EKCert.Raw,
 			}))


### PR DESCRIPTION
Adds the client side of TPM joining, this makes more sense in the context of the follow on PR: https://github.com/gravitational/teleport/pull/40512

As per RFD https://github.com/gravitational/teleport/pull/38613
Followed on by https://github.com/gravitational/teleport/pull/40512