### PR TITLE
Use `Restart=always` for the Teleport systemd service

### DIFF
--- a/examples/systemd/fips/teleport.service
+++ b/examples/systemd/fips/teleport.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config /etc/teleport.yaml --fips --pid-file=/run/teleport.pid

--- a/examples/systemd/production/auth/teleport.service
+++ b/examples/systemd/production/auth/teleport.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 # Set the nodes roles with the `--roles`
 # In most production environments you will not

--- a/examples/systemd/production/node/teleport.service
+++ b/examples/systemd/production/node/teleport.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 # Set the nodes roles with the `--roles`
 # In most production environments you will not

--- a/examples/systemd/production/proxy/teleport.service
+++ b/examples/systemd/production/proxy/teleport.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 # Set the nodes roles with the `--roles`
 # In most production environments you will not

--- a/examples/systemd/teleport.service
+++ b/examples/systemd/teleport.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config /etc/teleport.yaml --pid-file=/run/teleport.pid

--- a/lib/config/systemd.go
+++ b/lib/config/systemd.go
@@ -44,7 +44,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 EnvironmentFile=-{{ .EnvironmentFile }}
 ExecStart={{ .TeleportInstallationFile }} start --config {{ .TeleportConfigPath }} --pid-file={{ .PIDFile }}

--- a/lib/config/testdata/TestWriteSystemdUnitFile.golden
+++ b/lib/config/testdata/TestWriteSystemdUnitFile.golden
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 EnvironmentFile=-/custom/env/dir/teleport
 ExecStart=/custom/install/dir/teleport start --config /etc/teleport.yaml --pid-file=/custom/pid/dir/teleport.pid


### PR DESCRIPTION
The current systemd unit file for Teleport uses `Restart=on-failure`, but we just noticed a race condition that could cause Teleport to get terminated by an unhandled HUP signal, which systemd treats as a "clean" exit state. Seeing as the `teleport` binary will never exit on its own volition except after spawning a brand new `teleport` and checking that it's running, this PR sets the restart behavior to `always` instead.

Of note is that `Restart=always` will not restart the service if it's manually stopped via `systemctl stop` and similar systemd-level controls, only if the process exits "cleanly" (which is a bug).

changelog: ensured that systemd always restarts Teleport on any failure unless explicitly stopped