### PR TITLE
[v13] Validate application URL extracted from request route /web/launch/<app-url>

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -505,27 +505,27 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 				parts := strings.Split(r.URL.Path, "/")
 
 				if len(parts[3]) == 0 {
-					h.log.Warn("Application URL is missing from web/launch URL")
-					http.Error(w, "missing application URL", http.StatusBadRequest)
+					h.log.Warn("Application domain is missing from web/launch URL")
+					http.Error(w, "missing application domain", http.StatusBadRequest)
 					return
 				}
 
 				// grab the FQDN from the URL to allow in the connect-src CSP
-				applicationURL := "https://" + parts[3]
+				applicationOrigin := "https://" + parts[3]
 
-				// Parse to validate the URL extracted is in a valid format.
-				// An invalid URL is:
+				// Parse to validate the application domain extracted is in a valid format.
+				// An invalid domain is:
 				//  - having spaces
 				//  - having escape characters eg: %20
 				//  - invalid port after host eg: :unsafe-inline
-				_, err := url.Parse(applicationURL)
+				_, err := url.Parse(applicationOrigin)
 				if err != nil {
-					h.log.WithError(err).Warn("Failed to parse application URL extracted from web/launch.")
+					h.log.WithError(err).Warn("Failed to parse application domain extracted from web/launch.")
 					http.Error(w, err.Error(), http.StatusBadRequest)
 					return
 				}
 
-				httplib.SetAppLaunchContentSecurityPolicy(w.Header(), applicationURL+":*")
+				httplib.SetAppLaunchContentSecurityPolicy(w.Header(), applicationOrigin+":*")
 			} else {
 				httplib.SetIndexContentSecurityPolicy(w.Header(), cfg.ClusterFeatures)
 			}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -503,6 +503,13 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 				// legacy app access needs to make a CORS fetch request,
 				// so we only set the default CSP on that page
 				parts := strings.Split(r.URL.Path, "/")
+
+				if len(parts[3]) == 0 {
+					h.log.Warn("Application URL is missing from web/launch URL")
+					http.Error(w, "missing application URL", http.StatusBadRequest)
+					return
+				}
+
 				// grab the FQDN from the URL to allow in the connect-src CSP
 				applicationURL := "https://" + parts[3]
 
@@ -513,7 +520,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 				//  - invalid port after host eg: :unsafe-inline
 				_, err := url.Parse(applicationURL)
 				if err != nil {
-					h.log.WithError(err).Warn("Failed to parse application URL extracted from web/launcher.")
+					h.log.WithError(err).Warn("Failed to parse application URL extracted from web/launch.")
 					http.Error(w, err.Error(), http.StatusBadRequest)
 					return
 				}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -6013,6 +6013,72 @@ func TestListConnectionsDiagnostic(t *testing.T) {
 	require.Equal(t, receivedConnectionDiagnostic.Traces[0].Details, "some details")
 }
 
+func TestWebLauncherURL(t *testing.T) {
+	t.Parallel()
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, "foo@example.com", nil /* roles */)
+
+	testcases := []struct {
+		desc           string
+		appURL         string
+		wantBadRequest bool
+	}{
+		{
+			desc:   "valid semicolon",
+			appURL: "dumper.localhost;testing",
+		},
+		{
+			desc:   "valid with query (question mark)",
+			appURL: "dumper.localhost?foo",
+		},
+		{
+			desc:   "valid with multipath",
+			appURL: "dumper.localhost/foo/bar/",
+		},
+		{
+			desc:   "valid with multipath with query",
+			appURL: "dumper.localhost/foo/bar?foo=bar",
+		},
+		{
+			desc:           "invalid use of semicolon, invalid port",
+			appURL:         "dumper.localhost;script-src:something",
+			wantBadRequest: true,
+		},
+		{
+			desc:           "invalid use of escape characters (space)",
+			appURL:         "dumper.localhost;%20script-src%20unsafe-inline%20;",
+			wantBadRequest: true,
+		},
+		{
+			desc:           "invalid use of escape characters (double encoded space)",
+			appURL:         "dumper.localhost;%2520script-src%20unsafe-inline%2520;",
+			wantBadRequest: true,
+		},
+		{
+			desc:           "invalid use of spaces",
+			appURL:         "dumper.localhost; script-src * unsafe-inline;",
+			wantBadRequest: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			str := fmt.Sprintf("%s/%s/%s", proxy.webURL.String(), "web/launch", tc.appURL)
+
+			resp, err := pack.clt.HTTPClient().Get(str)
+			require.NoError(t, err)
+
+			if tc.wantBadRequest {
+				require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			} else {
+				require.Equal(t, http.StatusOK, resp.StatusCode)
+			}
+		})
+	}
+
+}
+
 func TestDiagnoseSSHConnection(t *testing.T) {
 	ctx := context.Background()
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -6020,60 +6020,67 @@ func TestWebLauncherURL(t *testing.T) {
 	pack := proxy.authPack(t, "foo@example.com", nil /* roles */)
 
 	testcases := []struct {
-		desc           string
-		appURL         string
-		wantBadRequest bool
+		desc       string
+		appURL     string
+		statusCode int
 	}{
 		{
-			desc:   "valid semicolon",
-			appURL: "dumper.localhost;testing",
+			desc:       "valid semicolon",
+			appURL:     "dumper.localhost;testing",
+			statusCode: http.StatusOK,
 		},
 		{
-			desc:   "valid with query (question mark)",
-			appURL: "dumper.localhost?foo",
+			desc:       "valid with query (question mark)",
+			appURL:     "dumper.localhost?foo",
+			statusCode: http.StatusOK,
 		},
 		{
-			desc:   "valid with multipath",
-			appURL: "dumper.localhost/foo/bar/",
+			desc:       "valid with multipath",
+			appURL:     "dumper.localhost/foo/bar/",
+			statusCode: http.StatusOK,
 		},
 		{
-			desc:   "valid with multipath with query",
-			appURL: "dumper.localhost/foo/bar?foo=bar",
+			desc:       "valid with multipath with query",
+			appURL:     "dumper.localhost/foo/bar?foo=bar",
+			statusCode: http.StatusOK,
 		},
 		{
-			desc:           "invalid use of semicolon, invalid port",
-			appURL:         "dumper.localhost;script-src:something",
-			wantBadRequest: true,
+			desc:       "invalid: empty application url",
+			appURL:     "/",
+			statusCode: http.StatusBadRequest,
 		},
 		{
-			desc:           "invalid use of escape characters (space)",
-			appURL:         "dumper.localhost;%20script-src%20unsafe-inline%20;",
-			wantBadRequest: true,
+			desc:       "invalid use of semicolon, invalid port",
+			appURL:     "dumper.localhost;script-src:something",
+			statusCode: http.StatusBadRequest,
 		},
 		{
-			desc:           "invalid use of escape characters (double encoded space)",
-			appURL:         "dumper.localhost;%2520script-src%20unsafe-inline%2520;",
-			wantBadRequest: true,
+			desc:       "invalid use of escape characters (space)",
+			appURL:     "dumper.localhost;%20script-src%20unsafe-inline%20;",
+			statusCode: http.StatusBadRequest,
 		},
 		{
-			desc:           "invalid use of spaces",
-			appURL:         "dumper.localhost; script-src * unsafe-inline;",
-			wantBadRequest: true,
+			desc:       "invalid use of escape characters (double encoded space)",
+			appURL:     "dumper.localhost;%2520script-src%2520unsafe-inline%2520;",
+			statusCode: http.StatusBadRequest,
+		},
+		{
+			desc:       "invalid use of spaces",
+			appURL:     "dumper.localhost; script-src * unsafe-inline;",
+			statusCode: http.StatusBadRequest,
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
-			str := fmt.Sprintf("%s/%s/%s", proxy.webURL.String(), "web/launch", tc.appURL)
-
-			resp, err := pack.clt.HTTPClient().Get(str)
+			url, err := url.JoinPath(proxy.webURL.String(), "web", "launch", tc.appURL)
 			require.NoError(t, err)
 
-			if tc.wantBadRequest {
-				require.Equal(t, http.StatusBadRequest, resp.StatusCode)
-			} else {
-				require.Equal(t, http.StatusOK, resp.StatusCode)
-			}
+			resp, err := pack.clt.HTTPClient().Get(url)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, tc.statusCode, resp.StatusCode)
 		})
 	}
 


### PR DESCRIPTION
Backport #41236 to branch/v13

changelog: Validate application URL extracted from the web application launcher request route
