### PR TITLE
fix flaky `TestCredentialsCache`

### DIFF
--- a/lib/integrations/externalauditstorage/configurator_test.go
+++ b/lib/integrations/externalauditstorage/configurator_test.go
@@ -202,6 +202,13 @@ func TestCredentialsCache(t *testing.T) {
 	require.NoError(t, err)
 
 	clock := clockwork.NewFakeClock()
+	advanceClock := func(d time.Duration) {
+		// Wait for the run loop to actually wait on the clock ticker before advancing. If we advance before
+		// the loop waits on the ticker, it may never tick.
+		clock.BlockUntil(1)
+		clock.Advance(d)
+	}
+
 	stsClient := &fakeSTSClient{
 		clock: clock,
 	}
@@ -260,25 +267,25 @@ func TestCredentialsCache(t *testing.T) {
 	// Test immediately
 	checkRetrieveCredentialsWithExpiry(t, initialCredentialExpiry)
 	// Advance to 1 minute before first refresh attempt
-	clock.Advance(TokenLifetime - refreshBeforeExpirationPeriod - time.Minute)
+	advanceClock(TokenLifetime - refreshBeforeExpirationPeriod - time.Minute)
 	checkRetrieveCredentialsWithExpiry(t, initialCredentialExpiry)
 	// Advance to 1 minute after first refresh attempt
-	clock.Advance(2 * time.Minute)
+	advanceClock(2 * time.Minute)
 	checkRetrieveCredentialsWithExpiry(t, initialCredentialExpiry)
 	// Advance to 1 minute before credential expiry
-	clock.Advance(refreshBeforeExpirationPeriod - 2*time.Minute)
+	advanceClock(refreshBeforeExpirationPeriod - 2*time.Minute)
 	checkRetrieveCredentialsWithExpiry(t, initialCredentialExpiry)
 
 	// Advance 1 minute past the credential expiry and make sure we get the
 	// expected error.
-	clock.Advance(2 * time.Minute)
+	advanceClock(2 * time.Minute)
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		checkRetrieveCredentials(t, stsError)
 	}, waitFor, tick)
 
 	// Fix STS and make sure we stop getting errors within refreshCheckInterval
 	stsClient.setError(nil)
-	clock.Advance(refreshCheckInterval)
+	advanceClock(refreshCheckInterval)
 	newCredentialExpiry := clock.Now().Add(TokenLifetime)
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		checkRetrieveCredentialsWithExpiry(t, newCredentialExpiry)
@@ -290,7 +297,7 @@ func TestCredentialsCache(t *testing.T) {
 	// clients should never see an error retrieving credentials.
 	expectedRefreshTime := newCredentialExpiry.Add(-refreshBeforeExpirationPeriod)
 	credentialsUpdated := false
-	for done := newCredentialExpiry.Add(10 * time.Minute); clock.Now().Before(done); clock.Advance(time.Minute) {
+	for done := newCredentialExpiry.Add(10 * time.Minute); clock.Now().Before(done); advanceClock(time.Minute) {
 		if clock.Now().Sub(expectedRefreshTime).Abs() < 5*time.Minute ||
 			clock.Now().Sub(newCredentialExpiry).Abs() < 5*time.Minute {
 			// Within one of the 10-minute outage windows, make the STS client return errors.

--- a/lib/integrations/externalauditstorage/configurator_test.go
+++ b/lib/integrations/externalauditstorage/configurator_test.go
@@ -297,14 +297,17 @@ func TestCredentialsCache(t *testing.T) {
 	// clients should never see an error retrieving credentials.
 	expectedRefreshTime := newCredentialExpiry.Add(-refreshBeforeExpirationPeriod)
 	credentialsUpdated := false
-	for done := newCredentialExpiry.Add(10 * time.Minute); clock.Now().Before(done); advanceClock(time.Minute) {
+	done := newCredentialExpiry.Add(10 * time.Minute)
+	for clock.Now().Before(done) {
 		if clock.Now().Sub(expectedRefreshTime).Abs() < 5*time.Minute ||
 			clock.Now().Sub(newCredentialExpiry).Abs() < 5*time.Minute {
 			// Within one of the 10-minute outage windows, make the STS client return errors.
 			stsClient.setError(stsError)
+			advanceClock(time.Minute)
 		} else {
 			// Not within an outage window, STS client should not return errors.
 			stsClient.setError(nil)
+			advanceClock(time.Minute)
 
 			if !credentialsUpdated && clock.Now().After(expectedRefreshTime) {
 				// This is after the expected refresh time and not within an outage window, for the test to
@@ -314,7 +317,7 @@ func TestCredentialsCache(t *testing.T) {
 				require.EventuallyWithT(t, func(t *assert.CollectT) {
 					creds, err := provider.Retrieve(ctx)
 					assert.NoError(t, err)
-					assert.WithinDuration(t, expectedExpiry, creds.Expires, time.Minute)
+					assert.WithinDuration(t, expectedExpiry, creds.Expires, 2*time.Minute)
 				}, waitFor, tick)
 				credentialsUpdated = true
 			}


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/40619

This commit fixes the flakiness in TestCredentialsCache (for real this time).

The cache runs a loop in a goroutine that waits on a ticker and refreshes credentials as necessary based on some criteria. This is a design choice that makes the credential cache able to tolerate brief outages of the Teleport Proxy or AWS STS even if they happen to coincide with the time the credential would usually be refreshed.

The test repeatedly advances a fake clock and makes sure that the credential cache is able/not able to get creds as expected. The flakiness arises when the testcase advances the clock before the run loop gets a chance to create the ticker and wait on it. This is solved by waiting to advance the clock until there is at least one goroutine waiting on the clock.

The test now passes 50000 times in a docker container with 0.25 cpus and 100000 times on my laptop. Without the fix it usually failed within around 5000 runs.