### PR TITLE
[v14] docs: Use db-client instead of db_client for tctl auth export

### DIFF
--- a/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
@@ -118,7 +118,7 @@ Next, for each CockroachDB node, export Teleport's `db_client` CA using `tctl`
 `ca-client.crt`:
 
 ```code
-$ tctl auth export --type=db_client >> <Var name="/path/to/cockroachdb/certs/dir" />/ca-client.crt
+$ tctl auth export --type=db-client >> <Var name="/path/to/cockroachdb/certs/dir" />/ca-client.crt
 ```
 
 (!docs/pages/includes/database-access/custom-db-ca.mdx db="CockroachDB" protocol="cockroachdb" port="26257"!)

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -140,7 +140,7 @@ accordingly to grant the user appropriate database permissions.
   additional trusted CA by concatenating it with your CA's certificate:
   
   ```code
-  $ tctl auth export --type=db_client > db-client-ca.crt
+  $ tctl auth export --type=db-client > db-client-ca.crt
   $ cat <Var name="/path/to/your/ca.crt" /> db-client-ca.crt > /etc/certs/mongo.cas
   ```
 

--- a/docs/pages/database-access/guides/redis-cluster.mdx
+++ b/docs/pages/database-access/guides/redis-cluster.mdx
@@ -76,7 +76,7 @@ Install and configure Teleport where you will run the Teleport Database Service:
 Export your Teleport cluster's `db_client` CA cert and concatenate it with your Redis 
 Cluster's CA cert (in PEM format):
 ```code
-$ tctl auth export --type=db_client > db-client-ca.crt
+$ tctl auth export --type=db-client > db-client-ca.crt
 $ cat <Var name="/path/to/your/ca.crt" /> db-client-ca.crt > pem-bundle.cas
 ```
 


### PR DESCRIPTION
Backport #40867 to branch/v14