### PR TITLE
Hide a couple of sensitive auth.Server methods

### DIFF
--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -116,9 +116,10 @@ type SessionCreds struct {
 	ID string `json:"id"`
 }
 
-// AuthenticateUser authenticates user based on the request type.
-// Returns the username of the authenticated user.
-func (a *Server) AuthenticateUser(ctx context.Context, req AuthenticateUserRequest) (services.UserState, services.AccessChecker, error) {
+// authenticateUserLogin implements the bulk of user login authentication.
+// Used by the top-level local login methods, [Server.AuthenticateSSHUser] and
+// [Server.AuthenticateWebUser]
+func (a *Server) authenticateUserLogin(ctx context.Context, req AuthenticateUserRequest) (services.UserState, services.AccessChecker, error) {
 	username := req.Username
 
 	requiredExt := mfav1.ChallengeExtensions{
@@ -668,7 +669,7 @@ func (a *Server) AuthenticateWebUser(ctx context.Context, req AuthenticateUserRe
 		return session, nil
 	}
 
-	user, _, err := a.AuthenticateUser(ctx, req)
+	user, _, err := a.authenticateUserLogin(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -825,7 +826,7 @@ func (a *Server) AuthenticateSSHUser(ctx context.Context, req AuthenticateSSHReq
 
 	// It's safe to extract the roles and traits directly from services.User as
 	// this endpoint is only used for local accounts.
-	user, checker, err := a.AuthenticateUser(ctx, req.AuthenticateUserRequest)
+	user, checker, err := a.authenticateUserLogin(ctx, req.AuthenticateUserRequest)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/methods_test.go
+++ b/lib/auth/methods_test.go
@@ -38,7 +38,7 @@ func TestServerAuthenticateUserUserAgentTrim(t *testing.T) {
 		},
 	}
 	// Ignoring the error here because we really just care that the event was logged.
-	(&Server{emitter: emitter}).AuthenticateUser(ctx, r)
+	(&Server{emitter: emitter}).authenticateUserLogin(ctx, r)
 	event := emitter.LastEvent()
 	loginEvent, ok := event.(*apievents.UserLogin)
 	require.True(t, ok)

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -100,10 +100,11 @@ func (a *Server) ChangeUserAuthentication(ctx context.Context, req *proto.Change
 	}, nil
 }
 
-// ResetPassword deletes the user's password. This method is used to invalidate
-// existing user password during password reset process. This function doesn't
-// fail if the user doesn't have a password or the user doesn't exist at all.
-func (a *Server) ResetPassword(ctx context.Context, username string) error {
+// resetPassword deletes the user's password. Used to invalidate existing user
+// password during password reset process.
+//
+// It does not fail if the user doesn't exist or doesn't have a password.
+func (a *Server) resetPassword(ctx context.Context, username string) error {
 	if err := a.DeletePassword(ctx, username); err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -859,7 +859,7 @@ func TestResetPassword(t *testing.T) {
 
 	// Reset password.
 	ctx := context.Background()
-	err = s.a.ResetPassword(ctx, "dave")
+	err = s.a.resetPassword(ctx, "dave")
 	require.NoError(t, err)
 
 	// Make sure that the password has been reset.
@@ -870,7 +870,7 @@ func TestResetPassword(t *testing.T) {
 
 	// Make sure that we can reset once again (i.e. we don't complain if there's
 	// no password).
-	err = s.a.ResetPassword(ctx, "dave")
+	err = s.a.resetPassword(ctx, "dave")
 	require.NoError(t, err)
 }
 

--- a/lib/auth/usertoken.go
+++ b/lib/auth/usertoken.go
@@ -154,7 +154,7 @@ func (a *Server) CreateResetPasswordToken(ctx context.Context, req CreateUserTok
 		return nil, trace.Wrap(err)
 	}
 
-	if err := a.ResetPassword(ctx, req.Name); err != nil {
+	if err := a.resetPassword(ctx, req.Name); err != nil {
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Make the AuthenticateUser and ResetPassword methods private. Arguably most of auth.Server should be private, but these are middle-of-the-chain methods that should not be getting (non-specialized) callers.