### PR TITLE
web: replace Azure AD references with Entra ID

### DIFF
--- a/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
+++ b/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
@@ -51,7 +51,7 @@ export function AuthConnectors(props: State) {
       ? 'Creating a new github connector'
       : 'Editing github connector';
   const description =
-    'Auth connectors allow Teleport to authenticate users via an external identity source such as Okta, Active Directory, GitHub, etc. This authentication method is commonly known as single sign-on (SSO).';
+    'Auth connectors allow Teleport to authenticate users via an external identity source such as Okta, Microsoft Entra ID, GitHub, etc. This authentication method is commonly known as single sign-on (SSO).';
 
   function handleOnSave(content: string) {
     const name = resources.item.name;

--- a/web/packages/teleport/src/AuthConnectors/ssoIcons/getSsoIcon.tsx
+++ b/web/packages/teleport/src/AuthConnectors/ssoIcons/getSsoIcon.tsx
@@ -69,7 +69,7 @@ export default function getSsoIcon(kind: AuthProviderType) {
           </MultiIconContainer>
         ),
         desc,
-        info: 'Okta, OneLogin, Azure Active Directory, etc.',
+        info: 'Okta, OneLogin, Microsoft Entra ID, etc.',
       };
     case 'oidc':
     default:


### PR DESCRIPTION
Azure AD is now Microsoft Entra ID: https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id

Updates #33405
