### PR TITLE
[v15] Integration: Allow empty regions

### DIFF
--- a/lib/integrations/awsoidc/clients.go
+++ b/lib/integrations/awsoidc/clients.go
@@ -67,8 +67,10 @@ func (req *AWSClientRequest) CheckAndSetDefaults() error {
 		return trace.BadParameter("role arn is required")
 	}
 
-	if err := awsutils.IsValidRegion(req.Region); err != nil {
-		return trace.Wrap(err)
+	if req.Region != "" {
+		if err := awsutils.IsValidRegion(req.Region); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	return nil

--- a/lib/integrations/awsoidc/clients_test.go
+++ b/lib/integrations/awsoidc/clients_test.go
@@ -45,4 +45,14 @@ func TestCheckAndSetDefaults(t *testing.T) {
 		}).CheckAndSetDefaults()
 		require.NoError(t, err)
 	})
+
+	t.Run("empty region", func(t *testing.T) {
+		err := (&AWSClientRequest{
+			IntegrationName: "my-integration",
+			Token:           "token",
+			RoleARN:         "some-arn",
+			Region:          "",
+		}).CheckAndSetDefaults()
+		require.NoError(t, err)
+	})
 }

--- a/lib/integrations/awsoidc/clientsv1.go
+++ b/lib/integrations/awsoidc/clientsv1.go
@@ -54,10 +54,11 @@ type IntegrationTokenGenerator interface {
 // NewSessionV1 creates a new AWS Session for the region using the integration as source of credentials.
 // This session is usable for AWS SDK Go V1.
 func NewSessionV1(ctx context.Context, client IntegrationTokenGenerator, region string, integrationName string) (*session.Session, error) {
-	if err := utilsaws.IsValidRegion(region); err != nil {
-		return nil, trace.Wrap(err)
+	if region != "" {
+		if err := utilsaws.IsValidRegion(region); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
-
 	integration, err := client.GetIntegration(ctx, integrationName)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/integrations/awsoidc/clientsv1_test.go
+++ b/lib/integrations/awsoidc/clientsv1_test.go
@@ -94,6 +94,15 @@ func TestNewSessionV1(t *testing.T) {
 			},
 		},
 		{
+			name:        "valid with empty region",
+			region:      "",
+			integration: "myawsintegration",
+			expectedErr: require.NoError,
+			sessionValidator: func(t *testing.T, s *session.Session) {
+				require.Equal(t, aws.String(""), s.Config.Region)
+			},
+		},
+		{
 			name:        "not found error when integration is missing",
 			region:      "us-dummy-1",
 			integration: "not-found",


### PR DESCRIPTION
Backport #40984 to branch/v15

changelog: Allow AWS integration to be used for global services without specifying a valid region.
