### PR TITLE
Docs: prefer v3 for teleport.yaml config examples

### DIFF
--- a/docs/pages/auto-discovery/servers/azure-discovery.mdx
+++ b/docs/pages/auto-discovery/servers/azure-discovery.mdx
@@ -236,13 +236,12 @@ In order to enable Azure instance discovery the `discovery_service.azure` sectio
 of `teleport.yaml` must include at least one entry:
 
 ```yaml
-version: v2
+version: v3
 teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  auth_servers:
-  - "teleport.example.com:3080"
+  proxy_server: "<Var name="teleport.example.com" />:443"
 auth_service:
   enabled: off
 proxy_service:

--- a/docs/pages/auto-discovery/servers/ec2-discovery.mdx
+++ b/docs/pages/auto-discovery/servers/ec2-discovery.mdx
@@ -119,13 +119,12 @@ In order to enable EC2 instance discovery the `discovery_service.aws` section
 of `teleport.yaml` must include at least one entry:
 
 ```yaml
-version: v2
+version: v3
 teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  auth_servers:
-  - "teleport.example.com:3080"
+  proxy_server: "<Var name="teleport.example.com" />:443"
 auth_service:
   enabled: off
 proxy_service:


### PR DESCRIPTION
Aligned with GCP Discovery docs

Related: https://github.com/gravitational/teleport/issues/31180