### PR TITLE
Open Connect if DeviceTrustWeb token received

### DIFF
--- a/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.tsx
+++ b/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.tsx
@@ -16,16 +16,62 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { useEffect } from 'react';
 import styled from 'styled-components';
 import { Box, Flex, ButtonPrimary, Text, ButtonLink } from 'design';
 import { Link } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import cfg from 'teleport/config';
+import useTeleport from 'teleport/useTeleport';
+import { getPlatform } from 'design/platform';
+import history from 'teleport/services/history/history';
 
 import {
   DownloadConnect,
   DownloadLink,
+  getConnectDownloadLinks,
 } from 'shared/components/DownloadConnect/DownloadConnect';
+import { makeDeepLinkWithSafeInput } from 'shared/deepLinks';
+
+export const PassthroughPage = () => {
+  const ctx = useTeleport();
+  const { id, token } = useParams<{
+    id: string;
+    token: string;
+  }>();
+  const { cluster, username } = ctx.storeUser.state;
+  const deviceTrustAuthorize = makeDeepLinkWithSafeInput({
+    proxyHost: cluster?.publicURL,
+    username: username,
+    path: '/authenticate_web_device',
+    searchParams: {
+      id,
+      token,
+    },
+  });
+  const platform = getPlatform();
+  const downloadLinks = getConnectDownloadLinks(platform, cluster.proxyVersion);
+
+  useEffect(() => {
+    window.open(deviceTrustAuthorize);
+
+    // the deviceWebToken is only valid for 60 seconds, so we can forward
+    // to the dashboard
+    const id = window.setTimeout(() => {
+      history.push(cfg.routes.root, true);
+    }, 1000 * 60 /* 1 minute */);
+
+    return () => window.clearTimeout(id);
+  }, [deviceTrustAuthorize]);
+
+  return (
+    <DeviceTrustConnectPassthrough
+      downloadLinks={downloadLinks}
+      authorizeWebDeviceDeepLink={deviceTrustAuthorize}
+    />
+  );
+};
 
 export const DeviceTrustConnectPassthrough = ({
   authorizeWebDeviceDeepLink,
@@ -107,4 +153,5 @@ const BoldText = styled.span`
 const Wrapper = styled(Box)`
   text-align: center;
   line-height: 32px;
+  padding-top: 200px;
 `;

--- a/web/packages/teleport/src/Login/Login.test.tsx
+++ b/web/packages/teleport/src/Login/Login.test.tsx
@@ -45,7 +45,7 @@ test('basic rendering', () => {
 });
 
 test('login with redirect', async () => {
-  jest.spyOn(auth, 'login').mockResolvedValue(null);
+  jest.spyOn(auth, 'login').mockResolvedValue({});
 
   render(<Login />);
 
@@ -65,7 +65,7 @@ test('login with redirect', async () => {
 
 test('login with MFA, changing method to OTP', async () => {
   jest.spyOn(cfg, 'getAuth2faType').mockImplementation(() => 'optional');
-  jest.spyOn(auth, 'login').mockResolvedValue(null);
+  jest.spyOn(auth, 'login').mockResolvedValue({});
 
   render(<Login />);
 
@@ -115,7 +115,7 @@ test('login with SSO', () => {
 
 test('passwordless login', async () => {
   jest.spyOn(cfg, 'getPrimaryAuthType').mockReturnValue('passwordless');
-  jest.spyOn(auth, 'loginWithWebauthn').mockResolvedValue(undefined);
+  jest.spyOn(auth, 'loginWithWebauthn').mockResolvedValue({});
 
   render(<Login />);
 

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -210,31 +210,33 @@ export function TopBar({ CustomLogo, assistProps }: TopBarProps) {
           <ArrowLeft size="medium" />
         </ButtonIconContainer>
       )}
-      <Flex height="100%" alignItems="center">
-        {assistProps?.assistEnabled && (
-          <HoverTooltip
-            anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-            transformOrigin={{ vertical: 'top', horizontal: 'center' }}
-            tipContent="Teleport Assist"
-            css={`
-              height: 100%;
-            `}
-          >
-            <ButtonIconContainer
-              onClick={() =>
-                assistProps?.setShowAssist(!assistProps?.showAssist)
-              }
+      {!feature?.logoOnlyTopbar && (
+        <Flex height="100%" alignItems="center">
+          {assistProps?.assistEnabled && (
+            <HoverTooltip
+              anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+              transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+              tipContent="Teleport Assist"
+              css={`
+                height: 100%;
+              `}
             >
-              <ChatCircleSparkle
-                color={assistProps?.showAssist ? 'text.main' : 'text.muted'}
-                size={iconSize}
-              />
-            </ButtonIconContainer>
-          </HoverTooltip>
-        )}
-        <Notifications iconSize={iconSize} />
-        <UserMenuNav username={ctx.storeUser.state.username} />
-      </Flex>
+              <ButtonIconContainer
+                onClick={() =>
+                  assistProps?.setShowAssist(!assistProps?.showAssist)
+                }
+              >
+                <ChatCircleSparkle
+                  color={assistProps?.showAssist ? 'text.main' : 'text.muted'}
+                  size={iconSize}
+                />
+              </ButtonIconContainer>
+            </HoverTooltip>
+          )}
+          <Notifications iconSize={iconSize} />
+          <UserMenuNav username={ctx.storeUser.state.username} />
+        </Flex>
+      )}
     </TopBarContainer>
   );
 }

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -119,6 +119,7 @@ const cfg = {
     accountMfaDevices: '/web/account/twofactor',
     roles: '/web/roles',
     deviceTrust: `/web/devices`,
+    deviceTrustAuthorize: '/web/device/authorize/:id?/:token?',
     sso: '/web/sso',
     cluster: '/web/cluster/:clusterId/',
     clusters: '/web/clusters',
@@ -422,6 +423,10 @@ const cfg = {
 
   getAuthType() {
     return cfg.auth.authType;
+  },
+
+  getDeviceTrustAuthorizeRoute(id: string, token: string) {
+    return generatePath(cfg.routes.deviceTrustAuthorize, { id, token });
   },
 
   getSsoUrl(providerUrl, providerName, redirect) {


### PR DESCRIPTION
Requires https://github.com/gravitational/teleport/pull/40420
This PR will cause the webUI to open the "device trust passthrough page" if a `deviceWebToken` is received during login. Rather than forwarding to the homepage, it will forward to the 'pass through page' that will automatically open Connect (or instructions to download) 

https://github.com/gravitational/teleport.e/issues/3236

