### PR TITLE
Improve how bots are shown on ListUsers

### DIFF
--- a/lib/web/ui/user.go
+++ b/lib/web/ui/user.go
@@ -38,6 +38,8 @@ type UserListEntry struct {
 	AllTraits map[string][]string `json:"allTraits"`
 	// Origin is the type of upstream IdP that manages the user. May be empty.
 	Origin string `json:"origin"`
+	// IsBot is true if the user is a Bot User.
+	IsBot bool `json:"isBot"`
 }
 
 type userTraits struct {
@@ -83,6 +85,7 @@ func NewUserListEntry(teleUser types.User) (*UserListEntry, error) {
 		AuthType:  authType,
 		Origin:    teleUser.Origin(),
 		AllTraits: teleUser.GetTraits(),
+		IsBot:     teleUser.IsBot(),
 	}, nil
 }
 

--- a/lib/web/ui/user_test.go
+++ b/lib/web/ui/user_test.go
@@ -1,0 +1,74 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ui
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestNewUserListEntry(t *testing.T) {
+	tests := []struct {
+		name string
+		user types.User
+		want *UserListEntry
+	}{
+		{
+			name: "bot",
+			user: &types.UserV2{
+				Metadata: types.Metadata{
+					Name: "bot-bernard",
+					Labels: map[string]string{
+						types.BotLabel: "true",
+					},
+				},
+				Spec: types.UserSpecV2{
+					Roles: []string{"behavioral-analyst"},
+					Traits: map[string][]string{
+						"logins": {"arnold"},
+					},
+				},
+			},
+			want: &UserListEntry{
+				Name:     "bot-bernard",
+				Roles:    []string{"behavioral-analyst"},
+				AuthType: "local",
+				IsBot:    true,
+				AllTraits: map[string][]string{
+					"logins": {"arnold"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewUserListEntry(tt.user)
+			require.NoError(t, err)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewUserListEntry() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+}

--- a/web/packages/teleport/src/Users/UserList/UserList.tsx
+++ b/web/packages/teleport/src/Users/UserList/UserList.tsx
@@ -85,9 +85,13 @@ export default function UserList({
     />
   );
 
-  function renderAuthType(authType: string, origin: UserOrigin, isBot?: boolean) {
+  function renderAuthType(
+    authType: string,
+    origin: UserOrigin,
+    isBot?: boolean
+  ) {
     if (isBot) {
-        return 'Bot';
+      return 'Bot';
     }
 
     switch (authType) {

--- a/web/packages/teleport/src/Users/UserList/UserList.tsx
+++ b/web/packages/teleport/src/Users/UserList/UserList.tsx
@@ -61,9 +61,9 @@ export default function UserList({
           key: 'authType',
           headerText: 'Type',
           isSortable: true,
-          render: ({ authType, origin }) => (
+          render: ({ authType, origin, isBot }) => (
             <Cell style={{ textTransform: 'capitalize' }}>
-              {renderAuthType(authType, origin)}
+              {renderAuthType(authType, origin, isBot)}
             </Cell>
           ),
         },
@@ -85,7 +85,11 @@ export default function UserList({
     />
   );
 
-  function renderAuthType(authType: string, origin: UserOrigin) {
+  function renderAuthType(authType: string, origin: UserOrigin, isBot?: boolean) {
+    if (isBot) {
+        return 'Bot';
+    }
+
     switch (authType) {
       case 'github':
         return 'GitHub';
@@ -116,7 +120,7 @@ const ActionCell = ({
   onReset: (user: User) => void;
   onDelete: (user: User) => void;
 }) => {
-  if (!user.isLocal) {
+  if (user.isBot || !user.isLocal) {
     return <Cell align="right" />;
   }
 

--- a/web/packages/teleport/src/Users/Users.story.tsx
+++ b/web/packages/teleport/src/Users/Users.story.tsx
@@ -85,6 +85,13 @@ const users = [
     authType: 'teleport local user',
     isLocal: true,
   },
+  {
+    name: 'bot-little-robot',
+    roles: ['bot-little-robot'],
+    authType: 'teleport local user',
+    isLocal: true,
+    isBot: true,
+  },
 ];
 
 const roles = ['admin', 'testrole'];

--- a/web/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
+++ b/web/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
@@ -506,12 +506,12 @@ exports[`success state 1`] = `
           </strong>
            - 
           <strong>
-            6
+            7
           </strong>
            of
            
           <strong>
-            6
+            7
           </strong>
         </div>
       </div>
@@ -701,6 +701,31 @@ exports[`success state 1`] = `
               </span>
             </button>
           </td>
+        </tr>
+        <tr>
+          <td>
+            bot-little-robot
+          </td>
+          <td>
+            <div
+              class="c19 c25"
+            >
+              <div
+                class="c26"
+                kind="secondary"
+              >
+                bot-little-robot
+              </div>
+            </div>
+          </td>
+          <td
+            style="text-transform: capitalize;"
+          >
+            Bot
+          </td>
+          <td
+            align="right"
+          />
         </tr>
         <tr>
           <td>

--- a/web/packages/teleport/src/services/user/makeUser.ts
+++ b/web/packages/teleport/src/services/user/makeUser.ts
@@ -20,13 +20,14 @@ import { User } from './types';
 
 export default function makeUser(json: any): User {
   json = json || {};
-  const { name, roles, authType, origin, traits = {}, allTraits } = json;
+  const { name, roles, authType, origin, traits = {}, allTraits, isBot } = json;
 
   return {
     name,
     roles: roles ? roles.sort() : [],
     authType: authType === 'local' ? 'teleport local user' : authType,
     isLocal: authType === 'local',
+    isBot: isBot,
     origin: origin ? origin : '',
     traits: {
       logins: traits.logins || [],

--- a/web/packages/teleport/src/services/user/makeUser.ts
+++ b/web/packages/teleport/src/services/user/makeUser.ts
@@ -27,7 +27,7 @@ export default function makeUser(json: any): User {
     roles: roles ? roles.sort() : [],
     authType: authType === 'local' ? 'teleport local user' : authType,
     isLocal: authType === 'local',
-    isBot: isBot,
+    isBot,
     origin: origin ? origin : '',
     traits: {
       logins: traits.logins || [],

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -124,6 +124,8 @@ export interface User {
   origin?: UserOrigin;
   // isLocal is true if json.authType was 'local'.
   isLocal?: boolean;
+  // isBot is true if the user is a Bot User.
+  isBot?: boolean;
   // traits existed before field "externalTraits"
   // and returns only "specific" traits.
   traits?: UserTraits;

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -312,6 +312,7 @@ test('fetch users, null response values gives empty array', async () => {
   expect(response).toStrictEqual([
     {
       authType: '',
+      isBot: undefined,
       isLocal: false,
       name: '',
       roles: [],


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/41595

Changed to hide the options button as we do for SSO users, and changed the auth type column to display "Bot"

![image](https://github.com/gravitational/teleport/assets/16336790/374fc7eb-0bb4-4851-bb3f-d656ecc3e9ae)

changelog: Simplified how Bots are shown on the Users list page.