### PR TITLE
chore: Bump golangci-lint to v1.58.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,7 +95,7 @@ linters-settings:
     - name: unused-parameter
       disabled: true
   sloglint:
-    context-only: true
+    context: all
     key-naming-case: snake
     static-msg: true
   testifylint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -116,6 +116,6 @@ output:
   uniq-by-line: false
 
 run:
-  go: '1.21'
+  go: '1.22'
   build-tags: []
   timeout: 15m

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.22.3
-GOLANGCI_LINT_VERSION ?= v1.57.2
+GOLANGCI_LINT_VERSION ?= v1.58.1
 
 NODE_VERSION ?= 20.11.1
 

--- a/lib/vnet/dns/osnameservers_darwin_test.go
+++ b/lib/vnet/dns/osnameservers_darwin_test.go
@@ -24,9 +24,10 @@ import (
 	"net"
 	"testing"
 
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // TestOSUpstreamNameservers configures the DNS server to forward requests for all addresses to the OS's real


### PR DESCRIPTION
Update to the latest release.

* https://github.com/golangci/golangci-lint/releases/tag/v1.58.1
* https://github.com/golangci/golangci-lint/releases/tag/v1.58.0