### PR TITLE
auth: require a semaphore in order to complete uploads

### DIFF
--- a/api/types/semaphore.go
+++ b/api/types/semaphore.go
@@ -46,6 +46,11 @@ const SemaphoreKindHostUserModification = "host_user_modification"
 // the Access Monitoring feature during handling user queries.
 const SemaphoreKindAccessMonitoringLimiter = "access_monitoring_limiter"
 
+// SemaphoreKindUploadCompleter is the semaphore kind used by the
+// auth server's upload completer to protect access to the shared
+// session recordings backend.
+const SemaphoreKindUploadCompleter = "upload_completer"
+
 // Semaphore represents distributed semaphore concept
 type Semaphore interface {
 	// Resource contains common resource values

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2022,9 +2022,11 @@ func (process *TeleportProcess) initAuthService() error {
 		err = events.StartNewUploadCompleter(process.ExitContext(), events.UploadCompleterConfig{
 			Uploader:       uploadHandler,
 			Component:      teleport.ComponentAuth,
+			ClusterName:    clusterName,
 			AuditLog:       process.auditLog,
 			SessionTracker: authServer.Services,
-			ClusterName:    clusterName,
+			Semaphores:     authServer.Services,
+			ServerID:       cfg.HostUUID,
 		})
 		if err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
Having multiple auth servers attempt to complete uploads against the same shared backend results in racy behavior. This code is focused on cleanup and is not performance sensitive, so we leverage a semaphore to make sure only one auth server is attempting to complete uploads at any point in time.

changelog: Improve the reliability of the upload completer.