### PR TITLE
Add a deferred slog.Handler for use in package global variables

### DIFF
--- a/lib/utils/log/package_logger.go
+++ b/lib/utils/log/package_logger.go
@@ -1,0 +1,117 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package log
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"sync/atomic"
+)
+
+type packageHandler struct {
+	args   []any
+	meta   []metadata
+	logger atomic.Pointer[slog.Logger]
+}
+
+type metadata struct {
+	group string
+	attrs []slog.Attr
+}
+
+// NewPackageLogger creates a [slog.Logger] that defers setting
+// any groups or attributes until the first use of the logger.
+// This allows package global loggers to be created prior to
+// any custom [slog.Handler] can be set via [slog.Default] AND
+// still respect the formatting of the default handler set at
+// runtime.
+func NewPackageLogger(args ...any) *slog.Logger {
+	return slog.New(&packageHandler{args: args})
+}
+
+// Enabled returns whether the provided level will be included in output.
+func (d *packageHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	logger := d.getLogger()
+	return logger.Enabled(ctx, level)
+}
+
+func (d *packageHandler) getLogger() *slog.Logger {
+	logger := d.logger.Load()
+	if logger != nil {
+		return logger
+	}
+	logger = slog.With(d.args...)
+	for _, goa := range d.meta {
+		if goa.group != "" {
+			logger = logger.WithGroup(goa.group)
+		}
+
+		for _, attr := range goa.attrs {
+			logger = logger.With(attr)
+		}
+	}
+
+	if d.logger.CompareAndSwap(nil, logger) {
+		return logger
+	}
+
+	return d.getLogger()
+}
+
+// Handle formats the provided record and writes the underlying logger.
+func (d *packageHandler) Handle(ctx context.Context, record slog.Record) error {
+	logger := d.getLogger()
+	return logger.Handler().Handle(ctx, record)
+}
+
+// WithAttrs clones the current handler with the provided attributes
+// added to any existing attributes. If the underlying logger has not yet been
+// set, then the attributes are stored so that they can later be expanded.
+func (d *packageHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return d
+	}
+
+	logger := d.logger.Load()
+	if logger != nil {
+		return logger.Handler().WithAttrs(attrs)
+	}
+
+	return &packageHandler{
+		args: slices.Clone(d.args),
+		meta: append(slices.Clone(d.meta), metadata{attrs: attrs}),
+	}
+}
+
+// WithGroup opens a new group. If the underlying logger has not yet been
+// set, then the group is stored so that they can later be expanded.
+func (d *packageHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return d
+	}
+
+	logger := d.logger.Load()
+	if logger != nil {
+		return logger.Handler().WithGroup(name)
+	}
+
+	return &packageHandler{
+		args: slices.Clone(d.args),
+		meta: append(slices.Clone(d.meta), metadata{group: name}),
+	}
+}

--- a/lib/utils/log/package_logger_test.go
+++ b/lib/utils/log/package_logger_test.go
@@ -1,0 +1,89 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package log
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gravitational/teleport"
+)
+
+func TestPackageLogger(t *testing.T) {
+	ctx := context.Background()
+
+	logger := NewPackageLogger(teleport.ComponentKey, "test").With("animal", "llama")
+
+	logger2 := NewPackageLogger(teleport.ComponentKey, "test2").WithGroup("a").With("1", "foo").WithGroup("b").With("2", "bar")
+
+	w := &safeWriter{}
+	slog.SetDefault(slog.New(NewSlogTextHandler(w, SlogTextHandlerConfig{Level: TraceLevel, ConfiguredFields: []string{LevelField, ComponentField}})))
+
+	logger.DebugContext(ctx, "test 123")
+
+	logger.With("fruit", "pear").InfoContext(ctx, "abcxyz")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		logger2.DebugContext(ctx, "test 123")
+	}()
+
+	go func() {
+		defer wg.Done()
+		logger2.WithGroup("c").With("fruit", "pear").InfoContext(ctx, "abcxyz")
+	}()
+
+	expected := []string{
+		"DEBU [TEST]      test 123 animal:llama",
+		"INFO [TEST]      abcxyz animal:llama fruit:pear",
+		"DEBU [TEST2]     test 123 a.1:foo a.b.2:bar",
+		"INFO [TEST2]     abcxyz a.1:foo a.b.2:bar a.b.c.fruit:pear",
+	}
+
+	wg.Wait()
+
+	out := w.String()
+	for _, line := range expected {
+		assert.Contains(t, out, line)
+	}
+}
+
+type safeWriter struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *safeWriter) Write(p []byte) (n int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buf.Write(p)
+}
+
+func (s *safeWriter) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buf.String()
+}

--- a/rfd/0154-logging-guidelines.md
+++ b/rfd/0154-logging-guidelines.md
@@ -181,6 +181,18 @@ slog.InfoContext(ctx, "Speed threshold reached", "flux_capacitors_charged", true
 slog.LogAttrs(ctx, slog.LevelInfo, "Speed threshold reached", slog.Bool("flux_capacitors_charged", true), slog.String("operator", "doc brown"))
 ```
 
+
+Package global loggers should not use `slog.With` to create the logger. Doing so results in incorrect formatting
+because the default slog handler is used instead of the slog handler set at runtime (see 
+https://github.com/gravitational/teleport/issues/40629 for more details). Instead a global logger should be
+created with `logutils.NewPackageLogger` which allows formatting of attributes to be deferred until runtime
+so that the correct formatter is used.
+
+```go
+var logger = logutils.NewPackageLogger(teleport.ComponentKey, "llama")
+```
+
+
 ### Logging Standards
 
 There currently exists no logging standards within Teleport, which has resulted in various different patterns depending


### PR DESCRIPTION
The new packageHandler allows global slog.Loggers to be created with attributes and groups that are not expanded until runtime. This allows the data to be formatted with a custom slog.Handler which is set via slog.SetDefault instead of the default logger provided by log/slog.

Closes #40629