### PR TITLE
Expose `TeleportProcess.GetClusterFeatures` function

### DIFF
--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -100,7 +100,7 @@ func (process *TeleportProcess) initDiscoveryService() error {
 		ServerID:          process.Config.HostUUID,
 		Log:               process.log,
 		ClusterName:       conn.ClientIdentity.ClusterName,
-		ClusterFeatures:   process.getClusterFeatures,
+		ClusterFeatures:   process.GetClusterFeatures,
 		PollInterval:      process.Config.Discovery.PollInterval,
 		ServerCredentials: tlsConfig,
 		AccessGraphConfig: accessGraphCfg,

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -47,7 +47,7 @@ func (process *TeleportProcess) initKubernetes() {
 		if conn == nil {
 			return trace.Wrap(err)
 		}
-		if !process.getClusterFeatures().Kubernetes {
+		if !process.GetClusterFeatures().Kubernetes {
 			logger.WarnContext(process.ExitContext(), "Warning: Kubernetes service not initialized because Teleport Auth Server is not licensed for Kubernetes Access. Please contact the cluster administrator to enable it.")
 			return nil
 		}
@@ -224,7 +224,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 			LockWatcher:                   lockWatcher,
 			CheckImpersonationPermissions: cfg.Kube.CheckImpersonationPermissions,
 			PublicAddr:                    publicAddr,
-			ClusterFeatures:               process.getClusterFeatures,
+			ClusterFeatures:               process.GetClusterFeatures,
 		},
 		TLS:                  tlsConfig,
 		AccessPoint:          accessPoint,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -587,6 +587,11 @@ func (process *TeleportProcess) setClusterFeatures(features *proto.Features) {
 	}
 }
 
+// GetClusterFeatures returns the cluster features.
+func (process *TeleportProcess) GetClusterFeatures() proto.Features {
+	return process.getClusterFeatures()
+}
+
 func (process *TeleportProcess) getClusterFeatures() proto.Features {
 	process.Lock()
 	defer process.Unlock()

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -589,10 +589,6 @@ func (process *TeleportProcess) setClusterFeatures(features *proto.Features) {
 
 // GetClusterFeatures returns the cluster features.
 func (process *TeleportProcess) GetClusterFeatures() proto.Features {
-	return process.getClusterFeatures()
-}
-
-func (process *TeleportProcess) getClusterFeatures() proto.Features {
 	process.Lock()
 	defer process.Unlock()
 
@@ -1792,7 +1788,7 @@ func (process *TeleportProcess) initAuthService() error {
 	}
 
 	checkingEmitter, err := events.NewCheckingEmitter(events.CheckingEmitterConfig{
-		Inner:       events.NewMultiEmitter(events.NewLoggingEmitter(process.getClusterFeatures().Cloud), emitter),
+		Inner:       events.NewMultiEmitter(events.NewLoggingEmitter(process.GetClusterFeatures().Cloud), emitter),
 		Clock:       process.Clock,
 		ClusterName: clusterName,
 	})
@@ -2516,7 +2512,7 @@ func (process *TeleportProcess) proxyPublicAddr() utils.NetAddr {
 // It is caller's responsibility to call Close on the emitter once done.
 func (process *TeleportProcess) NewAsyncEmitter(clt apievents.Emitter) (*events.AsyncEmitter, error) {
 	emitter, err := events.NewCheckingEmitter(events.CheckingEmitterConfig{
-		Inner: events.NewMultiEmitter(events.NewLoggingEmitter(process.getClusterFeatures().Cloud), clt),
+		Inner: events.NewMultiEmitter(events.NewLoggingEmitter(process.GetClusterFeatures().Cloud), clt),
 		Clock: process.Clock,
 	})
 	if err != nil {
@@ -4176,7 +4172,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			HostUUID:         process.Config.HostUUID,
 			Context:          process.GracefulExitContext(),
 			StaticFS:         fs,
-			ClusterFeatures:  process.getClusterFeatures(),
+			ClusterFeatures:  process.GetClusterFeatures(),
 			GetProxyIdentity: func() (*auth.Identity, error) {
 				return process.GetIdentity(types.RoleProxy)
 			},
@@ -4561,7 +4557,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				// the provided connection certificate is from a proxy server and
 				// will impersonate the identity of the user that is making the request.
 				ConnTLSConfig:   tlsConfig.Clone(),
-				ClusterFeatures: process.getClusterFeatures,
+				ClusterFeatures: process.GetClusterFeatures,
 			},
 			TLS:                      tlsConfig.Clone(),
 			LimiterConfig:            cfg.Proxy.Limiter,


### PR DESCRIPTION
This PR exposes `TeleportProcess.GetClusterFeatures` so it can be used by external packages.