### PR TITLE
[vnet][4] host DNS configuration

### DIFF
--- a/lib/vnet/osconfig_darwin.go
+++ b/lib/vnet/osconfig_darwin.go
@@ -1,0 +1,118 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build darwin
+// +build darwin
+
+package vnet
+
+import (
+	"bufio"
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/gravitational/trace"
+)
+
+// configureOS configures the host OS according to [cfg]. It is safe to call repeatedly, and it is meant to be
+// called with an empty [osConfig] to deconfigure anything necessary before exiting.
+func configureOS(ctx context.Context, cfg *osConfig) error {
+	// There is no need to remove IPs or the IPv6 route, they will automatically be cleaned up when the
+	// process exits and the TUN is deleted.
+	if cfg.tunIPv6 != "" {
+		slog.InfoContext(ctx, "Setting IPv6 address for the TUN device.", "device", cfg.tunName, "address", cfg.tunIPv6)
+		cmd := exec.CommandContext(ctx, "ifconfig", cfg.tunName, "inet6", cfg.tunIPv6, "prefixlen", "64")
+		if err := cmd.Run(); err != nil {
+			return trace.Wrap(err, "running %v", cmd.Args)
+		}
+
+		slog.InfoContext(ctx, "Setting an IPv6 route for the VNet.")
+		cmd = exec.CommandContext(ctx, "route", "add", "-inet6", cfg.tunIPv6, "-prefixlen", "64", "-interface", cfg.tunName)
+		if err := cmd.Run(); err != nil {
+			return trace.Wrap(err, "running %v", cmd.Args)
+		}
+	}
+
+	if err := configureDNS(ctx, cfg.dnsAddr, cfg.dnsZones); err != nil {
+		return trace.Wrap(err, "configuring DNS")
+	}
+
+	return nil
+}
+
+const resolverFileComment = "# automatically installed by Teleport VNet"
+
+var resolverPath = filepath.Join("/", "etc", "resolver")
+
+func configureDNS(ctx context.Context, nameserver string, zones []string) error {
+	if len(nameserver) == 0 && len(zones) > 0 {
+		return trace.BadParameter("empty nameserver with non-empty zones")
+	}
+
+	slog.DebugContext(ctx, "Configuring DNS.", "nameserver", nameserver, "zones", zones)
+	if err := os.MkdirAll(resolverPath, os.FileMode(0755)); err != nil {
+		return trace.Wrap(err, "creating %s", resolverPath)
+	}
+
+	managedFiles, err := vnetManagedResolverFiles()
+	if err != nil {
+		return trace.Wrap(err, "finding VNet managed files in /etc/resolver")
+	}
+	for _, zone := range zones {
+		fileName := filepath.Join(resolverPath, zone)
+		delete(managedFiles, fileName)
+		contents := resolverFileComment + "\nnameserver " + nameserver
+		if err := os.WriteFile(fileName, []byte(contents), 0644); err != nil {
+			return trace.Wrap(err, "writing DNS configuration file %s", fileName)
+		}
+	}
+	// Delete stale files.
+	for fileName := range managedFiles {
+		if err := os.Remove(fileName); err != nil {
+			return trace.Wrap(err, "deleting VNet managed file %s", fileName)
+		}
+	}
+	return nil
+}
+
+func vnetManagedResolverFiles() (map[string]struct{}, error) {
+	entries, err := os.ReadDir(resolverPath)
+	if err != nil {
+		return nil, trace.Wrap(err, "reading %s", resolverPath)
+	}
+
+	matchingFiles := make(map[string]struct{})
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		filePath := filepath.Join(resolverPath, entry.Name())
+		file, err := os.Open(filePath)
+		if err != nil {
+			return nil, trace.Wrap(err, "opening %s", filePath)
+		}
+		scanner := bufio.NewScanner(file)
+		if scanner.Scan() {
+			if resolverFileComment == scanner.Text() {
+				matchingFiles[filePath] = struct{}{}
+			}
+		}
+	}
+	return matchingFiles, nil
+}

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -20,9 +20,14 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
 	"golang.zx2c4.com/wireguard/tun"
+
+	"github.com/gravitational/teleport/api/profile"
+	"github.com/gravitational/teleport/api/types"
 )
 
 // Run is a blocking call to create and start Teleport VNet.
@@ -34,9 +39,16 @@ func Run(ctx context.Context, appProvider AppProvider) error {
 
 	dnsIPv6 := ipv6WithSuffix(ipv6Prefix, []byte{2})
 
-	tun, err := CreateAndSetupTUNDevice(ctx, ipv6Prefix.String())
-	if err != nil {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	tunCh, adminCommandErrCh := CreateAndSetupTUNDevice(ctx, ipv6Prefix.String(), dnsIPv6.String())
+
+	var tun TUNDevice
+	select {
+	case err := <-adminCommandErrCh:
 		return trace.Wrap(err)
+	case tun = <-tunCh:
 	}
 
 	appResolver := NewTCPAppResolver(appProvider)
@@ -51,62 +63,161 @@ func Run(ctx context.Context, appProvider AppProvider) error {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(manager.Run(ctx))
+	allErrors := make(chan error, 4)
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		// Make sure to cancel the context if manager.Run terminates for any reason.
+		defer cancel()
+		err := trace.Wrap(manager.Run(ctx), "running VNet manager")
+		allErrors <- err
+		return err
+	})
+	g.Go(func() error {
+		var adminCommandErr error
+		select {
+		case adminCommandErr = <-adminCommandErrCh:
+			// The admin command exited before the context was canceled, cancel everything and exit.
+			cancel()
+		case <-ctx.Done():
+			// The context has been canceled, the admin command should now exit.
+			adminCommandErr = <-adminCommandErrCh
+		}
+		adminCommandErr = trace.Wrap(adminCommandErr, "running admin subcommand")
+		allErrors <- adminCommandErr
+		return adminCommandErr
+	})
+	// Deliberately ignoring the error from g.Wait() to return an aggregate of all errors.
+	_ = g.Wait()
+	close(allErrors)
+	return trace.NewAggregateFromChannel(allErrors, context.Background())
 }
 
-// AdminSubcommand is the tsh subcommand that should run as root that will
-// create and setup a TUN device and pass the file descriptor for that device
-// over the unix socket found at socketPath.
-func AdminSubcommand(ctx context.Context, socketPath, ipv6Prefix string) error {
-	tun, tunName, err := createAndSetupTUNDeviceAsRoot(ctx, ipv6Prefix)
-	if err != nil {
+// AdminSubcommand is the tsh subcommand that should run as root that will create and setup a TUN device and
+// pass the file descriptor for that device over the unix socket found at socketPath.
+//
+// It also handles host OS configuration that must run as root, and stays alive to keep the host configuration
+// up to date. It will stay running until the socket at [socketPath] is deleting or encountering an
+// unrecoverable error.
+func AdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	tunCh, errCh := createAndSetupTUNDeviceAsRoot(ctx, ipv6Prefix, dnsAddr)
+	var tun tun.Device
+	select {
+	case tun = <-tunCh:
+	case err := <-errCh:
 		return trace.Wrap(err, "performing admin setup")
 	}
-	if err := sendTUNNameAndFd(socketPath, tunName, tun.File().Fd()); err != nil {
-		return trace.Wrap(err)
+	tunName, err := tun.Name()
+	if err != nil {
+		return trace.Wrap(err, "getting TUN name")
 	}
-	return nil
+	if err := sendTUNNameAndFd(socketPath, tunName, tun.File().Fd()); err != nil {
+		return trace.Wrap(err, "sending TUN over socket")
+	}
+
+	// Stay alive until we get an error on errCh, indicating that the osConfig loop exited.
+	// If the socket is deleted, indicating that the parent process exited, cancel the context and then wait
+	// for an err or errCh.
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if _, err := os.Stat(socketPath); err != nil {
+				slog.DebugContext(ctx, "failed to stat socket path, assuming parent exited")
+				cancel()
+				return trace.Wrap(<-errCh)
+			}
+		case err = <-errCh:
+			return trace.Wrap(err)
+		}
+	}
 }
 
-// CreateAndSetupTUNDevice returns a virtual network device and configures the host OS to use that device for
+// CreateAndSetupTUNDevice creates a virtual network device and configures the host OS to use that device for
 // VNet connections.
-func CreateAndSetupTUNDevice(ctx context.Context, ipv6Prefix string) (tun.Device, error) {
-	var (
-		device tun.Device
-		name   string
-		err    error
-	)
+//
+// If not already running as root, it will spawn a root process to handle the TUN creation and host
+// configuration.
+//
+// After the TUN device is created, it will be sent on the result channel. Any error will be sent on the err
+// channel. Always select on both the result channel and the err channel when waiting for a result.
+//
+// This will keep running until [ctx] is canceled or an unrecoverable error is encountered, in order to keep
+// the host OS configuration up to date.
+func CreateAndSetupTUNDevice(ctx context.Context, ipv6Prefix, dnsAddr string) (<-chan tun.Device, <-chan error) {
 	if os.Getuid() == 0 {
 		// We can get here if the user runs `tsh vnet` as root, but it is not in the expected path when
 		// started as a regular user. Typically we expect `tsh vnet` to be run as a non-root user, and for
 		// AdminSubcommand to directly call createAndSetupTUNDeviceAsRoot.
-		device, name, err = createAndSetupTUNDeviceAsRoot(ctx, ipv6Prefix)
+		return createAndSetupTUNDeviceAsRoot(ctx, ipv6Prefix, dnsAddr)
 	} else {
-		device, name, err = createAndSetupTUNDeviceWithoutRoot(ctx, ipv6Prefix)
+		return createAndSetupTUNDeviceWithoutRoot(ctx, ipv6Prefix, dnsAddr)
 	}
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	slog.InfoContext(ctx, "Created TUN device.", "device", name)
-	return device, nil
 }
 
-func createAndSetupTUNDeviceAsRoot(ctx context.Context, ipv6Prefix string) (tun.Device, string, error) {
+// createAndSetupTUNDeviceAsRoot creates a virtual network device and configures the host OS to use that device for
+// VNet connections.
+//
+// After the TUN device is created, it will be sent on the result channel. Any error will be sent on the err
+// channel. Always select on both the result channel and the err channel when waiting for a result.
+//
+// This will keep running until [ctx] is canceled or an unrecoverable error is encountered, in order to keep
+// the host OS configuration up to date.
+func createAndSetupTUNDeviceAsRoot(ctx context.Context, ipv6Prefix, dnsAddr string) (<-chan tun.Device, <-chan error) {
+	tunCh := make(chan tun.Device, 1)
+	errCh := make(chan error, 1)
+
 	tun, tunName, err := createTUNDevice(ctx)
 	if err != nil {
-		return nil, "", trace.Wrap(err)
+		errCh <- trace.Wrap(err, "creating TUN device")
+		return tunCh, errCh
 	}
+	tunCh <- tun
 
-	tunIPv6 := ipv6Prefix + "1"
-	cfg := osConfig{
-		tunName: tunName,
-		tunIPv6: tunIPv6,
-	}
-	if err := configureOS(ctx, &cfg); err != nil {
-		return nil, "", trace.Wrap(err, "configuring OS")
-	}
+	go func() {
+		var err error
+		tunIPv6 := ipv6Prefix + "1"
+		cfg := osConfig{
+			tunName: tunName,
+			tunIPv6: tunIPv6,
+			dnsAddr: dnsAddr,
+		}
+		if cfg.dnsZones, err = dnsZones(); err != nil {
+			errCh <- trace.Wrap(err, "getting DNS zones")
+			return
+		}
+		if err := configureOS(ctx, &cfg); err != nil {
+			errCh <- trace.Wrap(err, "configuring OS")
+			return
+		}
 
-	return tun, tunName, nil
+		// Re-check the DNS zones every 10 seconds, and configure the host OS appropriately.
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+	loop:
+		for {
+			select {
+			case <-ticker.C:
+				if cfg.dnsZones, err = dnsZones(); err != nil {
+					errCh <- trace.Wrap(err, "getting DNS zones")
+					return
+				}
+				if err := configureOS(ctx, &cfg); err != nil {
+					errCh <- trace.Wrap(err, "configuring OS")
+					return
+				}
+			case <-ctx.Done():
+				break loop
+			}
+		}
+
+		// Shutting down, deconfigure OS.
+		errCh <- trace.Wrap(configureOS(ctx, &osConfig{}))
+	}()
+	return tunCh, errCh
 }
 
 func createTUNDevice(ctx context.Context) (tun.Device, string, error) {
@@ -123,6 +234,20 @@ func createTUNDevice(ctx context.Context) (tun.Device, string, error) {
 }
 
 type osConfig struct {
-	tunName string
-	tunIPv6 string
+	tunName  string
+	tunIPv6  string
+	dnsAddr  string
+	dnsZones []string
+}
+
+func dnsZones() ([]string, error) {
+	profileDir := profile.FullProfilePath(os.Getenv(types.HomeEnvVar))
+	profileNames, err := profile.ListProfileNames(profileDir)
+	if err != nil {
+		return nil, trace.Wrap(err, "listing profiles")
+	}
+	// profile names are Teleport proxy addresses.
+	// TODO(nklaassen): support leaf clusters and custom DNS zones.
+	// TODO(nklaassen): check if profiles are expired.
+	return profileNames, nil
 }

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -63,7 +63,7 @@ func Run(ctx context.Context, appProvider AppProvider) error {
 		return trace.Wrap(err)
 	}
 
-	allErrors := make(chan error, 4)
+	allErrors := make(chan error, 2)
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		// Make sure to cancel the context if manager.Run terminates for any reason.
@@ -119,7 +119,7 @@ func AdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string
 
 	// Stay alive until we get an error on errCh, indicating that the osConfig loop exited.
 	// If the socket is deleted, indicating that the parent process exited, cancel the context and then wait
-	// for an err or errCh.
+	// for the osConfig loop to exit and send an err on errCh.
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	for {

--- a/lib/vnet/setup_darwin.go
+++ b/lib/vnet/setup_darwin.go
@@ -106,7 +106,8 @@ set dnsAddr to "%s"
 do shell script quoted form of executableName & `+
 		`" %s -d --socket " & quoted form of socketPath & `+
 		`" --ipv6-prefix " & quoted form of ipv6Prefix & `+
-		`" --dns-addr " & quoted form of dnsAddr `+
+		`" --dns-addr " & quoted form of dnsAddr & `+
+		`" >/var/log/vnet.log 2>&1" `+
 		`with prompt "VNet wants to set up a virtual network device" with administrator privileges`,
 		executableName, socketPath, ipv6Prefix, dnsAddr, teleport.VnetAdminSetupSubCommand)
 

--- a/lib/vnet/setup_darwin.go
+++ b/lib/vnet/setup_darwin.go
@@ -33,63 +33,66 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 	"golang.zx2c4.com/wireguard/tun"
 
 	"github.com/gravitational/teleport"
 )
 
-const (
-	tunHandoverTimeout = time.Minute
-)
+// createAndSetupTUNDeviceWithoutRoot creates a virtual network device and configures the host OS to use that
+// device for VNet connections. It will spawn a root process to handle the TUN creation and host
+// configuration.
+//
+// After the TUN device is created, it will be sent on the result channel. Any error will be sent on the err
+// channel. Always select on both the result channel and the err channel when waiting for a result.
+//
+// This will keep running until [ctx] is canceled or an unrecoverable error is encountered, in order to keep
+// the host OS configuration up to date.
+func createAndSetupTUNDeviceWithoutRoot(ctx context.Context, ipv6Prefix, dnsAddr string) (<-chan tun.Device, <-chan error) {
+	tunCh := make(chan tun.Device, 1)
+	errCh := make(chan error, 1)
 
-func createAndSetupTUNDeviceWithoutRoot(ctx context.Context, ipv6Prefix string) (tun.Device, string, error) {
 	slog.InfoContext(ctx, "Spawning child process as root to create and setup TUN device")
 	socket, socketPath, err := createUnixSocket()
 	if err != nil {
-		return nil, "", trace.Wrap(err)
+		errCh <- trace.Wrap(err, "creating unix socket")
+		return tunCh, errCh
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	adminCommandErr := make(chan error, 1)
-	go func() {
-		adminCommandErr <- trace.Wrap(execAdminSubcommand(ctx, socketPath, ipv6Prefix))
-	}()
-
-	recvTunErr := make(chan error, 1)
-	var tunName string
-	var tunFd uintptr
-	go func() {
-		tunName, tunFd, err = recvTUNNameAndFd(ctx, socket)
-		recvTunErr <- trace.Wrap(err, "receiving TUN name and file descriptor")
-	}()
-
-loop:
-	for {
-		select {
-		case err := <-adminCommandErr:
-			if err != nil {
-				return nil, "", trace.Wrap(err)
-			}
-		case err := <-recvTunErr:
-			if err != nil {
-				return nil, "", trace.Wrap(err)
-			}
-			break loop
+	// Make sure all goroutines complete before sending an err on the error chan, to be sure they all have a
+	// chance to clean up before the process terminates.
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		// Requirements:
+		// - must close the socket concurrently with recvTUNNameAndFd if the context is canceled to unblock
+		//   a stuck AcceptUnix (can't defer).
+		// - must close the socket exactly once before letting the process terminate.
+		<-ctx.Done()
+		return trace.Wrap(socket.Close())
+	})
+	g.Go(func() error {
+		// Admin command is expected to run until ctx is canceled.
+		return trace.Wrap(execAdminSubcommand(ctx, socketPath, ipv6Prefix, dnsAddr))
+	})
+	g.Go(func() error {
+		tunName, tunFd, err := recvTUNNameAndFd(ctx, socket)
+		if err != nil {
+			return trace.Wrap(err, "receiving TUN name and file descriptor")
 		}
-	}
+		tunDevice, err := tun.CreateTUNFromFile(os.NewFile(tunFd, tunName), 0)
+		if err != nil {
+			return trace.Wrap(err, "creating TUN device from file descriptor")
+		}
+		tunCh <- tunDevice
+		return nil
+	})
+	go func() { errCh <- g.Wait() }()
 
-	tunDevice, err := tun.CreateTUNFromFile(os.NewFile(tunFd, ""), 0)
-	if err != nil {
-		return nil, "", trace.Wrap(err, "creating TUN device from file descriptor")
-	}
-
-	return tunDevice, tunName, nil
+	return tunCh, errCh
 }
 
-func execAdminSubcommand(ctx context.Context, socketPath, ipv6Prefix string) error {
+func execAdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
 	executableName, err := os.Executable()
 	if err != nil {
 		return trace.Wrap(err, "getting executable path")
@@ -99,11 +102,13 @@ func execAdminSubcommand(ctx context.Context, socketPath, ipv6Prefix string) err
 set executableName to "%s"
 set socketPath to "%s"
 set ipv6Prefix to "%s"
+set dnsAddr to "%s"
 do shell script quoted form of executableName & `+
-		`" %s --socket " & quoted form of socketPath & `+
-		`" --ipv6-prefix " & quoted form of ipv6Prefix `+
+		`" %s -d --socket " & quoted form of socketPath & `+
+		`" --ipv6-prefix " & quoted form of ipv6Prefix & `+
+		`" --dns-addr " & quoted form of dnsAddr `+
 		`with prompt "VNet wants to set up a virtual network device" with administrator privileges`,
-		executableName, socketPath, ipv6Prefix, teleport.VnetAdminSetupSubCommand)
+		executableName, socketPath, ipv6Prefix, dnsAddr, teleport.VnetAdminSetupSubCommand)
 
 	// The context we pass here has effect only on the password prompt being shown. Once osascript spawns the
 	// privileged process, canceling the context (and thus killing osascript) has no effect on the privileged
@@ -150,10 +155,8 @@ func sendTUNNameAndFd(socketPath, tunName string, fd uintptr) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer conn.Close()
 
-	err = conn.SetDeadline(time.Now().Add(tunHandoverTimeout))
-	if err != nil {
+	if err := conn.SetDeadline(time.Now().Add(time.Second)); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -168,25 +171,15 @@ func sendTUNNameAndFd(socketPath, tunName string, fd uintptr) error {
 // recvTUNNameAndFd receives the name of a TUN device and its open file descriptor over a unix socket, meant
 // for passing the TUN from the root process which must create it to the user process.
 func recvTUNNameAndFd(ctx context.Context, socket *net.UnixListener) (string, uintptr, error) {
-	ctx, cancel := context.WithTimeout(ctx, tunHandoverTimeout)
-	defer cancel()
-	deadline, _ := ctx.Deadline()
-
-	err := socket.SetDeadline(deadline)
-	if err != nil {
-		return "", 0, trace.Wrap(err)
-	}
-	go func() {
-		<-ctx.Done()
-		socket.Close()
-	}()
-
 	conn, err := socket.AcceptUnix()
 	if err != nil {
-		return "", 0, trace.Wrap(err)
+		return "", 0, trace.Wrap(err, "accepting connection on unix socket")
 	}
+
+	// Close the connection early to unblock reads if the context is canceled.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	go func() {
-		// Close the connection early to unblock reads if the context is canceled.
 		<-ctx.Done()
 		conn.Close()
 	}()
@@ -225,21 +218,4 @@ func recvTUNNameAndFd(ctx context.Context, socket *net.UnixListener) (string, ui
 	fd := uintptr(fds[0])
 
 	return tunName, fd, nil
-}
-
-func configureOS(ctx context.Context, cfg *osConfig) error {
-	if cfg.tunIPv6 != "" && cfg.tunName != "" {
-		slog.InfoContext(ctx, "Setting IPv6 address for the TUN device.", "device", cfg.tunName, "address", cfg.tunIPv6)
-		cmd := exec.CommandContext(ctx, "ifconfig", cfg.tunName, "inet6", cfg.tunIPv6, "prefixlen", "64")
-		if err := cmd.Run(); err != nil {
-			return trace.Wrap(err, "running %v", cmd.Args)
-		}
-
-		slog.InfoContext(ctx, "Setting an IPv6 route for the VNet.")
-		cmd = exec.CommandContext(ctx, "route", "add", "-inet6", cfg.tunIPv6, "-prefixlen", "64", "-interface", cfg.tunName)
-		if err := cmd.Run(); err != nil {
-			return trace.Wrap(err, "running %v", cmd.Args)
-		}
-	}
-	return nil
 }

--- a/lib/vnet/setup_other.go
+++ b/lib/vnet/setup_other.go
@@ -32,8 +32,10 @@ var (
 	ErrVnetNotImplemented = &trace.NotImplementedError{Message: "VNet is not implemented on " + runtime.GOOS}
 )
 
-func createAndSetupTUNDeviceWithoutRoot(ctx context.Context, ipv6Prefix string) (tun.Device, string, error) {
-	return nil, "", trace.Wrap(ErrVnetNotImplemented)
+func createAndSetupTUNDeviceWithoutRoot(ctx context.Context, ipv6Prefix, dnsAddr string) (<-chan tun.Device, <-chan error) {
+	errCh := make(chan error, 1)
+	errCh <- trace.Wrap(ErrVnetNotImplemented)
+	return nil, errCh
 }
 
 func sendTUNNameAndFd(socketPath, tunName string, fd uintptr) error {

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -49,21 +49,24 @@ func (c *vnetCommand) run(cf *CLIConf) error {
 
 type vnetAdminSetupCommand struct {
 	*kingpin.CmdClause
-	// ipv6Prefix is the IPv6 prefix for the VNet.
-	ipv6Prefix string
 	// socketPath is a path to a unix socket used for communication with the parent process.
 	socketPath string
+	// ipv6Prefix is the IPv6 prefix for the VNet.
+	ipv6Prefix string
+	// dnsAddr is the IP address for the VNet DNS server.
+	dnsAddr string
 }
 
 func newVnetAdminSetupCommand(app *kingpin.Application) *vnetAdminSetupCommand {
 	cmd := &vnetAdminSetupCommand{
 		CmdClause: app.Command(teleport.VnetAdminSetupSubCommand, "Start the VNet admin subprocess.").Hidden(),
 	}
-	cmd.Flag("ipv6-prefix", "IPv6 prefix for the VNet").StringVar(&cmd.ipv6Prefix)
 	cmd.Flag("socket", "unix socket path").StringVar(&cmd.socketPath)
+	cmd.Flag("ipv6-prefix", "IPv6 prefix for the VNet").StringVar(&cmd.ipv6Prefix)
+	cmd.Flag("dns-addr", "VNet DNS address").StringVar(&cmd.dnsAddr)
 	return cmd
 }
 
 func (c *vnetAdminSetupCommand) run(cf *CLIConf) error {
-	return trace.Wrap(vnet.AdminSubcommand(cf.Context, c.socketPath, c.ipv6Prefix))
+	return trace.Wrap(vnet.AdminSubcommand(cf.Context, c.socketPath, c.ipv6Prefix, c.dnsAddr))
 }


### PR DESCRIPTION
This is the fifth in a series of PRs implementing Teleport VNet [RFD](https://github.com/gravitational/teleport/blob/rfd/0163-vnet/rfd/0163-vnet.md). [parent](https://github.com/gravitational/teleport/pull/41031) [child](https://github.com/gravitational/teleport/pull/41033)

The PR configures the host OS to use the VNet DNS nameserver to resolve all subdomains of the proxy address of all active teleport profiles.

The admin subcommand is now a long-running command the continually keeps the DNS configuration files under `/etc/resolver` up to date. It will exit after the unix socket already used for communication between the two processes is deleted.