### PR TITLE
add redshift cluster e2e tests

### DIFF
--- a/.github/workflows/aws-e2e-tests-non-root.yaml
+++ b/.github/workflows/aws-e2e-tests-non-root.yaml
@@ -19,6 +19,10 @@ env:
   RDS_POSTGRES_INSTANCE_NAME: ci-database-e2e-tests-rds-postgres-instance-us-west-2-307493967395
   RDS_MYSQL_INSTANCE_NAME: ci-database-e2e-tests-rds-mysql-instance-us-west-2-307493967395
   RDS_MARIADB_INSTANCE_NAME: ci-database-e2e-tests-rds-mariadb-instance-us-west-2-307493967395
+  REDSHIFT_ACCESS_ROLE: arn:aws:iam::307493967395:role/ci-database-e2e-tests-redshift-access
+  REDSHIFT_DISCOVERY_ROLE: arn:aws:iam::307493967395:role/ci-database-e2e-tests-redshift-discovery
+  REDSHIFT_IAM_DB_USER: ci-database-e2e-tests-redshift-user
+  REDSHIFT_CLUSTER_NAME: ci-database-e2e-tests-redshift-cluster-us-west-2-307493967395
   REDSHIFT_SERVERLESS_ACCESS_ROLE: arn:aws:iam::307493967395:role/ci-database-e2e-tests-redshift-serverless-access
   REDSHIFT_SERVERLESS_DISCOVERY_ROLE: arn:aws:iam::307493967395:role/ci-database-e2e-tests-redshift-serverless-discovery
   REDSHIFT_SERVERLESS_ENDPOINT_NAME: ci-database-e2e-tests-redshift-serverless-workgroup-rss-access-us-west-2-307493967395

--- a/e2e/aws/databases_test.go
+++ b/e2e/aws/databases_test.go
@@ -21,6 +21,7 @@ package e2e
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -28,8 +29,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	mysqlclient "github.com/go-mysql-org/go-mysql/client"
 	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -59,6 +63,7 @@ func TestDatabases(t *testing.T) {
 	t.Run("unmatched discovery", awsDBDiscoveryUnmatched)
 	t.Run("rds", testRDS)
 	t.Run("redshift serverless", testRedshiftServerless)
+	t.Run("redshift cluster", testRedshiftCluster)
 }
 
 func awsDBDiscoveryUnmatched(t *testing.T) {
@@ -71,8 +76,9 @@ func awsDBDiscoveryUnmatched(t *testing.T) {
 	for matcherType, assumeRoleARN := range map[string]string{
 		// add a new matcher/role here to test that discovery properly
 		// does *not* that kind of database for some unmatched tag.
-		types.AWSMatcherRDS:                mustGetEnv(t, rdsDiscoveryRoleEnv),
-		types.AWSMatcherRedshiftServerless: mustGetEnv(t, rssDiscoveryRoleEnv),
+		types.AWSMatcherRDS:                mustGetEnv(t, rdsDiscoveryRoleARNEnv),
+		types.AWSMatcherRedshiftServerless: mustGetEnv(t, rssDiscoveryRoleARNEnv),
+		types.AWSMatcherRedshift:           mustGetEnv(t, redshiftDiscoveryRoleARNEnv),
 	} {
 		matchers = append(matchers, types.AWSMatcher{
 			Types: []string{matcherType},
@@ -157,8 +163,10 @@ func postgresLocalProxyConnTest(t *testing.T, cluster *helpers.TeleInstance, use
 	defer cancel()
 	lp := startLocalALPNProxy(t, ctx, user, cluster, route)
 
-	connString := fmt.Sprintf("postgres://%s@%v/%s",
-		route.Username, lp.GetAddr(), route.Database)
+	pgconnConfig, err := pgconn.ParseConfig(fmt.Sprintf("postgres://%v/", lp.GetAddr()))
+	require.NoError(t, err)
+	pgconnConfig.User = route.Username
+	pgconnConfig.Database = route.Database
 	var pgConn *pgconn.PgConn
 	// retry for a while, the database service might need time to give
 	// itself IAM rds:connect permissions.
@@ -166,7 +174,7 @@ func postgresLocalProxyConnTest(t *testing.T, cluster *helpers.TeleInstance, use
 		var err error
 		ctx, cancel := context.WithTimeout(context.Background(), connRetryTick)
 		defer cancel()
-		pgConn, err = pgconn.Connect(ctx, connString)
+		pgConn, err = pgconn.ConnectConfig(ctx, pgconnConfig)
 		assert.NoError(t, err)
 		assert.NotNil(t, pgConn)
 	}, waitForConnTimeout, connRetryTick, "connecting to postgres")
@@ -314,4 +322,72 @@ func waitForDatabases(t *testing.T, auth *service.TeleportProcess, wantNames ...
 			assert.Contains(t, seen, name)
 		}
 	}, 1*time.Minute, time.Second, "waiting for the database service to heartbeat the databases")
+}
+
+// dbUserLogin contains common info needed to connect as a db user via
+// password auth.
+type dbUserLogin struct {
+	username string
+	password string
+	address  string
+	port     int
+}
+
+func connectPostgres(t *testing.T, ctx context.Context, info dbUserLogin, dbName string) *pgx.Conn {
+	pgCfg, err := pgx.ParseConfig(fmt.Sprintf("postgres://%s:%d/?sslmode=verify-full", info.address, info.port))
+	require.NoError(t, err)
+	pgCfg.User = info.username
+	pgCfg.Password = info.password
+	pgCfg.Database = dbName
+	pgCfg.TLSConfig = &tls.Config{
+		ServerName: info.address,
+		RootCAs:    awsCertPool.Clone(),
+	}
+
+	conn, err := pgx.ConnectConfig(ctx, pgCfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = conn.Close(ctx)
+	})
+	return conn
+}
+
+// secretPassword is used to unmarshal an AWS Secrets Manager
+// user password secret.
+type secretPassword struct {
+	Password string `json:"password"`
+}
+
+// getMasterUserPassword is a helper that fetches a db master user and password
+// from AWS Secrets Manager.
+func getMasterUserPassword(t *testing.T, ctx context.Context, secretID string) string {
+	t.Helper()
+	secretVal := getSecretValue(t, ctx, secretID)
+	require.NotNil(t, secretVal.SecretString)
+	var secret secretPassword
+	if err := json.Unmarshal([]byte(*secretVal.SecretString), &secret); err != nil {
+		// being paranoid. I don't want to leak the secret string in test error
+		// logs.
+		require.FailNow(t, "error unmarshaling secret string")
+	}
+	if len(secret.Password) == 0 {
+		require.FailNow(t, "empty master user secret string")
+	}
+	return secret.Password
+}
+
+func getSecretValue(t *testing.T, ctx context.Context, secretID string) secretsmanager.GetSecretValueOutput {
+	t.Helper()
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(mustGetEnv(t, awsRegionEnv)),
+	)
+	require.NoError(t, err)
+
+	secretsClt := secretsmanager.NewFromConfig(cfg)
+	secretVal, err := secretsClt.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: &secretID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, secretVal)
+	return *secretVal
 }

--- a/e2e/aws/main_test.go
+++ b/e2e/aws/main_test.go
@@ -32,15 +32,16 @@ const (
 	// discoveryMatcherLabelsEnv is the env variable that specifies the matcher
 	// labels to use in test discovery services.
 	discoveryMatcherLabelsEnv = "DISCOVERY_MATCHER_LABELS"
-	// rdsAccessRoleEnv is the environment variable that specifies the IAM role
-	// that Teleport Database Service will assume to access RDS databases.
+	// rdsAccessRoleARNEnv is the environment variable that specifies the IAM
+	// role ARN that Teleport Database Service will assume to access RDS
+	// databases.
 	// See modules/databases-ci/ from cloud-terraform repo for more details.
-	rdsAccessRoleEnv = "RDS_ACCESS_ROLE"
-	// rdsDiscoveryRoleEnv is the environment variable that specifies the
-	// IAM role that Teleport Discovery Service will assume to discover
+	rdsAccessRoleARNEnv = "RDS_ACCESS_ROLE"
+	// rdsDiscoveryRoleARNEnv is the environment variable that specifies the
+	// IAM role ARN that Teleport Discovery Service will assume to discover
 	// RDS databases.
 	// See modules/databases-ci/ from cloud-terraform repo for more details.
-	rdsDiscoveryRoleEnv = "RDS_DISCOVERY_ROLE"
+	rdsDiscoveryRoleARNEnv = "RDS_DISCOVERY_ROLE"
 	// rdsPostgresInstanceNameEnv is the environment variable that specifies the
 	// name of the RDS Postgres DB instance that will be created by the Teleport
 	// Discovery Service.
@@ -53,16 +54,16 @@ const (
 	// name of the RDS MariaDB instance that will be created by the Teleport
 	// Discovery Service.
 	rdsMariaDBInstanceNameEnv = "RDS_MARIADB_INSTANCE_NAME"
-	// rssAccessRoleEnv is the environment variable that specifies the IAM role
-	// that Teleport Database Service will assume to access Redshift Serverless
-	// databases.
+	// rssAccessRoleARNEnv is the environment variable that specifies the IAM
+	// role ARN that Teleport Database Service will assume to access Redshift
+	// Serverless databases.
 	// See modules/databases-ci/ from cloud-terraform repo for more details.
-	rssAccessRoleEnv = "REDSHIFT_SERVERLESS_ACCESS_ROLE"
-	// rssDiscoveryRoleEnv is the environment variable that specifies the
-	// IAM role that Teleport Discovery Service will assume to discover
+	rssAccessRoleARNEnv = "REDSHIFT_SERVERLESS_ACCESS_ROLE"
+	// rssDiscoveryRoleARNEnv is the environment variable that specifies the
+	// IAM role ARN that Teleport Discovery Service will assume to discover
 	// Redshift Serverless databases.
 	// See modules/databases-ci/ from cloud-terraform repo for more details.
-	rssDiscoveryRoleEnv = "REDSHIFT_SERVERLESS_DISCOVERY_ROLE"
+	rssDiscoveryRoleARNEnv = "REDSHIFT_SERVERLESS_DISCOVERY_ROLE"
 	// rssNameEnv is the environment variable that specifies the
 	// name of the Redshift Serverless workgroup that will be created by the
 	// Teleport Discovery Service.
@@ -74,6 +75,23 @@ const (
 	// rssDBUserEnv is the name of the IAM role that tests will use as a
 	// database user to connect to Redshift Serverless.
 	rssDBUserEnv = "REDSHIFT_SERVERLESS_IAM_DB_USER"
+	// redshiftAccessRoleARNEnv is the environment variable that specifies the
+	// IAM role ARN that Teleport Database Service will assume to access Redshift
+	// cluster databases.
+	// See modules/databases-ci/ from cloud-terraform repo for more details.
+	redshiftAccessRoleARNEnv = "REDSHIFT_ACCESS_ROLE"
+	// redshiftDiscoveryRoleARNEnv is the environment variable that specifies the
+	// IAM role ARN that Teleport Discovery Service will assume to discover
+	// Redshift cluster databases.
+	// See modules/databases-ci/ from cloud-terraform repo for more details.
+	redshiftDiscoveryRoleARNEnv = "REDSHIFT_DISCOVERY_ROLE"
+	// redshiftNameEnv is the environment variable that specifies the
+	// name of the Redshift cluster db that will be created by the
+	// Teleport Discovery Service.
+	redshiftNameEnv = "REDSHIFT_CLUSTER_NAME"
+	// redshiftIAMDBUserEnv is the name of the IAM role that tests will use as a
+	// database user to connect to Redshift Serverless.
+	redshiftIAMDBUserEnv = "REDSHIFT_IAM_DB_USER"
 	// kubeSvcRoleARNEnv is the environment variable that specifies
 	// the IAM role that Teleport Kubernetes Service will assume to access the EKS cluster.
 	// This role needs to have the following permissions:

--- a/e2e/aws/rds_test.go
+++ b/e2e/aws/rds_test.go
@@ -21,7 +21,6 @@ package e2e
 import (
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
@@ -29,7 +28,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
-	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	mysqlclient "github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/jackc/pgx/v4"
@@ -74,9 +72,9 @@ func makeDBTestCluster(t *testing.T, accessRole, discoveryRole, discoveryMatcher
 // the engines together into subtests: postgres, mysql, etc.
 func testRDS(t *testing.T) {
 	t.Parallel()
-	// give everything 2 minutes to finish. Realistically it takes ~10-20
+	// Give everything some time to finish. Realistically it takes ~10-20
 	// seconds, but let's be generous to maybe avoid flakey failures.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	t.Cleanup(cancel)
 
 	// use random names so we can test auto provisioning these users with these
@@ -87,8 +85,8 @@ func testRDS(t *testing.T) {
 	autoRole1 := "auto_role1_" + randASCII(t, 6)
 	autoRole2 := "auto_role2_" + randASCII(t, 6)
 
-	accessRole := mustGetEnv(t, rdsAccessRoleEnv)
-	discoveryRole := mustGetEnv(t, rdsDiscoveryRoleEnv)
+	accessRole := mustGetEnv(t, rdsAccessRoleARNEnv)
+	discoveryRole := mustGetEnv(t, rdsDiscoveryRoleARNEnv)
 	opts := []testOptionsFunc{
 		withUserRole(t, autoUserKeep, "db-auto-user-keeper", makeAutoUserKeepRoleSpec(autoRole1, autoRole2)),
 		withUserRole(t, autoUserDrop, "db-auto-user-dropper", makeAutoUserDropRoleSpec(autoRole1, autoRole2)),
@@ -132,13 +130,20 @@ func testRDS(t *testing.T) {
 		autoRolesQuery := fmt.Sprintf("select 1 from %q.%q", testSchema, testTable)
 
 		t.Cleanup(func() {
-			// best effort cleanup everything created for the tests,
-			// including the auto drop user in case Teleport fails to do so.
-			_, _ = conn.Exec(ctx, fmt.Sprintf("DROP SCHEMA %q CASCADE", testSchema))
-			_, _ = conn.Exec(ctx, fmt.Sprintf("DROP ROLE %q", autoRole1))
-			_, _ = conn.Exec(ctx, fmt.Sprintf("DROP ROLE %q", autoRole2))
-			_, _ = conn.Exec(ctx, fmt.Sprintf("DROP USER %q", autoUserKeep))
-			_, _ = conn.Exec(ctx, fmt.Sprintf("DROP USER %q", autoUserDrop))
+			// users/roles can only be dropped after we drop the schema+table.
+			// So, rather than juggling the order of drops, just attempt to drop
+			// everything as part of test cleanup, regardless of what the test
+			// actually created successfully.
+			for _, stmt := range []string{
+				fmt.Sprintf("DROP SCHEMA %q CASCADE", testSchema),
+				fmt.Sprintf("DROP ROLE IF EXISTS %q", autoRole1),
+				fmt.Sprintf("DROP ROLE IF EXISTS %q", autoRole2),
+				fmt.Sprintf("DROP USER IF EXISTS %q", autoUserKeep),
+				fmt.Sprintf("DROP USER IF EXISTS %q", autoUserDrop),
+			} {
+				_, err := conn.Exec(ctx, stmt)
+				assert.NoError(t, err, "test cleanup failed, stmt=%q", stmt)
+			}
 		})
 
 		var pgxConnMu sync.Mutex
@@ -238,12 +243,17 @@ func testRDS(t *testing.T) {
 		t.Cleanup(func() {
 			// best effort cleanup all the users created for the tests,
 			// including the auto drop user in case Teleport fails to do so.
-			_, _ = conn.Execute(fmt.Sprintf("DROP TABLE %s", testTable1))
-			_, _ = conn.Execute(fmt.Sprintf("DROP TABLE %s", testTable2))
-			_, _ = conn.Execute(fmt.Sprintf("DROP ROLE %q", autoRole1))
-			_, _ = conn.Execute(fmt.Sprintf("DROP ROLE %q", autoRole2))
-			_, _ = conn.Execute(fmt.Sprintf("DROP USER %q", autoUserKeep))
-			_, _ = conn.Execute(fmt.Sprintf("DROP USER %q", autoUserDrop))
+			for _, stmt := range []string{
+				fmt.Sprintf("DROP TABLE %s", testTable1),
+				fmt.Sprintf("DROP TABLE %s", testTable2),
+				fmt.Sprintf("DROP ROLE IF EXISTS %q", autoRole1),
+				fmt.Sprintf("DROP ROLE IF EXISTS %q", autoRole2),
+				fmt.Sprintf("DROP USER IF EXISTS %q", autoUserKeep),
+				fmt.Sprintf("DROP USER IF EXISTS %q", autoUserDrop),
+			} {
+				_, err := conn.Execute(stmt)
+				assert.NoError(t, err, "test cleanup failed, stmt=%q", stmt)
+			}
 		})
 
 		for name, test := range map[string]struct {
@@ -358,15 +368,19 @@ func testRDS(t *testing.T) {
 		autoRolesQuery := fmt.Sprintf("SELECT 1 FROM %s JOIN %s", testTable1, testTable2)
 
 		t.Cleanup(func() {
-			// best effort cleanup all the users created by the tests.
-			// don't cleanup the admin or test runs will interfere with
-			// each other.
-			_, _ = conn.Execute(fmt.Sprintf("DROP ROLE %q", "tp-role-"+autoUserKeep))
-			_, _ = conn.Execute(fmt.Sprintf("DROP ROLE %q", "tp-role-"+autoUserDrop))
-			_, _ = conn.Execute(fmt.Sprintf("DROP USER %q", autoUserKeep))
-			_, _ = conn.Execute(fmt.Sprintf("DROP USER %q", autoUserDrop))
-			_, _ = conn.Execute("DELETE FROM teleport.user_attributes WHERE USER=?", autoUserKeep)
-			_, _ = conn.Execute("DELETE FROM teleport.user_attributes WHERE USER=?", autoUserDrop)
+			// best effort cleanup all the users created for the tests,
+			// including the auto drop user in case Teleport fails to do so.
+			for _, stmt := range []string{
+				fmt.Sprintf("DROP ROLE IF EXISTS %q", "tp-role-"+autoUserKeep),
+				fmt.Sprintf("DROP ROLE IF EXISTS %q", "tp-role-"+autoUserDrop),
+				fmt.Sprintf("DROP USER IF EXISTS %q", autoUserKeep),
+				fmt.Sprintf("DROP USER IF EXISTS %q", autoUserDrop),
+				fmt.Sprintf("DELETE FROM teleport.user_attributes WHERE USER=%q", autoUserKeep),
+				fmt.Sprintf("DELETE FROM teleport.user_attributes WHERE USER=%q", autoUserDrop),
+			} {
+				_, err := conn.Execute(stmt)
+				assert.NoError(t, err, "test cleanup failed, stmt=%q", stmt)
+			}
 		})
 
 		for name, test := range map[string]struct {
@@ -426,34 +440,11 @@ func testRDS(t *testing.T) {
 	})
 }
 
-// rdsAdminInfo contains common info needed to connect as an RDS admin user via
-// password auth.
-type rdsAdminInfo struct {
-	address,
-	username,
-	password string
-	port int
-}
-
 func connectAsRDSPostgresAdmin(t *testing.T, ctx context.Context, instanceID string) *pgx.Conn {
 	t.Helper()
 	info := getRDSAdminInfo(t, ctx, instanceID)
-	pgCfg, err := pgx.ParseConfig(fmt.Sprintf("postgres://%s:%d/?sslmode=verify-full", info.address, info.port))
-	require.NoError(t, err)
-	pgCfg.User = info.username
-	pgCfg.Password = info.password
-	pgCfg.Database = "postgres"
-	pgCfg.TLSConfig = &tls.Config{
-		ServerName: info.address,
-		RootCAs:    awsCertPool.Clone(),
-	}
-
-	conn, err := pgx.ConnectConfig(ctx, pgCfg)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = conn.Close(ctx)
-	})
-	return conn
+	const dbName = "postgres"
+	return connectPostgres(t, ctx, info, dbName)
 }
 
 // mySQLConn wraps a go-mysql conn to provide a client that's thread safe.
@@ -488,7 +479,7 @@ func connectAsRDSMySQLAdmin(t *testing.T, ctx context.Context, instanceID string
 	return &mySQLConn{conn: conn}
 }
 
-func getRDSAdminInfo(t *testing.T, ctx context.Context, instanceID string) rdsAdminInfo {
+func getRDSAdminInfo(t *testing.T, ctx context.Context, instanceID string) dbUserLogin {
 	t.Helper()
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(mustGetEnv(t, awsRegionEnv)),
@@ -507,46 +498,12 @@ func getRDSAdminInfo(t *testing.T, ctx context.Context, instanceID string) rdsAd
 	require.NotNil(t, dbInstance.MasterUserSecret.SecretArn)
 	require.NotEmpty(t, *dbInstance.MasterUsername)
 	require.NotEmpty(t, *dbInstance.MasterUserSecret.SecretArn)
-	return rdsAdminInfo{
+	return dbUserLogin{
+		username: *dbInstance.MasterUsername,
+		password: getMasterUserPassword(t, ctx, *dbInstance.MasterUserSecret.SecretArn),
 		address:  *dbInstance.Endpoint.Address,
 		port:     int(*dbInstance.Endpoint.Port),
-		username: *dbInstance.MasterUsername,
-		password: getRDSMasterUserPassword(t, ctx, *dbInstance.MasterUserSecret.SecretArn),
 	}
-}
-
-func getRDSMasterUserPassword(t *testing.T, ctx context.Context, secretID string) string {
-	t.Helper()
-	secretVal := getSecretValue(t, ctx, secretID)
-	type rdsMasterSecret struct {
-		User string `json:"username"`
-		Pass string `json:"password"`
-	}
-	var secret rdsMasterSecret
-	if err := json.Unmarshal([]byte(*secretVal.SecretString), &secret); err != nil {
-		// being paranoid. I don't want to leak the secret string in test error
-		// logs.
-		require.FailNow(t, "error unmarshaling secret string")
-	}
-	if len(secret.Pass) == 0 {
-		require.FailNow(t, "empty master user secret string")
-	}
-	return secret.Pass
-}
-
-func getSecretValue(t *testing.T, ctx context.Context, secretID string) *secretsmanager.GetSecretValueOutput {
-	t.Helper()
-	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(mustGetEnv(t, awsRegionEnv)),
-	)
-	require.NoError(t, err)
-
-	secretsClt := secretsmanager.NewFromConfig(cfg)
-	secretVal, err := secretsClt.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
-		SecretId: &secretID,
-	})
-	require.NoError(t, err)
-	return secretVal
 }
 
 // provisionRDSPostgresAutoUsersAdmin provisions an admin user suitable for auto-user
@@ -562,8 +519,11 @@ func provisionRDSPostgresAutoUsersAdmin(t *testing.T, ctx context.Context, conn 
 	// is not necessary.
 	// Don't cleanup the db admin after, because test runs would interfere
 	// with each other.
-	_, _ = conn.Exec(ctx, fmt.Sprintf("CREATE USER %q WITH login createrole", adminUser))
-	_, err := conn.Exec(ctx, fmt.Sprintf("GRANT rds_iam TO %q WITH ADMIN OPTION", adminUser))
+	_, err := conn.Exec(ctx, fmt.Sprintf("CREATE USER %q WITH login createrole", adminUser))
+	if err != nil {
+		require.ErrorContains(t, err, "already exists")
+	}
+	_, err = conn.Exec(ctx, fmt.Sprintf("GRANT rds_iam TO %q WITH ADMIN OPTION", adminUser))
 	if err != nil {
 		require.ErrorContains(t, err, "already a member")
 	}
@@ -632,54 +592,70 @@ func randASCII(t *testing.T, length int) string {
 }
 
 const (
-	autoUserWaitDur  = 20 * time.Second
-	autoUserWaitStep = 2 * time.Second
+	// autoUserWaitDur controls how long a test will wait for auto user
+	// deactivation or drop.
+	// The duration is generous - better to be slow sometimes than flakey.
+	autoUserWaitDur  = time.Minute
+	autoUserWaitStep = 10 * time.Second
 )
 
 func waitForPostgresAutoUserDeactivate(t *testing.T, ctx context.Context, conn *pgx.Conn, user string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		rows, err := conn.Query(ctx, "SELECT 1 FROM pg_roles WHERE rolname=$1", user)
-		if !assert.NoError(c, err) {
-			return
-		}
-		if !assert.True(c, rows.Next(), "user %q should not have been dropped after disconnecting", user) {
-			rows.Close()
-			return
-		}
+		// `Query` documents that it is always safe to attempt to read from the
+		// returned rows even if an error is returned.
+		// It also documents that the same error will be in rows.Err() and
+		// rows.Err() will also contain any error from executing the query after
+		// closing rows. Hence, we do not check the error until after reading
+		// and closing rows.
+		rows, _ := conn.Query(ctx, "SELECT 1 FROM pg_roles WHERE rolname=$1", user)
+		gotRow := rows.Next()
 		rows.Close()
+		if !assert.NoError(c, rows.Err()) {
+			return
+		}
+		if !assert.True(c, gotRow, "user %q should not have been dropped after disconnecting", user) {
+			return
+		}
 
-		rows, err = conn.Query(ctx, "SELECT 1 FROM pg_roles WHERE rolname = $1 AND rolcanlogin = false", user)
-		if !assert.NoError(c, err) {
-			return
-		}
-		if !assert.True(c, rows.Next(), "user %q should not be able to login after deactivating", user) {
-			rows.Close()
-			return
-		}
+		rows, _ = conn.Query(ctx, "SELECT 1 FROM pg_roles WHERE rolname = $1 AND rolcanlogin = false", user)
+		gotRow = rows.Next()
 		rows.Close()
+		if !assert.NoError(c, rows.Err()) {
+			return
+		}
+		if !assert.True(c, gotRow, "user %q should not be able to login after deactivating", user) {
+			return
+		}
 
-		rows, err = conn.Query(ctx, "SELECT 1 FROM pg_roles AS a WHERE pg_has_role($1, a.oid, 'member') AND a.rolname NOT IN ($1, 'teleport-auto-user')", user)
-		if !assert.NoError(c, err) {
-			return
-		}
-		if !assert.False(c, rows.Next(), "user %q should have lost all additional roles after deactivating", user) {
-			rows.Close()
-			return
-		}
+		rows, _ = conn.Query(ctx, "SELECT 1 FROM pg_roles AS a WHERE pg_has_role($1, a.oid, 'member') AND a.rolname NOT IN ($1, 'teleport-auto-user')", user)
+		gotRow = rows.Next()
 		rows.Close()
+		if !assert.NoError(c, rows.Err()) {
+			return
+		}
+		if !assert.False(c, gotRow, "user %q should have lost all additional roles after deactivating", user) {
+			return
+		}
 	}, autoUserWaitDur, autoUserWaitStep, "waiting for auto user %q to be deactivated", user)
 }
 
 func waitForPostgresAutoUserDrop(t *testing.T, ctx context.Context, conn *pgx.Conn, user string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		rows, err := conn.Query(ctx, "SELECT 1 FROM pg_roles WHERE rolname=$1", user)
-		if !assert.NoError(c, err) {
+		// `Query` documents that it is always safe to attempt to read from the
+		// returned rows even if an error is returned.
+		// It also documents that the same error will be in rows.Err() and
+		// rows.Err() will also contain any error from executing the query after
+		// closing rows. Hence, we do not check the error until after reading
+		// and closing rows.
+		rows, _ := conn.Query(ctx, "SELECT 1 FROM pg_roles WHERE rolname=$1", user)
+		gotRow := rows.Next()
+		rows.Close()
+		if !assert.NoError(c, rows.Err()) {
 			return
 		}
-		assert.False(c, rows.Next(), "user %q should have been dropped automatically after disconnecting", user)
-		rows.Close()
+		assert.False(c, gotRow, "user %q should have been dropped automatically after disconnecting", user)
 	}, autoUserWaitDur, autoUserWaitStep, "waiting for auto user %q to be dropped", user)
 }
 

--- a/e2e/aws/redshift_test.go
+++ b/e2e/aws/redshift_test.go
@@ -19,7 +19,17 @@
 package e2e
 
 import (
+	"context"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	"github.com/jackc/pgx/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -29,8 +39,8 @@ import (
 func testRedshiftServerless(t *testing.T) {
 	t.Skip("skipped until we fix the spacelift stack")
 	t.Parallel()
-	accessRole := mustGetEnv(t, rssAccessRoleEnv)
-	discoveryRole := mustGetEnv(t, rssDiscoveryRoleEnv)
+	accessRole := mustGetEnv(t, rssAccessRoleARNEnv)
+	discoveryRole := mustGetEnv(t, rssDiscoveryRoleARNEnv)
 	cluster := makeDBTestCluster(t, accessRole, discoveryRole, types.AWSMatcherRedshiftServerless)
 
 	// wait for the database to be discovered
@@ -55,4 +65,242 @@ func testRedshiftServerless(t *testing.T) {
 			postgresLocalProxyConnTest(t, cluster, hostUser, rssRoute, "select 1")
 		})
 	})
+}
+
+func testRedshiftCluster(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	t.Cleanup(cancel)
+
+	autoUserKeep := "auto_keep_" + randASCII(t, 6)
+	autoUserDrop := "auto_drop_" + randASCII(t, 6)
+	autoRole1 := "auto_role1_" + randASCII(t, 6)
+	autoRole2 := "auto_role2_" + randASCII(t, 6)
+	opts := []testOptionsFunc{
+		withUserRole(t, autoUserKeep, "db-auto-user-keeper", makeAutoUserKeepRoleSpec(autoRole1, autoRole2)),
+		withUserRole(t, autoUserDrop, "db-auto-user-dropper", makeAutoUserDropRoleSpec(autoRole1, autoRole2)),
+	}
+
+	accessRole := mustGetEnv(t, redshiftAccessRoleARNEnv)
+	discoveryRole := mustGetEnv(t, redshiftDiscoveryRoleARNEnv)
+	cluster := makeDBTestCluster(t, accessRole, discoveryRole, types.AWSMatcherRedshift, opts...)
+
+	// wait for the database to be discovered
+	redshiftDBName := mustGetEnv(t, redshiftNameEnv)
+	waitForDatabases(t, cluster.Process, redshiftDBName)
+	db, err := cluster.Process.GetAuthServer().GetDatabase(ctx, redshiftDBName)
+	require.NoError(t, err)
+	adminUser := mustGetDBAdmin(t, db)
+
+	conn := connectAsRedshiftClusterAdmin(t, ctx, db.GetAWS().Redshift.ClusterID)
+	provisionRedshiftAutoUsersAdmin(t, ctx, conn, adminUser.Name)
+
+	// create a new schema with tables that can only be accessed if the
+	// auto roles are granted by Teleport automatically.
+	testSchema := "test_" + randASCII(t, 4)
+	_, err = conn.Exec(ctx, fmt.Sprintf("CREATE SCHEMA %q", testSchema))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// users/roles can only be dropped after we drop the schema+table.
+		// So, rather than juggling the order of drops, just attempt to drop
+		// everything as part of test cleanup, regardless of what the test
+		// actually created successfully.
+		for _, stmt := range []string{
+			fmt.Sprintf("DROP SCHEMA %q CASCADE", testSchema),
+			fmt.Sprintf("DROP ROLE %q", autoRole1),
+			fmt.Sprintf("DROP ROLE %q", autoRole2),
+			fmt.Sprintf("DROP USER IF EXISTS %q", autoUserKeep),
+			fmt.Sprintf("DROP USER IF EXISTS %q", autoUserDrop),
+		} {
+			_, err := conn.Exec(ctx, stmt)
+			assert.NoError(t, err, "test cleanup failed, stmt=%q", stmt)
+		}
+	})
+	testTable := "ctf" // capture the flag :)
+	_, err = conn.Exec(ctx, fmt.Sprintf("CREATE TABLE %q.%q (id int)", testSchema, testTable))
+	require.NoError(t, err)
+
+	// create the roles that Teleport will auto assign.
+	// role 1 only allows usage of the test schema.
+	// role 2 only allows select of the test table in the test schema.
+	// a user needs to have both roles to select from the test table.
+	_, err = conn.Exec(ctx, fmt.Sprintf("CREATE ROLE %q", autoRole1))
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, fmt.Sprintf("CREATE ROLE %q", autoRole2))
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, fmt.Sprintf("GRANT USAGE ON SCHEMA %q TO ROLE %q", testSchema, autoRole1))
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, fmt.Sprintf("GRANT SELECT ON %q.%q TO ROLE %q", testSchema, testTable, autoRole2))
+	require.NoError(t, err)
+	autoRolesQuery := fmt.Sprintf("select 1 from %q.%q", testSchema, testTable)
+
+	var pgxConnMu sync.Mutex
+	for name, test := range map[string]struct {
+		user            string
+		dbUser          string
+		query           string
+		afterConnTestFn func(t *testing.T)
+	}{
+		"iam role": {
+			user: hostUser,
+			// role/<name> is the syntax we require for redshift IAM role auth
+			dbUser: "role/" + mustGetEnv(t, redshiftIAMDBUserEnv),
+			query:  "select 1",
+		},
+		"existing user": {
+			user:   hostUser,
+			dbUser: adminUser.Name,
+			query:  "select 1",
+		},
+		"auto user keep": {
+			user:   autoUserKeep,
+			dbUser: autoUserKeep,
+			query:  autoRolesQuery,
+			afterConnTestFn: func(t *testing.T) {
+				pgxConnMu.Lock()
+				defer pgxConnMu.Unlock()
+				waitForRedshiftAutoUserDeactivate(t, ctx, conn, autoUserKeep)
+			},
+		},
+		"auto user drop": {
+			user:   autoUserDrop,
+			dbUser: autoUserDrop,
+			query:  autoRolesQuery,
+			afterConnTestFn: func(t *testing.T) {
+				pgxConnMu.Lock()
+				defer pgxConnMu.Unlock()
+				waitForRedshiftAutoUserDrop(t, ctx, conn, autoUserDrop)
+			},
+		},
+	} {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			t.Run("connect", func(t *testing.T) {
+				route := tlsca.RouteToDatabase{
+					ServiceName: db.GetName(),
+					Protocol:    defaults.ProtocolPostgres,
+					Username:    test.dbUser,
+					Database:    "dev",
+				}
+				t.Run("via proxy", func(t *testing.T) {
+					t.Parallel()
+					postgresConnTest(t, cluster, test.user, route, test.query)
+				})
+				t.Run("via local proxy", func(t *testing.T) {
+					t.Parallel()
+					postgresLocalProxyConnTest(t, cluster, test.user, route, test.query)
+				})
+			})
+			if test.afterConnTestFn != nil {
+				test.afterConnTestFn(t)
+			}
+		})
+	}
+}
+
+func connectAsRedshiftClusterAdmin(t *testing.T, ctx context.Context, clusterID string) *pgx.Conn {
+	t.Helper()
+	info := getRedshiftAdminInfo(t, ctx, clusterID)
+	const dbName = "dev"
+	return connectPostgres(t, ctx, info, dbName)
+}
+
+func getRedshiftAdminInfo(t *testing.T, ctx context.Context, clusterID string) dbUserLogin {
+	t.Helper()
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(mustGetEnv(t, awsRegionEnv)),
+	)
+	require.NoError(t, err)
+	clt := redshift.NewFromConfig(cfg)
+	result, err := clt.DescribeClusters(ctx, &redshift.DescribeClustersInput{
+		ClusterIdentifier: &clusterID,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Clusters, 1)
+	dbInstance := result.Clusters[0]
+	require.NotNil(t, dbInstance.MasterUsername)
+	require.NotNil(t, dbInstance.MasterPasswordSecretArn)
+	require.NotEmpty(t, *dbInstance.MasterUsername)
+	require.NotEmpty(t, *dbInstance.MasterPasswordSecretArn)
+	return dbUserLogin{
+		username: *dbInstance.MasterUsername,
+		password: getMasterUserPassword(t, ctx, *dbInstance.MasterPasswordSecretArn),
+		address:  *dbInstance.Endpoint.Address,
+		port:     int(*dbInstance.Endpoint.Port),
+	}
+}
+
+// provisionRedshiftAutoUsersAdmin provisions an admin user suitable for auto-user
+// provisioning.
+func provisionRedshiftAutoUsersAdmin(t *testing.T, ctx context.Context, conn *pgx.Conn, adminUser string) {
+	t.Helper()
+	// Don't cleanup the db admin after, because test runs would interfere
+	// with each other.
+	_, err := conn.Exec(ctx, fmt.Sprintf("CREATE USER %q WITH PASSWORD DISABLE", adminUser))
+	if err != nil {
+		require.ErrorContains(t, err, "already exists")
+	}
+	_, err = conn.Exec(ctx, fmt.Sprintf(`GRANT ROLE "sys:superuser" TO %q`, adminUser))
+	if err != nil {
+		require.ErrorContains(t, err, "already a member")
+	}
+}
+
+func waitForRedshiftAutoUserDeactivate(t *testing.T, ctx context.Context, conn *pgx.Conn, user string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		// `Query` documents that it is always safe to attempt to read from the
+		// returned rows even if an error is returned.
+		// It also documents that the same error will be in rows.Err() and
+		// rows.Err() will also contain any error from executing the query after
+		// closing rows. Hence, we do not check the error until after reading
+		// and closing rows.
+		rows, _ := conn.Query(ctx, "SELECT 1 FROM pg_user_info as a WHERE a.usename = $1", user)
+		gotRow := rows.Next()
+		rows.Close()
+		if !assert.NoError(c, rows.Err()) {
+			return
+		}
+		if !assert.True(c, gotRow, "user %q should not have been dropped after disconnecting", user) {
+			return
+		}
+
+		rows, _ = conn.Query(ctx, "SELECT 1 FROM pg_user_info WHERE usename = $1 AND useconnlimit != 0", user)
+		gotRow = rows.Next()
+		rows.Close()
+		if !assert.NoError(c, rows.Err()) {
+			return
+		}
+		if !assert.False(c, gotRow, "user %q should not be able to login after deactivating", user) {
+			return
+		}
+
+		rows, _ = conn.Query(ctx, "SELECT 1 FROM svv_user_grants as a WHERE a.user_name = $1 AND a.role_name != 'teleport-auto-user'", user)
+		gotRow = rows.Next()
+		rows.Close()
+		if !assert.NoError(c, rows.Err()) {
+			return
+		}
+		assert.False(c, gotRow, "user %q should have lost all additional roles after deactivating", user)
+	}, autoUserWaitDur, autoUserWaitStep, "waiting for auto user %q to be deactivated", user)
+}
+
+func waitForRedshiftAutoUserDrop(t *testing.T, ctx context.Context, conn *pgx.Conn, user string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		// `Query` documents that it is always safe to attempt to read from the
+		// returned rows even if an error is returned.
+		// It also documents that the same error will be in rows.Err() and
+		// rows.Err() will also contain any error from executing the query after
+		// closing rows. Hence, we do not check the error until after reading
+		// and closing rows.
+		rows, _ := conn.Query(ctx, "SELECT 1 FROM pg_user_info WHERE usename=$1", user)
+		gotRow := rows.Next()
+		rows.Close()
+		if !assert.NoError(c, rows.Err()) {
+			return
+		}
+		assert.False(c, gotRow, "user %q should have been dropped automatically after disconnecting", user)
+	}, autoUserWaitDur, autoUserWaitStep, "waiting for auto user %q to be dropped", user)
 }

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/glue v1.80.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/rds v1.78.0
+	github.com/aws/aws-sdk-go-v2/service/redshift v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.28.6
 	github.com/aws/aws-sdk-go-v2/service/sns v1.29.4

--- a/go.sum
+++ b/go.sum
@@ -890,6 +890,8 @@ github.com/aws/aws-sdk-go-v2/service/kms v1.30.0 h1:yS0JkEdV6h9JOo8sy2JSpjX+i7vs
 github.com/aws/aws-sdk-go-v2/service/kms v1.30.0/go.mod h1:+I8VUUSVD4p5ISQtzpgSva4I8cJ4SQ4b1dcBcof7O+g=
 github.com/aws/aws-sdk-go-v2/service/rds v1.78.0 h1:EfurrcA19HaB9gZYd157DiozoPfkX2CH5/QnDZqNFrY=
 github.com/aws/aws-sdk-go-v2/service/rds v1.78.0/go.mod h1:Rw15qGaGWu3jO0dOz7JyvdOEjgae//YrJxVWLYGynvg=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.44.0 h1:j18lTPPqe+qlapn1R8//+ujvXdplku8V41xzBNNLtn0=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.44.0/go.mod h1:8ldsMsikORLj0GZUozSvbQdctrumAPYhizmj/3AAATI=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1 h1:6cnno47Me9bRykw9AEv9zkXE+5or7jz8TsskTTccbgc=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1/go.mod h1:qmdkIIAC+GCLASF7R2whgNrJADz0QZPX+Seiw/i4S3o=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.28.6 h1:TIOEjw0i2yyhmhRry3Oeu9YtiiHWISZ6j/irS1W3gX4=


### PR DESCRIPTION
This PR adds e2e tests for Redshift cluster auto discovery, IAM auth (as a db user and as an IAM role), and auto-user provisioning.