### PR TITLE
[v15] WebDiscover: Fix same route link not updating component

### DIFF
--- a/web/packages/teleport/src/Discover/Discover.tsx
+++ b/web/packages/teleport/src/Discover/Discover.tsx
@@ -17,7 +17,7 @@
  */
 
 import React from 'react';
-
+import { useLocation } from 'react-router';
 import { Prompt } from 'react-router-dom';
 import { Box } from 'design';
 
@@ -95,8 +95,9 @@ function DiscoverContent() {
 }
 
 export function DiscoverComponent({ eViewConfigs = [] }: Props) {
+  const location = useLocation();
   return (
-    <DiscoverProvider eViewConfigs={eViewConfigs}>
+    <DiscoverProvider eViewConfigs={eViewConfigs} key={location.key}>
       <DiscoverContent />
     </DiscoverProvider>
   );


### PR DESCRIPTION
Backport #41283 to branch/v15

changelog: Fix broken link for alternative EC2 installation during EC2 discover flow
