### PR TITLE
docs: moderation doc update

### DIFF
--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -83,9 +83,10 @@ Because this sample policy requires that at least one user with the `auditor` ro
 as a moderator to start SSH or Kubernetes sessions, a user assigned this `prod-access` role 
 won't be able to start any sessions until the policy requirements are fulfilled. 
 
-The `require_session_join` will apply to all of the user's SSH or Kubernetes sessions including
-other roles with different resource labeling. If you do not want to require session joining for
-all user sessions applying this as a Access Request role is recommended.
+The `require_session_join` rules apply to all of the user's sessions, including
+those that are accessible via other roles. If you do not want to require moderation
+for user sessions, we recommend using access requests to temporarily assume a role
+for resources that should require moderation.
 
 ### Required fields
 

--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -85,7 +85,7 @@ won't be able to start any sessions until the policy requirements are fulfilled.
 
 The `require_session_join` rules apply to all of the user's sessions, including
 those that are accessible via other roles. If you do not want to require moderation
-for user sessions, we recommend using access requests to temporarily assume a role
+for user sessions, we recommend using Access Requests to temporarily assume a role
 for resources that should require moderation.
 
 ### Required fields

--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -81,7 +81,11 @@ spec:
 
 Because this sample policy requires that at least one user with the `auditor` role to be present
 as a moderator to start SSH or Kubernetes sessions, a user assigned this `prod-access` role 
-won't be able to start any sessions on matching resources until the policy requirements are fulfilled.
+won't be able to start any sessions until the policy requirements are fulfilled. 
+
+The `require_session_join` will apply to all of the user's SSH or Kubernetes sessions including
+other roles with different resource labeling. If you do not want to require session joining for
+all user sessions applying this as a Access Request role is recommended.
 
 ### Required fields
 


### PR DESCRIPTION
If require session join is enabled in a role for a user that will apply to all of their interactive sessions including other roles. Updated language to make that more clear.