### PR TITLE
docs: update k8s deployment descs

### DIFF
--- a/docs/pages/deploy-a-cluster/introduction.mdx
+++ b/docs/pages/deploy-a-cluster/introduction.mdx
@@ -15,7 +15,7 @@ compute platform and cloud provider:
 
 You can deploy a complete, high-availability Teleport cluster on Kubernetes
 using our `teleport-cluster` Helm chart. These guides show you how to deploy the
-`teleport-cluster` Helm chart on your cloud or on-prem Kubernetes cluster:
+`teleport-cluster` Helm chart on your Kubernetes cluster:
 
 - [Google Cloud](./helm-deployments/gcp.mdx)
 - [AWS](./helm-deployments/aws.mdx)

--- a/docs/pages/deploy-a-cluster/introduction.mdx
+++ b/docs/pages/deploy-a-cluster/introduction.mdx
@@ -15,11 +15,13 @@ compute platform and cloud provider:
 
 You can deploy a complete, high-availability Teleport cluster on Kubernetes
 using our `teleport-cluster` Helm chart. These guides show you how to deploy the
-`teleport-cluster` Helm chart on your cloud:
+`teleport-cluster` Helm chart on your cloud or on-prem Kubernetes cluster:
 
 - [Google Cloud](./helm-deployments/gcp.mdx)
 - [AWS](./helm-deployments/aws.mdx)
-- [Kubernetes with SSO](./helm-deployments/kubernetes-cluster.mdx)
+- [Azure](./helm-deployments/azure.mdx)
+- [DigitalOcean](./helm-deployments/digitalocean.mdx)
+- [Standard Kubernetes Deployment](./helm-deployments/kubernetes-cluster.mdx)
 - [Custom Kubernetes Deployment](./helm-deployments/custom.mdx)
 
 ## Deploy using virtual machines

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -35,7 +35,7 @@ Get started with a guide for each mode:
 
 | `chartMode` | Purpose | Guide |
 | - | - | - |
-| `standalone` | Runs by relying only on Kubernetes resources. | [Getting Started - Kubernetes with SSO](../../deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx) |
+| `standalone` | Runs by relying only on Kubernetes resources. | [Getting Started - Kubernetes](../../deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx) |
 | `aws` | Leverages AWS managed services to store data. | [Running an HA Teleport cluster using an AWS EKS Cluster](../../deploy-a-cluster/helm-deployments/aws.mdx) |
 | `gcp` | Leverages GCP managed services to store data. | [Running an HA Teleport cluster using a Google Cloud GKE cluster](../../deploy-a-cluster/helm-deployments/gcp.mdx) |
 | `azure` | Leverages Azure managed services to store data. | [Running an HA Teleport cluster using a Microsoft Azure AKS cluster](../../deploy-a-cluster/helm-deployments/azure.mdx) |
@@ -858,7 +858,7 @@ policies to define access rules for the cluster.
 
 | `chartMode`  | Guide                                                                                                              |
 |--------------|--------------------------------------------------------------------------------------------------------------------|
-| `standalone` | [Getting Started - Kubernetes with SSO](../../deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx)            |
+| `standalone` | [Getting Started - Kubernetes](../../deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx)            |
 | `aws`        | [Running an HA Teleport cluster using an AWS EKS Cluster](../../deploy-a-cluster/helm-deployments/aws.mdx)         |
 | `gcp`        | [Running an HA Teleport cluster using a Google Cloud GKE cluster](../../deploy-a-cluster/helm-deployments/gcp.mdx) |
 | `azure`      | [Running an HA Teleport cluster using a Microsoft Azure AKS cluster](../../deploy-a-cluster/helm-deployments/azure.mdx) |


### PR DESCRIPTION
A few updates:
- Azure and Digital Ocean wasn't included
- k8s link wasn't SSO, retitled
- Mention cloud or on-prem k8s