### PR TITLE
Allow `ssh_config` generation to be disabled for Machine ID Identity Output

### DIFF
--- a/lib/tbot/config/output_identity.go
+++ b/lib/tbot/config/output_identity.go
@@ -154,7 +154,7 @@ func (o *IdentityOutput) CheckAndSetDefaults() error {
 
 	switch o.SSHConfigMode {
 	case SSHConfigModeNone:
-		log.DebugContext(context.TODO(), "Defaulting to SSHConfigModeOn")
+		log.DebugContext(context.Background(), "Defaulting to SSHConfigModeOn")
 		o.SSHConfigMode = SSHConfigModeOn
 	case SSHConfigModeOff, SSHConfigModeOn:
 	default:

--- a/lib/tbot/config/output_identity_test.go
+++ b/lib/tbot/config/output_identity_test.go
@@ -28,9 +28,10 @@ func TestIdentityOutput_YAML(t *testing.T) {
 		{
 			name: "full",
 			in: IdentityOutput{
-				Destination: dest,
-				Roles:       []string{"access"},
-				Cluster:     "leaf.example.com",
+				Destination:   dest,
+				Roles:         []string{"access"},
+				Cluster:       "leaf.example.com",
+				SSHConfigMode: SSHConfigModeOff,
 			},
 		},
 		{
@@ -49,9 +50,22 @@ func TestIdentityOutput_CheckAndSetDefaults(t *testing.T) {
 			name: "valid",
 			in: func() *IdentityOutput {
 				return &IdentityOutput{
-					Destination: memoryDestForTest(),
-					Roles:       []string{"access"},
+					Destination:   memoryDestForTest(),
+					Roles:         []string{"access"},
+					SSHConfigMode: SSHConfigModeOn,
 				}
+			},
+		},
+		{
+			name: "ssh config mode defaults",
+			in: func() *IdentityOutput {
+				return &IdentityOutput{
+					Destination: memoryDestForTest(),
+				}
+			},
+			want: &IdentityOutput{
+				Destination:   memoryDestForTest(),
+				SSHConfigMode: SSHConfigModeOn,
 			},
 		},
 		{
@@ -62,6 +76,16 @@ func TestIdentityOutput_CheckAndSetDefaults(t *testing.T) {
 				}
 			},
 			wantErr: "no destination configured for output",
+		},
+		{
+			name: "invalid ssh config mode",
+			in: func() *IdentityOutput {
+				return &IdentityOutput{
+					Destination:   memoryDestForTest(),
+					SSHConfigMode: "invalid",
+				}
+			},
+			wantErr: "ssh_config: unrecognized value \"invalid\"",
 		},
 	}
 	testCheckAndSetDefaults(t, tests)

--- a/lib/tbot/config/testdata/TestIdentityOutput_YAML/full.golden
+++ b/lib/tbot/config/testdata/TestIdentityOutput_YAML/full.golden
@@ -4,3 +4,4 @@ destination:
 roles:
   - access
 cluster: leaf.example.com
+ssh_config: "off"


### PR DESCRIPTION
We currently allow the Identity Output to be used to provide credentials for two main use-cases:

- Server Access (SSH)
- General API access (tctl, access plugins)

However, we always try to generate the ssh_config needed for SSH access. This is problematic for a few reasons:

- It requires a proxy to be online so that it can determine the address to include in the SSH config. In some cases, a `tbot` instance may run close to the auth server and it may be intended for this instance to come online before proxies are available.
- It's slower than necessary because of the time taken to generate the SSH Config.

As such, I've added an `ssh_config` option which can be  set to `on` or `off`. If unspecified, it defaults to the behaviour we've had historically (`on`).

example:
```yaml
- type: identity
  destination:
    type: directory
    path: /foo
  ssh_config: off # this will default to "on" if unspecified
```

changelog: Add the ability to control `ssh_config` generation in Machine ID's Identity Outputs. This allows the generation of the `ssh_config` to be disabled if unnecessary, improving performance and removing the dependency on the Proxy being online.