### PR TITLE
Remove github.com/sethvargo/go-diceware/diceware from client tools

### DIFF
--- a/lib/auth/accountrecovery.go
+++ b/lib/auth/accountrecovery.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/gravitational/trace"
-	"github.com/sethvargo/go-diceware/diceware"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 
@@ -413,7 +412,7 @@ func (a *Server) GetAccountRecoveryCodes(ctx context.Context, req *proto.GetAcco
 }
 
 func (a *Server) generateAndUpsertRecoveryCodes(ctx context.Context, username string) (*proto.RecoveryCodes, error) {
-	codes, err := generateRecoveryCodes()
+	codes, err := a.generateRecoveryCodes()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -478,15 +477,10 @@ func (a *Server) isAccountRecoveryAllowed(ctx context.Context) error {
 
 // generateRecoveryCodes returns an array of tokens where each token
 // have 8 random words prefixed with tele and concanatenated with dashes.
-func generateRecoveryCodes() ([]string, error) {
-	gen, err := diceware.NewGenerator(nil /* use default word list */)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+func (a *Server) generateRecoveryCodes() ([]string, error) {
 	tokenList := make([]string, numOfRecoveryCodes)
 	for i := 0; i < numOfRecoveryCodes; i++ {
-		list, err := gen.Generate(numWordsInRecoveryCode)
+		list, err := a.recoveryCodeGenerator.Generate(numWordsInRecoveryCode)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -119,6 +119,7 @@ func newTestPack(
 				RSAKeyPairSource: testauthority.New().GenerateKeyPair,
 			},
 		},
+		RecoveryCodeGenerator: FakeRecoverCodeGenerator{},
 	}
 	p.a, err = NewServer(authConfig, opts...)
 	if err != nil {
@@ -982,6 +983,7 @@ func TestUpdateConfig(t *testing.T) {
 				RSAKeyPairSource: testauthority.New().GenerateKeyPair,
 			},
 		},
+		RecoveryCodeGenerator: FakeRecoverCodeGenerator{},
 	}
 	authServer, err := NewServer(authConfig)
 	require.NoError(t, err)

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -86,6 +86,7 @@ func setupGithubContext(ctx context.Context, t *testing.T) *githubContext {
 				RSAKeyPairSource: authority.New().GenerateKeyPair,
 			},
 		},
+		RecoveryCodeGenerator: FakeRecoverCodeGenerator{},
 	}
 	tt.a, err = NewServer(authConfig)
 	require.NoError(t, err)

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -234,6 +234,25 @@ type TestAuthServer struct {
 	LockWatcher *services.LockWatcher
 }
 
+// FakeRecoverCodeGenerator is a [RecoveryCodeGenerator] that returns
+// uuids for codes.
+type FakeRecoverCodeGenerator struct{}
+
+// Generate returns a slice populated with uuids.
+func (FakeRecoverCodeGenerator) Generate(numWords int) ([]string, error) {
+	out := make([]string, 0, numWords)
+	for i := 0; i < numWords; i++ {
+		u, err := uuid.NewRandom()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		out = append(out, u.String())
+	}
+
+	return out, nil
+}
+
 // NewTestAuthServer returns new instances of Auth server
 func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 	ctx := context.Background()
@@ -302,9 +321,10 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 				RSAKeyPairSource: authority.New().GenerateKeyPair,
 			},
 		},
-		EmbeddingRetriever: ai.NewSimpleRetriever(),
-		HostUUID:           uuid.New().String(),
-		AccessLists:        accessLists,
+		EmbeddingRetriever:    ai.NewSimpleRetriever(),
+		HostUUID:              uuid.New().String(),
+		AccessLists:           accessLists,
+		RecoveryCodeGenerator: FakeRecoverCodeGenerator{},
 	},
 		WithClock(cfg.Clock),
 		WithEmbedder(cfg.Embedder),

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -303,6 +303,9 @@ type InitConfig struct {
 
 	// Notifications is a service that manages notifications.
 	Notifications services.Notifications
+
+	// RecoveryCodeGenerator used to generate random recovery codes.
+	RecoveryCodeGenerator RecoveryCodeGenerator
 }
 
 // Init instantiates and configures an instance of AuthServer

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -1002,7 +1002,8 @@ func setupConfig(t *testing.T) InitConfig {
 				RSAKeyPairSource: testauthority.New().GenerateKeyPair,
 			},
 		},
-		Tracer: tracing.NoopTracer(teleport.ComponentAuth),
+		Tracer:                tracing.NoopTracer(teleport.ComponentAuth),
+		RecoveryCodeGenerator: FakeRecoverCodeGenerator{},
 	}
 }
 

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -87,6 +87,7 @@ func setupPasswordSuite(t *testing.T) *passwordSuite {
 				RSAKeyPairSource: authority.New().GenerateKeyPair,
 			},
 		},
+		RecoveryCodeGenerator: FakeRecoverCodeGenerator{},
 	}
 	s.a, err = NewServer(authConfig)
 	require.NoError(t, err)

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -437,6 +437,7 @@ func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *Serve
 				RSAKeyPairSource: authority.New().GenerateKeyPair,
 			},
 		},
+		RecoveryCodeGenerator: FakeRecoverCodeGenerator{},
 	}
 	a, err := NewServer(authConfig)
 	require.NoError(t, err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sethvargo/go-diceware/diceware"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
@@ -1850,6 +1851,11 @@ func (process *TeleportProcess) initAuthService() error {
 		return trace.Wrap(err)
 	}
 
+	recoveryCodeGenerator, err := diceware.NewGenerator(nil /* use default word list */)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	// first, create the AuthServer
 	authServer, err := auth.Init(
 		process.ExitContext(),
@@ -1895,6 +1901,7 @@ func (process *TeleportProcess) initAuthService() error {
 			EmbeddingClient:         embedderClient,
 			Tracer:                  process.TracingProvider.Tracer(teleport.ComponentAuth),
 			CloudClients:            cloudClients,
+			RecoveryCodeGenerator:   recoveryCodeGenerator,
 		}, func(as *auth.Server) error {
 			if !process.Config.CachePolicy.Enabled {
 				return nil

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -138,6 +138,7 @@ func newMockServer(t *testing.T) *mockServer {
 				RSAKeyPairSource: testauthority.New().GenerateKeyPair,
 			},
 		},
+		RecoveryCodeGenerator: auth.FakeRecoverCodeGenerator{},
 	}
 
 	authServer, err := auth.NewServer(authCfg, auth.WithClock(clock))


### PR DESCRIPTION
Modifies the dependency tree of lib/auth by hiding diceware behind an interface to prevent tctl, tsh and tbot from depending on it. The static wordlist defiend in diceware results in bloating the memory used by the tools during runtime for something they will never use. This results in all tools now consuming roughly 1-2MB less memory.