### PR TITLE
add the "v" prefix in front of teleport version to correct links

### DIFF
--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -3,9 +3,9 @@ title: FedRAMP Compliance for Infrastructure Access
 description: How to configure SSH, Kubernetes, database, and web app access to be FedRAMP compliant, including support for FIPS 140-2.
 ---
 
-Teleport provides the foundation to meet FedRAMP requirements for the purposes of accessing infrastructure. 
+Teleport provides the foundation to meet FedRAMP requirements for the purposes of accessing infrastructure.
 This includes support for the Federal Information Processing Standard [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS\_140-2).
-This standard is the US government approved standard for cryptographic modules. This document explains how  
+This standard is the US government approved standard for cryptographic modules. This document explains how
 Teleport FIPS mode works and how it can help your company to become FedRAMP authorized.
 
 ## Obtain FedRAMP authorization with Teleport
@@ -32,37 +32,37 @@ government agencies.
 Teleport Enterprise customers can download the custom FIPS package from their
 [Teleport account](https://teleport.sh). Look for `Linux 64-bit (FedRAMP/FIPS)`.
 
-You also can follow the [Installation instructions](../../installation.mdx#linux) for 
-Teleport Enterprise edition to download and install the appropriate FIPS-compliant binaries for 
+You also can follow the [Installation instructions](../../installation.mdx#linux) for
+Teleport Enterprise edition to download and install the appropriate FIPS-compliant binaries for
 your operating environment and package manager or from compressed archive (tarball).
 
 For example, you can download and install from the compressed archive by running the following commands:
 
 ```code
-$ curl https://cdn.teleport.dev/teleport-ent-(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz.sha256
+$ curl https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz.sha256
 <checksum> <filename>
-$ curl -O https://cdn.teleport.dev/teleport-ent-(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
+$ curl -O https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
 
 # Verify that the checksums match
-$ shasum -a 256 teleport-ent-(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
+$ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
 
-$ tar -xvf teleport-ent-(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
+$ tar -xvf teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
 $ cd teleport-ent
 $ sudo ./install
 ```
 
-After you download and install, all of the Teleport Enterprise binaries are 
+After you download and install, all of the Teleport Enterprise binaries are
 installed in the `/usr/local/bin` directory. You can verify you have FIPS-compliant
-binaries installed by running the `teleport version` command and verifying that 
+binaries installed by running the `teleport version` command and verifying that
 the `X:boringcrypto` library is listed. For example:
 
 ```code
 $ teleport version
-Teleport Enterprise (= teleport.version =) (= teleport.git =) (= teleport.golang =) X:boringcrypto
+Teleport Enterprise (=teleport.version=) (= teleport.git =) (= teleport.golang =) X:boringcrypto
 ```
 
 If your Teleport cluster runs on AWS, the cluster can run in US-East or US-West regions for services
-with low or moderate impact levels. For services with a high impact level, the cluster must run 
+with low or moderate impact levels. For services with a high impact level, the cluster must run
 in a GovCloud region to support FIPS.
 
 ## Configure the Teleport Auth Service


### PR DESCRIPTION
Previous to this change, the url's here were missing an essential `v` in front of the teleport version (e.g. they were `15.3.1` instead of `v15.3.1`) resulting in broken links

```
$ curl https://cdn.teleport.dev/teleport-ent-15.3.1-linux-arm64-fips-bin.tar.gz.sha256
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>public/teleport-ent-15.3.1-linux-arm64-fips-bin.tar.gz.sha256</Key><RequestId>KJAB4Y274DFZ4QR8</RequestId><HostId>O460OX5MT7lI+fz7tP4fu3lfiRYorFvczRa3wYLF4AoyK+G7b/YZBeKiX20HI/rj6D5t6PQDnAxczOSDb6QIgA==</HostId></Error>
```

This change fixes that:

```
$ curl https://cdn.teleport.dev/teleport-ent-v15.3.1-linux-arm64-fips-bin.tar.gz.sha256
d2c98f0eab2169b67ced5d279a4c3deae2aa7ad26fca9b39e72835e9918f6e39  teleport-ent-v15.3.1-linux-arm64-fips-bin.tar.gz
```