### PR TITLE
Cleanup code relegated for deletion in v16

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -884,18 +884,6 @@ func (c *Client) CreateUser(ctx context.Context, user types.User) (types.User, e
 
 	resp, err := userspb.NewUsersServiceClient(c.conn).CreateUser(ctx, &userspb.CreateUserRequest{User: userV2})
 	if err != nil {
-		// TODO(tross): DELETE IN 16.0.0
-		if trace.IsNotImplemented(err) {
-			//nolint:staticcheck // SA1019. Kept for backward compatibility.
-			if _, err := c.grpc.CreateUser(ctx, userV2); err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			//nolint:staticcheck // SA1019. Kept for backward compatibility.
-			created, err := c.grpc.GetUser(ctx, &proto.GetUserRequest{Name: user.GetName()})
-			return created, trace.Wrap(err)
-		}
-
 		return nil, trace.Wrap(err)
 	}
 
@@ -926,18 +914,6 @@ func (c *Client) UpdateUser(ctx context.Context, user types.User) (types.User, e
 
 	resp, err := userspb.NewUsersServiceClient(c.conn).UpdateUser(ctx, &userspb.UpdateUserRequest{User: userV2})
 	if err != nil {
-		// TODO(tross): DELETE IN 16.0.0
-		if trace.IsNotImplemented(err) {
-			//nolint:staticcheck // SA1019. Kept for backward compatibility.
-			if _, err := c.grpc.UpdateUser(ctx, userV2); err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			//nolint:staticcheck // SA1019. Kept for backward compatibility.
-			updated, err := c.grpc.GetUser(ctx, &proto.GetUserRequest{Name: user.GetName()})
-			return updated, trace.Wrap(err)
-		}
-
 		return nil, trace.Wrap(err)
 	}
 
@@ -952,16 +928,6 @@ func (c *Client) GetUser(ctx context.Context, name string, withSecrets bool) (ty
 	}
 	resp, err := userspb.NewUsersServiceClient(c.conn).GetUser(ctx, &userspb.GetUserRequest{Name: name, WithSecrets: withSecrets})
 	if err != nil {
-		// TODO(tross): DELETE IN 16.0.0
-		if trace.IsNotImplemented(err) {
-			//nolint:staticcheck // SA1019. Kept for backward compatibility.
-			user, err := c.grpc.GetUser(ctx, &proto.GetUserRequest{
-				Name:        name,
-				WithSecrets: withSecrets,
-			})
-			return user, trace.Wrap(err)
-		}
-
 		return nil, trace.Wrap(err)
 	}
 	return resp.User, nil
@@ -972,12 +938,6 @@ func (c *Client) GetUser(ctx context.Context, name string, withSecrets bool) (ty
 func (c *Client) GetCurrentUser(ctx context.Context) (types.User, error) {
 	resp, err := userspb.NewUsersServiceClient(c.conn).GetUser(ctx, &userspb.GetUserRequest{CurrentUser: true})
 	if err != nil {
-		// TODO(tross): DELETE IN 16.0.0
-		if trace.IsNotImplemented(err) {
-			//nolint:staticcheck // SA1019. Kept for backward compatibility.
-			currentUser, err := c.grpc.GetCurrentUser(ctx, &emptypb.Empty{})
-			return currentUser, trace.Wrap(err)
-		}
 		return nil, trace.Wrap(err)
 	}
 	return resp.User, nil
@@ -1010,11 +970,6 @@ func (c *Client) GetUsers(ctx context.Context, withSecrets bool) ([]types.User, 
 	for {
 		rsp, err := c.ListUsers(ctx, &req)
 		if err != nil {
-			// TODO(tross): DELETE IN 16.0.0
-			if trace.IsNotImplemented(err) {
-				return c.getUsersCompat(ctx, withSecrets)
-			}
-
 			return nil, trace.Wrap(err)
 		}
 
@@ -1029,26 +984,6 @@ func (c *Client) GetUsers(ctx context.Context, withSecrets bool) ([]types.User, 
 	}
 
 	return out, nil
-}
-
-// getUsersCompat is a fallback used to load users when talking to older auth servers that
-// don't implement the newer ListUsers method.
-func (c *Client) getUsersCompat(ctx context.Context, withSecrets bool) ([]types.User, error) {
-	//nolint:staticcheck // SA1019. Kept for backward compatibility.
-	stream, err := c.grpc.GetUsers(ctx, &proto.GetUsersRequest{
-		WithSecrets: withSecrets,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var users []types.User
-	for user, err := stream.Recv(); !errors.Is(err, io.EOF); user, err = stream.Recv() {
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		users = append(users, user)
-	}
-	return users, nil
 }
 
 // ListUsers returns a page of users.
@@ -1085,13 +1020,6 @@ func (c *Client) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (
 // DeleteUser deletes a user by name.
 func (c *Client) DeleteUser(ctx context.Context, user string) error {
 	_, err := userspb.NewUsersServiceClient(c.conn).DeleteUser(ctx, &userspb.DeleteUserRequest{Name: user})
-	// TODO(tross): DELETE IN 16.0.0
-	if trace.IsNotImplemented(err) {
-		//nolint:staticcheck // SA1019. Kept for backward compatibility.
-		_, err := c.grpc.DeleteUser(ctx, &proto.DeleteUserRequest{Name: user})
-		return trace.Wrap(err)
-	}
-
 	return trace.Wrap(err)
 }
 
@@ -1987,25 +1915,6 @@ func (c *Client) UpsertOIDCConnector(ctx context.Context, oidcConnector types.OI
 	}
 
 	upserted, err := c.grpc.UpsertOIDCConnectorV2(ctx, &proto.UpsertOIDCConnectorRequest{Connector: connector})
-	// TODO(tross) DELETE IN 16.0.0
-	if err != nil && trace.IsNotImplemented(err) {
-		//nolint:staticcheck // SA1019. Kept for backward compatibility.
-		if _, err := c.grpc.UpsertOIDCConnector(ctx, connector); err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		conn, err := c.GetOIDCConnector(ctx, oidcConnector.GetName(), false)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		// Override the secrets with the values from the passed in connector since
-		// the call to GetOIDCConnector above did not request secrets.
-		conn.SetClientSecret(connector.GetClientSecret())
-		conn.SetGoogleServiceAccount(connector.GetGoogleServiceAccount())
-
-		return conn, nil
-	}
 	return upserted, trace.Wrap(err)
 }
 
@@ -2092,23 +2001,6 @@ func (c *Client) UpsertSAMLConnector(ctx context.Context, connector types.SAMLCo
 	}
 
 	upserted, err := c.grpc.UpsertSAMLConnectorV2(ctx, &proto.UpsertSAMLConnectorRequest{Connector: samlConnector})
-	// TODO(tross) DELETE IN 16.0.0
-	if err != nil && trace.IsNotImplemented(err) {
-		//nolint:staticcheck // SA1019. Kept for backward compatibility.
-		if _, err := c.grpc.UpsertSAMLConnector(ctx, samlConnector); err != nil {
-			return nil, trace.Wrap(err)
-		}
-		conn, err := c.GetSAMLConnector(ctx, samlConnector.GetName(), false)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		// Override the secrets with the values from the passed in connector since
-		// the call to GetSAMLConnector above did not request secrets.
-		conn.SetSigningKeyPair(connector.GetSigningKeyPair())
-
-		return conn, nil
-	}
 	return upserted, trace.Wrap(err)
 }
 
@@ -2194,24 +2086,6 @@ func (c *Client) UpsertGithubConnector(ctx context.Context, connector types.Gith
 		return nil, trace.BadParameter("invalid type %T", connector)
 	}
 	conn, err := c.grpc.UpsertGithubConnectorV2(ctx, &proto.UpsertGithubConnectorRequest{Connector: githubConnector})
-	// TODO(tross) DELETE IN 16.0.0
-	if err != nil && trace.IsNotImplemented(err) {
-		//nolint:staticcheck // SA1019. Kept for backward compatibility testing.
-		if _, err := c.grpc.UpsertGithubConnector(ctx, githubConnector); err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		resp, err := c.grpc.GetGithubConnector(ctx, &types.ResourceWithSecretsRequest{Name: connector.GetName(), WithSecrets: false})
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		// Override the client secret with the value from the passed in connector since
-		// the call to GetGithubConnector above did not request secrets.
-		resp.SetClientSecret(connector.GetClientSecret())
-
-		return resp, nil
-	}
 	return conn, trace.Wrap(err)
 }
 

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -115,7 +115,7 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.POST("/:version/authorities/:type/rotate/external", srv.WithAuth(srv.rotateExternalCertAuthority))
 
 	// Operations on users
-	// TODO(tross): DELETE IN 16.0.0
+	// TODO(tross): DELETE IN 17.0.0
 	srv.POST("/:version/users", srv.WithAuth(srv.upsertUser))
 
 	// Passwords and sessions

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2661,7 +2661,7 @@ func (a *ServerWithRoles) DeleteAccessRequest(ctx context.Context, name string) 
 }
 
 // GetUsers returns all existing users
-// TODO(tross): DELETE IN 16.0.0
+// TODO(tross): DELETE IN 17.0.0
 // Deprecated: use [usersv1.Service.ListUsers] instead.
 func (a *ServerWithRoles) GetUsers(ctx context.Context, withSecrets bool) ([]types.User, error) {
 	if withSecrets {
@@ -3338,7 +3338,7 @@ func (a *ServerWithRoles) trySettingConnectorNameToPasswordless(ctx context.Cont
 
 // UpdateUser updates an existing user in a backend.
 // Captures the auth user who modified the user record.
-// TODO(tross): DELETE IN 16.0.0
+// TODO(tross): DELETE IN 17.0.0
 // Deprecated: use [usersv1.Service.UpdateUser] instead.
 func (a *ServerWithRoles) UpdateUser(ctx context.Context, user types.User) (types.User, error) {
 	if err := a.action(apidefaults.Namespace, types.KindUser, types.VerbUpdate); err != nil {
@@ -3358,7 +3358,7 @@ func (a *ServerWithRoles) UpdateUser(ctx context.Context, user types.User) (type
 }
 
 // UpsertUser create or updates an existing user.
-// TODO(tross): DELETE IN 16.0.0
+// TODO(tross): DELETE IN 17.0.0
 // Deprecated: use [usersv1.Service.UpdateUser] instead.
 func (a *ServerWithRoles) UpsertUser(ctx context.Context, u types.User) (types.User, error) {
 	if err := a.action(apidefaults.Namespace, types.KindUser, types.VerbCreate, types.VerbUpdate); err != nil {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -529,31 +529,6 @@ func (c *Client) IntegrationAWSOIDCClient() integrationv1.AWSOIDCServiceClient {
 	return integrationv1.NewAWSOIDCServiceClient(c.APIClient.GetConnection())
 }
 
-// UpsertUser user updates user entry.
-// TODO(tross): DELETE IN 16.0.0
-func (c *Client) UpsertUser(ctx context.Context, user types.User) (types.User, error) {
-	upserted, err := c.APIClient.UpsertUser(ctx, user)
-	if err == nil {
-		return upserted, nil
-	}
-
-	if !trace.IsNotImplemented(err) {
-		return nil, trace.Wrap(err)
-	}
-
-	data, err := services.MarshalUser(user)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	_, err = c.HTTPClient.PostJSON(ctx, c.Endpoint("users"), &upsertUserRawReq{User: data})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	upserted, err = c.GetUser(ctx, user.GetName(), false)
-	return upserted, trace.Wrap(err)
-}
-
 // DiscoveryConfigClient returns a client for managing the DiscoveryConfig resource.
 func (c *Client) DiscoveryConfigClient() services.DiscoveryConfigWithStatusUpdater {
 	return c.APIClient.DiscoveryConfigClient()

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -144,7 +144,7 @@ type GRPCServer struct {
 
 	// usersService is used to forward deprecated users requests to
 	// the new service so that logic only needs to exist in one place.
-	// TODO(tross) DELETE IN 16.0.0
+	// TODO(tross) DELETE IN 17.0.0
 	usersService *usersv1.Service
 
 	// botService is used to forward requests to deprecated bot RPCs to the
@@ -822,7 +822,7 @@ func (g *GRPCServer) ClearAlertAcks(ctx context.Context, req *authpb.ClearAlertA
 }
 
 // GetUser returns a user matching the provided name if one exists.
-// TODO(tross): DELETE IN 16.0.0
+// TODO(tross): DELETE IN 17.0.0
 // Deprecated: use [usersv1.Service.GetUser] instead.
 func (g *GRPCServer) GetUser(ctx context.Context, req *authpb.GetUserRequest) (*types.UserV2, error) {
 	resp, err := g.usersService.GetUser(ctx, &userspb.GetUserRequest{Name: req.Name, WithSecrets: req.WithSecrets})
@@ -834,7 +834,7 @@ func (g *GRPCServer) GetUser(ctx context.Context, req *authpb.GetUserRequest) (*
 }
 
 // GetCurrentUser returns the currently authenticated user.
-// TODO(tross): DELETE IN 16.0.0
+// TODO(tross): DELETE IN 17.0.0
 // Deprecated: use [usersv1.Service.GetUser] instead.
 func (g *GRPCServer) GetCurrentUser(ctx context.Context, req *emptypb.Empty) (*types.UserV2, error) {
 	resp, err := g.usersService.GetUser(ctx, &userspb.GetUserRequest{CurrentUser: true})
@@ -868,7 +868,7 @@ func (g *GRPCServer) GetCurrentUserRoles(_ *emptypb.Empty, stream authpb.AuthSer
 }
 
 // GetUsers returns all users.
-// TODO(tross): DELETE IN 16.0.0
+// TODO(tross): DELETE IN 17.0.0
 // Deprecated: use [usersv1.Service.ListUsers] instead.
 func (g *GRPCServer) GetUsers(req *authpb.GetUsersRequest, stream authpb.AuthService_GetUsersServer) error {
 	auth, err := g.authenticate(stream.Context())
@@ -1163,7 +1163,7 @@ func (g *GRPCServer) Ping(ctx context.Context, req *authpb.PingRequest) (*authpb
 }
 
 // CreateUser inserts a new user entry in a backend.
-// TODO(tross): DELETE IN 16.0.0
+// TODO(tross): DELETE IN 17.0.0
 // Deprecated: use [usersv1.Service.CreateUser] instead.
 func (g *GRPCServer) CreateUser(ctx context.Context, req *types.UserV2) (*emptypb.Empty, error) {
 	resp, err := g.usersService.CreateUser(ctx, &userspb.CreateUserRequest{User: req})
@@ -1180,7 +1180,7 @@ func (g *GRPCServer) CreateUser(ctx context.Context, req *types.UserV2) (*emptyp
 // users service like other user CRUD methods to preserve update semantics.
 // This results in all updates blindly overwriting the existing user. Updating
 // users with [usersv1.Service.UpdateUser] is protected by optimistic locking.
-// TODO(tross): DELETE IN 16.0.0
+// TODO(tross): DELETE IN 17.0.0
 // Deprecated: use [usersv1.Service.UpdateUser] instead.
 func (g *GRPCServer) UpdateUser(ctx context.Context, req *types.UserV2) (*emptypb.Empty, error) {
 	auth, err := g.authenticate(ctx)

--- a/lib/auth/user.go
+++ b/lib/auth/user.go
@@ -38,7 +38,7 @@ import (
 )
 
 // CreateUser inserts a new user entry in a backend.
-// TODO(tross): DELETE IN 16.0.0
+// TODO(tross): DELETE IN 17.0.0
 // Deprecated: use [usersv1.Service.CreateUser] instead.
 func (a *Server) CreateUser(ctx context.Context, user types.User) (types.User, error) {
 	if user.GetCreatedBy().IsEmpty() {
@@ -83,7 +83,7 @@ func (a *Server) CreateUser(ctx context.Context, user types.User) (types.User, e
 }
 
 // UpdateUser updates an existing user in a backend.
-// TODO(tross): DELETE IN 16.0.0
+// TODO(tross): DELETE IN 17.0.0
 // Deprecated: use [usersv1.Service.UpdateUser] instead.
 func (a *Server) UpdateUser(ctx context.Context, user types.User) (types.User, error) {
 	prevUser, err := a.GetUser(ctx, user.GetName(), false)
@@ -145,7 +145,7 @@ func (a *Server) UpdateUser(ctx context.Context, user types.User) (types.User, e
 }
 
 // UpsertUser updates a user.
-// TODO(tross): DELETE IN 16.0.0
+// TODO(tross): DELETE IN 17.0.0
 // Deprecated: use [usersv1.Service.UpsertUser] instead.
 func (a *Server) UpsertUser(ctx context.Context, user types.User) (types.User, error) {
 	prevUser, err := a.GetUser(ctx, user.GetName(), false)
@@ -239,7 +239,7 @@ func (a *Server) CompareAndSwapUser(ctx context.Context, new, existing types.Use
 }
 
 // DeleteUser deletes an existing user in a backend by username.
-// TODO(tross): DELETE IN 16.0.0
+// TODO(tross): DELETE IN 17.0.0
 // Deprecated: use [usersv1.Service.DeleteUser] instead.
 func (a *Server) DeleteUser(ctx context.Context, user string) error {
 	prevUser, err := a.GetUser(ctx, user, false)

--- a/lib/services/configuration.go
+++ b/lib/services/configuration.go
@@ -83,7 +83,6 @@ type ClusterConfiguration interface {
 	// UpsertClusterAuditConfig creates a new cluster audit config or overwrites the existing cluster audit config.
 	UpsertClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error)
 	// SetClusterAuditConfig sets ClusterAuditConfig from the backend.
-	// TODO(tross): Deprecate/Remove this once everything is converted to use the new methods.
 	SetClusterAuditConfig(context.Context, types.ClusterAuditConfig) error
 	// DeleteClusterAuditConfig deletes ClusterAuditConfig from the backend.
 	DeleteClusterAuditConfig(ctx context.Context) error


### PR DESCRIPTION
Deletes the client fallback logic for users and auth connectors. The server side cleanup was punted to v17 to prevent any v14 clients from being unable to interact with a v16 control plane when trying to interact with users and auth connectors.