### PR TITLE
Add a retry mechanism to `UploadCompleter`'s `session.end` checker

### DIFF
--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -67,6 +67,18 @@ const (
 	// valuable info.
 	CorruptedSessionsDir = "corrupted"
 
+	// SessionsWithUnconfirmedSessionEnd is a subdirectory of sessions (/var/lib/teleport/log/upload/unconfirmed_session_ends)
+	// where session ids where it wasn't possible to confirm the session.end events are placed.
+	// An incomplete session is a session that was correctly
+	// uploaded to Auth server or final destination but it wasn't possible to ensure the session
+	// correctly had the session end event. Upload completer ensures the session.end event when it
+	// finishes uploading it but if the audit events storage is down, e.g. when database is failing
+	// but auth is still operational, the session recording will never be available because session
+	// completer never retries after the first session.end creation failure.
+	// Teleport uses this directory to track sessions that it couldn't ensure the proper session.end
+	// event.
+	SessionsWithUnconfirmedSessionEnd = "unconfirmed_session_ends"
+
 	// RecordsDir is an auth server subdirectory with session recordings that is used
 	// when the auth server is not configured for external cloud storage. It is not
 	// used by nodes, proxies, or other Teleport services.


### PR DESCRIPTION
When uploading session assets, `UploadCompleter` checks if the stale upload contains the `session.end` event. This check is done using `StreamSessionEvents` call to Auth Server to retrieve all the events recorded for a particular session. When the session misses the `session.end` event, the upload completer fakes it and creates it in order to Teleport being able to display the session recordings. Teleport requires `session.end` to be able to display them correctly.

The upload completer after finalyzing the upload, schedules a goroutine to run 2min after to properly range all events in the session and creating the event if missed.

The issue happens if the upload completer can successfuly complete the upload - auth is operational and s3 storage is also operationa -l but audit events backend isn't available at the time. In those cases, although the recording was correctly completed, emiting a `session.end` event will fail and no-one will be able to retrieve or analyze the session recordings content.

This PR adds a logic to keep ensuring the session properly has an end event until the audit log backend is operational again.