### PR TITLE
Allow reincluding tests in the flaky test detector

### DIFF
--- a/build.assets/tooling/cmd/difftest/main.go
+++ b/build.assets/tooling/cmd/difftest/main.go
@@ -184,8 +184,10 @@ func test(repoPath string, ref string, changedFiles []string) {
 			bail(err)
 		}
 
+		skipAll := slices.Contains(testsToSkip, "*")
+
 		for _, n := range r.New {
-			if slices.Contains(testsToSkip, n.RefName) || slices.Contains(testsToSkip, "*") {
+			if (skipAll || slices.Contains(testsToSkip, n.RefName)) && !slices.Contains(testsToSkip, "!"+n.RefName) {
 				log.Printf("-skipping %q (%s)\n", n.RefName, dir)
 				continue
 			}
@@ -198,7 +200,7 @@ func test(repoPath string, ref string, changedFiles []string) {
 		}
 
 		for _, n := range r.Changed {
-			if slices.Contains(testsToSkip, n.RefName) || slices.Contains(testsToSkip, "*") {
+			if (skipAll || slices.Contains(testsToSkip, n.RefName)) && !slices.Contains(testsToSkip, "!"+n.RefName) {
 				log.Printf("-skipping %q (%s)\n", n.RefName, dir)
 				continue
 			}


### PR DESCRIPTION
This PR makes it possible to mark a test as not excluded by the flaky test detector by commenting `/excludeflake !TestFoo`; this allows running only specific tests in the flaky test detector by doing `/excludeflake * !TestFoo`.