### PR TITLE
Use the local cache for ssh_service agent pool

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2877,7 +2877,7 @@ func (process *TeleportProcess) initSSH() error {
 					HostUUID:             conn.ServerIdentity.ID.HostUUID,
 					Resolver:             conn.TunnelProxyResolver(),
 					Client:               conn.Client,
-					AccessPoint:          conn.Client,
+					AccessPoint:          authClient,
 					HostSigner:           conn.ServerIdentity.KeySigner,
 					Cluster:              conn.ServerIdentity.Cert.Extensions[utils.CertExtensionAuthority],
 					Server:               serverHandler,


### PR DESCRIPTION
The agent pool created for ssh services populated the AccessPoint, which is meant to be the local cache, with an actual auth client instead of the cache. This causes additional load on Auth to retrieve items like cluster networking config that are already provided in the local cache.