### PR TITLE
[vnet][3] DNS resolution

### DIFF
--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -57,7 +57,7 @@ type TCPAppResolver struct {
 // TCPHandlers that will proxy TCP connection to Teleport TCP apps.
 //
 // It uses [appProvider] to list and retrieve cluster clients which are expected to be cached to avoid
-// repeated/unecessary dials to the cluster. These clients are then used to list TCP apps that should be
+// repeated/unnecessary dials to the cluster. These clients are then used to list TCP apps that should be
 // handled.
 //
 // [appProvider] is also used to get app certificates used to dial the apps.

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -23,14 +23,15 @@ import (
 	"net"
 	"strings"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/singleflight"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // AppProvider is an interface providing the necessary methods to log in to apps and get clients able to list
@@ -167,7 +168,12 @@ func newTCPAppHandler(
 }
 
 func (h *tcpAppHandler) HandleTCPConnector(ctx context.Context, connector func() (net.Conn, error)) error {
-	return trace.NotImplemented("HandleTCPConnector not implemented. profile=%s leaf_cluster=%s app=%s", h.profileName, h.leafClusterName, h.app.GetName())
+	conn, err := connector()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// HandleTCPConnector not implemented yet - just echo input back to output.
+	return trace.Wrap(utils.ProxyConn(ctx, conn, conn))
 }
 
 func isSubdomain(appFQDN, proxyAddress string) bool {

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -109,7 +109,6 @@ func (r *TCPAppResolver) resolveTCPHandlerForCluster(
 	clt apiclient.GetResourcesClient,
 	profileName, leafClusterName, fqdn string,
 ) (handler TCPHandler, match bool, err error) {
-
 	// An app public_addr could technically be full-qualified or not, match either way.
 	expr := fmt.Sprintf(`(resource.spec.public_addr == "%s" || resource.spec.public_addr == "%s") && hasPrefix(resource.spec.uri, "tcp://")`,
 		strings.TrimSuffix(fqdn, "."), fqdn)

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -23,11 +23,12 @@ import (
 	"net"
 	"strings"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
+	"golang.org/x/sync/singleflight"
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
 )
@@ -39,9 +40,6 @@ type AppProvider interface {
 	// ListProfiles lists the names of all profiles saved for the user.
 	ListProfiles() ([]string, error)
 
-	// GetProfile returns the named profile for the user.
-	GetProfile(string) (*profile.Profile, error)
-
 	// GetCachedClient returns a [*client.ClusterClient] for the given profile and leaf cluster.
 	// [leafClusterName] may be empty when requesting a client for the root cluster. Returned clients are
 	// expected to be cached, as this may be called frequently.
@@ -51,6 +49,8 @@ type AppProvider interface {
 // TCPAppResolver implements [TCPHandlerResolver] for Teleport TCP apps.
 type TCPAppResolver struct {
 	appProvider AppProvider
+	group       singleflight.Group
+	slog        *slog.Logger
 }
 
 // NewTCPAppResolver returns a new *TCPAppResolver which will resolve full-qualified domain names to
@@ -64,72 +64,110 @@ type TCPAppResolver struct {
 func NewTCPAppResolver(appProvider AppProvider) *TCPAppResolver {
 	return &TCPAppResolver{
 		appProvider: appProvider,
+		slog:        slog.With(teleport.ComponentKey, "VNet.AppResolver"),
 	}
 }
 
 // ResolveTCPHandler resolves a fully-qualified domain name to a TCPHandler for a Teleport TCP app that should
 // be used to handle all future TCP connections to [fqdn].
 func (r *TCPAppResolver) ResolveTCPHandler(ctx context.Context, fqdn string) (handler TCPHandler, match bool, err error) {
-	// TODO(nklaassen): singleflight
-	return r.resolveTCPHandler(ctx, fqdn)
+	// Use a singleflight group to avoid the extra work of querying for the same fqdn multiple times
+	// concurrently, which is likely because DNS clients often ask for A and AAAA records in quick succession.
+	// Caching at this layer shouldn't be necessary because the [Manager] will "cache" positive results by
+	// assigning an address to the returned handler and returning that address to all future queries.
+	resAny, err, _ := r.group.Do(fqdn, func() (any, error) {
+		return r.resolveTCPHandler(ctx, fqdn)
+	})
+	res := resAny.(result)
+	return res.handler, res.match, trace.Wrap(err)
 }
 
-func (r *TCPAppResolver) resolveTCPHandler(ctx context.Context, fqdn string) (handler TCPHandler, match bool, err error) {
+type result struct {
+	handler *tcpAppHandler
+	match   bool
+}
+
+func (r *TCPAppResolver) resolveTCPHandler(ctx context.Context, fqdn string) (result, error) {
 	profileNames, err := r.appProvider.ListProfiles()
 	if err != nil {
-		return nil, false, trace.Wrap(err, "listing profiles")
+		return result{}, trace.Wrap(err, "listing profiles")
 	}
 	appPublicAddr := strings.TrimSuffix(fqdn, ".")
 	for _, profileName := range profileNames {
-		if !isSubdomain(fqdn, profileName) {
-			// TODO(nklaassen): handle custom DNS zones and leaf clusters.
+		slog := r.slog.With("profile", profileName, "fqdn", fqdn)
+
+		rootClient, err := r.appProvider.GetCachedClient(ctx, profileName, "")
+		if err != nil {
+			// The user might be logged out from this one cluster (and retryWithRelogin isn't working). Don't
+			// return an error so that DNS resolution will be forwarded upstream instead of failing, to avoid
+			// breaking e.g. web app access (we don't know if this is a web or TCP app yet because we can't log in).
+			slog.InfoContext(ctx, "Failed to get teleport client.", "error", err)
 			continue
 		}
-		leafClusterName := ""
 
-		clusterClient, err := r.appProvider.GetCachedClient(ctx, profileName, leafClusterName)
-		if err != nil {
-			// The user might be logged out from the cluster and not able to log in. Don't return an error so
-			// that DNS resolution will be forwarded upstream instead of failing, to avoid breaking e.g. web
-			// app access (we don't know if this is a web or TCP app because we can't log in).
-			slog.WarnContext(ctx, "Failed to get teleport client, DNS request will be forwarded upstream.", "profile_name", profileName, "error", err, "fqdn", fqdn)
-			return nil, false, nil
-		}
-
-		appServers, err := apiclient.GetAllResources[types.AppServer](ctx, clusterClient.AuthClient, &proto.ListResourcesRequest{
-			ResourceType:        types.KindAppServer,
-			PredicateExpression: fmt.Sprintf(`resource.spec.public_addr == "%s" && hasPrefix(resource.spec.uri, "tcp://")`, appPublicAddr),
-		})
-		if err != nil {
-			return nil, false, trace.Wrap(err, "listing application servers")
-		}
-
-		for _, appServer := range appServers {
-			app := appServer.GetApp()
-			if app.GetPublicAddr() == appPublicAddr && app.IsTCP() {
-				appHandler, err := newTCPAppHandler(app)
-				if err != nil {
-					return nil, false, trace.Wrap(err)
-				}
-				return appHandler, true, nil
+		if isSubdomain(fqdn, profileName) {
+			res, err := r.resolveTCPHandlerForCluster(ctx, slog, rootClient.CurrentCluster(), profileName, "", appPublicAddr)
+			if res.match || err != nil {
+				return res, trace.Wrap(err)
 			}
+			// TODO(nklaassen): handle custom DNS zones.
+			return result{}, nil
 		}
+
+		// TODO(nklaassen): support leaf clusters.
 	}
-	return nil, false, nil
+	return result{}, nil
+}
+
+func (r *TCPAppResolver) resolveTCPHandlerForCluster(
+	ctx context.Context,
+	slog *slog.Logger,
+	clt apiclient.GetResourcesClient,
+	profileName, leafClusterName, appPublicAddr string,
+) (result, error) {
+	resp, err := apiclient.GetResourcePage[types.AppServer](ctx, clt, &proto.ListResourcesRequest{
+		ResourceType:        types.KindAppServer,
+		PredicateExpression: fmt.Sprintf(`resource.spec.public_addr == "%s" && hasPrefix(resource.spec.uri, "tcp://")`, appPublicAddr),
+		Limit:               1,
+	})
+	if err != nil {
+		// Don't return an error so we can try to find the app in different clusters or forward the request upstream.
+		slog.InfoContext(ctx, "Failed to list application servers.", "error", err)
+		return result{}, nil
+	}
+	if len(resp.Resources) == 0 {
+		return result{}, nil
+	}
+	app := resp.Resources[0].GetApp()
+	appHandler, err := newTCPAppHandler(ctx, r.appProvider, profileName, leafClusterName, app)
+	if err != nil {
+		return result{}, trace.Wrap(err)
+	}
+	return result{handler: appHandler, match: true}, nil
 }
 
 type tcpAppHandler struct {
-	app types.Application
+	profileName     string
+	leafClusterName string
+	app             types.Application
 }
 
-func newTCPAppHandler(app types.Application) (*tcpAppHandler, error) {
+func newTCPAppHandler(
+	ctx context.Context,
+	appProvider AppProvider,
+	profileName string,
+	leafClusterName string,
+	app types.Application,
+) (*tcpAppHandler, error) {
 	return &tcpAppHandler{
-		app: app,
+		profileName:     profileName,
+		leafClusterName: leafClusterName,
+		app:             app,
 	}, nil
 }
 
 func (h *tcpAppHandler) HandleTCPConnector(ctx context.Context, connector func() (net.Conn, error)) error {
-	return trace.NotImplemented("HandleTCPConnector is not implemented yet. App: %q", h.app.GetName())
+	return trace.NotImplemented("HandleTCPConnector not implemented. profile=%s leaf_cluster=%s app=%s", h.profileName, h.leafClusterName, h.app.GetName())
 }
 
 func isSubdomain(appFQDN, proxyAddress string) bool {

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -1,0 +1,141 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/profile"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/client"
+)
+
+// AppProvider is an interface providing the necessary methods to log in to apps and get clients able to list
+// apps in all clusters in all current profiles. This should be the minimum necessary interface that needs to
+// be implemented differently for Connect and `tsh vnet`.
+type AppProvider interface {
+	// ListProfiles lists the names of all profiles saved for the user.
+	ListProfiles() ([]string, error)
+
+	// GetProfile returns the named profile for the user.
+	GetProfile(string) (*profile.Profile, error)
+
+	// GetCachedClient returns a [*client.ClusterClient] for the given profile and leaf cluster.
+	// [leafClusterName] may be empty when requesting a client for the root cluster. Returned clients are
+	// expected to be cached, as this may be called frequently.
+	GetCachedClient(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error)
+}
+
+// TCPAppResolver implements [TCPHandlerResolver] for Teleport TCP apps.
+type TCPAppResolver struct {
+	appProvider AppProvider
+}
+
+// NewTCPAppResolver returns a new *TCPAppResolver which will resolve full-qualified domain names to
+// TCPHandlers that will proxy TCP connection to Teleport TCP apps.
+//
+// It uses [appProvider] to list and retrieve cluster clients which are expected to be cached to avoid
+// repeated/unecessary dials to the cluster. These clients are then used to list TCP apps that should be
+// handled.
+//
+// [appProvider] is also used to get app certificates used to dial the apps.
+func NewTCPAppResolver(appProvider AppProvider) *TCPAppResolver {
+	return &TCPAppResolver{
+		appProvider: appProvider,
+	}
+}
+
+// ResolveTCPHandler resolves a fully-qualified domain name to a TCPHandler for a Teleport TCP app that should
+// be used to handle all future TCP connections to [fqdn].
+func (r *TCPAppResolver) ResolveTCPHandler(ctx context.Context, fqdn string) (handler TCPHandler, match bool, err error) {
+	// TODO(nklaassen): singleflight
+	return r.resolveTCPHandler(ctx, fqdn)
+}
+
+func (r *TCPAppResolver) resolveTCPHandler(ctx context.Context, fqdn string) (handler TCPHandler, match bool, err error) {
+	profileNames, err := r.appProvider.ListProfiles()
+	if err != nil {
+		return nil, false, trace.Wrap(err, "listing profiles")
+	}
+	appPublicAddr := strings.TrimSuffix(fqdn, ".")
+	for _, profileName := range profileNames {
+		if !isSubdomain(fqdn, profileName) {
+			// TODO(nklaassen): handle custom DNS zones and leaf clusters.
+			continue
+		}
+		leafClusterName := ""
+
+		clusterClient, err := r.appProvider.GetCachedClient(ctx, profileName, leafClusterName)
+		if err != nil {
+			// The user might be logged out from the cluster and not able to log in. Don't return an error so
+			// that DNS resolution will be forwarded upstream instead of failing, to avoid breaking e.g. web
+			// app access (we don't know if this is a web or TCP app because we can't log in).
+			slog.WarnContext(ctx, "Failed to get teleport client, DNS request will be forwarded upstream.", "profile_name", profileName, "error", err, "fqdn", fqdn)
+			return nil, false, nil
+		}
+
+		appServers, err := apiclient.GetAllResources[types.AppServer](ctx, clusterClient.AuthClient, &proto.ListResourcesRequest{
+			ResourceType:        types.KindAppServer,
+			PredicateExpression: fmt.Sprintf(`resource.spec.public_addr == "%s" && hasPrefix(resource.spec.uri, "tcp://")`, appPublicAddr),
+		})
+		if err != nil {
+			return nil, false, trace.Wrap(err, "listing application servers")
+		}
+
+		for _, appServer := range appServers {
+			app := appServer.GetApp()
+			if app.GetPublicAddr() == appPublicAddr && app.IsTCP() {
+				appHandler, err := newTCPAppHandler(app)
+				if err != nil {
+					return nil, false, trace.Wrap(err)
+				}
+				return appHandler, true, nil
+			}
+		}
+	}
+	return nil, false, nil
+}
+
+type tcpAppHandler struct {
+	app types.Application
+}
+
+func newTCPAppHandler(app types.Application) (*tcpAppHandler, error) {
+	return &tcpAppHandler{
+		app: app,
+	}, nil
+}
+
+func (h *tcpAppHandler) HandleTCPConnector(ctx context.Context, connector func() (net.Conn, error)) error {
+	return trace.NotImplemented("HandleTCPConnector is not implemented yet. App: %q", h.app.GetName())
+}
+
+func isSubdomain(appFQDN, proxyAddress string) bool {
+	// Fully-qualify the proxy address
+	if !strings.HasSuffix(proxyAddress, ".") {
+		proxyAddress = proxyAddress + "."
+	}
+	return strings.HasSuffix(appFQDN, "."+proxyAddress)
+}

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Run is a blocking call to create and start Teleport VNet.
-func Run(ctx context.Context, tcpHandlerResolver TCPHandlerResolver) error {
+func Run(ctx context.Context, appProvider AppProvider) error {
 	ipv6Prefix, err := IPv6Prefix()
 	if err != nil {
 		return trace.Wrap(err)
@@ -39,11 +39,13 @@ func Run(ctx context.Context, tcpHandlerResolver TCPHandlerResolver) error {
 		return trace.Wrap(err)
 	}
 
+	appResolver := NewTCPAppResolver(appProvider)
+
 	manager, err := NewManager(&Config{
 		TUNDevice:          tun,
 		IPv6Prefix:         ipv6Prefix,
 		DNSIPv6:            dnsIPv6,
-		TCPHandlerResolver: tcpHandlerResolver,
+		TCPHandlerResolver: appResolver,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -26,11 +26,13 @@ import (
 )
 
 // Run is a blocking call to create and start Teleport VNet.
-func Run(ctx context.Context) error {
+func Run(ctx context.Context, tcpHandlerResolver TCPHandlerResolver) error {
 	ipv6Prefix, err := IPv6Prefix()
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	dnsIPv6 := ipv6WithSuffix(ipv6Prefix, []byte{2})
 
 	tun, err := CreateAndSetupTUNDevice(ctx, ipv6Prefix.String())
 	if err != nil {
@@ -38,8 +40,10 @@ func Run(ctx context.Context) error {
 	}
 
 	manager, err := NewManager(&Config{
-		TUNDevice:  tun,
-		IPv6Prefix: ipv6Prefix,
+		TUNDevice:          tun,
+		IPv6Prefix:         ipv6Prefix,
+		DNSIPv6:            dnsIPv6,
+		TCPHandlerResolver: tcpHandlerResolver,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/vnet/vnet.go
+++ b/lib/vnet/vnet.go
@@ -465,7 +465,7 @@ func (m *Manager) handleUDPConcurrent(req *udp.ForwarderRequest) {
 	var wq waiter.Queue
 	endpoint, err := req.CreateEndpoint(&wq)
 	if err != nil {
-		slog.With("error", err).ErrorContext(ctx, "Failed to create UDP endpoint.")
+		slog.ErrorContext(ctx, "Failed to create UDP endpoint.", "error", err)
 		return
 	}
 

--- a/lib/vnet/vnet.go
+++ b/lib/vnet/vnet.go
@@ -251,7 +251,7 @@ func NewManager(cfg *Config) (*Manager, error) {
 		if err := m.assignUDPHandler(cfg.DNSIPv6, dnsServer); err != nil {
 			return nil, trace.Wrap(err)
 		}
-		slog.With("dns_addr", cfg.DNSIPv6).DebugContext(context.Background(), "Serving DNS on IPv6.")
+		slog.DebugContext(context.Background(), "Serving DNS on IPv6.", "dns_addr", cfg.DNSIPv6)
 	}
 
 	return m, nil
@@ -453,7 +453,7 @@ func (m *Manager) handleUDPConcurrent(req *udp.ForwarderRequest) {
 
 	handler, ok := m.getUDPHandler(id.LocalAddress)
 	if !ok {
-		slog.With("addr", id.LocalAddress).DebugContext(ctx, "No handler for address.")
+		slog.DebugContext(ctx, "No handler for address.", "addr", id.LocalAddress)
 		return
 	}
 
@@ -468,7 +468,7 @@ func (m *Manager) handleUDPConcurrent(req *udp.ForwarderRequest) {
 	defer conn.Close()
 
 	if err := handler.HandleUDP(ctx, conn); err != nil {
-		slog.With("error", err).DebugContext(ctx, "Error handling UDP conn.")
+		slog.DebugContext(ctx, "Error handling UDP conn.", "error", err)
 	}
 }
 

--- a/lib/vnet/vnet.go
+++ b/lib/vnet/vnet.go
@@ -458,7 +458,7 @@ func (m *Manager) handleUDPConcurrent(req *udp.ForwarderRequest) {
 
 	handler, ok := m.getUDPHandler(id.LocalAddress)
 	if !ok {
-		slog.DebugContext(ctx, "No handler for address.", "addr", id.LocalAddress)
+		slog.DebugContext(ctx, "No handler for address.")
 		return
 	}
 

--- a/lib/vnet/vnet.go
+++ b/lib/vnet/vnet.go
@@ -93,7 +93,7 @@ type TCPHandlerResolver interface {
 // [connector] to complete the TCP handshake and get the TCP conn. This is so that clients will see that the
 // TCP connection was refused, instead of seeing a successful TCP dial that is immediately closed.
 type TCPHandler interface {
-	HandleTCP(ctx context.Context, connector func() (net.Conn, error)) error
+	HandleTCPConnector(ctx context.Context, connector func() (net.Conn, error)) error
 }
 
 // UDPHandler defines the behavior for handling UDP connections from VNet.
@@ -400,7 +400,7 @@ func (m *Manager) handleTCP(req *tcp.ForwarderRequest) {
 		return conn, nil
 	}
 
-	if err := handler.HandleTCP(ctx, connector); err != nil {
+	if err := handler.HandleTCPConnector(ctx, connector); err != nil {
 		if errors.Is(err, context.Canceled) {
 			slog.DebugContext(ctx, "TCP connection handler returned early due to canceled context.")
 		} else {

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -226,7 +226,7 @@ func (f *echoAppResolver) ResolveTCPHandler(ctx context.Context, fqdn string) (h
 
 type echoHandler struct{}
 
-func (echoHandler) HandleTCP(ctx context.Context, connector func() (net.Conn, error)) error {
+func (echoHandler) HandleTCPConnector(ctx context.Context, connector func() (net.Conn, error)) error {
 	conn, err := connector()
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -39,7 +39,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -265,7 +265,7 @@ func (p *echoAppProvider) GetCachedClient(ctx context.Context, profileName, leaf
 // echoAppAuthClient is a fake auth client that answers GetResources requests with a static list of apps and
 // basic/faked predicate filtering.
 type echoAppAuthClient struct {
-	auth.ClientI
+	authclient.ClientI
 	clusterName string
 	apps        []string
 }

--- a/tool/tsh/common/vnet_common.go
+++ b/tool/tsh/common/vnet_common.go
@@ -1,0 +1,110 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"github.com/vulcand/predicate/builder"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/vnet"
+)
+
+type tcpAppResolver struct {
+	cf          *CLIConf
+	clientStore *client.Store
+}
+
+func newTCPAppResolver(cf *CLIConf) *tcpAppResolver {
+	clientStore := client.NewFSClientStore(cf.HomePath)
+	return &tcpAppResolver{
+		cf:          cf,
+		clientStore: clientStore,
+	}
+}
+
+// ResolveTCPHandler takes a fully-qualified domain name and, if it should be valid for a currently connected
+// app, returns a TCPHandler that should handle all future VNet TCP connections to that FQDN.
+func (r *tcpAppResolver) ResolveTCPHandler(ctx context.Context, fqdn string) (handler vnet.TCPHandler, match bool, err error) {
+	profileNames, err := r.clientStore.ListProfiles()
+	if err != nil {
+		return nil, false, trace.Wrap(err, "listing profiles")
+	}
+	appPublicAddr := strings.TrimSuffix(fqdn, ".")
+	for _, profileName := range profileNames {
+		if !isSubdomain(fqdn, profileName) {
+			// TODO(nklaassen): handle custom DNS zones and leaf clusters.
+			continue
+		}
+
+		tc, err := r.getTeleportClient(ctx, profileName)
+		if err != nil {
+			return nil, false, trace.Wrap(err, "getting Teleport client")
+		}
+
+		appServers, err := tc.ListAppServersWithFilters(ctx, &proto.ListResourcesRequest{
+			ResourceType: types.KindAppServer,
+			PredicateExpression: builder.Equals(
+				builder.Identifier("resource.spec.public_addr"),
+				builder.String(appPublicAddr),
+			).String(),
+		})
+		if err != nil {
+			return nil, false, trace.Wrap(err, "listing application servers")
+		}
+
+		for _, appServer := range appServers {
+			app := appServer.GetApp()
+			if app.GetPublicAddr() == appPublicAddr && app.IsTCP() {
+				return &tcpAppHandler{
+					app: app,
+				}, true, nil
+			}
+		}
+	}
+	return nil, false, nil
+}
+
+func (r *tcpAppResolver) getTeleportClient(ctx context.Context, profileName string) (*client.TeleportClient, error) {
+	// TODO(nklaassen): handle leaf clusters.
+	// TODO(nklaassen/ravicious): cache clients and handle certificate expiry.
+	tc, err := makeClientForProxy(r.cf, profileName)
+	return tc, trace.Wrap(err)
+}
+
+type tcpAppHandler struct {
+	app types.Application
+}
+
+// HandleTCP handles a TCP connection from VNet and proxies it to the application.
+func (h *tcpAppHandler) HandleTCP(ctx context.Context, connector func() (net.Conn, error)) error {
+	return trace.NotImplemented("HandleTCP is not implemented for TCP app handler")
+}
+
+func isSubdomain(appFQDN, proxyAddress string) bool {
+	// Fully-qualify the proxy address
+	if !strings.HasSuffix(proxyAddress, ".") {
+		proxyAddress = proxyAddress + "."
+	}
+	return strings.HasSuffix(appFQDN, "."+proxyAddress)
+}

--- a/tool/tsh/common/vnet_common.go
+++ b/tool/tsh/common/vnet_common.go
@@ -18,11 +18,11 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 
 	"github.com/gravitational/trace"
-	"github.com/vulcand/predicate/builder"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
@@ -63,11 +63,8 @@ func (r *tcpAppResolver) ResolveTCPHandler(ctx context.Context, fqdn string) (ha
 		}
 
 		appServers, err := tc.ListAppServersWithFilters(ctx, &proto.ListResourcesRequest{
-			ResourceType: types.KindAppServer,
-			PredicateExpression: builder.Equals(
-				builder.Identifier("resource.spec.public_addr"),
-				builder.String(appPublicAddr),
-			).String(),
+			ResourceType:        types.KindAppServer,
+			PredicateExpression: fmt.Sprintf(`resource.spec.public_addr == "%s" && hasPrefix(resource.spec.uri, "tcp://")`, appPublicAddr),
 		})
 		if err != nil {
 			return nil, false, trace.Wrap(err, "listing application servers")

--- a/tool/tsh/common/vnet_common.go
+++ b/tool/tsh/common/vnet_common.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/lib/client"
 )
 
@@ -42,11 +41,6 @@ func newVnetAppProvider(cf *CLIConf) (*vnetAppProvider, error) {
 // ListProfiles lists the names of all profiles saved for the user.
 func (p *vnetAppProvider) ListProfiles() ([]string, error) {
 	return p.clientStore.ListProfiles()
-}
-
-// GetProfile returns the named profile for the user.
-func (p *vnetAppProvider) GetProfile(profileName string) (*profile.Profile, error) {
-	return p.clientStore.GetProfile(profileName)
 }
 
 // GetCachedClient returns a [*client.ClusterClient] for the given profile and leaf cluster.

--- a/tool/tsh/common/vnet_common.go
+++ b/tool/tsh/common/vnet_common.go
@@ -96,8 +96,8 @@ type tcpAppHandler struct {
 	app types.Application
 }
 
-// HandleTCP handles a TCP connection from VNet and proxies it to the application.
-func (h *tcpAppHandler) HandleTCP(ctx context.Context, connector func() (net.Conn, error)) error {
+// HandleTCPConnector handles a TCP connection from VNet and proxies it to the application.
+func (h *tcpAppHandler) HandleTCPConnector(ctx context.Context, connector func() (net.Conn, error)) error {
 	return trace.NotImplemented("HandleTCP is not implemented for TCP app handler")
 }
 

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -40,8 +40,11 @@ func newVnetCommand(app *kingpin.Application) *vnetCommand {
 }
 
 func (c *vnetCommand) run(cf *CLIConf) error {
-	tcpHandlerResolver := newTCPAppResolver(cf)
-	return trace.Wrap(vnet.Run(cf.Context, tcpHandlerResolver))
+	appProvider, err := newVnetAppProvider(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(vnet.Run(cf.Context, appProvider))
 }
 
 type vnetAdminSetupCommand struct {

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -40,7 +40,8 @@ func newVnetCommand(app *kingpin.Application) *vnetCommand {
 }
 
 func (c *vnetCommand) run(cf *CLIConf) error {
-	return trace.Wrap(vnet.Run(cf.Context))
+	tcpHandlerResolver := newTCPAppResolver(cf)
+	return trace.Wrap(vnet.Run(cf.Context, tcpHandlerResolver))
 }
 
 type vnetAdminSetupCommand struct {

--- a/tool/tsh/common/vnet_other.go
+++ b/tool/tsh/common/vnet_other.go
@@ -45,6 +45,6 @@ func (vnetNotSupported) run(*CLIConf) error {
 
 var (
 	// Satisfy unused linter.
-	_ = (*tcpAppResolver)(nil)
-	_ = newTCPAppResolver
+	_ = (*vnetAppProvider)(nil)
+	_ = newVnetAppProvider
 )

--- a/tool/tsh/common/vnet_other.go
+++ b/tool/tsh/common/vnet_other.go
@@ -42,3 +42,9 @@ func (vnetNotSupported) FullCommand() string {
 func (vnetNotSupported) run(*CLIConf) error {
 	return trace.Wrap(vnet.ErrVnetNotImplemented)
 }
+
+var (
+	// Satisfy unused linter.
+	_ = (*tcpAppResolver)(nil)
+	_ = newTCPAppResolver
+)


### PR DESCRIPTION
This is the fourth in a series of PRs implementing Teleport VNet [RFD](https://github.com/gravitational/teleport/blob/rfd/0163-vnet/rfd/0163-vnet.md). [parent](https://github.com/gravitational/teleport/pull/40972) [child](https://github.com/gravitational/teleport/pull/41032)

This PR adds DNS resolution for Teleport apps in any currently active Teleport profile. Each app is assigned a V6 IP address the first time a DNS A or AAAA record is queried for its `public_addr`. Since IPv4 isn't supported yet, we return a NoRecord response for A queries. Clients should use the v6 address they can get from an AAAA query.

Host configuration of the DNS nameserver is added in https://github.com/gravitational/teleport/pull/41032
TCP forwarding to the app works in the mocked testcase, but forwarding to real Teleport apps (along with app logins) is added in https://github.com/gravitational/teleport/pull/41033
Client caching is added in https://github.com/gravitational/teleport/pull/41033
Custom DNS zone support is added in https://github.com/gravitational/teleport/pull/41545
IPv4 support is added in https://github.com/gravitational/teleport/pull/41542
TODO: leaf cluster support (coming in a future PR)