### PR TITLE
Document argocd workaround

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -269,6 +269,7 @@
     "appdomain",
     "appresources",
     "appuser",
+    "argoproj",
     "armv",
     "atburke",
     "attrname",

--- a/docs/pages/upgrading/cloud-kubernetes.mdx
+++ b/docs/pages/upgrading/cloud-kubernetes.mdx
@@ -124,6 +124,34 @@ To suspend automatic updates for an agent, annotate the agent deployment with
 `annotations.deployment` value in Helm, or by patching the deployment directly
 with `kubectl`.
 
+## ArgoCD deployments
+
+Automatic updates is not currently compatible with ArgoCD deployments. The Helm chart
+owns the version of the `teleport-agent` resource, so when the `teleport-agent-updater`
+modifies the image version of the `teleport-agent` resource, ArgoCD reports the `teleport-agent`
+resource as `OutOfSync`.
+
+As a workaround to this problem use a [Diff Customization](https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/#diffing-customization)
+to ignore the difference in image version. This can be done by ignoring differences
+of the `image` field. Here is an example deployment using the name `teleport-agent`
+and namespace `teleport`.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: teleport-agent
+spec
+  ignoreDifferences:
+  - group: apps
+    kind: StatefulSet
+    name: teleport-agent
+    namespace: teleport
+    jqPathExpressions:
+    - .spec.template.spec.containers[] | select(.name == "teleport").image
+...
+```
+
 ## Manually upgrading agents
 
 Run the following commands to upgrade Teleport agents running on Kubernetes.


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport/issues/39094.

While a proper fix is being worked on to support ArgoCD deployments by default, this PR adds documentation for a simple workaround to deploy Teleport with ArgoCD.

