### PR TITLE
Fix missing SSHD_CONFIG variable in Default Agentless Installer script

### DIFF
--- a/api/types/installers/agentless-installer.sh.tmpl
+++ b/api/types/installers/agentless-installer.sh.tmpl
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-set -o errexit
-set -o pipefail
-set -o nounset
+set -eu
 
 upgrade_endpoint="{{ .PublicProxyAddr }}/v1/webapi/automaticupgrades/channel/default"
 
@@ -36,8 +34,13 @@ run_teleport() {
   LABELS="$3"
   ADDRESS="$4"
 
+  OPENSSH_CONFIG="/etc/ssh/sshd_config"
+  if [ -n "${SSHD_CONFIG-}" ]; then
+    OPENSSH_CONFIG="${SSHD_CONFIG}"
+  fi
+
   sudo /usr/local/bin/teleport join openssh \
-    --openssh-config="${SSHD_CONFIG}" \
+    --openssh-config="${OPENSSH_CONFIG}" \
     --join-method=iam \
     --token="$TOKEN" \
     --proxy-server="{{ .PublicProxyAddr }}" \


### PR DESCRIPTION
changelog: Fix missing variable and script options in Default Agentless Installer script

Invalid `set` option:
```
  "stderr": "/tmp/installTeleport-random-uuid.sh: 4: set: Illegal option -o pipefail\nfailed to run commands: exit status 2",
```
Option was removed and we kept the same options we have for the Default Teleport Agent installation.

Missing SSHD_CONFIG error:
```
  "stderr": "/tmp/installTeleport-random-uuid.sh: 38: SSHD_CONFIG: parameter not set\nfailed to run commands: exit status 2"
```
A default `--openssh-config` was added which should work on 99% of the installations.


This does not fix the issue below because we are not able to inject the SSHD_CONFIG variable with the current document version.
If we end up requiring two SSM Documents, we can go back to this.
For now, we can always duplicate/edit the installer script to be explicit about the SSHD_CONFIG.
Related: https://github.com/gravitational/teleport/issues/38035