### PR TITLE
Remove unnecessary version checks

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -149,12 +149,6 @@ const (
 	// NoLoginPrefix is the prefix used for nologin certificate principals.
 	NoLoginPrefix = "-teleport-nologin-"
 
-	// DatabaseCAMinVersion is the minimum Teleport version that supports Database Certificate Authority.
-	DatabaseCAMinVersion = "10.0.0"
-
-	// OpenSSHCAMinVersion is the minimum Teleport version that supports OpenSSH Certificate Authority.
-	OpenSSHCAMinVersion = "12.0.0"
-
 	// SSHRSAType is the string which specifies an "ssh-rsa" formatted keypair
 	SSHRSAType = "ssh-rsa"
 

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -374,26 +374,10 @@ func TestValidateTrustedCluster(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.Len(t, resp.CAs, 3)
+		require.Len(t, resp.CAs, 4)
 		require.ElementsMatch(t,
-			[]types.CertAuthType{types.HostCA, types.UserCA, types.DatabaseCA},
-			[]types.CertAuthType{resp.CAs[0].GetType(), resp.CAs[1].GetType(), resp.CAs[2].GetType()},
-		)
-	})
-
-	t.Run("OpenSSH CA not returned for pre v12", func(t *testing.T) {
-		leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "leafcluster"))
-		resp, err := a.validateTrustedCluster(ctx, &ValidateTrustedClusterRequest{
-			Token:           validToken,
-			CAs:             []types.CertAuthority{leafClusterCA},
-			TeleportVersion: "11.0.0",
-		})
-		require.NoError(t, err)
-
-		require.Len(t, resp.CAs, 3)
-		require.ElementsMatch(t,
-			[]types.CertAuthType{types.HostCA, types.UserCA, types.DatabaseCA},
-			[]types.CertAuthType{resp.CAs[0].GetType(), resp.CAs[1].GetType(), resp.CAs[2].GetType()},
+			[]types.CertAuthType{types.HostCA, types.UserCA, types.DatabaseCA, types.OpenSSHCA},
+			[]types.CertAuthType{resp.CAs[0].GetType(), resp.CAs[1].GetType(), resp.CAs[2].GetType(), resp.CAs[3].GetType()},
 		)
 	})
 


### PR DESCRIPTION
The OpenSSH CA is supported in all supported versions of Teleport, so we no longer need these checks that were added for backwards compatibility.