### PR TITLE
Automatically import GCP labels

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1017,6 +1017,7 @@ const (
 	InstanceMetadataTypeDisabled InstanceMetadataType = "disabled"
 	InstanceMetadataTypeEC2      InstanceMetadataType = "EC2"
 	InstanceMetadataTypeAzure    InstanceMetadataType = "Azure"
+	InstanceMetadataTypeGCP      InstanceMetadataType = "GCP"
 )
 
 // OriginValues lists all possible origin values.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	cloud.google.com/go/firestore v1.15.0
 	cloud.google.com/go/iam v1.1.8
 	cloud.google.com/go/kms v1.15.9
+	cloud.google.com/go/resourcemanager v1.9.7
 	cloud.google.com/go/spanner v1.60.0
 	cloud.google.com/go/storage v1.40.0
 	connectrpc.com/connect v1.16.1

--- a/go.sum
+++ b/go.sum
@@ -472,6 +472,8 @@ cloud.google.com/go/resourcemanager v1.4.0/go.mod h1:MwxuzkumyTX7/a3n37gmsT3py7L
 cloud.google.com/go/resourcemanager v1.5.0/go.mod h1:eQoXNAiAvCf5PXxWxXjhKQoTMaUSNrEfg+6qdf/wots=
 cloud.google.com/go/resourcemanager v1.6.0/go.mod h1:YcpXGRs8fDzcUl1Xw8uOVmI8JEadvhRIkoXXUNVYcVo=
 cloud.google.com/go/resourcemanager v1.7.0/go.mod h1:HlD3m6+bwhzj9XCouqmeiGuni95NTrExfhoSrkC/3EI=
+cloud.google.com/go/resourcemanager v1.9.7 h1:SdvD0PaPX60+yeKoSe16mawFpM0EPuiPPihTIVlhRsY=
+cloud.google.com/go/resourcemanager v1.9.7/go.mod h1:cQH6lJwESufxEu6KepsoNAsjrUtYYNXRwxm4QFE5g8A=
 cloud.google.com/go/resourcesettings v1.3.0/go.mod h1:lzew8VfESA5DQ8gdlHwMrqZs1S9V87v3oCnKCWoOuQU=
 cloud.google.com/go/resourcesettings v1.4.0/go.mod h1:ldiH9IJpcrlC3VSuCGvjR5of/ezRrOxFtpJoJo5SmXg=
 cloud.google.com/go/resourcesettings v1.5.0/go.mod h1:+xJF7QSG6undsQDfsCJyqWXyBwUoJLhetkRMDRnIoXA=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -24,6 +24,7 @@ require (
 )
 
 require (
+	cloud.google.com/go v0.112.2 // indirect
 	cloud.google.com/go/auth v0.3.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.2 // indirect
 	cloud.google.com/go/compute v1.26.0 // indirect
@@ -31,6 +32,8 @@ require (
 	cloud.google.com/go/container v1.35.1 // indirect
 	cloud.google.com/go/iam v1.1.8 // indirect
 	cloud.google.com/go/kms v1.15.9 // indirect
+	cloud.google.com/go/longrunning v0.5.6 // indirect
+	cloud.google.com/go/resourcemanager v1.9.7 // indirect
 	connectrpc.com/connect v1.16.1 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -357,6 +357,8 @@ cloud.google.com/go/logging v1.7.0/go.mod h1:3xjP2CjkM3ZkO73aj4ASA5wRPGGCRrPIAeN
 cloud.google.com/go/longrunning v0.1.1/go.mod h1:UUFxuDWkv22EuY93jjmDMFT5GPQKeFVJBIF6QlTqdsE=
 cloud.google.com/go/longrunning v0.3.0/go.mod h1:qth9Y41RRSUE69rDcOn6DdK3HfQfsUI0YSmW3iIlLJc=
 cloud.google.com/go/longrunning v0.4.1/go.mod h1:4iWDqhBZ70CvZ6BfETbvam3T8FMvLK+eFj0E6AaRQTo=
+cloud.google.com/go/longrunning v0.5.6 h1:xAe8+0YaWoCKr9t1+aWe+OeQgN/iJK1fEgZSXmjuEaE=
+cloud.google.com/go/longrunning v0.5.6/go.mod h1:vUaDrWYOMKRuhiv6JBnn49YxCPz2Ayn9GqyjaBT8/mA=
 cloud.google.com/go/managedidentities v1.3.0/go.mod h1:UzlW3cBOiPrzucO5qWkNkh0w33KFtBJU281hacNvsdE=
 cloud.google.com/go/managedidentities v1.4.0/go.mod h1:NWSBYbEMgqmbZsLIyKvxrYbtqOsxY1ZrGM+9RgDqInM=
 cloud.google.com/go/managedidentities v1.5.0/go.mod h1:+dWcZ0JlUmpuxpIDfyP5pP5y0bLdRwOS4Lp7gMni/LA=
@@ -466,6 +468,8 @@ cloud.google.com/go/resourcemanager v1.4.0/go.mod h1:MwxuzkumyTX7/a3n37gmsT3py7L
 cloud.google.com/go/resourcemanager v1.5.0/go.mod h1:eQoXNAiAvCf5PXxWxXjhKQoTMaUSNrEfg+6qdf/wots=
 cloud.google.com/go/resourcemanager v1.6.0/go.mod h1:YcpXGRs8fDzcUl1Xw8uOVmI8JEadvhRIkoXXUNVYcVo=
 cloud.google.com/go/resourcemanager v1.7.0/go.mod h1:HlD3m6+bwhzj9XCouqmeiGuni95NTrExfhoSrkC/3EI=
+cloud.google.com/go/resourcemanager v1.9.7 h1:SdvD0PaPX60+yeKoSe16mawFpM0EPuiPPihTIVlhRsY=
+cloud.google.com/go/resourcemanager v1.9.7/go.mod h1:cQH6lJwESufxEu6KepsoNAsjrUtYYNXRwxm4QFE5g8A=
 cloud.google.com/go/resourcesettings v1.3.0/go.mod h1:lzew8VfESA5DQ8gdlHwMrqZs1S9V87v3oCnKCWoOuQU=
 cloud.google.com/go/resourcesettings v1.4.0/go.mod h1:ldiH9IJpcrlC3VSuCGvjR5of/ezRrOxFtpJoJo5SmXg=
 cloud.google.com/go/resourcesettings v1.5.0/go.mod h1:+xJF7QSG6undsQDfsCJyqWXyBwUoJLhetkRMDRnIoXA=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -33,6 +33,7 @@ require (
 	cloud.google.com/go/iam v1.1.8 // indirect
 	cloud.google.com/go/kms v1.15.9 // indirect
 	cloud.google.com/go/longrunning v0.5.6 // indirect
+	cloud.google.com/go/resourcemanager v1.9.7 // indirect
 	cloud.google.com/go/spanner v1.60.0 // indirect
 	cloud.google.com/go/storage v1.40.0 // indirect
 	connectrpc.com/connect v1.16.1 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -473,6 +473,8 @@ cloud.google.com/go/resourcemanager v1.4.0/go.mod h1:MwxuzkumyTX7/a3n37gmsT3py7L
 cloud.google.com/go/resourcemanager v1.5.0/go.mod h1:eQoXNAiAvCf5PXxWxXjhKQoTMaUSNrEfg+6qdf/wots=
 cloud.google.com/go/resourcemanager v1.6.0/go.mod h1:YcpXGRs8fDzcUl1Xw8uOVmI8JEadvhRIkoXXUNVYcVo=
 cloud.google.com/go/resourcemanager v1.7.0/go.mod h1:HlD3m6+bwhzj9XCouqmeiGuni95NTrExfhoSrkC/3EI=
+cloud.google.com/go/resourcemanager v1.9.7 h1:SdvD0PaPX60+yeKoSe16mawFpM0EPuiPPihTIVlhRsY=
+cloud.google.com/go/resourcemanager v1.9.7/go.mod h1:cQH6lJwESufxEu6KepsoNAsjrUtYYNXRwxm4QFE5g8A=
 cloud.google.com/go/resourcesettings v1.3.0/go.mod h1:lzew8VfESA5DQ8gdlHwMrqZs1S9V87v3oCnKCWoOuQU=
 cloud.google.com/go/resourcesettings v1.4.0/go.mod h1:ldiH9IJpcrlC3VSuCGvjR5of/ezRrOxFtpJoJo5SmXg=
 cloud.google.com/go/resourcesettings v1.5.0/go.mod h1:+xJF7QSG6undsQDfsCJyqWXyBwUoJLhetkRMDRnIoXA=

--- a/lib/cloud/gcp/vm.go
+++ b/lib/cloud/gcp/vm.go
@@ -32,11 +32,14 @@ import (
 
 	compute "cloud.google.com/go/compute/apiv1"
 	"cloud.google.com/go/compute/apiv1/computepb"
+	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
+	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
@@ -75,6 +78,10 @@ type InstancesClient interface {
 	AddSSHKey(ctx context.Context, req *SSHKeyRequest) error
 	// RemoveSSHKey removes an SSH key from a GCP VM's metadata.
 	RemoveSSHKey(ctx context.Context, req *SSHKeyRequest) error
+	// GetInstanceTags gets the GCP tags associated with an instance (which are
+	// distinct from its labels). It is separate from GetInstance because fetching
+	// tags requires its own permissions.
+	GetInstanceTags(ctx context.Context, req *InstanceRequest) (map[string]string, error)
 }
 
 // InstancesClientConfig is the client configuration for InstancesClient.
@@ -233,9 +240,9 @@ func (clt *instancesClient) StreamInstances(ctx context.Context, projectID, zone
 		getInstances = func() ([]*Instance, error) {
 			resp, err := it.Next()
 			if resp == nil {
-				return nil, trace.Wrap(err)
+				return nil, trace.Wrap(convertAPIError(err))
 			}
-			return []*Instance{toInstance(resp, projectID)}, trace.Wrap(err)
+			return []*Instance{toInstance(resp, projectID)}, trace.Wrap(convertAPIError(err))
 		}
 	}
 
@@ -256,6 +263,11 @@ type InstanceRequest struct {
 	Zone string
 	// Name is the instance's name.
 	Name string
+	// ID is the instance's ID.
+	ID uint64
+	// WithoutHostKeys indicates that the client should not request the instance's
+	// host keys.
+	WithoutHostKeys bool
 }
 
 func (req *InstanceRequest) CheckAndSetDefaults() error {
@@ -312,13 +324,54 @@ func (clt *instancesClient) GetInstance(ctx context.Context, req *InstanceReques
 	inst := toInstance(resp, req.ProjectID)
 	inst.ProjectID = req.ProjectID
 
-	hostKeys, err := clt.getHostKeys(ctx, req)
-	if err == nil {
-		inst.hostKeys = hostKeys
-	} else if !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
+	if !req.WithoutHostKeys {
+		hostKeys, err := clt.getHostKeys(ctx, req)
+		if err == nil {
+			inst.hostKeys = hostKeys
+		} else if !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return inst, nil
+}
+
+func (clt *instancesClient) getTagBindingsClient(ctx context.Context, zone string) (*resourcemanager.TagBindingsClient, error) {
+	var opts []option.ClientOption
+	if zone != "" {
+		endpoint := zone + "-cloudresourcemanager.googleapis.com:443"
+		opts = append(opts, option.WithEndpoint(endpoint))
+	}
+	return resourcemanager.NewTagBindingsClient(ctx, opts...)
+}
+
+// GetInstanceTags gets the GCP tags for the instance.
+func (clt *instancesClient) GetInstanceTags(ctx context.Context, req *InstanceRequest) (map[string]string, error) {
+	tagClient, err := clt.getTagBindingsClient(ctx, req.Zone)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	it := tagClient.ListEffectiveTags(ctx, &resourcemanagerpb.ListEffectiveTagsRequest{
+		Parent: fmt.Sprintf(
+			"//compute.googleapis.com/projects/%s/zones/%s/instances/%d",
+			req.ProjectID, req.Zone, req.ID,
+		),
+	})
+
+	tags := make(map[string]string)
+	for {
+		resp, err := it.Next()
+		if err != nil {
+			if errors.Is(err, iterator.Done) {
+				return tags, nil
+			}
+			return nil, trace.Wrap(convertAPIError(err))
+		}
+		// Tag value is in the form <project-name>/<key>/<value>
+		fields := strings.Split(resp.GetNamespacedTagValue(), "/")
+		k := fields[len(fields)-2]
+		v := fields[len(fields)-1]
+		tags[k] = v
+	}
 }
 
 // SSHKeyRequest contains parameters to add/removed SSH keys from an instance.

--- a/lib/cloud/gcp/vm_test.go
+++ b/lib/cloud/gcp/vm_test.go
@@ -122,6 +122,10 @@ func (m *mockInstance) GetInstance(ctx context.Context, req *InstanceRequest) (*
 	return m.instance, nil
 }
 
+func (m *mockInstance) GetInstanceTags(ctx context.Context, req *InstanceRequest) (map[string]string, error) {
+	return nil, nil
+}
+
 func (m *mockInstance) AddSSHKey(ctx context.Context, req *SSHKeyRequest) error {
 	m.authorizedKey = req.PublicKey
 	return nil

--- a/lib/cloud/imds/gcp/imds.go
+++ b/lib/cloud/imds/gcp/imds.go
@@ -22,14 +22,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
+	"sync"
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/gcp"
 	"github.com/gravitational/teleport/lib/defaults"
 )
+
+const gcpHostnameTag = "label/" + types.CloudHostnameTag
 
 // contextRoundTripper is a http.RoundTripper that adds a context.Context to
 // requests.
@@ -41,6 +49,149 @@ type contextRoundTripper struct {
 func (rt contextRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := rt.transport.RoundTrip(req.WithContext(rt.ctx))
 	return resp, trace.Wrap(err)
+}
+
+type metadataGetter func(ctx context.Context, path string) (string, error)
+
+// InstanceMetadataClient is a client for GCP instance metadata.
+type InstanceMetadataClient struct {
+	instancesClient gcp.InstancesClient
+	getMetadata     metadataGetter
+
+	labelPermissionErrorOnce sync.Once
+	tagPermissionErrorOnce   sync.Once
+}
+
+// NewInstanceMetadataClient creates a new instance metadata client.
+func NewInstanceMetadataClient(ctx context.Context) (*InstanceMetadataClient, error) {
+	instancesClient, err := gcp.NewInstancesClient(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &InstanceMetadataClient{
+		instancesClient: instancesClient,
+		getMetadata:     getMetadata,
+	}, nil
+}
+
+// IsAvailable checks if instance metadata is available.
+func (client *InstanceMetadataClient) IsAvailable(ctx context.Context) bool {
+	instanceData, err := client.getMetadata(ctx, "instance")
+	return err == nil && instanceData != ""
+}
+
+// GetTags gets all of the GCP instance's labels (note: these are separate from
+// its tags, which we do not use).
+func (client *InstanceMetadataClient) GetTags(ctx context.Context) (map[string]string, error) {
+	// Get a bunch of info from instance metadata.
+	projectID, err := client.GetProjectID(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	zone, err := client.GetZone(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	name, err := client.GetName(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	idStr, err := client.GetID(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	id, err := strconv.ParseUint(idStr, 10, 64)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	req := &gcp.InstanceRequest{
+		ProjectID:       projectID,
+		Zone:            zone,
+		Name:            name,
+		ID:              id,
+		WithoutHostKeys: true,
+	}
+	// Get labels.
+	var gcpLabels map[string]string
+	inst, err := client.instancesClient.GetInstance(ctx, req)
+	if err == nil {
+		gcpLabels = inst.Labels
+	} else if trace.IsAccessDenied(err) {
+		client.labelPermissionErrorOnce.Do(func() {
+			slog.WarnContext(ctx, "Access denied to instance labels, does the instance have compute.instances.get permission?", "error", err)
+		})
+	} else {
+		return nil, trace.Wrap(err)
+	}
+
+	// Get tags.
+	gcpTags, err := client.instancesClient.GetInstanceTags(ctx, req)
+	if trace.IsAccessDenied(err) {
+		client.tagPermissionErrorOnce.Do(func() {
+			slog.WarnContext(ctx, "Access denied to resource management tags, does the instance have compute.instances.listEffectiveTags permission?", "error", err)
+		})
+	} else if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tags := make(map[string]string, len(gcpLabels)+len(gcpTags))
+	for k, v := range gcpLabels {
+		tags["label/"+k] = v
+	}
+	for k, v := range gcpTags {
+		tags["tag/"+k] = v
+	}
+
+	return tags, nil
+}
+
+// GetHostname gets the hostname set by the cloud instance that Teleport
+// should use, if any.
+func (client *InstanceMetadataClient) GetHostname(ctx context.Context) (string, error) {
+	tags, err := client.GetTags(ctx)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	value, ok := tags[gcpHostnameTag]
+	if !ok {
+		return "", trace.NotFound("label %q not found", gcpHostnameTag)
+	}
+	return value, nil
+}
+
+// GetType gets the cloud instance type.
+func (client *InstanceMetadataClient) GetType() types.InstanceMetadataType {
+	return types.InstanceMetadataTypeGCP
+}
+
+// GetID gets the ID of the cloud instance.
+func (client *InstanceMetadataClient) GetID(ctx context.Context) (string, error) {
+	id, err := client.getMetadata(ctx, "instance/id")
+	return id, trace.Wrap(err)
+}
+
+// GetProjectID gets the instance's project ID.
+func (client *InstanceMetadataClient) GetProjectID(ctx context.Context) (string, error) {
+	projectID, err := client.getMetadata(ctx, "project/project-id")
+	return projectID, trace.Wrap(err)
+}
+
+// GetZone gets the instance's zone.
+func (client *InstanceMetadataClient) GetZone(ctx context.Context) (string, error) {
+	fullZone, err := client.getMetadata(ctx, "instance/zone")
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	// zone is formatted as "projects/<project number>/zones/<zone>", we just need the last part
+	zoneParts := strings.Split(fullZone, "/")
+	return zoneParts[len(zoneParts)-1], nil
+}
+
+// GetName gets the instance's name.
+func (client *InstanceMetadataClient) GetName(ctx context.Context) (string, error) {
+	name, err := client.getMetadata(ctx, "instance/name")
+	return name, trace.Wrap(err)
 }
 
 // getMetadataClient gets an instance metadata client that will use the

--- a/lib/cloud/imds/gcp/imds_test.go
+++ b/lib/cloud/imds/gcp/imds_test.go
@@ -1,0 +1,179 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package gcp
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/cloud/gcp"
+)
+
+func makeMetadataGetter(values map[string]string) metadataGetter {
+	return func(ctx context.Context, path string) (string, error) {
+		value, ok := values[path]
+		if ok {
+			return value, nil
+		}
+		return "", trace.NotFound("no value for %v", path)
+	}
+}
+
+type mockInstanceGetter struct {
+	gcp.InstancesClient
+	instance    *gcp.Instance
+	instanceErr error
+	tags        map[string]string
+	tagsErr     error
+}
+
+func (m *mockInstanceGetter) GetInstance(ctx context.Context, req *gcp.InstanceRequest) (*gcp.Instance, error) {
+	return m.instance, m.instanceErr
+}
+
+func (m *mockInstanceGetter) GetInstanceTags(ctx context.Context, req *gcp.InstanceRequest) (map[string]string, error) {
+	return m.tags, m.tagsErr
+}
+
+func TestIsInstanceMetadataAvailable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not available", func(t *testing.T) {
+		client := &InstanceMetadataClient{
+			getMetadata: func(ctx context.Context, path string) (string, error) {
+				return "", trace.NotFound("")
+			},
+		}
+		require.False(t, client.IsAvailable(context.Background()))
+	})
+
+	t.Run("on gcp", func(t *testing.T) {
+		if os.Getenv("TELEPORT_TEST_GCP") == "" {
+			t.Skip("not on gcp")
+		}
+		client, err := NewInstanceMetadataClient(context.Background())
+		require.NoError(t, err)
+		require.True(t, client.IsAvailable(context.Background()))
+	})
+}
+
+func TestGetTags(t *testing.T) {
+	t.Parallel()
+
+	defaultMetadataGetter := makeMetadataGetter(map[string]string{
+		"project/project-id": "myproject",
+		"instance/zone":      "myzone",
+		"instance/name":      "myname",
+		"instance/id":        "12345678",
+	})
+	defaultInstance := &gcp.Instance{
+		ProjectID: "myproject",
+		Zone:      "myzone",
+		Name:      "myname",
+		Labels: map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	tests := []struct {
+		name            string
+		getMetadata     metadataGetter
+		instancesClient *mockInstanceGetter
+		assertErr       require.ErrorAssertionFunc
+		expectedTags    map[string]string
+	}{
+		{
+			name:        "ok",
+			getMetadata: defaultMetadataGetter,
+			instancesClient: &mockInstanceGetter{
+				instance: defaultInstance,
+				tags: map[string]string{
+					"baz": "quux",
+				},
+			},
+			assertErr: require.NoError,
+			expectedTags: map[string]string{
+				"label/foo": "bar",
+				"tag/baz":   "quux",
+			},
+		},
+		{
+			name:        "not on gcp",
+			getMetadata: makeMetadataGetter(nil),
+			instancesClient: &mockInstanceGetter{
+				instance: defaultInstance,
+			},
+			assertErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsNotFound(err), i...)
+			},
+		},
+		{
+			name:        "instance not found",
+			getMetadata: defaultMetadataGetter,
+			instancesClient: &mockInstanceGetter{
+				instanceErr: trace.NotFound(""),
+			},
+			assertErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsNotFound(err), i...)
+			},
+		},
+		{
+			name:        "denied access to instance",
+			getMetadata: defaultMetadataGetter,
+			instancesClient: &mockInstanceGetter{
+				instanceErr: trace.AccessDenied(""),
+				tags: map[string]string{
+					"baz": "quux",
+				},
+			},
+			assertErr: require.NoError,
+			expectedTags: map[string]string{
+				"tag/baz": "quux",
+			},
+		},
+		{
+			name:        "denied access to tags",
+			getMetadata: defaultMetadataGetter,
+			instancesClient: &mockInstanceGetter{
+				instance: defaultInstance,
+				tagsErr:  trace.AccessDenied(""),
+			},
+			assertErr: require.NoError,
+			expectedTags: map[string]string{
+				"label/foo": "bar",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &InstanceMetadataClient{
+				getMetadata:     tc.getMetadata,
+				instancesClient: tc.instancesClient,
+			}
+			tags, err := client.GetTags(context.Background())
+			tc.assertErr(t, err)
+			require.Equal(t, tc.expectedTags, tags)
+		})
+	}
+}

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -2541,6 +2541,10 @@ func (m *mockGCPClient) GetInstance(_ context.Context, _ *gcp.InstanceRequest) (
 	return nil, trace.NotFound("disabled for test")
 }
 
+func (m *mockGCPClient) GetInstanceTags(_ context.Context, _ *gcp.InstanceRequest) (map[string]string, error) {
+	return nil, nil
+}
+
 func (m *mockGCPClient) AddSSHKey(_ context.Context, _ *gcp.SSHKeyRequest) error {
 	return nil
 }


### PR DESCRIPTION
This change adds the ability for Teleport to automatically import labels and tags from the GCP instance it's running on, just like EC2 and Azure.

Note:
- GCP instances can have both [labels](https://cloud.google.com/compute/docs/labeling-resources) and [tags](https://cloud.google.com/resource-manager/docs/tags/tags-creating-and-managing), which are distinct entities. This change imports both, separated by the `label/` and `tag/` prefix, respectively.
- The instance must have a service principal with at least the `compute.instances.get` permission to fetch labels and the `compute.instances.listEffectiveTags` permission to fetch tags. It doesn't have to have both (i.e. an instance with only get permission will only fetch labels).

Resolves #36829.

Changelog: Added automatic GCP label importing