### PR TITLE
Extends generic service wrapper to support conditional updates

### DIFF
--- a/lib/services/local/generic/generic_wrapper.go
+++ b/lib/services/local/generic/generic_wrapper.go
@@ -93,6 +93,13 @@ func (s ServiceWrapper[T]) UpdateResource(ctx context.Context, resource T) (T, e
 	return adapter.resource, trace.Wrap(err)
 }
 
+// ConditionalUpdateResource updates an existing resource if the provided
+// resource and the existing resource have matching revisions.
+func (s ServiceWrapper[T]) ConditionalUpdateResource(ctx context.Context, resource T) (T, error) {
+	adapter, err := s.service.ConditionalUpdateResource(ctx, newResourceMetadataAdapter(resource))
+	return adapter.resource, trace.Wrap(err)
+}
+
 // CreateResource creates a new resource.
 func (s ServiceWrapper[T]) CreateResource(ctx context.Context, resource T) (T, error) {
 	adapter, err := s.service.CreateResource(ctx, newResourceMetadataAdapter(resource))

--- a/lib/services/local/generic/generic_wrapper_test.go
+++ b/lib/services/local/generic/generic_wrapper_test.go
@@ -186,6 +186,16 @@ func TestGenericWrapperCRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(r1, r, cmpopts.IgnoreFields(headerv1.Metadata{}, "Id"), ignoreUnexported))
 
+	// Conditionally updating a resource fails if revisions do not match
+	r.Metadata.Revision = "fake"
+	_, err = service.ConditionalUpdateResource(ctx, r)
+	require.True(t, trace.IsCompareFailed(err))
+
+	// Conditionally updating a resource is allowed when revisions match
+	r.Metadata.Revision = r1.Metadata.Revision
+	r1, err = service.ConditionalUpdateResource(ctx, r1)
+	require.NoError(t, err)
+
 	// Update a resource that doesn't exist.
 	doesNotExist := newTestResource153("doesnotexist")
 	_, err = service.UpdateResource(ctx, doesNotExist)


### PR DESCRIPTION
This was an oversight when the wrapper was created since none of the initial RFD 153 compliant resources used optimistic locking.