### PR TITLE
feat: Add webauthn diagnostic commands to tctl

### DIFF
--- a/tool/common/touchid/touchid.go
+++ b/tool/common/touchid/touchid.go
@@ -16,9 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package common
+package touchid
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -31,38 +32,54 @@ import (
 	"github.com/gravitational/teleport/lib/auth/touchid"
 )
 
-type touchIDCommand struct {
-	diag *touchIDDiagCommand
-	ls   *touchIDLsCommand
-	rm   *touchIDRmCommand
+// Command implements the "touchid" hidden/utility commands.
+type Command struct {
+	Diag *DiagCommand
+	Ls   *LsCommand
+	Rm   *RmCommand
 }
 
-// newTouchIDCommand returns touchid subcommands.
-// diag is always available.
-// ls and rm may not be available depending on binary and platform limitations.
-func newTouchIDCommand(app *kingpin.Application) *touchIDCommand {
+// NewCommand returns touchid subcommands.
+// Diag is always available.
+// Ls and Rm may not be available depending on binary and platform limitations.
+func NewCommand(app *kingpin.Application) *Command {
 	tid := app.Command("touchid", "Manage Touch ID credentials").Hidden()
-	cmd := &touchIDCommand{
-		diag: newTouchIDDiagCommand(tid),
+	cmd := &Command{
+		Diag: newDiagCommand(tid),
 	}
 	if touchid.IsAvailable() {
-		cmd.ls = newTouchIDLsCommand(tid)
-		cmd.rm = newTouchIDRmCommand(tid)
+		cmd.Ls = newLsCommand(tid)
+		cmd.Rm = newRmCommand(tid)
 	}
 	return cmd
 }
 
-type touchIDDiagCommand struct {
+func (c *Command) TryRun(ctx context.Context, selectedCommand string) (match bool, err error) {
+	switch {
+	case c.Diag.FullCommand() == selectedCommand:
+		return true, trace.Wrap(c.Diag.Run())
+	case c.Ls != nil && c.Ls.FullCommand() == selectedCommand:
+		return true, trace.Wrap(c.Ls.Run())
+	case c.Rm != nil && c.Rm.FullCommand() == selectedCommand:
+		return true, trace.Wrap(c.Rm.Run())
+	default:
+		return false, nil
+	}
+}
+
+// DiagCommand implements the "touchid diag" command.
+type DiagCommand struct {
 	*kingpin.CmdClause
 }
 
-func newTouchIDDiagCommand(app *kingpin.CmdClause) *touchIDDiagCommand {
-	return &touchIDDiagCommand{
+func newDiagCommand(app *kingpin.CmdClause) *DiagCommand {
+	return &DiagCommand{
 		CmdClause: app.Command("diag", "Run Touch ID diagnostics").Hidden(),
 	}
 }
 
-func (c *touchIDDiagCommand) run(cf *CLIConf) error {
+// Run executes the "touchid diag" command.
+func (c *DiagCommand) Run() error {
 	res, err := touchid.Diag()
 	if err != nil {
 		return trace.Wrap(err)
@@ -82,17 +99,19 @@ func (c *touchIDDiagCommand) run(cf *CLIConf) error {
 	return nil
 }
 
-type touchIDLsCommand struct {
+// LsCommand implements the "touchid ls" command.
+type LsCommand struct {
 	*kingpin.CmdClause
 }
 
-func newTouchIDLsCommand(app *kingpin.CmdClause) *touchIDLsCommand {
-	return &touchIDLsCommand{
+func newLsCommand(app *kingpin.CmdClause) *LsCommand {
+	return &LsCommand{
 		CmdClause: app.Command("ls", "Get a list of system Touch ID credentials").Hidden(),
 	}
 }
 
-func (c *touchIDLsCommand) run(cf *CLIConf) error {
+// Run executes the "touchid ls" command.
+func (c *LsCommand) Run() error {
 	infos, err := touchid.ListCredentials()
 	if err != nil {
 		return trace.Wrap(err)
@@ -124,28 +143,30 @@ func (c *touchIDLsCommand) run(cf *CLIConf) error {
 	return nil
 }
 
-type touchIDRmCommand struct {
+// RmCommand implements the "touchid rm" command.
+type RmCommand struct {
 	*kingpin.CmdClause
 
 	credentialID string
 }
 
-func newTouchIDRmCommand(app *kingpin.CmdClause) *touchIDRmCommand {
-	c := &touchIDRmCommand{
+func newRmCommand(app *kingpin.CmdClause) *RmCommand {
+	c := &RmCommand{
 		CmdClause: app.Command("rm", "Remove a Touch ID credential").Hidden(),
 	}
 	c.Arg("id", "ID of the Touch ID credential to remove").Required().StringVar(&c.credentialID)
 	return c
 }
 
-func (c *touchIDRmCommand) FullCommand() string {
+func (c *RmCommand) FullCommand() string {
 	if c.CmdClause == nil {
 		return "touchid rm"
 	}
 	return c.CmdClause.FullCommand()
 }
 
-func (c *touchIDRmCommand) run(cf *CLIConf) error {
+// Run executes the "touchid rm" command.
+func (c *RmCommand) Run() error {
 	if err := touchid.DeleteCredential(c.credentialID); err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/cmds.go
+++ b/tool/tctl/common/cmds.go
@@ -59,5 +59,6 @@ func Commands() []CLICommand {
 		&configure.SSOConfigureCommand{},
 		&tester.SSOTestCommand{},
 		&fido2Command{},
+		&webauthnwinCommand{},
 	}
 }

--- a/tool/tctl/common/cmds.go
+++ b/tool/tctl/common/cmds.go
@@ -58,5 +58,6 @@ func Commands() []CLICommand {
 		&PluginsCommand{},
 		&configure.SSOConfigureCommand{},
 		&tester.SSOTestCommand{},
+		&fido2Command{},
 	}
 }

--- a/tool/tctl/common/cmds.go
+++ b/tool/tctl/common/cmds.go
@@ -60,5 +60,6 @@ func Commands() []CLICommand {
 		&tester.SSOTestCommand{},
 		&fido2Command{},
 		&webauthnwinCommand{},
+		&touchIDCommand{},
 	}
 }

--- a/tool/tctl/common/fido2.go
+++ b/tool/tctl/common/fido2.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/alecthomas/kingpin/v2"
+
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/tool/common/fido2"

--- a/tool/tctl/common/fido2.go
+++ b/tool/tctl/common/fido2.go
@@ -1,0 +1,39 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"context"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/tool/common/fido2"
+)
+
+// fido2Command adapts fido2.Command for tctl.
+type fido2Command struct {
+	impl *fido2.Command
+}
+
+func (c *fido2Command) Initialize(app *kingpin.Application, _ *servicecfg.Config) {
+	c.impl = fido2.NewCommand(app)
+}
+
+func (c *fido2Command) TryRun(ctx context.Context, selectedCommand string, _ *auth.Client) (match bool, err error) {
+	return c.impl.TryRun(ctx, selectedCommand)
+}

--- a/tool/tctl/common/touchid.go
+++ b/tool/tctl/common/touchid.go
@@ -1,0 +1,39 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"context"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/tool/common/touchid"
+)
+
+// touchIDCommand adapts touchid.Commmand for tclt.
+type touchIDCommand struct {
+	impl *touchid.Command
+}
+
+func (c *touchIDCommand) Initialize(app *kingpin.Application, _ *servicecfg.Config) {
+	c.impl = touchid.NewCommand(app)
+}
+
+func (c *touchIDCommand) TryRun(ctx context.Context, selectedCommand string, _ *auth.Client) (match bool, err error) {
+	return c.impl.TryRun(ctx, selectedCommand)
+}

--- a/tool/tctl/common/touchid.go
+++ b/tool/tctl/common/touchid.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/teleport/tool/common/touchid"
 )
 
-// touchIDCommand adapts touchid.Commmand for tclt.
+// touchIDCommand adapts touchid.Command for tclt.
 type touchIDCommand struct {
 	impl *touchid.Command
 }

--- a/tool/tctl/common/touchid.go
+++ b/tool/tctl/common/touchid.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/alecthomas/kingpin/v2"
+
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/tool/common/touchid"

--- a/tool/tctl/common/webauthnwin.go
+++ b/tool/tctl/common/webauthnwin.go
@@ -1,0 +1,39 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"context"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/tool/common/webauthnwin"
+)
+
+// webauthnwinCommand adapts webauthnwin.Command for tctl.
+type webauthnwinCommand struct {
+	impl *webauthnwin.Command
+}
+
+func (c *webauthnwinCommand) Initialize(app *kingpin.Application, _ *servicecfg.Config) {
+	c.impl = webauthnwin.NewCommand(app)
+}
+
+func (c *webauthnwinCommand) TryRun(ctx context.Context, selectedCommand string, _ *auth.Client) (match bool, err error) {
+	return c.impl.TryRun(ctx, selectedCommand)
+}

--- a/tool/tctl/common/webauthnwin.go
+++ b/tool/tctl/common/webauthnwin.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/alecthomas/kingpin/v2"
+
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/tool/common/webauthnwin"

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1548,9 +1548,9 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	default:
 		// Handle commands that might not be available.
 		switch {
-		case tid.Ls != nil && command == tid.Ls.FullCommand():
+		case tid.Ls.MatchesCommand(command):
 			err = tid.Ls.Run()
-		case tid.Rm != nil && command == tid.Rm.FullCommand():
+		case tid.Rm.MatchesCommand(command):
 			err = tid.Rm.Run()
 		default:
 			// This should only happen when there's a missing switch case above.

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/ghodss/yaml"
+	"github.com/gravitational/teleport/tool/common/touchid"
 	"github.com/gravitational/teleport/tool/common/webauthnwin"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -1167,7 +1168,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	// FIDO2, TouchID and WebAuthnWin commands.
 	f2 := fido2.NewCommand(app)
-	tid := newTouchIDCommand(app)
+	tid := touchid.NewCommand(app)
 	wanwin := webauthnwin.NewCommand(app)
 
 	// Device Trust commands.
@@ -1517,8 +1518,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = f2.Diag.Run(cf.Context)
 	case f2.Attobj.FullCommand():
 		err = f2.Attobj.Run()
-	case tid.diag.FullCommand():
-		err = tid.diag.run(&cf)
+	case tid.Diag.FullCommand():
+		err = tid.Diag.Run()
 	case wanwin.Diag.FullCommand():
 		err = wanwin.Diag.Run(cf.Context)
 	case deviceCmd.enroll.FullCommand():
@@ -1547,10 +1548,10 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	default:
 		// Handle commands that might not be available.
 		switch {
-		case tid.ls != nil && command == tid.ls.FullCommand():
-			err = tid.ls.run(&cf)
-		case tid.rm != nil && command == tid.rm.FullCommand():
-			err = tid.rm.run(&cf)
+		case tid.Ls != nil && command == tid.Ls.FullCommand():
+			err = tid.Ls.Run()
+		case tid.Rm != nil && command == tid.Rm.FullCommand():
+			err = tid.Rm.Run()
 		default:
 			// This should only happen when there's a missing switch case above.
 			err = trace.BadParameter("command %q not configured", command)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/ghodss/yaml"
+	"github.com/gravitational/teleport/tool/common/webauthnwin"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
@@ -1167,7 +1168,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// FIDO2, TouchID and WebAuthnWin commands.
 	f2 := fido2.NewCommand(app)
 	tid := newTouchIDCommand(app)
-	webauthnwin := newWebauthnwinCommand(app)
+	wanwin := webauthnwin.NewCommand(app)
 
 	// Device Trust commands.
 	deviceCmd := newDeviceCommand(app)
@@ -1518,8 +1519,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = f2.Attobj.Run()
 	case tid.diag.FullCommand():
 		err = tid.diag.run(&cf)
-	case webauthnwin.diag.FullCommand():
-		err = webauthnwin.diag.run(&cf)
+	case wanwin.Diag.FullCommand():
+		err = wanwin.Diag.Run(cf.Context)
 	case deviceCmd.enroll.FullCommand():
 		err = deviceCmd.enroll.run(&cf)
 	case deviceCmd.collect.FullCommand():

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -89,6 +89,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils/diagnostics/latency"
 	"github.com/gravitational/teleport/lib/utils/mlock"
 	"github.com/gravitational/teleport/tool/common"
+	"github.com/gravitational/teleport/tool/common/fido2"
 )
 
 var log = logrus.WithFields(logrus.Fields{
@@ -1164,7 +1165,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	}
 
 	// FIDO2, TouchID and WebAuthnWin commands.
-	f2 := newFIDO2Command(app)
+	f2 := fido2.NewCommand(app)
 	tid := newTouchIDCommand(app)
 	webauthnwin := newWebauthnwinCommand(app)
 
@@ -1511,10 +1512,10 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = onDaemonStart(&cf)
 	case daemonStop.FullCommand():
 		err = onDaemonStop(&cf)
-	case f2.diag.FullCommand():
-		err = f2.diag.run(&cf)
-	case f2.attobj.FullCommand():
-		err = f2.attobj.run(&cf)
+	case f2.Diag.FullCommand():
+		err = f2.Diag.Run(cf.Context)
+	case f2.Attobj.FullCommand():
+		err = f2.Attobj.Run()
 	case tid.diag.FullCommand():
 		err = tid.diag.run(&cf)
 	case webauthnwin.diag.FullCommand():

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -46,8 +46,6 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/ghodss/yaml"
-	"github.com/gravitational/teleport/tool/common/touchid"
-	"github.com/gravitational/teleport/tool/common/webauthnwin"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
@@ -92,6 +90,8 @@ import (
 	"github.com/gravitational/teleport/lib/utils/mlock"
 	"github.com/gravitational/teleport/tool/common"
 	"github.com/gravitational/teleport/tool/common/fido2"
+	"github.com/gravitational/teleport/tool/common/touchid"
+	"github.com/gravitational/teleport/tool/common/webauthnwin"
 )
 
 var log = logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
Adds the following hidden/utility commands to tctl:

* fido2 diag
* fido2 attobj
* webauthnwin diag
* touchid diag
* touchid ls
* touchid rm

Since admin actions the fido2 and webauthnwin families are applicable. Touch ID isn't yet applicable, but it might be in a near future so I'm already porting those. It's useful to have the diag commands in the `tctl` binary as they can easily detect whether build tags, signing or entitlements are missing.

Closes #39629

Changelog: Add webauthn diagnostics commands to tctl