### PR TITLE
Remove denied AWS Roles in AWS Role Web picker

### DIFF
--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -774,6 +774,8 @@ func (a *accessChecker) GetAllowedLoginsForResource(resource AccessCheckable) ([
 	// true otherwise.
 	mapped := make(map[string]bool)
 
+	resourceAsApp, resourceIsApp := resource.(interface{ IsAWSConsole() bool })
+
 	for _, role := range a.RoleSet {
 		var loginGetter func(types.RoleConditionType) []string
 
@@ -782,6 +784,12 @@ func (a *accessChecker) GetAllowedLoginsForResource(resource AccessCheckable) ([
 			loginGetter = role.GetLogins
 		case types.KindWindowsDesktop:
 			loginGetter = role.GetWindowsLogins
+		case types.KindApp:
+			if !resourceIsApp || !resourceAsApp.IsAWSConsole() {
+				return nil, trace.BadParameter("received unsupported resource type for Application kind: %T", resource)
+			}
+
+			loginGetter = role.GetAWSRoleARNs
 		default:
 			return nil, trace.BadParameter("received unsupported resource kind: %s", resource.GetKind())
 		}
@@ -812,6 +820,12 @@ func (a *accessChecker) GetAllowedLoginsForResource(resource AccessCheckable) ([
 		newLoginMatcher = NewLoginMatcher
 	case types.KindWindowsDesktop:
 		newLoginMatcher = NewWindowsLoginMatcher
+	case types.KindApp:
+		if !resourceIsApp || !resourceAsApp.IsAWSConsole() {
+			return nil, trace.BadParameter("received unsupported resource type for Application: %T", resource)
+		}
+
+		newLoginMatcher = NewAppAWSLoginMatcher
 	default:
 		return nil, trace.BadParameter("received unsupported resource kind: %s", resource.GetKind())
 	}

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -785,8 +785,12 @@ func (a *accessChecker) GetAllowedLoginsForResource(resource AccessCheckable) ([
 		case types.KindWindowsDesktop:
 			loginGetter = role.GetWindowsLogins
 		case types.KindApp:
-			if !resourceIsApp || !resourceAsApp.IsAWSConsole() {
+			if !resourceIsApp {
 				return nil, trace.BadParameter("received unsupported resource type for Application kind: %T", resource)
+			}
+			// For Apps, only AWS currently supports listing the possible logins.
+			if !resourceAsApp.IsAWSConsole() {
+				return []string{}, nil
 			}
 
 			loginGetter = role.GetAWSRoleARNs

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -790,7 +790,7 @@ func (a *accessChecker) GetAllowedLoginsForResource(resource AccessCheckable) ([
 			}
 			// For Apps, only AWS currently supports listing the possible logins.
 			if !resourceAsApp.IsAWSConsole() {
-				return []string{}, nil
+				return nil, nil
 			}
 
 			loginGetter = role.GetAWSRoleARNs

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2294,6 +2294,27 @@ func (l *windowsLoginMatcher) Match(role types.Role, typ types.RoleConditionType
 	return false, nil
 }
 
+type awsAppLoginMatcher struct {
+	awsRole string
+}
+
+// NewAppAWSLoginMatcher creates a RoleMatcher that checks whether the role's
+// AWS Role ARN match the specified condition.
+func NewAppAWSLoginMatcher(awsRole string) RoleMatcher {
+	return &awsAppLoginMatcher{awsRole: awsRole}
+}
+
+// Match matches an AWS Role ARN login against a role.
+func (l *awsAppLoginMatcher) Match(role types.Role, typ types.RoleConditionType) (bool, error) {
+	awsRoles := role.GetAWSRoleARNs(typ)
+	for _, awsRole := range awsRoles {
+		if l.awsRole == awsRole {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 type kubernetesClusterLabelMatcher struct {
 	clusterLabels map[string]string
 	userTraits    wrappers.Traits

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -4110,15 +4110,19 @@ func TestGetAllowedLoginsForResource(t *testing.T) {
 					Namespaces:           []string{apidefaults.Namespace},
 					Logins:               allowLogins,
 					WindowsDesktopLogins: allowLogins,
+					AWSRoleARNs:          allowLogins,
 					NodeLabels:           allowLabels,
 					WindowsDesktopLabels: allowLabels,
+					AppLabels:            allowLabels,
 				},
 				Deny: types.RoleConditions{
 					Namespaces:           []string{apidefaults.Namespace},
 					Logins:               denyLogins,
 					WindowsDesktopLogins: denyLogins,
+					AWSRoleARNs:          denyLogins,
 					NodeLabels:           denyLabels,
 					WindowsDesktopLabels: denyLabels,
+					AppLabels:            denyLabels,
 				},
 			},
 		}
@@ -4286,14 +4290,18 @@ func TestGetAllowedLoginsForResource(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			server := mustMakeTestServer(tc.labels)
 			desktop := mustMakeTestWindowsDesktop(tc.labels)
+			app := mustMakeTestAWSApp(tc.labels)
 
 			serverLogins, err := accessChecker.GetAllowedLoginsForResource(server)
 			require.NoError(t, err)
 			desktopLogins, err := accessChecker.GetAllowedLoginsForResource(desktop)
 			require.NoError(t, err)
+			awsARNLogins, err := accessChecker.GetAllowedLoginsForResource(app)
+			require.NoError(t, err)
 
 			require.ElementsMatch(t, tc.expectedLogins, serverLogins)
 			require.ElementsMatch(t, tc.expectedLogins, desktopLogins)
+			require.ElementsMatch(t, tc.expectedLogins, awsARNLogins)
 		})
 	}
 }
@@ -4314,6 +4322,22 @@ func mustMakeTestWindowsDesktop(labels map[string]string) types.WindowsDesktop {
 		panic(err)
 	}
 	return d
+}
+
+func mustMakeTestAWSApp(labels map[string]string) types.Application {
+	app, err := types.NewAppV3(types.Metadata{
+		Name:   "my-app",
+		Labels: labels,
+	},
+		types.AppSpecV3{
+			URI:   "https://some-addr.com",
+			Cloud: "AWS",
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+	return app
 }
 
 func TestCheckDatabaseRoles(t *testing.T) {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1304,6 +1304,26 @@ func TestUnifiedResourcesGet(t *testing.T) {
 	_, err = env.server.Auth().UpsertApplicationServer(context.Background(), awsAppServer)
 	require.NoError(t, err)
 
+	app, err := types.NewAppV3(
+		types.Metadata{
+			Name: "my-app",
+			Labels: map[string]string{
+				"env": "prod",
+			},
+		},
+		types.AppSpecV3{
+			URI: "localhost:8080",
+		})
+	require.NoError(t, err)
+	appServer, err := types.NewAppServerV3FromApp(
+		app,
+		"localhost",
+		"host-id",
+	)
+	require.NoError(t, err)
+	_, err = env.server.Auth().UpsertApplicationServer(context.Background(), appServer)
+	require.NoError(t, err)
+
 	// Add nodes
 	for i := 0; i < 20; i++ {
 		name := fmt.Sprintf("server-%d", i)
@@ -1356,7 +1376,8 @@ func TestUnifiedResourcesGet(t *testing.T) {
 	res := clusterNodesGetResponse{}
 	require.NoError(t, json.Unmarshal(re.Bytes(), &res))
 	require.Equal(t, types.KindApp, res.Items[0].Kind)
-	require.Equal(t, types.KindDatabase, res.Items[1].Kind)
+	require.Equal(t, types.KindApp, res.Items[1].Kind)
+	require.Equal(t, types.KindDatabase, res.Items[2].Kind)
 
 	// test sort type desc
 	query = url.Values{"sort": []string{"kind:desc"}}
@@ -1395,10 +1416,10 @@ func TestUnifiedResourcesGet(t *testing.T) {
 	require.NoError(t, err)
 	res = clusterNodesGetResponse{}
 	require.NoError(t, json.Unmarshal(re.Bytes(), &res))
-	require.Len(t, res.Items, 9)
+	require.Len(t, res.Items, 10)
 	require.Equal(t, "", res.StartKey)
 
-	// Inly list valid AWS Roles for AWS Apps are listed
+	// Only list valid AWS Roles for AWS Apps
 	query = url.Values{
 		"search": []string{"my-aws-app"},
 		"sort":   []string{"name"},

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -136,6 +136,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	utilsaws "github.com/gravitational/teleport/lib/utils/aws"
 	websession "github.com/gravitational/teleport/lib/web/session"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
@@ -1260,7 +1261,48 @@ func TestUnifiedResourcesGet(t *testing.T) {
 	t.Parallel()
 	env := newWebPack(t, 1)
 	proxy := env.proxies[0]
-	pack := proxy.authPack(t, "test-user@example.com", nil)
+	username := "test-user@example.com"
+
+	u, err := user.Current()
+	require.NoError(t, err)
+	loginUser := u.Username
+
+	role := defaultRoleForNewUser(&types.UserV2{Metadata: types.Metadata{Name: username}}, loginUser)
+	role.SetAWSRoleARNs(types.Allow, []string{"arn:aws:iam::999999999999:role/ProdInstance"})
+	role.SetAppLabels(types.Allow, types.Labels{"env": []string{"prod"}})
+
+	// This role is used to test that DevInstance AWS Role is only available to AppServices that have env:dev label.
+	roleForDev, err := types.NewRole("dev-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AWSRoleARNs: []string{"arn:aws:iam::999999999999:role/DevInstance"},
+			AppLabels:   types.Labels{"env": []string{"dev"}},
+		},
+	})
+	require.NoError(t, err)
+
+	pack := proxy.authPack(t, username, []types.Role{role, roleForDev})
+
+	// add aws AppServer
+	awsApp, err := types.NewAppV3(
+		types.Metadata{
+			Name: "my-aws-app",
+			Labels: map[string]string{
+				"env": "prod",
+			},
+		},
+		types.AppSpecV3{
+			URI:   "localhost:8080",
+			Cloud: "AWS",
+		})
+	require.NoError(t, err)
+	awsAppServer, err := types.NewAppServerV3FromApp(
+		awsApp,
+		"localhost",
+		"host-id",
+	)
+	require.NoError(t, err)
+	_, err = env.server.Auth().UpsertApplicationServer(context.Background(), awsAppServer)
+	require.NoError(t, err)
 
 	// Add nodes
 	for i := 0; i < 20; i++ {
@@ -1313,7 +1355,8 @@ func TestUnifiedResourcesGet(t *testing.T) {
 	require.NoError(t, err)
 	res := clusterNodesGetResponse{}
 	require.NoError(t, json.Unmarshal(re.Bytes(), &res))
-	require.Equal(t, types.KindDatabase, res.Items[0].Kind)
+	require.Equal(t, types.KindApp, res.Items[0].Kind)
+	require.Equal(t, types.KindDatabase, res.Items[1].Kind)
 
 	// test sort type desc
 	query = url.Values{"sort": []string{"kind:desc"}}
@@ -1352,8 +1395,26 @@ func TestUnifiedResourcesGet(t *testing.T) {
 	require.NoError(t, err)
 	res = clusterNodesGetResponse{}
 	require.NoError(t, json.Unmarshal(re.Bytes(), &res))
-	require.Len(t, res.Items, 8)
+	require.Len(t, res.Items, 9)
 	require.Equal(t, "", res.StartKey)
+
+	// Inly list valid AWS Roles for AWS Apps are listed
+	query = url.Values{
+		"search": []string{"my-aws-app"},
+		"sort":   []string{"name"},
+	}
+	re, err = pack.clt.Get(context.Background(), endpoint, query)
+	require.NoError(t, err)
+	listResp := struct {
+		Items []ui.App `json:"Items"`
+	}{}
+	require.NoError(t, json.Unmarshal(re.Bytes(), &listResp))
+	require.Len(t, listResp.Items, 1)
+	expectedRoles := []utilsaws.Role{
+		{Name: "ProdInstance", Display: "ProdInstance", ARN: "arn:aws:iam::999999999999:role/ProdInstance", AccountID: "999999999999"},
+	}
+	require.Equal(t, expectedRoles, listResp.Items[0].AWSRoles)
+	t.Log(string(re.Bytes()), listResp)
 }
 
 type clusterAlertsGetResponse struct {

--- a/lib/web/ui/app.go
+++ b/lib/web/ui/app.go
@@ -24,7 +24,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/aws"
 )
@@ -81,8 +80,9 @@ type MakeAppsConfig struct {
 	AppsToUserGroups map[string]types.UserGroups
 	// AppServersAndSAMLIdPServiceProviders is a list of AppServers and SAMLIdPServiceProviders.
 	AppServersAndSAMLIdPServiceProviders types.AppServersOrSAMLIdPServiceProviders
-	// Identity is identity of the logged in user.
-	Identity *tlsca.Identity
+	// AllowedAWSRolesLookup is a map of AWS IAM Role ARNs available to each App for the logged user.
+	// Only used for AWS Console Apps.
+	AllowedAWSRolesLookup map[string][]string
 	// UserGroupLookup is a map of user groups to provide to each App
 	UserGroupLookup map[string]types.UserGroup
 	// Logger is a logger used for debugging while making an app
@@ -138,7 +138,8 @@ func MakeApp(app types.Application, c MakeAppsConfig) App {
 	}
 
 	if app.IsAWSConsole() {
-		resultApp.AWSRoles = aws.FilterAWSRoles(c.Identity.AWSRoleARNs,
+		allowedAWSRoles := c.AllowedAWSRolesLookup[app.GetName()]
+		resultApp.AWSRoles = aws.FilterAWSRoles(allowedAWSRoles,
 			app.GetAWSAccountID())
 	}
 
@@ -199,7 +200,8 @@ func MakeApps(c MakeAppsConfig) []App {
 			}
 
 			if app.IsAWSConsole() {
-				resultApp.AWSRoles = aws.FilterAWSRoles(c.Identity.AWSRoleARNs,
+				allowedAWSRoles := c.AllowedAWSRolesLookup[app.GetName()]
+				resultApp.AWSRoles = aws.FilterAWSRoles(allowedAWSRoles,
 					app.GetAWSAccountID())
 			}
 


### PR DESCRIPTION
This PR uses the accessChecker to remove AWS Roles which users don't have access to.

Previously, all the AWS Roles that the user had access to would be listed.
After this change, only the AWS Roles actually available to the user will be displayed.

changelog: Remove invalid AWS Roles from Web UI picker

See https://github.com/gravitational/teleport/issues/41499 for more details

Fixes: https://github.com/gravitational/teleport/issues/41499