### PR TITLE
[v14] Reduce parallelism when polling from AWS APIs

### DIFF
--- a/lib/kube/proxy/cluster_details.go
+++ b/lib/kube/proxy/cluster_details.go
@@ -288,7 +288,7 @@ func getAWSResourceMatcherToCluster(kubeCluster types.KubeCluster, resourceMatch
 func getAWSClientRestConfig(cloudClients cloud.Clients, clock clockwork.Clock, resourceMatchers []services.ResourceMatcher) dynamicCredsClient {
 	return func(ctx context.Context, cluster types.KubeCluster) (*rest.Config, time.Time, error) {
 		region := cluster.GetAWSConfig().Region
-		opts := []cloud.AWSAssumeRoleOptionFn{
+		opts := []cloud.AWSOptionsFn{
 			cloud.WithAmbientCredentials(),
 		}
 		if awsAssume := getAWSResourceMatcherToCluster(cluster, resourceMatchers); awsAssume != nil {

--- a/lib/srv/discovery/fetchers/aws-sync/ec2.go
+++ b/lib/srv/discovery/fetchers/aws-sync/ec2.go
@@ -61,10 +61,10 @@ func (a *awsFetcher) fetchAWSEC2Instances(ctx context.Context) ([]*accessgraphv1
 		errs    []error
 	)
 	eG, ctx := errgroup.WithContext(ctx)
-	// Set the limit to 10 to avoid too many concurrent requests.
+	// Set the limit to 5 to avoid too many concurrent requests.
 	// This is a temporary solution until we have a better way to limit the
 	// number of concurrent requests.
-	eG.SetLimit(10)
+	eG.SetLimit(5)
 	collectHosts := func(lHosts []*accessgraphv1alpha.AWSInstanceV1, err error) {
 		hostsMu.Lock()
 		defer hostsMu.Unlock()

--- a/lib/srv/discovery/fetchers/aws-sync/eks.go
+++ b/lib/srv/discovery/fetchers/aws-sync/eks.go
@@ -61,10 +61,10 @@ func (a *awsFetcher) fetchAWSSEKSClusters(ctx context.Context) (fetchAWSEKSClust
 		errs    []error
 	)
 	eG, ctx := errgroup.WithContext(ctx)
-	// Set the limit to 10 to avoid too many concurrent requests.
+	// Set the limit to 5 to avoid too many concurrent requests.
 	// This is a temporary solution until we have a better way to limit the
 	// number of concurrent requests.
-	eG.SetLimit(10)
+	eG.SetLimit(5)
 	collectClusters := func(cluster *accessgraphv1alpha.AWSEKSClusterV1,
 		clusterAssociatedPolicies []*accessgraphv1alpha.AWSEKSAssociatedAccessPolicyV1,
 		clusterAccessEntries []*accessgraphv1alpha.AWSEKSClusterAccessEntryV1,

--- a/lib/srv/discovery/fetchers/aws-sync/groups.go
+++ b/lib/srv/discovery/fetchers/aws-sync/groups.go
@@ -46,7 +46,7 @@ func (a *awsFetcher) pollAWSGroups(ctx context.Context, result *Resources, colle
 		// These goroutines are fetching inline and attached policies for each group.
 		// We also have other goroutines fetching inline and attached policies for users
 		// and roles.
-		eG.SetLimit(10)
+		eG.SetLimit(5)
 		groupsMu := sync.Mutex{}
 		for _, group := range result.Groups {
 			group := group

--- a/lib/srv/discovery/fetchers/aws-sync/policies.go
+++ b/lib/srv/discovery/fetchers/aws-sync/policies.go
@@ -71,7 +71,7 @@ func (a *awsFetcher) fetchPolicies(ctx context.Context) ([]*accessgraphv1alpha.A
 		return nil, trace.Wrap(err)
 	}
 	eGroup, ctx := errgroup.WithContext(ctx)
-	eGroup.SetLimit(10)
+	eGroup.SetLimit(5)
 	pageSize := int64(20)
 	err = iamClient.ListPoliciesPagesWithContext(
 		ctx,

--- a/lib/srv/discovery/fetchers/aws-sync/rds.go
+++ b/lib/srv/discovery/fetchers/aws-sync/rds.go
@@ -54,10 +54,10 @@ func (a *awsFetcher) fetchAWSRDSDatabases(ctx context.Context) (
 		errs    []error
 	)
 	eG, ctx := errgroup.WithContext(ctx)
-	// Set the limit to 10 to avoid too many concurrent requests.
+	// Set the limit to 5 to avoid too many concurrent requests.
 	// This is a temporary solution until we have a better way to limit the
 	// number of concurrent requests.
-	eG.SetLimit(10)
+	eG.SetLimit(5)
 	collectDBs := func(db *accessgraphv1alpha.AWSRDSDatabaseV1, err error) {
 		hostsMu.Lock()
 		defer hostsMu.Unlock()

--- a/lib/srv/discovery/fetchers/aws-sync/roles.go
+++ b/lib/srv/discovery/fetchers/aws-sync/roles.go
@@ -49,7 +49,7 @@ func (a *awsFetcher) pollAWSRoles(ctx context.Context, result *Resources, collec
 		// These goroutines are fetching inline and attached policies for each group.
 		// We also have other goroutines fetching inline and attached policies for users
 		// and roles.
-		eG.SetLimit(10)
+		eG.SetLimit(5)
 		roleMu := sync.Mutex{}
 		for _, role := range result.Roles {
 			role := role

--- a/lib/srv/discovery/fetchers/aws-sync/s3.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3.go
@@ -51,10 +51,10 @@ func (a *awsFetcher) fetchS3Buckets(ctx context.Context) ([]*accessgraphv1alpha.
 	var errs []error
 	var mu sync.Mutex
 	eG, ctx := errgroup.WithContext(ctx)
-	// Set the limit to 10 to avoid too many concurrent requests.
+	// Set the limit to 5 to avoid too many concurrent requests.
 	// This is a temporary solution until we have a better way to limit the
 	// number of concurrent requests.
-	eG.SetLimit(10)
+	eG.SetLimit(5)
 	collect := func(s3 *accessgraphv1alpha.AWSS3BucketV1, err error) {
 		mu.Lock()
 		defer mu.Unlock()

--- a/lib/srv/discovery/fetchers/aws-sync/users.go
+++ b/lib/srv/discovery/fetchers/aws-sync/users.go
@@ -47,7 +47,7 @@ func (a *awsFetcher) pollAWSUsers(ctx context.Context, result *Resources, collec
 		// These goroutines are fetching inline and attached policies for each group.
 		// We also have other goroutines fetching inline and attached policies for users
 		// and roles.
-		eG.SetLimit(10)
+		eG.SetLimit(5)
 		usersMu := sync.Mutex{}
 		// fetch user inline policies, attached policies, and groups in parallel
 		// and collect the results.

--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -48,7 +48,7 @@ type eksFetcher struct {
 // EKSClientGetter is an interface for getting an EKS client.
 type EKSClientGetter interface {
 	// GetAWSEKSClient returns AWS EKS client for the specified region.
-	GetAWSEKSClient(ctx context.Context, region string, opts ...cloud.AWSAssumeRoleOptionFn) (eksiface.EKSAPI, error)
+	GetAWSEKSClient(ctx context.Context, region string, opts ...cloud.AWSOptionsFn) (eksiface.EKSAPI, error)
 }
 
 // EKSFetcherConfig configures the EKS fetcher.

--- a/lib/srv/discovery/fetchers/eks_test.go
+++ b/lib/srv/discovery/fetchers/eks_test.go
@@ -117,7 +117,7 @@ func TestEKSFetcher(t *testing.T) {
 
 type mockEKSClientGetter struct{}
 
-func (e *mockEKSClientGetter) GetAWSEKSClient(ctx context.Context, region string, opts ...cloud.AWSAssumeRoleOptionFn) (eksiface.EKSAPI, error) {
+func (e *mockEKSClientGetter) GetAWSEKSClient(ctx context.Context, region string, opts ...cloud.AWSOptionsFn) (eksiface.EKSAPI, error) {
 	return newPopulatedEKSMock(), nil
 }
 

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -40,7 +40,7 @@ type mockClients struct {
 	azureClient azure.VirtualMachinesClient
 }
 
-func (c *mockClients) GetAWSEC2Client(ctx context.Context, region string, _ ...cloud.AWSAssumeRoleOptionFn) (ec2iface.EC2API, error) {
+func (c *mockClients) GetAWSEC2Client(ctx context.Context, region string, _ ...cloud.AWSOptionsFn) (ec2iface.EC2API, error) {
 	return c.ec2Client, nil
 }
 


### PR DESCRIPTION
Backport #40775 to branch/v14

changelog: Reduced parallelism when polling AWS resources to prevent API throttling when exporting them to Teleport Access Graph
