### PR TITLE
Attempt to stabilize TestShutdown/regular_shutdown

### DIFF
--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -465,6 +465,8 @@ func (s *Server) close(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	shouldDeleteApps := services.ShouldDeleteServerHeartbeatsOnShutdown(ctx)
+
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(100)
 	for name := range s.apps {
@@ -476,24 +478,25 @@ func (s *Server) close(ctx context.Context) error {
 		}
 
 		if heartbeat != nil {
-			s.log.Debugf("Stopping app %q.", name)
+			log := s.log.WithField("app", name)
+			log.Debug("Stopping app")
 			if err := heartbeat.Close(); err != nil {
 				s.log.WithError(err).Warnf("Failed to stop app %q.", name)
 			} else {
-				s.log.Debugf("Stopped app %q.", name)
+				log.Debug("Stopped app")
 			}
-		}
 
-		if heartbeat != nil && services.ShouldDeleteServerHeartbeatsOnShutdown(ctx) {
-			g.Go(func() error {
-				s.log.Debugf("Deleting app %q.", name)
-				if err := s.removeAppServer(gctx, name); err != nil {
-					s.log.WithError(err).Warnf("Failed to delete app %q.", name)
-				} else {
-					s.log.Debugf("Deleted app %q.", name)
-				}
-				return nil
-			})
+			if shouldDeleteApps {
+				g.Go(func() error {
+					log.Debug("Deleting app")
+					if err := s.removeAppServer(gctx, name); err != nil {
+						log.WithError(err).Warnf("Failed to delete app %q.", name)
+					} else {
+						log.Debugf("Deleted app")
+					}
+					return nil
+				})
+			}
 		}
 	}
 

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -539,7 +539,7 @@ func TestShutdown(t *testing.T) {
 			require.Empty(t, cmp.Diff(appServers[0].GetApp(), app0, cmpopts.IgnoreFields(types.Metadata{}, "Revision", "Expires")))
 
 			// Shutdown should not return error.
-			shutdownCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+			shutdownCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 			t.Cleanup(cancel)
 			if test.hasForkedChild {
 				shutdownCtx = services.ProcessForkedContext(shutdownCtx)
@@ -551,7 +551,7 @@ func TestShutdown(t *testing.T) {
 			appServersAfterShutdown, err := s.authClient.GetApplicationServers(ctx, defaults.Namespace)
 			require.NoError(t, err)
 			if test.wantAppServersAfterShutdown {
-				require.Empty(t, cmp.Diff(appServers[0].GetApp(), app0, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+				require.Empty(t, cmp.Diff(appServersAfterShutdown[0].GetApp(), app0, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 			} else {
 				require.Empty(t, appServersAfterShutdown)
 			}


### PR DESCRIPTION
The failure caught in the nightly test runs show that during shutdown the app is stopped but not attempted to be deleted. I've tweaked some of the code path for app deletion during shutdown and increased the shutdown timeout to 10s in the hopes it allows deletion to be executed.

```
{"caller":"app/watcher.go:70","component":"app:service","level":"debug","message":"Not initializing application resource watcher.","timestamp":"2024-05-16T11:17:33Z"}
{"caller":"app/server.go:479","component":"app:service","level":"debug","message":"Stopping app \"app0\".","timestamp":"2024-05-16T11:17:33Z"}
{"caller":"app/server.go:483","component":"app:service","level":"debug","message":"Stopped app \"app0\".","timestamp":"2024-05-16T11:17:33Z"}
{"caller":"backend/buffer.go:283","component":"buffer","level":"debug","message":"Removing watcher d17b3465-9b6e-482b-b478-17bdcf11f97a.root.example.com (0xc000ffdec0) via external close.","timestamp":"2024-05-16T11:17:33Z"}
    server_test.go:556: 
        	Error Trace:	/__w/teleport.e/teleport.e/lib/srv/app/server_test.go:556
        	Error:      	Should be empty, but was [AppServer(Name=app0, Version=16.0.0-dev, Hostname=test, HostID=7024bf4f-07e6-4785-b63f-567f8c4c2526, App=App(Name=app0, PublicAddr=, Labels=map[teleport.dev/origin:config-file]))]
        	Test:       	TestShutdown/regular_shutdown
```
