### PR TITLE
Make access plugin tests work with mandatory 2fa

### DIFF
--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -20,7 +20,6 @@ package accesslist
 
 import (
 	"context"
-	"github.com/gravitational/teleport/api/constants"
 	"sync"
 	"testing"
 	"time"
@@ -30,6 +29,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -20,6 +20,7 @@ package accesslist
 
 import (
 	"context"
+	"github.com/gravitational/teleport/api/constants"
 	"sync"
 	"testing"
 	"time"
@@ -110,13 +111,8 @@ func TestAccessListReminders(t *testing.T) {
 
 	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
 
-	server, err := auth.NewTestServer(auth.TestServerConfig{
-		Auth: auth.TestAuthServerConfig{
-			Dir:   t.TempDir(),
-			Clock: clockwork.NewFakeClock(),
-		},
-	})
-	require.NoError(t, err)
+	server := newTestAuth(t)
+
 	as := server.Auth()
 	t.Cleanup(func() {
 		require.NoError(t, as.Close())
@@ -217,13 +213,7 @@ func TestAccessListReminders_BadClient(t *testing.T) {
 
 	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
 
-	server, err := auth.NewTestServer(auth.TestServerConfig{
-		Auth: auth.TestAuthServerConfig{
-			Dir:   t.TempDir(),
-			Clock: clockwork.NewFakeClock(),
-		},
-	})
-	require.NoError(t, err)
+	server := newTestAuth(t)
 	as := server.Auth()
 	t.Cleanup(func() {
 		require.NoError(t, as.Close())
@@ -292,4 +282,21 @@ func advanceAndLookForRecipients(t *testing.T,
 	clock.BlockUntil(1)
 
 	require.ElementsMatch(t, expectedRecipients, bot.getLastRecipients())
+}
+
+func newTestAuth(t *testing.T) *auth.TestServer {
+	server, err := auth.NewTestServer(auth.TestServerConfig{
+		Auth: auth.TestAuthServerConfig{
+			Dir:   t.TempDir(),
+			Clock: clockwork.NewFakeClock(),
+			AuthPreferenceSpec: &types.AuthPreferenceSpecV2{
+				SecondFactor: constants.SecondFactorOn,
+				Webauthn: &types.Webauthn{
+					RPID: "localhost",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return server
 }

--- a/integrations/lib/testing/integration/authhelper.go
+++ b/integrations/lib/testing/integration/authhelper.go
@@ -60,6 +60,17 @@ func (a *MinimalAuthHelper) StartServer(t *testing.T) *client.Client {
 	if a.AuthConfig.Dir == "" {
 		a.AuthConfig.Dir = a.dir
 	}
+
+	// If there's no auth preference spec, we turn 2FA on as it is mandatory since v16.
+	if a.AuthConfig.AuthPreferenceSpec == nil {
+		a.AuthConfig.AuthPreferenceSpec = &types.AuthPreferenceSpecV2{
+			SecondFactor: constants.SecondFactorOn,
+			Webauthn: &types.Webauthn{
+				RPID: "localhost",
+			},
+		}
+	}
+
 	authServer, err := libauth.NewTestAuthServer(a.AuthConfig)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Fix plugin tests that broke with https://github.com/gravitational/teleport/pull/40956