### PR TITLE
[v15] fix: prevent deleting AWS OIDC integration used by EAS

### DIFF
--- a/api/gen/proto/go/teleport/integration/v1/integration_service.pb.go
+++ b/api/gen/proto/go/teleport/integration/v1/integration_service.pb.go
@@ -358,6 +358,7 @@ func (x *DeleteIntegrationRequest) GetName() string {
 }
 
 // DeleteAllIntegrationsRequest is the request for deleting all integrations.
+// DEPRECATED: Can't delete all integrations over gRPC.
 type DeleteAllIntegrationsRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/api/gen/proto/go/teleport/integration/v1/integration_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/integration/v1/integration_service_grpc.pb.go
@@ -59,6 +59,7 @@ type IntegrationServiceClient interface {
 	// DeleteIntegration removes the specified Integration resource.
 	DeleteIntegration(ctx context.Context, in *DeleteIntegrationRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// DeleteAllIntegrations removes all Integrations.
+	// DEPRECATED: Can't delete all integrations over gRPC.
 	DeleteAllIntegrations(ctx context.Context, in *DeleteAllIntegrationsRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// GenerateAWSOIDCToken generates a token to be used when executing an AWS OIDC Integration action.
 	GenerateAWSOIDCToken(ctx context.Context, in *GenerateAWSOIDCTokenRequest, opts ...grpc.CallOption) (*GenerateAWSOIDCTokenResponse, error)
@@ -150,6 +151,7 @@ type IntegrationServiceServer interface {
 	// DeleteIntegration removes the specified Integration resource.
 	DeleteIntegration(context.Context, *DeleteIntegrationRequest) (*emptypb.Empty, error)
 	// DeleteAllIntegrations removes all Integrations.
+	// DEPRECATED: Can't delete all integrations over gRPC.
 	DeleteAllIntegrations(context.Context, *DeleteAllIntegrationsRequest) (*emptypb.Empty, error)
 	// GenerateAWSOIDCToken generates a token to be used when executing an AWS OIDC Integration action.
 	GenerateAWSOIDCToken(context.Context, *GenerateAWSOIDCTokenRequest) (*GenerateAWSOIDCTokenResponse, error)

--- a/api/proto/teleport/integration/v1/integration_service.proto
+++ b/api/proto/teleport/integration/v1/integration_service.proto
@@ -39,6 +39,7 @@ service IntegrationService {
   rpc DeleteIntegration(DeleteIntegrationRequest) returns (google.protobuf.Empty);
 
   // DeleteAllIntegrations removes all Integrations.
+  // DEPRECATED: Can't delete all integrations over gRPC.
   rpc DeleteAllIntegrations(DeleteAllIntegrationsRequest) returns (google.protobuf.Empty);
 
   // GenerateAWSOIDCToken generates a token to be used when executing an AWS OIDC Integration action.
@@ -88,6 +89,7 @@ message DeleteIntegrationRequest {
 }
 
 // DeleteAllIntegrationsRequest is the request for deleting all integrations.
+// DEPRECATED: Can't delete all integrations over gRPC.
 message DeleteAllIntegrationsRequest {}
 
 // GenerateAWSOIDCTokenRequest are the parameters used to request an AWS OIDC

--- a/api/types/externalauditstorage/externalauditstorage.go
+++ b/api/types/externalauditstorage/externalauditstorage.go
@@ -234,9 +234,14 @@ func (a *ExternalAuditStorage) MatchSearch(values []string) bool {
 	return types.MatchSearch(fieldVals, values, nil)
 }
 
-// CloneResource returns a copy of the resource as types.ResourceWithLabels.
-func (a *ExternalAuditStorage) CloneResource() types.ResourceWithLabels {
+// Clone returs a copy of the resource.
+func (a *ExternalAuditStorage) Clone() *ExternalAuditStorage {
 	var copy *ExternalAuditStorage
 	utils.StrictObjectToStruct(a, &copy)
 	return copy
+}
+
+// CloneResource returns a copy of the resource as types.ResourceWithLabels.
+func (a *ExternalAuditStorage) CloneResource() types.ResourceWithLabels {
+	return a.Clone()
 }

--- a/lib/auth/integration/integrationv1/service.go
+++ b/lib/auth/integration/integrationv1/service.go
@@ -248,19 +248,7 @@ func (s *Service) DeleteIntegration(ctx context.Context, req *integrationpb.Dele
 }
 
 // DeleteAllIntegrations removes all Integration resources.
+// DEPRECATED: can't delete all integrations over gRPC.
 func (s *Service) DeleteAllIntegrations(ctx context.Context, _ *integrationpb.DeleteAllIntegrationsRequest) (*emptypb.Empty, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbDelete); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := s.backend.DeleteAllIntegrations(ctx); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return &emptypb.Empty{}, nil
+	return nil, trace.BadParameter("DeleteAllIntegrations is deprecated")
 }

--- a/lib/backend/helpers.go
+++ b/lib/backend/helpers.go
@@ -37,7 +37,7 @@ func FlagKey(parts ...string) []byte {
 	return internalKey(flagsPrefix, parts...)
 }
 
-func lockKey(parts ...string) []byte {
+func LockKey(parts ...string) []byte {
 	return internalKey(locksPrefix, parts...)
 }
 
@@ -88,7 +88,7 @@ func AcquireLock(ctx context.Context, cfg LockConfiguration) (Lock, error) {
 	if err != nil {
 		return Lock{}, trace.Wrap(err)
 	}
-	key := lockKey(cfg.LockName)
+	key := LockKey(cfg.LockName)
 	id, err := randomID()
 	if err != nil {
 		return Lock{}, trace.Wrap(err)

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -878,7 +878,7 @@ func New(config Config) (*Cache, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	integrationsCache, err := local.NewIntegrationsService(config.Backend)
+	integrationsCache, err := local.NewIntegrationsService(config.Backend, local.WithIntegrationsServiceCacheMode(true))
 	if err != nil {
 		cancel()
 		return nil, trace.Wrap(err)

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -261,7 +261,7 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	}
 	p.okta = oktaSvc
 
-	igSvc, err := local.NewIntegrationsService(p.backend)
+	igSvc, err := local.NewIntegrationsService(p.backend, local.WithIntegrationsServiceCacheMode(true))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6187,13 +6187,13 @@ func (process *TeleportProcess) newExternalAuditStorageConfigurator() (*external
 	// watcher initialized.
 	watcher.WaitInit(process.GracefulExitContext())
 
-	ecaSvc := local.NewExternalAuditStorageService(process.backend)
+	easSvc := local.NewExternalAuditStorageService(process.backend)
 	integrationSvc, err := local.NewIntegrationsService(process.backend)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	statusService := local.NewStatusService(process.backend)
-	return externalauditstorage.NewConfigurator(process.ExitContext(), ecaSvc, integrationSvc, statusService)
+	return externalauditstorage.NewConfigurator(process.ExitContext(), easSvc, integrationSvc, statusService)
 }
 
 // createLockedPIDFile creates a PID file in the path specified by pidFile

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -504,17 +504,17 @@ func TestAthenaAuditLogSetup(t *testing.T) {
 	_, err = integrationSvc.CreateIntegration(ctx, oidcIntegration)
 	require.NoError(t, err)
 
-	ecaSvc := local.NewExternalAuditStorageService(backend)
-	_, err = ecaSvc.GenerateDraftExternalAuditStorage(ctx, "aws-integration-1", "us-west-2")
+	easSvc := local.NewExternalAuditStorageService(backend)
+	_, err = easSvc.GenerateDraftExternalAuditStorage(ctx, "aws-integration-1", "us-west-2")
 	require.NoError(t, err)
 
 	statusService := local.NewStatusService(process.backend)
 
-	externalAuditStorageDisabled, err := externalauditstorage.NewConfigurator(ctx, ecaSvc, integrationSvc, statusService)
+	externalAuditStorageDisabled, err := externalauditstorage.NewConfigurator(ctx, easSvc, integrationSvc, statusService)
 	require.NoError(t, err)
-	err = ecaSvc.PromoteToClusterExternalAuditStorage(ctx)
+	err = easSvc.PromoteToClusterExternalAuditStorage(ctx)
 	require.NoError(t, err)
-	externalAuditStorageEnabled, err := externalauditstorage.NewConfigurator(ctx, ecaSvc, integrationSvc, statusService)
+	externalAuditStorageEnabled, err := externalauditstorage.NewConfigurator(ctx, easSvc, integrationSvc, statusService)
 	require.NoError(t, err)
 
 	tests := []struct {

--- a/lib/services/local/externalauditstorage.go
+++ b/lib/services/local/externalauditstorage.go
@@ -20,7 +20,6 @@ package local
 
 import (
 	"context"
-	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -36,8 +35,6 @@ const (
 	externalAuditStoragePrefix      = "external_audit_storage"
 	externalAuditStorageDraftName   = "draft"
 	externalAuditStorageClusterName = "cluster"
-	externalAuditStorageLockName    = "external_audit_storage_lock"
-	externalAuditStorageLockTTL     = 10 * time.Second
 )
 
 var (
@@ -51,6 +48,7 @@ type ExternalAuditStorageService struct {
 	logger  *logrus.Entry
 }
 
+// NewExternalAuditStorageService returns a new *ExternalAuditStorageService or an error if it fails.
 func NewExternalAuditStorageService(backend backend.Backend) *ExternalAuditStorageService {
 	return &ExternalAuditStorageService{
 		backend: backend,
@@ -60,18 +58,14 @@ func NewExternalAuditStorageService(backend backend.Backend) *ExternalAuditStora
 
 // GetDraftExternalAuditStorage returns the draft External Audit Storage resource.
 func (s *ExternalAuditStorageService) GetDraftExternalAuditStorage(ctx context.Context) (*externalauditstorage.ExternalAuditStorage, error) {
-	item, err := s.backend.Get(ctx, draftExternalAuditStorageBackendKey)
+	eas, err := getExternalAuditStorage(ctx, s.backend, draftExternalAuditStorageBackendKey)
 	if err != nil {
 		if trace.IsNotFound(err) {
-			return nil, trace.NotFound("cluster external_audit_storage is not found")
+			return nil, trace.NotFound("draft external_audit_storage is not found")
 		}
 		return nil, trace.Wrap(err)
 	}
-	out, err := services.UnmarshalExternalAuditStorage(item.Value)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return out, nil
+	return eas, nil
 }
 
 // CreateDraftExternalAudit creates the draft External Audit Storage resource if
@@ -81,26 +75,44 @@ func (s *ExternalAuditStorageService) CreateDraftExternalAuditStorage(ctx contex
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	item := backend.Item{
+		Key:   draftExternalAuditStorageBackendKey,
+		Value: value,
+	}
 
-	// Lock is used here and in Promote to prevent the possibility of deleting a
-	// newly created draft after the previous one was promoted.
-	err = backend.RunWhileLocked(ctx, backend.RunWhileLockedConfig{
-		LockConfiguration: backend.LockConfiguration{
-			Backend:  s.backend,
-			LockName: externalAuditStorageLockName,
-			TTL:      externalAuditStorageLockTTL,
-		},
-	}, func(ctx context.Context) error {
-		_, err = s.backend.Create(ctx, backend.Item{
-			Key:   draftExternalAuditStorageBackendKey,
-			Value: value,
-		})
-		return trace.Wrap(err)
-	})
-	if trace.IsAlreadyExists(err) {
+	// First check if a draft already exists for a nicer error message than the one returned by AtomicWrite.
+	_, err = s.backend.Get(ctx, draftExternalAuditStorageBackendKey)
+	if err == nil {
 		return nil, trace.AlreadyExists("draft external_audit_storage already exists")
 	}
-	return in, trace.Wrap(err)
+
+	// Check that the referenced AWS OIDC integration actually exists.
+	integrationKey, integrationRevision, err := s.checkAWSIntegration(ctx, in.Spec.IntegrationName)
+	if err != nil {
+		return nil, trace.Wrap(err, "checking AWS OIDC integration")
+	}
+
+	revision, err := s.backend.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			// Make sure the AWS OIDC integration checked above hasn't changed.
+			Key:       integrationKey,
+			Condition: backend.Revision(integrationRevision),
+			Action:    backend.Nop(),
+		},
+		{
+			// Create the new draft EAS integration if one doesn't already exist.
+			Key:       item.Key,
+			Condition: backend.NotExists(),
+			Action:    backend.Put(item),
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	out := in.Clone()
+	out.SetRevision(revision)
+	return out, nil
 }
 
 // UpsertDraftExternalAudit upserts the draft External Audit Storage resource.
@@ -109,24 +121,38 @@ func (s *ExternalAuditStorageService) UpsertDraftExternalAuditStorage(ctx contex
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	item := backend.Item{
+		Key:   draftExternalAuditStorageBackendKey,
+		Value: value,
+	}
 
-	// Lock is used here and in Promote to prevent upserting in the middle
-	// of a promotion and the possibility of deleting a newly upserted draft
-	// after the previous one was promoted.
-	err = backend.RunWhileLocked(ctx, backend.RunWhileLockedConfig{
-		LockConfiguration: backend.LockConfiguration{
-			Backend:  s.backend,
-			LockName: externalAuditStorageLockName,
-			TTL:      externalAuditStorageLockTTL,
+	// Check that the referenced AWS OIDC integration actually exists.
+	integrationKey, integrationRevision, err := s.checkAWSIntegration(ctx, in.Spec.IntegrationName)
+	if err != nil {
+		return nil, trace.Wrap(err, "checking AWS OIDC integration")
+	}
+
+	revision, err := s.backend.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			// Make sure the AWS OIDC integration checked above hasn't changed.
+			Key:       integrationKey,
+			Condition: backend.Revision(integrationRevision),
+			Action:    backend.Nop(),
 		},
-	}, func(ctx context.Context) error {
-		_, err = s.backend.Put(ctx, backend.Item{
-			Key:   draftExternalAuditStorageBackendKey,
-			Value: value,
-		})
-		return trace.Wrap(err)
+		{
+			// Upsert the new draft EAS integration.
+			Key:       item.Key,
+			Condition: backend.Whatever(),
+			Action:    backend.Put(item),
+		},
 	})
-	return in, trace.Wrap(err)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	out := in.Clone()
+	out.SetRevision(revision)
+	return out, nil
 }
 
 // GenerateDraftExternalAuditStorage creates a new draft ExternalAuditStorage with
@@ -138,30 +164,10 @@ func (s *ExternalAuditStorageService) GenerateDraftExternalAuditStorage(ctx cont
 		return nil, trace.Wrap(err)
 	}
 
-	value, err := services.MarshalExternalAuditStorage(generated)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	err = backend.RunWhileLocked(ctx, backend.RunWhileLockedConfig{
-		LockConfiguration: backend.LockConfiguration{
-			Backend:  s.backend,
-			LockName: externalAuditStorageLockName,
-			TTL:      externalAuditStorageLockTTL,
-		},
-	}, func(ctx context.Context) error {
-		_, err = s.backend.Create(ctx, backend.Item{
-			Key:   draftExternalAuditStorageBackendKey,
-			Value: value,
-		})
-		return trace.Wrap(err)
-	})
-	if trace.IsAlreadyExists(err) {
-		return nil, trace.AlreadyExists("draft external_audit_storage already exists")
-	}
-	return generated, trace.Wrap(err)
+	return s.CreateDraftExternalAuditStorage(ctx, generated)
 }
 
-// DeleteDraftExternalAudit removes the draft External Audit Storage resource.
+// DeleteDraftExternalAudit removes the draft ExternalAuditStorage resource.
 func (s *ExternalAuditStorageService) DeleteDraftExternalAuditStorage(ctx context.Context) error {
 	err := s.backend.Delete(ctx, draftExternalAuditStorageBackendKey)
 	if trace.IsNotFound(err) {
@@ -170,73 +176,106 @@ func (s *ExternalAuditStorageService) DeleteDraftExternalAuditStorage(ctx contex
 	return trace.Wrap(err)
 }
 
-// GetClusterExternalAuditStorage returns the cluster External Audit Storage resource.
+// GetClusterExternalAuditStorage returns the cluster ExternalAuditStorage resource.
 func (s *ExternalAuditStorageService) GetClusterExternalAuditStorage(ctx context.Context) (*externalauditstorage.ExternalAuditStorage, error) {
-	item, err := s.backend.Get(ctx, clusterExternalAuditStorageBackendKey)
+	eas, err := getExternalAuditStorage(ctx, s.backend, clusterExternalAuditStorageBackendKey)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("cluster external_audit_storage is not found")
 		}
 		return nil, trace.Wrap(err)
 	}
-	out, err := services.UnmarshalExternalAuditStorage(item.Value)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return out, nil
+	return eas, nil
 }
 
-// PromoteToClusterExternalAuditStorage promotes draft to cluster external
-// cloud audit resource.
+// PromoteToClusterExternalAuditStorage promotes the current draft to be the cluster ExternalAuditStorage
+// resource.
 func (s *ExternalAuditStorageService) PromoteToClusterExternalAuditStorage(ctx context.Context) error {
-	// Lock is used here and in Create/Upsert/GenerateDraft to prevent upserting
-	// in the middle of a promotion and the possibility of deleting a newly
-	// created draft after the previous one was promoted.
-	err := backend.RunWhileLocked(ctx, backend.RunWhileLockedConfig{
-		LockConfiguration: backend.LockConfiguration{
-			Backend:  s.backend,
-			LockName: externalAuditStorageLockName,
-			TTL:      externalAuditStorageLockTTL,
-		},
-	}, func(ctx context.Context) error {
-		draft, err := s.GetDraftExternalAuditStorage(ctx)
-		if err != nil {
-			if trace.IsNotFound(err) {
-				return trace.BadParameter("can't promote to cluster when draft does not exist")
-			}
-			return trace.Wrap(err)
+	draft, err := s.GetDraftExternalAuditStorage(ctx)
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return trace.BadParameter("can't promote to cluster when draft does not exist")
 		}
-		out, err := externalauditstorage.NewClusterExternalAuditStorage(header.Metadata{}, draft.Spec)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		value, err := services.MarshalExternalAuditStorage(out)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		_, err = s.backend.Put(ctx, backend.Item{
-			Key:   clusterExternalAuditStorageBackendKey,
-			Value: value,
-		})
-		if err != nil {
-			return trace.Wrap(err)
-		}
+		return trace.Wrap(err)
+	}
 
-		// Clean up the current draft which has now been promoted.
-		// Failing to delete the current draft is not critical and the promotion
-		// has already succeeded, so just log any failure and return nil.
-		if err := s.backend.Delete(ctx, draftExternalAuditStorageBackendKey); err != nil {
-			s.logger.Info("failed to delete current draft external_audit_storage after promoting to cluster")
-		}
-		return nil
+	cluster, err := externalauditstorage.NewClusterExternalAuditStorage(header.Metadata{}, draft.Spec)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	value, err := services.MarshalExternalAuditStorage(cluster)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	item := backend.Item{
+		Key:   clusterExternalAuditStorageBackendKey,
+		Value: value,
+	}
+
+	integrationKey, integrationRevision, err := s.checkAWSIntegration(ctx, draft.Spec.IntegrationName)
+	if err != nil {
+		return trace.Wrap(err, "checking AWS OIDC integration")
+	}
+
+	_, err = s.backend.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			// Make sure the AWS OIDC integration checked above hasn't changed.
+			Key:       integrationKey,
+			Condition: backend.Revision(integrationRevision),
+			Action:    backend.Nop(),
+		},
+		{
+			// Make sure the draft EAS integration copied above hasn't changed, and delete it after the
+			// promotion.
+			Key:       draftExternalAuditStorageBackendKey,
+			Condition: backend.Revision(draft.GetRevision()),
+			Action:    backend.Delete(),
+		},
+		{
+			// Upsert the new cluster EAS integration.
+			Key:       item.Key,
+			Condition: backend.Whatever(),
+			Action:    backend.Put(item),
+		},
 	})
 	return trace.Wrap(err)
 }
 
+// DisableClusterExternalAuditStorage disables External Audit Storage in the cluster by deleting the cluster
+// EAS configuration.
 func (s *ExternalAuditStorageService) DisableClusterExternalAuditStorage(ctx context.Context) error {
 	err := s.backend.Delete(ctx, clusterExternalAuditStorageBackendKey)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+// checkAWSIntegration checks that [integrationName] names an AWS OIDC integration that currently exists, and
+// returns the backend key and revision if the AWS OIDC integration.
+func (s *ExternalAuditStorageService) checkAWSIntegration(ctx context.Context, integrationName string) (key []byte, revision string, err error) {
+	integrationsSvc, err := NewIntegrationsService(s.backend)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	integration, err := integrationsSvc.GetIntegration(ctx, integrationName)
+	if err != nil {
+		return nil, "", trace.Wrap(err, "getting integration")
+	}
+	if integration.GetAWSOIDCIntegrationSpec() == nil {
+		return nil, "", trace.BadParameter("%q is not an AWS OIDC integration", integrationName)
+	}
+	return integrationsSvc.svc.MakeKey(integrationName), integration.GetRevision(), nil
+}
+
+func getExternalAuditStorage(ctx context.Context, bk backend.Backend, key []byte) (*externalauditstorage.ExternalAuditStorage, error) {
+	item, err := bk.Get(ctx, key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	out, err := services.UnmarshalExternalAuditStorage(item.Value, services.WithRevision(item.Revision), services.WithResourceID(item.ID))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return out, nil
 }

--- a/lib/services/local/externalauditstorage_test.go
+++ b/lib/services/local/externalauditstorage_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/lib/backend"
@@ -76,19 +77,48 @@ func TestExternalAuditStorageService(t *testing.T) {
 
 	t.Run("create draft", func(t *testing.T) {
 		// Given no draft
-		// When CreateDraftExternalAuditStorage
-		// Then draft is returned on GetDraftExternalAuditStorage
-		// And GetClusterExternalCloutAudit returns not found.
-		// And CreateDraftExternalAuditStorage again returns AlreadyExists
+		// When CreateDraftExternalAuditStorage with non-existing OIDC
+		// integration
+		// Then an error is returned
 
 		// When
 		_, err := service.CreateDraftExternalAuditStorage(ctx, draftFromSpec1)
+		// Then
+		require.Error(t, err)
+	})
+
+	oidcIntegration, err := types.NewIntegrationAWSOIDC(
+		types.Metadata{Name: spec1.IntegrationName},
+		&types.AWSOIDCIntegrationSpecV1{
+			RoleARN: "test-role",
+		},
+	)
+	require.NoError(t, err)
+
+	integrationsSvc, err := NewIntegrationsService(mem)
+	require.NoError(t, err)
+	_, err = integrationsSvc.CreateIntegration(ctx, oidcIntegration)
+	require.NoError(t, err)
+
+	t.Run("create draft", func(t *testing.T) {
+		// Given no draft
+		// When CreateDraftExternalAuditStorage
+		// Then draft is returned on GetDraftExternalAuditStorage
+		// And GetClusterExternalAuditStorage returns not found.
+		// And CreateDraftExternalAuditStorage again returns AlreadyExists
+
+		// When
+		created, err := service.CreateDraftExternalAuditStorage(ctx, draftFromSpec1)
 		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(draftFromSpec1, created, cmpOpts...))
+		require.NotEmpty(t, created.GetRevision())
 
 		// Then
-		out, err := service.GetDraftExternalAuditStorage(ctx)
+		got, err := service.GetDraftExternalAuditStorage(ctx)
 		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(draftFromSpec1, out, cmpOpts...))
+		require.Empty(t, cmp.Diff(created, got, cmpOpts...))
+		require.Equal(t, created.GetRevision(), got.GetRevision())
+
 		// And
 		_, err = service.GetClusterExternalAuditStorage(ctx)
 		require.Error(t, err)
@@ -105,13 +135,17 @@ func TestExternalAuditStorageService(t *testing.T) {
 		// And GetClusterExternalCloutAudit returns not found.
 
 		// When
-		_, err := service.UpsertDraftExternalAuditStorage(ctx, draftFromSpec1)
+		created, err := service.UpsertDraftExternalAuditStorage(ctx, draftFromSpec1)
 		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(draftFromSpec1, created, cmpOpts...))
+		require.NotEmpty(t, created.GetRevision())
 
 		// Then
-		out, err := service.GetDraftExternalAuditStorage(ctx)
+		got, err := service.GetDraftExternalAuditStorage(ctx)
 		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(draftFromSpec1, out, cmpOpts...))
+		require.Empty(t, cmp.Diff(created, got, cmpOpts...))
+		require.Equal(t, created.GetRevision(), got.GetRevision())
+
 		// And
 		_, err = service.GetClusterExternalAuditStorage(ctx)
 		require.Error(t, err)
@@ -125,7 +159,7 @@ func TestExternalAuditStorageService(t *testing.T) {
 
 		// When
 		err := service.PromoteToClusterExternalAuditStorage(ctx)
-		require.NoError(t, err)
+		require.NoError(t, err, trace.DebugReport(err))
 		// Then
 		out, err := service.GetClusterExternalAuditStorage(ctx)
 		require.NoError(t, err)
@@ -197,7 +231,7 @@ func TestExternalAuditStorageService(t *testing.T) {
 		// Given no draft
 
 		// When GenerateDraftExternalAuditStorage
-		generateResp, err := service.GenerateDraftExternalAuditStorage(ctx, "test-integration", "us-west-2")
+		generateResp, err := service.GenerateDraftExternalAuditStorage(ctx, "aws-integration-1", "us-west-2")
 		require.NoError(t, err)
 
 		// Then draft is returned with generated values
@@ -205,7 +239,7 @@ func TestExternalAuditStorageService(t *testing.T) {
 		nonce := strings.TrimPrefix(spec.PolicyName, "ExternalAuditStoragePolicy-")
 		underscoreNonce := strings.ReplaceAll(nonce, "-", "_")
 		expectedSpec := externalauditstorage.ExternalAuditStorageSpec{
-			IntegrationName:        "test-integration",
+			IntegrationName:        "aws-integration-1",
 			PolicyName:             "ExternalAuditStoragePolicy-" + nonce,
 			Region:                 "us-west-2",
 			SessionRecordingsURI:   "s3://teleport-longterm-" + nonce + "/sessions",
@@ -223,7 +257,7 @@ func TestExternalAuditStorageService(t *testing.T) {
 		assert.Empty(t, cmp.Diff(generateResp, getResp, cmpOpts...))
 
 		// And can't generate when there is an existing draft
-		_, err = service.GenerateDraftExternalAuditStorage(ctx, "test-integration", "us-west-2")
+		_, err = service.GenerateDraftExternalAuditStorage(ctx, "aws-integration-1", "us-west-2")
 		require.Error(t, err)
 		assert.True(t, trace.IsAlreadyExists(err), "expected AlreadyExists error, got %v", err)
 	})

--- a/lib/services/local/externalauditstorage_watcher_test.go
+++ b/lib/services/local/externalauditstorage_watcher_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -42,6 +43,18 @@ func TestClusterExternalAuditWatcher(t *testing.T) {
 	require.NoError(t, err)
 
 	svc := NewExternalAuditStorageService(bk)
+
+	integrationsSvc, err := NewIntegrationsService(bk)
+	require.NoError(t, err)
+
+	oidcIntegration, err := types.NewIntegrationAWSOIDC(
+		types.Metadata{Name: "test-integration"},
+		&types.AWSOIDCIntegrationSpecV1{
+			RoleARN: "test-role",
+		},
+	)
+	require.NoError(t, err)
+	integrationsSvc.CreateIntegration(ctx, oidcIntegration)
 
 	ch := make(chan string)
 
@@ -141,6 +154,17 @@ func TestClusterExternalAuditWatcher_WatcherClosed(t *testing.T) {
 	require.NoError(t, err)
 
 	svc := NewExternalAuditStorageService(bk)
+	integrationsSvc, err := NewIntegrationsService(bk)
+	require.NoError(t, err)
+
+	oidcIntegration, err := types.NewIntegrationAWSOIDC(
+		types.Metadata{Name: "test-integration"},
+		&types.AWSOIDCIntegrationSpecV1{
+			RoleARN: "test-role",
+		},
+	)
+	require.NoError(t, err)
+	integrationsSvc.CreateIntegration(ctx, oidcIntegration)
 
 	interceptor := &watcherInterceptor{
 		Backend:  bk,

--- a/lib/services/local/integrations.go
+++ b/lib/services/local/integrations.go
@@ -36,11 +36,24 @@ const (
 
 // IntegrationsService manages Integrations in the Backend.
 type IntegrationsService struct {
-	svc generic.Service[types.Integration]
+	svc       generic.Service[types.Integration]
+	backend   backend.Backend
+	cacheMode bool
+}
+
+// IntegrationsServiceOption is a functional option for the IntegrationsService.
+type IntegrationsServiceOption func(*IntegrationsService)
+
+// WithIntegrationsServiceCacheMode configures the IntegrationsService to skip certain checks against deleting
+// integrations referenced by other components and should only be used in e.g. a local cache.
+func WithIntegrationsServiceCacheMode(cacheMode bool) func(*IntegrationsService) {
+	return func(svc *IntegrationsService) {
+		svc.cacheMode = cacheMode
+	}
 }
 
 // NewIntegrationsService creates a new IntegrationsService.
-func NewIntegrationsService(backend backend.Backend) (*IntegrationsService, error) {
+func NewIntegrationsService(backend backend.Backend, opts ...IntegrationsServiceOption) (*IntegrationsService, error) {
 	svc, err := generic.NewService(&generic.ServiceConfig[types.Integration]{
 		Backend:       backend,
 		PageLimit:     defaults.MaxIterationLimit,
@@ -52,10 +65,14 @@ func NewIntegrationsService(backend backend.Backend) (*IntegrationsService, erro
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	return &IntegrationsService{
-		svc: *svc,
-	}, nil
+	integrationsSvc := &IntegrationsService{
+		svc:     *svc,
+		backend: backend,
+	}
+	for _, opt := range opts {
+		opt(integrationsSvc)
+	}
+	return integrationsSvc, nil
 }
 
 // ListIntegrations returns a paginated list of Integration resources.
@@ -100,10 +117,66 @@ func (s *IntegrationsService) UpdateIntegration(ctx context.Context, ig types.In
 
 // DeleteIntegration removes the specified Integration resource.
 func (s *IntegrationsService) DeleteIntegration(ctx context.Context, name string) error {
-	return trace.Wrap(s.svc.DeleteResource(ctx, name))
+	if s.cacheMode {
+		// No checks are done in cache mode.
+		return trace.Wrap(s.svc.DeleteResource(ctx, name))
+	}
+
+	// First check if the integration exists to return NotFound in case it doesn't.
+	if _, err := s.svc.GetResource(ctx, name); err != nil {
+		return trace.Wrap(err)
+	}
+
+	conditionalActions, err := notReferencedByEAS(ctx, s.backend, name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	conditionalActions = append(conditionalActions, backend.ConditionalAction{
+		Key:       s.svc.MakeKey(name),
+		Condition: backend.Exists(),
+		Action:    backend.Delete(),
+	})
+	_, err = s.backend.AtomicWrite(ctx, conditionalActions)
+	return trace.Wrap(err)
 }
 
-// DeleteAllIntegrations removes all Integration resources.
+// notReferencedByEAS returns a slice of ConditionalActions to use with a backend.AtomicWrite to ensure that
+// integration [name] is not referenced by any EAS (External Audit Storage) integration.
+func notReferencedByEAS(ctx context.Context, bk backend.Backend, name string) ([]backend.ConditionalAction, error) {
+	var conditionalActions []backend.ConditionalAction
+	for _, key := range [][]byte{draftExternalAuditStorageBackendKey, clusterExternalAuditStorageBackendKey} {
+		condition := backend.ConditionalAction{
+			Key:    key,
+			Action: backend.Nop(),
+			// Condition: will be set below based on existence of key.
+		}
+
+		eas, err := getExternalAuditStorage(ctx, bk, key)
+		if err != nil {
+			if !trace.IsNotFound(err) {
+				return nil, trace.Wrap(err)
+			}
+			// If this EAS configuration currently doesn't exist, make sure it still doesn't exist when
+			// deleting the AWS integration.
+			condition.Condition = backend.NotExists()
+		} else {
+			if eas.Spec.IntegrationName == name {
+				return nil, trace.BadParameter("cannot delete AWS OIDC integration currently referenced by External Audit Storage integration")
+			}
+			// If this EAS configuration currently doesn't reference the AWS integration being deleted, make
+			// sure it hasn't changed when deleting the AWS integration.
+			condition.Condition = backend.Revision(eas.GetRevision())
+		}
+
+		conditionalActions = append(conditionalActions, condition)
+	}
+	return conditionalActions, nil
+}
+
+// DeleteAllIntegrations removes all Integration resources. This should only be used in a cache.
 func (s *IntegrationsService) DeleteAllIntegrations(ctx context.Context) error {
+	if !s.cacheMode {
+		return trace.BadParameter("Deleting all integrations is not supported, this is a bug")
+	}
 	return trace.Wrap(s.svc.DeleteAllResources(ctx))
 }


### PR DESCRIPTION
Backport #40630 to branch/v15

changelog: prevent deleting AWS OIDC integration used by External Audit Storage.
