### PR TITLE
[v13] Allow configuring `clusterDomain` in `teleport-cluster` helm chart

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -657,6 +657,25 @@ It is recommended to set resource requests/limits for each container based on th
         memory: 2Gi
   ```
 
+## `global`
+
+### `global.clusterDomain`
+
+| Type     | Default value                                    |
+|----------|--------------------------------------------------|
+| `string` | `cluster.local` |
+
+`global.clusterDomain` sets the the domain suffix used by the Kubernetes DNS service. 
+This is used to resolve service names in the cluster.
+
+`values.yaml` example:
+
+  ```yaml
+  global:
+    clusterDomain: custom-domain.org
+  ```
+
+
 ## `teleportVersionOverride`
 
 | Type     | Default value |

--- a/examples/chart/teleport-cluster/templates/_helpers.tpl
+++ b/examples/chart/teleport-cluster/templates/_helpers.tpl
@@ -87,5 +87,10 @@ teleport.dev/majorVersion: '{{ include "teleport-cluster.majorVersion" . }}'
 {{/* In most places we want to use the FQDN instead of relying on Kubernetes ndots behaviour
      for performance reasons */}}
 {{- define "teleport-cluster.auth.serviceFQDN" -}}
-{{ include "teleport-cluster.auth.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
+{{ include "teleport-cluster.auth.serviceName" . }}.{{ .Release.Namespace }}.svc.{{ include "teleport-cluster.clusterDomain" . }}
+{{- end -}}
+
+{{/* Returns the cluster domain if set, otherwise fallback to "cluster.local" */}}
+{{- define "teleport-cluster.clusterDomain" -}}
+{{ default "cluster.local" .Values.global.clusterDomain }}
 {{- end -}}

--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -108,7 +108,7 @@ spec:
             - teleport
             - wait
             - no-resolve
-            - '{{ include "teleport-cluster.auth.previousVersionServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local'
+            - '{{ include "teleport-cluster.auth.previousVersionServiceName" . }}.{{ .Release.Namespace }}.svc.{{ include "teleport-cluster.clusterDomain" . }}'
 {{- if $proxy.securityContext }}
           securityContext: {{- toYaml $proxy.securityContext | nindent 12 }}
 {{- end }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -1741,3 +1741,64 @@ matches snapshot for volumes.yaml:
           output: stderr
           severity: INFO
       version: v3
+sets clusterDomain on Configmap:
+  1: |
+    apiVersion: v1
+    data:
+      apply-on-startup.yaml: |
+        kind: token
+        version: v2
+        metadata:
+          name: RELEASE-NAME-proxy
+          expires: "2050-01-01T00:00:00Z"
+        spec:
+          roles: [Proxy]
+          join_method: kubernetes
+          kubernetes:
+            allow:
+              - service_account: "NAMESPACE:RELEASE-NAME-proxy"
+      teleport.yaml: |-
+        auth_service:
+          authentication:
+            local_auth: true
+            second_factor: "on"
+            type: local
+            webauthn:
+              rp_id: teleport.example.com
+          cluster_name: teleport.example.com
+          enabled: true
+          proxy_listener_mode: separate
+        kubernetes_service:
+          enabled: true
+          kube_cluster_name: teleport.example.com
+          listen_addr: 0.0.0.0:3026
+          public_addr: RELEASE-NAME-auth.NAMESPACE.svc.test.com:3026
+        proxy_service:
+          enabled: false
+        ssh_service:
+          enabled: false
+        teleport:
+          auth_server: 127.0.0.1:3025
+          log:
+            format:
+              extra_fields:
+              - timestamp
+              - level
+              - component
+              - caller
+              output: text
+            output: stderr
+            severity: INFO
+        version: v3
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/component: auth
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-cluster
+        app.kubernetes.io/version: 13.4.24
+        helm.sh/chart: teleport-cluster-13.4.24
+        teleport.dev/majorVersion: "13"
+      name: RELEASE-NAME-auth
+      namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -528,3 +528,39 @@ matches snapshot for separate-postgres-listener.yaml:
           output: stderr
           severity: INFO
       version: v3
+sets clusterDomain on Configmap:
+  1: |
+    apiVersion: v1
+    data:
+      teleport.yaml: |-
+        auth_service:
+          enabled: false
+        proxy_service:
+          enabled: true
+          kube_listen_addr: 0.0.0.0:3026
+          listen_addr: 0.0.0.0:3023
+          mysql_listen_addr: 0.0.0.0:3036
+          public_addr: teleport.example.com:443
+          tunnel_listen_addr: 0.0.0.0:3024
+        ssh_service:
+          enabled: false
+        teleport:
+          auth_server: RELEASE-NAME-auth.NAMESPACE.svc.test.com:3025
+          join_params:
+            method: kubernetes
+            token_name: RELEASE-NAME-proxy
+          log:
+            format:
+              extra_fields:
+              - timestamp
+              - level
+              - component
+              - caller
+              output: text
+            output: stderr
+            severity: INFO
+        version: v3
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME-proxy
+      namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -1,3 +1,135 @@
+sets clusterDomain on Deployment Pods:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        kubernetes.io/deployment: test-annotation
+        kubernetes.io/deployment-different: 3
+      labels:
+        app.kubernetes.io/component: proxy
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-cluster
+        app.kubernetes.io/version: 13.4.24
+        helm.sh/chart: teleport-cluster-13.4.24
+        teleport.dev/majorVersion: "13"
+      name: RELEASE-NAME-proxy
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: proxy
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      template:
+        metadata:
+          annotations:
+            checksum/config: 562f5bf84fefdb100172da37abf15fc49706da001ce70d5ef45950cd0802c93e
+            kubernetes.io/pod: test-annotation
+            kubernetes.io/pod-different: 4
+          labels:
+            app.kubernetes.io/component: proxy
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: teleport-cluster
+            app.kubernetes.io/version: 13.4.24
+            helm.sh/chart: teleport-cluster-13.4.24
+            teleport.dev/majorVersion: "13"
+        spec:
+          affinity:
+            podAntiAffinity: null
+          automountServiceAccountToken: false
+          containers:
+          - args:
+            - --diag-addr=0.0.0.0:3000
+            image: public.ecr.aws/gravitational/teleport-distroless:13.4.24
+            imagePullPolicy: IfNotPresent
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - teleport
+                  - wait
+                  - duration
+                  - 30s
+            livenessProbe:
+              failureThreshold: 6
+              httpGet:
+                path: /healthz
+                port: diag
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              timeoutSeconds: 1
+            name: teleport
+            ports:
+            - containerPort: 3080
+              name: tls
+              protocol: TCP
+            - containerPort: 3023
+              name: sshproxy
+              protocol: TCP
+            - containerPort: 3024
+              name: sshtun
+              protocol: TCP
+            - containerPort: 3026
+              name: kube
+              protocol: TCP
+            - containerPort: 3036
+              name: mysql
+              protocol: TCP
+            - containerPort: 3000
+              name: diag
+              protocol: TCP
+            readinessProbe:
+              failureThreshold: 12
+              httpGet:
+                path: /readyz
+                port: diag
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              timeoutSeconds: 1
+            volumeMounts:
+            - mountPath: /etc/teleport
+              name: config
+              readOnly: true
+            - mountPath: /var/lib/teleport
+              name: data
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: proxy-serviceaccount-token
+              readOnly: true
+          initContainers:
+          - command:
+            - teleport
+            - wait
+            - no-resolve
+            - RELEASE-NAME-auth-v12.NAMESPACE.svc.test.com
+            image: public.ecr.aws/gravitational/teleport-distroless:13.4.24
+            name: wait-auth-update
+          serviceAccountName: RELEASE-NAME-proxy
+          terminationGracePeriodSeconds: 60
+          volumes:
+          - name: proxy-serviceaccount-token
+            projected:
+              sources:
+              - serviceAccountToken:
+                  path: token
+              - configMap:
+                  items:
+                  - key: ca.crt
+                    path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                  - fieldRef:
+                      fieldPath: metadata.namespace
+                    path: namespace
+          - configMap:
+              name: RELEASE-NAME-proxy
+            name: config
+          - emptyDir: {}
+            name: data
 should provision initContainer correctly when set in values:
   1: |
     - command:

--- a/examples/chart/teleport-cluster/tests/auth_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_config_test.yaml
@@ -527,3 +527,14 @@ tests:
     asserts:
       - matchSnapshot:
           path: data.teleport\.yaml
+          
+  - it: sets clusterDomain on Configmap
+    set:
+      clusterName: teleport.example.com
+      global:
+        clusterDomain: test.com
+    asserts:
+      - matchSnapshot: {}
+      - matchRegex:
+          path: data.teleport\.yaml
+          pattern: 'svc.test.com:3026'

--- a/examples/chart/teleport-cluster/tests/proxy_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_config_test.yaml
@@ -233,3 +233,13 @@ tests:
           of: ConfigMap
       - matchSnapshot:
           path: data.teleport\.yaml
+  - it: sets clusterDomain on Configmap
+    set:
+      clusterName: teleport.example.com
+      global:
+        clusterDomain: test.com
+    asserts:
+      - matchSnapshot: {}
+      - matchRegex:
+          path: data.teleport\.yaml
+          pattern: 'svc.test.com:3025'

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -939,3 +939,16 @@ tests:
             mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             name: proxy-serviceaccount-token
             readOnly: true
+  - it: sets clusterDomain on Deployment Pods
+    template: proxy/deployment.yaml
+    values:
+      - ../.lint/annotations.yaml
+    set:
+      global:
+        clusterDomain: test.com
+    asserts:
+      - matchSnapshot: {}
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[3]
+          pattern: ".svc.test.com$"
+

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -6,6 +6,7 @@
         "authentication",
         "enterprise",
         "operator",
+        "global",
         "podSecurityPolicy",
         "labels",
         "chartMode",
@@ -258,6 +259,20 @@
         "installCRDs": {
             "$id": "#/properties/installCRDs",
             "type": "boolean"
+        },
+        "global": {
+            "$id": "#/properties/global",
+            "type": "object",
+            "required": [
+                "clusterDomain"
+            ],
+            "properties": {
+                "clusterDomain": {
+                    "$id": "#/properties/global/properties/clusterDomain",
+                    "type": "string",
+                    "default": "cluster.local"
+                }
+            }
         },
         "operator": {
             "$id": "#/properties/operator",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -248,7 +248,20 @@ operator:
 podSecurityPolicy:
   enabled: true
 
-# Labels is a map of key-value pairs about this cluster
+# The `global` section contains values that are shared between the main chart and all subcharts.
+global:
+  # The `clusterDomain` value controls the domain suffix used in the Kubernetes
+  # DNS service. This is used to resolve service names in the cluster.
+  # The default value is `cluster.local`.
+
+  # WARNING: Changing this value must match the Kubernetes cluster's configuration 
+  # otherwise Teleport will not be able to resolve service names.
+  clusterDomain: cluster.local
+
+# Labels is a map of key-value pairs about this cluster. Those labels are used
+# in Teleport to access the Kuebrnetes cluster. They must not be confused with
+# `extraLabels` which are additional labels to add on Kubernetes resources
+# created by the Helm chart.
 labels: {}
 
 # Mode to deploy the chart in. The default is "standalone". Options:


### PR DESCRIPTION
Backport #41311 to branch/v13

changelog: Allow setting Kubernetes Cluster name when using non-default addresses. 
