### PR TITLE
Lower dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
       day: "sunday"
       time: "09:00" # 9am UTC
     ignore:
@@ -42,7 +42,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/api"
     schedule:
-      interval: weekly
+      interval: monthly
       day: "sunday"
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 20
@@ -64,7 +64,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/assets/aws"
     schedule:
-      interval: weekly
+      interval: monthly
       day: "sunday"
       time: "09:00" # 9am UTC
     ignore:
@@ -89,7 +89,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/assets/backport"
     schedule:
-      interval: weekly
+      interval: monthly
       day: "sunday"
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 20
@@ -110,7 +110,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/build.assets/tooling"
     schedule:
-      interval: weekly
+      interval: monthly
       day: "sunday"
       time: "09:00" # 9am UTC
     ignore:
@@ -135,7 +135,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/integrations/terraform"
     schedule:
-      interval: weekly
+      interval: monthly
       day: "sunday"
       time: "09:00" # 9am UTC
     ignore:
@@ -163,7 +163,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/integrations/event-handler"
     schedule:
-      interval: weekly
+      interval: monthly
       day: "sunday"
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 20
@@ -187,7 +187,7 @@ updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
       day: "sunday"
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 20
@@ -209,7 +209,7 @@ updates:
   - package-ecosystem: cargo
     directory: "/lib/srv/desktop/rdp/rdpclient"
     schedule:
-      interval: weekly
+      interval: monthly
       day: "sunday"
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 20
@@ -231,7 +231,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/.github/workflows"
     schedule:
-      interval: weekly
+      interval: monthly
       day: monday
       time: "09:00"
       timezone: "America/Los_Angeles"
@@ -246,7 +246,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/.github/actions"
     schedule:
-      interval: weekly
+      interval: monthly
       day: monday
       time: "09:00"
       timezone: "America/Los_Angeles"


### PR DESCRIPTION
Monthly is the most we can do after weekly.

* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval