### PR TITLE
Allow a unix socket to be used as listener for Machine ID `database-tunnel`

### DIFF
--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"net/url"
 
 	"github.com/gravitational/trace"
 
@@ -180,13 +179,9 @@ func (s *DatabaseTunnelService) Run(ctx context.Context) error {
 
 	l := s.cfg.Listener
 	if l == nil {
-		listenUrl, err := url.Parse(s.cfg.Listen)
-		if err != nil {
-			return trace.Wrap(err, "parsing listen url")
-		}
-
-		s.log.DebugContext(ctx, "Opening listener for database tunnel.", "address", listenUrl.String())
-		l, err = net.Listen("tcp", listenUrl.Host)
+		s.log.DebugContext(ctx, "Opening listener for database tunnel.", "listen", s.cfg.Listen)
+		var err error
+		l, err = createListener(ctx, s.log, s.cfg.Listen)
 		if err != nil {
 			return trace.Wrap(err, "opening listener")
 		}

--- a/lib/tbot/service_spiffe_workload_api.go
+++ b/lib/tbot/service_spiffe_workload_api.go
@@ -176,7 +176,8 @@ func createListener(ctx context.Context, log *slog.Logger, addr string) (net.Lis
 	}
 
 	switch parsed.Scheme {
-	case "tcp":
+	// If no scheme is provided, default to TCP.
+	case "tcp", "":
 		return net.Listen("tcp", parsed.Host)
 	case "unix":
 		absPath, err := filepath.Abs(parsed.Path)


### PR DESCRIPTION
We already support this for the SPIFFE workload API service so I figured it makes sense to support it for the `database-tunnel` service as well.

changelog: Allows the listener for the `tbot` `database-tunnel` service to be set to a unix socket.