### PR TITLE
[v15] Update proxy templates to support resource filtering

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -1090,7 +1090,24 @@ proxy_templates:
   # Optional host server address to connect to (`%h:%p`).
   #
   # Port defaults to 3022 if not explicitly provided with `--port`.
+  # If provided, it will take precedence over host resolution via
+  # query or search.
   host: "$1:$3"
+
+  # Optional predicate expression to resolve the target host with.
+  #
+  # Query by predicate expression similar to tsh ls --query.
+  # Has priority over search but will be ignored if a host is provided.
+  #
+  # See https://goteleport.com/docs/reference/predicate-language/#resource-filtering for
+  # predicate expression examples.
+  query: "labels.env == $1"
+
+  # Optional fuzzy search terms to resolve the target host with.
+  #
+  # Search by a list of comma separated keywords similar to tsh ls --search.
+  # Only applied if host and search are not provided.
+  search: "$1"
 
 # Multiple templates can be provided. They are evaluated in order and the first
 # match takes effect.

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	libclient "github.com/gravitational/teleport/lib/client"
@@ -62,13 +63,37 @@ func onProxyCommandSSH(cf *CLIConf) error {
 			return trace.Wrap(err)
 		}
 
-		targetHost, targetPort, err := net.SplitHostPort(tc.Host)
-		if err != nil {
-			targetHost = tc.Host
-			targetPort = strconv.Itoa(tc.HostPort)
+		var target string
+		switch {
+		case tc.Host != "":
+			targetHost, targetPort, err := net.SplitHostPort(tc.Host)
+			if err != nil {
+				targetHost = tc.Host
+				targetPort = strconv.Itoa(tc.HostPort)
+			}
+			targetHost = cleanTargetHost(targetHost, tc.WebProxyHost(), clt.ClusterName())
+			target = net.JoinHostPort(targetHost, targetPort)
+		case len(tc.SearchKeywords) != 0 || tc.PredicateExpression != "":
+			nodes, err := client.GetAllResources[types.Server](cf.Context, clt.AuthClient, tc.ResourceFilter(types.KindNode))
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			if len(nodes) == 0 {
+				return trace.NotFound("no matching SSH hosts found for search terms or query expression")
+			}
+
+			if len(nodes) > 1 {
+				return trace.BadParameter("found multiple matching SSH hosts %v", nodes[:2])
+			}
+
+			// Dialing is happening by UUID but a port is still required by
+			// the Proxy dial request. Zero is an indicator to the Proxy that
+			// it may chose the appropriate port based on the target server.
+			target = fmt.Sprintf("%s:0", nodes[0].GetName())
+		default:
+			return trace.BadParameter("no hostname, search terms or query expression provided")
 		}
-		targetHost = cleanTargetHost(targetHost, tc.WebProxyHost(), clt.ClusterName())
-		target := net.JoinHostPort(targetHost, targetPort)
 
 		conn, _, err := clt.DialHostWithResumption(cf.Context, target, clt.ClusterName(), tc.LocalAgent().ExtendedAgent)
 		if err != nil {

--- a/tool/tsh/common/tshconfig_test.go
+++ b/tool/tsh/common/tshconfig_test.go
@@ -279,6 +279,14 @@ func TestProxyTemplatesApply(t *testing.T) {
 				Template: `^(.+)\.(au.example.com):(.+)$`,
 				Host:     "$1:4022",
 			},
+			{
+				Template: `^(.+)\.search.example.com:(.+)$`,
+				Search:   "$1",
+			},
+			{
+				Template: `^(.+)\.query.example.com:(.+)$`,
+				Query:    `labels.animal == "$1"`,
+			},
 		},
 	}
 	require.NoError(t, tshConfig.Check())
@@ -289,6 +297,8 @@ func TestProxyTemplatesApply(t *testing.T) {
 		outProxy       string
 		outHost        string
 		outCluster     string
+		outSearch      string
+		outQuery       string
 		outMatch       bool
 	}{
 		{
@@ -322,14 +332,33 @@ func TestProxyTemplatesApply(t *testing.T) {
 			inFullHostname: "node-1.cn.example.com:3022",
 			outMatch:       false,
 		},
+		{
+			testName:       "matches search",
+			inFullHostname: "llama.search.example.com:3022",
+			outSearch:      "llama",
+			outMatch:       true,
+		},
+		{
+			testName:       "matches query",
+			inFullHostname: "llama.query.example.com:3022",
+			outQuery:       `labels.animal == "llama"`,
+			outMatch:       true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
-			proxy, host, cluster, match := tshConfig.ProxyTemplates.Apply(test.inFullHostname)
-			require.Equal(t, test.outProxy, proxy)
-			require.Equal(t, test.outHost, host)
-			require.Equal(t, test.outCluster, cluster)
+			expanded, match := tshConfig.ProxyTemplates.Apply(test.inFullHostname)
 			require.Equal(t, test.outMatch, match)
+			if !match {
+				require.Nil(t, expanded)
+				return
+			}
+
+			require.Equal(t, test.outProxy, expanded.Proxy)
+			require.Equal(t, test.outHost, expanded.Host)
+			require.Equal(t, test.outCluster, expanded.Cluster)
+			require.Equal(t, test.outSearch, expanded.Search)
+			require.Equal(t, test.outQuery, expanded.Query)
 		})
 	}
 }


### PR DESCRIPTION
Backport #40918 to branch/v15

changelog: Extend proxy templates to allow the target host to be resolved via a predicate expression or fuzzy matching.
