### PR TITLE
Docs: AWS OIDC Integration set up guide

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -769,6 +769,10 @@
             {
               "title": "Using Teleport's CA with GitHub",
               "slug": "/management/guides/ssh-key-extensions/"
+            },
+            {
+              "title": "AWS OIDC Integration",
+              "slug": "/management/guides/awsoidc-integration/"
             }
           ]
         },

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -299,6 +299,7 @@
     "awsconsole",
     "awsdatabases",
     "awskms",
+    "awsoidc",
     "awsuser",
     "azblob",
     "azuread",

--- a/docs/pages/management/guides/awsoidc-integration.mdx
+++ b/docs/pages/management/guides/awsoidc-integration.mdx
@@ -18,6 +18,7 @@ As an alternative to this guide, you can use the Teleport Web UI (Access Managem
 
 ## How it works
 Teleport is added as an Identity Provider in AWS by exposing the `openid-configuration` and public keys in a public S3 bucket.
+This runs alongside your existing cluster and no extra configuration or services are required.
 
 This allows Teleport to assume a configured IAM role and access AWS resources.
 

--- a/docs/pages/management/guides/awsoidc-integration.mdx
+++ b/docs/pages/management/guides/awsoidc-integration.mdx
@@ -12,15 +12,15 @@ The following features use an AWS OIDC integration to interact with AWS:
 - EC2 Auto Discovery
 - [Access Graph AWS Sync](../../access-controls/access-graph/aws-sync.mdx)
 
-It targets users who would prefer a more manual approach or which to use a more Infrastrcutre as Code oriented flow.
+It targets users who would prefer a more manual approach or to manage the integration with Infrastructure as Code tools.
 
 As an alternative to this guide, you can use the Teleport Web UI (Access Management / Enroll New Integration).
 
 ## How it works
-Teleport is added as an Identity Provider in AWS by exposing the `openid-configuration` and public keys in a public S3 bucket.
-This runs alongside your existing cluster and no extra configuration or services are required.
+Teleport is added as an [OpenID Connect identity provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html) to establish trust with your AWS account and assume a configured IAM role in order to access AWS resources.
 
-This allows Teleport to assume a configured IAM role and access AWS resources.
+For this to work, the `openid-configuration` and public keys are exposed in a public S3 bucket.
+The integration requires no extra configuration or services to run.
 
 Initially, no policy is added to the IAM role, but users are asked to add them the first time they are trying to use a given feature.
 For example, when setting up [External Audit Storage](../../choose-an-edition/teleport-cloud/external-audit-storage.mdx), you will be asked to add the required policies to this IAM role.
@@ -56,7 +56,7 @@ spec:
 
 
 ## Step 2/5. Upload public keys to S3
-AWS OIDC integration uses OpenID Connect to grant access to AWS APIs.
+The AWS OIDC integration uses OpenID Connect to grant access to AWS APIs.
 Configuring OpenID Connect requires exposing the configuration file and the public keys, which AWS fetches to validate the requests.
 
 Those files should be exposed in S3, for which we'll need to pick a bucket <Var name="s3-bucket"/> and a prefix <Var name="s3-prefix"/>.

--- a/docs/pages/management/guides/awsoidc-integration.mdx
+++ b/docs/pages/management/guides/awsoidc-integration.mdx
@@ -3,30 +3,31 @@ title: AWS OIDC Integration
 description: How to connect your AWS account with Teleport and provide access to AWS resources.
 ---
 
-This guide explains how to set up the Teleport AWS OIDC Integration.
-It targets users who would prefer a more manual approach or which to use a more Infrastrcutre as Code oriented flow.
+This guide explains how to set up the Teleport AWS OIDC integration.
 
-As an alternative to this guide, you can use the Teleport Web UI (Access Management / Enroll New Integration).
-
-With an integration you will no longer need to deploy Teleport Agents in AWS manually for most use cases.
-The following features use an Integration to interact with AWS:
+With the AWS OIDC integration you will no longer need to deploy Teleport agents in AWS manually for most use cases.
+The following features use an AWS OIDC integration to interact with AWS:
 - [External Audit Storage](../../choose-an-edition/teleport-cloud/external-audit-storage.mdx)
 - RDS Auto Discovery
 - EC2 Auto Discovery
 - [Access Graph AWS Sync](../../access-controls/access-graph/aws-sync.mdx)
 
+It targets users who would prefer a more manual approach or which to use a more Infrastrcutre as Code oriented flow.
+
+As an alternative to this guide, you can use the Teleport Web UI (Access Management / Enroll New Integration).
+
 ## How it works
 Teleport is added as an Identity Provider in AWS by exposing the `openid-configuration` and public keys in a public S3 bucket.
 
-This allows Teleport to assume a configured Role and access AWS resources.
+This allows Teleport to assume a configured IAM role and access AWS resources.
 
-Initially, no policy is added to the IAM Role, but users are asked to add them the first time they are trying to use a given feature.
-For example, when setting up [External Audit Storage](../../choose-an-edition/teleport-cloud/external-audit-storage.mdx), you will be asked to add the required policies to this IAM Role.
+Initially, no policy is added to the IAM role, but users are asked to add them the first time they are trying to use a given feature.
+For example, when setting up [External Audit Storage](../../choose-an-edition/teleport-cloud/external-audit-storage.mdx), you will be asked to add the required policies to this IAM role.
 
 ## Prerequisites
 
 - A running Teleport cluster.
-- Access to the AWS Account.
+- AWS Account with permissions to create public S3 buckets, IAM Identity Providers and roles
 
 ## Step 1/5. Configure RBAC
 
@@ -49,11 +50,12 @@ spec:
       - list
       - read
       - delete
+      - use
 ```
 
 
 ## Step 2/5. Upload public keys to S3
-AWS OIDC Integration uses OpenID Connect to grant access to AWS APIs.
+AWS OIDC integration uses OpenID Connect to grant access to AWS APIs.
 Configuring OpenID Connect requires exposing the configuration file and the public keys, which AWS fetches to validate the requests.
 
 Those files should be exposed in S3, for which we'll need to pick a bucket <Var name="s3-bucket"/> and a prefix <Var name="s3-prefix"/>.
@@ -98,10 +100,10 @@ https://<Var name="s3-bucket"/>.s3.amazonaws.com/<Var name="s3-prefix"/>
 ```
 - Audience: `discover.teleport`
 
-## Step 4/5. Create IAM Role
-An IAM Role must be created to assign the required policies to the Integration <Var name="iam-role"/>.
+## Step 4/5. Create IAM role
+An IAM role must be created to assign the required policies to the integration <Var name="iam-role"/>.
 
-This IAM Role is created without any policy, as those are added depending on the feature you would like to use, for example when setting up [Access Graph AWS Sync](../../access-controls/access-graph/aws-sync.mdx).
+This IAM role is created without any policy, as those are added depending on the feature you would like to use, for example when setting up [Access Graph AWS Sync](../../access-controls/access-graph/aws-sync.mdx).
 However, it must be configured to allow the Identity Provider to assume it.
 To achieve this, add the following Trust Relationship:
 ```json
@@ -124,14 +126,14 @@ To achieve this, add the following Trust Relationship:
 }
 ```
 
-It is also required to add the following tags, which are used by Teleport to ensure it can change the IAM Role when onboarding new features:
+It is also required to add the following tags, which are used by Teleport to ensure it can change the IAM role when onboarding new features:
 ```code
 teleport.dev/cluster      <Var name="cluster-name"/>
 teleport.dev/origin       integration_awsoidc
 teleport.dev/integration  <Var name="my-integration"/>
 ```
 
-## Step 5/5. Create Integration resource
+## Step 5/5. Create integration resource
 Create a file called `awsoidc-integration.yaml` with the following content:
 
 ```yaml
@@ -146,7 +148,7 @@ spec:
     issuer_s3_uri: s3://<Var name="s3-bucket"/>/<Var name="s3-prefix"/>
 ```
 
-We specify the IAM Role and the S3 URI which has the openid-configuration and public keys.
+We specify the IAM role and the S3 URI which has the openid-configuration and public keys.
 
 Create the resource:
 ```code
@@ -156,8 +158,8 @@ integration '<Var name="my-integration"/>' has been created
 
 After the set up is complete, you can now use the "Enroll New Resource" flow in Teleport Web UI, or other integration dependent features.
 
-## Next Steps
+## Next steps
 
-Now that you have an Integration, you can use the following features:
+Now that you have an integration, you can use the following features:
 - [Access Graph AWS Sync](../../access-controls/access-graph/aws-sync.mdx)
 - [External Audit Storage](../../choose-an-edition/teleport-cloud/external-audit-storage.mdx)

--- a/docs/pages/management/guides/awsoidc-integration.mdx
+++ b/docs/pages/management/guides/awsoidc-integration.mdx
@@ -4,6 +4,9 @@ description: How to connect your AWS account with Teleport and provide access to
 ---
 
 This guide explains how to set up the Teleport AWS OIDC Integration.
+It targets users who would prefer a more manual approach or which to use a more Infrastrcutre as Code oriented flow.
+
+As an alternative to this guide, you can use the Teleport Web UI (Access Management / Enroll New Integration).
 
 With an integration you will no longer need to deploy Teleport Agents in AWS manually for most use cases.
 The following features use an Integration to interact with AWS:
@@ -18,6 +21,7 @@ Teleport is added as an Identity Provider in AWS by exposing the `openid-configu
 This allows Teleport to assume a configured Role and access AWS resources.
 
 Initially, no policy is added to the IAM Role, but users are asked to add them the first time they are trying to use a given feature.
+For example, when setting up [External Audit Storage](../../choose-an-edition/teleport-cloud/external-audit-storage.mdx), you will be asked to add the required policies to this IAM Role.
 
 ## Prerequisites
 
@@ -97,7 +101,7 @@ https://<Var name="s3-bucket"/>.s3.amazonaws.com/<Var name="s3-prefix"/>
 ## Step 4/5. Create IAM Role
 An IAM Role must be created to assign the required policies to the Integration <Var name="iam-role"/>.
 
-This IAM Role is created without any policy, as those are added depending on the feature you would like to use.
+This IAM Role is created without any policy, as those are added depending on the feature you would like to use, for example when setting up [Access Graph AWS Sync](../../access-controls/access-graph/aws-sync.mdx).
 However, it must be configured to allow the Identity Provider to assume it.
 To achieve this, add the following Trust Relationship:
 ```json
@@ -128,6 +132,8 @@ teleport.dev/integration  <Var name="my-integration"/>
 ```
 
 ## Step 5/5. Create Integration resource
+Create a file called `awsoidc-integration.yaml` with the following content:
+
 ```yaml
 kind: integration
 sub_kind: aws-oidc
@@ -140,4 +146,18 @@ spec:
     issuer_s3_uri: s3://<Var name="s3-bucket"/>/<Var name="s3-prefix"/>
 ```
 
-After the set up is complete, you can now use the "Enroll New Resource" flow in WebUI, or other integration dependent features.
+We specify the IAM Role and the S3 URI which has the openid-configuration and public keys.
+
+Create the resource:
+```code
+$ tctl create -f awsoidc-integration.yaml
+integration '<Var name="my-integration"/>' has been created
+```
+
+After the set up is complete, you can now use the "Enroll New Resource" flow in Teleport Web UI, or other integration dependent features.
+
+## Next Steps
+
+Now that you have an Integration, you can use the following features:
+- [Access Graph AWS Sync](../../access-controls/access-graph/aws-sync.mdx)
+- [External Audit Storage](../../choose-an-edition/teleport-cloud/external-audit-storage.mdx)

--- a/docs/pages/management/guides/awsoidc-integration.mdx
+++ b/docs/pages/management/guides/awsoidc-integration.mdx
@@ -1,0 +1,143 @@
+---
+title: AWS OIDC Integration
+description: How to connect your AWS account with Teleport and provide access to AWS resources.
+---
+
+This guide explains how to set up the Teleport AWS OIDC Integration.
+
+With an integration you will no longer need to deploy Teleport Agents in AWS manually for most use cases.
+The following features use an Integration to interact with AWS:
+- [External Audit Storage](../../choose-an-edition/teleport-cloud/external-audit-storage.mdx)
+- RDS Auto Discovery
+- EC2 Auto Discovery
+- [Access Graph AWS Sync](../../access-controls/access-graph/aws-sync.mdx)
+
+## How it works
+Teleport is added as an Identity Provider in AWS by exposing the `openid-configuration` and public keys in a public S3 bucket.
+
+This allows Teleport to assume a configured Role and access AWS resources.
+
+Initially, no policy is added to the IAM Role, but users are asked to add them the first time they are trying to use a given feature.
+
+## Prerequisites
+
+- A running Teleport cluster.
+- Access to the AWS Account.
+
+## Step 1/5. Configure RBAC
+
+To configure the integration you will need the following allow rules in one of your Teleport roles.
+These are available by default in the preset `editor` role:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: example
+spec:
+  allow:
+    rules:
+    - resources:
+      - integration
+      verbs:
+      - create
+      - update
+      - list
+      - read
+      - delete
+```
+
+
+## Step 2/5. Upload public keys to S3
+AWS OIDC Integration uses OpenID Connect to grant access to AWS APIs.
+Configuring OpenID Connect requires exposing the configuration file and the public keys, which AWS fetches to validate the requests.
+
+Those files should be exposed in S3, for which we'll need to pick a bucket <Var name="s3-bucket"/> and a prefix <Var name="s3-prefix"/>.
+
+Download the current configuration and public keys:
+```code
+$ mkdir .well-known
+$ curl https://<Var name="teleport.example.com"/>/.well-known/openid-configuration > .well-known/openid-configuration
+$ curl https://<Var name="teleport.example.com"/>/.well-known/jwks-oidc > .well-known/jwks
+```
+
+Edit the `openid-configuration` and replace the `issuer` and `jwks_uri` fields with with the S3 location:
+```json
+{
+  "issuer": "<Var name="s3-bucket"/>.s3.amazonaws.com/<Var name="s3-prefix"/>",
+  "jwks_uri": "https://<Var name="s3-bucket"/>.s3.amazonaws.com/<Var name="s3-prefix"/>/.well-known/jwks",
+  // other fields
+}
+```
+
+Upload those files to `<Var name="s3-bucket"/>` bucket:
+```code
+<Var name="s3-bucket"/>
+└── <Var name="s3-prefix"/>
+    └── .well-known
+        ├── openid-configuration
+        └── jwks
+```
+
+Make those objects public (either using Bucket Policies or ACLs):
+```bash
+$ curl https://<Var name="s3-bucket"/>.s3.amazonaws.com/<Var name="s3-prefix"/>/.well-known/openid-configuration
+$ curl https://<Var name="s3-bucket"/>.s3.amazonaws.com/<Var name="s3-prefix"/>/.well-known/jwks
+```
+
+## Step 3/5. Configure the Identity Provider in AWS
+Navigate to [AWS IAM Identity Provider](https://console.aws.amazon.com/iam/home#/identity_providers/create) and configure the Identity Provider:
+- Provider type: OpenID Connect
+- Provider URL:
+```code
+https://<Var name="s3-bucket"/>.s3.amazonaws.com/<Var name="s3-prefix"/>
+```
+- Audience: `discover.teleport`
+
+## Step 4/5. Create IAM Role
+An IAM Role must be created to assign the required policies to the Integration <Var name="iam-role"/>.
+
+This IAM Role is created without any policy, as those are added depending on the feature you would like to use.
+However, it must be configured to allow the Identity Provider to assume it.
+To achieve this, add the following Trust Relationship:
+```json
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Federated": "arn:aws:iam::<Var name="aws-account-id" description="AWS Account ID"/>:oidc-provider/<Var name="s3-bucket"/>.s3.amazonaws.com/<Var name="s3-prefix"/>"
+			},
+			"Action": "sts:AssumeRoleWithWebIdentity",
+			"Condition": {
+				"StringEquals": {
+					"<Var name="s3-bucket"/>.s3.amazonaws.com/<Var name="s3-prefix"/>:aud": "discover.teleport"
+				}
+			}
+		}
+	]
+}
+```
+
+It is also required to add the following tags, which are used by Teleport to ensure it can change the IAM Role when onboarding new features:
+```code
+teleport.dev/cluster      <Var name="cluster-name"/>
+teleport.dev/origin       integration_awsoidc
+teleport.dev/integration  <Var name="my-integration"/>
+```
+
+## Step 5/5. Create Integration resource
+```yaml
+kind: integration
+sub_kind: aws-oidc
+version: v1
+metadata:
+  name: <Var name="my-integration"/>
+spec:
+  aws_oidc:
+    role_arn: "arn:aws:iam::<Var name="aws-account-id"/>:role/<Var name="iam-role"/>"
+    issuer_s3_uri: s3://<Var name="s3-bucket"/>/<Var name="s3-prefix"/>
+```
+
+After the set up is complete, you can now use the "Enroll New Resource" flow in WebUI, or other integration dependent features.


### PR DESCRIPTION
Added a guide that explains how to set up the AWS OIDC integration without using the UI.