### PR TITLE
Update proxy templates to support resource filtering

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -1090,7 +1090,24 @@ proxy_templates:
   # Optional host server address to connect to (`%h:%p`).
   #
   # Port defaults to 3022 if not explicitly provided with `--port`.
+  # If provided, it will take precedence over host resolution via
+  # query or search.
   host: "$1:$3"
+
+  # Optional predicate expression to resolve the target host with.
+  #
+  # Query by predicate expression similar to tsh ls --query.
+  # Has priority over search but will be ignored if a host is provided.
+  #
+  # See https://goteleport.com/docs/reference/predicate-language/#resource-filtering for
+  # predicate expression examples.
+  query: "labels.env == $1"
+
+  # Optional fuzzy search terms to resolve the target host with.
+  #
+  # Search by a list of comma separated keywords similar to tsh ls --search.
+  # Only applied if host and search are not provided.
+  search: "$1"
 
 # Multiple templates can be provided. They are evaluated in order and the first
 # match takes effect.

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	libclient "github.com/gravitational/teleport/lib/client"
@@ -62,13 +63,37 @@ func onProxyCommandSSH(cf *CLIConf) error {
 			return trace.Wrap(err)
 		}
 
-		targetHost, targetPort, err := net.SplitHostPort(tc.Host)
-		if err != nil {
-			targetHost = tc.Host
-			targetPort = strconv.Itoa(tc.HostPort)
+		var target string
+		switch {
+		case tc.Host != "":
+			targetHost, targetPort, err := net.SplitHostPort(tc.Host)
+			if err != nil {
+				targetHost = tc.Host
+				targetPort = strconv.Itoa(tc.HostPort)
+			}
+			targetHost = cleanTargetHost(targetHost, tc.WebProxyHost(), clt.ClusterName())
+			target = net.JoinHostPort(targetHost, targetPort)
+		case len(tc.SearchKeywords) != 0 || tc.PredicateExpression != "":
+			nodes, err := client.GetAllResources[types.Server](cf.Context, clt.AuthClient, tc.ResourceFilter(types.KindNode))
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			if len(nodes) == 0 {
+				return trace.NotFound("no matching SSH hosts found for search terms or query expression")
+			}
+
+			if len(nodes) > 1 {
+				return trace.BadParameter("found multiple matching SSH hosts %v", nodes[:2])
+			}
+
+			// Dialing is happening by UUID but a port is still required by
+			// the Proxy dial request. Zero is an indicator to the Proxy that
+			// it may chose the appropriate port based on the target server.
+			target = fmt.Sprintf("%s:0", nodes[0].GetName())
+		default:
+			return trace.BadParameter("no hostname, search terms or query expression provided")
 		}
-		targetHost = cleanTargetHost(targetHost, tc.WebProxyHost(), clt.ClusterName())
-		target := net.JoinHostPort(targetHost, targetPort)
 
 		conn, _, err := clt.DialHostWithResumption(cf.Context, target, clt.ClusterName(), tc.LocalAgent().ExtendedAgent)
 		if err != nil {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3807,13 +3807,13 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 	}
 
 	// Check if this host has a matching proxy template.
-	tProxy, tHost, tCluster, tMatched := cf.TSHConfig.ProxyTemplates.Apply(fullHostName)
+	expanded, tMatched := cf.TSHConfig.ProxyTemplates.Apply(fullHostName)
 	if !tMatched && useProxyTemplate {
 		return nil, trace.BadParameter("proxy jump contains {{proxy}} variable but did not match any of the templates in tsh config")
 	} else if tMatched {
-		if tHost != "" {
-			c.Host = tHost
-			log.Debugf("Will connect to host %q according to proxy template.", tHost)
+		if expanded.Host != "" {
+			c.Host = expanded.Host
+			log.Debugf("Will connect to host %q according to proxy template.", expanded.Host)
 
 			if host, port, err := net.SplitHostPort(c.Host); err == nil {
 				c.Host = host
@@ -3822,17 +3822,27 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 					return nil, trace.Wrap(err)
 				}
 			}
+		} else if expanded.Query != "" {
+			log.Debugf("Will query for hosts via %q according to proxy template.", expanded.Query)
+			cf.PredicateExpression = expanded.Query
+			// The PredicateExpression is ignored if the Host is populated.
+			c.Host = ""
+		} else if expanded.Search != "" {
+			log.Debugf("Will search for hosts via %q according to proxy template.", expanded.Search)
+			cf.SearchKeywords = expanded.Search
+			// The SearchKeywords are ignored if the Host is populated.
+			c.Host = ""
 		}
 
 		// Don't overwrite proxy jump if explicitly provided
-		if cf.ProxyJump == "" && tProxy != "" {
-			cf.ProxyJump = tProxy
-			log.Debugf("Will connect to proxy %q according to proxy template.", tProxy)
+		if cf.ProxyJump == "" && expanded.Proxy != "" {
+			cf.ProxyJump = expanded.Proxy
+			log.Debugf("Will connect to proxy %q according to proxy template.", expanded.Proxy)
 		}
 
-		if tCluster != "" {
-			cf.SiteName = tCluster
-			log.Debugf("Will connect to cluster %q according to proxy template.", tCluster)
+		if expanded.Cluster != "" {
+			cf.SiteName = expanded.Cluster
+			log.Debugf("Will connect to cluster %q according to proxy template.", expanded.Cluster)
 		}
 	}
 
@@ -3947,7 +3957,6 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 	c.KeyTTL = time.Minute * time.Duration(cf.MinsToLive)
 	c.InsecureSkipVerify = cf.InsecureSkipVerify
 	c.PredicateExpression = cf.PredicateExpression
-
 	if cf.SearchKeywords != "" {
 		c.SearchKeywords = client.ParseSearchKeywords(cf.SearchKeywords, ',')
 	}

--- a/tool/tsh/common/tshconfig_test.go
+++ b/tool/tsh/common/tshconfig_test.go
@@ -279,6 +279,14 @@ func TestProxyTemplatesApply(t *testing.T) {
 				Template: `^(.+)\.(au.example.com):(.+)$`,
 				Host:     "$1:4022",
 			},
+			{
+				Template: `^(.+)\.search.example.com:(.+)$`,
+				Search:   "$1",
+			},
+			{
+				Template: `^(.+)\.query.example.com:(.+)$`,
+				Query:    `labels.animal == "$1"`,
+			},
 		},
 	}
 	require.NoError(t, tshConfig.Check())
@@ -289,6 +297,8 @@ func TestProxyTemplatesApply(t *testing.T) {
 		outProxy       string
 		outHost        string
 		outCluster     string
+		outSearch      string
+		outQuery       string
 		outMatch       bool
 	}{
 		{
@@ -322,14 +332,33 @@ func TestProxyTemplatesApply(t *testing.T) {
 			inFullHostname: "node-1.cn.example.com:3022",
 			outMatch:       false,
 		},
+		{
+			testName:       "matches search",
+			inFullHostname: "llama.search.example.com:3022",
+			outSearch:      "llama",
+			outMatch:       true,
+		},
+		{
+			testName:       "matches query",
+			inFullHostname: "llama.query.example.com:3022",
+			outQuery:       `labels.animal == "llama"`,
+			outMatch:       true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
-			proxy, host, cluster, match := tshConfig.ProxyTemplates.Apply(test.inFullHostname)
-			require.Equal(t, test.outProxy, proxy)
-			require.Equal(t, test.outHost, host)
-			require.Equal(t, test.outCluster, cluster)
+			expanded, match := tshConfig.ProxyTemplates.Apply(test.inFullHostname)
 			require.Equal(t, test.outMatch, match)
+			if !match {
+				require.Nil(t, expanded)
+				return
+			}
+
+			require.Equal(t, test.outProxy, expanded.Proxy)
+			require.Equal(t, test.outHost, expanded.Host)
+			require.Equal(t, test.outCluster, expanded.Cluster)
+			require.Equal(t, test.outSearch, expanded.Search)
+			require.Equal(t, test.outQuery, expanded.Query)
 		})
 	}
 }


### PR DESCRIPTION
Historically proxy templates have only supported an exact hostname match via the `Host` field defined. This limits some of the benefits of using proxy templates and forces users to do a bunch of extra work in their ssh config. For example, if a user today wanted to leverage proxy templates to connect to a host via a label, predicate expression, or fuzzy match, they would be required to use tsh ls, find the matching UUID or hostname and provide that to tsh for evaluation with the template expression.

SSH Config:
```
Match Host *.foo.example.com
    ProxyCommand tsh proxy ssh  %r@$(tsh ls --search=$(echo %h | cut -d. -f1) -f json | jq -r '.[0].metadata.name'):%p
```

The above requires multiple sub-shells, a connection to the Auth server, and jq to be installed on the client machine in order to work.

To reduce the amount of effort required to connect to a resource proxy templates have been updated with a `Search` and a `Query` field to support fuzzy search and predicate expressions much like `tsh ls --search` and `tsh ls --query`. The order of operations for matching the target host is: 1) Host, 2) Predicate Expression, 3) Query.

In addition to the proxy template changes, tsh proxy ssh has also been updated to allow resolving the target via searching or querying -- though ONLY via proxy templates. There are no additional `--query` or `--search` flags added to tsh proxy ssh for the time being. This is mostly for CLI UX reasons since neither tsh ssh or tsh proxy ssh support those flags today, and only allow filtering by label via supplying key value pairs in the hostname  (tsh ssh alice@foo=bar,env=dev).

tsh proxy ssh is however still limited to connecting to a single host at a time. If there are no matches, or multiple matches found as a result of target resolution, then an error is returned.

With the new functionality, the above example can be simplified to the following.

SSH Config:
```
Match Host *.foo.example.com
    ProxyCommand tsh proxy ssh  %r@%h
```

Proxy Template:
```
- template: '^(.*).example.com:\d+$'
  search: "$1"
```

This shifts the responsibility of host resolution from the caller to tsh. It allows resolution to happen in the same process that will initiate the connection, reducing a dial to the cluster, and eliminating the need for any sub-shells, or extra tools outside of tsh to be present.

Changelog: Extend proxy templates to allow the target host to be resolved via a predicate expression or fuzzy matching.
