### PR TITLE
docs: add local user password policy

### DIFF
--- a/docs/pages/reference/authentication.mdx
+++ b/docs/pages/reference/authentication.mdx
@@ -117,14 +117,13 @@ $ tctl create -f cap.yaml
 </TabItem>
 </Tabs>
 
-### Local user login failure rules
+### Local user policies
 
-A local user is blocked from attempting logins if, within a 30 minute window, a local user has multiple:
+Teleport requires that passwords for local users be at least 12 characters long.
 
-- failed login attempts or
-- failed password resets
-
-The block lasts 30 minutes. After the block has expired the user may attempt to log in again.
+Additionally, Teleport will lock local user accounts if there are multiple
+failed login attempts within a 30-minute window. The account will remain locked
+for 30 minutes before the user can attempt to log in again.
 
 Overriding a block is available to users with rights to maintain `user` resources,
 available in the built-in `editor` role. To turn off a block, update the user entry,


### PR DESCRIPTION
Also removes the outdated mention of locking accounts after failed password reset attempts. This functionality was removed in #35325 but the docs were not updated.

Closes #41135