### PR TITLE
Update "agent ports" Networking Reference section

### DIFF
--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -233,21 +233,16 @@ Service, Kubernetes Service, and other services that protect resources in your
 infrastructure, there is no need to open ports on the machines running the
 agents to the public internet. 
 
-Some Teleport services listen for traffic to one of their proxied resources,
-meaning that you can expose ports on that service's host directly to clients.
-This is useful when you need to connect to resources directly if the Proxy
-Service becomes unavailable. 
+<Details title="Direct connections to agents">
 
-<Admonition
-  type="tip"
-  title="Note"
->
-  In Teleport Cloud, the Auth and Proxy Services run in Teleport-owned infrastructure.
-For this reason, Teleport Cloud customers must connect their resources via reverse tunnels.
-Exposing ports for direct dial is only supported in self-hosted deployments.
-</Admonition>
+If you run a self-hosted Teleport cluster, you can join an agent [directly to
+the Teleport Auth
+Service](../agents/join-services-to-your-cluster/join-token.mdx#start-your-teleport-process-with-the-invite-token).
+In this setup, certain Teleport services open their own listeners rather than
+accepting connections via reverse tunnel. The Proxy Service connects to these
+agent services by dialing them directly.
 
-The table below describes the ports that each Teleport Service opens for proxied
+The table below describes the ports that each Teleport service opens for proxied
 traffic:
 
 | Port | Service | Traffic Type |
@@ -256,6 +251,9 @@ traffic:
 | 3026 | Kubernetes Service | HTTPS traffic to a Kubernetes API server.| 
 | 3028 | Windows Desktop Service | Teleport Desktop Protocol traffic from Teleport clients.|
 
-You can only access enrolled applications and databases through the Teleport Proxy Service.
-The Teleport Application Service and Teleport Database Service use reverse tunnel
-connections through the Teleport Proxy Service and cannot expose ports directly.
+You can only access enrolled applications and desktops through the Teleport
+Proxy Service. The Teleport Application Service and Teleport Database Service
+use reverse tunnel connections through the Teleport Proxy Service and cannot
+expose ports directly.
+
+</Details>


### PR DESCRIPTION
The current guide suggests that you can connect directly to the Windows Desktop Service in order to access a desktop, but this is incorrect. Change the section to provide a more accurate description of direct agent dialling.

Since we recommend joining agents to a cluster via the Proxy Service, this change also adds direct dialling information to a `Details` box.