### PR TITLE
[v14] fix: Emit login failure event in the /mfa/login/begin step

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3086,6 +3086,15 @@ func (a *Server) CreateAuthenticateChallenge(ctx context.Context, req *proto.Cre
 		if err := a.WithUserLock(username, func() error {
 			return a.checkPasswordWOToken(username, req.GetUserCredentials().GetPassword())
 		}); err != nil {
+			// This is only ever used as a means to acquire a login challenge, so
+			// let's issue an authentication failure event.
+			if err := a.emitAuthAuditEvent(ctx, authAuditProps{
+				username: username,
+				authErr:  err,
+			}); err != nil {
+				log.WithError(err).Warn("Failed to emit login event")
+				// err swallowed on purpose.
+			}
 			return nil, trace.Wrap(err)
 		}
 

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -1549,7 +1549,6 @@ func configureForMFA(t *testing.T, srv *TestTLSServer) *configureMFAResp {
 		Webauthn: &types.Webauthn{
 			RPID: "localhost",
 		},
-		// Use default Webauthn config.
 	})
 	require.NoError(t, err)
 

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -611,9 +611,6 @@ func TestCreateAuthenticateChallenge_failedLoginAudit(t *testing.T) {
 					Password: []byte(mfa.Password + "BAD"),
 				},
 			},
-			ChallengeExtensions: &mfav1.ChallengeExtensions{
-				Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_LOGIN,
-			},
 		})
 		assert.ErrorContains(t, err, "password", "CreateAuthenticateChallenge error mismatch")
 

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -126,7 +126,7 @@ func (a *Server) authenticateUserLogin(ctx context.Context, req AuthenticateUser
 			clientMetadata: req.ClientMetadata,
 			authErr:        err,
 		}); err != nil {
-			log.WithError(err).Warn("Failed to emit login event.")
+			log.WithError(err).Warn("Failed to emit login event")
 		}
 		return nil, nil, trace.Wrap(err)
 	}
@@ -178,7 +178,7 @@ func (a *Server) authenticateUserLogin(ctx context.Context, req AuthenticateUser
 			checker:        checker,
 			authErr:        err,
 		}); err != nil {
-			log.WithError(err).Warn("Failed to emit login event.")
+			log.WithError(err).Warn("Failed to emit login event")
 		}
 		return nil, nil, trace.Wrap(err)
 	}
@@ -190,7 +190,7 @@ func (a *Server) authenticateUserLogin(ctx context.Context, req AuthenticateUser
 		mfaDevice:      mfaDev,
 		checker:        checker,
 	}); err != nil {
-		log.WithError(err).Warn("Failed to emit login event.")
+		log.WithError(err).Warn("Failed to emit login event")
 	}
 
 	return userState, checker, trace.Wrap(err)


### PR DESCRIPTION
Backport #41419 to branch/v14

#36837

changelog: Emit login login failed audit events for invalid passwords on password+webauthn local authentication.
