### PR TITLE
[v13] Use `Restart=always` for the Teleport systemd service

### DIFF
--- a/examples/systemd/fips/teleport.service
+++ b/examples/systemd/fips/teleport.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --fips --pid-file=/run/teleport.pid

--- a/examples/systemd/production/auth/teleport.service
+++ b/examples/systemd/production/auth/teleport.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 # Set the nodes roles with the `--roles`
 # In most production environments you will not

--- a/examples/systemd/production/node/teleport.service
+++ b/examples/systemd/production/node/teleport.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 # Set the nodes roles with the `--roles`
 # In most production environments you will not

--- a/examples/systemd/production/proxy/teleport.service
+++ b/examples/systemd/production/proxy/teleport.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 # Set the nodes roles with the `--roles`
 # In most production environments you will not

--- a/examples/systemd/teleport.service
+++ b/examples/systemd/teleport.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --pid-file=/run/teleport.pid

--- a/lib/config/systemd.go
+++ b/lib/config/systemd.go
@@ -38,7 +38,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 EnvironmentFile=-{{ .EnvironmentFile }}
 ExecStart={{ .TeleportInstallationFile }} start --pid-file={{ .PIDFile }}

--- a/lib/config/testdata/TestWriteSystemdUnitFile.golden
+++ b/lib/config/testdata/TestWriteSystemdUnitFile.golden
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartSec=5
 EnvironmentFile=-/custom/env/dir/teleport
 ExecStart=/custom/install/dir/teleport start --pid-file=/custom/pid/dir/teleport.pid


### PR DESCRIPTION
Backport #41564 to branch/v13

changelog: ensured that systemd always restarts Teleport on any failure unless explicitly stopped
