### PR TITLE
[v14] WebDiscover: displays user or db name holder instead of wildcards for tsh db connect suggestion

### DIFF
--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.test.tsx
@@ -86,6 +86,10 @@ test('custom db name and user is respected when defined', async () => {
   // Test with custom fields.
   await userEvent.click(screen.getByText('user1'));
   await userEvent.click(screen.getByText('*'));
+  expect(
+    screen.getByText(/--db-user=<user> --db-name=name1/i)
+  ).toBeInTheDocument();
+
   await userEvent.type(
     screen.getByPlaceholderText(/custom-database-user-name/i),
     'custom-user'
@@ -95,6 +99,10 @@ test('custom db name and user is respected when defined', async () => {
   // The first wildcard is on screen from selecting
   // it for db users dropdown.
   await userEvent.click(screen.getAllByText('*')[1]);
+  expect(
+    screen.getByText(/--db-user=custom-user --db-name=<name>/i)
+  ).toBeInTheDocument();
+
   await userEvent.type(
     screen.getByPlaceholderText(/custom-database-name/i),
     'custom-name'

--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
@@ -72,9 +72,11 @@ export function TestConnection() {
   const [customDbUser, setCustomDbUser] = useState('');
   const [customDbName, setCustomDbName] = useState('');
 
-  let tshDbCmd = `tsh db connect ${db.name} --db-user=${customDbUser || selectedDbUser.value}`;
+  const dbUser = getInputValue(customDbUser || selectedDbUser.value, 'user');
+  let tshDbCmd = `tsh db connect ${db.name} --db-user=${dbUser}`;
   if (customDbName || selectedDbName) {
-    tshDbCmd += ` --db-name=${customDbName || selectedDbName.value}`;
+    const dbName = getInputValue(customDbName || selectedDbName.value, 'name');
+    tshDbCmd += ` --db-name=${dbName}`;
   }
 
   function makeTestConnRequest() {
@@ -225,4 +227,11 @@ export function TestConnection() {
       )}
     </Validation>
   );
+}
+
+function getInputValue(input: string, inputKind: 'name' | 'user') {
+  if (input == WILD_CARD) {
+    return inputKind === 'name' ? '<name>' : '<user>';
+  }
+  return input;
 }


### PR DESCRIPTION
backport (#41314) to branch/v14

manual but clean backport (auto backport failed b/c a required PR wasn't backported yet)