### PR TITLE
test for auto user deactivation audit event

### DIFF
--- a/lib/srv/db/autousers_test.go
+++ b/lib/srv/db/autousers_test.go
@@ -28,9 +28,11 @@ import (
 
 	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/label"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
+	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/srv/db/common/databaseobjectimportrule"
 	"github.com/gravitational/teleport/lib/srv/db/mongodb"
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
@@ -214,6 +216,10 @@ func TestAutoUsersPostgres(t *testing.T) {
 			case <-time.After(5 * time.Second):
 				t.Fatal("user not deactivated after 5s")
 			}
+
+			ev := waitForDatabaseUserDeactivateEvent(t, testCtx)
+			require.Equal(t, "alice", ev.User)
+			require.Equal(t, "alice", ev.DatabaseUser)
 		})
 	}
 }
@@ -368,6 +374,10 @@ func TestAutoUsersMySQL(t *testing.T) {
 			case <-time.After(5 * time.Second):
 				t.Fatal("user not deactivated after 5s")
 			}
+
+			ev := waitForDatabaseUserDeactivateEvent(t, testCtx)
+			require.Equal(t, tc.teleportUser, ev.User)
+			require.Equal(t, tc.expectDatabaseUser, ev.DatabaseUser)
 		})
 	}
 }
@@ -451,6 +461,21 @@ func TestAutoUsersMongoDB(t *testing.T) {
 			case <-time.After(5 * time.Second):
 				t.Fatal("user not deactivated after 5s")
 			}
+
+			ev := waitForDatabaseUserDeactivateEvent(t, testCtx)
+			require.Equal(t, username, ev.User)
+			require.Equal(t, "alice", ev.DatabaseUser)
 		})
 	}
+}
+
+func waitForDatabaseUserDeactivateEvent(t *testing.T, testCtx *testContext) *apievents.DatabaseUserDeactivate {
+	t.Helper()
+	const code = libevents.DatabaseSessionUserDeactivateCode
+	event := waitForEvent(t, testCtx, code)
+	require.Equal(t, code, event.GetCode())
+
+	ev, ok := event.(*apievents.DatabaseUserDeactivate)
+	require.True(t, ok)
+	return ev
 }


### PR DESCRIPTION
This PR updates test cases for database auto user provisioning to ensure that deactivation audit events are being sent.

In my [PR that added support for spanner](https://github.com/gravitational/teleport/pull/40859) I noticed and fixed an issue where our mock mysql db sends a response that causes a panic right before the mysql user deactivation audit event is emitted.
We have a deferred `recover()` in our db server, so it didn't cause a test failure but it did silently prevent the audit event.
That panic is probably not realistically going to happen, but I guarded against it anyway.

I didn't extract [that extra guard in the mysql code](https://github.com/gravitational/teleport/commit/12c113bc8430cfdf3a611523a70d4ee377749aa0#diff-f29f86158d8dbc56f9a235df2faa3f5694df55d955cc3e97c33d1de708370a37R523-R527) from the spanner PR before merging, so here's this PR which I will backport to v14 along with the mysql panic fix.

I ensured that these test updates fail without the mysql fix.