### PR TITLE
Update testplan for device trust web

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -609,6 +609,9 @@ pre-release build (eg: `https://cdn.teleport.dev/teleport-ent-v16.0.0-alpha.2-li
 Client-side enrollment requires a signed `tsh` for macOS, make sure to use the
 `tsh` binary from `tsh.app`.
 
+Additionally, Device Trust Web requires Teleport Connect to be installed (device
+authentication for the Web is handled by Connect).
+
 A simple formula for testing device authorization is:
 
 ```shell
@@ -617,12 +620,8 @@ A simple formula for testing device authorization is:
 tsh ssh node-that-requires-device-trust
 > ERROR: ssh: rejected: administratively prohibited (unauthorized device)
 
-# Register the device.
-# Get the serial number from `tsh device asset-tag`.
-tctl devices add --os=macos --asset-tag=<SERIAL_NUMBER> --enroll
-
-# Enroll the device.
-tsh device enroll --token=<TOKEN_FROM_COMMAND_ABOVE>
+# Register/enroll the device.
+tsh device enroll --current-device
 tsh logout; tsh login
 
 # After enrollment
@@ -669,6 +668,22 @@ tsh ssh node-that-requires-device-trust
     teleport-device-id ...
     ```
 
+- [ ] Device authentication
+  - [ ] tsh or Connect
+    - [ ] SSH
+    - [ ] DB Access
+    - [ ] K8s Access
+  - [ ] Web UI (requires Connect)
+    - [ ] SSH
+    - [ ] App Access
+    - [ ] Desktop Access
+
+    Confirm that it works by failing first. Most protocols can be tested using
+    device_trust.mode="required". App Acess and Deskop Access require a custom
+    role (see [enforcing device trust][enforcing-device-trust]).
+
+[enforcing-device-trust]: https://goteleport.com/docs/access-controls/device-trust/enforcing-device-trust/#app-access-support).
+
 - [ ] Device authorization
   - [ ] device_trust.mode other than "off" or "" not allowed (OSS)
   - [ ] device_trust.mode="off" doesn't impede access (Enterprise and OSS)
@@ -679,6 +694,7 @@ tsh ssh node-that-requires-device-trust
     - [ ] DB Access
     - [ ] K8s Access
     - [ ] App Access NOT enforced in global mode
+    - [ ] Desktop Access NOT enforced in global mode
   - [ ] device_trust.mode="required" is enforced by processes and not only by
         Auth APIs
     - [ ] SSH
@@ -695,20 +711,25 @@ tsh ssh node-that-requires-device-trust
     - [ ] DB Access
     - [ ] K8s Access
     - [ ] App Access
+    - [ ] Desktop Access
   - [ ] Device authorization works correctly for both require_session_mfa=false
         and require_session_mfa=true
     - [ ] SSH
     - [ ] DB Access
     - [ ] K8s Access
+    - [ ] Desktop Access
   - [ ] Device authorization applies to Trusted Clusters
         (root with mode="optional" and leaf with mode="required")
-  - [ ] Device authorization __does not apply__ to Windows Desktop access
-        (both cluster-wide and role)
 
 - [ ] Device audit (see [lib/events/codes.go][device_event_codes])
   - [ ] Inventory management actions issue events (success only)
   - [ ] Device enrollment issues device event (any outcomes)
   - [ ] Device authorization issues device event (any outcomes)
+  - [ ] Device web authentication issues "Device Web Token Created" and "Device
+        Web Authentication Confirmed" events
+  - [ ] Device web authentication events have web_session_id set.
+        Corresponding "Device Authenticated" events have both
+        web_authentication=true and web_session_id set.
   - [ ] Events with [UserMetadata][event_trusted_device] contain TrustedDevice
         data (for certificates with device extensions)
 


### PR DESCRIPTION
I've added an explicit "device authentication" section (previously implied by device authorization), as that seems important to have with the addition of web support.

https://github.com/gravitational/teleport.e/issues/3236