### PR TITLE
Simplify some `Tabs` component uses

### DIFF
--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -102,105 +102,99 @@ will be able to act as a system administrator and auditor at the same time.
 Next, follow the instructions to set up an authentication connector that maps
 users within your SSO solution to Teleport roles.
 
+### Teleport Enterprise
+
+Create a SAML or OIDC application that Teleport can integrate with, then
+create an authentication connector that maps users within your application to
+Teleport roles.
+
 <Tabs>
-  <TabItem label="Teleport Community Edition" scope={["oss"]}>
+<TabItem label="SAML">
 
-    Save the file below as `github.yaml` and update the fields. You will need to
-    set up a
-    [GitHub OAuth 2.0 Connector](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/)
-    app. Any member belonging to the GitHub organization `octocats` and on team
-    `admin` will be able to assume the built-in role `access`.
+Follow our [SAML Okta Guide](./sso/okta.mdx) to
+create a SAML application.
 
-    ```yaml
-    kind: github
-    version: v3
-    metadata:
-      # connector name that will be used with `tsh --auth=github login`
-      name: github
-    spec:
-      # client ID of GitHub OAuth app
-      client_id: client-id
-      # client secret of GitHub OAuth app
-      client_secret: client-secret
-      # This name will be shown on UI login screen
-      display: GitHub
-      # Change tele.example.com to your domain name
-      redirect_url: https://tele.example.com:443/v1/webapi/github/callback
-      # Map github teams to teleport roles
-      teams_to_roles:
-        - organization: octocats # GitHub organization name
-          team: admin            # GitHub team name within that organization
-          # map github admin team to Teleport's "access" role
-          roles: ["access"]
-    ```
+Save the file below as `okta.yaml` and update the `acs` field.
+Any member in Okta group `okta-admin` will assume a built-in role `admin`.
 
-    Create the `github` resource:
+```yaml
+kind: saml
+version: v2
+metadata:
+  name: okta
+spec:
+  acs: https://tele.example.com/v1/webapi/saml/acs
+  attributes_to_roles:
+  - {name: "groups", value: "okta-admin", roles: ["access"]}
+  entity_descriptor: |
+    <?xml !!! Make sure to shift all lines in XML descriptor
+    with 4 spaces, otherwise things will not work
+```
 
-    ```code
-    $ tctl create github.yaml
-    ```
+Create the `saml` resource:
 
-  </TabItem>
+```code
+$ tctl create okta.yaml
+```
 
-  <TabItem label="Commercial Editions"  scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem label="OIDC">
 
-  Create a SAML or OIDC application that Teleport can integrate with, then
-  create an authentication connector that maps users within your application to
-  Teleport roles.
+Follow our [OIDC guides](./sso/oidc.mdx#identity-providers) to
+create an OIDC application.
 
-  <Tabs>
-  <TabItem label="SAML">
+Copy the YAML below to a file called `oidc.yaml` and edit the information to
+include the details of your OIDC application.
 
-  Follow our [SAML Okta Guide](./sso/okta.mdx) to
-  create a SAML application.
+```yaml
+(!examples/resources/oidc-connector.yaml!)
+```
 
-  Save the file below as `okta.yaml` and update the `acs` field.
-  Any member in Okta group `okta-admin` will assume a built-in role `admin`.
+Create the `oidc` resource:
 
-  ```yaml
-  kind: saml
-  version: v2
-  metadata:
-    name: okta
-  spec:
-    acs: https://tele.example.com/v1/webapi/saml/acs
-    attributes_to_roles:
-    - {name: "groups", value: "okta-admin", roles: ["access"]}
-    entity_descriptor: |
-      <?xml !!! Make sure to shift all lines in XML descriptor
-      with 4 spaces, otherwise things will not work
-  ```
+```code
+$ tctl create okta.yaml
+```
 
-  Create the `saml` resource:
-
-  ```code
-  $ tctl create okta.yaml
-  ```
-
-  </TabItem>
-  <TabItem label="OIDC">
-
-  Follow our [OIDC guides](./sso/oidc.mdx#identity-providers) to
-  create an OIDC application.
-
-  Copy the YAML below to a file called `oidc.yaml` and edit the information to
-  include the details of your OIDC application.
-
-  ```yaml
-  (!examples/resources/oidc-connector.yaml!)
-  ```
-
-  Create the `oidc` resource:
-
-  ```code
-  $ tctl create okta.yaml
-  ```
-
-  </TabItem>
-  </Tabs>
-
-  </TabItem>
+</TabItem>
 </Tabs>
+
+### Teleport Community Edition
+
+Save the file below as `github.yaml` and update the fields. You will need to
+set up a
+[GitHub OAuth 2.0 Connector](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/)
+app. Any member belonging to the GitHub organization `octocats` and on team
+`admin` will be able to assume the built-in role `access`.
+
+```yaml
+kind: github
+version: v3
+metadata:
+  # connector name that will be used with `tsh --auth=github login`
+  name: github
+spec:
+  # client ID of GitHub OAuth app
+  client_id: client-id
+  # client secret of GitHub OAuth app
+  client_secret: client-secret
+  # This name will be shown on UI login screen
+  display: GitHub
+  # Change tele.example.com to your domain name
+  redirect_url: https://tele.example.com:443/v1/webapi/github/callback
+  # Map github teams to teleport roles
+  teams_to_roles:
+    - organization: octocats # GitHub organization name
+      team: admin            # GitHub team name within that organization
+      # map github admin team to Teleport's "access" role
+      roles: ["access"]
+```
+
+Create the `github` resource:
+
+```code
+$ tctl create github.yaml
+```
 
 ## Step 3/3. Create a custom role
 

--- a/docs/pages/access-controls/guides/webauthn.mdx
+++ b/docs/pages/access-controls/guides/webauthn.mdx
@@ -266,57 +266,8 @@ auth_service:
       - "/path/to/u2f_attestation_ca.pem"
 ```
 
-The migrated WebAuthn configuration is:
-
-<Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-<Tabs>
-  <TabItem label="Static Config">
-
-    ```yaml
-    # snippet from /etc/teleport.yaml:
-    auth_service:
-      authentication:
-        type: local
-        second_factor: on # changed from "u2f"
-        u2f:
-          # Keep the app_id to avoid re-registering U2F devices.
-          app_id: https://example.com
-        webauthn:
-          # rp_id is the public domain of the Teleport Proxy Service.
-          # It's similar to the U2F app_id, but without "https://" or port number.
-          rp_id: example.com
-          attestation_allowed_cas:
-          - "/path/to/u2f_attestation_ca.pem"
-    ```
-
-  </TabItem>
-  <TabItem label="Dynamic resources">
-
-    ```yaml
-    kind: cluster_auth_preference
-    version: v2
-    metadata:
-      name: cluster-auth-preference
-    spec:
-      type: local
-      second_factor: "on" # changed from "u2f"
-      u2f:
-        # Keep the app_id to avoid re-registering U2F devices.
-        app_id: https://example.com
-      webauthn:
-        # rp_id is the public domain of the Teleport Proxy Service.
-        # It's similar to the U2F app_id, but without "https://" or port number.
-        rp_id: example.com
-        attestation_allowed_cas:
-        - "/path/to/u2f_attestation_ca.pem"
-    ```
-
-  </TabItem>
-</Tabs>
-</TabItem>
-
-<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
+You can replace this configuration with its WebAuthn equivalent using a
+`cluster_auth_preference` similar to the following:
 
 ```yaml
 kind: cluster_auth_preference
@@ -337,9 +288,25 @@ spec:
     - "/path/to/u2f_attestation_ca.pem"
 ```
 
-</TabItem>
+On a self-hosted cluster, you can configure WebAuthn with a Teleport Auth
+Service configuration similar to the following:
 
-</Tabs>
+```yaml
+# snippet from /etc/teleport.yaml:
+auth_service:
+  authentication:
+    type: local
+    second_factor: on # changed from "u2f"
+    u2f:
+      # Keep the app_id to avoid re-registering U2F devices.
+      app_id: https://example.com
+    webauthn:
+      # rp_id is the public domain of the Teleport Proxy Service.
+      # It's similar to the U2F app_id, but without "https://" or port number.
+      rp_id: example.com
+      attestation_allowed_cas:
+      - "/path/to/u2f_attestation_ca.pem"
+```
 
 ## Next steps
 

--- a/docs/pages/database-access/enroll-managed-databases/mongodb-atlas.mdx
+++ b/docs/pages/database-access/enroll-managed-databases/mongodb-atlas.mdx
@@ -45,9 +45,6 @@ Install Teleport on the host where you will run the Teleport Database Service:
 Next, start the Database Service.
 
 <Tabs>
-<TabItem scope={["enterprise","oss"]} label="Self-Hosted">
-
-<Tabs>
 <TabItem label="Teleport CLI">
 
 On the node where you will run the Database Service, start Teleport, pointing
@@ -56,7 +53,7 @@ the `--auth-server` flag at the address of your Teleport Proxy Service:
 ```code
 $ sudo teleport db start \
   --token=/tmp/token \
-  --auth-server=teleport.example.com:443 \
+  --auth-server=<Var name="example.teleport.sh:443" /> \
   --name=mongodb-atlas \
   --protocol=mongodb \
   --uri=mongodb+srv://cluster0.abcde.mongodb.net \
@@ -79,7 +76,7 @@ in `/etc/teleport.yaml`:
 version: v3
 teleport:
   auth_token: "/tmp/token"
-  proxy_server: teleport.example.com:443
+  proxy_server: <Var name="example.teleport.sh:443" />
 
 # disable services that are on by default
 ssh_service: { enabled: no }
@@ -94,7 +91,6 @@ db_service:
     uri: "mongodb+srv://cluster0.abcde.mongodb.net"
     static_labels:
       env: "dev"
-
 ```
 
 (!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
@@ -102,54 +98,6 @@ db_service:
 See the full [YAML reference](../reference/configuration.mdx) for details.
 
 </TabItem>
-</Tabs>
-</TabItem>
-
-<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
-<Tabs>
-<TabItem label="Teleport CLI">
-
-On the node where you will run the Database Service, start Teleport, pointing the
-`--auth-server` flag at the address of your Teleport Cloud tenant, e.g.,
-`mytenant.teleport.sh`.
-
-```code
-$ sudo teleport db start \
-  --token=/tmp/token \
-  --auth-server=mytenant.teleport.sh:443 \
-  --name=mongodb-atlas \
-  --protocol=mongodb \
-  --uri=mongodb+srv://cluster0.abcde.mongodb.net \
-  --labels=env=dev
-```
-
-</TabItem>
-<TabItem label="Configuration file">
-
-On the node where you will run the Teleport Database Service, run
-`teleport db start` with the following in `/etc/teleport.yaml`:
-
-```yaml
-version: v3
-teleport:
-  auth_token: "/tmp/token"
-  proxy_server: mytenant.teleport.sh:443
-db_service:
-  enabled: "yes"
-  databases:
-  - name: "mongodb-atlas"
-    protocol: "mongodb"
-    uri: "mongodb+srv://cluster0.abcde.mongodb.net"
-    static_labels:
-      env: "dev"
-```
-
-See the full [YAML reference](../reference/configuration.mdx) for details.
-
-</TabItem>
-</Tabs>
-</TabItem>
-
 </Tabs>
 
 See below for details on how to configure the Teleport Database Service.

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -764,11 +764,10 @@ chart.
 
 ## macOS
 
-<Tabs dropdownView dropdownCaption="Teleport Edition">
-<TabItem label="Community Edition" scope={["oss","team"]}>
-  <Tabs>
-  <TabItem label="Teleport package" >
-  You can download one of the following .pkg installers for macOS:
+<Tabs>
+<TabItem label="Community Edition">
+
+You can download one of the following .pkg installers for macOS:
 
   |Link|Binaries|
   |-|-|
@@ -789,55 +788,21 @@ chart.
   # /usr/local/bin/teleport
   ```
 
-</TabItem>
-<TabItem label="Homebrew">
+<Notice type="danger">
 
-  <Notice type="danger">
+We do not recommend using Homebrew to install Teleport.  The Teleport package in
+Homebrew is not maintained by Teleport and we can't guarantee its reliability or
+security.
 
-  The Teleport package in Homebrew is not maintained by Teleport and we can't
-  guarantee its reliability or security.
-
-  </Notice>
-
-  ### Warnings
-
-  We recommend the use of our [official
-  Teleport packages](https://goteleport.com/download). Binaries provided by Homebrew
-  are not signed by Teleport, so features that require signed and notarized binaries
-  (TouchID, Device Trust) are not available in Homebrew builds.
-
-  The `tctl` release available on Homebrew is the open source edition, and
-  cannot manage configuration resources unique to Teleport Enterprise and
-  Teleport Enterprise Cloud (e.g., OIDC and SAML connectors). For Teleport
-  Enterprise and Enterprise Cloud, we recommend installing the official Teleport
-  Enterprise edition of `tctl`.
-
-  ### Installing Teleport with Homebrew
-
-  To install Teleport with Homebrew, run the following command:
-
-  ```code
-  $ brew install teleport
-  ```
-
-  If you choose to use Homebrew, you must verify that the versions of `tsh`
-  and `tctl` you run on your local machine are compatible with the versions
-  you run on your infrastructure. Homebrew usually ships the latest release of
-  Teleport, which may be incompatible with older versions. See our
-  [compatibility policy](upgrading.mdx) for details.
-
-  To verify versions, log in to your cluster and compare the output of `tctl status`
-  against `tsh version` and `tctl version`.
+</Notice>
 
 </TabItem>
-</Tabs>
-</TabItem>
-<TabItem label="Enterprise" scope="enterprise">
+<TabItem label="Self-Hosted Enterprise">
 
 (!docs/pages/includes/enterprise/install-macos.mdx!)
 
 </TabItem>
-<TabItem label="Enterprise Cloud" scope="cloud">
+<TabItem label="Cloud-Hosted Enterprise">
 
 (!docs/pages/includes/cloud/install-macos.mdx!)
 

--- a/docs/pages/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/management/admin/uninstall-teleport.mdx
@@ -69,12 +69,22 @@ $ docker stop teleport
 
 ## Step 2/3. Remove Teleport binaries
 
-<Tabs dropdownView dropdownCaption="Teleport Edition">
-  <TabItem label="Teleport Community Edition" scope="oss">
-  <Tabs>
+Follow the steps for your operating system to remove Teleport binaries.
+
+### Linux
+
+Follow the instructions for your Linux distribution:
+
+<Tabs>
   <TabItem label="Debian/Ubuntu Linux (DEB)">
 
   Uninstall the Teleport binary using APT:
+
+  ```code
+  $ sudo apt-get -y remove teleport-ent
+  ```
+
+  For Teleport Community Edition, use the following command:
 
   ```code
   $ sudo apt-get -y remove teleport
@@ -90,119 +100,8 @@ $ docker stop teleport
   If the commands above do not work, you may have installed Teleport using a standalone DEB package. Remove it with:
 
   ```code
-  $ sudo dpkg -r teleport
-  ```
-  </Admonition>
-
-  </TabItem>
-  <TabItem label="Amazon Linux 2/RHEL (RPM)">
-
-  Uninstall the Teleport binary using YUM:
-
-  ```code
-  $ sudo yum -y remove teleport
-  # Optional: Use DNF on newer distributions
-  # $ sudo dnf -y remove teleport
-  ```
-
-  Uninstall the Teleport YUM repo:
-
-  ```code
-  $ sudo rm -f /etc/yum.repos.d/teleport.repo
-  ```
-
-  <Admonition type="notice" title="Uninstall standalone RPM package">
-  If the commands above do not work, you may have installed Teleport using a standalone RPM package. Remove it with:
-
-  ```code
-  $ sudo rpm -e teleport
-  ```
-  </Admonition>
-
-  </TabItem>
-  <TabItem label="Linux Tarball">
-
-  <Admonition type="notice">
-  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
-  You can use `dirname $(which teleport)` to look this up automatically.
-  </Admonition>
-
-  Remove the Teleport binaries from the machine:
-
-  ```code
-  $ sudo rm -f /usr/local/bin/tbot
-  $ sudo rm -f /usr/local/bin/tctl
-  $ sudo rm -f /usr/local/bin/teleport
-  $ sudo rm -f /usr/local/bin/tsh
-  ```
-
-  </TabItem>
-  <TabItem label="MacOS">
-
-  <Admonition type="notice">
-  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
-  You can use `dirname $(which teleport)` to look this up automatically.
-  </Admonition>
-
-  Remove the Teleport binaries from the machine:
-
-  ```code
-  $ sudo rm -f /usr/local/bin/tbot
-  $ sudo rm -f /usr/local/bin/tctl
-  $ sudo rm -f /usr/local/bin/teleport
-  $ sudo rm -f /usr/local/bin/tsh
-  ```
-
-  <Admonition type="notice" title="Uninstall MacOS client tools">
-  If you installed the MacOS `tsh`-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
-
-  ```code
-  $ sudo rm -rf /Applications/tsh.app
-  $ sudo rm -rf /Applications/Teleport\ Connect.app
-  ```
-  </Admonition>
-
-  </TabItem>
-  <TabItem label="Windows">
-
-  Remove the `tsh.exe` binary from the machine:
-
-  ```code
-  $ del C:\Path\To\tsh.exe
-  ```
-
-(!docs/pages/includes/uninstall-teleport-connect-windows.mdx!)
-
-  </TabItem>
-  </Tabs>
-  </TabItem>
-  <TabItem label="Enterprise" scope="enterprise">
-
-  <Tabs>
-  <TabItem label="Debian/Ubuntu Linux (DEB)">
-
-  Uninstall the Teleport binary using APT:
-
-  ```code
-  $ sudo apt-get -y remove teleport-ent
-  # Optional: If using the Teleport FIPS package
-  # $ sudo apt-get -y remove teleport-ent-fips
-  ```
-
-  Uninstall the Teleport APT repo:
-
-  ```code
-  $ sudo rm -f /etc/apt/sources.list.d/teleport.list
-  ```
-
-  <Admonition type="notice" title="Uninstall standalone DEB package">
-  If the commands above do not work, you may have installed Teleport using a standalone DEB package. Remove it with:
-
-  ```code
-  # Enterprise
+  # Use "teleport" instead of "teleport-ent" for Teleport Community Edition
   $ sudo dpkg -r teleport-ent
-  # Enterprise FIPS
-  # $ sudo dpkg -r teleport-ent-fips
   ```
   </Admonition>
 
@@ -212,12 +111,10 @@ $ docker stop teleport
   Uninstall the Teleport binary using YUM:
 
   ```code
+  # Change the package name to "teleport" for Teleport Community Edition
   $ sudo yum -y remove teleport-ent
   # Optional: Use DNF on newer distributions
   # $ sudo dnf -y remove teleport-ent
-  # Optional: If using the Teleport FIPS package
-  # $ sudo yum -y remove teleport-ent-fips
-  # $ sudo dnf -y remove teleport-ent-fips
   ```
 
   Uninstall the Teleport YUM repo:
@@ -230,10 +127,8 @@ $ docker stop teleport
   If the commands above do not work, you may have installed Teleport using a standalone RPM package. Remove it with:
 
   ```code
-  # Enterprise
+  # Use "teleport" for Teleport Community Edition
   $ sudo rpm -e teleport-ent
-  # Enterprise FIPS
-  # $ sudo rpm -e teleport-ent-fips
   ```
   </Admonition>
 
@@ -254,162 +149,43 @@ $ docker stop teleport
   $ sudo rm -f /usr/local/bin/tsh
   ```
 
-  </TabItem>
-  <TabItem label="MacOS">
-
-  <Admonition type="notice">
-  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
-  You can use `dirname $(which teleport)` to look this up automatically.
-  </Admonition>
-
-  Remove the Teleport binaries from the machine:
-
-  ```code
-  $ sudo rm -f /usr/local/bin/tbot
-  $ sudo rm -f /usr/local/bin/tctl
-  $ sudo rm -f /usr/local/bin/teleport
-  $ sudo rm -f /usr/local/bin/tsh
-  ```
-
-  <Admonition type="notice" title="Uninstall MacOS client tools">
-  If you installed the MacOS `tsh` client-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
-
-  ```code
-  $ sudo rm -rf /Applications/tsh.app
-  $ sudo rm -rf /Applications/Teleport\ Connect.app
-  ```
-  </Admonition>
-
-  </TabItem>
-  <TabItem label="Windows">
-
-  Remove the `tsh.exe` binary from the machine:
-
-  ```code
-  $ del C:\Path\To\tsh.exe
-  ```
-
-(!docs/pages/includes/uninstall-teleport-connect-windows.mdx!)
-
-  </TabItem>
-  </Tabs>
-  </TabItem>
-  <TabItem label="Teleport Enterprise Cloud" >
-
-  <Tabs>
-  <TabItem label="Debian/Ubuntu Linux (DEB)">
-
-  Uninstall the Teleport binary using APT:
-
-  ```code
-  $ sudo apt-get -y remove teleport-ent
-  # NOTE: Older Teleport Enterprise Cloud users may be running Teleport Community Edition binaries instead
-  # $ sudo apt-get -y remove teleport
-  ```
-
-  Uninstall the Teleport APT repo:
-
-  ```code
-  $ sudo rm -f /etc/apt/sources.list.d/teleport.list
-  ```
-
-  <Admonition type="notice" title="Uninstall standalone DEB package">
-  If the commands above do not work, you may have installed Teleport using a standalone DEB package. Remove it with:
-
-  ```code
-  $ sudo dpkg -r teleport-ent
-  # NOTE: Older Teleport Enterprise Cloud users may be running Teleport Community Edition binaries instead
-  # $ sudo dpkg -r teleport
-  ```
-  </Admonition>
-
-  </TabItem>
-  <TabItem label="Amazon Linux 2/RHEL (RPM)">
-
-  Uninstall the Teleport binary using YUM:
-
-  ```code
-  $ sudo yum -y remove teleport-ent
-  # Optional: Use DNF on newer distributions
-  # $ sudo dnf -y remove teleport-ent
-  # NOTE: Older Teleport Enterprise Cloud users may be running Teleport Community Edition binaries instead
-  # $ sudo yum -y remove teleport
-  # $ sudo dnf -y remove teleport
-  ```
-
-  Uninstall the Teleport YUM repo:
-
-  ```code
-  $ sudo rm -f /etc/yum.repos.d/teleport.repo
-  ```
-
-  <Admonition type="notice" title="Uninstall standalone RPM package">
-  If the commands above do not work, you may have installed Teleport using a standalone RPM package. Remove it with:
-
-  ```code
-  $ sudo rpm -e teleport-ent
-  # NOTE: Older Teleport Enterprise Cloud users may be running Teleport Community Edition binaries instead
-  # $ sudo rpm -e teleport
-  ```
-  </Admonition>
-
-  </TabItem>
-  <TabItem label="Linux Tarball">
-
-  <Admonition type="notice">
-  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
-  You can use `dirname $(which teleport)` to look this up automatically.
-  </Admonition>
-
-  Remove the Teleport binaries from the machine:
-
-  ```code
-  $ sudo rm -f /usr/local/bin/tbot
-  $ sudo rm -f /usr/local/bin/tctl
-  $ sudo rm -f /usr/local/bin/teleport
-  $ sudo rm -f /usr/local/bin/tsh
-  ```
-
-  </TabItem>
-  <TabItem label="MacOS">
-
-  <Admonition type="notice">
-  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
-  You can use `dirname $(which teleport)` to look this up automatically.
-  </Admonition>
-
-  Remove the Teleport binaries from the machine:
-
-  ```code
-  $ sudo rm -f /usr/local/bin/tbot
-  $ sudo rm -f /usr/local/bin/tctl
-  $ sudo rm -f /usr/local/bin/teleport
-  $ sudo rm -f /usr/local/bin/tsh
-  ```
-
-  <Admonition type="notice" title="Uninstall MacOS client tools">
-  If you installed the MacOS `tsh` client-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
-
-  ```code
-  $ sudo rm -rf /Applications/tsh.app
-  $ sudo rm -rf /Applications/Teleport\ Connect.app
-  ```
-  </Admonition>
-
-  </TabItem>
-  <TabItem label="Windows">
-
-  Remove the `tsh.exe` binary from the machine:
-
-  ```code
-  $ del C:\Path\To\tsh.exe
-  ```
-(!docs/pages/includes/uninstall-teleport-connect-windows.mdx!)
-
-  </TabItem>
-  </Tabs>
   </TabItem>
 </Tabs>
+
+
+### macOS
+
+  <Admonition type="notice">
+  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
+  You can use `dirname $(which teleport)` to look this up automatically.
+  </Admonition>
+
+  Remove the Teleport binaries from the machine:
+
+  ```code
+  $ sudo rm -f /usr/local/bin/tbot
+  $ sudo rm -f /usr/local/bin/tctl
+  $ sudo rm -f /usr/local/bin/teleport
+  $ sudo rm -f /usr/local/bin/tsh
+  ```
+
+  <Admonition type="notice" title="Uninstall MacOS client tools">
+  If you installed the MacOS `tsh` client-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
+
+  ```code
+  $ sudo rm -rf /Applications/tsh.app
+  $ sudo rm -rf /Applications/Teleport\ Connect.app
+  ```
+  </Admonition>
+
+### Windows
+
+  Remove the `tsh.exe` binary from the machine:
+
+  ```code
+  $ del C:\Path\To\tsh.exe
+  ```
+(!docs/pages/includes/uninstall-teleport-connect-windows.mdx!)
 
 ## Step 3/3. Remove Teleport data and configuration files
 


### PR DESCRIPTION
See #35870

Using `Tabs` components within a `TabItem` results in a poor user experience. This chagne removes some instances of this pattern:

- WebAuthn guide
- MongoDB Atlas guide
- Installation page: Remove Homebrew instructions in favor of a Notice advising against using Homebrew.
- Uninstall Teleport guide
- Access Controls Getting Started