### PR TITLE
Use proquints for recovery codes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -169,7 +169,6 @@ require (
 	github.com/schollz/progressbar/v3 v3.14.2
 	github.com/scim2/filter-parser/v2 v2.2.0
 	github.com/segmentio/parquet-go v0.0.0-20230712180008-5d42db8f0d47
-	github.com/sethvargo/go-diceware v0.3.0
 	github.com/sigstore/cosign/v2 v2.2.4
 	github.com/sigstore/sigstore v1.8.3
 	github.com/sijms/go-ora/v2 v2.8.10

--- a/go.sum
+++ b/go.sum
@@ -2153,8 +2153,6 @@ github.com/segmentio/parquet-go v0.0.0-20230712180008-5d42db8f0d47 h1:5am1AKPVBj
 github.com/segmentio/parquet-go v0.0.0-20230712180008-5d42db8f0d47/go.mod h1:+J0xQnJjm8DuQUHBO7t57EnmPbstT6+b45+p3DC9k1Q=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
-github.com/sethvargo/go-diceware v0.3.0 h1:UVVEfmN/uF50JfWAN7nbY6CiAlp5xeSx+5U0lWKkMCQ=
-github.com/sethvargo/go-diceware v0.3.0/go.mod h1:lH5Q/oSPMivseNdhMERAC7Ti5oOPqsaVddU1BcN1CY0=
 github.com/shabbyrobe/gocovmerge v0.0.0-20190829150210-3e036491d500/go.mod h1:+njLrG5wSeoG4Ds61rFgEzKvenR2UHbjMoDHsczxly0=
 github.com/shabbyrobe/gocovmerge v0.0.0-20230507112040-c3350d9342df h1:S77Pf5fIGMa7oSwp8SQPp7Hb4ZiI38K3RNBKD2LLeEM=
 github.com/shabbyrobe/gocovmerge v0.0.0-20230507112040-c3350d9342df/go.mod h1:dcuzJZ83w/SqN9k4eQqwKYMgmKWzg/KzJAURBhRL1tc=

--- a/lib/auth/accountrecovery.go
+++ b/lib/auth/accountrecovery.go
@@ -20,11 +20,12 @@ package auth
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/binary"
 	"net/mail"
 	"strings"
 
 	"github.com/gravitational/trace"
-	"github.com/sethvargo/go-diceware/diceware"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 
@@ -479,20 +480,45 @@ func (a *Server) isAccountRecoveryAllowed(ctx context.Context) error {
 // generateRecoveryCodes returns an array of tokens where each token
 // have 8 random words prefixed with tele and concanatenated with dashes.
 func generateRecoveryCodes() ([]string, error) {
-	gen, err := diceware.NewGenerator(nil /* use default word list */)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	tokenList := make([]string, 0, numOfRecoveryCodes)
 
-	tokenList := make([]string, numOfRecoveryCodes)
 	for i := 0; i < numOfRecoveryCodes; i++ {
-		list, err := gen.Generate(numWordsInRecoveryCode)
-		if err != nil {
+		wordIDs := make([]uint16, numWordsInRecoveryCode)
+		if err := binary.Read(rand.Reader, binary.NativeEndian, wordIDs); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		tokenList[i] = "tele-" + strings.Join(list, "-")
+		words := make([]string, 0, 1+len(wordIDs))
+		words = append(words, "tele")
+		for _, id := range wordIDs {
+			words = append(words, encodeProquint(id))
+		}
+
+		tokenList = append(tokenList, strings.Join(words, "-"))
 	}
 
 	return tokenList, nil
+}
+
+// encodeProquint returns a five-letter word based on a uint16.
+// This proquint implementation is adapted from upspin.io:
+// https://github.com/upspin/upspin/blob/master/key/proquint/proquint.go
+// For the algorithm, see https://arxiv.org/html/0901.4016
+func encodeProquint(x uint16) string {
+	const consonants = "bdfghjklmnprstvz"
+	const vowels = "aiou"
+
+	cons3 := x & 0b1111
+	vow2 := (x >> 4) & 0b11
+	cons2 := (x >> 6) & 0b1111
+	vow1 := (x >> 10) & 0b11
+	cons1 := x >> 12
+
+	return string([]byte{
+		consonants[cons1],
+		vowels[vow1],
+		consonants[cons2],
+		vowels[vow2],
+		consonants[cons3],
+	})
 }

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -20,9 +20,11 @@ package auth
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"math/rand"
+	"net/netip"
 	"strings"
 	"testing"
 	"time"
@@ -1352,4 +1354,35 @@ func createUserWithSecondFactors(testServer *TestTLSServer) (*userAuthCreds, err
 		totpDev:       totpDev,
 		webDev:        webDev,
 	}, nil
+}
+
+func TestProquint(t *testing.T) {
+	t.Parallel()
+
+	// source: https://arxiv.org/html/0901.4016
+	proquintTestCases := []struct{ address, proquint string }{
+		{"127.0.0.1", "lusab-babad"},
+		{"63.84.220.193", "gutih-tugad"},
+		{"63.118.7.35", "gutuk-bisog"},
+		{"140.98.193.141", "mudof-sakat"},
+		{"64.255.6.200", "haguz-biram"},
+		{"128.30.52.45", "mabiv-gibot"},
+		{"147.67.119.2", "natag-lisaf"},
+		{"212.58.253.68", "tibup-zujah"},
+		{"216.35.68.215", "tobog-higil"},
+		{"216.68.232.21", "todah-vobij"},
+		{"198.81.129.136", "sinid-makam"},
+		{"12.110.110.204", "budov-kuras"},
+	}
+
+	for _, tc := range proquintTestCases {
+		addr, err := netip.ParseAddr(tc.address)
+		require.NoError(t, err)
+		require.True(t, addr.Is4())
+		addr4 := addr.As4()
+
+		hi, lo := binary.BigEndian.Uint16(addr4[:2]), binary.BigEndian.Uint16(addr4[2:])
+		proquint := encodeProquint(hi) + "-" + encodeProquint(lo)
+		require.Equal(t, tc.proquint, proquint, "wrong encoding for address %v", addr)
+	}
 }


### PR DESCRIPTION
The `github.com/sethvargo/go-diceware` library that we use to generate friendly recovery codes unconditionally causes a ~1.5MB allocation at runtime, since it uses a map in a `var`; while this is a relatively small cost for a long running `teleport` process, this cost is incurred even by binaries that are intended to be much leaner (such as `tsh` or `tbot`) and that might end up running in multiple copies (hundreds or thousands) on a given machine. That fixed cost also happens on every new re-execution of `teleport` to handle shell execution, port forwarding and various other bits of functionality that must happen in a separate process - which is pretty silly, considering that most of those are not in the auth service, which is the only component that needs to generate recovery codes.

Adding to the aforementioned issue, #5685 is still very much a problem, and trimming one more dependency is worth in and of itself.

This PR thus proposes to change the recovery code generation to use proquints (PRO-nouncable QUINT-uplets of alternating unambiguous consonants and vowels, [arXiv:0901.4016 [cs.SE]](https://arxiv.org/html/0901.4016)), which we've been successfully using in Cloud to generate random pronounceable identifiers for a while now. As a bonus, this makes the recovery codes slightly less guessable (from ~103 to 128 bits of entropy each).

Example of the account recovery UI after the change: 
<img width="1054" alt="proquints-recovery" src="https://github.com/gravitational/teleport/assets/886075/c80e04af-a666-4be7-b18d-f0d3a14fc7c6">

Existing recovery codes are stored hashed in the user `recoverycodes` resource, and will continue working as normal after this change.