### PR TITLE
fix: Emit login failure event in the /mfa/login/begin step

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3291,6 +3291,15 @@ func (a *Server) CreateAuthenticateChallenge(ctx context.Context, req *proto.Cre
 		if err := a.WithUserLock(ctx, username, func() error {
 			return a.checkPasswordWOToken(ctx, username, req.GetUserCredentials().GetPassword())
 		}); err != nil {
+			// This is only ever used as a means to acquire a login challenge, so
+			// let's issue an authentication failure event.
+			if err := a.emitAuthAuditEvent(ctx, authAuditProps{
+				username: username,
+				authErr:  err,
+			}); err != nil {
+				log.WithError(err).Warn("Failed to emit login event")
+				// err swallowed on purpose.
+			}
 			return nil, trace.Wrap(err)
 		}
 

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -1887,7 +1887,6 @@ func configureForMFA(t *testing.T, srv *TestTLSServer) *configureMFAResp {
 		Webauthn: &types.Webauthn{
 			RPID: "localhost",
 		},
-		// Use default Webauthn config.
 	})
 	require.NoError(t, err)
 

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -38,6 +38,8 @@ import (
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -606,6 +608,50 @@ func TestCreateAuthenticateChallenge_mfaVerification(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCreateAuthenticateChallenge_failedLoginAudit tests a password+webauthn
+// login scenario where the user types the wrong password.
+// This should issue a "Local Login Failed" audit event.
+func TestCreateAuthenticateChallenge_failedLoginAudit(t *testing.T) {
+	t.Parallel()
+
+	testServer := newTestTLSServer(t)
+	emitter := &eventstest.MockRecorderEmitter{}
+	authServer := testServer.Auth()
+	authServer.SetEmitter(emitter)
+
+	ctx := context.Background()
+
+	// Set the cluster to require 2nd factor, create the user, set a password and
+	// register a webauthn device.
+	// password+OTP logins go through another route.
+	mfa := configureForMFA(t, testServer)
+
+	// Proxy identity is used during login.
+	proxyClient, err := testServer.NewClient(TestBuiltin(types.RoleProxy))
+	require.NoError(t, err, "NewClient(RoleProxy) failed")
+
+	t.Run("emits audit event", func(t *testing.T) {
+		emitter.Reset()
+		_, err := proxyClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
+			Request: &proto.CreateAuthenticateChallengeRequest_UserCredentials{
+				UserCredentials: &proto.UserCredentials{
+					Username: mfa.User,
+					Password: []byte(mfa.Password + "BAD"),
+				},
+			},
+			ChallengeExtensions: &mfav1.ChallengeExtensions{
+				Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_LOGIN,
+			},
+		})
+		assert.ErrorContains(t, err, "password", "CreateAuthenticateChallenge error mismatch")
+
+		event := emitter.LastEvent()
+		require.NotNil(t, event, "No audit event emitted")
+		assert.Equal(t, events.UserLoginEvent, event.GetType(), "event.Type mismatch")
+		assert.Equal(t, events.UserLocalLoginFailureCode, event.GetCode(), "event.Code mismatch")
+	})
 }
 
 func TestCreateRegisterChallenge(t *testing.T) {

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -135,7 +135,7 @@ func (a *Server) authenticateUserLogin(ctx context.Context, req AuthenticateUser
 			clientMetadata: req.ClientMetadata,
 			authErr:        err,
 		}); err != nil {
-			log.WithError(err).Warn("Failed to emit login event.")
+			log.WithError(err).Warn("Failed to emit login event")
 		}
 		return nil, nil, trace.Wrap(err)
 	}
@@ -187,7 +187,7 @@ func (a *Server) authenticateUserLogin(ctx context.Context, req AuthenticateUser
 			checker:        checker,
 			authErr:        err,
 		}); err != nil {
-			log.WithError(err).Warn("Failed to emit login event.")
+			log.WithError(err).Warn("Failed to emit login event")
 		}
 		return nil, nil, trace.Wrap(err)
 	}
@@ -199,7 +199,7 @@ func (a *Server) authenticateUserLogin(ctx context.Context, req AuthenticateUser
 		mfaDevice:      mfaDev,
 		checker:        checker,
 	}); err != nil {
-		log.WithError(err).Warn("Failed to emit login event.")
+		log.WithError(err).Warn("Failed to emit login event")
 	}
 
 	return userState, checker, trace.Wrap(err)


### PR DESCRIPTION
Emit the "Local Login Failed" event if the user fails a password check on CreateAuthenticateChallenge, which previously was a silent failure. This puts password+webauthn login audit on par with password+otp (which skips CreateAuthenticateChallenge entirely).

This is the only missing audit event from #36837 that can be addressed. As stated above, password+otp failures are already covered. Tapping the incorrect key, as mentioned in the issues, causes only a client-side failure.

#36837

Changelog: Emit login login failed audit events for invalid passwords on password+webauthn local authentication.