### PR TITLE
[v14] Allow `ssh_config` generation to be disabled for Machine ID Identity Output

### DIFF
--- a/lib/tbot/config/output_identity.go
+++ b/lib/tbot/config/output_identity.go
@@ -31,6 +31,25 @@ import (
 
 const IdentityOutputType = "identity"
 
+// SSHConfigMode controls whether to write an ssh_config file to the
+// destination directory.
+type SSHConfigMode string
+
+const (
+	// SSHConfigModeNone will default to SSHConfigModeOn.
+	SSHConfigModeNone SSHConfigMode = ""
+	// SSHConfigModeOff will not write an ssh_config file. This is useful where
+	// you do not want to use SSH functionality and would like to avoid
+	// pinging the proxy.
+	SSHConfigModeOff SSHConfigMode = "off"
+	// SSHConfigModeOn will write an ssh_config file to the destination
+	// directory.
+	// Causes the generation of:
+	// - ssh_config
+	// - known_hosts
+	SSHConfigModeOn SSHConfigMode = "on"
+)
+
 // IdentityOutput produces credentials which can be used with `tsh`, `tctl`,
 // `openssh` and most SSH compatible tooling. It can also be used with the
 // Teleport API and things which use the API client (e.g the terraform provider)
@@ -52,19 +71,26 @@ type IdentityOutput struct {
 	// For now, only SSH is supported.
 	Cluster string `yaml:"cluster,omitempty"`
 
+	// SSHConfigMode controls whether to write an ssh_config file to the
+	// destination directory. Defaults to SSHConfigModeOn.
+	SSHConfigMode SSHConfigMode `yaml:"ssh_config,omitempty"`
+
 	destPath string
 }
 
 func (o *IdentityOutput) templates() []template {
-	return []template{
+	templates := []template{
 		&templateTLSCAs{},
-		&templateSSHClient{
+		&templateIdentity{},
+	}
+	if o.SSHConfigMode == SSHConfigModeOn {
+		templates = append(templates, &templateSSHClient{
 			getSSHVersion:        openssh.GetSystemSSHVersion,
 			executablePathGetter: os.Executable,
 			destPath:             o.destPath,
-		},
-		&templateIdentity{},
+		})
 	}
+	return templates
 }
 
 func (o *IdentityOutput) Render(ctx context.Context, p provider, ident *identity.Identity) error {
@@ -119,6 +145,15 @@ func (o *IdentityOutput) CheckAndSetDefaults() error {
 		// their own config, we can't predict where paths will be in practice.)
 		log.Infof("Note: no ssh_config will be written for non-filesystem "+
 			"destination %q.", o.Destination)
+	}
+
+	switch o.SSHConfigMode {
+	case SSHConfigModeNone:
+		log.DebugContext(context.TODO(), "Defaulting to SSHConfigModeOn")
+		o.SSHConfigMode = SSHConfigModeOn
+	case SSHConfigModeOff, SSHConfigModeOn:
+	default:
+		return trace.BadParameter("ssh_config: unrecognized value %q", o.SSHConfigMode)
 	}
 
 	return nil

--- a/lib/tbot/config/output_identity.go
+++ b/lib/tbot/config/output_identity.go
@@ -149,7 +149,7 @@ func (o *IdentityOutput) CheckAndSetDefaults() error {
 
 	switch o.SSHConfigMode {
 	case SSHConfigModeNone:
-		log.DebugContext(context.Background(), "Defaulting to SSHConfigModeOn")
+		log.Debug("Defaulting to SSHConfigModeOn")
 		o.SSHConfigMode = SSHConfigModeOn
 	case SSHConfigModeOff, SSHConfigModeOn:
 	default:

--- a/lib/tbot/config/output_identity.go
+++ b/lib/tbot/config/output_identity.go
@@ -149,7 +149,7 @@ func (o *IdentityOutput) CheckAndSetDefaults() error {
 
 	switch o.SSHConfigMode {
 	case SSHConfigModeNone:
-		log.DebugContext(context.TODO(), "Defaulting to SSHConfigModeOn")
+		log.DebugContext(context.Background(), "Defaulting to SSHConfigModeOn")
 		o.SSHConfigMode = SSHConfigModeOn
 	case SSHConfigModeOff, SSHConfigModeOn:
 	default:

--- a/lib/tbot/config/output_identity_test.go
+++ b/lib/tbot/config/output_identity_test.go
@@ -26,9 +26,10 @@ func TestIdentityOutput_YAML(t *testing.T) {
 		{
 			name: "full",
 			in: IdentityOutput{
-				Destination: dest,
-				Roles:       []string{"access"},
-				Cluster:     "leaf.example.com",
+				Destination:   dest,
+				Roles:         []string{"access"},
+				Cluster:       "leaf.example.com",
+				SSHConfigMode: SSHConfigModeOff,
 			},
 		},
 		{
@@ -47,9 +48,22 @@ func TestIdentityOutput_CheckAndSetDefaults(t *testing.T) {
 			name: "valid",
 			in: func() *IdentityOutput {
 				return &IdentityOutput{
-					Destination: memoryDestForTest(),
-					Roles:       []string{"access"},
+					Destination:   memoryDestForTest(),
+					Roles:         []string{"access"},
+					SSHConfigMode: SSHConfigModeOn,
 				}
+			},
+		},
+		{
+			name: "ssh config mode defaults",
+			in: func() *IdentityOutput {
+				return &IdentityOutput{
+					Destination: memoryDestForTest(),
+				}
+			},
+			want: &IdentityOutput{
+				Destination:   memoryDestForTest(),
+				SSHConfigMode: SSHConfigModeOn,
 			},
 		},
 		{
@@ -60,6 +74,16 @@ func TestIdentityOutput_CheckAndSetDefaults(t *testing.T) {
 				}
 			},
 			wantErr: "no destination configured for output",
+		},
+		{
+			name: "invalid ssh config mode",
+			in: func() *IdentityOutput {
+				return &IdentityOutput{
+					Destination:   memoryDestForTest(),
+					SSHConfigMode: "invalid",
+				}
+			},
+			wantErr: "ssh_config: unrecognized value \"invalid\"",
 		},
 	}
 	testCheckAndSetDefaults(t, tests)

--- a/lib/tbot/config/testdata/TestIdentityOutput_YAML/full.golden
+++ b/lib/tbot/config/testdata/TestIdentityOutput_YAML/full.golden
@@ -4,3 +4,4 @@ destination:
 roles:
   - access
 cluster: leaf.example.com
+ssh_config: "off"


### PR DESCRIPTION
Backport #40776 to branch/v14

changelog: Add the ability to control `ssh_config` generation in Machine ID's Identity Outputs. This allows the generation of the `ssh_config` to be disabled if unnecessary, improving performance and removing the dependency on the Proxy being online.
