### PR TITLE
fix racy use of tls configs

### DIFF
--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -216,7 +216,7 @@ func NewTLSServer(ctx context.Context, cfg TLSServerConfig) (*TLSServer, error) 
 	}
 
 	server.clientTLSConfigGenerator, err = NewClientTLSConfigGenerator(ClientTLSConfigGeneratorConfig{
-		TLS:                  server.cfg.TLS,
+		TLS:                  server.cfg.TLS.Clone(),
 		ClusterName:          localClusterName.GetClusterName(),
 		PermitRemoteClusters: true,
 		AccessPoint:          server.cfg.AccessPoint,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4383,7 +4383,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	// clientTLSConfigGenerator pre-generates specialized per-cluster client TLS config values
 	clientTLSConfigGenerator, err := auth.NewClientTLSConfigGenerator(auth.ClientTLSConfigGeneratorConfig{
-		TLS:                  tlscfg,
+		TLS:                  tlscfg.Clone(),
 		ClusterName:          clusterName,
 		PermitRemoteClusters: true,
 		AccessPoint:          accessPoint,


### PR DESCRIPTION
Fixes a [race condition](https://github.com/gravitational/teleport/actions/runs/8913190896/job/24478192986) introduced in https://github.com/gravitational/teleport/pull/41077.

The client tls config generator was being passed references to the same TLS config instance that would then subsequently be configured to call back into the client TLS config generator to get client configs.  This introduced a race because assignment of the `GetConfigForClient` field happens after the generator has been started:

```golang
generator, err := auth.NewClientTLSConfigGenerator(auth.ClientTLSConfigGeneratorConfig{
	TLS:                  tlsConfig, // background goroutine started that here that will read 'tslConfig'
	// ...
})

tlsConfig.GetConfigForClient = generator.GetConfigForClient // write occurs here
```

The fix for this issue is to clone the root config before passing it to the generator.