### PR TITLE
add publish plugin make targets and fix docker builds

### DIFF
--- a/integrations/access/Dockerfile
+++ b/integrations/access/Dockerfile
@@ -16,7 +16,7 @@ COPY api/ api/
 RUN go mod download
 
 # Copy in code
-COPY version.go constants.go gitref.go ./
+COPY version.go constants.go ./
 COPY lib/ ./lib/
 COPY build.assets/images.mk build.assets/arch.mk ./build.assets/
 COPY integrations/lib/ ./integrations/lib/

--- a/integrations/access/common.mk
+++ b/integrations/access/common.mk
@@ -23,7 +23,10 @@ DOCKER_IMAGE_BASE = $(DOCKER_PRIVATE_REGISTRY)/gravitational
 DOCKER_IMAGE = $(DOCKER_IMAGE_BASE)/$(DOCKER_NAME):$(DOCKER_VERSION)
 DOCKER_ECR_PUBLIC_REGISTRY = public.ecr.aws/gravitational
 DOCKER_IMAGE_ECR_PUBLIC = $(DOCKER_ECR_PUBLIC_REGISTRY)/$(DOCKER_NAME):$(DOCKER_VERSION)
-DOCKER_BUILD_ARGS = --load --platform="$(OS)/$(ARCH)" --build-arg ACCESS_PLUGIN=$(ACCESS_PLUGIN) --VERSION=$(VERSION) --build-arg BUILDBOX=$(BUILDBOX)
+DOCKER_BUILD_ARGS = --load --platform="$(OS)/$(ARCH)" --build-arg ACCESS_PLUGIN=$(ACCESS_PLUGIN) --build-arg VERSION=$(VERSION) --build-arg BUILDBOX=$(BUILDBOX)
+# In staging
+# DOCKER_PRIVATE_REGISTRY = 603330915152.dkr.ecr.us-west-2.amazonaws.com
+# DOCKER_ECR_PUBLIC_REGISTRY = public.ecr.aws/gravitational-staging
 
 .PHONY: $(BINARY)
 $(BINARY):
@@ -60,3 +63,9 @@ docker-build: ## Build docker image with the plugin.
 .PHONY: docker-push
 docker-push: ## Push docker image with the plugin.
 	docker push ${DOCKER_IMAGE}
+
+.PHONY: docker-publish
+docker-publish: ## Publishes a docker image from the private ECR registry to the public one.
+	docker pull ${DOCKER_IMAGE}
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_ECR_PUBLIC}
+	docker push ${DOCKER_IMAGE_ECR_PUBLIC}

--- a/integrations/event-handler/Dockerfile
+++ b/integrations/event-handler/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /go/src/github.com/gravitational/teleport/
 
 # Copy dependencies and go.mod
 COPY api/ api/
-COPY version.go constants.go gitref.go go.mod go.sum ./
+COPY version.go constants.go go.mod go.sum ./
 COPY lib/ ./lib/
 COPY build.assets/images.mk build.assets/arch.mk ./build.assets/
 COPY integrations/lib/ ./integrations/lib/

--- a/integrations/event-handler/Makefile
+++ b/integrations/event-handler/Makefile
@@ -38,6 +38,9 @@ DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg GITREF=$(GI
 RELEASE_NAME = teleport-event-handler
 RELEASE = $(RELEASE_NAME)-v$(VERSION)-$(OS)-$(ARCH)-bin
 RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
+# In staging
+# DOCKER_PRIVATE_REGISTRY = 603330915152.dkr.ecr.us-west-2.amazonaws.com
+# DOCKER_ECR_PUBLIC_REGISTRY = public.ecr.aws/gravitational-staging
 
 .PHONY: build
 build: clean
@@ -69,13 +72,10 @@ docker-build: ## Build docker image with the plugin.
 docker-push:
 	docker push ${DOCKER_IMAGE}
 
-.PHONY: docker-promote
-docker-promote: docker-promote-ecr-public
-
-.PHONY: docker-promote-ecr-public
-docker-promote-ecr-public:
-	docker pull ${DOCKER_IMAGE} && \
-	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_ECR_PUBLIC} && \
+.PHONY: docker-publish
+docker-publish: ## Publishes a docker image from the private ECR registry to the public one.
+	docker pull ${DOCKER_IMAGE}
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_ECR_PUBLIC}
 	docker push ${DOCKER_IMAGE_ECR_PUBLIC}
 
 .PHONY: install


### PR DESCRIPTION
Followup PR on the plugin Make targets used in CI:
- fixes a bad docker build arg
- do not require gitref.go in the Dockerfile
- add docker-publish targets

```bash
make -C integrations/event-handler docker-publish OS=linux ARCH=arm64 VERSION=16.0.0-hugomake.1 DOCKER_PRIVATE_REGISTRY=603330915152.dkr.ecr.us-west-2.amazonaws.com DOCKER_ECR_PUBLIC_REGISTRY=public.ecr.aws/x1d3w1e5
```