### PR TITLE
[v13] fix: Use 32-char buf.lock commits

### DIFF
--- a/api/proto/buf.lock
+++ b/api/proto/buf.lock
@@ -4,7 +4,7 @@ deps:
   - remote: buf.build
     owner: gogo
     repository: protobuf
-    commit: b03c65ea87cdc3521ede29f62fe3ce239267c1bc
+    commit: 4df00b267f944190a229ce3695781e99
   - remote: buf.build
     owner: googleapis
     repository: googleapis


### PR DESCRIPTION
Backport #41776 to branch/v13