### PR TITLE
[v14] filter expired requests from cache reads

### DIFF
--- a/lib/services/access_request_cache_test.go
+++ b/lib/services/access_request_cache_test.go
@@ -252,3 +252,105 @@ func TestAccessRequestCacheBasics(t *testing.T) {
 		}
 	}
 }
+
+func TestAccessRequestCacheExpiryFiltering(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bk, err := memory.New(memory.Config{
+		// set backend into mirror mode so that it does not expire items
+		// automatically.
+		Mirror: true,
+	})
+	require.NoError(t, err)
+
+	svcs := accessRequestServices{
+		Events:           local.NewEventsService(bk),
+		DynamicAccessExt: local.NewDynamicAccessService(bk),
+	}
+
+	cache, err := services.NewAccessRequestCache(services.AccessRequestCacheConfig{
+		Events: svcs,
+		Getter: svcs,
+	})
+	require.NoError(t, err)
+
+	// describe a set of test requests, some of which are expired
+	rrs := []struct {
+		name    string
+		id      string
+		expired bool
+	}{
+		{
+			id:      "00000000-0000-0000-0000-000000000005",
+			name:    "bob",
+			expired: true,
+		},
+		{
+			id:      "00000000-0000-0000-0000-000000000004",
+			name:    "bob",
+			expired: false,
+		},
+		{
+			id:      "00000000-0000-0000-0000-000000000003",
+			name:    "alice",
+			expired: true,
+		},
+		{
+			id:      "00000000-0000-0000-0000-000000000002",
+			name:    "alice",
+			expired: false,
+		},
+		{
+			id:      "00000000-0000-0000-0000-000000000001",
+			name:    "jan",
+			expired: true,
+		},
+	}
+
+	// insert test requests into backend, and aggregate the IDs of the subset that
+	// are unexpired so that we can check them against cache reads later.
+	var unexpiredRequestIDs []string
+	for _, rr := range rrs {
+		r, err := types.NewAccessRequest(rr.id, rr.name, "some-role")
+		require.NoError(t, err)
+
+		if rr.expired {
+			r.SetExpiry(time.Now().Add(-time.Minute * 30).UTC())
+		} else {
+			unexpiredRequestIDs = append(unexpiredRequestIDs, rr.id)
+			r.SetExpiry(time.Now().Add(time.Minute * 30).UTC())
+		}
+		_, err = svcs.CreateAccessRequestV2(ctx, r)
+		require.NoError(t, err)
+	}
+
+	// verify that once cache replication completes, only the unexpired requests are served
+	timeout := time.After(time.Second * 30)
+	for {
+		rsp, err := cache.ListAccessRequests(ctx, &proto.ListAccessRequestsRequest{
+			Limit: int32(len(rrs)),
+		})
+		require.NoError(t, err)
+
+		if len(rsp.AccessRequests) >= len(unexpiredRequestIDs) {
+			// once cache is returning the expected number of requests, verify that
+			// the set of requests returned is exactly the unexpired subset.
+			var returnedRequestIDs []string
+			for _, req := range rsp.AccessRequests {
+				returnedRequestIDs = append(returnedRequestIDs, req.GetName())
+			}
+
+			require.ElementsMatch(t, unexpiredRequestIDs, returnedRequestIDs)
+			break
+		}
+
+		select {
+		case <-timeout:
+			require.FailNow(t, "timeout waiting for access request cache to populate")
+		case <-time.After(time.Millisecond * 200):
+		}
+	}
+}


### PR DESCRIPTION
Backport #40858 to branch/v14

changelog: Fixed access requests lingering in the UI and tctl after expiry