### PR TITLE
skip redshift serverless e2e test

### DIFF
--- a/e2e/aws/redshift_test.go
+++ b/e2e/aws/redshift_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 func testRedshiftServerless(t *testing.T) {
-	// skip until we fix the spacelift stack
-	t.Skip()
+	t.Skip("skipped until we fix the spacelift stack")
 	t.Parallel()
 	accessRole := mustGetEnv(t, rssAccessRoleEnv)
 	discoveryRole := mustGetEnv(t, rssDiscoveryRoleEnv)

--- a/e2e/aws/redshift_test.go
+++ b/e2e/aws/redshift_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func testRedshiftServerless(t *testing.T) {
+	// skip until we fix the spacelift stack
+	t.Skip()
 	t.Parallel()
 	accessRole := mustGetEnv(t, rssAccessRoleEnv)
 	discoveryRole := mustGetEnv(t, rssDiscoveryRoleEnv)


### PR DESCRIPTION
There was another problem with fully recreating our e2e test infra over the weekend. Currently the redshift serverless test is failing, this PR just skips that test until we fix it.