### PR TITLE
Add `AccessGraphPlugin` system role

### DIFF
--- a/api/types/system_role.go
+++ b/api/types/system_role.go
@@ -77,32 +77,37 @@ const (
 	// device inventory.
 	// Device Trust requires Teleport Enteprise.
 	RoleMDM SystemRole = "MDM"
+
+	// RoleAccessGraphPlugin is a role for Access Graph plugins to access
+	// Teleport's internal API and access graph.
+	RoleAccessGraphPlugin SystemRole = "AccessGraphPlugin"
 )
 
 // roleMappings maps a set of allowed lowercase system role names
 // to the proper system role
 var roleMappings = map[string]SystemRole{
-	"auth":            RoleAuth,
-	"node":            RoleNode,
-	"proxy":           RoleProxy,
-	"admin":           RoleAdmin,
-	"provisiontoken":  RoleProvisionToken,
-	"trusted_cluster": RoleTrustedCluster,
-	"trustedcluster":  RoleTrustedCluster,
-	"signup":          RoleSignup,
-	"nop":             RoleNop,
-	"remoteproxy":     RoleRemoteProxy,
-	"remote_proxy":    RoleRemoteProxy,
-	"kube":            RoleKube,
-	"app":             RoleApp,
-	"db":              RoleDatabase,
-	"windowsdesktop":  RoleWindowsDesktop,
-	"windows_desktop": RoleWindowsDesktop,
-	"bot":             RoleBot,
-	"instance":        RoleInstance,
-	"discovery":       RoleDiscovery,
-	"okta":            RoleOkta,
-	"mdm":             RoleMDM,
+	"auth":              RoleAuth,
+	"node":              RoleNode,
+	"proxy":             RoleProxy,
+	"admin":             RoleAdmin,
+	"provisiontoken":    RoleProvisionToken,
+	"trusted_cluster":   RoleTrustedCluster,
+	"trustedcluster":    RoleTrustedCluster,
+	"signup":            RoleSignup,
+	"nop":               RoleNop,
+	"remoteproxy":       RoleRemoteProxy,
+	"remote_proxy":      RoleRemoteProxy,
+	"kube":              RoleKube,
+	"app":               RoleApp,
+	"db":                RoleDatabase,
+	"windowsdesktop":    RoleWindowsDesktop,
+	"windows_desktop":   RoleWindowsDesktop,
+	"bot":               RoleBot,
+	"instance":          RoleInstance,
+	"discovery":         RoleDiscovery,
+	"okta":              RoleOkta,
+	"mdm":               RoleMDM,
+	"accessgraphplugin": RoleAccessGraphPlugin,
 }
 
 func normalizedSystemRole(s string) SystemRole {
@@ -124,16 +129,17 @@ func normalizedSystemRoles(s []string) []SystemRole {
 // teleport services (e.g. db, kube, etc), excluding those which represent remote
 // services (i.e. remoteproxy).
 var localServiceMappings = map[SystemRole]struct{}{
-	RoleAuth:           {},
-	RoleNode:           {},
-	RoleProxy:          {},
-	RoleKube:           {},
-	RoleApp:            {},
-	RoleDatabase:       {},
-	RoleWindowsDesktop: {},
-	RoleDiscovery:      {},
-	RoleOkta:           {},
-	RoleMDM:            {},
+	RoleAuth:              {},
+	RoleNode:              {},
+	RoleProxy:             {},
+	RoleKube:              {},
+	RoleApp:               {},
+	RoleDatabase:          {},
+	RoleWindowsDesktop:    {},
+	RoleDiscovery:         {},
+	RoleOkta:              {},
+	RoleMDM:               {},
+	RoleAccessGraphPlugin: {},
 }
 
 // controlPlaneMapping is the subset of local services which are definitively control plane

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -5455,9 +5455,9 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 
 	roles := types.LocalServiceMappings()
 	for _, role := range roles {
-		// RoleMDM services don't create events by themselves, instead they rely on
+		// RoleMDM and AccessGraphPlugin services don't create events by themselves, instead they rely on
 		// Auth to issue events.
-		if role == types.RoleAuth || role == types.RoleMDM {
+		if role == types.RoleAuth || role == types.RoleMDM || role == types.RoleAccessGraphPlugin {
 			continue
 		}
 

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1177,6 +1177,21 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 					},
 				},
 			})
+
+	case types.RoleAccessGraphPlugin:
+		// RoleAccessGraphPlugin is a special role that is used by the Access Graph plugins
+		// to access the semaphore resource.
+		return services.RoleFromSpec(
+			role.String(),
+			types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					Namespaces: []string{types.Wildcard},
+					Rules: []types.Rule{
+						types.NewRule(types.KindSemaphore, services.RW()),
+					},
+				},
+			})
+
 	}
 
 	return nil, trace.NotFound("builtin role %q is not recognized", role.String())


### PR DESCRIPTION
This PR introduces the `AccessGraphPlugin` system role used by Access Graph plugins to access the Auth server API and Access Graph api.

Part of https://github.com/gravitational/access-graph/issues/635