### PR TITLE
[vnet][6] IPv4 support

### DIFF
--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -50,6 +50,7 @@ import (
 	samlidppb "github.com/gravitational/teleport/api/gen/proto/go/teleport/samlidp/v1"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	userpreferencesv1 "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
@@ -1659,6 +1660,11 @@ type ClientI interface {
 	// still get a client when calling this method, but all RPCs will return
 	// "not implemented" errors (as per the default gRPC behavior).
 	ClusterConfigClient() clusterconfigpb.ClusterConfigServiceClient
+
+	// VnetConfigServiceClietn returns a VnetConfig service client.
+	// Clients connecting to older Teleport versions still get a client when calling this method, but all RPCs
+	// will return "not implemented" errors (as per the default gRPC behavior).
+	VnetConfigServiceClient() vnet.VnetConfigServiceClient
 
 	// CloneHTTPClient creates a new HTTP client with the same configuration.
 	CloneHTTPClient(params ...roundtrip.ClientParam) (*HTTPClient, error)

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -1661,7 +1661,7 @@ type ClientI interface {
 	// "not implemented" errors (as per the default gRPC behavior).
 	ClusterConfigClient() clusterconfigpb.ClusterConfigServiceClient
 
-	// VnetConfigServiceClietn returns a VnetConfig service client.
+	// VnetConfigServiceClient returns a VnetConfig service client.
 	// Clients connecting to older Teleport versions still get a client when calling this method, but all RPCs
 	// will return "not implemented" errors (as per the default gRPC behavior).
 	VnetConfigServiceClient() vnet.VnetConfigServiceClient

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -95,19 +95,17 @@ type TCPAppResolver struct {
 //
 // [appProvider] is also used to get app certificates used to dial the apps.
 func NewTCPAppResolver(appProvider AppProvider, opts ...tcpAppResolverOption) (*TCPAppResolver, error) {
-	clusterConfigCache, err := newClusterConfigCache(appProvider.GetVnetConfig)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	r := &TCPAppResolver{
-		appProvider:        appProvider,
-		slog:               slog.With(teleport.ComponentKey, "VNet.AppResolver"),
-		clusterConfigCache: clusterConfigCache,
-		clock:              clockwork.NewRealClock(),
+		appProvider: appProvider,
+		slog:        slog.With(teleport.ComponentKey, "VNet.AppResolver"),
 	}
 	for _, opt := range opts {
 		opt(r)
 	}
+	if r.clock == nil {
+		r.clock = clockwork.NewRealClock()
+	}
+	r.clusterConfigCache = newClusterConfigCache(appProvider.GetVnetConfig, r.clock)
 	return r, nil
 }
 

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -17,6 +17,7 @@
 package vnet
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -185,10 +186,7 @@ func (r *TCPAppResolver) resolveTCPHandlerForCluster(
 	vnetConfig, err := r.clusterConfigCache.getVnetConfig(ctx, profileName, leafClusterName)
 	switch {
 	case err == nil:
-		cidrRange = vnetConfig.GetSpec().GetIpv4CidrRange()
-		if cidrRange == "" {
-			cidrRange = defaultIPv4CIDRRange
-		}
+		cidrRange = cmp.Or(vnetConfig.GetSpec().GetIpv4CidrRange(), defaultIPv4CIDRRange)
 	case trace.IsNotFound(err) || trace.IsNotImplemented(err):
 		cidrRange = defaultIPv4CIDRRange
 	default:

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -119,8 +119,10 @@ func withClock(clock clockwork.Clock) tcpAppResolverOption {
 	}
 }
 
-// ResolveTCPHandler resolves a fully-qualified domain name to a TCPHandlerSpec for a Teleport TCP app that should
+// ResolveTCPHandler resolves a fully-qualified domain name to a [TCPHandlerSpec] for a Teleport TCP app that should
 // be used to handle all future TCP connections to [fqdn].
+// Avoid using [trace.Wrap] on [ErrNoTCPHandler] to prevent collecting a full stack trace on every unhandled
+// query.
 func (r *TCPAppResolver) ResolveTCPHandler(ctx context.Context, fqdn string) (*TCPHandlerSpec, error) {
 	profileNames, err := r.appProvider.ListProfiles()
 	if err != nil {
@@ -152,6 +154,10 @@ func (r *TCPAppResolver) ResolveTCPHandler(ctx context.Context, fqdn string) (*T
 	return nil, ErrNoTCPHandler
 }
 
+// resolveTCPHandlerForCluster takes a cluster client and resolves [fqdn] to a [TCPHandlerSpec] if a matching
+// app is found in that cluster.
+// Avoid using [trace.Wrap] on [ErrNoTCPHandler] to prevent collecting a full stack trace on every unhandled
+// query.
 func (r *TCPAppResolver) resolveTCPHandlerForCluster(
 	ctx context.Context,
 	slog *slog.Logger,

--- a/lib/vnet/clusterconfigcache.go
+++ b/lib/vnet/clusterconfigcache.go
@@ -68,9 +68,9 @@ func (c *clusterConfigCache) getVnetConfig(ctx context.Context, profileName, lea
 	vnetConfig, err, _ := c.flightGroup.Do(k, func() (any, error) {
 		// Check the cache inside flightGroup.Do to avoid the chance of immediate repeat calls to the cluster.
 		c.mu.RLock()
-		existingCacheEntry, existingCacheEntryExists := c.cache[k]
+		existingCacheEntry, existingCacheEntryFound := c.cache[k]
 		c.mu.RUnlock()
-		if existingCacheEntryExists && !existingCacheEntry.stale(c.clock) {
+		if existingCacheEntryFound && !existingCacheEntry.stale(c.clock) {
 			return existingCacheEntry.vnetConfig, nil
 		}
 
@@ -84,7 +84,7 @@ func (c *clusterConfigCache) getVnetConfig(ctx context.Context, profileName, lea
 			// It's better to return a stale cached VnetConfig than an error. The profile probably expired and
 			// we want to keep functioning until a relogin. We don't expect the VnetConfig to change very
 			// often.
-			if existingCacheEntryExists {
+			if existingCacheEntryFound {
 				return existingCacheEntry.vnetConfig, nil
 			}
 			return nil, trace.Wrap(err)

--- a/lib/vnet/clusterconfigcache.go
+++ b/lib/vnet/clusterconfigcache.go
@@ -1,0 +1,67 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+type getClusterConfigFunc = func(ctx context.Context, profileName, leafClusterName string) (*vnet.VnetConfig, error)
+
+type clusterConfigCache struct {
+	get      getClusterConfigFunc
+	ttlCache *utils.FnCache
+}
+
+func newClusterConfigCache(get getClusterConfigFunc) (*clusterConfigCache, error) {
+	ttlCache, err := utils.NewFnCache(utils.FnCacheConfig{
+		TTL: 5 * time.Minute,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &clusterConfigCache{
+		get:      get,
+		ttlCache: ttlCache,
+	}, nil
+}
+
+func (c *clusterConfigCache) getVnetConfig(ctx context.Context, profileName, leafClusterName string) (*vnet.VnetConfig, error) {
+	k := clusterCacheKey{
+		profileName:     profileName,
+		leafClusterName: leafClusterName,
+	}
+	vnetConfig, err := utils.FnCacheGet(ctx, c.ttlCache, k, func(ctx context.Context) (*vnet.VnetConfig, error) {
+		return c.get(ctx, profileName, leafClusterName)
+	})
+	if trace.IsNotFound(err) || trace.IsNotImplemented(err) {
+		// Default to the empty config on NotFound for NotImplemented.
+		return &vnet.VnetConfig{}, nil
+	}
+	return vnetConfig, trace.Wrap(err)
+}
+
+type clusterCacheKey struct {
+	profileName     string
+	leafClusterName string
+}

--- a/lib/vnet/clusterconfigcache.go
+++ b/lib/vnet/clusterconfigcache.go
@@ -46,18 +46,18 @@ func (e *cacheEntry) stale(clock clockwork.Clock) bool {
 // cached entry. This is desirable in cases where the profile for a cluster expires during VNet operation,
 // it's better to use the stale custom DNS zones than to remove all DNS configuration for that cluster.
 type clusterConfigCache struct {
+	flightGroup singleflight.Group
+	clock       clockwork.Clock
 	get         getClusterConfigFunc
 	cache       map[string]cacheEntry
 	mu          sync.RWMutex
-	flightGroup singleflight.Group
-	clock       clockwork.Clock
 }
 
 func newClusterConfigCache(get getClusterConfigFunc, clock clockwork.Clock) *clusterConfigCache {
 	return &clusterConfigCache{
+		clock: clock,
 		get:   get,
 		cache: make(map[string]cacheEntry),
-		clock: clock,
 	}
 }
 

--- a/lib/vnet/ipbits.go
+++ b/lib/vnet/ipbits.go
@@ -52,8 +52,7 @@ func NewIPv6Prefix() (tcpip.Address, error) {
 //
 // The strategy here is to start with a random address from the range, and if it's free return it, else
 // increment it until a free address is found. This should have pretty good performance when the range is
-// mostly free, and degrade as it fills. On my laptop this can assign a full range of 256k addresses in ~2
-// seconds, with the final scan to decide the range is full taking ~5ms, so it should be good enough.
+// mostly free, and degrade as it fills. 
 //
 // Most importantly, this strategy allows us to assign IPs in different, possibly overlapping ranges, from
 // different clusters without being overly complicated or risking collision.

--- a/lib/vnet/ipbits.go
+++ b/lib/vnet/ipbits.go
@@ -1,0 +1,141 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	mathrand "math/rand/v2"
+	"net"
+
+	"github.com/gravitational/trace"
+	"gvisor.dev/gvisor/pkg/tcpip"
+)
+
+// NewIPv6Prefix returns a Unique Local IPv6 Unicast Address which will be used as a 64-bit prefix for all v6
+// IP addresses in the VNet.
+func NewIPv6Prefix() (tcpip.Address, error) {
+	// |   8 bits   |  40 bits   |  16 bits  |          64 bits           |
+	// +------------+------------+-----------+----------------------------+
+	// | ULA Prefix | Global ID  | Subnet ID |        Interface ID        |
+	// +------------+------------+-----------+----------------------------+
+	// ULA Prefix is always 0xfd
+	// Global ID is random bytes for the specific VNet instance
+	// Subnet ID is always 0
+	// Interface ID will be the IPv4 address prefixed with zeros.
+	var bytes [16]byte
+	bytes[0] = 0xfd
+	if _, err := rand.Read(bytes[1:6]); err != nil {
+		return tcpip.Address{}, trace.Wrap(err)
+	}
+	return tcpip.AddrFrom16(bytes), nil
+}
+
+// randomFreeIPv4InNet randomly selects a free address from the IP network range [ipNet], it will call [free]
+// to decide if the address is free and it can return, or it needs to keep looking. It will return an error if
+// the range is too small or if all of the addresses in the range have been exhausted.
+//
+// The strategy here is to start with a random address from the range, and if it's free return it, else
+// increment it until a free address is found. This should have pretty good performance when the range is
+// mostly free, and degrade as it fills. On my laptop this can assign a full range of 256k addresses in ~2
+// seconds, with the final scan to decide the range is full taking ~5ms, so it should be good enough.
+//
+// Most importantly, this strategy allows us to assign IPs in different, possibly overlapping ranges, from
+// different clusters without being overly complicated or risking collision.
+func randomFreeIPv4InNet(ipNet *net.IPNet, free func(ipv4) bool) (ipv4, error) {
+	if len(ipNet.Mask) != 4 || len(ipNet.IP) != 4 {
+		return 0, trace.BadParameter("CIDR range must be IPv4, got %q", ipNet.String())
+	}
+	if leadingOnes, totalBits := ipNet.Mask.Size(); totalBits-leadingOnes < 5 {
+		// We have fewer than 5 bits (32 unique addresses)
+		return 0, trace.BadParameter("CIDR range must have at least 5 free bits, got %q", ipNet.String())
+	}
+
+	netMask := ipv4(binary.BigEndian.Uint32(ipNet.Mask))
+	netPrefix := ipv4(binary.BigEndian.Uint32(ipNet.IP))
+	fmt.Println(netPrefix.String(), netMask.String())
+
+	// Pick a random starting point and increment until finding a free address.
+	randAddrSuffix := ipv4(mathrand.Uint32())
+
+	// Set all leading bits that overlap with the mask to 0.
+	randAddrSuffix &= ^netMask
+	// Skip 0 and 1, the broadcast address and interface address.
+	if randAddrSuffix < 2 {
+		randAddrSuffix = 2
+	}
+
+	// Record the first attempted suffix to break out of the loop when we get back to it, indicating that the
+	// range is full and all IPs are exhausted.
+	firstAttempt := randAddrSuffix
+	for {
+		randAddr := netPrefix | randAddrSuffix
+		if free(randAddr) {
+			return randAddr, nil
+		}
+
+		randAddrSuffix++
+
+		// Set all leading bits that overlap with the mask to 0. This will wrap around the top of the range
+		// back to the beginning.
+		randAddrSuffix &= ^netMask
+		// Skip 0 and 1, the broadcast address and interface address.
+		if randAddrSuffix < 2 {
+			randAddrSuffix = 2
+		}
+
+		if randAddrSuffix == firstAttempt {
+			break
+		}
+	}
+	return 0, trace.Wrap(fmt.Errorf("Exhausted all IPs in range %q", ipNet.String()))
+}
+
+// ipv4 holds a v4 IP address as a uint32 so we can do math on it.
+type ipv4 uint32
+
+func (i ipv4) String() string {
+	return net.IP(i.asSlice()).String()
+}
+
+func (i ipv4) asArray() [4]byte {
+	var bytes [4]byte
+	binary.BigEndian.PutUint32(bytes[:], uint32(i))
+	return bytes
+}
+
+func (i ipv4) asSlice() []byte {
+	bytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(bytes, uint32(i))
+	return bytes
+}
+
+func ipv4Suffix(addr tcpip.Address) ipv4 {
+	bytes := addr.AsSlice()
+	bytes = bytes[len(bytes)-4:]
+	return ipv4(binary.BigEndian.Uint32(bytes))
+}
+
+func ipv6WithSuffix(prefix tcpip.Address, suffix []byte) tcpip.Address {
+	addrBytes := prefix.As16()
+	offset := len(addrBytes) - len(suffix)
+	for i, b := range suffix {
+		addrBytes[offset+i] = b
+	}
+	return tcpip.AddrFrom16(addrBytes)
+}

--- a/lib/vnet/ipbits.go
+++ b/lib/vnet/ipbits.go
@@ -52,7 +52,7 @@ func NewIPv6Prefix() (tcpip.Address, error) {
 //
 // The strategy here is to start with a random address from the range, and if it's free return it, else
 // increment it until a free address is found. This should have pretty good performance when the range is
-// mostly free, and degrade as it fills. 
+// mostly free, and degrade as it fills.
 //
 // Most importantly, this strategy allows us to assign IPs in different, possibly overlapping ranges, from
 // different clusters without being overly complicated or risking collision.

--- a/lib/vnet/ipbits_test.go
+++ b/lib/vnet/ipbits_test.go
@@ -1,0 +1,56 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRandomFreeIPv4InNet(t *testing.T) {
+	t.Parallel()
+
+	cidr := "192.168.1.0/24"
+
+	_, ipNet, err := net.ParseCIDR(cidr)
+	require.NoError(t, err)
+
+	// Total available IPs in the range excluding 0 and 1 suffixes which should not be assigned
+	leadingOnes, totalBits := ipNet.Mask.Size()
+	freeIPCount := 1<<(totalBits-leadingOnes) - 2
+
+	assignedIPs := make(map[ipv4]struct{}, freeIPCount)
+	ipIsFree := func(ip ipv4) bool {
+		_, taken := assignedIPs[ip]
+		return !taken
+	}
+
+	// Assign every free IP.
+	for i := 0; i < freeIPCount; i++ {
+		ip, err := randomFreeIPv4InNet(ipNet, ipIsFree)
+		require.NoError(t, err)
+		assignedIPs[ip] = struct{}{}
+	}
+
+	require.Len(t, assignedIPs, freeIPCount)
+
+	// Try to assign 1 more IP.
+	_, err = randomFreeIPv4InNet(ipNet, ipIsFree)
+	require.ErrorContains(t, err, "Exhausted all IPs in range")
+}

--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -118,7 +118,9 @@ func (c *osConfigurator) updateOSConfiguration(ctx context.Context) error {
 	if c.tunIPv4 == "" && len(cidrRanges) > 0 {
 		// Choose an IPv4 address for the TUN interface from the CIDR range of one arbitrary currently
 		// logged-in cluster. Only one IPv4 address is needed.
-		c.setTunIPv4FromCIDR(cidrRanges[0])
+		if err := c.setTunIPv4FromCIDR(cidrRanges[0]); err != nil {
+			return trace.Wrap(err, "setting TUN IPv4 address")
+		}
 	}
 
 	err = configureOS(ctx, &osConfig{

--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -140,14 +140,14 @@ func (c *osConfigurator) setTunIPv4FromCIDR(cidrRange string) error {
 		return nil
 	}
 
-	_, net, err := net.ParseCIDR(cidrRange)
+	_, ipnet, err := net.ParseCIDR(cidrRange)
 	if err != nil {
 		return trace.Wrap(err, "parsing CIDR %q", cidrRange)
 	}
 
-	// net.IP is the network address, ending in 0s, like 100.64.0.0
+	// ipnet.IP is the network address, ending in 0s, like 100.64.0.0
 	// Add 1 to assign the TUN address, like 100.64.0.1
-	tunAddress := net.IP
+	tunAddress := ipnet.IP
 	tunAddress[len(tunAddress)-1]++
 	c.tunIPv4 = tunAddress.String()
 	return nil

--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -43,18 +43,13 @@ type osConfig struct {
 }
 
 type osConfigurator struct {
-	// Static config values.
-	tunName string
-	tunIPv6 string
-	dnsAddr string
-
-	// Computed config values.
-	tunIPv4 string
-
-	// Other state.
-	homePath           string
 	clientStore        *client.Store
 	clusterConfigCache *clusterConfigCache
+	tunName            string
+	tunIPv6            string
+	dnsAddr            string
+	homePath           string
+	tunIPv4            string
 }
 
 func newOSConfigurator(tunName, ipv6Prefix, dnsAddr string) (*osConfigurator, error) {

--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -17,6 +17,7 @@
 package vnet
 
 import (
+	"cmp"
 	"context"
 	"log/slog"
 	"net"
@@ -105,10 +106,7 @@ func (c *osConfigurator) updateOSConfiguration(ctx context.Context) error {
 		// TODO(nklaassen): add the custom DNS zones as well, after the rest of VNet supports it.
 		dnsZones = append(dnsZones, profileName)
 
-		cidrRange := vnetConfig.GetSpec().GetIpv4CidrRange()
-		if cidrRange == "" {
-			cidrRange = defaultIPv4CIDRRange
-		}
+		cidrRange := cmp.Or(vnetConfig.GetSpec().GetIpv4CidrRange(), defaultIPv4CIDRRange)
 		cidrRanges = append(cidrRanges, cidrRange)
 	}
 

--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -57,7 +57,7 @@ type osConfigurator struct {
 	clusterConfigCache *clusterConfigCache
 }
 
-func newOSConfigurator(ctx context.Context, tunName, ipv6Prefix, dnsAddr string) (*osConfigurator, error) {
+func newOSConfigurator(tunName, ipv6Prefix, dnsAddr string) (*osConfigurator, error) {
 	homePath := os.Getenv(types.HomeEnvVar)
 	if homePath == "" {
 		// This runs as root so we need to be configured with the user's home path.

--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -1,0 +1,194 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"os"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
+	"github.com/gravitational/teleport/api/profile"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/client"
+)
+
+type osConfig struct {
+	tunName    string
+	tunIPv4    string
+	tunIPv6    string
+	cidrRanges []string
+	dnsAddr    string
+	dnsZones   []string
+}
+
+type osConfigurator struct {
+	// Static config values.
+	tunName string
+	tunIPv6 string
+	dnsAddr string
+
+	// Computed config values.
+	tunIPv4 string
+
+	// Other state.
+	homePath           string
+	clientStore        *client.Store
+	clusterConfigCache *clusterConfigCache
+}
+
+func newOSConfigurator(ctx context.Context, tunName, ipv6Prefix, dnsAddr string) (*osConfigurator, error) {
+	homePath := os.Getenv(types.HomeEnvVar)
+	if homePath == "" {
+		// This runs as root so we need to be configured with the user's home path.
+		return nil, trace.BadParameter("%s must be set", types.HomeEnvVar)
+	}
+
+	// ipv6Prefix always looks like "fdxx:xxxx:xxxx::"
+	// Set the IPv6 address for the TUN to "fdxx:xxxx:xxxx::1", the first valid address in the range.
+	tunIPv6 := ipv6Prefix + "1"
+
+	configurator := &osConfigurator{
+		tunName:     tunName,
+		tunIPv6:     tunIPv6,
+		dnsAddr:     dnsAddr,
+		homePath:    homePath,
+		clientStore: client.NewFSClientStore(homePath),
+	}
+
+	clusterConfigCache, err := newClusterConfigCache(configurator.getVnetConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	configurator.clusterConfigCache = clusterConfigCache
+
+	return configurator, nil
+}
+
+func (c *osConfigurator) updateOSConfiguration(ctx context.Context) error {
+	var dnsZones []string
+	var cidrRanges []string
+
+	profileNames, err := profile.ListProfileNames(c.homePath)
+	if err != nil {
+		return trace.Wrap(err, "listing user profiles")
+	}
+	for _, profileName := range profileNames {
+		// TODO(nklaassen): support leaf clusters
+		vnetConfig, err := c.clusterConfigCache.getVnetConfig(ctx, profileName, "" /*leafClusterName*/)
+		if err != nil {
+			slog.WarnContext(ctx,
+				"Failed to load VNet configuration, profile may be expired, not configuring VNet for this cluster",
+				"profile", profileName, "error", err)
+			continue
+		}
+
+		// profileName is the web proxy address, add the default DNS zone for it.
+		// TODO(nklaassen): add the custom DNS zones as well, after the rest of VNet supports it.
+		dnsZones = append(dnsZones, profileName)
+
+		cidrRange := vnetConfig.GetSpec().GetIpv4CidrRange()
+		if cidrRange == "" {
+			cidrRange = defaultIPv4CIDRRange
+		}
+		cidrRanges = append(cidrRanges, cidrRange)
+	}
+
+	dnsZones = utils.Deduplicate(dnsZones)
+	cidrRanges = utils.Deduplicate(cidrRanges)
+
+	if c.tunIPv4 == "" && len(cidrRanges) > 0 {
+		// Choose an IPv4 address for the TUN interface from the CIDR range of one arbitrary currently
+		// logged-in cluster. Only one IPv4 address is needed.
+		c.setTunIPv4FromCIDR(cidrRanges[0])
+	}
+
+	err = configureOS(ctx, &osConfig{
+		tunName:    c.tunName,
+		tunIPv6:    c.tunIPv6,
+		tunIPv4:    c.tunIPv4,
+		dnsAddr:    c.dnsAddr,
+		dnsZones:   dnsZones,
+		cidrRanges: cidrRanges,
+	})
+	return trace.Wrap(err, "configuring OS")
+}
+
+func (c *osConfigurator) deconfigureOS() error {
+	// configureOS is meant to be called with an empty config to deconfigure anything necessary.
+	// Pass context.Background() because we are likely deconfiguring because we received a signal to terminate
+	// and all contexts have been canceled.
+	return trace.Wrap(configureOS(context.Background(), &osConfig{}))
+}
+
+func (c *osConfigurator) setTunIPv4FromCIDR(cidrRange string) error {
+	if c.tunIPv4 != "" {
+		return nil
+	}
+
+	_, net, err := net.ParseCIDR(cidrRange)
+	if err != nil {
+		return trace.Wrap(err, "parsing CIDR %q", cidrRange)
+	}
+
+	// net.IP is the network address, ending in 0s, like 100.64.0.0
+	// Add 1 to assign the TUN address, like 100.64.0.1
+	tunAddress := net.IP
+	tunAddress[len(tunAddress)-1]++
+	c.tunIPv4 = tunAddress.String()
+	return nil
+}
+
+func (c *osConfigurator) getVnetConfig(ctx context.Context, profileName, leafClusterName string) (*vnet.VnetConfig, error) {
+	clt, err := c.vnetConfigClient(ctx, profileName, leafClusterName)
+	if err != nil {
+		return nil, trace.Wrap(err, "getting vnet client for profile %s %s", profileName, leafClusterName)
+	}
+
+	vnetConfig, err := clt.GetVnetConfig(ctx, &vnet.GetVnetConfigRequest{})
+	return vnetConfig, trace.Wrap(err)
+}
+
+func (c *osConfigurator) vnetConfigClient(ctx context.Context, profileName, leafClusterName string) (vnet.VnetConfigServiceClient, error) {
+	// This runs in the root process, so obviously we don't have access to the client cache in the user
+	// process. This loads cluster profiles and credentials from TELEPORT_HOME.
+	clientConfig := &client.Config{
+		ClientStore: c.clientStore,
+	}
+	if err := clientConfig.LoadProfile(c.clientStore, profileName); err != nil {
+		return nil, trace.Wrap(err, "loading client profile")
+	}
+	if leafClusterName != "" {
+		clientConfig.SiteName = leafClusterName
+	}
+	tc, err := client.NewClient(clientConfig)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating new teleport client")
+	}
+
+	clusterClt, err := tc.ConnectToCluster(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err, "connecting to cluster")
+	}
+
+	vnetConfigClt := clusterClt.CurrentCluster().VnetConfigServiceClient()
+	return vnetConfigClt, nil
+}

--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/profile"
@@ -74,12 +75,7 @@ func newOSConfigurator(ctx context.Context, tunName, ipv6Prefix, dnsAddr string)
 		homePath:    homePath,
 		clientStore: client.NewFSClientStore(homePath),
 	}
-
-	clusterConfigCache, err := newClusterConfigCache(configurator.getVnetConfig)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	configurator.clusterConfigCache = clusterConfigCache
+	configurator.clusterConfigCache = newClusterConfigCache(configurator.getVnetConfig, clockwork.NewRealClock())
 
 	return configurator, nil
 }

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -25,14 +25,11 @@ import (
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
 	"golang.zx2c4.com/wireguard/tun"
-
-	"github.com/gravitational/teleport/api/profile"
-	"github.com/gravitational/teleport/api/types"
 )
 
 // Run is a blocking call to create and start Teleport VNet.
 func Run(ctx context.Context, appProvider AppProvider) error {
-	ipv6Prefix, err := IPv6Prefix()
+	ipv6Prefix, err := NewIPv6Prefix()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -51,7 +48,10 @@ func Run(ctx context.Context, appProvider AppProvider) error {
 	case tun = <-tunCh:
 	}
 
-	appResolver := NewTCPAppResolver(appProvider)
+	appResolver, err := NewTCPAppResolver(appProvider)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 
 	manager, err := NewManager(&Config{
 		TUNDevice:          tun,
@@ -177,40 +177,32 @@ func createAndSetupTUNDeviceAsRoot(ctx context.Context, ipv6Prefix, dnsAddr stri
 	}
 	tunCh <- tun
 
+	osConfigurator, err := newOSConfigurator(ctx, tunName, ipv6Prefix, dnsAddr)
+	if err != nil {
+		errCh <- trace.Wrap(err, "creating OS configurator")
+		return tunCh, errCh
+	}
+
 	go func() {
 		defer func() {
 			// Shutting down, deconfigure OS.
-			errCh <- trace.Wrap(configureOS(context.Background(), &osConfig{}))
+			errCh <- trace.Wrap(osConfigurator.deconfigureOS())
 		}()
 
-		var err error
-		tunIPv6 := ipv6Prefix + "1"
-		cfg := osConfig{
-			tunName: tunName,
-			tunIPv6: tunIPv6,
-			dnsAddr: dnsAddr,
-		}
-		if cfg.dnsZones, err = dnsZones(); err != nil {
-			errCh <- trace.Wrap(err, "getting DNS zones")
-			return
-		}
-		if err := configureOS(ctx, &cfg); err != nil {
-			errCh <- trace.Wrap(err, "configuring OS")
+		if err := osConfigurator.updateOSConfiguration(ctx); err != nil {
+			errCh <- trace.Wrap(err, "applying initial OS configuration")
 			return
 		}
 
-		// Re-check the DNS zones every 10 seconds, and configure the host OS appropriately.
+		// Re-configure the host OS every 10 seconds. This will pick up any newly logged-in clusters by
+		// reading profiles from TELEPORT_HOME.
 		ticker := time.NewTicker(10 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				if cfg.dnsZones, err = dnsZones(); err != nil {
-					errCh <- trace.Wrap(err, "getting DNS zones")
-					return
-				}
-				if err := configureOS(ctx, &cfg); err != nil {
-					errCh <- trace.Wrap(err, "configuring OS")
+				if err := osConfigurator.updateOSConfiguration(ctx); err != nil {
+					errCh <- trace.Wrap(err, "updating OS configuration")
 					return
 				}
 			case <-ctx.Done():
@@ -232,23 +224,4 @@ func createTUNDevice(ctx context.Context) (tun.Device, string, error) {
 		return nil, "", trace.Wrap(err, "getting TUN device name")
 	}
 	return dev, name, nil
-}
-
-type osConfig struct {
-	tunName  string
-	tunIPv6  string
-	dnsAddr  string
-	dnsZones []string
-}
-
-func dnsZones() ([]string, error) {
-	profileDir := profile.FullProfilePath(os.Getenv(types.HomeEnvVar))
-	profileNames, err := profile.ListProfileNames(profileDir)
-	if err != nil {
-		return nil, trace.Wrap(err, "listing profiles")
-	}
-	// profile names are Teleport proxy addresses.
-	// TODO(nklaassen): support leaf clusters and custom DNS zones.
-	// TODO(nklaassen): check if profiles are expired.
-	return profileNames, nil
 }

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -177,7 +177,7 @@ func createAndSetupTUNDeviceAsRoot(ctx context.Context, ipv6Prefix, dnsAddr stri
 	}
 	tunCh <- tun
 
-	osConfigurator, err := newOSConfigurator(ctx, tunName, ipv6Prefix, dnsAddr)
+	osConfigurator, err := newOSConfigurator(tunName, ipv6Prefix, dnsAddr)
 	if err != nil {
 		errCh <- trace.Wrap(err, "creating OS configurator")
 		return tunCh, errCh

--- a/lib/vnet/setup_darwin.go
+++ b/lib/vnet/setup_darwin.go
@@ -38,6 +38,8 @@ import (
 	"golang.zx2c4.com/wireguard/tun"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/profile"
+	"github.com/gravitational/teleport/api/types"
 )
 
 // createAndSetupTUNDeviceWithoutRoot creates a virtual network device and configures the host OS to use that
@@ -96,6 +98,11 @@ func execAdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr st
 	executableName, err := os.Executable()
 	if err != nil {
 		return trace.Wrap(err, "getting executable path")
+	}
+
+	if homePath := os.Getenv(types.HomeEnvVar); homePath == "" {
+		// Explicitly set TELEPORT_HOME if not already set.
+		os.Setenv(types.HomeEnvVar, profile.FullProfilePath(""))
 	}
 
 	appleScript := fmt.Sprintf(`

--- a/lib/vnet/vnet.go
+++ b/lib/vnet/vnet.go
@@ -93,12 +93,13 @@ type TCPHandlerResolver interface {
 	// If [fqdn] matches a Teleport-managed TCP app it must return a TCPHandlerSpec defining the range to
 	// assign an IP from, and a handler for future connections to any assigned IPs.
 	//
-	// If [fqdn] does not match it must return ErrNoTCPHandler. Avoid using [trace.Wrap] for expected errors
-	// to avoid the overhead of capturing a full stack trace.
+	// If [fqdn] does not match it must return ErrNoTCPHandler.
 	ResolveTCPHandler(ctx context.Context, fqdn string) (*TCPHandlerSpec, error)
 }
 
 // ErrNoTCPHandler should be returned by [TCPHandlerResolver]s when no handler matches the FQDN.
+// Avoid using [trace.Wrap] on ErrNoTCPHandler where possible, this isn't an unexpected error that we would
+// expect to need to debug and [trace.Wrap] incurs overhead to collect a full stack trace.
 var ErrNoTCPHandler = errors.New("no handler for address")
 
 // TCPHandlerSpec specifies a VNet TCP handler.

--- a/lib/vnet/vnet.go
+++ b/lib/vnet/vnet.go
@@ -18,7 +18,6 @@ package vnet
 
 import (
 	"context"
-	"crypto/rand"
 	"errors"
 	"log/slog"
 	"net"
@@ -33,8 +32,8 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
-	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
-	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
+	ipv4network "gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	ipv6network "gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
 	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
@@ -49,6 +48,7 @@ const (
 	mtu                              = 1500
 	tcpReceiveBufferSize             = 0 // 0 means a default will be used.
 	maxInFlightTCPConnectionAttempts = 1024
+	defaultIPv4CIDRRange             = "100.64.0.0/10"
 )
 
 // Config holds configuration parameters for the VNet.
@@ -82,19 +82,31 @@ func (c *Config) CheckAndSetDefaults() error {
 	return nil
 }
 
-// TCPHandlerResolver describes a type that can resolve a fully-qualified domain name to a TCP handler that
-// should handle all future TCP connections to that FDQN.
+// TCPHandlerResolver describes a type that can resolve a fully-qualified domain name to a TCPHandlerSpec that
+// defines the CIDR range to assign an IP to that handler from, and a handler for all future connections to
+// that IP address.
 //
 // Implementations beware - an FQDN always ends with a '.'.
 type TCPHandlerResolver interface {
 	// ResolveTCPHandler decides if [fqdn] should match a TCP handler.
 	//
-	// If [fqdn] matches a Teleport-managed TCP app, it must return a TCPHandler for future connections to any assigned IPs.
+	// If [fqdn] matches a Teleport-managed TCP app it must return a TCPHandlerSpec defining the range to
+	// assign an IP from, and a handler for future connections to any assigned IPs.
 	//
-	// If [fqdn] does not match an app it must return with match == false && err == nil, in this case the DNS
-	// request will be forwarded to upstream nameservers. Only return a non-nil error for truly unexpected
-	// errors that should cause a DNS request to fail.
-	ResolveTCPHandler(ctx context.Context, fqdn string) (handler TCPHandler, match bool, err error)
+	// If [fqdn] does not match it must return ErrNoTCPHandler. Avoid using [trace.Wrap] for expected errors
+	// to avoid the overhead of capturing a full stack trace.
+	ResolveTCPHandler(ctx context.Context, fqdn string) (*TCPHandlerSpec, error)
+}
+
+// ErrNoTCPHandler should be returned by [TCPHandlerResolver]s when no handler matches the FQDN.
+var ErrNoTCPHandler = errors.New("no handler for address")
+
+// TCPHandlerSpec specifies a VNet TCP handler.
+type TCPHandlerSpec struct {
+	// IPv4CIDRRange is the network that any V4 IP address should be assigned to this handler from.
+	IPv4CIDRRange string
+	// TCPHandler is the handler for TCP connections.
+	TCPHandler TCPHandler
 }
 
 // TCPHandler defines the behavior for handling TCP connections from VNet.
@@ -109,25 +121,6 @@ type TCPHandler interface {
 // UDPHandler defines the behavior for handling UDP connections from VNet.
 type UDPHandler interface {
 	HandleUDP(context.Context, net.Conn) error
-}
-
-// IPv6Prefix returns a Unique Local IPv6 Unicast Address which will be used as a 64-bit prefix for all v6 IP
-// addresses in the VNet.
-func IPv6Prefix() (tcpip.Address, error) {
-	// |   8 bits   |  40 bits   |  16 bits  |          64 bits           |
-	// +------------+------------+-----------+----------------------------+
-	// | ULA Prefix | Global ID  | Subnet ID |        Interface ID        |
-	// +------------+------------+-----------+----------------------------+
-	// ULA Prefix is always 0xfd
-	// Global ID is random bytes for the specific VNet instance
-	// Subnet ID is always 0
-	// Interface ID will be the IPv4 address prefixed with zeros.
-	var bytes [16]byte
-	bytes[0] = 0xfd
-	if _, err := rand.Read(bytes[1:6]); err != nil {
-		return tcpip.Address{}, trace.Wrap(err)
-	}
-	return tcpip.AddrFrom16(bytes), nil
 }
 
 // TUNDevice abstracts a virtual network TUN device.
@@ -196,20 +189,26 @@ type Manager struct {
 }
 
 type state struct {
-	mu                   sync.RWMutex
-	tcpHandlers          map[tcpip.Address]TCPHandler
-	udpHandlers          map[tcpip.Address]UDPHandler
-	appIPs               map[string]tcpip.Address
-	lastAssignedIPSuffix uint32
+	mu sync.RWMutex
+
+	// Each app gets assigned both an IPv4 address and an IPv6 address, where the 4-bit suffix of the IPv6
+	// matches the IPv4 address exactly. All per-app state references the smaller IPv4 address only and
+	// lookups based on an IPv6 address can use the 4-byte suffix.
+
+	// tcpHandlers holds the map of IP addresses to assigned TCP handlers.
+	tcpHandlers map[ipv4]TCPHandler
+	// appIPs holds the map of app FQDNs to their assigned IP address, it like a reverse map of [tcpHandlers].
+	appIPs map[string]ipv4
+
+	// udpHandlers holds the map of IP addresses to assigned UDP handlers.
+	udpHandlers map[ipv4]UDPHandler
 }
 
 func newState() state {
 	return state{
-		tcpHandlers: make(map[tcpip.Address]TCPHandler),
-		udpHandlers: make(map[tcpip.Address]UDPHandler),
-		appIPs:      make(map[string]tcpip.Address),
-		// Suffix 0 is reserved, suffix 1 is assigned to the NIC, suffix 2 is assigned to the DNS server.
-		lastAssignedIPSuffix: 2,
+		tcpHandlers: make(map[ipv4]TCPHandler),
+		udpHandlers: make(map[ipv4]UDPHandler),
+		appIPs:      make(map[string]ipv4),
 	}
 }
 
@@ -273,7 +272,7 @@ func NewManager(cfg *Config) (*Manager, error) {
 
 func createStack() (*stack.Stack, *channel.Endpoint, error) {
 	netStack := stack.New(stack.Options{
-		NetworkProtocols:   []stack.NetworkProtocolFactory{ipv6.NewProtocol},
+		NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4network.NewProtocol, ipv6network.NewProtocol},
 		TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol, udp.NewProtocol},
 	})
 
@@ -291,14 +290,24 @@ func createStack() (*stack.Stack, *channel.Endpoint, error) {
 
 func installVnetRoutes(stack *stack.Stack) error {
 	// Make the network stack pass all outbound IP packets to the NIC, regardless of destination IP address.
+	ipv4Subnet, err := tcpip.NewSubnet(tcpip.AddrFrom4([4]byte{}), tcpip.MaskFromBytes(make([]byte, 4)))
+	if err != nil {
+		return trace.Wrap(err, "creating VNet IPv4 subnet")
+	}
 	ipv6Subnet, err := tcpip.NewSubnet(tcpip.AddrFrom16([16]byte{}), tcpip.MaskFromBytes(make([]byte, 16)))
 	if err != nil {
 		return trace.Wrap(err, "creating VNet IPv6 subnet")
 	}
-	stack.SetRouteTable([]tcpip.Route{{
-		Destination: ipv6Subnet,
-		NIC:         nicID,
-	}})
+	stack.SetRouteTable([]tcpip.Route{
+		{
+			Destination: ipv4Subnet,
+			NIC:         nicID,
+		},
+		{
+			Destination: ipv6Subnet,
+			NIC:         nicID,
+		},
+	})
 	return nil
 }
 
@@ -426,28 +435,40 @@ func (m *Manager) handleTCP(req *tcp.ForwarderRequest) {
 func (m *Manager) getTCPHandler(addr tcpip.Address) (TCPHandler, bool) {
 	m.state.mu.RLock()
 	defer m.state.mu.RUnlock()
-	handler, ok := m.state.tcpHandlers[addr]
+	handler, ok := m.state.tcpHandlers[ipv4Suffix(addr)]
 	return handler, ok
 }
 
-// assignTCPHandler assigns an IP address under [m.ipv6Prefix] to [handler], and returns that new assigned
-// address.
-func (m *Manager) assignTCPHandler(handler TCPHandler, fqdn string) (tcpip.Address, error) {
+// assignTCPHandler assigns an IPv4 address to [handlerSpec] from its preferred CIDR range, and returns that
+// new assigned address.
+func (m *Manager) assignTCPHandler(handlerSpec *TCPHandlerSpec, fqdn string) (ipv4, error) {
+	_, ipNet, err := net.ParseCIDR(handlerSpec.IPv4CIDRRange)
+	if err != nil {
+		return 0, trace.Wrap(err, "parsing CIDR %q", handlerSpec.IPv4CIDRRange)
+	}
+
 	m.state.mu.Lock()
 	defer m.state.mu.Unlock()
 
-	m.state.lastAssignedIPSuffix++
-	ipSuffix := m.state.lastAssignedIPSuffix
-
-	addr := ipv6WithSuffix(m.ipv6Prefix, u32ToBytes(ipSuffix))
-
-	m.state.tcpHandlers[addr] = handler
-	m.state.appIPs[fqdn] = addr
-	if err := m.addProtocolAddress(addr); err != nil {
-		return addr, trace.Wrap(err)
+	ip, err := randomFreeIPv4InNet(ipNet, func(ip ipv4) bool {
+		_, taken := m.state.tcpHandlers[ip]
+		return !taken
+	})
+	if err != nil {
+		return 0, trace.Wrap(err, "assigning IP address")
 	}
 
-	return addr, nil
+	m.state.tcpHandlers[ip] = handlerSpec.TCPHandler
+	m.state.appIPs[fqdn] = ip
+
+	if err := m.addProtocolAddress(tcpip.AddrFrom4(ip.asArray())); err != nil {
+		return 0, trace.Wrap(err)
+	}
+	if err := m.addProtocolAddress(ipv6WithSuffix(m.ipv6Prefix, ip.asSlice())); err != nil {
+		return 0, trace.Wrap(err)
+	}
+
+	return ip, nil
 }
 
 func (m *Manager) handleUDP(req *udp.ForwarderRequest) {
@@ -509,76 +530,58 @@ func (m *Manager) handleUDPConcurrent(req *udp.ForwarderRequest) {
 }
 
 func (m *Manager) getUDPHandler(addr tcpip.Address) (UDPHandler, bool) {
+	ipv4 := ipv4Suffix(addr)
 	m.state.mu.RLock()
 	defer m.state.mu.RUnlock()
-	handler, ok := m.state.udpHandlers[addr]
+	handler, ok := m.state.udpHandlers[ipv4]
 	return handler, ok
 }
 
 func (m *Manager) assignUDPHandler(addr tcpip.Address, handler UDPHandler) error {
+	ipv4 := ipv4Suffix(addr)
 	m.state.mu.Lock()
 	defer m.state.mu.Unlock()
-	if _, ok := m.state.udpHandlers[addr]; ok {
+	if _, ok := m.state.udpHandlers[ipv4]; ok {
 		return trace.AlreadyExists("Handler for %s is already set", addr)
 	}
 	if err := m.addProtocolAddress(addr); err != nil {
 		return trace.Wrap(err)
 	}
-	m.state.udpHandlers[addr] = handler
+	m.state.udpHandlers[ipv4] = handler
 	return nil
 }
 
 // ResolveA implements [dns.Resolver.ResolveA].
 func (m *Manager) ResolveA(ctx context.Context, fqdn string) (dns.Result, error) {
-	result, err := m.resolveAAAA(ctx, fqdn)
-	if err != nil {
-		return dns.Result{}, trace.Wrap(err)
-	}
-	if result.AAAA != ([16]byte{}) {
-		// Matched a known app but not supporting IPv4 yet, return NoRecord.
-		return dns.Result{
-			NoRecord: true,
-		}, nil
-	}
-	return result, nil
-}
-
-// ResolveAAAA implements [dns.Resolver.ResolveAAAA].
-func (m *Manager) ResolveAAAA(ctx context.Context, fqdn string) (dns.Result, error) {
-	result, err := m.resolveAAAA(ctx, fqdn)
-	return result, trace.Wrap(err)
-}
-
-func (m *Manager) resolveAAAA(ctx context.Context, fqdn string) (dns.Result, error) {
 	// Do the actual resolution within a [singleflight.Group] keyed by [fqdn] to avoid concurrent requests to
 	// resolve an FQDN and then assign an address to it.
 	resultAny, err, _ := m.resolveHandlerGroup.Do(fqdn, func() (any, error) {
-		// If we've already assigned an IPv6 address to this app, resolve to it.
-		if ip, ok := m.appIPv6(fqdn); ok {
+		// If we've already assigned an IP address to this app, resolve to it.
+		if ip, ok := m.appIPv4(fqdn); ok {
 			return dns.Result{
-				AAAA: ip.As16(),
+				A: ip.asArray(),
 			}, nil
 		}
 
-		// If fqdn is a Teleport-managed app, create a new [TCPHandler] for it.
-		tcpHandler, found, err := m.tcpHandlerResolver.ResolveTCPHandler(ctx, fqdn)
+		// If fqdn is a Teleport-managed app, create a new handler for it.
+		handlerSpec, err := m.tcpHandlerResolver.ResolveTCPHandler(ctx, fqdn)
 		if err != nil {
+			if errors.Is(err, ErrNoTCPHandler) {
+				// Did not find any known app, forward the DNS request upstream.
+				return dns.Result{}, nil
+			}
 			return dns.Result{}, trace.Wrap(err, "resolving TCP handler for fqdn %q", fqdn)
 		}
-		if !found {
-			// Did not find any known app, forward the DNS request upstream.
-			return dns.Result{}, nil
-		}
 
-		// Assign an unused IPv6 address to this app's [TCPHandler].
-		addr, err := m.assignTCPHandler(tcpHandler, fqdn)
+		// Assign an unused IP address to this app's handler.
+		ip, err := m.assignTCPHandler(handlerSpec, fqdn)
 		if err != nil {
 			return dns.Result{}, trace.Wrap(err, "assigning address to handler for %q", fqdn)
 		}
 
 		// And resolve to the assigned address.
 		return dns.Result{
-			AAAA: addr.As16(),
+			A: ip.asArray(),
 		}, nil
 	})
 	if err != nil {
@@ -587,11 +590,24 @@ func (m *Manager) resolveAAAA(ctx context.Context, fqdn string) (dns.Result, err
 	return resultAny.(dns.Result), nil
 }
 
-func (m *Manager) appIPv6(fqdn string) (tcpip.Address, bool) {
+// ResolveAAAA implements [dns.Resolver.ResolveAAAA].
+func (m *Manager) ResolveAAAA(ctx context.Context, fqdn string) (dns.Result, error) {
+	result, err := m.ResolveA(ctx, fqdn)
+	if err != nil {
+		return dns.Result{}, trace.Wrap(err)
+	}
+	if result.A != ([4]byte{}) {
+		result.AAAA = ipv6WithSuffix(m.ipv6Prefix, result.A[:]).As16()
+		result.A = [4]byte{}
+	}
+	return result, nil
+}
+
+func (m *Manager) appIPv4(fqdn string) (ipv4, bool) {
 	m.state.mu.RLock()
 	defer m.state.mu.RUnlock()
-	ip, ok := m.state.appIPs[fqdn]
-	return ip, ok
+	ipv4, ok := m.state.appIPs[fqdn]
+	return ipv4, ok
 }
 
 func forwardBetweenTunAndNetstack(ctx context.Context, tun TUNDevice, linkEndpoint *channel.Endpoint) error {
@@ -665,9 +681,9 @@ func protocolAddress(addr tcpip.Address) (tcpip.ProtocolAddress, error) {
 	var protocol tcpip.NetworkProtocolNumber
 	switch addrWithPrefix.PrefixLen {
 	case 32:
-		protocol = ipv4.ProtocolNumber
+		protocol = ipv4network.ProtocolNumber
 	case 128:
-		protocol = ipv6.ProtocolNumber
+		protocol = ipv6network.ProtocolNumber
 	default:
 		return tcpip.ProtocolAddress{}, trace.BadParameter("unhandled prefix len %d", addrWithPrefix.PrefixLen)
 	}
@@ -685,22 +701,4 @@ func protocolVersion(b byte) (tcpip.NetworkProtocolNumber, bool) {
 		return header.IPv6ProtocolNumber, true
 	}
 	return 0, false
-}
-
-func ipv6WithSuffix(prefix tcpip.Address, suffix []byte) tcpip.Address {
-	addrBytes := prefix.As16()
-	offset := len(addrBytes) - len(suffix)
-	for i, b := range suffix {
-		addrBytes[offset+i] = b
-	}
-	return tcpip.AddrFrom16(addrBytes)
-}
-
-func u32ToBytes(i uint32) []byte {
-	bytes := make([]byte, 4)
-	bytes[0] = byte(i >> 24)
-	bytes[1] = byte(i >> 16)
-	bytes[2] = byte(i >> 8)
-	bytes[3] = byte(i >> 0)
-	return bytes
 }

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -39,6 +39,8 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+	"github.com/zeebo/assert"
+	"golang.org/x/exp/maps"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
 	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
@@ -46,6 +48,8 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
@@ -106,7 +110,7 @@ func newTestPack(t *testing.T, ctx context.Context, clock clockwork.FakeClock, a
 	require.Nil(t, tcpErr)
 
 	// Route the VNet range to the TUN interface - this emulates the route that will be installed on the host.
-	vnetIPv6Prefix, err := IPv6Prefix()
+	vnetIPv6Prefix, err := NewIPv6Prefix()
 	require.NoError(t, err)
 	subnet, err := tcpip.NewSubnet(vnetIPv6Prefix, tcpip.MaskFromBytes(net.CIDRMask(64, 128)))
 	require.NoError(t, err)
@@ -117,14 +121,15 @@ func newTestPack(t *testing.T, ctx context.Context, clock clockwork.FakeClock, a
 
 	dnsIPv6 := ipv6WithSuffix(vnetIPv6Prefix, []byte{2})
 
-	tcpAppResolver := NewTCPAppResolver(appProvider, withClock(clock))
+	tcpHandlerResolver, err := NewTCPAppResolver(appProvider, withClock(clock))
+	require.NoError(t, err)
 
 	// Create the VNet and connect it to the other side of the TUN.
 	manager, err := NewManager(&Config{
 		TUNDevice:                tun2,
 		IPv6Prefix:               vnetIPv6Prefix,
 		DNSIPv6:                  dnsIPv6,
-		TCPHandlerResolver:       tcpAppResolver,
+		TCPHandlerResolver:       tcpHandlerResolver,
 		upstreamNameserverSource: noUpstreamNameservers{},
 	})
 	require.NoError(t, err)
@@ -225,53 +230,59 @@ func (n noUpstreamNameservers) UpstreamNameservers(ctx context.Context) ([]strin
 	return nil, nil
 }
 
+type testClusterSpec struct {
+	apps         []string
+	cidrRange    string
+	leafClusters map[string]testClusterSpec
+}
+
 type echoAppProvider struct {
-	profiles       []string
-	clients        map[string]map[string]*client.ClusterClient
+	clusters       map[string]testClusterSpec
 	dialOpts       DialOptions
+	clientCert     tls.Certificate
 	reissueAppCert func() tls.Certificate
 }
 
 // newEchoAppProvider returns an app provider with the list of named apps in each profile and leaf cluster.
-func newEchoAppProvider(apps map[string]map[string][]string, dialOpts DialOptions, reissueAppCert func() tls.Certificate) *echoAppProvider {
-	p := &echoAppProvider{
-		clients:        make(map[string]map[string]*client.ClusterClient, len(apps)),
+func newEchoAppProvider(clusterSpecs map[string]testClusterSpec, dialOpts DialOptions, reissueAppCert func() tls.Certificate) *echoAppProvider {
+	return &echoAppProvider{
+		clusters:       clusterSpecs,
 		dialOpts:       dialOpts,
 		reissueAppCert: reissueAppCert,
 	}
-	for profileName, leafClusters := range apps {
-		p.profiles = append(p.profiles, profileName)
-		p.clients[profileName] = make(map[string]*client.ClusterClient, len(leafClusters))
-		for leafClusterName, apps := range leafClusters {
-			clusterName := profileName
-			if leafClusterName != "" {
-				clusterName = leafClusterName
-			}
-			p.clients[profileName][leafClusterName] = &client.ClusterClient{
-				AuthClient: &echoAppAuthClient{
-					clusterName: clusterName,
-					apps:        apps,
-				},
-			}
-		}
-	}
-	return p
 }
 
 // ListProfiles lists the names of all profiles saved for the user.
 func (p *echoAppProvider) ListProfiles() ([]string, error) {
-	return p.profiles, nil
+	return maps.Keys(p.clusters), nil
 }
 
 // GetCachedClient returns a [*client.ClusterClient] for the given profile and leaf cluster.
 // [leafClusterName] may be empty when requesting a client for the root cluster. Returned clients are
 // expected to be cached, as this may be called frequently.
 func (p *echoAppProvider) GetCachedClient(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error) {
-	c, ok := p.clients[profileName][leafClusterName]
+	rootCluster, ok := p.clusters[profileName]
 	if !ok {
-		return nil, trace.NotFound("no client for %s:%s", profileName, leafClusterName)
+		return nil, trace.NotFound("no cluster for %s", profileName)
 	}
-	return c, nil
+	if leafClusterName == "" {
+		return &client.ClusterClient{
+			AuthClient: &echoAppAuthClient{
+				clusterName: profileName,
+				apps:        rootCluster.apps,
+			},
+		}, nil
+	}
+	leafCluster, ok := rootCluster.leafClusters[leafClusterName]
+	if !ok {
+		return nil, trace.NotFound("no cluster for %s.%s", profileName, leafClusterName)
+	}
+	return &client.ClusterClient{
+		AuthClient: &echoAppAuthClient{
+			clusterName: leafClusterName,
+			apps:        leafCluster.apps,
+		},
+	}, nil
 }
 
 func (p *echoAppProvider) ReissueAppCert(ctx context.Context, profileName, leafClusterName string, app types.Application) (tls.Certificate, error) {
@@ -280,6 +291,45 @@ func (p *echoAppProvider) ReissueAppCert(ctx context.Context, profileName, leafC
 
 func (p *echoAppProvider) GetDialOptions(ctx context.Context, profileName string) (*DialOptions, error) {
 	return &p.dialOpts, nil
+}
+
+func (p *echoAppProvider) GetVnetConfig(ctx context.Context, profileName, leafClusterName string) (*vnet.VnetConfig, error) {
+	rootCluster, ok := p.clusters[profileName]
+	if !ok {
+		return nil, trace.Errorf("no cluster for %s", profileName)
+	}
+	if leafClusterName == "" {
+		if rootCluster.cidrRange == "" {
+			return nil, trace.NotFound("vnet_config not found")
+		}
+		return &vnet.VnetConfig{
+			Kind:    types.KindVnetConfig,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "vnet-config",
+			},
+			Spec: &vnet.VnetConfigSpec{
+				Ipv4CidrRange: rootCluster.cidrRange,
+			},
+		}, nil
+	}
+	leafCluster, ok := rootCluster.leafClusters[leafClusterName]
+	if !ok {
+		return nil, trace.Errorf("no cluster for %s.%s", profileName, leafClusterName)
+	}
+	if leafCluster.cidrRange == "" {
+		return nil, trace.NotFound("vnet_config not found")
+	}
+	return &vnet.VnetConfig{
+		Kind:    types.KindVnetConfig,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: "vnet-config",
+		},
+		Spec: &vnet.VnetConfigSpec{
+			Ipv4CidrRange: leafCluster.cidrRange,
+		},
+	}, nil
 }
 
 // echoAppAuthClient is a fake auth client that answers GetResources requests with a static list of apps and
@@ -416,36 +466,52 @@ func TestDialFakeApp(t *testing.T) {
 		return newClientCert(t, ca, "testclient", clock.Now().Add(appCertLifetime))
 	}
 
-	appProvider := newEchoAppProvider(map[string]map[string][]string{
-		"root1.example.com": map[string][]string{
-			"":                 {"echo1", "echo2"},
-			"leaf.example.com": {"echo1"},
+	appProvider := newEchoAppProvider(map[string]testClusterSpec{
+		"root1.example.com": {
+			apps:      []string{"echo1", "echo2"},
+			cidrRange: "192.168.2.0/24",
+			leafClusters: map[string]testClusterSpec{
+				"leaf1.example.com": {
+					apps: []string{"echo1"},
+				},
+			},
 		},
-		"root2.example.com": map[string][]string{
-			"":                  {"echo1", "echo2"},
-			"leaf2.example.com": {"echo1"},
+		"root2.example.com": {
+			apps: []string{"echo1", "echo2"},
+			leafClusters: map[string]testClusterSpec{
+				"leaf2.example.com": {
+					apps: []string{"echo1"},
+				},
+			},
 		},
 	}, dialOpts, reissueClientCert)
 
-	validAppNames := []string{
-		"echo1.root1.example.com",
-		"echo2.root1.example.com",
-		"echo1.root2.example.com",
-		"echo2.root2.example.com",
-		// Leaf clusters not yet supported.
-	}
-
-	invalidAppNames := []string{
-		"not.an.app.example.com.",
-		"echo1.leaf1.example.com.",
-		"echo1.leaf2.example.com.",
-	}
-
 	p := newTestPack(t, ctx, clock, appProvider)
+
+	validTestCases := []struct {
+		app        string
+		expectCIDR string
+	}{
+		{
+			app:        "echo1.root1.example.com",
+			expectCIDR: "192.168.2.0/24",
+		},
+		{
+			app:        "echo2.root1.example.com",
+			expectCIDR: "192.168.2.0/24",
+		},
+		{
+			app:        "echo1.root2.example.com",
+			expectCIDR: defaultIPv4CIDRRange,
+		},
+		{
+			app:        "echo2.root2.example.com",
+			expectCIDR: defaultIPv4CIDRRange,
+		},
+	}
 
 	t.Run("valid", func(t *testing.T) {
 		t.Parallel()
-
 		// Connect to each app 3 times, advancing the clock past the cert lifetime between each
 		// connection to trigger a cert refresh.
 		//
@@ -453,14 +519,27 @@ func TestDialFakeApp(t *testing.T) {
 		// the inner app dial/connection tests to run in parallel because they don't advance the clock.
 		for i := 0; i < 3; i++ {
 			t.Run(fmt.Sprint(i), func(t *testing.T) {
-				for _, app := range validAppNames {
-					app := app
-					t.Run(app, func(t *testing.T) {
+				for _, tc := range validTestCases {
+					tc := tc
+					t.Run(tc.app, func(t *testing.T) {
 						t.Parallel()
 
-						conn, err := p.dialHost(ctx, app)
+						_, expectNet, err := net.ParseCIDR(tc.expectCIDR)
 						require.NoError(t, err)
-						t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+						conn, err := p.dialHost(ctx, tc.app)
+						require.NoError(t, err)
+						t.Cleanup(func() { assert.NoError(t, conn.Close()) })
+
+						remoteAddr, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+						require.NoError(t, err)
+						remoteIP := net.ParseIP(remoteAddr)
+						require.NotNil(t, remoteIP)
+
+						// The app name may have resolved to a v4 or v6 address, either way the 4-byte suffix should be a
+						// valid IPv4 address in the expected CIDR range.
+						remoteIPSuffix := remoteIP[len(remoteIP)-4:]
+						require.True(t, expectNet.Contains(remoteIPSuffix), "expected CIDR range %s does not include remote IP %s", expectNet, remoteIPSuffix)
 
 						testEchoConnection(t, conn)
 					})
@@ -471,18 +550,21 @@ func TestDialFakeApp(t *testing.T) {
 	})
 
 	t.Run("invalid", func(t *testing.T) {
-		// It's safe to run these invalid app tests in parallel because they fail the DNS lookup and don't
-		// even make it to a TCP dial, so the clock used for TLS cert expiry doesn't matter.
 		t.Parallel()
-		for _, app := range invalidAppNames {
-			app := app
-			t.Run("invalid/"+app, func(t *testing.T) {
+		invalidTestCases := []string{
+			"not.an.app.example.com.",
+			// Leaf clusters not supported yet.
+			"echo1.leaf1.example.com.",
+			"echo2.leaf1.example.com.",
+		}
+		for _, fqdn := range invalidTestCases {
+			t.Run(fqdn, func(t *testing.T) {
 				t.Parallel()
-
 				ctx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
 				defer cancel()
-				_, err := p.lookupHost(ctx, app)
-				require.Error(t, err, "asdf")
+				_, err := p.lookupHost(ctx, fqdn)
+				require.Error(t, err)
+				return
 			})
 		}
 	})

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -239,7 +239,6 @@ type testClusterSpec struct {
 type echoAppProvider struct {
 	clusters       map[string]testClusterSpec
 	dialOpts       DialOptions
-	clientCert     tls.Certificate
 	reissueAppCert func() tls.Certificate
 }
 
@@ -564,7 +563,6 @@ func TestDialFakeApp(t *testing.T) {
 				defer cancel()
 				_, err := p.lookupHost(ctx, fqdn)
 				require.Error(t, err)
-				return
 			})
 		}
 	})

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -38,8 +38,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/zeebo/assert"
 	"golang.org/x/exp/maps"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"

--- a/tool/tsh/common/vnet_common.go
+++ b/tool/tsh/common/vnet_common.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	vnetproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/clientcache"
@@ -112,6 +113,16 @@ func (p *vnetAppProvider) GetDialOptions(ctx context.Context, profileName string
 		}
 	}
 	return dialOpts, nil
+}
+
+func (p *vnetAppProvider) GetVnetConfig(ctx context.Context, profileName, leafClusterName string) (*vnetproto.VnetConfig, error) {
+	clusterClient, err := p.clientCache.Get(ctx, profileName, leafClusterName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	vnetConfigClient := clusterClient.AuthClient.VnetConfigServiceClient()
+	vnetConfig, err := vnetConfigClient.GetVnetConfig(ctx, &vnetproto.GetVnetConfigRequest{})
+	return vnetConfig, trace.Wrap(err)
 }
 
 // getRootClusterCACertPool returns a certificate pool for the root cluster of the given profile.


### PR DESCRIPTION
This is the seventh in a series of PRs implementing Teleport VNet [RFD](https://github.com/gravitational/teleport/blob/rfd/0163-vnet/rfd/0163-vnet.md). [parent](https://github.com/gravitational/teleport/pull/41033)

This PR adds support for VNet to assign local IPv4 addresses to apps, with addresses from user-configurable CIDR ranges, configured in the cluster-wide `vnet_config` resource.

This requires the user VNet process to check the cluster `vnet_config` and assign an IPv4 address from the configured range, or the default range `100.64.0.0/10`.

The admin process also has the check the cluster `vnet_config` in order to assign IPv4 routes in the host OS, to route IP requests in the configured ranges to the TUN virtual network interface.

Both the user and admin processes will cache each cluster `vnet_config` for 5 minutes and refresh after that point as necessary. This is an attempt to strike a balance between eventual consistency for users, and not having every user in the cluster constantly fetching the cluster vnet_config