### PR TITLE
Add docs for GCP label/tag imports

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -559,6 +559,11 @@ and with tag `foo`: `bar`. Verify that a node running on the instance has label
 `aws/foo=bar`.
 - [ ] Create an Azure VM with tag `foo`: `bar`. Verify that a node running on the
 instance has label `azure/foo=bar`.
+- [ ] Create a GCP instance with [the required permissions]((https://goteleport.com/docs/management/guides/gcp-tags/))
+and with [label](https://cloud.google.com/compute/docs/labeling-resources)
+`foo`: `bar` and [tag](https://cloud.google.com/resource-manager/docs/tags/tags-overview)
+`baz`: `quux`. Verify that a node running on the instance has labels
+`gcp/label/foo=bar` and `gcp/tag/baz=quux`.
 
 ### Passwordless
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -767,6 +767,10 @@
               "slug": "/management/guides/ec2-tags/"
             },
             {
+              "title": "GCP Tags and Labels",
+              "slug": "/management/guides/gcp-tags/"
+            },
+            {
               "title": "Using Teleport's CA with GitHub",
               "slug": "/management/guides/ssh-key-extensions/"
             },

--- a/docs/pages/management/guides.mdx
+++ b/docs/pages/management/guides.mdx
@@ -8,8 +8,10 @@ You can integrate Teleport with third-party tools in order to complete various
 tasks in your cluster. These guides describe Teleport integrations that are not
 documented elsewhere:
 
-  - [EC2 tags as Teleport Node labels](./guides/ec2-tags.mdx). How to set up
-    Teleport Node labels based on EC2 tags.
+  - [EC2 tags as Teleport agent labels](./guides/ec2-tags.mdx). How to set up
+    Teleport agent labels based on EC2 tags.
+  - [GCP tags and labels as Teleport agent labels](./guides/gcp-tags.mdx). How
+    to set up Teleport agent labels based on GCP tags and labels.
   - [Using Teleport's Certificate Authority with
     GitHub](./guides/ssh-key-extensions.mdx). Use Teleport's short-lived
     certificates with GitHub's Certificate Authority.

--- a/docs/pages/management/guides/gcp-tags.mdx
+++ b/docs/pages/management/guides/gcp-tags.mdx
@@ -1,0 +1,79 @@
+---
+title: GCP Tags and Labels as Teleport Agent Labels
+description: How to set up Teleport agent labels based on GCP tags and labels
+h1: Sync GCP Tags/Labels and Teleport agent labels
+---
+
+When running on an Google Compute Engine instance, Teleport will automatically detect and import GCP
+[tags](https://cloud.google.com/resource-manager/docs/tags/tags-overview) (key-value pairs that are
+their own resource) and [labels](https://cloud.google.com/compute/docs/labeling-resources) (key-value
+pairs that are specific to each instance)
+as Teleport labels for SSH nodes, applications, databases, and Kubernetes clusters. Both tags and labels imported
+this way will have the `gcp/` prefix; additionally, tags will receive the `tag/` infix and labels will receive
+the `label/` infix. For example, an instance with label `foo=bar` and tag `baz=quux` will have the Teleport labels
+`gcp/label/foo=bar` and `gcp/tag/baz=quux`.
+
+When the Teleport process starts, it fetches all tags and labels from 
+the GCP API and adds them as labels. The process will update the tags every hour, 
+so newly created or deleted tags will be reflected in the labels.
+
+If the GCP label `TeleportHostname` (case-sensitive) is present, its value will override the node's hostname. This
+does not apply to GCP tags.
+
+```bash
+$ tsh ls
+Node Name            Address        Labels                                                                                                                  
+-------------------- -------------- -------------------------------------------------------------------------------------------
+fakehost.example.com 127.0.0.1:3022 gcp/label/testing=yes,gcp/tag/environment=staging,gcp/TeleportHostname=fakehost.example.com
+```
+
+<Notice type="note">
+  For services that manage multiple resources (such as the Database Service), each resource will receive the
+  same tags and labels from GCP.
+</Notice>
+
+## Prerequisites
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+- One Teleport agent running on a GCP Compute instance. See
+  [our guides](../../agents/join-services-to-your-cluster.mdx) for how to set up Teleport agents.
+
+## Configure service account on instances with Teleport nodes
+
+Create a service account that will give Teleport the IAM permissions needed
+to import tags and labels. Copy the following and paste it into a file called
+`teleport-labels-role.yaml`:
+```yaml
+# teleport-labels-role.yaml
+title: "teleport-labels"
+description: "A role to enable Teleport to import tags and labels"
+stage: "ALPHA"
+includedPermissions:
+- compute.instances.get
+- compute.instances.listEffectiveTags
+```
+
+Then run the following command to create the role:
+```code
+$ gcloud iam roles create teleport_labels \
+--project=<Var name="project_id" description="GCP project ID" /> \
+--file=teleport-labels-role.yaml
+```
+
+Run the following command to create the service account:
+```code
+$ gcloud iam service-accounts create teleport-labels \
+--description="A service account to enable Teleport to import tags and labels" \
+--display-name="teleport-labels"
+```
+
+Run the following command to add the new role to the new service account:
+```code
+$ gcloud projects add-iam-policy-binding <Var name="project_id" description="GCP project ID" /> \
+--member="serviceAccount:teleport-labels@<Var name="project_id" />.iam.gserviceaccount.com" \
+--role="projects/<Var name="project_id" />/roles/teleport_labels"
+```
+
+If you want to only import labels or only import tags, you can leave
+`compute.instances.listEffectiveTags` or `compute.instances.get`
+out of your created service account's permissions, respectively.


### PR DESCRIPTION
This change adds docs and updates the testplan for automatic GCP label/tag imports (#41246).