### PR TITLE
[v13] Improve how bots are shown on ListUsers (#41644)

### DIFF
--- a/lib/web/ui/user.go
+++ b/lib/web/ui/user.go
@@ -34,6 +34,8 @@ type UserListEntry struct {
 	// Different from "userTraits" where "userTraits"
 	// "selectively" returns traits.
 	AllTraits map[string][]string `json:"allTraits"`
+	// IsBot is true if the user is a Bot User.
+	IsBot bool `json:"isBot"`
 }
 
 type userTraits struct {
@@ -78,6 +80,7 @@ func NewUserListEntry(teleUser types.User) (*UserListEntry, error) {
 		Roles:     teleUser.GetRoles(),
 		AuthType:  authType,
 		AllTraits: teleUser.GetTraits(),
+		IsBot:     teleUser.IsBot(),
 	}, nil
 }
 

--- a/lib/web/ui/user_test.go
+++ b/lib/web/ui/user_test.go
@@ -1,0 +1,74 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ui
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestNewUserListEntry(t *testing.T) {
+	tests := []struct {
+		name string
+		user types.User
+		want *UserListEntry
+	}{
+		{
+			name: "bot",
+			user: &types.UserV2{
+				Metadata: types.Metadata{
+					Name: "bot-bernard",
+					Labels: map[string]string{
+						types.BotLabel: "true",
+					},
+				},
+				Spec: types.UserSpecV2{
+					Roles: []string{"behavioral-analyst"},
+					Traits: map[string][]string{
+						"logins": {"arnold"},
+					},
+				},
+			},
+			want: &UserListEntry{
+				Name:     "bot-bernard",
+				Roles:    []string{"behavioral-analyst"},
+				AuthType: "local",
+				IsBot:    true,
+				AllTraits: map[string][]string{
+					"logins": {"arnold"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewUserListEntry(tt.user)
+			require.NoError(t, err)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewUserListEntry() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+}

--- a/lib/web/ui/user_test.go
+++ b/lib/web/ui/user_test.go
@@ -39,7 +39,7 @@ func TestNewUserListEntry(t *testing.T) {
 				Metadata: types.Metadata{
 					Name: "bot-bernard",
 					Labels: map[string]string{
-						types.BotLabel: "true",
+						types.BotGenerationLabel: "0",
 					},
 				},
 				Spec: types.UserSpecV2{

--- a/web/packages/teleport/src/Users/UserList/UserList.tsx
+++ b/web/packages/teleport/src/Users/UserList/UserList.tsx
@@ -59,9 +59,9 @@ export default function UserList({
           key: 'authType',
           headerText: 'Type',
           isSortable: true,
-          render: ({ authType }) => (
+          render: ({ authType, isBot }) => (
             <Cell style={{ textTransform: 'capitalize' }}>
-              {renderAuthType(authType)}
+              {renderAuthType(authType, isBot)}
             </Cell>
           ),
         },
@@ -83,7 +83,14 @@ export default function UserList({
     />
   );
 
-  function renderAuthType(authType: string) {
+  function renderAuthType(
+    authType: string,
+    isBot?: boolean
+  ) {
+    if (isBot) {
+      return 'Bot';
+    }
+
     switch (authType) {
       case 'github':
         return 'GitHub';
@@ -107,7 +114,7 @@ const ActionCell = ({
   onReset: (user: User) => void;
   onDelete: (user: User) => void;
 }) => {
-  if (!user.isLocal) {
+  if (user.isBot || !user.isLocal) {
     return <Cell align="right" />;
   }
 

--- a/web/packages/teleport/src/Users/UserList/UserList.tsx
+++ b/web/packages/teleport/src/Users/UserList/UserList.tsx
@@ -83,10 +83,7 @@ export default function UserList({
     />
   );
 
-  function renderAuthType(
-    authType: string,
-    isBot?: boolean
-  ) {
+  function renderAuthType(authType: string, isBot?: boolean) {
     if (isBot) {
       return 'Bot';
     }

--- a/web/packages/teleport/src/Users/Users.story.tsx
+++ b/web/packages/teleport/src/Users/Users.story.tsx
@@ -83,6 +83,13 @@ const users = [
     authType: 'teleport local user',
     isLocal: true,
   },
+  {
+    name: 'bot-little-robot',
+    roles: ['bot-little-robot'],
+    authType: 'teleport local user',
+    isLocal: true,
+    isBot: true,
+  },
 ];
 
 const roles = ['admin', 'testrole'];

--- a/web/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
+++ b/web/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
@@ -511,12 +511,12 @@ exports[`success state 1`] = `
               </strong>
                - 
               <strong>
-                6
+                7
               </strong>
                of
                
               <strong>
-                6
+                7
               </strong>
             </div>
           </div>
@@ -621,6 +621,31 @@ exports[`success state 1`] = `
                 />
               </button>
             </td>
+          </tr>
+          <tr>
+            <td>
+              bot-little-robot
+            </td>
+            <td>
+              <div
+                class="c22"
+              >
+                <div
+                  class="c23"
+                  kind="secondary"
+                >
+                  bot-little-robot
+                </div>
+              </div>
+            </td>
+            <td
+              style="text-transform: capitalize;"
+            >
+              Bot
+            </td>
+            <td
+              align="right"
+            />
           </tr>
           <tr>
             <td>

--- a/web/packages/teleport/src/services/user/makeUser.ts
+++ b/web/packages/teleport/src/services/user/makeUser.ts
@@ -18,13 +18,14 @@ import { User } from './types';
 
 export default function makeUser(json: any): User {
   json = json || {};
-  const { name, roles, authType, traits = {}, allTraits } = json;
+  const { name, roles, authType, traits = {}, allTraits, isBot } = json;
 
   return {
     name,
     roles: roles ? roles.sort() : [],
     authType: authType === 'local' ? 'teleport local user' : authType,
     isLocal: authType === 'local',
+    isBot,
     traits: {
       logins: traits.logins || [],
       databaseUsers: traits.databaseUsers || [],

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -97,6 +97,8 @@ export interface User {
   authType?: string;
   // isLocal is true if json.authType was 'local'.
   isLocal?: boolean;
+  // isBot is true if the user is a Bot User.
+  isBot?: boolean;
   // traits existed before field "externalTraits"
   // and returns only "specific" traits.
   traits?: UserTraits;

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -266,6 +266,7 @@ test('fetch users, null response values gives empty array', async () => {
   expect(response).toStrictEqual([
     {
       authType: '',
+      isBot: undefined,
       isLocal: false,
       name: '',
       roles: [],


### PR DESCRIPTION
Backports #41644
changelog: Simplified how Bots are shown on the Users list page.