### PR TITLE
Start using authclient.Client/ClientI/NewClient

### DIFF
--- a/integration/db/fixture.go
+++ b/integration/db/fixture.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -63,7 +64,7 @@ type databaseClusterPack struct {
 	User             types.User
 	role             types.Role
 	dbProcess        *service.TeleportProcess
-	dbAuthClient     *auth.Client
+	dbAuthClient     *authclient.Client
 	PostgresService  servicecfg.Database
 	postgresAddr     string
 	postgres         *postgres.TestServer
@@ -425,7 +426,7 @@ type databaseAgentStartParams struct {
 
 // startRootDatabaseAgent starts a database agent with the provided
 // configuration on the root cluster.
-func (p *DatabasePack) startRootDatabaseAgent(t *testing.T, params databaseAgentStartParams) (*service.TeleportProcess, *auth.Client) {
+func (p *DatabasePack) startRootDatabaseAgent(t *testing.T, params databaseAgentStartParams) (*service.TeleportProcess, *authclient.Client) {
 	conf := servicecfg.MakeDefaultConfig()
 	conf.DataDir = t.TempDir()
 	conf.SetToken("static-token-value")

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -48,6 +48,7 @@ import (
 	clientproto "github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keygen"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend"
@@ -408,7 +409,7 @@ func NewInstance(t *testing.T, cfg InstanceConfig) *TeleInstance {
 // GetSiteAPI is a helper which returns an API endpoint to a site with
 // a given name. i endpoint implements HTTP-over-SSH access to the
 // site's auth server.
-func (i *TeleInstance) GetSiteAPI(siteName string) auth.ClientI {
+func (i *TeleInstance) GetSiteAPI(siteName string) authclient.ClientI {
 	siteTunnel, err := i.Tunnel.GetSite(siteName)
 	if err != nil {
 		log.Warn(err)
@@ -849,7 +850,7 @@ func (i *TeleInstance) StartApps(configs []*servicecfg.Config) ([]*service.Telep
 }
 
 // StartDatabase starts the database access service with the provided config.
-func (i *TeleInstance) StartDatabase(conf *servicecfg.Config) (*service.TeleportProcess, *auth.Client, error) {
+func (i *TeleInstance) StartDatabase(conf *servicecfg.Config) (*service.TeleportProcess, *authclient.Client, error) {
 	dataDir, err := os.MkdirTemp("", "cluster-"+i.Secrets.SiteName)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -892,7 +893,7 @@ func (i *TeleInstance) StartDatabase(conf *servicecfg.Config) (*service.Teleport
 	}
 
 	// Retrieve auth server connector.
-	var client *auth.Client
+	var client *authclient.Client
 	for _, event := range receivedEvents {
 		if event.Name == service.DatabasesIdentityEvent {
 			conn, ok := (event.Payload).(*service.Connector)

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/etcdbk"
@@ -179,7 +180,7 @@ func TestHSMRotation(t *testing.T) {
 	require.NoError(t, allServices.waitForRestart(ctx))
 }
 
-func getAdminClient(authDataDir string, authAddr string) (*auth.Client, error) {
+func getAdminClient(authDataDir string, authAddr string) (*authclient.Client, error) {
 	identity, err := auth.ReadLocalIdentity(
 		filepath.Join(authDataDir, teleport.ComponentProcess),
 		auth.IdentityID{Role: types.RoleAdmin})
@@ -192,7 +193,7 @@ func getAdminClient(authDataDir string, authAddr string) (*auth.Client, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := auth.NewClient(client.Config{
+	clt, err := authclient.NewClient(client.Config{
 		Addrs: []string{authAddr},
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -78,6 +78,7 @@ import (
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
@@ -440,7 +441,7 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 
 			// wait 10 seconds for both nodes to show up, otherwise
 			// we'll have trouble connecting to the node below.
-			waitForNodes := func(site auth.ClientI, count int) error {
+			waitForNodes := func(site authclient.ClientI, count int) error {
 				tickCh := time.Tick(500 * time.Millisecond)
 				stopCh := time.After(10 * time.Second)
 				for {
@@ -489,7 +490,7 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 			}()
 
 			// wait until we've found the session in the audit log
-			getSession := func(site auth.ClientI) (types.SessionTracker, error) {
+			getSession := func(site authclient.ClientI) (types.SessionTracker, error) {
 				timeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 				sessions, err := waitForSessionToBeEstablished(timeout, defaults.Namespace, site)
@@ -569,7 +570,7 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 			require.Contains(t, text, "exit")
 
 			// Wait until session.start, session.leave, and session.end events have arrived.
-			getSessions := func(site auth.ClientI) ([]events.EventFields, error) {
+			getSessions := func(site authclient.ClientI) ([]events.EventFields, error) {
 				tickCh := time.Tick(500 * time.Millisecond)
 				stopCh := time.After(10 * time.Second)
 				for {
@@ -885,7 +886,7 @@ func testUUIDBasedProxy(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// wait up to 10 seconds for supplied node names to show up.
-	waitForNodes := func(site auth.ClientI, nodes ...string) error {
+	waitForNodes := func(site authclient.ClientI, nodes ...string) error {
 		tickCh := time.Tick(500 * time.Millisecond)
 		stopCh := time.After(10 * time.Second)
 	Outer:
@@ -1626,7 +1627,7 @@ func testIPPropagation(t *testing.T, suite *integrationTestSuite) {
 		authClientCfg, err := clt.ProxyClient.ClientConfig(ctx, clusterName)
 		require.NoError(t, err)
 		authClientCfg.DialOpts = nil
-		authClient, err := auth.NewClient(authClientCfg)
+		authClient, err := authclient.NewClient(authClientCfg)
 		require.NoError(t, err)
 
 		pingResp, err := authClient.Ping(ctx)
@@ -2563,7 +2564,7 @@ func twoClustersTunnel(t *testing.T, suite *integrationTestSuite, now time.Time,
 	require.NoError(t, err)
 	require.Equal(t, outputA.String(), outputB.String())
 
-	clientHasEvents := func(site auth.ClientI, count int) func() bool {
+	clientHasEvents := func(site authclient.ClientI, count int) func() bool {
 		// only look for exec events
 		eventTypes := []string{events.ExecEvent}
 
@@ -6069,7 +6070,7 @@ func testList(t *testing.T, suite *integrationTestSuite) {
 
 	// Wait 10 seconds for both nodes to show up to make sure they both have
 	// registered themselves.
-	waitForNodes := func(clt auth.ClientI, count int) error {
+	waitForNodes := func(clt authclient.ClientI, count int) error {
 		tickCh := time.Tick(500 * time.Millisecond)
 		stopCh := time.After(10 * time.Second)
 		for {

--- a/integration/joinopenssh_test.go
+++ b/integration/joinopenssh_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/openssh"
 	"github.com/gravitational/teleport/lib/service"
@@ -129,7 +129,7 @@ func TestJoinOpenSSH(t *testing.T) {
 	require.ElementsMatch(t, bytes.Split(bytes.TrimSpace(cabytes), []byte("\n")), allOpenSSHCAs)
 }
 
-func getOpenSSHCAs(t *testing.T, ctx context.Context, cl auth.ClientI) [][]byte {
+func getOpenSSHCAs(t *testing.T, ctx context.Context, cl authclient.ClientI) [][]byte {
 	t.Helper()
 	cas, err := cl.GetCertAuthorities(ctx, types.OpenSSHCA, false)
 	require.NoError(t, err)

--- a/integration/port_forwarding_test.go
+++ b/integration/port_forwarding_test.go
@@ -37,7 +37,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -56,7 +56,7 @@ func extractPort(svr *httptest.Server) (int, error) {
 	return n, nil
 }
 
-func waitForSessionToBeEstablished(ctx context.Context, namespace string, site auth.ClientI) ([]types.SessionTracker, error) {
+func waitForSessionToBeEstablished(ctx context.Context, namespace string, site authclient.ClientI) ([]types.SessionTracker, error) {
 
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()

--- a/integration/proxy/proxy_tunnel_strategy_test.go
+++ b/integration/proxy/proxy_tunnel_strategy_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -59,7 +60,7 @@ type proxyTunnelStrategy struct {
 	node    *helpers.TeleInstance
 
 	db           *helpers.TeleInstance
-	dbAuthClient *auth.Client
+	dbAuthClient *authclient.Client
 	postgresDB   *postgres.TestServer
 
 	log *logrus.Logger
@@ -461,7 +462,7 @@ func (p *proxyTunnelStrategy) makeDatabase(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	var client *auth.Client
+	var client *authclient.Client
 	for _, event := range receivedEvents {
 		if event.Name == service.DatabasesIdentityEvent {
 			conn, ok := (event.Payload).(*service.Connector)

--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -39,6 +39,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/bpf"
@@ -64,7 +65,7 @@ type SrvCtx struct {
 	signer     ssh.Signer
 	server     *auth.TestServer
 	clock      clockwork.FakeClock
-	nodeClient *auth.Client
+	nodeClient *authclient.Client
 	nodeID     string
 	utmpPath   string
 	wtmpPath   string

--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
@@ -391,7 +392,7 @@ func TestListAccessRequests(t *testing.T) {
 	require.Len(t, reqs, requestsPerUser)
 
 	// verify that access-control filtering is applied and exercise a different combination of sort params
-	for _, clt := range []ClientI{clientA, clientB} {
+	for _, clt := range []authclient.ClientI{clientA, clientB} {
 		reqs = nil
 		nextKey = ""
 		for {
@@ -1018,9 +1019,9 @@ func testMultiAccessRequests(t *testing.T, testPack *accessRequestTestPack) {
 	requesterClient, err := testPack.tlsServer.NewClient(requester)
 	require.NoError(t, err)
 
-	type newClientFunc func(*testing.T, *Client, *proto.Certs) (*Client, *proto.Certs)
+	type newClientFunc func(*testing.T, *authclient.Client, *proto.Certs) (*authclient.Client, *proto.Certs)
 	updateClientWithNewAndDroppedRequests := func(newRequests, dropRequests []string) newClientFunc {
-		return func(t *testing.T, clt *Client, _ *proto.Certs) (*Client, *proto.Certs) {
+		return func(t *testing.T, clt *authclient.Client, _ *proto.Certs) (*authclient.Client, *proto.Certs) {
 			certs, err := clt.GenerateUserCerts(ctx, proto.UserCertsRequest{
 				PublicKey:          testPack.pubKey,
 				Username:           username,
@@ -1041,7 +1042,7 @@ func testMultiAccessRequests(t *testing.T, testPack *accessRequestTestPack) {
 		return updateClientWithNewAndDroppedRequests(nil, dropRequests)
 	}
 	failToApplyAccessRequests := func(reqs ...string) newClientFunc {
-		return func(t *testing.T, clt *Client, certs *proto.Certs) (*Client, *proto.Certs) {
+		return func(t *testing.T, clt *authclient.Client, certs *proto.Certs) (*authclient.Client, *proto.Certs) {
 			// assert that this request fails
 			_, err := clt.GenerateUserCerts(ctx, proto.UserCertsRequest{
 				PublicKey:      testPack.pubKey,
@@ -1664,7 +1665,7 @@ func TestAssumeStartTime_SetAccessRequestState(t *testing.T) {
 
 type accessRequestWithStartTime struct {
 	testPack                      *accessRequestTestPack
-	requesterClient               *Client
+	requesterClient               *authclient.Client
 	invalidMaxedAssumeStartTime   time.Time
 	invalidExpiredAssumeStartTime time.Time
 	validStartTime                time.Time

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -1525,7 +1526,7 @@ func (w *OktaWrapper) Close() error {
 
 // NewRemoteProxyCachingAccessPoint returns new caching access point using
 // access point policy
-type NewRemoteProxyCachingAccessPoint func(clt ClientI, cacheName []string) (RemoteProxyAccessPoint, error)
+type NewRemoteProxyCachingAccessPoint func(clt authclient.ClientI, cacheName []string) (RemoteProxyAccessPoint, error)
 
 // notImplementedMessage is the message to return for endpoints that are not
 // implemented. This is due to how service interfaces are used with Teleport.

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -487,7 +488,7 @@ func TestCreateAuthenticateChallenge_mfaVerification(t *testing.T) {
 	require.NoError(t, err, "UpsertRole(%q)", joinNoMFARole.GetName())
 
 	const normalLogin = "llama"
-	createUser := func(role types.Role) *Client {
+	createUser := func(role types.Role) *authclient.Client {
 		// Create a user with MFA devices...
 		userCreds, err := createUserWithSecondFactors(testServer)
 		require.NoError(t, err, "createUserWithSecondFactors")
@@ -530,7 +531,7 @@ func TestCreateAuthenticateChallenge_mfaVerification(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		userClient      *Client
+		userClient      *authclient.Client
 		req             *proto.CreateAuthenticateChallengeRequest
 		wantMFARequired proto.MFARequired
 		wantChallenges  bool

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -62,6 +62,7 @@ import (
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -3192,7 +3193,7 @@ func TestDeleteMFADeviceSync_lastDevice(t *testing.T) {
 		require.NoError(t, err, "UpsertAuthPreference")
 	}
 
-	deleteDevice := func(userClient *Client, testDev *TestDevice) error {
+	deleteDevice := func(userClient *authclient.Client, testDev *TestDevice) error {
 		// Issue and solve authn challenge.
 		authnChal, err := userClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 			Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -41,6 +41,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/cloud/azure"
@@ -56,7 +57,7 @@ func renewBotCerts(
 	botUser string,
 	publicKey []byte,
 	privateKey []byte,
-) (*Client, *proto.Certs, tls.Certificate, error) {
+) (*authclient.Client, *proto.Certs, tls.Certificate, error) {
 	client := srv.NewClientWithCert(tlsCert)
 
 	certs, err := client.GenerateUserCerts(ctx, proto.UserCertsRequest{

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -23,10 +23,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 )
 
-// MissingNamespaceError indicates that the client failed to
-// provide the namespace in the request.
-const MissingNamespaceError = authclient.MissingNamespaceError
-
 type APIClient = authclient.Client
 type Client = authclient.Client
 type ClientI = authclient.ClientI
@@ -37,9 +33,9 @@ type ClientI = authclient.ClientI
 // no dialer is given, the first address will be used. This address must
 // be an auth server address.
 //
-// NOTE: This client is being deprecated in favor of the gRPC Client in
-// teleport/api/client. This Client should only be used internally, or for
+// NOTE: This client is being deprecated in favor of the [grpc.Client] in
+// teleport/api/client. The [authclient.Client] should only be used internally, or for
 // functionality that hasn't been ported to the new client yet.
-func NewClient(cfg client.Config, params ...roundtrip.ClientParam) (*Client, error) {
+func NewClient(cfg client.Config, params ...roundtrip.ClientParam) (*authclient.Client, error) {
 	return authclient.NewClient(cfg, params...)
 }

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -52,13 +52,13 @@ import (
 // ErrGithubNoTeams results from a github user not belonging to any teams.
 var ErrGithubNoTeams = trace.BadParameter("user does not belong to any teams configured in connector; the configuration may have typos.")
 
-// GithubConverter is a thin wrapper around the ClientI interface that
+// GithubConverter is a thin wrapper around the [authclient.ClientI] interface that
 // ensures GitHub auth connectors use the registered implementation.
 type GithubConverter struct {
 	authclient.ClientI
 }
 
-// WithGithubConnectorConversions takes a ClientI and returns one that
+// WithGithubConnectorConversions takes a [authclient.ClientI]  and returns one that
 // ensures returned or passed [types.GithubConnector] interfaces
 // use the registered implementation for the following methods:
 //

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -2205,7 +2205,7 @@ func (g *GRPCServer) DeleteRole(ctx context.Context, req *authpb.DeleteRoleReque
 //
 // This function bypasses the `ServerWithRoles` RBAC layer. This is not
 // usually how the gRPC layer accesses the underlying auth server API's but it's done
-// here to avoid bloating the ClientI interface with special logic that isn't designed to be touched
+// here to avoid bloating the [authclient.ClientI]  interface with special logic that isn't designed to be touched
 // by anyone external to this process. This is not the norm and caution should be taken
 // when looking at or modifying this function. This is the same approach taken by other MFA
 // related gRPC API endpoints.

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
@@ -487,7 +488,7 @@ func (d *mfaDevices) webAuthHandler(t *testing.T, challenge *proto.MFAAuthentica
 	return mfaResp
 }
 
-func addOneOfEachMFADevice(t *testing.T, userClient *Client, clock clockwork.Clock, origin string) mfaDevices {
+func addOneOfEachMFADevice(t *testing.T, userClient *authclient.Client, clock clockwork.Clock, origin string) mfaDevices {
 	const totpName = "totp-dev"
 	const webName = "webauthn-dev"
 
@@ -523,7 +524,7 @@ type mfaAddTestOpts struct {
 	assertRegisteredDev func(*testing.T, *types.MFADevice)
 }
 
-func testAddMFADevice(ctx context.Context, t *testing.T, authClient *Client, opts mfaAddTestOpts) {
+func testAddMFADevice(ctx context.Context, t *testing.T, authClient *authclient.Client, opts mfaAddTestOpts) {
 	authChal, err := authClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 		Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
 			ContextUser: &proto.ContextUser{},
@@ -563,7 +564,7 @@ type mfaDeleteTestOpts struct {
 	checkErr    require.ErrorAssertionFunc
 }
 
-func testDeleteMFADevice(ctx context.Context, t *testing.T, authClient *Client, opts mfaDeleteTestOpts) {
+func testDeleteMFADevice(ctx context.Context, t *testing.T, authClient *authclient.Client, opts mfaDeleteTestOpts) {
 	// Issue and solve authn challenge.
 	authnChal, err := authClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 		Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
@@ -869,7 +870,7 @@ func TestGenerateUserCerts_deviceAuthz(t *testing.T) {
 	}
 
 	// generateCertsMFA is used to generate single-use, MFA-enabled certificates.
-	generateCertsMFA := func(t *testing.T, client *Client, req proto.UserCertsRequest) (cert *proto.Certs, err error) {
+	generateCertsMFA := func(t *testing.T, client *authclient.Client, req proto.UserCertsRequest) (cert *proto.Certs, err error) {
 		defer func() {
 			// Translate gRPC to trace errors, as our clients do.
 			err = trail.FromGRPC(err)
@@ -892,7 +893,7 @@ func TestGenerateUserCerts_deviceAuthz(t *testing.T) {
 	tests := []struct {
 		name               string
 		clusterDeviceMode  string
-		client             *Client
+		client             *authclient.Client
 		req                proto.UserCertsRequest
 		skipLoginCerts     bool // aka non-MFA issuance.
 		skipSingleUseCerts bool // aka MFA/streaming issuance.
@@ -1033,7 +1034,7 @@ func TestRegisterFirstDevice_deviceAuthz(t *testing.T) {
 	tests := []struct {
 		name               string
 		clusterDeviceMode  string
-		client             *Client
+		client             *authclient.Client
 		skipLoginCerts     bool // aka non-MFA issuance.
 		skipSingleUseCerts bool // aka MFA/streaming issuance.
 		assertErr          func(t *testing.T, err error)
@@ -1236,7 +1237,7 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 
 	tests := []struct {
 		desc      string
-		newClient func() (*Client, error) // optional, makes a new client for the test.
+		newClient func() (*authclient.Client, error) // optional, makes a new client for the test.
 		opts      generateUserSingleUseCertsTestOpts
 	}{
 		{
@@ -1609,7 +1610,7 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 		},
 		{
 			desc: "device extensions copied SSH cert",
-			newClient: func() (*Client, error) {
+			newClient: func() (*authclient.Client, error) {
 				u := TestUser(user.GetName())
 				u.TTL = 1 * time.Hour
 
@@ -1656,7 +1657,7 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 		},
 		{
 			desc: "device extensions copied TLS cert",
-			newClient: func() (*Client, error) {
+			newClient: func() (*authclient.Client, error) {
 				u := TestUser(user.GetName())
 				u.TTL = 1 * time.Hour
 
@@ -1895,7 +1896,7 @@ type generateUserSingleUseCertsTestOpts struct {
 	verifyCert         func(*testing.T, *proto.Certs)
 }
 
-func testGenerateUserSingleUseCerts(ctx context.Context, t *testing.T, cl *Client, opts generateUserSingleUseCertsTestOpts) {
+func testGenerateUserSingleUseCerts(ctx context.Context, t *testing.T, cl *authclient.Client, opts generateUserSingleUseCertsTestOpts) {
 	authnChal, err := cl.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 		Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
 			ContextUser: &proto.ContextUser{},
@@ -2330,7 +2331,7 @@ func TestIsMFARequired_App(t *testing.T) {
 
 // testOriginDynamicStored tests setting a ResourceWithOrigin via the server
 // API always results in the resource being stored with OriginDynamic.
-func testOriginDynamicStored(t *testing.T, setWithOrigin func(*Client, string) error, getStored func(*Server) (types.ResourceWithOrigin, error)) {
+func testOriginDynamicStored(t *testing.T, setWithOrigin func(*authclient.Client, string) error, getStored func(*Server) (types.ResourceWithOrigin, error)) {
 	srv := newTestTLSServer(t)
 
 	// Create a fake user.
@@ -2355,7 +2356,7 @@ func TestAuthPreferenceOriginDynamic(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	setWithOrigin := func(cl *Client, origin string) error {
+	setWithOrigin := func(cl *authclient.Client, origin string) error {
 		authPref := types.DefaultAuthPreference()
 		authPref.SetOrigin(origin)
 		_, err := cl.UpsertAuthPreference(ctx, authPref)
@@ -2373,7 +2374,7 @@ func TestClusterNetworkingConfigOriginDynamic(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	setWithOrigin := func(cl *Client, origin string) error {
+	setWithOrigin := func(cl *authclient.Client, origin string) error {
 		netConfig := types.DefaultClusterNetworkingConfig()
 		netConfig.SetOrigin(origin)
 		_, err := cl.UpsertClusterNetworkingConfig(ctx, netConfig)
@@ -2391,7 +2392,7 @@ func TestSessionRecordingConfigOriginDynamic(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	setWithOrigin := func(cl *Client, origin string) error {
+	setWithOrigin := func(cl *authclient.Client, origin string) error {
 		recConfig := types.DefaultSessionRecordingConfig()
 		recConfig.SetOrigin(origin)
 		_, err := cl.UpsertSessionRecordingConfig(ctx, recConfig)
@@ -3469,11 +3470,11 @@ func TestListResources(t *testing.T) {
 
 	testCases := map[string]struct {
 		resourceType   string
-		createResource func(name string, clt *Client) error
+		createResource func(name string, clt *authclient.Client) error
 	}{
 		"DatabaseServers": {
 			resourceType: types.KindDatabaseServer,
-			createResource: func(name string, clt *Client) error {
+			createResource: func(name string, clt *authclient.Client) error {
 				server, err := types.NewDatabaseServerV3(types.Metadata{
 					Name: name,
 				}, types.DatabaseServerSpecV3{
@@ -3491,7 +3492,7 @@ func TestListResources(t *testing.T) {
 		},
 		"ApplicationServers": {
 			resourceType: types.KindAppServer,
-			createResource: func(name string, clt *Client) error {
+			createResource: func(name string, clt *authclient.Client) error {
 				app, err := types.NewAppV3(types.Metadata{
 					Name: name,
 				}, types.AppSpecV3{
@@ -3518,7 +3519,7 @@ func TestListResources(t *testing.T) {
 		},
 		"KubeServer": {
 			resourceType: types.KindKubeServer,
-			createResource: func(name string, clt *Client) error {
+			createResource: func(name string, clt *authclient.Client) error {
 				kube, err := types.NewKubernetesClusterV3(
 					types.Metadata{
 						Name:   name,
@@ -3540,7 +3541,7 @@ func TestListResources(t *testing.T) {
 		},
 		"Node": {
 			resourceType: types.KindNode,
-			createResource: func(name string, clt *Client) error {
+			createResource: func(name string, clt *authclient.Client) error {
 				server, err := types.NewServer(name, types.KindNode, types.ServerSpecV2{})
 				if err != nil {
 					return err
@@ -3552,7 +3553,7 @@ func TestListResources(t *testing.T) {
 		},
 		"WindowsDesktops": {
 			resourceType: types.KindWindowsDesktop,
-			createResource: func(name string, clt *Client) error {
+			createResource: func(name string, clt *authclient.Client) error {
 				desktop, err := types.NewWindowsDesktopV3(name, nil,
 					types.WindowsDesktopSpecV3{Addr: "_", HostID: "_"})
 				if err != nil {
@@ -3649,11 +3650,11 @@ func TestCustomRateLimiting(t *testing.T) {
 	tests := []struct {
 		name  string
 		burst int
-		fn    func(*Client) error
+		fn    func(*authclient.Client) error
 	}{
 		{
 			name: "RPC ChangeUserAuthentication",
-			fn: func(clt *Client) error {
+			fn: func(clt *authclient.Client) error {
 				_, err := clt.ChangeUserAuthentication(ctx, &proto.ChangeUserAuthenticationRequest{})
 				return err
 			},
@@ -3661,28 +3662,28 @@ func TestCustomRateLimiting(t *testing.T) {
 		{
 			name:  "RPC CreateAuthenticateChallenge",
 			burst: defaults.LimiterBurst,
-			fn: func(clt *Client) error {
+			fn: func(clt *authclient.Client) error {
 				_, err := clt.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{})
 				return err
 			},
 		},
 		{
 			name: "RPC GetAccountRecoveryToken",
-			fn: func(clt *Client) error {
+			fn: func(clt *authclient.Client) error {
 				_, err := clt.GetAccountRecoveryToken(ctx, &proto.GetAccountRecoveryTokenRequest{})
 				return err
 			},
 		},
 		{
 			name: "RPC StartAccountRecovery",
-			fn: func(clt *Client) error {
+			fn: func(clt *authclient.Client) error {
 				_, err := clt.StartAccountRecovery(ctx, &proto.StartAccountRecoveryRequest{})
 				return err
 			},
 		},
 		{
 			name: "RPC VerifyAccountRecovery",
-			fn: func(clt *Client) error {
+			fn: func(clt *authclient.Client) error {
 				_, err := clt.VerifyAccountRecovery(ctx, &proto.VerifyAccountRecoveryRequest{})
 				return err
 			},

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/ai"
 	"github.com/gravitational/teleport/lib/ai/embedding"
 	"github.com/gravitational/teleport/lib/auth/accesspoint"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/native"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
@@ -184,7 +185,7 @@ func (a *TestServer) Auth() *Server {
 	return a.AuthServer.AuthServer
 }
 
-func (a *TestServer) NewClient(identity TestIdentity) (*Client, error) {
+func (a *TestServer) NewClient(identity TestIdentity) (*authclient.Client, error) {
 	return a.TLS.NewClient(identity)
 }
 
@@ -756,7 +757,7 @@ func WithAccessGraphConfig(config AccessGraphConfig) TestTLSServerOption {
 
 // NewRemoteClient creates new client to the remote server using identity
 // generated for this certificate authority
-func (a *TestAuthServer) NewRemoteClient(identity TestIdentity, addr net.Addr, pool *x509.CertPool) (*Client, error) {
+func (a *TestAuthServer) NewRemoteClient(identity TestIdentity, addr net.Addr, pool *x509.CertPool) (*authclient.Client, error) {
 	tlsConfig := utils.TLSConfig(a.CipherSuites)
 	cert, err := a.NewCertificate(identity)
 	if err != nil {
@@ -767,7 +768,7 @@ func (a *TestAuthServer) NewRemoteClient(identity TestIdentity, addr net.Addr, p
 	tlsConfig.ServerName = apiutils.EncodeClusterName(a.ClusterName)
 	tlsConfig.Time = a.AuthServer.clock.Now
 
-	return NewClient(client.Config{
+	return authclient.NewClient(client.Config{
 		Addrs: []string{addr.String()},
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
@@ -973,7 +974,7 @@ func TestRemoteBuiltin(role types.SystemRole, remoteCluster string) TestIdentity
 }
 
 // NewClientFromWebSession returns new authenticated client from web session
-func (t *TestTLSServer) NewClientFromWebSession(sess types.WebSession) (*Client, error) {
+func (t *TestTLSServer) NewClientFromWebSession(sess types.WebSession) (*authclient.Client, error) {
 	tlsConfig, err := t.Identity.TLSConfig(t.AuthServer.CipherSuites)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -985,7 +986,7 @@ func (t *TestTLSServer) NewClientFromWebSession(sess types.WebSession) (*Client,
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	tlsConfig.Time = t.AuthServer.AuthServer.clock.Now
 
-	return NewClient(client.Config{
+	return authclient.NewClient(client.Config{
 		Addrs: []string{t.Addr().String()},
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
@@ -1026,7 +1027,7 @@ func (t *TestTLSServer) ClientTLSConfig(identity TestIdentity) (*tls.Config, err
 
 // CloneClient uses the same credentials as the passed client
 // but forces the client to be recreated
-func (t *TestTLSServer) CloneClient(tt *testing.T, clt *Client) *Client {
+func (t *TestTLSServer) CloneClient(tt *testing.T, clt *authclient.Client) *authclient.Client {
 	tlsConfig := clt.Config()
 	// When cloning a client, we want to make sure that we don't reuse
 	// the same session ticket cache. The session ticket cache should not be
@@ -1037,7 +1038,7 @@ func (t *TestTLSServer) CloneClient(tt *testing.T, clt *Client) *Client {
 		tlsConfig.ClientSessionCache = tls.NewLRUClientSessionCache(utils.DefaultLRUCapacity)
 	}
 
-	newClient, err := NewClient(client.Config{
+	newClient, err := authclient.NewClient(client.Config{
 		Addrs: []string{t.Addr().String()},
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
@@ -1053,14 +1054,14 @@ func (t *TestTLSServer) CloneClient(tt *testing.T, clt *Client) *Client {
 }
 
 // NewClientWithCert creates a new client using given cert and private key
-func (t *TestTLSServer) NewClientWithCert(clientCert tls.Certificate) *Client {
+func (t *TestTLSServer) NewClientWithCert(clientCert tls.Certificate) *authclient.Client {
 	tlsConfig, err := t.Identity.TLSConfig(t.AuthServer.CipherSuites)
 	if err != nil {
 		panic(err)
 	}
 	tlsConfig.Time = t.AuthServer.AuthServer.clock.Now
 	tlsConfig.Certificates = []tls.Certificate{clientCert}
-	newClient, err := NewClient(client.Config{
+	newClient, err := authclient.NewClient(client.Config{
 		Addrs: []string{t.Addr().String()},
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
@@ -1074,13 +1075,13 @@ func (t *TestTLSServer) NewClientWithCert(clientCert tls.Certificate) *Client {
 }
 
 // NewClient returns new client to test server authenticated with identity
-func (t *TestTLSServer) NewClient(identity TestIdentity) (*Client, error) {
+func (t *TestTLSServer) NewClient(identity TestIdentity) (*authclient.Client, error) {
 	tlsConfig, err := t.ClientTLSConfig(identity)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	newClient, err := NewClient(client.Config{
+	newClient, err := authclient.NewClient(client.Config{
 		DialInBackground: true,
 		Addrs:            []string{t.Addr().String()},
 		Credentials: []client.Credentials{

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/aws"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/circleci"
 	"github.com/gravitational/teleport/lib/cloud/azure"
@@ -395,7 +396,7 @@ func registerThroughAuth(
 	ctx, span := tracer.Start(ctx, "registerThroughAuth")
 	defer func() { tracing.EndSpan(span, err) }()
 
-	var client *Client
+	var client *authclient.Client
 	// Build a client for the Auth Server with different certificate validation
 	// depending on the configured values for Insecure, CAPins and CAPath.
 	switch {
@@ -521,7 +522,7 @@ func verifyALPNUpgradedConn(clock clockwork.Clock) func(tls.ConnectionState) err
 // insecureRegisterClient attempts to connects to the Auth Server using the
 // CA on disk. If no CA is found on disk, Teleport will not verify the Auth
 // Server it is connecting to.
-func insecureRegisterClient(params RegisterParams) (*Client, error) {
+func insecureRegisterClient(params RegisterParams) (*authclient.Client, error) {
 	log.Warnf("Joining cluster without validating the identity of the Auth " +
 		"Server. This may open you up to a Man-In-The-Middle (MITM) attack if an " +
 		"attacker can gain privileged network access. To remedy this, use the CA pin " +
@@ -532,7 +533,7 @@ func insecureRegisterClient(params RegisterParams) (*Client, error) {
 	tlsConfig.Time = params.Clock.Now
 	tlsConfig.InsecureSkipVerify = true
 
-	client, err := NewClient(client.Config{
+	client, err := authclient.NewClient(client.Config{
 		Addrs: getHostAddresses(params),
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
@@ -567,13 +568,13 @@ func readCA(path string) (*x509.Certificate, error) {
 // know we are connecting to the expected Auth Server.
 func pinRegisterClient(
 	ctx context.Context, params RegisterParams,
-) (*Client, error) {
+) (*authclient.Client, error) {
 	// Build a insecure client to the Auth Server. This is safe because even if
 	// an attacker were to MITM this connection the CA pin will not match below.
 	tlsConfig := utils.TLSConfig(params.CipherSuites)
 	tlsConfig.InsecureSkipVerify = true
 	tlsConfig.Time = params.Clock.Now
-	authClient, err := NewClient(client.Config{
+	authClient, err := authclient.NewClient(client.Config{
 		Addrs: getHostAddresses(params),
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
@@ -624,7 +625,7 @@ func pinRegisterClient(
 	}
 	tlsConfig.RootCAs = certPool
 
-	authClient, err = NewClient(client.Config{
+	authClient, err = authclient.NewClient(client.Config{
 		Addrs: getHostAddresses(params),
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
@@ -638,7 +639,7 @@ func pinRegisterClient(
 	return authClient, nil
 }
 
-func caPathRegisterClient(params RegisterParams) (*Client, error) {
+func caPathRegisterClient(params RegisterParams) (*authclient.Client, error) {
 	tlsConfig := utils.TLSConfig(params.CipherSuites)
 	tlsConfig.Time = params.Clock.Now
 
@@ -662,7 +663,7 @@ func caPathRegisterClient(params RegisterParams) (*Client, error) {
 
 	log.Infof("Joining remote cluster %v, validating connection with certificate on disk.", cert.Subject.CommonName)
 
-	client, err := NewClient(client.Config{
+	client, err := authclient.NewClient(client.Config{
 		Addrs: getHostAddresses(params),
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
@@ -839,7 +840,7 @@ func registerUsingTPMMethod(
 // in the cluster (rotating certificates for existing members)
 type ReRegisterParams struct {
 	// Client is an authenticated client using old credentials
-	Client ClientI
+	Client authclient.ClientI
 	// ID is identity ID
 	ID IdentityID
 	// AdditionalPrincipals is a list of additional principals to dial

--- a/lib/client/ca_export.go
+++ b/lib/client/ca_export.go
@@ -30,7 +30,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils"
 )
@@ -75,17 +75,17 @@ type ExportAuthoritiesRequest struct {
 // For example:
 // > @cert-authority *.cluster-a ssh-rsa AAA... type=host
 // URL encoding is used to pass the CA type and allowed logins into the comment field.
-func ExportAuthorities(ctx context.Context, client auth.ClientI, req ExportAuthoritiesRequest) (string, error) {
+func ExportAuthorities(ctx context.Context, client authclient.ClientI, req ExportAuthoritiesRequest) (string, error) {
 	return exportAuth(ctx, client, req, false /* exportSecrets */)
 }
 
 // ExportAuthoritiesSecrets exports the Authority Certificate secrets (private keys).
 // See ExportAuthorities for more information.
-func ExportAuthoritiesSecrets(ctx context.Context, client auth.ClientI, req ExportAuthoritiesRequest) (string, error) {
+func ExportAuthoritiesSecrets(ctx context.Context, client authclient.ClientI, req ExportAuthoritiesRequest) (string, error) {
 	return exportAuth(ctx, client, req, true /* exportSecrets */)
 }
 
-func exportAuth(ctx context.Context, client auth.ClientI, req ExportAuthoritiesRequest, exportSecrets bool) (string, error) {
+func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthoritiesRequest, exportSecrets bool) (string, error) {
 	var typesToExport []types.CertAuthType
 
 	if exportSecrets {
@@ -272,7 +272,7 @@ type exportTLSAuthorityRequest struct {
 	ExportPrivateKeys bool
 }
 
-func exportTLSAuthority(ctx context.Context, client auth.ClientI, req exportTLSAuthorityRequest) (string, error) {
+func exportTLSAuthority(ctx context.Context, client authclient.ClientI, req exportTLSAuthorityRequest) (string, error) {
 	clusterName, err := client.GetDomainName(ctx)
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -330,7 +330,7 @@ func userOrOpenSSHCAFormat(ca types.CertAuthority, keyBytes []byte) (string, err
 //	@cert-authority *.cluster-a ssh-rsa AAA... type=host
 //
 // URL encoding is used to pass the CA type and allowed logins into the comment field.
-func hostCAFormat(ca types.CertAuthority, keyBytes []byte, client auth.ClientI) (string, error) {
+func hostCAFormat(ca types.CertAuthority, keyBytes []byte, client authclient.ClientI) (string, error) {
 	roles, err := services.FetchRoles(ca.GetRoles(), client, nil /* traits */)
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/lib/client/ca_export_test.go
+++ b/lib/client/ca_export_test.go
@@ -31,10 +31,11 @@ import (
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 )
 
 type mockAuthClient struct {
-	auth.ClientI
+	authclient.ClientI
 	server *auth.Server
 }
 

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -48,7 +48,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/sshutils/sftp"
@@ -136,7 +136,7 @@ type ReissueParams struct {
 	// It can be nil.
 	MFACheck *proto.IsMFARequiredResponse
 	// AuthClient is the client used for the MFACheck that can be reused
-	AuthClient auth.ClientI
+	AuthClient authclient.ClientI
 	// RequesterName identifies who is sending the cert reissue request.
 	RequesterName proto.UserCertsRequest_Requester
 }
@@ -229,7 +229,7 @@ type PromptMFAChallengeHandler func(ctx context.Context, proxyAddr string, c *pr
 // sharedAuthClient is a wrapper around auth.ClientI which
 // prevents the underlying client from being closed.
 type sharedAuthClient struct {
-	auth.ClientI
+	authclient.ClientI
 }
 
 // Close is a no-op
@@ -888,7 +888,7 @@ func (c *NodeClient) Close() error {
 }
 
 // GetPaginatedSessions grabs up to 'max' sessions.
-func GetPaginatedSessions(ctx context.Context, fromUTC, toUTC time.Time, pageSize int, order types.EventOrder, max int, authClient auth.ClientI) ([]apievents.AuditEvent, error) {
+func GetPaginatedSessions(ctx context.Context, fromUTC, toUTC time.Time, pageSize int, order types.EventOrder, max int, authClient authclient.ClientI) ([]apievents.AuditEvent, error) {
 	prevEventKey := ""
 	var sessions []apievents.AuditEvent
 	for {

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -33,6 +33,7 @@ import (
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/resumption"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -42,7 +43,7 @@ import (
 type ClusterClient struct {
 	tc          *TeleportClient
 	ProxyClient *proxyclient.Client
-	AuthClient  auth.ClientI
+	AuthClient  authclient.ClientI
 	Tracer      oteltrace.Tracer
 	cluster     string
 	root        string
@@ -66,7 +67,7 @@ func (c *ClusterClient) RootClusterName() string {
 // CurrentCluster returns an authenticated auth server client for the local cluster.
 // The returned auth server client does not need to be closed, it will be closed
 // when the ClusterClient is closed.
-func (c *ClusterClient) CurrentCluster() auth.ClientI {
+func (c *ClusterClient) CurrentCluster() authclient.ClientI {
 	// The auth.ClientI is wrapped in an sharedAuthClient to prevent callers from
 	// being able to close the client. The auth.ClientI is only to be closed
 	// when the ClusterClient is closed.
@@ -75,13 +76,13 @@ func (c *ClusterClient) CurrentCluster() auth.ClientI {
 
 // ConnectToRootCluster connects to the auth server of the root cluster
 // via proxy. It returns connected and authenticated auth server client.
-func (c *ClusterClient) ConnectToRootCluster(ctx context.Context) (auth.ClientI, error) {
+func (c *ClusterClient) ConnectToRootCluster(ctx context.Context) (authclient.ClientI, error) {
 	root, err := c.ConnectToCluster(ctx, c.root)
 	return root, trace.Wrap(err)
 }
 
 // ConnectToCluster connects to the auth server of the given cluster via proxy. It returns connected and authenticated auth server client
-func (c *ClusterClient) ConnectToCluster(ctx context.Context, clusterName string) (auth.ClientI, error) {
+func (c *ClusterClient) ConnectToCluster(ctx context.Context, clusterName string) (authclient.ClientI, error) {
 	if c.cluster == clusterName {
 		return c.CurrentCluster(), nil
 	}
@@ -91,7 +92,7 @@ func (c *ClusterClient) ConnectToCluster(ctx context.Context, clusterName string
 		return nil, trace.Wrap(err)
 	}
 
-	authClient, err := auth.NewClient(clientConfig)
+	authClient, err := authclient.NewClient(clientConfig)
 	return authClient, trace.Wrap(err)
 }
 
@@ -280,7 +281,7 @@ func (c *ClusterClient) SessionSSHConfig(ctx context.Context, user string, targe
 			return nil, trace.Wrap(err)
 		}
 
-		authClient, err := auth.NewClient(cfg)
+		authClient, err := authclient.NewClient(cfg)
 		if err != nil {
 			return nil, trace.Wrap(MFARequiredUnknown(err))
 		}

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proxy"
 	"github.com/gravitational/teleport/api/mfa"
 	webauthnpb "github.com/gravitational/teleport/api/types/webauthn"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/services"
@@ -38,7 +38,7 @@ import (
 )
 
 type fakeAuthClient struct {
-	auth.ClientI
+	authclient.ClientI
 
 	isMFARequired     func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error)
 	generateUserCerts func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error)

--- a/lib/client/conntest/connection_tester.go
+++ b/lib/client/conntest/connection_tester.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 )
 
@@ -156,7 +156,7 @@ type ConnectionTesterConfig struct {
 
 	// UserClient is an auth client that has a User's identity.
 	// This is the user that is running the SSH Connection Test.
-	UserClient auth.ClientI
+	UserClient authclient.ClientI
 
 	// ProxyHostPort is the proxy to use in the `--proxy` format (host:webPort,sshPort)
 	ProxyHostPort string

--- a/lib/client/conntest/externalcloudaudit.go
+++ b/lib/client/conntest/externalcloudaudit.go
@@ -25,13 +25,13 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 )
 
 // ExternalAuditStorageConnectionTesterConfig defines the config fields for ExternalAuditStorageConnectionTester.
 type ExternalAuditStorageConnectionTesterConfig struct {
 	// UserClient is an auth client that has a User's identity.
-	UserClient auth.ClientI
+	UserClient authclient.ClientI
 }
 
 // ExternalAuditStorageConnectionTester implements the ConnectionTester interface for testing External Audit Storage access.

--- a/lib/client/conntest/kube.go
+++ b/lib/client/conntest/kube.go
@@ -34,14 +34,14 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 )
 
 // KubeConnectionTesterConfig defines the config fields for KubeConnectionTester.
 type KubeConnectionTesterConfig struct {
 	// UserClient is an auth client that has a User's identity.
-	UserClient auth.ClientI
+	UserClient authclient.ClientI
 
 	// ProxyHostPort is the proxy to use in the `--proxy` format (host:webPort,sshPort)
 	ProxyHostPort string

--- a/lib/client/conntest/ssh.go
+++ b/lib/client/conntest/ssh.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/connectmycomputer"
 	libsshutils "github.com/gravitational/teleport/lib/sshutils"
@@ -44,7 +45,7 @@ import (
 type SSHConnectionTesterConfig struct {
 	// UserClient is an auth client that has a User's identity.
 	// This is the user that is running the SSH Connection Test.
-	UserClient auth.ClientI
+	UserClient authclient.ClientI
 
 	// ProxyHostPort is the proxy to use in the `--proxy` format (host:webPort,sshPort)
 	ProxyHostPort string

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -67,6 +67,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -111,7 +112,7 @@ type ForwarderConfig struct {
 	// Authz authenticates user
 	Authz authz.Authorizer
 	// AuthClient is a auth server client.
-	AuthClient auth.ClientI
+	AuthClient authclient.ClientI
 	// CachingAuthClient is a caching auth server client for read-only access.
 	CachingAuthClient auth.ReadKubernetesAccessPoint
 	// Emitter is used to emit audit events

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -1129,7 +1130,7 @@ func newMockForwader(ctx context.Context, t *testing.T) *Forwarder {
 // mockCSRClient to intercept ProcessKubeCSR requests, record them and return a
 // stub response.
 type mockCSRClient struct {
-	auth.ClientI
+	authclient.ClientI
 
 	clock           clockwork.Clock
 	ca              *tlsca.CertAuthority
@@ -1321,7 +1322,7 @@ func newTestForwarder(ctx context.Context, cfg ForwarderConfig) *Forwarder {
 }
 
 type mockSemaphoreClient struct {
-	auth.ClientI
+	authclient.ClientI
 	sem   types.Semaphores
 	roles map[string]types.Role
 }

--- a/lib/kube/proxy/server_test.go
+++ b/lib/kube/proxy/server_test.go
@@ -42,7 +42,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -275,7 +275,7 @@ func TestHeartbeat(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
 	type args struct {
-		kubeClusterGetter func(auth.ClientI) []string
+		kubeClusterGetter func(authclient.ClientI) []string
 	}
 	tests := []struct {
 		name      string
@@ -285,7 +285,7 @@ func TestHeartbeat(t *testing.T) {
 		{
 			name: "List KubeServers",
 			args: args{
-				kubeClusterGetter: func(authClient auth.ClientI) []string {
+				kubeClusterGetter: func(authClient authclient.ClientI) []string {
 					rsp, err := authClient.ListResources(testCtx.Context, proto.ListResourcesRequest{
 						ResourceType: types.KindKubeServer,
 						Limit:        10,

--- a/lib/kube/proxy/sess_test.go
+++ b/lib/kube/proxy/sess_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
@@ -187,7 +188,7 @@ func Test_session_trackSession(t *testing.T) {
 		Name:    "name",
 	}
 	type args struct {
-		authClient auth.ClientI
+		authClient authclient.ClientI
 		policies   []*types.SessionTrackerPolicySet
 	}
 	tests := []struct {
@@ -283,7 +284,7 @@ func Test_session_trackSession(t *testing.T) {
 }
 
 type mockSessionTrackerService struct {
-	auth.ClientI
+	authclient.ClientI
 	returnErr bool
 }
 

--- a/lib/kube/proxy/utils_testing.go
+++ b/lib/kube/proxy/utils_testing.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keygen"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
@@ -66,7 +67,7 @@ type TestContext struct {
 	ClusterName          string
 	TLSServer            *auth.TestTLSServer
 	AuthServer           *auth.Server
-	AuthClient           *auth.Client
+	AuthClient           *authclient.Client
 	Authz                authz.Authorizer
 	KubeServer           *TLSServer
 	KubeProxy            *TLSServer
@@ -570,7 +571,7 @@ func (c *TestContext) NewJoiningSession(cfg *rest.Config, sessionID string, mode
 // and ResumeAuditStream methods to use a events.TeeStreamer to leverage the StreamEmitter
 // even when recording mode is *-sync.
 type authClientWithStreamer struct {
-	*auth.Client
+	*authclient.Client
 	streamer events.Streamer
 }
 
@@ -588,7 +589,7 @@ func (a *authClientWithStreamer) ResumeAuditStream(ctx context.Context, sID sess
 }
 
 type fakeClient struct {
-	auth.ClientI
+	authclient.ClientI
 	closeC chan struct{}
 }
 

--- a/lib/proxy/peer/client.go
+++ b/lib/proxy/peer/client.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 	streamutils "github.com/gravitational/teleport/api/utils/grpc/stream"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -52,7 +53,7 @@ type ClientConfig struct {
 	// ID is the ID of this server proxy
 	ID string
 	// AuthClient is an auth client
-	AuthClient auth.ClientI
+	AuthClient authclient.ClientI
 	// AccessPoint is a caching auth client
 	AccessPoint auth.ProxyAccessPoint
 	// TLSConfig is the proxy client TLS configuration.

--- a/lib/proxy/peer/helpers_test.go
+++ b/lib/proxy/peer/helpers_test.go
@@ -36,6 +36,7 @@ import (
 	clientapi "github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -43,7 +44,7 @@ import (
 )
 
 type mockAuthClient struct {
-	auth.ClientI
+	authclient.ClientI
 }
 
 func (c mockAuthClient) GetProxies() ([]types.Server, error) {

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -39,7 +39,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/agentless"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
@@ -550,7 +550,7 @@ func (r *Router) DialSite(ctx context.Context, clusterName string, clientSrcAddr
 }
 
 // GetSiteClient returns an auth client for the provided cluster.
-func (r *Router) GetSiteClient(ctx context.Context, clusterName string) (auth.ClientI, error) {
+func (r *Router) GetSiteClient(ctx context.Context, clusterName string) (authclient.ClientI, error) {
 	if clusterName == r.clusterName {
 		return r.localSite.GetClient()
 	}

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/agentless"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -590,7 +590,7 @@ func (r testRemoteSite) DialAuthServer(reversetunnelclient.DialParams) (net.Conn
 	return r.conn, r.err
 }
 
-func (r testRemoteSite) GetClient() (auth.ClientI, error) {
+func (r testRemoteSite) GetClient() (authclient.ClientI, error) {
 	return nil, nil
 }
 

--- a/lib/puttyhosts/puttyhosts.go
+++ b/lib/puttyhosts/puttyhosts.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/sshutils"
 )
@@ -175,7 +175,7 @@ func getAllHostCAs(tc *client.TeleportClient, cfContext context.Context) ([]type
 	var err error
 	// get all CAs for the cluster (including trusted clusters)
 	var cas []types.CertAuthority
-	err = tc.WithRootClusterClient(cfContext, func(clt auth.ClientI) error {
+	err = tc.WithRootClusterClient(cfContext, func(clt authclient.ClientI) error {
 		cas, err = clt.GetCertAuthorities(cfContext, types.HostCA, false /* exportSecrets */)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnel/track"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -101,7 +102,7 @@ type AgentPool struct {
 type AgentPoolConfig struct {
 	// Client is client to the auth server this agent connects to receive
 	// a list of pools
-	Client auth.ClientI
+	Client authclient.ClientI
 	// AccessPoint is a lightweight access point
 	// that can optionally cache some values
 	AccessPoint auth.AccessCache

--- a/lib/reversetunnel/agentpool_test.go
+++ b/lib/reversetunnel/agentpool_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/reversetunnel/track"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -59,7 +59,7 @@ func (m *mockAgent) GetProxyID() (string, bool) {
 }
 
 type mockClient struct {
-	auth.ClientI
+	authclient.ClientI
 	ssh.Signer
 	mockGetClusterNetworkingConfig func(context.Context) (types.ClusterNetworkingConfig, error)
 }

--- a/lib/reversetunnel/cache.go
+++ b/lib/reversetunnel/cache.go
@@ -32,7 +32,7 @@ import (
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/defaults"
 )
@@ -41,12 +41,12 @@ type certificateCache struct {
 	mu sync.Mutex
 
 	cache      *ttlmap.TTLMap
-	authClient auth.ClientI
+	authClient authclient.ClientI
 }
 
 // newHostCertificateCache creates a shared host certificate cache that is
 // used by the forwarding server.
-func newHostCertificateCache(authClient auth.ClientI) (*certificateCache, error) {
+func newHostCertificateCache(authClient authclient.ClientI) (*certificateCache, error) {
 	native.PrecomputeKeys() // ensure native package is set to precompute keys
 	cache, err := ttlmap.New(defaults.HostCertCacheSize)
 	if err != nil {

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/observability/metrics"
@@ -147,7 +148,7 @@ type localSite struct {
 	srv         *server
 
 	// client provides access to the Auth Server API of the local cluster.
-	client auth.ClientI
+	client authclient.ClientI
 	// accessPoint provides access to a cached subset of the Auth Server API of
 	// the local cluster.
 	accessPoint auth.RemoteProxyAccessPoint
@@ -198,7 +199,7 @@ func (s *localSite) NodeWatcher() (*services.NodeWatcher, error) {
 }
 
 // GetClient returns a client to the full Auth Server API.
-func (s *localSite) GetClient() (auth.ClientI, error) {
+func (s *localSite) GetClient() (authclient.ClientI, error) {
 	return s.client, nil
 }
 

--- a/lib/reversetunnel/localsite_test.go
+++ b/lib/reversetunnel/localsite_test.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -342,7 +342,7 @@ func TestProxyResync(t *testing.T) {
 }
 
 type mockLocalSiteClient struct {
-	auth.Client
+	authclient.Client
 
 	proxies []types.Server
 }

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -98,7 +99,7 @@ func (p *clusterPeers) NodeWatcher() (*services.NodeWatcher, error) {
 	return peer.NodeWatcher()
 }
 
-func (p *clusterPeers) GetClient() (auth.ClientI, error) {
+func (p *clusterPeers) GetClient() (authclient.ClientI, error) {
 	peer, err := p.pickPeer()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -206,7 +207,7 @@ func (s *clusterPeer) NodeWatcher() (*services.NodeWatcher, error) {
 	return nil, trace.ConnectionProblem(nil, "unable to fetch node watcher, this proxy %v has not been discovered yet, try again later", s)
 }
 
-func (s *clusterPeer) GetClient() (auth.ClientI, error) {
+func (s *clusterPeer) GetClient() (authclient.ClientI, error) {
 	return nil, trace.ConnectionProblem(nil, "unable to fetch client, this proxy %v has not been discovered yet, try again later", s)
 }
 

--- a/lib/reversetunnel/rc_manager.go
+++ b/lib/reversetunnel/rc_manager.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport"
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -62,7 +63,7 @@ type remoteClusterKey struct {
 // RemoteClusterTunnelManager.
 type RemoteClusterTunnelManagerConfig struct {
 	// AuthClient is client to the auth server.
-	AuthClient auth.ClientI
+	AuthClient authclient.ClientI
 	// AccessPoint is a lightweight access point that can optionally cache some
 	// values.
 	AccessPoint auth.ProxyAccessPoint

--- a/lib/reversetunnel/rc_manager_test.go
+++ b/lib/reversetunnel/rc_manager_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -183,7 +183,7 @@ func TestRemoteClusterTunnelManagerSync(t *testing.T) {
 }
 
 type mockAuthClient struct {
-	auth.ClientI
+	authclient.ClientI
 
 	reverseTunnels    []types.ReverseTunnel
 	reverseTunnelsErr error

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/limiter"
@@ -85,7 +86,7 @@ type server struct {
 
 	// localAuthClient provides access to the full Auth Server API for the
 	// local cluster.
-	localAuthClient auth.ClientI
+	localAuthClient authclient.ClientI
 	// localAccessPoint provides access to a cached subset of the Auth
 	// Server API.
 	localAccessPoint auth.ProxyAccessPoint
@@ -142,7 +143,7 @@ type Config struct {
 	// Limiter is optional request limiter
 	Limiter *limiter.Limiter
 	// LocalAuthClient provides access to a full AuthClient for the local cluster.
-	LocalAuthClient auth.ClientI
+	LocalAuthClient authclient.ClientI
 	// AccessPoint provides access to a subset of AuthClient of the cluster.
 	// AccessPoint caches values and can still return results during connection
 	// problems.
@@ -1289,7 +1290,7 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 // **WARNING**: Ensure that the version below matches the version in which backward incompatible
 // changes were introduced so that the cache is created successfully. Otherwise, the remote cache may
 // never become healthy due to unknown resources.
-func createRemoteAccessPoint(srv *server, clt auth.ClientI, version, domainName string) (auth.RemoteProxyAccessPoint, error) {
+func createRemoteAccessPoint(srv *server, clt authclient.ClientI, version, domainName string) (auth.RemoteProxyAccessPoint, error) {
 	ok, err := utils.MinVerWithoutPreRelease(version, utils.VersionBeforeAlpha("13.0.0"))
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -216,7 +217,7 @@ func TestCreateRemoteAccessPoint(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			newProxyFn := func(clt auth.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
+			newProxyFn := func(clt authclient.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
 				if tt.oldRemoteProxy {
 					return nil, errors.New("expected to create an old remote proxy")
 				}
@@ -224,7 +225,7 @@ func TestCreateRemoteAccessPoint(t *testing.T) {
 				return nil, nil
 			}
 
-			oldProxyFn := func(clt auth.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
+			oldProxyFn := func(clt authclient.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
 				if !tt.oldRemoteProxy {
 					return nil, errors.New("expected to create an new remote proxy")
 				}

--- a/lib/reversetunnelclient/api.go
+++ b/lib/reversetunnelclient/api.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/proxy/peer"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/teleagent"
@@ -118,7 +119,7 @@ type RemoteSite interface {
 	// GetStatus returns status of this site (either offline or connected)
 	GetStatus() string
 	// GetClient returns client connected to remote auth server
-	GetClient() (auth.ClientI, error)
+	GetClient() (authclient.ClientI, error)
 	// CachingAccessPoint returns access point that is lightweight
 	// but is resilient to auth server crashes
 	CachingAccessPoint() (auth.RemoteProxyAccessPoint, error)

--- a/lib/service/awsoidc.go
+++ b/lib/service/awsoidc.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
@@ -103,7 +103,7 @@ type AWSOIDCDeployServiceUpdaterConfig struct {
 	// Log is the logger
 	Log *slog.Logger
 	// AuthClient is the auth api client
-	AuthClient *auth.Client
+	AuthClient *authclient.Client
 	// Clock is the local clock
 	Clock clockwork.Clock
 	// TeleportClusterName specifies the teleport cluster name

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/discovery"
@@ -146,7 +146,7 @@ func (process *TeleportProcess) integrationOnlyCredentials() bool {
 
 // buildAccessGraphFromTAGOrFallbackToAuth builds the AccessGraphConfig from the Teleport Agent configuration or falls back to the Auth server's configuration.
 // If the AccessGraph configuration is not enabled locally, it will fall back to the Auth server's configuration.
-func buildAccessGraphFromTAGOrFallbackToAuth(ctx context.Context, config *servicecfg.Config, client auth.ClientI, logger *slog.Logger) (discovery.AccessGraphConfig, error) {
+func buildAccessGraphFromTAGOrFallbackToAuth(ctx context.Context, config *servicecfg.Config, client authclient.ClientI, logger *slog.Logger) (discovery.AccessGraphConfig, error) {
 	var (
 		accessGraphCAData []byte
 		err               error

--- a/lib/service/discovery_test.go
+++ b/lib/service/discovery_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/discovery"
@@ -166,7 +166,7 @@ func TestTeleportProcess_initDiscoveryService(t *testing.T) {
 }
 
 type fakeClient struct {
-	auth.ClientI
+	authclient.ClientI
 	rsp *clusterconfigpb.AccessGraphConfig
 	err error
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -86,6 +86,7 @@ import (
 	"github.com/gravitational/teleport/lib/auditd"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/accesspoint"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keygen"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/authz"
@@ -304,7 +305,7 @@ type Connector struct {
 	ServerIdentity *auth.Identity
 
 	// Client is authenticated client with credentials from ClientIdentity.
-	Client *auth.Client
+	Client *authclient.Client
 
 	// ReusedClient, if true, indicates that the client reference is owned by
 	// a different connector and should not be closed.
@@ -1367,7 +1368,7 @@ func (process *TeleportProcess) getInstanceConnector() *Connector {
 // instance client has yet to be created, or this is an auth-only instance. Auth-only instances cannot use
 // the instance client because auth servers need to be able to fully initialize without a valid CA in order
 // to support HSMs.
-func (process *TeleportProcess) getInstanceClient() *auth.Client {
+func (process *TeleportProcess) getInstanceClient() *authclient.Client {
 	conn := process.getInstanceConnector()
 	if conn == nil {
 		return nil
@@ -2328,7 +2329,7 @@ func (process *TeleportProcess) newAccessCache(cfg accesspoint.AccessCacheConfig
 }
 
 // newLocalCacheForNode returns new instance of access point configured for a local proxy.
-func (process *TeleportProcess) newLocalCacheForNode(clt auth.ClientI, cacheName []string) (auth.NodeAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForNode(clt authclient.ClientI, cacheName []string) (auth.NodeAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2343,7 +2344,7 @@ func (process *TeleportProcess) newLocalCacheForNode(clt auth.ClientI, cacheName
 }
 
 // newLocalCacheForKubernetes returns new instance of access point configured for a kubernetes service.
-func (process *TeleportProcess) newLocalCacheForKubernetes(clt auth.ClientI, cacheName []string) (auth.KubernetesAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForKubernetes(clt authclient.ClientI, cacheName []string) (auth.KubernetesAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2358,7 +2359,7 @@ func (process *TeleportProcess) newLocalCacheForKubernetes(clt auth.ClientI, cac
 }
 
 // newLocalCacheForDatabase returns new instance of access point configured for a database service.
-func (process *TeleportProcess) newLocalCacheForDatabase(clt auth.ClientI, cacheName []string) (auth.DatabaseAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForDatabase(clt authclient.ClientI, cacheName []string) (auth.DatabaseAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2383,13 +2384,13 @@ type discoveryConfigClient interface {
 
 // combinedDiscoveryClient is an auth.Client client with other, specific, services added to it.
 type combinedDiscoveryClient struct {
-	auth.ClientI
+	authclient.ClientI
 	discoveryConfigClient
 	eksClustersEnroller
 }
 
 // newLocalCacheForDiscovery returns a new instance of access point for a discovery service.
-func (process *TeleportProcess) newLocalCacheForDiscovery(clt auth.ClientI, cacheName []string) (auth.DiscoveryAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForDiscovery(clt authclient.ClientI, cacheName []string) (auth.DiscoveryAccessPoint, error) {
 	client := combinedDiscoveryClient{
 		ClientI:               clt,
 		discoveryConfigClient: clt.DiscoveryConfigClient(),
@@ -2408,7 +2409,7 @@ func (process *TeleportProcess) newLocalCacheForDiscovery(clt auth.ClientI, cach
 }
 
 // newLocalCacheForProxy returns new instance of access point configured for a local proxy.
-func (process *TeleportProcess) newLocalCacheForProxy(clt auth.ClientI, cacheName []string) (auth.ProxyAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForProxy(clt authclient.ClientI, cacheName []string) (auth.ProxyAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2423,7 +2424,7 @@ func (process *TeleportProcess) newLocalCacheForProxy(clt auth.ClientI, cacheNam
 }
 
 // newLocalCacheForRemoteProxy returns new instance of access point configured for a remote proxy.
-func (process *TeleportProcess) newLocalCacheForRemoteProxy(clt auth.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForRemoteProxy(clt authclient.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2441,7 +2442,7 @@ func (process *TeleportProcess) newLocalCacheForRemoteProxy(clt auth.ClientI, ca
 //
 // newLocalCacheForOldRemoteProxy returns new instance of access point
 // configured for an old remote proxy.
-func (process *TeleportProcess) newLocalCacheForOldRemoteProxy(clt auth.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForOldRemoteProxy(clt authclient.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2456,7 +2457,7 @@ func (process *TeleportProcess) newLocalCacheForOldRemoteProxy(clt auth.ClientI,
 }
 
 // newLocalCacheForApps returns new instance of access point configured for a remote proxy.
-func (process *TeleportProcess) newLocalCacheForApps(clt auth.ClientI, cacheName []string) (auth.AppsAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForApps(clt authclient.ClientI, cacheName []string) (auth.AppsAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2471,7 +2472,7 @@ func (process *TeleportProcess) newLocalCacheForApps(clt auth.ClientI, cacheName
 }
 
 // newLocalCacheForWindowsDesktop returns new instance of access point configured for a windows desktop service.
-func (process *TeleportProcess) newLocalCacheForWindowsDesktop(clt auth.ClientI, cacheName []string) (auth.WindowsDesktopAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForWindowsDesktop(clt authclient.ClientI, cacheName []string) (auth.WindowsDesktopAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2485,12 +2486,12 @@ func (process *TeleportProcess) newLocalCacheForWindowsDesktop(clt auth.ClientI,
 	return auth.NewWindowsDesktopWrapper(clt, cache), nil
 }
 
-// accessPointWrapper is a wrapper around auth.ClientI that reduces the surface area of the
+// accessPointWrapper is a wrapper around [authclient.ClientI]  that reduces the surface area of the
 // auth.ClientI.DiscoveryConfigClient interface to services.DiscoveryConfigs.
-// Cache doesn't implement the full auth.ClientI interface, so we need to wrap auth.ClientI
+// Cache doesn't implement the full [authclient.ClientI]  interface, so we need to wrap [authclient.ClientI]
 // to make it compatible with the services.DiscoveryConfigs interface.
 type accessPointWrapper struct {
-	auth.ClientI
+	authclient.ClientI
 }
 
 func (a accessPointWrapper) CrownJewelClient() services.CrownJewels {
@@ -2502,7 +2503,7 @@ func (a accessPointWrapper) DiscoveryConfigClient() services.DiscoveryConfigs {
 }
 
 // NewLocalCache returns new instance of access point
-func (process *TeleportProcess) NewLocalCache(clt auth.ClientI, setupConfig cache.SetupConfigFn, cacheName []string) (*cache.Cache, error) {
+func (process *TeleportProcess) NewLocalCache(clt authclient.ClientI, setupConfig cache.SetupConfigFn, cacheName []string) (*cache.Cache, error) {
 	return process.newAccessCache(accesspoint.AccessCacheConfig{
 		Services:  &accessPointWrapper{ClientI: clt},
 		Setup:     setupConfig,

--- a/lib/srv/alpnproxy/helpers_test.go
+++ b/lib/srv/alpnproxy/helpers_test.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -52,7 +53,7 @@ type Suite struct {
 	ca             *tlsca.CertAuthority
 	authServer     *auth.TestAuthServer
 	tlsServer      *auth.TestTLSServer
-	accessPoint    *auth.Client
+	accessPoint    *authclient.Client
 }
 
 func NewSuite(t *testing.T) *Suite {

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
@@ -81,7 +82,7 @@ type ConnectionsHandlerConfig struct {
 	HostID string
 
 	// AuthClient is a client directly connected to the Auth server.
-	AuthClient auth.ClientI
+	AuthClient authclient.ClientI
 
 	// AccessPoint is a caching client connected to the Auth Server.
 	AccessPoint auth.AppsAccessPoint

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -35,6 +35,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -55,7 +56,7 @@ type Config struct {
 	Clock clockwork.Clock
 
 	// AuthClient is a client directly connected to the Auth server.
-	AuthClient *auth.Client
+	AuthClient *authclient.Client
 
 	// AccessPoint is a caching client connected to the Auth Server.
 	AccessPoint auth.AppsAccessPoint

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -52,6 +52,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
@@ -79,7 +80,7 @@ type Suite struct {
 	dataDir      string
 	authServer   *auth.TestAuthServer
 	tlsServer    *auth.TestTLSServer
-	authClient   *auth.Client
+	authClient   *authclient.Client
 	appServer    *Server
 	hostCertPool *x509.CertPool
 

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/client"
@@ -1431,7 +1432,7 @@ type testContext struct {
 	clusterName    string
 	tlsServer      *auth.TestTLSServer
 	authServer     *auth.Server
-	authClient     *auth.Client
+	authClient     *authclient.Client
 	proxyServer    *ProxyServer
 	mux            *multiplexer.Mux
 	mysqlListener  net.Listener

--- a/lib/srv/db/common/autousers.go
+++ b/lib/srv/db/common/autousers.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -38,7 +38,7 @@ import (
 // UserProvisioner handles automatic database user creation.
 type UserProvisioner struct {
 	// AuthClient is the cluster auth server client.
-	AuthClient *auth.Client
+	AuthClient *authclient.Client
 	// Backend is the particular database implementation.
 	Backend AutoUsers
 	// Log is the logger.

--- a/lib/srv/db/common/engines.go
+++ b/lib/srv/db/common/engines.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/srv/db/common/enterprise"
 )
@@ -102,7 +102,7 @@ type EngineConfig struct {
 	// Audit emits database access audit events.
 	Audit Audit
 	// AuthClient is the cluster auth server client.
-	AuthClient *auth.Client
+	AuthClient *authclient.Client
 	// CloudClients provides access to cloud API clients.
 	CloudClients cloud.Clients
 	// Context is the database server close context.

--- a/lib/srv/db/common/engines_test.go
+++ b/lib/srv/db/common/engines_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cloud"
 )
 
@@ -48,7 +48,7 @@ func TestRegisterEngine(t *testing.T) {
 		Log:          logrus.StandardLogger(),
 		Auth:         &testAuth{},
 		Audit:        &testAudit{},
-		AuthClient:   &auth.Client{},
+		AuthClient:   &authclient.Client{},
 		CloudClients: cloudClients,
 	}
 	require.NoError(t, ec.CheckAndSetDefaults())

--- a/lib/srv/db/common/test.go
+++ b/lib/srv/db/common/test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/services"
@@ -162,7 +163,7 @@ func MakeTestServerTLSConfig(config TestServerConfig) (*tls.Config, error) {
 // TestClientConfig combines parameters for a test Postgres/MySQL client.
 type TestClientConfig struct {
 	// AuthClient will be used to retrieve trusted CA.
-	AuthClient auth.ClientI
+	AuthClient authclient.ClientI
 	// AuthServer will be used to generate database access certificate for a user.
 	AuthServer *auth.Server
 	// Address is the address to connect to (web proxy).

--- a/lib/srv/db/mysql/gcp_test.go
+++ b/lib/srv/db/mysql/gcp_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -171,7 +172,7 @@ func Test_getGCPUserAndPassowrd(t *testing.T) {
 	}
 }
 
-func makeAuthClient(t *testing.T) *auth.Client {
+func makeAuthClient(t *testing.T) *authclient.Client {
 	t.Helper()
 
 	authServer, err := auth.NewTestAuthServer(auth.TestAuthServerConfig{

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -83,7 +84,7 @@ type ConnMonitor interface {
 // ProxyServerConfig is the proxy configuration.
 type ProxyServerConfig struct {
 	// AuthClient is the authenticated client to the auth server.
-	AuthClient *auth.Client
+	AuthClient *authclient.Client
 	// AccessPoint is the caching client connected to the auth server.
 	AccessPoint auth.ReadDatabaseAccessPoint
 	// Authorizer is responsible for authorizing user identities.

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	clients "github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -88,7 +89,7 @@ type Config struct {
 	// DataDir is the path to the data directory for the server.
 	DataDir string
 	// AuthClient is a client directly connected to the Auth server.
-	AuthClient *auth.Client
+	AuthClient *authclient.Client
 	// AccessPoint is a caching client connected to the Auth Server.
 	AccessPoint auth.DatabaseAccessPoint
 	// Emitter is used to emit audit events.

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/windows"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -165,7 +166,7 @@ type WindowsServiceConfig struct {
 	// AccessPoint is the Auth API client (with caching).
 	AccessPoint auth.WindowsDesktopAccessPoint
 	// AuthClient is the Auth API client (without caching).
-	AuthClient auth.ClientI
+	AuthClient authclient.ClientI
 	// ConnLimiter limits the number of active connections per client IP.
 	ConnLimiter *limiter.ConnectionsLimiter
 	// Heartbeat contains configuration for service heartbeats.

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -72,6 +72,7 @@ import (
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/azure"
@@ -2914,7 +2915,7 @@ func (d *combinedDiscoveryClient) UpdateDiscoveryConfigStatus(ctx context.Contex
 	return nil, trace.BadParameter("not implemented.")
 }
 
-func getDiscoveryAccessPoint(authServer *auth.Server, authClient auth.ClientI) auth.DiscoveryAccessPoint {
+func getDiscoveryAccessPoint(authServer *auth.Server, authClient authclient.ClientI) auth.DiscoveryAccessPoint {
 	return &combinedDiscoveryClient{Server: authServer, eksClustersEnroller: authClient.IntegrationAWSOIDCClient(), discoveryConfigStatusUpdater: authClient.DiscoveryConfigClient()}
 
 }

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/cloud"
@@ -284,7 +285,7 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 		existingKubeServers          []types.KubeServer
 		awsMatchers                  []types.AWSMatcher
 		expectedServersToExistInAuth []types.KubeServer
-		accessPoint                  func(*testing.T, *auth.Server, auth.ClientI) auth.DiscoveryAccessPoint
+		accessPoint                  func(*testing.T, *auth.Server, authclient.ClientI) auth.DiscoveryAccessPoint
 		discoveryConfig              func(*testing.T) *discoveryconfig.DiscoveryConfig
 	}{
 		{
@@ -292,7 +293,7 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 			discoveryConfig: func(t *testing.T) *discoveryconfig.DiscoveryConfig {
 				return getDc()
 			},
-			accessPoint: func(t *testing.T, authServer *auth.Server, authClient auth.ClientI) auth.DiscoveryAccessPoint {
+			accessPoint: func(t *testing.T, authServer *auth.Server, authClient authclient.ClientI) auth.DiscoveryAccessPoint {
 				return &accessPointWrapper{
 					DiscoveryAccessPoint: getDiscoveryAccessPoint(authServer, authClient),
 					enrollEKSClusters: func(ctx context.Context, request *integrationpb.EnrollEKSClustersRequest, _ ...grpc.CallOption) (*integrationpb.EnrollEKSClustersResponse, error) {
@@ -320,7 +321,7 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 			discoveryConfig: func(t *testing.T) *discoveryconfig.DiscoveryConfig {
 				return getDc()
 			},
-			accessPoint: func(t *testing.T, authServer *auth.Server, authClient auth.ClientI) auth.DiscoveryAccessPoint {
+			accessPoint: func(t *testing.T, authServer *auth.Server, authClient authclient.ClientI) auth.DiscoveryAccessPoint {
 				return &accessPointWrapper{
 					DiscoveryAccessPoint: getDiscoveryAccessPoint(authServer, authClient),
 					enrollEKSClusters: func(ctx context.Context, request *integrationpb.EnrollEKSClustersRequest, _ ...grpc.CallOption) (*integrationpb.EnrollEKSClustersResponse, error) {
@@ -350,7 +351,7 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 			discoveryConfig: func(t *testing.T) *discoveryconfig.DiscoveryConfig {
 				return getDc()
 			},
-			accessPoint: func(t *testing.T, authServer *auth.Server, authClient auth.ClientI) auth.DiscoveryAccessPoint {
+			accessPoint: func(t *testing.T, authServer *auth.Server, authClient authclient.ClientI) auth.DiscoveryAccessPoint {
 				return &accessPointWrapper{
 					DiscoveryAccessPoint: getDiscoveryAccessPoint(authServer, authClient),
 					enrollEKSClusters: func(ctx context.Context, request *integrationpb.EnrollEKSClustersRequest, _ ...grpc.CallOption) (*integrationpb.EnrollEKSClustersResponse, error) {

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/bpf"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
@@ -144,7 +145,7 @@ type Server struct {
 	// the server supports. If omitted the defaults will be used.
 	macAlgorithms []string
 
-	authClient      auth.ClientI
+	authClient      authclient.ClientI
 	authService     srv.AccessPoint
 	sessionRegistry *srv.SessionRegistry
 	dataDir         string
@@ -183,7 +184,7 @@ type ServerConfig struct {
 	// LocalAuthClient is a client that provides access to this local cluster.
 	// This is used for actions that should always happen on the local cluster
 	// and not remote clusters, such as session recording.
-	LocalAuthClient auth.ClientI
+	LocalAuthClient authclient.ClientI
 	// TargetClusterAccessPoint is a client that provides access to the cluster
 	// of the server being connected to, whether it is the local cluster or a
 	// remote cluster.

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/bpf"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -714,7 +715,7 @@ func New(
 	dataDir string,
 	advertiseAddr string,
 	proxyPublicAddr utils.NetAddr,
-	auth auth.ClientI,
+	auth authclient.ClientI,
 	options ...ServerOption,
 ) (*Server, error) {
 	// read the host UUID:

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -60,6 +60,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/bpf"
@@ -442,7 +443,7 @@ loop:
 	require.Equal(t, "echo 1", execEvent.CommandMetadata.Command)
 }
 
-func newProxyClient(t *testing.T, testSvr *auth.TestServer) (*auth.Client, string) {
+func newProxyClient(t *testing.T, testSvr *auth.TestServer) (*authclient.Client, string) {
 	// create proxy client used in some tests
 	proxyID := uuid.New().String()
 	proxyClient, err := testSvr.NewClient(auth.TestIdentity{
@@ -455,7 +456,7 @@ func newProxyClient(t *testing.T, testSvr *auth.TestServer) (*auth.Client, strin
 	return proxyClient, proxyID
 }
 
-func newNodeClient(t *testing.T, testSvr *auth.TestServer) (*auth.Client, string) {
+func newNodeClient(t *testing.T, testSvr *auth.TestServer) (*authclient.Client, string) {
 	nodeID := uuid.New().String()
 	nodeClient, err := testSvr.NewClient(auth.TestIdentity{
 		I: authz.BuiltinRole{
@@ -1466,7 +1467,7 @@ func mustListen(t *testing.T) (net.Listener, utils.NetAddr) {
 	return l, addr
 }
 
-func noCache(clt auth.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
+func noCache(clt authclient.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
 	return clt, nil
 }
 

--- a/lib/tbot/database_access.go
+++ b/lib/tbot/database_access.go
@@ -28,11 +28,11 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	libdefaults "github.com/gravitational/teleport/lib/defaults"
 )
 
-func getDatabase(ctx context.Context, clt *auth.Client, name string) (types.Database, error) {
+func getDatabase(ctx context.Context, clt *authclient.Client, name string) (types.Database, error) {
 	ctx, span := tracer.Start(ctx, "getDatabase")
 	defer span.End()
 
@@ -59,7 +59,7 @@ func getDatabase(ctx context.Context, clt *auth.Client, name string) (types.Data
 func getRouteToDatabase(
 	ctx context.Context,
 	log *slog.Logger,
-	client *auth.Client,
+	client *authclient.Client,
 	service string,
 	username string,
 	database string,

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
@@ -59,7 +60,7 @@ type identityService struct {
 	resolver          reversetunnelclient.Resolver
 
 	mu     sync.Mutex
-	client *auth.Client
+	client *authclient.Client
 	facade *identity.Facade
 }
 
@@ -72,7 +73,7 @@ func (s *identityService) GetIdentity() *identity.Identity {
 
 // GetClient returns the facaded client for the Bot identity for use by other
 // components of `tbot`. Consumers should not call `Close` on the client.
-func (s *identityService) GetClient() *auth.Client {
+func (s *identityService) GetClient() *authclient.Client {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.client
@@ -350,7 +351,7 @@ func botIdentityFromAuth(
 	ctx context.Context,
 	log *slog.Logger,
 	ident *identity.Identity,
-	client *auth.Client,
+	client *authclient.Client,
 	ttl time.Duration,
 ) (*identity.Identity, error) {
 	ctx, span := tracer.Start(ctx, "botIdentityFromAuth")

--- a/lib/tbot/service_ca_rotation.go
+++ b/lib/tbot/service_ca_rotation.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 )
 
 // debouncer accepts a duration, and a function. When `attempt` is called on
@@ -129,7 +129,7 @@ const caRotationRetryBackoff = time.Second * 2
 type caRotationService struct {
 	log               *slog.Logger
 	reloadBroadcaster *channelBroadcaster
-	botClient         *auth.Client
+	botClient         *authclient.Client
 	getBotIdentity    getBotIdentityFn
 }
 

--- a/lib/tbot/service_ca_rotation_test.go
+++ b/lib/tbot/service_ca_rotation_test.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -210,7 +210,7 @@ func setupServerForCARotationTest(
 	t *testing.T,
 	wg *sync.WaitGroup,
 	//nolint:unused // used in skipped test
-) (*auth.Client, func() *service.TeleportProcess, *config.FileConfig) {
+) (*authclient.Client, func() *service.TeleportProcess, *config.FileConfig) {
 	fc, fds := testhelpers.DefaultConfig(t)
 
 	cfg := servicecfg.MakeDefaultConfig()

--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
@@ -69,7 +69,7 @@ type DatabaseTunnelService struct {
 	proxyPingCache *proxyPingCache
 	log            *slog.Logger
 	resolver       reversetunnelclient.Resolver
-	botClient      *auth.Client
+	botClient      *authclient.Client
 	getBotIdentity getBotIdentityFn
 }
 

--- a/lib/tbot/service_outputs.go
+++ b/lib/tbot/service_outputs.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
@@ -62,7 +63,7 @@ type outputsService struct {
 	reloadBroadcaster *channelBroadcaster
 	proxyPingCache    *proxyPingCache
 	authPingCache     *authPingCache
-	botClient         *auth.Client
+	botClient         *authclient.Client
 	getBotIdentity    getBotIdentityFn
 	cfg               *config.BotConfig
 	resolver          reversetunnelclient.Resolver
@@ -305,7 +306,7 @@ type identityConfigurator = func(req *proto.UserCertsRequest)
 // certs.
 func generateIdentity(
 	ctx context.Context,
-	client *auth.Client,
+	client *authclient.Client,
 	currentIdentity *identity.Identity,
 	roles []string,
 	ttl time.Duration,
@@ -389,7 +390,7 @@ func generateIdentity(
 	return newIdentity, nil
 }
 
-func getKubeCluster(ctx context.Context, clt *auth.Client, name string) (types.KubeCluster, error) {
+func getKubeCluster(ctx context.Context, clt *authclient.Client, name string) (types.KubeCluster, error) {
 	ctx, span := tracer.Start(ctx, "getKubeCluster")
 	defer span.End()
 
@@ -413,7 +414,7 @@ func getKubeCluster(ctx context.Context, clt *auth.Client, name string) (types.K
 	return cluster, trace.Wrap(err)
 }
 
-func getApp(ctx context.Context, clt *auth.Client, appName string) (types.Application, error) {
+func getApp(ctx context.Context, clt *authclient.Client, appName string) (types.Application, error) {
 	ctx, span := tracer.Start(ctx, "getApp")
 	defer span.End()
 
@@ -440,7 +441,7 @@ func getApp(ctx context.Context, clt *auth.Client, appName string) (types.Applic
 	return apps[0], nil
 }
 
-func (s *outputsService) getRouteToApp(ctx context.Context, botIdentity *identity.Identity, client *auth.Client, output *config.ApplicationOutput) (proto.RouteToApp, error) {
+func (s *outputsService) getRouteToApp(ctx context.Context, botIdentity *identity.Identity, client *authclient.Client, output *config.ApplicationOutput) (proto.RouteToApp, error) {
 	ctx, span := tracer.Start(ctx, "outputsService/getRouteToApp")
 	defer span.End()
 
@@ -469,11 +470,11 @@ func (s *outputsService) getRouteToApp(ctx context.Context, botIdentity *identit
 // impersonated identity.
 func (s *outputsService) generateImpersonatedIdentity(
 	ctx context.Context,
-	botClient *auth.Client,
+	botClient *authclient.Client,
 	botIdentity *identity.Identity,
 	output config.Output,
 	defaultRoles []string,
-) (impersonatedIdentity *identity.Identity, impersonatedClient *auth.Client, err error) {
+) (impersonatedIdentity *identity.Identity, impersonatedClient *authclient.Client, err error) {
 	ctx, span := tracer.Start(ctx, "outputsService/generateImpersonatedIdentity")
 	defer span.End()
 
@@ -657,7 +658,7 @@ func fetchDefaultRoles(ctx context.Context, roleGetter services.RoleGetter, iden
 // requests for the same information. This is shared between all of the
 // outputs.
 type outputRenewalCache struct {
-	client         *auth.Client
+	client         *authclient.Client
 	cfg            *config.BotConfig
 	proxyPingCache *proxyPingCache
 	authPingCache  *authPingCache
@@ -730,7 +731,7 @@ type outputProvider struct {
 	*outputRenewalCache
 	// impersonatedClient is a client using the impersonated identity configured
 	// for that output.
-	impersonatedClient *auth.Client
+	impersonatedClient *authclient.Client
 }
 
 // GetRemoteClusters uses the impersonatedClient to call GetRemoteClusters.

--- a/lib/tbot/service_spiffe_workload_api.go
+++ b/lib/tbot/service_spiffe_workload_api.go
@@ -48,7 +48,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -73,7 +73,7 @@ type SPIFFEWorkloadAPIService struct {
 	botCfg      *config.BotConfig
 	cfg         *config.SPIFFEWorkloadAPIService
 	log         *slog.Logger
-	botClient   *auth.Client
+	botClient   *authclient.Client
 	resolver    reversetunnelclient.Resolver
 	// rootReloadBroadcaster allows the service to listen for CA rotations and
 	// update the trust bundle cache.
@@ -83,7 +83,7 @@ type SPIFFEWorkloadAPIService struct {
 	trustBundleBroadcast *channelBroadcaster
 
 	// client holds the impersonated client for the service
-	client *auth.Client
+	client *authclient.Client
 
 	trustDomain string
 

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gravitational/teleport/api/metadata"
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -460,7 +459,7 @@ func clientForFacade(
 	log *slog.Logger,
 	cfg *config.BotConfig,
 	facade *identity.Facade,
-	resolver reversetunnelclient.Resolver) (_ *auth.Client, err error) {
+	resolver reversetunnelclient.Resolver) (_ *authclient.Client, err error) {
 	ctx, span := tracer.Start(ctx, "clientForFacade")
 	defer func() { apitracing.EndSpan(span, err) }()
 
@@ -507,7 +506,7 @@ func clientForFacade(
 }
 
 type authPingCache struct {
-	client *auth.Client
+	client *authclient.Client
 	log    *slog.Logger
 
 	mu          sync.RWMutex

--- a/lib/tbot/testhelpers/srv.go
+++ b/lib/tbot/testhelpers/srv.go
@@ -129,7 +129,7 @@ func MakeAndRunTestAuthServer(t *testing.T, log *slog.Logger, fc *config.FileCon
 // MakeDefaultAuthClient reimplements the bare minimum needed to create a
 // default root-level auth client for a Teleport server started by
 // MakeAndRunTestAuthServer.
-func MakeDefaultAuthClient(t *testing.T, fc *config.FileConfig) *auth.Client {
+func MakeDefaultAuthClient(t *testing.T, fc *config.FileConfig) *authclient.Client {
 	t.Helper()
 
 	cfg := servicecfg.MakeDefaultConfig()
@@ -175,7 +175,7 @@ func MakeDefaultAuthClient(t *testing.T, fc *config.FileConfig) *auth.Client {
 }
 
 // MakeBot creates a server-side bot and returns joining parameters.
-func MakeBot(t *testing.T, client *auth.Client, name string, roles ...string) (*botconfig.OnboardingConfig, *machineidv1pb.Bot) {
+func MakeBot(t *testing.T, client *authclient.Client, name string, roles ...string) (*botconfig.OnboardingConfig, *machineidv1pb.Bot) {
 	ctx := context.TODO()
 	t.Helper()
 

--- a/lib/teleterm/clusters/cluster.go
+++ b/lib/teleterm/clusters/cluster.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
@@ -85,7 +85,7 @@ func (c *Cluster) Connected() bool {
 // GetWithDetails makes requests to the auth server to return details of the current
 // Cluster that cannot be found on the disk only, including details about the user
 // and enabled enterprise features. This method requires a valid cert.
-func (c *Cluster) GetWithDetails(ctx context.Context, authClient auth.ClientI) (*ClusterWithDetails, error) {
+func (c *Cluster) GetWithDetails(ctx context.Context, authClient authclient.ClientI) (*ClusterWithDetails, error) {
 	var (
 		clusterPingResponse *webclient.PingResponse
 		authPingResponse    proto.PingResponse
@@ -231,7 +231,7 @@ func (c *Cluster) GetRoles(ctx context.Context) ([]*types.Role, error) {
 }
 
 // GetRequestableRoles returns the requestable roles for the currently logged-in user
-func (c *Cluster) GetRequestableRoles(ctx context.Context, req *api.GetRequestableRolesRequest, authClient auth.ClientI) (*types.AccessCapabilities, error) {
+func (c *Cluster) GetRequestableRoles(ctx context.Context, req *api.GetRequestableRolesRequest, authClient authclient.ClientI) (*types.AccessCapabilities, error) {
 	var (
 		err      error
 		response *types.AccessCapabilities

--- a/lib/teleterm/clusters/cluster_access_requests.go
+++ b/lib/teleterm/clusters/cluster_access_requests.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/accessrequest"
 	"github.com/gravitational/teleport/api/types"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
@@ -46,7 +46,7 @@ type AccessRequest struct {
 }
 
 // GetAccessRequest returns a specific access request by ID and includes resource details
-func (c *Cluster) GetAccessRequest(ctx context.Context, rootAuthClient auth.ClientI, req types.AccessRequestFilter) (*AccessRequest, error) {
+func (c *Cluster) GetAccessRequest(ctx context.Context, rootAuthClient authclient.ClientI, req types.AccessRequestFilter) (*AccessRequest, error) {
 	var (
 		request         types.AccessRequest
 		resourceDetails map[string]ResourceDetails
@@ -82,7 +82,7 @@ func (c *Cluster) GetAccessRequest(ctx context.Context, rootAuthClient auth.Clie
 }
 
 // Returns all access requests available to the user.
-func (c *Cluster) GetAccessRequests(ctx context.Context, rootAuthClient auth.ClientI, req types.AccessRequestFilter) ([]AccessRequest, error) {
+func (c *Cluster) GetAccessRequests(ctx context.Context, rootAuthClient authclient.ClientI, req types.AccessRequestFilter) ([]AccessRequest, error) {
 	var (
 		requests []types.AccessRequest
 		err      error
@@ -107,7 +107,7 @@ func (c *Cluster) GetAccessRequests(ctx context.Context, rootAuthClient auth.Cli
 }
 
 // Creates an access request.
-func (c *Cluster) CreateAccessRequest(ctx context.Context, rootAuthClient auth.ClientI, req *api.CreateAccessRequestRequest) (*AccessRequest, error) {
+func (c *Cluster) CreateAccessRequest(ctx context.Context, rootAuthClient authclient.ClientI, req *api.CreateAccessRequestRequest) (*AccessRequest, error) {
 	var (
 		err     error
 		request types.AccessRequest
@@ -162,7 +162,7 @@ func (c *Cluster) CreateAccessRequest(ctx context.Context, rootAuthClient auth.C
 	}, nil
 }
 
-func (c *Cluster) ReviewAccessRequest(ctx context.Context, rootAuthClient auth.ClientI, req *api.ReviewAccessRequestRequest) (*AccessRequest, error) {
+func (c *Cluster) ReviewAccessRequest(ctx context.Context, rootAuthClient authclient.ClientI, req *api.ReviewAccessRequestRequest) (*AccessRequest, error) {
 	var (
 		err            error
 		updatedRequest types.AccessRequest
@@ -205,7 +205,7 @@ func (c *Cluster) ReviewAccessRequest(ctx context.Context, rootAuthClient auth.C
 	}, nil
 }
 
-func (c *Cluster) DeleteAccessRequest(ctx context.Context, rootAuthClient auth.ClientI, req *api.DeleteAccessRequestRequest) error {
+func (c *Cluster) DeleteAccessRequest(ctx context.Context, rootAuthClient authclient.ClientI, req *api.DeleteAccessRequestRequest) error {
 	err := AddMetadataToRetryableError(ctx, func() error {
 		return rootAuthClient.DeleteAccessRequest(ctx, req.AccessRequestId)
 	})
@@ -238,7 +238,7 @@ func (c *Cluster) AssumeRole(ctx context.Context, rootClient *client.ClusterClie
 	return trace.Wrap(err)
 }
 
-func getResourceDetails(ctx context.Context, req types.AccessRequest, rootAuthClient auth.ClientI) (map[string]ResourceDetails, error) {
+func getResourceDetails(ctx context.Context, req types.AccessRequest, rootAuthClient authclient.ClientI) (map[string]ResourceDetails, error) {
 	resourceIDsByCluster := accessrequest.GetResourceIDsByCluster(req)
 
 	resourceDetails := make(map[string]ResourceDetails)

--- a/lib/teleterm/clusters/cluster_apps.go
+++ b/lib/teleterm/clusters/cluster_apps.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/utils"
@@ -66,7 +67,7 @@ type AppOrSAMLIdPServiceProvider struct {
 }
 
 // GetApps returns a paginated apps list
-func (c *Cluster) GetApps(ctx context.Context, authClient auth.ClientI, r *api.GetAppsRequest) (*GetAppsResponse, error) {
+func (c *Cluster) GetApps(ctx context.Context, authClient authclient.ClientI, r *api.GetAppsRequest) (*GetAppsResponse, error) {
 	var (
 		page apiclient.ResourcePage[types.AppServerOrSAMLIdPServiceProvider]
 		err  error
@@ -125,7 +126,7 @@ type GetAppsResponse struct {
 	TotalCount int
 }
 
-func (c *Cluster) getApp(ctx context.Context, authClient auth.ClientI, appName string) (types.Application, error) {
+func (c *Cluster) getApp(ctx context.Context, authClient authclient.ClientI, appName string) (types.Application, error) {
 	var app types.Application
 	err := AddMetadataToRetryableError(ctx, func() error {
 		apps, err := apiclient.GetAllResources[types.AppServer](ctx, authClient, &proto.ListResourcesRequest{

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	dbprofile "github.com/gravitational/teleport/lib/client/db"
 	"github.com/gravitational/teleport/lib/client/db/dbcmd"
@@ -47,7 +47,7 @@ type Database struct {
 }
 
 // GetDatabase returns a database
-func (c *Cluster) GetDatabase(ctx context.Context, authClient auth.ClientI, dbURI uri.ResourceURI) (*Database, error) {
+func (c *Cluster) GetDatabase(ctx context.Context, authClient authclient.ClientI, dbURI uri.ResourceURI) (*Database, error) {
 	var database types.Database
 	dbName := dbURI.GetDbName()
 	err := AddMetadataToRetryableError(ctx, func() error {
@@ -77,7 +77,7 @@ func (c *Cluster) GetDatabase(ctx context.Context, authClient auth.ClientI, dbUR
 	}, err
 }
 
-func (c *Cluster) GetDatabases(ctx context.Context, authClient auth.ClientI, r *api.GetDatabasesRequest) (*GetDatabasesResponse, error) {
+func (c *Cluster) GetDatabases(ctx context.Context, authClient authclient.ClientI, r *api.GetDatabasesRequest) (*GetDatabasesResponse, error) {
 	var (
 		page apiclient.ResourcePage[types.DatabaseServer]
 		err  error
@@ -158,7 +158,7 @@ func (c *Cluster) reissueDBCerts(ctx context.Context, clusterClient *client.Clus
 }
 
 // GetAllowedDatabaseUsers returns allowed users for the given database based on the role set.
-func (c *Cluster) GetAllowedDatabaseUsers(ctx context.Context, authClient auth.ClientI, dbURI string) ([]string, error) {
+func (c *Cluster) GetAllowedDatabaseUsers(ctx context.Context, authClient authclient.ClientI, dbURI string) ([]string, error) {
 	dbResourceURI, err := uri.ParseDBURI(dbURI)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster_headless.go
+++ b/lib/teleterm/clusters/cluster_headless.go
@@ -26,11 +26,11 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 )
 
 // WatchPendingHeadlessAuthentications watches the backend for pending headless authentication requests for the user.
-func (c *Cluster) WatchPendingHeadlessAuthentications(ctx context.Context, rootAuthClient auth.ClientI) (watcher types.Watcher, close func(), err error) {
+func (c *Cluster) WatchPendingHeadlessAuthentications(ctx context.Context, rootAuthClient authclient.ClientI) (watcher types.Watcher, close func(), err error) {
 	watcher, err = rootAuthClient.WatchPendingHeadlessAuthentications(ctx)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -44,7 +44,7 @@ func (c *Cluster) WatchPendingHeadlessAuthentications(ctx context.Context, rootA
 }
 
 // WatchHeadlessAuthentications watches the backend for headless authentication events for the user.
-func (c *Cluster) WatchHeadlessAuthentications(ctx context.Context, rootAuthClient auth.ClientI) (watcher types.Watcher, close func(), err error) {
+func (c *Cluster) WatchHeadlessAuthentications(ctx context.Context, rootAuthClient authclient.ClientI) (watcher types.Watcher, close func(), err error) {
 	watch := types.Watch{
 		Kinds: []types.WatchKind{{
 			Kind: types.KindHeadlessAuthentication,
@@ -68,7 +68,7 @@ func (c *Cluster) WatchHeadlessAuthentications(ctx context.Context, rootAuthClie
 
 // UpdateHeadlessAuthenticationState updates the headless authentication matching the given id to the given state.
 // MFA will be prompted when updating to the approve state.
-func (c *Cluster) UpdateHeadlessAuthenticationState(ctx context.Context, rootAuthClient auth.ClientI, headlessID string, state types.HeadlessAuthenticationState) error {
+func (c *Cluster) UpdateHeadlessAuthenticationState(ctx context.Context, rootAuthClient authclient.ClientI, headlessID string, state types.HeadlessAuthenticationState) error {
 	err := AddMetadataToRetryableError(ctx, func() error {
 		// If changing state to approved, create an MFA challenge and prompt for MFA.
 		var mfaResponse *proto.MFAAuthenticateResponse

--- a/lib/teleterm/clusters/cluster_kubes.go
+++ b/lib/teleterm/clusters/cluster_kubes.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	kubeclient "github.com/gravitational/teleport/lib/client/kube"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
@@ -48,7 +48,7 @@ type Kube struct {
 }
 
 // GetKubes returns a paginated kubes list
-func (c *Cluster) GetKubes(ctx context.Context, authClient auth.ClientI, r *api.GetKubesRequest) (*GetKubesResponse, error) {
+func (c *Cluster) GetKubes(ctx context.Context, authClient authclient.ClientI, r *api.GetKubesRequest) (*GetKubesResponse, error) {
 	var (
 		page apiclient.ResourcePage[types.KubeCluster]
 		err  error
@@ -150,7 +150,7 @@ func (c *Cluster) reissueKubeCert(ctx context.Context, clusterClient *client.Clu
 	return cert, nil
 }
 
-func (c *Cluster) getKube(ctx context.Context, authClient auth.ClientI, kubeCluster string) (types.KubeCluster, error) {
+func (c *Cluster) getKube(ctx context.Context, authClient authclient.ClientI, kubeCluster string) (types.KubeCluster, error) {
 	var kubeClusters []types.KubeCluster
 	err := AddMetadataToRetryableError(ctx, func() error {
 		var err error

--- a/lib/teleterm/clusters/cluster_servers.go
+++ b/lib/teleterm/clusters/cluster_servers.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 )
@@ -42,7 +42,7 @@ type Server struct {
 }
 
 // GetServers returns a paginated list of servers.
-func (c *Cluster) GetServers(ctx context.Context, r *api.GetServersRequest, authClient auth.ClientI) (*GetServersResponse, error) {
+func (c *Cluster) GetServers(ctx context.Context, r *api.GetServersRequest, authClient authclient.ClientI) (*GetServersResponse, error) {
 	var (
 		page apiclient.ResourcePage[types.Server]
 		err  error

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	dtauthn "github.com/gravitational/teleport/lib/devicetrust/authn"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
@@ -1026,7 +1026,7 @@ func (s *Service) GetUserPreferences(ctx context.Context, clusterURI uri.Resourc
 	err = clusters.AddMetadataToRetryableError(ctx, func() error {
 		rootAuthClient := rootProxyClient.CurrentCluster()
 
-		var leafAuthClient auth.ClientI
+		var leafAuthClient authclient.ClientI
 		if clusterURI.IsLeaf() {
 			leafProxyClient, err := s.GetCachedClient(ctx, clusterURI.GetClusterURI())
 			if err != nil {
@@ -1059,7 +1059,7 @@ func (s *Service) UpdateUserPreferences(ctx context.Context, clusterURI uri.Reso
 	err = clusters.AddMetadataToRetryableError(ctx, func() error {
 		rootAuthClient := rootProxyClient.CurrentCluster()
 
-		var leafAuthClient auth.ClientI
+		var leafAuthClient authclient.ClientI
 		if clusterURI.IsLeaf() {
 			leafProxyClient, err := s.GetCachedClient(ctx, clusterURI.GetClusterURI())
 			if err != nil {

--- a/lib/uds/cred_other.go
+++ b/lib/uds/cred_other.go
@@ -20,7 +20,11 @@
 
 package uds
 
-import "net"
+import (
+	"net"
+
+	"github.com/gravitational/trace"
+)
 
 func getCreds(conn *net.UnixConn) (*Creds, error) {
 	return nil, trace.NotImplemented("getCreds")

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -216,7 +216,7 @@ type Config struct {
 	// DomainName is a domain name served by web handler
 	DomainName string
 	// ProxyClient is a client that authenticated as proxy
-	ProxyClient auth.ClientI
+	ProxyClient authclient.ClientI
 	// ProxySSHAddr points to the SSH address of the proxy
 	ProxySSHAddr utils.NetAddr
 	// ProxyKubeAddr points to the Kube address of the proxy
@@ -984,7 +984,7 @@ func (h *Handler) bindDefaultEndpoints() {
 }
 
 // GetProxyClient returns authenticated auth server client
-func (h *Handler) GetProxyClient() auth.ClientI {
+func (h *Handler) GetProxyClient() authclient.ClientI {
 	return h.cfg.ProxyClient
 }
 
@@ -1250,7 +1250,7 @@ func deviceTrustDisabled(cap types.AuthPreference) bool {
 	return dtconfig.GetEffectiveMode(cap.GetDeviceTrust()) == constants.DeviceTrustModeOff
 }
 
-func getAuthSettings(ctx context.Context, authClient auth.ClientI) (webclient.AuthenticationSettings, error) {
+func getAuthSettings(ctx context.Context, authClient authclient.ClientI) (webclient.AuthenticationSettings, error) {
 	authPreference, err := authClient.GetAuthPreference(ctx)
 	if err != nil {
 		return webclient.AuthenticationSettings{}, trace.Wrap(err)
@@ -3369,7 +3369,7 @@ func (h *Handler) generateSession(req *TerminalRequest, clusterName string, scx 
 }
 
 // fetchExistingSession fetches an active or pending SSH session by the SessionID passed in the TerminalRequest.
-func (h *Handler) fetchExistingSession(ctx context.Context, clt auth.ClientI, req *TerminalRequest, siteName string) (session.Session, types.SessionTracker, error) {
+func (h *Handler) fetchExistingSession(ctx context.Context, clt authclient.ClientI, req *TerminalRequest, siteName string) (session.Session, types.SessionTracker, error) {
 	sessionID, err := session.ParseID(req.SessionID.String())
 	if err != nil {
 		return session.Session{}, nil, trace.Wrap(err)
@@ -3527,7 +3527,7 @@ func (h *Handler) clusterSearchEvents(w http.ResponseWriter, r *http.Request, p 
 		eventTypes = strings.Split(include, ",")
 	}
 
-	searchEvents := func(clt auth.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error) {
+	searchEvents := func(clt authclient.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error) {
 		return clt.SearchEvents(r.Context(), events.SearchEventsRequest{
 			From:       from,
 			To:         to,
@@ -3555,7 +3555,7 @@ func (h *Handler) clusterSearchEvents(w http.ResponseWriter, r *http.Request, p 
 //	            for ascending and descending respectively.
 //	            If no order is provided it defaults to descending.
 func (h *Handler) clusterSearchSessionEvents(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
-	searchSessionEvents := func(clt auth.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error) {
+	searchSessionEvents := func(clt authclient.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error) {
 		return clt.SearchSessionEvents(r.Context(), events.SearchSessionEventsRequest{
 			From:     from,
 			To:       to,
@@ -3569,7 +3569,7 @@ func (h *Handler) clusterSearchSessionEvents(w http.ResponseWriter, r *http.Requ
 
 // clusterEventsList returns a list of audit events obtained using the provided
 // searchEvents method.
-func clusterEventsList(ctx context.Context, sctx *SessionContext, site reversetunnelclient.RemoteSite, values url.Values, searchEvents func(clt auth.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error)) (interface{}, error) {
+func clusterEventsList(ctx context.Context, sctx *SessionContext, site reversetunnelclient.RemoteSite, values url.Values, searchEvents func(clt authclient.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error)) (interface{}, error) {
 	from, err := queryTime(values, "from", time.Now().UTC().AddDate(0, -1, 0))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -4136,7 +4136,7 @@ type ClusterClientProvider interface {
 	// UserClientForCluster returns a client to the local or remote cluster
 	// identified by clusterName and is authenticated with the identity of the
 	// user.
-	UserClientForCluster(ctx context.Context, clusterName string) (auth.ClientI, error)
+	UserClientForCluster(ctx context.Context, clusterName string) (authclient.ClientI, error)
 }
 
 type clusterClientProvider struct {
@@ -4146,7 +4146,7 @@ type clusterClientProvider struct {
 
 // UserClientForCluster returns a client to the local or remote cluster
 // identified by clusterName and is authenticated with the identity of the user.
-func (r clusterClientProvider) UserClientForCluster(ctx context.Context, clusterName string) (auth.ClientI, error) {
+func (r clusterClientProvider) UserClientForCluster(ctx context.Context, clusterName string) (authclient.ClientI, error) {
 	site, err := r.h.getSiteByClusterName(r.ctx, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -4216,7 +4216,7 @@ func (h *Handler) WithProvisionTokenAuth(fn ProvisionTokenHandler) httprouter.Ha
 // This is possible because the latest call - DeleteToken - returns an error if the resource doesn't exist
 // This is currently true for all the backends as explained here
 // https://github.com/gravitational/teleport/commit/24fcadc375d8359e80790b3ebeaa36bd8dd2822f
-func consumeTokenForAPICall(ctx context.Context, proxyClient auth.ClientI, tokenName string) (types.ProvisionToken, error) {
+func consumeTokenForAPICall(ctx context.Context, proxyClient authclient.ClientI, tokenName string) (types.ProvisionToken, error) {
 	token, err := proxyClient.GetToken(ctx, tokenName)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -99,6 +99,7 @@ import (
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/agentless"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	tlsutils "github.com/gravitational/teleport/lib/auth/keygen"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	"github.com/gravitational/teleport/lib/auth/native"
@@ -156,7 +157,7 @@ type WebSuite struct {
 
 	mockU2F     *mocku2f.Key
 	server      *auth.TestServer
-	proxyClient *auth.Client
+	proxyClient *authclient.Client
 	clock       clockwork.FakeClock
 }
 
@@ -636,7 +637,7 @@ func (s *WebSuite) addNode(t *testing.T, uuid string, hostname string, address s
 	return node
 }
 
-func noCache(clt auth.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
+func noCache(clt authclient.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
 	return clt, nil
 }
 
@@ -2206,7 +2207,7 @@ func TestDesktopAccessMFARequiresMfa(t *testing.T) {
 		name           string
 		authPref       types.AuthPreferenceSpecV2
 		mfaHandler     func(t *testing.T, ws *websocket.Conn, dev *auth.TestDevice)
-		registerDevice func(t *testing.T, ctx context.Context, clt *auth.Client) *auth.TestDevice
+		registerDevice func(t *testing.T, ctx context.Context, clt *authclient.Client) *auth.TestDevice
 	}{
 		{
 			name: "webauthn",
@@ -2219,7 +2220,7 @@ func TestDesktopAccessMFARequiresMfa(t *testing.T) {
 				RequireMFAType: types.RequireMFAType_SESSION,
 			},
 			mfaHandler: handleDesktopMFAWebauthnChallenge,
-			registerDevice: func(t *testing.T, ctx context.Context, clt *auth.Client) *auth.TestDevice {
+			registerDevice: func(t *testing.T, ctx context.Context, clt *authclient.Client) *auth.TestDevice {
 				webauthnDev, err := auth.RegisterTestDevice(ctx, clt, "webauthn", authproto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil /* authenticator */)
 				require.NoError(t, err)
 				return webauthnDev
@@ -7795,7 +7796,7 @@ func newWebPack(t *testing.T, numProxies int, opts ...proxyOption) *webPack {
 // wrappedAuthClient is used when tests need to mock or replace parts of the
 // underlying auth.Client used by the Proxy.
 type wrappedAuthClient struct {
-	*auth.Client
+	*authclient.Client
 	devicesClient devicepb.DeviceTrustServiceClient
 }
 
@@ -7834,7 +7835,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 	t.Cleanup(func() { require.NoError(t, authClient.Close()) })
 
 	// Replace underlying devicesClient, if the option was supplied.
-	var client auth.ClientI
+	var client authclient.ClientI
 	if cfg.devicesClientOverride != nil {
 		client = &wrappedAuthClient{
 			Client:        authClient,
@@ -8135,7 +8136,7 @@ type webPack struct {
 
 type testProxy struct {
 	clock   clockwork.FakeClock
-	client  auth.ClientI
+	client  authclient.ClientI
 	auth    *auth.TestTLSServer
 	revTun  reversetunnelclient.Server
 	node    *regular.Server
@@ -9618,7 +9619,7 @@ func TestSimultaneousAuthenticateRequest(t *testing.T) {
 
 // mockedPingTestProxy is a test proxy with a mocked Ping method
 type mockedPingTestProxy struct {
-	auth.ClientI
+	authclient.ClientI
 	mockedPing func(ctx context.Context) (authproto.PingResponse, error)
 }
 
@@ -9875,7 +9876,7 @@ func TestModeratedSessionWithMFA(t *testing.T) {
 }
 
 type proxyClientMock struct {
-	auth.ClientI
+	authclient.ClientI
 	tokens map[string]types.ProvisionToken
 }
 

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -51,7 +52,7 @@ type HandlerConfig struct {
 	// Clock is used to control time in tests.
 	Clock clockwork.Clock
 	// AuthClient is a direct client to auth.
-	AuthClient auth.ClientI
+	AuthClient authclient.ClientI
 	// AccessPoint is caching client to auth.
 	AccessPoint auth.ProxyAccessPoint
 	// ProxyClient holds connections to leaf clusters.

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -45,7 +45,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -478,7 +478,7 @@ type testServer struct {
 	serverURL *url.URL
 }
 
-func setup(t *testing.T, clock clockwork.FakeClock, authClient auth.ClientI, proxyClient reversetunnelclient.Tunnel) *testServer {
+func setup(t *testing.T, clock clockwork.FakeClock, authClient authclient.ClientI, proxyClient reversetunnelclient.Tunnel) *testServer {
 	appHandler, err := NewHandler(context.Background(), &HandlerConfig{
 		Clock:                 clock,
 		AuthClient:            authClient,
@@ -538,7 +538,7 @@ func (p *testServer) makeRequest(t *testing.T, method, endpoint string, reqBody 
 }
 
 type mockAuthClient struct {
-	auth.ClientI
+	authclient.ClientI
 	clusterName   string
 	appSession    types.WebSession
 	sessionError  error

--- a/lib/web/assistant.go
+++ b/lib/web/assistant.go
@@ -35,7 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/ai/model/tools"
 	"github.com/gravitational/teleport/lib/ai/tokens"
 	"github.com/gravitational/teleport/lib/assist"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 )
 
@@ -90,7 +90,7 @@ func (h *Handler) reserveTokens(usedTokens *tokens.TokenCount) (int, int) {
 }
 
 // reportTokenUsage sends a token usage event for an action.
-func (h *Handler) reportActionTokenUsage(authClient auth.ClientI, usedTokens *tokens.TokenCount, action string) {
+func (h *Handler) reportActionTokenUsage(authClient authclient.ClientI, usedTokens *tokens.TokenCount, action string) {
 	// Create a new context to not be bounded by the request timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -114,7 +114,7 @@ func (h *Handler) reportActionTokenUsage(authClient auth.ClientI, usedTokens *to
 	}
 }
 
-func checkAssistEnabled(a auth.ClientI, ctx context.Context) error {
+func checkAssistEnabled(a authclient.ClientI, ctx context.Context) error {
 	enabled, err := a.IsAssistEnabled(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -229,7 +229,7 @@ func runAssistant(h *Handler, w http.ResponseWriter, r *http.Request,
 }
 
 // assistGenAuditQueryLoop reads the user's input and generates an audit query.
-func (h *Handler) assistGenAuditQueryLoop(ctx context.Context, assistClient *assist.Assist, authClient auth.ClientI, ws *websocket.Conn, username string) error {
+func (h *Handler) assistGenAuditQueryLoop(ctx context.Context, assistClient *assist.Assist, authClient authclient.ClientI, ws *websocket.Conn, username string) error {
 	for {
 		_, payload, err := ws.ReadMessage()
 		if err != nil {
@@ -260,7 +260,7 @@ func (h *Handler) assistGenAuditQueryLoop(ctx context.Context, assistClient *ass
 }
 
 // assistSSHExplainOutputLoop reads the user's input and generates a command summary.
-func (h *Handler) assistSSHExplainOutputLoop(ctx context.Context, assistClient *assist.Assist, authClient auth.ClientI, ws *websocket.Conn) error {
+func (h *Handler) assistSSHExplainOutputLoop(ctx context.Context, assistClient *assist.Assist, authClient authclient.ClientI, ws *websocket.Conn) error {
 	_, payload, err := ws.ReadMessage()
 	if err != nil {
 		if wsIsClosed(err) {
@@ -298,7 +298,7 @@ func (h *Handler) assistSSHExplainOutputLoop(ctx context.Context, assistClient *
 }
 
 // assistSSHCommandLoop reads the user's input and generates a Linux command.
-func (h *Handler) assistGenSSHCommandLoop(ctx context.Context, assistClient *assist.Assist, authClient auth.ClientI, ws *websocket.Conn, username string) error {
+func (h *Handler) assistGenSSHCommandLoop(ctx context.Context, assistClient *assist.Assist, authClient authclient.ClientI, ws *websocket.Conn, username string) error {
 	chat, err := assistClient.NewLightweightChat(username)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -46,7 +46,7 @@ import (
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/client"
@@ -218,7 +218,7 @@ const (
 	SNISuffix = ".desktop." + constants.APIDomain
 )
 
-func (h *Handler) desktopTLSConfig(ctx context.Context, ws *websocket.Conn, clusterClient auth.ClientI, sessCtx *SessionContext, desktopName, username, siteName string) (_ *tls.Config, err error) {
+func (h *Handler) desktopTLSConfig(ctx context.Context, ws *websocket.Conn, clusterClient authclient.ClientI, sessCtx *SessionContext, desktopName, username, siteName string) (_ *tls.Config, err error) {
 	ctx, span := h.tracer.Start(ctx, "desktop/TLSConfig")
 	defer func() {
 		span.RecordError(err)
@@ -299,7 +299,7 @@ func (h *Handler) desktopTLSConfig(ctx context.Context, ws *websocket.Conn, clus
 // performMFACeremony completes the mfa ceremony and returns the raw TLS certificate
 // on success. The user will be prompted to tap their security key by the UI
 // in order to perform the assertion.
-func (h *Handler) performMFACeremony(ctx context.Context, authClient auth.ClientI, ws *websocket.Conn, certsReq *proto.UserCertsRequest) (_ []byte, err error) {
+func (h *Handler) performMFACeremony(ctx context.Context, authClient authclient.ClientI, ws *websocket.Conn, certsReq *proto.UserCertsRequest) (_ []byte, err error) {
 	ctx, span := h.tracer.Start(ctx, "desktop/performMFACeremony")
 	defer func() {
 		span.RecordError(err)
@@ -379,7 +379,7 @@ func readClientScreenSpec(ws *websocket.Conn) (*tdp.ClientScreenSpec, error) {
 
 type connector struct {
 	log           *logrus.Entry
-	clt           auth.ClientI
+	clt           authclient.ClientI
 	site          reversetunnelclient.RemoteSite
 	clientSrcAddr net.Addr
 	clientDstAddr net.Addr

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/multiplexer"
@@ -158,7 +158,7 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 type fileTransfer struct {
 	// sctx is a web session context for the currently logged in user.
 	sctx          *SessionContext
-	authClient    auth.ClientI
+	authClient    authclient.ClientI
 	proxyHostPort string
 }
 

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -39,7 +39,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/aws"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
@@ -698,7 +698,7 @@ func (h *Handler) awsOIDCRequiredDatabasesVPCS(w http.ResponseWriter, r *http.Re
 	return resp, nil
 }
 
-func awsOIDCListAllDatabases(ctx context.Context, clt auth.ClientI, integration, region string) ([]*types.DatabaseV3, error) {
+func awsOIDCListAllDatabases(ctx context.Context, clt authclient.ClientI, integration, region string) ([]*types.DatabaseV3, error) {
 	nextToken := ""
 	var fetchedRDSs []*types.DatabaseV3
 
@@ -748,7 +748,7 @@ func awsOIDCListAllDatabases(ctx context.Context, clt auth.ClientI, integration,
 	return fetchedRDSs, nil
 }
 
-func awsOIDCRequiredVPCSHelper(ctx context.Context, clt auth.ClientI, req ui.AWSOIDCRequiredVPCSRequest, fetchedRDSs []*types.DatabaseV3) (*ui.AWSOIDCRequiredVPCSResponse, error) {
+func awsOIDCRequiredVPCSHelper(ctx context.Context, clt authclient.ClientI, req ui.AWSOIDCRequiredVPCSRequest, fetchedRDSs []*types.DatabaseV3) (*ui.AWSOIDCRequiredVPCSResponse, error) {
 	// Get all database services with ecs/fargate metadata label.
 	nextToken := ""
 	fetchedDbSvcs := []types.DatabaseService{}

--- a/lib/web/kube.go
+++ b/lib/web/kube.go
@@ -45,7 +45,7 @@ import (
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
@@ -63,7 +63,7 @@ type podHandler struct {
 	ws                  *websocket.Conn
 	keepAliveInterval   time.Duration
 	log                 *logrus.Entry
-	userClient          auth.ClientI
+	userClient          authclient.ClientI
 	localCA             types.CertAuthority
 
 	// closedByClient indicates if the websocket connection was closed by the

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -50,6 +50,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/modules"
@@ -93,7 +94,7 @@ type SessionContextConfig struct {
 
 	// RootClient holds a connection to the root auth. Note that requests made using this
 	// client are made with the identity of the user and are NOT cached.
-	RootClient *auth.Client
+	RootClient *authclient.Client
 
 	// UnsafeCachedAuthClient holds a read-only cache to root auth. Note this access
 	// point cache is authenticated with the identity of the node, not of the
@@ -112,7 +113,7 @@ type SessionContextConfig struct {
 	Session types.WebSession
 
 	// newRemoteClient is used by tests to override how remote clients are constructed to allow for fake sites
-	newRemoteClient func(ctx context.Context, sessionContext *SessionContext, site reversetunnelclient.RemoteSite) (auth.ClientI, error)
+	newRemoteClient func(ctx context.Context, sessionContext *SessionContext, site reversetunnelclient.RemoteSite) (authclient.ClientI, error)
 }
 
 func (c *SessionContextConfig) CheckAndSetDefaults() error {
@@ -209,7 +210,7 @@ func (c *SessionContext) validateBearerToken(ctx context.Context, token string) 
 }
 
 // GetClient returns the client connected to the auth server
-func (c *SessionContext) GetClient() (auth.ClientI, error) {
+func (c *SessionContext) GetClient() (authclient.ClientI, error) {
 	return c.cfg.RootClient, nil
 }
 
@@ -218,11 +219,11 @@ func (c *SessionContext) GetClientConnection() *grpc.ClientConn {
 	return c.cfg.RootClient.GetConnection()
 }
 
-// GetUserClient will return an auth.ClientI with the role of the user at
+// GetUserClient will return an [authclient.ClientI]  with the role of the user at
 // the requested site. If the site is local a client with the users local role
 // is returned. If the site is remote a client with the users remote role is
 // returned.
-func (c *SessionContext) GetUserClient(ctx context.Context, site reversetunnelclient.RemoteSite) (auth.ClientI, error) {
+func (c *SessionContext) GetUserClient(ctx context.Context, site reversetunnelclient.RemoteSite) (authclient.ClientI, error) {
 	// if we're trying to access the local cluster, pass back the local client.
 	if c.cfg.RootClusterName == site.GetName() {
 		return c.cfg.RootClient, nil
@@ -233,15 +234,15 @@ func (c *SessionContext) GetUserClient(ctx context.Context, site reversetunnelcl
 	return clt, trace.Wrap(err)
 }
 
-// remoteClient returns an auth.ClientI with the role of the user at
+// remoteClient returns an [authclient.ClientI]  with the role of the user at
 // the requested [site]. All remote clients are lazily created
 // when they are first requested and then cached. Subsequent requests
 // will return the previously created client to prevent having more than
-// a single auth.ClientI per site for a user.
+// a single [authclient.ClientI]  per site for a user.
 //
 // A [singleflight.Group] is leveraged to prevent duplicate requests for remote
 // clients at the same time to race.
-func (c *SessionContext) remoteClient(ctx context.Context, site reversetunnelclient.RemoteSite) (auth.ClientI, error) {
+func (c *SessionContext) remoteClient(ctx context.Context, site reversetunnelclient.RemoteSite) (authclient.ClientI, error) {
 	cltI, err, _ := c.remoteClientGroup.Do(site.GetName(), func() (interface{}, error) {
 		// check if we already have a connection to this cluster
 		if clt, ok := c.remoteClientCache.getRemoteClient(site); ok {
@@ -268,7 +269,7 @@ func (c *SessionContext) remoteClient(ctx context.Context, site reversetunnelcli
 		return nil, trace.Wrap(err)
 	}
 
-	clt, ok := cltI.(auth.ClientI)
+	clt, ok := cltI.(authclient.ClientI)
 	if !ok {
 		return nil, trace.BadParameter("unexpected type %T received for auth client", cltI)
 	}
@@ -277,7 +278,7 @@ func (c *SessionContext) remoteClient(ctx context.Context, site reversetunnelcli
 }
 
 // newRemoteClient returns a client to a remote cluster with the role of current user.
-func newRemoteClient(ctx context.Context, sctx *SessionContext, site reversetunnelclient.RemoteSite) (auth.ClientI, error) {
+func newRemoteClient(ctx context.Context, sctx *SessionContext, site reversetunnelclient.RemoteSite) (authclient.ClientI, error) {
 	clt, err := sctx.newRemoteTLSClient(ctx, site)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -393,7 +394,7 @@ func (c *SessionContext) ClientTLSConfig(ctx context.Context, clusterName ...str
 	return tlsConfig, nil
 }
 
-func (c *SessionContext) newRemoteTLSClient(ctx context.Context, cluster reversetunnelclient.RemoteSite) (auth.ClientI, error) {
+func (c *SessionContext) newRemoteTLSClient(ctx context.Context, cluster reversetunnelclient.RemoteSite) (authclient.ClientI, error) {
 	tlsConfig, err := c.ClientTLSConfig(ctx, cluster.GetName())
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -401,7 +402,7 @@ func (c *SessionContext) newRemoteTLSClient(ctx context.Context, cluster reverse
 
 	clientSrcAddr, clientDstAddr := authz.ClientAddrsFromContext(ctx)
 
-	return auth.NewClient(apiclient.Config{
+	return authclient.NewClient(apiclient.Config{
 		Context: ctx,
 		Dialer:  clusterDialer(cluster, clientSrcAddr, clientDstAddr),
 		Credentials: []apiclient.Credentials{
@@ -618,7 +619,7 @@ func (c *SessionContext) expired(ctx context.Context) bool {
 const cachedSessionLingeringThreshold = 2 * time.Minute
 
 type sessionCacheOptions struct {
-	proxyClient  auth.ClientI
+	proxyClient  authclient.ClientI
 	accessPoint  auth.ReadProxyAccessPoint
 	servers      []utils.NetAddr
 	cipherSuites []uint16
@@ -677,7 +678,7 @@ func newSessionCache(ctx context.Context, config sessionCacheOptions) (*sessionC
 // and holds in-memory contexts associated with each session
 type sessionCache struct {
 	log         logrus.FieldLogger
-	proxyClient auth.ClientI
+	proxyClient authclient.ClientI
 	authServers []utils.NetAddr
 	accessPoint auth.ReadProxyAccessPoint
 	closer      *utils.CloseBroadcaster
@@ -1142,7 +1143,7 @@ func (s *sessionCache) newSessionContextFromSession(ctx context.Context, session
 		return nil, trace.Wrap(err)
 	}
 
-	userClient, err := auth.NewClient(apiclient.Config{
+	userClient, err := authclient.NewClient(apiclient.Config{
 		Addrs:                utils.NetAddrsToStrings(s.authServers),
 		Credentials:          []apiclient.Credentials{apiclient.LoadTLS(tlsConfig)},
 		CircuitBreakerConfig: breaker.NoopBreakerConfig(),
@@ -1282,17 +1283,17 @@ func sessionKey(user, sessionID string) string {
 type remoteClientCache struct {
 	sync.Mutex
 	clients map[string]struct {
-		auth.ClientI
+		authclient.ClientI
 		reversetunnelclient.RemoteSite
 	}
 }
 
-func (c *remoteClientCache) addRemoteClient(site reversetunnelclient.RemoteSite, remoteClient auth.ClientI) error {
+func (c *remoteClientCache) addRemoteClient(site reversetunnelclient.RemoteSite, remoteClient authclient.ClientI) error {
 	c.Lock()
 	defer c.Unlock()
 	if c.clients == nil {
 		c.clients = make(map[string]struct {
-			auth.ClientI
+			authclient.ClientI
 			reversetunnelclient.RemoteSite
 		})
 	}
@@ -1301,13 +1302,13 @@ func (c *remoteClientCache) addRemoteClient(site reversetunnelclient.RemoteSite,
 		err = c.clients[site.GetName()].ClientI.Close()
 	}
 	c.clients[site.GetName()] = struct {
-		auth.ClientI
+		authclient.ClientI
 		reversetunnelclient.RemoteSite
 	}{remoteClient, site}
 	return err
 }
 
-func (c *remoteClientCache) getRemoteClient(site reversetunnelclient.RemoteSite) (auth.ClientI, bool) {
+func (c *remoteClientCache) getRemoteClient(site reversetunnelclient.RemoteSite) (authclient.ClientI, bool) {
 	c.Lock()
 	defer c.Unlock()
 	remoteClt, ok := c.clients[site.GetName()]

--- a/lib/web/sessions_test.go
+++ b/lib/web/sessions_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/utils"
@@ -80,13 +80,13 @@ func (m *mockRemoteSite) GetName() string {
 	return m.name
 }
 
-func newMockClientI(openCount *atomic.Int32, closeErr error) auth.ClientI {
+func newMockClientI(openCount *atomic.Int32, closeErr error) authclient.ClientI {
 	openCount.Add(1)
 	return &mockClientI{openCount: openCount, closeErr: closeErr}
 }
 
 type mockClientI struct {
-	auth.ClientI
+	authclient.ClientI
 	openCount *atomic.Int32
 	closeErr  error
 }
@@ -108,7 +108,7 @@ func TestGetUserClient(t *testing.T) {
 	sctx := SessionContext{
 		cfg: SessionContextConfig{
 			RootClusterName: "local",
-			newRemoteClient: func(ctx context.Context, sessionContext *SessionContext, site reversetunnelclient.RemoteSite) (auth.ClientI, error) {
+			newRemoteClient: func(ctx context.Context, sessionContext *SessionContext, site reversetunnelclient.RemoteSite) (authclient.ClientI, error) {
 				return newMockClientI(&openCount, nil), nil
 			},
 		},
@@ -148,7 +148,7 @@ func TestGetUserClient(t *testing.T) {
 	// and ensure that the first request creates the client
 	// and the second request is provided the cached value
 	type result struct {
-		clt auth.ClientI
+		clt authclient.ClientI
 		err error
 	}
 
@@ -164,7 +164,7 @@ func TestGetUserClient(t *testing.T) {
 	}()
 
 	timeout := time.After(10 * time.Second)
-	clients := make([]auth.ClientI, 2)
+	clients := make([]authclient.ClientI, 2)
 	for i := 0; i < 2; i++ {
 		select {
 		case res := <-resultCh:

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -34,7 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -125,7 +125,7 @@ func (c *AccessRequestCommand) Initialize(app *kingpin.Application, config *serv
 }
 
 // TryRun takes the CLI command as an argument (like "access-request list") and executes it.
-func (c *AccessRequestCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *AccessRequestCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.requestList.FullCommand():
 		err = c.List(ctx, client)
@@ -149,7 +149,7 @@ func (c *AccessRequestCommand) TryRun(ctx context.Context, cmd string, client *a
 	return true, trace.Wrap(err)
 }
 
-func (c *AccessRequestCommand) List(ctx context.Context, client *auth.Client) error {
+func (c *AccessRequestCommand) List(ctx context.Context, client *authclient.Client) error {
 	var index proto.AccessRequestSort
 	switch c.sortIndex {
 	case "created":
@@ -192,7 +192,7 @@ func (c *AccessRequestCommand) List(ctx context.Context, client *auth.Client) er
 	return nil
 }
 
-func (c *AccessRequestCommand) Get(ctx context.Context, client *auth.Client) error {
+func (c *AccessRequestCommand) Get(ctx context.Context, client *authclient.Client) error {
 	reqs := []types.AccessRequest{}
 	for _, reqID := range strings.Split(c.reqIDs, ",") {
 		req, err := client.GetAccessRequests(ctx, types.AccessRequestFilter{
@@ -247,7 +247,7 @@ func (c *AccessRequestCommand) splitRoles() []string {
 	return roles
 }
 
-func (c *AccessRequestCommand) Approve(ctx context.Context, client *auth.Client) error {
+func (c *AccessRequestCommand) Approve(ctx context.Context, client *authclient.Client) error {
 	if c.delegator != "" {
 		ctx = authz.WithDelegator(ctx, c.delegator)
 	}
@@ -278,7 +278,7 @@ func (c *AccessRequestCommand) Approve(ctx context.Context, client *auth.Client)
 	return nil
 }
 
-func (c *AccessRequestCommand) Deny(ctx context.Context, client *auth.Client) error {
+func (c *AccessRequestCommand) Deny(ctx context.Context, client *authclient.Client) error {
 	if c.delegator != "" {
 		ctx = authz.WithDelegator(ctx, c.delegator)
 	}
@@ -299,7 +299,7 @@ func (c *AccessRequestCommand) Deny(ctx context.Context, client *auth.Client) er
 	return nil
 }
 
-func (c *AccessRequestCommand) Create(ctx context.Context, client *auth.Client) error {
+func (c *AccessRequestCommand) Create(ctx context.Context, client *authclient.Client) error {
 	if len(c.roles) == 0 && len(c.requestedResourceIDs) == 0 {
 		c.roles = "*"
 	}
@@ -315,7 +315,7 @@ func (c *AccessRequestCommand) Create(ctx context.Context, client *auth.Client) 
 
 	if c.dryRun {
 		users := &struct {
-			*auth.Client
+			*authclient.Client
 			services.UserLoginStatesGetter
 		}{
 			Client:                client,
@@ -335,7 +335,7 @@ func (c *AccessRequestCommand) Create(ctx context.Context, client *auth.Client) 
 	return nil
 }
 
-func (c *AccessRequestCommand) Delete(ctx context.Context, client *auth.Client) error {
+func (c *AccessRequestCommand) Delete(ctx context.Context, client *authclient.Client) error {
 	var approvedTokens []string
 	for _, reqID := range strings.Split(c.reqIDs, ",") {
 		// Fetch the requests first to see if they were approved to provide the
@@ -375,7 +375,7 @@ func (c *AccessRequestCommand) Delete(ctx context.Context, client *auth.Client) 
 	return nil
 }
 
-func (c *AccessRequestCommand) Caps(ctx context.Context, client *auth.Client) error {
+func (c *AccessRequestCommand) Caps(ctx context.Context, client *authclient.Client) error {
 	caps, err := client.GetAccessCapabilities(ctx, types.AccessCapabilitiesRequest{
 		User:               c.user,
 		RequestableRoles:   true,
@@ -411,7 +411,7 @@ func (c *AccessRequestCommand) Caps(ctx context.Context, client *auth.Client) er
 	}
 }
 
-func (c *AccessRequestCommand) Review(ctx context.Context, client *auth.Client) error {
+func (c *AccessRequestCommand) Review(ctx context.Context, client *authclient.Client) error {
 	if c.approve == c.deny {
 		return trace.BadParameter("must supply exactly one of '--approve' or '--deny'")
 	}

--- a/tool/tctl/common/accessmonitoring/command.go
+++ b/tool/tctl/common/accessmonitoring/command.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/secreports"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -112,9 +112,9 @@ func (c *Command) initAuditReportsCommands(auditCmd *kingpin.CmdClause, cfg *ser
 	})
 }
 
-type runFunc func(context.Context, *auth.Client) error
+type runFunc func(context.Context, *authclient.Client) error
 
-func (c *Command) TryRun(ctx context.Context, selectedCommand string, authClient *auth.Client) (match bool, err error) {
+func (c *Command) TryRun(ctx context.Context, selectedCommand string, authClient *authclient.Client) (match bool, err error) {
 	handler, ok := c.innerCmdMap[selectedCommand]
 	if !ok {
 		return false, nil
@@ -128,7 +128,7 @@ func (c *Command) TryRun(ctx context.Context, selectedCommand string, authClient
 	}
 }
 
-func (c *cmdHandler) onAuditQueryExec(ctx context.Context, authClient *auth.Client) error {
+func (c *cmdHandler) onAuditQueryExec(ctx context.Context, authClient *authclient.Client) error {
 	if c.auditQuery == "" {
 		buff, err := io.ReadAll(os.Stdin)
 		if err != nil {
@@ -146,7 +146,7 @@ func (c *cmdHandler) onAuditQueryExec(ctx context.Context, authClient *auth.Clie
 	return nil
 }
 
-func (c *cmdHandler) onAuditQueryGet(ctx context.Context, authClient *auth.Client) error {
+func (c *cmdHandler) onAuditQueryGet(ctx context.Context, authClient *authclient.Client) error {
 	auditQuery, err := authClient.SecReportsClient().GetSecurityAuditQuery(ctx, c.name)
 	if err != nil {
 		return trace.Wrap(err)
@@ -157,7 +157,7 @@ func (c *cmdHandler) onAuditQueryGet(ctx context.Context, authClient *auth.Clien
 	return nil
 }
 
-func (c *cmdHandler) onAuditQueryLs(ctx context.Context, authClient *auth.Client) error {
+func (c *cmdHandler) onAuditQueryLs(ctx context.Context, authClient *authclient.Client) error {
 	auditQueries, err := authClient.SecReportsClient().GetSecurityAuditQueries(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -168,14 +168,14 @@ func (c *cmdHandler) onAuditQueryLs(ctx context.Context, authClient *auth.Client
 	return nil
 }
 
-func (c *cmdHandler) onAuditQueryRm(ctx context.Context, authClient *auth.Client) error {
+func (c *cmdHandler) onAuditQueryRm(ctx context.Context, authClient *authclient.Client) error {
 	if err := authClient.SecReportsClient().DeleteSecurityAuditQuery(ctx, c.name); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
 }
 
-func (c *cmdHandler) onAuditQuerySchema(ctx context.Context, authClient *auth.Client) error {
+func (c *cmdHandler) onAuditQuerySchema(ctx context.Context, authClient *authclient.Client) error {
 	resp, err := authClient.SecReportsClient().GetSchema(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -193,7 +193,7 @@ func (c *cmdHandler) onAuditQuerySchema(ctx context.Context, authClient *auth.Cl
 	return nil
 }
 
-func (c *cmdHandler) onAuditQueryCreate(ctx context.Context, authClient *auth.Client) error {
+func (c *cmdHandler) onAuditQueryCreate(ctx context.Context, authClient *authclient.Client) error {
 	if c.auditQuery == "" {
 		return trace.BadParameter("audit query required")
 	}
@@ -213,7 +213,7 @@ func (c *cmdHandler) onAuditQueryCreate(ctx context.Context, authClient *auth.Cl
 	return nil
 }
 
-func (c *cmdHandler) onAuditReportLs(ctx context.Context, authClient *auth.Client) error {
+func (c *cmdHandler) onAuditReportLs(ctx context.Context, authClient *authclient.Client) error {
 	reports, err := authClient.SecReportsClient().GetSecurityReports(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -224,7 +224,7 @@ func (c *cmdHandler) onAuditReportLs(ctx context.Context, authClient *auth.Clien
 	return trace.Wrap(err)
 }
 
-func (c *cmdHandler) onAuditReportGet(ctx context.Context, authClient *auth.Client) error {
+func (c *cmdHandler) onAuditReportGet(ctx context.Context, authClient *authclient.Client) error {
 	details, err := authClient.SecReportsClient().GetSecurityReportResult(ctx, c.name, c.days)
 	if err != nil {
 		return trace.Wrap(err)
@@ -235,7 +235,7 @@ func (c *cmdHandler) onAuditReportGet(ctx context.Context, authClient *auth.Clie
 	return nil
 }
 
-func (c *cmdHandler) onAuditReportRun(ctx context.Context, authClient *auth.Client) error {
+func (c *cmdHandler) onAuditReportRun(ctx context.Context, authClient *authclient.Client) error {
 	err := authClient.SecReportsClient().RunSecurityReport(ctx, c.name, c.days)
 	if err != nil {
 		return trace.Wrap(err)
@@ -243,7 +243,7 @@ func (c *cmdHandler) onAuditReportRun(ctx context.Context, authClient *auth.Clie
 	return nil
 }
 
-func (c *cmdHandler) onAuditReportState(ctx context.Context, authClient *auth.Client) error {
+func (c *cmdHandler) onAuditReportState(ctx context.Context, authClient *authclient.Client) error {
 	state, err := authClient.SecReportsClient().GetSecurityReportExecutionState(ctx, c.name, int32(c.days))
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/acl_command.go
+++ b/tool/tctl/common/acl_command.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -84,7 +84,7 @@ func (c *ACLCommand) Initialize(app *kingpin.Application, _ *servicecfg.Config) 
 }
 
 // TryRun takes the CLI command as an argument (like "acl ls") and executes it.
-func (c *ACLCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *ACLCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.ls.FullCommand():
 		err = c.List(ctx, client)
@@ -103,7 +103,7 @@ func (c *ACLCommand) TryRun(ctx context.Context, cmd string, client *auth.Client
 }
 
 // List will list access lists visible to the user.
-func (c *ACLCommand) List(ctx context.Context, client *auth.Client) error {
+func (c *ACLCommand) List(ctx context.Context, client *authclient.Client) error {
 	var accessLists []*accesslist.AccessList
 	var nextKey string
 	for {
@@ -130,7 +130,7 @@ func (c *ACLCommand) List(ctx context.Context, client *auth.Client) error {
 }
 
 // Get will display information about an access list visible to the user.
-func (c *ACLCommand) Get(ctx context.Context, client *auth.Client) error {
+func (c *ACLCommand) Get(ctx context.Context, client *authclient.Client) error {
 	accessList, err := client.AccessListClient().GetAccessList(ctx, c.accessListName)
 	if err != nil {
 		return trace.Wrap(err)
@@ -140,7 +140,7 @@ func (c *ACLCommand) Get(ctx context.Context, client *auth.Client) error {
 }
 
 // UsersAdd will add a user to an access list.
-func (c *ACLCommand) UsersAdd(ctx context.Context, client *auth.Client) error {
+func (c *ACLCommand) UsersAdd(ctx context.Context, client *authclient.Client) error {
 	var expires time.Time
 	if c.expires != "" {
 		var err error
@@ -177,7 +177,7 @@ func (c *ACLCommand) UsersAdd(ctx context.Context, client *auth.Client) error {
 }
 
 // UsersRemove will remove a user to an access list.
-func (c *ACLCommand) UsersRemove(ctx context.Context, client *auth.Client) error {
+func (c *ACLCommand) UsersRemove(ctx context.Context, client *authclient.Client) error {
 	err := client.AccessListClient().DeleteAccessListMember(ctx, c.accessListName, c.userName)
 	if err != nil {
 		return trace.Wrap(err)
@@ -189,7 +189,7 @@ func (c *ACLCommand) UsersRemove(ctx context.Context, client *auth.Client) error
 }
 
 // UsersList will list the users in an access list.
-func (c *ACLCommand) UsersList(ctx context.Context, client *auth.Client) error {
+func (c *ACLCommand) UsersList(ctx context.Context, client *authclient.Client) error {
 	members, nextToken, err := client.AccessListClient().ListAccessListMembers(ctx, c.accessListName, 0, "")
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -940,10 +940,10 @@ func (s *adminActionTestSuite) testEditCommand(t *testing.T, ctx context.Context
 type adminActionTestSuite struct {
 	authServer *auth.Server
 	// userClientWithMFA supports MFA prompt for admin actions.
-	userClientWithMFA *auth.Client
+	userClientWithMFA *authclient.Client
 	// userClientWithMFA does not support MFA prompt for admin actions.
-	userClientNoMFA  *auth.Client
-	localAdminClient *auth.Client
+	userClientNoMFA  *authclient.Client
+	localAdminClient *authclient.Client
 }
 
 func newAdminActionTestSuite(t *testing.T) *adminActionTestSuite {
@@ -1039,7 +1039,7 @@ func newAdminActionTestSuite(t *testing.T) *adminActionTestSuite {
 	)
 	require.NoError(t, err)
 
-	userClientNoMFA, err := auth.NewClient(client.Config{
+	userClientNoMFA, err := authclient.NewClient(client.Config{
 		Addrs: []string{authAddr.String()},
 		Credentials: []client.Credentials{
 			client.LoadProfile(tshHome, ""),
@@ -1053,7 +1053,7 @@ func newAdminActionTestSuite(t *testing.T) *adminActionTestSuite {
 	})
 	require.NoError(t, err)
 
-	userClientWithMFA, err := auth.NewClient(client.Config{
+	userClientWithMFA, err := authclient.NewClient(client.Config{
 		Addrs: []string{authAddr.String()},
 		Credentials: []client.Credentials{
 			client.LoadProfile(tshHome, ""),
@@ -1125,7 +1125,7 @@ func (s *adminActionTestSuite) testCommand(t *testing.T, ctx context.Context, tc
 	})
 }
 
-func runTestCase(t *testing.T, ctx context.Context, client *auth.Client, tc adminActionTestCase) error {
+func runTestCase(t *testing.T, ctx context.Context, client *authclient.Client, tc adminActionTestCase) error {
 	t.Helper()
 
 	if tc.setup != nil {

--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -34,7 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
@@ -93,7 +93,7 @@ func (c *AlertCommand) Initialize(app *kingpin.Application, config *servicecfg.C
 }
 
 // TryRun takes the CLI command as an argument (like "alerts ls") and executes it.
-func (c *AlertCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *AlertCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.alertList.FullCommand():
 		err = c.List(ctx, client)
@@ -107,7 +107,7 @@ func (c *AlertCommand) TryRun(ctx context.Context, cmd string, client *auth.Clie
 	return true, trace.Wrap(err)
 }
 
-func (c *AlertCommand) ListAck(ctx context.Context, client *auth.Client) error {
+func (c *AlertCommand) ListAck(ctx context.Context, client *authclient.Client) error {
 	acks, err := client.GetAlertAcks(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -125,7 +125,7 @@ func (c *AlertCommand) ListAck(ctx context.Context, client *auth.Client) error {
 	return nil
 }
 
-func (c *AlertCommand) Ack(ctx context.Context, client *auth.Client) error {
+func (c *AlertCommand) Ack(ctx context.Context, client *authclient.Client) error {
 	if c.clear {
 		return c.ClearAck(ctx, client)
 	}
@@ -154,7 +154,7 @@ func (c *AlertCommand) Ack(ctx context.Context, client *auth.Client) error {
 	return nil
 }
 
-func (c *AlertCommand) ClearAck(ctx context.Context, client *auth.Client) error {
+func (c *AlertCommand) ClearAck(ctx context.Context, client *authclient.Client) error {
 	req := proto.ClearAlertAcksRequest{
 		AlertID: c.alertID,
 	}
@@ -168,7 +168,7 @@ func (c *AlertCommand) ClearAck(ctx context.Context, client *auth.Client) error 
 	return nil
 }
 
-func (c *AlertCommand) List(ctx context.Context, client *auth.Client) error {
+func (c *AlertCommand) List(ctx context.Context, client *authclient.Client) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)
@@ -240,7 +240,7 @@ func displayAlertsJSON(alerts []types.ClusterAlert) error {
 	return nil
 }
 
-func (c *AlertCommand) Create(ctx context.Context, client *auth.Client) error {
+func (c *AlertCommand) Create(ctx context.Context, client *authclient.Client) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/app_command.go
+++ b/tool/tctl/common/app_command.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
@@ -68,7 +68,7 @@ func (c *AppsCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 }
 
 // TryRun attempts to run subcommands like "apps ls".
-func (c *AppsCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *AppsCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.appsList.FullCommand():
 		err = c.ListApps(ctx, client)
@@ -80,7 +80,7 @@ func (c *AppsCommand) TryRun(ctx context.Context, cmd string, client *auth.Clien
 
 // ListApps prints the list of applications that have recently sent heartbeats
 // to the cluster.
-func (c *AppsCommand) ListApps(ctx context.Context, clt *auth.Client) error {
+func (c *AppsCommand) ListApps(ctx context.Context, clt *authclient.Client) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -41,6 +41,7 @@ import (
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keygen"
 	"github.com/gravitational/teleport/lib/auth/windows"
 	"github.com/gravitational/teleport/lib/client"
@@ -169,7 +170,7 @@ func (a *AuthCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 
 // TryRun takes the CLI command as an argument (like "auth gen") and executes it
 // or returns match=false if 'cmd' does not belong to it
-func (a *AuthCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (a *AuthCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case a.authGenerate.FullCommand():
 		err = a.GenerateKeys(ctx)
@@ -217,7 +218,7 @@ var allowedCRLCertificateTypes = []string{
 // ExportAuthorities outputs the list of authorities in OpenSSH compatible formats
 // If --type flag is given, only prints keys for CAs of this type, otherwise
 // prints all keys
-func (a *AuthCommand) ExportAuthorities(ctx context.Context, clt *auth.Client) error {
+func (a *AuthCommand) ExportAuthorities(ctx context.Context, clt *authclient.Client) error {
 	exportFunc := client.ExportAuthorities
 	if a.exportPrivateKeys {
 		exportFunc = client.ExportAuthoritiesSecrets
@@ -418,7 +419,7 @@ func (a *AuthCommand) generateSnowflakeKey(ctx context.Context, clusterAPI certi
 }
 
 // RotateCertAuthority starts or restarts certificate authority rotation process
-func (a *AuthCommand) RotateCertAuthority(ctx context.Context, client *auth.Client) error {
+func (a *AuthCommand) RotateCertAuthority(ctx context.Context, client *authclient.Client) error {
 	req := types.RotateRequest{
 		Type:        types.CertAuthType(a.rotateType),
 		GracePeriod: &a.rotateGracePeriod,
@@ -442,7 +443,7 @@ func (a *AuthCommand) RotateCertAuthority(ctx context.Context, client *auth.Clie
 }
 
 // ListAuthServers prints a list of connected auth servers
-func (a *AuthCommand) ListAuthServers(ctx context.Context, clusterAPI *auth.Client) error {
+func (a *AuthCommand) ListAuthServers(ctx context.Context, clusterAPI *authclient.Client) error {
 	servers, err := clusterAPI.GetAuthServers()
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/fixtures"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/identityfile"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -381,7 +381,7 @@ func (p *pingSrv) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 }
 
 type mockClient struct {
-	*auth.Client
+	*authclient.Client
 
 	clusterName    types.ClusterName
 	userCerts      *proto.Certs

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -42,7 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -105,7 +105,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 }
 
 // TryRun attempts to run subcommands.
-func (c *BotsCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *BotsCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.botsList.FullCommand():
 		err = c.ListBots(ctx, client)
@@ -126,7 +126,7 @@ func (c *BotsCommand) TryRun(ctx context.Context, cmd string, client *auth.Clien
 
 // ListBots writes a listing of the cluster's certificate renewal bots
 // to standard out.
-func (c *BotsCommand) ListBots(ctx context.Context, client *auth.Client) error {
+func (c *BotsCommand) ListBots(ctx context.Context, client *authclient.Client) error {
 	var bots []*machineidv1pb.Bot
 	req := &machineidv1pb.ListBotsRequest{}
 	for {
@@ -203,7 +203,7 @@ Please note:
 `))
 
 // AddBot adds a new certificate renewal bot to the cluster.
-func (c *BotsCommand) AddBot(ctx context.Context, client *auth.Client) error {
+func (c *BotsCommand) AddBot(ctx context.Context, client *authclient.Client) error {
 	// Prompt for admin action MFA if required, allowing reuse for UpsertToken and CreateBot.
 	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/)
 	if err == nil {
@@ -337,7 +337,7 @@ func (c *BotsCommand) AddBot(ctx context.Context, client *auth.Client) error {
 	return startMessageTemplate.Execute(os.Stdout, templateData)
 }
 
-func (c *BotsCommand) RemoveBot(ctx context.Context, client *auth.Client) error {
+func (c *BotsCommand) RemoveBot(ctx context.Context, client *authclient.Client) error {
 	_, err := client.BotServiceClient().DeleteBot(ctx, &machineidv1pb.DeleteBotRequest{
 		BotName: c.botName,
 	})
@@ -350,7 +350,7 @@ func (c *BotsCommand) RemoveBot(ctx context.Context, client *auth.Client) error 
 	return nil
 }
 
-func (c *BotsCommand) LockBot(ctx context.Context, client *auth.Client) error {
+func (c *BotsCommand) LockBot(ctx context.Context, client *authclient.Client) error {
 	lockExpiry, err := computeLockExpiry(c.lockExpires, c.lockTTL)
 	if err != nil {
 		return trace.Wrap(err)
@@ -503,7 +503,7 @@ func (c *BotsCommand) updateBotRoles(ctx context.Context, client clientRoleGette
 }
 
 // UpdateBot performs various updates to existing bot users and roles.
-func (c *BotsCommand) UpdateBot(ctx context.Context, client *auth.Client) error {
+func (c *BotsCommand) UpdateBot(ctx context.Context, client *authclient.Client) error {
 	bot, err := client.BotServiceClient().GetBot(ctx, &machineidv1pb.GetBotRequest{
 		BotName: c.botName,
 	})

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
@@ -68,7 +68,7 @@ func (c *DBCommand) Initialize(app *kingpin.Application, config *servicecfg.Conf
 }
 
 // TryRun attempts to run subcommands like "db ls".
-func (c *DBCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *DBCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.dbList.FullCommand():
 		err = c.ListDatabases(ctx, client)
@@ -80,7 +80,7 @@ func (c *DBCommand) TryRun(ctx context.Context, cmd string, client *auth.Client)
 
 // ListDatabases prints the list of database proxies that have recently sent
 // heartbeats to the cluster.
-func (c *DBCommand) ListDatabases(ctx context.Context, clt *auth.Client) error {
+func (c *DBCommand) ListDatabases(ctx context.Context, clt *authclient.Client) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/desktop_command.go
+++ b/tool/tctl/common/desktop_command.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
@@ -57,7 +57,7 @@ func (c *DesktopCommand) Initialize(app *kingpin.Application, config *servicecfg
 }
 
 // TryRun attempts to run subcommands like "desktop ls".
-func (c *DesktopCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *DesktopCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.desktopList.FullCommand():
 		err = c.ListDesktop(ctx, client)
@@ -69,7 +69,7 @@ func (c *DesktopCommand) TryRun(ctx context.Context, cmd string, client *auth.Cl
 
 // ListDesktop prints the list of desktops that have recently sent heartbeats
 // to the cluster.
-func (c *DesktopCommand) ListDesktop(ctx context.Context, client *auth.Client) error {
+func (c *DesktopCommand) ListDesktop(ctx context.Context, client *authclient.Client) error {
 	desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/devices.go
+++ b/tool/tctl/common/devices.go
@@ -34,7 +34,7 @@ import (
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/devicetrust"
 	dtnative "github.com/gravitational/teleport/lib/devicetrust/native"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -109,10 +109,10 @@ func (c *DevicesCommand) Initialize(app *kingpin.Application, cfg *servicecfg.Co
 
 // runner is used as a simple interface for subcommands.
 type runner interface {
-	Run(context.Context, *auth.Client) error
+	Run(context.Context, *authclient.Client) error
 }
 
-func (c *DevicesCommand) TryRun(ctx context.Context, selectedCommand string, authClient *auth.Client) (match bool, err error) {
+func (c *DevicesCommand) TryRun(ctx context.Context, selectedCommand string, authClient *authclient.Client) (match bool, err error) {
 	innerCmd, ok := map[string]runner{
 		"devices add":    &c.add,
 		"devices ls":     &c.ls,
@@ -140,7 +140,7 @@ type deviceAddCommand struct {
 	enrollTTL time.Duration
 }
 
-func (c *deviceAddCommand) Run(ctx context.Context, authClient *auth.Client) error {
+func (c *deviceAddCommand) Run(ctx context.Context, authClient *authclient.Client) error {
 	if _, err := c.setCurrentDevice(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -208,7 +208,7 @@ tsh device enroll --token=%v
 
 type deviceListCommand struct{}
 
-func (c *deviceListCommand) Run(ctx context.Context, authClient *auth.Client) error {
+func (c *deviceListCommand) Run(ctx context.Context, authClient *authclient.Client) error {
 	devices := authClient.DevicesClient()
 
 	// List all devices.
@@ -267,7 +267,7 @@ type deviceRemoveCommand struct {
 	deviceID string
 }
 
-func (c *deviceRemoveCommand) Run(ctx context.Context, authClient *auth.Client) error {
+func (c *deviceRemoveCommand) Run(ctx context.Context, authClient *authclient.Client) error {
 	switch ok, err := c.setCurrentDevice(); {
 	case err != nil:
 		return trace.Wrap(err)
@@ -307,7 +307,7 @@ type deviceEnrollCommand struct {
 	ttl      time.Duration
 }
 
-func (c *deviceEnrollCommand) Run(ctx context.Context, authClient *auth.Client) error {
+func (c *deviceEnrollCommand) Run(ctx context.Context, authClient *authclient.Client) error {
 	switch ok, err := c.setCurrentDevice(); {
 	case err != nil:
 		return trace.Wrap(err)
@@ -355,7 +355,7 @@ type deviceLockCommand struct {
 	ttl      time.Duration
 }
 
-func (c *deviceLockCommand) Run(ctx context.Context, authClient *auth.Client) error {
+func (c *deviceLockCommand) Run(ctx context.Context, authClient *authclient.Client) error {
 	switch ok, err := c.setCurrentDevice(); {
 	case err != nil:
 		return trace.Wrap(err)

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -34,7 +34,7 @@ import (
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -66,7 +66,7 @@ func (e *EditCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 	$ tctl edit rc/remote`).SetValue(&e.ref)
 }
 
-func (e *EditCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (bool, error) {
+func (e *EditCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (bool, error) {
 	if cmd != e.cmd.FullCommand() {
 		return false, nil
 	}
@@ -96,7 +96,7 @@ func (e *EditCommand) runEditor(ctx context.Context, name string) error {
 	return nil
 }
 
-func (e *EditCommand) editResource(ctx context.Context, client *auth.Client) error {
+func (e *EditCommand) editResource(ctx context.Context, client *authclient.Client) error {
 	f, err := os.CreateTemp("", "teleport-resource*.yaml")
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/modules"
@@ -48,7 +48,7 @@ func TestEditResources(t *testing.T) {
 
 	tests := []struct {
 		kind string
-		edit func(t *testing.T, fc *config.FileConfig, clt *auth.Client)
+		edit func(t *testing.T, fc *config.FileConfig, clt *authclient.Client)
 	}{
 		{
 			kind: types.KindGithubConnector,
@@ -83,7 +83,7 @@ func TestEditResources(t *testing.T) {
 	}
 }
 
-func testEditGithubConnector(t *testing.T, fc *config.FileConfig, clt *auth.Client) {
+func testEditGithubConnector(t *testing.T, fc *config.FileConfig, clt *authclient.Client) {
 	ctx := context.Background()
 
 	expected, err := types.NewGithubConnector("github", types.GithubConnectorSpecV3{
@@ -133,7 +133,7 @@ func testEditGithubConnector(t *testing.T, fc *config.FileConfig, clt *auth.Clie
 	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
 }
 
-func testEditRole(t *testing.T, fc *config.FileConfig, clt *auth.Client) {
+func testEditRole(t *testing.T, fc *config.FileConfig, clt *authclient.Client) {
 	ctx := context.Background()
 
 	expected, err := types.NewRole("test-role", types.RoleSpecV6{})
@@ -171,7 +171,7 @@ func testEditRole(t *testing.T, fc *config.FileConfig, clt *auth.Client) {
 	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
 }
 
-func testEditUser(t *testing.T, fc *config.FileConfig, clt *auth.Client) {
+func testEditUser(t *testing.T, fc *config.FileConfig, clt *authclient.Client) {
 	ctx := context.Background()
 
 	expected, err := types.NewUser("llama")
@@ -210,7 +210,7 @@ func testEditUser(t *testing.T, fc *config.FileConfig, clt *auth.Client) {
 	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
 }
 
-func testEditClusterNetworkingConfig(t *testing.T, fc *config.FileConfig, clt *auth.Client) {
+func testEditClusterNetworkingConfig(t *testing.T, fc *config.FileConfig, clt *authclient.Client) {
 	ctx := context.Background()
 
 	expected := types.DefaultClusterNetworkingConfig()
@@ -250,7 +250,7 @@ func testEditClusterNetworkingConfig(t *testing.T, fc *config.FileConfig, clt *a
 	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
 }
 
-func testEditAuthPreference(t *testing.T, fc *config.FileConfig, clt *auth.Client) {
+func testEditAuthPreference(t *testing.T, fc *config.FileConfig, clt *authclient.Client) {
 	ctx := context.Background()
 
 	expected := types.DefaultAuthPreference()
@@ -288,7 +288,7 @@ func testEditAuthPreference(t *testing.T, fc *config.FileConfig, clt *auth.Clien
 	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
 }
 
-func testEditSessionRecordingConfig(t *testing.T, fc *config.FileConfig, clt *auth.Client) {
+func testEditSessionRecordingConfig(t *testing.T, fc *config.FileConfig, clt *authclient.Client) {
 	ctx := context.Background()
 
 	expected := types.DefaultSessionRecordingConfig()
@@ -346,7 +346,7 @@ func TestEditEnterpriseResources(t *testing.T) {
 
 	tests := []struct {
 		kind string
-		edit func(t *testing.T, fc *config.FileConfig, clt *auth.Client)
+		edit func(t *testing.T, fc *config.FileConfig, clt *authclient.Client)
 	}{
 		{
 			kind: types.KindOIDCConnector,
@@ -365,7 +365,7 @@ func TestEditEnterpriseResources(t *testing.T) {
 	}
 }
 
-func testEditOIDCConnector(t *testing.T, fc *config.FileConfig, clt *auth.Client) {
+func testEditOIDCConnector(t *testing.T, fc *config.FileConfig, clt *authclient.Client) {
 	ctx := context.Background()
 	expected, err := types.NewOIDCConnector("oidc", types.OIDCConnectorSpecV3{
 		ClientID:     "12345",
@@ -417,7 +417,7 @@ func testEditOIDCConnector(t *testing.T, fc *config.FileConfig, clt *auth.Client
 	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
 }
 
-func testEditSAMLConnector(t *testing.T, fc *config.FileConfig, clt *auth.Client) {
+func testEditSAMLConnector(t *testing.T, fc *config.FileConfig, clt *authclient.Client) {
 	ctx := context.Background()
 
 	expected, err := types.NewSAMLConnector("saml", types.SAMLConnectorSpecV2{

--- a/tool/tctl/common/externalauditstorage_command.go
+++ b/tool/tctl/common/externalauditstorage_command.go
@@ -24,7 +24,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
@@ -55,7 +55,7 @@ func (c *ExternalAuditStorageCommand) Initialize(app *kingpin.Application, confi
 }
 
 // TryRun attempts to run subcommands.
-func (c *ExternalAuditStorageCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *ExternalAuditStorageCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.promote.FullCommand():
 		err = c.Promote(ctx, client)
@@ -69,13 +69,13 @@ func (c *ExternalAuditStorageCommand) TryRun(ctx context.Context, cmd string, cl
 
 // Promote calls PromoteToClusterExternalAuditStorage, which results in enabling
 // External Audit Storage in the cluster based on existing draft.
-func (c *ExternalAuditStorageCommand) Promote(ctx context.Context, clt *auth.Client) error {
+func (c *ExternalAuditStorageCommand) Promote(ctx context.Context, clt *authclient.Client) error {
 	return trace.Wrap(clt.ExternalAuditStorageClient().PromoteToClusterExternalAuditStorage(ctx))
 }
 
 // Generate creates an External Audit Storage configuration with randomized
 // resource names and saves it as the current draft.
-func (c *ExternalAuditStorageCommand) Generate(ctx context.Context, clt *auth.Client) error {
+func (c *ExternalAuditStorageCommand) Generate(ctx context.Context, clt *authclient.Client) error {
 	_, err := clt.ExternalAuditStorageClient().GenerateDraftExternalAuditStorage(ctx, c.integrationName, c.region)
 	return trace.Wrap(err)
 }

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/gravitational/teleport/api/breaker"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/config"
@@ -74,7 +73,7 @@ func withEditor(editor func(string) error) optionsFunc {
 	}
 }
 
-func getAuthClient(ctx context.Context, t *testing.T, fc *config.FileConfig, opts ...optionsFunc) *auth.Client {
+func getAuthClient(ctx context.Context, t *testing.T, fc *config.FileConfig, opts ...optionsFunc) *authclient.Client {
 	var options options
 	for _, v := range opts {
 		v(&options)
@@ -104,7 +103,7 @@ func getAuthClient(ctx context.Context, t *testing.T, fc *config.FileConfig, opt
 
 type cliCommand interface {
 	Initialize(app *kingpin.Application, cfg *servicecfg.Config)
-	TryRun(ctx context.Context, cmd string, client *auth.Client) (bool, error)
+	TryRun(ctx context.Context, cmd string, client *authclient.Client) (bool, error)
 }
 
 func runCommand(t *testing.T, fc *config.FileConfig, cmd cliCommand, args []string, opts ...optionsFunc) error {

--- a/tool/tctl/common/idp_command.go
+++ b/tool/tctl/common/idp_command.go
@@ -33,7 +33,7 @@ import (
 	samlidpv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/samlidp/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
@@ -45,7 +45,7 @@ import (
 // $ tctl idp oidc <command> [<args> ...]
 type subcommandRunner interface {
 	initialize(parent *kingpin.CmdClause, cfg *servicecfg.Config)
-	tryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error)
+	tryRun(ctx context.Context, selectedCommand string, c *authclient.Client) (match bool, err error)
 }
 
 // IdPCommand implements all commands under "tctl idp".
@@ -79,7 +79,7 @@ Examples:
 }
 
 // TryRun calls tryRun for each subcommand, and returns (false, nil) if none of them match.
-func (i *IdPCommand) TryRun(ctx context.Context, cmd string, c *auth.Client) (match bool, err error) {
+func (i *IdPCommand) TryRun(ctx context.Context, cmd string, c *authclient.Client) (match bool, err error) {
 	for _, subcommandRunner := range i.subcommandRunners {
 		match, err = subcommandRunner.tryRun(ctx, cmd, c)
 		if err != nil {
@@ -121,7 +121,7 @@ Examples:
 	s.testAttributeMapping.cmd = testAttrMap
 }
 
-func (s *samlIdPCommand) tryRun(ctx context.Context, cmd string, c *auth.Client) (match bool, err error) {
+func (s *samlIdPCommand) tryRun(ctx context.Context, cmd string, c *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case s.testAttributeMapping.cmd.FullCommand():
 		return true, trace.Wrap(s.testAttributeMapping.run(ctx, c))
@@ -139,7 +139,7 @@ type testAttributeMapping struct {
 	outFormat       string
 }
 
-func (t *testAttributeMapping) run(ctx context.Context, c *auth.Client) error {
+func (t *testAttributeMapping) run(ctx context.Context, c *authclient.Client) error {
 	serviceProvider, err := parseSPFile(t.serviceProvider)
 	if err != nil {
 		return trace.Wrap(err)
@@ -217,7 +217,7 @@ func parseSPFile(fileName string) (types.SAMLIdPServiceProviderV1, error) {
 }
 
 // getUsersFromAPIOrFile parses user from spec file. If file is not found, it fetches user from backend.
-func getUsersFromAPIOrFile(ctx context.Context, usernamesOrFileNames []string, c *auth.Client) ([]*types.UserV2, error) {
+func getUsersFromAPIOrFile(ctx context.Context, usernamesOrFileNames []string, c *authclient.Client) ([]*types.UserV2, error) {
 	flattenedUsernamesOrFileNames := flattenSlice(usernamesOrFileNames)
 	var users []*types.UserV2
 

--- a/tool/tctl/common/inventory_command.go
+++ b/tool/tctl/common/inventory_command.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 	vc "github.com/gravitational/teleport/lib/versioncontrol"
@@ -85,7 +85,7 @@ func (c *InventoryCommand) Initialize(app *kingpin.Application, config *servicec
 }
 
 // TryRun takes the CLI command as an argument (like "inventory status") and executes it.
-func (c *InventoryCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *InventoryCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.inventoryStatus.FullCommand():
 		err = c.Status(ctx, client)
@@ -99,7 +99,7 @@ func (c *InventoryCommand) TryRun(ctx context.Context, cmd string, client *auth.
 	return true, trace.Wrap(err)
 }
 
-func (c *InventoryCommand) Status(ctx context.Context, client *auth.Client) error {
+func (c *InventoryCommand) Status(ctx context.Context, client *authclient.Client) error {
 	rsp, err := client.GetInventoryStatus(ctx, proto.InventoryStatusRequest{
 		Connected: c.getConnected,
 	})
@@ -174,7 +174,7 @@ func printHierarchicalData(data map[string]any, indent string, depth int) {
 	}
 }
 
-func (c *InventoryCommand) List(ctx context.Context, client *auth.Client) error {
+func (c *InventoryCommand) List(ctx context.Context, client *authclient.Client) error {
 	var services []types.SystemRole
 	var err error
 	if c.services != "" {
@@ -247,7 +247,7 @@ func (c *InventoryCommand) List(ctx context.Context, client *auth.Client) error 
 	}
 }
 
-func (c *InventoryCommand) Ping(ctx context.Context, client *auth.Client) error {
+func (c *InventoryCommand) Ping(ctx context.Context, client *authclient.Client) error {
 	rsp, err := client.PingInventory(ctx, proto.InventoryPingRequest{
 		ServerID:   c.serverID,
 		ControlLog: c.controlLog,

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
@@ -68,7 +68,7 @@ func (c *KubeCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 }
 
 // TryRun attempts to run subcommands like "kube ls".
-func (c *KubeCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *KubeCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.kubeList.FullCommand():
 		err = c.ListKube(ctx, client)
@@ -80,7 +80,7 @@ func (c *KubeCommand) TryRun(ctx context.Context, cmd string, client *auth.Clien
 
 // ListKube prints the list of kube clusters that have recently sent heartbeats
 // to the cluster.
-func (c *KubeCommand) ListKube(ctx context.Context, clt *auth.Client) error {
+func (c *KubeCommand) ListKube(ctx context.Context, clt *authclient.Client) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/loadtest_command.go
+++ b/tool/tctl/common/loadtest_command.go
@@ -35,7 +35,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cache"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -79,7 +79,7 @@ func (c *LoadtestCommand) Initialize(app *kingpin.Application, config *servicecf
 }
 
 // TryRun takes the CLI command as an argument (like "loadtest node-heartbeats") and executes it.
-func (c *LoadtestCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *LoadtestCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.nodeHeartbeats.FullCommand():
 		err = c.NodeHeartbeats(ctx, client)
@@ -91,7 +91,7 @@ func (c *LoadtestCommand) TryRun(ctx context.Context, cmd string, client *auth.C
 	return true, trace.Wrap(err)
 }
 
-func (c *LoadtestCommand) NodeHeartbeats(ctx context.Context, client *auth.Client) error {
+func (c *LoadtestCommand) NodeHeartbeats(ctx context.Context, client *authclient.Client) error {
 	infof := func(format string, args ...any) {
 		fmt.Fprintf(os.Stderr, "[i] "+format+"\n", args...)
 	}
@@ -211,7 +211,7 @@ func (c *LoadtestCommand) NodeHeartbeats(ctx context.Context, client *auth.Clien
 	}
 }
 
-func (c *LoadtestCommand) Watch(ctx context.Context, client *auth.Client) error {
+func (c *LoadtestCommand) Watch(ctx context.Context, client *authclient.Client) error {
 	var kinds []types.WatchKind
 	for _, kind := range strings.Split(c.kind, ",") {
 		kind = strings.TrimSpace(kind)

--- a/tool/tctl/common/lock_command.go
+++ b/tool/tctl/common/lock_command.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
@@ -60,7 +60,7 @@ func (c *LockCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 }
 
 // TryRun attempts to run subcommands.
-func (c *LockCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *LockCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.mainCmd.FullCommand():
 		err = c.CreateLock(ctx, client)
@@ -71,7 +71,7 @@ func (c *LockCommand) TryRun(ctx context.Context, cmd string, client *auth.Clien
 }
 
 // CreateLock creates a lock for the main `tctl lock` command.
-func (c *LockCommand) CreateLock(ctx context.Context, client *auth.Client) error {
+func (c *LockCommand) CreateLock(ctx context.Context, client *authclient.Client) error {
 	lockExpiry, err := computeLockExpiry(c.expires, c.ttl)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/loginrule/command.go
+++ b/tool/tctl/common/loginrule/command.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gravitational/teleport"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -41,7 +41,7 @@ import (
 
 type subcommand interface {
 	initialize(parent *kingpin.CmdClause, cfg *servicecfg.Config)
-	tryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error)
+	tryRun(ctx context.Context, selectedCommand string, c *authclient.Client) (match bool, err error)
 }
 
 // Command implements all commands under "tctl login_rule".
@@ -64,7 +64,7 @@ func (t *Command) Initialize(app *kingpin.Application, cfg *servicecfg.Config) {
 
 // TryRun calls tryRun for each subcommand, and if none of them match returns
 // (false, nil)
-func (t *Command) TryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error) {
+func (t *Command) TryRun(ctx context.Context, selectedCommand string, c *authclient.Client) (match bool, err error) {
 	for _, subcommand := range t.subcommands {
 		match, err = subcommand.tryRun(ctx, selectedCommand, c)
 		if err != nil {
@@ -112,7 +112,7 @@ Examples:
   > echo '{"groups": ["example"]}' | tctl login_rule test --resource-file rule.yaml`)
 }
 
-func (t *testCommand) tryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error) {
+func (t *testCommand) tryRun(ctx context.Context, selectedCommand string, c *authclient.Client) (match bool, err error) {
 	if selectedCommand != t.cmd.FullCommand() {
 		return false, nil
 	}
@@ -124,7 +124,7 @@ func (t *testCommand) tryRun(ctx context.Context, selectedCommand string, c *aut
 	return true, trace.Wrap(t.run(ctx, c))
 }
 
-func (t *testCommand) run(ctx context.Context, c *auth.Client) error {
+func (t *testCommand) run(ctx context.Context, c *authclient.Client) error {
 	loginRules, err := parseLoginRuleFiles(t.inputResourceFiles)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -99,7 +99,7 @@ func (c *NodeCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 }
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
-func (c *NodeCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *NodeCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.nodeAdd.FullCommand():
 		err = c.Invite(ctx, client)
@@ -137,7 +137,7 @@ Please note:
 
 // Invite generates a token which can be used to add another SSH node
 // to a cluster
-func (c *NodeCommand) Invite(ctx context.Context, client *auth.Client) error {
+func (c *NodeCommand) Invite(ctx context.Context, client *authclient.Client) error {
 	// parse --roles flag
 	roles, err := types.ParseTeleportRoles(c.roles)
 	if err != nil {
@@ -230,7 +230,7 @@ func (c *NodeCommand) Invite(ctx context.Context, client *auth.Client) error {
 
 // ListActive retrieves the list of nodes who recently sent heartbeats to
 // to a cluster and prints it to stdout
-func (c *NodeCommand) ListActive(ctx context.Context, clt *auth.Client) error {
+func (c *NodeCommand) ListActive(ctx context.Context, clt *authclient.Client) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/plugins_command.go
+++ b/tool/tctl/common/plugins_command.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport"
 	pluginsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
@@ -128,7 +128,7 @@ func (p *PluginsCommand) initDelete(parent *kingpin.CmdClause) {
 }
 
 // Delete implements `tctl plugins delete`, deleting a plugin from the Teleport cluster
-func (p *PluginsCommand) Delete(ctx context.Context, client *auth.Client) error {
+func (p *PluginsCommand) Delete(ctx context.Context, client *authclient.Client) error {
 	log := p.config.Logger.With("plugin", p.delete.name)
 	plugins := client.PluginsClient()
 
@@ -145,7 +145,7 @@ func (p *PluginsCommand) Delete(ctx context.Context, client *auth.Client) error 
 }
 
 // Cleanup cleans up the given plugin.
-func (p *PluginsCommand) Cleanup(ctx context.Context, clusterAPI *auth.Client) error {
+func (p *PluginsCommand) Cleanup(ctx context.Context, clusterAPI *authclient.Client) error {
 	needsCleanup, err := clusterAPI.PluginsClient().NeedsCleanup(ctx, &pluginsv1.NeedsCleanupRequest{
 		Type: p.pluginType,
 	})
@@ -191,7 +191,7 @@ func (p *PluginsCommand) Cleanup(ctx context.Context, clusterAPI *auth.Client) e
 
 // InstallSCIM implements `tctl plugins install scim`, installing a SCIM integration
 // plugin into the teleport cluster
-func (p *PluginsCommand) InstallSCIM(ctx context.Context, client *auth.Client) error {
+func (p *PluginsCommand) InstallSCIM(ctx context.Context, client *authclient.Client) error {
 	log := p.config.Logger.With(logFieldPlugin, p.install.name)
 
 	log.DebugContext(ctx, "Fetching cluster info...")
@@ -284,7 +284,7 @@ func (p *PluginsCommand) InstallSCIM(ctx context.Context, client *auth.Client) e
 }
 
 // TryRun runs the plugins command
-func (p *PluginsCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (p *PluginsCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case p.cleanupCmd.FullCommand():
 		err = p.Cleanup(ctx, client)

--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
@@ -49,7 +49,7 @@ func (p *ProxyCommand) Initialize(app *kingpin.Application, config *servicecfg.C
 }
 
 // ListProxies prints currently connected proxies
-func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI *auth.Client) error {
+func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI *authclient.Client) error {
 	proxies, err := clusterAPI.GetProxies()
 	if err != nil {
 		return trace.Wrap(err)
@@ -72,7 +72,7 @@ func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI *auth.Client)
 }
 
 // TryRun runs the proxy command
-func (p *ProxyCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (p *ProxyCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case p.lsCmd.FullCommand():
 		err = p.ListProxies(ctx, client)

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -68,7 +68,7 @@ func (c *RecordingsCommand) Initialize(app *kingpin.Application, config *service
 }
 
 // TryRun attempts to run subcommands like "recordings ls".
-func (c *RecordingsCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *RecordingsCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.recordingsList.FullCommand():
 		err = c.ListRecordings(ctx, client)
@@ -78,7 +78,7 @@ func (c *RecordingsCommand) TryRun(ctx context.Context, cmd string, client *auth
 	return true, trace.Wrap(err)
 }
 
-func (c *RecordingsCommand) ListRecordings(ctx context.Context, tc *auth.Client) error {
+func (c *RecordingsCommand) ListRecordings(ctx context.Context, tc *authclient.Client) error {
 	fromUTC, toUTC, err := defaults.SearchSessionRange(clockwork.NewRealClock(), c.fromUTC, c.toUTC, c.recordingsSince)
 	if err != nil {
 		return trace.Errorf("cannot request recordings: %v", err)

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -56,7 +56,7 @@ import (
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/api/types/secreports"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/devicetrust"
@@ -69,7 +69,7 @@ import (
 )
 
 // ResourceCreateHandler is the generic implementation of a resource creation handler
-type ResourceCreateHandler func(context.Context, *auth.Client, services.UnknownResource) error
+type ResourceCreateHandler func(context.Context, *authclient.Client, services.UnknownResource) error
 
 // ResourceKind is the string form of a resource, i.e. "oidc"
 type ResourceKind string
@@ -213,7 +213,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *servicec
 
 // TryRun takes the CLI command as an argument (like "auth gen") and executes it
 // or returns match=false if 'cmd' does not belong to it
-func (rc *ResourceCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (rc *ResourceCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	// tctl get
 	case rc.getCmd.FullCommand():
@@ -245,7 +245,7 @@ func (rc *ResourceCommand) GetRef() services.Ref {
 }
 
 // Get prints one or many resources of a certain type
-func (rc *ResourceCommand) Get(ctx context.Context, client *auth.Client) error {
+func (rc *ResourceCommand) Get(ctx context.Context, client *authclient.Client) error {
 	if rc.refs.IsAll() {
 		return rc.GetAll(ctx, client)
 	}
@@ -271,7 +271,7 @@ func (rc *ResourceCommand) Get(ctx context.Context, client *auth.Client) error {
 	return trace.BadParameter("unsupported format")
 }
 
-func (rc *ResourceCommand) GetMany(ctx context.Context, client *auth.Client) error {
+func (rc *ResourceCommand) GetMany(ctx context.Context, client *authclient.Client) error {
 	if rc.format != teleport.YAML {
 		return trace.BadParameter("mixed resource types only support YAML formatting")
 	}
@@ -290,7 +290,7 @@ func (rc *ResourceCommand) GetMany(ctx context.Context, client *auth.Client) err
 	return nil
 }
 
-func (rc *ResourceCommand) GetAll(ctx context.Context, client *auth.Client) error {
+func (rc *ResourceCommand) GetAll(ctx context.Context, client *authclient.Client) error {
 	rc.withSecrets = true
 	allKinds := services.GetResourceMarshalerKinds()
 	allRefs := make([]services.Ref, 0, len(allKinds))
@@ -305,7 +305,7 @@ func (rc *ResourceCommand) GetAll(ctx context.Context, client *auth.Client) erro
 }
 
 // Create updates or inserts one or many resources
-func (rc *ResourceCommand) Create(ctx context.Context, client *auth.Client) (err error) {
+func (rc *ResourceCommand) Create(ctx context.Context, client *authclient.Client) (err error) {
 	var reader io.Reader
 	if rc.filename == "" {
 		reader = os.Stdin
@@ -350,7 +350,7 @@ func (rc *ResourceCommand) Create(ctx context.Context, client *auth.Client) (err
 }
 
 // createTrustedCluster implements `tctl create cluster.yaml` command
-func (rc *ResourceCommand) createTrustedCluster(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createTrustedCluster(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	tc, err := services.UnmarshalTrustedCluster(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -388,7 +388,7 @@ func (rc *ResourceCommand) createTrustedCluster(ctx context.Context, client *aut
 }
 
 // createCertAuthority creates certificate authority
-func (rc *ResourceCommand) createCertAuthority(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createCertAuthority(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	certAuthority, err := services.UnmarshalCertAuthority(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -401,7 +401,7 @@ func (rc *ResourceCommand) createCertAuthority(ctx context.Context, client *auth
 }
 
 // createGithubConnector creates a Github connector
-func (rc *ResourceCommand) createGithubConnector(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createGithubConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	connector, err := services.UnmarshalGithubConnector(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -431,7 +431,7 @@ func (rc *ResourceCommand) createGithubConnector(ctx context.Context, client *au
 }
 
 // updateGithubConnector updates an existing Github connector.
-func (rc *ResourceCommand) updateGithubConnector(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateGithubConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	connector, err := services.UnmarshalGithubConnector(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -445,7 +445,7 @@ func (rc *ResourceCommand) updateGithubConnector(ctx context.Context, client *au
 }
 
 // createRole implements `tctl create role.yaml` command.
-func (rc *ResourceCommand) createRole(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createRole(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	role, err := services.UnmarshalRole(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -479,7 +479,7 @@ func (rc *ResourceCommand) createRole(ctx context.Context, client *auth.Client, 
 	return nil
 }
 
-func (rc *ResourceCommand) updateRole(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateRole(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	role, err := services.UnmarshalRole(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -539,7 +539,7 @@ func warnAboutDynamicLabelsInDenyRule(logger utils.Logger, r types.Role) {
 }
 
 // createUser implements `tctl create user.yaml` command.
-func (rc *ResourceCommand) createUser(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createUser(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	user, err := services.UnmarshalUser(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -576,7 +576,7 @@ func (rc *ResourceCommand) createUser(ctx context.Context, client *auth.Client, 
 	return nil
 }
 
-func (rc *ResourceCommand) createBot(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createBot(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	bot := &machineidv1pb.Bot{}
 	if err := protojson.Unmarshal(raw.Raw, bot); err != nil {
 		return trace.Wrap(err)
@@ -602,7 +602,7 @@ func (rc *ResourceCommand) createBot(ctx context.Context, client *auth.Client, r
 	return nil
 }
 
-func (rc *ResourceCommand) createDatabaseObjectImportRule(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDatabaseObjectImportRule(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	rule, err := databaseobjectimportrule.UnmarshalJSON(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -627,7 +627,7 @@ func (rc *ResourceCommand) createDatabaseObjectImportRule(ctx context.Context, c
 	return nil
 }
 
-func (rc *ResourceCommand) createDatabaseObject(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDatabaseObject(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	object, err := databaseobject.UnmarshalJSON(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -653,7 +653,7 @@ func (rc *ResourceCommand) createDatabaseObject(ctx context.Context, client *aut
 }
 
 // updateUser implements `tctl create user.yaml` command.
-func (rc *ResourceCommand) updateUser(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateUser(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	user, err := services.UnmarshalUser(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -668,7 +668,7 @@ func (rc *ResourceCommand) updateUser(ctx context.Context, client *auth.Client, 
 }
 
 // createAuthPreference implements `tctl create cap.yaml` command.
-func (rc *ResourceCommand) createAuthPreference(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAuthPreference(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	newAuthPref, err := services.UnmarshalAuthPreference(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -689,7 +689,7 @@ func (rc *ResourceCommand) createAuthPreference(ctx context.Context, client *aut
 	return nil
 }
 
-func (rc *ResourceCommand) updateAuthPreference(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateAuthPreference(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	newAuthPref, err := services.UnmarshalAuthPreference(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -703,7 +703,7 @@ func (rc *ResourceCommand) updateAuthPreference(ctx context.Context, client *aut
 }
 
 // createClusterNetworkingConfig implements `tctl create netconfig.yaml` command.
-func (rc *ResourceCommand) createClusterNetworkingConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createClusterNetworkingConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	newNetConfig, err := services.UnmarshalClusterNetworkingConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -725,7 +725,7 @@ func (rc *ResourceCommand) createClusterNetworkingConfig(ctx context.Context, cl
 }
 
 // updateClusterNetworkingConfig
-func (rc *ResourceCommand) updateClusterNetworkingConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateClusterNetworkingConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	newNetConfig, err := services.UnmarshalClusterNetworkingConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -738,7 +738,7 @@ func (rc *ResourceCommand) updateClusterNetworkingConfig(ctx context.Context, cl
 	return nil
 }
 
-func (rc *ResourceCommand) createClusterMaintenanceConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createClusterMaintenanceConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	var cmc types.ClusterMaintenanceConfigV1
 	if err := utils.FastUnmarshal(raw.Raw, &cmc); err != nil {
 		return trace.Wrap(err)
@@ -762,7 +762,7 @@ func (rc *ResourceCommand) createClusterMaintenanceConfig(ctx context.Context, c
 }
 
 // createSessionRecordingConfig implements `tctl create recconfig.yaml` command.
-func (rc *ResourceCommand) createSessionRecordingConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createSessionRecordingConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	newRecConfig, err := services.UnmarshalSessionRecordingConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -783,7 +783,7 @@ func (rc *ResourceCommand) createSessionRecordingConfig(ctx context.Context, cli
 	return nil
 }
 
-func (rc *ResourceCommand) updateSessionRecordingConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateSessionRecordingConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	newRecConfig, err := services.UnmarshalSessionRecordingConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -797,7 +797,7 @@ func (rc *ResourceCommand) updateSessionRecordingConfig(ctx context.Context, cli
 }
 
 // createExternalAuditStorage implements `tctl create external_audit_storage` command.
-func (rc *ResourceCommand) createExternalAuditStorage(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createExternalAuditStorage(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	draft, err := services.UnmarshalExternalAuditStorage(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -818,7 +818,7 @@ func (rc *ResourceCommand) createExternalAuditStorage(ctx context.Context, clien
 }
 
 // createLock implements `tctl create lock.yaml` command.
-func (rc *ResourceCommand) createLock(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createLock(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	lock, err := services.UnmarshalLock(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -844,7 +844,7 @@ func (rc *ResourceCommand) createLock(ctx context.Context, client *auth.Client, 
 }
 
 // createNetworkRestrictions implements `tctl create net_restrict.yaml` command.
-func (rc *ResourceCommand) createNetworkRestrictions(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createNetworkRestrictions(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	newNetRestricts, err := services.UnmarshalNetworkRestrictions(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -857,7 +857,7 @@ func (rc *ResourceCommand) createNetworkRestrictions(ctx context.Context, client
 	return nil
 }
 
-func (rc *ResourceCommand) createWindowsDesktop(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createWindowsDesktop(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	wd, err := services.UnmarshalWindowsDesktop(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -871,7 +871,7 @@ func (rc *ResourceCommand) createWindowsDesktop(ctx context.Context, client *aut
 	return nil
 }
 
-func (rc *ResourceCommand) createAppServer(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAppServer(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	appServer, err := services.UnmarshalAppServer(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -886,7 +886,7 @@ func (rc *ResourceCommand) createAppServer(ctx context.Context, client *auth.Cli
 	return nil
 }
 
-func (rc *ResourceCommand) createApp(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createApp(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	app, err := services.UnmarshalApp(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -908,7 +908,7 @@ func (rc *ResourceCommand) createApp(ctx context.Context, client *auth.Client, r
 	return nil
 }
 
-func (rc *ResourceCommand) createKubeCluster(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createKubeCluster(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	cluster, err := services.UnmarshalKubeCluster(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -930,7 +930,7 @@ func (rc *ResourceCommand) createKubeCluster(ctx context.Context, client *auth.C
 	return nil
 }
 
-func (rc *ResourceCommand) createCrownJewel(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createCrownJewel(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	crownJewel, err := services.UnmarshalCrownJewel(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -952,7 +952,7 @@ func (rc *ResourceCommand) createCrownJewel(ctx context.Context, client *auth.Cl
 	return nil
 }
 
-func (rc *ResourceCommand) updateCrownJewel(ctx context.Context, client *auth.Client, resource services.UnknownResource) error {
+func (rc *ResourceCommand) updateCrownJewel(ctx context.Context, client *authclient.Client, resource services.UnknownResource) error {
 	in, err := services.UnmarshalCrownJewel(resource.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -964,7 +964,7 @@ func (rc *ResourceCommand) updateCrownJewel(ctx context.Context, client *auth.Cl
 	return nil
 }
 
-func (rc *ResourceCommand) createDatabase(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDatabase(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	database, err := services.UnmarshalDatabase(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -987,7 +987,7 @@ func (rc *ResourceCommand) createDatabase(ctx context.Context, client *auth.Clie
 	return nil
 }
 
-func (rc *ResourceCommand) createToken(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createToken(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	token, err := services.UnmarshalProvisionToken(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1001,7 +1001,7 @@ func (rc *ResourceCommand) createToken(ctx context.Context, client *auth.Client,
 	return nil
 }
 
-func (rc *ResourceCommand) createInstaller(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createInstaller(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	inst, err := services.UnmarshalInstaller(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1015,7 +1015,7 @@ func (rc *ResourceCommand) createInstaller(ctx context.Context, client *auth.Cli
 	return nil
 }
 
-func (rc *ResourceCommand) createUIConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createUIConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	uic, err := services.UnmarshalUIConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1028,7 +1028,7 @@ func (rc *ResourceCommand) createUIConfig(ctx context.Context, client *auth.Clie
 	return nil
 }
 
-func (rc *ResourceCommand) createNode(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createNode(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	server, err := services.UnmarshalServer(raw.Raw, types.KindNode)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1056,7 +1056,7 @@ func (rc *ResourceCommand) createNode(ctx context.Context, client *auth.Client, 
 	return nil
 }
 
-func (rc *ResourceCommand) createOIDCConnector(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createOIDCConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	conn, err := services.UnmarshalOIDCConnector(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1085,7 +1085,7 @@ func (rc *ResourceCommand) createOIDCConnector(ctx context.Context, client *auth
 }
 
 // updateGithubConnector updates an existing OIDC connector.
-func (rc *ResourceCommand) updateOIDCConnector(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateOIDCConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	connector, err := services.UnmarshalOIDCConnector(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1098,7 +1098,7 @@ func (rc *ResourceCommand) updateOIDCConnector(ctx context.Context, client *auth
 	return nil
 }
 
-func (rc *ResourceCommand) createSAMLConnector(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createSAMLConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	// Create services.SAMLConnector from raw YAML to extract the connector name.
 	conn, err := services.UnmarshalSAMLConnector(raw.Raw)
 	if err != nil {
@@ -1130,7 +1130,7 @@ func (rc *ResourceCommand) createSAMLConnector(ctx context.Context, client *auth
 	return nil
 }
 
-func (rc *ResourceCommand) updateSAMLConnector(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateSAMLConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	// Create services.SAMLConnector from raw YAML to extract the connector name.
 	conn, err := services.UnmarshalSAMLConnector(raw.Raw)
 	if err != nil {
@@ -1144,7 +1144,7 @@ func (rc *ResourceCommand) updateSAMLConnector(ctx context.Context, client *auth
 	return nil
 }
 
-func (rc *ResourceCommand) createLoginRule(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createLoginRule(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	rule, err := loginrule.UnmarshalLoginRule(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1171,7 +1171,7 @@ func (rc *ResourceCommand) createLoginRule(ctx context.Context, client *auth.Cli
 	return nil
 }
 
-func (rc *ResourceCommand) createSAMLIdPServiceProvider(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createSAMLIdPServiceProvider(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	// Create services.SAMLIdPServiceProvider from raw YAML to extract the service provider name.
 	sp, err := services.UnmarshalSAMLIdPServiceProvider(raw.Raw)
 	if err != nil {
@@ -1208,7 +1208,7 @@ func (rc *ResourceCommand) createSAMLIdPServiceProvider(ctx context.Context, cli
 	return nil
 }
 
-func (rc *ResourceCommand) createDevice(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDevice(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	res, err := services.UnmarshalDevice(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1248,7 +1248,7 @@ func (rc *ResourceCommand) createDevice(ctx context.Context, client *auth.Client
 	return nil
 }
 
-func (rc *ResourceCommand) createOktaImportRule(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createOktaImportRule(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	importRule, err := services.UnmarshalOktaImportRule(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1269,7 +1269,7 @@ func (rc *ResourceCommand) createOktaImportRule(ctx context.Context, client *aut
 	return nil
 }
 
-func (rc *ResourceCommand) createIntegration(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createIntegration(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	integration, err := services.UnmarshalIntegration(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1317,7 +1317,7 @@ func (rc *ResourceCommand) createIntegration(ctx context.Context, client *auth.C
 	return nil
 }
 
-func (rc *ResourceCommand) createDiscoveryConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDiscoveryConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	discoveryConfig, err := services.UnmarshalDiscoveryConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1342,7 +1342,7 @@ func (rc *ResourceCommand) createDiscoveryConfig(ctx context.Context, client *au
 	return nil
 }
 
-func (rc *ResourceCommand) createAccessList(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAccessList(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	accessList, err := services.UnmarshalAccessList(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1366,7 +1366,7 @@ func (rc *ResourceCommand) createAccessList(ctx context.Context, client *auth.Cl
 	return nil
 }
 
-func (rc *ResourceCommand) createServerInfo(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createServerInfo(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	si, err := services.UnmarshalServerInfo(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1395,7 +1395,7 @@ func (rc *ResourceCommand) createServerInfo(ctx context.Context, client *auth.Cl
 }
 
 // Delete deletes resource by name
-func (rc *ResourceCommand) Delete(ctx context.Context, client *auth.Client) (err error) {
+func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client) (err error) {
 	singletonResources := []string{
 		types.KindClusterAuthPreference,
 		types.KindClusterMaintenanceConfig,
@@ -1784,7 +1784,7 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *auth.Client) (err
 	return nil
 }
 
-func resetAuthPreference(ctx context.Context, client *auth.Client) error {
+func resetAuthPreference(ctx context.Context, client *authclient.Client) error {
 	storedAuthPref, err := client.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1798,7 +1798,7 @@ func resetAuthPreference(ctx context.Context, client *auth.Client) error {
 	return trace.Wrap(client.ResetAuthPreference(ctx))
 }
 
-func resetClusterNetworkingConfig(ctx context.Context, client *auth.Client) error {
+func resetClusterNetworkingConfig(ctx context.Context, client *authclient.Client) error {
 	storedNetConfig, err := client.GetClusterNetworkingConfig(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1812,7 +1812,7 @@ func resetClusterNetworkingConfig(ctx context.Context, client *auth.Client) erro
 	return trace.Wrap(client.ResetClusterNetworkingConfig(ctx))
 }
 
-func resetSessionRecordingConfig(ctx context.Context, client *auth.Client) error {
+func resetSessionRecordingConfig(ctx context.Context, client *authclient.Client) error {
 	storedRecConfig, err := client.GetSessionRecordingConfig(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1826,12 +1826,12 @@ func resetSessionRecordingConfig(ctx context.Context, client *auth.Client) error
 	return trace.Wrap(client.ResetSessionRecordingConfig(ctx))
 }
 
-func resetNetworkRestrictions(ctx context.Context, client *auth.Client) error {
+func resetNetworkRestrictions(ctx context.Context, client *authclient.Client) error {
 	return trace.Wrap(client.DeleteNetworkRestrictions(ctx))
 }
 
 // UpdateFields updates select resource fields: expiry and labels
-func (rc *ResourceCommand) UpdateFields(ctx context.Context, clt *auth.Client) error {
+func (rc *ResourceCommand) UpdateFields(ctx context.Context, clt *authclient.Client) error {
 	if rc.ref.Kind == "" || rc.ref.Name == "" {
 		return trace.BadParameter("provide a full resource name to update, for example:\n$ tctl update rc/remote --set-labels=env=prod\n")
 	}
@@ -1888,7 +1888,7 @@ func (rc *ResourceCommand) IsForced() bool {
 }
 
 // getCollection lists all resources of a given type
-func (rc *ResourceCommand) getCollection(ctx context.Context, client *auth.Client) (ResourceCollection, error) {
+func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient.Client) (ResourceCollection, error) {
 	if rc.ref.Kind == "" {
 		return nil, trace.BadParameter("specify resource to list, e.g. 'tctl get roles'")
 	}
@@ -2782,7 +2782,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *auth.Clien
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }
 
-func getSAMLConnectors(ctx context.Context, client *auth.Client, name string, withSecrets bool) ([]types.SAMLConnector, error) {
+func getSAMLConnectors(ctx context.Context, client *authclient.Client, name string, withSecrets bool) ([]types.SAMLConnector, error) {
 	if name == "" {
 		connectors, err := client.GetSAMLConnectors(ctx, withSecrets)
 		if err != nil {
@@ -2797,7 +2797,7 @@ func getSAMLConnectors(ctx context.Context, client *auth.Client, name string, wi
 	return []types.SAMLConnector{connector}, nil
 }
 
-func getOIDCConnectors(ctx context.Context, client *auth.Client, name string, withSecrets bool) ([]types.OIDCConnector, error) {
+func getOIDCConnectors(ctx context.Context, client *authclient.Client, name string, withSecrets bool) ([]types.OIDCConnector, error) {
 	if name == "" {
 		connectors, err := client.GetOIDCConnectors(ctx, withSecrets)
 		if err != nil {
@@ -2812,7 +2812,7 @@ func getOIDCConnectors(ctx context.Context, client *auth.Client, name string, wi
 	return []types.OIDCConnector{connector}, nil
 }
 
-func getGithubConnectors(ctx context.Context, client *auth.Client, name string, withSecrets bool) ([]types.GithubConnector, error) {
+func getGithubConnectors(ctx context.Context, client *authclient.Client, name string, withSecrets bool) ([]types.GithubConnector, error) {
 	if name == "" {
 		connectors, err := client.GetGithubConnectors(ctx, withSecrets)
 		if err != nil {
@@ -2971,7 +2971,7 @@ $ tctl rm %s`,
 		ref.String(), resDesc, strings.Join(names, "\n"), exampleRef.String())
 }
 
-func (rc *ResourceCommand) createAuditQuery(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAuditQuery(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	in, err := services.UnmarshalAuditQuery(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -2987,7 +2987,7 @@ func (rc *ResourceCommand) createAuditQuery(ctx context.Context, client *auth.Cl
 	return nil
 }
 
-func (rc *ResourceCommand) createSecurityReport(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createSecurityReport(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	in, err := services.UnmarshalSecurityReport(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3003,7 +3003,7 @@ func (rc *ResourceCommand) createSecurityReport(ctx context.Context, client *aut
 	return nil
 }
 
-func (rc *ResourceCommand) createAccessMonitoringRule(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAccessMonitoringRule(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	in, err := services.UnmarshalAccessMonitoringRule(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3025,7 +3025,7 @@ func (rc *ResourceCommand) createAccessMonitoringRule(ctx context.Context, clien
 	return nil
 }
 
-func (rc *ResourceCommand) updateAccessMonitoringRule(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateAccessMonitoringRule(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	in, err := services.UnmarshalAccessMonitoringRule(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/saml_command.go
+++ b/tool/tctl/common/saml_command.go
@@ -25,7 +25,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
@@ -51,7 +51,7 @@ func (cmd *SAMLCommand) Initialize(app *kingpin.Application, cfg *servicecfg.Con
 
 // TryRun is executed after the CLI parsing is done. The command must
 // determine if selectedCommand belongs to it and return match=true
-func (cmd *SAMLCommand) TryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error) {
+func (cmd *SAMLCommand) TryRun(ctx context.Context, selectedCommand string, c *authclient.Client) (match bool, err error) {
 	if selectedCommand == cmd.exportCmd.FullCommand() {
 		return true, trace.Wrap(cmd.export(ctx, c))
 	}
@@ -59,7 +59,7 @@ func (cmd *SAMLCommand) TryRun(ctx context.Context, selectedCommand string, c *a
 }
 
 // export executes 'tctl saml export <connector_name>'
-func (cmd *SAMLCommand) export(ctx context.Context, c *auth.Client) error {
+func (cmd *SAMLCommand) export(ctx context.Context, c *authclient.Client) error {
 	sc, err := c.GetSAMLConnector(ctx, cmd.connectorName, false)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/status_command.go
+++ b/tool/tctl/common/status_command.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -48,7 +48,7 @@ func (c *StatusCommand) Initialize(app *kingpin.Application, config *servicecfg.
 }
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
-func (c *StatusCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *StatusCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.status.FullCommand():
 		err = c.Status(ctx, client)
@@ -64,7 +64,7 @@ type caFetchError struct {
 }
 
 // Status is called to execute "status" CLI command.
-func (c *StatusCommand) Status(ctx context.Context, client *auth.Client) error {
+func (c *StatusCommand) Status(ctx context.Context, client *authclient.Client) error {
 	pingRsp, err := client.Ping(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -94,7 +94,7 @@ type CLICommand interface {
 
 	// TryRun is executed after the CLI parsing is done. The command must
 	// determine if selectedCommand belongs to it and return match=true
-	TryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error)
+	TryRun(ctx context.Context, selectedCommand string, c *authclient.Client) (match bool, err error)
 }
 
 // Run is the same as 'make'. It helps to share the code between different

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -37,7 +37,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -143,7 +143,7 @@ func (c *TokensCommand) Initialize(app *kingpin.Application, config *servicecfg.
 }
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
-func (c *TokensCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *TokensCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.tokenAdd.FullCommand():
 		err = c.Add(ctx, client)
@@ -158,7 +158,7 @@ func (c *TokensCommand) TryRun(ctx context.Context, cmd string, client *auth.Cli
 }
 
 // Add is called to execute "tokens add ..." command.
-func (c *TokensCommand) Add(ctx context.Context, client *auth.Client) error {
+func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) error {
 	// Parse string to see if it's a type of role that Teleport supports.
 	roles, err := types.ParseTeleportRoles(c.tokenType)
 	if err != nil {
@@ -359,7 +359,7 @@ func (c *TokensCommand) Add(ctx context.Context, client *auth.Client) error {
 }
 
 // Del is called to execute "tokens del ..." command.
-func (c *TokensCommand) Del(ctx context.Context, client *auth.Client) error {
+func (c *TokensCommand) Del(ctx context.Context, client *authclient.Client) error {
 	if c.value == "" {
 		return trace.Errorf("Need an argument: token")
 	}
@@ -371,7 +371,7 @@ func (c *TokensCommand) Del(ctx context.Context, client *auth.Client) error {
 }
 
 // List is called to execute "tokens ls" command.
-func (c *TokensCommand) List(ctx context.Context, client *auth.Client) error {
+func (c *TokensCommand) List(ctx context.Context, client *authclient.Client) error {
 	tokens, err := client.GetTokens(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/top_command.go
+++ b/tool/tctl/common/top_command.go
@@ -41,7 +41,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -65,7 +65,7 @@ func (c *TopCommand) Initialize(app *kingpin.Application, config *servicecfg.Con
 }
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
-func (c *TopCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (c *TopCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case c.top.FullCommand():
 		diagClient, err := roundtrip.NewClient(*c.diagURL, "")

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -153,7 +154,7 @@ func (u *UserCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 }
 
 // TryRun takes the CLI command as an argument (like "users add") and executes it.
-func (u *UserCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
+func (u *UserCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (match bool, err error) {
 	switch cmd {
 	case u.userAdd.FullCommand():
 		err = u.Add(ctx, client)
@@ -172,7 +173,7 @@ func (u *UserCommand) TryRun(ctx context.Context, cmd string, client *auth.Clien
 }
 
 // ResetPassword resets user password and generates a token to setup new password
-func (u *UserCommand) ResetPassword(ctx context.Context, client *auth.Client) error {
+func (u *UserCommand) ResetPassword(ctx context.Context, client *authclient.Client) error {
 	req := auth.CreateUserTokenRequest{
 		Name: u.login,
 		TTL:  u.ttl,
@@ -234,7 +235,7 @@ func (u *UserCommand) printResetPasswordToken(token types.UserToken, messageForm
 
 // Add implements `tctl users add` for the enterprise edition. Unlike the OSS
 // version, this one requires --roles flag to be set
-func (u *UserCommand) Add(ctx context.Context, client *auth.Client) error {
+func (u *UserCommand) Add(ctx context.Context, client *authclient.Client) error {
 	u.allowedRoles = flattenSlice(u.allowedRoles)
 	u.allowedLogins = flattenSlice(u.allowedLogins)
 	u.allowedWindowsLogins = flattenSlice(u.allowedWindowsLogins)
@@ -364,7 +365,7 @@ func printTokenAsText(token types.UserToken, messageFormat string) error {
 }
 
 // Update updates existing user
-func (u *UserCommand) Update(ctx context.Context, client *auth.Client) error {
+func (u *UserCommand) Update(ctx context.Context, client *authclient.Client) error {
 	user, err := client.GetUser(ctx, u.login, false)
 	if err != nil {
 		return trace.Wrap(err)
@@ -486,7 +487,7 @@ func (u *UserCommand) Update(ctx context.Context, client *auth.Client) error {
 }
 
 // List prints all existing user accounts
-func (u *UserCommand) List(ctx context.Context, client *auth.Client) error {
+func (u *UserCommand) List(ctx context.Context, client *authclient.Client) error {
 	users, err := client.GetUsers(ctx, false)
 	if err != nil {
 		return trace.Wrap(err)
@@ -515,7 +516,7 @@ func (u *UserCommand) List(ctx context.Context, client *auth.Client) error {
 
 // Delete deletes teleport user(s). User IDs are passed as a comma-separated
 // list in UserCommand.login
-func (u *UserCommand) Delete(ctx context.Context, client *auth.Client) error {
+func (u *UserCommand) Delete(ctx context.Context, client *authclient.Client) error {
 	for _, l := range strings.Split(u.login, ",") {
 		if err := client.DeleteUser(ctx, l); err != nil {
 			return trace.Wrap(err)

--- a/tool/tctl/sso/configure/command.go
+++ b/tool/tctl/sso/configure/command.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -43,7 +43,7 @@ type SSOConfigureCommand struct {
 
 type AuthKindCommand struct {
 	Parsed bool
-	Run    func(ctx context.Context, clt *auth.Client) error
+	Run    func(ctx context.Context, clt *authclient.Client) error
 }
 
 // Initialize allows a caller-defined command to plug itself into CLI
@@ -59,7 +59,7 @@ func (cmd *SSOConfigureCommand) Initialize(app *kingpin.Application, cfg *servic
 
 // TryRun is executed after the CLI parsing is done. The command must
 // determine if selectedCommand belongs to it and return match=true
-func (cmd *SSOConfigureCommand) TryRun(ctx context.Context, selectedCommand string, clt *auth.Client) (match bool, err error) {
+func (cmd *SSOConfigureCommand) TryRun(ctx context.Context, selectedCommand string, clt *authclient.Client) (match bool, err error) {
 	for _, subCommand := range cmd.AuthCommands {
 		if subCommand.Parsed {
 			// the default tctl logging behavior is to ignore all logs, unless --debug is present.

--- a/tool/tctl/sso/configure/github.go
+++ b/tool/tctl/sso/configure/github.go
@@ -28,7 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -87,7 +87,7 @@ Examples:
   Generate the configuration and immediately test it using "tctl sso test" command.`)
 
 	preset := &AuthKindCommand{
-		Run: func(ctx context.Context, clt *auth.Client) error { return ghRunFunc(ctx, cmd, &spec, gh, clt) },
+		Run: func(ctx context.Context, clt *authclient.Client) error { return ghRunFunc(ctx, cmd, &spec, gh, clt) },
 	}
 
 	sub.Action(func(ctx *kingpin.ParseContext) error {
@@ -98,7 +98,7 @@ Examples:
 	return preset
 }
 
-func ghRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.GithubConnectorSpecV3, flags *ghExtraFlags, clt *auth.Client) error {
+func ghRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.GithubConnectorSpecV3, flags *ghExtraFlags, clt *authclient.Client) error {
 	if err := specCheckRoles(ctx, cmd.Logger, spec, flags.ignoreMissingRoles, clt); err != nil {
 		return trace.Wrap(err)
 	}
@@ -115,7 +115,7 @@ func ghRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.Github
 }
 
 // ResolveCallbackURL deals with common pattern of resolving callback URL for IdP to use.
-func ResolveCallbackURL(logger *logrus.Entry, clt *auth.Client, fieldName string, callbackPattern string) string {
+func ResolveCallbackURL(logger *logrus.Entry, clt *authclient.Client, fieldName string, callbackPattern string) string {
 	var callbackURL string
 
 	logger.Infof("%v empty, resolving automatically.", fieldName)
@@ -142,7 +142,7 @@ func ResolveCallbackURL(logger *logrus.Entry, clt *auth.Client, fieldName string
 	return callbackURL
 }
 
-func specCheckRoles(ctx context.Context, logger *logrus.Entry, spec *types.GithubConnectorSpecV3, ignoreMissingRoles bool, clt *auth.Client) error {
+func specCheckRoles(ctx context.Context, logger *logrus.Entry, spec *types.GithubConnectorSpecV3, ignoreMissingRoles bool, clt *authclient.Client) error {
 	allRoles, err := clt.GetRoles(ctx)
 	if err != nil {
 		logger.WithError(err).Warn("Unable to get roles list. Skipping teams-to-roles sanity checks.")

--- a/tool/tctl/sso/configure/oidc.go
+++ b/tool/tctl/sso/configure/oidc.go
@@ -33,7 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/tool/tctl/sso/configure/flags"
 	"github.com/gravitational/teleport/tool/tctl/sso/tester"
@@ -207,7 +207,9 @@ Examples:
   Generate the configuration and immediately test it using "tctl sso test" command.`, presets))
 
 	preset := &AuthKindCommand{
-		Run: func(ctx context.Context, clt *auth.Client) error { return oidcRunFunc(ctx, cmd, &spec, extra, clt) },
+		Run: func(ctx context.Context, clt *authclient.Client) error {
+			return oidcRunFunc(ctx, cmd, &spec, extra, clt)
+		},
 	}
 
 	sub.Action(func(ctx *kingpin.ParseContext) error {
@@ -218,7 +220,7 @@ Examples:
 	return preset
 }
 
-func oidcRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.OIDCConnectorSpecV3, flags *oidcExtraFlags, clt *auth.Client) error {
+func oidcRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.OIDCConnectorSpecV3, flags *oidcExtraFlags, clt *authclient.Client) error {
 	if flags.googleID != "" {
 		if spec.ClientID != "" {
 			return trace.BadParameter("Conflicting flags: --id and --google-id. Provide only one.")

--- a/tool/tctl/sso/configure/saml.go
+++ b/tool/tctl/sso/configure/saml.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -153,7 +153,9 @@ Examples:
 `, presets))
 
 	preset := &AuthKindCommand{
-		Run: func(ctx context.Context, clt *auth.Client) error { return samlRunFunc(ctx, cmd, &spec, saml, clt) },
+		Run: func(ctx context.Context, clt *authclient.Client) error {
+			return samlRunFunc(ctx, cmd, &spec, saml, clt)
+		},
 	}
 
 	sub.Action(func(ctx *kingpin.ParseContext) error {
@@ -169,7 +171,7 @@ func samlRunFunc(
 	cmd *SSOConfigureCommand,
 	spec *types.SAMLConnectorSpecV2,
 	flags *samlExtraFlags,
-	clt *auth.Client,
+	clt *authclient.Client,
 ) error {
 	// apply preset, if chosen
 	p := samlPresets.getPreset(flags.chosenPreset)

--- a/tool/tctl/sso/tester/command.go
+++ b/tool/tctl/sso/tester/command.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -49,7 +50,7 @@ type SSOTestCommand struct {
 	connectorFileName string
 
 	// Handlers is a mapping between auth kind and appropriate handling function
-	Handlers map[string]func(c *auth.Client, connBytes []byte) (*AuthRequestInfo, error)
+	Handlers map[string]func(c *authclient.Client, connBytes []byte) (*AuthRequestInfo, error)
 	// GetDiagInfoFields provides auth kind-specific diagnostic info fields.
 	GetDiagInfoFields map[string]func(diag *types.SSODiagnosticInfo, debug bool) []string
 	// Browser to use in login flow.
@@ -80,7 +81,7 @@ Examples:
 
   > tctl sso configure github ... | tee connector.yaml | tctl sso test`)
 
-	cmd.Handlers = map[string]func(c *auth.Client, connBytes []byte) (*AuthRequestInfo, error){
+	cmd.Handlers = map[string]func(c *authclient.Client, connBytes []byte) (*AuthRequestInfo, error){
 		types.KindGithubConnector: handleGithubConnector,
 		types.KindSAMLConnector:   handleSAMLConnector,
 		types.KindOIDCConnector:   handleOIDCConnector,
@@ -103,7 +104,7 @@ func (cmd *SSOTestCommand) getSupportedKinds() []string {
 	return kinds
 }
 
-func (cmd *SSOTestCommand) ssoTestCommand(ctx context.Context, c *auth.Client) error {
+func (cmd *SSOTestCommand) ssoTestCommand(ctx context.Context, c *authclient.Client) error {
 	reader := os.Stdin
 	if cmd.connectorFileName != "" {
 		f, err := utils.OpenFileAllowingUnsafeLinks(cmd.connectorFileName)
@@ -153,7 +154,7 @@ func (cmd *SSOTestCommand) ssoTestCommand(ctx context.Context, c *auth.Client) e
 
 // TryRun is executed after the CLI parsing is done. The command must
 // determine if selectedCommand belongs to it and return match=true
-func (cmd *SSOTestCommand) TryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error) {
+func (cmd *SSOTestCommand) TryRun(ctx context.Context, selectedCommand string, c *authclient.Client) (match bool, err error) {
 	if selectedCommand == cmd.ssoTestCmd.FullCommand() {
 		return true, cmd.ssoTestCommand(ctx, c)
 	}
@@ -170,7 +171,7 @@ type AuthRequestInfo struct {
 	RequestCreateErr error
 }
 
-func (cmd *SSOTestCommand) runSSOLoginFlow(ctx context.Context, protocol string, c *auth.Client, config *client.RedirectorConfig) (*auth.SSHLoginResponse, error) {
+func (cmd *SSOTestCommand) runSSOLoginFlow(ctx context.Context, protocol string, c *authclient.Client, config *client.RedirectorConfig) (*auth.SSHLoginResponse, error) {
 	key, err := client.GenerateRSAKey()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/tctl/sso/tester/github.go
+++ b/tool/tctl/sso/tester/github.go
@@ -25,13 +25,13 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 )
 
-func githubTest(c *auth.Client, connector types.GithubConnector) (*AuthRequestInfo, error) {
+func githubTest(c *authclient.Client, connector types.GithubConnector) (*AuthRequestInfo, error) {
 	ctx := context.Background()
 	// get connector spec
 	var spec types.GithubConnectorSpecV3
@@ -75,7 +75,7 @@ func githubTest(c *auth.Client, connector types.GithubConnector) (*AuthRequestIn
 	return requestInfo, nil
 }
 
-func handleGithubConnector(c *auth.Client, connBytes []byte) (*AuthRequestInfo, error) {
+func handleGithubConnector(c *authclient.Client, connBytes []byte) (*AuthRequestInfo, error) {
 	conn, err := services.UnmarshalGithubConnector(connBytes)
 	if err != nil {
 		return nil, trace.Wrap(err, "Unable to load GitHub connector. Correct the definition and try again.")

--- a/tool/tctl/sso/tester/oidc.go
+++ b/tool/tctl/sso/tester/oidc.go
@@ -23,13 +23,13 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 )
 
-func handleOIDCConnector(c *auth.Client, connBytes []byte) (*AuthRequestInfo, error) {
+func handleOIDCConnector(c *authclient.Client, connBytes []byte) (*AuthRequestInfo, error) {
 	conn, err := services.UnmarshalOIDCConnector(connBytes)
 	if err != nil {
 		return nil, trace.Wrap(err, "Unable to load OIDC connector. Correct the definition and try again.")
@@ -42,7 +42,7 @@ func handleOIDCConnector(c *auth.Client, connBytes []byte) (*AuthRequestInfo, er
 	return requestInfo, nil
 }
 
-func oidcTest(c *auth.Client, connector types.OIDCConnector) (*AuthRequestInfo, error) {
+func oidcTest(c *authclient.Client, connector types.OIDCConnector) (*AuthRequestInfo, error) {
 	ctx := context.Background()
 	// get connector spec
 	var spec types.OIDCConnectorSpecV3

--- a/tool/tctl/sso/tester/saml.go
+++ b/tool/tctl/sso/tester/saml.go
@@ -23,13 +23,13 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 )
 
-func handleSAMLConnector(c *auth.Client, connBytes []byte) (*AuthRequestInfo, error) {
+func handleSAMLConnector(c *authclient.Client, connBytes []byte) (*AuthRequestInfo, error) {
 	conn, err := services.UnmarshalSAMLConnector(connBytes)
 	if err != nil {
 		return nil, trace.Wrap(err, "Unable to load SAML connector. Correct the definition and try again.")
@@ -42,7 +42,7 @@ func handleSAMLConnector(c *auth.Client, connBytes []byte) (*AuthRequestInfo, er
 	return requestInfo, nil
 }
 
-func samlTest(c *auth.Client, samlConnector types.SAMLConnector) (*AuthRequestInfo, error) {
+func samlTest(c *authclient.Client, samlConnector types.SAMLConnector) (*AuthRequestInfo, error) {
 	ctx := context.Background()
 	// get connector spec
 	var spec types.SAMLConnectorSpecV2

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -36,7 +36,7 @@ import (
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -57,7 +57,7 @@ func onRequestList(cf *CLIConf) error {
 
 	var reqs []types.AccessRequest
 
-	err = tc.WithRootClusterClient(cf.Context, func(clt auth.ClientI) error {
+	err = tc.WithRootClusterClient(cf.Context, func(clt authclient.ClientI) error {
 		reqs, err = clt.GetAccessRequests(cf.Context, types.AccessRequestFilter{})
 		return trace.Wrap(err)
 	})
@@ -151,7 +151,7 @@ func onRequestShow(cf *CLIConf) error {
 	}
 
 	var req types.AccessRequest
-	err = tc.WithRootClusterClient(cf.Context, func(clt auth.ClientI) error {
+	err = tc.WithRootClusterClient(cf.Context, func(clt authclient.ClientI) error {
 		req, err = services.GetAccessRequest(cf.Context, clt, cf.RequestID)
 		return trace.Wrap(err)
 	})
@@ -327,7 +327,7 @@ func onRequestReview(cf *CLIConf) error {
 	}
 
 	var req types.AccessRequest
-	err = tc.WithRootClusterClient(cf.Context, func(clt auth.ClientI) error {
+	err = tc.WithRootClusterClient(cf.Context, func(clt authclient.ClientI) error {
 		req, err = clt.SubmitAccessReview(cf.Context, types.AccessReviewSubmission{
 			RequestID: cf.RequestID,
 			Review: types.AccessReview{

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -65,7 +65,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keypaths"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	kubeclient "github.com/gravitational/teleport/lib/client/kube"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -1651,7 +1651,7 @@ func (c *kubeLoginCommand) accessRequestForKubeCluster(ctx context.Context, cf *
 		// we will get an error here.
 		req.SetDryRun(true)
 		req.SetRequestReason("Dry run, this request will not be created. If you see this, there is a bug.")
-		if err := tc.WithRootClusterClient(ctx, func(clt auth.ClientI) error {
+		if err := tc.WithRootClusterClient(ctx, func(clt authclient.ClientI) error {
 			req, err = clt.CreateAccessRequestV2(ctx, req)
 			return trace.Wrap(err)
 		}); err != nil {


### PR DESCRIPTION
Consumes the new auth client created in #41460. The changes introduced were performed with a series of gofmt rewrite rules.

```bash
$ find ./lib/auth -type f -name '*.go' -exec gofmt -w -l -r "ClientI -> authclient.ClientI" {} \;
$ find ./lib/auth -type f -name '*.go' -exec gofmt -w -l -r "Client -> authclient.Client" {} \;
$ find ./lib/auth -type f -name '*.go' -exec gofmt -w -l -r "NewClient -> authclient.NewClientI" {} \;
$ find . -type f -name '*.go' -exec gofmt -w -l -r "auth.ClientI -> authclient.ClientI" {} \;
$ find . -type f -name '*.go' -exec gofmt -w -l -r "auth.Client -> authclient.Client" {} \;
$ find . -type f -name '*.go' -exec gofmt -w -l -r "auth.NewClient -> authclient.NewClient" {} \;
```