### PR TITLE
Update public docs for device trust web

### DIFF
--- a/docs/pages/access-controls/device-trust.mdx
+++ b/docs/pages/access-controls/device-trust.mdx
@@ -5,17 +5,7 @@ layout: tocless-doc
 videoBanner: gBQyj_X1LVw
 ---
 
-<Admonition type="notice">
-  Device Trust supports the following components:
-
-  - User devices: macOS, Windows and Linux.
-  - Teleport client: `tsh` and Teleport connect.
-  - Resources: Apps (role-based enforcement only), SSH nodes, databases, and
-    Kubernetes clusters
-
-  Support for the Web UI and desktop access are planned for upcoming Teleport
-  versions.
-</Admonition>
+(!docs/pages/includes/device-trust/support-notice.mdx!)
 
 ## Concepts
 

--- a/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
@@ -78,11 +78,6 @@ Enterprise clusters run in `optional` mode by default. Changing the mode to
 `required` will enforce a trusted device for all SSH, Database and Kubernetes
 accesses.
 
-<Admonition type="warning" title="Web UI">
-The Web UI is not capable of trusted device access. Only `tsh` and Teleport
-Connect are able to fulfill device mode `required`.
-</Admonition>
-
 To enable device mode `required` update your configuration as follows:
 
 <Tabs dropDownCaption="Teleport Deployment">

--- a/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
@@ -149,7 +149,7 @@ leaf clusters.
 
 ## App Access support
 
-Apps may enforce device trust via [role-based enforcement](
+The Teleport App Service may enforce device trust via [role-based enforcement](
 #role-based-trusted-device-enforcement).
 
 To access apps protected by device trust using the Web UI (Teleport v16 or
@@ -203,8 +203,8 @@ Now the alice user can only access `env:production` apps using a trusted device.
 
 ## Desktop Access support
 
-Desktop access may enforce device trust via [role-based enforcement](
-#role-based-trusted-device-enforcement).
+The Teleport Desktop Service may enforce device trust via [role-based
+enforcement]( #role-based-trusted-device-enforcement).
 
 To access desktops protected by device trust make sure your device is
 [registered and enrolled](./device-management.mdx#register-a-trusted-device),

--- a/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
@@ -201,6 +201,58 @@ version: v2
 
 Now the alice user can only access `env:production` apps using a trusted device.
 
+## Desktop Access support
+
+Desktop access may enforce device trust via [role-based enforcement](
+#role-based-trusted-device-enforcement).
+
+To access desktops protected by device trust make sure your device is
+[registered and enrolled](./device-management.mdx#register-a-trusted-device),
+install [Teleport Connect](
+../../connect-your-client/teleport-connect.mdx#installation--upgrade), and
+follow the instructions during login.
+
+As an example, to enforce device trust for all `env:production` desktops, save
+the role below as `require-trusted-device-desktops.yaml`:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: require-trusted-device-desktops
+spec:
+  options:
+    device_trust_mode: "required"
+  allow:
+    windows_desktop_labels:
+      env: "production"
+    windows_desktop_logins: ["Administrator", "alice"]
+```
+
+Create the role and assign it to a user:
+
+```code
+$ tctl create require-trusted-device-desktops.yaml
+$ tctl edit users/alice
+```
+
+```diff
+kind: user
+metadata:
+  name: alice
+  # (...)
+spec:
+  roles:
+  - access
+  - editor
++ - require-trusted-device-desktops
+  # (...)
+version: v2
+```
+
+Now the alice user can only access `env:production` desktops using a trusted
+device.
+
 ## Locking a device
 
 Similar to [session and identity locking](../guides/locking.mdx), a device can

--- a/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
@@ -152,8 +152,8 @@ leaf clusters.
 Apps may enforce device trust via [role-based enforcement](
 #role-based-trusted-device-enforcement).
 
-To access apps protected by device trust using the Web UI, make sure your device
-is [registered and enrolled](
+To access apps protected by device trust using the Web UI (Teleport v16 or
+later), make sure your device is [registered and enrolled](
 ./device-management.mdx#register-a-trusted-device), install [Teleport Connect](
 ../../connect-your-client/teleport-connect.mdx#installation--upgrade), and
 follow the instructions during login.

--- a/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
@@ -150,13 +150,19 @@ leaf clusters.
 ## App Access support
 
 Apps may enforce device trust via [role-based enforcement](
-#role-based-trusted-device-enforcement). Any apps that enforce device trust must
-be accessed using tsh commands such as [tsh proxy app](
-../../reference/cli/tsh.mdx#tsh-proxy-app) or using the certificates issued by
-`tsh app login`. Direct access to those apps via the Web UI is not yet
-available.
+#role-based-trusted-device-enforcement).
 
-For example, to enforce device trust for all `env:production` apps, save the
+To access apps protected by device trust using the Web UI, make sure your device
+is [registered and enrolled](
+./device-management.mdx#register-a-trusted-device), install [Teleport Connect](
+../../connect-your-client/teleport-connect.mdx#installation--upgrade), and
+follow the instructions during login.
+
+Alternatively, you may use [tsh proxy app](
+../../reference/cli/tsh.mdx#tsh-proxy-app) or the certificates issued by
+`tsh app login`.
+
+As an example, to enforce device trust for all `env:production` apps, save the
 role below as `require-trusted-device-apps.yaml`:
 
 ```yaml
@@ -194,8 +200,6 @@ version: v2
 ```
 
 Now the alice user can only access `env:production` apps using a trusted device.
-For example, to access an app called `myapp`, alice runs `tsh proxy app myapp -p
-8888` and opens http://localhost:8888 in her browser.
 
 ## Locking a device
 

--- a/docs/pages/access-controls/device-trust/guide.mdx
+++ b/docs/pages/access-controls/device-trust/guide.mdx
@@ -4,17 +4,7 @@ description: Get started with Teleport Device Trust
 videoBanner: gBQyj_X1LVw
 ---
 
-<Admonition type="notice">
-  Device Trust supports the following components:
-
-  - User devices: macOS, Windows and Linux.
-  - Teleport client: `tsh` and Teleport connect.
-  - Resources: Apps (role-based enforcement only), SSH nodes, databases, and
-    Kubernetes clusters
-
-  Support for the Web UI and desktop access are planned for upcoming Teleport
-  versions.
-</Admonition>
+(!docs/pages/includes/device-trust/support-notice.mdx!)
 
 Device Trust requires two of the following steps to have been configured:
 

--- a/docs/pages/includes/device-trust/prereqs.mdx
+++ b/docs/pages/includes/device-trust/prereqs.mdx
@@ -10,3 +10,5 @@
   - A user with permissions to use the /dev/tpmrm0 device (typically done by
     assigning the `tss` group to the user).
   - `tsh` v15.0.0 or newer. [Install tsh for Linux](../../installation.mdx#linux).
+- To authenticate a Web UI session you need [Teleport Connect](
+  ../../connect-your-client/teleport-connect.mdx#installation--upgrade)

--- a/docs/pages/includes/device-trust/support-notice.mdx
+++ b/docs/pages/includes/device-trust/support-notice.mdx
@@ -1,0 +1,10 @@
+<Admonition type="notice">
+  Device Trust supports all platforms and clients, including `tsh`, Teleport
+  Connect and the Web UI (requires Teleport Connect to be installed).
+
+  The following resources are protected by device trust:
+
+  - Role-based enforcement only: Apps and Desktops
+  - Cluster and role-based enforcement: SSH nodes, databases, and Kubernetes
+    clusters
+</Admonition>

--- a/docs/pages/includes/device-trust/troubleshooting.mdx
+++ b/docs/pages/includes/device-trust/troubleshooting.mdx
@@ -26,17 +26,10 @@ https://github.com/tpm2-software/tpm2-tss/blob/ede63dd1ac1f0a46029d457304edcac21
 
 ### App access and "access to this app requires a trusted device"
 
-A Teleport admin configured the particular app you are trying to access to
-require a trusted device.
+Follow the instructions in the [Web UI troubleshooting section](
+#web-ui-fails-to-authenticate-trusted-device) below.
 
-There are a few situations that might cause the error:
-
-1. You are trying to access the app using the Web UI.
-
-2. You are trying to access the app using an untrusted device.
-
-The Web UI is currently not capable of device authentication. To access apps
-protected by device trust you need to use one of the tsh commands described by
+Alternatively, you may use one of the tsh commands described by
 [App Access support](
 ../../access-controls/device-trust/enforcing-device-trust.mdx#app-access-support).
 For example, for an app called `myapp`, run `tsh proxy app myapp -p 8888`, then
@@ -46,3 +39,21 @@ If you are already running `tsh proxy app`, or using the certificates acquired
 from `tsh app login`, then it's likely your device isn't registered or enrolled.
 In this case, follow the advice from the [unauthorized device section](
 #unauthorized-device-errors-using-a-trusted-device) above.
+
+### Web UI fails to authenticate trusted device
+
+The Web UI attempts to authenticate your device using Teleport Connect during
+login. If you are not asked to authenticate your device immediately after login,
+follow the steps below:
+
+1. Make sure your device is [registered and enrolled](
+   ../../access-controls/device-trust/device-management.mdx#register-a-trusted-device)
+2. Install [Teleport Connect](
+   ../../connect-your-client/teleport-connect.mdx#installation--upgrade)
+3. Make sure Teleport Connect can access the same resource you are trying to
+   access on the Web
+4. Ask your cluster administrator if device trust is enabled (cluster mode
+   "optional" or higher)
+
+If all of the above steps are done, try logging out from the Web UI and logging
+in again.

--- a/docs/pages/includes/device-trust/troubleshooting.mdx
+++ b/docs/pages/includes/device-trust/troubleshooting.mdx
@@ -27,7 +27,7 @@ https://github.com/tpm2-software/tpm2-tss/blob/ede63dd1ac1f0a46029d457304edcac21
 ### App access and "access to this app requires a trusted device"
 
 Follow the instructions in the [Web UI troubleshooting section](
-#web-ui-fails-to-authenticate-trusted-device) below.
+#web-ui-fails-to-authenticate-trusted-device) below (Teleport v16 or later).
 
 Alternatively, you may use one of the tsh commands described by
 [App Access support](

--- a/docs/pages/includes/device-trust/troubleshooting.mdx
+++ b/docs/pages/includes/device-trust/troubleshooting.mdx
@@ -40,6 +40,11 @@ from `tsh app login`, then it's likely your device isn't registered or enrolled.
 In this case, follow the advice from the [unauthorized device section](
 #unauthorized-device-errors-using-a-trusted-device) above.
 
+### Desktop access and "access to this app requires a trusted device"
+
+Follow the instructions in the [Web UI troubleshooting section](
+#web-ui-fails-to-authenticate-trusted-device) below.
+
 ### Web UI fails to authenticate trusted device
 
 The Web UI attempts to authenticate your device using Teleport Connect during


### PR DESCRIPTION
Update Device Trust pages in preparation for device trust web:

* Remove notices that say the Web UI isn't supported
* Mention Connect as a prereq
* Update the App Access section (Web UI access is now possible)
* Add a Desktop Access section (role-based enforcement is now possible)
* Add/update troubleshooting

https://github.com/gravitational/teleport.e/issues/3236