### PR TITLE
ensure kube watcher writes and flushes are sequential

### DIFF
--- a/lib/kube/proxy/responsewriters/watcher.go
+++ b/lib/kube/proxy/responsewriters/watcher.go
@@ -54,6 +54,8 @@ const (
 // If the user is not allowed, the event is ignored.
 // If allowed, the event is encoded into the user's response.
 type WatcherResponseWriter struct {
+	// mtx protects target and ensures writes happen sequentially.
+	mtx sync.Mutex
 	// target is the user response writer.
 	// everything written will be received by the user.
 	target http.ResponseWriter
@@ -196,6 +198,13 @@ func (w *WatcherResponseWriter) Close() error {
 
 // Flush flushes the response into the target and returns.
 func (w *WatcherResponseWriter) Flush() {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+
+	w.flushUnlocked()
+}
+
+func (w *WatcherResponseWriter) flushUnlocked() {
 	if flusher, ok := w.target.(http.Flusher); ok {
 		flusher.Flush()
 	}
@@ -244,10 +253,9 @@ func (w *WatcherResponseWriter) watchDecoder(contentType string, writer io.Write
 
 	// watchEncoderGuard prevents multiple sources to push events at the same time.
 	// only one source is able to push and flush events to ensure proper json formatting.
-	var watchEncoderGuard sync.Mutex
 	writeEventAndFlush := func(evt *watch.Event) error {
-		watchEncoderGuard.Lock()
-		defer watchEncoderGuard.Unlock()
+		w.mtx.Lock()
+		defer w.mtx.Unlock()
 		// encode the event into the target connection.
 		if err := watchEncoder.Encode(evt); err != nil {
 			return trace.Wrap(err)
@@ -263,7 +271,7 @@ func (w *WatcherResponseWriter) watchDecoder(contentType string, writer io.Write
 		// an abort.
 		// To avoid this, we flush the response after each event to ensure that
 		// the user receives the event as a chunk.
-		w.Flush()
+		w.flushUnlocked()
 		return nil
 	}
 

--- a/lib/kube/proxy/responsewriters/watcher.go
+++ b/lib/kube/proxy/responsewriters/watcher.go
@@ -201,10 +201,10 @@ func (w *WatcherResponseWriter) Flush() {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
 
-	w.flushUnlocked()
+	w.flushLocked()
 }
 
-func (w *WatcherResponseWriter) flushUnlocked() {
+func (w *WatcherResponseWriter) flushLocked() {
 	if flusher, ok := w.target.(http.Flusher); ok {
 		flusher.Flush()
 	}
@@ -271,7 +271,7 @@ func (w *WatcherResponseWriter) watchDecoder(contentType string, writer io.Write
 		// an abort.
 		// To avoid this, we flush the response after each event to ensure that
 		// the user receives the event as a chunk.
-		w.flushUnlocked()
+		w.flushLocked()
 		return nil
 	}
 


### PR DESCRIPTION
Fixes a race found in https://github.com/gravitational/teleport/issues/40969. Prometheus metrics that are written to the `WatcherResponseWriter` sometimes raced with writes from the `WatcherResponseWriter` itself.

Updates https://github.com/gravitational/teleport/issues/40969.

changelog: ensure responses to Kubernetes watch requests are written sequentially