### PR TITLE
add condition check dynamo permission to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ for setup instructions.
 Teleport Assist chat has been removed from Teleport 16. Assist is still available
 in the SSH Web Terminal and Audit Monitoring.
 
+#### DynamoDB permission requirements have changed
+
+Teleport clusters using the dynamodb backend must now have the `dynamodb:ConditionCheckItem`
+permission. For a full list of all required permissions see the dynamo backend iam
+policy [example](docs/pages/includes/dynamodb-iam-policy.mdx).
+
 ## 15.0.0 (xx/xx/24)
 
 ### New features

--- a/docs/pages/includes/dynamodb-iam-policy.mdx
+++ b/docs/pages/includes/dynamodb-iam-policy.mdx
@@ -85,6 +85,7 @@ You'll need to replace these values in the policy example below:
                 "dynamodb:DescribeTable",
                 "dynamodb:GetShardIterator",
                 "dynamodb:GetItem",
+                "dynamodb:ConditionCheckItem",
                 "dynamodb:UpdateTable",
                 "dynamodb:GetRecords",
                 "dynamodb:UpdateContinuousBackups"
@@ -156,6 +157,7 @@ You'll need to replace these values in the policy example below:
                 "dynamodb:DescribeTable",
                 "dynamodb:GetShardIterator",
                 "dynamodb:GetItem",
+                "dynamodb:ConditionCheckItem",
                 "dynamodb:UpdateTable",
                 "dynamodb:GetRecords",
                 "dynamodb:UpdateContinuousBackups"


### PR DESCRIPTION
Updates docs to include missing dynamo permission that is required for `AtomicWrite` based backend operations.