### PR TITLE
feat!: Apply role-based device enforcement to Desktop Service

### DIFF
--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -160,10 +160,10 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(logger *slog
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,
 		Logger:      process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentWindowsDesktop, process.id)),
-		// Device authorization breaks browser-based access.
 		DeviceAuthorization: authz.DeviceAuthorizationOpts{
+			// Ignore the global device_trust.mode toggle, but allow role-based
+			// settings to be applied.
 			DisableGlobalMode: true,
-			DisableRoleMode:   true,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Apply the role-based "device_trust_mode" to Desktop Access. This is the first step in the gradual transition described at [RFD 0009e][1], the second step being full enforcement for both App Access and Desktop Access (possibly in v17).

This is now viable due to the upcoming release of Web UI support for Device Trust.

Note that this is a breaking change in the behavior of roles. Note also that device_trust_mode takes into consideration [the targets of the role][2], like require_session_mfa does.

https://github.com/gravitational/teleport.e/issues/3236

Changelog: BREAKING CHANGE: Allow role device_trust_mode to take effect on Desktop Access. This may cause a behavior change if you have device_trust_mode=required roles that also targets deskops. (You may use Device Trust Web to bless your Web UI session.)

[1]: https://github.com/gravitational/teleport.e/blob/master/rfd/0009e-device-trust-web-support.md#ux

[2]: https://goteleport.com/docs/access-controls/device-trust/enforcing-device-trust/#role-based-trusted-device-enforcement