### PR TITLE
Update depguard rules

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,6 +32,7 @@ jobs:
               - 'build.assets/Makefile'
               - 'build.assets/Dockerfile*'
               - 'Makefile'
+              - '.golangci.yml'
             has_rust:
               - '.github/workflows/lint.yaml'
               - '**.rs'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -104,6 +104,42 @@ linters-settings:
             desc: 'experimental project, not to be confused with official Go packages'
           - pkg: golang.org/x/exp/slices
             desc: 'use "slices" instead'
+      # Prevent logrus from being imported by api. Once everything in teleport has been converted
+      # to use log/slog this should be moved into the main block above.
+      logrus:
+        files:
+          - '**/api/**'
+        deny:
+          - pkg: github.com/sirupsen/logrus
+            desc: 'use "log/slog" instead'
+      # Prevent importing internal packages in client tools or packages containing
+      # common interfaces consumed by them that are known to bloat binaries or break builds
+      # because they only support a single platform.
+      client-tools:
+        files:
+          # Tests can do anything
+          - "!$test"
+          - '**/tool/tbot/**'
+          - '**/lib/tbot/**'
+          - '**/tool/tctl/**'
+          - '**/tool/tsh/**'
+          - '**/lib/client/**'
+          - '**/lib/services/**'
+          - '**/lib/service/servicecfg/**'
+          - '**/lib/reversetunnelclient/**'
+          - '**/lib/auth/authclient/**'
+        allow:
+          - github.com/gravitational/teleport/lib/cloud/imds
+        deny:
+          - pkg: github.com/gravitational/teleport/lib/auth$
+            desc: 'lib/auth should not be imported to prevent increasing binary size, prefer lib/auth/authclient instead'
+          - pkg: github.com/gravitational/teleport/lib/cloud
+            desc: 'lib/cloud should not be imported to prevent increasing binary size'
+          - pkg: github.com/gravitational/teleport/lib/srv$
+            desc: 'lib/srv prevents client tools from build on non-linux platforms'
+          - pkg: github.com/gravitational/teleport/lib/web$
+            desc: 'lib/web should not be imported to prevent increasing binary size'
+        list-mode: lax
   errorlint:
     comparison: true
     asserts: true


### PR DESCRIPTION
Adds new depguard rules to prevent importing internal packages into client tools that are known to cause binary bloat or prevent building on all supported platforms.

The main motivation for this is to prevent any regressions of the recent refactoring to reduce client tool sizes.
