### PR TITLE
curb resource-level access request write capabilities

### DIFF
--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -234,6 +234,127 @@ func waitForAccessRequests(t *testing.T, ctx context.Context, getter services.Ac
 	}
 }
 
+// TestAccessRequestResourceRBACLimits verifies the special constraint conditions put on resource-level access
+// request permissions (create/update) to mitigate their power.
+func TestAccessRequestResourceRBACLimits(t *testing.T) {
+	const (
+		staticRoleName  = "static-role"
+		dynamicRoleName = "dynamic-role"
+		userName        = "alice@example.com"
+		otherUserName   = "bob@example.com"
+	)
+
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+
+	authServer, err := NewTestAuthServer(TestAuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: clock,
+	})
+	require.NoError(t, err)
+	defer authServer.Close()
+
+	tlsServer, err := authServer.NewTestTLSServer()
+	require.NoError(t, err)
+	defer tlsServer.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	staticRole, err := types.NewRole(staticRoleName, types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				Roles: []string{dynamicRoleName},
+			},
+			Rules: []types.Rule{
+				types.NewRule(types.KindAccessRequest, services.RW()),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	dynamicRole, err := types.NewRole(dynamicRoleName, types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	_, err = tlsServer.Auth().UpsertRole(ctx, staticRole)
+	require.NoError(t, err)
+
+	_, err = tlsServer.Auth().UpsertRole(ctx, dynamicRole)
+	require.NoError(t, err)
+
+	user, err := types.NewUser(userName)
+	require.NoError(t, err)
+
+	user.SetRoles([]string{staticRoleName})
+	_, err = tlsServer.Auth().UpsertUser(ctx, user)
+	require.NoError(t, err)
+
+	otherUser, err := types.NewUser(otherUserName)
+	require.NoError(t, err)
+
+	otherUser.SetRoles([]string{staticRoleName})
+	_, err = tlsServer.Auth().UpsertUser(ctx, otherUser)
+	require.NoError(t, err)
+
+	clt, err := tlsServer.NewClient(TestUser(userName))
+	require.NoError(t, err)
+	defer clt.Close()
+
+	// try to create a pre-approved request for self
+	req, err := services.NewAccessRequest(userName, dynamicRoleName)
+	require.NoError(t, err)
+
+	req.SetState(types.RequestState_APPROVED)
+	_, err = clt.CreateAccessRequestV2(ctx, req)
+	require.Error(t, err)
+
+	// verify that we got the expected rejection
+	require.Equal(t, "cannot create access request for self in non-pending state", err.Error())
+
+	// verify that creating pre-approved requests for others still works
+	// (note: we'd like to eventually deprecate ability too).
+	req, err = services.NewAccessRequest(otherUserName, dynamicRoleName)
+	require.NoError(t, err)
+
+	req.SetState(types.RequestState_APPROVED)
+
+	_, err = clt.CreateAccessRequestV2(ctx, req)
+	require.NoError(t, err)
+
+	// create a pending request for self
+	req, err = services.NewAccessRequest(userName, dynamicRoleName)
+	require.NoError(t, err)
+
+	req.SetState(types.RequestState_PENDING)
+	req, err = clt.CreateAccessRequestV2(ctx, req)
+	require.NoError(t, err)
+
+	// attempt to self-approve
+	err = clt.SetAccessRequestState(ctx, types.AccessRequestUpdate{
+		RequestID: req.GetName(),
+		State:     types.RequestState_APPROVED,
+	})
+	require.Error(t, err)
+
+	// verify that we got the expected rejection
+	require.Equal(t, "directly updating the state of your own access requests is not permitted", err.Error())
+
+	req, err = services.NewAccessRequest(otherUserName, dynamicRoleName)
+	require.NoError(t, err)
+
+	req.SetState(types.RequestState_PENDING)
+	req, err = clt.CreateAccessRequestV2(ctx, req)
+	require.NoError(t, err)
+
+	// approve other
+	err = clt.SetAccessRequestState(ctx, types.AccessRequestUpdate{
+		RequestID: req.GetName(),
+		State:     types.RequestState_APPROVED,
+	})
+	require.NoError(t, err)
+}
+
 // TestListAccessRequests tests some basic functionality of the ListAccessRequests API, including access-control,
 // filtering, sort, and pagination.
 func TestListAccessRequests(t *testing.T) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2503,6 +2503,18 @@ func (a *ServerWithRoles) CreateAccessRequestV2(ctx context.Context, req types.A
 		}
 	}
 
+	if !req.GetState().IsPending() {
+		if authz.IsCurrentUser(a.context, req.GetUser()) {
+			return nil, trace.AccessDenied("cannot create access request for self in non-pending state")
+		}
+
+		if len(a.context.Identity.GetIdentity().ActiveRequests) != 0 {
+			return nil, trace.AccessDenied("cannot create access requests in non-pending state while using an access request")
+		}
+
+		log.Warnf("Use of resource-level access request 'create' permission by user %q to create non-pending access request for user %q. Creation of non-pending requests will be deprecated in future version of teleport. Consider migrating to a workflow with a separate approval step.", a.context.User.GetName(), req.GetUser())
+	}
+
 	if !authz.IsCurrentUser(a.context, req.GetUser()) {
 		// If this request was authorized by allow rules and not ownership, require MFA.
 		if err := a.context.AuthorizeAdminAction(); err != nil {
@@ -2522,12 +2534,32 @@ func (a *ServerWithRoles) SetAccessRequestState(ctx context.Context, params type
 		return trace.Wrap(err)
 	}
 
+	if len(a.context.Identity.GetIdentity().ActiveRequests) != 0 {
+		return trace.AccessDenied("cannot directly update the state of an access request while using an access request")
+	}
+
 	if err := a.context.AuthorizeAdminAction(); err != nil {
 		return trace.Wrap(err)
 	}
 
 	if params.State.IsPromoted() {
 		return trace.BadParameter("state promoted can be only set when promoting to access list")
+	}
+
+	// load the request to verify additional access-control limits
+	reqs, err := a.GetAccessRequests(ctx, types.AccessRequestFilter{
+		ID: params.RequestID,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if len(reqs) < 1 {
+		return trace.NotFound("cannot set state of access request %q (not found)", params.RequestID)
+	}
+
+	if authz.IsCurrentUser(a.context, reqs[0].GetUser()) {
+		return trace.AccessDenied("directly updating the state of your own access requests is not permitted")
 	}
 
 	return a.authServer.SetAccessRequestState(ctx, params)


### PR DESCRIPTION
The very first iteration of the access request API had a very simplistic access-control model, where admins could approve any request at any time.  It was mostly intended to be used for break-glass scenarios, and for integration with custom automation.  Since then, we've moved away from the model of blanket permissions being granted to a few, in favor of granular and narrowly-scoped review permissions being granted to many.  In this new model, the old blanket resource-level permissions have become a bit of a footgun.  While we likely can't deprecate them entirely, we can soften some of their rough edges.

This PR introduces two minor breaking changes to resource-level access request write permissions which should slightly reduce their power without meaningfully impacting intended usecases (e.g. custom automation):

- Directly setting states for *your own* access requests is no longer supported.
- Directly setting states for access requests is no longer permitted when the calling identity has active requests applied. 

changelog: blanket/resource-level access request write permissions no longer support self-approval or recursion.