### PR TITLE
Remove unused `GetTSHVersion` helper function

### DIFF
--- a/lib/tbot/tshwrap/wrap.go
+++ b/lib/tbot/tshwrap/wrap.go
@@ -20,13 +20,11 @@ package tshwrap
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
@@ -125,28 +123,6 @@ func (w *Wrapper) Exec(env map[string]string, args ...string) error {
 	child.Stderr = os.Stderr
 
 	return trace.Wrap(child.Run(), "unable to execute tsh")
-}
-
-// GetTSHVersion queries the system tsh for its version.
-func GetTSHVersion(w *Wrapper) (*semver.Version, error) {
-	rawVersion, err := w.capture(w.path, "version", "-f", "json")
-	if err != nil {
-		return nil, trace.Wrap(err, "querying tsh version")
-	}
-
-	versionInfo := struct {
-		Version string `json:"version"`
-	}{}
-	if err := json.Unmarshal(rawVersion, &versionInfo); err != nil {
-		return nil, trace.Wrap(err, "error deserializing tsh version from string: %s", rawVersion)
-	}
-
-	sv, err := semver.NewVersion(versionInfo.Version)
-	if err != nil {
-		return nil, trace.Wrap(err, "error parsing tsh version: %s", versionInfo.Version)
-	}
-
-	return sv, nil
 }
 
 // GetDestinationDirectory attempts to select an unambiguous destination, either from


### PR DESCRIPTION
PR https://github.com/gravitational/teleport/pull/41342 removed the only call-site of this function. I figure it's better to remove it than keep it around.