### PR TITLE
[vnet] `vnet_config` resource

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -86,6 +86,7 @@ import (
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	userloginstatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	userpreferencespb "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/metadata"
@@ -871,6 +872,11 @@ func (c *Client) WorkloadIdentityServiceClient() machineidv1pb.WorkloadIdentityS
 // NotificationServiceClient returns a notification service client that can be used to fetch notifications.
 func (c *Client) NotificationServiceClient() notificationsv1pb.NotificationServiceClient {
 	return notificationsv1pb.NewNotificationServiceClient(c.conn)
+}
+
+// VnetConfigServiceClient returns an unadorned client for the VNet config service.
+func (c *Client) VnetConfigServiceClient() vnet.VnetConfigServiceClient {
+	return vnet.NewVnetConfigServiceClient(c.conn)
 }
 
 // Ping gets basic info about the auth server.

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -523,6 +523,9 @@ const (
 	// KindUserNotificationState is a resource which tracks whether a user has clicked on or dismissed a notification.
 	KindUserNotificationState = "user_notification_state"
 
+	// KindVnetConfig is a resource which holds cluster-wide configuration for VNet.
+	KindVnetConfig = "vnet_config"
+
 	// V7 is the seventh version of resources.
 	V7 = "v7"
 

--- a/lib/auth/crownjewel/crownjewelv1/service_test.go
+++ b/lib/auth/crownjewel/crownjewelv1/service_test.go
@@ -180,7 +180,7 @@ type fakeChecker struct {
 
 func (f fakeChecker) CheckAccessToRule(_ services.RuleContext, _ string, resource string, verb string) error {
 	if resource == types.KindCrownJewel {
-		for slices.Contains(f.allowedVerbs, verb) {
+		if slices.Contains(f.allowedVerbs, verb) {
 			return nil
 		}
 	}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -66,6 +66,7 @@ import (
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	userloginstatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	userpreferencespb "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/metadata"
@@ -91,6 +92,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/userloginstate"
 	"github.com/gravitational/teleport/lib/auth/userpreferences/userpreferencesv1"
 	"github.com/gravitational/teleport/lib/auth/users/usersv1"
+	"github.com/gravitational/teleport/lib/auth/vnetconfig/v1"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -5313,6 +5315,13 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		return nil, trace.Wrap(err)
 	}
 	notificationsv1.RegisterNotificationServiceServer(server, notificationsServer)
+
+	vnetConfigStorage, err := local.NewVnetConfigService(cfg.AuthServer.bk)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	vnetConfigServiceServer := vnetconfig.NewVnetConfigService(vnetConfigStorage, cfg.Authorizer)
+	vnet.RegisterVnetConfigServiceServer(server, vnetConfigServiceServer)
 
 	// Only register the service if this is an open source build. Enterprise builds
 	// register the actual service via an auth plugin, if we register here then all

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5320,7 +5320,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	vnetConfigServiceServer := vnetconfig.NewVnetConfigService(vnetConfigStorage, cfg.Authorizer)
+	vnetConfigServiceServer := vnetconfig.NewService(vnetConfigStorage, cfg.Authorizer)
 	vnet.RegisterVnetConfigServiceServer(server, vnetConfigServiceServer)
 
 	// Only register the service if this is an open source build. Enterprise builds

--- a/lib/auth/vnetconfig/v1/service.go
+++ b/lib/auth/vnetconfig/v1/service.go
@@ -1,0 +1,184 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package vnetconfig
+
+import (
+	"context"
+
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type VnetConfigService struct {
+	// Opting out of forward compatibility, this service must implement all service methods.
+	vnet.UnsafeVnetConfigServiceServer
+
+	storage    *local.VnetConfigService
+	authorizer authz.Authorizer
+}
+
+func NewVnetConfigService(storage *local.VnetConfigService, authorizer authz.Authorizer) *VnetConfigService {
+	return &VnetConfigService{
+		storage:    storage,
+		authorizer: authorizer,
+	}
+}
+
+func (s *VnetConfigService) GetVnetConfig(ctx context.Context, _ *vnet.GetVnetConfigRequest) (*vnet.VnetConfig, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindVnetConfig, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	vnetConfig, err := s.storage.GetVnetConfig(ctx)
+	if err != nil {
+		return nil, utils.OpaqueAccessDenied(err)
+	}
+
+	if err := checkAccessToResource(authCtx, vnetConfig, types.VerbRead); err != nil {
+		return nil, utils.OpaqueAccessDenied(err)
+	}
+
+	return vnetConfig, nil
+}
+
+func (s *VnetConfigService) CreateVnetConfig(ctx context.Context, req *vnet.CreateVnetConfigRequest) (*vnet.VnetConfig, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := checkAccessToResource(authCtx, req.VnetConfig, types.VerbCreate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	vnetConfig, err := s.storage.CreateVnetConfig(ctx, req.VnetConfig)
+	return vnetConfig, trace.Wrap(err)
+}
+
+func (s *VnetConfigService) UpdateVnetConfig(ctx context.Context, req *vnet.UpdateVnetConfigRequest) (*vnet.VnetConfig, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := checkAccessToResource(authCtx, req.VnetConfig, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	oldVnetConfig, err := s.storage.GetVnetConfig(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := checkAccessToResource(authCtx, oldVnetConfig, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	vnetConfig, err := s.storage.CreateVnetConfig(ctx, req.VnetConfig)
+	return vnetConfig, trace.Wrap(err)
+}
+
+func (s *VnetConfigService) UpsertVnetConfig(ctx context.Context, req *vnet.UpsertVnetConfigRequest) (*vnet.VnetConfig, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// To upsert you must be allowed to Create and Update the new resource.
+	if err := checkAccessToResource(authCtx, req.VnetConfig, types.VerbCreate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Try a few times to Create or Update the resource, in case we race with another Create or Update.
+	for i := 0; i < 5; i++ {
+		// To upsert you must be allowed to Update the existing resource, if there is one.
+		existingVnetConfig, err := s.storage.GetVnetConfig(ctx)
+		if err != nil && !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
+		if err == nil {
+			// There is an existing resource, make sure the user is allowed to Update it.
+			if err := checkAccessToResource(authCtx, existingVnetConfig, types.VerbUpdate); err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			// Make sure the resource revision doesn't change between the authz check and the write.
+			newVnetConfig := proto.Clone(req.VnetConfig).(*vnet.VnetConfig)
+			newVnetConfig.Metadata.Revision = existingVnetConfig.Metadata.Revision
+			vnetConfig, err := s.storage.UpdateVnetConfig(ctx, newVnetConfig)
+			if trace.IsCompareFailed(err) {
+				continue
+			}
+			return vnetConfig, trace.Wrap(err)
+		}
+
+		// There is no existing resource, just Create the new one.
+		vnetConfig, err := s.storage.CreateVnetConfig(ctx, req.VnetConfig)
+		if trace.IsAlreadyExists(err) {
+			continue
+		}
+		return vnetConfig, trace.Wrap(err)
+	}
+
+	return nil, trace.CompareFailed("failed to upsert vnet_config within 5 attempts")
+}
+
+func (s *VnetConfigService) DeleteVnetConfig(ctx context.Context, _ *vnet.DeleteVnetConfigRequest) (*emptypb.Empty, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindVnetConfig, types.VerbDelete); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	existingVnetConfig, err := s.storage.GetVnetConfig(ctx)
+	if err != nil {
+		if trace.IsNotFound(err) {
+			// Nothing to delete
+			return &emptypb.Empty{}, nil
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	if err := checkAccessToResource(authCtx, existingVnetConfig, types.VerbDelete); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.storage.DeleteVnetConfig(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func checkAccessToResource(authCtx *authz.Context, vnetConfig *vnet.VnetConfig, verb string, additionalVerbs ...string) error {
+	return trace.Wrap(authCtx.CheckAccessToResource(types.Resource153ToLegacy(vnetConfig), verb, additionalVerbs...))
+}

--- a/lib/auth/vnetconfig/v1/service.go
+++ b/lib/auth/vnetconfig/v1/service.go
@@ -115,7 +115,8 @@ func (s *Service) UpsertVnetConfig(ctx context.Context, req *vnet.UpsertVnetConf
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.AuthorizeAdminAction(); err != nil {
+	// Support reused MFA for bulk tctl create requests.
+	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/vnetconfig/v1/service.go
+++ b/lib/auth/vnetconfig/v1/service.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/lib/services/local"
 )
 
+// Service implements the gRPC API layer for the singleton VnetConfig resource.
 type Service struct {
 	// Opting out of forward compatibility, this service must implement all service methods.
 	vnet.UnsafeVnetConfigServiceServer
@@ -38,6 +39,7 @@ type Service struct {
 	authorizer authz.Authorizer
 }
 
+// NewService returns a new VnetConfig API service using the given storage layer and authorizer.
 func NewService(storage *local.VnetConfigService, authorizer authz.Authorizer) *Service {
 	return &Service{
 		storage:    storage,
@@ -45,6 +47,7 @@ func NewService(storage *local.VnetConfigService, authorizer authz.Authorizer) *
 	}
 }
 
+// GetVnetConfig returns the singleton VnetConfig resource.
 func (s *Service) GetVnetConfig(ctx context.Context, _ *vnet.GetVnetConfigRequest) (*vnet.VnetConfig, error) {
 	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
@@ -63,6 +66,7 @@ func (s *Service) GetVnetConfig(ctx context.Context, _ *vnet.GetVnetConfigReques
 	return vnetConfig, nil
 }
 
+// CreateVnetConfig creates a VnetConfig resource.
 func (s *Service) CreateVnetConfig(ctx context.Context, req *vnet.CreateVnetConfigRequest) (*vnet.VnetConfig, error) {
 	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
@@ -81,6 +85,7 @@ func (s *Service) CreateVnetConfig(ctx context.Context, req *vnet.CreateVnetConf
 	return vnetConfig, trace.Wrap(err)
 }
 
+// UpdateVnetConfig updates a VnetConfig resource.
 func (s *Service) UpdateVnetConfig(ctx context.Context, req *vnet.UpdateVnetConfigRequest) (*vnet.VnetConfig, error) {
 	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
@@ -99,13 +104,13 @@ func (s *Service) UpdateVnetConfig(ctx context.Context, req *vnet.UpdateVnetConf
 	return vnetConfig, trace.Wrap(err)
 }
 
+// UpsertVnetConfig does basic validation and upserts a VnetConfig resource.
 func (s *Service) UpsertVnetConfig(ctx context.Context, req *vnet.UpsertVnetConfigRequest) (*vnet.VnetConfig, error) {
 	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// To upsert you must be allowed to Create and Update the new resource.
 	if err := authCtx.CheckAccessToKind(types.KindVnetConfig, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -118,6 +123,7 @@ func (s *Service) UpsertVnetConfig(ctx context.Context, req *vnet.UpsertVnetConf
 	return vnetConfig, trace.Wrap(err)
 }
 
+// DeleteVnetConfig deletes the singleton VnetConfig resource.
 func (s *Service) DeleteVnetConfig(ctx context.Context, _ *vnet.DeleteVnetConfigRequest) (*emptypb.Empty, error) {
 	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {

--- a/lib/auth/vnetconfig/v1/service.go
+++ b/lib/auth/vnetconfig/v1/service.go
@@ -101,7 +101,7 @@ func (s *VnetConfigService) UpdateVnetConfig(ctx context.Context, req *vnet.Upda
 		return nil, trace.Wrap(err)
 	}
 
-	vnetConfig, err := s.storage.CreateVnetConfig(ctx, req.VnetConfig)
+	vnetConfig, err := s.storage.UpdateVnetConfig(ctx, req.VnetConfig)
 	return vnetConfig, trace.Wrap(err)
 }
 
@@ -112,7 +112,7 @@ func (s *VnetConfigService) UpsertVnetConfig(ctx context.Context, req *vnet.Upse
 	}
 
 	// To upsert you must be allowed to Create and Update the new resource.
-	if err := checkAccessToResource(authCtx, req.VnetConfig, types.VerbCreate); err != nil {
+	if err := checkAccessToResource(authCtx, req.VnetConfig, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/vnetconfig/v1/service.go
+++ b/lib/auth/vnetconfig/v1/service.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
-	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // Service implements the gRPC API layer for the singleton VnetConfig resource.
@@ -35,12 +35,12 @@ type Service struct {
 	// Opting out of forward compatibility, this service must implement all service methods.
 	vnet.UnsafeVnetConfigServiceServer
 
-	storage    *local.VnetConfigService
+	storage    services.VnetConfigService
 	authorizer authz.Authorizer
 }
 
 // NewService returns a new VnetConfig API service using the given storage layer and authorizer.
-func NewService(storage *local.VnetConfigService, authorizer authz.Authorizer) *Service {
+func NewService(storage services.VnetConfigService, authorizer authz.Authorizer) *Service {
 	return &Service{
 		storage:    storage,
 		authorizer: authorizer,

--- a/lib/auth/vnetconfig/v1/service_test.go
+++ b/lib/auth/vnetconfig/v1/service_test.go
@@ -84,6 +84,9 @@ func TestServiceAccess(t *testing.T) {
 			allowedStates: []authz.AdminActionAuthState{authz.AdminActionAuthNotRequired, authz.AdminActionAuthMFAVerified},
 			allowedVerbs:  []string{types.VerbDelete},
 			action: func(service *Service) error {
+				if _, err := service.storage.CreateVnetConfig(ctx, vnetConfig); err != nil {
+					return trace.Wrap(err, "creating vnet_config as pre-req for Delete test")
+				}
 				_, err := service.DeleteVnetConfig(ctx, &vnet.DeleteVnetConfigRequest{})
 				return trace.Wrap(err)
 			},

--- a/lib/auth/vnetconfig/v1/service_test.go
+++ b/lib/auth/vnetconfig/v1/service_test.go
@@ -1,0 +1,84 @@
+package vnetconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	header "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVnetConfigService(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	backend, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	storage, err := local.NewVnetConfigService(backend)
+	require.NoError(t, err)
+
+	checker := fakeChecker{
+		allowedVerbs: []string{types.VerbRead, types.VerbUpdate, types.VerbCreate, types.VerbDelete},
+	}
+
+	authorizer := authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+		user, err := types.NewUser("alice")
+		if err != nil {
+			return nil, err
+		}
+		return &authz.Context{
+			User:    user,
+			Checker: checker,
+		}, nil
+	})
+
+	service := NewVnetConfigService(storage, authorizer)
+
+	vnetConfig := &vnet.VnetConfig{
+		Kind:    types.KindVnetConfig,
+		Version: types.V1,
+		Metadata: &header.Metadata{
+			Name: "vnet-config",
+		},
+		Spec: &vnet.VnetConfigSpec{
+			CidrRange: "100.64.0.0/10",
+			CustomDnsZones: []*vnet.CustomDNSZone{
+				{Suffix: "example.com"},
+				{Suffix: "test.example.com"},
+			},
+		},
+	}
+
+	createdVnetConfig, err := service.CreateVnetConfig(ctx, &vnet.CreateVnetConfigRequest{VnetConfig: vnetConfig})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(vnetConfig, createdVnetConfig,
+		cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
+		cmpopts.IgnoreUnexported(vnet.VnetConfig{}, vnet.VnetConfigSpec{}, vnet.CustomDNSZone{}, header.Metadata{})))
+}
+
+type fakeChecker struct {
+	allowedVerbs []string
+	services.AccessChecker
+}
+
+func (f fakeChecker) CheckAccessToRule(_ services.RuleContext, _ string, resource string, verb string) error {
+	if resource == types.KindVnetConfig {
+		for _, allowedVerb := range f.allowedVerbs {
+			if allowedVerb == verb {
+				return nil
+			}
+		}
+	}
+
+	return trace.AccessDenied("access denied to rule=%v/verb=%v", resource, verb)
+}

--- a/lib/auth/vnetconfig/v1/service_test.go
+++ b/lib/auth/vnetconfig/v1/service_test.go
@@ -92,18 +92,26 @@ func TestServiceAccess(t *testing.T) {
 			},
 		},
 		{
-			name:          "UpsertVnetConfig",
-			allowedStates: []authz.AdminActionAuthState{authz.AdminActionAuthNotRequired, authz.AdminActionAuthMFAVerified},
-			allowedVerbs:  []string{types.VerbCreate, types.VerbUpdate},
+			name: "UpsertVnetConfig",
+			allowedStates: []authz.AdminActionAuthState{
+				authz.AdminActionAuthNotRequired,
+				authz.AdminActionAuthMFAVerified,
+				authz.AdminActionAuthMFAVerifiedWithReuse,
+			},
+			allowedVerbs: []string{types.VerbCreate, types.VerbUpdate},
 			action: func(service *Service) error {
 				_, err := service.UpsertVnetConfig(ctx, &vnet.UpsertVnetConfigRequest{VnetConfig: vnetConfig})
 				return trace.Wrap(err)
 			},
 		},
 		{
-			name:          "UpsertVnetConfig with existing",
-			allowedStates: []authz.AdminActionAuthState{authz.AdminActionAuthNotRequired, authz.AdminActionAuthMFAVerified},
-			allowedVerbs:  []string{types.VerbCreate, types.VerbUpdate},
+			name: "UpsertVnetConfig with existing",
+			allowedStates: []authz.AdminActionAuthState{
+				authz.AdminActionAuthNotRequired,
+				authz.AdminActionAuthMFAVerified,
+				authz.AdminActionAuthMFAVerifiedWithReuse,
+			},
+			allowedVerbs: []string{types.VerbCreate, types.VerbUpdate},
 			action: func(service *Service) error {
 				if _, err := service.storage.CreateVnetConfig(ctx, vnetConfig); err != nil {
 					return trace.Wrap(err, "creating vnet_config as pre-req for Upsert test")

--- a/lib/services/local/vnet_config.go
+++ b/lib/services/local/vnet_config.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package local
 
 import (

--- a/lib/services/local/vnet_config.go
+++ b/lib/services/local/vnet_config.go
@@ -62,7 +62,8 @@ func NewVnetConfigService(backend backend.Backend) (*VnetConfigService, error) {
 
 // GetVnetConfig returns the singleton VnetConfig resource.
 func (s *VnetConfigService) GetVnetConfig(ctx context.Context) (*vnet.VnetConfig, error) {
-	return s.svc.GetResource(ctx, vnetConfigSingletonName)
+	vnetConfig, err := s.svc.GetResource(ctx, vnetConfigSingletonName)
+	return vnetConfig, trace.Wrap(err)
 }
 
 // CreateVnetConfig does basic validation and creates a VnetConfig resource.
@@ -70,7 +71,8 @@ func (s *VnetConfigService) CreateVnetConfig(ctx context.Context, vnetConfig *vn
 	if err := validateVnetConfig(vnetConfig); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return s.svc.CreateResource(ctx, vnetConfig)
+	vnetConfig, err := s.svc.CreateResource(ctx, vnetConfig)
+	return vnetConfig, trace.Wrap(err)
 }
 
 // UpdateVnetConfig does basic validation and updates a VnetConfig resource.
@@ -78,7 +80,8 @@ func (s *VnetConfigService) UpdateVnetConfig(ctx context.Context, vnetConfig *vn
 	if err := validateVnetConfig(vnetConfig); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return s.svc.ConditionalUpdateResource(ctx, vnetConfig)
+	vnetConfig, err := s.svc.ConditionalUpdateResource(ctx, vnetConfig)
+	return vnetConfig, trace.Wrap(err)
 }
 
 // UpsertVnetConfig does basic validation and upserts a VnetConfig resource.
@@ -86,12 +89,13 @@ func (s *VnetConfigService) UpsertVnetConfig(ctx context.Context, vnetConfig *vn
 	if err := validateVnetConfig(vnetConfig); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return s.svc.UpsertResource(ctx, vnetConfig)
+	vnetConfig, err := s.svc.UpsertResource(ctx, vnetConfig)
+	return vnetConfig, trace.Wrap(err)
 }
 
 // DeleteVnetConfig deletes the singleton VnetConfig resource.
 func (s *VnetConfigService) DeleteVnetConfig(ctx context.Context) error {
-	return s.svc.DeleteResource(ctx, vnetConfigSingletonName)
+	return trace.Wrap(s.svc.DeleteResource(ctx, vnetConfigSingletonName))
 }
 
 func validateVnetConfig(vnetConfig *vnet.VnetConfig) error {

--- a/lib/services/local/vnet_config.go
+++ b/lib/services/local/vnet_config.go
@@ -35,11 +35,13 @@ const (
 	vnetConfigSingletonName = "vnet-config"
 )
 
+// VnetConfigService implements the storage layer for the VnetConfig resource.
 type VnetConfigService struct {
 	slog *slog.Logger
 	svc  *generic.ServiceWrapper[*vnet.VnetConfig]
 }
 
+// NewVnetConfigService returns a new VnetConfig storage service.
 func NewVnetConfigService(backend backend.Backend) (*VnetConfigService, error) {
 	svc, err := generic.NewServiceWrapper(
 		backend,
@@ -58,10 +60,12 @@ func NewVnetConfigService(backend backend.Backend) (*VnetConfigService, error) {
 	}, nil
 }
 
+// GetVnetConfig returns the singleton VnetConfig resource.
 func (s *VnetConfigService) GetVnetConfig(ctx context.Context) (*vnet.VnetConfig, error) {
 	return s.svc.GetResource(ctx, vnetConfigSingletonName)
 }
 
+// CreateVnetConfig does basic validation and creates a VnetConfig resource.
 func (s *VnetConfigService) CreateVnetConfig(ctx context.Context, vnetConfig *vnet.VnetConfig) (*vnet.VnetConfig, error) {
 	if err := validateVnetConfig(vnetConfig); err != nil {
 		return nil, trace.Wrap(err)
@@ -69,6 +73,7 @@ func (s *VnetConfigService) CreateVnetConfig(ctx context.Context, vnetConfig *vn
 	return s.svc.CreateResource(ctx, vnetConfig)
 }
 
+// UpdateVnetConfig does basic validation and updates a VnetConfig resource.
 func (s *VnetConfigService) UpdateVnetConfig(ctx context.Context, vnetConfig *vnet.VnetConfig) (*vnet.VnetConfig, error) {
 	if err := validateVnetConfig(vnetConfig); err != nil {
 		return nil, trace.Wrap(err)
@@ -76,6 +81,7 @@ func (s *VnetConfigService) UpdateVnetConfig(ctx context.Context, vnetConfig *vn
 	return s.svc.ConditionalUpdateResource(ctx, vnetConfig)
 }
 
+// UpsertVnetConfig does basic validation and upserts a VnetConfig resource.
 func (s *VnetConfigService) UpsertVnetConfig(ctx context.Context, vnetConfig *vnet.VnetConfig) (*vnet.VnetConfig, error) {
 	if err := validateVnetConfig(vnetConfig); err != nil {
 		return nil, trace.Wrap(err)
@@ -83,6 +89,7 @@ func (s *VnetConfigService) UpsertVnetConfig(ctx context.Context, vnetConfig *vn
 	return s.svc.UpsertResource(ctx, vnetConfig)
 }
 
+// DeleteVnetConfig deletes the singleton VnetConfig resource.
 func (s *VnetConfigService) DeleteVnetConfig(ctx context.Context) error {
 	return s.svc.DeleteResource(ctx, vnetConfigSingletonName)
 }

--- a/lib/services/local/vnet_config.go
+++ b/lib/services/local/vnet_config.go
@@ -97,13 +97,13 @@ func validateVnetConfig(vnetConfig *vnet.VnetConfig) error {
 	if vnetConfig.GetMetadata().GetName() != vnetConfigSingletonName {
 		return trace.BadParameter("name must be %q", vnetConfigSingletonName)
 	}
-	if cidrRange := vnetConfig.GetSpec().GetCidrRange(); cidrRange != "" {
+	if cidrRange := vnetConfig.GetSpec().GetIpv4CidrRange(); cidrRange != "" {
 		ip, _, err := net.ParseCIDR(cidrRange)
 		if err != nil {
-			return trace.Wrap(err, "parsing cidr_range")
+			return trace.Wrap(err, "parsing ipv4_cidr_range")
 		}
 		if ip4 := ip.To4(); ip4 == nil {
-			return trace.BadParameter("cidr_range must be IPv4")
+			return trace.BadParameter("ipv4_cidr_range must be valid IPv4")
 		}
 	}
 	return nil

--- a/lib/services/local/vnet_config.go
+++ b/lib/services/local/vnet_config.go
@@ -1,0 +1,94 @@
+package local
+
+import (
+	"context"
+	"log/slog"
+	"net"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
+	"github.com/gravitational/trace"
+)
+
+const (
+	vnetConfigPrefix        = "vnet_config"
+	vnetConfigSingletonName = "vnet-config"
+)
+
+type VnetConfigService struct {
+	slog *slog.Logger
+	svc  *generic.ServiceWrapper[*vnet.VnetConfig]
+}
+
+func NewVnetConfigService(backend backend.Backend) (*VnetConfigService, error) {
+	svc, err := generic.NewServiceWrapper(
+		backend,
+		types.KindVnetConfig,
+		vnetConfigPrefix,
+		services.MarshalProtoResource[*vnet.VnetConfig],
+		services.UnmarshalProtoResource[*vnet.VnetConfig],
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &VnetConfigService{
+		svc:  svc,
+		slog: slog.With(teleport.ComponentKey, "VnetConfig.local"),
+	}, nil
+}
+
+func (s *VnetConfigService) GetVnetConfig(ctx context.Context) (*vnet.VnetConfig, error) {
+	return s.svc.GetResource(ctx, vnetConfigSingletonName)
+}
+
+func (s *VnetConfigService) CreateVnetConfig(ctx context.Context, vnetConfig *vnet.VnetConfig) (*vnet.VnetConfig, error) {
+	if err := validateVnetConfig(vnetConfig); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return s.svc.CreateResource(ctx, vnetConfig)
+}
+
+func (s *VnetConfigService) UpdateVnetConfig(ctx context.Context, vnetConfig *vnet.VnetConfig) (*vnet.VnetConfig, error) {
+	if err := validateVnetConfig(vnetConfig); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return s.svc.ConditionalUpdateResource(ctx, vnetConfig)
+}
+
+func (s *VnetConfigService) UpsertVnetConfig(ctx context.Context, vnetConfig *vnet.VnetConfig) (*vnet.VnetConfig, error) {
+	if err := validateVnetConfig(vnetConfig); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return s.svc.UpsertResource(ctx, vnetConfig)
+}
+
+func (s *VnetConfigService) DeleteVnetConfig(ctx context.Context) error {
+	return s.svc.DeleteResource(ctx, vnetConfigSingletonName)
+}
+
+func validateVnetConfig(vnetConfig *vnet.VnetConfig) error {
+	if vnetConfig.GetKind() != types.KindVnetConfig {
+		return trace.BadParameter("kind must be %q", types.KindVnetConfig)
+	}
+	if vnetConfig.GetVersion() != types.V1 {
+		return trace.BadParameter("version must be %q", types.V1)
+	}
+	if vnetConfig.GetMetadata().GetName() != vnetConfigSingletonName {
+		return trace.BadParameter("name must be %q", vnetConfigSingletonName)
+	}
+	if cidrRange := vnetConfig.GetSpec().GetCidrRange(); cidrRange != "" {
+		ip, _, err := net.ParseCIDR(cidrRange)
+		if err != nil {
+			return trace.Wrap(err, "parsing cidr_range")
+		}
+		if ip4 := ip.To4(); ip4 == nil {
+			return trace.BadParameter("cidr_range must be IPv4")
+		}
+	}
+	return nil
+}

--- a/lib/services/local/vnet_config_test.go
+++ b/lib/services/local/vnet_config_test.go
@@ -152,12 +152,53 @@ func TestVnetConfigValidation(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "empty zone suffix",
+			config: &vnet.VnetConfig{
+				Kind:     types.KindVnetConfig,
+				Version:  types.V1,
+				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+				Spec: &vnet.VnetConfigSpec{
+					Ipv4CidrRange: "192.168.1.0/24",
+					CustomDnsZones: []*vnet.CustomDNSZone{
+						&vnet.CustomDNSZone{
+							Suffix: "",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid zone suffix",
+			config: &vnet.VnetConfig{
+				Kind:     types.KindVnetConfig,
+				Version:  types.V1,
+				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+				Spec: &vnet.VnetConfigSpec{
+					Ipv4CidrRange: "192.168.1.0/24",
+					CustomDnsZones: []*vnet.CustomDNSZone{
+						&vnet.CustomDNSZone{
+							Suffix: "$#@!",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "valid",
 			config: &vnet.VnetConfig{
 				Kind:     types.KindVnetConfig,
 				Version:  types.V1,
 				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
-				Spec:     &vnet.VnetConfigSpec{Ipv4CidrRange: "192.168.1.0/24"},
+				Spec: &vnet.VnetConfigSpec{
+					Ipv4CidrRange: "192.168.1.0/24",
+					CustomDnsZones: []*vnet.CustomDNSZone{
+						&vnet.CustomDNSZone{
+							Suffix: "teleport.example.com",
+						},
+					},
+				},
 			},
 		},
 	} {

--- a/lib/services/local/vnet_config_test.go
+++ b/lib/services/local/vnet_config_test.go
@@ -178,7 +178,7 @@ func TestVnetConfigValidation(t *testing.T) {
 					Ipv4CidrRange: "192.168.1.0/24",
 					CustomDnsZones: []*vnet.CustomDNSZone{
 						&vnet.CustomDNSZone{
-							Suffix: "$#@!",
+							Suffix: "invalid.character$",
 						},
 					},
 				},

--- a/lib/services/local/vnet_config_test.go
+++ b/lib/services/local/vnet_config_test.go
@@ -45,7 +45,7 @@ func TestVnetConfigService(t *testing.T) {
 		Kind:     types.KindVnetConfig,
 		Version:  types.V1,
 		Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
-		Spec:     &vnet.VnetConfigSpec{CidrRange: "192.168.1.0/24"},
+		Spec:     &vnet.VnetConfigSpec{Ipv4CidrRange: "192.168.1.0/24"},
 	}
 
 	// The following are not subtests because they depend on each other.
@@ -117,7 +117,7 @@ func TestVnetConfigValidation(t *testing.T) {
 				Kind:     "invalidKind",
 				Version:  types.V1,
 				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
-				Spec:     &vnet.VnetConfigSpec{CidrRange: "192.168.1.0/24"},
+				Spec:     &vnet.VnetConfigSpec{Ipv4CidrRange: "192.168.1.0/24"},
 			},
 			wantErr: true,
 		},
@@ -127,7 +127,7 @@ func TestVnetConfigValidation(t *testing.T) {
 				Kind:     types.KindVnetConfig,
 				Version:  "v2",
 				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
-				Spec:     &vnet.VnetConfigSpec{CidrRange: "192.168.1.0/24"},
+				Spec:     &vnet.VnetConfigSpec{Ipv4CidrRange: "192.168.1.0/24"},
 			},
 			wantErr: true,
 		},
@@ -137,7 +137,7 @@ func TestVnetConfigValidation(t *testing.T) {
 				Kind:     types.KindVnetConfig,
 				Version:  types.V1,
 				Metadata: &headerv1.Metadata{Name: "wrong-name"},
-				Spec:     &vnet.VnetConfigSpec{CidrRange: "192.168.1.0/24"},
+				Spec:     &vnet.VnetConfigSpec{Ipv4CidrRange: "192.168.1.0/24"},
 			},
 			wantErr: true,
 		},
@@ -147,7 +147,7 @@ func TestVnetConfigValidation(t *testing.T) {
 				Kind:     types.KindVnetConfig,
 				Version:  types.V1,
 				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
-				Spec:     &vnet.VnetConfigSpec{CidrRange: "192.168.300.0/24"},
+				Spec:     &vnet.VnetConfigSpec{Ipv4CidrRange: "192.168.300.0/24"},
 			},
 			wantErr: true,
 		},
@@ -157,7 +157,7 @@ func TestVnetConfigValidation(t *testing.T) {
 				Kind:     types.KindVnetConfig,
 				Version:  types.V1,
 				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
-				Spec:     &vnet.VnetConfigSpec{CidrRange: "192.168.1.0/24"},
+				Spec:     &vnet.VnetConfigSpec{Ipv4CidrRange: "192.168.1.0/24"},
 			},
 		},
 	} {

--- a/lib/services/local/vnet_config_test.go
+++ b/lib/services/local/vnet_config_test.go
@@ -1,0 +1,174 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package local
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend/memory"
+)
+
+func TestVnetConfigService(t *testing.T) {
+	t.Parallel()
+
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	service, err := NewVnetConfigService(bk)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	vnetConfig := &vnet.VnetConfig{
+		Kind:     types.KindVnetConfig,
+		Version:  types.V1,
+		Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+		Spec:     &vnet.VnetConfigSpec{CidrRange: "192.168.1.0/24"},
+	}
+
+	// The following are not subtests because they depend on each other.
+
+	// Create
+	created, err := service.CreateVnetConfig(ctx, vnetConfig)
+	require.NoError(t, err)
+	diff := cmp.Diff(vnetConfig, created,
+		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
+		cmpopts.IgnoreUnexported(vnet.VnetConfig{}, vnet.VnetConfigSpec{}, vnet.CustomDNSZone{}, headerv1.Metadata{}),
+	)
+	require.Empty(t, diff)
+	require.NotEmpty(t, created.GetMetadata().GetRevision())
+
+	// Get
+	got, err := service.GetVnetConfig(ctx)
+	require.NoError(t, err)
+	diff = cmp.Diff(vnetConfig, got,
+		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
+		cmpopts.IgnoreUnexported(vnet.VnetConfig{}, vnet.VnetConfigSpec{}, vnet.CustomDNSZone{}, headerv1.Metadata{}),
+	)
+	require.Empty(t, diff)
+	require.Equal(t, created.GetMetadata().GetRevision(), got.GetMetadata().GetRevision())
+
+	// Update
+	vnetConfig.Spec.CustomDnsZones = append(vnetConfig.Spec.CustomDnsZones, &vnet.CustomDNSZone{Suffix: "example.com"})
+	updated, err := service.UpdateVnetConfig(ctx, vnetConfig)
+	require.NoError(t, err)
+	require.NotEqual(t, got.GetSpec().GetCustomDnsZones(), updated.GetSpec().GetCustomDnsZones())
+
+	// Upsert
+	_, err = service.UpsertVnetConfig(ctx, vnetConfig)
+	require.NoError(t, err)
+
+	// Delete
+	err = service.DeleteVnetConfig(ctx)
+	require.NoError(t, err)
+
+	// Get none
+	_, err = service.GetVnetConfig(ctx)
+	var notFoundError *trace.NotFoundError
+	require.ErrorAs(t, err, &notFoundError)
+
+	// Update none
+	_, err = service.UpdateVnetConfig(ctx, vnetConfig)
+	var compareFailedError *trace.CompareFailedError
+	require.ErrorAs(t, err, &compareFailedError)
+}
+
+func TestVnetConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	service, err := NewVnetConfigService(bk)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name    string
+		config  *vnet.VnetConfig
+		wantErr bool
+	}{
+		{
+			name: "invalid kind",
+			config: &vnet.VnetConfig{
+				Kind:     "invalidKind",
+				Version:  types.V1,
+				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+				Spec:     &vnet.VnetConfigSpec{CidrRange: "192.168.1.0/24"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid version",
+			config: &vnet.VnetConfig{
+				Kind:     types.KindVnetConfig,
+				Version:  "v2",
+				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+				Spec:     &vnet.VnetConfigSpec{CidrRange: "192.168.1.0/24"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid name",
+			config: &vnet.VnetConfig{
+				Kind:     types.KindVnetConfig,
+				Version:  types.V1,
+				Metadata: &headerv1.Metadata{Name: "wrong-name"},
+				Spec:     &vnet.VnetConfigSpec{CidrRange: "192.168.1.0/24"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid CIDR",
+			config: &vnet.VnetConfig{
+				Kind:     types.KindVnetConfig,
+				Version:  types.V1,
+				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+				Spec:     &vnet.VnetConfigSpec{CidrRange: "192.168.300.0/24"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid",
+			config: &vnet.VnetConfig{
+				Kind:     types.KindVnetConfig,
+				Version:  types.V1,
+				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+				Spec:     &vnet.VnetConfigSpec{CidrRange: "192.168.1.0/24"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Attempt to create with invalid config to test validation
+			_, err := service.CreateVnetConfig(ctx, tc.config)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -176,6 +176,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindServerInfo, RW()),
 					types.NewRule(types.KindAccessMonitoringRule, RW()),
 					types.NewRule(types.KindAppServer, RW()),
+					types.NewRule(types.KindVnetConfig, RW()),
 				},
 			},
 		},

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -242,6 +242,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindDatabaseObject, nil
 	case types.KindCrownJewel, "crown_jewels":
 		return types.KindCrownJewel, nil
+	case types.KindVnetConfig:
+		return types.KindVnetConfig, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }

--- a/lib/services/vnet_config.go
+++ b/lib/services/vnet_config.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package services
 
 import (

--- a/lib/services/vnet_config.go
+++ b/lib/services/vnet_config.go
@@ -1,0 +1,25 @@
+package services
+
+import (
+	"context"
+
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
+)
+
+// VnetConfigService is an interface for the VnetConfig service.
+type VnetConfigService interface {
+	// GetVnetConfig returns the singleton VnetConfig resource.
+	GetVnetConfig(context.Context) (*vnet.VnetConfig, error)
+
+	// CreateVnetConfig does basic validation and creates a VnetConfig resource.
+	CreateVnetConfig(ctx context.Context, vnetConfig *vnet.VnetConfig) (*vnet.VnetConfig, error)
+
+	// UpdateVnetConfig does basic validation and updates a VnetConfig resource.
+	UpdateVnetConfig(ctx context.Context, vnetConfig *vnet.VnetConfig) (*vnet.VnetConfig, error)
+
+	// UpsertVnetConfig does basic validation and upserts a VnetConfig resource.
+	UpsertVnetConfig(ctx context.Context, vnetConfig *vnet.VnetConfig) (*vnet.VnetConfig, error)
+
+	// DeleteVnetConfig deletes the singleton VnetConfig resource.
+	DeleteVnetConfig(ctx context.Context) error
+}

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -35,6 +35,7 @@ import (
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
@@ -1463,4 +1464,22 @@ func (c *accessListCollection) writeText(w io.Writer, verbose bool) error {
 	}
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)
+}
+
+type vnetConfigCollection struct {
+	vnetConfig *vnet.VnetConfig
+}
+
+func (c *vnetConfigCollection) resources() []types.Resource {
+	return []types.Resource{types.Resource153ToLegacy(c.vnetConfig)}
+}
+
+func (c *vnetConfigCollection) writeText(w io.Writer, verbose bool) error {
+	var dnsZoneSuffixes []string
+	for _, dnsZone := range c.vnetConfig.Spec.CustomDnsZones {
+		dnsZoneSuffixes = append(dnsZoneSuffixes, dnsZone.Suffix)
+	}
+	fmt.Fprintln(w, "cidr_range:      ", c.vnetConfig.Spec.CidrRange)
+	fmt.Fprintln(w, "custom_dns_zones:", strings.Join(dnsZoneSuffixes, " "))
+	return nil
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1479,7 +1479,11 @@ func (c *vnetConfigCollection) writeText(w io.Writer, verbose bool) error {
 	for _, dnsZone := range c.vnetConfig.Spec.CustomDnsZones {
 		dnsZoneSuffixes = append(dnsZoneSuffixes, dnsZone.Suffix)
 	}
-	fmt.Fprintln(w, "ipv4_cidr_range: ", c.vnetConfig.Spec.Ipv4CidrRange)
-	fmt.Fprintln(w, "custom_dns_zones:", strings.Join(dnsZoneSuffixes, ", "))
-	return nil
+	t := asciitable.MakeTable([]string{"IPv4 CIDR range", "Custom DNS Zones"})
+	t.AddRow([]string{
+		c.vnetConfig.GetSpec().GetIpv4CidrRange(),
+		strings.Join(dnsZoneSuffixes, ", "),
+	})
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1480,6 +1480,6 @@ func (c *vnetConfigCollection) writeText(w io.Writer, verbose bool) error {
 		dnsZoneSuffixes = append(dnsZoneSuffixes, dnsZone.Suffix)
 	}
 	fmt.Fprintln(w, "ipv4_cidr_range: ", c.vnetConfig.Spec.Ipv4CidrRange)
-	fmt.Fprintln(w, "custom_dns_zones:", strings.Join(dnsZoneSuffixes, " "))
+	fmt.Fprintln(w, "custom_dns_zones:", strings.Join(dnsZoneSuffixes, ", "))
 	return nil
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1479,7 +1479,7 @@ func (c *vnetConfigCollection) writeText(w io.Writer, verbose bool) error {
 	for _, dnsZone := range c.vnetConfig.Spec.CustomDnsZones {
 		dnsZoneSuffixes = append(dnsZoneSuffixes, dnsZone.Suffix)
 	}
-	fmt.Fprintln(w, "cidr_range:      ", c.vnetConfig.Spec.CidrRange)
+	fmt.Fprintln(w, "ipv4_cidr_range: ", c.vnetConfig.Spec.Ipv4CidrRange)
 	fmt.Fprintln(w, "custom_dns_zones:", strings.Join(dnsZoneSuffixes, " "))
 	return nil
 }

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -3046,7 +3046,7 @@ func (rc *ResourceCommand) updateAccessMonitoringRule(ctx context.Context, clien
 	return nil
 }
 
-func (rc *ResourceCommand) createVnetConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createVnetConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	vnetConfig, err := services.UnmarshalProtoResource[*vnet.VnetConfig](raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3065,7 +3065,7 @@ func (rc *ResourceCommand) createVnetConfig(ctx context.Context, client *auth.Cl
 	return nil
 }
 
-func (rc *ResourceCommand) updateVnetConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateVnetConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	vnetConfig, err := services.UnmarshalProtoResource[*vnet.VnetConfig](raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This PR adds a storage layer, gRPC service, and `tctl` support for `vnet_config` resources https://github.com/gravitational/teleport/blob/master/rfd/0163-vnet.md

TODO: support resource bootstrap and add to the cache, tracked in https://github.com/gravitational/teleport/issues/39330