### PR TITLE
[v15] docs: Revert plugins version to 15.2.1 temporarily

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2224,7 +2224,7 @@
       "url": "teleport.example.com",
       "golang": "1.21",
       "plugin": {
-        "version": "15.2.2"
+        "version": "15.2.1"
       },
       "helm_repo_url": "https://charts.releases.teleport.dev",
       "latest_oss_docker_image": "public.ecr.aws/gravitational/teleport-distroless:15.2.2",


### PR DESCRIPTION
While we're investigating why 15.2.2 plugins didn't get published correctly.