### PR TITLE
Machine ID: Basic Unix Workload Attestation

### DIFF
--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -387,6 +387,35 @@ svids:
       # ip specifies the IP SANs. If omitted, no IP SANs are included.
       ip:
         - 10.0.0.1
+    # rules specifies a list of workload attestation rules. At least one of
+    # these rules must be satisfied by the workload in order for it to receive
+    # this SVID.
+    #
+    # If no rules are specified, the SVID will be issued to all workloads that
+    # connect to this service.
+    rules:
+        # unix is a group of workload attestation criteria that are available
+        # when the workload is running on the same host, and is connected to
+        # the Workload API using a Unix socket.
+        #
+        # If any of the criteria in this group are specified, then workloads
+        # that do not connect using a Unix socket will not receive this SVID.
+      - unix:
+          # uid is the ID of the user that the workload process must be running
+          # as to receive this SVID.
+          #
+          # If unspecified, the UID is not checked.
+          uid: 1000
+          # pid is the ID that the workload process must have to receive this
+          # SVID.
+          #
+          # If unspecified, the PID is not checked.
+          pid: 1234
+          # gid is the ID of the primary group that the workload process must be
+          # running as to receive this SVID.
+          #
+          # If unspecified, the GID is not checked.
+          gid: 50
 ```
 
 #### `database-tunnel`

--- a/docs/pages/machine-id/workload-identity.mdx
+++ b/docs/pages/machine-id/workload-identity.mdx
@@ -112,9 +112,8 @@ workloads.
 
 The Workload API is usually exposed by an agent that is installed on the same
 host as the workloads and is accessed using a unix socket rather than a TCP
-endpoint. As this API is unauthenticated, the unix socket means that standard
-Linux filesystem access controls can be used to restrict access to specific
-workloads running on the host.
+endpoint. It can perform basic authentication and authorization of the workload
+before issuing SVIDs. This is known as Workload Attestation.
 
 ## Teleport's Workload Identity
 

--- a/docs/pages/machine-id/workload-identity/getting-started.mdx
+++ b/docs/pages/machine-id/workload-identity/getting-started.mdx
@@ -122,6 +122,41 @@ services:
       - 10.0.0.1
 ```
 
+### Configuring Unix Workload Attestation
+
+By default, an SVID listed under the Workload API service will be issued to any
+workload that connects to the Workload API. You may wish to restrict which SVIDs
+are issued based on certain characteristics of the workload. This is known as
+Workload Attestation.
+
+When using the Unix listener, `tbot` supports workload attestation based on
+three characteristics of the workload process:
+
+- `uid`: The UID of the user that the workload process is running as.
+- `gid`: The primary GID of the user that the workload process is running as.
+- `pid`: The PID of the workload process.
+
+To configure Workload Attestation, you configure a set of rules for each SVID.
+Each rule is a list of characteristics, and all characteristics within the rule
+must match for that rule to pass. If you have multiple rules, any one rule can
+pass for the SVID to be issued.
+
+For example, to configure an SVID to be issued only to workloads that are
+running as the user with ID 1000 or running as a user with a primary group ID
+of 50:
+
+```yaml
+services:
+- type: spiffe-workload-api
+  listen: unix:///opt/machine-id/workload.sock
+  svids:
+  - path: /svc/foo
+    hint: my-hint
+    rules:
+      - uid: 1000
+      - gid: 50
+```
+
 ## Step 3/4. Testing the Workload API with `tbot spiffe-inspect`
 
 The `tbot` binary includes a `spiffe-inspect` command that can be used to

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -253,13 +253,15 @@ func TestBotConfig_YAML(t *testing.T) {
 				Services: []ServiceConfig{
 					&SPIFFEWorkloadAPIService{
 						Listen: "unix:///var/run/spiffe.sock",
-						SVIDs: []SVIDRequest{
+						SVIDs: []SVIDRequestWithRules{
 							{
-								Path: "/bar",
-								Hint: "my hint",
-								SANS: SVIDRequestSANs{
-									DNS: []string{"foo.bar"},
-									IP:  []string{"10.0.0.1"},
+								SVIDRequest: SVIDRequest{
+									Path: "/bar",
+									Hint: "my hint",
+									SANS: SVIDRequestSANs{
+										DNS: []string{"foo.bar"},
+										IP:  []string{"10.0.0.1"},
+									},
 								},
 							},
 						},

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -263,6 +263,20 @@ func TestBotConfig_YAML(t *testing.T) {
 										IP:  []string{"10.0.0.1"},
 									},
 								},
+								Rules: []SVIDRequestRule{
+									{
+										Unix: SVIDRequestRuleUnix{
+											PID: ptr(100),
+											UID: ptr(1000),
+											GID: ptr(1234),
+										},
+									},
+									{
+										Unix: SVIDRequestRuleUnix{
+											PID: ptr(100),
+										},
+									},
+								},
 							},
 						},
 					},

--- a/lib/tbot/config/output_spiffe_svid.go
+++ b/lib/tbot/config/output_spiffe_svid.go
@@ -25,6 +25,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"log/slog"
 	"net"
 	"strings"
 	"time"
@@ -71,6 +72,15 @@ type SVIDRequest struct {
 	// SANS is the Subject Alternative Names that are requested to be included
 	// in the SVID.
 	SANS SVIDRequestSANs `yaml:"sans,omitempty"`
+}
+
+func (o SVIDRequest) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("path", o.Path),
+		slog.String("hint", o.Hint),
+		slog.Any("dns_sans", o.SANS.DNS),
+		slog.Any("ip_sans", o.SANS.IP),
+	)
 }
 
 // CheckAndSetDefaults checks the SVIDRequest values and sets any defaults.

--- a/lib/tbot/config/service_spiffe_workload_api.go
+++ b/lib/tbot/config/service_spiffe_workload_api.go
@@ -25,6 +25,46 @@ import (
 
 const SPIFFEWorkloadAPIServiceType = "spiffe-workload-api"
 
+// SVIDRequestWithRules is the configuration for a single SVID along with the
+// workload attestation rules that must be passed by a workload for this SVID
+// to be issued to it.
+type SVIDRequestWithRules struct {
+	SVIDRequest `yaml:",inline"`
+	// Rules is a list of workload attestation rules. At least one rule must be
+	// satisfied for the SVID to be issued to a workload.
+	//
+	// If no rules are specified, the SVID will be issued to all workloads that
+	// connect to this listener.
+	Rules []SVIDRequestRule `yaml:"rules,omitempty"`
+}
+
+// SVIDRequestRuleUnix is a workload attestation ruleset for workloads that
+// connect via Unix domain sockets.
+type SVIDRequestRuleUnix struct {
+	// PID is the process ID that a process must have to be issued this SVID.
+	//
+	// If unspecified, the process ID is not checked.
+	PID *int `yaml:"pid,omitempty"`
+	// UID is the user ID that a process must have to be issued this SVID.
+	//
+	// If unspecified, the user ID is not checked.
+	UID *int `yaml:"uid,omitempty"`
+	// GID is the primary group ID that a process must have to be issued this
+	// SVID.
+	//
+	// If unspecified, the primary group ID is not checked.
+	GID *int `yaml:"gid,omitempty"`
+}
+
+// SVIDRequestRule is an individual workload attestation rule. All values
+// specified within the rule must be satisfied for the rule itself to pass.
+type SVIDRequestRule struct {
+	// Unix is the workload attestation ruleset for workloads that connect via
+	// Unix domain sockets. If any value here is set, the rule will not pass
+	// unless the workload is connecting via a Unix domain socket.
+	Unix SVIDRequestRuleUnix `yaml:"unix"`
+}
+
 // SPIFFEWorkloadAPIService is the configuration for the SPIFFE Workload API
 // service.
 type SPIFFEWorkloadAPIService struct {
@@ -33,7 +73,7 @@ type SPIFFEWorkloadAPIService struct {
 	Listen string `yaml:"listen"`
 	// SVIDs is the list of SVIDs that the SPIFFE Workload API server should
 	// provide.
-	SVIDs []SVIDRequest `yaml:"svids"`
+	SVIDs []SVIDRequestWithRules `yaml:"svids"`
 }
 
 func (s *SPIFFEWorkloadAPIService) Type() string {

--- a/lib/tbot/config/service_spiffe_workload_api.go
+++ b/lib/tbot/config/service_spiffe_workload_api.go
@@ -19,6 +19,8 @@
 package config
 
 import (
+	"log/slog"
+
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"
 )
@@ -63,6 +65,22 @@ type SVIDRequestRule struct {
 	// Unix domain sockets. If any value here is set, the rule will not pass
 	// unless the workload is connecting via a Unix domain socket.
 	Unix SVIDRequestRuleUnix `yaml:"unix"`
+}
+
+func (o SVIDRequestRule) LogValue() slog.Value {
+	var unixAttrs []any
+	if o.Unix.PID != nil {
+		unixAttrs = append(unixAttrs, slog.Int("pid", *o.Unix.PID))
+	}
+	if o.Unix.GID != nil {
+		unixAttrs = append(unixAttrs, slog.Int("gid", *o.Unix.GID))
+	}
+	if o.Unix.UID != nil {
+		unixAttrs = append(unixAttrs, slog.Int("uid", *o.Unix.UID))
+	}
+	return slog.GroupValue(
+		slog.Group("unix", unixAttrs...),
+	)
 }
 
 // SPIFFEWorkloadAPIService is the configuration for the SPIFFE Workload API

--- a/lib/tbot/config/service_spiffe_workload_api_test.go
+++ b/lib/tbot/config/service_spiffe_workload_api_test.go
@@ -22,6 +22,10 @@ import (
 	"testing"
 )
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func TestSPIFFEWorkloadAPIService_YAML(t *testing.T) {
 	t.Parallel()
 
@@ -30,13 +34,29 @@ func TestSPIFFEWorkloadAPIService_YAML(t *testing.T) {
 			name: "full",
 			in: SPIFFEWorkloadAPIService{
 				Listen: "unix:///var/run/spiffe.sock",
-				SVIDs: []SVIDRequest{
+				SVIDs: []SVIDRequestWithRules{
 					{
-						Path: "/foo",
-						Hint: "hint",
-						SANS: SVIDRequestSANs{
-							DNS: []string{"example.com"},
-							IP:  []string{"10.0.0.1", "10.42.0.1"},
+						SVIDRequest: SVIDRequest{
+							Path: "/foo",
+							Hint: "hint",
+							SANS: SVIDRequestSANs{
+								DNS: []string{"example.com"},
+								IP:  []string{"10.0.0.1", "10.42.0.1"},
+							},
+						},
+						Rules: []SVIDRequestRule{
+							{
+								Unix: SVIDRequestRuleUnix{
+									PID: ptr(100),
+									UID: ptr(1000),
+									GID: ptr(1234),
+								},
+							},
+							{
+								Unix: SVIDRequestRuleUnix{
+									PID: ptr(100),
+								},
+							},
 						},
 					},
 				},
@@ -46,9 +66,11 @@ func TestSPIFFEWorkloadAPIService_YAML(t *testing.T) {
 			name: "minimal",
 			in: SPIFFEWorkloadAPIService{
 				Listen: "unix:///var/run/spiffe.sock",
-				SVIDs: []SVIDRequest{
+				SVIDs: []SVIDRequestWithRules{
 					{
-						Path: "/foo",
+						SVIDRequest: SVIDRequest{
+							Path: "/foo",
+						},
 					},
 				},
 			},
@@ -66,13 +88,15 @@ func TestSPIFFEWorkloadAPIService_CheckAndSetDefaults(t *testing.T) {
 			in: func() *SPIFFEWorkloadAPIService {
 				return &SPIFFEWorkloadAPIService{
 					Listen: "unix:///var/run/spiffe.sock",
-					SVIDs: []SVIDRequest{
+					SVIDs: []SVIDRequestWithRules{
 						{
-							Path: "/foo",
-							Hint: "hint",
-							SANS: SVIDRequestSANs{
-								DNS: []string{"example.com"},
-								IP:  []string{"10.0.0.1", "10.42.0.1"},
+							SVIDRequest: SVIDRequest{
+								Path: "/foo",
+								Hint: "hint",
+								SANS: SVIDRequestSANs{
+									DNS: []string{"example.com"},
+									IP:  []string{"10.0.0.1", "10.42.0.1"},
+								},
 							},
 						},
 					},
@@ -84,13 +108,15 @@ func TestSPIFFEWorkloadAPIService_CheckAndSetDefaults(t *testing.T) {
 			in: func() *SPIFFEWorkloadAPIService {
 				return &SPIFFEWorkloadAPIService{
 					Listen: "unix:///var/run/spiffe.sock",
-					SVIDs: []SVIDRequest{
+					SVIDs: []SVIDRequestWithRules{
 						{
-							Path: "",
-							Hint: "hint",
-							SANS: SVIDRequestSANs{
-								DNS: []string{"example.com"},
-								IP:  []string{"10.0.0.1", "10.42.0.1"},
+							SVIDRequest: SVIDRequest{
+								Path: "",
+								Hint: "hint",
+								SANS: SVIDRequestSANs{
+									DNS: []string{"example.com"},
+									IP:  []string{"10.0.0.1", "10.42.0.1"},
+								},
 							},
 						},
 					},
@@ -103,13 +129,15 @@ func TestSPIFFEWorkloadAPIService_CheckAndSetDefaults(t *testing.T) {
 			in: func() *SPIFFEWorkloadAPIService {
 				return &SPIFFEWorkloadAPIService{
 					Listen: "unix:///var/run/spiffe.sock",
-					SVIDs: []SVIDRequest{
+					SVIDs: []SVIDRequestWithRules{
 						{
-							Path: "foo",
-							Hint: "hint",
-							SANS: SVIDRequestSANs{
-								DNS: []string{"example.com"},
-								IP:  []string{"10.0.0.1", "10.42.0.1"},
+							SVIDRequest: SVIDRequest{
+								Path: "foo",
+								Hint: "hint",
+								SANS: SVIDRequestSANs{
+									DNS: []string{"example.com"},
+									IP:  []string{"10.0.0.1", "10.42.0.1"},
+								},
 							},
 						},
 					},
@@ -122,13 +150,15 @@ func TestSPIFFEWorkloadAPIService_CheckAndSetDefaults(t *testing.T) {
 			in: func() *SPIFFEWorkloadAPIService {
 				return &SPIFFEWorkloadAPIService{
 					Listen: "",
-					SVIDs: []SVIDRequest{
+					SVIDs: []SVIDRequestWithRules{
 						{
-							Path: "foo",
-							Hint: "hint",
-							SANS: SVIDRequestSANs{
-								DNS: []string{"example.com"},
-								IP:  []string{"10.0.0.1", "10.42.0.1"},
+							SVIDRequest: SVIDRequest{
+								Path: "foo",
+								Hint: "hint",
+								SANS: SVIDRequestSANs{
+									DNS: []string{"example.com"},
+									IP:  []string{"10.0.0.1", "10.42.0.1"},
+								},
 							},
 						},
 					},
@@ -141,13 +171,15 @@ func TestSPIFFEWorkloadAPIService_CheckAndSetDefaults(t *testing.T) {
 			in: func() *SPIFFEWorkloadAPIService {
 				return &SPIFFEWorkloadAPIService{
 					Listen: "unix:///var/run/spiffe.sock",
-					SVIDs: []SVIDRequest{
+					SVIDs: []SVIDRequestWithRules{
 						{
-							Path: "/foo",
-							Hint: "hint",
-							SANS: SVIDRequestSANs{
-								DNS: []string{"example.com"},
-								IP:  []string{"invalid ip"},
+							SVIDRequest: SVIDRequest{
+								Path: "/foo",
+								Hint: "hint",
+								SANS: SVIDRequestSANs{
+									DNS: []string{"example.com"},
+									IP:  []string{"invalid ip"},
+								},
 							},
 						},
 					},

--- a/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
+++ b/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
@@ -30,6 +30,13 @@ services:
             - foo.bar
           ip:
             - 10.0.0.1
+        rules:
+          - unix:
+              pid: 100
+              uid: 1000
+              gid: 1234
+          - unix:
+              pid: 100
   - type: example
     message: llama
 debug: true

--- a/lib/tbot/config/testdata/TestSPIFFEWorkloadAPIService_YAML/full.golden
+++ b/lib/tbot/config/testdata/TestSPIFFEWorkloadAPIService_YAML/full.golden
@@ -9,3 +9,10 @@ svids:
       ip:
         - 10.0.0.1
         - 10.42.0.1
+    rules:
+      - unix:
+          pid: 100
+          uid: 1000
+          gid: 1234
+      - unix:
+          pid: 100

--- a/lib/tbot/service_spiffe_workload_api.go
+++ b/lib/tbot/service_spiffe_workload_api.go
@@ -376,14 +376,16 @@ func (s *SPIFFEWorkloadAPIService) fetchX509SVIDs(
 		// provide additional metadata about the client.
 		log.InfoContext(ctx,
 			"Issued SVID for workload",
-			"svid_type", "x509",
-			"spiffe_id", svidRes.SpiffeId,
-			"serial_number", serialString(cert.SerialNumber),
-			"hint", svidRes.Hint,
-			"not_after", cert.NotAfter,
-			"not_before", cert.NotBefore,
-			"dns_sans", cert.DNSNames,
-			"ip_sans", cert.IPAddresses,
+			slog.Group("svid",
+				"type", "x509",
+				"spiffe_id", svidRes.SpiffeId,
+				"serial_number", serialString(cert.SerialNumber),
+				"hint", svidRes.Hint,
+				"not_after", cert.NotAfter,
+				"not_before", cert.NotBefore,
+				"dns_sans", cert.DNSNames,
+				"ip_sans", cert.IPAddresses,
+			),
 		)
 	}
 

--- a/lib/tbot/service_spiffe_workload_api.go
+++ b/lib/tbot/service_spiffe_workload_api.go
@@ -396,6 +396,8 @@ func (s *SPIFFEWorkloadAPIService) fetchX509SVIDs(
 	return svids, nil
 }
 
+// filterSVIDRequests filters the SVID requests based on the workload
+// attestation.
 func filterSVIDRequests(
 	ctx context.Context,
 	log *slog.Logger,

--- a/lib/tbot/service_spiffe_workload_api_test.go
+++ b/lib/tbot/service_spiffe_workload_api_test.go
@@ -1,0 +1,237 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"context"
+	"testing"
+
+	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/uds"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func TestSPIFFEWorkloadAPIService_filterSVIDRequests(t *testing.T) {
+	ctx := context.Background()
+	log := utils.NewSlogLoggerForTests()
+	tests := []struct {
+		name string
+		uds  *uds.Creds
+		in   []config.SVIDRequestWithRules
+		want []config.SVIDRequest
+	}{
+		{
+			name: "no rules",
+			uds:  nil,
+			in: []config.SVIDRequestWithRules{
+				{
+					SVIDRequest: config.SVIDRequest{
+						Path: "/foo",
+					},
+				},
+				{
+					SVIDRequest: config.SVIDRequest{
+						Path: "/bar",
+					},
+				},
+			},
+			want: []config.SVIDRequest{
+				{
+					Path: "/foo",
+				},
+				{
+					Path: "/bar",
+				},
+			},
+		},
+		{
+			name: "no rules with uds",
+			uds: &uds.Creds{
+				UID: 1000,
+				GID: 1001,
+				PID: 1002,
+			},
+			in: []config.SVIDRequestWithRules{
+				{
+					SVIDRequest: config.SVIDRequest{
+						Path: "/foo",
+					},
+				},
+				{
+					SVIDRequest: config.SVIDRequest{
+						Path: "/bar",
+					},
+				},
+			},
+			want: []config.SVIDRequest{
+				{
+					Path: "/foo",
+				},
+				{
+					Path: "/bar",
+				},
+			},
+		},
+		{
+			name: "no matching rules with uds",
+			uds: &uds.Creds{
+				UID: 1000,
+				GID: 1001,
+				PID: 1002,
+			},
+			in: []config.SVIDRequestWithRules{
+				{
+					SVIDRequest: config.SVIDRequest{
+						Path: "/foo",
+					},
+					Rules: []config.SVIDRequestRule{
+						{
+							Unix: config.SVIDRequestRuleUnix{
+								UID: ptr(1000),
+								PID: ptr(1),
+							},
+						},
+						{
+							Unix: config.SVIDRequestRuleUnix{
+								GID: ptr(1),
+							},
+						},
+					},
+				},
+				{
+					SVIDRequest: config.SVIDRequest{
+						Path: "/bar",
+					},
+					Rules: []config.SVIDRequestRule{
+						{
+							Unix: config.SVIDRequestRuleUnix{
+								UID: ptr(1),
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "no matching rules without uds",
+			uds:  nil,
+			in: []config.SVIDRequestWithRules{
+				{
+					SVIDRequest: config.SVIDRequest{
+						Path: "/foo",
+					},
+					Rules: []config.SVIDRequestRule{
+						{
+							Unix: config.SVIDRequestRuleUnix{
+								PID: ptr(1),
+							},
+						},
+						{
+							Unix: config.SVIDRequestRuleUnix{
+								GID: ptr(1),
+							},
+						},
+					},
+				},
+				{
+					SVIDRequest: config.SVIDRequest{
+						Path: "/bar",
+					},
+					Rules: []config.SVIDRequestRule{
+						{
+							Unix: config.SVIDRequestRuleUnix{
+								UID: ptr(1),
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "some matching rules with uds",
+			uds: &uds.Creds{
+				UID: 1000,
+				GID: 1001,
+				PID: 1002,
+			},
+			in: []config.SVIDRequestWithRules{
+				{
+					SVIDRequest: config.SVIDRequest{
+						Path: "/fizz",
+					},
+					Rules: []config.SVIDRequestRule{
+						{
+							Unix: config.SVIDRequestRuleUnix{
+								UID: ptr(1),
+							},
+						},
+					},
+				},
+				{
+					SVIDRequest: config.SVIDRequest{
+						Path: "/foo",
+					},
+					Rules: []config.SVIDRequestRule{},
+				},
+				{
+					SVIDRequest: config.SVIDRequest{
+						Path: "/bar",
+					},
+					Rules: []config.SVIDRequestRule{
+						{
+							Unix: config.SVIDRequestRuleUnix{
+								UID: ptr(1000),
+								GID: ptr(1500),
+							},
+						},
+						{
+							Unix: config.SVIDRequestRuleUnix{
+								UID: ptr(1000),
+								PID: ptr(1002),
+							},
+						},
+					},
+				},
+			},
+			want: []config.SVIDRequest{
+				{
+					Path: "/foo",
+				},
+				{
+					Path: "/bar",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterSVIDRequests(ctx, log, tt.in, tt.uds)
+			assert.Empty(t, gocmp.Diff(tt.want, got))
+		})
+	}
+}

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -660,13 +660,15 @@ func TestBotSPIFFEWorkloadAPI(t *testing.T) {
 			ServiceConfigs: []config.ServiceConfig{
 				&config.SPIFFEWorkloadAPIService{
 					Listen: socketPath,
-					SVIDs: []config.SVIDRequest{
+					SVIDs: []config.SVIDRequestWithRules{
 						{
-							Path: "/foo",
-							Hint: "hint",
-							SANS: config.SVIDRequestSANs{
-								DNS: []string{"example.com"},
-								IP:  []string{"10.0.0.1"},
+							SVIDRequest: config.SVIDRequest{
+								Path: "/foo",
+								Hint: "hint",
+								SANS: config.SVIDRequestSANs{
+									DNS: []string{"example.com"},
+									IP:  []string{"10.0.0.1"},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/39866

A super basic initial pass at Workload Attestation for Unix. This will likely become much more complex in future as we'll begin to look up other information based on the PID, but for now, this just sets the stage.

Example config:

```yaml
services:
  - type: spiffe-workload-api
    listen: unix:///Users/noah/code/gravitational/workload-identity-experiment/workload.sock
    svids:
      - path: /bar
        hint: test-1
        sans:
          dns:
          - example.com
          - foo.example.com
          ip:
          - 14.1.1.1
        rules:
          - unix:
              uid: 502
          - unix:
              gid: 20
```

changelog: Basic Unix workload attestation added to the `tbot` SPIFFE workload API. You can now restrict the issuance of certain SVIDs to processes running with a certain UID, GID or PID.