### PR TITLE
[vnet][7] custom DNS zones

### DIFF
--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -227,7 +227,11 @@ func (p *appProvider) ListProfiles() ([]string, error) {
 	return profiles, trace.Wrap(err)
 }
 
-func (p *appProvider) GetCachedClient(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error) {
+func (p *appProvider) GetCachedClient(ctx context.Context, profileName, leafClusterName string) (vnet.ClusterClient, error) {
+	return p.getCachedClient(ctx, profileName, leafClusterName)
+}
+
+func (p *appProvider) getCachedClient(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error) {
 	uri := uri.NewClusterURI(profileName).AppendLeafCluster(leafClusterName)
 	client, err := p.daemonService.GetCachedClient(ctx, uri)
 	return client, trace.Wrap(err)
@@ -305,7 +309,7 @@ func (p *appProvider) GetDialOptions(ctx context.Context, profileName string) (*
 }
 
 func (p *appProvider) GetVnetConfig(ctx context.Context, profileName, leafClusterName string) (*vnetproto.VnetConfig, error) {
-	clusterClient, err := p.GetCachedClient(ctx, profileName, leafClusterName)
+	clusterClient, err := p.getCachedClient(ctx, profileName, leafClusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -151,7 +151,7 @@ func (r *TCPAppResolver) ResolveTCPHandler(ctx context.Context, fqdn string) (*T
 			// return an error so that DNS resolution will be forwarded upstream instead of failing, to avoid
 			// breaking e.g. web app access (we don't know if this is a web or TCP app yet because we can't
 			// log in).
-			slog.InfoContext(ctx, "Failed to get teleport client.", "error", err)
+			slog.ErrorContext(ctx, "Failed to get teleport client.", "error", err)
 			continue
 		}
 		return r.resolveTCPHandlerForCluster(ctx, slog, rootClient.CurrentCluster(), profileName, "", fqdn)
@@ -167,7 +167,7 @@ func (r *TCPAppResolver) fqdnMatchesProfile(ctx context.Context, profileName, fq
 	// TODO(nklaassen): support leaf clusters.
 	vnetConfig, err := r.clusterConfigCache.getVnetConfig(ctx, profileName, "" /*leafClustername*/)
 	if err != nil {
-		r.slog.DebugContext(ctx, "Failed to get VnetConfig, not checking custom DNS zones.", "profile", profileName, "error", err)
+		r.slog.ErrorContext(ctx, "Failed to get VnetConfig, not checking custom DNS zones.", "profile", profileName, "error", err)
 		return false
 	}
 	return slices.ContainsFunc(vnetConfig.GetSpec().GetCustomDnsZones(), func(zone *vnet.CustomDNSZone) bool {

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -206,7 +206,8 @@ func (r *TCPAppResolver) fqdnMatchesProfile(ctx context.Context, profileName, fq
 		}
 		// The queried app fqdn is a subdomain of this custom zone suffix. Check if the custom zone is valid.
 		if err := r.customDNSZoneChecker.validate(ctx, clusterName, zone.GetSuffix()); err != nil {
-			return false, trace.Wrap(err, "validating custom DNS zone %q for cluster %q", zone.GetSuffix(), clusterName)
+			r.slog.ErrorContext(ctx, "Failed to validate custom DNS zone %q for cluster %q", "error", err)
+			return false, trace.Wrap(err, "validating custom DNS zone")
 		}
 		return true, nil
 	}

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
@@ -50,7 +51,7 @@ type AppProvider interface {
 	// GetCachedClient returns a [*client.ClusterClient] for the given profile and leaf cluster.
 	// [leafClusterName] may be empty when requesting a client for the root cluster. Returned clients are
 	// expected to be cached, as this may be called frequently.
-	GetCachedClient(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error)
+	GetCachedClient(ctx context.Context, profileName, leafClusterName string) (ClusterClient, error)
 
 	// ReissueAppCert returns a new app certificate for the given app in the named profile and leaf cluster.
 	// Implementations may trigger a re-login to the cluster, but if they do, they MUST clear all cached
@@ -70,6 +71,12 @@ type AppProvider interface {
 	// The connection won't be established until OnNewConnection returns. Returning an error prevents
 	// the connection from being made.
 	OnNewConnection(ctx context.Context, profileName, leafClusterName string, app types.Application) error
+}
+
+// ClusterClient is an interface defining the subset of [client.ClusterClient] methods used by [AppProvider].
+type ClusterClient interface {
+	CurrentCluster() authclient.ClientI
+	ClusterName() string
 }
 
 // DialOptions holds ALPN dial options for dialing apps.

--- a/lib/vnet/customdnszonevalidator.go
+++ b/lib/vnet/customdnszonevalidator.go
@@ -1,0 +1,71 @@
+package vnet
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"slices"
+	"sync"
+
+	"github.com/gravitational/trace"
+)
+
+const (
+	clusterTXTRecordPrefix = "teleport-cluster="
+)
+
+type lookupTXTFunc = func(ctx context.Context, domain string) (txtRecords []string, err error)
+
+// customDNSZoneValidator validates custom DNS zones by making sure that they have a DNS TXT record of
+// "teleport-cluster=<cluster-name>" for the cluster in which they are used. This is meant to avoid the
+// possibility of a rogue application advertising a public_addr with a DNS name not controlled by the cluster
+// admins, which could be used to trick VNet users.
+//
+// After finding that a zone is valid once, this is cached indefinitely. Invalid zones are a misconfiguration
+// so we don't cache negative results
+type customDNSZoneValidator struct {
+	lookupTXT  lookupTXTFunc
+	validZones map[string]struct{}
+	mu         sync.RWMutex
+}
+
+func newCustomDNSZoneValidator(lookupTXT lookupTXTFunc) *customDNSZoneValidator {
+	if lookupTXT == nil {
+		var resolver net.Resolver
+		lookupTXT = resolver.LookupTXT
+	}
+	return &customDNSZoneValidator{
+		lookupTXT:  lookupTXT,
+		validZones: make(map[string]struct{}),
+	}
+}
+
+// validate returns an error if [customDNSZone] is not valid for [clusterName].
+func (c *customDNSZoneValidator) validate(ctx context.Context, clusterName, customDNSZone string) error {
+	c.mu.RLock()
+	_, ok := c.validZones[customDNSZone]
+	c.mu.RUnlock()
+	if ok {
+		return nil
+	}
+
+	requiredTXTRecord := clusterTXTRecordPrefix + clusterName
+	slog.InfoContext(ctx, "Checking validity of custom DNS zone by querying for required TXT record.", "zone", customDNSZone, "record", requiredTXTRecord)
+
+	records, err := c.lookupTXT(ctx, customDNSZone)
+	if err != nil {
+		return trace.Wrap(err, "looking up TXT records for %q", customDNSZone)
+	}
+
+	valid := slices.Contains(records, requiredTXTRecord)
+	if !valid {
+		return trace.BadParameter(`custom DNS zone %q does not have required TXT record %q`, customDNSZone, requiredTXTRecord)
+	}
+
+	slog.DebugContext(ctx, "Custom DNS zone has valid TXT record.", "zone", customDNSZone, "cluster", clusterName)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.validZones[customDNSZone] = struct{}{}
+	return nil
+}

--- a/lib/vnet/customdnszonevalidator.go
+++ b/lib/vnet/customdnszonevalidator.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package vnet
 
 import (

--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -96,6 +97,12 @@ func (c *osConfigurator) updateOSConfiguration(ctx context.Context) error {
 		// profileName is the web proxy address, add the default DNS zone for it.
 		// TODO(nklaassen): add the custom DNS zones as well, after the rest of VNet supports it.
 		dnsZones = append(dnsZones, profileName)
+		for _, zone := range vnetConfig.GetSpec().GetCustomDnsZones() {
+			suffix := zone.GetSuffix()
+			// Trim any leading or trailing "." to match expected format.
+			zone := strings.TrimPrefix(strings.TrimSuffix(suffix, "."), ".")
+			dnsZones = append(dnsZones, zone)
+		}
 
 		cidrRange := cmp.Or(vnetConfig.GetSpec().GetIpv4CidrRange(), defaultIPv4CIDRRange)
 		cidrRanges = append(cidrRanges, cidrRange)

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -407,7 +407,12 @@ func TestDialFakeApp(t *testing.T) {
 
 	appProvider := newEchoAppProvider(map[string]testClusterSpec{
 		"root1.example.com": {
-			apps:           []string{"echo1.root1.example.com", "echo2.root1.example.com", "echo.myzone.example.com"},
+			apps: []string{
+				"echo1.root1.example.com",
+				"echo2.root1.example.com",
+				"echo.myzone.example.com",
+				"echo.nested.myzone.example.com",
+			},
 			cidrRange:      "192.168.2.0/24",
 			customDNSZones: []string{"myzone.example.com"},
 			leafClusters: map[string]testClusterSpec{
@@ -442,6 +447,10 @@ func TestDialFakeApp(t *testing.T) {
 		},
 		{
 			app:        "echo.myzone.example.com",
+			expectCIDR: "192.168.2.0/24",
+		},
+		{
+			app:        "echo.nested.myzone.example.com",
 			expectCIDR: "192.168.2.0/24",
 		},
 		{

--- a/tool/tsh/common/vnet_common.go
+++ b/tool/tsh/common/vnet_common.go
@@ -72,7 +72,7 @@ func (p *vnetAppProvider) ListProfiles() ([]string, error) {
 
 // GetCachedClient returns a cached [*client.ClusterClient] for the given profile and leaf cluster.
 // [leafClusterName] may be empty when requesting a client for the root cluster.
-func (p *vnetAppProvider) GetCachedClient(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error) {
+func (p *vnetAppProvider) GetCachedClient(ctx context.Context, profileName, leafClusterName string) (vnet.ClusterClient, error) {
 	return p.clientCache.Get(ctx, profileName, leafClusterName)
 }
 
@@ -202,11 +202,11 @@ func (p *vnetAppProvider) reissueAppCert(ctx context.Context, tc *client.Telepor
 		RequesterName:  proto.UserCertsRequest_TSH_APP_LOCAL_PROXY,
 	}
 
-	clusterClient, err := p.GetCachedClient(ctx, profileName, leafClusterName)
+	clusterClient, err := p.clientCache.Get(ctx, profileName, leafClusterName)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err, "getting cached cluster client")
 	}
-	rootClient, err := p.GetCachedClient(ctx, profileName, "")
+	rootClient, err := p.clientCache.Get(ctx, profileName, "")
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err, "getting cached root client")
 	}


### PR DESCRIPTION
This is the eighth in a series of PRs implementing Teleport VNet [RFD](https://github.com/gravitational/teleport/blob/rfd/0163-vnet/rfd/0163-vnet.md). [parent](https://github.com/gravitational/teleport/pull/41542)

This PR adds support for custom DNS zones - which means that TCP apps with a non-default `public_addr` that is not a subdomain of the proxy address can be resolved locally with VNet.

To avoid requiring the VNet DNS nameserver to handle all DNS queries on the host and check every cluster for a matching app, the complete list of custom DNS zones must be configured statically cluster-wide in the `vnet_config` resource. All zones configured here will have all DNS queries for subdomains of those zones handled by VNet. If there is an app with a matching `public_addr`, VNet will handle that request, else the DNS request will be forwarded to upstream DNS servers and the user will be able to connect to those non-VNet apps normally.