### PR TITLE
rfd: fix spelling error

### DIFF
--- a/rfd/0136-modern-signature-algorithms.md
+++ b/rfd/0136-modern-signature-algorithms.md
@@ -481,7 +481,7 @@ The main TLS private key will now be held in
 All TLS x509 cert files will be renamed from `<name>-x509.pem` to
 `<name>-cert.pem` so that any software trying to use the old `<name>-x509.pem`
 along with the outdated private key location will fail to load both files,
-instead of succesfully opening the files but failing with some confusing error
+instead of successfully opening the files but failing with some confusing error
 when the private key does not match the certificate.
 
 RPCs such as `GenerateUserCerts` will also need to change to support passing

--- a/rfd/cspell.json
+++ b/rfd/cspell.json
@@ -569,7 +569,6 @@
     "subselection",
     "subselects",
     "subtests",
-    "succesfully",
     "suchinformation",
     "sudoer",
     "sudoersfile",
@@ -693,9 +692,6 @@
     "Yubikeys",
     "Zdunek",
     "Zilla"
-    
   ],
-  "flagWords": [
-    "hte"
-  ]
+  "flagWords": ["hte"]
 }


### PR DESCRIPTION
In #31798 we added the incorrect spelling to the dictionary instead of fixing the mistake.