### PR TITLE
S3: abort uploads which are already present in the bucket

### DIFF
--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -85,7 +85,7 @@ var incompleteSessionUploads = prometheus.NewGauge(
 	prometheus.GaugeOpts{
 		Namespace: "teleport",
 		Name:      teleport.MetricIncompleteSessionUploads,
-		Help:      "Number of sessions not yet uploaded to auth",
+		Help:      "Number of uploads not completed",
 	},
 )
 
@@ -196,7 +196,6 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 		if err != nil {
 			if trace.IsNotFound(err) {
 				log.WithError(err).Warn("Missing parts, moving on to next upload")
-				incompleteSessionUploads.Dec()
 				continue
 			}
 			return trace.Wrap(err, "listing parts")
@@ -212,7 +211,6 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 		}
 		log.Debug("Completed upload")
 		completed++
-		incompleteSessionUploads.Dec()
 
 		if len(parts) == 0 {
 			continue

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -338,7 +338,7 @@ func (h *Handler) getOldestVersion(ctx context.Context, bucket string, prefix st
 	return versions[0].ID, nil
 }
 
-// delete bucket deletes bucket and all it's contents and is used in tests
+// delete bucket deletes bucket and all its contents and is used in tests
 func (h *Handler) deleteBucket(ctx context.Context) error {
 	// first, list and delete all the objects in the bucket
 	out, err := h.client.ListObjectVersionsWithContext(ctx, &s3.ListObjectVersionsInput{

--- a/lib/events/s3sessions/s3stream_test.go
+++ b/lib/events/s3sessions/s3stream_test.go
@@ -1,0 +1,94 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package s3sessions
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/session"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAbortsCompletedUploads(t *testing.T) {
+	t.Setenv("TELEPORT_ABORT_COMPLETED_UPLOADS", "yes")
+
+	client := &mockS3{}
+	h := &Handler{
+		client: client,
+		Entry:  logrus.NewEntry(&logrus.Logger{Out: io.Discard}),
+	}
+
+	upload := events.StreamUpload{
+		ID:        "upload-id",
+		SessionID: session.NewID(),
+		Initiated: time.Now(),
+	}
+	parts := []events.StreamPart{
+		{Number: 1, ETag: "etag1"},
+	}
+
+	ctx := context.Background()
+	require.NoError(t, h.CompleteUpload(ctx, upload, parts))
+	require.Len(t, client.abortedUploadIDs, 1, "1 upload should have been aborted")
+	require.Equal(t, upload.ID, client.abortedUploadIDs[0])
+}
+
+type mockS3 struct {
+	s3iface.S3API
+
+	abortedUploadIDs []string
+}
+
+func (m *mockS3) CompleteMultipartUploadWithContext(
+	ctx aws.Context,
+	in *s3.CompleteMultipartUploadInput,
+	opts ...request.Option,
+) (*s3.CompleteMultipartUploadOutput, error) {
+	return nil, awserr.New(s3.ErrCodeNoSuchUpload, "upload not found", errors.New("not found"))
+}
+
+func (m *mockS3) GetObjectWithContext(
+	ctx aws.Context,
+	in *s3.GetObjectInput,
+	opts ...request.Option,
+) (*s3.GetObjectOutput, error) {
+	return &s3.GetObjectOutput{
+		LastModified: aws.Time(time.Now().Add(-1 * time.Hour)),
+	}, nil
+}
+
+func (m *mockS3) AbortMultipartUploadWithContext(
+	ctx aws.Context,
+	in *s3.AbortMultipartUploadInput,
+	opts ...request.Option,
+) (*s3.AbortMultipartUploadOutput, error) {
+	m.abortedUploadIDs = append(m.abortedUploadIDs, aws.StringValue(in.UploadId))
+	return nil, nil
+}


### PR DESCRIPTION
This change addresses some 'upload not found' errors we've observed when using S3 as a session recording backend in high-availability clusters. Since these clusters run multiple auth servers, and there is no coordination between the upload completers in each auth server (at least until #40926 merges), it's possible for multiple separate uploads to exist for the same session recording. In this case, the S3 API returns a "not found" error even though the recording file is already present in S3, which causes the upload completer to continuously try to complete the upload.

Fix this by checking if the uploaded file is already present. If it is, we can safely abandon the current upload, which will prevent the endless retry loop that we see today.

Note: for now, the abort functionally is opt-in and requires the TELEPORT_ABORT_COMPLETED_UPLOADS environment variable to be set to "yes". If unset, Teleport will log the uploads it would have aborted, but will otherwise do nothing.

Additionally, we also stop manually decrementing the incomplete uploads prometheus metric. There are typically multiple auth servers running, so attempting to guess at how many uploads remain whithout knowledge of what the other auth server is doing is prone to error.