### PR TITLE
docs: updates recommendation for commercial editions help

### DIFF
--- a/docs/pages/management/admin/troubleshooting.mdx
+++ b/docs/pages/management/admin/troubleshooting.mdx
@@ -142,7 +142,8 @@ Teleport v9.0.4 git: go1.18
 
 <Tabs>
 <TabItem scope={["cloud", "enterprise","team"]} label="Commercial Teleport Editions">
-If you need help, please ask on our [community forum](https://github.com/gravitational/teleport/discussions). You can also open an [issue on GitHub](https://github.com/gravitational/teleport/issues) or create a ticket through your [Teleport account](https://teleport.sh).
+If you have a question or need assistance please submit a request 
+through the [Teleport support site](https://support.goteleport.com).
 
 </TabItem>
 <TabItem scope={["oss"]} label="Teleport Community Edition">

--- a/docs/pages/management/admin/troubleshooting.mdx
+++ b/docs/pages/management/admin/troubleshooting.mdx
@@ -143,7 +143,7 @@ Teleport v9.0.4 git: go1.18
 <Tabs>
 <TabItem scope={["cloud", "enterprise","team"]} label="Commercial Teleport Editions">
 If you have a question or need assistance please submit a request 
-through the [Teleport support site](https://support.goteleport.com).
+through the [Teleport support portal](https://support.goteleport.com).
 
 </TabItem>
 <TabItem scope={["oss"]} label="Teleport Community Edition">


### PR DESCRIPTION
Enterprise customers should use the support site, not first directed to community resources.