### PR TITLE
Fix integration filtering in AwsAccount selector

### DIFF
--- a/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.tsx
@@ -112,14 +112,12 @@ export function AwsAccount() {
   function fetchAwsIntegrations() {
     run(() =>
       integrationService.fetchIntegrations().then(res => {
-        const options = res.items.map(i => {
-          if (i.kind === 'aws-oidc') {
-            return {
-              value: i,
-              label: i.name,
-            };
-          }
-        });
+        const options = res.items
+          .filter(i => i.kind === 'aws-oidc')
+          .map(i => ({
+            value: i,
+            label: i.name,
+          }));
         setAwsIntegrations(options);
 
         // Auto select the only option.


### PR DESCRIPTION
After https://github.com/gravitational/teleport/pull/40998 added a new integration kind (`azure-oidc`), the selector for AWS integration to use in the Discover flow stopped working (would display an empty list, crash when user attempts to type in the name manually). This seems to be because the existing code maps unknown integration types to `undefined` (by an implicit return if the kind does not match `aws-oidc`).

This fixes this by filtering for only `aws-oidc` as a separate step. 