### PR TITLE
[v15] Ignores resizes when a desktop has `screen_size` set

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -239,7 +239,7 @@ func (c *Client) readClientSize() error {
 			continue
 		}
 
-		if c.cfg.Width != 0 && c.cfg.Height != 0 {
+		if c.cfg.hasSizeOverride() {
 			// Some desktops have a screen size in their resource definition.
 			// If non-zero then we always request this screen size.
 			c.cfg.Log.Debugf("Forcing a screen size of %dx%d", c.cfg.Width, c.cfg.Height)
@@ -394,6 +394,12 @@ func (c *Client) startInputStreaming(stopCh chan struct{}) error {
 
 		switch m := msg.(type) {
 		case tdp.ClientScreenSpec:
+			// If the client has specified a fixed screen size, we don't
+			// need to send a screen resize event.
+			if c.cfg.hasSizeOverride() {
+				continue
+			}
+
 			c.cfg.Log.Debugf("Client changed screen size: %d x %d", m.Width, m.Height)
 			if errCode := C.client_write_screen_resize(
 				C.ulong(c.handle),

--- a/lib/srv/desktop/rdp/rdpclient/client_common.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_common.go
@@ -94,3 +94,10 @@ func (c *Config) checkAndSetDefaults() error {
 	c.Log = c.Log.WithField("rdp-addr", c.Addr)
 	return nil
 }
+
+// hasSizeOverride returns true if the width and height have been set.
+// This will be true when a user has specified a fixed `screen_size` for
+// a given desktop.
+func (c *Config) hasSizeOverride() bool { //nolint:unused // used in client.go that is behind desktop_access_rdp build flag
+	return c.Width != 0 && c.Height != 0
+}

--- a/web/packages/teleport/src/DesktopSession/useTdpClientCanvas.tsx
+++ b/web/packages/teleport/src/DesktopSession/useTdpClientCanvas.tsx
@@ -126,7 +126,6 @@ export default function useTdpClientCanvas(props: Props) {
   ) => {
     // The first image fragment we see signals a successful TDP connection.
     if (!initialTdpConnectionSucceeded.current) {
-      syncCanvas(ctx.canvas, getDisplaySize());
       setTdpConnection({ status: 'success' });
       initialTdpConnectionSucceeded.current = true;
     }


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/41198 to branch/v15

changelog: Fixed `screen_size` behavior for Windows Desktops, which was being overridden by the new resize feature.