### PR TITLE
[v15] Allow `ssh_config` generation to be disabled for Machine ID Identity Output

### DIFF
--- a/lib/tbot/config/output_identity.go
+++ b/lib/tbot/config/output_identity.go
@@ -154,7 +154,7 @@ func (o *IdentityOutput) CheckAndSetDefaults() error {
 
 	switch o.SSHConfigMode {
 	case SSHConfigModeNone:
-		log.DebugContext(context.TODO(), "Defaulting to SSHConfigModeOn")
+		log.DebugContext(context.Background(), "Defaulting to SSHConfigModeOn")
 		o.SSHConfigMode = SSHConfigModeOn
 	case SSHConfigModeOff, SSHConfigModeOn:
 	default:

--- a/lib/tbot/config/output_identity_test.go
+++ b/lib/tbot/config/output_identity_test.go
@@ -28,9 +28,10 @@ func TestIdentityOutput_YAML(t *testing.T) {
 		{
 			name: "full",
 			in: IdentityOutput{
-				Destination: dest,
-				Roles:       []string{"access"},
-				Cluster:     "leaf.example.com",
+				Destination:   dest,
+				Roles:         []string{"access"},
+				Cluster:       "leaf.example.com",
+				SSHConfigMode: SSHConfigModeOff,
 			},
 		},
 		{
@@ -49,9 +50,22 @@ func TestIdentityOutput_CheckAndSetDefaults(t *testing.T) {
 			name: "valid",
 			in: func() *IdentityOutput {
 				return &IdentityOutput{
-					Destination: memoryDestForTest(),
-					Roles:       []string{"access"},
+					Destination:   memoryDestForTest(),
+					Roles:         []string{"access"},
+					SSHConfigMode: SSHConfigModeOn,
 				}
+			},
+		},
+		{
+			name: "ssh config mode defaults",
+			in: func() *IdentityOutput {
+				return &IdentityOutput{
+					Destination: memoryDestForTest(),
+				}
+			},
+			want: &IdentityOutput{
+				Destination:   memoryDestForTest(),
+				SSHConfigMode: SSHConfigModeOn,
 			},
 		},
 		{
@@ -62,6 +76,16 @@ func TestIdentityOutput_CheckAndSetDefaults(t *testing.T) {
 				}
 			},
 			wantErr: "no destination configured for output",
+		},
+		{
+			name: "invalid ssh config mode",
+			in: func() *IdentityOutput {
+				return &IdentityOutput{
+					Destination:   memoryDestForTest(),
+					SSHConfigMode: "invalid",
+				}
+			},
+			wantErr: "ssh_config: unrecognized value \"invalid\"",
 		},
 	}
 	testCheckAndSetDefaults(t, tests)

--- a/lib/tbot/config/testdata/TestIdentityOutput_YAML/full.golden
+++ b/lib/tbot/config/testdata/TestIdentityOutput_YAML/full.golden
@@ -4,3 +4,4 @@ destination:
 roles:
   - access
 cluster: leaf.example.com
+ssh_config: "off"


### PR DESCRIPTION
Backport #40776 to branch/v15

changelog: Add the ability to control `ssh_config` generation in Machine ID's Identity Outputs. This allows the generation of the `ssh_config` to be disabled if unnecessary, improving performance and removing the dependency on the Proxy being online.
