### PR TITLE
web: ensure active sessions show up correctly

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2791,6 +2791,14 @@ func (set RoleSet) CanCopyFiles() bool {
 	return true
 }
 
+// CanJoinSessions returns true if at least one role in the role set
+// allows the user to join active sessions.
+func (set RoleSet) CanJoinSessions() bool {
+	return slices.ContainsFunc(set, func(r types.Role) bool {
+		return len(r.GetSessionJoinPolicies()) > 0
+	})
+}
+
 // CertificateFormat returns the most permissive certificate format in a
 // RoleSet.
 func (set RoleSet) CertificateFormat() string {

--- a/lib/services/useracl.go
+++ b/lib/services/useracl.go
@@ -136,7 +136,6 @@ func newAccess(roleSet RoleSet, ctx *Context, kind string) ResourceAccess {
 func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, desktopRecordingEnabled, accessMonitoringEnabled bool) UserACL {
 	ctx := &Context{User: user}
 	recordedSessionAccess := newAccess(userRoles, ctx, types.KindSession)
-	activeSessionAccess := newAccess(userRoles, ctx, types.KindSSHSession)
 	roleAccess := newAccess(userRoles, ctx, types.KindRole)
 	authConnectors := newAccess(userRoles, ctx, types.KindAuthConnector)
 	trustedClusterAccess := newAccess(userRoles, ctx, types.KindTrustedCluster)
@@ -152,6 +151,14 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 	desktopAccess := newAccess(userRoles, ctx, types.KindWindowsDesktop)
 	cnDiagnosticAccess := newAccess(userRoles, ctx, types.KindConnectionDiagnostic)
 	samlIdpServiceProviderAccess := newAccess(userRoles, ctx, types.KindSAMLIdPServiceProvider)
+
+	// active sessions are a special case - if a user's role set has any join_sessions
+	// policies then the ACL must permit showing active sessions
+	activeSessionAccess := newAccess(userRoles, ctx, types.KindSSHSession)
+	if userRoles.CanJoinSessions() {
+		activeSessionAccess.List = true
+		activeSessionAccess.Read = true
+	}
 
 	var assistAccess ResourceAccess
 	if features.Assist {

--- a/lib/services/useracl_test.go
+++ b/lib/services/useracl_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client/proto"
@@ -160,6 +161,35 @@ func TestNewUserACLCloud(t *testing.T) {
 	// cloud-specific asserts
 	require.Empty(t, cmp.Diff(userContext.Billing, allowedRW))
 	require.Empty(t, cmp.Diff(userContext.Desktops, allowedRW))
+}
+
+func TestJoinSessionsACL(t *testing.T) {
+	t.Parallel()
+
+	user := &types.UserV2{
+		Metadata: types.Metadata{},
+	}
+	// create a role denying list/read to all resources,
+	// but allowing the ability to join sessions
+	role := &types.RoleV6{}
+	role.SetRules(types.Deny, []types.Rule{
+		{
+			Resources: []string{"*"},
+			Verbs:     RO(),
+		},
+	})
+	role.SetSessionJoinPolicies([]*types.SessionJoinPolicy{
+		{
+			Name:  "join all",
+			Roles: []string{"*"},
+			Modes: []string{string(types.SessionObserverMode)},
+			Kinds: []string{string(types.SSHSessionKind), string(types.KubernetesSessionKind)},
+		},
+	})
+	roleSet := []types.Role{role}
+	acl := NewUserACL(user, roleSet, proto.Features{}, true, false)
+	assert.True(t, acl.ActiveSessions.List)
+	assert.True(t, acl.ActiveSessions.Read)
 }
 
 func TestNewAccessMonitoring(t *testing.T) {


### PR DESCRIPTION
This ensures that users who have permissions to join active sessions see the active sessions option in the web UI, even if they have a wildcard deny rule.

Note: this does not make any changes to the RBAC system, it only brings the web UI logic in sync with the existing RBAC system.

Closes gravitational/security-findings#26

Changelog: ensure that the active sessions page shows up in the web UI for users with permissions to join sessions.