### PR TITLE
Add flux deployment workaround

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -445,6 +445,7 @@
     "fklvk",
     "flexi",
     "fluentd",
+    "fluxcd",
     "ftmg",
     "fullchain",
     "gacc",

--- a/docs/pages/upgrading/cloud-kubernetes.mdx
+++ b/docs/pages/upgrading/cloud-kubernetes.mdx
@@ -124,23 +124,26 @@ To suspend automatic updates for an agent, annotate the agent deployment with
 `annotations.deployment` value in Helm, or by patching the deployment directly
 with `kubectl`.
 
-## ArgoCD deployments
+## GitOps
 
-Automatic updates is not currently compatible with ArgoCD deployments. The Helm chart
-owns the version of the `teleport-agent` resource, so when the `teleport-agent-updater`
-modifies the image version of the `teleport-agent` resource, ArgoCD reports the `teleport-agent`
-resource as `OutOfSync`.
+Automatic updates is incompatible with some GitOps tools used for continuous deployment.
+The Teleport Helm chart owns the version of the `teleport-agent` resource, so when
+the `teleport-agent-updater` modifies the image version of the `teleport-agent` resource,
+the GitOps tool will detect a drift or a diff in the `teleport-agent` resource.
 
+### ArgoCD deployments
+
+After an automatic update, ArgoCD reports the `teleport-agent` resource as `OutOfSync`.
 As a workaround to this problem use a [Diff Customization](https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/#diffing-customization)
-to ignore the difference in image version. This can be done by ignoring differences
-of the `image` field. Here is an example deployment using the name `teleport-agent`
-and namespace `teleport`.
+to ignore the difference in image version. Here is an example deployment using the
+name `teleport-agent` and namespace `teleport`.
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: teleport-agent
+  namespace: teleport
 spec
   ignoreDifferences:
   - group: apps
@@ -149,6 +152,31 @@ spec
     namespace: teleport
     jqPathExpressions:
     - .spec.template.spec.containers[] | select(.name == "teleport").image
+...
+```
+
+### FluxCD deployments
+
+After an automatic update, FluxCD reports a `DriftDetected` event. As a workaround
+to this problem modify the [Drift detection](https://fluxcd.io/flux/components/helm/helmreleases/#drift-detection)
+configuration to ignore the difference in image version. Here is an example deployment
+using the name `teleport-agent` and namespace `teleport`.
+
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: teleport-agent
+  namespace: teleport
+spec
+  driftDetection:
+    mode: enabled
+    ignore:
+    - paths: ["/spec/template/spec/containers/0/image"]
+      target:
+        kind: StatefulSet
+        name: teleport-agent
+        namespace: teleport
 ...
 ```
 

--- a/docs/pages/upgrading/cloud-kubernetes.mdx
+++ b/docs/pages/upgrading/cloud-kubernetes.mdx
@@ -126,7 +126,7 @@ with `kubectl`.
 
 ## GitOps
 
-Automatic updates is incompatible with some GitOps tools used for continuous deployment.
+Automatic updates are incompatible with some GitOps tools used for continuous deployment.
 The Teleport Helm chart owns the version of the `teleport-agent` resource, so when
 the `teleport-agent-updater` modifies the image version of the `teleport-agent` resource,
 the GitOps tool will detect a drift or a diff in the `teleport-agent` resource.
@@ -158,7 +158,7 @@ spec
 ### FluxCD deployments
 
 After an automatic update, FluxCD reports a `DriftDetected` event. As a workaround
-to this problem modify the [Drift detection](https://fluxcd.io/flux/components/helm/helmreleases/#drift-detection)
+to this problem modify the [drift detection](https://fluxcd.io/flux/components/helm/helmreleases/#drift-detection)
 configuration to ignore the difference in image version. Here is an example deployment
 using the name `teleport-agent` and namespace `teleport`.
 

--- a/docs/pages/upgrading/cloud-kubernetes.mdx
+++ b/docs/pages/upgrading/cloud-kubernetes.mdx
@@ -127,9 +127,9 @@ with `kubectl`.
 ## GitOps
 
 Automatic updates are incompatible with some GitOps tools used for continuous deployment.
-The Teleport Helm chart owns the version of the `teleport-agent` resource, so when
-the `teleport-agent-updater` modifies the image version of the `teleport-agent` resource,
-the GitOps tool will detect a drift or a diff in the `teleport-agent` resource.
+The `teleport-kube-agent` Helm chart owns the version of the `teleport-agent` resource,
+so when the `teleport-agent-updater` modifies the image version of the `teleport-agent`
+resource, the GitOps tool will detect a drift or a diff in the `teleport-agent` resource.
 
 ### ArgoCD deployments
 


### PR DESCRIPTION
Similarly to https://github.com/gravitational/teleport/pull/40782, this PR documents a temporary workaround to deploy Teleport using FluxCD.