### PR TITLE
[v15] docs: update quotes in code block for gcp workforce identity

### DIFF
--- a/docs/pages/access-controls/idps/saml-gcp-workforce-identity-federation.mdx
+++ b/docs/pages/access-controls/idps/saml-gcp-workforce-identity-federation.mdx
@@ -115,7 +115,7 @@ pool user `test@example.com` with a permissions to browse GCP project resources.
 
 ```
 gcloud projects add-iam-policy-binding GCP_PROJECT_ID \
- --role=”roles/browser”  \
+ --role="roles/browser"  \
  --member="principal://iam.googleapis.com/locations/global/workforcePools/<pool id>/subject/test@example.com"
 ```
 
@@ -178,8 +178,8 @@ Next, an IAM policy must be created referencing GCP group.
 
 ```
 gcloud projects add-iam-policy-binding <GCP_Project_ID> \
- --role=”roles/browser”  \
- --member=”principalSet://iam.googleapis.com/locations/global/workforcePools/<pool id>/group/gcp-dev”
+ --role="roles/browser"  \
+ --member="principalSet://iam.googleapis.com/locations/global/workforcePools/<pool id>/group/gcp-dev"
 ```
 
 Since Teleport role was mapped as a GCP group with attribute mapping, the policy will grant


### PR DESCRIPTION
Backport #40879 to branch/v15