### PR TITLE
Add tbot ssh-proxy-command

### DIFF
--- a/api/client/proxy/client.go
+++ b/api/client/proxy/client.go
@@ -388,6 +388,7 @@ func (c *Client) ClientConfig(ctx context.Context, cluster string) (client.Confi
 			ALPNConnUpgradeRequired:    c.cfg.ALPNConnUpgradeRequired,
 			DialOpts:                   c.cfg.DialOpts,
 			InsecureAddressDiscovery:   c.cfg.InsecureSkipVerify,
+			DialInBackground:           true,
 		}, nil
 	}
 

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -189,6 +189,27 @@ type CLIConf struct {
 	// TraceExporter is a manually provided URI to send traces to instead of
 	// forwarding them to the Auth service.
 	TraceExporter string
+
+	// User is the os login to use for ssh connections.
+	User string
+	// Host is the target ssh machine to connect to.
+	Host string
+	// Post is the post of the ssh machine to connect on.
+	Port string
+
+	// EnableResumption turns on automatic session resumption to prevent connections from
+	// being dropped if Proxy connectivity is lost.
+	EnableResumption bool
+
+	// TLSRoutingEnabled indicates whether the cluster has TLS routing enabled.
+	TLSRoutingEnabled bool
+
+	// ConnectionUpgradeRequired indicates that an ALPN connection upgrade is required
+	// for connections to the cluster.
+	ConnectionUpgradeRequired bool
+
+	// TSHConfigPath is the path to a tsh config file.
+	TSHConfigPath string
 }
 
 // AzureOnboardingConfig holds configuration relevant to the "azure" join method.

--- a/lib/tbot/ssh_proxy.go
+++ b/lib/tbot/ssh_proxy.go
@@ -1,0 +1,268 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tbot
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh/agent"
+	"google.golang.org/grpc"
+
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	proxyclient "github.com/gravitational/teleport/api/client/proxy"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
+	libclient "github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/client/identityfile"
+	"github.com/gravitational/teleport/lib/resumption"
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/tshwrap"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// ProxySSHConfig contains configuration parameters required
+// to initialize the local ssh proxy.
+type ProxySSHConfig struct {
+	BotConfig                 *config.BotConfig
+	TSHConfigPath             string
+	ProxyServer               string
+	Cluster                   string
+	User                      string
+	Host                      string
+	Port                      string
+	EnableResumption          bool
+	TLSRoutingEnabled         bool
+	ConnectionUpgradeRequired bool
+	Log                       *slog.Logger
+}
+
+// ProxySSH creates a local ssh proxy, dialing a node and transferring data through
+// stdin and stdout, to be used as an OpenSSH/PuTTY proxy command.
+func ProxySSH(ctx context.Context, proxyConfig ProxySSHConfig) error {
+	tshConfig, err := libclient.LoadTSHConfig(proxyConfig.TSHConfigPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	proxy := proxyConfig.ProxyServer
+	cluster := proxyConfig.Cluster
+	targetHost := proxyConfig.Host
+	expanded, matched := tshConfig.ProxyTemplates.Apply(net.JoinHostPort(proxyConfig.Host, proxyConfig.Port))
+	if matched {
+		proxyConfig.Log.DebugContext(ctx, "proxy templated matched", "populated_template", expanded)
+		if expanded.Cluster != "" {
+			cluster = expanded.Cluster
+		}
+		if expanded.Proxy != "" {
+			proxy = expanded.Proxy
+		}
+		if expanded.Host != "" {
+			targetHost = expanded.Host
+		}
+	}
+
+	proxyHost, _, err := net.SplitHostPort(proxy)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	facade, keyring, err := parseIdentity(proxyConfig.BotConfig, proxyHost, cluster)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	sshConfig, err := facade.SSHClientConfig()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if proxyConfig.User != "" {
+		sshConfig.User = proxyConfig.User
+	}
+
+	if cluster == "" {
+		cluster = facade.Get().ClusterName
+	}
+
+	pclt, err := proxyclient.NewClient(ctx, proxyclient.ClientConfig{
+		ProxyAddress:      proxy,
+		TLSRoutingEnabled: proxyConfig.TLSRoutingEnabled,
+		TLSConfigFunc: func(cluster string) (*tls.Config, error) {
+			cfg, err := facade.TLSConfig()
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			// The facade TLS config is tailored toward connections to the Auth service.
+			// Override the server name to be the proxy and blank out the next protos to
+			// avoid hitting the proxy web listener.
+			cfg.ServerName = proxyHost
+			cfg.NextProtos = nil
+			return cfg, nil
+		},
+		UnaryInterceptors:       []grpc.UnaryClientInterceptor{interceptors.GRPCClientUnaryErrorInterceptor},
+		StreamInterceptors:      []grpc.StreamClientInterceptor{interceptors.GRPCClientStreamErrorInterceptor},
+		SSHConfig:               sshConfig,
+		InsecureSkipVerify:      proxyConfig.BotConfig.Insecure,
+		ALPNConnUpgradeRequired: proxyConfig.ConnectionUpgradeRequired,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var target string
+	if expanded == nil || (len(expanded.Search) == 0 && expanded.Query == "") {
+		targetHost = cleanTargetHost(targetHost, proxyHost, cluster)
+		target = net.JoinHostPort(targetHost, proxyConfig.Port)
+	} else {
+		authConfig, err := pclt.ClientConfig(ctx, cluster)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		// Override the credentials with the facade, which is tailored for
+		// connections to auth. The proxy client will try to use the TLS
+		// config from above that was explicitly tailored for connecting
+		// to the proxy, and if reused, will result in handshake failures.
+		authConfig.Credentials = []client.Credentials{facade}
+
+		node, err := resolveTargetHost(ctx, authConfig, expanded.Search, expanded.Query)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		proxyConfig.Log.DebugContext(ctx, "found matching SSH host", "host_uuid", node.GetName(), "host_name", node.GetHostname())
+
+		target = net.JoinHostPort(node.GetName(), "0")
+	}
+
+	conn, _, err := pclt.DialHost(ctx, target, cluster, keyring)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if proxyConfig.EnableResumption {
+		conn, err = resumption.WrapSSHClientConn(ctx, conn, func(ctx context.Context, hostID string) (net.Conn, error) {
+			// if the connection is being resumed, it means that
+			// we didn't need the agent in the first place
+			var noAgent agent.ExtendedAgent
+			conn, _, err := pclt.DialHost(ctx, net.JoinHostPort(hostID, "0"), cluster, noAgent)
+			return conn, err
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	defer conn.Close()
+
+	err = trace.Wrap(utils.ProxyConn(ctx, utils.CombinedStdio{}, conn))
+	if errors.Is(err, context.Canceled) {
+		err = nil
+	}
+
+	return trace.Wrap(err)
+}
+
+// resolveTargetHost determines the ssh instance to be connected to based on either
+// the provided search or query. The auth client is intentionally single use and
+// closed to reduce resource consumption after the host has been resolved. Any future
+// changes that require an additional request to auth should reuse the client instead
+// of creating one per request.
+func resolveTargetHost(ctx context.Context, cfg client.Config, search, query string) (types.Server, error) {
+	apiClient, err := client.New(ctx, cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer apiClient.Close()
+
+	nodes, err := client.GetAllResources[types.Server](ctx, apiClient, &proto.ListResourcesRequest{
+		ResourceType:        types.KindNode,
+		SearchKeywords:      libclient.ParseSearchKeywords(search, ','),
+		PredicateExpression: query,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if len(nodes) == 0 {
+		return nil, trace.NotFound("no matching SSH hosts found for search terms or query expression")
+	}
+
+	if len(nodes) > 1 {
+		return nil, trace.BadParameter("found multiple matching SSH hosts %v", nodes[:2])
+	}
+
+	return nodes[0], nil
+}
+
+func parseIdentity(botConfig *config.BotConfig, proxy, cluster string) (*identity.Facade, agent.ExtendedAgent, error) {
+	destination, err := tshwrap.GetDestinationDirectory(botConfig)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	identityPath := filepath.Join(destination.Path, config.IdentityFilePath)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	key, err := identityfile.KeyFromIdentityFile(identityPath, proxy, cluster)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	i, err := identity.ReadIdentityFromStore(&identity.LoadIdentityParams{
+		PrivateKeyBytes: key.PrivateKeyPEM(),
+		PublicKeyBytes:  key.MarshalSSHPublicKey(),
+	}, &proto.Certs{
+		SSH:        key.Cert,
+		TLS:        key.TLSCert,
+		TLSCACerts: key.TLSCAs(),
+	})
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	agentKey, err := key.AsAgentKey()
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	keyring, ok := agent.NewKeyring().(agent.ExtendedAgent)
+	if !ok {
+		return nil, nil, trace.BadParameter("unexpected keyring type %T, expected agent.ExtendedAgent (this is a bug)", keyring)
+	}
+	if err := keyring.Add(agentKey); err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return identity.NewFacade(botConfig.FIPS, botConfig.Insecure, i), keyring, nil
+}
+
+func cleanTargetHost(targetHost, proxyHost, siteName string) string {
+	targetHost = strings.TrimSuffix(targetHost, "."+proxyHost)
+	targetHost = strings.TrimSuffix(targetHost, "."+siteName)
+	return targetHost
+}

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -25,6 +25,9 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"runtime"
+	"runtime/pprof"
+	runtimetrace "runtime/trace"
 	"strings"
 	"syscall"
 	"time"
@@ -59,7 +62,7 @@ func main() {
 
 const appHelp = `Teleport Machine ID
 
-Machine ID issues and renews short-lived certificates so your machines can 
+Machine ID issues and renews short-lived certificates so your machines can
 access Teleport protected resources in the same way your engineers do!
 
 Find out more at https://goteleport.com/docs/machine-id/introduction/`
@@ -68,12 +71,17 @@ func Run(args []string, stdout io.Writer) error {
 	var cf config.CLIConf
 	ctx := context.Background()
 
+	var cpuProfile, memProfile, traceProfile string
+
 	app := utils.InitCLIParser("tbot", appHelp).Interspersed(false)
 	app.Flag("debug", "Verbose logging to stdout.").Short('d').BoolVar(&cf.Debug)
 	app.Flag("config", "Path to a configuration file.").Short('c').StringVar(&cf.ConfigPath)
 	app.Flag("fips", "Runs tbot in FIPS compliance mode. This requires the FIPS binary is in use.").BoolVar(&cf.FIPS)
 	app.Flag("trace", "Capture and export distributed traces.").Hidden().BoolVar(&cf.Trace)
 	app.Flag("trace-exporter", "An OTLP exporter URL to send spans to.").Hidden().StringVar(&cf.TraceExporter)
+	app.Flag("mem-profile", "Write memory profile to file").Hidden().StringVar(&memProfile)
+	app.Flag("cpu-profile", "Write CPU profile to file").Hidden().StringVar(&cpuProfile)
+	app.Flag("trace-profile", "Write trace profile to file").Hidden().StringVar(&traceProfile)
 	app.HelpFlag.Short('h')
 
 	joinMethodList := fmt.Sprintf(
@@ -158,6 +166,18 @@ func Run(args []string, stdout io.Writer) error {
 		"Arguments to `tsh proxy ...`; prefix with `-- ` to ensure flags are passed correctly.",
 	))
 
+	sshProxyCmd := app.Command("ssh-proxy-command", "An OpenSSH/PuTTY proxy command").Hidden()
+	sshProxyCmd.Flag("destination-dir", "The destination directory with which to authenticate tsh").StringVar(&cf.DestinationDir)
+	sshProxyCmd.Flag("cluster", "The cluster name. Extracted from the certificate if unset.").StringVar(&cf.Cluster)
+	sshProxyCmd.Flag("user", "The remote user name for the connection").Required().StringVar(&cf.User)
+	sshProxyCmd.Flag("host", "The remote host to connect to").Required().StringVar(&cf.Host)
+	sshProxyCmd.Flag("port", "The remote port to connect on.").StringVar(&cf.Port)
+	sshProxyCmd.Flag("proxy-server", "The Teleport proxy server to use, in host:port form.").Required().StringVar(&cf.ProxyServer)
+	sshProxyCmd.Flag("tls-routing", "Whether the Teleport cluster has tls routing enabled.").Required().BoolVar(&cf.TLSRoutingEnabled)
+	sshProxyCmd.Flag("connection-upgrade", "Whether the Teleport cluster requires an ALPN connection upgrade.").Required().BoolVar(&cf.ConnectionUpgradeRequired)
+	sshProxyCmd.Flag("proxy-templates", "The path to a file containing proxy templates to be evaluated.").StringVar(&cf.TSHConfigPath)
+	sshProxyCmd.Flag("resume", "Enable SSH connection resumption").BoolVar(&cf.EnableResumption)
+
 	kubeCmd := app.Command("kube", "Kubernetes helpers").Hidden()
 	kubeCredentialsCmd := kubeCmd.Command("credentials", "Get credentials for kubectl access").Hidden()
 	kubeCredentialsCmd.Flag("destination-dir", "The destination directory with which to generate Kubernetes credentials").Required().StringVar(&cf.DestinationDir)
@@ -225,6 +245,48 @@ func Run(args []string, stdout io.Writer) error {
 		}()
 	}
 
+	if cpuProfile != "" {
+		log.DebugContext(ctx, "capturing CPU profile", "profile_path", cpuProfile)
+		f, err := os.Create(cpuProfile)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			return trace.Wrap(err)
+		}
+		defer pprof.StopCPUProfile()
+	}
+
+	if memProfile != "" {
+		log.DebugContext(ctx, "capturing memory profile", "profile_path", memProfile)
+		defer func() {
+			f, err := os.Create(memProfile)
+			if err != nil {
+				return
+			}
+			defer f.Close()
+			runtime.GC()
+			if err := pprof.WriteHeapProfile(f); err != nil {
+				return
+			}
+		}()
+	}
+
+	if traceProfile != "" {
+		log.DebugContext(ctx, "capturing trace profile", "profile_path", traceProfile)
+		f, err := os.Create(traceProfile)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer f.Close()
+
+		if err := runtimetrace.Start(f); err != nil {
+			return trace.Wrap(err)
+		}
+		defer runtimetrace.Stop()
+	}
+
 	// If migration is specified, we want to run this before the config is
 	// loaded normally.
 	if migrateCmd.FullCommand() == command {
@@ -249,6 +311,8 @@ func Run(args []string, stdout io.Writer) error {
 		err = onDBCommand(botConfig, &cf)
 	case proxyCmd.FullCommand():
 		err = onProxyCommand(botConfig, &cf)
+	case sshProxyCmd.FullCommand():
+		err = onSSHProxyCommand(botConfig, &cf)
 	case kubeCredentialsCmd.FullCommand():
 		err = onKubeCredentialsCommand(ctx, botConfig)
 	case spiffeInspectCmd.FullCommand():

--- a/tool/tbot/proxy_ssh.go
+++ b/tool/tbot/proxy_ssh.go
@@ -1,0 +1,56 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/tbot"
+	"github.com/gravitational/teleport/lib/tbot/config"
+)
+
+// onSSHProxyCommand is meant to be used as an OpenSSH/PuTTY proxy command. While this
+// provides the same functionality as `tbot proxy ssh` it does so without invoking
+// `tsh proxy ssh` which results in much less memory and cpu consumption. This will
+// eventually supersede `tbot proxy ssh` as it becomes more feature rich and supports
+// all the edge cases.
+func onSSHProxyCommand(botConfig *config.BotConfig, cf *config.CLIConf) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if cf.Port == "" {
+		cf.Port = "0"
+	}
+
+	proxySSHConfig := tbot.ProxySSHConfig{
+		BotConfig:                 botConfig,
+		ProxyServer:               cf.ProxyServer,
+		Cluster:                   cf.Cluster,
+		User:                      cf.User,
+		Host:                      cf.Host,
+		Port:                      cf.Port,
+		EnableResumption:          cf.EnableResumption,
+		TLSRoutingEnabled:         cf.TLSRoutingEnabled,
+		ConnectionUpgradeRequired: cf.ConnectionUpgradeRequired,
+		TSHConfigPath:             cf.TSHConfigPath,
+		Log:                       log,
+	}
+
+	return trace.Wrap(tbot.ProxySSH(ctx, proxySSHConfig))
+}

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"crypto/x509/pkix"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -103,8 +102,7 @@ func onProxyCommandSSH(cf *CLIConf) error {
 
 		defer conn.Close()
 
-		stdio := utils.CombineReadWriteCloser(io.NopCloser(os.Stdin), utils.NopWriteCloser(os.Stdout))
-		return trace.Wrap(utils.ProxyConn(cf.Context, stdio, conn))
+		return trace.Wrap(utils.ProxyConn(cf.Context, utils.CombinedStdio{}, conn))
 	}))
 }
 

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/db/dbcmd"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -677,7 +678,7 @@ func TestTSHProxyTemplate(t *testing.T) {
 	tshHome, _ := mustLoginSetEnv(t, s)
 
 	// Create proxy template configuration.
-	tshConfigFile := filepath.Join(tshHome, tshConfigPath)
+	tshConfigFile := filepath.Join(tshHome, client.TSHConfigPath)
 	require.NoError(t, os.MkdirAll(filepath.Dir(tshConfigFile), 0o777))
 	require.NoError(t, os.WriteFile(tshConfigFile, []byte(fmt.Sprintf(`
 proxy_templates:

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -442,7 +442,7 @@ type CLIConf struct {
 	displayParticipantRequirements bool
 
 	// TSHConfig is the loaded tsh configuration file ~/.tsh/config/config.yaml.
-	TSHConfig TSHConfig
+	TSHConfig client.TSHConfig
 
 	// ListAll specifies if an ls command should return results from all clusters and proxies.
 	ListAll bool
@@ -1190,7 +1190,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// configs
 	setEnvFlags(&cf)
 
-	confOptions, err := loadAllConfigs(cf)
+	confOptions, err := client.LoadAllConfigs(cf.GlobalTshConfigPath, cf.HomePath)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
The new subcommand is meant to be a replacement for `tbot proxy ssh` which does the ssh proxying entirely within tbot to reduce resource consumption. The old mechanism spawned a tsh process to perform the proxying which leads to increased CPU and memory consumption - which can be quite problematic when used as an OpenSSH ProxyCommand for an ansible playbook.

The new command also deviates in behavior from tsh proxy ssh in that, for the moment, it requires users to explicitly dictate whether tls routing, alpn connection upgrades instead of guessing by making a call to webapi/ping. This again turns out to be quite resource intensive when tbot is used as an OpenSSH ProxyCommand for an ansible playbook.

In the future tbot can look this information up out of band and store it in the proper location so that `tbot ssh-proxy-command` can consume it directly without users needing to provide it. The behavior as is provides a path toward the future while also allowing users to gain the performance improvements now.