### PR TITLE
Correctly reissue certificates for leaf resources in tsh proxy kube

### DIFF
--- a/lib/srv/alpnproxy/kube.go
+++ b/lib/srv/alpnproxy/kube.go
@@ -240,7 +240,12 @@ func (m *KubeMiddleware) reissueCertIfExpired(ctx context.Context, cert tls.Cert
 	if m.isCertReissuingRunning.CompareAndSwap(false, true) {
 		go func() {
 			defer m.isCertReissuingRunning.Store(false)
-			newCert, err := m.certReissuer(context.Background(), identity.TeleportCluster, identity.KubernetesCluster)
+
+			cluster := identity.TeleportCluster
+			if identity.RouteToCluster != "" {
+				cluster = identity.RouteToCluster
+			}
+			newCert, err := m.certReissuer(ctx, cluster, identity.KubernetesCluster)
 			if err == nil {
 				m.certsMu.Lock()
 				m.certs[serverName] = newCert


### PR DESCRIPTION
When renewing certificates the RouteToCluster was always being set to the root cluster instead of the leaf cluster. This causes issues with per session mfa because the root cluster can't find the target kubernetes cluster which causes the renewal process to fail. Now during renewal the RouteToCluster is copied from the active user certificate if it existed.

Closes #41022.


Changelog:  Fix a bug that was preventing tsh proxy kube certificate renewal from working when accessing a leaf kubernetes cluster via the root.