### PR TITLE
Fix paging in security audit queries and reports methods

### DIFF
--- a/api/client/secreport/secreport.go
+++ b/api/client/secreport/secreport.go
@@ -44,9 +44,10 @@ func (c *Client) GetSecurityAuditQueries(ctx context.Context) ([]*secreports.Aud
 			return nil, trace.Wrap(err)
 		}
 		items = append(items, resp.GetQueries()...)
-		if nextKey == "" {
+		if resp.GetNextPageToken() == "" {
 			break
 		}
+		nextKey = resp.GetNextPageToken()
 	}
 	out, err := v1.FromProtoAuditQueries(items)
 	if err != nil {
@@ -84,9 +85,10 @@ func (c *Client) GetSecurityReports(ctx context.Context) ([]*secreports.Report, 
 			return nil, trace.Wrap(err)
 		}
 		resources = append(resources, resp.GetReports()...)
-		if nextKey == "" {
+		if resp.GetNextPageToken() == "" {
 			break
 		}
+		nextKey = resp.GetNextPageToken()
 	}
 	out := make([]*secreports.Report, 0, len(resources))
 	for _, v := range resources {


### PR DESCRIPTION
`nextKey` was checked, but not modified, which meant that two methods acted as if the first page received was always the last.