### PR TITLE
Add a small hint on filtering databases listed from `tsh`

### DIFF
--- a/tool/tsh/common/db_print.go
+++ b/tool/tsh/common/db_print.go
@@ -141,3 +141,28 @@ func formatDatabaseRolesForDB(database types.Database, accessChecker services.Ac
 	}
 	return ""
 }
+
+func shouldShowListDatabasesHint(cf *CLIConf, numRows int) bool {
+	selector := newDatabaseResourceSelectors(cf)
+
+	return numRows >= minNumRowsToShowListDatabasesHint &&
+		cf.command == "db ls" &&
+		cf.SearchKeywords == "" &&
+		selector.IsEmpty()
+}
+
+func maybeShowListDatabasesHint(cf *CLIConf, w io.Writer, numRows int) {
+	if !shouldShowListDatabasesHint(cf, numRows) {
+		return
+	}
+
+	fmt.Fprint(w, listDatabaseHint)
+}
+
+// minNumRowsToShowListDatabasesHint is an arbitrary number selected to show
+// filtering hint for `tsh db ls` command when too many databases are listed.
+const minNumRowsToShowListDatabasesHint = 20
+
+const listDatabaseHint = "" +
+	"hint: use 'tsh db ls --search foo,bar' to search keywords\n" +
+	"      use 'tsh db ls key1=value1,key2=value2' to filter databases by labels\n\n"

--- a/tool/tsh/common/db_print_test.go
+++ b/tool/tsh/common/db_print_test.go
@@ -19,6 +19,7 @@
 package common
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -193,6 +194,83 @@ func Test_formatDatabaseRolesForDB(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.expect, formatDatabaseRolesForDB(test.database, test.accessChecker))
+		})
+	}
+}
+
+func Test_maybeShowListDatabaseHint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cf       *CLIConf
+		numRows  int
+		wantHint bool
+	}{
+		{
+			name: "show hint when number is big",
+			cf: &CLIConf{
+				command: "db ls",
+			},
+			numRows:  25,
+			wantHint: true,
+		},
+		{
+			name: "no hint for tsh db connect",
+			cf: &CLIConf{
+				command: "db connect",
+			},
+			numRows:  25,
+			wantHint: false,
+		},
+		{
+			name: "no hint when number is small",
+			cf: &CLIConf{
+				command: "db ls",
+			},
+			numRows:  15,
+			wantHint: false,
+		},
+		{
+			name: "no hint when search flag exists",
+			cf: &CLIConf{
+				command:        "db ls",
+				SearchKeywords: "foo",
+			},
+			numRows:  25,
+			wantHint: false,
+		},
+		{
+			name: "no hint when query flag exists",
+			cf: &CLIConf{
+				command:             "db ls",
+				PredicateExpression: "labels[\"key\"] == \"value\"",
+			},
+			numRows:  25,
+			wantHint: false,
+		},
+		{
+			name: "no hint when labels exist",
+			cf: &CLIConf{
+				command: "db ls",
+				Labels:  "key=value",
+			},
+			numRows:  25,
+			wantHint: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			maybeShowListDatabasesHint(test.cf, &buf, test.numRows)
+
+			if test.wantHint {
+				require.Contains(t, buf.String(), "hint")
+			} else {
+				require.Empty(t, buf.String())
+			}
 		})
 	}
 }

--- a/tool/tsh/common/help.go
+++ b/tool/tsh/common/help.go
@@ -61,5 +61,5 @@ Examples:
   $ tsh db ls --all -v
 
   Get database names using "jq":
-  $ tsh db ls --format json  | jq -r .[].metadata.name`
+  $ tsh db ls --format json  | jq -r '.[].metadata.name'`
 )

--- a/tool/tsh/common/help.go
+++ b/tool/tsh/common/help.go
@@ -48,4 +48,18 @@ EXAMPLES:
 
   Check with your Teleport cluster administrator that your user's roles should have nodes available.
   `
+
+	dbListHelp = `
+Examples:
+  Search databases with keywords:
+  $ tsh db ls --search foo,bar
+
+  Filter databases with labels:
+  $ tsh db ls key1=value1,key2=value2
+
+  List databases from all clusters with extra fields:
+  $ tsh db ls --all -v
+
+  Get database names using "jq":
+  $ tsh db ls --format json  | jq -r .[].metadata.name`
 )

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2987,6 +2987,8 @@ func showDatabasesAsText(cf *CLIConf, w io.Writer, databases []types.Database, a
 		rows:    rows,
 		verbose: verbose,
 	})
+
+	maybeShowListDatabasesHint(cf, w, len(rows))
 }
 
 func printDatabasesWithClusters(cf *CLIConf, dbListings []databaseListing, active []tlsca.RouteToDatabase) {
@@ -3007,6 +3009,8 @@ func printDatabasesWithClusters(cf *CLIConf, dbListings []databaseListing, activ
 		showProxyAndCluster: true,
 		verbose:             cf.Verbose,
 	})
+
+	maybeShowListDatabasesHint(cf, cf.Stdout(), len(rows))
 }
 
 func formatActiveDB(active tlsca.RouteToDatabase, displayName string) string {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -901,6 +901,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	dbList.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
 	dbList.Flag("all", "List databases from all clusters and proxies.").Short('R').BoolVar(&cf.ListAll)
 	dbList.Arg("labels", labelHelp).StringVar(&cf.Labels)
+	dbList.Alias(dbListHelp)
 	dbLogin := db.Command("login", "Retrieve credentials for a database.")
 	// don't require <db> positional argument, user can select with --labels/--query alone.
 	dbLogin.Arg("db", "Database to retrieve credentials for. Can be obtained from 'tsh db ls' output.").StringVar(&cf.DatabaseService)


### PR DESCRIPTION
Add a small hint to help users filtering results when too many databases are listed in `tsh db ls`

Example:
```
$ tsh db ls
Name                          Description Allowed Users              Labels                   Connect 
----------------------------- ----------- -------------------------- ------------------------ ------- 
mongo-atlas                               [*], except: [alice]                                        
oracle                                    [*], except: [alice]                                        
rds-proxy-mssql                           [*], except: [alice]                                        
self-hosted-cockroachdb                   [*], except: [alice]                                        
self-hosted-mariadb                       [*], except: [alice]                                        
self-hosted-mariadb-auto-drop             [STeve] (Auto-provisioned) db-auto-user-mode=drop           
self-hosted-mariadb-auto-keep             [STeve] (Auto-provisioned) db-auto-user-mode=keep           
self-hosted-mongo                         [*], except: [alice]                                        
self-hosted-mysql                         [*], except: [alice]                                        
self-hosted-postgres                      [*], except: [alice]                                        
self-hosted-postgres-drop                 [STeve] (Auto-provisioned) db-auto-user-mode=drop           
self-hosted-postgres-import               [*], except: [alice]       db-auto-user-mode=import         
self-hosted-postgres-keep                 [STeve] (Auto-provisioned) db-auto-user-mode=keep           
self-hosted-redis                         [*], except: [alice]                                        
self-hosted-redis-cluster                 [*], except: [alice]                                        
test-db1                                  [*], except: [alice]       dept=food,env=prod               
test-db2                                  [*], except: [alice]       dept=food,env=dev                
test-db3                                  [*], except: [alice]       dept=keyboard,env=prod           
test-db4                                  [*], except: [alice]       dept=keyboard,env=dev            
test-db5                                  [*], except: [alice]       env=staging                      

hint: use 'tsh db ls --search foo,bar' to search keywords
      use 'tsh db ls key1=value1,key2=value2' to filter databases by labels

$ tsh db ls -h
usage: tsh db ls [<flags>] [<labels>]

List all available databases.

Flags:
...
Args:
  [<labels>]  List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)

Aliases:

Examples:
  Search databases with keywords:
  $ tsh db ls --search foo,bar

  Filter databases with labels:
  $ tsh db ls key1=value1,key2=value2

  List databases from all clusters with extra fields:
  $ tsh db ls --all -v

  Get database names using "jq":
  $ tsh db ls --format json  | jq -r .[].metadata.name
```