### PR TITLE
Remove `tsh version` invocation from `tbot proxy` commands

### DIFF
--- a/lib/tbot/tshwrap/wrap.go
+++ b/lib/tbot/tshwrap/wrap.go
@@ -44,10 +44,6 @@ const (
 	// TSHVarName is the name of the environment variable that can override the
 	// tsh path that would otherwise be located on the $PATH.
 	TSHVarName = "TSH"
-
-	// TSHMinVersion is the minimum version of tsh that supports Machine ID
-	// proxies.
-	TSHMinVersion = "9.3.0"
 )
 
 var log = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentTBot)
@@ -151,31 +147,6 @@ func GetTSHVersion(w *Wrapper) (*semver.Version, error) {
 	}
 
 	return sv, nil
-}
-
-// CheckTSHSupported checks if the current tsh supports Machine ID.
-func CheckTSHSupported(w *Wrapper) error {
-	version, err := GetTSHVersion(w)
-	if err != nil {
-		return trace.Wrap(err, "unable to determine tsh version")
-	}
-
-	minVersion := semver.New(TSHMinVersion)
-	if version.LessThan(*minVersion) {
-		return trace.BadParameter(
-			"installed tsh version %s does not support Machine ID proxies, "+
-				"please upgrade to at least %s",
-			version, minVersion,
-		)
-	}
-
-	log.DebugContext(
-		context.TODO(),
-		"tsh version is supported",
-		"version", version,
-	)
-
-	return nil
 }
 
 // GetDestinationDirectory attempts to select an unambiguous destination, either from

--- a/lib/tbot/tshwrap/wrap_test.go
+++ b/lib/tbot/tshwrap/wrap_test.go
@@ -19,11 +19,9 @@
 package tshwrap
 
 import (
-	"fmt"
 	"path/filepath"
 	"testing"
 
-	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -32,54 +30,6 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 )
-
-// TestTSHSupported ensures that the tsh version check works as expected (and,
-// implicitly, that the version capture and parsing works.)
-func TestTSHSupported(t *testing.T) {
-	version := func(v string) []byte {
-		return []byte(fmt.Sprintf(`{"version": "%s"}`, v))
-	}
-
-	tests := []struct {
-		name   string
-		out    []byte
-		err    error
-		expect func(t require.TestingT, err error, msgAndArgs ...interface{})
-	}{
-		{
-			// Before `-f json` is supported
-			name:   "very old tsh",
-			err:    trace.Errorf("unsupported"),
-			expect: require.Error,
-		},
-		{
-			name:   "too old",
-			out:    version("9.2.0"),
-			expect: require.Error,
-		},
-		{
-			name:   "supported",
-			out:    version(TSHMinVersion),
-			expect: require.NoError,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			wrapper := Wrapper{
-				path: "tsh", // path is arbitrary here
-				capture: func(tshPaths string, args ...string) ([]byte, error) {
-					if tt.err != nil {
-						return nil, tt.err
-					}
-					return tt.out, nil
-				},
-			}
-
-			tt.expect(t, CheckTSHSupported(&wrapper))
-		})
-	}
-}
 
 // TestGetEnvForTSH ensures we generate a valid minimum subset of environment
 // parameters needed for tsh wrappers to work.

--- a/tool/tbot/db.go
+++ b/tool/tbot/db.go
@@ -34,10 +34,6 @@ func onDBCommand(botConfig *config.BotConfig, cf *config.CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	if err := tshwrap.CheckTSHSupported(wrapper); err != nil {
-		return trace.Wrap(err)
-	}
-
 	destination, err := tshwrap.GetDestinationDirectory(botConfig)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tbot/proxy.go
+++ b/tool/tbot/proxy.go
@@ -35,10 +35,6 @@ func onProxyCommand(botConfig *config.BotConfig, cf *config.CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	if err := tshwrap.CheckTSHSupported(wrapper); err != nil {
-		return trace.Wrap(err)
-	}
-
 	destination, err := tshwrap.GetDestinationDirectory(botConfig)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This version check originally existed to ensure that the `tsh` being invoked was compatible, however, this version check has stayed at v9, long before our compatibility window.

Unfortunately, invoking `tsh version` is slower and more resource intense than you may first expect. The large dependency tree of `tsh` means a fair amount (24MiB) of heap is allocated, and over thousands of invocations of `tbot proxy` this is fairly significant. Additionally, `tsh version` pings the proxy server to determine the version, and this means additional latency before any useful work takes place.