### PR TITLE
[v13] Automatically download CA for MongoDB Atlas

### DIFF
--- a/lib/srv/db/ca.go
+++ b/lib/srv/db/ca.go
@@ -105,6 +105,7 @@ func (s *Server) shouldInitCACertLocked(database types.Database) bool {
 		types.DatabaseTypeMemoryDB,
 		types.DatabaseTypeAWSKeyspaces,
 		types.DatabaseTypeDynamoDB,
+		types.DatabaseTypeMongoAtlas,
 		types.DatabaseTypeCloudSQL,
 		types.DatabaseTypeAzure:
 		return true
@@ -195,6 +196,11 @@ func (s *Server) getCACertPaths(database types.Database) ([]string, error) {
 
 	case types.DatabaseTypeAWSKeyspaces:
 		return []string{filepath.Join(s.cfg.DataDir, filepath.Base(amazonKeyspacesCAURL))}, nil
+
+	case types.DatabaseTypeMongoAtlas:
+		return []string{
+			filepath.Join(s.cfg.DataDir, filepath.Base(isrgRootX1URL)),
+		}, nil
 	}
 
 	return nil, trace.BadParameter("%v doesn't support automatic CA download", database)
@@ -317,6 +323,8 @@ func (d *realDownloader) Download(ctx context.Context, database types.Database, 
 		return nil, nil, trace.BadParameter("unknown Azure CA %q", hint)
 	case types.DatabaseTypeAWSKeyspaces:
 		return d.downloadFromURL(amazonKeyspacesCAURL)
+	case types.DatabaseTypeMongoAtlas:
+		return d.downloadFromURL(isrgRootX1URL)
 	}
 	return nil, nil, trace.BadParameter("%v doesn't support automatic CA download", database)
 }
@@ -341,6 +349,8 @@ func (d *realDownloader) GetVersion(ctx context.Context, database types.Database
 		return nil, trace.BadParameter("unknown Azure CA %q", hint)
 	case types.DatabaseTypeAWSKeyspaces:
 		return d.getVersionFromURL(database, amazonKeyspacesCAURL)
+	case types.DatabaseTypeMongoAtlas:
+		return d.getVersionFromURL(database, isrgRootX1URL)
 	}
 
 	return nil, trace.NotImplemented("%v doesn't support fetching CA version", database)
@@ -502,6 +512,13 @@ const (
 	// presented by AWS Keyspace. See:
 	// https://docs.aws.amazon.com/keyspaces/latest/devguide/using_go_driver.html
 	amazonKeyspacesCAURL = "https://certs.secureserver.net/repository/sf-class2-root.crt"
+
+	// isrgRootX1URL is the URL to download ISRG Root X1 CA for Let's Encrypt. See:
+	// https://letsencrypt.org/certificates/
+	//
+	// MongoDB Atlas uses certificates signed by Let's Encrypt:
+	// https://www.mongodb.com/docs/atlas/reference/faq/security/#which-certificate-authority-signs-mongodb-atlas-tls-certificates-
+	isrgRootX1URL = "https://letsencrypt.org/certs/isrgrootx1.pem"
 
 	// cloudSQLDownloadError is the error message that gets returned when
 	// we failed to download root certificate for Cloud SQL instance.

--- a/lib/srv/db/ca_test.go
+++ b/lib/srv/db/ca_test.go
@@ -111,6 +111,14 @@ func TestInitCACert(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	mongodbAtlas, err := types.NewDatabaseV3(types.Metadata{
+		Name: "mongodb-atlas",
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolMongoDB,
+		URI:      "mongodb+srv://test.xxxx.mongodb.net",
+	})
+	require.NoError(t, err)
+
 	cloudSQL, err := types.NewDatabaseV3(types.Metadata{
 		Name: "cloud-sql",
 	}, types.DatabaseSpecV3{
@@ -130,7 +138,7 @@ func TestInitCACert(t *testing.T) {
 	require.NoError(t, err)
 
 	allDatabases := []types.Database{
-		selfHosted, rds, rdsWithCert, redshift, redshiftServerless, cloudSQL, azureMySQL, memoryDB,
+		selfHosted, rds, rdsWithCert, redshift, redshiftServerless, cloudSQL, azureMySQL, memoryDB, mongodbAtlas,
 	}
 
 	tests := []struct {
@@ -177,6 +185,11 @@ func TestInitCACert(t *testing.T) {
 			desc:     "should download Azure CA when it's not set",
 			database: azureMySQL.GetName(),
 			cert:     fixtures.TLSCACertPEM + "\n" + fixtures.TLSCACertPEM, // Two CA files.
+		},
+		{
+			desc:     "should download MongoDB Atlas CA when it's not set",
+			database: mongodbAtlas.GetName(),
+			cert:     fixtures.TLSCACertPEM,
 		},
 	}
 


### PR DESCRIPTION
Backport #41289 to branch/v13

changelog: Added support to automatically download CA for MongoDB Atlas databases
