### PR TITLE
Fetch resources using `ListUnifiedResources` in the search bar

### DIFF
--- a/web/packages/teleterm/src/services/tshd/app.ts
+++ b/web/packages/teleterm/src/services/tshd/app.ts
@@ -83,3 +83,28 @@ export function isWebApp(app: App): boolean {
     app.endpointUri.startsWith('https://')
   );
 }
+
+/**
+ * Returns address with protocol which is an app protocol + a public address.
+ * If the public address is empty, it falls back to the endpoint URI.
+ *
+ * Always empty for SAML applications.
+ */
+export function getAppAddrWithProtocol(source: App): string {
+  const { publicAddr, endpointUri } = source;
+
+  const isTcp = endpointUri && endpointUri.startsWith('tcp://');
+  const isCloud = endpointUri && endpointUri.startsWith('cloud://');
+  let addrWithProtocol = endpointUri;
+  if (publicAddr) {
+    if (isCloud) {
+      addrWithProtocol = `cloud://${publicAddr}`;
+    } else if (isTcp) {
+      addrWithProtocol = `tcp://${publicAddr}`;
+    } else {
+      addrWithProtocol = `https://${publicAddr}`;
+    }
+  }
+
+  return addrWithProtocol;
+}

--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -19,8 +19,6 @@
 import * as tsh from './types';
 import { TshdRpcError } from './cloneableClient';
 
-import type { App } from 'teleterm/ui/services/clusters';
-
 export const rootClusterUri = '/clusters/teleport-local';
 export const leafClusterUri = `${rootClusterUri}/leaves/leaf`;
 
@@ -60,7 +58,7 @@ export const makeKube = (props: Partial<tsh.Kube> = {}): tsh.Kube => ({
   ...props,
 });
 
-export const makeApp = (props: Partial<App> = {}): App => ({
+export const makeApp = (props: Partial<tsh.App> = {}): tsh.App => ({
   name: 'foo',
   labels: [],
   endpointUri: 'tcp://localhost:3000',
@@ -71,7 +69,6 @@ export const makeApp = (props: Partial<App> = {}): App => ({
   fqdn: 'local-app.example.com:3000',
   samlApp: false,
   uri: appUri,
-  addrWithProtocol: 'tcp://local-app.example.com:3000',
   awsRoles: [],
   ...props,
 });

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/NewRequest/useNewRequest.ts
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/NewRequest/useNewRequest.ts
@@ -28,7 +28,6 @@ import {
   makeDatabase,
   makeServer,
   makeKube,
-  getAppAddrWithProtocol,
 } from 'teleterm/ui/services/clusters';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 
@@ -39,6 +38,7 @@ import {
 } from 'teleterm/services/tshd/types';
 import { routing } from 'teleterm/ui/uri';
 import { useWorkspaceLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
+import { getAppAddrWithProtocol } from 'teleterm/services/tshd/app';
 
 import type {
   ResourceLabel,

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/NewRequest/useNewRequest.ts
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/NewRequest/useNewRequest.ts
@@ -28,7 +28,7 @@ import {
   makeDatabase,
   makeServer,
   makeKube,
-  makeApp,
+  getAppAddrWithProtocol,
 } from 'teleterm/ui/services/clusters';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 
@@ -96,7 +96,9 @@ export default function useNewRequest() {
           teleportApps.App,
           'name' | 'labels' | 'description' | 'userGroups' | 'addrWithProtocol'
         > = {
-          ...makeApp(source),
+          name: tshdApp.name,
+          labels: tshdApp.labels,
+          addrWithProtocol: getAppAddrWithProtocol(source),
           description: tshdApp.desc,
           //TODO(gzdunek): Enable requesting apps via user groups in Connect.
           // To make this work, we need

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -57,7 +57,7 @@ import {
   DocumentCluster,
   DocumentClusterResourceKind,
 } from 'teleterm/ui/services/workspacesService';
-import { getAppAddrWithProtocol } from 'teleterm/ui/services/clusters';
+import { getAppAddrWithProtocol } from 'teleterm/services/tshd/app';
 
 import {
   ConnectServerActionButton,

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -57,7 +57,7 @@ import {
   DocumentCluster,
   DocumentClusterResourceKind,
 } from 'teleterm/ui/services/workspacesService';
-import { makeApp } from 'teleterm/ui/services/clusters';
+import { getAppAddrWithProtocol } from 'teleterm/ui/services/clusters';
 
 import {
   ConnectServerActionButton,
@@ -346,7 +346,7 @@ const mapToSharedResource = (
       };
     }
     case 'app': {
-      const app = makeApp(resource.resource);
+      const { resource: app } = resource;
 
       return {
         resource: {
@@ -354,7 +354,7 @@ const mapToSharedResource = (
           labels: app.labels,
           name: app.name,
           id: app.name,
-          addrWithProtocol: app.addrWithProtocol,
+          addrWithProtocol: getAppAddrWithProtocol(app),
           awsConsole: app.awsConsole,
           description: app.desc,
           friendlyName: app.friendlyName,

--- a/web/packages/teleterm/src/ui/Search/ResourceSearchErrors.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/ResourceSearchErrors.story.tsx
@@ -34,44 +34,20 @@ export const Story = () => (
     errors={[
       new ResourceSearchError(
         '/clusters/foo',
-        'server',
         new Error(
           '14 UNAVAILABLE: connection error: desc = "transport: authentication handshake failed: EOF"'
         )
       ),
       new ResourceSearchError(
         '/clusters/bar',
-        'database',
         new Error(
           '2 UNKNOWN: Unable to connect to ssh proxy at teleport.local:443. Confirm connectivity and availability.\n	dial tcp: lookup teleport.local: no such host'
         )
       ),
       new ResourceSearchError(
         '/clusters/baz',
-        'kube',
         new Error(
           '14 UNAVAILABLE: connection error: desc = "transport: authentication handshake failed: EOF"'
-        )
-      ),
-      new ResourceSearchError(
-        '/clusters/foo',
-        'server',
-        new Error(
-          '2 UNKNOWN: Unable to connect to ssh proxy at teleport.local:443. Confirm connectivity and availability.\n	dial tcp: lookup teleport.local: no such host'
-        )
-      ),
-      new ResourceSearchError(
-        '/clusters/baz',
-        'kube',
-        new Error(
-          '14 UNAVAILABLE: connection error: desc = "transport: authentication handshake failed: EOF"'
-        )
-      ),
-      new ResourceSearchError(
-        '/clusters/foo',
-        'server',
-        new Error(
-          '2 UNKNOWN: Unable to connect to ssh proxy at teleport.local:443. Confirm connectivity and availability.\n	dial tcp: lookup teleport.local: no such host'
         )
       ),
     ]}

--- a/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
@@ -182,7 +182,6 @@ it('notifies about resource search errors and allows to display details', () => 
 
   const resourceSearchError = new ResourceSearchError(
     '/clusters/foo',
-    'server',
     new Error('whoops')
   );
 
@@ -223,7 +222,7 @@ it('notifies about resource search errors and allows to display details', () => 
   expect(results).toHaveTextContent(
     'Some of the search results are incomplete.'
   );
-  expect(results).toHaveTextContent('Could not fetch servers from foo');
+  expect(results).toHaveTextContent('Could not fetch resources from foo');
   expect(results).not.toHaveTextContent(resourceSearchError.cause['message']);
 
   act(() => screen.getByText('Show details').click());
@@ -243,7 +242,6 @@ it('maintains focus on the search input after closing a resource search error mo
 
   const resourceSearchError = new ResourceSearchError(
     '/clusters/foo',
-    'server',
     new Error('whoops')
   );
 
@@ -303,7 +301,6 @@ it('shows a login modal when a request to a cluster from the current workspace f
   const cluster = makeRootCluster();
   const resourceSearchError = new ResourceSearchError(
     cluster.uri,
-    'server',
     makeRetryableError()
   );
   const resourceSearchResult = {

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
@@ -31,13 +31,11 @@ describe('getActionPickerStatus', () => {
     it('partitions resource search errors into clusters with expired certs and non-retryable errors', () => {
       const retryableError = new ResourceSearchError(
         '/clusters/foo',
-        'server',
         makeRetryableError()
       );
 
       const nonRetryableError = new ResourceSearchError(
         '/clusters/bar',
-        'database',
         new Error('whoops')
       );
 
@@ -68,7 +66,6 @@ describe('getActionPickerStatus', () => {
       const offlineCluster = makeRootCluster({ connected: false });
       const retryableError = new ResourceSearchError(
         '/clusters/foo',
-        'server',
         makeRetryableError()
       );
 
@@ -95,17 +92,8 @@ describe('getActionPickerStatus', () => {
 
     it('includes a cluster with expired cert only once even if multiple requests fail with retryable errors', () => {
       const retryableErrors = [
-        new ResourceSearchError(
-          '/clusters/foo',
-          'server',
-          makeRetryableError()
-        ),
-        new ResourceSearchError(
-          '/clusters/foo',
-          'database',
-          makeRetryableError()
-        ),
-        new ResourceSearchError('/clusters/foo', 'kube', makeRetryableError()),
+        new ResourceSearchError('/clusters/foo', makeRetryableError()),
+        new ResourceSearchError('/clusters/foo', makeRetryableError()),
       ];
       const status = getActionPickerStatus({
         inputValue: 'foo',
@@ -186,15 +174,10 @@ describe('getActionPickerStatus', () => {
     it('returns non-retryable errors when fetching a preview after selecting a filter fails', () => {
       const nonRetryableError = new ResourceSearchError(
         '/clusters/bar',
-        'server',
         new Error('non-retryable error')
       );
       const resourceSearchErrors = [
-        new ResourceSearchError(
-          '/clusters/foo',
-          'server',
-          makeRetryableError()
-        ),
+        new ResourceSearchError('/clusters/foo', makeRetryableError()),
         nonRetryableError,
       ];
       const status = getActionPickerStatus({

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -50,7 +50,6 @@ import { ResourceSearchError } from 'teleterm/ui/services/resources';
 import { isRetryable } from 'teleterm/ui/utils/retryWithRelogin';
 import { assertUnreachable } from 'teleterm/ui/utils';
 import { isWebApp } from 'teleterm/services/tshd/app';
-import { App } from 'teleterm/ui/services/clusters';
 
 import { SearchAction } from '../actions';
 import { useSearchContext } from '../SearchContext';
@@ -790,7 +789,7 @@ export function AppItem(props: SearchResultItem<SearchResultApp>) {
   );
 }
 
-function getAppItemCopy($appName: React.JSX.Element, app: App) {
+function getAppItemCopy($appName: React.JSX.Element, app: tsh.App) {
   if (app.samlApp) {
     return <>Log in to {$appName} in the browser</>;
   }

--- a/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
@@ -534,7 +534,6 @@ const AuxiliaryItems = () => {
             errors={[
               new ResourceSearchError(
                 '/clusters/foo',
-                'server',
                 new Error(
                   '14 UNAVAILABLE: connection error: desc = "transport: authentication handshake failed: EOF"'
                 )
@@ -548,7 +547,6 @@ const AuxiliaryItems = () => {
             errors={[
               new ResourceSearchError(
                 '/clusters/bar',
-                'database',
                 new Error(
                   '2 UNKNOWN: Unable to connect to ssh proxy at teleport.local:443. Confirm connectivity and availability.\n	dial tcp: lookup teleport.local: no such host'
                 )

--- a/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
@@ -21,6 +21,8 @@ import { makeSuccessAttempt } from 'shared/hooks/useAsync';
 
 import { Flex } from 'design';
 
+import { App } from 'gen-proto-ts/teleport/lib/teleterm/v1/app_pb';
+
 import { routing } from 'teleterm/ui/uri';
 import {
   makeDatabase,
@@ -31,6 +33,7 @@ import {
   makeApp,
 } from 'teleterm/services/tshd/testHelpers';
 import { ResourceSearchError } from 'teleterm/ui/services/resources';
+import { getAppAddrWithProtocol } from 'teleterm/ui/services/clusters';
 
 import { SearchResult } from '../searchResult';
 import { makeResourceResult } from '../testHelpers';
@@ -102,6 +105,11 @@ export const ResultsNarrow = () => {
   return <Results maxWidth="300px" />;
 };
 
+function makeAppWithAddr(props: Partial<App>) {
+  const app = makeApp(props);
+  return { ...app, addrWithProtocol: getAppAddrWithProtocol(app) };
+}
+
 const SearchResultItems = () => {
   const searchResults: SearchResult[] = [
     makeResourceResult({
@@ -168,11 +176,10 @@ const SearchResultItems = () => {
     }),
     makeResourceResult({
       kind: 'app',
-      resource: makeApp({
+      resource: makeAppWithAddr({
         uri: `${clusterUri}/apps/web-app`,
         name: 'web-app',
         endpointUri: 'http://localhost:3000',
-        addrWithProtocol: 'http://local-app.example.com:3000',
         desc: '',
         labels: makeLabelsList({
           access: 'cloudwatch-metrics,ec2,s3,cloudtrail',
@@ -185,11 +192,10 @@ const SearchResultItems = () => {
     }),
     makeResourceResult({
       kind: 'app',
-      resource: makeApp({
+      resource: makeAppWithAddr({
         uri: `${clusterUri}/apps/saml-app`,
         name: 'saml-app',
         endpointUri: '',
-        addrWithProtocol: '',
         samlApp: true,
         desc: 'SAML Application',
         labels: makeLabelsList({
@@ -203,7 +209,7 @@ const SearchResultItems = () => {
     }),
     makeResourceResult({
       kind: 'app',
-      resource: makeApp({
+      resource: makeAppWithAddr({
         uri: `${clusterUri}/apps/no-desc`,
         name: 'no-desc',
         desc: '',
@@ -218,7 +224,7 @@ const SearchResultItems = () => {
     }),
     makeResourceResult({
       kind: 'app',
-      resource: makeApp({
+      resource: makeAppWithAddr({
         uri: `${clusterUri}/apps/short-desc`,
         name: 'short-desc',
         desc: 'Lorem ipsum',
@@ -233,7 +239,7 @@ const SearchResultItems = () => {
     }),
     makeResourceResult({
       kind: 'app',
-      resource: makeApp({
+      resource: makeAppWithAddr({
         uri: `${clusterUri}/apps/long-desc`,
         name: 'long-desc',
         desc: 'Eget dignissim lectus nisi vitae nunc',
@@ -248,7 +254,7 @@ const SearchResultItems = () => {
     }),
     makeResourceResult({
       kind: 'app',
-      resource: makeApp({
+      resource: makeAppWithAddr({
         uri: `${clusterUri}/apps/super-long-desc`,
         name: 'super-long-desc',
         desc: 'Duis id tortor at purus tincidunt finibus. Mauris eu semper orci, non commodo lacus. Praesent sollicitudin magna id laoreet porta. Nunc lobortis varius sem vel fringilla.',
@@ -263,7 +269,7 @@ const SearchResultItems = () => {
     }),
     makeResourceResult({
       kind: 'app',
-      resource: makeApp({
+      resource: makeAppWithAddr({
         name: 'super-long-app-with-uuid-1f96e498-88ec-442f-a25b-569fa915041c',
         desc: 'short-desc',
         uri: `${longClusterUri}/apps/super-long-desc`,
@@ -549,7 +555,6 @@ const AuxiliaryItems = () => {
               ),
               new ResourceSearchError(
                 '/clusters/foo',
-                'server',
                 new Error(
                   '14 UNAVAILABLE: connection error: desc = "transport: authentication handshake failed: EOF"'
                 )

--- a/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
@@ -33,7 +33,7 @@ import {
   makeApp,
 } from 'teleterm/services/tshd/testHelpers';
 import { ResourceSearchError } from 'teleterm/ui/services/resources';
-import { getAppAddrWithProtocol } from 'teleterm/ui/services/clusters';
+import { getAppAddrWithProtocol } from 'teleterm/services/tshd/app';
 
 import { SearchResult } from '../searchResult';
 import { makeResourceResult } from '../testHelpers';

--- a/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
@@ -190,7 +190,7 @@ describe('useResourceSearch', () => {
       clusterUri: cluster.uri,
       search: '',
       filters: [],
-      limit: 5,
+      limit: 20,
     });
     expect(appContext.resourcesService.searchResources).toHaveBeenCalledTimes(
       1

--- a/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
@@ -143,7 +143,7 @@ describe('useResourceSearch', () => {
       }));
     jest
       .spyOn(appContext.resourcesService, 'searchResources')
-      .mockResolvedValue([{ status: 'fulfilled', value: servers }]);
+      .mockResolvedValue(servers);
 
     const { result } = renderHook(() => useResourceSearch(), {
       wrapper: ({ children }) => (
@@ -174,7 +174,7 @@ describe('useResourceSearch', () => {
     });
     jest
       .spyOn(appContext.resourcesService, 'searchResources')
-      .mockResolvedValue([{ status: 'fulfilled', value: [] }]);
+      .mockResolvedValue([]);
 
     const { result } = renderHook(() => useResourceSearch(), {
       wrapper: ({ children }) => (
@@ -205,7 +205,7 @@ describe('useResourceSearch', () => {
     });
     jest
       .spyOn(appContext.resourcesService, 'searchResources')
-      .mockResolvedValue([{ status: 'fulfilled', value: [] }]);
+      .mockResolvedValue([]);
 
     const { result } = renderHook(() => useResourceSearch(), {
       wrapper: ({ children }) => (
@@ -226,7 +226,7 @@ describe('useResourceSearch', () => {
     });
     jest
       .spyOn(appContext.resourcesService, 'searchResources')
-      .mockResolvedValue([{ status: 'fulfilled', value: [] }]);
+      .mockResolvedValue([]);
 
     const { result } = renderHook(() => useResourceSearch(), {
       wrapper: ({ children }) => (

--- a/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
@@ -190,7 +190,7 @@ describe('useResourceSearch', () => {
       clusterUri: cluster.uri,
       search: '',
       filters: [],
-      limit: 20,
+      limit: 10,
     });
     expect(appContext.resourcesService.searchResources).toHaveBeenCalledTimes(
       1

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -88,9 +88,9 @@ export function useResourceSearch() {
         }
         case 'preview': {
           // In preview mode we know that the user didn't specify any search terms. So instead of
-          // fetching all 100 resources for each request, we fetch only a bunch of them to show
+          // fetching all 100 resources, we fetch only a bunch of them to show
           // example results in the UI.
-          limit = 5;
+          limit = 20;
           break;
         }
         case 'full-search': {

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -43,6 +43,7 @@ export type CrossClusterResourceSearchResult = {
   search: string;
 };
 
+const MAX_RANKED_RESULTS = 10;
 const SUPPORTED_RESOURCE_TYPES: ResourceTypeFilter[] = [
   'node',
   'app',
@@ -90,7 +91,7 @@ export function useResourceSearch() {
           // In preview mode we know that the user didn't specify any search terms. So instead of
           // fetching all 100 resources, we fetch only a bunch of them to show
           // example results in the UI.
-          limit = 20;
+          limit = MAX_RANKED_RESULTS;
           break;
         }
         case 'full-search': {
@@ -262,7 +263,7 @@ export function rankResults(
         b.score - a.score ||
         collator.compare(mainResourceName(a), mainResourceName(b))
     )
-    .slice(0, 10);
+    .slice(0, MAX_RANKED_RESULTS);
 }
 
 function populateMatches(

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -116,20 +116,16 @@ export function useResourceSearch() {
           )
         : connectedClusters;
 
-      // ResourcesService.searchResources uses Promise.allSettled so the returned promise will never
-      // get rejected.
-      const promiseResults = (
-        await Promise.all(
-          clustersToSearch.map(cluster =>
-            resourcesService.searchResources({
-              clusterUri: cluster.uri,
-              search,
-              filters: resourceTypeSearchFilters.map(f => f.resourceType),
-              limit,
-            })
-          )
+      const promiseResults = await Promise.allSettled(
+        clustersToSearch.map(cluster =>
+          resourcesService.searchResources({
+            clusterUri: cluster.uri,
+            search,
+            filters: resourceTypeSearchFilters.map(f => f.resourceType),
+            limit,
+          })
         )
-      ).flat();
+      );
 
       const results: resourcesServiceTypes.SearchResult[] = [];
       const errors: resourcesServiceTypes.ResourceSearchError[] = [];

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -30,7 +30,6 @@ import { Cluster } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
 import { Kube } from 'gen-proto-ts/teleport/lib/teleterm/v1/kube_pb';
 import { Server } from 'gen-proto-ts/teleport/lib/teleterm/v1/server_pb';
 import { Database } from 'gen-proto-ts/teleport/lib/teleterm/v1/database_pb';
-import { App as TshdApp } from 'gen-proto-ts/teleport/lib/teleterm/v1/app_pb';
 import {
   CreateAccessRequestRequest,
   GetRequestableRolesRequest,
@@ -773,29 +772,4 @@ export function makeKube(source: Kube) {
     name: source.name,
     labels: source.labels,
   };
-}
-
-/**
- * Returns address with protocol which is an app protocol + a public address.
- * If the public address is empty, it falls back to the endpoint URI.
- *
- * Always empty for SAML applications.
- */
-export function getAppAddrWithProtocol(source: TshdApp): string {
-  const { publicAddr, endpointUri } = source;
-
-  const isTcp = endpointUri && endpointUri.startsWith('tcp://');
-  const isCloud = endpointUri && endpointUri.startsWith('cloud://');
-  let addrWithProtocol = endpointUri;
-  if (publicAddr) {
-    if (isCloud) {
-      addrWithProtocol = `cloud://${publicAddr}`;
-    } else if (isTcp) {
-      addrWithProtocol = `tcp://${publicAddr}`;
-    } else {
-      addrWithProtocol = `https://${publicAddr}`;
-    }
-  }
-
-  return addrWithProtocol;
 }

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -775,17 +775,13 @@ export function makeKube(source: Kube) {
   };
 }
 
-export interface App extends TshdApp {
-  /**
-   * `addrWithProtocol` is an app protocol + a public address.
-   * If the public address is empty, it falls back to the endpoint URI.
-   *
-   * Always empty for SAML applications.
-   */
-  addrWithProtocol: string;
-}
-
-export function makeApp(source: TshdApp): App {
+/**
+ * Returns address with protocol which is an app protocol + a public address.
+ * If the public address is empty, it falls back to the endpoint URI.
+ *
+ * Always empty for SAML applications.
+ */
+export function getAppAddrWithProtocol(source: TshdApp): string {
   const { publicAddr, endpointUri } = source;
 
   const isTcp = endpointUri && endpointUri.startsWith('tcp://');
@@ -801,5 +797,5 @@ export function makeApp(source: TshdApp): App {
     }
   }
 
-  return { ...source, addrWithProtocol };
+  return addrWithProtocol;
 }

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -271,7 +271,7 @@ export type SearchResultDatabase = {
 export type SearchResultKube = { kind: 'kube'; resource: types.Kube };
 export type SearchResultApp = {
   kind: 'app';
-  resource: App;
+  resource: types.App & { addrWithProtocol: string };
 };
 
 export type SearchResult =

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -230,28 +230,24 @@ export class AmbiguousHostnameError extends Error {
 export class ResourceSearchError extends Error {
   constructor(
     public clusterUri: uri.ClusterUri,
-    public resourceKind: SearchResult['kind'],
     cause: Error | TshdRpcError
   ) {
-    super(
-      `Error while fetching resources of type ${resourceKind} from cluster ${clusterUri}`,
-      { cause }
-    );
+    super(`Error while fetching resources from cluster ${clusterUri}`, {
+      cause,
+    });
     this.name = 'ResourceSearchError';
     this.clusterUri = clusterUri;
-    this.resourceKind = resourceKind;
   }
 
   messageWithClusterName(
     getClusterName: (resourceUri: uri.ClusterOrResourceUri) => string,
     opts = { capitalize: true }
   ) {
-    const resource = pluralize(2, this.resourceKind);
     const cluster = getClusterName(this.clusterUri);
 
     return `${
       opts.capitalize ? 'Could' : 'could'
-    } not fetch ${resource} from ${cluster}`;
+    } not fetch resources from ${cluster}`;
   }
 
   messageAndCauseWithClusterName(

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -29,7 +29,8 @@ import {
 } from 'teleterm/helpers';
 
 import Logger from 'teleterm/logger';
-import { getAppAddrWithProtocol } from 'teleterm/ui/services/clusters';
+
+import { getAppAddrWithProtocol } from 'teleterm/services/tshd/app';
 
 import type { TshdClient } from 'teleterm/services/tshd';
 import type * as types from 'teleterm/services/tshd/types';


### PR DESCRIPTION
In upcoming PRs we are going to allow requesting resources from the 'main resources' page.
This will work by returning resources that the user can request and displaying the "+ Add to Request" button instead of "Connect".

We should support this mechanism in the search bar too, and the first step is converting it to use `ListUnifiedResources` instead of individual calls for `GetApps`, `GetKubes`, etc.

Another benefit is a small performance improvement, sending one request should be faster than four (even concurrent).