### PR TITLE
[docs] update RDS guides

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1280,52 +1280,52 @@
           "slug": "/database-access/enroll-aws-databases/",
           "entries": [
             {
-              "title": "AWS Cross-Account Database Access",
-              "slug": "/database-access/enroll-aws-databases/aws-cross-account/"
-            },
-            {
-              "title": "AWS DynamoDB",
+              "title": "Amazon DynamoDB",
               "slug": "/database-access/enroll-aws-databases/aws-dynamodb/"
             },
             {
-              "title": "AWS OpenSearch",
-              "slug": "/database-access/enroll-aws-databases/aws-opensearch/"
-            },
-            {
-              "title": "AWS RDS Proxy for MariaDB/MySQL",
-              "slug": "/database-access/enroll-aws-databases/rds-proxy-mysql/"
-            },
-            {
-              "title": "Microsoft SQL Server with Active Directory authentication",
-              "slug": "/database-access/enroll-aws-databases/sql-server-ad/"
-            },
-            {
-              "title": "AWS ElastiCache and AWS MemoryDB for Redis",
+              "title": "Amazon ElastiCache and MemoryDB for Redis",
               "slug": "/database-access/enroll-aws-databases/redis-aws/"
             },
             {
-              "title": "AWS Keyspaces (Apache Cassandra)",
+              "title": "Amazon Keyspaces (Apache Cassandra)",
               "slug": "/database-access/enroll-aws-databases/aws-cassandra-keyspaces/"
             },
             {
-              "title": "AWS RDS Proxy for PostgreSQL",
-              "slug": "/database-access/enroll-aws-databases/rds-proxy-postgres/"
+              "title": "Amazon OpenSearch",
+              "slug": "/database-access/enroll-aws-databases/aws-opensearch/"
             },
             {
-              "title": "Redshift Serverless on AWS",
-              "slug": "/database-access/enroll-aws-databases/redshift-serverless/"
+              "title": "Amazon RDS Proxy for MariaDB/MySQL",
+              "slug": "/database-access/enroll-aws-databases/rds-proxy-mysql/"
             },
             {
-              "title": "AWS RDS Proxy for Microsoft SQL Server",
+              "title": "Amazon RDS Proxy for Microsoft SQL Server",
               "slug": "/database-access/enroll-aws-databases/rds-proxy-sqlserver/"
             },
             {
-              "title": "Redshift on AWS",
+              "title": "Amazon RDS Proxy for PostgreSQL",
+              "slug": "/database-access/enroll-aws-databases/rds-proxy-postgres/"
+            },
+            {
+              "title": "Amazon RDS and Aurora",
+              "slug": "/database-access/enroll-aws-databases/rds/"
+            },
+            {
+              "title": "Amazon RDS for Microsoft SQL Server",
+              "slug": "/database-access/enroll-aws-databases/sql-server-ad/"
+            },
+            {
+              "title": "Amazon Redshift",
               "slug": "/database-access/enroll-aws-databases/postgres-redshift/"
             },
             {
-              "title": "AWS RDS and Aurora",
-              "slug": "/database-access/enroll-aws-databases/rds/"
+              "title": "Amazon Redshift Serverless",
+              "slug": "/database-access/enroll-aws-databases/redshift-serverless/"
+            },
+            {
+              "title": "Cross-Account Access",
+              "slug": "/database-access/enroll-aws-databases/aws-cross-account/"
             }
           ]
         },

--- a/docs/pages/database-access/enroll-aws-databases.mdx
+++ b/docs/pages/database-access/enroll-aws-databases.mdx
@@ -17,14 +17,14 @@ Access](./enroll-aws-databases/aws-cross-account.mdx).
 Read the following guides for how to protect a specific AWS-managed database
 with Teleport:
 
-- [Amazon Redshift](./enroll-aws-databases/postgres-redshift.mdx)
-- [Amazon Redshift Serverless](./enroll-aws-databases/redshift-serverless.mdx)
-- [Amazon RDS](./enroll-aws-databases/rds.mdx)
-- [Amazon RDS for SQL Server](./enroll-aws-databases/sql-server-ad.mdx)
-- [Amazon RDS Proxy for PostgreSQL](./enroll-aws-databases/rds-proxy-postgres.mdx)
-- [Amazon RDS Proxy for Microsoft SQL Server](./enroll-aws-databases/rds-proxy-sqlserver.mdx)
-- [Amazon RDS Proxy MySQL](./enroll-aws-databases/rds-proxy-mysql.mdx)
-- [Amazon OpenSearch](./enroll-aws-databases/aws-opensearch.mdx)
 - [Amazon DynamoDB](./enroll-aws-databases/aws-dynamodb.mdx)
-- [Amazon Keyspaces (Apache Cassandra)](./enroll-aws-databases/aws-cassandra-keyspaces.mdx)
 - [Amazon ElastiCache and MemoryDB for Redis](./enroll-aws-databases/redis-aws.mdx)
+- [Amazon Keyspaces (Apache Cassandra)](./enroll-aws-databases/aws-cassandra-keyspaces.mdx)
+- [Amazon OpenSearch](./enroll-aws-databases/aws-opensearch.mdx)
+- [Amazon RDS Proxy MySQL](./enroll-aws-databases/rds-proxy-mysql.mdx)
+- [Amazon RDS Proxy for Microsoft SQL Server](./enroll-aws-databases/rds-proxy-sqlserver.mdx)
+- [Amazon RDS Proxy for PostgreSQL](./enroll-aws-databases/rds-proxy-postgres.mdx)
+- [Amazon RDS and Aurora](./enroll-aws-databases/rds.mdx)
+- [Amazon RDS for SQL Server](./enroll-aws-databases/sql-server-ad.mdx)
+- [Amazon Redshift Serverless](./enroll-aws-databases/redshift-serverless.mdx)
+- [Amazon Redshift](./enroll-aws-databases/postgres-redshift.mdx)

--- a/docs/pages/database-access/enroll-aws-databases/rds.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/rds.mdx
@@ -14,7 +14,7 @@ description: How to configure Teleport database access with AWS RDS and Aurora f
 <TabItem label="Self-Hosted">
 ![Teleport Architecture RDS Self-Hosted](../../../img/database-access/guides/rds_selfhosted.png)
 </TabItem>
-<TabItem label="Teleport Enterprise (cloud-hosted)">
+<TabItem label="Cloud-Hosted">
 ![Teleport Architecture RDS Cloud-Hosted](../../../img/database-access/guides/rds_cloud.png)
 </TabItem>
 
@@ -139,7 +139,7 @@ Next, get your environment ready to run the Teleport Database Service:
 Provide the following information and then generate a configuration file for the
 Teleport Database Service:
 - <Var name="example.teleport.sh:443" /> The host **and port** of your Teleport
-Proxy Service or Enterprise Cloud site
+Proxy Service or cloud-hosted Teleport Enterprise site
 - <Var name="protocol" /> The protocol of the database you want to proxy, either
 `mysql` or `postgres`
 - <Var name="endpoint:port" /> The endpoint **and port** of the database - the

--- a/docs/pages/database-access/enroll-aws-databases/rds.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/rds.mdx
@@ -11,11 +11,11 @@ description: How to configure Teleport database access with AWS RDS and Aurora f
 (!docs/pages/includes/database-access/how-it-works/iam.mdx db="RDS" cloud="AWS"!)
 
 <Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-![Teleport Database Access RDS Self-Hosted](../../../img/database-access/guides/rds_selfhosted.png)
+<TabItem label="Self-Hosted">
+![Teleport Architecture RDS Self-Hosted](../../../img/database-access/guides/rds_selfhosted.png)
 </TabItem>
-<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
-![Teleport Database Access RDS Cloud](../../../img/database-access/guides/rds_cloud.png)
+<TabItem label="Teleport Enterprise (cloud-hosted)">
+![Teleport Architecture RDS Cloud-Hosted](../../../img/database-access/guides/rds_cloud.png)
 </TabItem>
 
 </Tabs>
@@ -136,43 +136,24 @@ Next, get your environment ready to run the Teleport Database Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-Generate a configuration for the Teleport Database Service:
-
-Generate a configuration file for the Teleport Database Service. Run one of the
-following commands, depending on whether you want to proxy an AWS Aurora or
-Amazon RDS instance. 
-
-Assign <Var name="example.teleport.sh:443" /> to the host **and port** of your
-Teleport Proxy Service or Enterprise Cloud site. Assign <Var name="us-west-1" />
-to the region associated with the RDS database.
-
-Run the following command to proxy an AWS Aurora cluster, assigning <Var
-name="RDS_URI" /> to your cluster's domain name and port and <Var
-name="protocol" /> to either `postgres` or `mysql`, depending on the database
-you want to proxy:
+Provide the following information and then generate a configuration file for the
+Teleport Database Service:
+- <Var name="example.teleport.sh:443" /> The host **and port** of your Teleport
+Proxy Service or Enterprise Cloud site
+- <Var name="protocol" /> The protocol of the database you want to proxy, either
+`mysql` or `postgres`
+- <Var name="endpoint:port" /> The endpoint **and port** of the database - the
+cluster endpoint for Aurora or the instance endpoint for an RDS instance, e.g.
+`myrds.us-east-1.rds.amazonaws.com:5432`
 
 ```code
 $ sudo teleport db configure create \
    -o file \
-   --name="postgres-rds" \
+   --name=rds-example \
    --proxy=<Var name="example.teleport.sh:443" />  \
    --protocol=<Var name="protocol" /> \
-   --uri=<Var name="RDS_URI" /> \
-   --token=/tmp/token
-```
-
-Run the following command to proxy an AWS RDS instance, assigning <Var
-name="RDS_URI" /> to your instance's domain name and port and <Var
-name="protocol" /> to either `postgres` or `mysql`, depending on the database
-you want to proxy:
-
-```code
-$ sudo teleport db configure create \
-   -o file \
-   --name="postgres-rds" \
-   --proxy=<Var name="example.teleport.sh:443" />  \
-   --protocol=<Var name="protocol" /> \
-   --uri=<Var name="RDS_URI" /> \
+   --uri=<Var name="endpoint:port" /> \
+   --labels=env=dev \
    --token=/tmp/token
 ```
 
@@ -339,7 +320,7 @@ Token                            Type Labels Expiry Time (UTC)
 Create a Helm values file called `values.yaml`, assigning <Var name="token" />
 to the value of the join token you retrieved above, <Var
 name="example.teleport.sh:443" /> to the host **and port** of your Teleport
-Proxy Service, and <Var name="rds-uri" /> to the host **and port** of your RDS
+Proxy Service, and <Var name="endpoint:port" /> to the host **and port** of your RDS
 database (e.g., `myrds.us-east-1.rds.amazonaws.com:5432`):
 
 ```var
@@ -348,12 +329,10 @@ proxyAddr: <Var name="example.teleport.sh:443" />
 roles: db
 databases:
 - name: example
-  uri: "<Var name="rds-uri" />"
+  uri: "<Var name="endpoint:port" />"
   protocol: <Var name="protocol" />
   static_labels:
     env: dev
-  aws:
-    region: "<Var name="rds-region" />"
 annotations:
   serviceAccount:
     eks.amazonaws.com/role-arn: arn:aws:iam::<Var name="aws-account" />:role/teleport-rds-role
@@ -421,24 +400,15 @@ Once the Database Service has started and joined the cluster, log in as the
 ```code
 $ tsh login --proxy=<Var name="example.teleport.sh:443" /> --user=alice
 $ tsh db ls
-# Name         Description Labels
-# ------------ ----------- --------
-# postgres-rds 
+# Name        Description Labels
+# ----------- ----------- --------
+# rds-example             env=dev
 ```
 
-Retrieve credentials for a database and connect to it as the `alice` user,
-assigning <Var name="postgres-rds" /> to the name of a database resource listed
-by `tsh db ls`:
+Retrieve credentials for the database and connect to it as the `alice` user:
 
 ```code
-$ tsh db connect <Var name="postgres-rds" /> --db-user=alice
-```
-
-You can optionally specify the database name to use by default when connecting
-to the database instance:
-
-```code
-$ tsh db connect --db-user=postgres --db-name=postgres <Var name="postgres-rds" />
+$ tsh db connect --db-user=postgres --db-name=postgres rds-example
 ```
 
 <Admonition type="note" title="Note">
@@ -449,7 +419,7 @@ $ tsh db connect --db-user=postgres --db-name=postgres <Var name="postgres-rds" 
 Log out of the database and remove credentials:
 
 ```code
-$ tsh db logout <Var name="postgres-rds" /> 
+$ tsh db logout rds-example
 ```
 
 ## Troubleshooting

--- a/docs/pages/includes/database-access/rds-proxy.mdx
+++ b/docs/pages/includes/database-access/rds-proxy.mdx
@@ -3,11 +3,11 @@
 (!docs/pages/includes/database-access/how-it-works/iam.mdx db="RDS Proxy" cloud="AWS"!)
 
 <Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-![Teleport Database Access RDS Proxy Self-Hosted](../../../img/database-access/guides/rds-proxy_selfhosted.png)
+<TabItem label="Self-Hosted">
+![Teleport Architecture RDS Proxy Self-Hosted](../../../img/database-access/guides/rds-proxy_selfhosted.png)
 </TabItem>
-<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
-![Teleport Database Access RDS Proxy Cloud](../../../img/database-access/guides/rds-proxy_cloud.png)
+<TabItem label="Teleport Enterprise (cloud-hosted)">
+![Teleport Architecture RDS Proxy Cloud-Hosted](../../../img/database-access/guides/rds-proxy_cloud.png)
 </TabItem>
 
 </Tabs>
@@ -34,54 +34,49 @@ automatically enroll all AWS databases in your infrastructure.
   Service.
 - (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/5. Create a Database Service configuration
+## Step 1/7. Install Teleport
+
+(!docs/pages/includes/install-linux.mdx!)
+
+## Step 2/7. Create a Teleport Database Service configuration
 
 (!docs/pages/includes/database-access/token.mdx!)
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 
-Install Teleport on the host where you will run the Teleport Database Service:
-
-(!docs/pages/includes/install-linux.mdx!)
-
-(!docs/pages/includes/aws-credentials.mdx service="the Teleport Database Service"!)
-
 Create the Database Service configuration. Replace <Var
-name="teleport.example.com" /> with the domain name of your Teleport Proxy
-Service or Teleport Cloud account (e.g. `example.teleport.sh`) and 
-<Var name="DATABASE_URI" /> with the host and port of the database you want to
-proxy:
+name="teleport.example.com:443" /> with the domain name **and port** of your
+Teleport Proxy Service or Teleport Enterprise (cloud-hosted) account and
+<Var name="endpoint:port" /> with the host **and port** of the database endpoint:
 
 ```code
 $ sudo teleport db configure create \
    -o file \
-   --proxy=<Var name="teleport.example.com"/>:443 \
-   --uri=<Var name="DATABASE_URI" /> \
+   --proxy=<Var name="teleport.example.com:443"/> \
+   --uri=<Var name="endpoint:port" /> \
    --protocol={{ protocol }} \
-   --token=/tmp/token
+   --token=/tmp/token \
+   --labels=env=dev
 ```
 
-The command will generate a Database Service configuration with RDS Proxy
-instances auto-discovery enabled on the <Var name="us-west-1" /> region and
+The command will generate a Teleport Database Service configuration file and
 place it at the `/etc/teleport.yaml` location.
 
-## Step 2/5. Create an IAM policy for Teleport
+## Step 3/7. Configure AWS Credentials
 
-Teleport needs AWS IAM permissions to be able to discover and register RDS
-Proxy instances.
+(!docs/pages/includes/aws-credentials.mdx service="the Teleport Database Service"!)
+
+## Step 4/7. Create an IAM policy for Teleport
+
+Teleport needs AWS IAM permissions to be able to access RDS Proxy instances.
 
 (!docs/pages/includes/database-access/aws-bootstrap.mdx!)
 
-## Step 3/5. Start the Database Service
+## Step 5/7. Start the Database Service
 
 (!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
-The Database Service will discover all RDS Proxy instances according to the
-configuration and register them in the cluster. In addition to the primary
-endpoints of the RDS Proxy instances, their custom endpoints will also be
-registered.
-
-## Step 4/5. Configure database user credentials
+## Step 6/7. Configure database user credentials
 
 The Database Service connects to an RDS Proxy instance using IAM
 authentication. In addition, the RDS Proxy instance must also be able to
@@ -169,21 +164,20 @@ IAMAuth=REQUIRED AuthScheme=SECRETS,SecretArn=arn-of-non-teleport-user,IAMAuth=D
 See `aws rds modify-db-proxy help` for more information.
 </Admonition>
 
-## Step 5/5. Connect
+## Step 7/7. Connect
 
 Once the Database Service has started and joined the cluster, log in to see the
-registered databases:
+registered database:
 
 ```code
-$ tsh login --proxy=<Var name="teleport.example.com" /> --user=alice
+$ tsh login --proxy=<Var name="teleport.example.com:443" /> --user=alice
 $ tsh db ls
 Name                         Description                     Labels
 ---------------------------- ------------------------------- -------
 rds-proxy                    RDS Proxy in us-west-1          ...
-rds-proxy-my-reader-endpoint RDS Proxy endpoint in us-west-1 ...
 ```
 
-To retrieve credentials for a database and connect to it:
+Retrieve credentials for the database and connect to it as the `alice` user:
 
 ```code
 $ tsh db connect --db-user=alice --db-name=dev rds-proxy

--- a/docs/pages/includes/database-access/rds-proxy.mdx
+++ b/docs/pages/includes/database-access/rds-proxy.mdx
@@ -6,7 +6,7 @@
 <TabItem label="Self-Hosted">
 ![Teleport Architecture RDS Proxy Self-Hosted](../../../img/database-access/guides/rds-proxy_selfhosted.png)
 </TabItem>
-<TabItem label="Teleport Enterprise (cloud-hosted)">
+<TabItem label="Cloud-Hosted">
 ![Teleport Architecture RDS Proxy Cloud-Hosted](../../../img/database-access/guides/rds-proxy_cloud.png)
 </TabItem>
 
@@ -46,7 +46,7 @@ automatically enroll all AWS databases in your infrastructure.
 
 Create the Database Service configuration. Replace <Var
 name="teleport.example.com:443" /> with the domain name **and port** of your
-Teleport Proxy Service or Teleport Enterprise (cloud-hosted) account and
+Teleport Proxy Service or cloud-hosted Teleport Enterprise account and
 <Var name="endpoint:port" /> with the host **and port** of the database endpoint:
 
 ```code


### PR DESCRIPTION
This is a docs only PR that updates our RDS guides.

For the RDS Aurora/instance guide:
1. condenses the RDS guide's `teleport db configure` commands from 2 to 1
1. eliminates the unused region variable and the unnecessary helm chart region variable (teleport will derive it from the uri)
1. changes the example database name to "rds-example" instead of a configurable variable. The database name isn't relevant to the guide and we shouldn't use a variable for because it messes up the example `tsh db ls` output table format.

For RDS Proxy:
1. split up the first step, which was doing a lot, into separate steps: `install teleport > configure teleport > configure aws credentials`.
1. removed outdated explanation about `teleport db configure create` - the example command doesn't output the deprecated db discovery config