### PR TITLE
Reject unsupported clients by default

### DIFF
--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -28,6 +28,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
@@ -671,26 +673,27 @@ func (f fakeConn) Close() error {
 func TestValidateClientVersion(t *testing.T) {
 	cases := []struct {
 		name          string
-		middleware    Middleware
+		middleware    *Middleware
 		clientVersion string
 		errAssertion  func(t *testing.T, err error)
 	}{
 		{
-			name: "rejection disabled",
+			name:       "rejection disabled",
+			middleware: &Middleware{},
 			errAssertion: func(t *testing.T, err error) {
 				require.NoError(t, err)
 			},
 		},
 		{
 			name:       "rejection enabled and client version not specified",
-			middleware: Middleware{OldestSupportedVersion: &teleport.MinClientSemVersion},
+			middleware: &Middleware{OldestSupportedVersion: &teleport.MinClientSemVersion},
 			errAssertion: func(t *testing.T, err error) {
 				require.NoError(t, err)
 			},
 		},
 		{
 			name:          "client rejected",
-			middleware:    Middleware{OldestSupportedVersion: &teleport.MinClientSemVersion},
+			middleware:    &Middleware{OldestSupportedVersion: &teleport.MinClientSemVersion},
 			clientVersion: semver.Version{Major: teleport.SemVersion.Major - 2}.String(),
 			errAssertion: func(t *testing.T, err error) {
 				require.True(t, trace.IsAccessDenied(err), "got %T, expected access denied error", err)
@@ -698,7 +701,7 @@ func TestValidateClientVersion(t *testing.T) {
 		},
 		{
 			name:          "valid client v-1",
-			middleware:    Middleware{OldestSupportedVersion: &teleport.MinClientSemVersion},
+			middleware:    &Middleware{OldestSupportedVersion: &teleport.MinClientSemVersion},
 			clientVersion: semver.Version{Major: teleport.SemVersion.Major - 1}.String(),
 			errAssertion: func(t *testing.T, err error) {
 				require.NoError(t, err)
@@ -706,7 +709,7 @@ func TestValidateClientVersion(t *testing.T) {
 		},
 		{
 			name:          "valid client v-0",
-			middleware:    Middleware{OldestSupportedVersion: &teleport.MinClientSemVersion},
+			middleware:    &Middleware{OldestSupportedVersion: &teleport.MinClientSemVersion},
 			clientVersion: semver.Version{Major: teleport.SemVersion.Major}.String(),
 			errAssertion: func(t *testing.T, err error) {
 				require.NoError(t, err)
@@ -714,7 +717,7 @@ func TestValidateClientVersion(t *testing.T) {
 		},
 		{
 			name:          "invalid client version",
-			middleware:    Middleware{OldestSupportedVersion: &teleport.MinClientSemVersion},
+			middleware:    &Middleware{OldestSupportedVersion: &teleport.MinClientSemVersion},
 			clientVersion: "abc123",
 			errAssertion: func(t *testing.T, err error) {
 				require.True(t, trace.IsAccessDenied(err), "got %T, expected access denied error", err)
@@ -731,5 +734,59 @@ func TestValidateClientVersion(t *testing.T) {
 
 			tt.errAssertion(t, tt.middleware.ValidateClientVersion(ctx, IdentityInfo{Conn: fakeConn{}, IdentityGetter: TestBuiltin(types.RoleNode).I}))
 		})
+	}
+}
+
+func TestRejectedClientClusterAlert(t *testing.T) {
+	var alerts []types.ClusterAlert
+	mw := Middleware{
+		OldestSupportedVersion: &teleport.MinClientSemVersion,
+		AlertCreator: func(ctx context.Context, a types.ClusterAlert) error {
+			alerts = append(alerts, a)
+			return nil
+		},
+	}
+
+	// Validate an unsupported client, which should trigger an alert
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+		"version": semver.Version{Major: teleport.SemVersion.Major - 20}.String(),
+	}))
+	err := mw.ValidateClientVersion(ctx, IdentityInfo{Conn: fakeConn{}, IdentityGetter: TestBuiltin(types.RoleNode).I})
+	assert.Error(t, err)
+
+	// Validate a client with an unknown version, which should trigger an alert, however,
+	// due to rate limiting of 1 alert per 24h no alert should be created.
+	ctx = metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+		"version": "abcd",
+	}))
+	err = mw.ValidateClientVersion(ctx, IdentityInfo{Conn: fakeConn{}, IdentityGetter: TestBuiltin(types.RoleNode).I})
+	assert.Error(t, err)
+
+	// Assert that only a single alert was created based on the above rejections.
+	require.Len(t, alerts, 1)
+	require.Equal(t, "rejected-unsupported-connection", alerts[0].GetName())
+
+	// Reset the last alert time to a time beyond the rate limit, allowing the next
+	// rejection to trigger another alert.
+	mw.lastRejectedAlertTime.Store(time.Now().Add(-25 * time.Hour).UnixNano())
+
+	// Validate two unsupported clients in parallel to verify that concurrent attempts
+	// to create an alert are prevented.
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := mw.ValidateClientVersion(ctx, IdentityInfo{Conn: fakeConn{}, IdentityGetter: TestBuiltin(types.RoleNode).I})
+			assert.Error(t, err)
+		}()
+	}
+
+	wg.Wait()
+
+	// Assert that only a single additional alert was created.
+	require.Len(t, alerts, 2)
+	for _, alert := range alerts {
+		assert.Equal(t, "rejected-unsupported-connection", alert.GetName())
 	}
 }


### PR DESCRIPTION
#38026 made rejecting client running unusupported major versions an opt-in behavior. Moving forward(v16 and beyond) this is now going to be an opt-out behavior(TELEPORT_UNSTABLE_ALLOW_OLD_CLIENTS=yes). In addition, a cluster alert is now being emitted once for the life of an Auth process if it rejects an unsupported client - with visibility limited to users with token:create permissions.