### PR TITLE
Fix SSH sessions recorded on proxy not being fully closed

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -910,18 +910,19 @@ func (s *session) haltTerminal() {
 // prematurely can result in missing audit events, session recordings, and other
 // unexpected errors.
 func (s *session) Close() error {
-	s.Stop()
-
 	s.BroadcastMessage("Closing session...")
 	s.log.Infof("Closing session")
 
-	serverSessions.Dec()
-
-	// Remove session parties and close client connections.
+	// Remove session parties and close client connections. Since terminals
+	// might await for all the parties to be released, we must called it first.
+	// Closing the parties will cause their SSH channel to be closed, meaning
+	// any gorouting reading from it will be released.
 	for _, p := range s.getParties() {
 		p.Close()
 	}
 
+	s.Stop()
+	serverSessions.Dec()
 	s.registry.removeSession(s)
 
 	// Complete the session recording

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -914,9 +914,9 @@ func (s *session) Close() error {
 	s.log.Infof("Closing session")
 
 	// Remove session parties and close client connections. Since terminals
-	// might await for all the parties to be released, we must called it first.
+	// might await for all the parties to be released, we must close them first.
 	// Closing the parties will cause their SSH channel to be closed, meaning
-	// any gorouting reading from it will be released.
+	// any goroutine reading from it will be released.
 	for _, p := range s.getParties() {
 		p.Close()
 	}

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -20,7 +20,9 @@ package srv
 
 import (
 	"context"
+	"crypto/ed25519"
 	"io"
+	"net"
 	"os/user"
 	"sync/atomic"
 	"testing"
@@ -31,10 +33,12 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/term"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -43,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/sshutils/sftp"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -986,5 +991,178 @@ func TestSessionRecordingMode(t *testing.T) {
 			gotMode := sess.sessionRecordingMode()
 			require.Equal(t, tt.expectedMode, gotMode)
 		})
+	}
+}
+
+func TestCloseProxySession(t *testing.T) {
+	srv := newMockServer(t)
+	srv.component = teleport.ComponentProxy
+
+	reg, _ := NewSessionRegistry(SessionRegistryConfig{
+		Srv:                   srv,
+		SessionTrackerService: srv.auth,
+	})
+	t.Cleanup(func() { reg.Close() })
+
+	scx := newTestServerContext(t, reg.Srv, nil)
+	sid := string(rsession.NewID())
+	scx.SetEnv(sshutils.SessionEnvVar, sid)
+
+	// Open a new session
+	sshChanOpen := newMockSSHChannel()
+	// Always close the session from the client side to avoid it being stuck
+	// on closing (server side).
+	t.Cleanup(func() { sshChanOpen.Close() })
+	go func() {
+		// Consume stdout sent to the channel
+		io.ReadAll(sshChanOpen)
+	}()
+
+	err := reg.OpenSession(context.Background(), sshChanOpen, scx)
+	require.NoError(t, err)
+	require.NotNil(t, scx.session)
+
+	// After the session is open, we force a close comming from the server. Do
+	// this inside a goroutine to avoid being blocked.
+	closeChan := make(chan error)
+	go func() {
+		closeChan <- scx.session.Close()
+	}()
+
+	select {
+	case err := <-closeChan:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "expected session to be closed")
+	}
+}
+
+// TestClodeRemoteSession given a remote session recording at proxy ensure that
+// closing the session releases all the resources, and return properly to the
+// user.
+func TestCloseRemoteSession(t *testing.T) {
+	srv := newMockServer(t)
+	srv.component = teleport.ComponentProxy
+
+	// init a session registry
+	reg, _ := NewSessionRegistry(SessionRegistryConfig{
+		Srv:                   srv,
+		SessionTrackerService: srv.auth,
+	})
+	t.Cleanup(func() { reg.Close() })
+
+	scx := newTestServerContext(t, reg.Srv, nil)
+	scx.SessionRecordingConfig.SetMode(types.RecordAtProxy)
+	scx.RemoteSession = mockSSHSession(t)
+
+	sid := string(rsession.NewID())
+	scx.SetEnv(sshutils.SessionEnvVar, sid)
+
+	// Open a new session
+	sshChanOpen := newMockSSHChannel()
+	// Always close the session from the client side to avoid it being stuck
+	// on closing (server side).
+	t.Cleanup(func() { sshChanOpen.Close() })
+	go func() {
+		// Consume stdout sent to the channel
+		io.ReadAll(sshChanOpen)
+	}()
+
+	err := reg.OpenSession(context.Background(), sshChanOpen, scx)
+	require.NoError(t, err)
+	require.NotNil(t, scx.session)
+
+	// After the session is open, we force a close comming from the server. Do
+	// this inside a goroutine to avoid being blocked.
+	closeChan := make(chan error)
+	go func() {
+		closeChan <- scx.session.Close()
+	}()
+
+	select {
+	case err := <-closeChan:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "expected session to be closed")
+	}
+}
+
+func mockSSHSession(t *testing.T) *tracessh.Session {
+	ctx := context.Background()
+
+	_, key, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(key)
+	require.NoError(t, err)
+
+	cfg := &ssh.ServerConfig{NoClientAuth: true}
+	cfg.AddHostKey(signer)
+
+	listener, err := net.Listen("tcp", "localhost:")
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			t.Logf("error while accepting ssh connections: %s", err)
+		}
+
+		srvConn, chCh, reqCh, err := ssh.NewServerConn(conn, cfg)
+		go ssh.DiscardRequests(reqCh)
+		go func() {
+			for newChannel := range chCh {
+				channel, requests, err := newChannel.Accept()
+				if err != nil {
+					t.Logf("Failed to handle new channel: %s", err)
+					continue
+				}
+
+				go func() {
+					for req := range requests {
+						req.Reply(true, nil)
+					}
+				}()
+
+				sessTerm := term.NewTerminal(channel, "> ")
+				go func() {
+					defer channel.Close()
+					for {
+						line, err := sessTerm.ReadLine()
+						if err != nil {
+							break
+						}
+						t.Log(line)
+					}
+				}()
+			}
+		}()
+
+		srvConn.Wait()
+	}()
+
+	// Establish a connection to the newly created server.
+	sessCh := make(chan *tracessh.Session)
+	go func() {
+		client, err := tracessh.Dial(ctx, listener.Addr().Network(), listener.Addr().String(), &ssh.ClientConfig{
+			User:            "user",
+			Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+			HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
+		})
+		require.NoError(t, err)
+
+		sess, err := client.NewSession(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { sess.Close() })
+
+		sessCh <- sess
+	}()
+
+	select {
+	case sess := <-sessCh:
+		return sess
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "expected SSH session but got nothing")
+		return nil
 	}
 }

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -1020,7 +1020,7 @@ func TestCloseProxySession(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, scx.session)
 
-	// After the session is open, we force a close comming from the server. Do
+	// After the session is open, we force a close coming from the server. Do
 	// this inside a goroutine to avoid being blocked.
 	closeChan := make(chan error)
 	go func() {

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -994,8 +994,6 @@ func TestSessionRecordingMode(t *testing.T) {
 }
 
 func TestCloseProxySession(t *testing.T) {
-	t.Helper()
-
 	srv := newMockServer(t)
 	srv.component = teleport.ComponentProxy
 
@@ -1085,6 +1083,8 @@ func TestCloseRemoteSession(t *testing.T) {
 }
 
 func mockSSHSession(t *testing.T) *tracessh.Session {
+	t.Helper()
+
 	ctx := context.Background()
 
 	_, key, err := ed25519.GenerateKey(nil)

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -1067,7 +1067,7 @@ func TestCloseRemoteSession(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, scx.session)
 
-	// After the session is open, we force a close comming from the server. Do
+	// After the session is open, we force a close coming from the server. Do
 	// this inside a goroutine to avoid being blocked.
 	closeChan := make(chan error)
 	go func() {

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -651,7 +651,6 @@ func (t *remoteTerminal) PID() int {
 }
 
 func (t *remoteTerminal) Close() error {
-	t.wg.Wait()
 	// this closes the underlying stdin,stdout,stderr which is what ptyBuffer is
 	// hooked to directly
 	err := t.session.Close()
@@ -659,8 +658,12 @@ func (t *remoteTerminal) Close() error {
 		return trace.Wrap(err)
 	}
 
-	t.log.Debugf("Closed remote terminal and underlying SSH session")
+	// Wait for parties to be relased after closing the remote session. This
+	// avoid cases where the parties are blocked, reading from the remote
+	// session.
+	t.wg.Wait()
 
+	t.log.Debugf("Closed remote terminal and underlying SSH session")
 	return nil
 }
 


### PR DESCRIPTION
This issue affects only SSH sessions recorded at Proxy. When the `session.Close` is called from the Proxy, the session is not properly closed, leaving it open.

The problem was related to the session waiting for the parties to be closed (`s.term.AddParty(-1)`). This PR updates the close flow from `session.Close` and `remoteTerminal.Close` to fix it (commented on code).