### PR TITLE
docs: update k8s auto discovery aws policy example

### DIFF
--- a/docs/pages/auto-discovery/kubernetes/aws.mdx
+++ b/docs/pages/auto-discovery/kubernetes/aws.mdx
@@ -65,7 +65,7 @@ describe EKS clusters:
 }
 ```
 
-Update `Resource` entries to match your AWS accounts EKS resources `arn:aws:eks:{Region}:{Account}:cluster/{ClusterName}`.
+Update `Resource` entries to match your AWS account's EKS resources, which have ARNs in the following format: `arn:aws:eks:{Region}:{Account}:cluster/{ClusterName}`.
 
 ## Step 2/3. Configure EKS cluster authorization
 

--- a/docs/pages/auto-discovery/kubernetes/aws.mdx
+++ b/docs/pages/auto-discovery/kubernetes/aws.mdx
@@ -59,11 +59,13 @@ describe EKS clusters:
                 "eks:DescribeCluster",
                 "eks:ListClusters"
             ],
-            "Resource": "*"
+            "Resource": "<Var name="arn:aws:eks:*:123456789012:cluster/*" />"
         }
     ]
 }
 ```
+
+Update `Resource` entries to match your AWS accounts EKS resources `arn:aws:eks:{Region}:{Account}:cluster/{ClusterName}`.
 
 ## Step 2/3. Configure EKS cluster authorization
 


### PR DESCRIPTION
Using a `eks` arn is best practice over allowing all resource types.