### PR TITLE
Extend target resolution for ssh connections to use predicates and fuzzy search

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1319,14 +1319,14 @@ func (tc *TeleportClient) RootClusterName(ctx context.Context) (string, error) {
 	return name, nil
 }
 
-type targetNode struct {
-	hostname string
-	addr     string
+type TargetNode struct {
+	Hostname string
+	Addr     string
 }
 
-// getTargetNodes returns a list of node addresses this SSH command needs to
+// GetTargetNodes returns a list of node addresses this SSH command needs to
 // operate on.
-func (tc *TeleportClient) getTargetNodes(ctx context.Context, clt client.GetResourcesClient, options SSHOptions) ([]targetNode, error) {
+func (tc *TeleportClient) GetTargetNodes(ctx context.Context, clt client.GetResourcesClient, options SSHOptions) ([]TargetNode, error) {
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/getTargetNodes",
@@ -1335,16 +1335,16 @@ func (tc *TeleportClient) getTargetNodes(ctx context.Context, clt client.GetReso
 	defer span.End()
 
 	if options.HostAddress != "" {
-		return []targetNode{
+		return []TargetNode{
 			{
-				hostname: options.HostAddress,
-				addr:     options.HostAddress,
+				Hostname: options.HostAddress,
+				Addr:     options.HostAddress,
 			},
 		}, nil
 	}
 
 	// use the target node that was explicitly provided if valid
-	if len(tc.Labels) == 0 {
+	if len(tc.Labels) == 0 && tc.PredicateExpression == "" && len(tc.SearchKeywords) == 0 {
 		// detect the common error when users use host:port address format
 		_, port, err := net.SplitHostPort(tc.Host)
 		// client has used host:port notation
@@ -1353,10 +1353,10 @@ func (tc *TeleportClient) getTargetNodes(ctx context.Context, clt client.GetReso
 		}
 
 		addr := net.JoinHostPort(tc.Host, strconv.Itoa(tc.HostPort))
-		return []targetNode{
+		return []TargetNode{
 			{
-				hostname: tc.Host,
-				addr:     addr,
+				Hostname: tc.Host,
+				Addr:     addr,
 			},
 		}, nil
 	}
@@ -1367,12 +1367,12 @@ func (tc *TeleportClient) getTargetNodes(ctx context.Context, clt client.GetReso
 		return nil, trace.Wrap(err)
 	}
 
-	retval := make([]targetNode, 0, len(nodes))
+	retval := make([]TargetNode, 0, len(nodes))
 	for _, resource := range nodes {
 		// always dial nodes by UUID
-		retval = append(retval, targetNode{
-			hostname: resource.GetHostname(),
-			addr:     fmt.Sprintf("%s:0", resource.GetName()),
+		retval = append(retval, TargetNode{
+			Hostname: resource.GetHostname(),
+			Addr:     fmt.Sprintf("%s:0", resource.GetName()),
 		})
 	}
 
@@ -1628,7 +1628,7 @@ func (tc *TeleportClient) SSH(ctx context.Context, command []string, runLocally 
 	defer clt.Close()
 
 	// which nodes are we executing this commands on?
-	nodeAddrs, err := tc.getTargetNodes(ctx, clt.AuthClient, options)
+	nodeAddrs, err := tc.GetTargetNodes(ctx, clt.AuthClient, options)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1639,7 +1639,7 @@ func (tc *TeleportClient) SSH(ctx context.Context, command []string, runLocally 
 	if len(nodeAddrs) > 1 {
 		return tc.runShellOrCommandOnMultipleNodes(ctx, clt, nodeAddrs, command)
 	}
-	return tc.runShellOrCommandOnSingleNode(ctx, clt, nodeAddrs[0].addr, command, runLocally)
+	return tc.runShellOrCommandOnSingleNode(ctx, clt, nodeAddrs[0].Addr, command, runLocally)
 }
 
 // ConnectToNode attempts to establish a connection to the node resolved to by the provided
@@ -1648,7 +1648,7 @@ func (tc *TeleportClient) SSH(ctx context.Context, command []string, runLocally 
 // fail the error from the connection attempt with the already provisioned certificates will
 // be returned. The client from whichever attempt succeeds first will be returned.
 func (tc *TeleportClient) ConnectToNode(ctx context.Context, clt *ClusterClient, nodeDetails NodeDetails, user string) (_ *NodeClient, err error) {
-	node := nodeName(targetNode{addr: nodeDetails.Addr})
+	node := nodeName(TargetNode{Addr: nodeDetails.Addr})
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/ConnectToNode",
@@ -1802,7 +1802,7 @@ func (m MFARequiredUnknownErr) Is(err error) bool {
 // if it is required, then the mfa ceremony is attempted. The target host is dialed once the ceremony
 // completes and new certificates are retrieved.
 func (tc *TeleportClient) connectToNodeWithMFA(ctx context.Context, clt *ClusterClient, nodeDetails NodeDetails, user string) (*NodeClient, error) {
-	node := nodeName(targetNode{addr: nodeDetails.Addr})
+	node := nodeName(TargetNode{Addr: nodeDetails.Addr})
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/connectToNodeWithMFA",
@@ -1911,11 +1911,11 @@ func (tc *TeleportClient) runShellOrCommandOnSingleNode(ctx context.Context, clt
 	return trace.Wrap(nodeClient.RunInteractiveShell(ctx, types.SessionPeerMode, nil, nil))
 }
 
-func (tc *TeleportClient) runShellOrCommandOnMultipleNodes(ctx context.Context, clt *ClusterClient, nodes []targetNode, command []string) error {
+func (tc *TeleportClient) runShellOrCommandOnMultipleNodes(ctx context.Context, clt *ClusterClient, nodes []TargetNode, command []string) error {
 	cluster := clt.ClusterName()
 	nodeAddrs := make([]string, 0, len(nodes))
 	for _, node := range nodes {
-		nodeAddrs = append(nodeAddrs, node.addr)
+		nodeAddrs = append(nodeAddrs, node.Addr)
 	}
 	ctx, span := tc.Tracer.Start(
 		ctx,
@@ -2633,7 +2633,7 @@ type execResult struct {
 }
 
 // runCommandOnNodes executes a given bash command on a bunch of remote nodes.
-func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterClient, nodes []targetNode, command []string) error {
+func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterClient, nodes []TargetNode, command []string) error {
 	cluster := clt.ClusterName()
 	ctx, span := tc.Tracer.Start(
 		ctx,
@@ -2651,7 +2651,7 @@ func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterCli
 	mfaRequiredCheck, err := clt.AuthClient.IsMFARequired(ctx, &proto.IsMFARequiredRequest{
 		Target: &proto.IsMFARequiredRequest_Node{
 			Node: &proto.NodeLogin{
-				Node:  nodeName(targetNode{addr: nodes[0].addr}),
+				Node:  nodeName(TargetNode{Addr: nodes[0].Addr}),
 				Login: tc.Config.HostLogin,
 			},
 		},
@@ -2677,7 +2677,7 @@ func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterCli
 				gctx,
 				"teleportClient/executingCommand",
 				oteltrace.WithSpanKind(oteltrace.SpanKindClient),
-				oteltrace.WithAttributes(attribute.String("node", node.addr)),
+				oteltrace.WithAttributes(attribute.String("node", node.Addr)),
 			)
 			defer span.End()
 
@@ -2685,11 +2685,11 @@ func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterCli
 				ctx,
 				clt,
 				NodeDetails{
-					Addr:      node.addr,
+					Addr:      node.Addr,
 					Namespace: tc.Namespace,
 					Cluster:   cluster,
 					MFACheck:  mfaRequiredCheck,
-					hostname:  node.hostname,
+					hostname:  node.Hostname,
 				},
 				tc.Config.HostLogin,
 			)

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -238,13 +238,13 @@ func (a sharedAuthClient) Close() error {
 }
 
 // nodeName removes the port number from the hostname, if present
-func nodeName(node targetNode) string {
-	if node.hostname != "" {
-		return node.hostname
+func nodeName(node TargetNode) string {
+	if node.Hostname != "" {
+		return node.Hostname
 	}
-	n, _, err := net.SplitHostPort(node.addr)
+	n, _, err := net.SplitHostPort(node.Addr)
 	if err != nil {
-		return node.addr
+		return node.Addr
 	}
 	return n
 }
@@ -268,7 +268,7 @@ type NodeDetails struct {
 
 // String returns a user-friendly name
 func (n NodeDetails) String() string {
-	parts := []string{nodeName(targetNode{addr: n.Addr})}
+	parts := []string{nodeName(TargetNode{Addr: n.Addr})}
 	if n.Cluster != "" {
 		parts = append(parts, "on cluster", n.Cluster)
 	}

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -40,9 +40,9 @@ import (
 )
 
 func TestHelperFunctions(t *testing.T) {
-	assert.Equal(t, "one", nodeName(targetNode{addr: "one"}))
-	assert.Equal(t, "one", nodeName(targetNode{addr: "one:22"}))
-	assert.Equal(t, "example.com", nodeName(targetNode{addr: "one", hostname: "example.com"}))
+	assert.Equal(t, "one", nodeName(TargetNode{Addr: "one"}))
+	assert.Equal(t, "one", nodeName(TargetNode{Addr: "one:22"}))
+	assert.Equal(t, "example.com", nodeName(TargetNode{Addr: "one", Hostname: "example.com"}))
 }
 
 func TestNewSession(t *testing.T) {

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -301,7 +301,7 @@ func (c *ClusterClient) SessionSSHConfig(ctx context.Context, user string, targe
 	key, err = c.performMFACeremony(ctx,
 		mfaClt,
 		ReissueParams{
-			NodeName:       nodeName(targetNode{addr: target.Addr}),
+			NodeName:       nodeName(TargetNode{Addr: target.Addr}),
 			RouteToCluster: target.Cluster,
 			MFACheck:       target.MFACheck,
 		},

--- a/tool/tsh/common/tshconfig_test.go
+++ b/tool/tsh/common/tshconfig_test.go
@@ -279,6 +279,14 @@ func TestProxyTemplatesApply(t *testing.T) {
 				Template: `^(.+)\.(au.example.com):(.+)$`,
 				Host:     "$1:4022",
 			},
+			{
+				Template: `^(.+)\(search.com:(.+)$`,
+				Search: "$1"
+			},
+			{
+				Template: `^(.+)\query.com:(.+)$`,
+				Query: `labels.env == "$1"`
+			}
 		},
 	}
 	require.NoError(t, tshConfig.Check())
@@ -289,6 +297,8 @@ func TestProxyTemplatesApply(t *testing.T) {
 		outProxy       string
 		outHost        string
 		outCluster     string
+		outSearch      string
+		outPredicate   string
 		outMatch       bool
 	}{
 		{
@@ -325,11 +335,13 @@ func TestProxyTemplatesApply(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
-			proxy, host, cluster, match := tshConfig.ProxyTemplates.Apply(test.inFullHostname)
+			proxy, host, cluster, search, query, match := tshConfig.ProxyTemplates.Apply(test.inFullHostname)
 			require.Equal(t, test.outProxy, proxy)
 			require.Equal(t, test.outHost, host)
 			require.Equal(t, test.outCluster, cluster)
 			require.Equal(t, test.outMatch, match)
+			require.Equal(t, test.outSearch, search)
+			require.Equal(t, test.outPredicate, query)
 		})
 	}
 }


### PR DESCRIPTION
tsh had the ability to connect to a host by name, ip, or by matching on a set of provided labels. However, if the target needed to be identified by some other data associated with the types.Server it required a two step process involving tsh ls:

`tsh ssh foo@$(tsh ls --search=<needle> --format json | jq -r \'.[0].metadata.name\')`

Not only is this a lot to type and remember, but it also requires that jq be present to work. To make this simpler on end users, tsh now supports --search and --query directly. The above can be invoked directly via:

`tsh ssh --search=<needle>` or `tsh ssh --query='labels.foo == "bar"`

In addition to updating tsh ssh, this also adds the same changes to tsh proxy ssh. The only difference between the two is the behavior for when there are multiple matches. If tsh ssh --search/--query has multiple matches the behavior is the same as today when `tsh ssh user@foo=bar` has multiple matches. tsh proxy ssh however is limited to a single match, if more than one server are found then and error is returned and the process is aborted.

To unlock the full power of tsh proxy ssh --query/--search, the tsh proxy_templates have also been extended to include a corresponding Search and Query field. The order of precedence for resolving hosts in proxy_templates is Host, Search, Query.