### PR TITLE
[v15] Fix auto approval with duplicated service names + increase PD timeout

### DIFF
--- a/integrations/access/common/annotations.go
+++ b/integrations/access/common/annotations.go
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package common
 
 import (

--- a/integrations/access/common/annotations.go
+++ b/integrations/access/common/annotations.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"slices"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// GetServiceNamesFromAnnotations reads systems annotations from an access
+// requests and returns the services to notify/use for approval.
+// The list is sorted and duplicates are removed.
+func GetServiceNamesFromAnnotations(req types.AccessRequest, annotationKey string) ([]string, error) {
+	serviceNames, ok := req.GetSystemAnnotations()[annotationKey]
+	if !ok {
+		return nil, trace.NotFound("request annotation %s is missing", annotationKey)
+	}
+	if len(serviceNames) == 0 {
+		return nil, trace.BadParameter("request annotation %s is present but empty", annotationKey)
+	}
+	slices.Sort(serviceNames)
+	return slices.Compact(serviceNames), nil
+}

--- a/integrations/access/common/annotations_test.go
+++ b/integrations/access/common/annotations_test.go
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package common
 
 import (

--- a/integrations/access/common/annotations_test.go
+++ b/integrations/access/common/annotations_test.go
@@ -1,0 +1,65 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestGetServiceNamesFromAnnotations(t *testing.T) {
+	testAnnotationKey := "test-key"
+	tests := []struct {
+		name        string
+		annotations map[string][]string
+		want        []string
+		assertErr   require.ErrorAssertionFunc
+	}{
+		{
+			name:        "Returns 'not found' when annotation is not present",
+			annotations: map[string][]string{"other-key": {"foo", "bar"}},
+			want:        nil,
+			assertErr: func(t require.TestingT, err error, i ...interface{}) {
+				expectedErr := &trace.NotFoundError{}
+				require.ErrorAs(t, err, &expectedErr)
+			},
+		},
+		{
+			name:        "Returns 'bad parameter' when annotation is empty",
+			annotations: map[string][]string{"test-key": nil},
+			want:        nil,
+			assertErr: func(t require.TestingT, err error, i ...interface{}) {
+				expectedErr := &trace.BadParameterError{}
+				require.ErrorAs(t, err, &expectedErr)
+			},
+		},
+		{
+			name:        "Single service name",
+			annotations: map[string][]string{"test-key": {"foo"}},
+			want:        []string{"foo"},
+			assertErr:   require.NoError,
+		},
+		{
+			name:        "Multiple service names",
+			annotations: map[string][]string{"test-key": {"foo", "bar"}},
+			want:        []string{"foo", "bar"},
+			assertErr:   require.NoError,
+		},
+		{
+			name:        "Duplicated service names are deduplicated",
+			annotations: map[string][]string{"test-key": {"foo", "bar", "foo", "bar"}},
+			want:        []string{"foo", "bar"},
+			assertErr:   require.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := &types.AccessRequestV3{Spec: types.AccessRequestSpecV3{SystemAnnotations: tt.annotations}}
+			got, err := GetServiceNamesFromAnnotations(request, testAnnotationKey)
+			tt.assertErr(t, err)
+			require.ElementsMatch(t, tt.want, got)
+		})
+	}
+}

--- a/integrations/access/opsgenie/app.go
+++ b/integrations/access/opsgenie/app.go
@@ -31,6 +31,7 @@ import (
 	tp "github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/backoff"
@@ -274,19 +275,13 @@ func (a *App) onDeletedRequest(ctx context.Context, reqID string) error {
 }
 
 func (a *App) getNotifyServiceNames(req types.AccessRequest) ([]string, error) {
-	services, ok := req.GetSystemAnnotations()[types.TeleportNamespace+types.ReqAnnotationNotifySchedulesLabel]
-	if !ok {
-		return nil, trace.NotFound("notify services not specified")
-	}
-	return services, nil
+	annotationKey := types.TeleportNamespace + types.ReqAnnotationNotifySchedulesLabel
+	return common.GetServiceNamesFromAnnotations(req, annotationKey)
 }
 
 func (a *App) getOnCallServiceNames(req types.AccessRequest) ([]string, error) {
-	services, ok := req.GetSystemAnnotations()[types.TeleportNamespace+types.ReqAnnotationApproveSchedulesLabel]
-	if !ok {
-		return nil, trace.NotFound("on-call schedules not specified")
-	}
-	return services, nil
+	annotationKey := types.TeleportNamespace + types.ReqAnnotationApproveSchedulesLabel
+	return common.GetServiceNamesFromAnnotations(req, annotationKey)
 }
 
 func (a *App) tryNotifyService(ctx context.Context, req types.AccessRequest) (bool, error) {

--- a/integrations/access/servicenow/app.go
+++ b/integrations/access/servicenow/app.go
@@ -49,7 +49,7 @@ const (
 	// initTimeout is used to bound execution time of health check and teleport version check.
 	initTimeout = time.Second * 10
 	// handlerTimeout is used to bound the execution time of watcher event handler.
-	handlerTimeout = time.Second * 5
+	handlerTimeout = time.Second * 30
 	// modifyPluginDataBackoffBase is an initial (minimum) backoff value.
 	modifyPluginDataBackoffBase = time.Millisecond
 	// modifyPluginDataBackoffMax is a backoff threshold
@@ -316,11 +316,8 @@ func (a *App) onDeletedRequest(ctx context.Context, reqID string) error {
 }
 
 func (a *App) getOnCallServiceNames(req types.AccessRequest) ([]string, error) {
-	services, ok := req.GetSystemAnnotations()[types.TeleportNamespace+types.ReqAnnotationApproveSchedulesLabel]
-	if !ok {
-		return nil, trace.NotFound("on-call schedules not specified")
-	}
-	return services, nil
+	annotationKey := types.TeleportNamespace + types.ReqAnnotationApproveSchedulesLabel
+	return common.GetServiceNamesFromAnnotations(req, annotationKey)
 }
 
 // createIncident posts an incident with request information.


### PR DESCRIPTION
Backport #41477 to branch/v15

changelog: Fix a bug in the PagerDuty, Opgenie and ServiceNow access plugins that were doing duplicate calls when access requests containing duplicate service names. Also increases the timeout so slow external API requests are less likely to fail.
