### PR TITLE
Remove VarList instances from the docs

### DIFF
--- a/docs/pages/choose-an-edition/teleport-enterprise/aws-kms.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/aws-kms.mdx
@@ -36,8 +36,6 @@ higher.
 
 - An AWS account.
 
-<VarList/>
-
 ## Step 1/5. Configure AWS IAM permissions
 
 Your Teleport Auth Service will need permissions to create, sign with, list,

--- a/docs/pages/choose-an-edition/teleport-enterprise/gcp-kms.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/gcp-kms.mdx
@@ -36,8 +36,6 @@ higher.
 
 - A Google Cloud account.
 
-<VarList/>
-
 ## Step 1/5. Create a key ring in GCP
 
 Each Teleport Auth Server will need to be configured to use a GCP key ring

--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -7,8 +7,6 @@ This guide covers the basics of authenticating to Teleport and
 accessing resources. It's written for end-users of resources protected by
 Teleport, and includes links to more detailed documentation at the end.
 
-<VarList/>
-
 ## Client tools
 
 ### tsh

--- a/docs/pages/server-access/guides/vscode.mdx
+++ b/docs/pages/server-access/guides/vscode.mdx
@@ -24,10 +24,6 @@ older clients can use `ssh.exe` from either [Git for Windows][git] or
 Microsoft's [Win32-OpenSSH project][win32-openssh].
 </Admonition>
 
-- Update the variables below with your environment's information to use our example commands directly.
-
-<VarList/>
-
 ## Step 1/3. First-time setup
 
 Configure your local SSH client to access Teleport Nodes. Replace <Var name="teleport.example.com" description="Path to your Teleport Proxy Service or Cloud tenant"/> with the address of your Teleport Proxy Service (e.g., `mytenant.teleport.sh` for Teleport Cloud users), and replace <Var name="alice" description="Your teleport user"/> with your Teleport user.


### PR DESCRIPTION
Closes #41443

The VarList component has failed to render for a long time (at least six months). Since the component has not received widespread adoption in docs pages, remove instances of the component in preparation for removing the component itself from the docs engine.