### PR TITLE
changes in teleport-event-handler.toml docs

### DIFF
--- a/docs/pages/includes/start-event-handler.mdx
+++ b/docs/pages/includes/start-event-handler.mdx
@@ -15,8 +15,8 @@ After=network.target
 
 [Service]
 Type=simple
-Restart=on-failure
-ExecStart=/usr/local/bin/teleport-event-handler start --config=/etc/teleport-event-handler.toml --teleport-refresh-enabled true
+Restart=always
+ExecStart=/usr/local/bin/teleport-event-handler start --config=/etc/teleport-event-handler.toml --teleport-refresh-enabled=true
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/teleport-event-handler.pid
 


### PR DESCRIPTION
Changes:

Change 1
In the `teleport-event-handler start --config=/etc/teleport-event-handler.toml --teleport-refresh-enabled true` command will create `Teleport event handler: error: unexpected argument true` error as shown in the below image 

<img width="1422" alt="Screenshot 2024-05-17 at 9 50 59 AM" src="https://github.com/gravitational/teleport/assets/59112642/26a9acb8-b8de-4be5-97df-39adc60f0cba">

It is due to teleport-event-handler tasks `true` as a separate argument instead of considering it is the input of the `--teleport-refresh-enabled` argument; by giving an argument with `=` as `--teleport-refresh-enabled=true` will fix this

Change 2
Sometimes, teleport-event-handler exit with error 0 even some errors occurs, while having `Restart=on-failure` in config will not restart the service as the exit code is 0, by changing it to `Restart=always` will restart the service even the teleport-event-handler exit with error 0.

I understand this may create other issues on some situations, like the service might exit intentionally without any errors. Still, the systems will restart the service as having Restart=always in the unit config.

But here, teleport-event-handler is a log exporting service; it is intended to run continuously in most situations, So  Restart=always will not make any issues in most situations