### PR TITLE
WebDiscover: displays user or db name holder instead of wildcards for tsh db connect suggestion

### DIFF
--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.test.tsx
@@ -86,6 +86,10 @@ test('custom db name and user is respected when defined', async () => {
   // Test with custom fields.
   await userEvent.click(screen.getByText('user1'));
   await userEvent.click(screen.getByText('*'));
+  expect(
+    screen.getByText(/--db-user=<user> --db-name=name1/i)
+  ).toBeInTheDocument();
+
   await userEvent.type(
     screen.getByPlaceholderText(/custom-database-user-name/i),
     'custom-user'
@@ -95,6 +99,10 @@ test('custom db name and user is respected when defined', async () => {
   // The first wildcard is on screen from selecting
   // it for db users dropdown.
   await userEvent.click(screen.getAllByText('*')[1]);
+  expect(
+    screen.getByText(/--db-user=custom-user --db-name=<name>/i)
+  ).toBeInTheDocument();
+
   await userEvent.type(
     screen.getByPlaceholderText(/custom-database-name/i),
     'custom-name'

--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
@@ -75,9 +75,18 @@ export function TestConnection() {
   const [customDbUser, setCustomDbUser] = useState('');
   const [customDbName, setCustomDbName] = useState('');
 
-  let tshDbCmd = `tsh db connect ${db.name} --db-user=${customDbUser || selectedDbUser.value}`;
-  if (customDbName || selectedDbName) {
-    tshDbCmd += ` --db-name=${customDbName || selectedDbName.value}`;
+  let tshDbCmd = `tsh db connect ${db.name} --db-user=`;
+
+  // do not display wildcard as the user
+  const dbUser = customDbUser || selectedDbUser.value;
+  if (dbUser == '*') tshDbCmd += `<database-user>`;
+  else tshDbCmd += `${customDbUser || selectedDbUser.value}`;
+
+  const dbName = customDbName || selectedDbName.value;
+  if (dbName) {
+    // do not show wildcard as the database name
+    if (dbName == '*') tshDbCmd += ` --db-name=<database-name>`;
+    else tshDbCmd += ` --db-name=${customDbName || selectedDbName}`;
   }
 
   function makeTestConnRequest() {

--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
@@ -86,7 +86,7 @@ export function TestConnection() {
   if (dbName) {
     // do not show wildcard as the database name
     if (dbName == '*') tshDbCmd += ` --db-name=<name>`;
-    else tshDbCmd += ` --db-name=${customDbName || selectedDbName}`;
+    else tshDbCmd += ` --db-name=${customDbName || selectedDbName.value}`;
   }
 
   function makeTestConnRequest() {

--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
@@ -75,18 +75,11 @@ export function TestConnection() {
   const [customDbUser, setCustomDbUser] = useState('');
   const [customDbName, setCustomDbName] = useState('');
 
-  let tshDbCmd = `tsh db connect ${db.name} --db-user=`;
-
-  // do not display wildcard as the user
-  const dbUser = customDbUser || selectedDbUser.value;
-  if (dbUser == '*') tshDbCmd += `<user>`;
-  else tshDbCmd += `${customDbUser || selectedDbUser.value}`;
-
-  const dbName = customDbName || selectedDbName.value;
-  if (dbName) {
-    // do not show wildcard as the database name
-    if (dbName == '*') tshDbCmd += ` --db-name=<name>`;
-    else tshDbCmd += ` --db-name=${customDbName || selectedDbName.value}`;
+  const dbUser = getInputValue(customDbUser || selectedDbUser.value, 'user');
+  let tshDbCmd = `tsh db connect ${db.name} --db-user=${dbUser}`;
+  if (customDbName || selectedDbName) {
+    const dbName = getInputValue(customDbName || selectedDbName.value, 'name');
+    tshDbCmd += ` --db-name=${dbName}`;
   }
 
   function makeTestConnRequest() {
@@ -238,4 +231,11 @@ export function TestConnection() {
       )}
     </Validation>
   );
+}
+
+function getInputValue(input: string, inputKind: 'name' | 'user') {
+  if (input == WILD_CARD) {
+    return inputKind === 'name' ? '<name>' : '<user>';
+  }
+  return input;
 }

--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
@@ -79,13 +79,13 @@ export function TestConnection() {
 
   // do not display wildcard as the user
   const dbUser = customDbUser || selectedDbUser.value;
-  if (dbUser == '*') tshDbCmd += `<database-user>`;
+  if (dbUser == '*') tshDbCmd += `<user>`;
   else tshDbCmd += `${customDbUser || selectedDbUser.value}`;
 
   const dbName = customDbName || selectedDbName.value;
   if (dbName) {
     // do not show wildcard as the database name
-    if (dbName == '*') tshDbCmd += ` --db-name=<database-name>`;
+    if (dbName == '*') tshDbCmd += ` --db-name=<name>`;
     else tshDbCmd += ` --db-name=${customDbName || selectedDbName}`;
   }
 


### PR DESCRIPTION
fixes #41312

