### PR TITLE
WebDiscover: Fix same route link not updating component

### DIFF
--- a/web/packages/teleport/src/Discover/Discover.tsx
+++ b/web/packages/teleport/src/Discover/Discover.tsx
@@ -17,7 +17,7 @@
  */
 
 import React from 'react';
-
+import { useLocation } from 'react-router';
 import { Prompt } from 'react-router-dom';
 import { Box } from 'design';
 
@@ -95,8 +95,9 @@ function DiscoverContent() {
 }
 
 export function DiscoverComponent({ eViewConfigs = [] }: Props) {
+  const location = useLocation();
   return (
-    <DiscoverProvider eViewConfigs={eViewConfigs}>
+    <DiscoverProvider eViewConfigs={eViewConfigs} key={location.key}>
       <DiscoverContent />
     </DiscoverProvider>
   );


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/41219

I was so confident in myself that I didn't actually try to click test the internal link before this went out. The problem was, the user was already on the route that the link was supposed to take them, so no updates were happening.

I added a key to the root component that upon change will create a new component instance. 


https://github.com/gravitational/teleport/assets/43280172/30cbfda7-a1ff-4574-9b23-871eb4ed5001

changelog: Fix broken link for alternative EC2 installation during EC2 discover flow
