### PR TITLE
Add notifications web endpoints

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -57,6 +57,7 @@ import (
 	"golang.org/x/mod/semver"
 	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
@@ -64,6 +65,7 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
@@ -981,6 +983,13 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.PUT("/webapi/sites/:site/machine-id/bot/:name", h.WithClusterAuth(h.updateBot))
 	// Delete Machine ID bot
 	h.DELETE("/webapi/sites/:site/machine-id/bot/:name", h.WithClusterAuth(h.deleteBot))
+
+	// GET a paginated list of notifications for a user
+	h.GET("/webapi/sites/:site/notifications", h.WithClusterAuth(h.notificationsGet))
+	// Upsert the timestamp of the latest notification that the user has seen.
+	h.PUT("/webapi/sites/:site/lastseennotification", h.WithClusterAuth(h.notificationsUpsertLastSeenTimestamp))
+	// Upsert a notification state when to mark a notification as read or hide it.
+	h.PUT("/webapi/sites/:site/notificationstate", h.WithClusterAuth(h.notificationsUpsertNotificationState))
 }
 
 // GetProxyClient returns authenticated auth server client
@@ -2940,6 +2949,127 @@ func (h *Handler) clusterNodesGet(w http.ResponseWriter, r *http.Request, p http
 		StartKey:   page.NextKey,
 		TotalCount: page.Total,
 	}, nil
+}
+
+// iso8601MilliFormat is the time format of dates returned from the frontend using Date().
+const iso8601MilliFormat = "2006-01-02T15:04:05.000Z0700"
+
+// notificationsGet returns a paginated list of notifications for a user.
+func (h *Handler) notificationsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	values := r.URL.Query()
+
+	limit, err := QueryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	startKey := values.Get("startKey")
+
+	response, err := clt.NotificationServiceClient().ListNotifications(r.Context(), &notificationsv1.ListNotificationsRequest{
+		PageSize:  limit,
+		PageToken: startKey,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var uiNotifications []ui.Notification
+
+	for _, notification := range response.Notifications {
+		uiNotif := ui.MakeNotification(notification)
+		uiNotifications = append(uiNotifications, uiNotif)
+	}
+
+	return GetNotificationsResponse{
+		Notifications:            uiNotifications,
+		NextKey:                  response.NextPageToken,
+		UserLastSeenNotification: response.UserLastSeenNotificationTimestamp.AsTime().Format(iso8601MilliFormat),
+	}, nil
+}
+
+type GetNotificationsResponse struct {
+	Notifications            []ui.Notification `json:"notifications"`
+	NextKey                  string            `json:"nextKey"`
+	UserLastSeenNotification string            `json:"userLastSeenNotification"`
+}
+
+// notificationsUpsertLastSeenTimestamp upserts a user's last seen notification timestamp.
+func (h *Handler) notificationsUpsertLastSeenTimestamp(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var req *UpsertUserLastSeenNotificationRequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	lastSeenTime, err := time.Parse(iso8601MilliFormat, req.Time)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resp, err := clt.NotificationServiceClient().UpsertUserLastSeenNotification(r.Context(), &notificationsv1.UpsertUserLastSeenNotificationRequest{
+		Username: sctx.GetUser(),
+		UserLastSeenNotification: &notificationsv1.UserLastSeenNotification{
+			Status: &notificationsv1.UserLastSeenNotificationStatus{
+				LastSeenTime: timestamppb.New(lastSeenTime),
+			},
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &UpsertUserLastSeenNotificationRequest{
+		Time: resp.Status.LastSeenTime.AsTime().Format(iso8601MilliFormat),
+	}, nil
+}
+
+type UpsertUserLastSeenNotificationRequest struct {
+	Time string `json:"time"`
+}
+
+// notificationsUpsertNotificationState upserts a user notification state.
+func (h *Handler) notificationsUpsertNotificationState(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var req *upsertUserNotificationStateRequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resp, err := clt.NotificationServiceClient().UpsertUserNotificationState(r.Context(), &notificationsv1.UpsertUserNotificationStateRequest{
+		Username: sctx.GetUser(),
+		UserNotificationState: &notificationsv1.UserNotificationState{
+			Spec: &notificationsv1.UserNotificationStateSpec{
+				NotificationId: req.NotificationId,
+			},
+			Status: &notificationsv1.UserNotificationStateStatus{
+				NotificationState: req.NotificationState,
+			},
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &upsertUserNotificationStateRequest{
+		NotificationId:    resp.GetSpec().GetNotificationId(),
+		NotificationState: resp.GetStatus().GetNotificationState(),
+	}, nil
+}
+
+type upsertUserNotificationStateRequest struct {
+	NotificationId    string                            `json:"notificationId"`
+	NotificationState notificationsv1.NotificationState `json:"notificationState"`
 }
 
 type getLoginAlertsResponse struct {

--- a/lib/web/notifications_test.go
+++ b/lib/web/notifications_test.go
@@ -1,0 +1,297 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/web/ui"
+)
+
+func TestNotifications(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	srv := env.server.Auth()
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	testRole, err := types.NewRole("auditors", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins: []string{"auditor", "user"},
+			Rules: []types.Rule{
+				{
+					Resources: []string{types.KindNode, types.KindDatabase},
+					Verbs:     services.RW(),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	username := "auditor"
+
+	pack := proxy.authPack(t, username, []types.Role{testRole})
+
+	// Describes a set of mock notifications to be created.
+	// The number in each notification's description represents the creation order of the notifications.
+	// eg. "auditor-3" will be the third notification created for auditor, and the third from last in the list (since it's the third oldest),
+	testNotifications := []struct {
+		userNotification   *notificationsv1.Notification
+		globalNotification *notificationsv1.GlobalNotification
+	}{
+		{
+			userNotification: newUserNotification(t, username, "auditor-1"),
+		},
+		{
+			userNotification: newUserNotification(t, username, "auditor-2"),
+		},
+		{
+			// Matcher matches by the role "auditors"
+			globalNotification: newGlobalNotification(t, "auditor-3", &notificationsv1.GlobalNotificationSpec{
+				Matcher: &notificationsv1.GlobalNotificationSpec_ByRoles{
+					ByRoles: &notificationsv1.ByRoles{
+						Roles: []string{"auditors"},
+					},
+				},
+			}),
+		},
+		{
+			// This should not be returned in the list since it's not for this user.
+			globalNotification: newGlobalNotification(t, "manager-1", &notificationsv1.GlobalNotificationSpec{
+				Matcher: &notificationsv1.GlobalNotificationSpec_ByRoles{
+					ByRoles: &notificationsv1.ByRoles{
+						Roles: []string{"managers"},
+					},
+				},
+			}),
+		},
+		{
+			userNotification: newUserNotification(t, username, "auditor-4"),
+		},
+		{
+			// Matcher matches all.
+			globalNotification: newGlobalNotification(t, "auditor-5", &notificationsv1.GlobalNotificationSpec{
+				Matcher: &notificationsv1.GlobalNotificationSpec_All{
+					All: true,
+				},
+			}),
+		},
+		{
+			// This should not be returned in the list since it's not for this user.
+			userNotification: newUserNotification(t, "manager", "manager-3"),
+		},
+		{
+			// Matcher matches by read & write permission on nodes.
+			globalNotification: newGlobalNotification(t, "auditor-6", &notificationsv1.GlobalNotificationSpec{
+				Matcher: &notificationsv1.GlobalNotificationSpec_ByPermissions{
+					ByPermissions: &notificationsv1.ByPermissions{
+						RoleConditions: []*types.RoleConditions{
+							{
+								Rules: []types.Rule{
+									{
+										Resources: []string{types.KindNode},
+										Verbs:     services.RW(),
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+		},
+		{
+			globalNotification: newGlobalNotification(t, "auditor-7", &notificationsv1.GlobalNotificationSpec{
+				Matcher: &notificationsv1.GlobalNotificationSpec_ByPermissions{
+					ByPermissions: &notificationsv1.ByPermissions{
+						RoleConditions: []*types.RoleConditions{
+							{
+								Logins: []string{"auditor"},
+							},
+							{
+								Logins: []string{"user"},
+							},
+						},
+					},
+				},
+				MatchAllConditions: true,
+			}),
+		},
+	}
+
+	// Upsert last seen timestamp.
+	lastSeenTimeString := "2024-05-08T19:00:47.836Z"
+	_, err = pack.clt.PutJSON(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "lastseennotification"),
+		UpsertUserLastSeenNotificationRequest{
+			Time: lastSeenTimeString,
+		})
+	require.NoError(t, err)
+
+	// Create the notifications.
+	notificationIdMap := map[string]string{}
+
+	for _, n := range testNotifications {
+		// We add a small delay to ensure that the timestamps in the generated UUID's are all different and in the correct order.
+		// This is to prevent flakiness caused by the notifications being created in such quick succession that the timestamps are the same.
+		env.clock.Advance(50 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
+		// Create the notification in the backend.
+		if n.globalNotification != nil {
+			created, err := srv.CreateGlobalNotification(ctx, n.globalNotification)
+			notificationIdMap[created.GetSpec().GetNotification().GetMetadata().GetLabels()[types.NotificationTitleLabel]] = created.GetMetadata().GetName()
+			require.NoError(t, err)
+			continue
+		}
+		created, err := srv.CreateUserNotification(ctx, n.userNotification)
+		notificationIdMap[created.GetMetadata().GetLabels()[types.NotificationTitleLabel]] = created.GetMetadata().GetName()
+		require.NoError(t, err)
+	}
+
+	expectedNotifications := []string{"auditor-7", "auditor-6", "auditor-5", "auditor-4", "auditor-3", "auditor-2", "auditor-1"}
+
+	var fetchedNotifications []ui.Notification
+
+	// Get a page of 4.
+	notificationsResp, err := pack.clt.Get(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
+		"limit": []string{"4"},
+	})
+	require.NoError(t, err)
+	unmarshaledNotificationsResp := unmarshalNotificationsResponse(t, notificationsResp.Bytes())
+	fetchedNotifications = append(fetchedNotifications, unmarshaledNotificationsResp.Notifications...)
+
+	expectedNextKeys := fmt.Sprintf("%s,%s",
+		notificationIdMap["auditor-2"],
+		notificationIdMap["auditor-3"])
+	require.Equal(t, expectedNotifications[:4], notificationsToTitlesList(t, unmarshaledNotificationsResp.Notifications))
+	require.Equal(t, expectedNextKeys, unmarshaledNotificationsResp.NextKey)
+
+	// Get a page of 10, starting from the previously returned keys.
+	notificationsResp, err = pack.clt.Get(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
+		"limit":    []string{"10"},
+		"startKey": []string{unmarshaledNotificationsResp.NextKey},
+	})
+	require.NoError(t, err)
+	unmarshaledNotificationsResp = unmarshalNotificationsResponse(t, notificationsResp.Bytes())
+	fetchedNotifications = append(fetchedNotifications, unmarshaledNotificationsResp.Notifications...)
+
+	require.Equal(t, expectedNotifications, notificationsToTitlesList(t, fetchedNotifications))
+	require.Equal(t, "", unmarshaledNotificationsResp.NextKey)
+	require.Equal(t, lastSeenTimeString, unmarshaledNotificationsResp.UserLastSeenNotification)
+
+	// Mark the most recent notification as clicked.
+	_, err = pack.clt.PutJSON(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notificationstate"),
+		upsertUserNotificationStateRequest{
+			NotificationId:    notificationIdMap["auditor-7"],
+			NotificationState: notificationsv1.NotificationState_NOTIFICATION_STATE_CLICKED,
+		})
+	require.NoError(t, err)
+
+	// Mark the last notification as dismissed.
+	_, err = pack.clt.PutJSON(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notificationstate"),
+		upsertUserNotificationStateRequest{
+			NotificationId:    notificationIdMap["auditor-1"],
+			NotificationState: notificationsv1.NotificationState_NOTIFICATION_STATE_DISMISSED,
+		})
+	require.NoError(t, err)
+
+	// List all notifications again.
+	notificationsResp, err = pack.clt.Get(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
+		"limit": []string{"10"},
+	})
+	require.NoError(t, err)
+	unmarshaledNotificationsResp = unmarshalNotificationsResponse(t, notificationsResp.Bytes())
+	// Expect the first notification to be marked as clicked.
+	require.True(t, unmarshaledNotificationsResp.Notifications[0].Clicked)
+	// Expect the returned list to include all notifications except the last one.
+	require.Equal(t, expectedNotifications[:6], notificationsToTitlesList(t, unmarshaledNotificationsResp.Notifications))
+
+}
+
+func unmarshalNotificationsResponse(t *testing.T, resp []byte) *GetNotificationsResponse {
+	var notificationsResp *GetNotificationsResponse
+
+	err := json.Unmarshal(resp, &notificationsResp)
+	require.NoError(t, err)
+
+	return notificationsResp
+}
+
+func newUserNotification(t *testing.T, username string, title string) *notificationsv1.Notification {
+	t.Helper()
+
+	notification := notificationsv1.Notification{
+		SubKind: "test-subkind",
+		Spec: &notificationsv1.NotificationSpec{
+			Username: username,
+		},
+		Metadata: &headerv1.Metadata{
+			Labels: map[string]string{
+				types.NotificationTitleLabel: title,
+			},
+		},
+	}
+
+	return &notification
+}
+
+func newGlobalNotification(t *testing.T, title string, spec *notificationsv1.GlobalNotificationSpec) *notificationsv1.GlobalNotification {
+	t.Helper()
+
+	spec.Notification = &notificationsv1.Notification{
+		SubKind: "test-subkind",
+		Spec:    &notificationsv1.NotificationSpec{},
+		Metadata: &headerv1.Metadata{
+			Labels: map[string]string{
+				types.NotificationTitleLabel: title,
+			},
+		},
+	}
+
+	notification := notificationsv1.GlobalNotification{
+		Spec: spec,
+	}
+
+	return &notification
+}
+
+// notificationsToTitlesList accepts a list of notifications notifications and returns a slice of strings containing their titles in order, this is used to compare against
+// the expected outputs.
+func notificationsToTitlesList(t *testing.T, notifications []ui.Notification) []string {
+	t.Helper()
+	var titles []string
+
+	for _, notif := range notifications {
+		title := notif.Title
+		titles = append(titles, title)
+	}
+
+	return titles
+}

--- a/lib/web/ui/notification.go
+++ b/lib/web/ui/notification.go
@@ -1,0 +1,51 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ui
+
+import (
+	"time"
+
+	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+type Notification struct {
+	Id      string    `json:"id"`
+	Title   string    `json:"title"`
+	SubKind string    `json:"subKind"`
+	Created time.Time `json:"created"`
+	Clicked bool      `json:"clicked"`
+	Labels  []Label   `json:"labels"`
+}
+
+// MakeNotification creates a notification object for the WebUI.
+func MakeNotification(notification *notificationsv1.Notification) Notification {
+	labels := makeLabels(notification.Metadata.Labels)
+
+	clicked := notification.Metadata.GetLabels()[types.NotificationClickedLabel] == "true"
+
+	return Notification{
+		Id:      notification.Metadata.GetName(),
+		Title:   notification.Metadata.GetLabels()[types.NotificationTitleLabel],
+		SubKind: notification.SubKind,
+		Created: notification.Spec.Created.AsTime(),
+		Clicked: clicked,
+		Labels:  labels,
+	}
+}

--- a/web/packages/teleport/src/Notifications/Notification.story.tsx
+++ b/web/packages/teleport/src/Notifications/Notification.story.tsx
@@ -24,7 +24,10 @@ import { rest } from 'msw';
 
 import { Flex } from 'design';
 
-import { NotificationSubKind } from 'teleport/services/notifications';
+import {
+  NotificationSubKind,
+  UpsertNotificationStateRequest,
+} from 'teleport/services/notifications';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import cfg from 'teleport/config';
 
@@ -45,27 +48,29 @@ export const NotificationTypes = () => {
   const ctx = createTeleportContext();
 
   return (
-    <ContextProvider ctx={ctx}>
-      Enterprise notifications can be viewed in the
-      "TeleportE/Notifications/Notification Types E" story.
-      <Flex
-        mt={4}
-        p={4}
-        gap={4}
-        css={`
-          background: ${props => props.theme.colors.levels.surface};
-          width: fit-content;
-          height: fit-content;
-          flex-direction: column;
-        `}
-      >
-        {mockNotifications.map(notification => {
-          return (
-            <Notification notification={notification} key={notification.id} />
-          );
-        })}
-      </Flex>
-    </ContextProvider>
+    <MemoryRouter>
+      <ContextProvider ctx={ctx}>
+        Enterprise notifications can be viewed in the
+        "TeleportE/Notifications/Notification Types E" story.
+        <Flex
+          mt={4}
+          p={4}
+          gap={4}
+          css={`
+            background: ${props => props.theme.colors.levels.surface};
+            width: fit-content;
+            height: fit-content;
+            flex-direction: column;
+          `}
+        >
+          {mockNotifications.map(notification => {
+            return (
+              <Notification notification={notification} key={notification.id} />
+            );
+          })}
+        </Flex>
+      </ContextProvider>
+    </MemoryRouter>
   );
 };
 
@@ -75,6 +80,38 @@ NotificationsList.parameters = {
     handlers: [
       rest.get(cfg.api.notificationsPath, (req, res, ctx) =>
         res.once(ctx.json(mockNotificationsResponseFirstPage))
+      ),
+      rest.put(cfg.api.notificationLastSeenTimePath, (req, res, ctx) =>
+        res(ctx.delay(2000), ctx.json({ time: Date.now() }))
+      ),
+      rest.put(cfg.api.notificationStatePath, (req, res, ctx) => {
+        const body = req.body as UpsertNotificationStateRequest;
+        return res(ctx.json({ notificationState: body.notificationState }));
+      }),
+      rest.get(cfg.api.notificationsPath, (req, res, ctx) =>
+        res(ctx.delay(2000), ctx.json(mockNotificationsResponseSecondPage))
+      ),
+    ],
+  },
+};
+
+export const NotificationListNotificationStateErrors = () => <ListComponent />;
+NotificationListNotificationStateErrors.parameters = {
+  msw: {
+    handlers: [
+      rest.get(cfg.api.notificationsPath, (req, res, ctx) =>
+        res.once(ctx.json(mockNotificationsResponseFirstPage))
+      ),
+      rest.put(cfg.api.notificationLastSeenTimePath, (req, res, ctx) =>
+        res(ctx.json({ time: Date.now() }))
+      ),
+      rest.put(cfg.api.notificationStatePath, (req, res, ctx) =>
+        res(
+          ctx.status(403),
+          ctx.json({
+            message: 'failed to update state',
+          })
+        )
       ),
       rest.get(cfg.api.notificationsPath, (req, res, ctx) =>
         res(ctx.delay(2000), ctx.json(mockNotificationsResponseSecondPage))
@@ -90,8 +127,7 @@ NotificationsListEmpty.parameters = {
       rest.get(cfg.api.notificationsPath, (req, res, ctx) =>
         res(
           ctx.json({
-            userNotificationsNextKey: '',
-            globalNotificationsNextKey: '',
+            nextKey: '',
             userLastSeenNotification: subDays(Date.now(), 15).toISOString(), // 15 days ago
             notifications: [],
           })
@@ -138,8 +174,7 @@ const ListComponent = () => {
 };
 
 const mockNotificationsResponseFirstPage = {
-  userNotificationsNextKey: '16',
-  globalNotificationsNextKey: '',
+  nextKey: '16,',
   userLastSeenNotification: subMinutes(Date.now(), 12).toISOString(), // 12 minutes ago
   notifications: [
     {
@@ -341,8 +376,7 @@ const mockNotificationsResponseFirstPage = {
 };
 
 const mockNotificationsResponseSecondPage = {
-  userNotificationsNextKey: '',
-  globalNotificationsNextKey: '',
+  nextKey: '',
   userLastSeenNotification: subDays(Date.now(), 60).toISOString(), // 60 days ago
   notifications: [
     {

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -359,7 +359,10 @@ const cfg = {
       '/webapi/scripts/integrations/configure/gcp-workforce-saml.sh?orgId=:orgId&poolName=:poolName&poolProviderName=:poolProviderName',
 
     notificationsPath:
-      '/v1/webapi/sites/:clusterId/notifications?limit=:limit?&userNotificationsStartKey=:userNotificationsStartKey?&globalNotificationsStartKey=:globalNotificationsStartKey?',
+      '/v1/webapi/sites/:clusterId/notifications?limit=:limit?&startKeys=:startKey?',
+    notificationLastSeenTimePath:
+      '/v1/webapi/sites/:clusterId/lastseennotification',
+    notificationStatePath: '/v1/webapi/sites/:clusterId/notificationstate',
 
     yaml: {
       parse: '/v1/webapi/yaml/parse/:kind',
@@ -1113,6 +1116,14 @@ const cfg = {
     return generatePath(cfg.api.notificationsPath, { ...params });
   },
 
+  getNotificationLastSeenUrl(clusterId: string) {
+    return generatePath(cfg.api.notificationLastSeenTimePath, { clusterId });
+  },
+
+  getNotificationStateUrl(clusterId: string) {
+    return generatePath(cfg.api.notificationStatePath, { clusterId });
+  },
+
   init(backendConfig = {}) {
     mergeDeep(this, backendConfig);
   },
@@ -1237,8 +1248,7 @@ export interface UrlGcpWorkforceConfigParam {
 export interface UrlNotificationParams {
   clusterId: string;
   limit?: number;
-  userNotificationsStartKey?: string;
-  globalNotificationsStartKey?: string;
+  startKey?: string;
 }
 
 export default cfg;

--- a/web/packages/teleport/src/services/notifications/types.ts
+++ b/web/packages/teleport/src/services/notifications/types.ts
@@ -24,17 +24,41 @@ export type FetchNotificationsResponse = {
    */
   notifications: Notification[];
   /**
-   * userNotificationsNextKey is the nextKey for the user-specific notifications list.
+   * nextKey is the next page keys for both lists (user-specific notifications & global notifications)
+   * separated by a comma, ie. "<user-specific notifications nextKey>,<global notifications nextKey>".
+   * If either one of these nextKeys is "end", it means we have reached the end of that list.
    */
-  userNotificationsNextKey: string;
-  /**
-   * globalNotificationsNextKey is the nextKey for the global notifications list.
-   */
-  globalNotificationsNextKey: string;
+  nextKey: string;
   /**
    * userLastSeenNotification is  the timestamp of the last notification the  user has seen.
    */
   userLastSeenNotification: Date;
+};
+
+/**
+ * UpsertLastSeenNotificationRequest is the request to upsert the timestamp of the latest notification that
+ * the user has seen.
+ */
+export type UpsertLastSeenNotificationRequest = {
+  /**
+   * time is the timestamp of the last seen notification.
+   */
+  time: Date;
+};
+
+/**
+ * UpsertNotificationStateRequest is the request made when a user updates a notification's state by marking it
+ * as "clicked" or "dismissed".
+ */
+export type UpsertNotificationStateRequest = {
+  /**
+   * notificationId is the id of the notification.
+   */
+  notificationId: string;
+  /**
+   * notificationState is the state to upsert, either "CLICKED" or "DISMISSED".
+   */
+  notificationState: NotificationState;
 };
 
 export type Notification = {
@@ -63,4 +87,21 @@ export enum NotificationSubKind {
   AccessRequestDenied = 'access-request-denied',
   /** AccessRequestNowAssumable is the notification for when an approved access request that was scheduled for a later date is now assumable. */
   AccessRequestNowAssumable = 'access-request-now-assumable',
+}
+
+/**
+ * NotificationState the state of a notification for a user. This can represent either "clicked" or "dismissed".
+ *
+ * This should be kept in sync with teleport.notifications.v1.NotificationState.
+ */
+export enum NotificationState {
+  UNSPECIFIED = 0,
+  /**
+   * NOTIFICATION_STATE_CLICKED marks this notification as having been clicked on by the user.
+   */
+  CLICKED = 1,
+  /**
+   * NOTIFICATION_STATE_DISMISSED marks this notification as having been dismissed by the user.
+   */
+  DISMISSED = 2,
 }


### PR DESCRIPTION
## Purpose

Part of #37704 

Adds web endpoints for the notifications system as well as implements the frontend logic for updating last seen time and notification states.

This PR is based on the changes from:

- https://github.com/gravitational/teleport/pull/39942