### PR TITLE
add node permissions to operator

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/config.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/config.yaml
@@ -123,6 +123,14 @@ data:
               - read
               - update
               - delete
+          - resources:
+              - node
+            verbs:
+              - list
+              - create
+              - read
+              - update
+              - delete
       deny: {}
     version: v7
     ---


### PR DESCRIPTION
changelog: Fixed a permissions issue that prevented the teleport-cluster helm chart operator from registering agentless ssh servers.

This issue prevented a customer from registering nodes while following our guide https://goteleport.com/docs/management/dynamic-resources/agentless-ssh-servers/

```
...*snip*...
status:
  conditions:
...*snip*...
  - lastTransitionTime: "2024-04-29T19:51:14Z"
    message: 'Teleport returned the error: access denied to perform action "create"
      on "node", access denied to perform action "update" on "node"'
    reason: TeleportError
    status: "False"
    type: SuccessfullyReconciled
...*snip*...
```