### PR TITLE
Show real proxy hostnames in VNet UI

### DIFF
--- a/web/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
@@ -44,6 +44,20 @@ const rootClusterUri = '/clusters/foo';
 export function Story() {
   const appContext = new MockAppContext();
   prepareAppContext(appContext);
+  appContext.clustersService.setState(draft => {
+    const rootCluster1 = makeRootCluster({
+      uri: rootClusterUri,
+      name: 'teleport.example.sh',
+      proxyHost: 'teleport.example.sh:443',
+    });
+    const rootCluster2 = makeRootCluster({
+      uri: '/clusters/bar',
+      name: 'bar.example.com',
+      proxyHost: 'bar.example.com:3080',
+    });
+    draft.clusters.set(rootCluster1.uri, rootCluster1);
+    draft.clusters.set(rootCluster2.uri, rootCluster2);
+  });
 
   return (
     <AppContextProvider value={appContext}>
@@ -95,7 +109,7 @@ export function MultipleClusters() {
   );
 }
 
-export function JustVnet() {
+export function JustVnetWithNoClusters() {
   const appContext = new MockAppContext();
   prepareAppContext(appContext);
   appContext.connectionTracker.getConnections = () => [];

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -26,7 +26,7 @@ import * as whatwg from 'whatwg-url';
 import { useStoreSelector } from 'teleterm/ui/hooks/useStoreSelector';
 
 import { useVnetContext } from './vnetContext';
-import { VnetSliderStepHeader, AppConnectionItem } from './VnetConnectionItem';
+import { VnetSliderStepHeader } from './VnetConnectionItem';
 
 /**
  * VnetSliderStep is the second step of StepSlider used in TopBar/Connections. It is shown after
@@ -94,19 +94,6 @@ export const VnetSliderStep = (props: StepComponentProps) => {
             <Text p={textSpacing}>
               Proxying TCP connections to {rootProxyHostnames.join(', ')}
             </Text>
-            <Flex flexDirection="column" gap={1}>
-              <AppConnectionItem app="api.company.private" status="on" />
-              <AppConnectionItem app="kafka.teleport-local.dev" status="on" />
-              <AppConnectionItem
-                app="redis.teleport-local.dev"
-                status="error"
-                error={dnsError}
-              />
-              <AppConnectionItem
-                app="aerospike.teleport-local.dev"
-                status="off"
-              />
-            </Flex>
           </>
         ))}
     </Box>
@@ -114,5 +101,3 @@ export const VnetSliderStep = (props: StepComponentProps) => {
 };
 
 const textSpacing = 1;
-
-const dnsError = `DNS query for "redis.teleport-local.dev" in custom DNS zone failed: no matching Teleport app and upstream nameserver did not respond`;

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -16,10 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { useCallback } from 'react';
 import { StepComponentProps } from 'design/StepSlider';
 import { Box, Flex, Text } from 'design';
 import { mergeRefs } from 'shared/libs/mergeRefs';
 import { useRefAutoFocus } from 'shared/hooks';
+import * as whatwg from 'whatwg-url';
+
+import { useStoreSelector } from 'teleterm/ui/hooks/useStoreSelector';
 
 import { useVnetContext } from './vnetContext';
 import { VnetSliderStepHeader, AppConnectionItem } from './VnetConnectionItem';
@@ -34,6 +38,14 @@ export const VnetSliderStep = (props: StepComponentProps) => {
   const autoFocusRef = useRefAutoFocus<HTMLElement>({
     shouldFocus: visible,
   });
+  const clusters = useStoreSelector(
+    'clustersService',
+    useCallback(state => state.clusters, [])
+  );
+  const rootClusters = [...clusters.values()].filter(cluster => !cluster.leaf);
+  const rootProxyHostnames = rootClusters.map(
+    cluster => new whatwg.URL(`https://${cluster.proxyHost}`).hostname
+  );
 
   return (
     // Padding needs to align with the padding of the previous slider step.
@@ -70,26 +82,33 @@ export const VnetSliderStep = (props: StepComponentProps) => {
         )}
       </Flex>
 
-      {status === 'running' && (
-        <>
+      {status === 'running' &&
+        (rootClusters.length === 0 ? (
           <Text p={textSpacing}>
-            Proxying connections to .teleport-local.dev, .company.private
+            No clusters connected yet, VNet is not proxying any connections.
           </Text>
-          <Flex flexDirection="column" gap={1}>
-            <AppConnectionItem app="api.company.private" status="on" />
-            <AppConnectionItem app="kafka.teleport-local.dev" status="on" />
-            <AppConnectionItem
-              app="redis.teleport-local.dev"
-              status="error"
-              error={dnsError}
-            />
-            <AppConnectionItem
-              app="aerospike.teleport-local.dev"
-              status="off"
-            />
-          </Flex>
-        </>
-      )}
+        ) : (
+          <>
+            {/* TODO(ravicious): Add leaf clusters and custom DNS zones when support for them
+                lands in VNet. */}
+            <Text p={textSpacing}>
+              Proxying TCP connections to {rootProxyHostnames.join(', ')}
+            </Text>
+            <Flex flexDirection="column" gap={1}>
+              <AppConnectionItem app="api.company.private" status="on" />
+              <AppConnectionItem app="kafka.teleport-local.dev" status="on" />
+              <AppConnectionItem
+                app="redis.teleport-local.dev"
+                status="error"
+                error={dnsError}
+              />
+              <AppConnectionItem
+                app="aerospike.teleport-local.dev"
+                status="off"
+              />
+            </Flex>
+          </>
+        ))}
     </Box>
   );
 };


### PR DESCRIPTION
<img width="1273" alt="real-proxyhosts" src="https://github.com/gravitational/teleport/assets/27113/01826312-4ad4-4b7d-9c32-0f4ece8325aa">

As the support for leaf clusters and custom DNS zones has not landed just yet, for now we show what's supported which is proxy hostnames of root clusters.

I also removed the fake connections since recent VNet connections are not going to land in v16.0.