### PR TITLE
fix: Enforce allow_passwordless server-side

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -35,6 +35,21 @@ import (
 	"github.com/gravitational/teleport/api/utils/tlsutils"
 )
 
+var (
+	// ErrPasswordlessRequiresWebauthn is issued if a passwordless challenge is
+	// requested but WebAuthn isn't enabled.
+	ErrPasswordlessRequiresWebauthn = &trace.BadParameterError{
+		Message: "passwordless requires WebAuthn",
+	}
+
+	// ErrPasswordlessDisabledBySettings is issued if a passwordless challenge is
+	// requested but passwordless is disabled by cluster settings.
+	// See AuthPreferenceV2.AuthPreferenceV2.
+	ErrPasswordlessDisabledBySettings = &trace.BadParameterError{
+		Message: "passwordless disabled by cluster settings",
+	}
+)
+
 // AuthPreference defines the authentication preferences for a specific
 // cluster. It defines the type (local, oidc) and second factor (off, otp, oidc).
 // AuthPreference is a configuration resource, never create more than one instance

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2469,6 +2469,10 @@ func (h *Handler) mfaLoginBegin(w http.ResponseWriter, r *http.Request, p httpro
 
 	mfaChallenge, err := h.auth.proxyClient.CreateAuthenticateChallenge(r.Context(), mfaReq)
 	if err != nil {
+		// Do not obfuscate config-related errors.
+		if errors.Is(err, types.ErrPasswordlessRequiresWebauthn) || errors.Is(err, types.ErrPasswordlessDisabledBySettings) {
+			return nil, trace.Wrap(err)
+		}
 		return nil, trace.AccessDenied("invalid credentials")
 	}
 

--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -276,6 +276,42 @@ func TestAuthenticate_passwordless(t *testing.T) {
 			test.login(t, assertionResp)
 		})
 	}
+
+	// Test a couple of config-mismatch scenarios.
+	// They progressively alter the cluster's auth preference.
+
+	t.Run("allow_passwordless=false", func(t *testing.T) {
+		// Set allow_passwordless=false
+		authPref, err := authServer.GetAuthPreference(ctx)
+		require.NoError(t, err, "GetAuthPreference failed")
+		authPref.SetAllowPasswordless(false)
+		_, err = authServer.UpsertAuthPreference(ctx, authPref)
+		require.NoError(t, err, "UpsertAuthPreference failed")
+
+		// GET /webapi/mfa/login/begin.
+		ep := clt.Endpoint("webapi", "mfa", "login", "begin")
+		_, err = clt.PostJSON(ctx, ep, &client.MFAChallengeRequest{
+			Passwordless: true, // no username and password
+		})
+		assert.ErrorIs(t, err, types.ErrPasswordlessDisabledBySettings, "/webapi/mfa/login/begin error mismatch")
+	})
+
+	t.Run("webauthn disabled", func(t *testing.T) {
+		authPref, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
+			Type:         constants.Local,
+			SecondFactor: constants.SecondFactorOTP, // disable webauthn
+		})
+		require.NoError(t, err, "NewAuthPreference failed")
+		_, err = authServer.UpsertAuthPreference(ctx, authPref)
+		require.NoError(t, err, "UpsertAuthPreference failed")
+
+		// GET /webapi/mfa/login/begin.
+		ep := clt.Endpoint("webapi", "mfa", "login", "begin")
+		_, err = clt.PostJSON(ctx, ep, &client.MFAChallengeRequest{
+			Passwordless: true, // no username and password
+		})
+		assert.ErrorIs(t, err, types.ErrPasswordlessRequiresWebauthn, "/webapi/mfa/login/begin error mismatch")
+	})
 }
 
 func TestAuthenticate_rateLimiting(t *testing.T) {


### PR DESCRIPTION
While looking into another issue I noticed that allow_passwordless is not enforced server-side, so here's the fix.

Changelog: Enforce allow_passwordless server-side