### PR TITLE
Ignore `AccessListsMember`'s `IneligibleStatus` field

### DIFF
--- a/lib/services/compare.go
+++ b/lib/services/compare.go
@@ -43,7 +43,8 @@ func CompareResources[T any](resA, resB T) int {
 			cmpopts.IgnoreFields(types.UserSpecV2{}, "Status"),
 			cmpopts.IgnoreFields(accesslist.AccessList{}, "Status"),
 			cmpopts.IgnoreUnexported(headerv1.Metadata{}),
-			cmpopts.IgnoreFields(accesslist.AccessListMemberSpec{}, "IneligibleStatus"), /* IneligibleStatus must be ignored in comparison */
+			// Managed by IneligibleStatusReconciler, ignored by all others.
+			cmpopts.IgnoreFields(accesslist.AccessListMemberSpec{}, "IneligibleStatus"),
 			cmpopts.EquateEmpty(),
 		)
 	}

--- a/lib/services/compare.go
+++ b/lib/services/compare.go
@@ -43,6 +43,7 @@ func CompareResources[T any](resA, resB T) int {
 			cmpopts.IgnoreFields(types.UserSpecV2{}, "Status"),
 			cmpopts.IgnoreFields(accesslist.AccessList{}, "Status"),
 			cmpopts.IgnoreUnexported(headerv1.Metadata{}),
+			cmpopts.IgnoreFields(accesslist.AccessListMemberSpec{}, "IneligibleStatus"), /* IneligibleStatus must be ignored in comparison */
 			cmpopts.EquateEmpty(),
 		)
 	}

--- a/lib/services/compare_test.go
+++ b/lib/services/compare_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/accesslist"
 )
 
 func TestCompareResources(t *testing.T) {
@@ -31,6 +33,17 @@ func TestCompareResources(t *testing.T) {
 	// These results should be forced since we're going through a custom compare function.
 	compareTestCase(t, "IsEqual equal", &compareResourceWithEqual{true}, &compareResourceWithEqual{false}, Equal)
 	compareTestCase(t, "IsEqual not equal", &compareResourceWithEqual{false}, &compareResourceWithEqual{false}, Different)
+
+	// These results compare AccessListMemberSpec, which should ignore the IneligibleStatus field.
+	newAccessListMemberSpec := func(ineligibleStatus, accessList string) accesslist.AccessListMemberSpec {
+		return accesslist.AccessListMemberSpec{
+			AccessList:       accessList,
+			IneligibleStatus: ineligibleStatus,
+		}
+	}
+	compareTestCase(t, "cmp equal with equal IneligibleStatus", newAccessListMemberSpec("status1", "accessList1"), newAccessListMemberSpec("status1", "accessList1"), Equal)
+	compareTestCase(t, "cmp equal with different IneligibleStatus", newAccessListMemberSpec("status1", "accessList1"), newAccessListMemberSpec("status2", "accessList1"), Equal)
+	compareTestCase(t, "cmp not equal", newAccessListMemberSpec("status1", "accessList1"), newAccessListMemberSpec("status1", "accessList2"), Different)
 }
 
 func compareTestCase[T any](t *testing.T, name string, resA, resB T, expected int) {


### PR DESCRIPTION
This PR discards the `IneligibleStatus` field when comparing `AccessListMember`.

This field is managed by `IneligibleStatusReconciler` and should be ignored when using other reconcilers.