### PR TITLE
[v15] charts/teleport-cluster: configurable podSecurityContext

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -2041,6 +2041,23 @@ See [the GitHub PR](https://github.com/gravitational/teleport/pull/36251) for te
       memory: 2Gi
   ```
 
+## `podSecurityContext`
+
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+
+The `podSecurityContext` applies to the main Teleport pods.
+
+`values.yaml` example:
+
+  ```yaml
+  podSecurityContext:
+    fsGroup: 65532
+  ```
+
 ## `securityContext`
 
 | Type     | Default value |

--- a/examples/chart/teleport-cluster/.lint/pod-security-context-empty.yaml
+++ b/examples/chart/teleport-cluster/.lint/pod-security-context-empty.yaml
@@ -1,0 +1,1 @@
+clusterName: helm-lint

--- a/examples/chart/teleport-cluster/.lint/pod-security-context.yaml
+++ b/examples/chart/teleport-cluster/.lint/pod-security-context.yaml
@@ -1,0 +1,7 @@
+clusterName: helm-lint
+podSecurityContext:
+  fsGroup: 99
+  fsGroupChangePolicy: OnRootMismatch
+  runAsGroup: 99
+  runAsNonRoot: true
+  runAsUser: 99

--- a/examples/chart/teleport-cluster/templates/auth/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/deployment.yaml
@@ -294,5 +294,8 @@ spec:
 {{- if $auth.priorityClassName }}
       priorityClassName: {{ $auth.priorityClassName }}
 {{- end }}
+{{- if $auth.podSecurityContext }}
+      securityContext: {{- toYaml $auth.podSecurityContext | nindent 8 }}
+{{- end }}
       serviceAccountName: {{ include "teleport-cluster.auth.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ $auth.terminationGracePeriodSeconds }}

--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -325,5 +325,8 @@ spec:
 {{- if $proxy.priorityClassName }}
       priorityClassName: {{ $proxy.priorityClassName }}
 {{- end }}
+{{- if $proxy.podSecurityContext }}
+      securityContext: {{- toYaml $proxy.podSecurityContext | nindent 8 }}
+{{- end }}
       serviceAccountName: {{ include "teleport-cluster.proxy.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ $proxy.terminationGracePeriodSeconds }}

--- a/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
@@ -126,6 +126,35 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
+  - it: should set podSecurityContext when set in values
+    template: auth/deployment.yaml
+    values:
+      - ../.lint/pod-security-context.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 99
+      - equal:
+          path: spec.template.spec.securityContext.fsGroupChangePolicy
+          value: OnRootMismatch
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 99
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 99
+
+  - it: should not set podSecurityContext when is empty object (default value)
+    template: auth/deployment.yaml
+    values:
+      - ../.lint/pod-security-context-empty.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.securityContext
+
   - it: should set securityContext when set in values
     template: auth/deployment.yaml
     values:

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -164,6 +164,35 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
+  - it: should set podSecurityContext when set in values
+    template: proxy/deployment.yaml
+    values:
+      - ../.lint/pod-security-context.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 99
+      - equal:
+          path: spec.template.spec.securityContext.fsGroupChangePolicy
+          value: OnRootMismatch
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 99
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 99
+
+  - it: should not set podSecurityContext when is empty object (default value)
+    template: proxy/deployment.yaml
+    values:
+      - ../.lint/pod-security-context-empty.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.securityContext
+
   - it: should set securityContext when set in values
     template: proxy/deployment.yaml
     values:

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -943,6 +943,11 @@
             "type": "object",
             "default": {}
         },
+        "podSecurityContext": {
+            "$id": "#/properties/podSecurityContext",
+            "type": "object",
+            "default": {}
+        },
         "securityContext": {
             "$id": "#/properties/securityContext",
             "type": "object",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -746,6 +746,10 @@ resources: {}
 #  limits:
 #    memory: "2Gi"
 
+# Pod security context for any pods created by the chart
+podSecurityContext: {}
+  # fsGroup: 65532
+
 # Security context to add to the container
 securityContext: {}
   # runAsUser: 99


### PR DESCRIPTION
Backport #40945 to branch/v15

changelog: makes `podSecurityContext` configurable in the `teleport-cluster` Helm chart.
