### PR TITLE
[docs] update db guide introductions

### DIFF
--- a/docs/pages/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
@@ -3,7 +3,7 @@ title: Database Access with Amazon Keyspaces (Apache Cassandra)
 description: How to configure Teleport database access with Amazon Keyspaces (Apache Cassandra)
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="Amazon Keyspaces (Apache Cassandra)" dbConfigure="Amazon Keyspaces database with IAM authentication" dbName="Amazon Keyspaces" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon Keyspaces (Apache Cassandra)" dbConfigure="with IAM authentication"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-aws-databases/aws-dynamodb.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-dynamodb.mdx
@@ -3,7 +3,7 @@ title: Database Access with Amazon DynamoDB
 description: How to access Amazon DynamoDB with Teleport database access
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="Amazon DynamoDB" dbConfigure="Amazon DynamoDB database with IAM authentication" dbName="Amazon DynamoDB" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon DynamoDB" dbConfigure="with IAM authentication"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-aws-databases/aws-opensearch.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-opensearch.mdx
@@ -3,7 +3,7 @@ title: Database Access with AWS OpenSearch
 description: How to access AWS OpenSearch with Teleport database access
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS OpenSearch" dbConfigure="AWS OpenSearch Service via REST API with IAM Authentication" dbName="AWS OpenSearch" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon OpenSearch" dbConfigure="via REST API with IAM Authentication"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-aws-databases/postgres-redshift.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/postgres-redshift.mdx
@@ -4,7 +4,7 @@ description: How to configure Teleport database access with Amazon Redshift Post
 videoBanner: UFhT52d5bYg
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="Amazon Redshift" dbConfigure="Amazon Redshift database with IAM authentication" dbName="Amazon Redshift" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon Redshift" dbConfigure="with IAM authentication"!)
 
 ## How it works
 
@@ -147,7 +147,7 @@ Service access to AWS credentials.
 
 (!docs/pages/includes/start-teleport.mdx service="the Database Service"!)
 
-The Database Service will proxy the AWs Redshift cluster with the ID you
+The Database Service will proxy the Amazon Redshift cluster with the ID you
 specified earlier. Keep in mind that AWS IAM changes may not propagate
 immediately and can take a few minutes to come into effect.
 

--- a/docs/pages/database-access/enroll-aws-databases/rds-proxy-mysql.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/rds-proxy-mysql.mdx
@@ -3,6 +3,6 @@ title: Database Access with AWS RDS Proxy for MariaDB/MySQL
 description: How to configure Teleport database access with AWS RDS Proxy for MariaDB/MySQL.
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS RDS proxy for MariaDB or MySQL" dbConfigure="AWS RDS proxy for MariaDB or MySQL with IAM authentication" dbName="AWS RDS proxy for MariaDB or MySQL" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS proxy for MariaDB or MySQL" dbConfigure="with IAM authentication"!)
 
 (!docs/pages/includes/database-access/rds-proxy.mdx protocol="mysql" !)

--- a/docs/pages/database-access/enroll-aws-databases/rds-proxy-postgres.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/rds-proxy-postgres.mdx
@@ -3,6 +3,6 @@ title: Database Access with AWS RDS Proxy for PostgreSQL
 description: How to configure Teleport database access with AWS RDS Proxy for PostgreSQL
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS RDS proxy for PostgreSQL" dbConfigure="AWS RDS proxy for PostgreSQL with IAM authentication" dbName="AWS RDS proxy for PostgreSQL" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS proxy for PostgreSQL" dbConfigure="with IAM authentication"!)
 
 (!docs/pages/includes/database-access/rds-proxy.mdx protocol="postgres"!)

--- a/docs/pages/database-access/enroll-aws-databases/rds-proxy-sqlserver.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/rds-proxy-sqlserver.mdx
@@ -3,6 +3,6 @@ title: Database Access with AWS RDS Proxy for Microsoft SQL Server
 description: How to configure Teleport database access with AWS RDS Proxy for Microsoft SQL Server
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS RDS proxy for Microsoft SQL Server" dbConfigure="AWS RDS proxy for Microsoft SQL Server with IAM authentication" dbName="AWS RDS proxy for Microsoft SQL Server" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS proxy for Microsoft SQL Server" dbConfigure="with IAM authentication"!)
 
 (!docs/pages/includes/database-access/rds-proxy.mdx protocol="sqlserver" !)

--- a/docs/pages/database-access/enroll-aws-databases/rds.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/rds.mdx
@@ -4,17 +4,7 @@ h1: Database Access with AWS RDS and Aurora for PostgreSQL, MySQL and MariaDB
 description: How to configure Teleport database access with AWS RDS and Aurora for PostgreSQL, MySQL and MariaDB.
 ---
 
-Access to AWS or RDS Aurora databases can be provided by [Teleport Database
-Access](../introduction.mdx). This allows for
-fine-grain access control through [Teleport's RBAC](../rbac.mdx).
-
-This guide demonstrates how to use Teleport to connect to AWS or RDS Aurora databases.
-
-In this guide, you will:
-
-1. Configure AWS RDS or Aurora databases with IAM authentication.
-1. Join the AWS RDS or Aurora databases to your Teleport cluster.
-1. Connect to the AWS RDS or Aurora database via the Teleport Database Service.
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS or Aurora" dbConfigure="with IAM authentication"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-aws-databases/redis-aws.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/redis-aws.mdx
@@ -3,7 +3,7 @@ title: Database Access with AWS ElastiCache and AWS MemoryDB for Redis
 description: How to configure Teleport database access with AWS ElastiCache and AWS MemoryDB for Redis.
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS ElastiCache and MemoryDB for Redis cluster" dbConfigure="AWS ElastiCache and MemoryDB for Redis cluster database with IAM authentication" dbName="AWS ElastiCache and MemoryDB for Redis" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon ElastiCache or MemoryDB for Redis" dbConfigure="with IAM authentication"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-aws-databases/redshift-serverless.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/redshift-serverless.mdx
@@ -3,7 +3,7 @@ title: Database Access with Redshift Serverless on AWS
 description: How to configure Teleport database access with Amazon Redshift Serverless.
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="Amazon Redshift Serverless" dbConfigure="Amazon Redshift Serverless database with IAM authentication" dbName="Amazon Redshift Serverless" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon Redshift Serverless" dbConfigure="with IAM authentication"!)
 
 This guide will help you to:
 

--- a/docs/pages/database-access/enroll-aws-databases/sql-server-ad.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/sql-server-ad.mdx
@@ -4,7 +4,7 @@ description: How to configure Teleport database access with Microsoft SQL Server
 videoBanner: k2wz79XCexY
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="Microsoft SQL Server" dbConfigure="Microsoft SQL Server database with Active Directory authentication" dbName="Microsoft SQL Server" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Microsoft SQL Server" dbConfigure="with Active Directory authentication"!)
 
 This guide will focus on Amazon RDS for SQL Server using AWS-managed Active
 Directory authentication.

--- a/docs/pages/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
@@ -3,7 +3,7 @@ title: Database Access with Azure PostgreSQL and MySQL
 description: How to configure Teleport database access with Azure Database for PostgreSQL and MySQL.
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="Azure PostgreSQL or MySQL" dbConfigure="Azure PostgreSQL or MySQL database with IAM authentication" dbName="Azure PostgreSQL or MySQL" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Azure PostgreSQL or MySQL" dbConfigure="with Microsoft Entra ID-based authentication"!)
 
 Database auto-discovery for Azure PostgreSQL/MySQL flexible servers is available starting from
 Teleport `12.0`.

--- a/docs/pages/database-access/enroll-azure-databases/azure-redis.mdx
+++ b/docs/pages/database-access/enroll-azure-databases/azure-redis.mdx
@@ -3,7 +3,7 @@ title: Database Access with Azure Cache for Redis
 description: How to configure Teleport database access with Azure Cache for Redis
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="Azure Cache for Redis" dbConfigure="Azure Cache for Redis with IAM authentication" dbName="Azure Cache for Redis" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Azure Cache for Redis" dbConfigure="with Microsoft Entra ID-based authentication"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-azure-databases/azure-sql-server-ad.mdx
+++ b/docs/pages/database-access/enroll-azure-databases/azure-sql-server-ad.mdx
@@ -3,7 +3,7 @@ title: Database Access with SQL Server on Azure
 description: How to configure Teleport database access with Azure SQL Server using Azure Active Directory authentication.
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="Azure SQL Server" dbConfigure="Azure SQL Server using Azure Active Directory authentication" dbName="Azure SQL Server" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Azure SQL Server" dbConfigure="with Microsoft Entra ID-based authentication"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
@@ -3,7 +3,7 @@ title: Database Access with MySQL on GCP Cloud SQL
 description: How to configure Teleport database access with GCP Cloud SQL MySQL.
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="MySQL on Google Cloud SQL" dbConfigure="MySQL on Google Cloud SQL with a service account" dbName="MySQL on Google Cloud SQL" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="MySQL on Google Cloud SQL" dbConfigure="with a service account"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
@@ -4,7 +4,7 @@ description: How to configure Teleport database access with GCP Cloud SQL Postgr
 videoBanner: br9LZ3ZXqCk
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="PostgreSQL on Google Cloud SQL" dbConfigure="PostgreSQL on Google Cloud SQL with a service account" dbName="PostgreSQL on Google Cloud SQL" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="PostgreSQL on Google Cloud SQL" dbConfigure="with a service account"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-managed-databases/mongodb-atlas.mdx
+++ b/docs/pages/database-access/enroll-managed-databases/mongodb-atlas.mdx
@@ -4,7 +4,7 @@ description: How to configure Teleport database access with MongoDB Atlas.
 videoBanner: mu_ZKTjnFJ8
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="MongoDB Atlas cluster" dbConfigure="MongoDB Atlas with mutual TLS authentication or AWS IAM" dbName="MongoDB Atlas" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="MongoDB Atlas" dbConfigure="with either IAM or mutual TLS authentication"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-managed-databases/snowflake.mdx
+++ b/docs/pages/database-access/enroll-managed-databases/snowflake.mdx
@@ -3,7 +3,7 @@ title: Database Access with Snowflake
 description: How to configure Teleport database access with Snowflake.
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="Snowflake" dbConfigure="Snowflake database with key pair authentication" dbName="Snowflake" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Snowflake" dbConfigure="with key pair authentication"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
@@ -3,7 +3,7 @@ title: Database Access with Cassandra and ScyllaDB
 description: How to configure Teleport database access with Cassandra and ScyllaDB.
 ---
 
-(!docs/pages/includes/database-access/self-hosted-introduction.mdx  dbType="Cassandra or ScyllaDB" dbConfigure="Cassandra or ScyllaDB" dbName="Cassandra or ScyllaDB" !)
+(!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Cassandra or ScyllaDB"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted.mdx
@@ -3,7 +3,7 @@ title: Database Access with Self-Hosted CockroachDB
 description: How to configure Teleport database access with self-hosted CockroachDB.
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="CockroachDB" dbConfigure="CockroachDB" dbName="CockroachDB" !)
+(!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="CockroachDB"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/elastic.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/elastic.mdx
@@ -3,7 +3,7 @@ title: Database Access with Elasticsearch
 description: How to configure Teleport database access with Elasticsearch.
 ---
 
-(!docs/pages/includes/database-access/self-hosted-introduction.mdx  dbType="Elasticsearch" dbConfigure="Self-hosted Elasticsearch" dbName="Elasticsearch" !)
+(!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Elasticsearch"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
@@ -4,7 +4,7 @@ description: How to configure Teleport database access with self-hosted MongoDB.
 videoBanner: 6lgVObxoLkc
 ---
 
-(!docs/pages/includes/database-access/self-hosted-introduction.mdx  dbType="MongoDB cluster" dbConfigure="MongoDB cluster" dbName="MongoDB" !)
+(!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="MongoDB"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
@@ -3,7 +3,7 @@ title: Database Access with Self-Hosted MySQL/MariaDB
 description: How to configure Teleport database access with self-hosted MySQL/MariaDB.
 ---
 
-(!docs/pages/includes/database-access/self-hosted-introduction.mdx  dbType="MySQL or MariaDB" dbConfigure="MySQL or MariaDB database" dbName="MySQL or MariaDB" !)
+(!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="MySQL or MariaDB"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
@@ -3,7 +3,7 @@ title: Database Access with Oracle
 description: How to configure Teleport database access with Oracle.
 ---
 
-(!docs/pages/includes/database-access/self-hosted-introduction.mdx  dbType="Oracle" dbConfigure="Oracle" dbName="Oracle" !)
+(!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Oracle"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
@@ -3,7 +3,7 @@ title: Database Access with Self-Hosted PostgreSQL
 description: How to configure Teleport database access with self-hosted PostgreSQL.
 ---
 
-(!docs/pages/includes/database-access/self-hosted-introduction.mdx  dbType="PostgreSQL" dbConfigure="PostgreSQL database" dbName="PostgreSQL" !)
+(!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="PostgreSQL"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/redis-cluster.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/redis-cluster.mdx
@@ -5,7 +5,7 @@ description: How to configure Teleport database access with Redis Cluster.
 
 If you want to configure Redis Standalone, please read [Database Access with Redis](redis.mdx).
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="Redis cluster" dbConfigure="Redis cluster database" dbName="Redis cluster" !)
+(!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Redis cluster"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/redis.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/redis.mdx
@@ -5,7 +5,7 @@ description: How to configure Teleport database access with Redis.
 
 If you want to configure Redis Cluster, please read [Database Access with Redis Cluster](redis-cluster.mdx).
 
-(!docs/pages/includes/database-access/self-hosted-introduction.mdx  dbType="Redis" dbConfigure="Redis database" dbName="Redis" !)
+(!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Redis"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/sql-server-ad-pkinit.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/sql-server-ad-pkinit.mdx
@@ -3,7 +3,7 @@ title: Microsoft SQL Server access with PKINIT authentication
 description: How to configure Microsoft SQL Server access with Active Directory PKINIT authentication.
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="Microsoft SQL Server" dbConfigure="Microsoft SQL Server database with PKINIT authentication" dbName="Microsoft SQL Server" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="Microsoft SQL Server" dbConfigure="with PKINIT authentication"!)
 
 ## How it works
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/vitess.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/vitess.mdx
@@ -3,7 +3,7 @@ title: Database Access with Vitess (MySQL protocol)
 description: How to configure Teleport database access for Vitess (MySQL protocol)
 ---
 
-(!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Vitess (MySQL)" dbConfigure="Vitess database (MySQL protocol)" dbName="Vitess" !)
+(!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Vitess (MySQL)"!)
 
 ## How it works
 

--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -3,7 +3,7 @@ title: Database Access Getting Started Guide
 description: Getting started with Teleport database access and AWS Aurora PostgreSQL.
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="PostgreSQL AWS Aurora" dbConfigure="AWS Aurora database with IAM authentication" dbName="Aurora" !)
+(!docs/pages/includes/database-access/db-introduction.mdx dbType="PostgreSQL Amazon Aurora" dbConfigure="with IAM authentication"!)
 
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">

--- a/docs/pages/includes/database-access/db-introduction.mdx
+++ b/docs/pages/includes/database-access/db-introduction.mdx
@@ -1,10 +1,10 @@
-Teleport can provide secure access to {{ dbName }} via the  [Teleport Database
+Teleport can provide secure access to {{ dbType }} via the  [Teleport Database
 Service](../../database-access/introduction.mdx). This allows for
 fine-grained access control through [Teleport's RBAC](../../database-access/rbac.mdx).
 
 In this guide, you will:
 
-1. Configure an {{ dbConfigure }}.
-1. Join the {{ dbName }} database to your Teleport cluster.
-1. Connect to the {{ dbName }} database via the Teleport Database Service.
+1. Configure your {{ dbType }} database {{ dbConfigure }}.
+1. Add the database to your Teleport cluster.
+1. Connect to the database via Teleport
 

--- a/docs/pages/includes/database-access/how-it-works/iam.mdx
+++ b/docs/pages/includes/database-access/how-it-works/iam.mdx
@@ -1,4 +1,4 @@
 The Teleport Database Service uses IAM authentication to communicate with 
-{{ db }}. When a user connects to the database via Teleport, the Database
-Service obtains {{ cloud }} credentials and authenticates to {{ cloud }} as an
-IAM principal with permissions to manage the database.
+{{ db }}. When a user connects to the database via Teleport, the Teleport
+Database Service obtains {{ cloud }} credentials and authenticates to
+{{ cloud }} as an IAM principal with permissions to manage the database.

--- a/docs/pages/includes/database-access/how-it-works/mtls.mdx
+++ b/docs/pages/includes/database-access/how-it-works/mtls.mdx
@@ -2,6 +2,6 @@ The Teleport Database Service authenticates to your self-hosted {{ db }}
 database using mutual TLS. {{ db }} trusts the Teleport certificate authority
 for database clients, and presents a certificate signed by either the Teleport
 database CA or a custom CA. When a user initiates a database session, the
-Database Service presents a certificate signed by Teleport. The authenticated
-connection then proxies client traffic from the user.
+Teleport Database Service presents a certificate signed by Teleport. The
+authenticated connection then proxies client traffic from the user.
 

--- a/docs/pages/includes/database-access/self-hosted-introduction.mdx
+++ b/docs/pages/includes/database-access/self-hosted-introduction.mdx
@@ -1,4 +1,4 @@
-Teleport can provide secure access to {{ dbName }} via the  [Teleport Database
+Teleport can provide secure access to {{ dbType }} via the [Teleport Database
 Service](../../database-access/introduction.mdx). This allows for fine-grained
 access control through the [Teleport RBAC
 system](../../database-access/rbac.mdx).


### PR DESCRIPTION
This PR updates the introduction snippets for database guides.

I simplified the snippets and removed some redundant parameters.

I also changed the cockroach and redis cluster guides to use the "self hosted" variant of the intro.