### PR TITLE
[v13] fix: return `OpaqueAccessDenied` for `NotFound` remote cluster errors

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2403,7 +2403,7 @@ func testInvalidLogins(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	err = tc.SSH(context.Background(), cmd, false)
-	require.ErrorIs(t, err, trace.NotFound("failed to dial target host\n\tcluster \"wrong-site\" is not found"))
+	require.ErrorIs(t, err, trace.NotFound("failed to dial target host\n\tlooking up remote cluster \"wrong-site\"\n\t\tnot found"))
 }
 
 // TestTwoClustersTunnel creates two teleport clusters: "a" and "b" and creates a

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4526,7 +4526,7 @@ func (a *ServerWithRoles) GetRemoteCluster(clusterName string) (types.RemoteClus
 	}
 	cluster, err := a.authServer.GetRemoteCluster(clusterName)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, utils.OpaqueAccessDenied(err)
 	}
 	if err := a.context.Checker.CheckAccessToRemoteCluster(cluster); err != nil {
 		return nil, utils.OpaqueAccessDenied(err)

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -223,7 +223,7 @@ func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.
 	if clusterName != r.clusterName {
 		remoteSite, err := r.getRemoteCluster(ctx, clusterName, accessChecker)
 		if err != nil {
-			return nil, targetTeleportVersion, trace.Wrap(err)
+			return nil, targetTeleportVersion, trace.Wrap(err, "looking up remote cluster %q", clusterName)
 		}
 		site = remoteSite
 	}
@@ -331,12 +331,12 @@ func (r *Router) getRemoteCluster(ctx context.Context, clusterName string, check
 
 	site, err := r.siteGetter.GetSite(clusterName)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, utils.OpaqueAccessDenied(err)
 	}
 
 	rc, err := r.clusterGetter.GetRemoteCluster(clusterName)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, utils.OpaqueAccessDenied(err)
 	}
 
 	if err := checker.CheckAccessToRemoteCluster(rc); err != nil {

--- a/lib/reversetunnelclient/api_with_roles.go
+++ b/lib/reversetunnelclient/api_with_roles.go
@@ -86,14 +86,14 @@ func (t *TunnelWithRoles) GetSites() ([]RemoteSite, error) {
 func (t *TunnelWithRoles) GetSite(clusterName string) (RemoteSite, error) {
 	cluster, err := t.tunnel.GetSite(clusterName)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, utils.OpaqueAccessDenied(err)
 	}
 	if t.localCluster == cluster.GetName() {
 		return cluster, nil
 	}
 	rc, err := t.access.GetRemoteCluster(clusterName)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, utils.OpaqueAccessDenied(err)
 	}
 	if err := t.accessChecker.CheckAccessToRemoteCluster(rc); err != nil {
 		return nil, utils.OpaqueAccessDenied(err)

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -424,10 +424,11 @@ func IsCertExpiredError(err error) bool {
 	return strings.Contains(trace.Unwrap(err).Error(), "ssh: cert has expired")
 }
 
-// OpaqueAccessDenied returns a generic NotFound instead of AccessDenied
-// so as to avoid leaking the existence of secret resources.
+// OpaqueAccessDenied returns a generic [trace.NotFoundError] if [err] is a [trace.NotFoundError] or
+// a [trace.AccessDeniedError] so as to avoid leaking the existence of secret resources,
+// for other error types it returns the original error.
 func OpaqueAccessDenied(err error) error {
-	if trace.IsAccessDenied(err) {
+	if trace.IsNotFound(err) || trace.IsAccessDenied(err) {
 		return trace.NotFound("not found")
 	}
 	return trace.Wrap(err)


### PR DESCRIPTION
Backport #40571 to branch/v13

This commit modifies OpaqueAccessDenied to return an identical generic NotFound error whether the input error is NotFound or AccessDenied. The commit also updates all call sites of OpaqueAccessDenied to use it in the paths where there is any error fetching the resource as well as when access is denied.

It doesn't do much good to return AccessDenied errors as NotFound, if they don't match the NotFound error you would get if the resource really didn't exist.
It's trivial to tell the errors apart and discover the existence of a resource you shouldn't be allowed to access.
The commit attempts to mitigate that issue and properly hide the existence of resources the user should not be allowed to list.

Changelog: Generic "not found" errors are returned whether a remote cluster can't be found or access is denied.