### PR TITLE
Improve handling of various lifecycle erorrs in VNet

### DIFF
--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -86,6 +86,9 @@ func Run(ctx context.Context, cancel context.CancelFunc, manager *Manager, admin
 		case adminCommandErr = <-adminCommandErrCh:
 			// The admin command exited before the context was canceled, cancel everything and exit.
 			cancel()
+			if adminCommandErr == nil {
+				allErrors <- trace.Errorf("admin subcommand exited prematurely with no error (likely because socket was removed)")
+			}
 		case <-ctx.Done():
 			// The context has been canceled, the admin command should now exit.
 			adminCommandErr = <-adminCommandErrCh

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -18,7 +18,7 @@ package vnet
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"time"
@@ -28,99 +28,142 @@ import (
 	"golang.zx2c4.com/wireguard/tun"
 )
 
-// Setup spins up a separate process with the admin subcommand to create a TUN device. It returns
-// Manager that uses this TUN device, along with an error channel which receives an error if the
-// admin subcommand stops running. Setup should be used in conjunction with Run.
-func Setup(ctx context.Context, appProvider AppProvider) (*Manager, <-chan error, error) {
+// SetupAndRun creates a network stack for VNet and runs it in the background. To do this, it also
+// needs to launch an admin subcommand in the background. It returns [ProcessManager] which controls
+// the lifecycle of both background tasks.
+//
+// The caller is expected to call Close on the process manager to close the network stack, clean
+// up any resources used by it and terminate the admin subcommand.
+//
+// ctx is used to wait for setup steps that happen before SetupAndRun hands out the control to the
+// process manager. If ctx gets canceled during SetupAndRun, the process manager gets closed along
+// with its background tasks.
+func SetupAndRun(ctx context.Context, appProvider AppProvider) (*ProcessManager, error) {
 	ipv6Prefix, err := NewIPv6Prefix()
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-
 	dnsIPv6 := ipv6WithSuffix(ipv6Prefix, []byte{2})
-	tunCh, adminCommandErrCh := CreateAndSetupTUNDevice(ctx, ipv6Prefix.String(), dnsIPv6.String())
 
-	var tun TUNDevice
+	pm, processCtx := newProcessManager()
+	success := false
+	defer func() {
+		if !success {
+			// Closes the socket and background tasks.
+			pm.Close()
+		}
+	}()
+
+	// Create the socket that's used to receive the TUN device from the admin subcommand.
+	socket, socketPath, err := createUnixSocket()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	slog.DebugContext(ctx, "Created unix socket for admin subcommand", "socket", socketPath)
+	go func() {
+		// Keep the socket open until the process context is canceled.
+		// Closing the socket signals the admin subcommand to terminate.
+		<-processCtx.Done()
+		_ = socket.Close()
+	}()
+
+	pm.AddCriticalBackgroundTask("admin subcommand", func() error {
+		return trace.Wrap(execAdminSubcommand(processCtx, socketPath, ipv6Prefix.String(), dnsIPv6.String()))
+	})
+
+	recvTUNErr := make(chan error, 1)
+	var tun tun.Device
+	go func() {
+		// Unblocks after receiving a TUN device or when the context gets canceled (and thus socket gets
+		// closed).
+		tunDevice, err := receiveTUNDevice(socket)
+		tun = tunDevice
+		recvTUNErr <- err
+	}()
+
 	select {
 	case <-ctx.Done():
-		return nil, nil, trace.Wrap(ctx.Err())
-	case err := <-adminCommandErrCh:
-		return nil, nil, trace.Wrap(err)
-	case tun = <-tunCh:
+		return nil, trace.Wrap(ctx.Err())
+	case <-processCtx.Done():
+		return nil, trace.Wrap(context.Cause(processCtx))
+	case err := <-recvTUNErr:
+		if err != nil {
+			if processCtx.Err() != nil {
+				// Both errors being present means that VNet failed to receive a TUN device because of a
+				// problem with the admin subcommand.
+				// Returning error from processCtx will be more informative to the user, e.g., the error
+				// will say "password prompt closed by user" instead of "read from closed socket".
+				slog.DebugContext(ctx, "Error from recvTUNErr ignored in favor of processCtx.Err", "error", err)
+				return nil, trace.Wrap(context.Cause(processCtx))
+			}
+			return nil, trace.Wrap(err, "receiving TUN from admin subcommand")
+		}
 	}
 
 	appResolver, err := NewTCPAppResolver(appProvider)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	manager, err := NewManager(&Config{
+	ns, err := newNetworkStack(&Config{
 		TUNDevice:          tun,
 		IPv6Prefix:         ipv6Prefix,
 		DNSIPv6:            dnsIPv6,
 		TCPHandlerResolver: appResolver,
 	})
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	return manager, adminCommandErrCh, nil
+	pm.AddCriticalBackgroundTask("network stack", func() error {
+		return trace.Wrap(ns.Run(processCtx))
+	})
+
+	success = true
+	return pm, nil
 }
 
-// Run is a blocking call that waits for either the admin subcommand or the VNet manager to exit and
-// makes sure the other one exits as well.
-//
-// It captures some peculiarities of running VNet that need to be handled both in tsh and Connect.
-//
-// cancel accepts a cause because when stopping manager, we need to differentiate between regular
-// cancellation (think Ctrl + C in a terminal) vs canceling because the admin subcommand exiting
-// prematurely.
-func Run(ctx context.Context, cancel context.CancelCauseFunc, manager *Manager, adminCommandErrCh <-chan error) error {
-	allErrors := make(chan error, 2)
+func newProcessManager() (*ProcessManager, context.Context) {
+	ctx, cancel := context.WithCancel(context.Background())
 	g, ctx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		// Make sure to cancel the context if manager.Run terminates for any reason.
-		defer cancel(nil)
-		err := trace.Wrap(manager.Run(ctx), "running VNet manager")
 
-		// If ctx was canceled due to a specific cause, do not put err into allErrors. The specific
-		// cause is going to be reported by another goroutine.
-		//
-		// If this goroutine added context.Canceled into the error aggregate, final callsites in the
-		// upper layers would have assumed that it was merely a context that was canceled, while the
-		// real reason would be more complex.
-		if errors.Is(err, context.Canceled) && !errors.Is(context.Cause(ctx), context.Canceled) {
-			return nil
+	return &ProcessManager{
+		g:      g,
+		cancel: cancel,
+	}, ctx
+}
+
+// ProcessManager handles background tasks needed to run VNet.
+// Its semantics are similar to an error group with a context, but it cancels the context whenever
+// any task returns prematurely, that is, a task exits while the context was not canceled.
+type ProcessManager struct {
+	g      *errgroup.Group
+	cancel context.CancelFunc
+}
+
+// AddCriticalBackgroundTask adds a function to the error group. [task] is expected to block until
+// the context returned by [newProcessManager] gets canceled. The context gets canceled either by
+// calling Close on [ProcessManager] or if any task returns.
+func (pm *ProcessManager) AddCriticalBackgroundTask(name string, task func() error) {
+	pm.g.Go(func() error {
+		err := task()
+		if err == nil {
+			// Make sure to always return an error so that the errgroup context is canceled.
+			err = fmt.Errorf("critical task %q exited prematurely", name)
 		}
-
-		allErrors <- err
-		return err
+		return trace.Wrap(err)
 	})
-	g.Go(func() error {
-		var adminCommandErr error
-		select {
-		case adminCommandErr = <-adminCommandErrCh:
-			// The admin command exited before the context was canceled, cancel everything and exit.
-			// This can happen if the admin subcommand crashes or gets killed.
+}
 
-			// If socket gets removed, the admin subcommand assumes it's because the process on the other
-			// end of this socket (running this code) has quit.
-			if adminCommandErr == nil {
-				adminCommandErr = trace.Errorf("admin subcommand exited prematurely with no error (likely because socket was removed)")
-			}
-			cancel(adminCommandErr)
-		case <-ctx.Done():
-			// The context has been canceled, the admin command should now exit.
-			adminCommandErr = <-adminCommandErrCh
-		}
-		adminCommandErr = trace.Wrap(adminCommandErr, "running admin subcommand")
-		allErrors <- adminCommandErr
-		return adminCommandErr
-	})
-	// Deliberately ignoring the error from g.Wait() to return an aggregate of all errors.
-	_ = g.Wait()
-	close(allErrors)
-	return trace.NewAggregateFromChannel(allErrors, context.Background())
+// Wait blocks and waits for the background tasks to finish, which typically happens when another
+// goroutine calls Close on the process manager.
+func (pm *ProcessManager) Wait() error {
+	return trace.Wrap(pm.g.Wait())
+}
+
+// Close stops any active background tasks by canceling the underlying context.
+func (pm *ProcessManager) Close() {
+	pm.cancel()
 }
 
 // AdminSubcommand is the tsh subcommand that should run as root that will create and setup a TUN device and
@@ -164,28 +207,6 @@ func AdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string
 		case err = <-errCh:
 			return trace.Wrap(err)
 		}
-	}
-}
-
-// CreateAndSetupTUNDevice creates a virtual network device and configures the host OS to use that device for
-// VNet connections.
-//
-// If not already running as root, it will spawn a root process to handle the TUN creation and host
-// configuration.
-//
-// After the TUN device is created, it will be sent on the result channel. Any error will be sent on the err
-// channel. Always select on both the result channel and the err channel when waiting for a result.
-//
-// This will keep running until [ctx] is canceled or an unrecoverable error is encountered, in order to keep
-// the host OS configuration up to date.
-func CreateAndSetupTUNDevice(ctx context.Context, ipv6Prefix, dnsAddr string) (<-chan tun.Device, <-chan error) {
-	if os.Getuid() == 0 {
-		// We can get here if the user runs `tsh vnet` as root, but it is not in the expected path when
-		// started as a regular user. Typically we expect `tsh vnet` to be run as a non-root user, and for
-		// AdminSubcommand to directly call createAndSetupTUNDeviceAsRoot.
-		return createAndSetupTUNDeviceAsRoot(ctx, ipv6Prefix, dnsAddr)
-	} else {
-		return createAndSetupTUNDeviceWithoutRoot(ctx, ipv6Prefix, dnsAddr)
 	}
 }
 

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -41,6 +41,8 @@ func Setup(ctx context.Context, appProvider AppProvider) (*Manager, <-chan error
 
 	var tun TUNDevice
 	select {
+	case <-ctx.Done():
+		return nil, nil, trace.Wrap(ctx.Err())
 	case err := <-adminCommandErrCh:
 		return nil, nil, trace.Wrap(err)
 	case tun = <-tunCh:

--- a/lib/vnet/setup_darwin.go
+++ b/lib/vnet/setup_darwin.go
@@ -71,6 +71,8 @@ func createAndSetupTUNDeviceWithoutRoot(ctx context.Context, ipv6Prefix, dnsAddr
 		//   a stuck AcceptUnix (can't defer).
 		// - must close the socket exactly once before letting the process terminate.
 		<-ctx.Done()
+		// When the socket gets closed, the admin process that's on the other end notices that and shuts
+		// down as well.
 		return trace.Wrap(socket.Close())
 	})
 	g.Go(func() error {

--- a/lib/vnet/setup_darwin.go
+++ b/lib/vnet/setup_darwin.go
@@ -137,8 +137,19 @@ do shell script quoted form of executableName & `+
 			if strings.Contains(stderr, "-128") {
 				return trace.Errorf("password prompt closed by user")
 			}
-			return trace.Wrap(exitError, "admin subcommand exited, stderr: %s", stderr)
+
+			if errors.Is(ctx.Err(), context.Canceled) {
+				slog.DebugContext(ctx, "osascript exiting due to canceled context", "stderr", stderr)
+				return nil
+			}
+
+			stderrDesc := ""
+			if stderr != "" {
+				stderrDesc = fmt.Sprintf(", stderr: %s", stderr)
+			}
+			return trace.Wrap(exitError, "osascript exited%s", stderrDesc)
 		}
+
 		return trace.Wrap(err)
 	}
 	return nil

--- a/lib/vnet/setup_darwin.go
+++ b/lib/vnet/setup_darwin.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net"
 	"os"
 	"os/exec"
@@ -33,7 +32,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 	"golang.zx2c4.com/wireguard/tun"
 
@@ -42,65 +40,16 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
-// createAndSetupTUNDeviceWithoutRoot creates a virtual network device and configures the host OS to use that
-// device for VNet connections. It will spawn a root process to handle the TUN creation and host
-// configuration.
-//
-// After the TUN device is created, it will be sent on the result channel. Any error will be sent on the err
-// channel. Always select on both the result channel and the err channel when waiting for a result.
-//
-// This will keep running until [ctx] is canceled or an unrecoverable error is encountered, in order to keep
-// the host OS configuration up to date.
-func createAndSetupTUNDeviceWithoutRoot(ctx context.Context, ipv6Prefix, dnsAddr string) (<-chan tun.Device, <-chan error) {
-	tunCh := make(chan tun.Device, 1)
-	errCh := make(chan error, 1)
-
-	slog.InfoContext(ctx, "Spawning child process as root to create and setup TUN device")
-	socket, socketPath, err := createUnixSocket()
+// receiveTUNDevice is a blocking call which waits for the admin subcommand to pass over the socket
+// the name and fd of the TUN device.
+func receiveTUNDevice(socket *net.UnixListener) (tun.Device, error) {
+	tunName, tunFd, err := recvTUNNameAndFd(socket)
 	if err != nil {
-		errCh <- trace.Wrap(err, "creating unix socket")
-		return tunCh, errCh
+		return nil, trace.Wrap(err, "receiving TUN name and file descriptor")
 	}
-	slog.DebugContext(ctx, "Created unix socket for admin subcommand", "socket", socketPath)
 
-	// Make sure all goroutines complete before sending an err on the error chan, to be sure they all have a
-	// chance to clean up before the process terminates.
-	g, ctx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		// Requirements:
-		// - must close the socket concurrently with recvTUNNameAndFd if ctx is canceled to unblock
-		//   a stuck AcceptUnix (can't defer).
-		// - must close the socket exactly once before letting the process terminate.
-		<-ctx.Done()
-		// When the socket gets closed, the admin process that's on the other end notices that and shuts
-		// down as well.
-		return trace.Wrap(socket.Close())
-	})
-	g.Go(func() error {
-		// Admin command is expected to run until ctx is canceled.
-		return trace.Wrap(execAdminSubcommand(ctx, socketPath, ipv6Prefix, dnsAddr))
-	})
-	g.Go(func() error {
-		tunName, tunFd, err := recvTUNNameAndFd(ctx, socket)
-		if err != nil {
-			if ctx.Err() != nil {
-				// The context was already canceled and the listener should have been closed,
-				// ignore the read error and return the ctx err to play nice.
-				return trace.Wrap(ctx.Err())
-			}
-			return trace.Wrap(err, "receiving TUN name and file descriptor")
-		}
-
-		tunDevice, err := tun.CreateTUNFromFile(os.NewFile(tunFd, tunName), 0)
-		if err != nil {
-			return trace.Wrap(err, "creating TUN device from file descriptor")
-		}
-		tunCh <- tunDevice
-		return nil
-	})
-	go func() { errCh <- g.Wait() }()
-
-	return tunCh, errCh
+	tunDevice, err := tun.CreateTUNFromFile(os.NewFile(tunFd, tunName), 0)
+	return tunDevice, trace.Wrap(err, "creating TUN device from file descriptor")
 }
 
 func execAdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
@@ -213,19 +162,12 @@ func sendTUNNameAndFd(socketPath, tunName string, fd uintptr) error {
 
 // recvTUNNameAndFd receives the name of a TUN device and its open file descriptor over a unix socket, meant
 // for passing the TUN from the root process which must create it to the user process.
-func recvTUNNameAndFd(ctx context.Context, socket *net.UnixListener) (string, uintptr, error) {
+func recvTUNNameAndFd(socket *net.UnixListener) (string, uintptr, error) {
 	conn, err := socket.AcceptUnix()
 	if err != nil {
 		return "", 0, trace.Wrap(err, "accepting connection on unix socket")
 	}
-
-	// Close the connection early to unblock reads if the context is canceled.
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go func() {
-		<-ctx.Done()
-		conn.Close()
-	}()
+	defer conn.Close()
 
 	msg := make([]byte, 128)
 	oob := make([]byte, unix.CmsgSpace(4)) // Fd is 4 bytes

--- a/lib/vnet/setup_other.go
+++ b/lib/vnet/setup_other.go
@@ -21,6 +21,7 @@ package vnet
 
 import (
 	"context"
+	"net"
 	"runtime"
 
 	"github.com/gravitational/trace"
@@ -32,16 +33,22 @@ var (
 	ErrVnetNotImplemented = &trace.NotImplementedError{Message: "VNet is not implemented on " + runtime.GOOS}
 )
 
-func createAndSetupTUNDeviceWithoutRoot(ctx context.Context, ipv6Prefix, dnsAddr string) (<-chan tun.Device, <-chan error) {
-	errCh := make(chan error, 1)
-	errCh <- trace.Wrap(ErrVnetNotImplemented)
-	return nil, errCh
+func createUnixSocket() (*net.UnixListener, string, error) {
+	return nil, "", trace.Wrap(ErrVnetNotImplemented)
 }
 
 func sendTUNNameAndFd(socketPath, tunName string, fd uintptr) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }
 
+func receiveTUNDevice(socket *net.UnixListener) (tun.Device, error) {
+	return nil, trace.Wrap(ErrVnetNotImplemented)
+}
+
 func configureOS(ctx context.Context, cfg *osConfig) error {
+	return trace.Wrap(ErrVnetNotImplemented)
+}
+
+func execAdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }

--- a/lib/vnet/setup_test.go
+++ b/lib/vnet/setup_test.go
@@ -46,9 +46,9 @@ func TestProcessManager_ReturnWithError(t *testing.T) {
 	pm, pmCtx := newProcessManager()
 	defer pm.Close()
 
-	taskErr := fmt.Errorf("lorem ipsum dolor sit amet")
+	expectedErr := fmt.Errorf("lorem ipsum dolor sit amet")
 	pm.AddCriticalBackgroundTask("return with error", func() error {
-		return taskErr
+		return expectedErr
 	})
 	pm.AddCriticalBackgroundTask("context-aware task", func() error {
 		<-pmCtx.Done()
@@ -56,7 +56,7 @@ func TestProcessManager_ReturnWithError(t *testing.T) {
 	})
 
 	err := pm.Wait()
-	require.ErrorIs(t, err, taskErr)
+	require.ErrorIs(t, err, expectedErr)
 	require.ErrorIs(t, err, context.Cause(pmCtx))
 }
 

--- a/lib/vnet/setup_test.go
+++ b/lib/vnet/setup_test.go
@@ -1,0 +1,77 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessManager_PrematureReturn(t *testing.T) {
+	pm, pmCtx := newProcessManager()
+	defer pm.Close()
+
+	pm.AddCriticalBackgroundTask("premature return", func() error {
+		return nil
+	})
+	pm.AddCriticalBackgroundTask("context-aware task", func() error {
+		<-pmCtx.Done()
+		return pmCtx.Err()
+	})
+
+	err := pm.Wait()
+	require.ErrorContains(t, err, "critical task \"premature return\" exited prematurely")
+	// Verify that the cancellation cause is propagated through the context.
+	require.ErrorIs(t, err, context.Cause(pmCtx))
+}
+
+func TestProcessManager_ReturnWithError(t *testing.T) {
+	pm, pmCtx := newProcessManager()
+	defer pm.Close()
+
+	taskErr := fmt.Errorf("lorem ipsum dolor sit amet")
+	pm.AddCriticalBackgroundTask("return with error", func() error {
+		return taskErr
+	})
+	pm.AddCriticalBackgroundTask("context-aware task", func() error {
+		<-pmCtx.Done()
+		return pmCtx.Err()
+	})
+
+	err := pm.Wait()
+	require.ErrorIs(t, err, taskErr)
+	require.ErrorIs(t, err, context.Cause(pmCtx))
+}
+
+func TestProcessManager_Close(t *testing.T) {
+	pm, pmCtx := newProcessManager()
+	defer pm.Close()
+
+	pm.AddCriticalBackgroundTask("context-aware task", func() error {
+		<-pmCtx.Done()
+		return pmCtx.Err()
+	})
+
+	pm.Close()
+
+	err := pm.Wait()
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, context.Cause(pmCtx))
+}

--- a/tool/tsh/common/vnet_common.go
+++ b/tool/tsh/common/vnet_common.go
@@ -105,6 +105,7 @@ func (p *vnetAppProvider) GetDialOptions(ctx context.Context, profileName string
 	dialOpts := &vnet.DialOptions{
 		WebProxyAddr:            profile.WebProxyAddr,
 		ALPNConnUpgradeRequired: profile.TLSRoutingConnUpgradeRequired,
+		InsecureSkipVerify:      p.cf.InsecureSkipVerify,
 	}
 	if dialOpts.ALPNConnUpgradeRequired {
 		dialOpts.RootClusterCACertPool, err = p.getRootClusterCACertPool(ctx, profileName)

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -21,6 +21,7 @@ package common
 
 import (
 	"context"
+	"errors"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
@@ -52,10 +53,16 @@ func (c *vnetCommand) run(cf *CLIConf) error {
 
 	manager, adminCommandErrCh, err := vnet.Setup(ctx, appProvider)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
 		return trace.Wrap(err)
 	}
 
 	err = vnet.Run(ctx, cancel, manager, adminCommandErrCh)
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
 	return trace.Wrap(err)
 }
 

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -20,9 +20,6 @@
 package common
 
 import (
-	"context"
-	"errors"
-
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
@@ -50,9 +47,6 @@ func (c *vnetCommand) run(cf *CLIConf) error {
 
 	processManager, err := vnet.SetupAndRun(cf.Context, appProvider)
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			return nil
-		}
 		return trace.Wrap(err)
 	}
 
@@ -61,11 +55,7 @@ func (c *vnetCommand) run(cf *CLIConf) error {
 		processManager.Close()
 	}()
 
-	err = processManager.Wait()
-	if errors.Is(err, context.Canceled) {
-		return nil
-	}
-	return trace.Wrap(err)
+	return trace.Wrap(processManager.Wait())
 }
 
 type vnetAdminSetupCommand struct {

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -48,8 +48,8 @@ func (c *vnetCommand) run(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	ctx, cancel := context.WithCancel(cf.Context)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(cf.Context)
+	defer cancel(nil)
 
 	manager, adminCommandErrCh, err := vnet.Setup(ctx, appProvider)
 	if err != nil {


### PR DESCRIPTION
This PR also prepares VNet for the integration with Connect. I described reasoning behind each change in commit messages.

A key piece of information to understand about VNet is that in this version we start a separate tsh command, `tsh vnet-admin-setup`. For now, we use `osascript -e "do shell script … with administrator privileges"` to execute this command with root privileges. This gives us the ability to create TUN devices and make system-wide DNS changes.

This command is started with [`os/exec.CommandContext`](https://pkg.go.dev/os/exec#CommandContext). The semantics of running a command through osascript are a little bit different, but ultimately they don't impact the implementation too much. E.g., cancelling the context passed to `os/exec.CommandContext` kills the osascript invocation, but not exactly `tsh vnet-admin-setup` since an unprivileged process can't kill privileged one. The admin subcommand quits when it detects that the socket, which is used to pass the TUN device, has been closed.

---

When it comes to testing the admin subcommand quitting prematurely, the way I do is I start `tsh vnet` and then I open Activity Monitor and search for `tsh`. If you go to View -> All Processes, Hierarchically, the admin subcommand is going to be under kernel_task -> launchd -> authtrampoline -> bash -> tsh (click on an item while pressing Option to recursively expand items). From there, you can get the PID to kill it (`sudo kill -s KILL <pid>`).

If you want to cause the admin subcommand to quit because of the removed socket, `tsh vnet -d` is going to report the socket path in the second log message. You don't need sudo to remove the socket.

Cases I tested:

* Interrupting `tsh vnet` while osascript prompt is shown.
* Interrupting `tsh vnet` after going through the osascript prompt (how the user would usually interrupt it).
* Removing the socket file while `tsh vnet -d` is running.
* Killing the admin process while `tsh vnet` is running.

---

We should also use `lib/utils/log.NewPackageLogger` instead of calling functions directly on `slog`. But I don't want to introduce too many conflicts right now since we have a couple of other VNet PRs open at the moment.