### PR TITLE
docs: Use db-client instead of db_client for tctl auth export

### DIFF
--- a/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
@@ -122,7 +122,7 @@ Next, for each CockroachDB node, export Teleport's `db_client` CA using `tctl`
 `ca-client.crt`:
 
 ```code
-$ tctl auth export --type=db_client >> <Var name="/path/to/cockroachdb/certs/dir" />/ca-client.crt
+$ tctl auth export --type=db-client >> <Var name="/path/to/cockroachdb/certs/dir" />/ca-client.crt
 ```
 
 (!docs/pages/includes/database-access/custom-db-ca.mdx db="CockroachDB" protocol="cockroachdb" port="26257"!)

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -144,7 +144,7 @@ accordingly to grant the user appropriate database permissions.
   additional trusted CA by concatenating it with your CA's certificate:
   
   ```code
-  $ tctl auth export --type=db_client > db-client-ca.crt
+  $ tctl auth export --type=db-client > db-client-ca.crt
   $ cat <Var name="/path/to/your/ca.crt" /> db-client-ca.crt > /etc/certs/mongo.cas
   ```
 

--- a/docs/pages/database-access/guides/redis-cluster.mdx
+++ b/docs/pages/database-access/guides/redis-cluster.mdx
@@ -80,7 +80,7 @@ Install and configure Teleport where you will run the Teleport Database Service:
 Export your Teleport cluster's `db_client` CA cert and concatenate it with your Redis 
 Cluster's CA cert (in PEM format):
 ```code
-$ tctl auth export --type=db_client > db-client-ca.crt
+$ tctl auth export --type=db-client > db-client-ca.crt
 $ cat <Var name="/path/to/your/ca.crt" /> db-client-ca.crt > pem-bundle.cas
 ```
 


### PR DESCRIPTION
In a couple of places, the docs tell you to use `tctl auth export --type=db_client`, but this results in an error:

```
$ tctl auth export --type=db_client
usage: tctl auth export [<flags>]

Export public cluster CA certificates to stdout.

Flags:
  -d, --[no-]debug     Enable verbose logging to stderr
  -c, --config         Path to a configuration file [/etc/teleport.yaml]. Can also be
                       set via the TELEPORT_CONFIG_FILE environment variable.
      --auth-server    Attempts to connect to specific auth/proxy address(es) instead of
                       local auth [127.0.0.1:3025]
  -i, --identity       Path to an identity file. Must be provided to make remote
                       connections to auth. An identity file can be exported with 'tctl
                       auth sign'
      --[no-]insecure  When specifying a proxy address in --auth-server, do not verify
                       its TLS certificate. Danger: any data you send can be intercepted
                       or modified by an attacker.
      --[no-]keys      if set, will print private keys
      --fingerprint    filter authority by fingerprint
      --compat         export certificates compatible with specific version of Teleport
      --type           export certificate type (user, host, tls-host, tls-user,
                       tls-user-der, windows, db, db-der, db-client, db-client-der,
                       openssh, saml-idp)

Aliases:

ERROR: enum value must be one of user,host,tls-host,tls-user,tls-user-der,windows,db,db-der,db-client,db-client-der,openssh,saml-idp, got 'db_client'
```

This PR changes the docs to use `db-client` instead. Other invocations such as `tctl auth rotate` and `tctl auth crl` expect `db_client`, so they weren't changed.