### PR TITLE
allow attaching to pods in kube integration tests

### DIFF
--- a/fixtures/ci-teleport-rbac/ci-teleport.yaml
+++ b/fixtures/ci-teleport-rbac/ci-teleport.yaml
@@ -56,6 +56,10 @@ rules:
   resources: ["pods/log"]
   verbs: ["get"]
   resourceNames: ["test-pod"]
+- apiGroups: [""]
+  resources: ["pods/attach"]
+  verbs: ["create"]
+  resourceNames: ["test-pod"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
`TestKube/EphemeralContainers` creates an ephemeral container that runs a short lived command `echo ...` and has a moderator join the session. Most of the time the command in the container will have finished before the users have a chance to attach to it, but sometimes that's not the case.

Fixes https://github.com/gravitational/teleport/issues/40969.