### PR TITLE
Simplify VNet setup

### DIFF
--- a/lib/teleterm/apiserver/apiserver.go
+++ b/lib/teleterm/apiserver/apiserver.go
@@ -30,7 +30,7 @@ import (
 	vnetapi "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/vnet/v1"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/teleterm/apiserver/handler"
-	vnet "github.com/gravitational/teleport/lib/teleterm/vnet"
+	"github.com/gravitational/teleport/lib/teleterm/vnet"
 	"github.com/gravitational/teleport/lib/utils"
 )
 

--- a/lib/teleterm/apiserver/apiserver.go
+++ b/lib/teleterm/apiserver/apiserver.go
@@ -64,8 +64,9 @@ func New(cfg Config) (*APIServer, error) {
 	}
 
 	vnetService, err := vnet.New(vnet.Config{
-		DaemonService: cfg.Daemon,
-		ClientStore:   cfg.ClientStore,
+		DaemonService:      cfg.Daemon,
+		ClientStore:        cfg.ClientStore,
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/teleterm/apiserver/config.go
+++ b/lib/teleterm/apiserver/config.go
@@ -32,7 +32,8 @@ import (
 // Config is the APIServer configuration
 type Config struct {
 	// HostAddr is the APIServer host address
-	HostAddr string
+	HostAddr           string
+	InsecureSkipVerify bool
 	// Daemon is the terminal daemon service
 	Daemon      *daemon.Service
 	ClientStore *client.Store

--- a/lib/teleterm/apiserver/config.go
+++ b/lib/teleterm/apiserver/config.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/daemon"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -33,7 +34,8 @@ type Config struct {
 	// HostAddr is the APIServer host address
 	HostAddr string
 	// Daemon is the terminal daemon service
-	Daemon *daemon.Service
+	Daemon      *daemon.Service
+	ClientStore *client.Store
 	// Log is a component logger
 	Log             logrus.FieldLogger
 	TshdServerCreds grpc.ServerOption
@@ -54,6 +56,10 @@ func (c *Config) CheckAndSetDefaults() error {
 
 	if c.Daemon == nil {
 		return trace.BadParameter("missing daemon service")
+	}
+
+	if c.ClientStore == nil {
+		return trace.BadParameter("missing client store")
 	}
 
 	if c.TshdServerCreds == nil {

--- a/lib/teleterm/clusters/cluster_apps.go
+++ b/lib/teleterm/clusters/cluster_apps.go
@@ -148,8 +148,8 @@ func (c *Cluster) getApp(ctx context.Context, authClient authclient.ClientI, app
 	return app, trace.Wrap(err)
 }
 
-// reissueAppCert issue new certificates for the app and saves them to disk.
-func (c *Cluster) reissueAppCert(ctx context.Context, clusterClient *client.ClusterClient, app types.Application) (tls.Certificate, error) {
+// ReissueAppCert issue new certificates for the app and saves them to disk.
+func (c *Cluster) ReissueAppCert(ctx context.Context, clusterClient *client.ClusterClient, app types.Application) (tls.Certificate, error) {
 	if app.IsAWSConsole() || app.IsGCP() || app.IsAzureCloud() {
 		return tls.Certificate{}, trace.BadParameter("cloud applications are not supported")
 	}

--- a/lib/teleterm/clusters/cluster_gateways.go
+++ b/lib/teleterm/clusters/cluster_gateways.go
@@ -165,7 +165,7 @@ func (c *Cluster) createAppGateway(ctx context.Context, params CreateGatewayPara
 	var cert tls.Certificate
 
 	if err := AddMetadataToRetryableError(ctx, func() error {
-		cert, err = c.reissueAppCert(ctx, params.ClusterClient, app)
+		cert, err = c.ReissueAppCert(ctx, params.ClusterClient, app)
 		return trace.Wrap(err)
 	}); err != nil {
 		return nil, trace.Wrap(err)
@@ -230,7 +230,7 @@ func (c *Cluster) ReissueGatewayCerts(ctx context.Context, clusterClient *client
 		}
 
 		// The cert is returned from this function and finally set on LocalProxy by the middleware.
-		cert, err := c.reissueAppCert(ctx, clusterClient, app)
+		cert, err := c.ReissueAppCert(ctx, clusterClient, app)
 		return cert, trace.Wrap(err)
 	default:
 		return tls.Certificate{}, trace.NotImplemented("ReissueGatewayCerts does not support this gateway kind %v", g.TargetURI().String())

--- a/lib/teleterm/teleterm.go
+++ b/lib/teleterm/teleterm.go
@@ -68,11 +68,12 @@ func Serve(ctx context.Context, cfg Config) error {
 	}
 
 	apiServer, err := apiserver.New(apiserver.Config{
-		HostAddr:        cfg.Addr,
-		Daemon:          daemonService,
-		TshdServerCreds: grpcCredentials.tshd,
-		ListeningC:      cfg.ListeningC,
-		ClientStore:     client.NewFSClientStore(cfg.HomeDir),
+		HostAddr:           cfg.Addr,
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+		Daemon:             daemonService,
+		TshdServerCreds:    grpcCredentials.tshd,
+		ListeningC:         cfg.ListeningC,
+		ClientStore:        client.NewFSClientStore(cfg.HomeDir),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/teleterm/teleterm.go
+++ b/lib/teleterm/teleterm.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/apiserver"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 	"github.com/gravitational/teleport/lib/teleterm/daemon"
@@ -71,6 +72,7 @@ func Serve(ctx context.Context, cfg Config) error {
 		Daemon:          daemonService,
 		TshdServerCreds: grpcCredentials.tshd,
 		ListeningC:      cfg.ListeningC,
+		ClientStore:     client.NewFSClientStore(cfg.HomeDir),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -108,16 +108,6 @@ func (s *Service) Start(ctx context.Context, req *api.StartRequest) (*api.StartR
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer func() {
-		if s.status != statusRunning {
-			err := processManager.Close()
-			if err != nil && !errors.Is(err, context.Canceled) {
-				log.ErrorContext(ctx, "VNet closed with an error", "error", err)
-			} else {
-				log.DebugContext(ctx, "VNet closed")
-			}
-		}
-	}()
 
 	go func() {
 		err := processManager.Wait()

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -156,7 +156,8 @@ func (s *Service) stopLocked() error {
 		return nil
 	}
 
-	err := s.processManager.Close()
+	s.processManager.Close()
+	err := s.processManager.Wait()
 	if err != nil && !errors.Is(err, context.Canceled) {
 		return trace.Wrap(err)
 	}

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -18,31 +18,269 @@ package service
 
 import (
 	"context"
-	"math/rand"
-	"time"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"sync"
 
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	vnetproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
+	"github.com/gravitational/teleport/api/types"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/vnet/v1"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/teleterm/api/uri"
+	"github.com/gravitational/teleport/lib/teleterm/daemon"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
+	"github.com/gravitational/teleport/lib/vnet"
 )
+
+var log = logutils.NewPackageLogger(teleport.ComponentKey, "term:vnet")
 
 // Service implements gRPC service for VNet.
 type Service struct {
 	api.UnimplementedVnetServiceServer
+
+	cfg       Config
+	mu        sync.Mutex
+	isRunning bool
+	isClosed  bool
+	// stopErrC is used to pass an error from goroutine that runs VNet in the background to the
+	// goroutine which handles RPC for stopping VNet. stopErrC gets closed after VNet stops. Starting
+	// VNet creates a new channel and assigns it as stopErrC.
+	//
+	// It's a buffered channel in case VNet crashes and there's no Stop RPC reading from stopErrC at
+	// that moment.
+	stopErrC chan error
+	// cancel stops the VNet instance running in a separate goroutine.
+	cancel context.CancelCauseFunc
+}
+
+// New creates an instance of Service.
+func New(cfg Config) (*Service, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &Service{
+		cfg: cfg,
+	}, nil
+}
+
+type Config struct {
+	DaemonService *daemon.Service
+	ClientStore   *client.Store
+}
+
+// CheckAndSetDefaults checks and sets the defaults
+func (c *Config) CheckAndSetDefaults() error {
+	if c.DaemonService == nil {
+		return trace.BadParameter("missing DaemonService")
+	}
+
+	if c.ClientStore == nil {
+		return trace.BadParameter("missing ClientStore")
+	}
+
+	return nil
 }
 
 func (s *Service) Start(ctx context.Context, req *api.StartRequest) (*api.StartResponse, error) {
-	n := rand.Intn(10)
-	randomDelay := time.Duration(n) * 100 * time.Millisecond
-	time.Sleep(randomDelay + 400*time.Millisecond)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.isClosed {
+		return nil, trace.CompareFailed("VNet service has been closed")
+	}
+
+	if s.isRunning {
+		return &api.StartResponse{}, nil
+	}
+
+	longCtx, cancelLongCtx := context.WithCancelCause(context.Background())
+	s.cancel = cancelLongCtx
+	defer func() {
+		// If by the end of this RPC the service is not running, make sure to cancel the long context.
+		if !s.isRunning {
+			cancelLongCtx(nil)
+		}
+	}()
+
+	appProvider := &appProvider{
+		daemonService: s.cfg.DaemonService,
+		clientStore:   s.cfg.ClientStore,
+	}
+
+	manager, adminCommandErrCh, err := vnet.Setup(ctx, longCtx, appProvider)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	s.stopErrC = make(chan error, 1)
+
+	go func() {
+		err := vnet.Run(longCtx, cancelLongCtx, manager, adminCommandErrCh)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.ErrorContext(longCtx, "VNet closed with an error", "error", err)
+			s.stopErrC <- err
+		}
+		close(s.stopErrC)
+
+		// TODO(ravicious): Notify the Electron app about change of VNet state, but only if it's
+		// running. If it's not running, then the Start RPC has already failed and forwarded the error
+		// to the user.
+
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		s.isRunning = false
+		cancelLongCtx(nil)
+	}()
+
+	s.isRunning = true
 	return &api.StartResponse{}, nil
 }
 
+// Stop stops VNet and cleans up used resources. Blocks until VNet stops or ctx is canceled.
 func (s *Service) Stop(ctx context.Context, req *api.StopRequest) (*api.StopResponse, error) {
-	return &api.StopResponse{}, nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	errC := make(chan error)
+
+	go func() {
+		errC <- trace.Wrap(s.stopLocked())
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, trace.Wrap(ctx.Err())
+	case err := <-errC:
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return &api.StopResponse{}, nil
+	}
+
 }
 
-// Close stops the current VNet instance and prevents new instances from being started.
-//
+func (s *Service) stopLocked() error {
+	if s.isClosed {
+		return trace.CompareFailed("VNet service has been closed")
+	}
+
+	if !s.isRunning {
+		return nil
+	}
+
+	s.cancel(nil)
+	s.isRunning = false
+
+	return trace.Wrap(<-s.stopErrC)
+}
+
+// Close stops VNet service and prevents it from being started again. Blocks until VNet stops.
 // Intended for cleanup code when tsh daemon gets terminated.
 func (s *Service) Close() error {
-	return nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	err := s.stopLocked()
+	s.isClosed = true
+
+	return trace.Wrap(err)
+}
+
+type appProvider struct {
+	daemonService *daemon.Service
+	clientStore   *client.Store
+}
+
+func (p *appProvider) ListProfiles() ([]string, error) {
+	profiles, err := p.clientStore.ListProfiles()
+	return profiles, trace.Wrap(err)
+}
+
+func (p *appProvider) GetCachedClient(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error) {
+	uri := uri.NewClusterURI(profileName).AppendLeafCluster(leafClusterName)
+	client, err := p.daemonService.GetCachedClient(ctx, uri)
+	return client, trace.Wrap(err)
+}
+
+func (p *appProvider) ReissueAppCert(ctx context.Context, profileName, leafClusterName string, app types.Application) (tls.Certificate, error) {
+	clusterURI := uri.NewClusterURI(profileName).AppendLeafCluster(leafClusterName)
+	cluster, _, err := p.daemonService.ResolveClusterURI(clusterURI)
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err)
+	}
+
+	client, err := p.daemonService.GetCachedClient(ctx, clusterURI)
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err)
+	}
+
+	// TODO(ravicious): Copy stuff from DaemonService.reissueGatewayCerts in order to handle expired certs.
+	cert, err := cluster.ReissueAppCert(ctx, client, app)
+	return cert, trace.Wrap(err)
+}
+
+// GetDialOptions returns ALPN dial options for the profile.
+func (p *appProvider) GetDialOptions(ctx context.Context, profileName string) (*vnet.DialOptions, error) {
+	profile, err := p.clientStore.GetProfile(profileName)
+	if err != nil {
+		return nil, trace.Wrap(err, "loading user profile")
+	}
+	dialOpts := &vnet.DialOptions{
+		WebProxyAddr:            profile.WebProxyAddr,
+		ALPNConnUpgradeRequired: profile.TLSRoutingConnUpgradeRequired,
+	}
+	if dialOpts.ALPNConnUpgradeRequired {
+		dialOpts.RootClusterCACertPool, err = p.getRootClusterCACertPool(ctx, profileName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	return dialOpts, nil
+}
+
+func (p *appProvider) GetVnetConfig(ctx context.Context, profileName, leafClusterName string) (*vnetproto.VnetConfig, error) {
+	clusterClient, err := p.GetCachedClient(ctx, profileName, leafClusterName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	vnetConfigClient := clusterClient.AuthClient.VnetConfigServiceClient()
+	vnetConfig, err := vnetConfigClient.GetVnetConfig(ctx, &vnetproto.GetVnetConfigRequest{})
+	return vnetConfig, trace.Wrap(err)
+}
+
+// getRootClusterCACertPool returns a certificate pool for the root cluster of the given profile.
+func (p *appProvider) getRootClusterCACertPool(ctx context.Context, profileName string) (*x509.CertPool, error) {
+	tc, err := p.newTeleportClient(ctx, profileName, "")
+	if err != nil {
+		return nil, trace.Wrap(err, "creating new client")
+	}
+	certPool, err := tc.RootClusterCACertPool(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err, "loading root cluster CA cert pool")
+	}
+	return certPool, nil
+}
+
+func (p *appProvider) newTeleportClient(ctx context.Context, profileName, leafClusterName string) (*client.TeleportClient, error) {
+	cfg := &client.Config{
+		ClientStore: p.clientStore,
+	}
+	if err := cfg.LoadProfile(p.clientStore, profileName); err != nil {
+		return nil, trace.Wrap(err, "loading client profile")
+	}
+	if leafClusterName != "" {
+		cfg.SiteName = leafClusterName
+	}
+	tc, err := client.NewClient(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating new client")
+	}
+	return tc, nil
 }

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -145,13 +145,13 @@ func (s *Service) Start(ctx context.Context, req *api.StartRequest) (*api.StartR
 		insecureSkipVerify: s.cfg.InsecureSkipVerify,
 	}
 
-	manager, err := vnet.Setup(ctx, appProvider, socket, ipv6Prefix, dnsIPv6)
+	ns, err := vnet.Setup(ctx, appProvider, socket, ipv6Prefix, dnsIPv6)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	g.Go(func() error {
-		return trace.Wrap(manager.Run(longCtx))
+		return trace.Wrap(ns.Run(longCtx))
 	})
 
 	s.stopErrC = make(chan error, 1)

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package service
+package vnet
 
 import (
 	"context"

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -76,8 +76,9 @@ func New(cfg Config) (*Service, error) {
 }
 
 type Config struct {
-	DaemonService *daemon.Service
-	ClientStore   *client.Store
+	DaemonService      *daemon.Service
+	ClientStore        *client.Store
+	InsecureSkipVerify bool
 }
 
 // CheckAndSetDefaults checks and sets the defaults
@@ -115,8 +116,9 @@ func (s *Service) Start(ctx context.Context, req *api.StartRequest) (*api.StartR
 	}()
 
 	appProvider := &appProvider{
-		daemonService: s.cfg.DaemonService,
-		clientStore:   s.cfg.ClientStore,
+		daemonService:      s.cfg.DaemonService,
+		clientStore:        s.cfg.ClientStore,
+		insecureSkipVerify: s.cfg.InsecureSkipVerify,
 	}
 
 	manager, adminCommandErrCh, err := vnet.Setup(ctx, longCtx, appProvider)
@@ -201,8 +203,9 @@ func (s *Service) Close() error {
 }
 
 type appProvider struct {
-	daemonService *daemon.Service
-	clientStore   *client.Store
+	daemonService      *daemon.Service
+	clientStore        *client.Store
+	insecureSkipVerify bool
 }
 
 func (p *appProvider) ListProfiles() ([]string, error) {
@@ -242,6 +245,7 @@ func (p *appProvider) GetDialOptions(ctx context.Context, profileName string) (*
 	dialOpts := &vnet.DialOptions{
 		WebProxyAddr:            profile.WebProxyAddr,
 		ALPNConnUpgradeRequired: profile.TLSRoutingConnUpgradeRequired,
+		InsecureSkipVerify:      p.insecureSkipVerify,
 	}
 	if dialOpts.ALPNConnUpgradeRequired {
 		dialOpts.RootClusterCACertPool, err = p.getRootClusterCACertPool(ctx, profileName)

--- a/lib/vnet/ipbits.go
+++ b/lib/vnet/ipbits.go
@@ -131,7 +131,7 @@ func ipv4Suffix(addr tcpip.Address) ipv4 {
 	return ipv4(binary.BigEndian.Uint32(bytes))
 }
 
-func IPv6WithSuffix(prefix tcpip.Address, suffix []byte) tcpip.Address {
+func ipv6WithSuffix(prefix tcpip.Address, suffix []byte) tcpip.Address {
 	addrBytes := prefix.As16()
 	offset := len(addrBytes) - len(suffix)
 	for i, b := range suffix {

--- a/lib/vnet/ipbits.go
+++ b/lib/vnet/ipbits.go
@@ -131,7 +131,7 @@ func ipv4Suffix(addr tcpip.Address) ipv4 {
 	return ipv4(binary.BigEndian.Uint32(bytes))
 }
 
-func ipv6WithSuffix(prefix tcpip.Address, suffix []byte) tcpip.Address {
+func IPv6WithSuffix(prefix tcpip.Address, suffix []byte) tcpip.Address {
 	addrBytes := prefix.As16()
 	offset := len(addrBytes) - len(suffix)
 	for i, b := range suffix {

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -31,8 +31,8 @@ import (
 // needs to launch an admin subcommand in the background. It returns [ProcessManager] which controls
 // the lifecycle of both background tasks.
 //
-// The caller is expected to call Close on the process manager to close the network stack and clean
-// up any resources used by it.
+// The caller is expected to call Close on the process manager to close the network stack, clean
+// up any resources used by it and terminate the admin subcommand.
 //
 // ctx is used to wait for setup steps that happen before SetupAndRun hands out the control to the
 // process manager. If ctx gets canceled during SetupAndRun, the process manager gets closed along

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -40,7 +40,7 @@ func CreateSocket(ctx context.Context) (*net.UnixListener, string, error) {
 }
 
 // TODO: Add comment.
-func Setup(ctx context.Context, appProvider AppProvider, socket *net.UnixListener, ipv6Prefix, dnsIPv6 tcpip.Address) (*Manager, error) {
+func Setup(ctx context.Context, appProvider AppProvider, socket *net.UnixListener, ipv6Prefix, dnsIPv6 tcpip.Address) (*NetworkStack, error) {
 	tun, err := receiveTUNDevice(ctx, socket)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -51,7 +51,7 @@ func Setup(ctx context.Context, appProvider AppProvider, socket *net.UnixListene
 		return nil, trace.Wrap(err)
 	}
 
-	manager, err := NewManager(&Config{
+	ns, err := NewNetworkStack(&Config{
 		TUNDevice:          tun,
 		IPv6Prefix:         ipv6Prefix,
 		DNSIPv6:            dnsIPv6,
@@ -61,7 +61,7 @@ func Setup(ctx context.Context, appProvider AppProvider, socket *net.UnixListene
 		return nil, trace.Wrap(err)
 	}
 
-	return manager, nil
+	return ns, nil
 }
 
 // AdminSubcommand is the tsh subcommand that should run as root that will create and setup a TUN device and

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -148,6 +148,7 @@ func (pm *ProcessManager) AddCriticalBackgroundTask(name string, task func() err
 	pm.g.Go(func() error {
 		err := task()
 		if err == nil {
+			// Make sure to always return an error so that the errgroup context is canceled.
 			err = fmt.Errorf("critical task %q exited prematurely", name)
 		}
 		return trace.Wrap(err)

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -43,7 +43,7 @@ func SetupAndRun(ctx context.Context, appProvider AppProvider) (*ProcessManager,
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	dnsIPv6 := IPv6WithSuffix(ipv6Prefix, []byte{2})
+	dnsIPv6 := ipv6WithSuffix(ipv6Prefix, []byte{2})
 
 	pm, processCtx := newProcessManager()
 	success := false

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -165,13 +165,9 @@ func (pm *ProcessManager) Wait() error {
 	return trace.Wrap(pm.g.Wait())
 }
 
-// Close stops any active background tasks by canceling the underlying context. It then returns the
-// error from the error group.
-func (pm *ProcessManager) Close() error {
-	go func() {
-		pm.cancel()
-	}()
-	return trace.Wrap(pm.g.Wait())
+// Close stops any active background tasks by canceling the underlying context.
+func (pm *ProcessManager) Close() {
+	pm.cancel()
 }
 
 // AdminSubcommand is the tsh subcommand that should run as root that will create and setup a TUN device and

--- a/lib/vnet/setup_darwin.go
+++ b/lib/vnet/setup_darwin.go
@@ -40,8 +40,10 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
-func receiveTUNDevice(ctx context.Context, socket *net.UnixListener) (tun.Device, error) {
-	tunName, tunFd, err := recvTUNNameAndFd(ctx, socket)
+// receiveTUNDevice is a blocking call which waits for the admin subcommand to pass over the socket
+// the name and fd of the TUN device.
+func receiveTUNDevice(socket *net.UnixListener) (tun.Device, error) {
+	tunName, tunFd, err := recvTUNNameAndFd(socket)
 	if err != nil {
 		return nil, trace.Wrap(err, "receiving TUN name and file descriptor")
 	}
@@ -50,7 +52,7 @@ func receiveTUNDevice(ctx context.Context, socket *net.UnixListener) (tun.Device
 	return tunDevice, trace.Wrap(err, "creating TUN device from file descriptor")
 }
 
-func ExecAdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
+func execAdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
 	executableName, err := os.Executable()
 	if err != nil {
 		return trace.Wrap(err, "getting executable path")
@@ -160,32 +162,12 @@ func sendTUNNameAndFd(socketPath, tunName string, fd uintptr) error {
 
 // recvTUNNameAndFd receives the name of a TUN device and its open file descriptor over a unix socket, meant
 // for passing the TUN from the root process which must create it to the user process.
-func recvTUNNameAndFd(ctx context.Context, socket *net.UnixListener) (string, uintptr, error) {
-	var conn *net.UnixConn
-	errC := make(chan error, 1)
-
-	go func() {
-		connection, err := socket.AcceptUnix()
-		conn = connection
-		errC <- err
-	}()
-
-	select {
-	case <-ctx.Done():
-		return "", 0, trace.Wrap(ctx.Err())
-	case err := <-errC:
-		if err != nil {
-			return "", 0, trace.Wrap(err, "accepting connection on unix socket")
-		}
+func recvTUNNameAndFd(socket *net.UnixListener) (string, uintptr, error) {
+	conn, err := socket.AcceptUnix()
+	if err != nil {
+		return "", 0, trace.Wrap(err, "accepting connection on unix socket")
 	}
-
-	// Close the connection early to unblock reads if the context is canceled.
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go func() {
-		<-ctx.Done()
-		conn.Close()
-	}()
+	defer conn.Close()
 
 	msg := make([]byte, 128)
 	oob := make([]byte, unix.CmsgSpace(4)) // Fd is 4 bytes

--- a/lib/vnet/setup_other.go
+++ b/lib/vnet/setup_other.go
@@ -21,6 +21,7 @@ package vnet
 
 import (
 	"context"
+	"net"
 	"runtime"
 
 	"github.com/gravitational/trace"
@@ -38,11 +39,15 @@ func createAndSetupTUNDeviceWithoutRoot(ctx context.Context, ipv6Prefix, dnsAddr
 	return nil, errCh
 }
 
+func createUnixSocket() (*net.UnixListener, string, error) {
+	return nil, "", trace.Wrap(ErrVnetNotImplemented)
+}
+
 func sendTUNNameAndFd(socketPath, tunName string, fd uintptr) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }
 
-func receiveTUNDevice(ctx context.Context, socket *net.UnixListener) (tun.Device, error) {
+func receiveTUNDevice(socket *net.UnixListener) (tun.Device, error) {
 	return nil, trace.Wrap(ErrVnetNotImplemented)
 }
 

--- a/lib/vnet/setup_other.go
+++ b/lib/vnet/setup_other.go
@@ -42,6 +42,14 @@ func sendTUNNameAndFd(socketPath, tunName string, fd uintptr) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }
 
+func receiveTUNDevice(ctx context.Context, socket *net.UnixListener) (tun.Device, error) {
+	return nil, trace.Wrap(ErrVnetNotImplemented)
+}
+
 func configureOS(ctx context.Context, cfg *osConfig) error {
+	return trace.Wrap(ErrVnetNotImplemented)
+}
+
+func ExecAdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }

--- a/lib/vnet/setup_other.go
+++ b/lib/vnet/setup_other.go
@@ -33,12 +33,6 @@ var (
 	ErrVnetNotImplemented = &trace.NotImplementedError{Message: "VNet is not implemented on " + runtime.GOOS}
 )
 
-func createAndSetupTUNDeviceWithoutRoot(ctx context.Context, ipv6Prefix, dnsAddr string) (<-chan tun.Device, <-chan error) {
-	errCh := make(chan error, 1)
-	errCh <- trace.Wrap(ErrVnetNotImplemented)
-	return nil, errCh
-}
-
 func createUnixSocket() (*net.UnixListener, string, error) {
 	return nil, "", trace.Wrap(ErrVnetNotImplemented)
 }

--- a/lib/vnet/setup_other.go
+++ b/lib/vnet/setup_other.go
@@ -50,6 +50,6 @@ func configureOS(ctx context.Context, cfg *osConfig) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }
 
-func ExecAdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
+func execAdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }

--- a/lib/vnet/setup_test.go
+++ b/lib/vnet/setup_test.go
@@ -1,0 +1,77 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessManager_PrematureReturn(t *testing.T) {
+	pm, pmCtx := newProcessManager()
+	defer pm.Close()
+
+	pm.AddCriticalBackgroundTask("premature return", func() error {
+		return nil
+	})
+	pm.AddCriticalBackgroundTask("context-aware task", func() error {
+		<-pmCtx.Done()
+		return pmCtx.Err()
+	})
+
+	err := pm.Wait()
+	require.ErrorContains(t, err, "critical task \"premature return\" exited prematurely")
+	// Verify that the cancellation cause is propagated through the context.
+	require.ErrorIs(t, err, context.Cause(pmCtx))
+}
+
+func TestProcessManager_ReturnWithError(t *testing.T) {
+	pm, pmCtx := newProcessManager()
+	defer pm.Close()
+
+	taskErr := fmt.Errorf("lorem ipsum dolor sit amet")
+	pm.AddCriticalBackgroundTask("return with error", func() error {
+		return taskErr
+	})
+	pm.AddCriticalBackgroundTask("context-aware task", func() error {
+		<-pmCtx.Done()
+		return pmCtx.Err()
+	})
+
+	err := pm.Wait()
+	require.ErrorIs(t, err, taskErr)
+	require.ErrorIs(t, err, context.Cause(pmCtx))
+}
+
+func TestProcessManager_Close(t *testing.T) {
+	pm, pmCtx := newProcessManager()
+	defer pm.Close()
+
+	pm.AddCriticalBackgroundTask("context-aware task", func() error {
+		<-pmCtx.Done()
+		return pmCtx.Err()
+	})
+
+	pm.Close()
+
+	err := pm.Wait()
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, context.Cause(pmCtx))
+}

--- a/lib/vnet/vnet.go
+++ b/lib/vnet/vnet.go
@@ -212,10 +212,10 @@ func newState() state {
 	}
 }
 
-// NewNetworkStack creates a new VNet network stack with the given configuration and root context.
+// newNetworkStack creates a new VNet network stack with the given configuration and root context.
 // It takes ownership of [cfg.TUNDevice] and will handle closing it before Run() returns. Call Run()
 // on the returned network stack to start the VNet.
-func NewNetworkStack(cfg *Config) (*NetworkStack, error) {
+func newNetworkStack(cfg *Config) (*NetworkStack, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/vnet/vnet.go
+++ b/lib/vnet/vnet.go
@@ -147,8 +147,8 @@ type TUNDevice interface {
 	Close() error
 }
 
-// Manager holds configuration and state for the VNet.
-type Manager struct {
+// NetworkStack holds configuration and state for the VNet.
+type NetworkStack struct {
 	// stack is the gVisor networking stack.
 	stack *stack.Stack
 
@@ -176,13 +176,13 @@ type Manager struct {
 
 	// destroyed is a channel that will be closed when the VNet is in the process of being destroyed.
 	// All goroutines should terminate quickly after either this is closed or the context passed to
-	// [Manager.Run] is canceled.
+	// [NetworkStack.Run] is canceled.
 	destroyed chan struct{}
-	// wg is a [sync.WaitGroup] that keeps track of all running goroutines started by the [Manager].
+	// wg is a [sync.WaitGroup] that keeps track of all running goroutines started by the [NetworkStack].
 	wg sync.WaitGroup
 
-	// state holds all mutable state for the Manager, it is currently protect by a single RWMutex, this could
-	// be optimized as necessary.
+	// state holds all mutable state for the NetworkStack, it is currently protect by a single
+	// RWMutex, this could be optimized as necessary.
 	state state
 
 	slog *slog.Logger
@@ -212,12 +212,10 @@ func newState() state {
 	}
 }
 
-// NewManager creates a new VNet manager with the given configuration and root
-// context. Call Run() on the returned manager to start the VNet.
-// NewManager creates a new VNet manager with the given configuration and root context. It takes ownership of
-// [cfg.TUNDevice] and will handle closing it before Run() returns. Call Run() on the returned manager to
-// start the VNet.
-func NewManager(cfg *Config) (*Manager, error) {
+// NewNetworkStack creates a new VNet network stack with the given configuration and root context.
+// It takes ownership of [cfg.TUNDevice] and will handle closing it before Run() returns. Call Run()
+// on the returned network stack to start the VNet.
+func NewNetworkStack(cfg *Config) (*NetworkStack, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -232,7 +230,7 @@ func NewManager(cfg *Config) (*Manager, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	m := &Manager{
+	ns := &NetworkStack{
 		tun:                cfg.TUNDevice,
 		stack:              stack,
 		linkEndpoint:       linkEndpoint,
@@ -243,11 +241,11 @@ func NewManager(cfg *Config) (*Manager, error) {
 		slog:               slog,
 	}
 
-	tcpForwarder := tcp.NewForwarder(m.stack, tcpReceiveBufferSize, maxInFlightTCPConnectionAttempts, m.handleTCP)
-	m.stack.SetTransportProtocolHandler(tcp.ProtocolNumber, tcpForwarder.HandlePacket)
+	tcpForwarder := tcp.NewForwarder(ns.stack, tcpReceiveBufferSize, maxInFlightTCPConnectionAttempts, ns.handleTCP)
+	ns.stack.SetTransportProtocolHandler(tcp.ProtocolNumber, tcpForwarder.HandlePacket)
 
-	udpForwarder := udp.NewForwarder(m.stack, m.handleUDP)
-	m.stack.SetTransportProtocolHandler(udp.ProtocolNumber, udpForwarder.HandlePacket)
+	udpForwarder := udp.NewForwarder(ns.stack, ns.handleUDP)
+	ns.stack.SetTransportProtocolHandler(udp.ProtocolNumber, udpForwarder.HandlePacket)
 
 	if cfg.DNSIPv6 != (tcpip.Address{}) {
 		upstreamNameserverSource := cfg.upstreamNameserverSource
@@ -257,17 +255,17 @@ func NewManager(cfg *Config) (*Manager, error) {
 				return nil, trace.Wrap(err)
 			}
 		}
-		dnsServer, err := dns.NewServer(m, upstreamNameserverSource)
+		dnsServer, err := dns.NewServer(ns, upstreamNameserverSource)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if err := m.assignUDPHandler(cfg.DNSIPv6, dnsServer); err != nil {
+		if err := ns.assignUDPHandler(cfg.DNSIPv6, dnsServer); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		slog.DebugContext(context.Background(), "Serving DNS on IPv6.", "dns_addr", cfg.DNSIPv6)
 	}
 
-	return m, nil
+	return ns, nil
 }
 
 func createStack() (*stack.Stack, *channel.Endpoint, error) {
@@ -313,8 +311,8 @@ func installVnetRoutes(stack *stack.Stack) error {
 
 // Run starts the VNet. It blocks until [ctx] is canceled, at which point it closes the link endpoint, waits
 // for all goroutines to terminate, and destroys the networking stack.
-func (m *Manager) Run(ctx context.Context) error {
-	m.slog.InfoContext(ctx, "Running Teleport VNet.", "ipv6_prefix", m.ipv6Prefix)
+func (ns *NetworkStack) Run(ctx context.Context) error {
+	ns.slog.InfoContext(ctx, "Running Teleport VNet.", "ipv6_prefix", ns.ipv6Prefix)
 
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -323,7 +321,7 @@ func (m *Manager) Run(ctx context.Context) error {
 	g.Go(func() error {
 		// Make sure to cancel the context in case this exits prematurely with a nil error.
 		defer cancel()
-		err := forwardBetweenTunAndNetstack(ctx, m.tun, m.linkEndpoint)
+		err := forwardBetweenTunAndNetstack(ctx, ns.tun, ns.linkEndpoint)
 		allErrors <- err
 		return err
 	})
@@ -332,13 +330,13 @@ func (m *Manager) Run(ctx context.Context) error {
 		// have canceled it) destroy everything and quit.
 		<-ctx.Done()
 
-		// In-flight connections should start terminating after closing [m.destroyed].
-		close(m.destroyed)
+		// In-flight connections should start terminating after closing [ns.destroyed].
+		close(ns.destroyed)
 
 		// Close the link endpoint and the TUN, this should cause [forwardBetweenTunAndNetstack] to terminate
 		// if it hasn't already.
-		m.linkEndpoint.Close()
-		err := trace.Wrap(m.tun.Close(), "closing TUN device")
+		ns.linkEndpoint.Close()
+		err := trace.Wrap(ns.tun.Close(), "closing TUN device")
 
 		allErrors <- err
 		return err
@@ -348,19 +346,19 @@ func (m *Manager) Run(ctx context.Context) error {
 	_ = g.Wait()
 
 	// Wait for all connections and goroutines to clean themselves up.
-	m.wg.Wait()
+	ns.wg.Wait()
 
 	// Now we can destroy the gVisor networking stack and wait for all its goroutines to terminate.
-	m.stack.Destroy()
+	ns.stack.Destroy()
 
 	close(allErrors)
 	return trace.NewAggregateFromChannel(allErrors, context.Background())
 }
 
-func (m *Manager) handleTCP(req *tcp.ForwarderRequest) {
+func (ns *NetworkStack) handleTCP(req *tcp.ForwarderRequest) {
 	// Add 1 to the waitgroup because the networking stack runs this in its own goroutine.
-	m.wg.Add(1)
-	defer m.wg.Done()
+	ns.wg.Add(1)
+	defer ns.wg.Done()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -375,11 +373,11 @@ func (m *Manager) handleTCP(req *tcp.ForwarderRequest) {
 	}()
 
 	id := req.ID()
-	slog := m.slog.With("request", id)
+	slog := ns.slog.With("request", id)
 	slog.DebugContext(ctx, "Handling TCP connection.")
 	defer slog.DebugContext(ctx, "Finished handling TCP connection.")
 
-	handler, ok := m.getTCPHandler(id.LocalAddress)
+	handler, ok := ns.getTCPHandler(id.LocalAddress)
 	if !ok {
 		slog.DebugContext(ctx, "No handler for address.", "addr", id.LocalAddress)
 		return
@@ -404,16 +402,16 @@ func (m *Manager) handleTCP(req *tcp.ForwarderRequest) {
 
 		conn, connClosed := newConnWithCloseNotifier(gonet.NewTCPConn(&wq, endpoint))
 
-		m.wg.Add(1)
+		ns.wg.Add(1)
 		go func() {
-			defer m.wg.Done()
+			defer ns.wg.Done()
 			select {
 			case <-connClosed:
 				// Conn is already being closed, nothing to do.
 				return
 			case <-notifyCh:
 				slog.DebugContext(ctx, "Got HUP or ERR, closing TCP conn.")
-			case <-m.destroyed:
+			case <-ns.destroyed:
 				slog.DebugContext(ctx, "VNet is being destroyed, closing TCP conn.")
 			}
 			cancel()
@@ -432,63 +430,63 @@ func (m *Manager) handleTCP(req *tcp.ForwarderRequest) {
 	}
 }
 
-func (m *Manager) getTCPHandler(addr tcpip.Address) (TCPHandler, bool) {
-	m.state.mu.RLock()
-	defer m.state.mu.RUnlock()
-	handler, ok := m.state.tcpHandlers[ipv4Suffix(addr)]
+func (ns *NetworkStack) getTCPHandler(addr tcpip.Address) (TCPHandler, bool) {
+	ns.state.mu.RLock()
+	defer ns.state.mu.RUnlock()
+	handler, ok := ns.state.tcpHandlers[ipv4Suffix(addr)]
 	return handler, ok
 }
 
 // assignTCPHandler assigns an IPv4 address to [handlerSpec] from its preferred CIDR range, and returns that
 // new assigned address.
-func (m *Manager) assignTCPHandler(handlerSpec *TCPHandlerSpec, fqdn string) (ipv4, error) {
+func (ns *NetworkStack) assignTCPHandler(handlerSpec *TCPHandlerSpec, fqdn string) (ipv4, error) {
 	_, ipNet, err := net.ParseCIDR(handlerSpec.IPv4CIDRRange)
 	if err != nil {
 		return 0, trace.Wrap(err, "parsing CIDR %q", handlerSpec.IPv4CIDRRange)
 	}
 
-	m.state.mu.Lock()
-	defer m.state.mu.Unlock()
+	ns.state.mu.Lock()
+	defer ns.state.mu.Unlock()
 
 	ip, err := randomFreeIPv4InNet(ipNet, func(ip ipv4) bool {
-		_, taken := m.state.tcpHandlers[ip]
+		_, taken := ns.state.tcpHandlers[ip]
 		return !taken
 	})
 	if err != nil {
 		return 0, trace.Wrap(err, "assigning IP address")
 	}
 
-	m.state.tcpHandlers[ip] = handlerSpec.TCPHandler
-	m.state.appIPs[fqdn] = ip
+	ns.state.tcpHandlers[ip] = handlerSpec.TCPHandler
+	ns.state.appIPs[fqdn] = ip
 
-	if err := m.addProtocolAddress(tcpip.AddrFrom4(ip.asArray())); err != nil {
+	if err := ns.addProtocolAddress(tcpip.AddrFrom4(ip.asArray())); err != nil {
 		return 0, trace.Wrap(err)
 	}
-	if err := m.addProtocolAddress(IPv6WithSuffix(m.ipv6Prefix, ip.asSlice())); err != nil {
+	if err := ns.addProtocolAddress(IPv6WithSuffix(ns.ipv6Prefix, ip.asSlice())); err != nil {
 		return 0, trace.Wrap(err)
 	}
 
 	return ip, nil
 }
 
-func (m *Manager) handleUDP(req *udp.ForwarderRequest) {
-	m.wg.Add(1)
+func (ns *NetworkStack) handleUDP(req *udp.ForwarderRequest) {
+	ns.wg.Add(1)
 	go func() {
-		defer m.wg.Done()
-		m.handleUDPConcurrent(req)
+		defer ns.wg.Done()
+		ns.handleUDPConcurrent(req)
 	}()
 }
 
-func (m *Manager) handleUDPConcurrent(req *udp.ForwarderRequest) {
+func (ns *NetworkStack) handleUDPConcurrent(req *udp.ForwarderRequest) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	id := req.ID()
-	slog := m.slog.With("request", id)
+	slog := ns.slog.With("request", id)
 	slog.DebugContext(ctx, "Handling UDP request.")
 	defer slog.DebugContext(ctx, "Finished handling UDP request.")
 
-	handler, ok := m.getUDPHandler(id.LocalAddress)
+	handler, ok := ns.getUDPHandler(id.LocalAddress)
 	if !ok {
 		slog.DebugContext(ctx, "No handler for address.")
 		return
@@ -501,7 +499,7 @@ func (m *Manager) handleUDPConcurrent(req *udp.ForwarderRequest) {
 		return
 	}
 
-	conn := gonet.NewUDPConn(m.stack, &wq, endpoint)
+	conn := gonet.NewUDPConn(ns.stack, &wq, endpoint)
 	defer conn.Close()
 
 	if err := handler.HandleUDP(ctx, conn); err != nil {
@@ -509,42 +507,42 @@ func (m *Manager) handleUDPConcurrent(req *udp.ForwarderRequest) {
 	}
 }
 
-func (m *Manager) getUDPHandler(addr tcpip.Address) (UDPHandler, bool) {
+func (ns *NetworkStack) getUDPHandler(addr tcpip.Address) (UDPHandler, bool) {
 	ipv4 := ipv4Suffix(addr)
-	m.state.mu.RLock()
-	defer m.state.mu.RUnlock()
-	handler, ok := m.state.udpHandlers[ipv4]
+	ns.state.mu.RLock()
+	defer ns.state.mu.RUnlock()
+	handler, ok := ns.state.udpHandlers[ipv4]
 	return handler, ok
 }
 
-func (m *Manager) assignUDPHandler(addr tcpip.Address, handler UDPHandler) error {
+func (ns *NetworkStack) assignUDPHandler(addr tcpip.Address, handler UDPHandler) error {
 	ipv4 := ipv4Suffix(addr)
-	m.state.mu.Lock()
-	defer m.state.mu.Unlock()
-	if _, ok := m.state.udpHandlers[ipv4]; ok {
+	ns.state.mu.Lock()
+	defer ns.state.mu.Unlock()
+	if _, ok := ns.state.udpHandlers[ipv4]; ok {
 		return trace.AlreadyExists("Handler for %s is already set", addr)
 	}
-	if err := m.addProtocolAddress(addr); err != nil {
+	if err := ns.addProtocolAddress(addr); err != nil {
 		return trace.Wrap(err)
 	}
-	m.state.udpHandlers[ipv4] = handler
+	ns.state.udpHandlers[ipv4] = handler
 	return nil
 }
 
 // ResolveA implements [dns.Resolver.ResolveA].
-func (m *Manager) ResolveA(ctx context.Context, fqdn string) (dns.Result, error) {
+func (ns *NetworkStack) ResolveA(ctx context.Context, fqdn string) (dns.Result, error) {
 	// Do the actual resolution within a [singleflight.Group] keyed by [fqdn] to avoid concurrent requests to
 	// resolve an FQDN and then assign an address to it.
-	resultAny, err, _ := m.resolveHandlerGroup.Do(fqdn, func() (any, error) {
+	resultAny, err, _ := ns.resolveHandlerGroup.Do(fqdn, func() (any, error) {
 		// If we've already assigned an IP address to this app, resolve to it.
-		if ip, ok := m.appIPv4(fqdn); ok {
+		if ip, ok := ns.appIPv4(fqdn); ok {
 			return dns.Result{
 				A: ip.asArray(),
 			}, nil
 		}
 
 		// If fqdn is a Teleport-managed app, create a new handler for it.
-		handlerSpec, err := m.tcpHandlerResolver.ResolveTCPHandler(ctx, fqdn)
+		handlerSpec, err := ns.tcpHandlerResolver.ResolveTCPHandler(ctx, fqdn)
 		if err != nil {
 			if errors.Is(err, ErrNoTCPHandler) {
 				// Did not find any known app, forward the DNS request upstream.
@@ -554,7 +552,7 @@ func (m *Manager) ResolveA(ctx context.Context, fqdn string) (dns.Result, error)
 		}
 
 		// Assign an unused IP address to this app's handler.
-		ip, err := m.assignTCPHandler(handlerSpec, fqdn)
+		ip, err := ns.assignTCPHandler(handlerSpec, fqdn)
 		if err != nil {
 			return dns.Result{}, trace.Wrap(err, "assigning address to handler for %q", fqdn)
 		}
@@ -571,22 +569,22 @@ func (m *Manager) ResolveA(ctx context.Context, fqdn string) (dns.Result, error)
 }
 
 // ResolveAAAA implements [dns.Resolver.ResolveAAAA].
-func (m *Manager) ResolveAAAA(ctx context.Context, fqdn string) (dns.Result, error) {
-	result, err := m.ResolveA(ctx, fqdn)
+func (ns *NetworkStack) ResolveAAAA(ctx context.Context, fqdn string) (dns.Result, error) {
+	result, err := ns.ResolveA(ctx, fqdn)
 	if err != nil {
 		return dns.Result{}, trace.Wrap(err)
 	}
 	if result.A != ([4]byte{}) {
-		result.AAAA = IPv6WithSuffix(m.ipv6Prefix, result.A[:]).As16()
+		result.AAAA = IPv6WithSuffix(ns.ipv6Prefix, result.A[:]).As16()
 		result.A = [4]byte{}
 	}
 	return result, nil
 }
 
-func (m *Manager) appIPv4(fqdn string) (ipv4, bool) {
-	m.state.mu.RLock()
-	defer m.state.mu.RUnlock()
-	ipv4, ok := m.state.appIPs[fqdn]
+func (ns *NetworkStack) appIPv4(fqdn string) (ipv4, bool) {
+	ns.state.mu.RLock()
+	defer ns.state.mu.RUnlock()
+	ipv4, ok := ns.state.appIPs[fqdn]
 	return ipv4, ok
 }
 
@@ -645,12 +643,12 @@ func forwardTUNtoNetstack(tun TUNDevice, linkEndpoint *channel.Endpoint) error {
 	}
 }
 
-func (m *Manager) addProtocolAddress(localAddress tcpip.Address) error {
+func (ns *NetworkStack) addProtocolAddress(localAddress tcpip.Address) error {
 	protocolAddress, err := protocolAddress(localAddress)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := m.stack.AddProtocolAddress(nicID, protocolAddress, stack.AddressProperties{}); err != nil {
+	if err := ns.stack.AddProtocolAddress(nicID, protocolAddress, stack.AddressProperties{}); err != nil {
 		return trace.Errorf("%s", err)
 	}
 	return nil

--- a/lib/vnet/vnet.go
+++ b/lib/vnet/vnet.go
@@ -464,7 +464,7 @@ func (m *Manager) assignTCPHandler(handlerSpec *TCPHandlerSpec, fqdn string) (ip
 	if err := m.addProtocolAddress(tcpip.AddrFrom4(ip.asArray())); err != nil {
 		return 0, trace.Wrap(err)
 	}
-	if err := m.addProtocolAddress(ipv6WithSuffix(m.ipv6Prefix, ip.asSlice())); err != nil {
+	if err := m.addProtocolAddress(IPv6WithSuffix(m.ipv6Prefix, ip.asSlice())); err != nil {
 		return 0, trace.Wrap(err)
 	}
 
@@ -577,7 +577,7 @@ func (m *Manager) ResolveAAAA(ctx context.Context, fqdn string) (dns.Result, err
 		return dns.Result{}, trace.Wrap(err)
 	}
 	if result.A != ([4]byte{}) {
-		result.AAAA = ipv6WithSuffix(m.ipv6Prefix, result.A[:]).As16()
+		result.AAAA = IPv6WithSuffix(m.ipv6Prefix, result.A[:]).As16()
 		result.A = [4]byte{}
 	}
 	return result, nil

--- a/lib/vnet/vnet.go
+++ b/lib/vnet/vnet.go
@@ -462,7 +462,7 @@ func (ns *NetworkStack) assignTCPHandler(handlerSpec *TCPHandlerSpec, fqdn strin
 	if err := ns.addProtocolAddress(tcpip.AddrFrom4(ip.asArray())); err != nil {
 		return 0, trace.Wrap(err)
 	}
-	if err := ns.addProtocolAddress(IPv6WithSuffix(ns.ipv6Prefix, ip.asSlice())); err != nil {
+	if err := ns.addProtocolAddress(ipv6WithSuffix(ns.ipv6Prefix, ip.asSlice())); err != nil {
 		return 0, trace.Wrap(err)
 	}
 
@@ -575,7 +575,7 @@ func (ns *NetworkStack) ResolveAAAA(ctx context.Context, fqdn string) (dns.Resul
 		return dns.Result{}, trace.Wrap(err)
 	}
 	if result.A != ([4]byte{}) {
-		result.AAAA = IPv6WithSuffix(ns.ipv6Prefix, result.A[:]).As16()
+		result.AAAA = ipv6WithSuffix(ns.ipv6Prefix, result.A[:]).As16()
 		result.A = [4]byte{}
 	}
 	return result, nil

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -119,8 +119,7 @@ func newTestPack(t *testing.T, ctx context.Context, clock clockwork.FakeClock, a
 		NIC:         nicID,
 	}})
 
-	dnsIPv6 := ipv6WithSuffix(vnetIPv6Prefix, []byte{2})
-
+	dnsIPv6 := IPv6WithSuffix(vnetIPv6Prefix, []byte{2})
 	tcpHandlerResolver, err := NewTCPAppResolver(appProvider, withClock(clock))
 	require.NoError(t, err)
 

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -124,7 +124,7 @@ func newTestPack(t *testing.T, ctx context.Context, clock clockwork.FakeClock, a
 	require.NoError(t, err)
 
 	// Create the VNet and connect it to the other side of the TUN.
-	ns, err := NewNetworkStack(&Config{
+	ns, err := newNetworkStack(&Config{
 		TUNDevice:                tun2,
 		IPv6Prefix:               vnetIPv6Prefix,
 		DNSIPv6:                  dnsIPv6,

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -64,7 +64,7 @@ func TestMain(m *testing.M) {
 type testPack struct {
 	vnetIPv6Prefix tcpip.Address
 	dnsIPv6        tcpip.Address
-	manager        *Manager
+	ns             *NetworkStack
 
 	testStack        *stack.Stack
 	testLinkEndpoint *channel.Endpoint
@@ -77,9 +77,9 @@ func newTestPack(t *testing.T, ctx context.Context, clock clockwork.FakeClock, a
 
 	// Create an isolated userspace networking stack that can be manipulated from test code. It will be
 	// connected to the VNet over the TUN interface. This emulates the host networking stack.
-	// This is a completely separate gvisor network stack than the one that will be created in NewManager -
-	// the two will be connected over a fake TUN interface. This exists so that the test can setup IP routes
-	// without affecting the host running the Test.
+	// This is a completely separate gvisor network stack than the one that will be created in
+	// NewNetworkStack - the two will be connected over a fake TUN interface. This exists so that the
+	// test can setup IP routes without affecting the host running the Test.
 	testStack, testLinkEndpoint, err := createStack()
 	require.NoError(t, err)
 
@@ -124,7 +124,7 @@ func newTestPack(t *testing.T, ctx context.Context, clock clockwork.FakeClock, a
 	require.NoError(t, err)
 
 	// Create the VNet and connect it to the other side of the TUN.
-	manager, err := NewManager(&Config{
+	ns, err := NewNetworkStack(&Config{
 		TUNDevice:                tun2,
 		IPv6Prefix:               vnetIPv6Prefix,
 		DNSIPv6:                  dnsIPv6,
@@ -136,7 +136,7 @@ func newTestPack(t *testing.T, ctx context.Context, clock clockwork.FakeClock, a
 	utils.RunTestBackgroundTask(ctx, t, &utils.TestBackgroundTask{
 		Name: "VNet",
 		Task: func(ctx context.Context) error {
-			if err := manager.Run(ctx); !errIsOK(err) {
+			if err := ns.Run(ctx); !errIsOK(err) {
 				return trace.Wrap(err)
 			}
 			return nil
@@ -146,7 +146,7 @@ func newTestPack(t *testing.T, ctx context.Context, clock clockwork.FakeClock, a
 	return &testPack{
 		vnetIPv6Prefix:   vnetIPv6Prefix,
 		dnsIPv6:          dnsIPv6,
-		manager:          manager,
+		ns:               ns,
 		testStack:        testStack,
 		testLinkEndpoint: testLinkEndpoint,
 		localAddress:     localAddress,
@@ -167,7 +167,7 @@ func (p *testPack) dialIPPort(ctx context.Context, addr tcpip.Address, port uint
 			NIC:      nicID,
 			Addr:     addr,
 			Port:     port,
-			LinkAddr: p.manager.linkEndpoint.LinkAddress(),
+			LinkAddr: p.ns.linkEndpoint.LinkAddress(),
 		},
 		ipv6.ProtocolNumber,
 	)
@@ -186,7 +186,7 @@ func (p *testPack) dialUDP(ctx context.Context, addr tcpip.Address, port uint16)
 			NIC:      nicID,
 			Addr:     addr,
 			Port:     port,
-			LinkAddr: p.manager.linkEndpoint.LinkAddress(),
+			LinkAddr: p.ns.linkEndpoint.LinkAddress(),
 		},
 		ipv6.ProtocolNumber,
 	)

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -238,7 +238,6 @@ type testClusterSpec struct {
 type echoAppProvider struct {
 	clusters       map[string]testClusterSpec
 	dialOpts       DialOptions
-	clientCert     tls.Certificate
 	reissueAppCert func() tls.Certificate
 }
 

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -119,7 +119,7 @@ func newTestPack(t *testing.T, ctx context.Context, clock clockwork.FakeClock, a
 		NIC:         nicID,
 	}})
 
-	dnsIPv6 := IPv6WithSuffix(vnetIPv6Prefix, []byte{2})
+	dnsIPv6 := ipv6WithSuffix(vnetIPv6Prefix, []byte{2})
 	tcpHandlerResolver, err := NewTCPAppResolver(appProvider, withClock(clock))
 	require.NoError(t, err)
 

--- a/tool/tsh/common/vnet_common.go
+++ b/tool/tsh/common/vnet_common.go
@@ -103,6 +103,7 @@ func (p *vnetAppProvider) GetDialOptions(ctx context.Context, profileName string
 	dialOpts := &vnet.DialOptions{
 		WebProxyAddr:            profile.WebProxyAddr,
 		ALPNConnUpgradeRequired: profile.TLSRoutingConnUpgradeRequired,
+		InsecureSkipVerify:      p.cf.InsecureSkipVerify,
 	}
 	if dialOpts.ALPNConnUpgradeRequired {
 		dialOpts.RootClusterCACertPool, err = p.getRootClusterCACertPool(ctx, profileName)

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -58,7 +58,7 @@ func (c *vnetCommand) run(cf *CLIConf) error {
 
 	go func() {
 		<-cf.Context.Done()
-		_ = processManager.Close()
+		processManager.Close()
 	}()
 
 	err = processManager.Wait()

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -51,7 +51,7 @@ func (c *vnetCommand) run(cf *CLIConf) error {
 	ctx, cancel := context.WithCancelCause(cf.Context)
 	defer cancel(nil)
 
-	manager, adminCommandErrCh, err := vnet.Setup(ctx, appProvider)
+	manager, adminCommandErrCh, err := vnet.Setup(ctx, ctx, appProvider)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/vnet"
@@ -49,41 +48,20 @@ func (c *vnetCommand) run(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	ctx, cancel := context.WithCancel(cf.Context)
-	defer cancel()
-	g, ctx := errgroup.WithContext(ctx)
-
-	socket, socketPath, err := vnet.CreateSocket(ctx)
+	processManager, err := vnet.SetupAndRun(cf.Context, appProvider)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
 		return trace.Wrap(err)
 	}
 
-	g.Go(func() error {
-		<-ctx.Done()
+	go func() {
+		<-cf.Context.Done()
+		_ = processManager.Close()
+	}()
 
-		return trace.Wrap(socket.Close())
-	})
-
-	ipv6Prefix, err := vnet.NewIPv6Prefix()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	dnsIPv6 := vnet.IPv6WithSuffix(ipv6Prefix, []byte{2})
-
-	g.Go(func() error {
-		return trace.Wrap(vnet.ExecAdminSubcommand(ctx, socketPath, ipv6Prefix.String(), dnsIPv6.String()))
-	})
-
-	manager, err := vnet.Setup(ctx, appProvider, socket, ipv6Prefix, dnsIPv6)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	g.Go(func() error {
-		return trace.Wrap(manager.Run(ctx))
-	})
-
-	err = g.Wait()
+	err = processManager.Wait()
 	if errors.Is(err, context.Canceled) {
 		return nil
 	}


### PR DESCRIPTION
After [a conversation with Alan](https://gravitational.slack.com/archives/C0DF0TPMY/p1715853418962919), I decided to try out a couple of improvements which could simplify what I've done in #41413.

In #41413, `vnet.Setup` and `vnet.Run` serve mostly as a big bags of stray functions that are needed to start VNet that I wanted to share between tsh and Connect. The main problem the split into `Setup` and `Run` was solving is that tsh can set up VNet and then start it while blocking the main thread, whereas Connect cannot do this. The RPC in Connect that sets up VNet needs to return after a successful setup and let the VNet manager and the admin subcommand run in the background.

This PR:

* Explicitly throws blocking calls into `errgroup` to get rid of all the shenanigans I was doing with contexts in #41413.
* Removes aggregation of errors from running the admin subcommand and VNet manager. If one fails we cancel the other and forward only the first error. This gets rid of a bunch of different shenanigans with `cancel`.

The setup code ends up being a little bit more elaborate, but I think it's easier to follow and doesn't raise as much red flags as the one I introduced in #41413 does.