### PR TITLE
docs: include db and desktop in anonymized usage reporting list

### DIFF
--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -26,6 +26,7 @@ The count of interactions includes the following:
 
 - Teleport logins
 - SSH and Kubernetes exec sessions
+- Desktop and Database sessions
 - Web sessions with registered HTTP applications
 - Connections with registered TCP applications
 - SSH port forwards


### PR DESCRIPTION
Per  this [code](https://github.com/gravitational/teleport/blob/b7776dcd761b3dfb4acb38f0ca85ab4038950827/lib/usagereporter/teleport/aggregating/reporter.go#L348) Desktop and DB sessions are counted too.