### PR TITLE
Add a fallback for EmitAuditEvents failure due to event conflicts (DynamoDB backend)

### DIFF
--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -112,6 +112,9 @@ type Config struct {
 	UIDGenerator utils.UID
 	// Endpoint is an optional non-AWS endpoint
 	Endpoint string
+	// DisableConflictCheck disables conflict checks when emitting an event.
+	// Disabling it can cause events to be lost due to them being overwritten.
+	DisableConflictCheck bool
 
 	// ReadMaxCapacity is the maximum provisioned read capacity.
 	ReadMaxCapacity int64
@@ -144,6 +147,10 @@ type Config struct {
 func (cfg *Config) SetFromURL(in *url.URL) error {
 	if endpoint := in.Query().Get(teleport.Endpoint); endpoint != "" {
 		cfg.Endpoint = endpoint
+	}
+
+	if disableConflictCheck := in.Query().Get("disable_conflict_check"); disableConflictCheck != "" {
+		cfg.DisableConflictCheck = true
 	}
 
 	const boolErrorTemplate = "failed to parse URI %q flag %q - %q, supported values are 'true', 'false', or any other" +
@@ -372,6 +379,16 @@ func (l *Log) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent) error
 			// In case of ValidationException: Item size has exceeded the maximum allowed size
 			// sanitize event length and retry upload operation.
 			return trace.Wrap(l.handleAWSValidationError(ctx, err, sessionID, in))
+		case trace.IsAlreadyExists(convertError(err)):
+			// Condition errors are directly related to the uniqueness of the
+			// item event index/session id. Since we can't change the session
+			// id, update the event index with a new value and retry the put
+			// item.
+			l.
+				WithError(err).
+				WithFields(log.Fields{"event_type": in.GetType(), "session_id": sessionID, "event_index": in.GetIndex()}).
+				Error("Conflict on event session_id and event_index")
+			return trace.Wrap(l.handleConditionError(ctx, sessionID, in))
 		}
 		return trace.Wrap(err)
 	}
@@ -389,6 +406,16 @@ func (l *Log) handleAWSValidationError(ctx context.Context, err error, sessionID
 	fields := log.Fields{"event_id": in.GetID(), "event_type": in.GetType()}
 	l.WithFields(fields).Info("Uploaded trimmed event to DynamoDB backend.")
 	events.MetricStoredTrimmedEvents.Inc()
+	return nil
+}
+
+func (l *Log) handleConditionError(ctx context.Context, sessionID string, in apievents.AuditEvent) error {
+	in.SetIndex(l.Clock.Now().UnixNano())
+
+	if err := l.putAuditEvent(ctx, sessionID, in); err != nil {
+		return trace.Wrap(err)
+	}
+	l.WithFields(log.Fields{"event_id": in.GetID(), "event_type": in.GetType()}).Debug("Event index overwritten")
 	return nil
 }
 
@@ -443,11 +470,17 @@ func (l *Log) createPutItem(sessionID string, in apievents.AuditEvent) (*dynamod
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &dynamodb.PutItemInput{
-		Item:                av,
-		TableName:           aws.String(l.Tablename),
-		ConditionExpression: aws.String("attribute_not_exists(SessionID) AND attribute_not_exists(EventIndex)"),
-	}, nil
+
+	input := &dynamodb.PutItemInput{
+		Item:      av,
+		TableName: aws.String(l.Tablename),
+	}
+
+	if !l.Config.DisableConflictCheck {
+		input.ConditionExpression = aws.String("attribute_not_exists(SessionID) AND attribute_not_exists(EventIndex)")
+	}
+
+	return input, nil
 }
 
 type messageSizeTrimmer interface {

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
@@ -68,6 +67,7 @@ func setupDynamoContext(t *testing.T) *dynamoContext {
 		Tablename:    fmt.Sprintf("teleport-test-%v", uuid.New().String()),
 		Clock:        fakeClock,
 		UIDGenerator: utils.NewFakeUID(),
+		Endpoint:     "http://localhost:8000",
 	})
 	require.NoError(t, err)
 
@@ -443,32 +443,37 @@ func TestEmitSessionEventsSameIndex(t *testing.T) {
 	tt := setupDynamoContext(t)
 	sessionID := session.NewID()
 
-	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 0)))
-	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 1)))
-	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 1)))
+	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 0, "")))
+	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 1, "")))
+	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 1, "")))
 }
 
-func generateEvent(sessionID session.ID, index int64) apievents.AuditEvent {
-	return &apievents.AppSessionChunk{
+// TestValidationErrorsHandling given events that return validation
+// errors (large event size and already exists), the emit should handle them
+// and succeed on emitting the event when it does support trimming.
+func TestValidationErrorsHandling(t *testing.T) {
+	ctx := context.Background()
+	tt := setupDynamoContext(t)
+	sessionID := session.NewID()
+	largeQuery := strings.Repeat("A", maxItemSize)
+
+	// First write should only trigger the large event size
+	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 0, largeQuery)))
+	// Second should trigger both errors.
+	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 0, largeQuery)))
+}
+
+func generateEvent(sessionID session.ID, index int64, query string) apievents.AuditEvent {
+	return &apievents.DatabaseSessionQuery{
 		Metadata: apievents.Metadata{
-			Type:        events.AppSessionChunkEvent,
-			Code:        events.AppSessionChunkCode,
+			Type:        events.DatabaseSessionQueryEvent,
 			ClusterName: "root",
 			Index:       index,
-		},
-		ServerMetadata: apievents.ServerMetadata{
-			ServerID:        uuid.New().String(),
-			ServerNamespace: apidefaults.Namespace,
 		},
 		SessionMetadata: apievents.SessionMetadata{
 			SessionID: sessionID.String(),
 		},
-		AppMetadata: apievents.AppMetadata{
-			AppURI:        "nginx",
-			AppPublicAddr: "https://nginx",
-			AppName:       "nginx",
-		},
-		SessionChunkID: uuid.New().String(),
+		DatabaseQuery: query,
 	}
 }
 

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -437,7 +437,7 @@ func TestConfig_CheckAndSetDefaults(t *testing.T) {
 }
 
 // TestEmitSessionEventsSameIndex given events that share the same session ID
-// and index, the emit should fail, avoiding any event to get overwritten.
+// and index, the emit should succeed.
 func TestEmitSessionEventsSameIndex(t *testing.T) {
 	ctx := context.Background()
 	tt := setupDynamoContext(t)
@@ -445,7 +445,7 @@ func TestEmitSessionEventsSameIndex(t *testing.T) {
 
 	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 0)))
 	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 1)))
-	require.Error(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 1)))
+	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 1)))
 }
 
 func generateEvent(sessionID session.ID, index int64) apievents.AuditEvent {


### PR DESCRIPTION
Closes #40126.

Adds a fallback for when the put item fails due to the condition exception (duplicate events).

In addition, we're adding a new option to disable condition checking, which can be configured through the DynamoDB URL. This option can be used to restore the old behavior.

NOTE: This is being solved on the DynamoDB events "layer" because multiple parts of Teleport are subject to this failure (not only the one described on the issue).

changelog: Fix audit event failures when using DynamoDB event storage.