### PR TITLE
docs: correct spelling of pinging

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -305,7 +305,7 @@ const (
 	DataDirParameterName = "data_dir"
 
 	// KeepAliveReqType is a SSH request type to keep the connection alive. A client and
-	// a server keep pining each other with it.
+	// a server keep pinging each other with it.
 	KeepAliveReqType = "keepalive@openssh.com"
 
 	// ClusterDetailsReqType is the name of a global request which returns cluster details like


### PR DESCRIPTION
During a routine review of server logs, a peculiar message caught our attention.  The log entries indicated "Failed sending keepalive requests". 

As the team delved deeper into resolving the issue, a humorous observation emerged amidst the technical troubleshooting. While reading the comments in the code repo, the concept of servers "pining after each other" made all of us stop and think, "Well, they may not be 'pinging,' but they sure seem to be 'pining' for each other!"

This light-hearted moment provided a brief respite from the intensity of our high paced operational environment.

Ultimately, this pull request just points out that "pining" would be a good way of describing an ICMP timeout but, ultimately we don't believe that is the intention of comment. 
