### PR TITLE
AWS OIDC App Access: add PublicAddr to App

### DIFF
--- a/api/types/appserver.go
+++ b/api/types/appserver.go
@@ -86,7 +86,7 @@ func NewAppServerV3FromApp(app *AppV3, hostname, hostID string) (*AppServerV3, e
 
 // NewAppServerForAWSOIDCIntegration creates a new AppServer that will be used to grant AWS App Access
 // using the AWSOIDC credentials.
-func NewAppServerForAWSOIDCIntegration(integrationName string, hostID string) (*AppServerV3, error) {
+func NewAppServerForAWSOIDCIntegration(integrationName, hostID, publicAddr string) (*AppServerV3, error) {
 	return NewAppServerV3(Metadata{
 		Name: integrationName,
 	}, AppServerSpecV3{
@@ -96,6 +96,7 @@ func NewAppServerForAWSOIDCIntegration(integrationName string, hostID string) (*
 		}, Spec: AppSpecV3{
 			URI:         constants.AWSConsoleURL,
 			Integration: integrationName,
+			PublicAddr:  publicAddr,
 		}},
 	})
 }

--- a/api/types/appserver_test.go
+++ b/api/types/appserver_test.go
@@ -62,6 +62,7 @@ func TestNewAppServerForAWSOIDCIntegration(t *testing.T) {
 		name           string
 		integratioName string
 		hostID         string
+		publicAddr     string
 		expectedApp    *AppServerV3
 		errCheck       require.ErrorAssertionFunc
 	}{
@@ -69,6 +70,7 @@ func TestNewAppServerForAWSOIDCIntegration(t *testing.T) {
 			name:           "valid",
 			integratioName: "valid",
 			hostID:         "my-host-id",
+			publicAddr:     "valid.proxy.example.com",
 			expectedApp: &AppServerV3{
 				Kind:    KindAppServer,
 				Version: V3,
@@ -90,6 +92,7 @@ func TestNewAppServerForAWSOIDCIntegration(t *testing.T) {
 							URI:         "https://console.aws.amazon.com",
 							Cloud:       "AWS",
 							Integration: "valid",
+							PublicAddr:  "valid.proxy.example.com",
 						},
 					},
 				},
@@ -103,7 +106,7 @@ func TestNewAppServerForAWSOIDCIntegration(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			app, err := NewAppServerForAWSOIDCIntegration(tt.integratioName, tt.hostID)
+			app, err := NewAppServerForAWSOIDCIntegration(tt.integratioName, tt.hostID, tt.publicAddr)
 			if tt.errCheck != nil {
 				tt.errCheck(t, err)
 			}

--- a/lib/srv/app/watcher.go
+++ b/lib/srv/app/watcher.go
@@ -149,7 +149,7 @@ func FindPublicAddr(client FindPublicAddrClient, appPublicAddr string, appName s
 		if err != nil {
 			return "", trace.Wrap(err)
 		}
-		return fmt.Sprintf("%v.%v", appName, addr.Host()), nil
+		return utils.DefaultAppPublicAddr(appName, addr.Host()), nil
 	}
 
 	// Fall back to cluster name.

--- a/lib/utils/app.go
+++ b/lib/utils/app.go
@@ -35,5 +35,11 @@ func AssembleAppFQDN(localClusterName string, localProxyDNSName string, appClust
 	if isLocalCluster && app.GetPublicAddr() != "" {
 		return app.GetPublicAddr()
 	}
-	return fmt.Sprintf("%v.%v", app.GetName(), localProxyDNSName)
+	return DefaultAppPublicAddr(app.GetName(), localProxyDNSName)
+}
+
+// DefaultAppPublicAddr returns the default publicAddr for an app.
+// Format: <appName>.<localProxyDNSName>
+func DefaultAppPublicAddr(appName, localProxyDNSName string) string {
+	return fmt.Sprintf("%v.%v", appName, localProxyDNSName)
 }

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/integrations/awsoidc/deployserviceconfig"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
+	libutils "github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/oidc"
 	"github.com/gravitational/teleport/lib/web/scripts/oneoff"
 	"github.com/gravitational/teleport/lib/web/ui"
@@ -953,7 +954,9 @@ func (h *Handler) awsOIDCCreateAWSAppAccess(w http.ResponseWriter, r *http.Reque
 
 	getUserGroupLookup := h.getUserGroupLookup(r.Context(), clt)
 
-	appServer, err := types.NewAppServerForAWSOIDCIntegration(integrationName, h.cfg.HostUUID)
+	publicAddr := libutils.DefaultAppPublicAddr(integrationName, h.PublicProxyAddr())
+
+	appServer, err := types.NewAppServerForAWSOIDCIntegration(integrationName, h.cfg.HostUUID, publicAddr)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -966,6 +966,7 @@ func TestAWSOIDCAppAccessAppServerCreation(t *testing.T) {
 	require.NoError(t, err)
 
 	proxy := env.proxies[0]
+	proxyPublicAddr := proxy.handler.handler.cfg.PublicProxyAddr
 	pack := proxy.authPack(t, "foo@example.com", []types.Role{roleTokenCRD})
 
 	myIntegration, err := types.NewIntegrationAWSOIDC(types.Metadata{
@@ -980,10 +981,8 @@ func TestAWSOIDCAppAccessAppServerCreation(t *testing.T) {
 
 	// Create the AWS App Access for the current integration.
 	endpoint := pack.clt.Endpoint("webapi", "sites", "localhost", "integrations", "aws-oidc", "my-integration", "aws-app-access")
-	x, err := pack.clt.PostJSON(context.Background(), endpoint, nil)
+	_, err = pack.clt.PostJSON(context.Background(), endpoint, nil)
 	require.NoError(t, err)
-
-	t.Log(x)
 
 	// Ensure the AppServer was correctly created.
 	appServers, err := env.server.Auth().GetApplicationServers(context.Background(), "default")
@@ -1009,6 +1008,7 @@ func TestAWSOIDCAppAccessAppServerCreation(t *testing.T) {
 					URI:         "https://console.aws.amazon.com",
 					Integration: "my-integration",
 					Cloud:       "AWS",
+					PublicAddr:  "my-integration." + proxyPublicAddr,
 				},
 			},
 		},

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1902,6 +1902,7 @@ spec:
     spec:
       uri: https://console.aws.amazon.com
       integration: my-integration
+	  public_addr: integration.example.com
     version: v3
   host_id: c6cfe5c2-653f-4e5d-a914-bfac5a7baf38
 version: v3
@@ -1918,6 +1919,7 @@ spec:
       name: my-integration
     spec:
       uri: https://console.aws.amazon.com
+	  public_addr: integration.example.com
     version: v3
   host_id: c6cfe5c2-653f-4e5d-a914-bfac5a7baf38
 version: v3
@@ -1940,7 +1942,7 @@ version: v3
 	appServers := mustDecodeJSON[[]*types.AppServerV3](t, buf)
 	require.Len(t, appServers, 1)
 
-	expectedAppServer, err := types.NewAppServerForAWSOIDCIntegration("my-integration", "c6cfe5c2-653f-4e5d-a914-bfac5a7baf38")
+	expectedAppServer, err := types.NewAppServerForAWSOIDCIntegration("my-integration", "c6cfe5c2-653f-4e5d-a914-bfac5a7baf38", "integration.example.com")
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(
 		expectedAppServer,

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1902,7 +1902,7 @@ spec:
     spec:
       uri: https://console.aws.amazon.com
       integration: my-integration
-	  public_addr: integration.example.com
+      public_addr: integration.example.com
     version: v3
   host_id: c6cfe5c2-653f-4e5d-a914-bfac5a7baf38
 version: v3
@@ -1919,7 +1919,7 @@ spec:
       name: my-integration
     spec:
       uri: https://console.aws.amazon.com
-	  public_addr: integration.example.com
+      public_addr: integration.example.com
     version: v3
   host_id: c6cfe5c2-653f-4e5d-a914-bfac5a7baf38
 version: v3


### PR DESCRIPTION
This PR adds a missing field to the App created to handle the AWS App Access when using the AWS OIDC credentials
The PublicAddr is required and was not being set.

Context https://github.com/gravitational/teleport/issues/30150