### PR TITLE
Cleanup tctl subcommands

### DIFF
--- a/tool/tctl/common/cmds.go
+++ b/tool/tctl/common/cmds.go
@@ -25,8 +25,7 @@ import (
 	"github.com/gravitational/teleport/tool/tctl/sso/tester"
 )
 
-// Commands returns the set of commands that are to oss and ent
-// variants of tctl.
+// Commands returns the set of available subcommands for tctl.
 func Commands() []CLICommand {
 	return []CLICommand{
 		&UserCommand{},
@@ -57,13 +56,6 @@ func Commands() []CLICommand {
 		&IdPCommand{},
 		&accessmonitoring.Command{},
 		&PluginsCommand{},
-	}
-}
-
-// OSSCommands returns the oss variants of commands that use different variants
-// for oss and ent.
-func OSSCommands() []CLICommand {
-	return []CLICommand{
 		&configure.SSOConfigureCommand{},
 		&tester.SSOTestCommand{},
 	}

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -23,8 +23,5 @@ import (
 )
 
 func main() {
-	// aggregate common and oss-specific command variants
-	commands := common.Commands()
-	commands = append(commands, common.OSSCommands()...)
-	common.Run(commands)
+	common.Run(common.Commands())
 }


### PR DESCRIPTION
tctl enterprise is no longer a thing so the split of OSS commands that get overwritten by ent can be removed.