### PR TITLE
[v13] fix: Emit login failure event in the /mfa/login/begin step

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2830,6 +2830,15 @@ func (a *Server) CreateAuthenticateChallenge(ctx context.Context, req *proto.Cre
 		if err := a.WithUserLock(username, func() error {
 			return a.checkPasswordWOToken(username, req.GetUserCredentials().GetPassword())
 		}); err != nil {
+			// This is only ever used as a means to acquire a login challenge, so
+			// let's issue an authentication failure event.
+			if err := a.emitAuthAuditEvent(ctx, authAuditProps{
+				username: username,
+				authErr:  err,
+			}); err != nil {
+				log.WithError(err).Warn("Failed to emit login event")
+				// err swallowed on purpose.
+			}
 			return nil, trace.Wrap(err)
 		}
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2830,12 +2830,24 @@ func (a *Server) CreateAuthenticateChallenge(ctx context.Context, req *proto.Cre
 		if err := a.WithUserLock(username, func() error {
 			return a.checkPasswordWOToken(username, req.GetUserCredentials().GetPassword())
 		}); err != nil {
+			event := &apievents.UserLogin{
+				Metadata: apievents.Metadata{
+					Type: events.UserLoginEvent,
+					Code: events.UserLocalLoginFailureCode,
+				},
+				UserMetadata: apievents.UserMetadata{
+					User: username,
+				},
+				Status: apievents.Status{
+					Success: false,
+					Error:   err.Error(),
+				},
+				Method: events.LoginMethodLocal,
+			}
+
 			// This is only ever used as a means to acquire a login challenge, so
 			// let's issue an authentication failure event.
-			if err := a.emitAuthAuditEvent(ctx, authAuditProps{
-				username: username,
-				authErr:  err,
-			}); err != nil {
+			if err := a.emitter.EmitAuditEvent(ctx, event); err != nil {
 				log.WithError(err).Warn("Failed to emit login event")
 				// err swallowed on purpose.
 			}

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -576,6 +578,50 @@ func TestCreateAuthenticateChallenge_mfaVerification(t *testing.T) {
 			assert.Equal(t, test.wantMFARequired, resp.Required, "resp.Required mismatch")
 		})
 	}
+}
+
+// TestCreateAuthenticateChallenge_failedLoginAudit tests a password+webauthn
+// login scenario where the user types the wrong password.
+// This should issue a "Local Login Failed" audit event.
+func TestCreateAuthenticateChallenge_failedLoginAudit(t *testing.T) {
+	t.Parallel()
+
+	testServer := newTestTLSServer(t)
+	emitter := &eventstest.MockRecorderEmitter{}
+	authServer := testServer.Auth()
+	authServer.SetEmitter(emitter)
+
+	ctx := context.Background()
+
+	// Set the cluster to require 2nd factor, create the user, set a password and
+	// register a webauthn device.
+	// password+OTP logins go through another route.
+	mfa := configureForMFA(t, testServer)
+
+	// Proxy identity is used during login.
+	proxyClient, err := testServer.NewClient(TestBuiltin(types.RoleProxy))
+	require.NoError(t, err, "NewClient(RoleProxy) failed")
+
+	t.Run("emits audit event", func(t *testing.T) {
+		emitter.Reset()
+		_, err := proxyClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
+			Request: &proto.CreateAuthenticateChallengeRequest_UserCredentials{
+				UserCredentials: &proto.UserCredentials{
+					Username: mfa.User,
+					Password: []byte(mfa.Password + "BAD"),
+				},
+			},
+			ChallengeExtensions: &mfav1.ChallengeExtensions{
+				Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_LOGIN,
+			},
+		})
+		assert.ErrorContains(t, err, "password", "CreateAuthenticateChallenge error mismatch")
+
+		event := emitter.LastEvent()
+		require.NotNil(t, event, "No audit event emitted")
+		assert.Equal(t, events.UserLoginEvent, event.GetType(), "event.Type mismatch")
+		assert.Equal(t, events.UserLocalLoginFailureCode, event.GetCode(), "event.Code mismatch")
+	})
 }
 
 func TestCreateRegisterChallenge(t *testing.T) {
@@ -1503,7 +1549,6 @@ func configureForMFA(t *testing.T, srv *TestTLSServer) *configureMFAResp {
 		Webauthn: &types.Webauthn{
 			RPID: "localhost",
 		},
-		// Use default Webauthn config.
 	})
 	require.NoError(t, err)
 

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -587,7 +587,7 @@ func TestCreateAuthenticateChallenge_failedLoginAudit(t *testing.T) {
 	t.Parallel()
 
 	testServer := newTestTLSServer(t)
-	emitter := &eventstest.MockRecorderEmitter{}
+	emitter := &eventstest.MockEmitter{}
 	authServer := testServer.Auth()
 	authServer.SetEmitter(emitter)
 
@@ -610,9 +610,6 @@ func TestCreateAuthenticateChallenge_failedLoginAudit(t *testing.T) {
 					Username: mfa.User,
 					Password: []byte(mfa.Password + "BAD"),
 				},
-			},
-			ChallengeExtensions: &mfav1.ChallengeExtensions{
-				Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_LOGIN,
 			},
 		})
 		assert.ErrorContains(t, err, "password", "CreateAuthenticateChallenge error mismatch")

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -156,7 +156,7 @@ func (a *Server) authenticateUserLogin(ctx context.Context, req AuthenticateUser
 	if err != nil {
 		event.Error = err.Error()
 		if err := a.emitter.EmitAuditEvent(a.closeCtx, event); err != nil {
-			log.WithError(err).Warn("Failed to emit login event.")
+			log.WithError(err).Warn("Failed to emit login event")
 		}
 		return nil, trace.Wrap(err)
 	}
@@ -194,7 +194,7 @@ func (a *Server) authenticateUserLogin(ctx context.Context, req AuthenticateUser
 		// Log MFA lock failure as an authn failure.
 		event.Error = err.Error()
 		if err := a.emitter.EmitAuditEvent(a.closeCtx, event); err != nil {
-			log.WithError(err).Warn("Failed to emit login event.")
+			log.WithError(err).Warn("Failed to emit login event")
 		}
 		return nil, trace.Wrap(err)
 	}
@@ -204,7 +204,7 @@ func (a *Server) authenticateUserLogin(ctx context.Context, req AuthenticateUser
 	event.Success = true
 	event.Error = ""
 	if err := a.emitter.EmitAuditEvent(a.closeCtx, event); err != nil {
-		log.WithError(err).Warn("Failed to emit login event.")
+		log.WithError(err).Warn("Failed to emit login event")
 	}
 
 	return userState, nil


### PR DESCRIPTION
Backport #41419 to branch/v13

#36837

changelog: Emit login login failed audit events for invalid passwords on password+webauthn local authentication.