### PR TITLE
services: Fix inconsistency in `ListPlugins` with  `pageSize=0`

### DIFF
--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -129,6 +129,9 @@ func (s *PluginsService) GetPlugins(ctx context.Context, withSecrets bool) ([]ty
 // ListPlugins returns a paginated list of plugin instances.
 // StartKey is a resource name, which is the suffix of its key.
 func (s *PluginsService) ListPlugins(ctx context.Context, limit int, startKey string, withSecrets bool) ([]types.Plugin, string, error) {
+	if limit <= 0 {
+		limit = apidefaults.DefaultChunkSize
+	}
 	// Get at most limit+1 results to determine if there will be a next key.
 	maxLimit := limit + 1
 

--- a/lib/services/local/plugins_test.go
+++ b/lib/services/local/plugins_test.go
@@ -207,4 +207,14 @@ func TestListPlugins(t *testing.T) {
 			cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
 		))
 	})
+
+	t.Run("zero page size uses default value", func(t *testing.T) {
+		fetchedPlugins, nextKey, err := service.ListPlugins(ctx, 0, "", true)
+		require.NoError(t, err)
+		require.Empty(t, nextKey)
+
+		require.Empty(t, cmp.Diff(insertedPlugins, fetchedPlugins,
+			cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
+		))
+	})
 }


### PR DESCRIPTION
`ListPlugins` endpoint doesn't enforce `size>0` nor it assumes the default page size when `pageSize = 0` is passed.
This results in the agent being in a deadloop because it cannot iterate through results.