### PR TITLE
Hardware Key Support for App Access

### DIFF
--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -60,8 +60,8 @@ like `tctl edit`. With touch required, hardware key support provides better secu
   sessions.
 
   Note: Web and app sessions are not backed by a hardware key directly, but they are strictly guarded by the
-  Auth/Proxy services. Therefore, web and app sessions are given permission to bypass hardware key support
-  and fallback to MFA prompts when user presence or verification is needed, like for per-session MFA.
+  Auth Service and Proxy Service. Therefore, web and app sessions are given permission to bypass hardware key support
+  and fall back to MFA prompts when user presence or verification is needed, like for per-session MFA.
 </Admonition>
 
 ## Prerequisites

--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -42,15 +42,12 @@ like `tctl edit`. With touch required, hardware key support provides better secu
     - Agentless OpenSSH server access.
     - Database access with `tsh proxy db` instead of `tsh db connect`.
     - Kubernetes access with `tsh proxy kube` instead of `tsh kube login`.
-    - Teleport Web UI
-      - Web sessions are not backed by a hardware key directly, but they are strictly guarded by the
-      Auth/Proxy services. Therefore, web sessions are given permission to bypass hardware key support
-      and fallback to MFA prompts when user presence or verification is needed, like for per-session MFA.
+    - Web access (Teleport Web UI).
+    - Application access.
 
   Not supported:
   
     - Desktop access.
-    - Application access.
     - Legacy OpenSSH server access
 
   If you require users to have a hardware key to access your infrastructure, they won't be able to
@@ -61,6 +58,10 @@ like `tctl edit`. With touch required, hardware key support provides better secu
   necessary, such as for roles with access to critical infrastructure. These roles can be accessed
   as needed with Access Requests so that users can avoid these issues for their normal login
   sessions.
+
+  Note: Web and app sessions are not backed by a hardware key directly, but they are strictly guarded by the
+  Auth/Proxy services. Therefore, web and app sessions are given permission to bypass hardware key support
+  and fallback to MFA prompts when user presence or verification is needed, like for per-session MFA.
 </Admonition>
 
 ## Prerequisites

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1999,8 +1999,6 @@ type certRequest struct {
 	connectionDiagnosticID string
 	// attestationStatement is an attestation statement associated with the given public key.
 	attestationStatement *keys.AttestationStatement
-	// skipAttestation is a server-side flag which is used to skip the attestation check.
-	skipAttestation bool
 	// deviceExtensions holds device-aware user certificate extensions.
 	deviceExtensions DeviceExtensions
 	// botName is the name of the bot requesting this cert, if any
@@ -2813,7 +2811,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		return nil, trace.Wrap(err)
 	}
 
-	if !req.skipAttestation && requiredKeyPolicy != keys.PrivateKeyPolicyNone {
+	if requiredKeyPolicy != keys.PrivateKeyPolicyNone {
 		// Try to attest the given hardware key using the given attestation statement.
 		attestationData, err := modules.GetModules().AttestHardwareKey(ctx, a, req.attestationStatement, cryptoPubKey, sessionTTL)
 		if trace.IsNotFound(err) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3142,6 +3142,11 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 					Traits:         accessInfo.Traits,
 					Roles:          accessInfo.Roles,
 					AccessRequests: req.AccessRequests,
+					// App sessions created through generateUserCerts are securely contained
+					// to the Proxy and Auth roles, and thus should pass hardware key requirements
+					// through the "web_session" attestation. User's will be required to provide
+					// MFA instead.
+					AttestWebSession: true,
 				},
 				PublicAddr:        req.RouteToApp.PublicAddr,
 				ClusterName:       req.RouteToApp.ClusterName,

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -305,6 +305,11 @@ func (a *Server) CreateAppSession(ctx context.Context, req *proto.CreateAppSessi
 			Roles:          roles,
 			Traits:         traits,
 			AccessRequests: identity.ActiveRequests,
+			// If the user's current identity is attested as a "web_session", it's secrets are only
+			// available to the Proxy and Auth roles, meaning this request is coming from the Proxy
+			// service on behalf of the user's Web Session. We can safely attest this child app session
+			// as a "web_session" as a result.
+			AttestWebSession: identity.PrivateKeyPolicy == keys.PrivateKeyPolicyWebSession,
 		},
 		PublicAddr:        req.PublicAddr,
 		ClusterName:       req.ClusterName,
@@ -354,14 +359,27 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 	}
 
 	// Create certificate for this session.
-	privateKey, publicKey, err := native.GenerateKeyPair()
+	priv, err := native.GeneratePrivateKey()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	if req.AttestWebSession {
+		// Upsert web session attestation data so that this key's certs
+		// will be marked with the web session private key policy.
+		webAttData, err := services.NewWebSessionAttestationData(priv.Public())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if err = a.UpsertKeyAttestationData(ctx, webAttData, req.SessionTTL); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	certs, err := a.generateUserCert(ctx, certRequest{
 		user:           user,
 		loginIP:        req.LoginIP,
-		publicKey:      publicKey,
+		publicKey:      priv.MarshalSSHPublicKey(),
 		checker:        checker,
 		ttl:            req.SessionTTL,
 		traits:         req.Traits,
@@ -375,9 +393,6 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		awsRoleARN:        req.AWSRoleARN,
 		azureIdentity:     req.AzureIdentity,
 		gcpServiceAccount: req.GCPServiceAccount,
-		// Since we are generating the keys and certs directly on the Auth Server,
-		// we need to skip attestation.
-		skipAttestation: true,
 		// Pass along device extensions from the user.
 		deviceExtensions: req.DeviceExtensions,
 		mfaVerified:      req.MFAVerified,
@@ -392,7 +407,7 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 	}
 	session, err := types.NewWebSession(sessionID, types.KindAppSession, types.WebSessionSpecV2{
 		User:        req.User,
-		Priv:        privateKey,
+		Priv:        priv.PrivateKeyPEM(),
 		Pub:         certs.SSH,
 		TLSCert:     certs.TLS,
 		LoginTime:   a.clock.Now().UTC(),

--- a/tool/tsh/common/hardware_key_test.go
+++ b/tool/tsh/common/hardware_key_test.go
@@ -21,17 +21,24 @@
 package common
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"os/user"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	testserver "github.com/gravitational/teleport/tool/teleport/testenv"
@@ -276,4 +283,200 @@ func TestHardwareKeySSH(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestHardwareKeyApp tests Hardware Key App flows.
+func TestHardwareKeyApp(t *testing.T) {
+	ctx := context.Background()
+
+	testModules := &modules.TestModules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			App: true,
+		},
+	}
+	modules.SetTestModules(t, testModules)
+
+	testserver.WithResyncInterval(t, 0)
+
+	isInsecure := lib.IsInsecureDevMode()
+	lib.SetInsecureDevMode(true)
+	t.Cleanup(func() {
+		lib.SetInsecureDevMode(isInsecure)
+	})
+
+	accessUser, err := types.NewUser("access")
+	require.NoError(t, err)
+	accessUser.SetRoles([]string{"access"})
+
+	user, err := user.Current()
+	require.NoError(t, err)
+	accessUser.SetLogins([]string{user.Name})
+	connector := mockConnector(t)
+
+	testServer := testserver.MakeTestServer(t,
+		testserver.WithBootstrap(connector, accessUser),
+		testserver.WithClusterName(t, "root"),
+		testserver.WithConfig(func(cfg *servicecfg.Config) {
+			cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+			cfg.Apps = servicecfg.AppsConfig{
+				Enabled: true,
+				Apps: []servicecfg.App{{
+					Name: "myapp",
+					URI:  startDummyHTTPServer(t, "myapp"),
+				}},
+			}
+		}),
+	)
+	authServer := testServer.GetAuthServer()
+	proxyAddr, err := testServer.ProxyWebAddr()
+	require.NoError(t, err)
+
+	// Set up user with MFA device since app login requires MFA when
+	// hardware key touch/pin is enabled.
+	origin := "https://127.0.0.1"
+	device, err := mocku2f.Create()
+	require.NoError(t, err)
+	device.SetPasswordless()
+
+	_, err = authServer.UpsertAuthPreference(ctx, &types.AuthPreferenceV2{
+		Spec: types.AuthPreferenceSpecV2{
+			SecondFactor: constants.SecondFactorOptional,
+			Webauthn: &types.Webauthn{
+				RPID: "127.0.0.1",
+			},
+		},
+	})
+	require.NoError(t, err)
+	registerDeviceForUser(t, authServer, device, accessUser.GetName(), origin)
+
+	// Login before adding hardware key requirement
+	tmpHomePath := t.TempDir()
+	err = Run(ctx, []string{
+		"login",
+		"--insecure",
+		"--proxy", proxyAddr.String(),
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, accessUser, connector.GetName()))
+	require.NoError(t, err)
+
+	// Require hardware key touch for the user.
+	accessRole, err := authServer.GetRole(ctx, "access")
+	require.NoError(t, err)
+	accessRole.SetOptions(types.RoleOptions{
+		RequireMFAType: types.RequireMFAType_HARDWARE_KEY_TOUCH,
+	})
+	_, err = authServer.UpsertRole(ctx, accessRole)
+	require.NoError(t, err)
+
+	testModules.MockAttestationData = nil
+	tmpHomePath = t.TempDir()
+
+	// App login fails without an attested hardware key login.
+	err = Run(ctx, []string{
+		"app",
+		"login",
+		"myapp",
+		"--insecure",
+		"--proxy", proxyAddr.String(),
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, accessUser, connector.GetName()))
+	require.Error(t, err)
+
+	// Proxy app fails without an attested hardware key login.
+	proxyCtx, proxyCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer proxyCancel()
+
+	err = Run(proxyCtx, []string{
+		"proxy",
+		"app",
+		"myapp",
+		"--insecure",
+		"--proxy", proxyAddr.String(),
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, accessUser, connector.GetName()))
+	require.Error(t, err)
+
+	// Set MockAttestationData to attest the expected key policy and try again.
+	testModules.MockAttestationData = &keys.AttestationData{
+		PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
+	}
+
+	// App commands will still fail without MFA, since the app sessions will
+	// only be attested as "web_session".
+	webauthnLoginOpt := setupWebAuthnChallengeSolver(device, false /* success */)
+
+	err = Run(ctx, []string{
+		"app",
+		"login",
+		"myapp",
+		"--insecure",
+		"--proxy", proxyAddr.String(),
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, accessUser, connector.GetName()), webauthnLoginOpt)
+	require.Error(t, err)
+
+	proxyCtx, proxyCancel = context.WithTimeout(ctx, 10*time.Second)
+	defer proxyCancel()
+
+	err = Run(proxyCtx, []string{
+		"proxy",
+		"app",
+		"myapp",
+		"--insecure",
+		"--proxy", proxyAddr.String(),
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, accessUser, connector.GetName()), webauthnLoginOpt)
+	require.Error(t, err)
+
+	// App commands will succeed with MFA.
+	webauthnLoginOpt = setupWebAuthnChallengeSolver(device, true /* success */)
+
+	// Test App login success.
+	err = Run(ctx, []string{
+		"app",
+		"login",
+		"myapp",
+		"--insecure",
+		"--proxy", proxyAddr.String(),
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, accessUser, connector.GetName()), webauthnLoginOpt)
+	require.NoError(t, err)
+
+	// Retrieve the app login config (private key, ca, and cert).
+	confOut := new(bytes.Buffer)
+	err = Run(ctx, []string{
+		"app",
+		"config",
+		"myapp",
+		"--format", "json",
+	}, setHomePath(tmpHomePath), setOverrideStdout(confOut))
+	require.NoError(t, err)
+
+	// Verify that we can connect to the app using the generated app cert.
+	var info appConfigInfo
+	require.NoError(t, json.Unmarshal(confOut.Bytes(), &info))
+
+	clientCert, err := tls.LoadX509KeyPair(info.Cert, info.Key)
+	require.NoError(t, err)
+
+	testDummyAppConn(t, "myapp", fmt.Sprintf("https://%v", proxyAddr.Addr), clientCert)
+
+	// Test Proxy app success.
+	localProxyPort := ports.Pop()
+	proxyCtx, proxyCancel = context.WithTimeout(ctx, 10*time.Second)
+	defer proxyCancel()
+
+	errC := make(chan error)
+	go func() {
+		errC <- Run(proxyCtx, []string{
+			"proxy",
+			"app",
+			"myapp",
+			"--port", localProxyPort,
+			"--insecure",
+			"--proxy", proxyAddr.String(),
+		}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, accessUser, connector.GetName()), webauthnLoginOpt)
+	}()
+
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		testDummyAppConn(t, "myapp", fmt.Sprintf("http://127.0.0.1:%v", localProxyPort))
+	}, 10*time.Second, time.Second)
+
+	proxyCancel()
+	assert.NoError(t, <-errC)
 }


### PR DESCRIPTION
changelog: Extend Hardware Key Support to cover Application Access.

Extend hardware key support to App Access as described in the [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0080-hardware-key-support.md#application-access).