### PR TITLE
refactor common proto resource (un)marshallers into generic functions

### DIFF
--- a/lib/services/access_monitoring_rules.go
+++ b/lib/services/access_monitoring_rules.go
@@ -23,13 +23,11 @@ import (
 	"slices"
 
 	"github.com/gravitational/trace"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport/api/defaults"
 	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 // AccessMonitoringRules is the AccessMonitoringRule service
@@ -98,27 +96,10 @@ func ValidateAccessMonitoringRule(accessMonitoringRule *accessmonitoringrulesv1.
 
 // MarshalAccessMonitoringRule marshals AccessMonitoringRule resource to JSON.
 func MarshalAccessMonitoringRule(accessMonitoringRule *accessmonitoringrulesv1.AccessMonitoringRule, opts ...MarshalOption) ([]byte, error) {
-	return utils.FastMarshal(accessMonitoringRule)
+	return FastMarshalProtoResourceDeprecated(accessMonitoringRule, opts...)
 }
 
 // UnmarshalAccessMonitoringRule unmarshals the AccessMonitoringRule resource.
 func UnmarshalAccessMonitoringRule(data []byte, opts ...MarshalOption) (*accessmonitoringrulesv1.AccessMonitoringRule, error) {
-	if len(data) == 0 {
-		return nil, trace.BadParameter("missing access monitoring rule data")
-	}
-	cfg, err := CollectOptions(opts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var accessMonitoringRule accessmonitoringrulesv1.AccessMonitoringRule
-	if err := utils.FastUnmarshal(data, &accessMonitoringRule); err != nil {
-		return nil, trace.BadParameter(err.Error())
-	}
-	if cfg.Revision != "" {
-		accessMonitoringRule.Metadata.Revision = cfg.Revision
-	}
-	if !cfg.Expires.IsZero() {
-		accessMonitoringRule.Metadata.Expires = timestamppb.New(cfg.Expires)
-	}
-	return &accessMonitoringRule, nil
+	return FastUnmarshalProtoResourceDeprecated[*accessmonitoringrulesv1.AccessMonitoringRule](data, opts...)
 }

--- a/lib/services/crown_jewel.go
+++ b/lib/services/crown_jewel.go
@@ -21,11 +21,6 @@ package services
 import (
 	"context"
 
-	"github.com/gravitational/trace"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
 	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
 )
 
@@ -49,39 +44,10 @@ type CrownJewels interface {
 
 // MarshalCrownJewel marshals the CrownJewel object into a JSON byte array.
 func MarshalCrownJewel(object *crownjewelv1.CrownJewel, opts ...MarshalOption) ([]byte, error) {
-	cfg, err := CollectOptions(opts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if !cfg.PreserveResourceID {
-		object = proto.Clone(object).(*crownjewelv1.CrownJewel)
-		object.Metadata.Revision = ""
-	}
-	data, err := protojson.Marshal(object)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return data, nil
+	return MarshalProtoResource(object, opts...)
 }
 
 // UnmarshalCrownJewel unmarshals the CrownJewel object from a JSON byte array.
 func UnmarshalCrownJewel(data []byte, opts ...MarshalOption) (*crownjewelv1.CrownJewel, error) {
-	if len(data) == 0 {
-		return nil, trace.BadParameter("missing crown jewel data")
-	}
-	cfg, err := CollectOptions(opts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var obj crownjewelv1.CrownJewel
-	if err := protojson.Unmarshal(data, &obj); err != nil {
-		return nil, trace.BadParameter(err.Error())
-	}
-	if cfg.Revision != "" {
-		obj.Metadata.Revision = cfg.Revision
-	}
-	if !cfg.Expires.IsZero() {
-		obj.Metadata.Expires = timestamppb.New(cfg.Expires)
-	}
-	return &obj, nil
+	return UnmarshalProtoResource[*crownjewelv1.CrownJewel](data, opts...)
 }

--- a/lib/services/local/databaseobject_test.go
+++ b/lib/services/local/databaseobject_test.go
@@ -270,9 +270,11 @@ func TestMarshalDatabaseObjectRoundTrip(t *testing.T) {
 	obj, err := databaseobject.NewDatabaseObject("dummy-table", spec)
 	require.NoError(t, err)
 
-	out, err := marshalDatabaseObject(obj)
+	//nolint:staticcheck // SA1019. Using this marshaler for json compatibility.
+	out, err := services.FastMarshalProtoResourceDeprecated(obj)
 	require.NoError(t, err)
-	newObj, err := unmarshalDatabaseObject(out)
+	//nolint:staticcheck // SA1019. Using this unmarshaler for json compatibility.
+	newObj, err := services.FastUnmarshalProtoResourceDeprecated[*dbobjectv1.DatabaseObject](out)
 	require.NoError(t, err)
 	require.True(t, proto.Equal(obj, newObj), "messages are not equal")
 }

--- a/lib/services/local/databaseobjectimportrule.go
+++ b/lib/services/local/databaseobjectimportrule.go
@@ -22,15 +22,12 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	databaseobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 // databaseObjectImportRuleService manages database object import rules in the backend.
@@ -77,54 +74,13 @@ func NewDatabaseObjectImportRuleService(backend backend.Backend) (services.Datab
 	service, err := generic.NewServiceWrapper(backend,
 		types.KindDatabaseObjectImportRule,
 		databaseObjectImportRulePrefix,
-		marshalDatabaseObjectImportRule,
-		unmarshalDatabaseObjectImportRule)
+		//nolint:staticcheck // SA1019. Using this marshaler for json compatibility.
+		services.FastMarshalProtoResourceDeprecated[*databaseobjectimportrulev1.DatabaseObjectImportRule],
+		//nolint:staticcheck // SA1019. Using this unmarshaler for json compatibility.
+		services.FastUnmarshalProtoResourceDeprecated[*databaseobjectimportrulev1.DatabaseObjectImportRule],
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &databaseObjectImportRuleService{service: service}, nil
-}
-
-func marshalDatabaseObjectImportRule(rule *databaseobjectimportrulev1.DatabaseObjectImportRule, opts ...services.MarshalOption) ([]byte, error) {
-	cfg, err := services.CollectOptions(opts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if !cfg.PreserveResourceID {
-		rule = proto.Clone(rule).(*databaseobjectimportrulev1.DatabaseObjectImportRule)
-		//nolint:staticcheck // SA1019. Deprecated, but still needed.
-		rule.Metadata.Id = 0
-		rule.Metadata.Revision = ""
-	}
-	data, err := utils.FastMarshal(rule)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return data, nil
-}
-
-func unmarshalDatabaseObjectImportRule(data []byte, opts ...services.MarshalOption) (*databaseobjectimportrulev1.DatabaseObjectImportRule, error) {
-	if len(data) == 0 {
-		return nil, trace.BadParameter("missing DatabaseObjectImportRule data")
-	}
-	cfg, err := services.CollectOptions(opts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var obj databaseobjectimportrulev1.DatabaseObjectImportRule
-	err = utils.FastUnmarshal(data, &obj)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if cfg.ID != 0 {
-		//nolint:staticcheck // SA1019. Id is deprecated, but still needed.
-		obj.Metadata.Id = cfg.ID
-	}
-	if cfg.Revision != "" {
-		obj.Metadata.Revision = cfg.Revision
-	}
-	if !cfg.Expires.IsZero() {
-		obj.Metadata.Expires = timestamppb.New(cfg.Expires)
-	}
-	return &obj, nil
 }

--- a/lib/services/local/databaseobjectimportrule_test.go
+++ b/lib/services/local/databaseobjectimportrule_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/types/label"
 	apilabels "github.com/gravitational/teleport/api/types/label"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/common/databaseobjectimportrule"
 )
 
@@ -207,9 +208,11 @@ func TestMarshalDatabaseObjectImportRuleRoundTrip(t *testing.T) {
 		Spec: spec,
 	}
 
-	out, err := marshalDatabaseObjectImportRule(obj)
+	//nolint:staticcheck // SA1019. Using this marshaler for json compatibility.
+	out, err := services.FastMarshalProtoResourceDeprecated(obj)
 	require.NoError(t, err)
-	newObj, err := unmarshalDatabaseObjectImportRule(out)
+	//nolint:staticcheck // SA1019. Using this unmarshaler for json compatibility.
+	newObj, err := services.FastUnmarshalProtoResourceDeprecated[*databaseobjectimportrulev1.DatabaseObjectImportRule](out)
 	require.NoError(t, err)
 	require.True(t, proto.Equal(obj, newObj), "messages are not equal")
 }

--- a/lib/services/notifications.go
+++ b/lib/services/notifications.go
@@ -22,12 +22,8 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 // Notifications defines an interface for managing notifications.
@@ -79,48 +75,12 @@ func MarshalNotification(notification *notificationsv1.Notification, opts ...Mar
 		return nil, trace.Wrap(err)
 	}
 
-	cfg, err := CollectOptions(opts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if !cfg.PreserveResourceID {
-		notification = proto.Clone(notification).(*notificationsv1.Notification)
-		//nolint:staticcheck // SA1019. Deprecated, but still needed.
-		notification.Metadata.Id = 0
-		notification.Metadata.Revision = ""
-	}
-	data, err := utils.FastMarshal(notification)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return data, nil
+	return FastMarshalProtoResourceDeprecated(notification, opts...)
 }
 
 // UnmarshalNotification unmarshals a Notification resource from JSON.
 func UnmarshalNotification(data []byte, opts ...MarshalOption) (*notificationsv1.Notification, error) {
-	if len(data) == 0 {
-		return nil, trace.BadParameter("missing notification data")
-	}
-	cfg, err := CollectOptions(opts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var obj notificationsv1.Notification
-	if err = utils.FastUnmarshal(data, &obj); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if cfg.ID != 0 {
-		//nolint:staticcheck // SA1019. Id is deprecated, but still needed.
-		obj.Metadata.Id = cfg.ID
-	}
-	if cfg.Revision != "" {
-		obj.Metadata.Revision = cfg.Revision
-	}
-	if !cfg.Expires.IsZero() {
-		obj.Metadata.Expires = timestamppb.New(cfg.Expires)
-	}
-
-	return &obj, nil
+	return FastUnmarshalProtoResourceDeprecated[*notificationsv1.Notification](data, opts...)
 }
 
 // ValidateGlobalNotification verifies that the necessary fields are configured for a global notification object.
@@ -150,49 +110,12 @@ func MarshalGlobalNotification(globalNotification *notificationsv1.GlobalNotific
 		return nil, trace.Wrap(err)
 	}
 
-	cfg, err := CollectOptions(opts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if !cfg.PreserveResourceID {
-		globalNotification = proto.Clone(globalNotification).(*notificationsv1.GlobalNotification)
-		//nolint:staticcheck // SA1019. Deprecated, but still needed.
-		globalNotification.Metadata.Id = 0
-		globalNotification.Metadata.Revision = ""
-	}
-	// We marshal with raw protojson here because utils.FastMarshal doesn't work with oneof.
-	data, err := protojson.Marshal(globalNotification)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return data, nil
+	return MarshalProtoResource(globalNotification, opts...)
 }
 
 // UnmarshalGlobalNotification unmarshals a GlobalNotification resource from JSON.
 func UnmarshalGlobalNotification(data []byte, opts ...MarshalOption) (*notificationsv1.GlobalNotification, error) {
-	if len(data) == 0 {
-		return nil, trace.BadParameter("missing notification data")
-	}
-	cfg, err := CollectOptions(opts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var obj notificationsv1.GlobalNotification
-	// We unmarshal with raw protojson here because utils.FastUnmarshal doesn't work with oneof.
-	if err = protojson.Unmarshal(data, &obj); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if cfg.ID != 0 {
-		//nolint:staticcheck // SA1019. Id is deprecated, but still needed.
-		obj.Metadata.Id = cfg.ID
-	}
-	if cfg.Revision != "" {
-		obj.Metadata.Revision = cfg.Revision
-	}
-	if !cfg.Expires.IsZero() {
-		obj.Metadata.Expires = timestamppb.New(cfg.Expires)
-	}
-	return &obj, nil
+	return UnmarshalProtoResource[*notificationsv1.GlobalNotification](data, opts...)
 }
 
 // ValidateUserNotificationState verifies that the necessary fields are configured for user notification state object.
@@ -214,47 +137,12 @@ func MarshalUserNotificationState(notificationState *notificationsv1.UserNotific
 		return nil, trace.Wrap(err)
 	}
 
-	cfg, err := CollectOptions(opts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if !cfg.PreserveResourceID {
-		notificationState = proto.Clone(notificationState).(*notificationsv1.UserNotificationState)
-		//nolint:staticcheck // SA1019. Deprecated, but still needed.
-		notificationState.Metadata.Id = 0
-		notificationState.Metadata.Revision = ""
-	}
-	data, err := utils.FastMarshal(notificationState)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return data, nil
+	return FastMarshalProtoResourceDeprecated(notificationState, opts...)
 }
 
 // UnmarshalUserNotificationState unmarshals a UserNotificationState resource from JSON.
 func UnmarshalUserNotificationState(data []byte, opts ...MarshalOption) (*notificationsv1.UserNotificationState, error) {
-	if len(data) == 0 {
-		return nil, trace.BadParameter("missing notification data")
-	}
-	cfg, err := CollectOptions(opts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var obj notificationsv1.UserNotificationState
-	if err = utils.FastUnmarshal(data, &obj); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if cfg.ID != 0 {
-		//nolint:staticcheck // SA1019. Id is deprecated, but still needed.
-		obj.Metadata.Id = cfg.ID
-	}
-	if cfg.Revision != "" {
-		obj.Metadata.Revision = cfg.Revision
-	}
-	if !cfg.Expires.IsZero() {
-		obj.Metadata.Expires = timestamppb.New(cfg.Expires)
-	}
-	return &obj, nil
+	return FastUnmarshalProtoResourceDeprecated[*notificationsv1.UserNotificationState](data, opts...)
 }
 
 // ValidateUserLastSeenNotification verifies that the necessary fields are configured for a user's last seen notification timestamp object.
@@ -272,45 +160,10 @@ func MarshalUserLastSeenNotification(userLastSeenNotification *notificationsv1.U
 		return nil, trace.Wrap(err)
 	}
 
-	cfg, err := CollectOptions(opts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if !cfg.PreserveResourceID {
-		userLastSeenNotification = proto.Clone(userLastSeenNotification).(*notificationsv1.UserLastSeenNotification)
-		//nolint:staticcheck // SA1019. Deprecated, but still needed.
-		userLastSeenNotification.Metadata.Id = 0
-		userLastSeenNotification.Metadata.Revision = ""
-	}
-	data, err := utils.FastMarshal(userLastSeenNotification)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return data, nil
+	return FastMarshalProtoResourceDeprecated(userLastSeenNotification, opts...)
 }
 
 // UnmarshalUserLastSeenNotification unmarshals a UserLastSeenNotification resource from JSON.
 func UnmarshalUserLastSeenNotification(data []byte, opts ...MarshalOption) (*notificationsv1.UserLastSeenNotification, error) {
-	if len(data) == 0 {
-		return nil, trace.BadParameter("missing notification data")
-	}
-	cfg, err := CollectOptions(opts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var obj notificationsv1.UserLastSeenNotification
-	if err = utils.FastUnmarshal(data, &obj); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if cfg.ID != 0 {
-		//nolint:staticcheck // SA1019. Id is deprecated, but still needed.
-		obj.Metadata.Id = cfg.ID
-	}
-	if cfg.Revision != "" {
-		obj.Metadata.Revision = cfg.Revision
-	}
-	if !cfg.Expires.IsZero() {
-		obj.Metadata.Expires = timestamppb.New(cfg.Expires)
-	}
-	return &obj, nil
+	return FastUnmarshalProtoResourceDeprecated[*notificationsv1.UserLastSeenNotification](data, opts...)
 }

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -27,11 +27,15 @@ import (
 
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/protoadapt"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // MarshalConfig specifies marshaling options
@@ -758,16 +762,142 @@ type resetProtoResource interface {
 	SetRevision(string)
 }
 
-// maybeResetProtoResourceID returns a clone of [r] with the identifiers
-// reset to default values if preserveResourceID is true, otherwise
-// this is a nop, and the original value is returned unaltered.
+// maybeResetProtoResourceID returns a clone of [r] with the identifiers reset to default values if
+// preserveResourceID is true, otherwise this is a nop, and the original value is returned unaltered.
+//
+// Prefer maybeResetProtoResourceIDv2 for newer RFD153-style resources, only one or the other should compile
+// for any given type.
 func maybeResetProtoResourceID[T resetProtoResource](preserveResourceID bool, r T) T {
 	if preserveResourceID {
 		return r
 	}
 
-	cp := utils.CloneProtoMsg(r)
+	cp := apiutils.CloneProtoMsg(r)
 	cp.SetResourceID(0)
 	cp.SetRevision("")
 	return cp
+}
+
+// ProtoResource abstracts a resource defined as a protobuf message.
+type ProtoResource interface {
+	proto.Message
+	// GetMetadata returns the generic resource metadata.
+	GetMetadata() *headerv1.Metadata
+}
+
+// ProtoResourcePtr is a ProtoResource that is also a pointer to T.
+type ProtoResourcePtr[T any] interface {
+	*T
+	ProtoResource
+}
+
+// maybeResetProtoResourceIDv2 returns a clone of [r] with the identifiers reset to default values if
+// preserveResourceID is true, otherwise this is a nop, and the original value is returned unaltered.
+//
+// This is like maybeResourceProtoResourceID but made for newer RFD153-style resources which implement a
+// different interface, only one or the other should compile for any given type.
+func maybeResetProtoResourceIDv2[T ProtoResource](preserveResourceID bool, r T) T {
+	if preserveResourceID {
+		return r
+	}
+
+	cp := proto.Clone(r).(T)
+	//nolint:staticcheck // SA1019. Id is deprecated, but still needed.
+	cp.GetMetadata().Id = 0
+	cp.GetMetadata().Revision = ""
+	return cp
+}
+
+// MarshalProtoResource marshals a ProtoResource to JSON using [protojson.Marshal] and respecting [opts].
+func MarshalProtoResource[T ProtoResource](resource T, opts ...MarshalOption) ([]byte, error) {
+	cfg, err := CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	resource = maybeResetProtoResourceIDv2(cfg.PreserveResourceID, resource)
+	data, err := protojson.Marshal(resource)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return data, nil
+}
+
+// UnmarshalProtoResource unmarshals a ProtoResource from JSON using [protojson.Unmarshal] and respecting [opts].
+// It is paramaterized on types T and U, where T is a pointer type that implements ProtoResource, and U is the
+// type that T points to. This is so that it can allocate an instance of U to unmarshal into without
+// reflection.
+func UnmarshalProtoResource[T ProtoResourcePtr[U], U any](data []byte, opts ...MarshalOption) (T, error) {
+	if len(data) == 0 {
+		return nil, trace.BadParameter("nothing to unmarshal")
+	}
+	cfg, err := CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var resource T = new(U)
+	err = protojson.Unmarshal(data, resource)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if cfg.ID != 0 {
+		//nolint:staticcheck // SA1019. Id is deprecated, but still needed.
+		resource.GetMetadata().Id = cfg.ID
+	}
+	if cfg.Revision != "" {
+		resource.GetMetadata().Revision = cfg.Revision
+	}
+	if !cfg.Expires.IsZero() {
+		resource.GetMetadata().Expires = timestamppb.New(cfg.Expires)
+	}
+	return resource, nil
+}
+
+// FastMarshalProtoResourceDeprecated marshals a ProtoResource to JSON using [utils.FastMarshal] and respecting [opts].
+//
+// Deprecated: this should not be used for new types, prefer [MarshalProtoResource]. Existing types should not
+// be converted to maintain compatibility.
+func FastMarshalProtoResourceDeprecated[T ProtoResource](resource T, opts ...MarshalOption) ([]byte, error) {
+	cfg, err := CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	resource = maybeResetProtoResourceIDv2(cfg.PreserveResourceID, resource)
+	data, err := utils.FastMarshal(resource)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return data, nil
+}
+
+// FastUnmarshalProtoResourceDeprecated unmarshals a ProtoResource from JSON using [utils.FastUnmarshal] and respecting [opts].
+// It is paramaterized on types T and U, where T is a pointer type that implements ProtoResource, and U is the
+// type that T points to. This is so that it can allocate an instance of U to unmarshal into without
+// reflection.
+//
+// Deprecated: this should not be used for new types, prefer [UnmarshalProtoResource]. Existing types should not
+// be converted to maintain compatibility.
+func FastUnmarshalProtoResourceDeprecated[T ProtoResourcePtr[U], U any](data []byte, opts ...MarshalOption) (T, error) {
+	if len(data) == 0 {
+		return nil, trace.BadParameter("nothing to unmarshal")
+	}
+	cfg, err := CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var resource T = new(U)
+	err = utils.FastUnmarshal(data, resource)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if cfg.ID != 0 {
+		//nolint:staticcheck // SA1019. Id is deprecated, but still needed.
+		resource.GetMetadata().Id = cfg.ID
+	}
+	if cfg.Revision != "" {
+		resource.GetMetadata().Revision = cfg.Revision
+	}
+	if !cfg.Expires.IsZero() {
+		resource.GetMetadata().Expires = timestamppb.New(cfg.Expires)
+	}
+	return resource, nil
 }

--- a/lib/services/resource_test.go
+++ b/lib/services/resource_test.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
@@ -279,7 +279,7 @@ func TestProtoResourceRoundtrip(t *testing.T) {
 
 			unmarshalled, err := tc.unmarshalFunc(marshaled)
 			require.NoError(t, err)
-			require.Empty(t, cmp.Diff(resource, unmarshalled, cmpopts.IgnoreUnexported(vnet.VnetConfig{}, vnet.VnetConfigSpec{}, headerv1.Metadata{})))
+			require.Empty(t, cmp.Diff(resource, unmarshalled, protocmp.Transform()))
 
 			revision := "123"
 			expires := time.Now()

--- a/lib/services/resource_test.go
+++ b/lib/services/resource_test.go
@@ -20,9 +20,14 @@ package services
 
 import (
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -236,6 +241,56 @@ func Test_setResourceName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := setResourceName(tt.overrideLabels, tt.meta, tt.firstNamePart, tt.extraNameParts...)
 			require.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestProtoResourceRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	resource := &vnet.VnetConfig{
+		Metadata: &headerv1.Metadata{
+			Name: "vnet_config",
+		},
+		Spec: &vnet.VnetConfigSpec{
+			Ipv4CidrRange: "100.64.0.0/10",
+		},
+	}
+
+	for _, tc := range []struct {
+		desc          string
+		marshalFunc   func(*vnet.VnetConfig, ...MarshalOption) ([]byte, error)
+		unmarshalFunc func([]byte, ...MarshalOption) (*vnet.VnetConfig, error)
+	}{
+		{
+			desc:          "deprecated",
+			marshalFunc:   FastMarshalProtoResourceDeprecated[*vnet.VnetConfig],
+			unmarshalFunc: FastUnmarshalProtoResourceDeprecated[*vnet.VnetConfig],
+		},
+		{
+			desc:          "new",
+			marshalFunc:   MarshalProtoResource[*vnet.VnetConfig],
+			unmarshalFunc: UnmarshalProtoResource[*vnet.VnetConfig],
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			marshaled, err := tc.marshalFunc(resource)
+			require.NoError(t, err)
+
+			unmarshalled, err := tc.unmarshalFunc(marshaled)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(resource, unmarshalled, cmpopts.IgnoreUnexported(vnet.VnetConfig{}, vnet.VnetConfigSpec{}, headerv1.Metadata{})))
+
+			revision := "123"
+			expires := time.Now()
+			resourceID := int64(1234)
+			unmarshalled, err = tc.unmarshalFunc(marshaled,
+				WithRevision(revision), WithExpires(expires), WithResourceID(resourceID))
+			require.NoError(t, err)
+			require.Equal(t, revision, unmarshalled.GetMetadata().GetRevision())
+			require.WithinDuration(t, expires, unmarshalled.GetMetadata().GetExpires().AsTime(), time.Millisecond)
+			//nolint:staticcheck // SA1019. Id is deprecated, but still needed.
+			require.Equal(t, resourceID, unmarshalled.GetMetadata().GetId())
 		})
 	}
 }


### PR DESCRIPTION
We have many implementations of resource marshallers and unmarshallers that are basically identical aside from the types. Most developers just find an existing resource and copy whatever it does.

This PR adds new generic marshal and unmarshal functions that should work for all new RFD153-style resources based on protobuf types generated with `buf`. The recommendation  for new types going forward is to use `services.MarshalProtoResource` and `services.UnmarshalProtoResource` for your type.

`services.FastMarshalProtoResourceDeprecated` and `services.FastUnmarshalProtoResourceDeprecated` were also added since 7 of the new types already wrote their (un)marshal functions based on `utils.FastMarshal`, which does not support some protobuf features like `oneof`. If someone takes the time to check if it would be safe to convert these types to the new protojson-based marshaler, they could potentially be converted.

For now in this PR, I am keeping all functionality identical and just refactoring common code into shared functions. The one exception to this is MarshalAccessMonitoringRule which previously just called `utils.FastMarshal` without considering the `MarshalOption`s, it now uses `FastMarshalProtoResourceDeprecated` which does respect the marshal options.