### PR TITLE
Join Script: add apt repo for Ubuntu 24.04

### DIFF
--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -990,7 +990,7 @@ is_repo_available() {
 
     # The following distros+version have a Teleport repository to install from.
     case "${ID}-${VERSION_ID}" in
-        ubuntu-16.04* | ubuntu-18.04* | ubuntu-20.04* | ubuntu-22.04* | \
+        ubuntu-16.04* | ubuntu-18.04* | ubuntu-20.04* | ubuntu-22.04* | ubuntu-24.04* |\
         debian-9* | debian-10* | debian-11* | debian-12* | \
         rhel-7* | rhel-8* | rhel-9* | \
         centos-7* | centos-8* | centos-9* | \


### PR DESCRIPTION
Depends on https://github.com/gravitational/teleport.e/pull/4045

changelog: Install Script used in discover wizard now supports Ubuntu 24.04