### PR TITLE
[v15] fix k8s moderated sessions bypass with ephemeral containers

### DIFF
--- a/fixtures/ci-teleport-rbac/ci-teleport.yaml
+++ b/fixtures/ci-teleport-rbac/ci-teleport.yaml
@@ -38,7 +38,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get"]
+  verbs: ["get", "list", "watch"]
   resourceNames: ["test-pod"]
 - apiGroups: [""]
   resources: ["pods/exec"]

--- a/fixtures/ci-teleport-rbac/ci-teleport.yaml
+++ b/fixtures/ci-teleport-rbac/ci-teleport.yaml
@@ -48,6 +48,14 @@ rules:
   resources: ["pods/portforward"]
   verbs: ["create"]
   resourceNames: ["test-pod"]
+- apiGroups: [""]
+  resources: ["pods/ephemeralcontainers"]
+  verbs: ["patch"]
+  resourceNames: ["test-pod"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+  resourceNames: ["test-pod"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/elastic/go-elasticsearch/v8 v8.11.1
 	github.com/elimity-com/scim v0.0.0-20230426070224-941a5eac92f3
+	github.com/evanphx/json-patch v5.7.0+incompatible
 	github.com/flynn/hid v0.0.0-20190502022136-f1b9b6cc019a
 	github.com/flynn/u2f v0.0.0-20180613185708-15554eb68e5d
 	github.com/fsouza/fake-gcs-server v1.47.7
@@ -308,7 +309,6 @@ require (
 	github.com/dvsekhvalnov/jose2go v1.6.0 // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.3.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
-	github.com/evanphx/json-patch v5.7.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -1352,7 +1352,7 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 	})
 
 	username := suite.me.Username
-	kubeUsers := []string{"alice@example.com"}
+	kubeUsers := []string{username}
 	kubeGroups := []string{kube.TestImpersonationGroup}
 	kubeAccessRole, err := types.NewRole("kubemaster", types.RoleSpecV6{
 		Allow: types.RoleConditions{
@@ -1364,7 +1364,10 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 			},
 			KubernetesResources: []types.KubernetesResource{
 				{
-					Kind: types.KindKubePod, Name: types.Wildcard, Namespace: types.Wildcard, Verbs: []string{types.Wildcard},
+					Kind:      types.KindKubePod,
+					Name:      types.Wildcard,
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
 				},
 			},
 		},
@@ -1416,6 +1419,7 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 	proxyClient, kubeConfig, err := kube.ProxyClient(kube.ProxyConfig{
 		T:          teleport,
 		Username:   username,
+		KubeUsers:  kubeUsers,
 		KubeGroups: kubeGroups,
 	})
 	require.NoError(t, err)
@@ -1429,11 +1433,13 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 	podJS, err := json.Marshal(pod)
 	require.NoError(t, err)
 
+	// create an ephemeral container and attach to it just like kubectl would
+	contName := "ephemeral-container"
+	sessCreatorTerm := NewTerminal(250)
 	group := &errgroup.Group{}
 	group.Go(func() error {
-		name := "debug-1"
-		cmd := []string{"/bin/sh", "echo", "hello from a debug container"}
-		debugPod, _, err := generateDebugContainer(name, cmd, pod)
+		cmd := []string{"/bin/sh", "echo", "hello from an ephemeral container"}
+		debugPod, _, err := generateDebugContainer(contName, cmd, pod)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1451,7 +1457,7 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		_, err = waitForContainer(ctx, podsClient, pod.Name, name)
+		_, err = waitForContainer(ctx, podsClient, pod.Name, contName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1459,8 +1465,11 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 		err = kubeExec(kubeConfig, attachToContainer, kubeExecArgs{
 			podName:      pod.Name,
 			podNamespace: testNamespace,
-			container:    name,
+			container:    contName,
 			command:      cmd,
+			stdout:       sessCreatorTerm,
+			stderr:       sessCreatorTerm,
+			stdin:        sessCreatorTerm,
 			tty:          true,
 		})
 		if err != nil {
@@ -1484,11 +1493,30 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 		session = sessions[0]
 	}, 10*time.Second, 100*time.Millisecond)
 
+	// join the created session as a moderator
 	group.Go(func() error {
+		// verify that the ephemeral container hasn't actually been created yet
+		proxyClient, _, err := kube.ProxyClient(kube.ProxyConfig{
+			T:          teleport,
+			Username:   moderatorUser,
+			KubeUsers:  kubeUsers,
+			KubeGroups: kubeGroups,
+		})
+		require.NoError(t, err)
+
+		podsClient := proxyClient.CoreV1().Pods(testNamespace)
+		pod, err := podsClient.Get(ctx, testPod, metav1.GetOptions{})
+		require.NoError(t, err)
+		for _, status := range pod.Status.EphemeralContainerStatuses {
+			if !assert.NotEqual(t, status.Name, contName) {
+				return trace.AlreadyExists("ephemeral container already started")
+			}
+		}
+
 		tc, err := teleport.NewClient(helpers.ClientConfig{
-			Login:   moderatorUser,
-			Cluster: helpers.Site,
-			Host:    Host,
+			TeleportUser: moderatorUser,
+			Cluster:      helpers.Site,
+			Host:         Host,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -1496,15 +1524,16 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 
 		stream, err := kubeJoin(kube.ProxyConfig{
 			T:          teleport,
-			Username:   username,
+			Username:   moderatorUser,
 			KubeUsers:  kubeUsers,
 			KubeGroups: kubeGroups,
-		}, tc, session, types.SessionPeerMode)
+		}, tc, session, types.SessionModeratorMode)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
-		return trace.Wrap(stream.Close())
+		stream.Wait()
+		return trace.Wrap(stream.Detach())
 	})
 
 	require.NoError(t, group.Wait())

--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -1,0 +1,423 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/gravitational/teleport"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
+	"github.com/gravitational/teleport/api/types/kubewaitingcontainer"
+	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// ephemeralContainers handles ephemeral container creation requests.
+// If a user that is required to be moderated attempts to create an
+// ephemeral container, the creation of that container will be delayed
+// until the requirements for the moderated session are met.
+func (f *Forwarder) ephemeralContainers(authCtx *authContext, w http.ResponseWriter, req *http.Request, p httprouter.Params) (resp any, err error) {
+	ctx, span := f.cfg.tracer.Start(
+		req.Context(),
+		"kube.Forwarder/ephemeralContainers",
+		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCMethodKey.String("ephemeralContainers"),
+			semconv.RPCSystemKey.String("kube"),
+		),
+	)
+	req = req.WithContext(ctx)
+	defer span.End()
+
+	// If the user can start a session by themselves, proxy the ephemeral
+	// container creation request. Otherwise if the user requires
+	// moderation reply with fake data so kubectl will attempt to start
+	// a session with this ephemeral container. Then we will wait to
+	// create the ephemeral container until the requirements for the
+	// moderated session are met. If we wait here kubectl will timeout,
+	// so make it wait to establish a session instead.
+	canStart, err := f.canStartSessionAlone(authCtx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if canStart {
+		return f.catchAll(authCtx, w, req)
+	}
+
+	sess, err := f.newClusterSession(req.Context(), *authCtx)
+	if err != nil {
+		// This error goes to kubernetes client and is not visible in the logs
+		// of the teleport server if not logged here.
+		f.log.Errorf("Failed to create cluster session: %v.", err)
+		return nil, trace.Wrap(err)
+	}
+	// sess.Close cancels the connection monitor context to release it sooner.
+	// When the server is under heavy load it can take a while to identify that
+	// the underlying connection is gone. This change prevents that and releases
+	// the resources as soon as we know the session is no longer active.
+	defer sess.close()
+
+	sess.upgradeToHTTP2 = true
+	sess.forwarder, err = f.makeSessionForwarder(sess)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := f.setupForwardingHeaders(sess, req, true /* withImpersonationHeaders */); err != nil {
+		// This error goes to kubernetes client and is not visible in the logs
+		// of the teleport server if not logged here.
+		f.log.Errorf("Failed to set up forwarding headers: %v.", err)
+		return nil, trace.Wrap(err)
+	}
+	if !f.isLocalKubeCluster(sess.teleportCluster.isRemote, sess.kubeClusterName) {
+		sess.forwarder.ServeHTTP(w, req)
+		return nil, nil
+	}
+
+	err = f.ephemeralContainersLocal(authCtx, sess, w, req)
+	return nil, trace.Wrap(err)
+}
+
+// ephemeralContainersLocal handles ephemeral container creation requests for
+// users that require moderation.
+func (f *Forwarder) ephemeralContainersLocal(authCtx *authContext, sess *clusterSession, w http.ResponseWriter, req *http.Request) (err error) {
+	// Fetch information on the requested pod and apply the patch
+	// so kubectl will think the ephemeral container has been created.
+	podPatch, err := utils.ReadAtMost(req.Body, teleport.MaxHTTPRequestSize)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := req.Body.Close(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	reqContentType := responsewriters.GetContentTypeHeader(req.Header)
+	// Remove "; charset=" if included in header.
+	if idx := strings.Index(reqContentType, ";"); idx > 0 {
+		reqContentType = reqContentType[:idx]
+	}
+
+	reqPatchType := apimachinerytypes.PatchType(reqContentType)
+	contentType, err := patchTypeToContentType(reqPatchType)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	encoder, decoder, err := newEncoderAndDecoderForContentType(
+		contentType,
+		newClientNegotiator(sess.codecFactory))
+	if err != nil {
+		return trace.Wrap(err, "failed to create encoder and decoder")
+	}
+
+	patchedPod, ephemeralContName, err := f.mergeEphemeralPatchWithCurrentPod(
+		req.Context(),
+		mergeEphemeralPatchWithCurrentPodConfig{
+			kubeCluster:   sess.kubeClusterName,
+			kubeNamespace: authCtx.kubeResource.Namespace,
+			podName:       authCtx.kubeResource.Name,
+			decoder:       decoder,
+			encoder:       encoder,
+			podPatch:      podPatch,
+			patchType:     reqPatchType,
+		},
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := f.createWaitingContainer(req.Context(), ephemeralContName, authCtx, podPatch, reqPatchType); err != nil {
+		return trace.Wrap(err)
+	}
+
+	responsewriters.SetContentTypeHeader(w, w.Header())
+	w.WriteHeader(http.StatusOK)
+
+	if err := encoder.Encode(patchedPod, w); err != nil {
+		return trace.Wrap(err)
+	}
+
+	f.emitAuditEvent(req, sess, http.StatusOK)
+	return trace.Wrap(err)
+}
+
+// mergeEphemeralPatchWithCurrentPodConfig is a configuration struct for
+// mergeEphemeralPatchWithCurrentPod.
+type mergeEphemeralPatchWithCurrentPodConfig struct {
+	kubeCluster   string
+	kubeNamespace string
+	podName       string
+	decoder       runtime.Decoder
+	encoder       runtime.Encoder
+	podPatch      []byte
+	patchType     apimachinerytypes.PatchType
+}
+
+// mergeEphemeralPatchWithCurrentPod merges the provided patch with the
+// current pod and returns the patched pod.
+// This function gets the current pod from the Kubernetes API server and
+// merges the provided patch with it. The patch is expected to be a strategic
+// merge patch that adds an ephemeral container to the pod.
+func (f *Forwarder) mergeEphemeralPatchWithCurrentPod(
+	ctx context.Context,
+	cfg mergeEphemeralPatchWithCurrentPodConfig,
+) (*corev1.Pod, string, error) {
+	details, err := f.findKubeDetailsByClusterName(cfg.kubeCluster)
+	if err != nil {
+		return nil, "", trace.NotFound("kubernetes cluster %q not found", cfg.kubeCluster)
+	}
+
+	pod, err := details.getKubeClient().CoreV1().
+		Pods(cfg.kubeNamespace).
+		Get(ctx, cfg.podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	podSerializedBuf := &bytes.Buffer{}
+	if err := cfg.encoder.Encode(pod, podSerializedBuf); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	patchedPod, ephemeralContName, err := patchPodWithDebugContainer(cfg.decoder, podSerializedBuf.Bytes(), cfg.podPatch, *pod, cfg.patchType)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return patchedPod, ephemeralContName, nil
+}
+
+func (f *Forwarder) createWaitingContainer(ctx context.Context, ephemeralContName string, authCtx *authContext, podPatch []byte, patchType apimachinerytypes.PatchType) error {
+	waitingCont, err := kubewaitingcontainer.NewKubeWaitingContainer(
+		ephemeralContName,
+		&kubewaitingcontainerpb.KubernetesWaitingContainerSpec{
+			Username:      authCtx.User.GetName(),
+			Cluster:       authCtx.kubeClusterName,
+			Namespace:     authCtx.kubeResource.Namespace,
+			PodName:       authCtx.kubeResource.Name,
+			ContainerName: ephemeralContName,
+			Patch:         podPatch,
+			PatchType:     string(patchType),
+		})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = f.cfg.AuthClient.CreateKubernetesWaitingContainer(ctx, waitingCont)
+	return trace.Wrap(err)
+}
+
+// impersonatedKubeClient returns a Kubernetes client that is impersonating
+// the identity in the provided authCtx.
+func (f *Forwarder) impersonatedKubeClient(authCtx *authContext, headers http.Header) (*kubernetes.Clientset, *kubeDetails, error) {
+	details, err := f.findKubeDetailsByClusterName(authCtx.kubeClusterName)
+	if err != nil {
+		return nil, nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterName)
+	}
+	restConfig := details.getKubeRestConfig()
+	kubeUser, kubeGroups, err := computeImpersonatedPrincipals(authCtx.kubeUsers, authCtx.kubeGroups, headers)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	restConfig.Impersonate = rest.ImpersonationConfig{
+		UserName: kubeUser,
+		Groups:   kubeGroups,
+	}
+	clientSet, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return clientSet, details, nil
+}
+
+// patchPodWithDebugContainer adds an ephemeral container to the provided spec of pod and
+// returns the patched result.
+func patchPodWithDebugContainer(decoder runtime.Decoder, podJson, podPatch []byte, pod corev1.Pod, patchType apimachinerytypes.PatchType) (*corev1.Pod, string, error) {
+	patchResult, err := patchPod(podJson, podPatch, pod, patchType)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	gvk := corev1.SchemeGroupVersion.WithKind("Pod")
+	decodedObj, _, err := decoder.Decode(patchResult, &gvk, nil)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	decodedObj.GetObjectKind().SetGroupVersionKind(gvk)
+
+	patchedPod, ok := decodedObj.(*corev1.Pod)
+	if !ok {
+		return nil, "", trace.CompareFailed("expected *corev1.Pod, got %T", decodedObj)
+	}
+
+	// The last container in the list is the one we just added.
+	ephemeralCont := patchedPod.Spec.EphemeralContainers[len(patchedPod.Spec.EphemeralContainers)-1]
+	if !ephemeralCont.TTY {
+		return nil, "", trace.AccessDenied("only interactive ephemeral containers are supported")
+	}
+
+	// Add the container to the status so kubectl will think it has started.
+	patchedPod.Status.EphemeralContainerStatuses = append(
+		pod.Status.EphemeralContainerStatuses,
+		corev1.ContainerStatus{
+			Name: ephemeralCont.Name,
+			State: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{
+					StartedAt: metav1.Now(),
+				},
+			},
+			Ready: true,
+		},
+	)
+
+	return patchedPod, ephemeralCont.Name, nil
+}
+
+// pushPodEvent writes a fake event that shows that an ephemeral container
+// started running on a given pod. This is so kubectl will attempt to start
+// a session which can be safely waiting on until the moderated session
+// is approved.
+func (f *Forwarder) getPatchedPodEvent(ctx context.Context, sess *clusterSession, waitingCont *kubewaitingcontainerpb.KubernetesWaitingContainer) (*watch.Event, error) {
+	contentType, err := patchTypeToContentType(apimachinerytypes.PatchType(waitingCont.Spec.PatchType))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	encoder, decoder, err := newEncoderAndDecoderForContentType(
+		contentType,
+		newClientNegotiator(sess.codecFactory),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to create encoder and decoder")
+	}
+
+	patchedPod, _, err := f.mergeEphemeralPatchWithCurrentPod(
+		ctx,
+		mergeEphemeralPatchWithCurrentPodConfig{
+			kubeCluster:   waitingCont.Spec.Cluster,
+			kubeNamespace: waitingCont.Spec.Namespace,
+			podName:       waitingCont.Spec.PodName,
+			decoder:       decoder,
+			encoder:       encoder,
+			podPatch:      waitingCont.Spec.Patch,
+			patchType:     apimachinerytypes.PatchType(waitingCont.Spec.PatchType),
+		},
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &watch.Event{
+		Type:   watch.Modified,
+		Object: patchedPod,
+	}, nil
+}
+
+// getUserEphemeralContainersForPod returns a list of ephemeral containers
+// created by the username and are waiting to be created for a given pod.
+func (f *Forwarder) getUserEphemeralContainersForPod(ctx context.Context, username, kubeCluster, namespace, pod string) ([]*kubewaitingcontainerpb.KubernetesWaitingContainer, error) {
+	var (
+		list      []*kubewaitingcontainerpb.KubernetesWaitingContainer
+		startPage string
+	)
+	for {
+		waitingContainers, nextPage, err := f.cfg.CachingAuthClient.ListKubernetesWaitingContainers(ctx, apidefaults.DefaultChunkSize, startPage)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		for _, cont := range waitingContainers {
+			if cont.Spec.Username != username ||
+				cont.Spec.Cluster != kubeCluster ||
+				cont.Spec.Namespace != namespace ||
+				cont.Spec.PodName != pod {
+				continue
+			}
+
+			list = append(list, cont)
+		}
+		if nextPage == "" {
+			break
+		}
+		startPage = nextPage
+	}
+	return list, nil
+}
+
+func getEphemeralContainerStatusByName(pod *corev1.Pod, containerName string) *corev1.ContainerStatus {
+	for _, status := range pod.Status.EphemeralContainerStatuses {
+		if status.Name == containerName {
+			return &status
+		}
+	}
+	return nil
+}
+
+func patchTypeToContentType(reqPatchType apimachinerytypes.PatchType) (string, error) {
+	var contentType string
+	switch reqPatchType {
+	case apimachinerytypes.JSONPatchType,
+		apimachinerytypes.MergePatchType,
+		apimachinerytypes.StrategicMergePatchType:
+		contentType = responsewriters.JSONContentType
+	case apimachinerytypes.ApplyPatchType:
+		contentType = responsewriters.YAMLContentType
+	default:
+		return "", trace.BadParameter("unsupported content type %q", reqPatchType)
+	}
+	return contentType, nil
+}
+
+// patchPod applies the provided patch to the pod and returns the patched pod data.
+// The patch type is used to determine how the patch should be applied.
+func patchPod(podData, patchData []byte, pod corev1.Pod, pt apimachinerytypes.PatchType) ([]byte, error) {
+	switch pt {
+	case apimachinerytypes.JSONPatchType:
+		patchObj, err := jsonpatch.DecodePatch(patchData)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		patchedObj, err := patchObj.Apply(podData)
+		return patchedObj, trace.Wrap(err)
+	case apimachinerytypes.MergePatchType:
+		patchedObj, err := jsonpatch.MergePatch(podData, patchData)
+		return patchedObj, trace.Wrap(err)
+	case apimachinerytypes.StrategicMergePatchType:
+		patchedObj, err := strategicpatch.StrategicMergePatch(podData, patchData, pod)
+		return patchedObj, trace.Wrap(err)
+	default:
+		return nil, trace.BadParameter("unsupported patch type %q", pt)
+	}
+}

--- a/lib/kube/proxy/ephemeral_containers_test.go
+++ b/lib/kube/proxy/ephemeral_containers_test.go
@@ -1,0 +1,92 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+)
+
+func Test_patchPod(t *testing.T) {
+	type args struct {
+		podData   []byte
+		patchData []byte
+		pod       corev1.Pod
+		pt        apimachinerytypes.PatchType
+	}
+	tests := []struct {
+		name string
+		args args
+		want []byte
+	}{
+		{
+			name: "patch pod with json patch",
+			args: args{
+				podData:   []byte(`{"metadata":{"name":"test-pod"}}`),
+				patchData: []byte(`[{"op":"replace","path":"/metadata/name","value":"new-test-pod"}]`),
+				pod: corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+					},
+				},
+				pt: apimachinerytypes.JSONPatchType,
+			},
+			want: []byte(`{"metadata":{"name":"new-test-pod"}}`),
+		},
+		{
+			name: "patch pod with merge patch",
+			args: args{
+				podData:   []byte(`{"metadata":{"name":"test-pod"}}`),
+				patchData: []byte(`{"metadata":{"name":"new-test-pod"}}`),
+				pod: corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+					},
+				},
+				pt: apimachinerytypes.MergePatchType,
+			},
+			want: []byte(`{"metadata":{"name":"new-test-pod"}}`),
+		},
+		{
+			name: "patch pod with strategic patch json",
+			args: args{
+				podData:   []byte(`{"metadata":{"name":"test-pod"}}`),
+				patchData: []byte(`{"metadata":{"name":"new-test-pod"}}`),
+				pod: corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+					},
+				},
+				pt: apimachinerytypes.MergePatchType,
+			},
+			want: []byte(`{"metadata":{"name":"new-test-pod"}}`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := patchPod(tt.args.podData, tt.args.patchData, tt.args.pod, tt.args.pt)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -282,7 +282,6 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 	}
 
 	router := httprouter.New()
-
 	router.UseRawPath = true
 
 	router.GET("/version", fwd.withAuth(
@@ -303,6 +302,9 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 	router.GET("/api/:ver/namespaces/:podNamespace/pods/:podName/portforward", fwd.withAuth(fwd.portForward))
 
 	router.POST("/apis/authorization.k8s.io/:ver/selfsubjectaccessreviews", fwd.withAuth(fwd.selfSubjectAccessReviews))
+
+	router.PATCH("/api/:ver/namespaces/:podNamespace/pods/:podName/ephemeralcontainers", fwd.withAuth(fwd.ephemeralContainers))
+	router.PUT("/api/:ver/namespaces/:podNamespace/pods/:podName/ephemeralcontainers", fwd.withAuth(fwd.ephemeralContainers))
 
 	router.GET("/api/:ver/teleport/join/:session", fwd.withAuthPassthrough(fwd.join))
 
@@ -1417,19 +1419,7 @@ func (f *Forwarder) acquireConnectionLock(ctx context.Context, user string, role
 
 // execNonInteractive handles all exec sessions without a TTY.
 func (f *Forwarder) execNonInteractive(ctx *authContext, w http.ResponseWriter, req *http.Request, p httprouter.Params, request remoteCommandRequest, proxy *remoteCommandProxy, sess *clusterSession) error {
-	roles, err := getRolesByName(f, ctx.Context.Identity.GetIdentity().Groups)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	var policySets []*types.SessionTrackerPolicySet
-	for _, role := range roles {
-		policySet := role.GetSessionPolicySet()
-		policySets = append(policySets, &policySet)
-	}
-
-	authorizer := auth.NewSessionAccessEvaluator(policySets, types.KubernetesSessionKind, ctx.User.GetName())
-	canStart, _, err := authorizer.FulfilledFor(nil)
+	canStart, err := f.canStartSessionAlone(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1545,6 +1535,19 @@ func (f *Forwarder) execNonInteractive(ctx *authContext, w http.ResponseWriter, 
 	execEvent.Code = events.ExecCode
 
 	return nil
+}
+
+// canStartSessionAlone returns true if the user associated with authCtx
+// is allowed to start a session without moderation.
+func (f *Forwarder) canStartSessionAlone(authCtx *authContext) (bool, error) {
+	policySets := authCtx.Checker.SessionPolicySets()
+	authorizer := auth.NewSessionAccessEvaluator(policySets, types.KubernetesSessionKind, authCtx.User.GetName())
+	canStart, _, err := authorizer.FulfilledFor(nil)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	return canStart, nil
 }
 
 func exitCode(err error) (errMsg, code string) {

--- a/lib/kube/proxy/resource_list.go
+++ b/lib/kube/proxy/resource_list.go
@@ -22,6 +22,9 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/gravitational/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
@@ -150,12 +153,81 @@ func (f *Forwarder) listResourcesWatcher(req *http.Request, w http.ResponseWrite
 	if err != nil {
 		return http.StatusInternalServerError, trace.Wrap(err)
 	}
+
+	// if this pod watch request is for a specific pod, watch for and
+	// push events that show ephemeral containers were started if there
+	// are any ephemeral containers waiting to be created for this pod
+	// by this user
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	if podName := isRequestTargetedToPod(req, sess.apiResource); podName != "" && ok {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			f.sendEphemeralContainerEvents(done, req, rw, sess, podName)
+		}()
+	}
+
 	// Forwards the request to the target cluster.
 	sess.forwarder.ServeHTTP(rw, req)
+	// Wait for the fake event pushing goroutine to finish
+	close(done)
+	wg.Wait()
 	// Once the request terminates, close the watcher and waits for resources
 	// cleanup.
 	err = rw.Close()
 	return rw.Status(), trace.Wrap(err)
+}
+
+// sendEphemeralContainerEvents will poll the list of ephemeral containers
+// each 5s from cache and see if they match the user and pod and namespace.
+// If any match exists, it will push a fake event to the watcher stream to trick
+// kubectl into creating the exec session.
+func (f *Forwarder) sendEphemeralContainerEvents(done <-chan struct{}, req *http.Request, rw *responsewriters.WatcherResponseWriter, sess *clusterSession, podName string) {
+	const backoff = 5 * time.Second
+	sentDebugContainers := map[string]struct{}{}
+	ticker := time.NewTicker(backoff)
+	defer ticker.Stop()
+	for {
+		wcs, err := f.getUserEphemeralContainersForPod(
+			req.Context(),
+			sess.User.GetName(),
+			sess.kubeClusterName,
+			sess.apiResource.namespace,
+			podName,
+		)
+		if err != nil {
+			f.log.WithError(err).Warn("error getting user ephemeral containers")
+			return
+		}
+
+		for _, wc := range wcs {
+			if _, ok := sentDebugContainers[wc.Spec.ContainerName]; ok {
+				continue
+			}
+			evt, err := f.getPatchedPodEvent(req.Context(), sess, wc)
+			if err != nil {
+				f.log.WithError(err).Warn("error pushing pod event")
+				continue
+			}
+			sentDebugContainers[wc.Spec.ContainerName] = struct{}{}
+			// push the event to the client
+			// this will lock until the event is pushed or the
+			// request context is done.
+			rw.PushVirtualEventToClient(req.Context(), evt)
+		}
+
+		// wait a bit before querying the cache again, or return
+		// if the request has finished
+		select {
+		case <-req.Context().Done():
+			return
+		case <-done:
+			return
+		case <-ticker.C:
+		}
+	}
 }
 
 // decompressInplace decompresses the response into the same buffer it was
@@ -179,4 +251,39 @@ func decompressInplace(memoryRW *responsewriters.MemoryResponseWriter) error {
 	default:
 		return nil
 	}
+}
+
+// isRequestTargetedToPod checks if the request is
+// possibly targeted to an ephemeral container. If it is, it returns the
+// name of the pod that the container is in.
+// This function is used to determine if a watch request is for a specific pod
+// because although the watch request is for a specific pod, the endpoint
+// is the same as the endpoint for the pod list request.
+// A request targeted to an ephemeral container will follow this template:
+// GET api/v1/namespaces/<namespace>/pods?fieldSelector=metadata.name%3D<pod_name>
+func isRequestTargetedToPod(req *http.Request, kube apiResource) string {
+	const podsResource = "pods"
+	if kube.resourceKind != podsResource {
+		return ""
+	}
+	if kube.namespace == "" {
+		return ""
+	}
+	if kube.resourceName != "" {
+		return ""
+	}
+
+	q := req.URL.Query()
+	fieldSel, ok := q["fieldSelector"]
+	if !ok {
+		return ""
+	}
+
+	for _, val := range fieldSel {
+		if podName, ok := strings.CutPrefix(val, "metadata.name="); ok {
+			return podName
+		}
+	}
+
+	return ""
 }

--- a/lib/kube/proxy/responsewriters/watcher.go
+++ b/lib/kube/proxy/responsewriters/watcher.go
@@ -276,7 +276,6 @@ func (w *WatcherResponseWriter) watchDecoder(contentType string, writer io.Write
 				}
 			case <-w.closeChan:
 				return nil
-
 			}
 		}
 	})

--- a/lib/kube/proxy/responsewriters/watcher.go
+++ b/lib/kube/proxy/responsewriters/watcher.go
@@ -19,10 +19,13 @@
 package responsewriters
 
 import (
+	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"mime"
 	"net/http"
+	"sync"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
@@ -34,8 +37,14 @@ import (
 )
 
 const (
-	ContentTypeHeader  = "Content-Type"
-	DefaultContentType = "application/json"
+	// DefaultContentTypeHeader is the default content type header used by the Kubernetes API
+	ContentTypeHeader = "Content-Type"
+	// JSONContentType is the JSON content type used by the Kubernetes API
+	JSONContentType = "application/json"
+	// YAMLContentType is the YAML content type used by the Kubernetes API
+	YAMLContentType = "application/yaml"
+	// DefaultContentType is the default content type used by the Kubernetes API
+	DefaultContentType = JSONContentType
 )
 
 // WatcherResponseWriter satisfies the http.ResponseWriter interface and
@@ -62,6 +71,12 @@ type WatcherResponseWriter struct {
 	negotiator runtime.ClientNegotiator
 	// filter hold the filtering rules to filter events.
 	filter FilterWrapper
+	// evtsChan is used to send fake events to target connection.
+	evtsChan chan *watch.Event
+	// closeChanGuard guards the closeChan close call
+	closeChanGuard sync.Once
+	// closeChan indicates if the watcher as been closed.
+	closeChan chan struct{}
 }
 
 // NewWatcherResponseWriter creates a new WatcherResponseWriter.
@@ -80,6 +95,8 @@ func NewWatcherResponseWriter(
 		pipeWriter: writer,
 		negotiator: negotiator,
 		filter:     filter,
+		closeChan:  make(chan struct{}),
+		evtsChan:   make(chan *watch.Event, 10),
 	}, nil
 }
 
@@ -103,6 +120,19 @@ func (w *WatcherResponseWriter) Write(buf []byte) (int, error) {
 // Header returns the target headers.
 func (w *WatcherResponseWriter) Header() http.Header {
 	return w.target.Header()
+}
+
+// PushVirtualEventToClient pushes a Teleport generated event to the target connection.
+// It's consumed by a goroutine spawn by watchDecoder.
+func (w *WatcherResponseWriter) PushVirtualEventToClient(ctx context.Context, evt *watch.Event) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-w.closeChan:
+		return
+		// wait until we can push the evts
+	case w.evtsChan <- evt:
+	}
 }
 
 // WriteHeader writes the status code and headers into the target http.ResponseWriter
@@ -154,6 +184,9 @@ func (w *WatcherResponseWriter) getStatus() int {
 // the spinned goroutine terminates.
 // After closes the writer pipe and flushes the response into target.
 func (w *WatcherResponseWriter) Close() error {
+	w.closeChanGuard.Do(func() {
+		close(w.closeChan)
+	})
 	w.pipeReader.CloseWithError(io.EOF)
 	err := w.group.Wait()
 	w.pipeWriter.CloseWithError(io.EOF)
@@ -208,6 +241,45 @@ func (w *WatcherResponseWriter) watchDecoder(contentType string, writer io.Write
 			return trace.Wrap(err)
 		}
 	}
+
+	// watchEncoderGuard prevents multiple sources to push events at the same time.
+	// only one source is able to push and flush events to ensure proper json formatting.
+	var watchEncoderGuard sync.Mutex
+	writeEventAndFlush := func(evt *watch.Event) error {
+		watchEncoderGuard.Lock()
+		defer watchEncoderGuard.Unlock()
+		// encode the event into the target connection.
+		if err := watchEncoder.Encode(evt); err != nil {
+			return trace.Wrap(err)
+		}
+		// Stream the response into the target connection, as we are dealing with
+		// streaming events. However, the Kubernetes API does not include the
+		// content-type as chunked. As a result, the forwarder is unaware that
+		// the connection is chunked and delays the response writing by buffering
+		// to minimize the number of writes.
+		// In cases where the connection stream is busy with events, the user may
+		// not receive individual events as chunks, leading to incomplete data.
+		// This could result in the user receiving malformed JSON and triggering
+		// an abort.
+		// To avoid this, we flush the response after each event to ensure that
+		// the user receives the event as a chunk.
+		w.Flush()
+		return nil
+	}
+
+	w.group.Go(func() error {
+		for {
+			select {
+			case evt := <-w.evtsChan:
+				if err := writeEventAndFlush(evt); err != nil {
+					slog.WarnContext(context.Background(), "error pushing fake pod event", "err", err)
+				}
+			case <-w.closeChan:
+				return nil
+
+			}
+		}
+	})
 	// wait for events received from upstream until the connection is terminated.
 	for {
 		eventType, obj, err := w.decodeStreamingMessage(streamingDecoder, objectDecoder)
@@ -226,14 +298,12 @@ func (w *WatcherResponseWriter) watchDecoder(contentType string, writer io.Write
 				err = encoder.Encode(obj, writer)
 				return trace.Wrap(err)
 			}
-			// encode the event into the target connection.
-			err = watchEncoder.Encode(
+			err := writeEventAndFlush(
 				&watch.Event{
 					Type:   eventType,
 					Object: obj,
 				},
 			)
-
 			return trace.Wrap(err)
 		default:
 			if filter != nil {
@@ -247,28 +317,15 @@ func (w *WatcherResponseWriter) watchDecoder(contentType string, writer io.Write
 					continue
 				}
 			}
-			// encode the event into the target connection.
-			err = watchEncoder.Encode(
+
+			if err := writeEventAndFlush(
 				&watch.Event{
 					Type:   eventType,
 					Object: obj,
 				},
-			)
-			if err != nil {
+			); err != nil {
 				return trace.Wrap(err)
 			}
-			// Stream the response into the target connection, as we are dealing with
-			// streaming events. However, the Kubernetes API does not include the
-			// content-type as chunked. As a result, the forwarder is unaware that
-			// the connection is chunked and delays the response writing by buffering
-			// to minimize the number of writes.
-			// In cases where the connection stream is busy with events, the user may
-			// not receive individual events as chunks, leading to incomplete data.
-			// This could result in the user receiving malformed JSON and triggering
-			// an abort.
-			// To avoid this, we flush the response after each event to ensure that
-			// the user receives the event as a chunk.
-			w.Flush()
 		}
 	}
 }

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -34,9 +34,20 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	kubeapitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/remotecommand"
+	watchtools "k8s.io/client-go/tools/watch"
 
 	"github.com/gravitational/teleport"
+	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
@@ -336,7 +347,9 @@ type session struct {
 
 	emitter apievents.Emitter
 
-	podName string
+	podName      string
+	podNamespace string
+	container    string
 
 	started bool
 
@@ -395,7 +408,13 @@ func newSession(ctx authContext, forwarder *Forwarder, req *http.Request, params
 
 	io := srv.NewTermManager()
 	streamContext, streamContextCancel := context.WithCancel(forwarder.ctx)
+	namespace := params.ByName("podNamespace")
+	podName := params.ByName("podName")
+	container := q.Get("container")
 	s := &session{
+		podName:                        podName,
+		podNamespace:                   namespace,
+		container:                      container,
 		ctx:                            ctx,
 		forwarder:                      forwarder,
 		req:                            req,
@@ -495,7 +514,7 @@ func (s *session) checkPresence() error {
 
 // launch waits until the session meets access requirements and then transitions the session
 // to a running state.
-func (s *session) launch() error {
+func (s *session) launch(isEphemeralCont bool) error {
 	defer func() {
 		err := s.Close()
 		if err != nil {
@@ -506,10 +525,13 @@ func (s *session) launch() error {
 	s.log.Debugf("Launching session: %v", s.id)
 
 	q := s.req.URL.Query()
+	namespace := s.params.ByName("podNamespace")
+	podName := s.params.ByName("podName")
+	container := q.Get("container")
 	request := &remoteCommandRequest{
-		podNamespace:       s.params.ByName("podNamespace"),
-		podName:            s.params.ByName("podName"),
-		containerName:      q.Get("container"),
+		podNamespace:       namespace,
+		podName:            podName,
+		containerName:      container,
 		cmd:                q["command"],
 		stdin:              utils.AsBool(q.Get("stdin")),
 		stdout:             utils.AsBool(q.Get("stdout")),
@@ -614,19 +636,68 @@ func (s *session) launch() error {
 	}
 
 	s.io.On()
-	if err = executor.StreamWithContext(s.streamContext, options); err != nil {
-		s.setTerminationErr(err)
-		s.reportErrorToSessionRecorder(err)
-		s.log.WithError(err).Warning("Executor failed while streaming.")
+	if streamErr := executor.StreamWithContext(s.streamContext, options); streamErr != nil {
+		onErr := func(err error) {
+			s.setTerminationErr(err)
+			s.reportErrorToSessionRecorder(err)
+			s.log.WithError(err).Warning("Executor failed while streaming.")
+		}
 
-		return trace.Wrap(err)
+		if !isEphemeralCont {
+			onErr(streamErr)
+			return trace.Wrap(streamErr)
+		}
+
+		// If attaching to the container failed, check if the container
+		// is terminated. If it is, try to stream the logs. If it's not
+		// terminated or can't be found return the original error.
+		clientSet, _, err := s.forwarder.impersonatedKubeClient(&s.sess.authContext, s.req.Header)
+		if err != nil {
+			onErr(err)
+			return trace.Wrap(err)
+		}
+		podClient := clientSet.CoreV1().Pods(namespace)
+
+		pod, err := podClient.Get(s.forwarder.ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			onErr(err)
+			return trace.Wrap(err)
+		}
+		status := getEphemeralContainerStatusByName(pod, container)
+		if status == nil {
+			// the container couldn't be found in the pod, return the
+			// original command streaming error
+			onErr(streamErr)
+			return trace.Wrap(streamErr)
+		}
+		if status.State.Terminated != nil {
+			if err := s.retrieveAlreadyStoppedPodLogs(
+				podClient,
+				namespace,
+				podName,
+				container,
+			); err != nil {
+				onErr(err)
+				return trace.Wrap(err)
+			}
+
+			return nil
+		}
+
+		onErr(streamErr)
+		return trace.Wrap(streamErr)
 	}
+
 	return nil
 }
 
 func (s *session) setTerminationErr(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.setTerminationErrUnlocked(err)
+}
+
+func (s *session) setTerminationErrUnlocked(err error) {
 	if s.terminationErr != nil {
 		return
 	}
@@ -942,8 +1013,27 @@ func (s *session) join(p *party, emitJoinEvent bool) error {
 
 	if !s.started {
 		if canStart {
+			// create an ephemeral container if this session will be
+			// running in one now that the moderated session is approved
+			startedEphemeralCont, err := s.createEphemeralContainer()
+			if err != nil {
+				// if the ephemeral container creation fails, close the session
+				// and return the error. We need to close the session here because
+				// we must inform all parties that the session is closing.
+				s.setTerminationErrUnlocked(err)
+				s.reportErrorToSessionRecorder(err)
+				s.log.WithError(err).Warning("Executor failed while creating ephemeral pod.")
+				go func() {
+					err := s.Close()
+					if err != nil {
+						s.log.WithError(err).Error("Failed to close session")
+					}
+				}()
+				return trace.Wrap(err)
+			}
+
 			go func() {
-				if err := s.launch(); err != nil {
+				if err := s.launch(startedEphemeralCont); err != nil {
 					s.log.WithError(err).Warning("Failed to launch Kubernetes session.")
 				}
 			}()
@@ -971,6 +1061,52 @@ func (s *session) join(p *party, emitJoinEvent bool) error {
 	}
 
 	return nil
+}
+
+// createEphemeralContainer creates an ephemeral container and waits for it to start.
+func (s *session) createEphemeralContainer() (bool, error) {
+	initUser := s.parties[s.initiator]
+	username := initUser.Ctx.Identity.GetIdentity().Username
+	namespace := s.params.ByName("podNamespace")
+	podName := s.params.ByName("podName")
+	container := s.req.URL.Query().Get("container")
+
+	waitingCont, err := s.forwarder.cfg.CachingAuthClient.GetKubernetesWaitingContainer(
+		s.forwarder.ctx,
+		&kubewaitingcontainerpb.GetKubernetesWaitingContainerRequest{
+			Username:      username,
+			Cluster:       s.ctx.kubeClusterName,
+			Namespace:     namespace,
+			PodName:       podName,
+			ContainerName: container,
+		},
+	)
+	if trace.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	if err = s.forwarder.cfg.AuthClient.DeleteKubernetesWaitingContainer(
+		s.forwarder.ctx,
+		&kubewaitingcontainerpb.DeleteKubernetesWaitingContainerRequest{
+			Username:      username,
+			Cluster:       s.ctx.kubeClusterName,
+			Namespace:     namespace,
+			PodName:       podName,
+			ContainerName: container,
+		},
+	); err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	s.log.Debugf("Creating ephemeral container %s on pod %s", container, podName)
+	err = s.patchAndWaitForPodEphemeralContainer(s.forwarder.ctx, &initUser.Ctx, s.req.Header, waitingCont)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	return true, nil
 }
 
 func (s *session) BroadcastMessage(format string, args ...any) {
@@ -1210,6 +1346,11 @@ func getRolesByName(forwarder *Forwarder, roleNames []string) ([]types.Role, err
 // While ctx is open, the session tracker's expiration will be extended
 // on an interval until the session tracker is closed.
 func (s *session) trackSession(p *party, policySet []*types.SessionTrackerPolicySet) error {
+	ctx := s.req.Context()
+	command := s.req.URL.Query()["command"]
+	if len(command) == 0 {
+		command = s.retrieveEphemeralContainerCommand(ctx, p.Ctx.User.GetName(), s.req.URL.Query().Get("container"))
+	}
 	trackerSpec := types.SessionTrackerSpecV1{
 		SessionID:         s.id.String(),
 		Kind:              string(types.KubernetesSessionKind),
@@ -1224,13 +1365,11 @@ func (s *session) trackSession(p *party, policySet []*types.SessionTrackerPolicy
 		Reason:            s.reason,
 		Invited:           s.invitedUsers,
 		HostID:            s.forwarder.cfg.HostID,
-		InitialCommand:    s.req.URL.Query()["command"],
+		InitialCommand:    command,
 	}
 
 	s.log.Debug("Creating session tracker")
 	sessionTrackerService := s.forwarder.cfg.AuthClient
-
-	ctx := s.req.Context()
 
 	tracker, err := srv.NewSessionTracker(ctx, trackerSpec, sessionTrackerService)
 	switch {
@@ -1268,4 +1407,136 @@ func (s *session) trackSession(p *party, policySet []*types.SessionTrackerPolicy
 
 func (s *session) getSessionMetadata() apievents.SessionMetadata {
 	return s.ctx.Identity.GetIdentity().GetSessionMetadata(s.id.String())
+}
+
+// patchPodWithEphemeralContainer creates an ephemeral container and waits
+// for it to start.
+func (s *session) patchAndWaitForPodEphemeralContainer(ctx context.Context, authCtx *authContext, headers http.Header, waitingCont *kubewaitingcontainerpb.KubernetesWaitingContainer) error {
+	fmt.Fprintf(s.io, "\r\nCreating ephemeral container %s in pod %s/%s\r\n", waitingCont.Spec.ContainerName, waitingCont.Spec.Namespace, waitingCont.Spec.PodName)
+
+	clientSet, _, err := s.forwarder.impersonatedKubeClient(authCtx, headers)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	podClient := clientSet.CoreV1().Pods(authCtx.kubeResource.Namespace)
+	_, err = podClient.Patch(ctx,
+		waitingCont.Spec.PodName,
+		kubeapitypes.StrategicMergePatchType,
+		waitingCont.Spec.Patch,
+		metav1.PatchOptions{},
+		"ephemeralcontainers")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Fprintf(s.io, "Pod %s/%s successfully patched. Waiting for container to become ready.\r\n",
+		waitingCont.Spec.Namespace,
+		waitingCont.Spec.PodName)
+
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", waitingCont.Spec.PodName).String()
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fieldSelector
+			return podClient.List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fieldSelector
+			return podClient.Watch(ctx, options)
+		},
+	}
+	_, err = watchtools.UntilWithSync(ctx, lw, &corev1.Pod{}, nil, func(ev watch.Event) (bool, error) {
+		switch ev.Type {
+		case watch.Deleted:
+			return false, trace.NotFound("pod %s not found", waitingCont.Spec.PodName)
+		}
+
+		p, ok := ev.Object.(*corev1.Pod)
+		if !ok {
+			return false, trace.BadParameter("watch did not return a pod: %v", ev.Object)
+		}
+
+		s := getEphemeralContainerStatusByName(p, waitingCont.Spec.ContainerName)
+		if s == nil {
+			return false, nil
+		}
+		if s.State.Running != nil || s.State.Terminated != nil {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Fprintf(s.io, "Ephemeral container %s is ready.\r\n", waitingCont.Spec.ContainerName)
+
+	return nil
+}
+
+// retrieveAlreadyStoppedPodLogs retrieves the logs of a stopped pod and writes them to the session's io writer.
+func (s *session) retrieveAlreadyStoppedPodLogs(podClient clientv1.PodInterface, namespace, podName, container string) error {
+	fmt.Fprintf(s.io, "Failed to attach to the container, attempting to stream logs instead...\r\n")
+	req := podClient.GetLogs(podName, &corev1.PodLogOptions{Container: container})
+	r, err := req.Stream(s.streamContext)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if _, err := io.Copy(s.io, r); err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(r.Close())
+}
+
+// retrieveEphemeralContainerCommand retrieves the command of an ephemeral container
+// if it exists.
+func (s *session) retrieveEphemeralContainerCommand(ctx context.Context, username, containerName string) []string {
+	containers, err := s.forwarder.getUserEphemeralContainersForPod(ctx, username, s.ctx.kubeClusterName, s.podNamespace, s.podName)
+	if err != nil {
+		s.log.WithError(err).Warn("Failed to retrieve ephemeral containers")
+		return nil
+	}
+	if len(containers) == 0 {
+		return nil
+	}
+	for _, container := range containers {
+		if container.GetMetadata().GetName() != containerName {
+			continue
+		}
+
+		contentType, err := patchTypeToContentType(apimachinerytypes.PatchType(container.Spec.PatchType))
+		if err != nil {
+			return nil
+		}
+		encoder, decoder, err := newEncoderAndDecoderForContentType(
+			contentType,
+			newClientNegotiator(s.sess.codecFactory),
+		)
+		if err != nil {
+			s.log.WithError(err).Warn("Failed to create encoder and decoder")
+			return nil
+		}
+		pod, _, err := s.forwarder.mergeEphemeralPatchWithCurrentPod(
+			ctx,
+			mergeEphemeralPatchWithCurrentPodConfig{
+				kubeCluster:   s.ctx.kubeClusterName,
+				kubeNamespace: s.podNamespace,
+				podName:       s.podName,
+				decoder:       decoder,
+				encoder:       encoder,
+				podPatch:      container.GetSpec().Patch,
+				patchType:     apimachinerytypes.PatchType(container.GetSpec().PatchType),
+			},
+		)
+		if err != nil {
+			s.log.WithError(err).Warn("Failed to merge ephemeral patch with current pod")
+			return nil
+		}
+		for _, ephemeral := range pod.Spec.EphemeralContainers {
+			if ephemeral.Name == containerName {
+				return ephemeral.Command
+			}
+		}
+
+	}
+	return nil
 }

--- a/lib/kube/proxy/sess_test.go
+++ b/lib/kube/proxy/sess_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 
 	"github.com/gravitational/teleport"
+	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
@@ -265,8 +266,9 @@ func Test_session_trackSession(t *testing.T) {
 				},
 				forwarder: &Forwarder{
 					cfg: ForwarderConfig{
-						Clock:      clockwork.NewFakeClock(),
-						AuthClient: tt.args.authClient,
+						Clock:             clockwork.NewFakeClock(),
+						AuthClient:        tt.args.authClient,
+						CachingAuthClient: tt.args.authClient,
 					},
 					ctx: context.Background(),
 				},
@@ -290,4 +292,8 @@ func (m *mockSessionTrackerService) CreateSessionTracker(ctx context.Context, tr
 		return nil, trace.ConnectionProblem(nil, "mock error")
 	}
 	return tracker, nil
+}
+
+func (m *mockSessionTrackerService) ListKubernetesWaitingContainers(ctx context.Context, pageSize int, pageToken string) ([]*kubewaitingcontainerpb.KubernetesWaitingContainer, string, error) {
+	return nil, "", nil
 }


### PR DESCRIPTION
Backports of https://github.com/gravitational/teleport/pull/40792 and https://github.com/gravitational/teleport/pull/40871.

changelog: properly enforce session moderation requirements when starting Kubernetes ephemeral containers