### PR TITLE
[v15] Keep SIGHUP handled while we have a pidfile written

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -842,11 +842,11 @@ func checkServerIdentity(ctx context.Context, conn *Connector, additionalPrincip
 	// certificate need to be updated.
 	if len(additionalPrincipals) != 0 && !conn.ServerIdentity.HasPrincipals(principalsToCheck) {
 		principalsChanged = true
-		logger.DebugContext(ctx, "Rotation in progress, updating SSH principals.", "additional_principals", additionalPrincipals, "current_principals", conn.ServerIdentity.Cert.ValidPrincipals)
+		logger.InfoContext(ctx, "Rotation in progress, updating SSH principals.", "identity", conn.ServerIdentity.ID.Role, "additional_principals", additionalPrincipals, "current_principals", conn.ServerIdentity.Cert.ValidPrincipals)
 	}
 	if len(dnsNames) != 0 && !conn.ServerIdentity.HasDNSNames(dnsNames) {
 		dnsNamesChanged = true
-		logger.DebugContext(ctx, "Rotation in progress, updating DNS names.", "additional_dns_names", dnsNames, "current_dns_names", conn.ServerIdentity.XCert.DNSNames)
+		logger.InfoContext(ctx, "Rotation in progress, updating DNS names.", "identity", conn.ServerIdentity.ID.Role, "additional_dns_names", dnsNames, "current_dns_names", conn.ServerIdentity.XCert.DNSNames)
 	}
 
 	return principalsChanged || dnsNamesChanged

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1291,7 +1291,9 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		// staticcheck complains about unbuffered channels given to
 		// [signal.Notify], and it's technically slightly faster to do a
 		// nonblocking send on a buffered channel that's full (see chansend in
-		// runtime/chan.go)
+		// runtime/chan.go); signal.Notify will never block when sending to a
+		// channel, so a full channel is not harmful to the rest of the signal
+		// handling machinery
 		c := make(chan os.Signal, 1)
 		c <- nil
 		signal.Notify(c, syscall.SIGHUP)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1288,9 +1288,13 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		// TODO(espadolini): get rid of this deliberate leak once in-process
 		// restarts are vanquished and signal management can be made more sane
 
-		//nolint:staticcheck // SA1017: we don't care about the channel being
-		//unbuffered because we're never going to receive from it anyway
-		signal.Notify(make(chan os.Signal), syscall.SIGHUP)
+		// staticcheck complains about unbuffered channels given to
+		// [signal.Notify], and it's technically slightly faster to do a
+		// nonblocking send on a buffered channel that's full (see chansend in
+		// runtime/chan.go)
+		c := make(chan os.Signal, 1)
+		c <- nil
+		signal.Notify(c, syscall.SIGHUP)
 
 		if err := createLockedPIDFile(cfg.PIDFile); err != nil {
 			return nil, trace.Wrap(err, "creating pidfile")

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -44,7 +44,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	awscredentials "github.com/aws/aws-sdk-go/aws/credentials"
@@ -676,7 +675,7 @@ type Process interface {
 	// Start starts the process in a non-blocking way
 	Start() error
 	// WaitForSignals waits for and handles system process signals.
-	WaitForSignals(context.Context) error
+	WaitForSignals(context.Context, <-chan os.Signal) error
 	// ExportFileDescriptors exports service listeners
 	// file descriptors used by the process.
 	ExportFileDescriptors() ([]*servicecfg.FileDescriptor, error)
@@ -704,6 +703,12 @@ func newTeleportProcess(cfg *servicecfg.Config) (Process, error) {
 // Run starts teleport processes, waits for signals
 // and handles internal process reloads.
 func Run(ctx context.Context, cfg servicecfg.Config, newTeleport NewProcess) error {
+	sigC := make(chan os.Signal, 1024)
+	// this should happen before the very first newTeleport, as that's the point
+	// where we MUST handle all the relevant OS signals
+	signal.Notify(sigC, teleportSignals...)
+	defer signal.Stop(sigC)
+
 	if newTeleport == nil {
 		newTeleport = newTeleportProcess
 	}
@@ -720,7 +725,7 @@ func Run(ctx context.Context, cfg servicecfg.Config, newTeleport NewProcess) err
 	}
 	// Wait and reload until called exit.
 	for {
-		srv, err = waitAndReload(ctx, cfg, srv, newTeleport)
+		srv, err = waitAndReload(ctx, sigC, cfg, srv, newTeleport)
 		if err != nil {
 			// This error means that was a clean shutdown
 			// and no reload is necessary.
@@ -732,8 +737,8 @@ func Run(ctx context.Context, cfg servicecfg.Config, newTeleport NewProcess) err
 	}
 }
 
-func waitAndReload(ctx context.Context, cfg servicecfg.Config, srv Process, newTeleport NewProcess) (Process, error) {
-	err := srv.WaitForSignals(ctx)
+func waitAndReload(ctx context.Context, sigC <-chan os.Signal, cfg servicecfg.Config, srv Process, newTeleport NewProcess) (Process, error) {
+	err := srv.WaitForSignals(ctx, sigC)
 	if err == nil {
 		return nil, ErrTeleportExited
 	}
@@ -1272,32 +1277,6 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 
 	// create the new pid file only after started successfully
 	if cfg.PIDFile != "" {
-		// The act of writing the pidfile greenlights the act of killing the
-		// process with HUP, which means that the signal handler for HUP must
-		// always be registered; however, there's some time between the
-		// synchronous call to NewTeleport and the call to
-		// (*TeleportProcess).WaitForSignals; in addition, due to in-process
-		// restarts, there's also some time between the termination of the old
-		// call to (*TeleportProcess).WaitForSignals and the new call, and a HUP
-		// while no signal handler is registered will trigger the default HUP
-		// behavior (killing the process). To avoid this, we deliberately leak a
-		// [signals.Notify] call (just like we're leaking the pidfile file
-		// descriptor that holds it locked). This will cause HUPs to be
-		// swallowed but that's better than the process getting killed.
-
-		// TODO(espadolini): get rid of this deliberate leak once in-process
-		// restarts are vanquished and signal management can be made more sane
-
-		// staticcheck complains about unbuffered channels given to
-		// [signal.Notify], and it's technically slightly faster to do a
-		// nonblocking send on a buffered channel that's full (see chansend in
-		// runtime/chan.go); signal.Notify will never block when sending to a
-		// channel, so a full channel is not harmful to the rest of the signal
-		// handling machinery
-		c := make(chan os.Signal, 1)
-		c <- nil
-		signal.Notify(c, syscall.SIGHUP)
-
 		if err := createLockedPIDFile(cfg.PIDFile); err != nil {
 			return nil, trace.Wrap(err, "creating pidfile")
 		}


### PR DESCRIPTION
Backport #41567 to branch/v15

changelog: fix a race condition triggered by a reload during the early phases of Teleport startup
