### PR TITLE
filter expired requests from cache reads

### DIFF
--- a/lib/services/access_request_cache_test.go
+++ b/lib/services/access_request_cache_test.go
@@ -271,3 +271,105 @@ func TestAccessRequestCacheBasics(t *testing.T) {
 		}
 	}
 }
+
+func TestAccessRequestCacheExpiryFiltering(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bk, err := memory.New(memory.Config{
+		// set backend into mirror mode so that it does not expire items
+		// automatically.
+		Mirror: true,
+	})
+	require.NoError(t, err)
+
+	svcs := accessRequestServices{
+		Events:           local.NewEventsService(bk),
+		DynamicAccessExt: local.NewDynamicAccessService(bk),
+	}
+
+	cache, err := services.NewAccessRequestCache(services.AccessRequestCacheConfig{
+		Events: svcs,
+		Getter: svcs,
+	})
+	require.NoError(t, err)
+
+	// describe a set of test requests, some of which are expired
+	rrs := []struct {
+		name    string
+		id      string
+		expired bool
+	}{
+		{
+			id:      "00000000-0000-0000-0000-000000000005",
+			name:    "bob",
+			expired: true,
+		},
+		{
+			id:      "00000000-0000-0000-0000-000000000004",
+			name:    "bob",
+			expired: false,
+		},
+		{
+			id:      "00000000-0000-0000-0000-000000000003",
+			name:    "alice",
+			expired: true,
+		},
+		{
+			id:      "00000000-0000-0000-0000-000000000002",
+			name:    "alice",
+			expired: false,
+		},
+		{
+			id:      "00000000-0000-0000-0000-000000000001",
+			name:    "jan",
+			expired: true,
+		},
+	}
+
+	// insert test requests into backend, and aggregate the IDs of the subset that
+	// are unexpired so that we can check them against cache reads later.
+	var unexpiredRequestIDs []string
+	for _, rr := range rrs {
+		r, err := types.NewAccessRequest(rr.id, rr.name, "some-role")
+		require.NoError(t, err)
+
+		if rr.expired {
+			r.SetExpiry(time.Now().Add(-time.Minute * 30).UTC())
+		} else {
+			unexpiredRequestIDs = append(unexpiredRequestIDs, rr.id)
+			r.SetExpiry(time.Now().Add(time.Minute * 30).UTC())
+		}
+		_, err = svcs.CreateAccessRequestV2(ctx, r)
+		require.NoError(t, err)
+	}
+
+	// verify that once cache replication completes, only the unexpired requests are served
+	timeout := time.After(time.Second * 30)
+	for {
+		rsp, err := cache.ListAccessRequests(ctx, &proto.ListAccessRequestsRequest{
+			Limit: int32(len(rrs)),
+		})
+		require.NoError(t, err)
+
+		if len(rsp.AccessRequests) >= len(unexpiredRequestIDs) {
+			// once cache is returning the expected number of requests, verify that
+			// the set of requests returned is exactly the unexpired subset.
+			var returnedRequestIDs []string
+			for _, req := range rsp.AccessRequests {
+				returnedRequestIDs = append(returnedRequestIDs, req.GetName())
+			}
+
+			require.ElementsMatch(t, unexpiredRequestIDs, returnedRequestIDs)
+			break
+		}
+
+		select {
+		case <-timeout:
+			require.FailNow(t, "timeout waiting for access request cache to populate")
+		case <-time.After(time.Millisecond * 200):
+		}
+	}
+}

--- a/lib/utils/log/slog_handler.go
+++ b/lib/utils/log/slog_handler.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"reflect"
 	"runtime"
 	"slices"
 	"strconv"
@@ -622,4 +623,22 @@ func StringerAttr(s fmt.Stringer) slog.LogValuer {
 
 func (s stringerAttr) LogValue() slog.Value {
 	return slog.StringValue(s.Stringer.String())
+}
+
+type typeAttr struct {
+	val any
+}
+
+// TypeAttr creates a lazily evaluated log value that presents the pretty type name of a value
+// as a string. It is roughly equivalent to the '%T' format option, and should only perform
+// reflection in the event that logs are actually being generated.
+func TypeAttr(val any) slog.LogValuer {
+	return typeAttr{val}
+}
+
+func (a typeAttr) LogValue() slog.Value {
+	if t := reflect.TypeOf(a.val); t != nil {
+		return slog.StringValue(t.String())
+	}
+	return slog.StringValue("nil")
 }


### PR DESCRIPTION
This PR modifies the access request cache to omit expired access requests from reads.  Historically, access requests were always read directly from the backend, and our backends filter out expired items from their reads.  Now that access requests are cached, we rely on the backends _actually expiring_ the access request items (and emitting the associated `OpDelete` event) to remove them from the cache.  This can create confusing UX as many of our backends a fairly lazy about actively expiring items.

In general, we've avoided actively filtering out expired values by default in most teleport logic.  It tends to lead to brittleness/confusion.  One notable exception is node resources, which we do actively expire from the cache, but only if they are significantly past their expiry point *and* new node heartbeats are observed arriving.  Long term I'd like to come up with a more general-purpose expiry strategy for resource caches, though it's unclear to me whether there is a "one size fits all" strategy.  Access requests are fairly safe to aggressively omit, but resources that regularly experience keepalives might "flicker" if cache evictions race with backend keepalives, which wouldn't be sound.

changelog: fixes an issue where access requests would linger in UI and tctl after expiry