### PR TITLE
[v15] Add Access Monitoring configuration to the chart

### DIFF
--- a/docs/pages/access-controls/access-monitoring.mdx
+++ b/docs/pages/access-controls/access-monitoring.mdx
@@ -140,7 +140,7 @@ Below, you can find the IAM permissions that allow the Auth Service to execute A
 ```
 </Details>
 
-You can use our [Terraform Example](https://github.com/gravitational/teleport/tree/master/examples/athena)
+You can use our [Terraform Example](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/athena)
 to set up Athena and Access Monitoring AWS resources and generate Athena Backend and Access Monitoring Teleport configuration:
 
 ```bash

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -1046,6 +1046,37 @@ Whether Teleport should configure DynamoDB's autoscaling. Defaults to `false`.
   demand" DynamoDB billing, which has more reliable performance.
 </Admonition>
 
+### `aws.accessMonitoring`
+
+`aws.accessMonitoring` configures the [Access Monitoring](../../access-controls/access-monitoring.mdx)
+feature of the Auth Service.
+
+Using this features requires setting up specific AWS infrastructure as described
+in [the AccessMonitoring configuration section](../../access-controls/access-monitoring.mdx#configuration).
+The [Terraform example](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/athena)
+code will output the chart values for this section.
+
+#### `aws.accessMonitoring.enabled`
+`aws.accessMonitoring.enabled` enables Access Monitoring. This requires
+`aws.athenaURL` to be set.
+
+#### `aws.accessMonitoring.reportResults`
+
+`aws.accessMonitoring.reportResults` is the bucket uri where the query results
+are reported.
+
+For example: `s3://example-athena-long-term/report_results`.
+
+#### `aws.accessMonitoring.roleARN`
+
+`aws.accessMonitoring.roleARN` is the ARN of the role that is assumed to run the
+reports.
+
+#### `aws.accessMonitoring.workgroup`
+
+`aws.accessMonitoring.workgroup` is the Athena workgroup in which Teleport runs
+queries.
+
 ## `gcp`
 
 `gcp` settings are described in the GCP guide: [Running an HA Teleport cluster using a Google Cloud GKE cluster](../../deploy-a-cluster/helm-deployments/gcp.mdx)

--- a/examples/athena/accessmonitoring.tf
+++ b/examples/athena/accessmonitoring.tf
@@ -133,3 +133,16 @@ output "access_monitoring_configuration" {
     }
   }), "\"", "") : null
 }
+
+output "access_monitoring_chart_configuration" {
+  value = var.access_monitoring ? replace(yamlencode({
+    "aws" : {
+      "accessMonitoring" : {
+        enabled : true,
+        roleARN : aws_iam_role.access_monitoring_role[0].arn,
+        reportResults : format("s3://%s/report_results", aws_s3_bucket.long_term_storage.bucket),
+        workgroup : aws_athena_workgroup.access_monitoring_workgroup[0].name
+      }
+    }
+  }), "\"", "") : null
+}

--- a/examples/chart/teleport-cluster/.lint/aws-access-monitoring.yaml
+++ b/examples/chart/teleport-cluster/.lint/aws-access-monitoring.yaml
@@ -1,0 +1,13 @@
+clusterName: test-aws-cluster
+chartMode: aws
+aws:
+  region: us-west-2
+  backendTable: test-dynamodb-backend-table
+  sessionRecordingBucket: test-s3-session-storage-bucket
+  athenaURL: 'athena://db.table?topicArn=arn:aws:sns:region:account_id:topic_name'
+
+  accessMonitoring:
+    enabled: true
+    reportResults: "s3://example-athena-long-term/report_results"
+    roleARN: "arn:aws:iam::123456789012:role/example_AccessMonitoringRole"
+    workgroup: "example_access_monitoring_workgroup"

--- a/examples/chart/teleport-cluster/templates/auth/_config.aws.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.aws.tpl
@@ -19,6 +19,16 @@
     {{- else }}
     auto_scaling: false
     {{- end }}
+  {{- if .Values.aws.accessMonitoring.enabled }}
+    {{- if not .Values.aws.athenaURL }}
+      {{- fail "AccessMonitoring requires an Athena Event backend" }}
+    {{- end }}
+  access_monitoring:
+    enabled: true
+    report_results: {{ .Values.aws.accessMonitoring.reportResults | quote }}
+    role_arn: {{ .Values.aws.accessMonitoring.roleARN | quote }}
+    workgroup: {{ .Values.aws.accessMonitoring.workgroup | quote }}
+  {{- end }}
 {{- end -}}
 
 {{- define "teleport-cluster.auth.config.aws.audit" -}}

--- a/examples/chart/teleport-cluster/templates/auth/_config.aws.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.aws.tpl
@@ -1,5 +1,9 @@
 {{- define "teleport-cluster.auth.config.aws" -}}
-{{ include "teleport-cluster.auth.config.common" . }}
+{{ mustMergeOverwrite (include "teleport-cluster.auth.config.common" . | fromYaml) (include "teleport-cluster.auth.config.aws.overrides" . | fromYaml) | toYaml }}
+{{- end -}}
+
+{{- define "teleport-cluster.auth.config.aws.overrides" -}}
+teleport:
   storage:
     type: dynamodb
     region: {{ required "aws.region is required in chart values" .Values.aws.region }}
@@ -7,7 +11,7 @@
     audit_events_uri: {{- include "teleport-cluster.auth.config.aws.audit" . | nindent 4 }}
     audit_sessions_uri: s3://{{ required "aws.sessionRecordingBucket is required in chart values" .Values.aws.sessionRecordingBucket }}
     continuous_backups: {{ required "aws.backups is required in chart values" .Values.aws.backups }}
-    {{- if .Values.aws.dynamoAutoScaling }}
+  {{- if .Values.aws.dynamoAutoScaling }}
     auto_scaling: true
     billing_mode: provisioned
     read_min_capacity: {{ required "aws.readMinCapacity is required when aws.dynamoAutoScaling is true" .Values.aws.readMinCapacity }}
@@ -16,13 +20,14 @@
     write_min_capacity: {{ required "aws.writeMinCapacity is required when aws.dynamoAutoScaling is true" .Values.aws.writeMinCapacity }}
     write_max_capacity: {{ required "aws.writeMaxCapacity is required when aws.dynamoAutoScaling is true" .Values.aws.writeMaxCapacity }}
     write_target_value: {{ required "aws.writeTargetValue is required when aws.dynamoAutoScaling is true" .Values.aws.writeTargetValue }}
-    {{- else }}
+  {{- else }}
     auto_scaling: false
-    {{- end }}
+  {{- end }}
   {{- if .Values.aws.accessMonitoring.enabled }}
     {{- if not .Values.aws.athenaURL }}
       {{- fail "AccessMonitoring requires an Athena Event backend" }}
     {{- end }}
+auth_service:
   access_monitoring:
     enabled: true
     report_results: {{ .Values.aws.accessMonitoring.reportResults | quote }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -13,6 +13,55 @@ adds a proxy token by default:
         kubernetes:
           allow:
             - service_account: "NAMESPACE:RELEASE-NAME-proxy"
+configures access monitoring when its values are set:
+  1: |
+    |-
+      auth_service:
+        authentication:
+          local_auth: true
+          second_factor: "on"
+          type: local
+          webauthn:
+            rp_id: test-aws-cluster
+        cluster_name: test-aws-cluster
+        enabled: true
+        proxy_listener_mode: separate
+      kubernetes_service:
+        enabled: true
+        kube_cluster_name: test-aws-cluster
+        listen_addr: 0.0.0.0:3026
+        public_addr: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3026
+      proxy_service:
+        enabled: false
+      ssh_service:
+        enabled: false
+      teleport:
+        access_monitoring:
+          enabled: true
+          report_results: s3://example-athena-long-term/report_results
+          role_arn: arn:aws:iam::123456789012:role/example_AccessMonitoringRole
+          workgroup: example_access_monitoring_workgroup
+        auth_server: 127.0.0.1:3025
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+        storage:
+          audit_events_uri:
+          - athena://db.table?topicArn=arn:aws:sns:region:account_id:topic_name
+          audit_sessions_uri: s3://test-s3-session-storage-bucket
+          auto_scaling: false
+          continuous_backups: false
+          region: us-west-2
+          table_name: test-dynamodb-backend-table
+          type: dynamodb
+      version: v3
 keeps the second factor type even when it's "off":
   1: |
     |-

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -17,6 +17,11 @@ configures access monitoring when its values are set:
   1: |
     |-
       auth_service:
+        access_monitoring:
+          enabled: true
+          report_results: s3://example-athena-long-term/report_results
+          role_arn: arn:aws:iam::123456789012:role/example_AccessMonitoringRole
+          workgroup: example_access_monitoring_workgroup
         authentication:
           local_auth: true
           second_factor: "on"
@@ -36,11 +41,6 @@ configures access monitoring when its values are set:
       ssh_service:
         enabled: false
       teleport:
-        access_monitoring:
-          enabled: true
-          report_results: s3://example-athena-long-term/report_results
-          role_arn: arn:aws:iam::123456789012:role/example_AccessMonitoringRole
-          workgroup: example_access_monitoring_workgroup
         auth_server: 127.0.0.1:3025
         log:
           format:

--- a/examples/chart/teleport-cluster/tests/auth_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_config_test.yaml
@@ -629,6 +629,37 @@ tests:
       - matchSnapshot:
           path: data.teleport\.yaml
 
+  - it: keeps the second factor type even when it's "off"
+    set:
+      clusterName: helm-lint
+      authentication:
+        secondFactor: 'off'
+    asserts:
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: fails if access monitoring is enabled without athena
+    set:
+      chartMode: aws
+      clusterName: "teleport.example.com"
+      aws:
+        region: asd
+        backendTable: asd
+        sessionRecordingBucket: asd
+        auditLogTable: my-dynamodb-table
+        accessMonitoring:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "AccessMonitoring requires an Athena Event backend"
+
+  - it: configures access monitoring when its values are set
+    values:
+      - ../.lint/aws-access-monitoring.yaml
+    asserts:
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
   - it: sets extraLabels on Configmap
     values:
       - ../.lint/annotations.yaml
@@ -653,15 +684,6 @@ tests:
     set:
       clusterName: helm-lint
       sessionRecording: 'off'
-    asserts:
-      - matchSnapshot:
-          path: data.teleport\.yaml
-
-  - it: keeps the second factor type even when it's "off"
-    set:
-      clusterName: helm-lint
-      authentication:
-        secondFactor: 'off'
     asserts:
       - matchSnapshot:
           path: data.teleport\.yaml

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -403,6 +403,20 @@ aws:
   writeMaxCapacity: null     # Integer
   writeTargetValue: null     # Float
 
+  # accessMonitoring configures the Access Monitoring feature of the Auth Service.
+  # Using this features requires setting up specific AWS infrastructure as described
+  # in https://goteleport.com/docs/access-controls/access-monitoring/#configuration
+  # The Terraform example code will output the chart values for this section.
+  accessMonitoring:
+    enabled: false
+    # reportResults is the bucket uri where query results are reported.
+    # Example: "s3://example-athena-long-term/report_results"
+    reportResults: ""
+    # roleARN is the ARN of the role that is assumed to run the reports.
+    roleARN: ""
+    # workgroup is the Athena workgroup in which Teleport runs queries.
+    workgroup: ""
+
 ##################################################
 # GCP-specific settings (only used in "gcp" mode)
 ##################################################


### PR DESCRIPTION
Backport #40765 to branch/v15

changelog: The `teleport-cluster` Helm chart can configure AccessMonitoring when running in `aws` mode.
