### PR TITLE
[v13] chore: Bump golangci-lint to v1.58.1

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -2,7 +2,7 @@
 # This file can be included in other Makefiles to avoid duplication.
 
 GOLANG_VERSION ?= go1.21.9
-GOLANGCI_LINT_VERSION ?= v1.57.2
+GOLANGCI_LINT_VERSION ?= v1.58.1
 
 NODE_VERSION ?= 20.11.1
 


### PR DESCRIPTION
Backport #41364 to branch/v13.