### PR TITLE
[v15] Mark users that have passwords as soon as they sign in

### DIFF
--- a/lib/auth/accountrecovery.go
+++ b/lib/auth/accountrecovery.go
@@ -198,7 +198,7 @@ func (a *Server) VerifyAccountRecovery(ctx context.Context, req *proto.VerifyAcc
 		}
 
 		if err := a.verifyAuthnRecovery(ctx, startToken, func() error {
-			return a.checkPasswordWOToken(startToken.GetUser(), req.GetPassword())
+			return a.checkPasswordWOToken(ctx, startToken.GetUser(), req.GetPassword())
 		}); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3190,7 +3190,7 @@ func (a *Server) CreateAuthenticateChallenge(ctx context.Context, req *proto.Cre
 		username = req.GetUserCredentials().GetUsername()
 
 		if err := a.WithUserLock(ctx, username, func() error {
-			return a.checkPasswordWOToken(username, req.GetUserCredentials().GetPassword())
+			return a.checkPasswordWOToken(ctx, username, req.GetUserCredentials().GetPassword())
 		}); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -421,7 +421,7 @@ func (a *Server) authenticateUserInternal(
 	case req.Webauthn != nil:
 		authenticateFn = func() (*types.MFADevice, error) {
 			if req.Pass != nil {
-				if err = a.checkPasswordWOToken(user, req.Pass.Password); err != nil {
+				if err = a.checkPasswordWOToken(ctx, user, req.Pass.Password); err != nil {
 					return nil, trace.Wrap(err)
 				}
 			}
@@ -441,7 +441,7 @@ func (a *Server) authenticateUserInternal(
 		authenticateFn = func() (*types.MFADevice, error) {
 			// OTP cannot be validated by validateMFAAuthResponse because we need to
 			// check the user's password too.
-			res, err := a.checkPassword(user, req.OTP.Password, req.OTP.Token)
+			res, err := a.checkPassword(ctx, user, req.OTP.Password, req.OTP.Token)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -507,7 +507,7 @@ func (a *Server) authenticateUserInternal(
 		return nil, "", trace.AccessDenied("missing second factor")
 	}
 	if err = a.WithUserLock(ctx, user, func() error {
-		return a.checkPasswordWOToken(user, req.Pass.Password)
+		return a.checkPasswordWOToken(ctx, user, req.Pass.Password)
 	}); err != nil {
 		if fieldErr := getErrorByTraceField(err); fieldErr != nil {
 			return nil, "", trace.Wrap(fieldErr)

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -163,9 +163,10 @@ func (a *Server) ChangePassword(ctx context.Context, req *proto.ChangePasswordRe
 	return nil
 }
 
-// checkPasswordWOToken checks just password without checking OTP tokens
-// used in case of SSH authentication, when token has been validated.
-func (a *Server) checkPasswordWOToken(user string, password []byte) error {
+// checkPasswordWOToken checks just password without checking OTP tokens. Marks
+// user's password state as SET if necessary.  Used in case of SSH or Web
+// authentication, when token has been validated.
+func (a *Server) checkPasswordWOToken(ctx context.Context, user string, password []byte) error {
 	const errMsg = "invalid username or password"
 
 	hash, err := a.GetPasswordHash(user)
@@ -190,6 +191,25 @@ func (a *Server) checkPasswordWOToken(user string, password []byte) error {
 		return trace.BadParameter(errMsg)
 	}
 
+	// At this point, we know that the user provided a correct password, so we may
+	// stop worrying about timing attacks against the user existence or password.
+	// Now mark the password state as SET to gradually transition those users for
+	// whom it's not known.
+	_, err = a.UpdateAndSwapUser(ctx, user, true /* withSecrets */, func(u types.User) (bool, error) {
+		if u.GetPasswordState() == types.PasswordState_PASSWORD_STATE_SET {
+			return false, nil
+		}
+		u.SetPasswordState(types.PasswordState_PASSWORD_STATE_SET)
+		return true, nil
+	})
+	if err != nil {
+		// Don't let the password state flag change fail the entire operation.
+		log.
+			WithError(err).
+			WithField("user", user).
+			Warn("Failed to set password state")
+	}
+
 	return nil
 }
 
@@ -198,8 +218,8 @@ type checkPasswordResult struct {
 }
 
 // checkPassword checks the password and OTP token. Called by tsh or lib/web/*.
-func (a *Server) checkPassword(user string, password []byte, otpToken string) (*checkPasswordResult, error) {
-	err := a.checkPasswordWOToken(user, password)
+func (a *Server) checkPassword(ctx context.Context, user string, password []byte, otpToken string) (*checkPasswordResult, error) {
+	err := a.checkPasswordWOToken(ctx, user, password)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -120,11 +120,12 @@ func setupPasswordSuite(t *testing.T) *passwordSuite {
 func TestUserNotFound(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
 	s := setupPasswordSuite(t)
 	username := "unknown-user"
 	password := "feefiefoefum"
 
-	err := s.a.checkPasswordWOToken(username, []byte(password))
+	err := s.a.checkPasswordWOToken(ctx, username, []byte(password))
 	require.Error(t, err)
 	// Make sure the error is not a NotFound. That would be a username oracle.
 	require.True(t, trace.IsBadParameter(err))
@@ -159,7 +160,7 @@ func TestPasswordLengthChange(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ensure that a shorter password still works for auth
-	err = authServer.checkPasswordWOToken(username, password)
+	err = authServer.checkPasswordWOToken(ctx, username, password)
 	require.NoError(t, err)
 }
 
@@ -357,7 +358,7 @@ func TestServer_ChangePassword(t *testing.T) {
 			require.NoError(t, userClient.ChangePassword(ctx, req), "changing password")
 
 			// Did the password change take effect?
-			require.NoError(t, authServer.checkPasswordWOToken(username, newPass), "password change didn't take effect")
+			require.NoError(t, authServer.checkPasswordWOToken(ctx, username, newPass), "password change didn't take effect")
 		})
 	}
 }
@@ -477,7 +478,7 @@ func TestServer_ChangePassword_Fails(t *testing.T) {
 				err, trace.Unwrap(err))
 
 			// Did the password change take effect?
-			assert.Error(t, authServer.checkPasswordWOToken(username, newPass), "password was changed")
+			assert.Error(t, authServer.checkPasswordWOToken(ctx, username, newPass), "password was changed")
 		})
 	}
 }
@@ -724,7 +725,7 @@ func TestChangeUserAuthentication(t *testing.T) {
 
 			// Test password is updated.
 			if len(validReq.NewPassword) != 0 {
-				err := authServer.checkPasswordWOToken(username, validReq.NewPassword)
+				err := authServer.checkPasswordWOToken(ctx, username, validReq.NewPassword)
 				require.NoError(t, err)
 			}
 

--- a/lib/auth/usertoken_test.go
+++ b/lib/auth/usertoken_test.go
@@ -76,7 +76,7 @@ func TestCreateResetPasswordToken(t *testing.T) {
 	require.Empty(t, devs)
 
 	// verify that password was reset
-	err = srv.Auth().checkPasswordWOToken(username, []byte(pass))
+	err = srv.Auth().checkPasswordWOToken(ctx, username, []byte(pass))
 	require.Error(t, err)
 
 	// create another reset token for the same user


### PR DESCRIPTION
Backport #40911 to branch/v15

The only merge conflict was changing the RFD status (the RFD doesn't exist on the v15 branch).

Retested manually:

- Password login success
- Password login failure
- Passwordless login success (Web only)

All in (OSS, Enterprise) x (Web, SSH) x (legacy user, regular user).