### PR TITLE
Make the hot reload output prettier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,8 @@ teleport-hot-reload:
 		--exclude-dir="node_modules" \
 		--exclude-dir="target" \
 		--exclude-dir="web/packages/*/node_modules" \
+		--color \
+		--log-prefix=false \
 		--build="make $(BUILDDIR)/teleport" \
 		--command="$(BUILDDIR)/teleport $(TELEPORT_ARGS)"
 


### PR DESCRIPTION
This PR makes the hot reload output a bit easier to read by allowing colors (so far, only on the compile daemon itself) as well as stripping unnecessary timestamp prefixes (which are not needed since we log timestamps anyway).

(Reopened from #41003)