### PR TITLE
[v14] allow attaching to pods in kube integration tests

### DIFF
--- a/fixtures/ci-teleport-rbac/ci-teleport.yaml
+++ b/fixtures/ci-teleport-rbac/ci-teleport.yaml
@@ -56,6 +56,10 @@ rules:
   resources: ["pods/log"]
   verbs: ["get"]
   resourceNames: ["test-pod"]
+- apiGroups: [""]
+  resources: ["pods/attach"]
+  verbs: ["create"]
+  resourceNames: ["test-pod"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/40971.