### PR TITLE
fix: Forbid SSO users from local logins or password changes

### DIFF
--- a/api/client/proto/authservice.pb.go
+++ b/api/client/proto/authservice.pb.go
@@ -15925,6 +15925,8 @@ type AuthServiceClient interface {
 	GetResetPasswordToken(ctx context.Context, in *GetResetPasswordTokenRequest, opts ...grpc.CallOption) (*types.UserTokenV3, error)
 	// CreateResetPasswordToken resets users current password and second factors and creates a reset
 	// password token.
+	//
+	// Only local users may be reset.
 	CreateResetPasswordToken(ctx context.Context, in *CreateResetPasswordTokenRequest, opts ...grpc.CallOption) (*types.UserTokenV3, error)
 	// GetUser gets a user resource by name.
 	//
@@ -15954,6 +15956,8 @@ type AuthServiceClient interface {
 	// Deprecated: Use [teleport.users.v1.UsersService] instead.
 	DeleteUser(ctx context.Context, in *DeleteUserRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// ChangePassword allows a user to change their own password.
+	//
+	// Only local users may change their password.
 	ChangePassword(ctx context.Context, in *ChangePasswordRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// AcquireSemaphore acquires lease with requested resources from semaphore.
 	AcquireSemaphore(ctx context.Context, in *types.AcquireSemaphoreRequest, opts ...grpc.CallOption) (*types.SemaphoreLease, error)
@@ -16354,6 +16358,8 @@ type AuthServiceClient interface {
 	// also adds a new MFA device. After successful invocation, a new web session is created as well
 	// as a new set of recovery codes (if user meets the requirements to receive them), invalidating
 	// any existing codes the user previously had.
+	//
+	// Only local users may be targeted by this RPC.
 	ChangeUserAuthentication(ctx context.Context, in *ChangeUserAuthenticationRequest, opts ...grpc.CallOption) (*ChangeUserAuthenticationResponse, error)
 	// StartAccountRecovery (exclusive to cloud users) is the first out of two step user
 	// verification needed to allow a user to recover their account. The first form of verification
@@ -16366,6 +16372,8 @@ type AuthServiceClient interface {
 	// user account gets temporarily locked from further recovery attempts and from logging in.
 	//
 	// Start tokens last RecoveryStartTokenTTL.
+	//
+	// Only local users may perform account recovery
 	StartAccountRecovery(ctx context.Context, in *StartAccountRecoveryRequest, opts ...grpc.CallOption) (*types.UserTokenV3, error)
 	// VerifyAccountRecovery (exclusive to cloud users) is the second step of the two step
 	// verification needed to allow a user to recover their account, after RPC StartAccountRecovery.
@@ -19290,6 +19298,8 @@ type AuthServiceServer interface {
 	GetResetPasswordToken(context.Context, *GetResetPasswordTokenRequest) (*types.UserTokenV3, error)
 	// CreateResetPasswordToken resets users current password and second factors and creates a reset
 	// password token.
+	//
+	// Only local users may be reset.
 	CreateResetPasswordToken(context.Context, *CreateResetPasswordTokenRequest) (*types.UserTokenV3, error)
 	// GetUser gets a user resource by name.
 	//
@@ -19319,6 +19329,8 @@ type AuthServiceServer interface {
 	// Deprecated: Use [teleport.users.v1.UsersService] instead.
 	DeleteUser(context.Context, *DeleteUserRequest) (*emptypb.Empty, error)
 	// ChangePassword allows a user to change their own password.
+	//
+	// Only local users may change their password.
 	ChangePassword(context.Context, *ChangePasswordRequest) (*emptypb.Empty, error)
 	// AcquireSemaphore acquires lease with requested resources from semaphore.
 	AcquireSemaphore(context.Context, *types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error)
@@ -19719,6 +19731,8 @@ type AuthServiceServer interface {
 	// also adds a new MFA device. After successful invocation, a new web session is created as well
 	// as a new set of recovery codes (if user meets the requirements to receive them), invalidating
 	// any existing codes the user previously had.
+	//
+	// Only local users may be targeted by this RPC.
 	ChangeUserAuthentication(context.Context, *ChangeUserAuthenticationRequest) (*ChangeUserAuthenticationResponse, error)
 	// StartAccountRecovery (exclusive to cloud users) is the first out of two step user
 	// verification needed to allow a user to recover their account. The first form of verification
@@ -19731,6 +19745,8 @@ type AuthServiceServer interface {
 	// user account gets temporarily locked from further recovery attempts and from logging in.
 	//
 	// Start tokens last RecoveryStartTokenTTL.
+	//
+	// Only local users may perform account recovery
 	StartAccountRecovery(context.Context, *StartAccountRecoveryRequest) (*types.UserTokenV3, error)
 	// VerifyAccountRecovery (exclusive to cloud users) is the second step of the two step
 	// verification needed to allow a user to recover their account, after RPC StartAccountRecovery.

--- a/api/proto/teleport/legacy/client/proto/authservice.proto
+++ b/api/proto/teleport/legacy/client/proto/authservice.proto
@@ -2676,6 +2676,8 @@ service AuthService {
   rpc GetResetPasswordToken(GetResetPasswordTokenRequest) returns (types.UserTokenV3);
   // CreateResetPasswordToken resets users current password and second factors and creates a reset
   // password token.
+  //
+  // Only local users may be reset.
   rpc CreateResetPasswordToken(CreateResetPasswordTokenRequest) returns (types.UserTokenV3);
 
   // GetUser gets a user resource by name.
@@ -2718,6 +2720,8 @@ service AuthService {
     option deprecated = true;
   }
   // ChangePassword allows a user to change their own password.
+  //
+  // Only local users may change their password.
   rpc ChangePassword(ChangePasswordRequest) returns (google.protobuf.Empty);
 
   // AcquireSemaphore acquires lease with requested resources from semaphore.
@@ -3187,6 +3191,8 @@ service AuthService {
   // also adds a new MFA device. After successful invocation, a new web session is created as well
   // as a new set of recovery codes (if user meets the requirements to receive them), invalidating
   // any existing codes the user previously had.
+  //
+  // Only local users may be targeted by this RPC.
   rpc ChangeUserAuthentication(ChangeUserAuthenticationRequest) returns (ChangeUserAuthenticationResponse);
 
   // StartAccountRecovery (exclusive to cloud users) is the first out of two step user
@@ -3200,6 +3206,8 @@ service AuthService {
   // user account gets temporarily locked from further recovery attempts and from logging in.
   //
   // Start tokens last RecoveryStartTokenTTL.
+  //
+  // Only local users may perform account recovery
   rpc StartAccountRecovery(StartAccountRecoveryRequest) returns (types.UserTokenV3);
   // VerifyAccountRecovery (exclusive to cloud users) is the second step of the two step
   // verification needed to allow a user to recover their account, after RPC StartAccountRecovery.

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -1114,6 +1114,10 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 	_, err = srv.Auth().UpsertAuthPreference(ctx, ap)
 	require.NoError(t, err)
 
+	const user = "llama@example.com"
+	_, _, err = CreateUserAndRole(srv.Auth(), user, []string{user}, nil /* allowRules */)
+	require.NoError(t, err, "CreateUserAndRole failed")
+
 	cases := []struct {
 		name       string
 		wantErr    bool
@@ -1123,7 +1127,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 			name:    "invalid token type",
 			wantErr: true,
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := srv.Auth().createRecoveryToken(ctx, "llama@example.com", UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := srv.Auth().createRecoveryToken(ctx, user, UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1155,7 +1159,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 		{
 			name: "recovery approved token",
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := srv.Auth().createRecoveryToken(ctx, "llama@example.com", UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := srv.Auth().createRecoveryToken(ctx, user, UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1166,7 +1170,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 		{
 			name: "privilege token",
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := srv.Auth().createPrivilegeToken(ctx, "llama@example.com", UserTokenTypePrivilege)
+				token, err := srv.Auth().createPrivilegeToken(ctx, user, UserTokenTypePrivilege)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1183,7 +1187,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 
 			switch {
 			case c.wantErr:
-				require.True(t, trace.IsAccessDenied(err))
+				require.True(t, trace.IsAccessDenied(err), "CreateAccountRecoveryCodes returned err=%v (%T), want AccessDenied", err, trace.Unwrap(err))
 
 			default:
 				require.NoError(t, err)

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/client/proto"
@@ -271,6 +272,12 @@ var (
 	// invalidUserpass2FError is the error for when either the provided username,
 	// password, or second factor is incorrect.
 	invalidUserPass2FError = trace.AccessDenied("invalid username, password or second factor")
+
+	// errSSOUserLocalAuth is issued for SSO users attempting local authentication
+	// or related actions (like trying to set a password)
+	// Kept purposefully vague, as such actions don't happen during normal
+	// utilization of the system.
+	errSSOUserLocalAuth = &trace.AccessDeniedError{Message: "invalid credentials"}
 )
 
 // IsInvalidLocalCredentialError checks if an error resulted from an incorrect username,
@@ -376,6 +383,22 @@ func (a *Server) authenticateUserInternal(
 				"passwordless authentication can only be used with the PASSWORDLESS scope")
 		}
 		return a.authenticatePasswordless(ctx, req)
+	}
+
+	// Disallow non-local users from local authentication.
+	// Passwordless does its own check, as the user is only known after the
+	// webauthn assertion is cleared.
+	switch u, err := a.GetUser(ctx, user, false /* withSecrets */); {
+	case trace.IsNotFound(err):
+		// Keep going if the user is not known.
+	case err != nil:
+		return nil, "", trace.Wrap(err)
+	case u.GetUserType() != types.UserTypeLocal:
+		log.WithFields(logrus.Fields{
+			"user":      user,
+			"user_type": u.GetUserType(),
+		}).Warn("Non-local user attempted local authentication")
+		return nil, "", trace.Wrap(errSSOUserLocalAuth)
 	}
 
 	// Try 2nd-factor-enabled authentication schemes first.

--- a/lib/auth/usertoken.go
+++ b/lib/auth/usertoken.go
@@ -148,10 +148,11 @@ func (a *Server) CreateResetPasswordToken(ctx context.Context, req CreateUserTok
 		return nil, trace.BadParameter("invalid reset password token request type")
 	}
 
-	// ResetPassword doesn't error for non-existent users, so first check if the
-	// user exists.
-	if _, err = a.GetUser(ctx, req.Name, false /* withSecrets */); err != nil {
+	switch user, err := a.GetUser(ctx, req.Name, false /* withSecrets */); {
+	case err != nil:
 		return nil, trace.Wrap(err)
+	case user.GetUserType() != types.UserTypeLocal:
+		return nil, trace.AccessDenied("only local users may be reset")
 	}
 
 	if err := a.ResetPassword(ctx, req.Name); err != nil {


### PR DESCRIPTION
Avoids possible scenarios where an SSO user gets a password for themselves and uses it to skip the actual SSO authentication.

Locking in local logins should be enough (AuthenticateSSHUser and AuthenticateWebUser), but I've gone the extra mile to forbid SSO users from having passwords or recovery codes as well.

It's worth noting that when I say "SSO user" I actually mean "non-local user".

Changelog: Forbid SSO users from local logins or password changes

https://github.com/gravitational/security-findings/issues/87