### PR TITLE
Forward to web if device trust authorize cancelled

### DIFF
--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
@@ -57,7 +57,10 @@ function renderDialog(dialog: Dialog, handleClose: () => void) {
         <AuthenticateWebDevice
           rootClusterUri={dialog.rootClusterUri}
           onAuthorize={dialog.onAuthorize}
-          onClose={handleClose}
+          onClose={() => {
+            dialog.onCancel();
+            handleClose();
+          }}
         />
       );
     }

--- a/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.ts
+++ b/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.ts
@@ -116,7 +116,9 @@ export class DeepLinksService {
     this.modalsService.openRegularDialog({
       kind: 'device-trust-authorize',
       rootClusterUri,
-      onCancel: () => {},
+      onCancel: () => {
+        window.open(`https://${rootCluster.proxyHost}/web`);
+      },
       onAuthorize: async () => {
         const result = await this.clustersService.authenticateWebDevice(
           rootClusterUri,


### PR DESCRIPTION
If a user decides to not authorize their session, the cancel button will now send them to /web in the browser. This will allow the user to continue using the web UI but without device trust enabled (similar to selecting 'continue without device trust' in the passthrough page)