### PR TITLE
webclient.Ping: Return error on unsuccessful response

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -226,16 +226,16 @@ func Ping(cfg *Config) (*PingResponse, error) {
 
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, trace.Wrap(err, "could not read ping response body")
+			return nil, trace.Wrap(err, "could not read ping response body; check the network connection")
 		}
 
 		errResp := &PingErrorResponse{}
 		if err := json.Unmarshal(bodyBytes, errResp); err != nil {
 			slog.DebugContext(req.Context(), "Could not parse ping response body", "body", string(bodyBytes))
-			return nil, trace.Wrap(err, "cannot parse unsuccessful ping response")
+			return nil, trace.Wrap(err, "cannot parse ping response; is proxy reachable?")
 		}
 
-		return nil, trace.Wrap(errors.New(errResp.Error.Message), "proxy service returned unsuccessful ping response")
+		return nil, trace.Wrap(errors.New(errResp.Error.Message), "proxy service returned unsuccessful ping response; Teleport cluster auth may be misconfigured")
 	}
 
 	pr := &PingResponse{}

--- a/api/client/webclient/webclient_test.go
+++ b/api/client/webclient/webclient_test.go
@@ -111,23 +111,52 @@ func TestPlainHttpFallback(t *testing.T) {
 }
 
 func TestPingError(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.RequestURI != "/webapi/ping" {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
+	t.Parallel()
 
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(PingErrorResponse{Error: PingError{Message: "lorem ipsum"}})
-	})
-	httpSvr := httptest.NewServer(handler)
-	defer httpSvr.Close()
-	proxyAddr := httpSvr.Listener.Addr().String()
+	testCases := []struct {
+		desc        string
+		writeBody   func(t *testing.T, w http.ResponseWriter)
+		errContains string
+	}{
+		{
+			desc: "unsuccessful response",
+			writeBody: func(t *testing.T, w http.ResponseWriter) {
+				err := json.NewEncoder(w).Encode(PingErrorResponse{Error: PingError{Message: "lorem ipsum"}})
+				require.NoError(t, err)
+			},
+			errContains: "lorem ipsum",
+		},
+		{
+			desc: "mangled response",
+			writeBody: func(t *testing.T, w http.ResponseWriter) {
+				_, err := w.Write([]byte("mangled lorem ipsum"))
+				require.NoError(t, err)
+			},
+			errContains: "invalid character",
+		},
+	}
 
-	_, err := Ping(
-		&Config{Context: context.Background(), ProxyAddr: proxyAddr, Insecure: true})
-	require.ErrorContains(t, err, "lorem ipsum")
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.RequestURI != "/webapi/ping" {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				testCase.writeBody(t, w)
+			})
+			httpSvr := httptest.NewServer(handler)
+			defer httpSvr.Close()
+			proxyAddr := httpSvr.Listener.Addr().String()
+
+			_, err := Ping(
+				&Config{Context: context.Background(), ProxyAddr: proxyAddr, Insecure: true})
+			require.ErrorContains(t, err, testCase.errContains)
+		})
+	}
 }
 
 func TestTunnelAddr(t *testing.T) {


### PR DESCRIPTION
Closes #40208.

We'd often get confusing error reports from users when they weren't able to log in to a cluster. It turns out the code in tsh and Connect that pings the proxy was not handling an error response correctly, and instead it was proceeding with an empty ping response. All this while /webapi/ping returned an actually useful piece of information about a misconfigured cluster – usually the connector was the problem.

This PR changes makes it so that if /webapi/ping returns anything else than 200, the client is going to return an error. I'm going to let it sit on master before backporting.

Feedback wrt to user messages welcome!

<details>
<summary>Before</summary>

```
$ tsh login --proxy=teleport-local.dev:3090
ERROR: unsupported authentication type: ""

$ tsh login -d --proxy=teleport-local.dev:3090
2024-05-08T16:21:31+02:00 INFO [CLIENT]    No teleport login given. defaulting to rav client/api.go:1113
2024-05-08T16:21:31+02:00 INFO [CLIENT]    no host login given. defaulting to rav client/api.go:1123
2024-05-08T16:21:31+02:00 INFO [CLIENT]    [KEY AGENT] Connected to the system agent: "/private/tmp/com.apple.launchd.n3b3Cd3cx3/Listeners" client/api.go:4460
2024-05-08T16:21:31+02:00 DEBU [TSH]       Pinging the proxy to fetch listening addresses for non-web ports. common/tsh.go:3705
2024-05-08T16:21:31+02:00 DEBU [CLIENT]    attempting to use loopback pool for local proxy addr: teleport-local.dev:3090 client/api.go:4418
2024-05-08T16:21:31+02:00 DEBU [CLIENT]    reading self-signed certs from: /var/lib/teleport/webproxy_cert.pem client/api.go:4426
2024-05-08T16:21:31+02:00 DEBU [CLIENT]    could not open any path in: /var/lib/teleport/webproxy_cert.pem client/api.go:4430
2024-05-08T16:21:31+02:00 DEBU  Attempting request to Proxy web api method:GET host:teleport-local.dev:3090 path:/webapi/ping trace_id:096fa35861df37eb3a0a39850e4ffb1d span_id:5c656c392a0ab347 webclient/webclient.go:130
2024-05-08T16:21:31+02:00 DEBU  ALPN connection upgrade test complete address:teleport-local.dev:3090 upgrade_required:false trace_id:096fa35861df37eb3a0a39850e4ffb1d span_id:5c656c392a0ab347 client/alpn_conn_upgrade.go:96

ERROR REPORT:
Original Error: *trace.BadParameterError unsupported authentication type: &#34;&#34;
Stack Trace:
	github.com/gravitational/teleport/lib/client/api.go:3439 github.com/gravitational/teleport/lib/client.(*TeleportClient).getSSHLoginFunc
	github.com/gravitational/teleport/lib/client/api.go:3193 github.com/gravitational/teleport/lib/client.(*TeleportClient).Login
	github.com/gravitational/teleport/tool/tsh/common/tsh.go:1938 github.com/gravitational/teleport/tool/tsh/common.onLogin
	github.com/gravitational/teleport/tool/tsh/common/tsh.go:1409 github.com/gravitational/teleport/tool/tsh/common.Run
	github.com/gravitational/teleport/tool/tsh/common/tsh.go:594 github.com/gravitational/teleport/tool/tsh/common.Main
	github.com/gravitational/teleport/tool/tsh/main.go:26 main.main
	runtime/proc.go:271 runtime.main
	runtime/asm_arm64.s:1222 runtime.goexit
User Message: unsupported authentication type: &#34;&#34;

```
</details>

<details open>
<summary>After</summary>

```
$ tsh login --proxy=teleport-local.dev:3090
ERROR: proxy service returned unsuccessful ping response
	oops, something went wrong

$ tsh login -d --proxy=teleport-local.dev:3090
2024-05-08T16:11:21+02:00 INFO [CLIENT]    No teleport login given. defaulting to rav client/api.go:1113
2024-05-08T16:11:21+02:00 INFO [CLIENT]    no host login given. defaulting to rav client/api.go:1123
2024-05-08T16:11:21+02:00 INFO [CLIENT]    [KEY AGENT] Connected to the system agent: "/private/tmp/com.apple.launchd.n3b3Cd3cx3/Listeners" client/api.go:4460
2024-05-08T16:11:21+02:00 DEBU [TSH]       Pinging the proxy to fetch listening addresses for non-web ports. common/tsh.go:3705
2024-05-08T16:11:21+02:00 DEBU [CLIENT]    attempting to use loopback pool for local proxy addr: teleport-local.dev:3090 client/api.go:4418
2024-05-08T16:11:21+02:00 DEBU [CLIENT]    reading self-signed certs from: /var/lib/teleport/webproxy_cert.pem client/api.go:4426
2024-05-08T16:11:21+02:00 DEBU [CLIENT]    could not open any path in: /var/lib/teleport/webproxy_cert.pem client/api.go:4430
2024-05-08T16:11:21+02:00 DEBU  Attempting request to Proxy web api method:GET host:teleport-local.dev:3090 path:/webapi/ping trace_id:3dd37f581ab85e40258ba7e36896e58d span_id:8c5b4fddcac4d4b0 webclient/webclient.go:130
2024-05-08T16:11:21+02:00 DEBU  Received unsuccessful ping response code:500 trace_id:3dd37f581ab85e40258ba7e36896e58d span_id:8c5b4fddcac4d4b0 webclient/webclient.go:224

ERROR REPORT:
Original Error: *errors.errorString oops, something went wrong
Stack Trace:
	github.com/gravitational/teleport/api@v0.0.0/client/webclient/webclient.go:231 github.com/gravitational/teleport/api/client/webclient.Ping
	github.com/gravitational/teleport/lib/client/api.go:4030 github.com/gravitational/teleport/lib/client.(*TeleportClient).Ping
	github.com/gravitational/teleport/tool/tsh/common/tsh.go:3706 github.com/gravitational/teleport/tool/tsh/common.makeClientForProxy
	github.com/gravitational/teleport/tool/tsh/common/tsh.go:3669 github.com/gravitational/teleport/tool/tsh/common.makeClient
	github.com/gravitational/teleport/tool/tsh/common/tsh.go:1819 github.com/gravitational/teleport/tool/tsh/common.onLogin
	github.com/gravitational/teleport/tool/tsh/common/tsh.go:1409 github.com/gravitational/teleport/tool/tsh/common.Run
	github.com/gravitational/teleport/tool/tsh/common/tsh.go:594 github.com/gravitational/teleport/tool/tsh/common.Main
	github.com/gravitational/teleport/tool/tsh/main.go:26 main.main
	runtime/proc.go:271 runtime.main
	runtime/asm_arm64.s:1222 runtime.goexit
User Message: proxy service returned unsuccessful ping response
	oops, something went wrong

```
</details>

changelog: Made tsh and Teleport Connect return early during login if ping to proxy service was not successful