### PR TITLE
docs: update identity links in edition comparsion

### DIFF
--- a/docs/pages/includes/edition-comparison.mdx
+++ b/docs/pages/includes/edition-comparison.mdx
@@ -33,7 +33,7 @@ _Available as an add-on to Teleport Enterprise_
 
 ||Community Edition|Enterprise|Cloud|
 |---|---|---|---|
-|Access Monitoring & Response|✖|✔|✔|
+|[Access Monitoring & Response](./access-controls/access-monitoring.mdx)|✖|✔|✔|
 |[Access Lists & Access Reviews](../access-controls/access-lists.mdx)|✖|✔|✔|
 |[Device Trust](../access-controls/device-trust/guide.mdx)|✖|✔|✔|
 |[Endpoint Management: Jamf](../access-controls/device-trust/jamf-integration.mdx)|✖|✔|✔|

--- a/docs/pages/includes/edition-comparison.mdx
+++ b/docs/pages/includes/edition-comparison.mdx
@@ -33,7 +33,7 @@ _Available as an add-on to Teleport Enterprise_
 
 ||Community Edition|Enterprise|Cloud|
 |---|---|---|---|
-|[Access Monitoring & Response](./access-controls/access-monitoring.mdx)|✖|✔|✔|
+|[Access Monitoring & Response](../access-controls/access-monitoring.mdx)|✖|✔|✔|
 |[Access Lists & Access Reviews](../access-controls/access-lists.mdx)|✖|✔|✔|
 |[Device Trust](../access-controls/device-trust/guide.mdx)|✖|✔|✔|
 |[Endpoint Management: Jamf](../access-controls/device-trust/jamf-integration.mdx)|✖|✔|✔|

--- a/docs/pages/includes/edition-comparison.mdx
+++ b/docs/pages/includes/edition-comparison.mdx
@@ -38,7 +38,7 @@ _Available as an add-on to Teleport Enterprise_
 |[Device Trust](../access-controls/device-trust/guide.mdx)|✖|✔|✔|
 |[Endpoint Management: Jamf](../access-controls/device-trust/jamf-integration.mdx)|✖|✔|✔|
 |[JIT Access Requests](../access-controls/guides/dual-authz.mdx)|Limited|✔|✔|
-|Session & Identity Locks|✖|✔|✔|
+|[Session & Identity Locks](../access-controls/guides/locking.mdx)|✖|✔|✔|
 
 ### Infrastructure access
 


### PR DESCRIPTION
Add in link to Locking and Access monitoring to Identity section in edition comparsion