### PR TITLE
Add toString to cloneable errors

### DIFF
--- a/web/packages/teleterm/src/services/tshd/cloneableClient.ts
+++ b/web/packages/teleterm/src/services/tshd/cloneableClient.ts
@@ -259,6 +259,7 @@ export type TshdRpcError = Pick<
    * It is taken from the error metadata.
    */
   isResolvableWithRelogin: boolean;
+  toString: () => string;
 };
 
 /**
@@ -313,6 +314,7 @@ function cloneError(error: unknown): TshdRpcError | Error | unknown {
       cause: error.cause,
       code: error.code,
       isResolvableWithRelogin: error.meta['is-resolvable-with-relogin'] === '1',
+      toString: () => error.toString(),
     } satisfies TshdRpcError;
   }
 
@@ -322,7 +324,8 @@ function cloneError(error: unknown): TshdRpcError | Error | unknown {
       message: error.message,
       stack: error.stack,
       cause: error.cause,
-    } satisfies Error;
+      toString: () => error.toString(),
+    };
   }
 
   return error;

--- a/web/packages/teleterm/src/ui/boot.tsx
+++ b/web/packages/teleterm/src/ui/boot.tsx
@@ -51,7 +51,9 @@ async function boot(): Promise<void> {
     renderApp(<App ctx={appContext} />);
   } catch (e) {
     logger.error('Failed to boot the React app', e);
-    renderApp(<FailedApp message={e.toString()} />);
+    renderApp(
+      <FailedApp message={`Could not start the application: ${e.toString()}`} />
+    );
   }
 }
 


### PR DESCRIPTION
Now that we fixed https://github.com/gravitational/teleport/issues/30753, errors which are passed to the renderer process from a privileged environment (such as the main process or the preload script, so for example RPC errors from the tsh daemon client) are converted from `Error` instances to plain objects. This way we can pass along some extra metadata that is usually contained within RPC errors. Those extra fields would get lost when passing [the context bridge](https://www.electronjs.org/docs/latest/api/context-bridge) since [the context bridge removes any extra fields from `Error` instances](https://www.electronjs.org/docs/latest/api/context-bridge#parameter--error--return-type-support).

There is a couple of places which depend on `Error.prototype.toString` to display errors in the UI. This PR adds `toString` to those "objectified" errors so that we can continue to properly display them in the UI.

| Before | After |
| --- | --- |
| ![before](https://github.com/gravitational/teleport/assets/27113/045b5277-6e7f-4ca8-8415-ded2239f974d) | ![after](https://github.com/gravitational/teleport/assets/27113/a37d3723-0f64-4cb6-bc8d-6641397c9249) |