### PR TITLE
Docs: add explicit token name and rbac rules for installers

### DIFF
--- a/docs/pages/auto-discovery/servers/ec2-discovery.mdx
+++ b/docs/pages/auto-discovery/servers/ec2-discovery.mdx
@@ -136,6 +136,10 @@ discovery_service:
   aws:
    - types: ["ec2"]
      regions: ["us-east-1","us-west-1"]
+     install:
+        join_params:
+          token_name: aws-discovery-iam-token
+          method: iam
      tags:
        "env": "prod" # Match EC2 instances where tag:env=prod
 ```

--- a/docs/pages/includes/server-access/custom-installer.mdx
+++ b/docs/pages/includes/server-access/custom-installer.mdx
@@ -1,4 +1,26 @@
 {{ cloud="foo" matcher="bar" matchTypes="baz" }}
+To customize an installer, your user must have a role that allows `list`, `create`, `read` and `update` verbs on the `installer` resource.
+
+Create a file called `installer-manager.yaml` with the following content:
+```yaml
+kind: role
+version: v5
+metadata:
+  name: installer-manager
+spec:
+  allow:
+    rules:
+      - resources: [installer]
+        verbs: [list, create, read, update]
+```
+
+```code
+$ tctl create -f installer-manager.yaml
+# role 'installer-manager' has been created
+```
+
+The preset `editor` role has the required permissions by default.
+
 To customize the default installer script, execute the following command on
 your workstation:
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -4574,6 +4574,45 @@ func TestDiscoveryConfig(t *testing.T) {
 			}},
 		},
 		{
+			desc:          "AWS section is filled using the example config in docs",
+			expectError:   require.NoError,
+			expectEnabled: require.True,
+			mutate: func(cfg cfgMap) {
+				cfg["discovery_service"].(cfgMap)["enabled"] = "yes"
+				cfg["discovery_service"].(cfgMap)["aws"] = []cfgMap{
+					{
+						"types":   []string{"ec2"},
+						"regions": []string{"us-east-1", "us-west-1"},
+						"install": map[string]map[string]string{
+							"join_params": {
+								"token_name": "aws-discovery-iam-token",
+								"method":     "iam",
+							},
+						},
+						"tags": cfgMap{
+							"discover_teleport": "yes",
+						},
+					},
+				}
+			},
+			expectedAWSMatchers: []types.AWSMatcher{{
+				Types:   []string{"ec2"},
+				Regions: []string{"us-east-1", "us-west-1"},
+				Tags: map[string]apiutils.Strings{
+					"discover_teleport": []string{"yes"},
+				},
+				Params: &types.InstallerParams{
+					JoinMethod:      types.JoinMethodIAM,
+					JoinToken:       types.IAMInviteTokenName,
+					SSHDConfig:      "/etc/ssh/sshd_config",
+					ScriptName:      installers.InstallerScriptName,
+					InstallTeleport: true,
+					EnrollMode:      types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
+				},
+				SSM: &types.AWSSSM{DocumentName: types.AWSInstallerDocument},
+			}},
+		},
+		{
 			desc:          "AWS section is filled with custom configs",
 			expectError:   require.NoError,
 			expectEnabled: require.True,


### PR DESCRIPTION
Related: https://github.com/gravitational/teleport/issues/31180