### PR TITLE
Remove header manipulation after request has been completed, when proxying k8s requests.

### DIFF
--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -925,6 +925,8 @@ func NewImpersonatorRoundTripper(rt http.RoundTripper) *ImpersonatorRoundTripper
 // RoundTrip implements http.RoundTripper interface to include the identity
 // in the request header.
 func (r *ImpersonatorRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+
 	identity, err := authz.UserFromContext(req.Context())
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -934,7 +936,6 @@ func (r *ImpersonatorRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 		return nil, trace.Wrap(err)
 	}
 	req.Header.Set(TeleportImpersonateUserHeader, string(b))
-	defer req.Header.Del(TeleportImpersonateUserHeader)
 
 	clientSrcAddr, err := authz.ClientSrcAddrFromContext(req.Context())
 	if err != nil {
@@ -942,7 +943,6 @@ func (r *ImpersonatorRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	}
 
 	req.Header.Set(TeleportImpersonateIPHeader, clientSrcAddr.String())
-	defer req.Header.Del(TeleportImpersonateIPHeader)
 
 	return r.RoundTripper.RoundTrip(req)
 }


### PR DESCRIPTION
This PR removes deferred deletion of http headers because It could lead to concurrent map read and write in case of abrupt request cancelation - we were deleting the header while internal `net` code was still trying to read it.

Changelog: Fix possible data race that could lead to concurrent map read and map write while proxying Kubernetes requests.

Fixes: #40717