### PR TITLE
[v13] Reload teleport service config on upgrade

### DIFF
--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -226,7 +226,7 @@ if [[ "${PACKAGE_TYPE}" == "pkg" ]]; then
         PKG_FILENAME="teleport-${TELEPORT_VERSION}${ARCH_TAG}.${PACKAGE_TYPE}"
     fi
 else
-    FILE_LIST="${TAR_PATH}/tsh ${TAR_PATH}/tctl ${TAR_PATH}/teleport ${TAR_PATH}/tbot ${TAR_PATH}/examples/systemd/teleport.service"
+    FILE_LIST="${TAR_PATH}/tsh ${TAR_PATH}/tctl ${TAR_PATH}/teleport ${TAR_PATH}/tbot ${TAR_PATH}/examples/systemd/teleport.service ${TAR_PATH}/examples/systemd/post-upgrade"
     LINUX_BINARY_FILE_LIST="${TAR_PATH}/tsh ${TAR_PATH}/tctl ${TAR_PATH}/tbot ${TAR_PATH}/teleport"
     LINUX_SYSTEMD_FILE_LIST="${TAR_PATH}/examples/systemd/teleport.service"
     EXTRA_DOCKER_OPTIONS=""
@@ -290,6 +290,10 @@ if [[ "${PACKAGE_TYPE}" != "pkg" ]]; then
         mv -v ${LINUX_CONFIG_FILE} ${PACKAGE_TEMPDIR}/buildroot${LINUX_CONFIG_DIR}
         CONFIG_FILE_STANZA="--config-files /src/buildroot${LINUX_CONFIG_DIR}/${LINUX_CONFIG_FILE} "
     fi
+
+    # include post-upgrade script
+    mv -v ${TAR_PATH}/examples/systemd/post-upgrade ${PACKAGE_TEMPDIR}
+
     # /var/lib/teleport
     # shellcheck disable=SC2174
     mkdir -p -m0700 ${PACKAGE_TEMPDIR}/buildroot${LINUX_DATA_DIR}
@@ -365,6 +369,7 @@ else
         --provides teleport \
         --prefix / \
         --verbose \
+        --after-upgrade /src/post-upgrade \
         ${CONFIG_FILE_STANZA} \
         ${FILE_PERMISSIONS_STANZA} \
         ${RPM_SIGN_STANZA} .

--- a/examples/systemd/post-upgrade
+++ b/examples/systemd/post-upgrade
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# this post upgrade script is run each time the teleport package is upgraded
+
+set -eu
+
+# skip reload and restart when systemd is disabled. This is only relevant when
+# testing in a container.
+if systemctl status > /dev/null 2>&1; then
+    # reload systemd configuration
+    systemctl daemon-reload
+fi

--- a/examples/systemd/post-upgrade
+++ b/examples/systemd/post-upgrade
@@ -6,7 +6,6 @@ set -eu
 
 # skip reload and restart when systemd is disabled. This is only relevant when
 # testing in a container.
-if systemctl status > /dev/null 2>&1; then
-    # reload systemd configuration
-    systemctl daemon-reload
+if [ -d /run/systemd/system ]; then
+    systemctl --system daemon-reload >/dev/null || true
 fi


### PR DESCRIPTION
Backport #41127 to branch/v13

changelog: teleport service config is now reloaded on upgrades
