### PR TITLE
[v15] add node permissions to operator

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/config.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/config.yaml
@@ -123,6 +123,14 @@ data:
               - read
               - update
               - delete
+          - resources:
+              - node
+            verbs:
+              - list
+              - create
+              - read
+              - update
+              - delete
       deny: {}
     version: v7
     ---


### PR DESCRIPTION
Backport #41082 to branch/v15

changelog: Fixed a permissions issue that prevented the teleport-cluster helm chart operator from registering agentless ssh servers.
