### PR TITLE
Remove support for disabling second factor authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Teleport clusters using the dynamodb backend must now have the `dynamodb:Conditi
 permission. For a full list of all required permissions see the dynamo backend iam
 policy [example](docs/pages/includes/dynamodb-iam-policy.mdx).
 
+#### Disabling second factor authentication_type
+
+Support for disabling second factor authentication has been removed
+>>>>>>> f4a18b1ac7 (dont allow disabling second factor)
+
 ## 15.0.0 (xx/xx/24)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ policy [example](docs/pages/includes/dynamodb-iam-policy.mdx).
 #### Disabling second factor authentication_type
 
 Support for disabling second factor authentication has been removed
->>>>>>> f4a18b1ac7 (dont allow disabling second factor)
 
 ## 15.0.0 (xx/xx/24)
 

--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -195,7 +195,7 @@ type SecondFactorType string
 
 const (
 	// SecondFactorOff means no second factor.
-	SecondFactorOff = SecondFactorType("off")
+	SecondFactorOff = SecondFactorType("off") // todo(amk): remove in 17
 	// SecondFactorOTP means that only OTP is supported for 2FA and 2FA is
 	// required for all users.
 	SecondFactorOTP = SecondFactorType("otp")
@@ -212,7 +212,7 @@ const (
 	SecondFactorOn = SecondFactorType("on")
 	// SecondFactorOptional means that all 2FA protocols are supported and 2FA
 	// is required only for users that have MFA devices registered.
-	SecondFactorOptional = SecondFactorType("optional")
+	SecondFactorOptional = SecondFactorType("optional") // todo(amk): remove in 17
 )
 
 // UnmarshalYAML supports parsing off|on into string on SecondFactorType.

--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -195,7 +195,7 @@ type SecondFactorType string
 
 const (
 	// SecondFactorOff means no second factor.
-	SecondFactorOff = SecondFactorType("off") // todo(amk): remove in 17
+	SecondFactorOff = SecondFactorType("off") // todo(lxea): DELETE IN 17
 	// SecondFactorOTP means that only OTP is supported for 2FA and 2FA is
 	// required for all users.
 	SecondFactorOTP = SecondFactorType("otp")
@@ -212,7 +212,7 @@ const (
 	SecondFactorOn = SecondFactorType("on")
 	// SecondFactorOptional means that all 2FA protocols are supported and 2FA
 	// is required only for users that have MFA devices registered.
-	SecondFactorOptional = SecondFactorType("optional") // todo(amk): remove in 17
+	SecondFactorOptional = SecondFactorType("optional") // todo(lxea): DELETE IN 17
 )
 
 // UnmarshalYAML supports parsing off|on into string on SecondFactorType.

--- a/constants.go
+++ b/constants.go
@@ -418,7 +418,7 @@ const (
 	MinimumEtcdVersion = "3.3.0"
 
 	// EnvVarAllowNoSecondFactor is used to allow disabling second factor auth
-	// todo(amk): remove in 17
+	// todo(lxea): DELETE IN 17
 	EnvVarAllowNoSecondFactor = "TELEPORT_ALLOW_NO_SECOND_FACTOR"
 )
 

--- a/constants.go
+++ b/constants.go
@@ -416,6 +416,10 @@ const (
 
 	// MinimumEtcdVersion is the minimum version of etcd supported by Teleport
 	MinimumEtcdVersion = "3.3.0"
+
+	// EnvVarAllowNoSecondFactor is used to allow disabling second factor auth
+	// todo(amk): remove in 17
+	EnvVarAllowNoSecondFactor = "TELEPORT_ALLOW_NO_SECOND_FACTOR"
 )
 
 const (

--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -42,7 +42,7 @@ per-session MFA with FIPS builds, provide the following in your `teleport.yaml`:
 teleport:
   auth_service:
     local_auth: false
-    second_factor: optional
+    second_factor: on
     webauthn:
       rp_id: teleport.example.com
 ```

--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -163,9 +163,8 @@ auth_service:
         # Defaults to false.
         require_session_mfa: false
 
-        # second_factor can be 'off', 'on', 'optional', 'otp' or 'webauthn'.
+        # second_factor can be 'on', 'otp' or 'webauthn'.
         # - 'on' requires either otp or webauthn second factor.
-        # - 'optional' allows otp and webauthn second factor.
         # - 'otp' and 'webauthn' require the corresponding second factor.
         second_factor: otp
 

--- a/docs/pages/reference/authentication.mdx
+++ b/docs/pages/reference/authentication.mdx
@@ -47,7 +47,9 @@ Add the following to your Teleport configuration file, which is stored in
   auth_service:
     authentication:
       type: local
-      second_factor: off
+      second_factor: on
+      webauthn:
+        rp_id: example.teleport.sh
   ```
 
 ### Dynamic resource

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -306,9 +306,9 @@ Defaults to Teleport's binary default when empty: `best_effort`.
 | `string` | `otp`         | Yes       | `auth_service.authentication.second_factor` |
 
 `authentication.secondFactor` controls the second factor used for local user authentication. Possible values supported by this chart
-are `off` (not recommended), `on`, `otp`, `optional` and `webauthn`.
+are `on`, `otp`, and `webauthn`.
 
-When set to `on`, `optional` or `webauthn`, the `authenticationSecondFactor.webauthn` section can also be used.
+When set to `on` or `webauthn`, the `authenticationSecondFactor.webauthn` section can also be used.
 The configured `rp_id` defaults to `clusterName`.
 
 <Admonition type="warning">

--- a/docs/pages/reference/resources.mdx
+++ b/docs/pages/reference/resources.mdx
@@ -222,7 +222,7 @@ metadata:
   name: cluster-auth-preference
 spec:
   # Sets the type of second factor to use.
-  # Possible values: "on", "off", "otp", "webauthn" and "optional".
+  # Possible values: "on", "otp" and "webauthn"
   # If "on" is set, all MFA protocols are supported.
   second_factor: "otp"
 

--- a/integration/conntest/database_test.go
+++ b/integration/conntest/database_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/conntest"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/common"
@@ -66,6 +67,8 @@ func startPostgresTestServer(t *testing.T, authServer *auth.Server) *postgres.Te
 }
 
 func TestDiagnoseConnectionForPostgresDatabases(t *testing.T) {
+	modules.SetInsecureTestMode(true)
+
 	ctx := context.Background()
 	diagnoseConnectionEndpoint := strings.Join([]string{"sites", "$site", "diagnostics", "connections"}, "/")
 

--- a/integration/helpers/testmain.go
+++ b/integration/helpers/testmain.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/tool/teleport/common"
@@ -35,6 +36,7 @@ func TestMainImplementation(m *testing.M) {
 	utils.InitLoggerForTests()
 	native.PrecomputeTestKeys(m)
 	SetTestTimeouts(3 * time.Second)
+	modules.SetInsecureTestMode(true)
 	// If the test is re-executing itself, execute the command that comes over
 	// the pipe.
 	if srv.IsReexec() {

--- a/integration/integrations/integration_test.go
+++ b/integration/integrations/integration_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -32,9 +33,15 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
+
+func TestMain(m *testing.M) {
+	modules.SetInsecureTestMode(true)
+	os.Exit(m.Run())
+}
 
 // TestIntegrationCRUD starts a Teleport cluster and using its Proxy Web server,
 // tests the CRUD operations over the Integration resource.

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -667,6 +668,7 @@ func TestKubePROXYProtocol(t *testing.T) {
 func TestKubeIPPinning(t *testing.T) {
 	lib.SetInsecureDevMode(true)
 	defer lib.SetInsecureDevMode(false)
+	modules.SetInsecureTestMode(true)
 
 	const (
 		kubeCluster = constants.KubeTeleportProxyALPNPrefix + "teleport.cluster.local"

--- a/lib/assist/assist_test.go
+++ b/lib/assist/assist_test.go
@@ -37,11 +37,13 @@ import (
 	"github.com/gravitational/teleport/lib/ai/model/tools"
 	aitest "github.com/gravitational/teleport/lib/ai/testutils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/modules"
 )
 
 func TestChatComplete(t *testing.T) {
 	t.Parallel()
 
+	modules.SetInsecureTestMode(true)
 	// Given an OpenAI server that returns a response for a chat completion request.
 	responses := []string{
 		generateCommandResponse(),

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -207,6 +207,7 @@ func newAuthSuite(t *testing.T) *testPack {
 func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
 	native.PrecomputeTestKeys(m)
+	modules.SetInsecureTestMode(true)
 	os.Exit(m.Run())
 }
 

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -24,6 +24,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -728,7 +729,10 @@ func initializeAuthPreference(ctx context.Context, asrv *Server, newAuthPref typ
 		}
 
 		if !shouldReplace {
-			return trace.Wrap(modules.ValidateResource(storedAuthPref))
+			if os.Getenv(teleport.EnvVarAllowNoSecondFactor) != "true" {
+				return trace.Wrap(modules.ValidateResource(storedAuthPref))
+			}
+			return nil
 		}
 
 		if storedAuthPref == nil {

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -728,7 +728,7 @@ func initializeAuthPreference(ctx context.Context, asrv *Server, newAuthPref typ
 		}
 
 		if !shouldReplace {
-			return nil
+			return trace.Wrap(modules.ValidateResource(storedAuthPref))
 		}
 
 		if storedAuthPref == nil {

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -319,11 +319,11 @@ func TestAuthPreference(t *testing.T) {
 }
 
 func TestAuthPreferenceSecondFactorOnly(t *testing.T) {
-	t.Parallel()
+	modules.SetInsecureTestMode(false)
+	defer modules.SetInsecureTestMode(true)
 	ctx := context.Background()
 
 	t.Run("starting with second_factor disabled fails", func(t *testing.T) {
-		t.Parallel()
 		conf := setupConfig(t)
 		authPref, err := types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
 			SecondFactor: constants.SecondFactorOff,
@@ -336,7 +336,6 @@ func TestAuthPreferenceSecondFactorOnly(t *testing.T) {
 	})
 
 	t.Run("starting with defaults and dynamically updating to disable second factor fails", func(t *testing.T) {
-		t.Parallel()
 		conf := setupConfig(t)
 		s, err := Init(ctx, conf)
 		require.NoError(t, err)

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -318,6 +318,37 @@ func TestAuthPreference(t *testing.T) {
 	})
 }
 
+func TestAuthPreferenceSecondFactorOnly(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("starting with second_factor disabled fails", func(t *testing.T) {
+		t.Parallel()
+		conf := setupConfig(t)
+		authPref, err := types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
+			SecondFactor: constants.SecondFactorOff,
+		})
+		require.NoError(t, err)
+
+		conf.AuthPreference = authPref
+		_, err = Init(ctx, conf)
+		require.Error(t, err)
+	})
+
+	t.Run("starting with defaults and dynamically updating to disable second factor fails", func(t *testing.T) {
+		t.Parallel()
+		conf := setupConfig(t)
+		s, err := Init(ctx, conf)
+		require.NoError(t, err)
+		authpref, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
+			SecondFactor: constants.SecondFactorOff,
+		})
+		require.NoError(t, err)
+		_, err = s.UpsertAuthPreference(ctx, authpref)
+		require.Error(t, err)
+	})
+}
+
 func TestClusterNetworkingConfig(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -40,7 +41,13 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
+	"github.com/gravitational/teleport/lib/modules"
 )
+
+func TestMain(m *testing.M) {
+	modules.SetInsecureTestMode(true)
+	os.Exit(m.Run())
+}
 
 func TestBotResourceName(t *testing.T) {
 	require.Equal(

--- a/lib/auth/presence/presencev1/service_test.go
+++ b/lib/auth/presence/presencev1/service_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -39,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/modules"
 )
 
 func newTestTLSServer(t testing.TB) *auth.TestTLSServer {
@@ -60,6 +62,11 @@ func newTestTLSServer(t testing.TB) *auth.TestTLSServer {
 	})
 
 	return srv
+}
+
+func TestMain(m *testing.M) {
+	modules.SetInsecureTestMode(true)
+	os.Exit(m.Run())
 }
 
 // TestGetRemoteCluster is an integration test that uses a real gRPC

--- a/lib/auth/windows/windows_test.go
+++ b/lib/auth/windows/windows_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/asn1"
+	"os"
 	"testing"
 	"time"
 
@@ -29,7 +30,13 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/modules"
 )
+
+func TestMain(m *testing.M) {
+	modules.SetInsecureTestMode(true)
+	os.Exit(m.Run())
+}
 
 // TestGenerateCredentials verifies that the smartcard certificates generated
 // by Teleport meet the requirements for Windows logon.

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
@@ -48,6 +49,7 @@ import (
 
 func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
+	modules.SetInsecureTestMode(true)
 	os.Exit(m.Run())
 }
 

--- a/lib/kube/grpc/grpc_test.go
+++ b/lib/kube/grpc/grpc_test.go
@@ -40,9 +40,11 @@ import (
 	kubeproxy "github.com/gravitational/teleport/lib/kube/proxy"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/modules"
 )
 
 func TestListKubernetesResources(t *testing.T) {
+	modules.SetInsecureTestMode(true)
 	var (
 		usernameWithFullAccess = "full_user"
 		usernameNoAccess       = "limited_user"

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"sort"
 	"sync/atomic"
 	"testing"
@@ -58,6 +59,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -88,6 +90,11 @@ func fakeClusterFeatures() proto.Features {
 	return proto.Features{
 		Kubernetes: true,
 	}
+}
+
+func TestMain(m *testing.M) {
+	modules.SetInsecureTestMode(true)
+	os.Exit(m.Run())
 }
 
 func TestAuthenticate(t *testing.T) {

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"crypto"
 	"fmt"
+	"os"
 	"runtime"
 	"sync"
 	"time"
@@ -331,11 +332,13 @@ func GetModules() Modules {
 
 // ValidateResource performs additional resource checks.
 func ValidateResource(res types.Resource) error {
-	switch r := res.(type) {
-	case types.AuthPreference:
-		switch r.GetSecondFactor() {
-		case constants.SecondFactorOff, constants.SecondFactorOptional:
-			return trace.BadParameter("cannot disable two-factor authentication")
+	if os.Getenv(teleport.EnvVarAllowNoSecondFactor) != "true" {
+		switch r := res.(type) {
+		case types.AuthPreference:
+			switch r.GetSecondFactor() {
+			case constants.SecondFactorOff, constants.SecondFactorOptional:
+				return trace.BadParameter("cannot disable two-factor authentication")
+			}
 		}
 	}
 
@@ -345,6 +348,11 @@ func ValidateResource(res types.Resource) error {
 	}
 
 	switch r := res.(type) {
+	case types.AuthPreference:
+		switch r.GetSecondFactor() {
+		case constants.SecondFactorOff, constants.SecondFactorOptional:
+			return trace.BadParameter("cannot disable two-factor authentication")
+		}
 	case types.SessionRecordingConfig:
 		switch r.GetMode() {
 		case types.RecordAtProxy, types.RecordAtProxySync:

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -332,8 +332,8 @@ func GetModules() Modules {
 
 // ValidateResource performs additional resource checks.
 func ValidateResource(res types.Resource) error {
-	// todo(lxea): remove condition in 17
-	if GetModules().Features().Cloud || os.Getenv(teleport.EnvVarAllowNoSecondFactor) != "true" {
+	// todo(lxea): DELETE IN 17
+	if GetModules().Features().Cloud || os.Getenv(teleport.EnvVarAllowNoSecondFactor) != "yes" {
 		switch r := res.(type) {
 		case types.AuthPreference:
 			switch r.GetSecondFactor() {

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -331,17 +331,20 @@ func GetModules() Modules {
 
 // ValidateResource performs additional resource checks.
 func ValidateResource(res types.Resource) error {
+	switch r := res.(type) {
+	case types.AuthPreference:
+		switch r.GetSecondFactor() {
+		case constants.SecondFactorOff, constants.SecondFactorOptional:
+			return trace.BadParameter("cannot disable two-factor authentication")
+		}
+	}
+
 	// All checks below are Cloud-specific.
 	if !GetModules().Features().Cloud {
 		return nil
 	}
 
 	switch r := res.(type) {
-	case types.AuthPreference:
-		switch r.GetSecondFactor() {
-		case constants.SecondFactorOff, constants.SecondFactorOptional:
-			return trace.BadParameter("cannot disable two-factor authentication on Cloud")
-		}
 	case types.SessionRecordingConfig:
 		switch r.GetMode() {
 		case types.RecordAtProxy, types.RecordAtProxySync:

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -332,10 +332,9 @@ func GetModules() Modules {
 
 // ValidateResource performs additional resource checks.
 func ValidateResource(res types.Resource) error {
-	// todo(lxea): DELETE IN 17
-	if (GetModules().Features().Cloud ||
-		os.Getenv(teleport.EnvVarAllowNoSecondFactor) != "yes") &&
-		!IsInsecureTestMode() {
+	// todo(lxea): DELETE IN 17 [remove env var, leave insecure test mode]
+	if GetModules().Features().Cloud ||
+		(os.Getenv(teleport.EnvVarAllowNoSecondFactor) != "yes" && !IsInsecureTestMode()) {
 
 		switch r := res.(type) {
 		case types.AuthPreference:

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -332,7 +332,8 @@ func GetModules() Modules {
 
 // ValidateResource performs additional resource checks.
 func ValidateResource(res types.Resource) error {
-	if os.Getenv(teleport.EnvVarAllowNoSecondFactor) != "true" {
+	// todo(lxea): remove condition in 17
+	if GetModules().Features().Cloud || os.Getenv(teleport.EnvVarAllowNoSecondFactor) != "true" {
 		switch r := res.(type) {
 		case types.AuthPreference:
 			switch r.GetSecondFactor() {
@@ -348,11 +349,6 @@ func ValidateResource(res types.Resource) error {
 	}
 
 	switch r := res.(type) {
-	case types.AuthPreference:
-		switch r.GetSecondFactor() {
-		case constants.SecondFactorOff, constants.SecondFactorOptional:
-			return trace.BadParameter("cannot disable two-factor authentication")
-		}
 	case types.SessionRecordingConfig:
 		switch r.GetMode() {
 		case types.RecordAtProxy, types.RecordAtProxySync:

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -20,6 +20,7 @@ package modules_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,11 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/modules"
 )
+
+func TestMain(m *testing.M) {
+	modules.SetInsecureTestMode(true)
+	os.Exit(m.Run())
+}
 
 func TestOSSModules(t *testing.T) {
 	require.False(t, modules.GetModules().IsBoringBinary())
@@ -54,7 +60,7 @@ func TestValidateAuthPreferenceOnCloud(t *testing.T) {
 
 	authPref.SetSecondFactor(constants.SecondFactorOff)
 	_, err = testServer.AuthServer.UpdateAuthPreference(ctx, authPref)
-	require.EqualError(t, err, "cannot disable two-factor authentication on Cloud")
+	require.EqualError(t, err, "cannot disable two-factor authentication")
 }
 
 func TestValidateSessionRecordingConfigOnCloud(t *testing.T) {

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -70,6 +70,7 @@ import (
 
 func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
+	modules.SetInsecureTestMode(true)
 	os.Exit(m.Run())
 }
 

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1195,11 +1195,6 @@ func (s *ServicesTestSuite) AuthPreference(t *testing.T) {
 	_, err = s.ConfigS.UpdateAuthPreference(ctx, gotAP)
 	require.True(t, trace.IsCompareFailed(err))
 
-	created.SetSecondFactor(constants.SecondFactorOff)
-	updated, err := s.ConfigS.UpdateAuthPreference(ctx, created)
-	require.NoError(t, err)
-	require.Equal(t, constants.SecondFactorOff, updated.GetSecondFactor())
-
 	// Validate that upserting overwrites the value regardless of the revision.
 	upserted, err := s.ConfigS.UpsertAuthPreference(ctx, gotAP)
 	require.NoError(t, err)

--- a/lib/srv/alpnproxy/proxy_test.go
+++ b/lib/srv/alpnproxy/proxy_test.go
@@ -28,6 +28,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -35,10 +36,16 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/utils/pingconn"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/srv/db/dbutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
+
+func TestMain(m *testing.M) {
+	modules.SetInsecureTestMode(true)
+	os.Exit(m.Run())
+}
 
 // TestProxySSHHandler tests the ALPN routing. Connection with ALPN 'teleport-proxy-ssh' value should
 // be forwarded and handled by custom ProtocolProxySSH ALPN protocol handler.

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -59,6 +59,7 @@ import (
 	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	libjwt "github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/labels"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/app/common"
@@ -69,6 +70,7 @@ import (
 func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
 	native.PrecomputeTestKeys(m)
+	modules.SetInsecureTestMode(true)
 	os.Exit(m.Run())
 }
 

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -97,6 +97,7 @@ import (
 func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
 	native.PrecomputeTestKeys(m)
+	modules.SetInsecureTestMode(true)
 	registerTestSnowflakeEngine()
 	registerTestElasticsearchEngine()
 	registerTestOpenSearchEngine()

--- a/lib/srv/db/mysql/engine_test.go
+++ b/lib/srv/db/mysql/engine_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -30,7 +31,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/modules"
 )
+
+func TestMain(m *testing.M) {
+	modules.SetInsecureTestMode(true)
+	os.Exit(m.Run())
+}
 
 func TestFetchMySQLVersion(t *testing.T) {
 	t.Parallel()

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"io"
 	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -36,9 +37,15 @@ import (
 	"github.com/gravitational/teleport/lib/auth/windows"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
+
+func TestMain(m *testing.M) {
+	modules.SetInsecureTestMode(true)
+	os.Exit(m.Run())
+}
 
 func TestConfigWildcardBaseDN(t *testing.T) {
 	cfg := &WindowsServiceConfig{

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"slices"
 	"sync"
@@ -77,11 +78,17 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/gcp"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	libevents "github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/srv/server"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 )
+
+func TestMain(m *testing.M) {
+	modules.SetInsecureTestMode(true)
+	os.Exit(m.Run())
+}
 
 type mockSSMClient struct {
 	ssmiface.SSMAPI

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -39,7 +40,7 @@ import (
 // it as an argument. Otherwise, it will run tests as normal.
 func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
-
+	modules.SetInsecureTestMode(true)
 	// If the test is re-executing itself, execute the command that comes over
 	// the pipe.
 	if IsReexec() {

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -66,6 +66,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	libproxy "github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -91,6 +92,7 @@ var wildcardAllow = types.Labels{
 // it as an argument. Otherwise it will run tests as normal.
 func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
+	modules.SetInsecureTestMode(true)
 	if srv.IsReexec() {
 		srv.RunAndExit(os.Args[1])
 		return

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -164,6 +164,7 @@ type WebSuite struct {
 // it as an argument. Otherwise, it will run tests as normal.
 func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
+	modules.SetInsecureTestMode(true)
 	// If the test is re-executing itself, execute the command that comes over
 	// the pipe.
 	if srv.IsReexec() {

--- a/tool/tctl/common/tctl_test.go
+++ b/tool/tctl/common/tctl_test.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,8 +29,14 @@ import (
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
+
+func TestMain(m *testing.M) {
+	modules.SetInsecureTestMode(true)
+	os.Exit(m.Run())
+}
 
 // TestConnect tests client config and connection logic.
 func TestConnect(t *testing.T) {

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -120,6 +120,7 @@ func TestMain(m *testing.M) {
 	}
 
 	modules.SetModules(&cliModules{})
+	modules.SetInsecureTestMode(true)
 
 	utils.InitLoggerForTests()
 	native.PrecomputeTestKeys(m)


### PR DESCRIPTION
## Test cases

- [x] Starting a new cluster with `second_factor: off` fails.
- [x] Starting a new cluster with `second_factor: optional` fails.
- [x] An existing cluster with `second_factor: off` fails to start after upgrading.
- [x] An existing cluster with `second_factor: optional` fails to start after upgrading.
- [x] Attempting to set `second_factor: off` via `teleport.yaml` fails
- [x] Attempting to set `second_factor: optional` via `teleport.yaml` fails
- [x] Attempting to set `second_factor: off` via `cluster_auth_preference` fails
- [x] Attempting to set `second_factor: optional` via `cluster_auth_preference` fails

## Success Criteria

- [x] Breaking change added to v16 changelog
- [x] Docs for `second_factor` field are updated
- [x] `second_factor` continues to default to `totp` if not otherwise provided (as we can't guess
- [x] Let's add an undocumented environment variable for 1 major version to restore the v15 behavior (of allowing 2FA to be disabled). 

closes #40849 