### PR TITLE
[v15] Remove denied AWS Roles in AWS Role Web picker

### DIFF
--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -773,6 +773,8 @@ func (a *accessChecker) GetAllowedLoginsForResource(resource AccessCheckable) ([
 	// true otherwise.
 	mapped := make(map[string]bool)
 
+	resourceAsApp, resourceIsApp := resource.(interface{ IsAWSConsole() bool })
+
 	for _, role := range a.RoleSet {
 		var loginGetter func(types.RoleConditionType) []string
 
@@ -781,6 +783,16 @@ func (a *accessChecker) GetAllowedLoginsForResource(resource AccessCheckable) ([
 			loginGetter = role.GetLogins
 		case types.KindWindowsDesktop:
 			loginGetter = role.GetWindowsLogins
+		case types.KindApp:
+			if !resourceIsApp {
+				return nil, trace.BadParameter("received unsupported resource type for Application kind: %T", resource)
+			}
+			// For Apps, only AWS currently supports listing the possible logins.
+			if !resourceAsApp.IsAWSConsole() {
+				return nil, nil
+			}
+
+			loginGetter = role.GetAWSRoleARNs
 		default:
 			return nil, trace.BadParameter("received unsupported resource kind: %s", resource.GetKind())
 		}
@@ -811,6 +823,12 @@ func (a *accessChecker) GetAllowedLoginsForResource(resource AccessCheckable) ([
 		newLoginMatcher = NewLoginMatcher
 	case types.KindWindowsDesktop:
 		newLoginMatcher = NewWindowsLoginMatcher
+	case types.KindApp:
+		if !resourceIsApp || !resourceAsApp.IsAWSConsole() {
+			return nil, trace.BadParameter("received unsupported resource type for Application: %T", resource)
+		}
+
+		newLoginMatcher = NewAppAWSLoginMatcher
 	default:
 		return nil, trace.BadParameter("received unsupported resource kind: %s", resource.GetKind())
 	}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2272,6 +2272,27 @@ func (l *windowsLoginMatcher) Match(role types.Role, typ types.RoleConditionType
 	return false, nil
 }
 
+type awsAppLoginMatcher struct {
+	awsRole string
+}
+
+// NewAppAWSLoginMatcher creates a RoleMatcher that checks whether the role's
+// AWS Role ARN match the specified condition.
+func NewAppAWSLoginMatcher(awsRole string) RoleMatcher {
+	return &awsAppLoginMatcher{awsRole: awsRole}
+}
+
+// Match matches an AWS Role ARN login against a role.
+func (l *awsAppLoginMatcher) Match(role types.Role, typ types.RoleConditionType) (bool, error) {
+	awsRoles := role.GetAWSRoleARNs(typ)
+	for _, awsRole := range awsRoles {
+		if l.awsRole == awsRole {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 type kubernetesClusterLabelMatcher struct {
 	clusterLabels map[string]string
 	userTraits    wrappers.Traits

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -4110,15 +4110,19 @@ func TestGetAllowedLoginsForResource(t *testing.T) {
 					Namespaces:           []string{apidefaults.Namespace},
 					Logins:               allowLogins,
 					WindowsDesktopLogins: allowLogins,
+					AWSRoleARNs:          allowLogins,
 					NodeLabels:           allowLabels,
 					WindowsDesktopLabels: allowLabels,
+					AppLabels:            allowLabels,
 				},
 				Deny: types.RoleConditions{
 					Namespaces:           []string{apidefaults.Namespace},
 					Logins:               denyLogins,
 					WindowsDesktopLogins: denyLogins,
+					AWSRoleARNs:          denyLogins,
 					NodeLabels:           denyLabels,
 					WindowsDesktopLabels: denyLabels,
+					AppLabels:            denyLabels,
 				},
 			},
 		}
@@ -4286,14 +4290,18 @@ func TestGetAllowedLoginsForResource(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			server := mustMakeTestServer(tc.labels)
 			desktop := mustMakeTestWindowsDesktop(tc.labels)
+			app := mustMakeTestAWSApp(tc.labels)
 
 			serverLogins, err := accessChecker.GetAllowedLoginsForResource(server)
 			require.NoError(t, err)
 			desktopLogins, err := accessChecker.GetAllowedLoginsForResource(desktop)
 			require.NoError(t, err)
+			awsARNLogins, err := accessChecker.GetAllowedLoginsForResource(app)
+			require.NoError(t, err)
 
 			require.ElementsMatch(t, tc.expectedLogins, serverLogins)
 			require.ElementsMatch(t, tc.expectedLogins, desktopLogins)
+			require.ElementsMatch(t, tc.expectedLogins, awsARNLogins)
 		})
 	}
 }
@@ -4314,6 +4322,22 @@ func mustMakeTestWindowsDesktop(labels map[string]string) types.WindowsDesktop {
 		panic(err)
 	}
 	return d
+}
+
+func mustMakeTestAWSApp(labels map[string]string) types.Application {
+	app, err := types.NewAppV3(types.Metadata{
+		Name:   "my-app",
+		Labels: labels,
+	},
+		types.AppSpecV3{
+			URI:   "https://some-addr.com",
+			Cloud: "AWS",
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+	return app
 }
 
 func TestCheckDatabaseRoles(t *testing.T) {

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -46,11 +46,6 @@ import (
 // clusterAppsGet returns a list of applications in a form the UI can present.
 // This includes Application Servers as well as SAML IdP Service providers.
 func (h *Handler) clusterAppsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
-	identity, err := sctx.GetIdentity()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	// Get a list of application servers and their proxied apps.
 	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
@@ -97,6 +92,12 @@ func (h *Handler) clusterAppsGet(w http.ResponseWriter, r *http.Request, p httpr
 		userGroupLookup[userGroup.GetName()] = userGroup
 	}
 
+	accessChecker, err := sctx.GetUserAccessChecker()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	allowedAWSRolesLookup := map[string][]string{}
 	var appsAndSPs types.AppServersOrSAMLIdPServiceProviders
 	appsToUserGroups := map[string]types.UserGroups{}
 	for _, appOrSP := range page.Resources {
@@ -104,6 +105,16 @@ func (h *Handler) clusterAppsGet(w http.ResponseWriter, r *http.Request, p httpr
 
 		if appOrSP.IsAppServer() {
 			app := appOrSP.GetAppServer().GetApp()
+
+			if app.IsAWSConsole() {
+				allowedAWSRoles, err := accessChecker.GetAllowedLoginsForResource(app)
+				if err != nil {
+					h.log.Debugf("Unable to find allowed AWS Roles for app %s, skipping", app.GetName())
+					continue
+				}
+
+				allowedAWSRolesLookup[app.GetName()] = allowedAWSRoles
+			}
 
 			ugs := types.UserGroups{}
 			for _, userGroupName := range app.GetUserGroups() {
@@ -125,7 +136,7 @@ func (h *Handler) clusterAppsGet(w http.ResponseWriter, r *http.Request, p httpr
 			LocalClusterName:                     h.auth.clusterName,
 			LocalProxyDNSName:                    h.proxyDNSName(),
 			AppClusterName:                       site.GetName(),
-			Identity:                             identity,
+			AllowedAWSRolesLookup:                allowedAWSRolesLookup,
 			AppsToUserGroups:                     appsToUserGroups,
 			AppServersAndSAMLIdPServiceProviders: appsAndSPs,
 		}),


### PR DESCRIPTION
Backport #41585 to v15

changelog: Remove invalid AWS Roles from Web UI picker