### PR TITLE
fix kube ephemeral container test flakiness

### DIFF
--- a/fixtures/ci-teleport-rbac/ci-teleport.yaml
+++ b/fixtures/ci-teleport-rbac/ci-teleport.yaml
@@ -48,6 +48,14 @@ rules:
   resources: ["pods/portforward"]
   verbs: ["create"]
   resourceNames: ["test-pod"]
+- apiGroups: [""]
+  resources: ["pods/ephemeralcontainers"]
+  verbs: ["patch"]
+  resourceNames: ["test-pod"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+  resourceNames: ["test-pod"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -1352,7 +1352,7 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 	})
 
 	username := suite.me.Username
-	kubeUsers := []string{"alice@example.com"}
+	kubeUsers := []string{username}
 	kubeGroups := []string{kube.TestImpersonationGroup}
 	kubeAccessRole, err := types.NewRole("kubemaster", types.RoleSpecV6{
 		Allow: types.RoleConditions{
@@ -1364,7 +1364,10 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 			},
 			KubernetesResources: []types.KubernetesResource{
 				{
-					Kind: types.KindKubePod, Name: types.Wildcard, Namespace: types.Wildcard, Verbs: []string{types.Wildcard},
+					Kind:      types.KindKubePod,
+					Name:      types.Wildcard,
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
 				},
 			},
 		},
@@ -1416,6 +1419,7 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 	proxyClient, kubeConfig, err := kube.ProxyClient(kube.ProxyConfig{
 		T:          teleport,
 		Username:   username,
+		KubeUsers:  kubeUsers,
 		KubeGroups: kubeGroups,
 	})
 	require.NoError(t, err)
@@ -1429,11 +1433,13 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 	podJS, err := json.Marshal(pod)
 	require.NoError(t, err)
 
+	// create an ephemeral container and attach to it just like kubectl would
+	contName := "ephemeral-container"
+	sessCreatorTerm := NewTerminal(250)
 	group := &errgroup.Group{}
 	group.Go(func() error {
-		name := "debug-1"
-		cmd := []string{"/bin/sh", "echo", "hello from a debug container"}
-		debugPod, _, err := generateDebugContainer(name, cmd, pod)
+		cmd := []string{"/bin/sh", "echo", "hello from an ephemeral container"}
+		debugPod, _, err := generateDebugContainer(contName, cmd, pod)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1451,7 +1457,7 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		_, err = waitForContainer(ctx, podsClient, pod.Name, name)
+		_, err = waitForContainer(ctx, podsClient, pod.Name, contName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1459,8 +1465,11 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 		err = kubeExec(kubeConfig, attachToContainer, kubeExecArgs{
 			podName:      pod.Name,
 			podNamespace: testNamespace,
-			container:    name,
+			container:    contName,
 			command:      cmd,
+			stdout:       sessCreatorTerm,
+			stderr:       sessCreatorTerm,
+			stdin:        sessCreatorTerm,
 			tty:          true,
 		})
 		if err != nil {
@@ -1484,11 +1493,30 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 		session = sessions[0]
 	}, 10*time.Second, 100*time.Millisecond)
 
+	// join the created session as a moderator
 	group.Go(func() error {
+		// verify that the ephemeral container hasn't actually been created yet
+		proxyClient, _, err := kube.ProxyClient(kube.ProxyConfig{
+			T:          teleport,
+			Username:   moderatorUser,
+			KubeUsers:  kubeUsers,
+			KubeGroups: kubeGroups,
+		})
+		require.NoError(t, err)
+
+		podsClient := proxyClient.CoreV1().Pods(testNamespace)
+		pod, err := podsClient.Get(ctx, testPod, metav1.GetOptions{})
+		require.NoError(t, err)
+		for _, status := range pod.Status.EphemeralContainerStatuses {
+			if !assert.NotEqual(t, status.Name, contName) {
+				return trace.AlreadyExists("ephemeral container already started")
+			}
+		}
+
 		tc, err := teleport.NewClient(helpers.ClientConfig{
-			Login:   moderatorUser,
-			Cluster: helpers.Site,
-			Host:    Host,
+			TeleportUser: moderatorUser,
+			Cluster:      helpers.Site,
+			Host:         Host,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -1496,15 +1524,16 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 
 		stream, err := kubeJoin(kube.ProxyConfig{
 			T:          teleport,
-			Username:   username,
+			Username:   moderatorUser,
 			KubeUsers:  kubeUsers,
 			KubeGroups: kubeGroups,
-		}, tc, session, types.SessionPeerMode)
+		}, tc, session, types.SessionModeratorMode)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
-		return trace.Wrap(stream.Close())
+		stream.Wait()
+		return trace.Wrap(stream.Detach())
 	})
 
 	require.NoError(t, group.Wait())

--- a/lib/kube/proxy/responsewriters/watcher.go
+++ b/lib/kube/proxy/responsewriters/watcher.go
@@ -276,7 +276,6 @@ func (w *WatcherResponseWriter) watchDecoder(contentType string, writer io.Write
 				}
 			case <-w.closeChan:
 				return nil
-
 			}
 		}
 	})


### PR DESCRIPTION
The Kubernetes backend expects clients to always have Stdout, Stderr, and Stdin set when executing in/attaching to a container, and not setting these would sometimes panic and cause the test to hang. While fixing this I added another check to test that an ephemeral container is only created once moderated session requirements have been met.

Fixes https://github.com/gravitational/teleport/issues/40850.