### PR TITLE
Discovery poll: wait PollInterval between fetches

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1502,7 +1502,7 @@ type Discovery struct {
 	DiscoveryGroup string `yaml:"discovery_group,omitempty"`
 	// PollInterval is the cadence at which the discovery server will run each of its
 	// discovery cycles.
-	// Default: [github.com/gravitational/teleport/lib/srv/.DefaultDiscoveryPollInterval]
+	// Default: [github.com/gravitational/teleport/lib/srv/discovery/common.DefaultDiscoveryPollInterval]
 	PollInterval time.Duration `yaml:"poll_interval,omitempty"`
 }
 

--- a/lib/service/servicecfg/discovery.go
+++ b/lib/service/servicecfg/discovery.go
@@ -46,7 +46,7 @@ type DiscoveryConfig struct {
 	DiscoveryGroup string
 	// PollInterval is the cadence at which the discovery server will run each of its
 	// discovery cycles.
-	// Default: [github.com/gravitational/teleport/lib/srv/.DefaultDiscoveryPollInterval]
+	// Default: [github.com/gravitational/teleport/lib/srv/discovery/common.DefaultDiscoveryPollInterval]
 	PollInterval time.Duration
 }
 

--- a/lib/srv/discovery/common/watcher.go
+++ b/lib/srv/discovery/common/watcher.go
@@ -122,11 +122,12 @@ func (w *Watcher) Start() {
 			pollTimer.Reset(w.cfg.Interval)
 
 		case <-w.cfg.TriggerFetchC:
+			w.fetchAndSend()
+
 			// stop and drain timer
 			if !pollTimer.Stop() {
 				<-pollTimer.Chan()
 			}
-			w.fetchAndSend()
 			pollTimer.Reset(w.cfg.Interval)
 
 		case <-w.ctx.Done():

--- a/lib/srv/discovery/common/watcher.go
+++ b/lib/srv/discovery/common/watcher.go
@@ -35,6 +35,11 @@ const (
 	concurrencyLimit = 5
 )
 
+const (
+	// DefaultDiscoveryPollInterval is the default interval that Discovery Services fetches resources.
+	DefaultDiscoveryPollInterval = 5 * time.Minute
+)
+
 // WatcherConfig is the common discovery watcher configuration.
 type WatcherConfig struct {
 	// FetchersFn is a function that returns the fetchers used for this watcher.
@@ -62,7 +67,7 @@ type WatcherConfig struct {
 // CheckAndSetDefaults validates the config.
 func (c *WatcherConfig) CheckAndSetDefaults() error {
 	if c.Interval == 0 {
-		c.Interval = 5 * time.Minute
+		c.Interval = DefaultDiscoveryPollInterval
 	}
 	if c.TriggerFetchC == nil {
 		c.TriggerFetchC = make(chan struct{})
@@ -106,16 +111,24 @@ func NewWatcher(ctx context.Context, config WatcherConfig) (*Watcher, error) {
 
 // Start starts fetching cloud resources and sending them to the channel.
 func (w *Watcher) Start() {
-	ticker := w.cfg.Clock.NewTicker(w.cfg.Interval)
-	defer ticker.Stop()
+	pollTimer := w.cfg.Clock.NewTimer(w.cfg.Interval)
+	defer pollTimer.Stop()
 	w.cfg.Log.Infof("Starting watcher.")
 	w.fetchAndSend()
 	for {
 		select {
-		case <-ticker.Chan():
+		case <-pollTimer.Chan():
 			w.fetchAndSend()
+			pollTimer.Reset(w.cfg.Interval)
+
 		case <-w.cfg.TriggerFetchC:
+			// stop and drain timer
+			if !pollTimer.Stop() {
+				<-pollTimer.Chan()
+			}
 			w.fetchAndSend()
+			pollTimer.Reset(w.cfg.Interval)
+
 		case <-w.ctx.Done():
 			w.cfg.Log.Infof("Watcher done.")
 			return

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -59,11 +59,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils/spreadwork"
 )
 
-const (
-	// DefaultDiscoveryPollInterval is the default interval that Discovery Services fetches resources.
-	DefaultDiscoveryPollInterval = 5 * time.Minute
-)
-
 var errNoInstances = errors.New("all fetched nodes already enrolled")
 
 // Matchers contains all matchers used by discovery service
@@ -140,7 +135,7 @@ type Config struct {
 	ClusterName string
 	// PollInterval is the cadence at which the discovery server will run each of its
 	// discovery cycles.
-	// Default: [github.com/gravitational/teleport/lib/srv.DefaultDiscoveryPollInterval]
+	// Default: [github.com/gravitational/teleport/lib/srv/discovery/common.DefaultDiscoveryPollInterval]
 	PollInterval time.Duration
 
 	// ServerCredentials are the credentials used to identify the discovery service
@@ -231,7 +226,7 @@ kubernetes matchers are present.`)
 	}
 
 	if c.PollInterval == 0 {
-		c.PollInterval = DefaultDiscoveryPollInterval
+		c.PollInterval = common.DefaultDiscoveryPollInterval
 	}
 
 	c.TriggerFetchC = make([]chan struct{}, 0)

--- a/lib/srv/server/watcher.go
+++ b/lib/srv/server/watcher.go
@@ -110,12 +110,12 @@ func (w *Watcher) Run() {
 			pollTimer.Reset(w.pollInterval)
 
 		case <-w.triggerFetchC:
+			w.fetchAndSubmit()
+
 			// stop and drain timer
 			if !pollTimer.Stop() {
 				<-pollTimer.C
 			}
-			w.fetchAndSubmit()
-			// Restart timer after event based trigger.
 			pollTimer.Reset(w.pollInterval)
 
 		case <-w.ctx.Done():

--- a/lib/srv/server/watcher.go
+++ b/lib/srv/server/watcher.go
@@ -89,8 +89,8 @@ func (w *Watcher) fetchAndSubmit() {
 
 // Run starts the watcher's main watch loop.
 func (w *Watcher) Run() {
-	ticker := time.NewTicker(w.pollInterval)
-	defer ticker.Stop()
+	pollTimer := time.NewTimer(w.pollInterval)
+	defer pollTimer.Stop()
 
 	if w.triggerFetchC == nil {
 		w.triggerFetchC = make(<-chan struct{})
@@ -104,10 +104,20 @@ func (w *Watcher) Run() {
 			for _, fetcher := range w.fetchersFn() {
 				w.sendInstancesOrLogError(fetcher.GetMatchingInstances(insts, true))
 			}
-		case <-ticker.C:
+
+		case <-pollTimer.C:
 			w.fetchAndSubmit()
+			pollTimer.Reset(w.pollInterval)
+
 		case <-w.triggerFetchC:
+			// stop and drain timer
+			if !pollTimer.Stop() {
+				<-pollTimer.C
+			}
 			w.fetchAndSubmit()
+			// Restart timer after event based trigger.
+			pollTimer.Reset(w.pollInterval)
+
 		case <-w.ctx.Done():
 			return
 		}


### PR DESCRIPTION
Instead of using a time.Ticker which would fire at specific intervals, we are now using a time.Timer which will wait PollInterval duration between API fetches.

Previously, with a low PollInterval or with a slow fetchAndSubmit, we could be hammering the external API by immediately calling a new fetchAndSubmit right after ending the current one.

This changes ensures we wait at least the specified interval before starting a new iteration (unless a DiscoveryConfig is changed, in that case the polling starts immediately).

https://github.com/gravitational/teleport/pull/41761#discussion_r1606914838