### PR TITLE
docs: openssh ssh example update

### DIFF
--- a/docs/pages/server-access/openssh/openssh-manual-install.mdx
+++ b/docs/pages/server-access/openssh/openssh-manual-install.mdx
@@ -492,7 +492,8 @@ $ PORT=22
 Next, SSH in to your remote host:
 
 ```code
-$ ssh -p ${PORT?} -F ssh_config_teleport "${USER?}@${ADDR?}.${CLUSTER?}"
+$ ADDR_NODE=openssh-node
+$ ssh -p ${PORT?} -F ssh_config_teleport "${USER?}@${ADDR_NODE?}.${CLUSTER?}"
 ```
 
 This name does not need to be resolvable via DNS as the connection will be


### PR DESCRIPTION
`ADDR` is used earlier in the process with a comma separated value. This can cause problems if it is reused for a ssh connection.