### PR TITLE
[v13] Allow RO permissions for cluster maintenance config

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -219,6 +219,7 @@ func NewPresetAccessRole() types.Role {
 					},
 					types.NewRule(types.KindInstance, RO()),
 					types.NewRule(types.KindAssistant, append(RW(), types.VerbUse)),
+					types.NewRule(types.KindClusterMaintenanceConfig, RO()),
 				},
 			},
 		},


### PR DESCRIPTION
Backport #41744 to branch/v13

changelog: Add read-only permissions for cluster maintenance config
