### PR TITLE
fix YAML messing session_recording type in chart

### DIFF
--- a/examples/chart/teleport-cluster/.lint/session-recording-off.yaml
+++ b/examples/chart/teleport-cluster/.lint/session-recording-off.yaml
@@ -1,0 +1,2 @@
+clusterName: helm-lint
+sessionRecording: "off"

--- a/examples/chart/teleport-cluster/templates/auth/_config.common.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.common.tpl
@@ -52,7 +52,7 @@ auth_service:
   {{- end }}
 {{- end }}
 {{- if .Values.sessionRecording }}
-  session_recording: {{ .Values.sessionRecording }}
+  session_recording: {{ .Values.sessionRecording | squote }}
 {{- end }}
 {{- if .Values.proxyListenerMode }}
   proxy_listener_mode: {{ .Values.proxyListenerMode }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -13,6 +13,39 @@ adds a proxy token by default:
         kubernetes:
           allow:
             - service_account: "NAMESPACE:RELEASE-NAME-proxy"
+keeps the second factor type even when it's "off":
+  1: |
+    |-
+      auth_service:
+        authentication:
+          local_auth: true
+          second_factor: "off"
+          type: local
+        cluster_name: helm-lint
+        enabled: true
+        proxy_listener_mode: separate
+      kubernetes_service:
+        enabled: true
+        kube_cluster_name: helm-lint
+        listen_addr: 0.0.0.0:3026
+        public_addr: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3026
+      proxy_service:
+        enabled: false
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: 127.0.0.1:3025
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
 keeps the session_recording type even when it's "off":
   1: |
     |-

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -13,6 +13,42 @@ adds a proxy token by default:
         kubernetes:
           allow:
             - service_account: "NAMESPACE:RELEASE-NAME-proxy"
+keeps the session_recording type even when it's "off":
+  1: |
+    |-
+      auth_service:
+        authentication:
+          local_auth: true
+          second_factor: "on"
+          type: local
+          webauthn:
+            rp_id: helm-lint
+        cluster_name: helm-lint
+        enabled: true
+        proxy_listener_mode: separate
+        session_recording: "off"
+      kubernetes_service:
+        enabled: true
+        kube_cluster_name: helm-lint
+        listen_addr: 0.0.0.0:3026
+        public_addr: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3026
+      proxy_service:
+        enabled: false
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: 127.0.0.1:3025
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
 matches snapshot for acme-off.yaml:
   1: |
     |-

--- a/examples/chart/teleport-cluster/tests/auth_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_config_test.yaml
@@ -648,3 +648,20 @@ tests:
       - equal:
           path: metadata.labels.baz
           value: overridden
+
+  - it: keeps the session_recording type even when it's "off"
+    set:
+      clusterName: helm-lint
+      sessionRecording: 'off'
+    asserts:
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: keeps the second factor type even when it's "off"
+    set:
+      clusterName: helm-lint
+      authentication:
+        secondFactor: 'off'
+    asserts:
+      - matchSnapshot:
+          path: data.teleport\.yaml


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/30131

Changelog: Fix a bug in the `teleport-cluster` Helm chart that happened when `sessionRecording` was `off`.