### PR TITLE
Add basic VNet integration to Connect

### DIFF
--- a/lib/teleterm/apiserver/apiserver.go
+++ b/lib/teleterm/apiserver/apiserver.go
@@ -30,7 +30,7 @@ import (
 	vnetapi "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/vnet/v1"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/teleterm/apiserver/handler"
-	vnet "github.com/gravitational/teleport/lib/teleterm/vnet"
+	"github.com/gravitational/teleport/lib/teleterm/vnet"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -63,7 +63,14 @@ func New(cfg Config) (*APIServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	vnetService := &vnet.Service{}
+	vnetService, err := vnet.New(vnet.Config{
+		DaemonService:      cfg.Daemon,
+		ClientStore:        cfg.ClientStore,
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	api.RegisterTerminalServiceServer(grpcServer, serviceHandler)
 	vnetapi.RegisterVnetServiceServer(grpcServer, vnetService)
@@ -84,7 +91,9 @@ func (s *APIServer) Serve() error {
 // Stop stops the server and closes all listeners
 func (s *APIServer) Stop() {
 	s.grpcServer.GracefulStop()
-	s.vnetService.Close()
+	if err := s.vnetService.Close(); err != nil {
+		log.WithError(err).Error("Error while closing VNet service")
+	}
 }
 
 func newListener(hostAddr string, listeningC chan<- utils.NetAddr) (net.Listener, error) {

--- a/lib/teleterm/apiserver/apiserver.go
+++ b/lib/teleterm/apiserver/apiserver.go
@@ -65,7 +65,6 @@ func New(cfg Config) (*APIServer, error) {
 
 	vnetService, err := vnet.New(vnet.Config{
 		DaemonService:      cfg.Daemon,
-		ClientStore:        cfg.ClientStore,
 		InsecureSkipVerify: cfg.InsecureSkipVerify,
 	})
 	if err != nil {

--- a/lib/teleterm/apiserver/config.go
+++ b/lib/teleterm/apiserver/config.go
@@ -24,7 +24,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/daemon"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -35,8 +34,7 @@ type Config struct {
 	HostAddr           string
 	InsecureSkipVerify bool
 	// Daemon is the terminal daemon service
-	Daemon      *daemon.Service
-	ClientStore *client.Store
+	Daemon *daemon.Service
 	// Log is a component logger
 	Log             logrus.FieldLogger
 	TshdServerCreds grpc.ServerOption
@@ -57,10 +55,6 @@ func (c *Config) CheckAndSetDefaults() error {
 
 	if c.Daemon == nil {
 		return trace.BadParameter("missing daemon service")
-	}
-
-	if c.ClientStore == nil {
-		return trace.BadParameter("missing client store")
 	}
 
 	if c.TshdServerCreds == nil {

--- a/lib/teleterm/apiserver/config.go
+++ b/lib/teleterm/apiserver/config.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/daemon"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -31,9 +32,11 @@ import (
 // Config is the APIServer configuration
 type Config struct {
 	// HostAddr is the APIServer host address
-	HostAddr string
+	HostAddr           string
+	InsecureSkipVerify bool
 	// Daemon is the terminal daemon service
-	Daemon *daemon.Service
+	Daemon      *daemon.Service
+	ClientStore *client.Store
 	// Log is a component logger
 	Log             logrus.FieldLogger
 	TshdServerCreds grpc.ServerOption
@@ -54,6 +57,10 @@ func (c *Config) CheckAndSetDefaults() error {
 
 	if c.Daemon == nil {
 		return trace.BadParameter("missing daemon service")
+	}
+
+	if c.ClientStore == nil {
+		return trace.BadParameter("missing client store")
 	}
 
 	if c.TshdServerCreds == nil {

--- a/lib/teleterm/clusters/cluster_apps.go
+++ b/lib/teleterm/clusters/cluster_apps.go
@@ -148,8 +148,8 @@ func (c *Cluster) getApp(ctx context.Context, authClient authclient.ClientI, app
 	return app, trace.Wrap(err)
 }
 
-// reissueAppCert issue new certificates for the app and saves them to disk.
-func (c *Cluster) reissueAppCert(ctx context.Context, clusterClient *client.ClusterClient, app types.Application) (tls.Certificate, error) {
+// ReissueAppCert issue new certificates for the app and saves them to disk.
+func (c *Cluster) ReissueAppCert(ctx context.Context, clusterClient *client.ClusterClient, app types.Application) (tls.Certificate, error) {
 	if app.IsAWSConsole() || app.IsGCP() || app.IsAzureCloud() {
 		return tls.Certificate{}, trace.BadParameter("cloud applications are not supported")
 	}

--- a/lib/teleterm/clusters/cluster_gateways.go
+++ b/lib/teleterm/clusters/cluster_gateways.go
@@ -165,7 +165,7 @@ func (c *Cluster) createAppGateway(ctx context.Context, params CreateGatewayPara
 	var cert tls.Certificate
 
 	if err := AddMetadataToRetryableError(ctx, func() error {
-		cert, err = c.reissueAppCert(ctx, params.ClusterClient, app)
+		cert, err = c.ReissueAppCert(ctx, params.ClusterClient, app)
 		return trace.Wrap(err)
 	}); err != nil {
 		return nil, trace.Wrap(err)
@@ -230,7 +230,7 @@ func (c *Cluster) ReissueGatewayCerts(ctx context.Context, clusterClient *client
 		}
 
 		// The cert is returned from this function and finally set on LocalProxy by the middleware.
-		cert, err := c.reissueAppCert(ctx, clusterClient, app)
+		cert, err := c.ReissueAppCert(ctx, clusterClient, app)
 		return cert, trace.Wrap(err)
 	default:
 		return tls.Certificate{}, trace.NotImplemented("ReissueGatewayCerts does not support this gateway kind %v", g.TargetURI().String())

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -39,9 +39,15 @@ func NewStorage(cfg Config) (*Storage, error) {
 	return &Storage{Config: cfg}, nil
 }
 
-// ReadAll reads clusters from profiles
-func (s *Storage) ReadAll() ([]*Cluster, error) {
+// ListProfileNames returns just the names of profiles in s.Dir.
+func (s *Storage) ListProfileNames() ([]string, error) {
 	pfNames, err := profile.ListProfileNames(s.Dir)
+	return pfNames, trace.Wrap(err)
+}
+
+// ListRootClusters reads root clusters from profiles.
+func (s *Storage) ListRootClusters() ([]*Cluster, error) {
+	pfNames, err := s.ListProfileNames()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/teleterm/daemon/config.go
+++ b/lib/teleterm/daemon/config.go
@@ -38,7 +38,7 @@ import (
 type Storage interface {
 	clusters.Resolver
 
-	ReadAll() ([]*clusters.Cluster, error)
+	ListRootClusters() ([]*clusters.Cluster, error)
 	Add(ctx context.Context, webProxyAddress string) (*clusters.Cluster, *client.TeleportClient, error)
 	Remove(ctx context.Context, profileName string) error
 	GetByResourceURI(resourceURI uri.ResourceURI) (*clusters.Cluster, *client.TeleportClient, error)

--- a/lib/teleterm/daemon/config.go
+++ b/lib/teleterm/daemon/config.go
@@ -38,6 +38,7 @@ import (
 type Storage interface {
 	clusters.Resolver
 
+	ListProfileNames() ([]string, error)
 	ListRootClusters() ([]*clusters.Cluster, error)
 	Add(ctx context.Context, webProxyAddress string) (*clusters.Cluster, *client.TeleportClient, error)
 	Remove(ctx context.Context, profileName string) error

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -160,6 +160,13 @@ func (s *Service) retryWithRelogin(ctx context.Context, reloginReq *api.ReloginR
 	return trace.Wrap(err)
 }
 
+// ListProfileNames lists profile names from storage. It's a lightweight alternative to
+// ListRootClusters, which also reads all profiles beyond their names and initializes clients.
+func (s *Service) ListProfileNames() ([]string, error) {
+	pfNames, err := s.cfg.Storage.ListProfileNames()
+	return pfNames, trace.Wrap(err)
+}
+
 // ListRootClusters returns a list of root clusters
 func (s *Service) ListRootClusters(ctx context.Context) ([]*clusters.Cluster, error) {
 	clusters, err := s.cfg.Storage.ListRootClusters()

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -162,12 +162,8 @@ func (s *Service) retryWithRelogin(ctx context.Context, reloginReq *api.ReloginR
 
 // ListRootClusters returns a list of root clusters
 func (s *Service) ListRootClusters(ctx context.Context) ([]*clusters.Cluster, error) {
-	clusters, err := s.cfg.Storage.ReadAll()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return clusters, nil
+	clusters, err := s.cfg.Storage.ListRootClusters()
+	return clusters, trace.Wrap(err)
 }
 
 // ListLeafClusters returns a list of leaf clusters

--- a/lib/teleterm/daemon/daemon_headless.go
+++ b/lib/teleterm/daemon/daemon_headless.go
@@ -75,7 +75,7 @@ func (s *Service) StartHeadlessWatchers() error {
 	s.headlessWatcherClosersMu.Lock()
 	defer s.headlessWatcherClosersMu.Unlock()
 
-	clusters, err := s.cfg.Storage.ReadAll()
+	clusters, err := s.cfg.Storage.ListRootClusters()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/teleterm/teleterm.go
+++ b/lib/teleterm/teleterm.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/apiserver"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 	"github.com/gravitational/teleport/lib/teleterm/daemon"
@@ -67,10 +68,12 @@ func Serve(ctx context.Context, cfg Config) error {
 	}
 
 	apiServer, err := apiserver.New(apiserver.Config{
-		HostAddr:        cfg.Addr,
-		Daemon:          daemonService,
-		TshdServerCreds: grpcCredentials.tshd,
-		ListeningC:      cfg.ListeningC,
+		HostAddr:           cfg.Addr,
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+		Daemon:             daemonService,
+		TshdServerCreds:    grpcCredentials.tshd,
+		ListeningC:         cfg.ListeningC,
+		ClientStore:        client.NewFSClientStore(cfg.HomeDir),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/teleterm/teleterm.go
+++ b/lib/teleterm/teleterm.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/apiserver"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 	"github.com/gravitational/teleport/lib/teleterm/daemon"
@@ -73,7 +72,6 @@ func Serve(ctx context.Context, cfg Config) error {
 		Daemon:             daemonService,
 		TshdServerCreds:    grpcCredentials.tshd,
 		ListeningC:         cfg.ListeningC,
-		ClientStore:        client.NewFSClientStore(cfg.HomeDir),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
@@ -35,7 +35,7 @@ import {
 import { ResourceSearchError } from 'teleterm/ui/services/resources';
 import { getAppAddrWithProtocol } from 'teleterm/services/tshd/app';
 
-import { SearchResult } from '../searchResult';
+import { SearchResult, SearchResultApp } from '../searchResult';
 import { makeResourceResult } from '../testHelpers';
 
 import {
@@ -44,9 +44,10 @@ import {
   ResourceSearchErrorsItem,
   TypeToSearchItem,
   AdvancedSearchEnabledItem,
+  AppItem,
 } from './ActionPicker';
 import { SuggestionsError, NoSuggestionsAvailable } from './ParameterPicker';
-import { ResultList } from './ResultList';
+import { NonInteractiveItem, ResultList } from './ResultList';
 
 import type * as uri from 'teleterm/ui/uri';
 
@@ -540,6 +541,7 @@ const SearchResultItems = () => {
             <Component
               searchResult={searchResult}
               getOptionalClusterName={routing.parseClusterName}
+              isVnetSupported={true}
             />
           ),
         };
@@ -577,6 +579,30 @@ const AuxiliaryItems = () => {
       })}
       ExtraTopComponent={
         <>
+          <NonInteractiveItem>
+            <AppItem
+              searchResult={
+                makeResourceResult({
+                  kind: 'app',
+                  resource: makeAppWithAddr({
+                    uri: `${clusterUri}/apps/tcp-app`,
+                    name: 'tcp-app-without-vnet',
+                    endpointUri: 'tcp://localhost:3001',
+                    desc: '',
+                    labels: makeLabelsList({
+                      access: 'cloudwatch-metrics,ec2,s3,cloudtrail',
+                      'aws/Environment': 'demo-13-biz',
+                      'aws/Owner': 'foobar',
+                      env: 'dev',
+                      'teleport.dev/origin': 'config-file',
+                    }),
+                  }),
+                }) as SearchResultApp
+              }
+              getOptionalClusterName={routing.parseClusterName}
+              isVnetSupported={false}
+            />
+          </NonInteractiveItem>
           <NoResultsItem
             clustersWithExpiredCerts={new Set()}
             getClusterName={routing.parseClusterName}

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.ts
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { copyToClipboard } from 'design/utils/copyToClipboard';
 import { App } from 'gen-proto-ts/teleport/lib/teleterm/v1/app_pb';
 import { Cluster } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
 
@@ -156,8 +155,17 @@ export async function connectToAppWithVnet(
   }
 
   const addrToCopy = getVnetAddr(cluster, target);
-  await copyToClipboard(addrToCopy);
-
+  try {
+    await navigator.clipboard.writeText(addrToCopy);
+  } catch (error) {
+    // On macOS, if the user uses the mouse rather than the keyboard to proceed with the osascript
+    // prompt, the Electron app throws an error about clipboard write permission being denied.
+    if (error['name'] === 'NotAllowedError') {
+      console.error(error);
+      return;
+    }
+    throw error;
+  }
   ctx.notificationsService.notifyInfo(`Copied ${addrToCopy} to clipboard`);
 }
 


### PR DESCRIPTION
This PR finally makes it so that the VNet gRPC service in lib/teleterm actually starts VNet.

https://github.com/gravitational/teleport/assets/27113/13e00ff0-648d-42f0-b724-2aef50fce037

Things left to do in subsequent PRs:

- Update the UI to show DNS zones that are being proxied, remove recent VNet connections from the UI.
- When VNet shuts down unexpectedly, make an RPC to the Electron app so that it can update its state accordingly.
- Handle expired certs.
- Rebase branch with telemetry.
   - Fix how usageReporting.enabled setting is read.