### PR TITLE
[vnet][0] setup virtual netstack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -203,6 +203,7 @@ require (
 	golang.org/x/term v0.19.0
 	golang.org/x/text v0.14.0
 	golang.org/x/time v0.5.0
+	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 	google.golang.org/api v0.176.1
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be
 	google.golang.org/grpc v1.63.2
@@ -214,6 +215,7 @@ require (
 	gopkg.in/mail.v2 v2.3.1
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
+	gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259
 	helm.sh/helm/v3 v3.14.4
 	k8s.io/api v0.30.0
 	k8s.io/apiextensions-apiserver v0.30.0
@@ -509,6 +511,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/tools v0.19.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
+	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20240325164216-beb30f47624b // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240325164216-beb30f47624b // indirect

--- a/go.sum
+++ b/go.sum
@@ -955,6 +955,7 @@ github.com/buildkite/go-pipeline v0.3.2/go.mod h1:iY5jzs3Afc8yHg6KDUcu3EJVkfaUkd
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
 github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -2843,6 +2844,10 @@ golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNq
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 h1:+cNy6SZtPcJQH3LJVLOSmiC7MMxXNOb3PU/VUEz+EhU=
 golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
+golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeunTOisW56dUokqW/FOteYJJ/yg=
+golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
+golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 h1:/jFs0duh4rdb8uIfPMv78iAJGcPKDeqAFnaLBropIC4=
+golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
 gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
 gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
@@ -3173,6 +3178,8 @@ gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.4.0 h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o=
 gotest.tools/v3 v3.4.0/go.mod h1:CtbdzLSsqVhDgMtKsx03ird5YTGB3ar27v0u/yKBW5g=
+gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 h1:TbRPT0HtzFP3Cno1zZo7yPzEEnfu8EjLfl6IU9VfqkQ=
+gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259/go.mod h1:AVgIgHMwK63XvmAzWG9vLQ41YnVHN0du0tEC46fI7yY=
 helm.sh/helm/v3 v3.14.4 h1:6FSpEfqyDalHq3kUr4gOMThhgY55kXUEjdQoyODYnrM=
 helm.sh/helm/v3 v3.14.4/go.mod h1:Tje7LL4gprZpuBNTbG34d1Xn5NmRT3OWfBRwpOSer9I=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/lib/utils/testhelpers.go
+++ b/lib/utils/testhelpers.go
@@ -1,0 +1,86 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+)
+
+// TestBackgroundTask is a task that should be run in the background for the remaining duration of a test and
+// reliably exit before the test completes.
+type TestBackgroundTask struct {
+	// Name is an identifier for the task that will be included in logs and error messages.
+	Name string
+
+	// Task is the function that will be called in a background goroutine to run the task.
+	//
+	// It must not terminate before the context is canceled, and it must reliably terminate after the context
+	// is canceled and Terminate is called.
+	//
+	// Any error other than [context.Canceled] will fail the test.
+	Task func(ctx context.Context) error
+
+	// Terminate is an optional function that will be called to terminate the task during test cleanup.
+	// It does not need to be set if the task will reliably terminate after context cancellation.
+	Terminate func() error
+}
+
+// RunTestBackgroundTask runs task.Task in the background for the remaining duration of the test.
+// During test cleanup it will cancel the context passed to the task, call task.Terminate if set, and wait for
+// the task to terminate before allowing the test to complete.
+func RunTestBackgroundTask(ctx context.Context, t *testing.T, task *TestBackgroundTask) {
+	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		err := task.Task(ctx)
+		if ctx.Err() == nil {
+			// The context hasn't been canceled yet, meaning the task has exited prematurely. This should
+			// fail the test even if the error is nil.
+			t.Errorf("Test background task %q exited prematurely with error: %s", task.Name, trace.DebugReport(err))
+			return
+		}
+		// The context has been canceled and the task has successfully exited, but any error other than
+		// context.Canceled should still fail the test.
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("Test background task %q exited with error: %+v", task.Name, trace.DebugReport(err))
+		}
+	}()
+
+	t.Cleanup(func() {
+		t.Logf("Cleanup: terminating test background task %q.", task.Name)
+		cancel()
+		if task.Terminate != nil {
+			if err := task.Terminate(); err != nil {
+				t.Errorf("Terminating test background task %q failed with error: %s", task.Name, trace.DebugReport(err))
+			}
+		}
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		select {
+		case <-ticker.C:
+			t.Logf("Waiting for test background task %q to terminate.", task.Name)
+		case <-done:
+		}
+	})
+}

--- a/lib/utils/testhelpers.go
+++ b/lib/utils/testhelpers.go
@@ -77,10 +77,13 @@ func RunTestBackgroundTask(ctx context.Context, t *testing.T, task *TestBackgrou
 		}
 		ticker := time.NewTicker(2 * time.Second)
 		defer ticker.Stop()
-		select {
-		case <-ticker.C:
-			t.Logf("Waiting for test background task %q to terminate.", task.Name)
-		case <-done:
+		for {
+			select {
+			case <-ticker.C:
+				t.Logf("Waiting for test background task %q to terminate.", task.Name)
+			case <-done:
+				return
+			}
 		}
 	})
 }

--- a/lib/vnet/vnet.go
+++ b/lib/vnet/vnet.go
@@ -338,7 +338,7 @@ func forwardBetweenTunAndNetstack(ctx context.Context, tun TUNDevice, linkEndpoi
 	slog.DebugContext(ctx, "Forwarding IP packets between OS and VNet.")
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error { return forwardNetstackToTUN(ctx, linkEndpoint, tun) })
-	g.Go(func() error { return forwardTUNtoNetstack(ctx, tun, linkEndpoint) })
+	g.Go(func() error { return forwardTUNtoNetstack(tun, linkEndpoint) })
 	g.Go(func() error {
 		<-ctx.Done()
 		linkEndpoint.Close()
@@ -369,7 +369,7 @@ func forwardNetstackToTUN(ctx context.Context, linkEndpoint *channel.Endpoint, t
 	}
 }
 
-func forwardTUNtoNetstack(ctx context.Context, tun TUNDevice, linkEndpoint *channel.Endpoint) error {
+func forwardTUNtoNetstack(tun TUNDevice, linkEndpoint *channel.Endpoint) error {
 	const readOffset = device.MessageTransportHeaderSize
 	bufs := make([][]byte, tun.BatchSize())
 	for i := range bufs {

--- a/lib/vnet/vnet.go
+++ b/lib/vnet/vnet.go
@@ -1,0 +1,441 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+	"golang.zx2c4.com/wireguard/device"
+	"gvisor.dev/gvisor/pkg/buffer"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
+	"gvisor.dev/gvisor/pkg/waiter"
+
+	"github.com/gravitational/teleport"
+)
+
+const (
+	nicID = 1
+	mtu   = 1500
+)
+
+// Config holds configuration parameters for the VNet.
+type Config struct {
+	// TUNDevice is the OS TUN virtual network interface.
+	TUNDevice TUNDevice
+	// IPv6Prefix is the IPv6 ULA prefix to use for all assigned VNet IP addresses.
+	IPv6Prefix tcpip.Address
+}
+
+// CheckAndSetDefaults checks the config and sets defaults.
+func (c *Config) CheckAndSetDefaults() error {
+	if c.TUNDevice == nil {
+		return trace.BadParameter("TUNdevice is required")
+	}
+	if c.IPv6Prefix.Len() != 16 || c.IPv6Prefix.AsSlice()[0] != 0xfd {
+		return trace.BadParameter("IPv6Prefix must be an IPv6 ULA address")
+	}
+	return nil
+}
+
+// IPv6Prefix returns a Unique Local IPv6 Unicast Address which will be used as a 64-bit prefix for all v6 IP
+// addresses in the VNet.
+func IPv6Prefix() (tcpip.Address, error) {
+	// |   8 bits   |  40 bits   |  16 bits  |          64 bits           |
+	// +------------+------------+-----------+----------------------------+
+	// | ULA Prefix | Global ID  | Subnet ID |        Interface ID        |
+	// +------------+------------+-----------+----------------------------+
+	// ULA Prefix is always 0xfd
+	// Global ID is random bytes for the specific VNet instance
+	// Subnet ID is always 0
+	// Interface ID will be the IPv4 address prefixed with zeros.
+	var bytes [16]byte
+	bytes[0] = 0xfd
+	if _, err := rand.Read(bytes[1:6]); err != nil {
+		return tcpip.Address{}, trace.Wrap(err)
+	}
+	return tcpip.AddrFrom16(bytes), nil
+}
+
+// TUNDevice abstracts a virtual network TUN device.
+type TUNDevice interface {
+	// Write one or more packets to the device (without any additional headers).
+	// On a successful write it returns the number of packets written. A nonzero
+	// offset can be used to instruct the Device on where to begin writing from
+	// each packet contained within the bufs slice.
+	Write(bufs [][]byte, offset int) (int, error)
+
+	// Read one or more packets from the Device (without any additional headers).
+	// On a successful read it returns the number of packets read, and sets
+	// packet lengths within the sizes slice. len(sizes) must be >= len(bufs).
+	// A nonzero offset can be used to instruct the Device on where to begin
+	// reading into each element of the bufs slice.
+	Read(bufs [][]byte, sizes []int, offset int) (n int, err error)
+
+	// BatchSize returns the preferred/max number of packets that can be read or
+	// written in a single read/write call. BatchSize must not change over the
+	// lifetime of a Device.
+	BatchSize() int
+
+	// Close stops the Device and closes the Event channel.
+	Close() error
+}
+
+// Manager holds configuration and state for the VNet.
+type Manager struct {
+	tun           TUNDevice
+	stack         *stack.Stack
+	linkEndpoint  *channel.Endpoint
+	ipv6Prefix    tcpip.Address
+	rootCtx       context.Context
+	rootCtxCancel context.CancelFunc
+	state         state
+	slog          *slog.Logger
+}
+
+type state struct {
+	mu               sync.RWMutex
+	tcpHandlers      map[tcpip.Address]tcpHandler
+	nextFreeIPSuffix uint32
+}
+
+func newState() state {
+	return state{
+		tcpHandlers:      make(map[tcpip.Address]tcpHandler),
+		nextFreeIPSuffix: 100<<24 + 64<<16 + 0<<8 + 2<<0,
+	}
+}
+
+// tcpConnector is a type of function that can be called to consume a TCP connection.
+type tcpConnector func() (io.ReadWriteCloser, error)
+type tcpHandler interface {
+	handleTCP(context.Context, tcpConnector) error
+}
+
+// NewManager creates a new VNet manager with the given configuration and root
+// context. Call Run() on the returned manager to start the VNet.
+func NewManager(ctx context.Context, cfg *Config) (*Manager, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	slog := slog.With(teleport.ComponentKey, "VNet")
+
+	stack, linkEndpoint, err := createStack()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := installVnetRoutes(stack, linkEndpoint); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	m := &Manager{
+		tun:           cfg.TUNDevice,
+		stack:         stack,
+		linkEndpoint:  linkEndpoint,
+		ipv6Prefix:    cfg.IPv6Prefix,
+		rootCtx:       ctx,
+		rootCtxCancel: cancel,
+		state:         newState(),
+		slog:          slog,
+	}
+
+	const (
+		tcpReceiveBufferSize          = 0 // 0 means a default will be used.
+		maxInFlightConnectionAttempts = 1024
+	)
+	tcpForwarder := tcp.NewForwarder(m.stack, tcpReceiveBufferSize, maxInFlightConnectionAttempts, m.handleTCP)
+	m.stack.SetTransportProtocolHandler(tcp.ProtocolNumber, tcpForwarder.HandlePacket)
+
+	return m, nil
+}
+
+func createStack() (*stack.Stack, *channel.Endpoint, error) {
+	netStack := stack.New(stack.Options{
+		NetworkProtocols:   []stack.NetworkProtocolFactory{ipv6.NewProtocol},
+		TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol},
+	})
+
+	const (
+		size     = 512
+		linkAddr = ""
+	)
+	linkEndpoint := channel.New(size, mtu, linkAddr)
+	if err := netStack.CreateNIC(nicID, linkEndpoint); err != nil {
+		return nil, nil, trace.Errorf("creating VNet NIC: %s", err)
+	}
+
+	return netStack, linkEndpoint, nil
+}
+
+func installVnetRoutes(netStack *stack.Stack, linkEndpoint *channel.Endpoint) error {
+	// Make the NIC accept all IP packets on the VNet, regardless of destination address.
+	if err := netStack.SetPromiscuousMode(nicID, true); err != nil {
+		return trace.Errorf("putting NIC in promiscuous mode: %s", err)
+	}
+	// Route everything to the one NIC.
+	ipv6Subnet, err := tcpip.NewSubnet(tcpip.AddrFrom16([16]byte{}), tcpip.MaskFromBytes(make([]byte, 16)))
+	if err != nil {
+		return trace.Wrap(err, "creating VNet IPv6 subnet")
+	}
+	netStack.SetRouteTable([]tcpip.Route{
+		{
+			Destination: ipv6Subnet,
+			NIC:         nicID,
+		},
+	})
+	return nil
+}
+
+// Run starts the VNet.
+func (m *Manager) Run() error {
+	defer m.rootCtxCancel()
+	go m.statsHandler()
+	m.slog.With("ipv6", m.ipv6Prefix).InfoContext(m.rootCtx, "Running Teleport VNet.")
+	return trace.Wrap(ignoreCancel(forwardBetweenTunAndNetstack(m.rootCtx, m.tun, m.linkEndpoint)))
+}
+
+// Destroy cancels the root context, destroys the networking stack, and closes the TUN device.
+func (m *Manager) Destroy() error {
+	m.rootCtxCancel()
+	err := m.tun.Close()
+	m.stack.Destroy()
+	return trace.Wrap(err)
+}
+
+func (m *Manager) handleTCP(req *tcp.ForwarderRequest) {
+	ctx, cancel := context.WithCancel(m.rootCtx)
+	defer cancel()
+
+	id := req.ID()
+	slog := m.slog.With("request", id)
+	slog.DebugContext(ctx, "Handling TCP connection.")
+	defer slog.DebugContext(ctx, "Finished handling TCP connection.")
+
+	handler, ok := m.getTCPHandler(id.LocalAddress)
+	if !ok {
+		slog.With("addr", id.LocalAddress).DebugContext(ctx, "No handler for address.")
+		req.Complete(true) // Send TCP reset.
+		return
+	}
+
+	var wq waiter.Queue
+	waitEntry, notifyCh := waiter.NewChannelEntry(waiter.EventHUp)
+	wq.EventRegister(&waitEntry)
+	defer wq.EventUnregister(&waitEntry)
+	go func() {
+		select {
+		case <-notifyCh:
+			slog.DebugContext(ctx, "Got HUP, canceling context.")
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	completed := false
+	connector := func() (io.ReadWriteCloser, error) {
+		endpoint, err := req.CreateEndpoint(&wq)
+		if err != nil {
+			// This err doesn't actually implement [error]
+			return nil, trace.Errorf("creating TCP endpoint: %s", err)
+		}
+		req.Complete(false) // Don't send TCP reset.
+		completed = true
+		endpoint.SocketOptions().SetKeepAlive(true)
+		conn := gonet.NewTCPConn(&wq, endpoint)
+		return conn, nil
+	}
+
+	if err := handler.handleTCP(ctx, connector); err != nil {
+		if errors.Is(err, context.Canceled) {
+			slog.DebugContext(ctx, "TCP connection handler returned early due to canceled context.")
+		} else {
+			slog.DebugContext(ctx, "Error handling TCP connection.", "err", err)
+		}
+	}
+	if !completed {
+		// Handler did not consume the connector.
+		req.Complete(true) // Send TCP reset.
+	}
+}
+
+func (m *Manager) getTCPHandler(addr tcpip.Address) (tcpHandler, bool) {
+	m.state.mu.RLock()
+	defer m.state.mu.RUnlock()
+	handler, ok := m.state.tcpHandlers[addr]
+	return handler, ok
+}
+
+func (m *Manager) assignTCPHandler(handler tcpHandler) (tcpip.Address, error) {
+	m.state.mu.Lock()
+	defer m.state.mu.Unlock()
+
+	ipSuffix := m.state.nextFreeIPSuffix
+	m.state.nextFreeIPSuffix++
+
+	addrBytes := m.ipv6Prefix.As16()
+	addrBytes[12] = byte(ipSuffix >> 24)
+	addrBytes[13] = byte(ipSuffix >> 16)
+	addrBytes[14] = byte(ipSuffix >> 8)
+	addrBytes[15] = byte(ipSuffix >> 0)
+	addr := tcpip.AddrFrom16(addrBytes)
+
+	m.state.tcpHandlers[addr] = handler
+	if err := m.addProtocolAddress(addr); err != nil {
+		return addr, trace.Wrap(err)
+	}
+
+	return addr, nil
+}
+
+func (m *Manager) statsHandler() {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGUSR1)
+	for {
+		select {
+		case <-m.rootCtx.Done():
+			return
+		case <-ch:
+		}
+		stats := m.stack.Stats()
+		fmt.Printf("%+v\n", stats)
+	}
+}
+
+func forwardBetweenTunAndNetstack(ctx context.Context, tun TUNDevice, linkEndpoint *channel.Endpoint) error {
+	slog.DebugContext(ctx, "Forwarding IP packets between OS and VNet.")
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error { return forwardNetstackToTUN(ctx, linkEndpoint, tun) })
+	g.Go(func() error { return forwardTUNtoNetstack(ctx, tun, linkEndpoint) })
+	g.Go(func() error {
+		<-ctx.Done()
+		linkEndpoint.Close()
+		tun.Close()
+		return ctx.Err()
+	})
+	return trace.Wrap(g.Wait())
+}
+
+func forwardNetstackToTUN(ctx context.Context, linkEndpoint *channel.Endpoint, tun TUNDevice) error {
+	bufs := [][]byte{make([]byte, device.MessageTransportHeaderSize+mtu)}
+	for {
+		packet := linkEndpoint.ReadContext(ctx)
+		if packet.IsNil() {
+			// Nil packet is returned when context is canceled.
+			return trace.Wrap(ctx.Err())
+		}
+		offset := device.MessageTransportHeaderSize
+		for _, s := range packet.AsSlices() {
+			offset += copy(bufs[0][offset:], s)
+		}
+		packet.DecRef()
+		bufs[0] = bufs[0][:offset]
+		if _, err := tun.Write(bufs, device.MessageTransportHeaderSize); err != nil {
+			return trace.Wrap(err, "writing packets to TUN")
+		}
+		bufs[0] = bufs[0][:cap(bufs[0])]
+	}
+}
+
+func forwardTUNtoNetstack(ctx context.Context, tun TUNDevice, linkEndpoint *channel.Endpoint) error {
+	const readOffset = device.MessageTransportHeaderSize
+	bufs := make([][]byte, tun.BatchSize())
+	for i := range bufs {
+		bufs[i] = make([]byte, device.MessageTransportHeaderSize+mtu)
+	}
+	sizes := make([]int, len(bufs))
+	for {
+		n, err := tun.Read(bufs, sizes, readOffset)
+		if err != nil {
+			return trace.Wrap(err, "reading packets from TUN")
+		}
+		for i := range sizes[:n] {
+			protocol, ok := protocolVersion(bufs[i][readOffset])
+			if !ok {
+				continue
+			}
+			packet := stack.NewPacketBuffer(stack.PacketBufferOptions{
+				Payload: buffer.MakeWithData(bufs[i][readOffset : readOffset+sizes[i]]),
+			})
+			linkEndpoint.InjectInbound(protocol, packet)
+			packet.DecRef()
+		}
+	}
+}
+
+func (m *Manager) addProtocolAddress(localAddress tcpip.Address) error {
+	protocolAddress, err := protocolAddress(localAddress)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := m.stack.AddProtocolAddress(nicID, protocolAddress, stack.AddressProperties{}); err != nil {
+		return trace.Errorf("%s", err)
+	}
+	return nil
+}
+
+func protocolAddress(addr tcpip.Address) (tcpip.ProtocolAddress, error) {
+	addrWithPrefix := addr.WithPrefix()
+	var protocol tcpip.NetworkProtocolNumber
+	switch addrWithPrefix.PrefixLen {
+	case 32:
+		protocol = ipv4.ProtocolNumber
+	case 128:
+		protocol = ipv6.ProtocolNumber
+	default:
+		return tcpip.ProtocolAddress{}, trace.BadParameter("unhandled prefix len %d", addrWithPrefix.PrefixLen)
+	}
+	return tcpip.ProtocolAddress{
+		AddressWithPrefix: addrWithPrefix,
+		Protocol:          protocol,
+	}, nil
+}
+
+func protocolVersion(b byte) (tcpip.NetworkProtocolNumber, bool) {
+	switch b >> 4 {
+	case 4:
+		return header.IPv4ProtocolNumber, true
+	case 6:
+		return header.IPv6ProtocolNumber, true
+	}
+	return 0, false
+}
+
+func ignoreCancel(err error) error {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -100,7 +100,7 @@ func newTestPack(t *testing.T, ctx context.Context) *testPack {
 	}})
 
 	// Create the VNet and connect it to the other side of the TUN.
-	manager, err := NewManager(ctx, &Config{
+	manager, err := NewManager(&Config{
 		TUNDevice:  tun2,
 		IPv6Prefix: vnetIPv6Prefix,
 	})
@@ -109,13 +109,13 @@ func newTestPack(t *testing.T, ctx context.Context) *testPack {
 	utils.RunTestBackgroundTask(ctx, t, &utils.TestBackgroundTask{
 		Name: "VNet",
 		Task: func(ctx context.Context) error {
-			if err := manager.Run(); !errIsOK(err) {
+			if err := manager.Run(ctx); !errIsOK(err) {
 				return trace.Wrap(err)
 			}
 			return nil
 		},
 		Terminate: func() error {
-			return trace.Wrap(manager.Destroy())
+			return trace.Wrap(tun2.Close(), manager.Destroy())
 		},
 	})
 

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -115,7 +115,9 @@ func newTestPack(t *testing.T, ctx context.Context) *testPack {
 			return nil
 		},
 		Terminate: func() error {
-			return trace.Wrap(tun2.Close(), manager.Destroy())
+			tunErr := tun2.Close()
+			destroyErr := manager.Destroy()
+			return trace.NewAggregate(tunErr, destroyErr)
 		},
 	})
 

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -1,0 +1,267 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestMain(m *testing.M) {
+	utils.InitLogger(utils.LoggingForCLI, slog.LevelDebug)
+	os.Exit(m.Run())
+}
+
+type testPack struct {
+	vnetIPv6Prefix tcpip.Address
+	manager        *Manager
+
+	testStack        *stack.Stack
+	testLinkEndpoint *channel.Endpoint
+	localAddress     tcpip.Address
+}
+
+func newTestPack(t *testing.T, ctx context.Context) *testPack {
+	ctx, cancel := context.WithCancel(ctx)
+
+	// Create two sides of an emulated TUN interface: writes to one can be read on the other, and vice versa.
+	tun1, tun2 := newSplitTUN()
+
+	// Create an isolated userspace networking stack that can be manipulated from test code. It will be
+	// connected to the VNet over the TUN interface. This emulates the host networking stack.
+	testStack, linkEndpoint, err := createStack()
+	require.NoError(t, err)
+
+	// Assign a local IP address to the test stack.
+	localAddress, err := randomULAAddress()
+	require.NoError(t, err)
+	protocolAddr, err := protocolAddress(localAddress)
+	require.NoError(t, err)
+	tcpErr := testStack.AddProtocolAddress(nicID, protocolAddr, stack.AddressProperties{})
+	require.Nil(t, tcpErr)
+
+	// Route the VNet range to the TUN interface - this emulates the route that will be installed on the host.
+	vnetIPv6Prefix, err := IPv6Prefix()
+	require.NoError(t, err)
+	subnet, err := tcpip.NewSubnet(vnetIPv6Prefix, tcpip.MaskFromBytes(net.CIDRMask(64, 128)))
+	require.NoError(t, err)
+	testStack.SetRouteTable([]tcpip.Route{{
+		Destination: subnet,
+		NIC:         nicID,
+	}})
+
+	go func() {
+		err := forwardBetweenTunAndNetstack(ctx, tun1, linkEndpoint)
+		if ignoreCancel(err) != nil {
+			slog.With("error", err).DebugContext(ctx, "Forwarding to test netstack failed, canceling context.")
+			cancel()
+		}
+	}()
+
+	// Create the VNet and connect it to the other side of the TUN.
+	manager, err := NewManager(ctx, &Config{
+		TUNDevice:  tun2,
+		IPv6Prefix: vnetIPv6Prefix,
+	})
+	require.NoError(t, err)
+
+	// Run the VNet in the background.
+	go func() {
+		err := manager.Run()
+		if ignoreCancel(err) != nil {
+			slog.With("error", err).DebugContext(ctx, "Running VNet failed, canceling context.")
+			cancel()
+		}
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		manager.Destroy()
+	})
+
+	return &testPack{
+		vnetIPv6Prefix:   vnetIPv6Prefix,
+		manager:          manager,
+		testStack:        testStack,
+		testLinkEndpoint: linkEndpoint,
+		localAddress:     localAddress,
+	}
+}
+
+// dial dials the VNet address [addr] from the test virtual netstack.
+func (p *testPack) dial(ctx context.Context, addr tcpip.Address) (*gonet.TCPConn, error) {
+	conn, err := gonet.DialTCPWithBind(
+		ctx,
+		p.testStack,
+		tcpip.FullAddress{
+			NIC:      nicID,
+			Addr:     p.localAddress,
+			LinkAddr: p.testLinkEndpoint.LinkAddress(),
+		},
+		tcpip.FullAddress{
+			NIC:      nicID,
+			Addr:     addr,
+			Port:     456,
+			LinkAddr: p.manager.linkEndpoint.LinkAddress(),
+		},
+		ipv6.ProtocolNumber,
+	)
+	return conn, trace.Wrap(err)
+}
+
+// TestVnetEcho is a preliminary VNet test that manually stalls an echo handler on a specific IP, TCP dials
+// it, and makes sure writes are echoed back to the TCP conn.
+func TestVnetEcho(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p := newTestPack(t, ctx)
+
+	dialAddress, err := p.manager.assignTCPHandler(echoHandler{})
+	require.NoError(t, err)
+
+	conn, err := p.dial(ctx, dialAddress)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	testString := "Hello, World!\n"
+	_, err = conn.Write([]byte(testString))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn.Close()) }()
+
+	scanner := bufio.NewScanner(conn)
+	require.True(t, scanner.Scan(), "scan failed: %v", scanner.Err())
+	line := scanner.Text()
+	require.Equal(t, strings.TrimSuffix(testString, "\n"), line)
+}
+
+type echoHandler struct{}
+
+func (echoHandler) handleTCP(ctx context.Context, connector tcpConnector) error {
+	conn, err := connector()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer conn.Close()
+	_, err = io.Copy(conn, conn)
+	return trace.Wrap(err)
+}
+
+func randomULAAddress() (tcpip.Address, error) {
+	prefix, err := IPv6Prefix()
+	if err != nil {
+		return tcpip.Address{}, trace.Wrap(err)
+	}
+	bytes := prefix.As16()
+	bytes[15] = 2
+	return tcpip.AddrFrom16(bytes), nil
+}
+
+var fakeTUNClosedErr = errors.New("TUN closed")
+
+type fakeTUN struct {
+	name                            string
+	readPacketsFrom, writePacketsTo chan []byte
+	closed                          chan struct{}
+	closeOnce                       func()
+}
+
+// newSplitTUN returns two fake TUN devices that are tied together: writes to one can be read on the other,
+// and vice versa.
+func newSplitTUN() (*fakeTUN, *fakeTUN) {
+	closed := make(chan struct{})
+	closeOnce := sync.OnceFunc(func() { close(closed) })
+	ab := make(chan []byte)
+	ba := make(chan []byte)
+	return &fakeTUN{
+			name:            "tun1",
+			readPacketsFrom: ab,
+			writePacketsTo:  ba,
+			closed:          closed,
+			closeOnce:       closeOnce,
+		}, &fakeTUN{
+			name:            "tun2",
+			readPacketsFrom: ba,
+			writePacketsTo:  ab,
+			closed:          closed,
+			closeOnce:       closeOnce,
+		}
+}
+
+func (f *fakeTUN) BatchSize() int {
+	return 1
+}
+
+// Write one or more packets to the device (without any additional headers).
+// On a successful write it returns the number of packets written. A nonzero
+// offset can be used to instruct the Device on where to begin writing from
+// each packet contained within the bufs slice.
+func (f *fakeTUN) Write(bufs [][]byte, offset int) (int, error) {
+	if len(bufs) != 1 {
+		return 0, trace.BadParameter("batchsize is 1")
+	}
+	packet := make([]byte, len(bufs[0][offset:]))
+	copy(packet, bufs[0][offset:])
+	select {
+	case <-f.closed:
+		return 0, fakeTUNClosedErr
+	case f.writePacketsTo <- packet:
+	}
+	return 1, nil
+}
+
+// Read one or more packets from the Device (without any additional headers).
+// On a successful read it returns the number of packets read, and sets
+// packet lengths within the sizes slice. len(sizes) must be >= len(bufs).
+// A nonzero offset can be used to instruct the Device on where to begin
+// reading into each element of the bufs slice.
+func (f *fakeTUN) Read(bufs [][]byte, sizes []int, offset int) (n int, err error) {
+	if len(bufs) != 1 {
+		return 0, trace.BadParameter("batchsize is 1")
+	}
+	var packet []byte
+	select {
+	case <-f.closed:
+		return 0, fakeTUNClosedErr
+	case packet = <-f.readPacketsFrom:
+	}
+	sizes[0] = copy(bufs[0][offset:], packet)
+	return 1, nil
+}
+
+func (f *fakeTUN) Close() error {
+	f.closeOnce()
+	return nil
+}

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -60,6 +60,9 @@ func newTestPack(t *testing.T, ctx context.Context) *testPack {
 
 	// Create an isolated userspace networking stack that can be manipulated from test code. It will be
 	// connected to the VNet over the TUN interface. This emulates the host networking stack.
+	// This is a completely separate gvisor network stack than the one that will be created in NewManager -
+	// the two will be connected over a fake TUN interface. This exists so that the test can setup IP routes
+	// without affecting the host running the Test.
 	testStack, linkEndpoint, err := createStack()
 	require.NoError(t, err)
 
@@ -168,6 +171,7 @@ func TestVnetEcho(t *testing.T) {
 			require.NoError(t, err)
 			defer conn.Close()
 
+			// The newline is necessary so that the bufio.Scanner can read a line.
 			testString := "Hello, World!\n"
 			_, err = conn.Write([]byte(testString))
 			require.NoError(t, err)


### PR DESCRIPTION
This is the first in a series of PRs implementing Teleport VNet [RFD](https://github.com/gravitational/teleport/blob/rfd/0163-vnet/rfd/0163-vnet.md). [child](https://github.com/gravitational/teleport/pull/40893)

This commit sets up virtual networking based on the gvisor netstack, and implements a unit testing strategy for exercising VNet's virtual network without relying on a real TUN interface from the host OS.