### PR TITLE
Document DiscoveryService poll interval configuration variable

### DIFF
--- a/docs/pages/includes/discovery/discovery-config.yaml
+++ b/docs/pages/includes/discovery/discovery-config.yaml
@@ -7,8 +7,7 @@ discovery_service:
     # managing discovered resources.
     discovery_group: "disc-group"
     # poll_interval is the cadence at which the discovery server will run each of its
-    # discovery cycles.
-    # Default: 5m
+    # discovery cycles. The default is 5m.
     poll_interval: 5m
     aws:
       # AWS resource types. Valid options are:

--- a/docs/pages/includes/discovery/discovery-config.yaml
+++ b/docs/pages/includes/discovery/discovery-config.yaml
@@ -6,6 +6,10 @@ discovery_service:
     # accounts. It prevents discovered services from colliding in Teleport when
     # managing discovered resources.
     discovery_group: "disc-group"
+    # poll_interval is the cadence at which the discovery server will run each of its
+    # discovery cycles.
+    # Default: 5m
+    poll_interval: 5m
     aws:
       # AWS resource types. Valid options are:
       # 'ec2' - discovers and registers AWS EC2 instances.

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1502,6 +1502,7 @@ type Discovery struct {
 	DiscoveryGroup string `yaml:"discovery_group,omitempty"`
 	// PollInterval is the cadence at which the discovery server will run each of its
 	// discovery cycles.
+	// Default: 5m
 	PollInterval time.Duration `yaml:"poll_interval,omitempty"`
 }
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1502,7 +1502,7 @@ type Discovery struct {
 	DiscoveryGroup string `yaml:"discovery_group,omitempty"`
 	// PollInterval is the cadence at which the discovery server will run each of its
 	// discovery cycles.
-	// Default: 5m
+	// Default: [github.com/gravitational/teleport/lib/srv/.DefaultDiscoveryPollInterval]
 	PollInterval time.Duration `yaml:"poll_interval,omitempty"`
 }
 

--- a/lib/service/servicecfg/discovery.go
+++ b/lib/service/servicecfg/discovery.go
@@ -46,6 +46,7 @@ type DiscoveryConfig struct {
 	DiscoveryGroup string
 	// PollInterval is the cadence at which the discovery server will run each of its
 	// discovery cycles.
+	// Default: 5m
 	PollInterval time.Duration
 }
 

--- a/lib/service/servicecfg/discovery.go
+++ b/lib/service/servicecfg/discovery.go
@@ -46,7 +46,7 @@ type DiscoveryConfig struct {
 	DiscoveryGroup string
 	// PollInterval is the cadence at which the discovery server will run each of its
 	// discovery cycles.
-	// Default: 5m
+	// Default: [github.com/gravitational/teleport/lib/srv/.DefaultDiscoveryPollInterval]
 	PollInterval time.Duration
 }
 

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -135,6 +135,7 @@ type Config struct {
 	ClusterName string
 	// PollInterval is the cadence at which the discovery server will run each of its
 	// discovery cycles.
+	// Default: 5m
 	PollInterval time.Duration
 
 	// ServerCredentials are the credentials used to identify the discovery service

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -59,6 +59,11 @@ import (
 	"github.com/gravitational/teleport/lib/utils/spreadwork"
 )
 
+const (
+	// DefaultDiscoveryPollInterval is the default interval that Discovery Services fetches resources.
+	DefaultDiscoveryPollInterval = 5 * time.Minute
+)
+
 var errNoInstances = errors.New("all fetched nodes already enrolled")
 
 // Matchers contains all matchers used by discovery service
@@ -135,7 +140,7 @@ type Config struct {
 	ClusterName string
 	// PollInterval is the cadence at which the discovery server will run each of its
 	// discovery cycles.
-	// Default: 5m
+	// Default: [github.com/gravitational/teleport/lib/srv.DefaultDiscoveryPollInterval]
 	PollInterval time.Duration
 
 	// ServerCredentials are the credentials used to identify the discovery service
@@ -226,7 +231,7 @@ kubernetes matchers are present.`)
 	}
 
 	if c.PollInterval == 0 {
-		c.PollInterval = 5 * time.Minute
+		c.PollInterval = DefaultDiscoveryPollInterval
 	}
 
 	c.TriggerFetchC = make([]chan struct{}, 0)


### PR DESCRIPTION
Document Poll Interval configuration.

This is used to trigger new fetches in the resource providers (AWS, GCP, Azure and Kube).