### PR TITLE
[v15] Fix missing SSHD_CONFIG variable in Default Agentless Installer script

### DIFF
--- a/api/types/installers/agentless-installer.sh.tmpl
+++ b/api/types/installers/agentless-installer.sh.tmpl
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-set -o errexit
-set -o pipefail
-set -o nounset
+set -eu
 
 upgrade_endpoint="{{ .PublicProxyAddr }}/v1/webapi/automaticupgrades/channel/default"
 
@@ -36,8 +34,13 @@ run_teleport() {
   LABELS="$3"
   ADDRESS="$4"
 
+  OPENSSH_CONFIG="/etc/ssh/sshd_config"
+  if [ -n "${SSHD_CONFIG-}" ]; then
+    OPENSSH_CONFIG="${SSHD_CONFIG}"
+  fi
+
   sudo /usr/local/bin/teleport join openssh \
-    --openssh-config="${SSHD_CONFIG}" \
+    --openssh-config="${OPENSSH_CONFIG}" \
     --join-method=iam \
     --token="$TOKEN" \
     --proxy-server="{{ .PublicProxyAddr }}" \


### PR DESCRIPTION
Backport #41523 to branch/v15

changelog: Fix missing variable and script options in Default Agentless Installer script
