### PR TITLE
[v14] Add extra volumes to the teleport updater

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -211,6 +211,43 @@ than a Teleport-published image.
 
 `extraArgs` contains additional arguments to pass to the updater binary.
 
+### `updater.extraVolumes`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`updater.extraVolumes` contains extra volumes to mount into the Updater pods.
+See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+for more details.
+
+For example:
+```yaml
+updater:
+  extraVolumes:
+  - name: myvolume
+    secret:
+      secretName: testSecret
+```
+
+### `updater.extraVolumeMounts`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`updater.extraVolumeMounts` contains extra volumes mounts for the updater.
+See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+for more details.
+
+For example:
+```yaml
+updater:
+  extraVolumesMounts:
+  - name: myvolume
+    mountPath: /path/on/host
+```
+
 ## `roleBindingName`
 
 | Type     | Default value | Required? |

--- a/examples/chart/teleport-kube-agent/.lint/updater-secret-docker.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/updater-secret-docker.yaml
@@ -1,0 +1,23 @@
+proxyAddr: proxy.example.com:3080
+roles: "custom"
+updater:
+  enabled: true
+  versionServer: https://my-custom-version-server/v1
+  releaseChannel: custom/preview
+  pullCredentials: docker
+  extraEnv:
+    - name: DOCKER_CONFIG
+      value: /mnt/docker/
+  extraVolumes:
+    - name: docker-config
+      projected:
+        sources:
+          - secret:
+              name: my-pull-secret
+              items:
+                - key: .dockerconfigjson
+                  path: config.json
+  extraVolumeMounts:
+    - name: docker-config
+      mountPath: "/mnt/docker"
+      readOnly: true

--- a/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
@@ -56,9 +56,6 @@ spec:
   {{- if $updater.tls.existingCASecretName }}
         - name: SSL_CERT_FILE
           value: /etc/teleport-tls-ca/ca.pem
-        # Used to track whether a Teleport agent was installed using this method.
-        - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
-          value: "true"
   {{- end }}
 {{- end }}
         args:
@@ -99,15 +96,27 @@ spec:
 {{- if $updater.resources }}
         resources: {{- toYaml $updater.resources | nindent 10 }}
 {{- end }}
-{{- if $updater.tls.existingCASecretName }}
+{{- if or $updater.tls.existingCASecretName .Values.updater.extraVolumeMounts }}
         volumeMounts:
-        - mountPath: /etc/teleport-tls-ca
-          name: "teleport-tls-ca"
-          readOnly: true
+  {{- if $updater.tls.existingCASecretName }}
+          - mountPath: /etc/teleport-tls-ca
+            name: "teleport-tls-ca"
+            readOnly: true
+  {{- end }}
+  {{- if .Values.updater.extraVolumeMounts }}
+          {{- toYaml .Values.updater.extraVolumeMounts | nindent 10 }}
+  {{- end }}
+{{- end }}
+{{- if or $updater.tls.existingCASecretName .Values.updater.extraVolumes }}
       volumes:
-      - name: "teleport-tls-ca"
-        secret:
-          secretName: {{ $updater.tls.existingCASecretName }}
+  {{- if .Values.updater.extraVolumes }}
+        {{- toYaml $updater.extraVolumes | nindent 8 }}
+  {{- end }}
+  {{- if $updater.tls.existingCASecretName }}
+        - name: "teleport-tls-ca"
+          secret:
+            secretName: {{ $updater.tls.existingCASecretName }}
+  {{- end }}
 {{- end }}
 {{- if $updater.priorityClassName }}
       priorityClassName: {{ $updater.priorityClassName }}

--- a/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
@@ -246,3 +246,32 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--foo=bar"
+
+  - it: sets extraVolumes when specified
+    values:
+      - ../.lint/updater-secret-docker.yaml
+      - ../.lint/existing-tls-secret-with-ca.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: docker-config
+            projected:
+              sources:
+                - secret:
+                    name: my-pull-secret
+                    items:
+                      - key: .dockerconfigjson
+                        path: config.json
+
+  - it: sets extraVolumeMounts when specified
+    values:
+      - ../.lint/updater-secret-docker.yaml
+      - ../.lint/existing-tls-secret-with-ca.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: docker-config
+            mountPath: "/mnt/docker"
+            readOnly: true

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -173,9 +173,38 @@ updater:
   # binary.
   extraArgs: []
 
-# If set, will use an existing volume mounted via extraVolumes
-# as the Teleport data directory.
-# If anything is set under the "storage" key, this will be ignored.
+  # updater.extraVolumes(list) -- contains extra volumes to mount into the Updater pods.
+  # See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+  # for more details.
+  #
+  # For example:
+  # ```yaml
+  # updater:
+  #   extraVolumes:
+  #   - name: myvolume
+  #     secret:
+  #       secretName: testSecret
+  # ```
+  extraVolumes: []
+
+  # updater.extraVolumeMounts(list) -- contains extra volumes mounts for the updater.
+  # See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+  # for more details.
+  #
+  # For example:
+  # ```yaml
+  # updater:
+  #   extraVolumesMounts:
+  #   - name: myvolume
+  #     mountPath: /path/on/host
+  # ```
+  extraVolumeMounts: []
+
+# existingDataVolume(string) -- is the name of an existing Kubernetes Persistent
+# Volume that should be mounted at `/var/lib/teleport`.
+#
+# This is only useful if you had a previous agent running with persistence enabled
+# and want for a new agent to reuse the volume.
 existingDataVolume: ""
 
 # If true, create & use Pod Security Policy resources


### PR DESCRIPTION
Backport #40915 to branch/v14

changelog: Allow mounting extra volumes in the updater pod deployed by the `teleport-kube-agent`chart.
