### PR TITLE
Refactor process state into its own package

### DIFF
--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -47,9 +47,9 @@ import (
 	"github.com/gravitational/teleport/api/breaker"
 	clientproto "github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keygen"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
@@ -255,8 +255,8 @@ func (s *InstanceSecrets) AsSlice() []*InstanceSecrets {
 	return []*InstanceSecrets{s}
 }
 
-func (s *InstanceSecrets) GetIdentity() *auth.Identity {
-	i, err := auth.ReadIdentityFromKeyPair(s.PrivKey, &clientproto.Certs{
+func (s *InstanceSecrets) GetIdentity() *state.Identity {
+	i, err := state.ReadIdentityFromKeyPair(s.PrivKey, &clientproto.Certs{
 		SSH:        s.Cert,
 		TLS:        s.TLSCert,
 		TLSCACerts: [][]byte{s.TLSCACert},

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -36,9 +36,9 @@ import (
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keystore"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/etcdbk"
 	"github.com/gravitational/teleport/lib/backend/lite"
@@ -181,9 +181,9 @@ func TestHSMRotation(t *testing.T) {
 }
 
 func getAdminClient(authDataDir string, authAddr string) (*authclient.Client, error) {
-	identity, err := auth.ReadLocalIdentity(
+	identity, err := state.ReadLocalIdentity(
 		filepath.Join(authDataDir, teleport.ComponentProcess),
-		auth.IdentityID{Role: types.RoleAdmin})
+		state.IdentityID{Role: types.RoleAdmin})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -54,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -665,7 +666,7 @@ func mustRegisterUsingIAMMethod(t *testing.T, proxyAddr utils.NetAddr, token str
 	node := uuid.NewString()
 	_, err = auth.Register(context.TODO(), auth.RegisterParams{
 		Token: token,
-		ID: auth.IdentityID{
+		ID: state.IdentityID{
 			Role:     types.RoleNode,
 			HostUUID: node,
 			NodeName: node,

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -119,7 +120,7 @@ func TestRegisterBotCertificateGenerationCheck(t *testing.T) {
 
 	certs, err := Register(ctx, RegisterParams{
 		Token: token.GetName(),
-		ID: IdentityID{
+		ID: state.IdentityID{
 			Role: types.RoleBot,
 		},
 		AuthServers:  []utils.NetAddr{*utils.MustParseAddr(srv.Addr().String())},
@@ -192,7 +193,7 @@ func TestRegisterBotCertificateGenerationStolen(t *testing.T) {
 
 	certs, err := Register(ctx, RegisterParams{
 		Token: token.GetName(),
-		ID: IdentityID{
+		ID: state.IdentityID{
 			Role: types.RoleBot,
 		},
 		AuthServers:  []utils.NetAddr{*utils.MustParseAddr(srv.Addr().String())},
@@ -268,7 +269,7 @@ func TestRegisterBotCertificateExtensions(t *testing.T) {
 
 	certs, err := Register(ctx, RegisterParams{
 		Token: token.GetName(),
-		ID: IdentityID{
+		ID: state.IdentityID{
 			Role: types.RoleBot,
 		},
 		AuthServers:  []utils.NetAddr{*utils.MustParseAddr(srv.Addr().String())},

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/auth/state"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
@@ -802,7 +803,7 @@ type TestTLSServer struct {
 	// TestTLSServerConfig is a configuration for TLS server
 	TestTLSServerConfig
 	// Identity is a generated TLS/SSH identity used to answer in TLS
-	Identity *Identity
+	Identity *state.Identity
 	// TLSServer is a configured TLS server
 	TLSServer *TLSServer
 }
@@ -1141,7 +1142,7 @@ func (t *TestTLSServer) Stop() error {
 }
 
 // NewServerIdentity generates new server identity, used in tests
-func NewServerIdentity(clt *Server, hostID string, role types.SystemRole) (*Identity, error) {
+func NewServerIdentity(clt *Server, hostID string, role types.SystemRole) (*state.Identity, error) {
 	priv, pub, err := native.GenerateKeyPair()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1164,7 +1165,7 @@ func NewServerIdentity(clt *Server, hostID string, role types.SystemRole) (*Iden
 		return nil, trace.Wrap(err)
 	}
 
-	return ReadIdentityFromKeyPair(priv, certs)
+	return state.ReadIdentityFromKeyPair(priv, certs)
 }
 
 // clt limits required interface to the necessary methods

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -36,7 +36,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	oteltrace "go.opentelemetry.io/otel/trace"
-	"golang.org/x/crypto/ssh"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
@@ -46,9 +45,6 @@ import (
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
-	apiutils "github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/api/utils/keys"
-	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/ai"
 	"github.com/gravitational/teleport/lib/ai/embedding"
@@ -57,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/auth/migration"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/events"
@@ -1106,8 +1103,22 @@ func checkResourceConsistency(ctx context.Context, keyStore *keystore.Manager, c
 	return nil
 }
 
+// Identity alias left to prevent breaking builds
+// TODO(tross): Delete after teleport.e is updated
+type Identity = state.Identity
+
+// IdentityID alias left to prevent breaking builds
+// TODO(tross): Delete after teleport.e is updated
+type IdentityID = state.IdentityID
+
+// ReadLocalIdentity left to prevent breaking builds
+// TODO(tross): Delete after teleport.e is updated
+func ReadLocalIdentity(dataDir string, id state.IdentityID) (*Identity, error) {
+	return state.ReadLocalIdentity(dataDir, id)
+}
+
 // GenerateIdentity generates identity for the auth server
-func GenerateIdentity(a *Server, id IdentityID, additionalPrincipals, dnsNames []string) (*Identity, error) {
+func GenerateIdentity(a *Server, id state.IdentityID, additionalPrincipals, dnsNames []string) (*state.Identity, error) {
 	priv, pub, err := native.GenerateKeyPair()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1131,61 +1142,7 @@ func GenerateIdentity(a *Server, id IdentityID, additionalPrincipals, dnsNames [
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return ReadIdentityFromKeyPair(priv, certs)
-}
-
-// Identity is collection of certificates and signers that represent server identity
-type Identity struct {
-	// ID specifies server unique ID, name and role
-	ID IdentityID
-	// KeyBytes is a PEM encoded private key
-	KeyBytes []byte
-	// CertBytes is a PEM encoded SSH host cert
-	CertBytes []byte
-	// TLSCertBytes is a PEM encoded TLS x509 client certificate
-	TLSCertBytes []byte
-	// TLSCACertBytes is a list of PEM encoded TLS x509 certificate of certificate authority
-	// associated with auth server services
-	TLSCACertsBytes [][]byte
-	// SSHCACertBytes is a list of SSH CAs encoded in the authorized_keys format.
-	SSHCACertBytes [][]byte
-	// KeySigner is an SSH host certificate signer
-	KeySigner ssh.Signer
-	// Cert is a parsed SSH certificate
-	Cert *ssh.Certificate
-	// XCert is X509 client certificate
-	XCert *x509.Certificate
-	// ClusterName is a name of host's cluster
-	ClusterName string
-	// SystemRoles is a list of additional system roles.
-	SystemRoles []string
-}
-
-// HasSystemRole checks if this identity encompasses the supplied system role.
-func (i *Identity) HasSystemRole(role types.SystemRole) bool {
-	// check identity's primary system role
-	if i.ID.Role == role {
-		return true
-	}
-
-	return slices.Contains(i.SystemRoles, string(role))
-}
-
-// String returns user-friendly representation of the identity.
-func (i *Identity) String() string {
-	var out []string
-	if i.XCert != nil {
-		out = append(out, fmt.Sprintf("cert(%v issued by %v:%v)", i.XCert.Subject.CommonName, i.XCert.Issuer.CommonName, i.XCert.Issuer.SerialNumber))
-	}
-	for j := range i.TLSCACertsBytes {
-		cert, err := tlsca.ParseCertificatePEM(i.TLSCACertsBytes[j])
-		if err != nil {
-			out = append(out, err.Error())
-		} else {
-			out = append(out, fmt.Sprintf("trust root(%v:%v)", cert.Subject.CommonName, cert.Subject.SerialNumber))
-		}
-	}
-	return fmt.Sprintf("Identity(%v, %v)", i.ID.Role, strings.Join(out, ","))
+	return state.ReadIdentityFromKeyPair(priv, certs)
 }
 
 // CertInfo returns diagnostic information about certificate
@@ -1214,265 +1171,6 @@ func CertAuthorityInfo(ca types.CertAuthority) string {
 		}
 	}
 	return fmt.Sprintf("cert authority(state: %v, phase: %v, roots: %v)", ca.GetRotation().State, ca.GetRotation().Phase, strings.Join(out, ", "))
-}
-
-// HasTLSConfig returns true if this identity has TLS certificate and private
-// key.
-func (i *Identity) HasTLSConfig() bool {
-	return len(i.TLSCACertsBytes) != 0 && len(i.TLSCertBytes) != 0
-}
-
-// HasPrincipals returns whether identity has principals
-func (i *Identity) HasPrincipals(additionalPrincipals []string) bool {
-	set := utils.StringsSet(i.Cert.ValidPrincipals)
-	for _, principal := range additionalPrincipals {
-		if _, ok := set[principal]; !ok {
-			return false
-		}
-	}
-	return true
-}
-
-// HasDNSNames returns true if TLS certificate has required DNS names
-func (i *Identity) HasDNSNames(dnsNames []string) bool {
-	if i.XCert == nil {
-		return false
-	}
-	set := utils.StringsSet(i.XCert.DNSNames)
-	for _, dnsName := range dnsNames {
-		if _, ok := set[dnsName]; !ok {
-			return false
-		}
-	}
-	return true
-}
-
-// TLSConfig returns TLS config for mutual TLS authentication
-// can return NotFound error if there are no TLS credentials setup for identity
-func (i *Identity) TLSConfig(cipherSuites []uint16) (*tls.Config, error) {
-	tlsConfig := utils.TLSConfig(cipherSuites)
-	if !i.HasTLSConfig() {
-		return nil, trace.NotFound("no TLS credentials setup for this identity")
-	}
-
-	tlsCert, err := keys.X509KeyPair(i.TLSCertBytes, i.KeyBytes)
-	if err != nil {
-		return nil, trace.BadParameter("failed to parse private key: %v", err)
-	}
-	certPool := x509.NewCertPool()
-	for j := range i.TLSCACertsBytes {
-		parsedCert, err := tlsca.ParseCertificatePEM(i.TLSCACertsBytes[j])
-		if err != nil {
-			return nil, trace.Wrap(err, "failed to parse CA certificate")
-		}
-		certPool.AddCert(parsedCert)
-	}
-	tlsConfig.Certificates = []tls.Certificate{tlsCert}
-	tlsConfig.RootCAs = certPool
-	tlsConfig.ClientCAs = certPool
-	tlsConfig.ServerName = apiutils.EncodeClusterName(i.ClusterName)
-	return tlsConfig, nil
-}
-
-func (i *Identity) getSSHCheckers() ([]ssh.PublicKey, error) {
-	checkers, err := apisshutils.ParseAuthorizedKeys(i.SSHCACertBytes)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return checkers, nil
-}
-
-// SSHClientConfig returns a ssh.ClientConfig used by nodes to connect to
-// the reverse tunnel server.
-func (i *Identity) SSHClientConfig(fips bool) (*ssh.ClientConfig, error) {
-	callback, err := apisshutils.NewHostKeyCallback(
-		apisshutils.HostKeyCallbackConfig{
-			GetHostCheckers: i.getSSHCheckers,
-			FIPS:            fips,
-		})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &ssh.ClientConfig{
-		User:            i.ID.HostUUID,
-		Auth:            []ssh.AuthMethod{ssh.PublicKeys(i.KeySigner)},
-		HostKeyCallback: callback,
-		Timeout:         apidefaults.DefaultIOTimeout,
-	}, nil
-}
-
-// IdentityID is a combination of role, host UUID, and node name.
-type IdentityID struct {
-	Role     types.SystemRole
-	HostUUID string
-	NodeName string
-}
-
-// HostID is host ID part of the host UUID that consists cluster name
-func (id *IdentityID) HostID() string {
-	return strings.SplitN(id.HostUUID, ".", 2)[0]
-}
-
-// Equals returns true if two identities are equal
-func (id *IdentityID) Equals(other IdentityID) bool {
-	return id.Role == other.Role && id.HostUUID == other.HostUUID
-}
-
-// String returns debug friendly representation of this identity
-func (id *IdentityID) String() string {
-	return fmt.Sprintf("Identity(hostuuid=%v, role=%v)", id.HostUUID, id.Role)
-}
-
-// ReadIdentityFromKeyPair reads SSH and TLS identity from key pair.
-func ReadIdentityFromKeyPair(privateKey []byte, certs *proto.Certs) (*Identity, error) {
-	identity, err := ReadSSHIdentityFromKeyPair(privateKey, certs.SSH)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if len(certs.SSHCACerts) != 0 {
-		identity.SSHCACertBytes = certs.SSHCACerts
-	}
-
-	if len(certs.TLSCACerts) != 0 {
-		// Parse the key pair to verify that identity parses properly for future use.
-		i, err := ReadTLSIdentityFromKeyPair(privateKey, certs.TLS, certs.TLSCACerts)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		identity.XCert = i.XCert
-		identity.TLSCertBytes = certs.TLS
-		identity.TLSCACertsBytes = certs.TLSCACerts
-		identity.SystemRoles = i.SystemRoles
-	}
-
-	return identity, nil
-}
-
-// ReadTLSIdentityFromKeyPair reads TLS identity from key pair
-func ReadTLSIdentityFromKeyPair(keyBytes, certBytes []byte, caCertsBytes [][]byte) (*Identity, error) {
-	if len(keyBytes) == 0 {
-		return nil, trace.BadParameter("missing private key")
-	}
-
-	if len(certBytes) == 0 {
-		return nil, trace.BadParameter("missing certificate")
-	}
-
-	cert, err := tlsca.ParseCertificatePEM(certBytes)
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to parse TLS certificate")
-	}
-
-	id, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if len(cert.Issuer.Organization) == 0 {
-		return nil, trace.BadParameter("missing CA organization")
-	}
-
-	clusterName := cert.Issuer.Organization[0]
-	if clusterName == "" {
-		return nil, trace.BadParameter("missing cluster name")
-	}
-	identity := &Identity{
-		ID:              IdentityID{HostUUID: id.Username, Role: types.SystemRole(id.Groups[0])},
-		ClusterName:     clusterName,
-		KeyBytes:        keyBytes,
-		TLSCertBytes:    certBytes,
-		TLSCACertsBytes: caCertsBytes,
-		XCert:           cert,
-		SystemRoles:     id.SystemRoles,
-	}
-	// The passed in ciphersuites don't appear to matter here since the returned
-	// *tls.Config is never actually used?
-	_, err = identity.TLSConfig(utils.DefaultCipherSuites())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return identity, nil
-}
-
-// ReadSSHIdentityFromKeyPair reads identity from initialized keypair
-func ReadSSHIdentityFromKeyPair(keyBytes, certBytes []byte) (*Identity, error) {
-	if len(keyBytes) == 0 {
-		return nil, trace.BadParameter("PrivateKey: missing private key")
-	}
-
-	if len(certBytes) == 0 {
-		return nil, trace.BadParameter("Cert: missing parameter")
-	}
-
-	cert, err := apisshutils.ParseCertificate(certBytes)
-	if err != nil {
-		return nil, trace.BadParameter("failed to parse server certificate: %v", err)
-	}
-
-	signer, err := ssh.ParsePrivateKey(keyBytes)
-	if err != nil {
-		return nil, trace.BadParameter("failed to parse private key: %v", err)
-	}
-	// this signer authenticates using certificate signed by the cert authority
-	// not only by the public key
-	certSigner, err := ssh.NewCertSigner(cert, signer)
-	if err != nil {
-		return nil, trace.BadParameter("unsupported private key: %v", err)
-	}
-
-	// check principals on certificate
-	if len(cert.ValidPrincipals) < 1 {
-		return nil, trace.BadParameter("valid principals: at least one valid principal is required")
-	}
-	for _, validPrincipal := range cert.ValidPrincipals {
-		if validPrincipal == "" {
-			return nil, trace.BadParameter("valid principal can not be empty: %q", cert.ValidPrincipals)
-		}
-	}
-
-	// check permissions on certificate
-	if len(cert.Permissions.Extensions) == 0 {
-		return nil, trace.BadParameter("extensions: missing needed extensions for host roles")
-	}
-	roleString := cert.Permissions.Extensions[utils.CertExtensionRole]
-	if roleString == "" {
-		return nil, trace.BadParameter("missing cert extension %v", utils.CertExtensionRole)
-	}
-	roles, err := types.ParseTeleportRoles(roleString)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	foundRoles := len(roles)
-	if foundRoles != 1 {
-		return nil, trace.Errorf("expected one role per certificate. found %d: '%s'",
-			foundRoles, roles.String())
-	}
-	role := roles[0]
-	clusterName := cert.Permissions.Extensions[utils.CertExtensionAuthority]
-	if clusterName == "" {
-		return nil, trace.BadParameter("missing cert extension %v", utils.CertExtensionAuthority)
-	}
-
-	return &Identity{
-		ID:          IdentityID{HostUUID: cert.ValidPrincipals[0], Role: role},
-		ClusterName: clusterName,
-		KeyBytes:    keyBytes,
-		CertBytes:   certBytes,
-		KeySigner:   certSigner,
-		Cert:        cert,
-	}, nil
-}
-
-// ReadLocalIdentity reads, parses and returns the given pub/pri key + cert from the
-// key storage (dataDir).
-func ReadLocalIdentity(dataDir string, id IdentityID) (*Identity, error) {
-	storage, err := NewProcessStorage(context.TODO(), dataDir)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer storage.Close()
-	return storage.ReadIdentity(IdentityCurrent, id.Role)
 }
 
 // DELETE IN: 2.7.0

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/keystore"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
@@ -75,10 +76,10 @@ func TestReadIdentity(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	id, err := ReadSSHIdentityFromKeyPair(priv, cert)
+	id, err := state.ReadSSHIdentityFromKeyPair(priv, cert)
 	require.NoError(t, err)
 	require.Equal(t, "example.com", id.ClusterName)
-	require.Equal(t, IdentityID{HostUUID: "id1.example.com", Role: types.RoleNode}, id.ID)
+	require.Equal(t, state.IdentityID{HostUUID: "id1.example.com", Role: types.RoleNode}, id.ID)
 	require.Equal(t, cert, id.CertBytes)
 	require.Equal(t, priv, id.KeyBytes)
 
@@ -108,7 +109,7 @@ func TestBadIdentity(t *testing.T) {
 	require.NoError(t, err)
 
 	// bad cert type
-	_, err = ReadSSHIdentityFromKeyPair(priv, pub)
+	_, err = state.ReadSSHIdentityFromKeyPair(priv, pub)
 	require.IsType(t, trace.BadParameter(""), err)
 
 	// missing authority domain
@@ -123,7 +124,7 @@ func TestBadIdentity(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = ReadSSHIdentityFromKeyPair(priv, cert)
+	_, err = state.ReadSSHIdentityFromKeyPair(priv, cert)
 	require.IsType(t, trace.BadParameter(""), err)
 
 	// missing host uuid
@@ -138,7 +139,7 @@ func TestBadIdentity(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = ReadSSHIdentityFromKeyPair(priv, cert)
+	_, err = state.ReadSSHIdentityFromKeyPair(priv, cert)
 	require.IsType(t, trace.BadParameter(""), err)
 
 	// unrecognized role
@@ -153,7 +154,7 @@ func TestBadIdentity(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = ReadSSHIdentityFromKeyPair(priv, cert)
+	_, err = state.ReadSSHIdentityFromKeyPair(priv, cert)
 	require.IsType(t, trace.BadParameter(""), err)
 }
 
@@ -1739,7 +1740,7 @@ func TestIdentityChecker(t *testing.T) {
 			t.Cleanup(func() { sshServer.Close() })
 			require.NoError(t, sshServer.Start())
 
-			identity, err := GenerateIdentity(authServer, IdentityID{
+			identity, err := GenerateIdentity(authServer, state.IdentityID{
 				Role:     types.RoleNode,
 				HostUUID: uuid.New().String(),
 				NodeName: "node-1",

--- a/lib/auth/join_test.go
+++ b/lib/auth/join_test.go
@@ -35,6 +35,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -372,7 +373,7 @@ func TestRegister_Bot(t *testing.T) {
 			start := srv.Clock().Now()
 			certs, err := Register(ctx, RegisterParams{
 				Token: test.token.GetName(),
-				ID: IdentityID{
+				ID: state.IdentityID{
 					Role: types.RoleBot,
 				},
 				AuthServers:  []utils.NetAddr{*utils.MustParseAddr(srv.Addr().String())},
@@ -475,7 +476,7 @@ func TestRegister_Bot_Expiry(t *testing.T) {
 
 			certs, err := Register(ctx, RegisterParams{
 				Token: tok.GetName(),
-				ID: IdentityID{
+				ID: state.IdentityID{
 					Role: types.RoleBot,
 				},
 				AuthServers:  []utils.NetAddr{*utils.MustParseAddr(srv.Addr().String())},

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/circleci"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
@@ -62,7 +63,7 @@ import (
 // LocalRegister is used to generate host keys when a node or proxy is running
 // within the same process as the Auth Server and as such, does not need to
 // use provisioning tokens.
-func LocalRegister(id IdentityID, authServer *Server, additionalPrincipals, dnsNames []string, remoteAddr string, systemRoles []types.SystemRole) (*Identity, error) {
+func LocalRegister(id state.IdentityID, authServer *Server, additionalPrincipals, dnsNames []string, remoteAddr string, systemRoles []types.SystemRole) (*state.Identity, error) {
 	priv, pub, err := native.GenerateKeyPair()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -95,7 +96,7 @@ func LocalRegister(id IdentityID, authServer *Server, additionalPrincipals, dnsN
 		return nil, trace.Wrap(err)
 	}
 
-	identity, err := ReadIdentityFromKeyPair(priv, certs)
+	identity, err := state.ReadIdentityFromKeyPair(priv, certs)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -116,7 +117,7 @@ type RegisterParams struct {
 	// Token is a secure token to join the cluster
 	Token string
 	// ID is identity ID
-	ID IdentityID
+	ID state.IdentityID
 	// AuthServers is a list of auth servers to dial
 	AuthServers []utils.NetAddr
 	// ProxyServer is a proxy server to dial
@@ -842,7 +843,7 @@ type ReRegisterParams struct {
 	// Client is an authenticated client using old credentials
 	Client authclient.ClientI
 	// ID is identity ID
-	ID IdentityID
+	ID state.IdentityID
 	// AdditionalPrincipals is a list of additional principals to dial
 	AdditionalPrincipals []string
 	// DNSNames is a list of DNS Names to add to the x509 client certificate
@@ -860,7 +861,7 @@ type ReRegisterParams struct {
 }
 
 // ReRegister renews the certificates and private keys based on the client's existing identity.
-func ReRegister(ctx context.Context, params ReRegisterParams) (*Identity, error) {
+func ReRegister(ctx context.Context, params ReRegisterParams) (*state.Identity, error) {
 	var rotation *types.Rotation
 	if !params.Rotation.IsZero() {
 		// older auths didn't distinguish between empty and nil rotation
@@ -884,5 +885,5 @@ func ReRegister(ctx context.Context, params ReRegisterParams) (*Identity, error)
 		return nil, trace.Wrap(err)
 	}
 
-	return ReadIdentityFromKeyPair(params.PrivateKey, certs)
+	return state.ReadIdentityFromKeyPair(params.PrivateKey, certs)
 }

--- a/lib/auth/state/identity.go
+++ b/lib/auth/state/identity.go
@@ -1,0 +1,351 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/keys"
+	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// IdentityID is a combination of role, host UUID, and node name.
+type IdentityID struct {
+	Role     types.SystemRole
+	HostUUID string
+	NodeName string
+}
+
+// HostID is host ID part of the host UUID that consists cluster name
+func (id *IdentityID) HostID() string {
+	return strings.SplitN(id.HostUUID, ".", 2)[0]
+}
+
+// Equals returns true if two identities are equal
+func (id *IdentityID) Equals(other IdentityID) bool {
+	return id.Role == other.Role && id.HostUUID == other.HostUUID
+}
+
+// String returns debug friendly representation of this identity
+func (id *IdentityID) String() string {
+	return fmt.Sprintf("Identity(hostuuid=%v, role=%v)", id.HostUUID, id.Role)
+}
+
+// Identity is collection of certificates and signers that represent server identity
+type Identity struct {
+	// ID specifies server unique ID, name and role
+	ID IdentityID
+	// KeyBytes is a PEM encoded private key
+	KeyBytes []byte
+	// CertBytes is a PEM encoded SSH host cert
+	CertBytes []byte
+	// TLSCertBytes is a PEM encoded TLS x509 client certificate
+	TLSCertBytes []byte
+	// TLSCACertBytes is a list of PEM encoded TLS x509 certificate of certificate authority
+	// associated with auth server services
+	TLSCACertsBytes [][]byte
+	// SSHCACertBytes is a list of SSH CAs encoded in the authorized_keys format.
+	SSHCACertBytes [][]byte
+	// KeySigner is an SSH host certificate signer
+	KeySigner ssh.Signer
+	// Cert is a parsed SSH certificate
+	Cert *ssh.Certificate
+	// XCert is X509 client certificate
+	XCert *x509.Certificate
+	// ClusterName is a name of host's cluster
+	ClusterName string
+	// SystemRoles is a list of additional system roles.
+	SystemRoles []string
+}
+
+// HasSystemRole checks if this identity encompasses the supplied system role.
+func (i *Identity) HasSystemRole(role types.SystemRole) bool {
+	// check identity's primary system role
+	if i.ID.Role == role {
+		return true
+	}
+
+	return slices.Contains(i.SystemRoles, string(role))
+}
+
+// String returns user-friendly representation of the identity.
+func (i *Identity) String() string {
+	var out []string
+	if i.XCert != nil {
+		out = append(out, fmt.Sprintf("cert(%v issued by %v:%v)", i.XCert.Subject.CommonName, i.XCert.Issuer.CommonName, i.XCert.Issuer.SerialNumber))
+	}
+	for j := range i.TLSCACertsBytes {
+		cert, err := tlsca.ParseCertificatePEM(i.TLSCACertsBytes[j])
+		if err != nil {
+			out = append(out, err.Error())
+		} else {
+			out = append(out, fmt.Sprintf("trust root(%v:%v)", cert.Subject.CommonName, cert.Subject.SerialNumber))
+		}
+	}
+	return fmt.Sprintf("Identity(%v, %v)", i.ID.Role, strings.Join(out, ","))
+}
+
+// HasTLSConfig returns true if this identity has TLS certificate and private
+// key.
+func (i *Identity) HasTLSConfig() bool {
+	return len(i.TLSCACertsBytes) != 0 && len(i.TLSCertBytes) != 0
+}
+
+// HasPrincipals returns whether identity has principals
+func (i *Identity) HasPrincipals(additionalPrincipals []string) bool {
+	set := utils.StringsSet(i.Cert.ValidPrincipals)
+	for _, principal := range additionalPrincipals {
+		if _, ok := set[principal]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// HasDNSNames returns true if TLS certificate has required DNS names
+func (i *Identity) HasDNSNames(dnsNames []string) bool {
+	if i.XCert == nil {
+		return false
+	}
+	set := utils.StringsSet(i.XCert.DNSNames)
+	for _, dnsName := range dnsNames {
+		if _, ok := set[dnsName]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// TLSConfig returns TLS config for mutual TLS authentication
+// can return NotFound error if there are no TLS credentials setup for identity
+func (i *Identity) TLSConfig(cipherSuites []uint16) (*tls.Config, error) {
+	tlsConfig := utils.TLSConfig(cipherSuites)
+	if !i.HasTLSConfig() {
+		return nil, trace.NotFound("no TLS credentials setup for this identity")
+	}
+
+	tlsCert, err := keys.X509KeyPair(i.TLSCertBytes, i.KeyBytes)
+	if err != nil {
+		return nil, trace.BadParameter("failed to parse private key: %v", err)
+	}
+	certPool := x509.NewCertPool()
+	for j := range i.TLSCACertsBytes {
+		parsedCert, err := tlsca.ParseCertificatePEM(i.TLSCACertsBytes[j])
+		if err != nil {
+			return nil, trace.Wrap(err, "failed to parse CA certificate")
+		}
+		certPool.AddCert(parsedCert)
+	}
+	tlsConfig.Certificates = []tls.Certificate{tlsCert}
+	tlsConfig.RootCAs = certPool
+	tlsConfig.ClientCAs = certPool
+	tlsConfig.ServerName = apiutils.EncodeClusterName(i.ClusterName)
+	return tlsConfig, nil
+}
+
+func (i *Identity) getSSHCheckers() ([]ssh.PublicKey, error) {
+	checkers, err := apisshutils.ParseAuthorizedKeys(i.SSHCACertBytes)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return checkers, nil
+}
+
+// SSHClientConfig returns a ssh.ClientConfig used by nodes to connect to
+// the reverse tunnel server.
+func (i *Identity) SSHClientConfig(fips bool) (*ssh.ClientConfig, error) {
+	callback, err := apisshutils.NewHostKeyCallback(
+		apisshutils.HostKeyCallbackConfig{
+			GetHostCheckers: i.getSSHCheckers,
+			FIPS:            fips,
+		})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &ssh.ClientConfig{
+		User:            i.ID.HostUUID,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(i.KeySigner)},
+		HostKeyCallback: callback,
+		Timeout:         apidefaults.DefaultIOTimeout,
+	}, nil
+}
+
+// ReadIdentityFromKeyPair reads SSH and TLS identity from key pair.
+func ReadIdentityFromKeyPair(privateKey []byte, certs *proto.Certs) (*Identity, error) {
+	identity, err := ReadSSHIdentityFromKeyPair(privateKey, certs.SSH)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if len(certs.SSHCACerts) != 0 {
+		identity.SSHCACertBytes = certs.SSHCACerts
+	}
+
+	if len(certs.TLSCACerts) != 0 {
+		// Parse the key pair to verify that identity parses properly for future use.
+		i, err := ReadTLSIdentityFromKeyPair(privateKey, certs.TLS, certs.TLSCACerts)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		identity.XCert = i.XCert
+		identity.TLSCertBytes = certs.TLS
+		identity.TLSCACertsBytes = certs.TLSCACerts
+		identity.SystemRoles = i.SystemRoles
+	}
+
+	return identity, nil
+}
+
+// ReadTLSIdentityFromKeyPair reads TLS identity from key pair
+func ReadTLSIdentityFromKeyPair(keyBytes, certBytes []byte, caCertsBytes [][]byte) (*Identity, error) {
+	if len(keyBytes) == 0 {
+		return nil, trace.BadParameter("missing private key")
+	}
+
+	if len(certBytes) == 0 {
+		return nil, trace.BadParameter("missing certificate")
+	}
+
+	cert, err := tlsca.ParseCertificatePEM(certBytes)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse TLS certificate")
+	}
+
+	id, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if len(cert.Issuer.Organization) == 0 {
+		return nil, trace.BadParameter("missing CA organization")
+	}
+
+	clusterName := cert.Issuer.Organization[0]
+	if clusterName == "" {
+		return nil, trace.BadParameter("missing cluster name")
+	}
+	identity := &Identity{
+		ID:              IdentityID{HostUUID: id.Username, Role: types.SystemRole(id.Groups[0])},
+		ClusterName:     clusterName,
+		KeyBytes:        keyBytes,
+		TLSCertBytes:    certBytes,
+		TLSCACertsBytes: caCertsBytes,
+		XCert:           cert,
+		SystemRoles:     id.SystemRoles,
+	}
+	// The passed in ciphersuites don't appear to matter here since the returned
+	// *tls.Config is never actually used?
+	_, err = identity.TLSConfig(utils.DefaultCipherSuites())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return identity, nil
+}
+
+// ReadSSHIdentityFromKeyPair reads identity from initialized keypair
+func ReadSSHIdentityFromKeyPair(keyBytes, certBytes []byte) (*Identity, error) {
+	if len(keyBytes) == 0 {
+		return nil, trace.BadParameter("PrivateKey: missing private key")
+	}
+
+	if len(certBytes) == 0 {
+		return nil, trace.BadParameter("Cert: missing parameter")
+	}
+
+	cert, err := apisshutils.ParseCertificate(certBytes)
+	if err != nil {
+		return nil, trace.BadParameter("failed to parse server certificate: %v", err)
+	}
+
+	signer, err := ssh.ParsePrivateKey(keyBytes)
+	if err != nil {
+		return nil, trace.BadParameter("failed to parse private key: %v", err)
+	}
+	// this signer authenticates using certificate signed by the cert authority
+	// not only by the public key
+	certSigner, err := ssh.NewCertSigner(cert, signer)
+	if err != nil {
+		return nil, trace.BadParameter("unsupported private key: %v", err)
+	}
+
+	// check principals on certificate
+	if len(cert.ValidPrincipals) < 1 {
+		return nil, trace.BadParameter("valid principals: at least one valid principal is required")
+	}
+	for _, validPrincipal := range cert.ValidPrincipals {
+		if validPrincipal == "" {
+			return nil, trace.BadParameter("valid principal can not be empty: %q", cert.ValidPrincipals)
+		}
+	}
+
+	// check permissions on certificate
+	if len(cert.Permissions.Extensions) == 0 {
+		return nil, trace.BadParameter("extensions: missing needed extensions for host roles")
+	}
+	roleString := cert.Permissions.Extensions[utils.CertExtensionRole]
+	if roleString == "" {
+		return nil, trace.BadParameter("missing cert extension %v", utils.CertExtensionRole)
+	}
+	roles, err := types.ParseTeleportRoles(roleString)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	foundRoles := len(roles)
+	if foundRoles != 1 {
+		return nil, trace.Errorf("expected one role per certificate. found %d: '%s'",
+			foundRoles, roles.String())
+	}
+	role := roles[0]
+	clusterName := cert.Permissions.Extensions[utils.CertExtensionAuthority]
+	if clusterName == "" {
+		return nil, trace.BadParameter("missing cert extension %v", utils.CertExtensionAuthority)
+	}
+
+	return &Identity{
+		ID:          IdentityID{HostUUID: cert.ValidPrincipals[0], Role: role},
+		ClusterName: clusterName,
+		KeyBytes:    keyBytes,
+		CertBytes:   certBytes,
+		KeySigner:   certSigner,
+		Cert:        cert,
+	}, nil
+}
+
+// ReadLocalIdentity reads, parses and returns the given pub/pri key + cert from the
+// key storage (dataDir).
+func ReadLocalIdentity(dataDir string, id IdentityID) (*Identity, error) {
+	storage, err := NewProcessStorage(context.TODO(), dataDir)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer storage.Close()
+	return storage.ReadIdentity(IdentityCurrent, id.Role)
+}

--- a/lib/auth/state/state.go
+++ b/lib/auth/state/state.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package state
 
 import (
 	"context"
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// stateBackend implements abstraction over local or remote storage backend methods
+// backend implements abstraction over local or remote storage backend methods
 // required for Identity/State storage.
 // As in backend.Backend, Item keys are assumed to be valid UTF8, which may be enforced by the
 // various Backend implementations.

--- a/lib/auth/state/state_unix.go
+++ b/lib/auth/state/state_unix.go
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package state
 
 import (
 	"context"

--- a/lib/auth/state/state_windows.go
+++ b/lib/auth/state/state_windows.go
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package state
 
 import (
 	"context"

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -57,6 +57,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -3396,7 +3397,7 @@ func TestRegisterCAPin(t *testing.T) {
 	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
-		ID: IdentityID{
+		ID: state.IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",
 			Role:     types.RoleProxy,
@@ -3414,7 +3415,7 @@ func TestRegisterCAPin(t *testing.T) {
 	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
-		ID: IdentityID{
+		ID: state.IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",
 			Role:     types.RoleProxy,
@@ -3431,7 +3432,7 @@ func TestRegisterCAPin(t *testing.T) {
 	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
-		ID: IdentityID{
+		ID: state.IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",
 			Role:     types.RoleProxy,
@@ -3448,7 +3449,7 @@ func TestRegisterCAPin(t *testing.T) {
 	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
-		ID: IdentityID{
+		ID: state.IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",
 			Role:     types.RoleProxy,
@@ -3484,7 +3485,7 @@ func TestRegisterCAPin(t *testing.T) {
 	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
-		ID: IdentityID{
+		ID: state.IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",
 			Role:     types.RoleProxy,
@@ -3529,7 +3530,7 @@ func TestRegisterCAPath(t *testing.T) {
 	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
-		ID: IdentityID{
+		ID: state.IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",
 			Role:     types.RoleProxy,
@@ -3558,7 +3559,7 @@ func TestRegisterCAPath(t *testing.T) {
 	_, err = Register(ctx, RegisterParams{
 		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
 		Token:       token,
-		ID: IdentityID{
+		ID: state.IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",
 			Role:     types.RoleProxy,

--- a/lib/openssh/sshd.go
+++ b/lib/openssh/sshd.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/state"
 )
 
 var (
@@ -150,7 +150,7 @@ func (s *SSHD) UpdateConfig(u SSHDConfigUpdate, restart bool) error {
 
 // WriteKeys writes the OpenSSH keys and CA from the Identity and the
 // OpenSSH CA to disk for the OpenSSH daemon to use
-func WriteKeys(keysdir string, id *auth.Identity, cas []types.CertAuthority) error {
+func WriteKeys(keysdir string, id *state.Identity, cas []types.CertAuthority) error {
 	if err := os.MkdirAll(keysdir, 0o755); err != nil {
 		return trace.ConvertSystemError(err)
 	}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/observability/metrics"
@@ -176,7 +177,7 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 	for _, opt := range opts {
 		opt(&options)
 	}
-	state, err := process.storage.GetState(context.TODO(), role)
+	processState, err := process.storage.GetState(context.TODO(), role)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
@@ -186,13 +187,13 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 		c, err := process.firstTimeConnect(role)
 		return c, trace.Wrap(err)
 	}
-	process.logger.DebugContext(process.ExitContext(), "Got connected state.", "rotation_state", logutils.StringerAttr(&state.Spec.Rotation))
+	process.logger.DebugContext(process.ExitContext(), "Got connected state.", "rotation_state", logutils.StringerAttr(&processState.Spec.Rotation))
 
 	identity, err := process.GetIdentity(role)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	rotation := state.Spec.Rotation
+	rotation := processState.Spec.Rotation
 
 	switch rotation.State {
 	// rotation is on standby, so just use whatever is current
@@ -236,7 +237,7 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 		case types.RotationPhaseUpdateClients:
 			// Clients should use updated credentials,
 			// while servers should use old credentials to answer auth requests.
-			newIdentity, err := process.storage.ReadIdentity(auth.IdentityReplacement, role)
+			newIdentity, err := process.storage.ReadIdentity(state.IdentityReplacement, role)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -251,7 +252,7 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 		case types.RotationPhaseUpdateServers:
 			// Servers and clients are using new identity credentials, but the
 			// identity is still set up to trust the old certificate authority certificates.
-			newIdentity, err := process.storage.ReadIdentity(auth.IdentityReplacement, role)
+			newIdentity, err := process.storage.ReadIdentity(state.IdentityReplacement, role)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -355,7 +356,7 @@ func (process *TeleportProcess) getCertAuthority(conn *Connector, id types.CertA
 // reRegister receives new identity credentials for proxy, node and auth.
 // In case if auth servers, the role is 'TeleportAdmin' and instead of using
 // TLS client this method uses the local auth server.
-func (process *TeleportProcess) reRegister(conn *Connector, additionalPrincipals []string, dnsNames []string, rotation types.Rotation) (*auth.Identity, error) {
+func (process *TeleportProcess) reRegister(conn *Connector, additionalPrincipals []string, dnsNames []string, rotation types.Rotation) (*state.Identity, error) {
 	id := conn.ClientIdentity.ID
 	if id.NodeName == "" {
 		id.NodeName = process.Config.Hostname
@@ -393,7 +394,7 @@ func (process *TeleportProcess) reRegister(conn *Connector, additionalPrincipals
 }
 
 func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connector, error) {
-	id := auth.IdentityID{
+	id := state.IdentityID{
 		Role:     role,
 		HostUUID: process.Config.HostUUID,
 		NodeName: process.Config.Hostname,
@@ -402,7 +403,7 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var identity *auth.Identity
+	var identity *state.Identity
 	if process.getLocalAuth() != nil {
 		// Auth service is on the same host, no need to go though the invitation
 		// procedure.
@@ -476,7 +477,7 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 			return nil, trace.Wrap(err)
 		}
 
-		identity, err = auth.ReadIdentityFromKeyPair(keyPair.PrivateKey, certs)
+		identity, err = state.ReadIdentityFromKeyPair(keyPair.PrivateKey, certs)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -507,12 +508,12 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 		return nil, trace.NewAggregate(err, connector.Close())
 	}
 
-	if err := process.storage.WriteIdentity(auth.IdentityCurrent, *identity); err != nil {
+	if err := process.storage.WriteIdentity(state.IdentityCurrent, *identity); err != nil {
 		process.logger.WarnContext(process.ExitContext(), "Failed to write identity to storage.", "identity", role, "error", err)
 	}
 
-	if err := process.storage.WriteState(role, auth.StateV2{
-		Spec: auth.StateSpecV2{
+	if err := process.storage.WriteState(role, state.StateV2{
+		Spec: state.StateSpecV2{
 			Rotation: ca.GetRotation(),
 		},
 	}); err != nil {
@@ -547,7 +548,7 @@ func (process *TeleportProcess) syncOpenSSHRotationState() error {
 		return trace.Wrap(err)
 	}
 
-	id, err := process.storage.ReadIdentity(auth.IdentityCurrent, types.RoleNode)
+	id, err := process.storage.ReadIdentity(state.IdentityCurrent, types.RoleNode)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -853,7 +854,7 @@ func checkServerIdentity(ctx context.Context, conn *Connector, additionalPrincip
 }
 
 // rotate is called to check if rotation should be triggered.
-func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2, remote types.Rotation) (*rotationStatus, error) {
+func (process *TeleportProcess) rotate(conn *Connector, localState state.StateV2, remote types.Rotation) (*rotationStatus, error) {
 	id := conn.ClientIdentity.ID
 	local := localState.Spec.Rotation
 
@@ -876,7 +877,7 @@ func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2,
 
 	const outOfSync = "%v and cluster rotation state (%v) is out of sync with local (%v). Clear local state and re-register this %v."
 
-	writeStateAndIdentity := func(name string, identity *auth.Identity) error {
+	writeStateAndIdentity := func(name string, identity *state.Identity) error {
 		err = storage.WriteIdentity(name, *identity)
 		if err != nil {
 			return trace.Wrap(err)
@@ -902,7 +903,7 @@ func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2,
 				if err != nil {
 					return nil, trace.Wrap(err)
 				}
-				err = storage.WriteIdentity(auth.IdentityCurrent, *identity)
+				err = storage.WriteIdentity(state.IdentityCurrent, *identity)
 				if err != nil {
 					return nil, trace.Wrap(err)
 				}
@@ -919,7 +920,7 @@ func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2,
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			err = writeStateAndIdentity(auth.IdentityCurrent, identity)
+			err = writeStateAndIdentity(state.IdentityCurrent, identity)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -956,7 +957,7 @@ func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2,
 				return nil, trace.Wrap(err)
 			}
 			process.logger.DebugContext(process.ExitContext(), "Re-registered, received new identity.", "identity", logutils.StringerAttr(identity))
-			err = writeStateAndIdentity(auth.IdentityReplacement, identity)
+			err = writeStateAndIdentity(state.IdentityReplacement, identity)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -969,11 +970,11 @@ func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2,
 				return nil, trace.CompareFailed(outOfSync, id.Role, remote, local, id.Role)
 			}
 			// Write the replacement identity as a current identity and reload the server.
-			replacement, err := storage.ReadIdentity(auth.IdentityReplacement, id.Role)
+			replacement, err := storage.ReadIdentity(state.IdentityReplacement, id.Role)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			err = writeStateAndIdentity(auth.IdentityCurrent, replacement)
+			err = writeStateAndIdentity(state.IdentityCurrent, replacement)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -988,7 +989,7 @@ func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2,
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			err = writeStateAndIdentity(auth.IdentityCurrent, identity)
+			err = writeStateAndIdentity(state.IdentityCurrent, identity)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -1004,7 +1005,7 @@ func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2,
 
 // getConnector gets an appropriate [Connector] for the given identity. The returned [Connector] is backed by the
 // instance client is reused if appropriate, otherwise a new client is created.
-func (process *TeleportProcess) getConnector(clientIdentity, serverIdentity *auth.Identity) (*Connector, error) {
+func (process *TeleportProcess) getConnector(clientIdentity, serverIdentity *state.Identity) (*Connector, error) {
 	if clientIdentity.ID.Role != types.RoleInstance {
 		// non-instance roles should wait to see if the instance client can be reused
 		// before acquiring their own client.
@@ -1053,7 +1054,7 @@ func (process *TeleportProcess) getConnector(clientIdentity, serverIdentity *aut
 // depending on what was specified in the config.
 // For config v1 and v2, it will attempt to direct dial the auth server, and fallback to trying to tunnel
 // to the Auth Server through the proxy.
-func (process *TeleportProcess) newClient(identity *auth.Identity) (*authclient.Client, *proto.PingResponse, error) {
+func (process *TeleportProcess) newClient(identity *state.Identity) (*authclient.Client, *proto.PingResponse, error) {
 	tlsConfig, err := identity.TLSConfig(process.Config.CipherSuites)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -90,6 +90,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keygen"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/backend"
@@ -299,11 +300,11 @@ const (
 type Connector struct {
 	// ClientIdentity is the identity to be used in internal cluster
 	// clients to the auth service.
-	ClientIdentity *auth.Identity
+	ClientIdentity *state.Identity
 
 	// ServerIdentity is the identity to be used in servers - serving SSH
 	// and x509 certificates to clients.
-	ServerIdentity *auth.Identity
+	ServerIdentity *state.Identity
 
 	// Client is authenticated client with credentials from ClientIdentity.
 	Client *authclient.Client
@@ -384,7 +385,7 @@ type TeleportProcess struct {
 	instanceRoles map[types.SystemRole]string
 
 	// identities of this process (credentials to auth sever, basically)
-	Identities map[types.SystemRole]*auth.Identity
+	Identities map[types.SystemRole]*state.Identity
 
 	// connectors is a list of connected clients and their identities
 	connectors map[types.SystemRole]*Connector
@@ -405,7 +406,7 @@ type TeleportProcess struct {
 	forkedTeleportCount atomic.Int32
 
 	// storage is a server local storage
-	storage *auth.ProcessStorage
+	storage *state.ProcessStorage
 
 	// id is a process id - used to identify different processes
 	// during in-process reloads.
@@ -488,7 +489,7 @@ func (process *TeleportProcess) OnHeartbeat(component string) func(err error) {
 	}
 }
 
-func (process *TeleportProcess) findStaticIdentity(id auth.IdentityID) (*auth.Identity, error) {
+func (process *TeleportProcess) findStaticIdentity(id state.IdentityID) (*state.Identity, error) {
 	for i := range process.Config.Identities {
 		identity := process.Config.Identities[i]
 		if identity.ID.Equals(id) {
@@ -622,7 +623,7 @@ func (process *TeleportProcess) getAuthSubjectiveAddr() string {
 // GetIdentity returns the process identity (credentials to the auth server) for a given
 // teleport Role. A teleport process can have any combination of 3 roles: auth, node, proxy
 // and they have their own identities
-func (process *TeleportProcess) GetIdentity(role types.SystemRole) (i *auth.Identity, err error) {
+func (process *TeleportProcess) GetIdentity(role types.SystemRole) (i *state.Identity, err error) {
 	var found bool
 
 	process.Lock()
@@ -632,8 +633,8 @@ func (process *TeleportProcess) GetIdentity(role types.SystemRole) (i *auth.Iden
 	if found {
 		return i, nil
 	}
-	i, err = process.storage.ReadIdentity(auth.IdentityCurrent, role)
-	id := auth.IdentityID{
+	i, err = process.storage.ReadIdentity(state.IdentityCurrent, role)
+	id := state.IdentityID{
 		Role:     role,
 		HostUUID: process.Config.HostUUID,
 		NodeName: process.Config.Hostname,
@@ -661,7 +662,7 @@ func (process *TeleportProcess) GetIdentity(role types.SystemRole) (i *auth.Iden
 				return nil, trace.Wrap(err)
 			}
 			process.logger.InfoContext(process.ExitContext(), "Found static identity in the config file, writing to disk.", "identity", logutils.StringerAttr(&id))
-			if err = process.storage.WriteIdentity(auth.IdentityCurrent, *i); err != nil {
+			if err = process.storage.WriteIdentity(state.IdentityCurrent, *i); err != nil {
 				return nil, trace.Wrap(err)
 			}
 		}
@@ -888,7 +889,7 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 	}
 
 	supervisor := NewSupervisor(processID, cfg.Log)
-	storage, err := auth.NewProcessStorage(supervisor.ExitContext(), filepath.Join(cfg.DataDir, teleport.ComponentProcess))
+	storage, err := state.NewProcessStorage(supervisor.ExitContext(), filepath.Join(cfg.DataDir, teleport.ComponentProcess))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -981,7 +982,7 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		Config:                 cfg,
 		instanceConnectorReady: make(chan struct{}),
 		instanceRoles:          make(map[types.SystemRole]string),
-		Identities:             make(map[types.SystemRole]*auth.Identity),
+		Identities:             make(map[types.SystemRole]*state.Identity),
 		connectors:             make(map[types.SystemRole]*Connector),
 		importedDescriptors:    cfg.FileDescriptors,
 		storage:                storage,
@@ -1799,7 +1800,7 @@ func (process *TeleportProcess) initAuthService() error {
 		}
 	}
 	clusterName := cfg.Auth.ClusterName.GetClusterName()
-	ident, err := process.storage.ReadIdentity(auth.IdentityCurrent, types.RoleAdmin)
+	ident, err := process.storage.ReadIdentity(state.IdentityCurrent, types.RoleAdmin)
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
@@ -4317,7 +4318,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Context:          process.GracefulExitContext(),
 			StaticFS:         fs,
 			ClusterFeatures:  process.GetClusterFeatures(),
-			GetProxyIdentity: func() (*auth.Identity, error) {
+			GetProxyIdentity: func() (*state.Identity, error) {
 				return process.GetIdentity(types.RoleProxy)
 			},
 			UI:              cfg.Proxy.UI,
@@ -5072,7 +5073,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	return nil
 }
 
-func (process *TeleportProcess) getPROXYSigner(ident *auth.Identity) (multiplexer.PROXYHeaderSigner, error) {
+func (process *TeleportProcess) getPROXYSigner(ident *state.Identity) (multiplexer.PROXYHeaderSigner, error) {
 	signer, err := utils.ParsePrivateKeyPEM(ident.KeyBytes)
 	if err != nil {
 		return nil, trace.Wrap(err, "could not parse identity's private key")

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -885,7 +886,7 @@ func TestSetupProxyTLSConfig(t *testing.T) {
 				Supervisor: NewSupervisor("process-id", cfg.Log),
 			}
 			conn := &Connector{
-				ServerIdentity: &auth.Identity{
+				ServerIdentity: &state.Identity{
 					Cert: &ssh.Certificate{
 						Permissions: ssh.Permissions{
 							Extensions: map[string]string{},
@@ -1049,7 +1050,7 @@ func Test_readOrGenerateHostID(t *testing.T) {
 	type args struct {
 		kubeBackend   *fakeKubeBackend
 		hostIDContent string
-		identity      []*auth.Identity
+		identity      []*state.Identity
 	}
 	tests := []struct {
 		name             string
@@ -1140,9 +1141,9 @@ func Test_readOrGenerateHostID(t *testing.T) {
 					getErr:  fmt.Errorf("key not found"),
 				},
 
-				identity: []*auth.Identity{
+				identity: []*state.Identity{
 					{
-						ID: auth.IdentityID{
+						ID: state.IdentityID{
 							HostUUID: id,
 						},
 					},

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -40,7 +40,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/cloud"
@@ -77,7 +77,7 @@ type Config struct {
 
 	// Identities is an optional list of pre-generated key pairs
 	// for teleport roles, this is helpful when server is preconfigured
-	Identities []*auth.Identity
+	Identities []*state.Identity
 
 	// AdvertiseIP is used to "publish" an alternative IP address or hostname this node
 	// can be reached on, if running behind NAT

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
@@ -404,7 +405,7 @@ func botIdentityFromToken(ctx context.Context, log *slog.Logger, cfg *config.Bot
 	expires := time.Now().Add(cfg.CertificateTTL)
 	params := auth.RegisterParams{
 		Token: token,
-		ID: auth.IdentityID{
+		ID: state.IdentityID{
 			Role: types.RoleBot,
 		},
 		PublicTLSKey:       tlsPublicKey,

--- a/lib/tbot/testhelpers/srv.go
+++ b/lib/tbot/testhelpers/srv.go
@@ -31,8 +31,8 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"
@@ -139,7 +139,7 @@ func MakeDefaultAuthClient(t *testing.T, fc *config.FileConfig) *authclient.Clie
 	cfg.HostUUID, err = utils.ReadHostUUID(cfg.DataDir)
 	require.NoError(t, err)
 
-	identity, err := auth.ReadLocalIdentity(filepath.Join(cfg.DataDir, teleport.ComponentProcess), auth.IdentityID{Role: types.RoleAdmin, HostUUID: cfg.HostUUID})
+	identity, err := state.ReadLocalIdentity(filepath.Join(cfg.DataDir, teleport.ComponentProcess), state.IdentityID{Role: types.RoleAdmin, HostUUID: cfg.HostUUID})
 	require.NoError(t, err)
 
 	authConfig := new(authclient.Config)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -75,6 +75,7 @@ import (
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/state"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
@@ -228,7 +229,7 @@ type Config struct {
 	// ProxyPublicAddr contains web proxy public addresses.
 	ProxyPublicAddrs []utils.NetAddr
 	// GetProxyIdentity returns the identity of the proxy.
-	GetProxyIdentity func() (*auth.Identity, error)
+	GetProxyIdentity func() (*state.Identity, error)
 	// CipherSuites is the list of cipher suites Teleport suppports.
 	CipherSuites []uint16
 
@@ -998,7 +999,7 @@ func (h *Handler) GetProxyClient() authclient.ClientI {
 }
 
 // GetProxyIdentity returns the identity of the proxy
-func (h *Handler) GetProxyIdentity() (*auth.Identity, error) {
+func (h *Handler) GetProxyIdentity() (*state.Identity, error) {
 	if h.cfg.GetProxyIdentity == nil {
 		return nil, trace.BadParameter("GetProxyIdentity function is not set")
 	}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -103,6 +103,7 @@ import (
 	tlsutils "github.com/gravitational/teleport/lib/auth/keygen"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/authz"
@@ -461,7 +462,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	if cfg.ClusterFeatures != nil {
 		features = *cfg.ClusterFeatures
 	}
-	authID := auth.IdentityID{
+	authID := state.IdentityID{
 		Role:     types.RoleProxy,
 		HostUUID: proxyID,
 	}
@@ -493,7 +494,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 		UI:                   cfg.uiConfig,
 		OpenAIConfig:         cfg.OpenAIConfig,
 		PresenceChecker:      cfg.presenceChecker,
-		GetProxyIdentity: func() (*auth.Identity, error) {
+		GetProxyIdentity: func() (*state.Identity, error) {
 			return proxyIdentity, nil
 		},
 		IntegrationAppHandler: &mockIntegrationAppHandler{},
@@ -2138,7 +2139,7 @@ func mustStartWindowsDesktopMock(t *testing.T, authClient *auth.Server) *windows
 	t.Cleanup(func() {
 		require.NoError(t, l.Close())
 	})
-	authID := auth.IdentityID{
+	authID := state.IdentityID{
 		Role:     types.RoleWindowsDesktop,
 		HostUUID: "windows_server",
 		NodeName: "windows_server",
@@ -8042,7 +8043,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 	fs, err := newDebugFileSystem()
 	require.NoError(t, err)
 
-	authID := auth.IdentityID{
+	authID := state.IdentityID{
 		Role:     types.RoleProxy,
 		HostUUID: proxyID,
 	}
@@ -8070,7 +8071,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		Router:                         router,
 		HealthCheckAppServer:           func(context.Context, string, string) error { return nil },
 		MinimalReverseTunnelRoutesOnly: cfg.minimalHandler,
-		GetProxyIdentity: func() (*auth.Identity, error) {
+		GetProxyIdentity: func() (*state.Identity, error) {
 			return proxyIdentity, nil
 		},
 		IntegrationAppHandler: &mockIntegrationAppHandler{},
@@ -8748,7 +8749,7 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 	require.NoError(t, err)
 
 	// TLS config for kube proxy and Kube service.
-	authID := auth.IdentityID{
+	authID := state.IdentityID{
 		Role:     role,
 		HostUUID: hostID,
 		NodeName: "kube_server",

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/auth/state"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	libclient "github.com/gravitational/teleport/lib/client"
@@ -1064,9 +1065,9 @@ func newAdminActionTestSuite(t *testing.T) *adminActionTestSuite {
 
 	hostUUID, err := utils.ReadHostUUID(process.Config.DataDir)
 	require.NoError(t, err)
-	localAdmin, err := auth.ReadLocalIdentity(
+	localAdmin, err := state.ReadLocalIdentity(
 		filepath.Join(process.Config.DataDir, teleport.ComponentProcess),
-		auth.IdentityID{Role: types.RoleAdmin, HostUUID: hostUUID},
+		state.IdentityID{Role: types.RoleAdmin, HostUUID: hostUUID},
 	)
 	require.NoError(t, err)
 	localAdminTLS, err := localAdmin.TLSConfig(nil)

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -40,8 +40,8 @@ import (
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/identityfile"
 	libmfa "github.com/gravitational/teleport/lib/client/mfa"
@@ -375,7 +375,7 @@ func ApplyConfig(ccf *GlobalCLIFlags, cfg *servicecfg.Config) (*authclient.Confi
 		}
 		return nil, trace.Wrap(err)
 	}
-	identity, err := auth.ReadLocalIdentity(filepath.Join(cfg.DataDir, teleport.ComponentProcess), auth.IdentityID{Role: types.RoleAdmin, HostUUID: cfg.HostUUID})
+	identity, err := state.ReadLocalIdentity(filepath.Join(cfg.DataDir, teleport.ComponentProcess), state.IdentityID{Role: types.RoleAdmin, HostUUID: cfg.HostUUID})
 	if err != nil {
 		// The "admin" identity is not present? This means the tctl is running
 		// NOT on the auth server


### PR DESCRIPTION
Creates a new lib/auth/state package that now contains all items related to process identity and local storage. Since these things are consumed by client tools isolating them in their own package will allow tools to trim the dependency tree by shedding lib/auth for a smaller package. No functional changes have been added in addition to moving code around. There are aliases to the old types left around to prevent breaking builds. They will be removed in a follow up when teleport.e is updated to consume the new package.