### PR TITLE
S3: add configurable ForcePathStyle as a URI parameter

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -379,6 +379,9 @@ const (
 	// SSEKMSKey is an optional switch to use an KMS CMK key for S3 SSE.
 	SSEKMSKey = "sse_kms_key"
 
+	// ForcePathStyle is an optional switch to force path style URI	for S3
+	ForcePathStyle = "force_path_style"
+
 	// SchemeFile configures local disk-based file storage for audit events
 	SchemeFile = "file"
 

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -74,6 +74,8 @@ type Config struct {
 	Path string
 	// Endpoint is an optional third party S3 compatible endpoint
 	Endpoint string
+	// ForcePathStyle forces the use of path style URLs
+	ForcePathStyle bool
 	// ACL is the canned ACL to send to S3
 	ACL string
 	// Session is an optional existing AWS client session
@@ -144,6 +146,14 @@ func (s *Config) SetFromURL(in *url.URL, inRegion string) error {
 		}
 	}
 
+	if val := in.Query().Get(teleport.ForcePathStyle); val != "" {
+		forcePathStyle, err := strconv.ParseBool(val)
+		if err != nil {
+			return trace.BadParameter(boolErrorTemplate, in.String(), teleport.ForcePathStyle, val)
+		}
+		s.ForcePathStyle = forcePathStyle
+	}
+
 	s.Region = region
 	s.Bucket = in.Host
 	s.Path = in.Path
@@ -164,7 +174,7 @@ func (s *Config) CheckAndSetDefaults() error {
 		}
 		if s.Endpoint != "" {
 			awsConfig.Endpoint = aws.String(s.Endpoint)
-			awsConfig.S3ForcePathStyle = aws.Bool(true)
+			awsConfig.S3ForcePathStyle = aws.Bool(s.ForcePathStyle)
 		}
 		if s.Insecure {
 			awsConfig.DisableSSL = aws.Bool(s.Insecure)


### PR DESCRIPTION
This commit, when merged, will allow the AWS config `S3ForcePathStyle` to be configurable as a URI parameter, making it more compatible, instead of hardcoded as `true`. See the following link[1] for an example. Thank you!

[1] [Use Amazon S3 SDKs to access OSS - Amazon S3 SDK for Go](https://www.alibabacloud.com/help/en/oss/developer-reference/use-amazon-s3-sdks-to-access-oss#section-sp0-q7h-dvj)