### PR TITLE
Do not show the discover onboarding popup when redirecting to TAG

### DIFF
--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -114,7 +114,10 @@ export function Main(props: MainProps) {
 
   const { alerts, dismissAlert } = useAlerts(props.initialAlerts);
 
-  const [showOnboardDiscover, setShowOnboardDiscover] = useState(true);
+  // if there is a redirectUrl, do not show the onboarding popup - it'll get in the way of the redirected page
+  const [showOnboardDiscover, setShowOnboardDiscover] = useState(
+    !ctx.redirectUrl
+  );
   const [showOnboardSurvey, setShowOnboardSurvey] = useState<boolean>(
     !!props.Questionnaire
   );
@@ -126,6 +129,8 @@ export function Main(props: MainProps) {
         exact: true,
       })
     ) {
+      // hide the onboarding popup if we're on the redirectUrl, just in case
+      setShowOnboardDiscover(false);
       ctx.redirectUrl = null;
     }
   }, [ctx, history.location.pathname]);


### PR DESCRIPTION
At the moment, when redirecting to TAG on first signup, both the discover & TAG onboarding popups are shown

![image](https://github.com/gravitational/teleport/assets/7922109/f5ac1bd4-1295-4a35-bdba-1a409bd4df52)

This hides the onboarding popup if there is a `redirectUrl` - if you're using the `redirectUrl` functionality, you probably don't want the onboarding popup to show over your redirected route