### PR TITLE
[v15] Correctly reissue certificates for leaf resources in tsh proxy kube

### DIFF
--- a/lib/srv/alpnproxy/kube.go
+++ b/lib/srv/alpnproxy/kube.go
@@ -240,7 +240,12 @@ func (m *KubeMiddleware) reissueCertIfExpired(ctx context.Context, cert tls.Cert
 	if m.isCertReissuingRunning.CompareAndSwap(false, true) {
 		go func() {
 			defer m.isCertReissuingRunning.Store(false)
-			newCert, err := m.certReissuer(context.Background(), identity.TeleportCluster, identity.KubernetesCluster)
+
+			cluster := identity.TeleportCluster
+			if identity.RouteToCluster != "" {
+				cluster = identity.RouteToCluster
+			}
+			newCert, err := m.certReissuer(ctx, cluster, identity.KubernetesCluster)
 			if err == nil {
 				m.certsMu.Lock()
 				m.certs[serverName] = newCert


### PR DESCRIPTION
Backport #41046 to branch/v15

changelog:  Fix a bug that was preventing tsh proxy kube certificate renewal from working when accessing a leaf kubernetes cluster via the root.
