### PR TITLE
Don't use unavailable identity verification methods when adding MFAs

### DIFF
--- a/web/packages/teleport/src/Account/Account.tsx
+++ b/web/packages/teleport/src/Account/Account.tsx
@@ -283,6 +283,7 @@ export function Account({
           usage={newDeviceUsage}
           auth2faType={cfg.getAuth2faType()}
           privilegeToken={token}
+          devices={devices}
           onClose={closeAddDeviceWizard}
           onSuccess={onAddDeviceSuccess}
         />

--- a/web/packages/teleport/src/Account/ManageDevices/AddAuthDeviceWizard/AddAuthDeviceWizard.story.tsx
+++ b/web/packages/teleport/src/Account/ManageDevices/AddAuthDeviceWizard/AddAuthDeviceWizard.story.tsx
@@ -33,6 +33,7 @@ import { ContextProvider } from 'teleport/index';
 import cfg from 'teleport/config';
 
 import {
+  AddAuthDeviceWizardStepProps,
   CreateDeviceStep,
   ReauthenticateStep,
   SaveDeviceStep,
@@ -59,6 +60,29 @@ initialize();
 
 export function Reauthenticate() {
   return <ReauthenticateStep {...stepProps} />;
+}
+
+export function ReauthenticateLimitedOptions() {
+  return (
+    <ReauthenticateStep
+      {...stepProps}
+      devices={[
+        {
+          id: '1',
+          description: 'Authenticator App',
+          name: 'gizmo',
+          registeredDate: new Date(1628799417000),
+          lastUsedDate: new Date(1628799417000),
+          type: 'totp',
+          usage: 'mfa',
+        },
+      ]}
+    />
+  );
+}
+
+export function ReauthenticateNoOptions() {
+  return <ReauthenticateStep {...stepProps} devices={[]} />;
 }
 
 export function CreatePasskey() {
@@ -130,7 +154,7 @@ export function SaveMfaAuthenticatorApp() {
   return <SaveDeviceStep {...stepProps} usage="mfa" newMfaDeviceType="otp" />;
 }
 
-const stepProps = {
+const stepProps: AddAuthDeviceWizardStepProps = {
   // StepComponentProps
   next: () => {},
   prev: () => {},
@@ -142,13 +166,32 @@ const stepProps = {
   // Other props
   privilegeToken: 'privilege-token',
   usage: 'passwordless' as DeviceUsage,
-  auth2faType: 'optional' as Auth2faType,
+  auth2faType: 'on' as Auth2faType,
   credential: { id: 'cred-id', type: 'public-key' },
   newMfaDeviceType: 'webauthn' as Auth2faType,
+  devices: [
+    {
+      id: '1',
+      description: 'Authenticator App',
+      name: 'gizmo',
+      registeredDate: new Date(1628799417000),
+      lastUsedDate: new Date(1628799417000),
+      type: 'totp',
+      usage: 'mfa',
+    },
+    {
+      id: '2',
+      description: 'Hardware Key',
+      name: 'key',
+      registeredDate: new Date(1623722252000),
+      lastUsedDate: new Date(1623981452000),
+      type: 'webauthn',
+      usage: 'mfa',
+    },
+  ],
   onNewMfaDeviceTypeChange: () => {},
   onDeviceCreated: () => {},
   onAuthenticated: () => {},
   onClose: () => {},
-  onPasskeyCreated: () => {},
   onSuccess: () => {},
 };

--- a/web/packages/teleport/src/Account/ManageDevices/AddAuthDeviceWizard/AddAuthDeviceWizard.test.tsx
+++ b/web/packages/teleport/src/Account/ManageDevices/AddAuthDeviceWizard/AddAuthDeviceWizard.test.tsx
@@ -25,7 +25,12 @@ import { userEvent, UserEvent } from '@testing-library/user-event';
 import TeleportContext from 'teleport/teleportContext';
 import { ContextProvider } from 'teleport';
 import MfaService from 'teleport/services/mfa';
-import auth, { DeviceUsage } from 'teleport/services/auth';
+import auth from 'teleport/services/auth';
+
+import {
+  AddAuthDeviceWizardStepProps,
+  createReauthOptions,
+} from './AddAuthDeviceWizard';
 
 import { AddAuthDeviceWizard } from '.';
 
@@ -33,6 +38,24 @@ const dummyCredential: Credential = { id: 'cred-id', type: 'public-key' };
 let ctx: TeleportContext;
 let user: UserEvent;
 let onSuccess: jest.Mock;
+
+function twice(arr) {
+  return [...arr, ...arr];
+}
+
+// Repeat devices twice to make sure we support multiple devices of the same
+// type and purpose.
+const deviceCases = {
+  all: twice([
+    { type: 'totp', usage: 'mfa' },
+    { type: 'webauthn', usage: 'mfa' },
+    { type: 'webauthn', usage: 'passwordless' },
+  ]),
+  authApps: twice([{ type: 'totp', usage: 'mfa' }]),
+  mfaDevices: twice([{ type: 'webauthn', usage: 'mfa' }]),
+  passkeys: twice([{ type: 'webauthn', usage: 'passwordless' }]),
+  none: [],
+};
 
 beforeEach(() => {
   ctx = new TeleportContext();
@@ -64,21 +87,16 @@ beforeEach(() => {
 
 afterEach(jest.resetAllMocks);
 
-function TestWizard({
-  privilegeToken,
-  usage,
-}: {
-  privilegeToken?: string;
-  usage: DeviceUsage;
-}) {
+function TestWizard(props: Partial<AddAuthDeviceWizardStepProps> = {}) {
   return (
     <ContextProvider ctx={ctx}>
       <AddAuthDeviceWizard
-        usage={usage}
+        usage="passwordless"
         auth2faType="optional"
-        privilegeToken={privilegeToken}
+        devices={deviceCases.all}
         onClose={() => {}}
         onSuccess={onSuccess}
+        {...props}
       />
     </ContextProvider>
   );
@@ -243,4 +261,80 @@ describe('flow with reauthentication', () => {
     });
     expect(onSuccess).toHaveBeenCalled();
   });
+
+  test('shows all authentication options', async () => {
+    render(
+      <TestWizard usage="mfa" auth2faType="on" devices={deviceCases.all} />
+    );
+
+    const reauthenticateStep = within(
+      screen.getByTestId('reauthenticate-step')
+    );
+    expect(
+      reauthenticateStep.queryByLabelText(/passkey or security key/i)
+    ).toBeVisible();
+    expect(
+      reauthenticateStep.queryByLabelText(/authenticator app/i)
+    ).toBeVisible();
+  });
+
+  test('limits authentication options to devices owned', async () => {
+    render(
+      <TestWizard usage="mfa" auth2faType="on" devices={deviceCases.authApps} />
+    );
+
+    const reauthenticateStep = within(
+      screen.getByTestId('reauthenticate-step')
+    );
+    expect(
+      reauthenticateStep.queryByLabelText(/passkey or security key/i)
+    ).not.toBeInTheDocument();
+    expect(
+      reauthenticateStep.queryByLabelText(/authenticator app/i)
+    ).toBeVisible();
+  });
+
+  test.each`
+    auth2faType   | deviceCase      | error
+    ${'otp'}      | ${'mfaDevices'} | ${/authenticator app is required/i}
+    ${'webauthn'} | ${'authApps'}   | ${/passkey or security key is required/i}
+    ${'on'}       | ${'none'}       | ${/identity verification is required/i}
+  `(
+    'shows an error if no way to authenticate for MFA type "$auth2faType"',
+    async ({ auth2faType, deviceCase, error }) => {
+      render(
+        <TestWizard
+          usage="mfa"
+          auth2faType={auth2faType}
+          devices={deviceCases[deviceCase]}
+        />
+      );
+
+      expect(screen.getByText(error)).toBeVisible();
+    }
+  );
 });
+
+test.each`
+  auth2faType   | deviceCase      | methods
+  ${'otp'}      | ${'all'}        | ${['otp']}
+  ${'off'}      | ${'all'}        | ${[]}
+  ${'optional'} | ${'all'}        | ${['webauthn', 'otp']}
+  ${'on'}       | ${'all'}        | ${['webauthn', 'otp']}
+  ${'webauthn'} | ${'all'}        | ${['webauthn']}
+  ${'optional'} | ${'authApps'}   | ${['otp']}
+  ${'optional'} | ${'mfaDevices'} | ${['webauthn']}
+  ${'optional'} | ${'passkeys'}   | ${['webauthn']}
+  ${'on'}       | ${'none'}       | ${[]}
+  ${'webauthn'} | ${'authApps'}   | ${[]}
+  ${'otp'}      | ${'mfaDevices'} | ${[]}
+`(
+  'createReauthOptions: auth2faType=$auth2faType, devices=$deviceCase',
+  ({ auth2faType, methods, deviceCase }) => {
+    const devices = deviceCases[deviceCase];
+    const reauthMethods = createReauthOptions(auth2faType, devices).map(
+      o => o.value
+    );
+    expect(reauthMethods).toEqual(methods);
+  }
+);

--- a/web/packages/teleport/src/Account/ManageDevices/AddAuthDeviceWizard/AddAuthDeviceWizard.tsx
+++ b/web/packages/teleport/src/Account/ManageDevices/AddAuthDeviceWizard/AddAuthDeviceWizard.tsx
@@ -30,7 +30,7 @@ import FieldInput from 'shared/components/FieldInput';
 import Validation, { Validator } from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
 import { useAsync } from 'shared/hooks/useAsync';
-import useAttempt from 'shared/hooks/useAttemptNext';
+import useAttempt, { Attempt } from 'shared/hooks/useAttemptNext';
 import { Auth2faType } from 'shared/services';
 import createMfaOptions, { MfaOption } from 'shared/utils/createMfaOptions';
 
@@ -41,6 +41,8 @@ import useReAuthenticate from 'teleport/components/ReAuthenticate/useReAuthentic
 import auth from 'teleport/services/auth/auth';
 import { DeviceUsage } from 'teleport/services/auth';
 import useTeleport from 'teleport/useTeleport';
+
+import { MfaDevice } from 'teleport/services/mfa';
 
 import { PasskeyBlurb } from '../../../components/Passkeys/PasskeyBlurb';
 
@@ -53,6 +55,7 @@ interface AddAuthDeviceWizardProps {
    * A privilege token that may have been created previously; if present, the
    * reauthentication step will be skipped.
    */
+  devices: MfaDevice[];
   privilegeToken?: string;
   onClose(): void;
   onSuccess(): void;
@@ -63,6 +66,7 @@ export function AddAuthDeviceWizard({
   privilegeToken: privilegeTokenProp = '',
   usage,
   auth2faType,
+  devices,
   onClose,
   onSuccess,
 }: AddAuthDeviceWizardProps) {
@@ -96,6 +100,7 @@ export function AddAuthDeviceWizard({
         privilegeToken={privilegeToken}
         credential={credential}
         newMfaDeviceType={newMfaDeviceType}
+        devices={devices}
         onClose={onClose}
         onAuthenticated={setPrivilegeToken}
         onNewMfaDeviceTypeChange={setNewMfaDeviceType}
@@ -111,13 +116,14 @@ const wizardFlows = {
   withoutReauthentication: [CreateDeviceStep, SaveDeviceStep],
 };
 
-type AddAuthDeviceWizardStepProps = StepComponentProps &
+export type AddAuthDeviceWizardStepProps = StepComponentProps &
   ReauthenticateStepProps &
   CreateDeviceStepProps &
   SaveKeyStepProps;
 
 interface ReauthenticateStepProps {
   auth2faType: Auth2faType;
+  devices: MfaDevice[];
   onAuthenticated(privilegeToken: string): void;
   onClose(): void;
 }
@@ -128,6 +134,7 @@ export function ReauthenticateStep({
   stepIndex,
   flowLength,
   auth2faType,
+  devices,
   onClose,
   onAuthenticated: onAuthenticatedProp,
 }: AddAuthDeviceWizardStepProps) {
@@ -139,12 +146,11 @@ export function ReauthenticateStep({
     useReAuthenticate({
       onAuthenticated,
     });
-  const mfaOptions = createMfaOptions({
-    auth2faType,
-    required: true,
-  });
+  const mfaOptions = createReauthOptions(auth2faType, devices);
 
-  const [mfaOption, setMfaOption] = useState<Auth2faType>(mfaOptions[0].value);
+  const [mfaOption, setMfaOption] = useState<Auth2faType | undefined>(
+    mfaOptions[0]?.value
+  );
   const [authCode, setAuthCode] = useState('');
 
   const onAuthCodeChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -165,13 +171,11 @@ export function ReauthenticateStep({
     }
   };
 
-  // This message relies on the status message produced by the auth server in
-  // lib/auth/Server.checkOTP function. Please keep these in sync.
-  const errorMessage =
-    attempt.statusText === 'invalid totp token'
-      ? 'Invalid authenticator code'
-      : attempt.statusText;
-
+  const errorMessage = getReauthenticationErrorMessage(
+    auth2faType,
+    mfaOptions.length,
+    attempt
+  );
   return (
     <div ref={refCallback} data-testid="reauthenticate-step">
       <DialogHeader
@@ -179,10 +183,8 @@ export function ReauthenticateStep({
         flowLength={flowLength}
         title="Verify Identity"
       />
-      {attempt.status === 'failed' && (
-        <OutlineDanger>{errorMessage}</OutlineDanger>
-      )}
-      Multi-factor type
+      {errorMessage && <OutlineDanger>{errorMessage}</OutlineDanger>}
+      {mfaOption && 'Multi-factor type'}
       <Validation>
         {({ validator }) => (
           <form onSubmit={e => onReauthenticate(e, validator)}>
@@ -212,9 +214,11 @@ export function ReauthenticateStep({
               />
             )}
             <Flex gap={2}>
-              <ButtonPrimary type="submit" block={true}>
-                Verify my identity
-              </ButtonPrimary>
+              {mfaOption && (
+                <ButtonPrimary type="submit" block={true}>
+                  Verify my identity
+                </ButtonPrimary>
+              )}
               <ButtonSecondary type="button" block={true} onClick={onClose}>
                 Cancel
               </ButtonSecondary>
@@ -223,6 +227,68 @@ export function ReauthenticateStep({
         )}
       </Validation>
     </div>
+  );
+}
+
+function getReauthenticationErrorMessage(
+  auth2faType: Auth2faType,
+  numMfaOptions: number,
+  attempt: Attempt
+): string {
+  if (numMfaOptions === 0) {
+    switch (auth2faType) {
+      case 'on':
+        return (
+          "Identity verification is required, but you don't have any" +
+          'passkeys or MFA methods registered. This may mean that the' +
+          'server configuration has changed. Please contact your ' +
+          'administrator.'
+        );
+      case 'otp':
+        return (
+          'Identity verification using authenticator app is required, but ' +
+          "you don't have any authenticator apps registered. This may mean " +
+          'that the server configuration has changed. Please contact your ' +
+          'administrator.'
+        );
+      case 'webauthn':
+        return (
+          'Identity verification using a passkey or security key is required, but ' +
+          "you don't have any such devices registered. This may mean " +
+          'that the server configuration has changed. Please contact your ' +
+          'administrator.'
+        );
+      case 'optional':
+      case 'off':
+        // This error message is not useful, but this condition should never
+        // happen, and if it does, it means something is broken, and we don't
+        // have a clue anyway.
+        return 'Unable to verify identity';
+      default:
+        auth2faType satisfies never;
+    }
+  }
+
+  if (attempt.status === 'failed') {
+    // This message relies on the status message produced by the auth server in
+    // lib/auth/Server.checkOTP function. Please keep these in sync.
+    if (attempt.statusText === 'invalid totp token') {
+      return 'Invalid authenticator code';
+    } else {
+      return attempt.statusText;
+    }
+  }
+}
+
+export function createReauthOptions(
+  auth2faType: Auth2faType,
+  devices: MfaDevice[]
+): MfaOption[] {
+  return createMfaOptions({ auth2faType, required: true }).filter(
+    ({ value }) => {
+      const deviceType = value === 'otp' ? 'totp' : value;
+      return devices.some(({ type }) => type === deviceType);
+    }
   );
 }
 


### PR DESCRIPTION
This change restricts the available identity verification methods to the ones that are configured in the user's account. It also provides error messaging for when no such method is available.

Note that the latter is an edge case that occurs only when the cluster configuration has been changed while the user was signed in, but nevertheless, it's possible.

| <img width="782" alt="Screenshot 2024-05-15 at 20 19 10" src="https://github.com/gravitational/teleport/assets/9391503/ae10114b-d017-4a84-b865-f574a5db48f3"> | <img width="782" alt="Screenshot 2024-05-15 at 20 17 27" src="https://github.com/gravitational/teleport/assets/9391503/7503ed05-513e-4408-95e6-4878b3b96f2e"> |
| - | - |

Closes #23443

Tested:
- Adding a passkey, having only a WebAuthn key
- Adding a passkey, having only an authenticator app
- Adding a WebAuthn key, having only a WebAuthn key
- Adding a WebAuthn key, having only an authenticator app
- Adding a WebAuthn key, having both methods available
- Adding an authenticator app, having only a WebAuthn key
- Adding an authenticator app, having only an authenticator app
- Adding a WebAuthn key, having no eligible MFA method (OTP required)
- Adding a WebAuthn key, having no eligible MFA method (WebAuthn required)