### PR TITLE
[docs] fix redundant install phrasing

### DIFF
--- a/docs/pages/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
@@ -34,8 +34,6 @@ description: How to configure Teleport database access with Amazon Keyspaces (Ap
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 
-Install Teleport on the host where you will run the Teleport Database Service:
-
 (!docs/pages/includes/install-linux.mdx!)
 
 <Tabs>

--- a/docs/pages/database-access/enroll-aws-databases/aws-dynamodb.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-dynamodb.mdx
@@ -159,10 +159,6 @@ the correct STS endpoint.
 
 ### Install and start Teleport
 
-Install Teleport on the host where you will run the Teleport Database
-Service. See our [Installation](../../installation.mdx) page for options
-besides Linux servers.
-
 (!docs/pages/includes/install-linux.mdx!)
 
 Create a file called `/etc/teleport.yaml` with the following content:

--- a/docs/pages/database-access/enroll-aws-databases/aws-opensearch.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-opensearch.mdx
@@ -196,10 +196,6 @@ Use the token provided by the output of this command in the next step.
 
 ### Install and start Teleport
 
-Install Teleport on the host where you will run the Teleport Database
-Service. See our [Installation](../../installation.mdx) page for options
-besides Linux servers.
-
 (!docs/pages/includes/install-linux.mdx!)
 
 <Tabs>

--- a/docs/pages/database-access/enroll-aws-databases/postgres-redshift.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/postgres-redshift.mdx
@@ -46,8 +46,6 @@ automatically enroll all AWS databases in your infrastructure.
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 
-Install Teleport on the host where you will run the Teleport Database Service:
-
 (!docs/pages/includes/install-linux.mdx!)
 
 On the node that is running the Database Service, create a configuration file.

--- a/docs/pages/database-access/enroll-aws-databases/rds.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/rds.mdx
@@ -134,8 +134,6 @@ Next, get your environment ready to run the Teleport Database Service:
 <Tabs>
 <TabItem label="Linux Host">
 
-Install Teleport on the host where you will run the Teleport Database Service:
-
 (!docs/pages/includes/install-linux.mdx!)
 
 Generate a configuration for the Teleport Database Service:

--- a/docs/pages/database-access/enroll-aws-databases/redis-aws.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/redis-aws.mdx
@@ -62,8 +62,6 @@ databases in your infrastructure.
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 
-Install Teleport on the host where you will run the Teleport Database Service:
-
 (!docs/pages/includes/install-linux.mdx!)
 
 Create the Database Service configuration:

--- a/docs/pages/database-access/enroll-aws-databases/redshift-serverless.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/redshift-serverless.mdx
@@ -138,8 +138,6 @@ role 'redshift-serverless-access' has been created
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 
-Install Teleport on the host where you will run the Teleport Database Service:
-
 (!docs/pages/includes/install-linux.mdx!)
 
 On the same host, run the following command:

--- a/docs/pages/database-access/enroll-aws-databases/sql-server-ad.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/sql-server-ad.mdx
@@ -207,8 +207,6 @@ KVNO Principal
 
 (!docs/pages/includes/database-access/token.mdx!)
 
-Install Teleport on the host where you will run the Teleport Database Service:
-
 (!docs/pages/includes/install-linux.mdx!)
 
 <Admonition type="note">


### PR DESCRIPTION
This is a docs-only PR that removes the redundant "install teleport" phrasing in various parts of our docs.

The `install-linux.mdx` partial starts with:

> Install Teleport on your Linux server:

So we had a lot of places that read like this:

> Install Teleport on the host where you will run the Teleport Database Service:
> Install Teleport on your Linux server:


Other places had:

> Install Teleport on the host where you will run the Teleport Database
> Service. See our [Installation](../../installation.mdx) page for options
> besides Linux servers.
> Install Teleport on your Linux server:

but the end of the partial already links to our installation guide, so it's also redundant:

> 
>    The installation script detects the package manager on your Linux server and
>    uses it to install Teleport binaries. To customize your installation, learn
>    about the Teleport package repositories in the [installation
>    guide](../installation.mdx#linux).
