### PR TITLE
Keep SIGHUP handled while we have a pidfile written

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -842,11 +842,11 @@ func checkServerIdentity(ctx context.Context, conn *Connector, additionalPrincip
 	// certificate need to be updated.
 	if len(additionalPrincipals) != 0 && !conn.ServerIdentity.HasPrincipals(principalsToCheck) {
 		principalsChanged = true
-		logger.DebugContext(ctx, "Rotation in progress, updating SSH principals.", "additional_principals", additionalPrincipals, "current_principals", conn.ServerIdentity.Cert.ValidPrincipals)
+		logger.InfoContext(ctx, "Rotation in progress, updating SSH principals.", "identity", conn.ServerIdentity.ID.Role, "additional_principals", additionalPrincipals, "current_principals", conn.ServerIdentity.Cert.ValidPrincipals)
 	}
 	if len(dnsNames) != 0 && !conn.ServerIdentity.HasDNSNames(dnsNames) {
 		dnsNamesChanged = true
-		logger.DebugContext(ctx, "Rotation in progress, updating DNS names.", "additional_dns_names", dnsNames, "current_dns_names", conn.ServerIdentity.XCert.DNSNames)
+		logger.InfoContext(ctx, "Rotation in progress, updating DNS names.", "identity", conn.ServerIdentity.ID.Role, "additional_dns_names", dnsNames, "current_dns_names", conn.ServerIdentity.XCert.DNSNames)
 	}
 
 	return principalsChanged || dnsNamesChanged

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1300,7 +1300,9 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		// staticcheck complains about unbuffered channels given to
 		// [signal.Notify], and it's technically slightly faster to do a
 		// nonblocking send on a buffered channel that's full (see chansend in
-		// runtime/chan.go)
+		// runtime/chan.go); signal.Notify will never block when sending to a
+		// channel, so a full channel is not harmful to the rest of the signal
+		// handling machinery
 		c := make(chan os.Signal, 1)
 		c <- nil
 		signal.Notify(c, syscall.SIGHUP)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -37,12 +37,14 @@ import (
 	"net/http/httputil"
 	"net/http/pprof"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	awscredentials "github.com/aws/aws-sdk-go/aws/credentials"
@@ -1279,6 +1281,26 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 
 	// create the new pid file only after started successfully
 	if cfg.PIDFile != "" {
+		// The act of writing the pidfile greenlights the act of killing the
+		// process with HUP, which means that the signal handler for HUP must
+		// always be registered; however, there's some time between the
+		// synchronous call to NewTeleport and the call to
+		// (*TeleportProcess).WaitForSignals; in addition, due to in-process
+		// restarts, there's also some time between the termination of the old
+		// call to (*TeleportProcess).WaitForSignals and the new call, and a HUP
+		// while no signal handler is registered will trigger the default HUP
+		// behavior (killing the process). To avoid this, we deliberately leak a
+		// [signals.Notify] call (just like we're leaking the pidfile file
+		// descriptor that holds it locked). This will cause HUPs to be
+		// swallowed but that's better than the process getting killed.
+
+		// TODO(espadolini): get rid of this deliberate leak once in-process
+		// restarts are vanquished and signal management can be made more sane
+
+		//nolint:staticcheck // SA1017: we don't care about the channel being
+		//unbuffered because we're never going to receive from it anyway
+		signal.Notify(make(chan os.Signal), syscall.SIGHUP)
+
 		if err := createLockedPIDFile(cfg.PIDFile); err != nil {
 			return nil, trace.Wrap(err, "creating pidfile")
 		}


### PR DESCRIPTION
This PR makes it so that we establish the appropriate signal handlers outside of individual calls to `WaitForSignals`, so we won't accidentally let SIGHUPs be default-handled (killing the process) during in-process restarts and in the very short period of time during Teleport startup between the creation of a `*TeleportProcess` (and thus a pidfile) and the signal handler being established.

This can be occasionally triggered by the `teleport-upgrader` if Teleport is restarted as part of the package installation and then reloaded during an early in-process restart triggered by a principals change.

This PR also increases the verbosity in `checkServerIdentity`, which should help diagnose why principals might've changed.

changelog: fix a race condition triggered by a reload during the early phases of Teleport startup