### PR TITLE
Clean up logging for cert generation

### DIFF
--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1194,10 +1194,11 @@ func (ca *CertAuthority) GenerateCertificate(req CertificateRequest) ([]byte, er
 	}
 
 	log.WithFields(logrus.Fields{
-		"not_after": req.NotAfter,
-		"dns_names": req.DNSNames,
-		"key_usage": req.KeyUsage,
-	}).Infof("Generating TLS certificate %v", req.Subject.String())
+		"not_after":   req.NotAfter,
+		"dns_names":   req.DNSNames,
+		"key_usage":   req.KeyUsage,
+		"common_name": req.Subject.CommonName,
+	}).Debug("Generating TLS certificate")
 
 	template := &x509.Certificate{
 		SerialNumber: serialNumber,


### PR DESCRIPTION
On a busy cluster, Teleport can issue hundreds or even thousands of TLS certificates in a short period of time. This can clutter the logs and make troubleshooting difficult.

- Decrease the severity from INFO to DEBUG
- Log only the common name, not the full subject

Before:

```
Generating TLS certificate 1.3.9999.1.15=#13046e6f6e65,1.3.9999.1.9=#13093132372e302e302e31,1.3.9999.1.7=#13097a61632d6c6f63616c,1.3.9999.1.2=#130e73797374656d3a6d617374657273,CN=zac,O=access+O=auditor+O=editor+O=requester,POSTALCODE={\"aws_role_arns\":null\,\"db_names\":null\,\"db_users\":null\,\"kubernetes_groups\":null\,\"kubernetes_users\":null\,\"logins\":[\"zmb\"]\,\"windows_logins\":[\"Administrator\"]},STREET=zac-local,L=zmb+L=doesnotexist+L=-teleport-internal-join dns_names:[] key_usage:5 not_after:2024-05-14 03:11:03.562838 +0000 UTC tlsca/ca.go:1200
```

After:
```
Generating TLS certificate common_name:zac dns_names:[] key_usage:5 not_after:2024-05-14 03:16:09.912425 +0000 UTC tlsca/ca.go:1201
```