### PR TITLE
Fix DeviceTrustWeb Connect double window open

### DIFF
--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
@@ -57,10 +57,11 @@ function renderDialog(dialog: Dialog, handleClose: () => void) {
         <AuthenticateWebDevice
           rootClusterUri={dialog.rootClusterUri}
           onAuthorize={dialog.onAuthorize}
-          onClose={() => {
-            dialog.onCancel();
+          onCancel={() => {
             handleClose();
+            dialog.onCancel();
           }}
+          onClose={handleClose}
         />
       );
     }

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/AuthenticateWebDevice/AuthenticateWebDevice.story.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/AuthenticateWebDevice/AuthenticateWebDevice.story.tsx
@@ -32,6 +32,7 @@ export const Dialog = () => (
     <AuthenticateWebDevice
       rootClusterUri={makeRootCluster().uri}
       onClose={() => {}}
+      onCancel={() => {}}
       onAuthorize={async () => {}}
     />
   </MockAppContextProvider>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/AuthenticateWebDevice/AuthenticateWebDevice.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/AuthenticateWebDevice/AuthenticateWebDevice.tsx
@@ -27,6 +27,7 @@ import { RootClusterUri, routing } from 'teleterm/ui/uri';
 
 type Props = {
   rootClusterUri: RootClusterUri;
+  onCancel(): void;
   onClose(): void;
   onAuthorize(): Promise<void>;
 };
@@ -34,6 +35,7 @@ type Props = {
 export const AuthenticateWebDevice = ({
   onAuthorize,
   onClose,
+  onCancel,
   rootClusterUri,
 }: Props) => {
   const [attempt, run] = useAsync(async () => {
@@ -66,7 +68,7 @@ export const AuthenticateWebDevice = ({
         </ButtonPrimary>
         <ButtonSecondary
           disabled={attempt.status === 'processing'}
-          onClick={onClose}
+          onClick={onCancel}
         >
           Cancel
         </ButtonSecondary>


### PR DESCRIPTION
This PR fixes a bug introduced when adding the "window.open" feature on cancel. It would run the 'close' method (which included an extra open) on a successful authorize. This separates the close and cancel methods and calls them correctly now. The desired behavior is:
1. on close -> dialog closes and open window to /web
2. on authorize -> dialog closes and open window to /webconfirm