### PR TITLE
[v14] guard against mysql panic

### DIFF
--- a/lib/srv/db/mysql/autousers.go
+++ b/lib/srv/db/mysql/autousers.go
@@ -510,11 +510,11 @@ func doTransaction(conn *clientConn, do func() error) error {
 }
 
 func readDeleteUserResult(res *mysql.Result) string {
-	if len(res.Values) != 1 && len(res.Values[0]) != 1 {
+	if res == nil || res.Resultset == nil ||
+		len(res.Resultset.Values) != 1 || len(res.Resultset.Values[0]) != 1 {
 		return ""
 	}
-
-	return string(res.Values[0][0].AsString())
+	return string(res.Resultset.Values[0][0].AsString())
 }
 
 func getCreateProcedureCommand(conn *clientConn, procedureName string) (string, bool) {

--- a/lib/srv/db/mysql/test.go
+++ b/lib/srv/db/mysql/test.go
@@ -317,7 +317,7 @@ func (h *testHandler) HandleStmtPrepare(prepare string) (int, int, interface{}, 
 	return params, 0, nil, nil
 }
 func (h *testHandler) HandleStmtExecute(_ interface{}, query string, args []interface{}) (*mysql.Result, error) {
-	h.log.Debugf("Received execute %q with args %+v.", args)
+	h.log.Debugf("Received execute %q with args %+v.", query, args)
 	if strings.HasPrefix(query, "CALL ") {
 		return h.handleCallProcedure(query, args)
 	}


### PR DESCRIPTION
Backports [this change](https://github.com/gravitational/teleport/commit/12c113bc8430cfdf3a611523a70d4ee377749aa0#diff-f29f86158d8dbc56f9a235df2faa3f5694df55d955cc3e97c33d1de708370a37R523-R527) and [this change](https://github.com/gravitational/teleport/commit/12c113bc8430cfdf3a611523a70d4ee377749aa0#diff-c9ec2ce7cbd420ec8d0851628224c7e886639b377902ca6aeb2298ca7721b85aR323) only from https://github.com/gravitational/teleport/pull/40859 to branch/v14.
These changes:
1. avoid a potential panic in mysql auto user deactivation flow
2. fix a `log.Debugf` call in a test :)

I had to omit the audit event tests from https://github.com/gravitational/teleport/pull/41497 since those events were added in v15.