### PR TITLE
Add documentation about `tbot`'s diagnostics service

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -551,6 +551,7 @@
     "libgcc",
     "libm",
     "libpq",
+    "livez",
     "lmnop",
     "loadbalancer",
     "localca",

--- a/docs/pages/machine-id/reference.mdx
+++ b/docs/pages/machine-id/reference.mdx
@@ -4,6 +4,7 @@ description: Configuration and CLI reference for Teleport Machine ID.
 ---
 
 - [Configuration](./reference/configuration.mdx)
+- [Diagnostics Service](./reference/diagnostics-service.mdx)
 - [GitHub Actions](./reference/github-actions.mdx)
 - [GitLab CI](./reference/gitlab.mdx)
 - [CLI](../reference/cli/tbot.mdx)

--- a/docs/pages/machine-id/reference/diagnostics-service.mdx
+++ b/docs/pages/machine-id/reference/diagnostics-service.mdx
@@ -19,13 +19,13 @@ to `127.0.0.1`, which will only allow access from the local machine.
 You can configure the diagnostics service using the `--diag-addr` CLI parameter:
 
 ```code
-$ tbot start -c my-config.yaml --diag-addr 127.0.0.1:1234
+$ tbot start -c my-config.yaml --diag-addr 127.0.0.1:3001
 ```
 
 Or directly within the configuration file using `diag_addr`:
 
 ```yaml
-diag_addr: 127.0.0.1:1234
+diag_addr: 127.0.0.1:3001
 ```
 
 ## Endpoints

--- a/docs/pages/machine-id/reference/diagnostics-service.mdx
+++ b/docs/pages/machine-id/reference/diagnostics-service.mdx
@@ -30,6 +30,8 @@ diag_addr: 127.0.0.1:3001
 
 ## Endpoints
 
+The diagnostics service exposes the following HTTP endpoints.
+
 ### `/livez`
 
 The `/livez` endpoint always returns with a 200 status code. This can be used

--- a/docs/pages/machine-id/reference/diagnostics-service.mdx
+++ b/docs/pages/machine-id/reference/diagnostics-service.mdx
@@ -18,7 +18,7 @@ to `127.0.0.1`, which will only allow access from the local machine.
 
 You can configure the diagnostics service using the `--diag-addr` CLI parameter:
 
-```script
+```code
 $ tbot start -c my-config.yaml --diag-addr 127.0.0.1:1234
 ```
 

--- a/docs/pages/machine-id/reference/diagnostics-service.mdx
+++ b/docs/pages/machine-id/reference/diagnostics-service.mdx
@@ -1,0 +1,64 @@
+---
+title: Diagnostics Service
+description: Reference information for the `tbot` diagnostics service.
+---
+
+The `tbot` process can optionally expose a diagnostics service. This is
+disabled by default, but once enabled, allows useful information about the
+running `tbot` process to be queried via HTTP.
+
+## Configuration
+
+To enable the diagnostics service, you must specify an address and port for
+it to listen on.
+
+For security reasons, you should ensure that access to this listener is
+restricted. In most cases, the most secure thing to do is to bind the listener
+to `127.0.0.1`, which will only allow access from the local machine.
+
+You can configure the diagnostics service using the `--diag-addr` CLI parameter:
+
+```script
+$ tbot start -c my-config.yaml --diag-addr 127.0.0.1:1234
+```
+
+Or directly within the configuration file using `diag_addr`:
+
+```yaml
+diag_addr: 127.0.0.1:1234
+```
+
+## Endpoints
+
+### `/livez`
+
+The `/livez` endpoint always returns with a 200 status code. This can be used
+to determine if the `tbot` process is running and has not crashed or hung.
+
+If deploying to Kubernetes, we recommend this endpoint is used for your
+Liveness Probe.
+
+### `/readyz`
+
+The `/readyz` endpoint currently returns the same information as `/livez`.
+
+In the future, this endpoint will be expanded to indicate whether the internal
+components of `tbot` have been able to generate certificates and are ready
+to serve requests.
+
+### `/metrics`
+
+The `/metrics` endpoint returns a Prometheus-compatible metrics snapshot.
+
+Currently, there are no `tbot` specific metrics, but, the metrics provided by
+the Go runtime are exposed and these can be used for monitoring the overall
+health of the `tbot` process.
+
+### `/debug/pprof`
+
+These endpoints allow the collection of pprof profiles for debugging purposes.
+You may be asked by a Teleport engineer to collect these if you are experiencing
+performance issues.
+
+They will only be enabled if the `-d`/`--debug` flag is provided when starting
+`tbot`. This is known as **debug mode**.

--- a/lib/tbot/service_diagnostics.go
+++ b/lib/tbot/service_diagnostics.go
@@ -62,7 +62,7 @@ func (s *diagnosticsService) Run(ctx context.Context) error {
 	}
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		msg := "404 - Not Found\n\nI'm a little tbot,\nshort and stout,\nthe page you seek,\nis not about."
+		msg := "404 - Not Found\n\nI'm a little tbot,\nshort and stout,\nthe page you seek,\nis not about.\n\nYou can find out more information about the diagnostics service at https://goteleport.com/docs/machine-id/reference/diagnostics-service/"
 		_, _ = w.Write([]byte(msg))
 	}))
 	mux.Handle("/livez", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adds information about how to enable the diagnostics service, and what endpoints it exposes.