### PR TITLE
[v13] Update Electron to 30.0.3 and Node.js to 20.13.0

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 GOLANG_VERSION ?= go1.21.9
 GOLANGCI_LINT_VERSION ?= v1.58.1
 
-NODE_VERSION ?= 20.11.1
+NODE_VERSION ?= 20.13.0
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.77.0

--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -49,7 +49,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.5.6",
     "@types/jsdom": "^21.1.0",
-    "@types/node": "^20.11.26",
+    "@types/node": "^20.12.11",
     "@types/react": "^16.8.19",
     "@types/react-router-dom": "^5.1.1",
     "@types/react-transition-group": "^4.4.5",

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -39,7 +39,7 @@
     "@types/node-forge": "^1.0.4",
     "clean-webpack-plugin": "4.0.0",
     "cross-env": "5.0.5",
-    "electron": "29.1.4",
+    "electron": "30.0.3",
     "electron-notarize": "^1.2.1",
     "eslint-import-resolver-webpack": "0.13.2",
     "eslint-loader": "3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3588,10 +3588,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^20.11.26", "@types/node@^20.9.0":
-  version "20.11.26"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.26.tgz#3fbda536e51d5c79281e1d9657dcb0131baabd2d"
-  integrity sha512-YwOMmyhNnAWijOBQweOJnQPl068Oqd4K3OFbTc6AHJwzweUwwWG3GIFY74OKks2PJUDkQPeddOQES9mLn1CTEQ==
+"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^20.12.11", "@types/node@^20.9.0":
+  version "20.12.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.11.tgz#c4ef00d3507000d17690643278a60dc55a9dc9be"
+  integrity sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==
   dependencies:
     undici-types "~5.26.4"
 
@@ -6708,10 +6708,10 @@ electron-to-chromium@^1.4.535:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.551.tgz#14db6660a88f66ce095ea2657abe5653bc7f42ed"
   integrity sha512-/Ng/W/kFv7wdEHYzxdK7Cv0BHEGSkSB3M0Ssl8Ndr1eMiYeas/+Mv4cNaDqamqWx6nd2uQZfPz6g25z25M/sdw==
 
-electron@29.1.4:
-  version "29.1.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-29.1.4.tgz#6c47467ba50be5dd60b99b8737f69cd12fc0733f"
-  integrity sha512-IWXys0SqgmIfrqXusUGQC0gGG7CCqA5vfmNsUMj8dFkAnK3lisKyjSESStWlrsste/OX/AAC5wsVlf23reUNnw==
+electron@30.0.3:
+  version "30.0.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-30.0.3.tgz#7c25ddb12ba89fd117991d010f1b274b1bafcb73"
+  integrity sha512-h+suwx6e0fnv/9wi0/cmCMtG+4LrPzJZa+3DEEpxcPcP+pcWnBI70t8QspxgMNIh2wzXLMD9XVqrLkEbiBAInw==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/41404 to branch/v13