### PR TITLE
Close session when there is recording errors (Sync modes)

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -197,6 +197,7 @@ func TestIntegrations(t *testing.T) {
 	t.Run("AuthLocalNodeControlStream", suite.bind(testAuthLocalNodeControlStream))
 	t.Run("AgentlessConnection", suite.bind(testAgentlessConnection))
 	t.Run("LeafAgentlessConnection", suite.bind(testTrustedClusterAgentless))
+	t.Run("SyncRecordingFailures", suite.bind(testSyncRecordingFailures))
 }
 
 // testDifferentPinnedIP tests connection is rejected when source IP doesn't match the pinned one
@@ -1138,6 +1139,150 @@ func testSessionRecordingModes(t *testing.T, suite *integrationTestSuite) {
 				term.Type("exit\n\r")
 				waitSessionTermination(t, errCh, require.NoError)
 			})
+		})
+	}
+}
+
+// testSyncRecordingFailures given a cluster with recording mode set to
+// sync, ensures the session is terminated in case of session recording
+// failures.
+//
+// To simulate failures, we will start an auth server, proxy and ssh server
+// separated. With the session running, we'll stop the auth server, causing any
+// sync recordings to fail. This will works for both, proxy and node recordings.
+func testSyncRecordingFailures(t *testing.T, suite *integrationTestSuite) {
+	ctx := context.Background()
+	tr := utils.NewTracer(utils.ThisFunction()).Start()
+	defer tr.Stop()
+
+	for _, test := range []struct {
+		mode string
+	}{
+		{mode: types.RecordAtNodeSync},
+		{mode: types.RecordAtProxySync},
+	} {
+		t.Run(test.mode, func(t *testing.T) {
+			t.Parallel()
+
+			recConfig, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
+				Mode: test.mode,
+			})
+			require.NoError(t, err)
+
+			authCfg := suite.defaultServiceConfig()
+			authCfg.Console = nil
+			authCfg.Log = utils.NewLoggerForTests()
+			authCfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
+			authCfg.InstanceMetadataClient = cloud.NewDisabledIMDSClient()
+			authCfg.Auth.Preference.SetSecondFactor("off")
+			authCfg.Auth.Enabled = true
+			authCfg.Auth.SessionRecordingConfig = recConfig
+			authCfg.Proxy.Enabled = false
+			authCfg.SSH.Enabled = false
+
+			auth := helpers.NewInstance(t, helpers.InstanceConfig{
+				ClusterName: helpers.Site,
+				HostID:      uuid.New().String(),
+				NodeName:    Host,
+				Log:         utils.NewLoggerForTests(),
+			})
+
+			require.NoError(t, auth.CreateEx(t, nil, authCfg))
+			require.NoError(t, auth.Start())
+			defer auth.StopAll()
+
+			username := suite.Me.Username
+			role, err := types.NewRole("devs", types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					Logins:     []string{username},
+					NodeLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+				},
+			})
+			require.NoError(t, err)
+			require.NoError(t, helpers.SetupUser(auth.Process, username, []types.Role{role}))
+
+			node := helpers.NewInstance(t, helpers.InstanceConfig{
+				ClusterName: helpers.Site,
+				HostID:      uuid.New().String(),
+				NodeName:    Host,
+				Log:         utils.NewLoggerForTests(),
+			})
+
+			// Create node config.
+			nodeCfg := servicecfg.MakeDefaultConfig()
+			nodeCfg.SetAuthServerAddress(authCfg.Auth.ListenAddr)
+			nodeCfg.SetToken("token")
+			nodeCfg.Auth.Enabled = false
+			nodeCfg.CachePolicy.Enabled = true
+			nodeCfg.DataDir = t.TempDir()
+			nodeCfg.Console = nil
+			nodeCfg.Log = utils.NewLoggerForTests()
+			nodeCfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
+			nodeCfg.InstanceMetadataClient = cloud.NewDisabledIMDSClient()
+
+			nodeCfg.Proxy.Enabled = true
+			nodeCfg.Proxy.DisableWebService = false
+			nodeCfg.Proxy.DisableWebInterface = true
+			nodeCfg.FileDescriptors = append(nodeCfg.FileDescriptors, node.Fds...)
+			nodeCfg.Proxy.SSHAddr.Addr = node.SSHProxy
+			nodeCfg.Proxy.WebAddr.Addr = node.Web
+			nodeCfg.Proxy.ReverseTunnelListenAddr.Addr = node.Secrets.TunnelAddr
+
+			nodeCfg.SSH.Enabled = true
+			nodeCfg.SSH.Addr.Addr = node.SSH
+
+			require.NoError(t, node.CreateWithConf(t, nodeCfg))
+			require.NoError(t, node.Start())
+			defer node.StopAll()
+
+			// Start session.
+			term := NewTerminal(250)
+			errCh := make(chan error)
+
+			cl, err := auth.NewClient(helpers.ClientConfig{
+				Login:   username,
+				Cluster: helpers.Site,
+				Host:    Host,
+				Port:    helpers.Port(t, node.SSH),
+				Proxy: &helpers.ProxyConfig{
+					SSHAddr: nodeCfg.Proxy.SSHAddr.String(),
+					WebAddr: nodeCfg.Proxy.WebAddr.String(),
+				},
+			})
+			require.NoError(t, err)
+			cl.Stdout = term
+			cl.Stdin = term
+
+			go func() {
+				errCh <- cl.SSH(ctx, []string{}, false)
+			}()
+
+			// Guarantee the session started properly.
+			select {
+			case err := <-errCh:
+				require.Fail(t, "failed to initialize the session: %s", err)
+			case <-time.After(time.Second):
+			}
+
+			// Run a command and give enough time for it to be processed and be
+			// recordered.
+			term.Type("echo Hello\n\r")
+			select {
+			case err := <-errCh:
+				require.Fail(t, "expected the session to not fail but got %q", err)
+			case <-time.After(5 * time.Second):
+			}
+
+			// Stop auth and send commands to the session again.
+			require.NoError(t, auth.StopAuth(false))
+			term.Type("echo Second Hello\n\r")
+
+			select {
+			case err := <-errCh:
+				require.Error(t, err)
+			case <-time.After(30 * time.Second):
+				require.Fail(t, "expected session to complete")
+			}
 		})
 	}
 }
@@ -8533,10 +8678,11 @@ func TestConnectivityWithoutAuth(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
 
 	tests := []struct {
-		name         string
-		adjustRole   func(r types.Role)
-		command      []string
-		sshAssertion func(t *testing.T, authRunning bool, errChan chan error, term *Terminal)
+		name          string
+		recordingMode string
+		adjustRole    func(r types.Role)
+		command       []string
+		sshAssertion  func(t *testing.T, authRunning bool, errChan chan error, term *Terminal)
 	}{
 		{
 			name:       "offline connectivity allowed",
@@ -8584,6 +8730,50 @@ func TestConnectivityWithoutAuth(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:          "proxy-sync recording requires auth connectivity",
+			recordingMode: types.RecordAtProxySync,
+			adjustRole:    func(r types.Role) {},
+			sshAssertion: func(t *testing.T, authRunning bool, errChan chan error, term *Terminal) {
+				term.Type("echo hi\n\rexit\n\r")
+
+				select {
+				case err := <-errChan:
+					t.Log("===>>>", err)
+					if !authRunning {
+						require.Error(t, err)
+						return
+					}
+
+					require.NoError(t, err)
+					require.Contains(t, term.AllOutput(), "hi")
+				case <-time.After(5 * time.Second):
+					t.Fatal("timeout waiting for session to exit")
+				}
+			},
+		},
+		{
+			name:          "node-sync recording requires auth connectivity",
+			recordingMode: types.RecordAtNodeSync,
+			adjustRole:    func(r types.Role) {},
+			sshAssertion: func(t *testing.T, authRunning bool, errChan chan error, term *Terminal) {
+				term.Type("echo hi\n\rexit\n\r")
+
+				select {
+				case err := <-errChan:
+					t.Log("===>>>", err)
+					if !authRunning {
+						require.Error(t, err)
+						return
+					}
+
+					require.NoError(t, err)
+					require.Contains(t, term.AllOutput(), "hi")
+				case <-time.After(5 * time.Second):
+					t.Fatal("timeout waiting for session to exit")
+				}
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -8602,6 +8792,16 @@ func TestConnectivityWithoutAuth(t *testing.T) {
 			authCfg.Auth.NoAudit = true
 			authCfg.Proxy.Enabled = false
 			authCfg.SSH.Enabled = false
+
+			if test.recordingMode != "" {
+				recConfig, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
+					Mode: test.recordingMode,
+				})
+				require.NoError(t, err)
+
+				authCfg.Auth.NoAudit = false
+				authCfg.Auth.SessionRecordingConfig = recConfig
+			}
 
 			privateKey, publicKey, err := testauthority.New().GenerateKeyPair()
 			require.NoError(t, err)

--- a/lib/events/recorder/recorder.go
+++ b/lib/events/recorder/recorder.go
@@ -91,6 +91,9 @@ type Config struct {
 	// StartTime represents the time the recorder started. If not zero, this
 	// value is used to generate the events index.
 	StartTime time.Time
+
+	// Strict defines if RecordEvent should return error when an event is lost.
+	Strict bool
 }
 
 // New returns a [events.SessionPreparerRecorder]. If session recording is disabled,
@@ -149,6 +152,7 @@ func New(cfg Config) (events.SessionPreparerRecorder, error) {
 		Clock:           cfg.Clock,
 		BackoffTimeout:  cfg.BackoffTimeout,
 		BackoffDuration: cfg.BackoffDuration,
+		Strict:          cfg.Strict,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/ctx_test.go
+++ b/lib/srv/ctx_test.go
@@ -51,7 +51,7 @@ func TestDecodeChildError(t *testing.T) {
 
 func TestCheckSFTPAllowed(t *testing.T) {
 	srv := newMockServer(t)
-	ctx := newTestServerContext(t, srv, nil)
+	ctx := newTestServerContext(t, srv, nil, types.DefaultSessionRecordingConfig())
 
 	tests := []struct {
 		name                 string

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
@@ -138,7 +139,7 @@ func TestLoginDefsParser(t *testing.T) {
 }
 
 func newExecServerContext(t *testing.T, srv Server) *ServerContext {
-	scx := newTestServerContext(t, srv, nil)
+	scx := newTestServerContext(t, srv, nil, types.DefaultSessionRecordingConfig())
 
 	term, err := newLocalTerminal(scx)
 	require.NoError(t, err)

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -50,7 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet) *ServerContext {
+func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet, recConfig types.SessionRecordingConfig) *ServerContext {
 	usr, err := user.Current()
 	require.NoError(t, err)
 
@@ -62,8 +62,6 @@ func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet) *S
 	sshConn.remoteAddr, _ = utils.ParseAddr("10.0.0.5:4817")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	recConfig := types.DefaultSessionRecordingConfig()
-	recConfig.SetMode(types.RecordOff)
 	clusterName := "localhost"
 	scx := &ServerContext{
 		Entry: logrus.NewEntry(logrus.StandardLogger()),

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -1099,7 +1099,7 @@ func TestCloseProxySession(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { reg.Close() })
 
-	scx := newTestServerContext(t, reg.Srv, nil)
+	scx := newTestServerContext(t, reg.Srv, nil, types.DefaultSessionRecordingConfig())
 
 	// Open a new session
 	sshChanOpen := newMockSSHChannel()
@@ -1144,8 +1144,11 @@ func TestCloseRemoteSession(t *testing.T) {
 	})
 	t.Cleanup(func() { reg.Close() })
 
-	scx := newTestServerContext(t, reg.Srv, nil)
-	scx.SessionRecordingConfig.SetMode(types.RecordAtProxy)
+	proxyRecording, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
+		Mode: types.RecordAtProxy,
+	})
+	require.NoError(t, err)
+	scx := newTestServerContext(t, reg.Srv, nil, proxyRecording)
 	scx.RemoteSession = mockSSHSession(t)
 
 	// Open a new session
@@ -1158,7 +1161,7 @@ func TestCloseRemoteSession(t *testing.T) {
 		io.ReadAll(sshChanOpen)
 	}()
 
-	err := reg.OpenSession(context.Background(), sshChanOpen, scx)
+	err = reg.OpenSession(context.Background(), sshChanOpen, scx)
 	require.NoError(t, err)
 	require.NotNil(t, scx.session)
 

--- a/lib/srv/term_test.go
+++ b/lib/srv/term_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 )
@@ -88,7 +89,7 @@ func TestTerminal_KillUnderlyingShell(t *testing.T) {
 	t.Parallel()
 
 	srv := newMockServer(t)
-	scx := newTestServerContext(t, srv, nil)
+	scx := newTestServerContext(t, srv, nil, types.DefaultSessionRecordingConfig())
 
 	shPath, err := exec.LookPath("sh")
 	require.NoError(t, err)


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport-private/issues/369

Ensures SSH sessions are closed when there is a session recording error when sync recording is configured. The change consists of always setting the session recording mode to `strict` when recording is set to sync (`node-sync` and `proxy-sync`) and returning an error from the `SessionWriter`.

For the `SessionWriter`, we're adding a new config `Strict` to indicate whether it should return an error on `RecordEvent`. This way, we can keep the current behavior for every protocol using the session. Later on, we can update other protocols to handle this behavior correctly.

changelog: Fix SSH sessions not being closed when there is a recording error on sync recording modes.