### PR TITLE
Disable resumption in `TestIntegrations/Shutdown/cli_sessions`

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1855,6 +1855,11 @@ func testShutdown(t *testing.T, suite *integrationTestSuite) {
 		{
 			name: "cli sessions",
 			createSession: func(t *testing.T, i *helpers.TeleInstance, term *Terminal, cfg helpers.ClientConfig) {
+				// TODO(espadolini): make the connection detach timeout (or the
+				// clock that it uses) configurable; in the meantime, disable
+				// connection resumption here, since it could occasionally make
+				// the server wait for a full minute before shutting down
+				cfg.DisableSSHResumption = true
 				tc, err := i.NewClient(cfg)
 				require.NoError(t, err)
 


### PR DESCRIPTION
This addresses the flakiness reported in #40703, but there's been a few other tests where we just disable connection resumption, and I'd like to add some way to keep it enabled (maybe with shorter grace timeouts or maybe with an externally controlled `clockwork.Clock` perhaps) so I'll keep that issue open even as this gets merged.