### PR TITLE
[v15] Bump rustls from 0.21.9 to 0.21.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,9 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.9"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
  "ring",


### PR DESCRIPTION
Backport #40731 to branch/v15

Changelog: Patched CVE-2024-32650.