### PR TITLE
Add DeviceTrust badge when session upgraded

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1012,8 +1012,16 @@ func (h *Handler) Close() error {
 	return h.auth.Close()
 }
 
+type userStatusResponse struct {
+	HasDeviceExtensions bool   `json:"hasDeviceExtensions,omitempty"`
+	Message             string `json:"message"` // Always set to "ok"
+}
+
 func (h *Handler) getUserStatus(w http.ResponseWriter, r *http.Request, _ httprouter.Params, c *SessionContext) (interface{}, error) {
-	return OK(), nil
+	return userStatusResponse{
+		HasDeviceExtensions: c.cfg.Session.GetHasDeviceExtensions(),
+		Message:             "ok",
+	}, nil
 }
 
 // handleGetUserOrResetToken has two handlers:

--- a/web/packages/teleport/src/TopBar/DeviceTrustIcon.tsx
+++ b/web/packages/teleport/src/TopBar/DeviceTrustIcon.tsx
@@ -1,0 +1,52 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+import { Flex } from 'design';
+import { ShieldCheck } from 'design/Icon';
+import { HoverTooltip } from 'shared/components/ToolTip';
+
+import session from 'teleport/services/websession';
+
+export const DeviceTrustIcon = ({ iconSize = 24 }: { iconSize?: number }) => {
+  const deviceTrusted = session.getIsDeviceTrusted();
+
+  if (!deviceTrusted) {
+    return null;
+  }
+
+  return (
+    <Wrapper>
+      <HoverTooltip
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+        tipContent={'This session is authorized with Device Trust'}
+        css={`
+          height: 100%;
+        `}
+      >
+        <ShieldCheck color="success.main" size={iconSize} />
+      </HoverTooltip>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled(Flex)`
+  height: 100%;
+  padding-left: 8px;
+`;

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -75,7 +75,6 @@ export function TopBar({ CustomLogo }: TopBarProps) {
   );
   const { currentWidth } = useLayout();
   const theme: Theme = useTheme();
-
   const [previousManagementRoute, setPreviousManagementRoute] = useState('');
 
   const handleLocationChange = useCallback(
@@ -207,7 +206,10 @@ export function TopBar({ CustomLogo }: TopBarProps) {
       {!feature?.logoOnlyTopbar && (
         <Flex height="100%" alignItems="center">
           <Notifications iconSize={iconSize} />
-          <UserMenuNav username={ctx.storeUser.state.username} />
+          <UserMenuNav
+            username={ctx.storeUser.state.username}
+            iconSize={iconSize}
+          />
         </Flex>
       )}
     </TopBarContainer>

--- a/web/packages/teleport/src/components/Authenticated/Authenticated.test.tsx
+++ b/web/packages/teleport/src/components/Authenticated/Authenticated.test.tsx
@@ -41,7 +41,7 @@ jest.mock('shared/libs/logger', () => {
 describe('session', () => {
   beforeEach(() => {
     jest.spyOn(session, 'isValid').mockImplementation(() => true);
-    jest.spyOn(session, 'validateCookieAndSession').mockResolvedValue(null);
+    jest.spyOn(session, 'validateCookieAndSession').mockResolvedValue({});
     jest.spyOn(session, 'ensureSession').mockImplementation();
     jest.spyOn(session, 'getInactivityTimeout').mockImplementation(() => 0);
     jest.spyOn(session, 'clear').mockImplementation();

--- a/web/packages/teleport/src/components/Authenticated/Authenticated.tsx
+++ b/web/packages/teleport/src/components/Authenticated/Authenticated.tsx
@@ -58,7 +58,10 @@ const Authenticated: React.FC<PropsWithChildren> = ({ children }) => {
       }
 
       try {
-        await session.validateCookieAndSession();
+        const result = await session.validateCookieAndSession();
+        if (result.hasDeviceExtensions) {
+          session.setIsDeviceTrusted();
+        }
         setAttempt({ status: 'success' });
       } catch (e) {
         if (e instanceof ApiError && e.response?.status == 403) {

--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.story.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.story.tsx
@@ -67,6 +67,7 @@ const props = {
       getLink: () => 'test2',
     },
   ],
+  iconSize: 24,
   username: 'george',
   logout: () => null,
 };

--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.test.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.test.tsx
@@ -100,7 +100,7 @@ function render(path: string) {
     <MemoryRouter initialEntries={[path]}>
       <TeleportContextProvider ctx={ctx}>
         <FeaturesContextProvider value={getOSSFeatures()}>
-          <UserMenuNav username="llama" />
+          <UserMenuNav iconSize={24} username="llama" />
         </FeaturesContextProvider>
       </TeleportContextProvider>
     </MemoryRouter>

--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
@@ -39,9 +39,11 @@ import {
   STARTING_TRANSITION_DELAY,
   INCREMENT_TRANSITION_DELAY,
 } from 'teleport/components/Dropdown';
+import { DeviceTrustIcon } from 'teleport/TopBar/DeviceTrustIcon';
 
 interface UserMenuNavProps {
   username: string;
+  iconSize: number;
 }
 
 const Container = styled.div`
@@ -69,7 +71,6 @@ const Username = styled(Text)`
   color: ${props => props.theme.colors.text.main};
   font-size: 14px;
   font-weight: 400;
-  padding-right: 40px;
   display: none;
   @media screen and (min-width: ${p => p.theme.breakpoints.large}px) {
     display: inline-flex;
@@ -99,6 +100,7 @@ const StyledAvatar = styled.div`
 
 const Arrow = styled.div`
   line-height: 0;
+  padding-left: 32px;
 
   svg {
     transform: ${p => (p.open ? 'rotate(-180deg)' : 'none')};
@@ -111,7 +113,7 @@ const Arrow = styled.div`
   }
 `;
 
-export function UserMenuNav({ username }: UserMenuNavProps) {
+export function UserMenuNav({ username, iconSize }: UserMenuNavProps) {
   const [open, setOpen] = useState(false);
   const theme = useTheme();
 
@@ -163,6 +165,7 @@ export function UserMenuNav({ username }: UserMenuNavProps) {
         <StyledAvatar>{initial}</StyledAvatar>
 
         <Username>{username}</Username>
+        <DeviceTrustIcon iconSize={iconSize} />
 
         <Arrow open={open}>
           <ChevronDown size="medium" />

--- a/web/packages/teleport/src/services/websession/websession.ts
+++ b/web/packages/teleport/src/services/websession/websession.ts
@@ -162,6 +162,16 @@ const session = {
     return !!this._isRenewing;
   },
 
+  getIsDeviceTrusted() {
+    return !!this._isDeviceTrusted;
+  },
+
+  // a session will never be "downgraded" so we can just set to true
+  // if this method is called.
+  setIsDeviceTrusted() {
+    this._isDeviceTrusted = true;
+  },
+
   _timeLeft() {
     const token = this._getBearerToken();
     if (!token) {


### PR DESCRIPTION
This PR will add a badge if the `webSession` has been upgraded with Device Trust.

This updates our `status` check to include a new field, `hasDeviceExtensions` which returns true if the certificate for the websession have been extended with device trust extensions.  In order to not have to "wait" for the first status check, I've changed the initial `validateCookieAndSession` to just be `fetchStatus`. For some reason, we did a bare `validateCookieAndSession` and then called it again in `fetchStatus` every time after. 

If the session is valid, the shield icon will appear (with a hover text shown in screenshot)
![Screenshot 2024-04-29 at 5 19 02 PM](https://github.com/gravitational/teleport/assets/5201977/4639e462-43c7-4a5d-b2f9-51fac56ba2e4)