### PR TITLE
[v14] skip redshift serverless e2e test

### DIFF
--- a/e2e/aws/redshift_test.go
+++ b/e2e/aws/redshift_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 func testRedshiftServerless(t *testing.T) {
-	// skip until we fix the spacelift stack
-	t.Skip()
+	t.Skip("skipped until we fix the spacelift stack")
 	t.Parallel()
 	accessRole := mustGetEnv(t, rssAccessRoleEnv)
 	discoveryRole := mustGetEnv(t, rssDiscoveryRoleEnv)

--- a/e2e/aws/redshift_test.go
+++ b/e2e/aws/redshift_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func testRedshiftServerless(t *testing.T) {
+	// skip until we fix the spacelift stack
+	t.Skip()
 	t.Parallel()
 	accessRole := mustGetEnv(t, rssAccessRoleEnv)
 	discoveryRole := mustGetEnv(t, rssDiscoveryRoleEnv)


### PR DESCRIPTION
Backport #41206 to branch/v14