### PR TITLE
[v15] use Update rather than ConditionCheck in dynamodbbk AtomicWrite

### DIFF
--- a/lib/backend/dynamo/atomicwrite.go
+++ b/lib/backend/dynamo/atomicwrite.go
@@ -105,11 +105,20 @@ func (b *Backend) AtomicWrite(ctx context.Context, condacts []backend.Conditiona
 				return "", trace.Wrap(err)
 			}
 
-			txnItem.ConditionCheck = &dynamodb.ConditionCheck{
+			// morally this should be a dynamodb.ConditionCheck transaction
+			// item, but condition checks use the dynamodb:ConditionCheckItem
+			// permission, which wasn't documented in v15 and earlier; an update
+			// operation in a TransactWrite costs the same in terms of write
+			// capacity as a condition check, so we update the potentially
+			// non-existent item by removing a top-level field that we know
+			// doesn't exist anyway
+			txnItem.Update = &dynamodb.Update{
 				ConditionExpression:       condExpr,
 				ExpressionAttributeValues: exprAttrValues,
 				Key:                       av,
 				TableName:                 tableName,
+
+				UpdateExpression: aws.String("REMOVE NotAField"),
 			}
 
 		case backend.KindPut:


### PR DESCRIPTION
The `AtomicWrite` operation in dynamodbbk requires `dynamodb:ConditionCheckItem` IAM permissions on the table, which wasn't documented but hasn't been noticed until #40851, which actually used a `backend.KindNop` conditional action. We're going to update the documentation for v16 and note the required changes in the release notes for v16, but we can use a workaround for v15 that doesn't require permission changes, which this PR implements.

This PR makes it so that any `KindNop` atomic write in dynamodbbk uses an `Update` `TransactWriteItem` that removes a nonexistent top-level field, which makes it so that the operation requires `dynamodb:UpdateItem` permissions even though the result is the same.

The `lib/backend/dynamo` tests fail in `master` and `branch/v15` with a role that only has the documented permissions, with an error like `unexpected error during atomic write: AccessDeniedException: User: <user arn> is not authorized to perform: dynamodb:ConditionCheckItem on resource: arn:aws:dynamodb:<region>:<account id>:table/<table name> because no identity-based policy allows the dynamodb:ConditionCheckItem action` and succeed after this change.

As a workaround for errors like that, adding `dynamodb:ConditionCheckItem` to the IAM permissions used by the Teleport auth server should solve the errors.

changelog: fix `AccessDeniedException` for `dynamodb:ConditionCheckItem` operations when using AWS DynamoDB for cluster state storage