### PR TITLE
helm: Expose flag to enable/disable passwordless auth

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -289,6 +289,16 @@ details.
 
 Defaults to Teleport's binary default when empty: `best_effort`.
 
+### `authentication.passwordless`
+
+| Type   | Default value | Required? | `teleport.yaml` equivalent               |
+|--------|---------------|-----------|------------------------------------------|
+| `bool` | `nil`         | No        | `auth_service.authentication.passwordless` |
+
+`authentication.passwordless` controls whether passwordless authentication is enabled.
+
+[Can be used to forbid passwordless access to your cluster](https://goteleport.com/docs/access-controls/guides/passwordless/#disable-passwordless)
+
 ### `authentication.secondFactor`
 
 | Type     | Default value | Required? | `teleport.yaml` equivalent                  |

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -297,7 +297,7 @@ Defaults to Teleport's binary default when empty: `best_effort`.
 
 `authentication.passwordless` controls whether passwordless authentication is enabled.
 
-[Can be used to forbid passwordless access to your cluster](https://goteleport.com/docs/access-controls/guides/passwordless/#disable-passwordless)
+[Can be used to forbid passwordless access to your cluster](../../access-controls/guides/passwordless.mdx#disable-passwordless)
 
 ### `authentication.secondFactor`
 

--- a/examples/chart/teleport-cluster/.lint/auth-disable-passwordless.yaml
+++ b/examples/chart/teleport-cluster/.lint/auth-disable-passwordless.yaml
@@ -1,0 +1,5 @@
+clusterName: helm-lint
+authentication:
+  type: "github"
+  passwordless: false
+  secondFactor: "off"

--- a/examples/chart/teleport-cluster/templates/auth/_config.common.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.common.tpl
@@ -27,6 +27,9 @@ auth_service:
   authentication:
     type: "{{ required "authentication.type is required in chart values" (coalesce .Values.authenticationType $authentication.type) }}"
     local_auth: {{ $authentication.localAuth }}
+{{- if $authentication.passwordless }}
+    passwordless: {{ $authentication.passwordless }}
+{{- end }}
 {{- if $authentication.connectorName }}
     connector_name: "{{ $authentication.connectorName }}"
 {{- end }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -187,6 +187,39 @@ matches snapshot for auth-disable-local.yaml:
           output: stderr
           severity: INFO
       version: v3
+matches snapshot for auth-disable-passwordless.yaml:
+  1: |
+    |-
+      auth_service:
+        authentication:
+          passwordless: false
+          second_factor: "off"
+          type: github
+        cluster_name: helm-lint
+        enabled: true
+        proxy_listener_mode: separate
+      kubernetes_service:
+        enabled: true
+        kube_cluster_name: helm-lint
+        listen_addr: 0.0.0.0:3026
+        public_addr: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3026
+      proxy_service:
+        enabled: false
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: 127.0.0.1:3025
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
 matches snapshot for auth-locking-mode.yaml:
   1: |
     |-


### PR DESCRIPTION
### Summary

Expose `auth_service.authentication.passwordless` flag, to give user control to enable/disable passwordless auth through helm chart.

- https://goteleport.com/docs/access-controls/guides/passwordless/#disable-passwordless


changelog: Expose `auth_service.authentication.passwordless` flag in `teleport-cluster` helm chart