### PR TITLE
[v14] make CockroachDB username case-insensitive

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -137,6 +137,9 @@ type Database interface {
 	// GetCloud gets the cloud this database is running on, or an empty string if it
 	// isn't running on a cloud provider.
 	GetCloud() string
+	// IsUsernameCaseInsensitive returns true if the database username is case
+	// insensitive.
+	IsUsernameCaseInsensitive() bool
 }
 
 // NewDatabaseV3 creates a new database resource.
@@ -1027,6 +1030,14 @@ func (d *DatabaseV3) GetEndpointType() string {
 	return ""
 }
 
+// IsUsernameCaseInsensitive returns true if the database username is case
+// insensitive.
+func (d *DatabaseV3) IsUsernameCaseInsensitive() bool {
+	// CockroachDB usernames are case-insensitive:
+	// https://www.cockroachlabs.com/docs/stable/create-user#user-names
+	return d.GetProtocol() == DatabaseProtocolCockroachDB
+}
+
 const (
 	// DatabaseProtocolPostgreSQL is the PostgreSQL database protocol.
 	DatabaseProtocolPostgreSQL = "postgres"
@@ -1038,6 +1049,8 @@ const (
 	DatabaseProtocolMySQL = "mysql"
 	// DatabaseProtocolMongoDB is the MongoDB database protocol.
 	DatabaseProtocolMongoDB = "mongodb"
+	// DatabaseProtocolCockroachDB is the CockroachDB database protocol.
+	DatabaseProtocolCockroachDB = "cockroachdb"
 
 	// DatabaseTypeSelfHosted is the self-hosted type of database.
 	DatabaseTypeSelfHosted = "self-hosted"

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1059,9 +1059,13 @@ func MatchDatabaseName(selectors []string, name string) (bool, string) {
 }
 
 // MatchDatabaseUser returns true if provided database user matches selectors.
-func MatchDatabaseUser(selectors []string, user string, matchWildcard bool) (bool, string) {
+func MatchDatabaseUser(selectors []string, user string, matchWildcard, caseFold bool) (bool, string) {
 	for _, u := range selectors {
-		if u == user {
+		if caseFold {
+			if strings.EqualFold(u, user) {
+				return true, "matched"
+			}
+		} else if u == user {
 			return true, "matched"
 		}
 		if matchWildcard && u == types.Wildcard {
@@ -2005,6 +2009,8 @@ type databaseUserMatcher struct {
 	user string
 	// alternativeNames is a list of alternative names for the database user.
 	alternativeNames []string
+	// caseInsensitive specifies if the username is case insensitive.
+	caseInsensitive bool
 }
 
 // NewDatabaseUserMatcher creates a RoleMatcher that checks whether the role's
@@ -2014,6 +2020,7 @@ func NewDatabaseUserMatcher(db types.Database, user string) RoleMatcher {
 		return &databaseUserMatcher{
 			user:             user,
 			alternativeNames: makeUsernamesForAWSRoleARN(db, user),
+			caseInsensitive:  db.IsUsernameCaseInsensitive(),
 		}
 	}
 
@@ -2021,21 +2028,26 @@ func NewDatabaseUserMatcher(db types.Database, user string) RoleMatcher {
 		return &databaseUserMatcher{
 			user:             user,
 			alternativeNames: makeAlternativeNamesForAWSRole(db, user),
+			caseInsensitive:  db.IsUsernameCaseInsensitive(),
 		}
 	}
 
-	return &databaseUserMatcher{user: user}
+	return &databaseUserMatcher{
+		user:            user,
+		caseInsensitive: db.IsUsernameCaseInsensitive(),
+	}
 }
 
 // Match matches database account name against provided role and condition.
 func (m *databaseUserMatcher) Match(role types.Role, condition types.RoleConditionType) (bool, error) {
 	selectors := role.GetDatabaseUsers(condition)
-	if match, _ := MatchDatabaseUser(selectors, m.user, true); match {
+
+	if match, _ := MatchDatabaseUser(selectors, m.user, true /*matchWildcard*/, m.caseInsensitive); match {
 		return true, nil
 	}
 
 	for _, altName := range m.alternativeNames {
-		if match, _ := MatchDatabaseUser(selectors, altName, false); match {
+		if match, _ := MatchDatabaseUser(selectors, altName, false /*matchWildcard*/, m.caseInsensitive); match {
 			return true, nil
 		}
 	}

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -3825,6 +3825,23 @@ func TestCheckAccessToDatabaseUser(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, dbSupportAWSRoles.SupportAWSIAMRoleARNAsUsers())
 
+	dbCockroachStage, err := types.NewDatabaseV3(types.Metadata{
+		Name:   "cockroachdb",
+		Labels: map[string]string{"env": "stage"},
+	}, types.DatabaseSpecV3{
+		Protocol: "cockroachdb",
+		URI:      "cockroachdb:26257",
+	})
+	require.NoError(t, err)
+	dbCockroachProd, err := types.NewDatabaseV3(types.Metadata{
+		Name:   "cockroachdb",
+		Labels: map[string]string{"env": "prod"},
+	}, types.DatabaseSpecV3{
+		Protocol: "cockroachdb",
+		URI:      "cockroachdb:26257",
+	})
+	require.NoError(t, err)
+
 	type access struct {
 		server types.Database
 		dbUser string
@@ -3842,6 +3859,7 @@ func TestCheckAccessToDatabaseUser(t *testing.T) {
 				{server: dbStage, dbUser: "superuser", access: false},
 				{server: dbStage, dbUser: "dev", access: true},
 				{server: dbStage, dbUser: "test", access: true},
+				{server: dbStage, dbUser: "SUPERUSER", access: true},
 			},
 		},
 		{
@@ -3881,6 +3899,27 @@ func TestCheckAccessToDatabaseUser(t *testing.T) {
 				{server: dbSupportAWSRoles, dbUser: "role/regular-user", access: false},
 				{server: dbSupportAWSRoles, dbUser: "arn:aws:iam::123456789012:role/regular-user", access: false},
 				{server: dbSupportAWSRoles, dbUser: "unknown-user", access: false},
+			},
+		},
+		{
+			name:  "(case-insensitive db) developer allowed any username in stage except superuser",
+			roles: RoleSet{roleDevStage, roleDevProd},
+			access: []access{
+				{server: dbCockroachStage, dbUser: "dev", access: true},
+				{server: dbCockroachStage, dbUser: "DEV", access: true},
+				{server: dbCockroachStage, dbUser: "test", access: true},
+				{server: dbCockroachStage, dbUser: "superuser", access: false},
+				{server: dbCockroachStage, dbUser: "SUPERUSER", access: false},
+			},
+		},
+		{
+			name:  "(case-insensitive db) developer allowed only specific username/database in prod database",
+			roles: RoleSet{roleDevStage, roleDevProd},
+			access: []access{
+				{server: dbCockroachProd, dbUser: "dev", access: true},
+				{server: dbCockroachProd, dbUser: "DEV", access: true},
+				{server: dbCockroachProd, dbUser: "superuser", access: false},
+				{server: dbCockroachProd, dbUser: "Superuser", access: false},
 			},
 		},
 	}


### PR DESCRIPTION
backport of https://github.com/gravitational/teleport/pull/41822 to branch/v14

changelog: Fixed a security issue denied CockroachDB users can be accessed with case-insensitive variants