### PR TITLE
Fix Resource Creation Event for EC2 Auto Discovery

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -815,9 +815,8 @@ func (s *Server) handleEC2Instances(instances *server.EC2Instances) error {
 	// to be rotated, we don't want to filter out existing OpenSSH nodes as
 	// they all need to have the command run on them
 	//
-	// Integration/EICE Nodes don't have heartbeat.
-	// Those Nodes must not be filtered, so that we can extend their expiration and sync labels.
-	if !instances.Rotation && instances.Integration == "" {
+	// EICE Nodes must never be filtered, so that we can extend their expiration and sync labels.
+	if !instances.Rotation && instances.EnrollMode != types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_EICE {
 		s.filterExistingEC2Nodes(instances)
 	}
 	if len(instances.Instances) == 0 {

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -141,11 +141,14 @@ func WithPollInterval(interval time.Duration) Option {
 func (instances *EC2Instances) MakeEvents() map[string]*usageeventsv1.ResourceCreateEvent {
 	resourceType := types.DiscoveredResourceNode
 
-	switch {
-	case instances.DocumentName == types.AWSAgentlessInstallerDocument:
-		resourceType = types.DiscoveredResourceAgentlessNode
-	case instances.Integration != "":
+	switch instances.EnrollMode {
+	case types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_EICE:
 		resourceType = types.DiscoveredResourceEICENode
+
+	case types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT:
+		if instances.DocumentName == types.AWSAgentlessInstallerDocument {
+			resourceType = types.DiscoveredResourceAgentlessNode
+		}
 	}
 
 	events := make(map[string]*usageeventsv1.ResourceCreateEvent, len(instances.Instances))


### PR DESCRIPTION
This PR ensures the proper ResourceType is set when emitting ResourceCreateEvent.

We now support running the Script/SSM mode using integration credentials, so having an integration is not equivalent to using the EICE mode.