### PR TITLE
Fail when JS test uses console.error or console.warn

### DIFF
--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -76,6 +76,7 @@
     "html-webpack-plugin": "^5.5.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-fail-on-console": "^3.2.0",
     "jest-styled-components": "^7.2.0",
     "jsdom": "^21.1.0",
     "jsdom-testing-mocks": "^1.9.0",

--- a/web/packages/shared/setupTests.tsx
+++ b/web/packages/shared/setupTests.tsx
@@ -17,6 +17,20 @@
  */
 
 const crypt = require('crypto');
+const path = require('path');
+
+const failOnConsole = require('jest-fail-on-console');
+
+let entFailOnConsoleIgnoreList = [];
+try {
+  entFailOnConsoleIgnoreList = require('../../../e/web/testsWithIgnoredConsole');
+} catch (err) {
+  // Ignore errors related to teleport.e not being present. This allows OSS users and OSS CI to run
+  // tests without teleport.e.
+  if (err['code'] !== 'MODULE_NOT_FOUND') {
+    throw err;
+  }
+}
 
 Object.defineProperty(globalThis, 'crypto', {
   value: {
@@ -29,3 +43,28 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   unobserve: jest.fn(),
   disconnect: jest.fn(),
 }));
+
+const rootDir = path.join(__dirname, '..', '..', '..');
+// Do not add new paths to this list, instead fix the underlying problem which causes console.error
+// or console.warn to be used.
+//
+// If the test is expected to use either of those console functions, follow the advice from the
+// error message.
+const failOnConsoleIgnoreList = new Set([
+  'web/packages/design/src/utils/match/matchers.test.ts',
+  'web/packages/shared/components/TextEditor/TextEditor.test.tsx',
+  'web/packages/teleport/src/components/BannerList/useAlerts.test.tsx',
+  'web/packages/teleport/src/Navigation/NavigationItem.test.tsx',
+  'web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx',
+  // As of the parent commit (708dac8e0d0), these two below are flakes.
+  // https://github.com/gravitational/teleport/pull/41252#discussion_r1595036569
+  'web/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx',
+  'web/packages/teleport/src/Recordings/Recordings.story.test.tsx',
+  ...entFailOnConsoleIgnoreList,
+]);
+failOnConsole({
+  skipTest: ({ testPath }) => {
+    const relativeTestPath = path.relative(rootDir, testPath);
+    return failOnConsoleIgnoreList.has(relativeTestPath);
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10224,6 +10224,11 @@ jest-environment-node@^29.7.0:
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
+jest-fail-on-console@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jest-fail-on-console/-/jest-fail-on-console-3.2.0.tgz#05fbf7d6084d04af7955aa8eb5a80fbc7cf46fa1"
+  integrity sha512-GSqvjURdT/U+yu9JEr3EUTEB4kZi9feXMWS/jXGXB/lsnXXHcdU9Xsm2tEupSdqSEtrhTjOCqEJseFMrQ1ryvg==
+
 jest-get-type@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"


### PR DESCRIPTION
Closes #34286.

`console.error` or `console.warn` used in tests typically point at an issue in either the code itself or the test setup, but they don't cause tests to fail.

```
    console.error
      Warning: An update to TestComponent inside a test was not wrapped in act(...).

      When testing, code that causes React state updates should be wrapped into act(...):

      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */

      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
          at TestComponent (/Users/rav/src/teleport/node_modules/@testing-library/react/dist/pure.js:278:5)



    console.error
      Warning: Failed prop type: Invalid prop `hasError` of type `string` supplied to `Input`, expected `boolean`.
```

Since #34286 was opened, `console` use in tests only grew, from 16 to 23 instances as of b6d4af111e002. Those messages pollute test output and might point to real issues in code or tests, but it's hard to know when your PR causes `console` to be used in tests.

This PR makes it so that calls to `console.error` or `console.warn` fail a test. Since we don't have time to fix existing issues, I added an ignore list.

If there's a test that expects either of those methods to be used, it can use them, they just have to be explicitly mocked.

From my quick tests, this PR does not slow down `yarn test`.