### PR TITLE
[v14] web: ensure active sessions show up correctly

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2674,6 +2674,14 @@ func (set RoleSet) CanCopyFiles() bool {
 	return true
 }
 
+// CanJoinSessions returns true if at least one role in the role set
+// allows the user to join active sessions.
+func (set RoleSet) CanJoinSessions() bool {
+	return slices.ContainsFunc(set, func(r types.Role) bool {
+		return len(r.GetSessionJoinPolicies()) > 0
+	})
+}
+
 // CertificateFormat returns the most permissive certificate format in a
 // RoleSet.
 func (set RoleSet) CertificateFormat() string {

--- a/lib/services/useracl_test.go
+++ b/lib/services/useracl_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client/proto"
@@ -157,6 +158,35 @@ func TestNewUserACLCloud(t *testing.T) {
 	// cloud-specific asserts
 	require.Empty(t, cmp.Diff(userContext.Billing, allowedRW))
 	require.Empty(t, cmp.Diff(userContext.Desktops, allowedRW))
+}
+
+func TestJoinSessionsACL(t *testing.T) {
+	t.Parallel()
+
+	user := &types.UserV2{
+		Metadata: types.Metadata{},
+	}
+	// create a role denying list/read to all resources,
+	// but allowing the ability to join sessions
+	role := &types.RoleV6{}
+	role.SetRules(types.Deny, []types.Rule{
+		{
+			Resources: []string{"*"},
+			Verbs:     RO(),
+		},
+	})
+	role.SetSessionJoinPolicies([]*types.SessionJoinPolicy{
+		{
+			Name:  "join all",
+			Roles: []string{"*"},
+			Modes: []string{string(types.SessionObserverMode)},
+			Kinds: []string{string(types.SSHSessionKind), string(types.KubernetesSessionKind)},
+		},
+	})
+	roleSet := []types.Role{role}
+	acl := NewUserACL(user, roleSet, proto.Features{}, true, false)
+	assert.True(t, acl.ActiveSessions.List)
+	assert.True(t, acl.ActiveSessions.Read)
 }
 
 func TestNewAccessMonitoring(t *testing.T) {


### PR DESCRIPTION
Backport #41193 to branch/v14

changelog: ensure that the active sessions page shows up in the web UI for users with permissions to join sessions.
