### PR TITLE
[vnet][5] app proxying

### DIFF
--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -51,6 +51,7 @@ import (
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client"
 	libclient "github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/client/clientcache"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -58,7 +59,6 @@ import (
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 	"github.com/gravitational/teleport/lib/teleterm/daemon"
 	"github.com/gravitational/teleport/lib/teleterm/gateway"
-	"github.com/gravitational/teleport/lib/teleterm/services/clientcache"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -200,8 +200,8 @@ func testGatewayCertRenewal(ctx context.Context, t *testing.T, params gatewayCer
 		CreateTshdEventsClientCredsFunc: func() (grpc.DialOption, error) {
 			return grpc.WithTransportCredentials(insecure.NewCredentials()), nil
 		},
-		CreateClientCacheFunc: func(resolveCluster daemon.ResolveClusterFunc) daemon.ClientCache {
-			return clientcache.NewNoCache(clientcache.ResolveClusterFunc(resolveCluster))
+		CreateClientCacheFunc: func(newClient clientcache.NewClientFunc) (daemon.ClientCache, error) {
+			return clientcache.NewNoCache(newClient), nil
 		},
 		KubeconfigsDir: t.TempDir(),
 		AgentsDir:      t.TempDir(),

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -601,9 +601,9 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error, 
 	case !IsErrorResolvableWithRelogin(fnErr):
 		return trace.Wrap(fnErr)
 	}
-	opt := retryWithReloginOptions{}
+	opt := defaultRetryWithReloginOptions()
 	for _, o := range opts {
-		o(&opt)
+		o(opt)
 	}
 	log.Debugf("Activating relogin on error=%q (type=%T)", fnErr, trace.Unwrap(fnErr))
 
@@ -650,9 +650,15 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error, 
 	}
 
 	// Save profile to record proxy credentials
-	if err := tc.SaveProfile(true); err != nil {
+	if err := tc.SaveProfile(opt.makeCurrentProfile); err != nil {
 		log.Warningf("Failed to save profile: %v", err)
 		return trace.Wrap(err)
+	}
+
+	if opt.afterLoginHook != nil {
+		if err := opt.afterLoginHook(); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	return fn()
@@ -666,13 +672,39 @@ type RetryWithReloginOption func(*retryWithReloginOptions)
 type retryWithReloginOptions struct {
 	// beforeLoginHook is a function that will be called before the login attempt.
 	beforeLoginHook func() error
+	// afterLoginHook is a function that will be called after a successful login.
+	afterLoginHook func() error
+	// makeCurrentProfile determines whether to update the current profile after login.
+	makeCurrentProfile bool
 }
 
-// WithBeforeLogin is a functional option for configuring a function that will
+func defaultRetryWithReloginOptions() *retryWithReloginOptions {
+	return &retryWithReloginOptions{
+		makeCurrentProfile: true,
+	}
+}
+
+// WithBeforeLoginHook is a functional option for configuring a function that will
 // be called before the login attempt.
 func WithBeforeLoginHook(fn func() error) RetryWithReloginOption {
 	return func(o *retryWithReloginOptions) {
 		o.beforeLoginHook = fn
+	}
+}
+
+// WithAfterLoginHook is a functional option for configuring a function that will
+// be called after a successful login.
+func WithAfterLoginHook(fn func() error) RetryWithReloginOption {
+	return func(o *retryWithReloginOptions) {
+		o.afterLoginHook = fn
+	}
+}
+
+// WithMakeCurrentProfile is a functional option for configuring whether to update the current profile after a
+// successful login.
+func WithMakeCurrentProfile(makeCurrentProfile bool) RetryWithReloginOption {
+	return func(o *retryWithReloginOptions) {
+		o.makeCurrentProfile = makeCurrentProfile
 	}
 }
 

--- a/lib/client/clientcache/clientcache.go
+++ b/lib/client/clientcache/clientcache.go
@@ -41,7 +41,12 @@ type Cache struct {
 	group singleflight.Group
 }
 
+// NewClientFunc is a function that will return a new [*client.TeleportClient] for a given profile and leaf
+// cluster. [leafClusterName] may be empty, in which case implementations should return a client for the root cluster.
 type NewClientFunc func(ctx context.Context, profileName, leafClusterName string) (*client.TeleportClient, error)
+
+// RetryWithReloginFunc is a function that should call [fn], and if it fails with an error that may be
+// resolved with a cluster relogin, attempts the relogin and calls [fn] again if the relogin is successful.
 type RetryWithReloginFunc func(ctx context.Context, tc *client.TeleportClient, fn func() error, opts ...client.RetryWithReloginOption) error
 
 // Config describes the client cache configuration.

--- a/lib/client/clientcache/clientcache.go
+++ b/lib/client/clientcache/clientcache.go
@@ -27,66 +27,85 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/teleterm/api/uri"
-	"github.com/gravitational/teleport/lib/teleterm/clusters"
 )
 
-// Cache stores clients keyed by cluster URI.
+// Cache stores clients keyed by profile name and leaf cluster name.
 // Safe for concurrent access.
 // Closes all clients and wipes the cache on Clear.
 type Cache struct {
 	cfg Config
-	mu  sync.Mutex
-	// clients keep mapping between cluster URI
-	// (both root and leaf) and cluster clients
-	clients map[uri.ResourceURI]*client.ClusterClient
-	// group prevents duplicate requests to create clients
-	// for a given cluster URI
+	mu  sync.RWMutex
+	// clients keeps a mapping from key (profile name and leaf cluster name) to cluster client.
+	clients map[key]*client.ClusterClient
+	// group prevents duplicate requests to create clients for a given cluster.
 	group singleflight.Group
 }
 
-type ResolveClusterFunc func(uri uri.ResourceURI) (*clusters.Cluster, *client.TeleportClient, error)
+type NewClientFunc func(ctx context.Context, profileName, leafClusterName string) (*client.TeleportClient, error)
+type RetryWithReloginFunc func(ctx context.Context, tc *client.TeleportClient, fn func() error, opts ...client.RetryWithReloginOption) error
 
 // Config describes the client cache configuration.
 type Config struct {
-	ResolveClusterFunc ResolveClusterFunc
-	Log                logrus.FieldLogger
+	NewClientFunc        NewClientFunc
+	RetryWithReloginFunc RetryWithReloginFunc
+	Log                  logrus.FieldLogger
 }
 
-func (c *Config) checkAndSetDefaults() {
+func (c *Config) checkAndSetDefaults() error {
+	if c.NewClientFunc == nil {
+		return trace.BadParameter("NewClientFunc is required")
+	}
+	if c.RetryWithReloginFunc == nil {
+		return trace.BadParameter("RetryWithReloginFunc is required")
+	}
 	if c.Log == nil {
 		c.Log = logrus.WithField(teleport.ComponentKey, "clientcache")
 	}
+	return nil
+}
+
+type key struct {
+	profile     string
+	leafCluster string
+}
+
+func (k key) String() string {
+	if k.leafCluster != "" {
+		return k.profile + "/" + k.leafCluster
+	}
+	return k.profile
 }
 
 // New creates an instance of Cache.
-func New(c Config) *Cache {
-	c.checkAndSetDefaults()
+func New(c Config) (*Cache, error) {
+	if err := c.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	return &Cache{
 		cfg:     c,
-		clients: make(map[uri.ResourceURI]*client.ClusterClient),
-	}
+		clients: make(map[key]*client.ClusterClient),
+	}, nil
 }
 
-// Get returns a client from the cache if there is one,
-// otherwise it dials the remote server.
+// Get returns a client from the cache if there is one, otherwise it dials the remote server.
 // The caller should not close the returned client.
-func (c *Cache) Get(ctx context.Context, clusterURI uri.ResourceURI) (*client.ClusterClient, error) {
-	groupClt, err, _ := c.group.Do(clusterURI.String(), func() (any, error) {
-		if fromCache := c.getFromCache(clusterURI); fromCache != nil {
-			c.cfg.Log.WithField("cluster", clusterURI.String()).Info("Retrieved client from cache.")
+func (c *Cache) Get(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error) {
+	k := key{profile: profileName, leafCluster: leafClusterName}
+	groupClt, err, _ := c.group.Do(k.String(), func() (any, error) {
+		if fromCache := c.getFromCache(k); fromCache != nil {
+			c.cfg.Log.WithField("cluster", k).Debug("Retrieved client from cache.")
 			return fromCache, nil
 		}
 
-		_, clusterClient, err := c.cfg.ResolveClusterFunc(clusterURI)
+		tc, err := c.cfg.NewClientFunc(ctx, profileName, leafClusterName)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
 		var newClient *client.ClusterClient
-		if err := clusters.AddMetadataToRetryableError(ctx, func() error {
-			clt, err := clusterClient.ConnectToCluster(ctx)
+		if err := c.cfg.RetryWithReloginFunc(ctx, tc, func() error {
+			clt, err := tc.ConnectToCluster(ctx)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -96,12 +115,10 @@ func (c *Cache) Get(ctx context.Context, clusterURI uri.ResourceURI) (*client.Cl
 			return nil, trace.Wrap(err)
 		}
 
-		// We'll save the client in the cache, so we don't have to
-		// build a new connection next time.
-		// All cached clients will be closed when the daemon exits.
-		c.addToCache(clusterURI, newClient)
+		// Save the client in the cache, so we don't have to build a new connection next time.
+		c.addToCache(k, newClient)
 
-		c.cfg.Log.WithField("cluster", clusterURI.String()).Info("Added client to cache.")
+		c.cfg.Log.WithField("cluster", k).Info("Added client to cache.")
 
 		return newClient, nil
 	})
@@ -117,30 +134,28 @@ func (c *Cache) Get(ctx context.Context, clusterURI uri.ResourceURI) (*client.Cl
 	return clt, nil
 }
 
-// ClearForRoot closes and removes clients from the cache
-// for the root cluster and its leaf clusters.
-func (c *Cache) ClearForRoot(clusterURI uri.ResourceURI) error {
+// ClearForRoot closes and removes clients from the cache for the root cluster and its leaf clusters.
+func (c *Cache) ClearForRoot(profileName string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	rootClusterURI := clusterURI.GetRootClusterURI()
 	var (
 		errors  []error
 		deleted []string
 	)
 
-	for resourceURI, clt := range c.clients {
-		if resourceURI.GetRootClusterURI() == rootClusterURI {
+	for k, clt := range c.clients {
+		if k.profile == profileName {
 			if err := clt.Close(); err != nil {
 				errors = append(errors, err)
 			}
-			deleted = append(deleted, resourceURI.GetClusterURI().String())
-			delete(c.clients, resourceURI)
+			deleted = append(deleted, k.String())
+			delete(c.clients, k)
 		}
 	}
 
 	c.cfg.Log.WithFields(
-		logrus.Fields{"cluster": rootClusterURI.String(), "clients": deleted},
+		logrus.Fields{"cluster": profileName, "clients": deleted},
 	).Info("Invalidated cached clients for root cluster.")
 
 	return trace.NewAggregate(errors...)
@@ -163,18 +178,18 @@ func (c *Cache) Clear() error {
 	return trace.NewAggregate(errors...)
 }
 
-func (c *Cache) addToCache(clusterURI uri.ResourceURI, clusterClient *client.ClusterClient) {
+func (c *Cache) addToCache(k key, clusterClient *client.ClusterClient) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.clients[clusterURI] = clusterClient
+	c.clients[k] = clusterClient
 }
 
-func (c *Cache) getFromCache(clusterURI uri.ResourceURI) *client.ClusterClient {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+func (c *Cache) getFromCache(k key) *client.ClusterClient {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
-	clt := c.clients[clusterURI]
+	clt := c.clients[k]
 	return clt
 }
 
@@ -183,24 +198,24 @@ func (c *Cache) getFromCache(clusterURI uri.ResourceURI) *client.ClusterClient {
 //
 // ClearForRoot and Clear still work as expected.
 type NoCache struct {
-	mu                 sync.Mutex
-	resolveClusterFunc ResolveClusterFunc
-	clients            []noCacheClient
+	mu            sync.Mutex
+	newClientFunc NewClientFunc
+	clients       []noCacheClient
 }
 
 type noCacheClient struct {
-	uri    uri.ResourceURI
+	k      key
 	client *client.ClusterClient
 }
 
-func NewNoCache(resolveClusterFunc ResolveClusterFunc) *NoCache {
+func NewNoCache(newClientFunc NewClientFunc) *NoCache {
 	return &NoCache{
-		resolveClusterFunc: resolveClusterFunc,
+		newClientFunc: newClientFunc,
 	}
 }
 
-func (c *NoCache) Get(ctx context.Context, clusterURI uri.ResourceURI) (*client.ClusterClient, error) {
-	_, clusterClient, err := c.resolveClusterFunc(clusterURI)
+func (c *NoCache) Get(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error) {
+	clusterClient, err := c.newClientFunc(ctx, profileName, leafClusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -212,7 +227,7 @@ func (c *NoCache) Get(ctx context.Context, clusterURI uri.ResourceURI) (*client.
 
 	c.mu.Lock()
 	c.clients = append(c.clients, noCacheClient{
-		uri:    clusterURI,
+		k:      key{profile: profileName, leafCluster: leafClusterName},
 		client: newClient,
 	})
 	c.mu.Unlock()
@@ -220,17 +235,16 @@ func (c *NoCache) Get(ctx context.Context, clusterURI uri.ResourceURI) (*client.
 	return newClient, nil
 }
 
-func (c *NoCache) ClearForRoot(clusterURI uri.ResourceURI) error {
+func (c *NoCache) ClearForRoot(profileName string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	rootClusterURI := clusterURI.GetRootClusterURI()
 	var (
 		errors []error
 	)
 
 	c.clients = slices.DeleteFunc(c.clients, func(ncc noCacheClient) bool {
-		belongsToCluster := ncc.uri.GetRootClusterURI() == rootClusterURI
+		belongsToCluster := ncc.k.profile == profileName
 
 		if belongsToCluster {
 			if err := ncc.client.Close(); err != nil {

--- a/lib/client/local_proxy_middleware.go
+++ b/lib/client/local_proxy_middleware.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"net"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -76,7 +75,7 @@ func NewAppCertChecker(tc *TeleportClient, appRoute proto.RouteToApp, clock cloc
 
 // OnNewConnection is a callback triggered when a new downstream connection is
 // accepted by the local proxy.
-func (c *CertChecker) OnNewConnection(ctx context.Context, lp *alpnproxy.LocalProxy, conn net.Conn) error {
+func (c *CertChecker) OnNewConnection(ctx context.Context, lp *alpnproxy.LocalProxy) error {
 	return trace.Wrap(c.ensureValidCerts(ctx, lp))
 }
 

--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -99,7 +99,7 @@ type LocalProxyMiddleware interface {
 	// OnNewConnection is a callback triggered when a new downstream connection is
 	// accepted by the local proxy. If an error is returned, the connection will be closed
 	// by the local proxy.
-	OnNewConnection(ctx context.Context, lp *LocalProxy, conn net.Conn) error
+	OnNewConnection(ctx context.Context, lp *LocalProxy) error
 	// OnStart is a callback triggered when the local proxy starts.
 	OnStart(ctx context.Context, lp *LocalProxy) error
 }
@@ -197,7 +197,7 @@ func (l *LocalProxy) start(ctx context.Context) error {
 		l.cfg.Log.Debug("Accepted downstream connection.")
 
 		if l.cfg.Middleware != nil {
-			if err := l.cfg.Middleware.OnNewConnection(ctx, l, conn); err != nil {
+			if err := l.cfg.Middleware.OnNewConnection(ctx, l); err != nil {
 				l.cfg.Log.WithError(err).Error("Middleware failed to handle client connection.")
 				if err := conn.Close(); err != nil && !utils.IsUseOfClosedNetworkError(err) {
 					l.cfg.Log.WithError(err).Debug("Failed to close client connection.")
@@ -232,19 +232,57 @@ func (l *LocalProxy) handleDownstreamConnection(ctx context.Context, downstreamC
 		return trace.Wrap(err)
 	}
 
-	tlsConn, err := client.DialALPN(ctx, l.cfg.RemoteProxyAddr, l.getALPNDialerConfig(cert))
+	upstreamConn, err := dialALPNMaybePing(ctx, l.cfg.RemoteProxyAddr, l.getALPNDialerConfig(cert))
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer tlsConn.Close()
-
-	var upstreamConn net.Conn = tlsConn
-	if common.IsPingProtocol(common.Protocol(tlsConn.ConnectionState().NegotiatedProtocol)) {
-		l.cfg.Log.Debug("Using ping connection")
-		upstreamConn = pingconn.NewTLS(tlsConn)
-	}
+	defer upstreamConn.Close()
 
 	return trace.Wrap(utils.ProxyConn(ctx, downstreamConn, upstreamConn))
+}
+
+// HandleTCPConnector injects an inbound TCP connection (via [connector]) that doesn't come in through any
+// net.Listener. It is used by VNet to share the common local proxy code. [connector] should be called as late
+// as possible so that in case of error VNet clients get a failed TCP dial (with RST) rather than a successful
+// dial with an immediately closed connection.
+func (l *LocalProxy) HandleTCPConnector(ctx context.Context, connector func() (net.Conn, error)) error {
+	if l.cfg.Middleware != nil {
+		if err := l.cfg.Middleware.OnNewConnection(ctx, l); err != nil {
+			return trace.Wrap(err, "middleware failed to handle client connection")
+		}
+	}
+
+	cert, err := l.getCertWithoutConn()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	upstreamConn, err := dialALPNMaybePing(ctx, l.cfg.RemoteProxyAddr, l.getALPNDialerConfig(cert))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer upstreamConn.Close()
+
+	downstreamConn, err := connector()
+	if err != nil {
+		return trace.Wrap(err, "getting downstream conn")
+	}
+	defer downstreamConn.Close()
+
+	return trace.Wrap(utils.ProxyConn(ctx, downstreamConn, upstreamConn))
+}
+
+// dialALPNMaybePing is a helper to dial using an ALPNDialer, it wraps the tls conn in a ping conn if
+// necessary, and returns a net.Conn if successful.
+func dialALPNMaybePing(ctx context.Context, addr string, cfg client.ALPNDialerConfig) (net.Conn, error) {
+	tlsConn, err := client.DialALPN(ctx, addr, cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if common.IsPingProtocol(common.Protocol(tlsConn.ConnectionState().NegotiatedProtocol)) {
+		return pingconn.NewTLS(tlsConn), nil
+	}
+	return tlsConn, nil
 }
 
 func (l *LocalProxy) Close() error {
@@ -499,6 +537,13 @@ func (l *LocalProxy) getCertForConn(downstreamConn net.Conn) (tls.Certificate, n
 		return cert, conn, nil
 	}
 	return tls.Certificate{}, downstreamConn, nil
+}
+
+func (l *LocalProxy) getCertWithoutConn() (tls.Certificate, error) {
+	if l.cfg.CheckCertNeeded {
+		return tls.Certificate{}, trace.BadParameter("getCertWithoutConn called while CheckCertNeeded is true: this is a bug")
+	}
+	return l.getCert(), nil
 }
 
 func (l *LocalProxy) isPostgresProxy() bool {

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -198,7 +198,7 @@ func (m *mockMiddlewareCounter) onStateChange() {
 	}
 }
 
-func (m *mockMiddlewareCounter) OnNewConnection(_ context.Context, _ *LocalProxy, _ net.Conn) error {
+func (m *mockMiddlewareCounter) OnNewConnection(_ context.Context, _ *LocalProxy) error {
 	m.Lock()
 	defer m.Unlock()
 	m.connCount++
@@ -292,7 +292,7 @@ type mockCertRenewer struct {
 	cert tls.Certificate
 }
 
-func (m *mockCertRenewer) OnNewConnection(_ context.Context, lp *LocalProxy, _ net.Conn) error {
+func (m *mockCertRenewer) OnNewConnection(_ context.Context, lp *LocalProxy) error {
 	lp.SetCert(m.cert)
 	return nil
 }
@@ -428,7 +428,7 @@ func TestCheckDBCerts(t *testing.T) {
 type mockMiddlewareConnUnauth struct {
 }
 
-func (m *mockMiddlewareConnUnauth) OnNewConnection(_ context.Context, _ *LocalProxy, _ net.Conn) error {
+func (m *mockMiddlewareConnUnauth) OnNewConnection(_ context.Context, _ *LocalProxy) error {
 	return trace.AccessDenied("access denied.")
 }
 

--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log/slog"
-	"net"
 
 	"github.com/gravitational/trace"
 
@@ -42,13 +41,13 @@ import (
 var _ alpnproxy.LocalProxyMiddleware = (*alpnProxyMiddleware)(nil)
 
 type alpnProxyMiddleware struct {
-	onNewConnection func(ctx context.Context, lp *alpnproxy.LocalProxy, conn net.Conn) error
+	onNewConnection func(ctx context.Context, lp *alpnproxy.LocalProxy) error
 	onStart         func(ctx context.Context, lp *alpnproxy.LocalProxy) error
 }
 
-func (a alpnProxyMiddleware) OnNewConnection(ctx context.Context, lp *alpnproxy.LocalProxy, conn net.Conn) error {
+func (a alpnProxyMiddleware) OnNewConnection(ctx context.Context, lp *alpnproxy.LocalProxy) error {
 	if a.onNewConnection != nil {
-		return a.onNewConnection(ctx, lp, conn)
+		return a.onNewConnection(ctx, lp)
 	}
 	return nil
 }
@@ -123,7 +122,7 @@ func (s *DatabaseTunnelService) buildLocalProxyConfig(ctx context.Context) (lpCf
 	s.log.DebugContext(ctx, "Issued initial certificate for local proxy.")
 
 	middleware := alpnProxyMiddleware{
-		onNewConnection: func(ctx context.Context, lp *alpnproxy.LocalProxy, conn net.Conn) error {
+		onNewConnection: func(ctx context.Context, lp *alpnproxy.LocalProxy) error {
 			ctx, span := tracer.Start(ctx, "DatabaseTunnelService/OnNewConnection")
 			defer span.End()
 

--- a/lib/teleterm/api/uri/uri.go
+++ b/lib/teleterm/api/uri/uri.go
@@ -164,12 +164,7 @@ func (r ResourceURI) GetRootClusterURI() ResourceURI {
 // If called on a leaf cluster resource URI, it'll return the URI of the leaf cluster.
 // If called on a root cluster URI or a leaf cluster URI, it's a noop.
 func (r ResourceURI) GetClusterURI() ResourceURI {
-	clusterURI := r.GetRootClusterURI()
-
-	if leafClusterName := r.GetLeafClusterName(); leafClusterName != "" {
-		clusterURI = clusterURI.AppendLeafCluster(leafClusterName)
-	}
-	return clusterURI
+	return r.GetRootClusterURI().AppendLeafCluster(r.GetLeafClusterName())
 }
 
 // AppendServer appends server segment to the URI
@@ -178,8 +173,12 @@ func (r ResourceURI) AppendServer(id string) ResourceURI {
 	return r
 }
 
-// AppendLeafCluster appends leaf cluster segment to the URI
+// AppendLeafCluster appends leaf cluster segment to the URI if name is not empty.
 func (r ResourceURI) AppendLeafCluster(name string) ResourceURI {
+	if name == "" {
+		return r
+	}
+
 	r.path = fmt.Sprintf("%v/leaves/%v", r.path, name)
 	return r
 }

--- a/lib/teleterm/api/uri/uri_test.go
+++ b/lib/teleterm/api/uri/uri_test.go
@@ -406,3 +406,29 @@ func TestIsLeaf(t *testing.T) {
 		})
 	}
 }
+
+func TestAppendLeafCluster(t *testing.T) {
+	tests := []struct {
+		profileName string
+		leafName    string
+		out         string
+	}{
+		{
+			profileName: "foo",
+			leafName:    "bar",
+			out:         "/clusters/foo/leaves/bar",
+		},
+		{
+			profileName: "foo",
+			leafName:    "",
+			out:         "/clusters/foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.out, func(t *testing.T) {
+			actualOut := uri.NewClusterURI(tt.profileName).AppendLeafCluster(tt.leafName).String()
+			require.Equal(t, tt.out, actualOut)
+		})
+	}
+}

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -196,25 +196,6 @@ func (s *Storage) addCluster(ctx context.Context, dir, webProxyAddress string) (
 	}, clusterClient, nil
 }
 
-func (s *Storage) NewClusterClient(ctx context.Context, profileName, leafClusterName string) (*client.TeleportClient, error) {
-	profileStore := client.NewFSProfileStore(s.Dir)
-
-	cfg := s.makeDefaultClientConfig()
-	if err := cfg.LoadProfile(profileStore, profileName); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if leafClusterName != "" {
-		cfg.SiteName = leafClusterName
-	}
-
-	clusterClient, err := client.NewClient(cfg)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return clusterClient, nil
-}
-
 // fromProfile creates a new cluster from its profile
 func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, *client.TeleportClient, error) {
 	if profileName == "" {
@@ -223,12 +204,21 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, *c
 
 	clusterNameForKey := profileName
 	clusterURI := uri.NewClusterURI(profileName)
+
+	profileStore := client.NewFSProfileStore(s.Dir)
+
+	cfg := s.makeDefaultClientConfig()
+	if err := cfg.LoadProfile(profileStore, profileName); err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
 	if leafClusterName != "" {
 		clusterNameForKey = leafClusterName
 		clusterURI = clusterURI.AppendLeafCluster(leafClusterName)
+		cfg.SiteName = leafClusterName
 	}
 
-	clusterClient, err := s.NewClusterClient(context.Background(), profileName, leafClusterName)
+	clusterClient, err := client.NewClient(cfg)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/teleterm/daemon/config.go
+++ b/lib/teleterm/daemon/config.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/client/clientcache"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
-	"github.com/gravitational/teleport/lib/teleterm/services/clientcache"
 	"github.com/gravitational/teleport/lib/teleterm/services/connectmycomputer"
 )
 
@@ -42,6 +42,7 @@ type Storage interface {
 	Add(ctx context.Context, webProxyAddress string) (*clusters.Cluster, *client.TeleportClient, error)
 	Remove(ctx context.Context, profileName string) error
 	GetByResourceURI(resourceURI uri.ResourceURI) (*clusters.Cluster, *client.TeleportClient, error)
+	NewClusterClient(ctx context.Context, profileName, leaftClusterName string) (*client.TeleportClient, error)
 }
 
 // Config is the cluster service config
@@ -72,7 +73,7 @@ type Config struct {
 	ConnectMyComputerNodeDelete       *connectmycomputer.NodeDelete
 	ConnectMyComputerNodeName         *connectmycomputer.NodeName
 
-	CreateClientCacheFunc func(resolver ResolveClusterFunc) ClientCache
+	CreateClientCacheFunc func(resolver clientcache.NewClientFunc) (ClientCache, error)
 }
 
 // ResolveClusterFunc returns a cluster by URI.
@@ -83,10 +84,10 @@ type ClientCache interface {
 	// Get returns a client from the cache if there is one,
 	// otherwise it dials the remote server.
 	// The caller should not close the returned client.
-	Get(ctx context.Context, clusterURI uri.ResourceURI) (*client.ClusterClient, error)
+	Get(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error)
 	// ClearForRoot closes and removes clients from the cache
 	// for the root cluster and its leaf clusters.
-	ClearForRoot(clusterURI uri.ResourceURI) error
+	ClearForRoot(profileName string) error
 	// Clear closes and removes all clients.
 	Clear() error
 }
@@ -161,10 +162,14 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if c.CreateClientCacheFunc == nil {
-		c.CreateClientCacheFunc = func(resolver ResolveClusterFunc) ClientCache {
+		c.CreateClientCacheFunc = func(newClientFunc clientcache.NewClientFunc) (ClientCache, error) {
+			retryWithRelogin := func(ctx context.Context, tc *client.TeleportClient, fn func() error, opts ...client.RetryWithReloginOption) error {
+				return clusters.AddMetadataToRetryableError(ctx, fn)
+			}
 			return clientcache.New(clientcache.Config{
-				Log:                c.Log,
-				ResolveClusterFunc: clientcache.ResolveClusterFunc(resolver),
+				Log:                  c.Log,
+				NewClientFunc:        newClientFunc,
+				RetryWithReloginFunc: clientcache.RetryWithReloginFunc(retryWithRelogin),
 			})
 		}
 	}

--- a/lib/teleterm/daemon/config.go
+++ b/lib/teleterm/daemon/config.go
@@ -42,7 +42,6 @@ type Storage interface {
 	Add(ctx context.Context, webProxyAddress string) (*clusters.Cluster, *client.TeleportClient, error)
 	Remove(ctx context.Context, profileName string) error
 	GetByResourceURI(resourceURI uri.ResourceURI) (*clusters.Cluster, *client.TeleportClient, error)
-	NewClusterClient(ctx context.Context, profileName, leaftClusterName string) (*client.TeleportClient, error)
 }
 
 // Config is the cluster service config

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -225,8 +225,11 @@ func (s *Service) RemoveCluster(ctx context.Context, uri string) error {
 	return nil
 }
 
+// NewClusterClient is a wrapper on ResolveClusterURI that can be passed as an argument to
+// s.cfg.CreateClientCacheFunc.
 func (s *Service) NewClusterClient(ctx context.Context, profileName, leafClusterName string) (*client.TeleportClient, error) {
-	clusterClient, err := s.cfg.Storage.NewClusterClient(ctx, profileName, leafClusterName)
+	uri := uri.NewClusterURI(profileName).AppendLeafCluster(leafClusterName)
+	_, clusterClient, err := s.ResolveClusterURI(uri)
 	return clusterClient, trace.Wrap(err)
 }
 

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -95,7 +95,11 @@ func New(cfg Config) (*Service, error) {
 	// That's because Daemon.ResolveClusterURI sets a custom MFAPromptConstructor that
 	// shows an MFA prompt in Connect.
 	// At the level of Storage.ResolveClusterFunc we don't have access to it.
-	service.clientCache = cfg.CreateClientCacheFunc(service.ResolveClusterURI)
+	service.clientCache, err = cfg.CreateClientCacheFunc(service.NewClusterClient)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return service, nil
 }
 
@@ -219,6 +223,11 @@ func (s *Service) RemoveCluster(ctx context.Context, uri string) error {
 	}
 
 	return nil
+}
+
+func (s *Service) NewClusterClient(ctx context.Context, profileName, leafClusterName string) (*client.TeleportClient, error) {
+	clusterClient, err := s.cfg.Storage.NewClusterClient(ctx, profileName, leafClusterName)
+	return clusterClient, trace.Wrap(err)
 }
 
 // ResolveCluster resolves a cluster by URI by reading data stored on disk in the profile.
@@ -1119,14 +1128,17 @@ func (s *Service) findGatewayByTargetURI(targetURI uri.ResourceURI) (gateway.Gat
 // GetCachedClient returns a client from the cache if it exists,
 // otherwise it dials the remote server.
 func (s *Service) GetCachedClient(ctx context.Context, clusterURI uri.ResourceURI) (*client.ClusterClient, error) {
-	clt, err := s.clientCache.Get(ctx, clusterURI)
+	profileName := clusterURI.GetProfileName()
+	leafClusterName := clusterURI.GetLeafClusterName()
+	clt, err := s.clientCache.Get(ctx, profileName, leafClusterName)
 	return clt, trace.Wrap(err)
 }
 
 // ClearCachedClientsForRoot closes and removes clients from the cache
 // for the root cluster and its leaf clusters.
 func (s *Service) ClearCachedClientsForRoot(clusterURI uri.ResourceURI) error {
-	return trace.Wrap(s.clientCache.ClearForRoot(clusterURI))
+	profileName := clusterURI.GetProfileName()
+	return trace.Wrap(s.clientCache.ClearForRoot(profileName))
 }
 
 // Service is the daemon service

--- a/lib/teleterm/daemon/daemon_test.go
+++ b/lib/teleterm/daemon/daemon_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/client/clientcache"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
@@ -272,8 +273,8 @@ func TestGatewayCRUD(t *testing.T) {
 				GatewayCreator: mockGatewayCreator,
 				KubeconfigsDir: t.TempDir(),
 				AgentsDir:      t.TempDir(),
-				CreateClientCacheFunc: func(resolver ResolveClusterFunc) ClientCache {
-					return fakeClientCache{}
+				CreateClientCacheFunc: func(newClientFunc clientcache.NewClientFunc) (ClientCache, error) {
+					return fakeClientCache{}, nil
 				},
 			})
 			require.NoError(t, err)
@@ -453,8 +454,8 @@ func TestRetryWithRelogin(t *testing.T) {
 				},
 				KubeconfigsDir: t.TempDir(),
 				AgentsDir:      t.TempDir(),
-				CreateClientCacheFunc: func(resolver ResolveClusterFunc) ClientCache {
-					return fakeClientCache{}
+				CreateClientCacheFunc: func(newClientFunc clientcache.NewClientFunc) (ClientCache, error) {
+					return fakeClientCache{}, nil
 				},
 			})
 			require.NoError(t, err)
@@ -506,8 +507,8 @@ func TestImportantModalSemaphore(t *testing.T) {
 		},
 		KubeconfigsDir: t.TempDir(),
 		AgentsDir:      t.TempDir(),
-		CreateClientCacheFunc: func(resolver ResolveClusterFunc) ClientCache {
-			return fakeClientCache{}
+		CreateClientCacheFunc: func(newClientFunc clientcache.NewClientFunc) (ClientCache, error) {
+			return fakeClientCache{}, nil
 		},
 	})
 	require.NoError(t, err)
@@ -657,8 +658,8 @@ func TestGetGatewayCLICommand(t *testing.T) {
 		},
 		KubeconfigsDir: t.TempDir(),
 		AgentsDir:      t.TempDir(),
-		CreateClientCacheFunc: func(resolver ResolveClusterFunc) ClientCache {
-			return fakeClientCache{}
+		CreateClientCacheFunc: func(newClientFunc clientcache.NewClientFunc) (ClientCache, error) {
+			return fakeClientCache{}, nil
 		},
 	})
 	require.NoError(t, err)
@@ -744,6 +745,6 @@ type fakeClientCache struct {
 	ClientCache
 }
 
-func (f fakeClientCache) Get(ctx context.Context, clusterURI uri.ResourceURI) (*client.ClusterClient, error) {
+func (f fakeClientCache) Get(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error) {
 	return &client.ClusterClient{}, nil
 }

--- a/lib/teleterm/gateway/app_middleware.go
+++ b/lib/teleterm/gateway/app_middleware.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"net"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -38,7 +37,7 @@ type appMiddleware struct {
 // it on the local proxy.
 // Other middlewares typically also handle MFA here. App access doesn't support per-session MFA yet,
 // so detecting expired certs is all this middleware can do.
-func (m *appMiddleware) OnNewConnection(ctx context.Context, lp *alpn.LocalProxy, conn net.Conn) error {
+func (m *appMiddleware) OnNewConnection(ctx context.Context, lp *alpn.LocalProxy) error {
 	err := lp.CheckCertExpiry()
 	if err == nil {
 		return nil

--- a/lib/teleterm/gateway/db_middleware.go
+++ b/lib/teleterm/gateway/db_middleware.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
-	"net"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -43,7 +42,7 @@ type dbMiddleware struct {
 //
 // In the future, DBCertChecker is going to be extended so that it's used by both tsh and Connect
 // and this middleware will be removed.
-func (m *dbMiddleware) OnNewConnection(ctx context.Context, lp *alpn.LocalProxy, conn net.Conn) error {
+func (m *dbMiddleware) OnNewConnection(ctx context.Context, lp *alpn.LocalProxy) error {
 	err := lp.CheckDBCert(m.dbRoute)
 	if err == nil {
 		return nil

--- a/lib/teleterm/gateway/db_middleware_test.go
+++ b/lib/teleterm/gateway/db_middleware_test.go
@@ -125,7 +125,7 @@ func TestDBMiddleware_OnNewConnection(t *testing.T) {
 
 			localProxy.SetCert(tlsCert)
 
-			err = middleware.OnNewConnection(ctx, localProxy, nil /* net.Conn, not used by middleware */)
+			err = middleware.OnNewConnection(ctx, localProxy)
 			tt.expectation(t, err, hasCalledOnExpiredCert)
 		})
 	}

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -471,7 +471,7 @@ func TestDialFakeApp(t *testing.T) {
 	})
 
 	t.Run("invalid", func(t *testing.T) {
-		// It's safe to run these invalid app tests in parallel becuase they fail the DNS lookup and don't
+		// It's safe to run these invalid app tests in parallel because they fail the DNS lookup and don't
 		// even make it to a TCP dial, so the clock used for TLS cert expiry doesn't matter.
 		t.Parallel()
 		for _, app := range invalidAppNames {

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -363,8 +363,8 @@ func TestDialFakeApp(t *testing.T) {
 					return trace.Wrap(err)
 				}
 				go func() {
-					err := utils.ProxyConn(ctx, conn, conn)
-					if errors.Is(err, context.Canceled) {
+					_, err := io.Copy(conn, conn)
+					if utils.IsOKNetworkError(err) {
 						err = nil
 					}
 					assert.NoError(t, err)
@@ -459,7 +459,7 @@ func TestDialFakeApp(t *testing.T) {
 
 func testEchoConnection(t *testing.T, conn net.Conn) {
 	const testString = "1........."
-	writeBuf := bytes.Repeat([]byte(testString), 10)
+	writeBuf := bytes.Repeat([]byte(testString), 200)
 	readBuf := make([]byte, len(writeBuf))
 
 	for i := 0; i < 10; i++ {

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -38,8 +38,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/zeebo/assert"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
 	"gvisor.dev/gvisor/pkg/tcpip/link/channel"

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -104,7 +104,7 @@ func appLogin(
 	ctx context.Context,
 	tc *client.TeleportClient,
 	clusterClient *client.ClusterClient,
-	rootClient auth.ClientI,
+	rootClient authclient.ClientI,
 	appCertParams client.ReissueParams,
 ) (*client.Key, error) {
 	// TODO (Joerger): DELETE IN v17.0.0

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -19,6 +19,7 @@
 package common
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509/pkix"
 	"fmt"
@@ -74,7 +75,6 @@ func onAppLogin(cf *CLIConf) error {
 		AccessRequests: profile.ActiveRequests.AccessRequests,
 	}
 
-	// TODO (Joerger): DELETE IN v17.0.0
 	clusterClient, err := tc.ConnectToCluster(cf.Context)
 	if err != nil {
 		return trace.Wrap(err)
@@ -83,12 +83,8 @@ func onAppLogin(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	appCertParams.RouteToApp.SessionID, err = authclient.TryCreateAppSessionForClientCertV15(cf.Context, rootClient, tc.Username, appCertParams.RouteToApp)
-	if err != nil {
-		return trace.Wrap(err)
-	}
 
-	key, _, err := clusterClient.IssueUserCertsWithMFA(cf.Context, appCertParams, tc.NewMFAPrompt(mfa.WithPromptReasonSessionMFA("Application", app.GetName())))
+	key, err := appLogin(cf.Context, tc, clusterClient, rootClient, appCertParams)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -102,6 +98,25 @@ func onAppLogin(cf *CLIConf) error {
 	}
 
 	return nil
+}
+
+func appLogin(
+	ctx context.Context,
+	tc *client.TeleportClient,
+	clusterClient *client.ClusterClient,
+	rootClient auth.ClientI,
+	appCertParams client.ReissueParams,
+) (*client.Key, error) {
+	// TODO (Joerger): DELETE IN v17.0.0
+	var err error
+	appCertParams.RouteToApp.SessionID, err = authclient.TryCreateAppSessionForClientCertV15(ctx, rootClient, tc.Username, appCertParams.RouteToApp)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	key, _, err := clusterClient.IssueUserCertsWithMFA(ctx, appCertParams,
+		tc.NewMFAPrompt(mfa.WithPromptReasonSessionMFA("Application", appCertParams.RouteToApp.Name)))
+	return key, trace.Wrap(err)
 }
 
 func getRouteToApp(cf *CLIConf, tc *client.TeleportClient, profile *client.ProfileStatus, app types.Application) (proto.RouteToApp, error) {

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -606,7 +606,7 @@ func loadAppCertificateWithAppLogin(cf *CLIConf, tc *libclient.TeleportClient, a
 		if !needLogin {
 			return tls.Certificate{}, trace.Wrap(err)
 		}
-		log.WithError(err).Debugf("Loading app certificate failed, attempting to login into app %q", appName)
+		log.WithError(err).Debugf("Loading app certificate failed, attempting to login to app %q", appName)
 		quiet := cf.Quiet
 		cf.Quiet = true
 		errLogin := onAppLogin(cf)

--- a/tool/tsh/common/vnet_common.go
+++ b/tool/tsh/common/vnet_common.go
@@ -143,7 +143,7 @@ func (p *vnetAppProvider) retryWithRelogin(ctx context.Context, tc *client.Telep
 
 	opts = append(opts,
 		client.WithBeforeLoginHook(func() error {
-			// Multiple concurrent logins in tsh would be bad UX, expecially when MFA is involved, so we only
+			// Multiple concurrent logins in tsh would be bad UX, especially when MFA is involved, so we only
 			// allow one login at a time. If another login is already in progress this just returns an error
 			// and no login will be attempted. Subsequent relogins can be attempted on the next client request
 			// after the current one finishes.

--- a/tool/tsh/common/vnet_common.go
+++ b/tool/tsh/common/vnet_common.go
@@ -18,24 +18,48 @@ package common
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log/slog"
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/client/clientcache"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/vnet"
 )
 
 // vnetAppProvider implement [vnet.AppProvider] in order to provide the necessary methods to log in to apps
 // and get clients able to list apps in all clusters in all current profiles.
 type vnetAppProvider struct {
+	cf          *CLIConf
 	clientStore *client.Store
+	clientCache *clientcache.Cache
 }
 
 func newVnetAppProvider(cf *CLIConf) (*vnetAppProvider, error) {
 	clientStore := client.NewFSClientStore(cf.HomePath)
 
-	return &vnetAppProvider{
+	p := &vnetAppProvider{
+		cf:          cf,
 		clientStore: clientStore,
-	}, nil
+	}
+
+	clientCache, err := clientcache.New(clientcache.Config{
+		NewClientFunc:        clientcache.NewClientFunc(p.newTeleportClient),
+		RetryWithReloginFunc: clientcache.RetryWithReloginFunc(p.retryWithRelogin),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "creating client cache")
+	}
+
+	p.clientCache = clientCache
+	return p, nil
+
 }
 
 // ListProfiles lists the names of all profiles saved for the user.
@@ -43,10 +67,126 @@ func (p *vnetAppProvider) ListProfiles() ([]string, error) {
 	return p.clientStore.ListProfiles()
 }
 
-// GetCachedClient returns a [*client.ClusterClient] for the given profile and leaf cluster.
+// GetCachedClient returns a cached [*client.ClusterClient] for the given profile and leaf cluster.
 // [leafClusterName] may be empty when requesting a client for the root cluster.
-// TODO: cache clients across calls.
 func (p *vnetAppProvider) GetCachedClient(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error) {
+	return p.clientCache.Get(ctx, profileName, leafClusterName)
+}
+
+// ReissueAppCert returns a new app certificate for the given app in the named profile and leaf cluster.
+// It uses retryWithRelogin to issue the new app cert. A relogin may not be necessary if the app cert lifetime
+// was shorter than the cluster cert lifetime, or if the user has already re-logged in to the cluster.
+// If a cluster relogin is completed, the cluster client cache will be cleared for the root cluster and all
+// leaf clusters of that root.
+func (p *vnetAppProvider) ReissueAppCert(ctx context.Context, profileName, leafClusterName string, app types.Application) (tls.Certificate, error) {
+	tc, err := p.newTeleportClient(ctx, profileName, leafClusterName)
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err)
+	}
+
+	var cert tls.Certificate
+	err = p.retryWithRelogin(ctx, tc, func() error {
+		var err error
+		cert, err = p.reissueAppCert(ctx, tc, profileName, leafClusterName, app)
+		return trace.Wrap(err, "reissuing app cert")
+	})
+	return cert, trace.Wrap(err)
+}
+
+// GetDialOptions returns ALPN dial options for the profile.
+func (p *vnetAppProvider) GetDialOptions(ctx context.Context, profileName string) (*vnet.DialOptions, error) {
+	profile, err := p.clientStore.GetProfile(profileName)
+	if err != nil {
+		return nil, trace.Wrap(err, "loading user profile")
+	}
+	dialOpts := &vnet.DialOptions{
+		WebProxyAddr:            profile.WebProxyAddr,
+		ALPNConnUpgradeRequired: profile.TLSRoutingConnUpgradeRequired,
+	}
+	if dialOpts.ALPNConnUpgradeRequired {
+		dialOpts.RootClusterCACertPool, err = p.getRootClusterCACertPool(ctx, profileName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	return dialOpts, nil
+}
+
+// getRootClusterCACertPool returns a certificate pool for the root cluster of the given profile.
+func (p *vnetAppProvider) getRootClusterCACertPool(ctx context.Context, profileName string) (*x509.CertPool, error) {
+	tc, err := p.newTeleportClient(ctx, profileName, "")
+	if err != nil {
+		return nil, trace.Wrap(err, "creating new client")
+	}
+	certPool, err := tc.RootClusterCACertPool(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err, "loading root cluster CA cert pool")
+	}
+	return certPool, nil
+}
+
+func (p *vnetAppProvider) retryWithRelogin(ctx context.Context, tc *client.TeleportClient, fn func() error, opts ...client.RetryWithReloginOption) error {
+	profileName, err := utils.Host(tc.WebProxyAddr)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	opts = append(opts,
+		client.WithBeforeLoginHook(func() error {
+			fmt.Printf("Login for cluster %s expired, attempting to log in again.\n", tc.SiteName)
+			return nil
+		}),
+		client.WithAfterLoginHook(func() error {
+			return trace.Wrap(p.clientCache.ClearForRoot(profileName), "clearing client cache after relogin")
+		}),
+		client.WithMakeCurrentProfile(false),
+	)
+	return client.RetryWithRelogin(ctx, tc, fn, opts...)
+}
+
+func (p *vnetAppProvider) reissueAppCert(ctx context.Context, tc *client.TeleportClient, profileName, leafClusterName string, app types.Application) (tls.Certificate, error) {
+	slog.InfoContext(ctx, "Reissuing cert for app.", "app_name", app.GetName(), "profile", profileName, "leaf_cluster", leafClusterName)
+
+	routeToApp := proto.RouteToApp{
+		Name:        app.GetName(),
+		PublicAddr:  app.GetPublicAddr(),
+		ClusterName: tc.SiteName,
+	}
+
+	profile, err := tc.ProfileStatus()
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err, "loading client profile")
+	}
+
+	appCertParams := client.ReissueParams{
+		RouteToCluster: tc.SiteName,
+		RouteToApp:     routeToApp,
+		AccessRequests: profile.ActiveRequests.AccessRequests,
+		RequesterName:  proto.UserCertsRequest_TSH_APP_LOCAL_PROXY,
+	}
+
+	clusterClient, err := p.GetCachedClient(ctx, profileName, leafClusterName)
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err, "getting cached cluster client")
+	}
+	rootClient, err := p.GetCachedClient(ctx, profileName, "")
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err, "getting cached root client")
+	}
+
+	key, err := appLogin(ctx, tc, clusterClient, rootClient.AuthClient, appCertParams)
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err, "logging in to app")
+	}
+
+	cert, err := key.AppTLSCert(app.GetName())
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err, "getting TLS cert from key")
+	}
+
+	return cert, nil
+}
+
+func (p *vnetAppProvider) newTeleportClient(ctx context.Context, profileName, leafClusterName string) (*client.TeleportClient, error) {
 	cfg := &client.Config{
 		ClientStore: p.clientStore,
 	}
@@ -60,7 +200,5 @@ func (p *vnetAppProvider) GetCachedClient(ctx context.Context, profileName, leaf
 	if err != nil {
 		return nil, trace.Wrap(err, "creating new client")
 	}
-
-	clusterClient, err := tc.ConnectToCluster(ctx)
-	return clusterClient, trace.Wrap(err)
+	return tc, nil
 }


### PR DESCRIPTION
This is the sixth in a series of PRs implementing Teleport VNet [RFD](https://github.com/gravitational/teleport/blob/rfd/0163-vnet/rfd/0163-vnet.md). [parent](https://github.com/gravitational/teleport/pull/41032)

This PR completes an MVP `tsh vnet` implementation - with this PR connections are now forwarded all the way to the Teleport app and VNet is actually usable.

```
│Nics-MacBook-Pro:teleport nic$ nc -v netcat.one.private 123
│Connection to netcat.one.private port 123 [tcp/ntp] succeeded!
│Hello
│world!
│
├──────────────────────────────────────────────────────────────
│Nics-MacBook-Pro:teleport nic$ nc -lkv 127.0.0.1 12345
│Hello
│world!
│
```

All teleport clients are cached, I moved the clientcache out of lib/teleterm to share it with Connect. App certificates are automatically reissued on expiry, with a relogin to the cluster if necessary. Per-session MFA is supported. Cached cluster clients will be evicted after a relogin.

This includes the implementation for `tsh vnet`, with a goal of making it very easy to implement in Connect as well, the `AppProvider` interface is mostly modelled around the APIs available in Connect and what is already does for app gateways.

`lib/vnet/vnet_test.go` exercises the app resolver and alpn dialing, but it does not exercise any of the `tsh` code, I'll be adding integration tests for that later.