### PR TITLE
Web: Add yaml package 

### DIFF
--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -98,7 +98,8 @@
     "webpack": "^5.76.2",
     "webpack-bundle-analyzer": "^4.6.1",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.9.3"
+    "webpack-dev-server": "^4.9.3",
+    "yaml": "^2.4.1"
   },
   "devDependencies": {
     "msw-storybook-addon": "^1.8.0",

--- a/web/packages/shared/components/FieldSelect/FieldSelectCreatable.story.tsx
+++ b/web/packages/shared/components/FieldSelect/FieldSelectCreatable.story.tsx
@@ -1,0 +1,92 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState } from 'react';
+import { Flex } from 'design';
+
+import { wait } from 'shared/utils/wait';
+import Validation from 'shared/components/Validation';
+import { Option } from 'shared/components/Select';
+
+import {
+  FieldSelectCreatable,
+  FieldSelectCreatableAsync,
+} from './FieldSelectCreatable';
+
+export default {
+  title: 'Shared/FieldSelectCreatable',
+};
+
+export function Default() {
+  const [selectedOptions, setSelectedOption] = useState<Option[]>([OPTIONS[0]]);
+  return (
+    <Validation>
+      {() => (
+        <Flex flexDirection="column">
+          <FieldSelectCreatable
+            inputId="test1"
+            label="FieldSelectCreatable multi"
+            onChange={option => setSelectedOption(option as Option[])}
+            value={selectedOptions}
+            isSearchable
+            options={OPTIONS}
+            isMulti
+          />
+          <FieldSelectCreatableAsync
+            inputId="test2"
+            label="FieldSelectCreatableAsync multi"
+            onChange={option => setSelectedOption(option as Option[])}
+            value={selectedOptions}
+            isSearchable
+            isMulti
+            loadOptions={async input => {
+              await wait(400);
+              return OPTIONS.filter(o => o.label.includes(input));
+            }}
+            noOptionsMessage={() => 'No options'}
+          />
+          <FieldSelectCreatableAsync
+            inputId="test3"
+            label="FieldSelectCreatableAsync with error"
+            onChange={undefined}
+            value={undefined}
+            isSearchable
+            isMulti
+            defaultOptions={true}
+            loadOptions={async () => {
+              await wait(400);
+              return Promise.reject('Network error');
+            }}
+            noOptionsMessage={() => 'No options'}
+          />
+        </Flex>
+      )}
+    </Validation>
+  );
+}
+
+Default.storyName = 'FieldSelectCreatable';
+
+const OPTIONS = [
+  { value: 'mac', label: 'Mac' },
+  {
+    value: 'windows',
+    label: 'Windows',
+  },
+  { value: 'linux', label: 'Linux' },
+];

--- a/web/packages/shared/components/FieldSelect/FieldSelectCreatable.tsx
+++ b/web/packages/shared/components/FieldSelect/FieldSelectCreatable.tsx
@@ -18,14 +18,18 @@
 
 import React from 'react';
 
-import { Box, LabelInput } from 'design';
+import { Box, Flex, LabelInput } from 'design';
 
+import { useAsync } from 'shared/hooks/useAsync';
+import { ToolTipInfo } from 'shared/components/ToolTip';
 import { useRule } from 'shared/components/Validation';
 
 import {
+  AsyncProps,
   SelectCreatable,
   CreatableProps as SelectCreatableProps,
 } from '../Select';
+import { SelectCreatableAsync } from '../Select/Select';
 
 import { LabelTip, defaultRule } from './shared';
 
@@ -40,6 +44,7 @@ import { LabelTip, defaultRule } from './shared';
  */
 export function FieldSelectCreatable({
   components,
+  toolTipContent = null,
   label,
   labelTip,
   value,
@@ -73,42 +78,178 @@ export function FieldSelectCreatable({
   const { valid, message } = useRule(rule(value));
   const hasError = Boolean(!valid);
   const labelText = hasError ? message : label;
+  const $inputElement = (
+    <SelectCreatable
+      components={components}
+      inputId={inputId}
+      name={name}
+      menuPosition={menuPosition}
+      hasError={hasError || markAsError}
+      isSimpleValue={isSimpleValue}
+      isSearchable={isSearchable}
+      isClearable={isClearable}
+      value={value}
+      onChange={onChange}
+      onKeyDown={onKeyDown}
+      onInputChange={onInputChange}
+      onBlur={onBlur}
+      inputValue={inputValue}
+      maxMenuHeight={maxMenuHeight}
+      placeholder={placeholder}
+      isMulti={isMulti}
+      autoFocus={autoFocus}
+      isDisabled={isDisabled}
+      elevated={elevated}
+      menuIsOpen={menuIsOpen}
+      stylesConfig={stylesConfig}
+      options={options}
+      formatCreateLabel={formatCreateLabel}
+      aria-label={ariaLabel}
+      customProps={customProps}
+    />
+  );
+
   return (
     <Box mb="4" {...styles}>
-      {label && (
-        <LabelInput htmlFor={inputId} hasError={hasError}>
-          {labelText}
-          {labelTip && <LabelTip text={labelTip} />}
+      {label ? (
+        <LabelInput mb={0} htmlFor={inputId} hasError={hasError}>
+          {toolTipContent ? (
+            <Flex gap={1} alignItems="center">
+              {labelText}
+              {labelTip && <LabelTip text={labelTip} />}
+              <ToolTipInfo children={toolTipContent} />
+            </Flex>
+          ) : (
+            <>
+              {labelText}
+              {labelTip && <LabelTip text={labelTip} />}
+            </>
+          )}
+          {$inputElement}
         </LabelInput>
+      ) : (
+        $inputElement
       )}
-      <SelectCreatable
-        components={components}
-        inputId={inputId}
-        name={name}
-        menuPosition={menuPosition}
-        hasError={hasError || markAsError}
-        isSimpleValue={isSimpleValue}
-        isSearchable={isSearchable}
-        isClearable={isClearable}
-        value={value}
-        onChange={onChange}
-        onKeyDown={onKeyDown}
-        onInputChange={onInputChange}
-        onBlur={onBlur}
-        inputValue={inputValue}
-        maxMenuHeight={maxMenuHeight}
-        placeholder={placeholder}
-        isMulti={isMulti}
-        autoFocus={autoFocus}
-        isDisabled={isDisabled}
-        elevated={elevated}
-        menuIsOpen={menuIsOpen}
-        stylesConfig={stylesConfig}
-        options={options}
-        formatCreateLabel={formatCreateLabel}
-        aria-label={ariaLabel}
-        customProps={customProps}
-      />
+    </Box>
+  );
+}
+
+/**
+ * A select creatable field that asynchronously loads options.
+ * The prop `loadOptions` accepts a callback that provides
+ * an `input` value used for filtering options on the call site.
+ *
+ * If `loadOptions` returns an error, the user can retry loading options by
+ * changing the input.
+ * Note: It is not possible to re-fetch the initial call for options.
+ * ReactSelect fetches them when the component mounts and then keeps in memory.
+ */
+export function FieldSelectCreatableAsync({
+  components,
+  toolTipContent = null,
+  label,
+  labelTip,
+  value,
+  name,
+  onChange,
+  placeholder,
+  maxMenuHeight,
+  isClearable,
+  isMulti,
+  menuIsOpen,
+  menuPosition,
+  inputValue,
+  onKeyDown,
+  onInputChange,
+  onBlur,
+  options,
+  formatCreateLabel,
+  ariaLabel,
+  rule = defaultRule,
+  stylesConfig,
+  isSearchable = false,
+  isSimpleValue = false,
+  autoFocus = false,
+  isDisabled = false,
+  elevated = false,
+  inputId = 'select',
+  markAsError = false,
+  customProps,
+  loadOptions,
+  noOptionsMessage,
+  defaultOptions,
+  ...styles
+}: AsyncProps & CreatableProps) {
+  const [attempt, runAttempt] = useAsync(loadOptions);
+  const { valid, message } = useRule(rule(value));
+  const hasError = Boolean(!valid);
+  const labelText = hasError ? message : label;
+  const $inputElement = (
+    <SelectCreatableAsync
+      components={components}
+      defaultOptions={defaultOptions}
+      inputId={inputId}
+      name={name}
+      menuPosition={menuPosition}
+      hasError={hasError || markAsError}
+      isSimpleValue={isSimpleValue}
+      isSearchable={isSearchable}
+      isClearable={isClearable}
+      value={value}
+      onChange={onChange}
+      onKeyDown={onKeyDown}
+      onInputChange={onInputChange}
+      onBlur={onBlur}
+      inputValue={inputValue}
+      maxMenuHeight={maxMenuHeight}
+      placeholder={placeholder}
+      isMulti={isMulti}
+      autoFocus={autoFocus}
+      isDisabled={isDisabled}
+      elevated={elevated}
+      menuIsOpen={menuIsOpen}
+      stylesConfig={stylesConfig}
+      options={options}
+      formatCreateLabel={formatCreateLabel}
+      aria-label={ariaLabel}
+      customProps={customProps}
+      loadOptions={async (input, option) => {
+        const [options, error] = await runAttempt(input, option);
+        if (error) {
+          return [];
+        }
+        return options;
+      }}
+      noOptionsMessage={() => {
+        if (attempt.status === 'error') {
+          return `Could not load options: ${attempt.error}`;
+        }
+        return noOptionsMessage();
+      }}
+    />
+  );
+
+  return (
+    <Box mb="4" {...styles}>
+      {label ? (
+        <LabelInput mb={0} htmlFor={inputId} hasError={hasError}>
+          {toolTipContent ? (
+            <Flex gap={1} alignItems="center">
+              {labelText}
+              {labelTip && <LabelTip text={labelTip} />}
+              <ToolTipInfo children={toolTipContent} />
+            </Flex>
+          ) : (
+            <>
+              {labelText}
+              {labelTip && <LabelTip text={labelTip} />}
+            </>
+          )}
+          {$inputElement}
+        </LabelInput>
+      ) : (
+        $inputElement
+      )}
     </Box>
   );
 }

--- a/web/packages/shared/components/Select/Select.tsx
+++ b/web/packages/shared/components/Select/Select.tsx
@@ -20,6 +20,7 @@ import React from 'react';
 import ReactSelect from 'react-select';
 import ReactSelectAsync from 'react-select/async';
 import CreatableSelect from 'react-select/creatable';
+import ReactSelectCreatableAsync from 'react-select/async-creatable';
 import styled from 'styled-components';
 import { width, space } from 'design/system';
 
@@ -78,6 +79,25 @@ export function SelectCreatable(props: CreatableProps) {
         className="react-select-container"
         classNamePrefix="react-select"
         styles={stylesConfig}
+        {...restOfProps}
+      />
+    </StyledSelect>
+  );
+}
+
+export function SelectCreatableAsync(props: AsyncProps & CreatableProps) {
+  const { hasError = false, stylesConfig, ...restOfProps } = props;
+  return (
+    <StyledSelect hasError={hasError}>
+      <ReactSelectCreatableAsync
+        className="react-select-container"
+        classNamePrefix="react-select"
+        styles={stylesConfig}
+        clearable={false}
+        isSearchable={true}
+        defaultOptions={false}
+        cacheOptions={false}
+        defaultMenuIsOpen={false}
         {...restOfProps}
       />
     </StyledSelect>

--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
@@ -146,12 +146,20 @@ export function useKeyBasedPagination<T>({
     [fetchFunc, stateRef, setState, fetchMoreSize, initialFetchSize]
   );
 
+  function updateFetchedResources(modifiedResources: T[]) {
+    setState({
+      ...stateRef.current,
+      resources: modifiedResources,
+    });
+  }
+
   return {
     fetch,
     clear,
     attempt: stateRef.current.attempt,
     resources: stateRef.current.resources,
     finished: stateRef.current.finished,
+    updateFetchedResources,
   };
 }
 
@@ -201,4 +209,11 @@ type KeyBasedPagination<T> = {
   attempt: Attempt;
   resources: T[];
   finished: boolean;
+  /**
+   * Used in conjunction with create/delete/update operations
+   * where changes are not propagated right away (from backend caching),
+   * so the frontend will modify the fetched resources in place
+   * instead of "re-fetching" data that can be stale.
+   */
+  updateFetchedResources(modifiedResources: T[]): void;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16238,6 +16238,11 @@ yaml@^1.10.0, yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.4.1.tgz#2e57e0b5e995292c25c75d2658f0664765210eed"
+  integrity sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==
+
 yargs-parser@^20.2.2, yargs-parser@^20.2.7:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/3933

Most important change is the addition of the new [yaml package](https://github.com/eemeli/yaml)

For more context, lets start with our existing YAML editors. The auth connector + role is strictly yaml, and the backend returns the YAML string which we then feed to our editor component.

The new feature i'm working on (and other future features) wants a `standard` editor where user edits the `object` fields by HTML input boxes we render for user, or by a `yaml` editor (same as existing auth connector and role editors). The feature also wants the two editor to be togglable with persistent state (for only the supported fields). This requires the `object` to be parsed into yaml and vice versa.

The purpose of a `standard` editor with limited editable fields, are for day 1 users.
The YAML editor are for advanced users who wants more flexibility

