### PR TITLE
Remove "--" arg for forwarding options in yarn scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "storybook-smoke-test": "yarn storybook --ci --smoke-test",
     "test": "jest",
     "test-coverage": "jest --coverage && web/scripts/print-coverage-link.sh",
-    "test-update-snapshot": "yarn test -- --updateSnapshot",
+    "test-update-snapshot": "yarn test --updateSnapshot",
     "tdd": "jest --watch",
     "lint": "yarn prettier-check && yarn eslint",
     "eslint": "eslint --quiet '+(e|web)/**/*.{ts,tsx,js,jsx,mts}'",


### PR DESCRIPTION
This resolves a warning:

    warning From Yarn 1.0 onwards, scripts don't require "--" for options to
    be forwarded. In a future version, any explicit "--" will be forwarded
    as-is to the scripts.