### PR TITLE
[v15] Add authentication method status indicators to the account settings page

### DIFF
--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -67,6 +67,8 @@ type UserContext struct {
 	ConsumedAccessRequestID string `json:"accessRequestId,omitempty"`
 	// AllowedSearchAsRoles is the SearchAsRoles the user has access to for creating access requests.
 	AllowedSearchAsRoles []string `json:"allowedSearchAsRoles"`
+	// PasswordState specifies whether the user has a password set or not.
+	PasswordSate types.PasswordState `json:"passwordState"`
 }
 
 func getAccessStrategy(roleset services.RoleSet) accessStrategy {
@@ -116,5 +118,6 @@ func NewUserContext(user types.User, userRoles services.RoleSet, features proto.
 		ACL:            acl,
 		AuthType:       authType,
 		AccessStrategy: accessStrategy,
+		PasswordSate:   user.GetPasswordState(),
 	}, nil
 }

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -36,6 +36,9 @@ func TestNewUserContext(t *testing.T) {
 		Metadata: types.Metadata{
 			Name: "root",
 		},
+		Status: types.UserStatusV2{
+			PasswordState: types.PasswordState_PASSWORD_STATE_SET,
+		},
 	}
 
 	// set some rules
@@ -55,6 +58,7 @@ func TestNewUserContext(t *testing.T) {
 		Type:   types.RequestStrategyOptional,
 		Prompt: "",
 	}))
+	require.Equal(t, types.PasswordState_PASSWORD_STATE_SET, userContext.PasswordSate)
 
 	// test local auth type
 	require.Equal(t, authLocal, userContext.AuthType)

--- a/web/packages/teleport/src/Account/Account.story.tsx
+++ b/web/packages/teleport/src/Account/Account.story.tsx
@@ -18,6 +18,8 @@
 
 import React from 'react';
 
+import { PasswordState } from 'teleport/services/user';
+
 import { Account, AccountProps } from './Account';
 
 export default {
@@ -28,6 +30,21 @@ export default {
 export const Loaded = () => <Account {...props} />;
 
 export const LoadedNoDevices = () => <Account {...props} devices={[]} />;
+
+export const LoadedPasswordStateUnspecified = () => (
+  <Account
+    {...props}
+    passwordState={PasswordState.PASSWORD_STATE_UNSPECIFIED}
+  />
+);
+
+export const LoadedPasswordUnset = () => (
+  <Account
+    {...props}
+    devices={props.devices.filter(d => d.usage === 'passwordless')}
+    passwordState={PasswordState.PASSWORD_STATE_UNSET}
+  />
+);
 
 export const LoadedPasskeysOff = () => (
   <Account {...props} canAddPasskeys={false} />
@@ -170,4 +187,6 @@ const props: AccountProps = {
   isReauthenticationRequired: false,
   addDeviceWizardVisible: false,
   closeAddDeviceWizard: () => {},
+  passwordState: PasswordState.PASSWORD_STATE_SET,
+  onPasswordChange: () => {},
 };

--- a/web/packages/teleport/src/Account/Account.test.tsx
+++ b/web/packages/teleport/src/Account/Account.test.tsx
@@ -18,76 +18,189 @@
 
 import { render, screen, waitFor } from 'design/utils/testing';
 
+import userEvent from '@testing-library/user-event';
+
 import { ContextProvider } from 'teleport';
 import TeleportContext from 'teleport/teleportContext';
 
 import { AccountPage as Account } from 'teleport/Account/Account';
 import cfg from 'teleport/config';
 import { createTeleportContext } from 'teleport/mocks/contexts';
+import { PasswordState } from 'teleport/services/user';
+import auth from 'teleport/services/auth/auth';
 
 const defaultAuthType = cfg.auth.second_factor;
 const defaultPasswordless = cfg.auth.allowPasswordless;
 
-describe('passkey + mfa button state', () => {
-  const ctx = createTeleportContext();
-
-  beforeEach(() => {
-    jest.spyOn(ctx.mfaService, 'fetchDevices').mockResolvedValue([]);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-    cfg.auth.second_factor = defaultAuthType;
-    cfg.auth.allowPasswordless = defaultPasswordless;
-  });
-
-  // Note: the "off" and "otp" cases don't make sense with passwordless turned
-  // on (the auth server wouldn't start in this configuration), but we're still
-  // testing them for completeness.
-  test.each`
-    mfa           | pwdless  | pkEnabled | mfaEnabled
-    ${'on'}       | ${true}  | ${true}   | ${true}
-    ${'on'}       | ${false} | ${false}  | ${true}
-    ${'optional'} | ${true}  | ${true}   | ${true}
-    ${'optional'} | ${false} | ${false}  | ${true}
-    ${'otp'}      | ${false} | ${false}  | ${true}
-    ${'otp'}      | ${true}  | ${true}   | ${true}
-    ${'webauthn'} | ${true}  | ${true}   | ${true}
-    ${'webauthn'} | ${false} | ${false}  | ${true}
-    ${'off'}      | ${false} | ${false}  | ${false}
-    ${'off'}      | ${true}  | ${true}   | ${false}
-  `(
-    '2fa($mfa) with pwdless($pwdless) = passkey($pkEnabled) mfa($mfaEnabled)',
-    async ({ mfa, pwdless, pkEnabled, mfaEnabled }) => {
-      cfg.auth.second_factor = mfa;
-      cfg.auth.allowPasswordless = pwdless;
-
-      renderComponent(ctx);
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('indicator')).not.toBeInTheDocument();
-      });
-
-      // If btns are disabled, the disabled attr has a value of empty string.
-      // If btns are not disabled, the disabled attr is null (not defined).
-
-      // eslint-disable-next-line jest-dom/prefer-to-have-attribute
-      expect(screen.getByText(/add a passkey/i).getAttribute('disabled')).toBe(
-        pkEnabled ? null : ''
-      );
-
-      // eslint-disable-next-line jest-dom/prefer-to-have-attribute
-      expect(screen.getByText(/add mfa/i).getAttribute('disabled')).toBe(
-        mfaEnabled ? null : ''
-      );
-    }
-  );
+afterEach(() => {
+  jest.clearAllMocks();
+  cfg.auth.second_factor = defaultAuthType;
+  cfg.auth.allowPasswordless = defaultPasswordless;
 });
 
-function renderComponent(ctx: TeleportContext) {
-  return render(
+async function renderComponent(ctx: TeleportContext) {
+  render(
     <ContextProvider ctx={ctx}>
       <Account />
     </ContextProvider>
   );
+  await waitFor(() => {
+    expect(screen.queryByTestId('indicator')).not.toBeInTheDocument();
+  });
 }
+
+// Note: the "off" and "otp" cases don't make sense with passwordless turned
+// on (the auth server wouldn't start in this configuration), but we're still
+// testing them for completeness.
+test.each`
+  mfa           | pwdless  | pkEnabled | mfaEnabled
+  ${'on'}       | ${true}  | ${true}   | ${true}
+  ${'on'}       | ${false} | ${false}  | ${true}
+  ${'optional'} | ${true}  | ${true}   | ${true}
+  ${'optional'} | ${false} | ${false}  | ${true}
+  ${'otp'}      | ${false} | ${false}  | ${true}
+  ${'otp'}      | ${true}  | ${true}   | ${true}
+  ${'webauthn'} | ${true}  | ${true}   | ${true}
+  ${'webauthn'} | ${false} | ${false}  | ${true}
+  ${'off'}      | ${false} | ${false}  | ${false}
+  ${'off'}      | ${true}  | ${true}   | ${false}
+`(
+  'passkey + mfa button state: 2fa($mfa) with pwdless($pwdless) => passkey($pkEnabled) mfa($mfaEnabled)',
+  async ({ mfa, pwdless, pkEnabled, mfaEnabled }) => {
+    const ctx = createTeleportContext();
+    jest.spyOn(ctx.mfaService, 'fetchDevices').mockResolvedValue([]);
+    cfg.auth.second_factor = mfa;
+    cfg.auth.allowPasswordless = pwdless;
+
+    await renderComponent(ctx);
+
+    // If btns are disabled, the disabled attr has a value of empty string.
+    // If btns are not disabled, the disabled attr is null (not defined).
+
+    // eslint-disable-next-line jest-dom/prefer-to-have-attribute
+    expect(screen.getByText(/add a passkey/i).getAttribute('disabled')).toBe(
+      pkEnabled ? null : ''
+    );
+
+    // eslint-disable-next-line jest-dom/prefer-to-have-attribute
+    expect(screen.getByText(/add mfa/i).getAttribute('disabled')).toBe(
+      mfaEnabled ? null : ''
+    );
+  }
+);
+
+const onePasskey = [
+  {
+    id: '1',
+    description: 'Hardware Key',
+    name: 'touch_id',
+    registeredDate: new Date(1628799417000),
+    lastUsedDate: new Date(1628799417000),
+    type: 'webauthn',
+    usage: 'passwordless',
+  },
+];
+
+test.each`
+  pwdless  | passkeys      | state
+  ${true}  | ${onePasskey} | ${'active'}
+  ${true}  | ${[]}         | ${''}
+  ${false} | ${onePasskey} | ${'inactive'}
+  ${false} | ${[]}         | ${''}
+`(
+  "Passkey state pill: passwordless=$pwdless, $passkeys.length passkey(s) => state='$state'",
+  async ({ pwdless, passkeys, state }) => {
+    const ctx = createTeleportContext();
+    jest.spyOn(ctx.mfaService, 'fetchDevices').mockResolvedValue(passkeys);
+    cfg.auth.second_factor = 'on';
+    cfg.auth.allowPasswordless = pwdless;
+
+    await renderComponent(ctx);
+
+    const statePill = screen.queryByTestId('passwordless-state-pill');
+    if (state) {
+      // Note: every alternative approach is even more complicated.
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(statePill).toHaveTextContent(state);
+    } else {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(statePill).not.toBeInTheDocument();
+    }
+  }
+);
+
+const oneMfaMethod = [
+  {
+    id: '1',
+    description: 'Hardware Key',
+    name: 'touch_id',
+    registeredDate: new Date(1628799417000),
+    lastUsedDate: new Date(1628799417000),
+    type: 'webauthn',
+    usage: 'mfa',
+  },
+];
+
+test.each`
+  mfa      | methods         | state
+  ${'on'}  | ${oneMfaMethod} | ${'active'}
+  ${'on'}  | ${[]}           | ${'inactive'}
+  ${'off'} | ${oneMfaMethod} | ${'inactive'}
+  ${'off'} | ${[]}           | ${'inactive'}
+`(
+  "MFA state pill: mfa=$mfa, $methods.length MFA method(s) => state='$state'",
+  async ({ mfa, methods, state }) => {
+    const ctx = createTeleportContext();
+    jest.spyOn(ctx.mfaService, 'fetchDevices').mockResolvedValue(methods);
+    cfg.auth.second_factor = mfa;
+
+    await renderComponent(ctx);
+
+    expect(screen.getByTestId('mfa-state-pill')).toHaveTextContent(state);
+  }
+);
+
+test.each`
+  passwordState                               | state
+  ${PasswordState.PASSWORD_STATE_UNSPECIFIED} | ${''}
+  ${PasswordState.PASSWORD_STATE_UNSET}       | ${'inactive'}
+  ${PasswordState.PASSWORD_STATE_SET}         | ${'active'}
+`(
+  "Password state $passwordState => state='$state'",
+  async ({ passwordState, state }) => {
+    const ctx = createTeleportContext();
+    ctx.storeUser.setState({ passwordState });
+    jest.spyOn(ctx.mfaService, 'fetchDevices').mockResolvedValue([]);
+
+    await renderComponent(ctx);
+
+    expect(screen.getByTestId('password-state-pill')).toHaveTextContent(state);
+  }
+);
+
+test('password change', async () => {
+  const user = userEvent.setup();
+  const ctx = createTeleportContext();
+  ctx.storeUser.setState({ passwordState: PasswordState.PASSWORD_STATE_UNSET });
+  jest.spyOn(ctx.mfaService, 'fetchDevices').mockResolvedValue([]);
+  jest.spyOn(auth, 'changePassword').mockResolvedValueOnce(undefined);
+
+  await renderComponent(ctx);
+  expect(screen.getByTestId('password-state-pill')).toHaveTextContent(
+    'inactive'
+  );
+
+  // Change the password
+  await user.click(screen.getByRole('button', { name: 'Change Password' }));
+  await user.type(screen.getByLabelText('Current Password'), 'old-password');
+  await user.type(screen.getByLabelText('New Password'), 'asdfasdfasdfasdf');
+  await user.type(
+    screen.getByLabelText('Confirm Password'),
+    'asdfasdfasdfasdf'
+  );
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+  // EXpect the dialog to disappear, and the state pill to change value.
+  expect(screen.queryByLabelText('New Password')).not.toBeInTheDocument();
+  expect(screen.getByTestId('password-state-pill')).toHaveTextContent('active');
+});

--- a/web/packages/teleport/src/Account/Account.tsx
+++ b/web/packages/teleport/src/Account/Account.tsx
@@ -23,6 +23,8 @@ import { Attempt } from 'shared/hooks/useAttemptNext';
 import * as Icon from 'design/Icon';
 import { Notification, NotificationItem } from 'shared/components/Notification';
 
+import { useStore } from 'shared/libs/stores';
+
 import useTeleport from 'teleport/useTeleport';
 import {
   FeatureBox,
@@ -36,6 +38,8 @@ import cfg from 'teleport/config';
 
 import { DeviceUsage } from 'teleport/services/auth';
 
+import { PasswordState } from 'teleport/services/user';
+
 import { AuthDeviceList } from './ManageDevices/AuthDeviceList/AuthDeviceList';
 import useManageDevices, {
   State as ManageDevicesState,
@@ -43,6 +47,7 @@ import useManageDevices, {
 import { ActionButtonPrimary, ActionButtonSecondary, Header } from './Header';
 import { PasswordBox } from './PasswordBox';
 import { AddAuthDeviceWizard } from './ManageDevices/AddAuthDeviceWizard';
+import { StatePill } from './StatePill';
 
 export interface EnterpriseComponentProps {
   // TODO(bl-nero): Consider moving the notifications to its own store and
@@ -59,19 +64,26 @@ export interface AccountPageProps {
 
 export function AccountPage({ enterpriseComponent }: AccountPageProps) {
   const ctx = useTeleport();
-  const isSso = ctx.storeUser.isSso();
+  const storeUser = useStore(ctx.storeUser);
+  const isSso = storeUser.isSso();
   const manageDevicesState = useManageDevices(ctx);
 
   const canAddPasskeys = cfg.isPasswordlessEnabled();
   const canAddMfa = cfg.isMfaEnabled();
+
+  function onPasswordChange() {
+    storeUser.setState({ passwordState: PasswordState.PASSWORD_STATE_SET });
+  }
 
   return (
     <Account
       isSso={isSso}
       canAddPasskeys={canAddPasskeys}
       canAddMfa={canAddMfa}
+      passwordState={storeUser.getPasswordState()}
       {...manageDevicesState}
       enterpriseComponent={enterpriseComponent}
+      onPasswordChange={onPasswordChange}
     />
   );
 }
@@ -80,6 +92,8 @@ export interface AccountProps extends ManageDevicesState, AccountPageProps {
   isSso: boolean;
   canAddPasskeys: boolean;
   canAddMfa: boolean;
+  passwordState: PasswordState;
+  onPasswordChange: () => void;
 }
 
 export function Account({
@@ -104,6 +118,8 @@ export function Account({
   canAddPasskeys,
   enterpriseComponent: EnterpriseComponent,
   newDeviceUsage,
+  passwordState,
+  onPasswordChange: onPasswordChangeCb,
 }: AccountProps) {
   const passkeys = devices.filter(d => d.usage === 'passwordless');
   const mfaDevices = devices.filter(d => d.usage === 'mfa');
@@ -152,6 +168,7 @@ export function Account({
 
   function onPasswordChange() {
     addNotification('info', 'Your password has been changed.');
+    onPasswordChangeCb();
   }
 
   function onAddDeviceSuccess() {
@@ -174,7 +191,8 @@ export function Account({
             <AuthDeviceList
               header={
                 <PasskeysHeader
-                  empty={devices.length === 0}
+                  empty={passkeys.length === 0}
+                  passkeysEnabled={canAddPasskeys}
                   disableAddPasskey={disableAddPasskey}
                   fetchDevicesAttempt={fetchDevicesAttempt}
                   onAddDevice={onAddDevice}
@@ -191,6 +209,7 @@ export function Account({
                 createRestrictedTokenAttempt.status === 'processing'
               }
               devices={devices}
+              passwordState={passwordState}
               onPasswordChange={onPasswordChange}
             />
           )}
@@ -198,10 +217,23 @@ export function Account({
             <AuthDeviceList
               header={
                 <Header
-                  title="Multi-factor Authentication"
+                  title={
+                    <>
+                      Multi-factor Authentication
+                      <span data-testid="mfa-state-pill">
+                        <StatePill
+                          state={
+                            canAddMfa && mfaDevices.length > 0
+                              ? 'active'
+                              : 'inactive'
+                          }
+                        />
+                      </span>
+                    </>
+                  }
                   description="Provide secondary authentication when signing in
-                with a password. Unlike passkeys, multi-factor methods do not
-                enable passwordless sign-in."
+                    with a password. Unlike passkeys, multi-factor methods do
+                    not enable passwordless sign-in."
                   icon={<Icon.ShieldCheck />}
                   showIndicator={fetchDevicesAttempt.status === 'processing'}
                   actions={
@@ -286,11 +318,13 @@ export function Account({
 function PasskeysHeader({
   empty,
   fetchDevicesAttempt,
+  passkeysEnabled,
   disableAddPasskey,
   onAddDevice,
 }: {
   empty: boolean;
   fetchDevicesAttempt: Attempt;
+  passkeysEnabled: boolean;
   disableAddPasskey: boolean;
   onAddDevice: (usage: DeviceUsage) => void;
 }) {
@@ -337,7 +371,14 @@ function PasskeysHeader({
 
   return (
     <Header
-      title="Passkeys"
+      title={
+        <>
+          Passkeys
+          <span data-testid="passwordless-state-pill">
+            <StatePill state={passkeysEnabled ? 'active' : 'inactive'} />
+          </span>
+        </>
+      }
       description="Enable secure passwordless sign-in using
                 fingerprint or facial recognition, a one-time code, or
                 a device password."

--- a/web/packages/teleport/src/Account/Account.tsx
+++ b/web/packages/teleport/src/Account/Account.tsx
@@ -218,18 +218,17 @@ export function Account({
               header={
                 <Header
                   title={
-                    <>
+                    <Flex gap={2}>
                       Multi-factor Authentication
-                      <span data-testid="mfa-state-pill">
-                        <StatePill
-                          state={
-                            canAddMfa && mfaDevices.length > 0
-                              ? 'active'
-                              : 'inactive'
-                          }
-                        />
-                      </span>
-                    </>
+                      <StatePill
+                        data-testid="mfa-state-pill"
+                        state={
+                          canAddMfa && mfaDevices.length > 0
+                            ? 'active'
+                            : 'inactive'
+                        }
+                      />
+                    </Flex>
                   }
                   description="Provide secondary authentication when signing in
                     with a password. Unlike passkeys, multi-factor methods do
@@ -372,12 +371,13 @@ function PasskeysHeader({
   return (
     <Header
       title={
-        <>
+        <Flex gap={2}>
           Passkeys
-          <span data-testid="passwordless-state-pill">
-            <StatePill state={passkeysEnabled ? 'active' : 'inactive'} />
-          </span>
-        </>
+          <StatePill
+            data-testid="passwordless-state-pill"
+            state={passkeysEnabled ? 'active' : 'inactive'}
+          />
+        </Flex>
       }
       description="Enable secure passwordless sign-in using
                 fingerprint or facial recognition, a one-time code, or

--- a/web/packages/teleport/src/Account/Header.tsx
+++ b/web/packages/teleport/src/Account/Header.tsx
@@ -28,7 +28,7 @@ import React from 'react';
 import styled, { useTheme, css } from 'styled-components';
 
 export interface HeaderProps {
-  title: string;
+  title: React.ReactNode;
   description?: string;
   icon: React.ReactNode;
   showIndicator?: boolean;

--- a/web/packages/teleport/src/Account/PasswordBox.tsx
+++ b/web/packages/teleport/src/Account/PasswordBox.tsx
@@ -26,18 +26,23 @@ import cfg from 'teleport/config';
 
 import { MfaDevice } from 'teleport/services/mfa';
 
+import { PasswordState } from 'teleport/services/user';
+
 import { ActionButtonSecondary, Header } from './Header';
 import { ChangePasswordWizard } from './ChangePasswordWizard';
+import { StatePill } from './StatePill';
 
 export interface PasswordBoxProps {
   changeDisabled: boolean;
   devices: MfaDevice[];
+  passwordState: PasswordState;
   onPasswordChange: () => void;
 }
 
 export function PasswordBox({
   changeDisabled,
   devices,
+  passwordState,
   onPasswordChange,
 }: PasswordBoxProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -51,7 +56,14 @@ export function PasswordBox({
     <Box>
       <SingleRowBox>
         <Header
-          title="Password"
+          title={
+            <>
+              Password
+              <span data-testid="password-state-pill">
+                <PasswordStatePill state={passwordState} />
+              </span>
+            </>
+          }
           icon={<Icon.Password />}
           actions={
             <ActionButtonSecondary
@@ -74,4 +86,15 @@ export function PasswordBox({
       )}
     </Box>
   );
+}
+
+function PasswordStatePill({ state }: { state: PasswordState }) {
+  switch (state) {
+    case PasswordState.PASSWORD_STATE_SET:
+      return <StatePill state="active" />;
+    case PasswordState.PASSWORD_STATE_UNSET:
+      return <StatePill state="inactive" />;
+    default:
+      return null;
+  }
 }

--- a/web/packages/teleport/src/Account/PasswordBox.tsx
+++ b/web/packages/teleport/src/Account/PasswordBox.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Box } from 'design';
+import { Box, Flex } from 'design';
 import { SingleRowBox } from 'design/MultiRowBox';
 import React, { useState } from 'react';
 
@@ -30,7 +30,7 @@ import { PasswordState } from 'teleport/services/user';
 
 import { ActionButtonSecondary, Header } from './Header';
 import { ChangePasswordWizard } from './ChangePasswordWizard';
-import { StatePill } from './StatePill';
+import { StatePill, AuthMethodState } from './StatePill';
 
 export interface PasswordBoxProps {
   changeDisabled: boolean;
@@ -57,12 +57,13 @@ export function PasswordBox({
       <SingleRowBox>
         <Header
           title={
-            <>
+            <Flex gap={2}>
               Password
-              <span data-testid="password-state-pill">
-                <PasswordStatePill state={passwordState} />
-              </span>
-            </>
+              <StatePill
+                data-testid="password-state-pill"
+                state={passwordStateToPillState(passwordState)}
+              />
+            </Flex>
           }
           icon={<Icon.Password />}
           actions={
@@ -88,13 +89,16 @@ export function PasswordBox({
   );
 }
 
-function PasswordStatePill({ state }: { state: PasswordState }) {
+function passwordStateToPillState(
+  state: PasswordState
+): AuthMethodState | undefined {
   switch (state) {
     case PasswordState.PASSWORD_STATE_SET:
-      return <StatePill state="active" />;
+      return 'active';
     case PasswordState.PASSWORD_STATE_UNSET:
-      return <StatePill state="inactive" />;
+      return 'inactive';
     default:
-      return null;
+      state satisfies never | PasswordState.PASSWORD_STATE_UNSPECIFIED;
+      return undefined;
   }
 }

--- a/web/packages/teleport/src/Account/StatePill.tsx
+++ b/web/packages/teleport/src/Account/StatePill.tsx
@@ -20,24 +20,32 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 
 /** State of an authentication method (password, MFA method, or passkey). */
-type State = 'active' | 'inactive';
+export type AuthMethodState = 'active' | 'inactive';
 
-export interface StatePillProps {
-  state: State;
+interface StatePillProps {
+  state: AuthMethodState | undefined;
+  'data-testid'?: string;
 }
 
 /**
  * Renders a pill component that represents a state of an authentication method.
  * The `state` property is both an enum value, as well as the UI text.
  */
-export function StatePill({ state }: StatePillProps) {
-  return <StatePillBody state={state}>{state}</StatePillBody>;
+export function StatePill({ state, 'data-testid': testId }: StatePillProps) {
+  // Explicitly return an empty element to ensure that potential future changes
+  // to the pill body style won't result as an ugly element with no text. At the
+  // same time, retain the test ID to simplify testing.
+  if (!state) return <span data-testid={testId}></span>;
+  return (
+    <StatePillBody state={state} data-testid={testId}>
+      {state}
+    </StatePillBody>
+  );
 }
 
 const StatePillBody = styled.span<StatePillProps>`
   font-size: 14px;
   display: inline-block;
-  margin: 0 ${props => props.theme.space[2]}px;
   padding: 0 ${props => props.theme.space[3]}px;
   border-radius: 1000px;
 
@@ -58,5 +66,7 @@ function statePillStyles({ state }: StatePillProps): string {
           props.theme.colors.interactive.tonal.neutral[0]};
         color: ${props => props.theme.colors.text.disabled};
       `;
+    default:
+      state satisfies never;
   }
 }

--- a/web/packages/teleport/src/Account/StatePill.tsx
+++ b/web/packages/teleport/src/Account/StatePill.tsx
@@ -1,0 +1,68 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Text } from 'design';
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+/** State of an authentication method (password, MFA method, or passkey). */
+type State = 'active' | 'inactive';
+
+/**
+ * Renders a pill component that represents a state of an authentication method.
+ * The `state` property is both an enum value, as well as the UI text.
+ */
+export function StatePill({ state }: { state: State }) {
+  return (
+    <StatePillBody state={state}>
+      <StatePillText typography="body1">{state}</StatePillText>
+    </StatePillBody>
+  );
+}
+
+const StatePillBody = styled.span<{ backgroundColor: string; color: string }>`
+  display: inline-block;
+  vertical-align: baseline;
+  margin: 0 ${props => props.theme.space[2]}px;
+  padding: 0 ${props => props.theme.space[3]}px;
+  border-radius: 1000px;
+  background-color: ${props => props.backgroundColor};
+
+  ${statePillStyles}
+`;
+
+function statePillStyles({ state }: { state: State }): string {
+  switch (state) {
+    case 'active':
+      return css`
+        background-color: ${props =>
+          props.theme.colors.interactive.tonal.success[0]};
+        color: ${props => props.theme.colors.success.main};
+      `;
+    case 'inactive':
+      return css`
+        background-color: ${props =>
+          props.theme.colors.interactive.tonal.neutral[0]};
+        color: ${props => props.theme.colors.text.disabled};
+      `;
+  }
+}
+
+const StatePillText = styled(Text)`
+  display: inline;
+`;

--- a/web/packages/teleport/src/Account/StatePill.tsx
+++ b/web/packages/teleport/src/Account/StatePill.tsx
@@ -16,37 +16,35 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Text } from 'design';
 import React from 'react';
 import styled, { css } from 'styled-components';
 
 /** State of an authentication method (password, MFA method, or passkey). */
 type State = 'active' | 'inactive';
 
+export interface StatePillProps {
+  state: State;
+}
+
 /**
  * Renders a pill component that represents a state of an authentication method.
  * The `state` property is both an enum value, as well as the UI text.
  */
-export function StatePill({ state }: { state: State }) {
-  return (
-    <StatePillBody state={state}>
-      <StatePillText typography="body1">{state}</StatePillText>
-    </StatePillBody>
-  );
+export function StatePill({ state }: StatePillProps) {
+  return <StatePillBody state={state}>{state}</StatePillBody>;
 }
 
-const StatePillBody = styled.span<{ backgroundColor: string; color: string }>`
+const StatePillBody = styled.span<StatePillProps>`
+  font-size: 14px;
   display: inline-block;
-  vertical-align: baseline;
   margin: 0 ${props => props.theme.space[2]}px;
   padding: 0 ${props => props.theme.space[3]}px;
   border-radius: 1000px;
-  background-color: ${props => props.backgroundColor};
 
   ${statePillStyles}
 `;
 
-function statePillStyles({ state }: { state: State }): string {
+function statePillStyles({ state }: StatePillProps): string {
   switch (state) {
     case 'active':
       return css`
@@ -62,7 +60,3 @@ function statePillStyles({ state }: { state: State }): string {
       `;
   }
 }
-
-const StatePillText = styled(Text)`
-  display: inline;
-`;

--- a/web/packages/teleport/src/services/user/makeUserContext.ts
+++ b/web/packages/teleport/src/services/user/makeUserContext.ts
@@ -19,7 +19,7 @@
 import { makeCluster } from '../clusters';
 
 import { makeAcl } from './makeAcl';
-import { UserContext, AccessCapabilities } from './types';
+import { UserContext, AccessCapabilities, PasswordState } from './types';
 
 export default function makeUserContext(json: any): UserContext {
   json = json || {};
@@ -32,6 +32,8 @@ export default function makeUserContext(json: any): UserContext {
   const accessStrategy = json.accessStrategy || defaultStrategy;
   const accessCapabilities = makeAccessCapabilities(json.accessCapabilities);
   const allowedSearchAsRoles = json.allowedSearchAsRoles || [];
+  const passwordState =
+    json.passwordState || PasswordState.PASSWORD_STATE_UNSPECIFIED;
 
   return {
     username,
@@ -42,6 +44,7 @@ export default function makeUserContext(json: any): UserContext {
     accessCapabilities,
     accessRequestId,
     allowedSearchAsRoles,
+    passwordState,
   };
 }
 

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -37,9 +37,24 @@ export interface UserContext {
   cluster: Cluster;
   accessStrategy: AccessStrategy;
   accessCapabilities: AccessCapabilities;
-  // accessRequestId is the ID of the access request from which additional roles to assume were obtained for the current session.
+  /**
+   * ID of the access request from which additional roles to assume were
+   * obtained for the current session.
+   */
   accessRequestId?: string;
   allowedSearchAsRoles: string[];
+  /** Indicates whether the user has a password set. */
+  passwordState: PasswordState;
+}
+
+/**
+ * Indicates whether a user has a password set. Corresponds to the PasswordState
+ * protocol buffers enum.
+ */
+export enum PasswordState {
+  PASSWORD_STATE_UNSPECIFIED = 0,
+  PASSWORD_STATE_UNSET = 1,
+  PASSWORD_STATE_SET = 2,
 }
 
 export interface Access {

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -20,6 +20,7 @@ import api from 'teleport/services/api';
 
 import user from './user';
 import { makeTraits } from './makeUser';
+import { PasswordState } from './types';
 
 test('undefined values in context response gives proper default values', async () => {
   const mockContext = {
@@ -296,6 +297,7 @@ test('undefined values in context response gives proper default values', async (
     // Test undefined roles and reviewers are set to empty arrays.
     accessCapabilities: { requestableRoles: [], suggestedReviewers: [] },
     allowedSearchAsRoles: [],
+    passwordState: PasswordState.PASSWORD_STATE_UNSPECIFIED,
   });
 });
 

--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -33,6 +33,10 @@ export default class StoreUserContext extends Store<UserContext> {
     return this.state?.username;
   }
 
+  getPasswordState() {
+    return this.state.passwordState;
+  }
+
   getClusterId() {
     return this.state.cluster.clusterId;
   }


### PR DESCRIPTION
Backport #40904 to branch/v15

changelog: Added indicators on the account settings page that tell which authentication methods are active.
