### PR TITLE
[v15] Fix a flaky test

### DIFF
--- a/integrations/access/accessrequest/app_test.go
+++ b/integrations/access/accessrequest/app_test.go
@@ -100,7 +100,7 @@ func TestOpsGenieGetMessageRecipients(t *testing.T) {
 				},
 			}
 			recipients := a.getMessageRecipients(ctx, req)
-			require.Equal(t, tt.expectedRecipients, recipients)
+			require.ElementsMatch(t, tt.expectedRecipients, recipients)
 		})
 	}
 


### PR DESCRIPTION
**Note: this is not a backport**. The test in question is not present in the master branch.

Fixing a test that causes flakiness that prevented me from merging https://github.com/gravitational/teleport/pull/40461 today. The test asserts on array contents, but the array is produced from a set, which makes the order of elements unstable.