### PR TITLE
[docs] remove steps to download isrgrootx1.pem for MongoDB atlas

### DIFF
--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -60,7 +60,6 @@ $ sudo teleport db start \
   --name=mongodb-atlas \
   --protocol=mongodb \
   --uri=mongodb+srv://cluster0.abcde.mongodb.net \
-  --ca-cert=/path/to/letsencrypt/isrgrootx1.pem \
   --labels=env=dev
 ```
 
@@ -93,8 +92,6 @@ db_service:
   - name: "mongodb-atlas"
     protocol: "mongodb"
     uri: "mongodb+srv://cluster0.abcde.mongodb.net"
-    tls:
-      ca_cert_file: "/path/to/letsencrypt/isrgrootx1.pem"
     static_labels:
       env: "dev"
 
@@ -123,7 +120,6 @@ $ sudo teleport db start \
   --name=mongodb-atlas \
   --protocol=mongodb \
   --uri=mongodb+srv://cluster0.abcde.mongodb.net \
-  --ca-cert=/path/to/letsencrypt/isrgrootx1.pem \
   --labels=env=dev
 ```
 
@@ -144,8 +140,6 @@ db_service:
   - name: "mongodb-atlas"
     protocol: "mongodb"
     uri: "mongodb+srv://cluster0.abcde.mongodb.net"
-    tls:
-      ca_cert_file: "/path/to/letsencrypt/isrgrootx1.pem"
     static_labels:
       env: "dev"
 ```
@@ -176,19 +170,6 @@ Use only the scheme and hostname parts of the connection string in the URI:
 ```code
 $ --uri=mongodb+srv://cluster0.abcde.mongodb.net
 ```
-
-### Atlas CA certificate
-
-MongoDB Atlas uses certificates signed by Let's Encrypt.
-
-Download the Let's Encrypt root certificate and use it as a CA in the Database
-Service configuration:
-
-```code
-$ curl -o /tmp/isrgrootx1.pem https://letsencrypt.org/certs/isrgrootx1.pem.txt
-```
-
-You can then use `/tmp/isrgrootx1.pem` as the value of the `db_service.databases[*].ca_cert_file` configuration option or `--ca-cert` CLI flag.
 
 ## Step 2/4. Create a Teleport user
 


### PR DESCRIPTION
Related PR:
- #41289

With the above change, there is no need to manually download the isrgrootx1.pem any more.

I don't plan to backport this doc change so that older branches still show this step for versions that don't have the above patch. 