### PR TITLE
[v15] chore: Bump Go to v1.21.10

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.21.9
+GOLANG_VERSION ?= go1.21.10
 GOLANGCI_LINT_VERSION ?= v1.57.2
 
 NODE_VERSION ?= 20.11.1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gravitational/teleport
 
 go 1.21
 
-toolchain go1.21.9
+toolchain go1.21.10
 
 require (
 	cloud.google.com/go/compute v1.25.0

--- a/integrations/event-handler/Makefile
+++ b/integrations/event-handler/Makefile
@@ -1,5 +1,5 @@
 VERSION?=15.2.0
-GO_VERSION=1.21.9
+GO_VERSION=1.21.10
 
 GITTAG=v$(VERSION)
 
@@ -53,7 +53,7 @@ release: build
 	tar -czf $(RELEASE).tar.gz $(RELEASE_NAME)
 	rm -rf $(RELEASE_NAME)/
 	@echo "---> Created $(RELEASE).tar.gz."
-  
+
 
 .PHONY: clean
 clean:
@@ -93,7 +93,7 @@ configure: build
 
 .PHONY: fluentd
 fluentd:
-	docker run -p 8888:8888 -v $(LOCALDIR)tmp:/keys -v $(LOCALDIR)tmp/fluent.conf:/fluentd/etc/fluent.conf fluent/fluentd:edge 
+	docker run -p 8888:8888 -v $(LOCALDIR)tmp:/keys -v $(LOCALDIR)tmp/fluent.conf:/fluentd/etc/fluent.conf fluent/fluentd:edge
 
 .PHONY: example
 example: build

--- a/integrations/event-handler/build.assets/Makefile
+++ b/integrations/event-handler/build.assets/Makefile
@@ -1,5 +1,5 @@
 VERSION=0.0.1
-GO_VERSION=1.21.9
+GO_VERSION=1.21.10
 LOCALDIR := $(dir $(CURDIR)/$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST)))
 TOP ?= $(abspath $(LOCALDIR)/../..)
 SRCDIR=/go/src/github.com/gravitational/teleport/integrations/event-handler

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -2,7 +2,7 @@ module github.com/gravitational/teleport/integrations/event-handler
 
 go 1.21
 
-toolchain go1.21.9
+toolchain go1.21.10
 
 require (
 	github.com/alecthomas/kong v0.9.0

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -2,7 +2,7 @@ module github.com/gravitational/teleport/integrations/terraform
 
 go 1.21
 
-toolchain go1.21.9
+toolchain go1.21.10
 
 require (
 	github.com/gogo/protobuf v1.3.2


### PR DESCRIPTION
Update Go to the latest patch.

* https://groups.google.com/g/golang-announce/c/wkkO4P9stm0/m/IcuqZRViCgAJ

Changelog: Updated Go to v1.21.10