### PR TITLE
Use `--proxy-server` when invoking `tbot proxy` for SSH

### DIFF
--- a/lib/config/openssh/openssh.go
+++ b/lib/config/openssh/openssh.go
@@ -55,7 +55,7 @@ Host *.{{ $clusterName }} !{{ $dot.ProxyHost }}
     {{- if eq $dot.AppName "tsh" }}
     ProxyCommand "{{ $dot.ExecutablePath }}" proxy ssh --cluster={{ $clusterName }} --proxy={{ $dot.ProxyHost }}:{{ $dot.ProxyPort }} %r@%h:%p
 {{- end }}{{- if eq $dot.AppName "tbot" }}
-    ProxyCommand "{{ $dot.ExecutablePath }}" proxy --destination-dir={{ $dot.DestinationDir }} --proxy={{ $dot.ProxyHost }}:{{ $dot.ProxyPort }} ssh --cluster={{ $clusterName }}  %r@%h:%p
+    ProxyCommand "{{ $dot.ExecutablePath }}" proxy --destination-dir={{ $dot.DestinationDir }} --proxy-server={{ $dot.ProxyHost }}:{{ $dot.ProxyPort }} ssh --cluster={{ $clusterName }}  %r@%h:%p
 {{- end }}
 {{- end }}
     {{- if ne $dot.Username "" }}

--- a/lib/tbot/config/testdata/TestTemplateSSHClient_Render/latest_OpenSSH/ssh_config.golden
+++ b/lib/tbot/config/testdata/TestTemplateSSHClient_Render/latest_OpenSSH/ssh_config.golden
@@ -10,7 +10,7 @@ Host *.tele.blackmesa.gov tele.blackmesa.gov
 # Flags for all tele.blackmesa.gov hosts except the proxy
 Host *.tele.blackmesa.gov !tele.blackmesa.gov
     Port 3022
-    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov:443 ssh --cluster=tele.blackmesa.gov  %r@%h:%p
+    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy-server=tele.blackmesa.gov:443 ssh --cluster=tele.blackmesa.gov  %r@%h:%p
 # Common flags for all tele.aperture.labs hosts
 Host *.tele.aperture.labs tele.blackmesa.gov
     UserKnownHostsFile "/test/dir/known_hosts"
@@ -21,6 +21,6 @@ Host *.tele.aperture.labs tele.blackmesa.gov
 # Flags for all tele.aperture.labs hosts except the proxy
 Host *.tele.aperture.labs !tele.blackmesa.gov
     Port 3022
-    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov:443 ssh --cluster=tele.aperture.labs  %r@%h:%p
+    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy-server=tele.blackmesa.gov:443 ssh --cluster=tele.aperture.labs  %r@%h:%p
 
 # End generated Teleport configuration

--- a/lib/tbot/config/testdata/TestTemplateSSHClient_Render/legacy_OpenSSH/ssh_config.golden
+++ b/lib/tbot/config/testdata/TestTemplateSSHClient_Render/legacy_OpenSSH/ssh_config.golden
@@ -10,7 +10,7 @@ Host *.tele.blackmesa.gov tele.blackmesa.gov
 # Flags for all tele.blackmesa.gov hosts except the proxy
 Host *.tele.blackmesa.gov !tele.blackmesa.gov
     Port 3022
-    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov:443 ssh --cluster=tele.blackmesa.gov  %r@%h:%p
+    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy-server=tele.blackmesa.gov:443 ssh --cluster=tele.blackmesa.gov  %r@%h:%p
 # Common flags for all tele.aperture.labs hosts
 Host *.tele.aperture.labs tele.blackmesa.gov
     UserKnownHostsFile "/test/dir/known_hosts"
@@ -21,6 +21,6 @@ Host *.tele.aperture.labs tele.blackmesa.gov
 # Flags for all tele.aperture.labs hosts except the proxy
 Host *.tele.aperture.labs !tele.blackmesa.gov
     Port 3022
-    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov:443 ssh --cluster=tele.aperture.labs  %r@%h:%p
+    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy-server=tele.blackmesa.gov:443 ssh --cluster=tele.aperture.labs  %r@%h:%p
 
 # End generated Teleport configuration


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/40733

changelog: Fixes a deprecation warning being shown when `tbot` is used with OpenSSH