### PR TITLE
Remove unused format param

### DIFF
--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -183,7 +183,7 @@ func (u *UserCommand) ResetPassword(ctx context.Context, client *auth.Client) er
 		return err
 	}
 
-	err = u.PrintResetPasswordToken(token, u.format)
+	err = u.PrintResetPasswordToken(token)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -192,9 +192,8 @@ func (u *UserCommand) ResetPassword(ctx context.Context, client *auth.Client) er
 }
 
 // PrintResetPasswordToken prints ResetPasswordToken
-func (u *UserCommand) PrintResetPasswordToken(token types.UserToken, format string) error {
+func (u *UserCommand) PrintResetPasswordToken(token types.UserToken) error {
 	err := u.printResetPasswordToken(token,
-		format,
 		"User %q has been reset. Share this URL with the user to complete password reset, link is valid for %v:\n%v\n\n",
 	)
 	if err != nil {
@@ -205,9 +204,8 @@ func (u *UserCommand) PrintResetPasswordToken(token types.UserToken, format stri
 }
 
 // PrintResetPasswordTokenAsInvite prints ResetPasswordToken as Invite
-func (u *UserCommand) PrintResetPasswordTokenAsInvite(token types.UserToken, format string) error {
+func (u *UserCommand) PrintResetPasswordTokenAsInvite(token types.UserToken) error {
 	err := u.printResetPasswordToken(token,
-		format,
 		"User %q has been created but requires a password. Share this URL with the user to complete user setup, link is valid for %v:\n%v\n\n")
 	if err != nil {
 		return trace.Wrap(err)
@@ -217,7 +215,7 @@ func (u *UserCommand) PrintResetPasswordTokenAsInvite(token types.UserToken, for
 }
 
 // PrintResetPasswordToken prints ResetPasswordToken
-func (u *UserCommand) printResetPasswordToken(token types.UserToken, format string, messageFormat string) (err error) {
+func (u *UserCommand) printResetPasswordToken(token types.UserToken, messageFormat string) (err error) {
 	switch strings.ToLower(u.format) {
 	case teleport.JSON:
 		err = printTokenAsJSON(token)
@@ -326,7 +324,7 @@ func (u *UserCommand) Add(ctx context.Context, client *auth.Client) error {
 		return trace.Wrap(err)
 	}
 
-	if err := u.PrintResetPasswordTokenAsInvite(token, u.format); err != nil {
+	if err := u.PrintResetPasswordTokenAsInvite(token); err != nil {
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
We were never actually using the passed-in value, and instead always read the format field of the reciever.

No functional change, as the value we passed in always happened to be the same as the format field we were using.