### PR TITLE
[v15] chore: Bump golangci-lint to v1.58.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,7 +84,7 @@ linters-settings:
     - name: unused-parameter
       disabled: true
   sloglint:
-    context-only: true
+    context: all
     key-naming-case: snake
     static-msg: true
   testifylint:

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.21.10
-GOLANGCI_LINT_VERSION ?= v1.57.2
+GOLANGCI_LINT_VERSION ?= v1.58.1
 
 NODE_VERSION ?= 20.11.1
 


### PR DESCRIPTION
Backport #41364 to branch/v15.
