### PR TITLE
[v13] make CockroachDB username case-insensitive

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -135,6 +135,9 @@ type Database interface {
 	// GetCloud gets the cloud this database is running on, or an empty string if it
 	// isn't running on a cloud provider.
 	GetCloud() string
+	// IsUsernameCaseInsensitive returns true if the database username is case
+	// insensitive.
+	IsUsernameCaseInsensitive() bool
 }
 
 // NewDatabaseV3 creates a new database resource.
@@ -961,9 +964,19 @@ func (d *DatabaseV3) GetEndpointType() string {
 	return ""
 }
 
+// IsUsernameCaseInsensitive returns true if the database username is case
+// insensitive.
+func (d *DatabaseV3) IsUsernameCaseInsensitive() bool {
+	// CockroachDB usernames are case-insensitive:
+	// https://www.cockroachlabs.com/docs/stable/create-user#user-names
+	return d.GetProtocol() == DatabaseProtocolCockroachDB
+}
+
 const (
 	// DatabaseProtocolPostgreSQL is the PostgreSQL database protocol.
 	DatabaseProtocolPostgreSQL = "postgres"
+	// DatabaseProtocolCockroachDB is the CockroachDB database protocol.
+	DatabaseProtocolCockroachDB = "cockroachdb"
 
 	// DatabaseTypeSelfHosted is the self-hosted type of database.
 	DatabaseTypeSelfHosted = "self-hosted"

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -3731,6 +3731,23 @@ func TestCheckAccessToDatabaseUser(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, dbSupportAWSRoles.SupportAWSIAMRoleARNAsUsers())
 
+	dbCockroachStage, err := types.NewDatabaseV3(types.Metadata{
+		Name:   "cockroachdb",
+		Labels: map[string]string{"env": "stage"},
+	}, types.DatabaseSpecV3{
+		Protocol: "cockroachdb",
+		URI:      "cockroachdb:26257",
+	})
+	require.NoError(t, err)
+	dbCockroachProd, err := types.NewDatabaseV3(types.Metadata{
+		Name:   "cockroachdb",
+		Labels: map[string]string{"env": "prod"},
+	}, types.DatabaseSpecV3{
+		Protocol: "cockroachdb",
+		URI:      "cockroachdb:26257",
+	})
+	require.NoError(t, err)
+
 	type access struct {
 		server types.Database
 		dbUser string
@@ -3748,6 +3765,7 @@ func TestCheckAccessToDatabaseUser(t *testing.T) {
 				{server: dbStage, dbUser: "superuser", access: false},
 				{server: dbStage, dbUser: "dev", access: true},
 				{server: dbStage, dbUser: "test", access: true},
+				{server: dbStage, dbUser: "SUPERUSER", access: true},
 			},
 		},
 		{
@@ -3787,6 +3805,27 @@ func TestCheckAccessToDatabaseUser(t *testing.T) {
 				{server: dbSupportAWSRoles, dbUser: "role/regular-user", access: false},
 				{server: dbSupportAWSRoles, dbUser: "arn:aws:iam::123456789012:role/regular-user", access: false},
 				{server: dbSupportAWSRoles, dbUser: "unknown-user", access: false},
+			},
+		},
+		{
+			name:  "(case-insensitive db) developer allowed any username in stage except superuser",
+			roles: RoleSet{roleDevStage, roleDevProd},
+			access: []access{
+				{server: dbCockroachStage, dbUser: "dev", access: true},
+				{server: dbCockroachStage, dbUser: "DEV", access: true},
+				{server: dbCockroachStage, dbUser: "test", access: true},
+				{server: dbCockroachStage, dbUser: "superuser", access: false},
+				{server: dbCockroachStage, dbUser: "SUPERUSER", access: false},
+			},
+		},
+		{
+			name:  "(case-insensitive db) developer allowed only specific username/database in prod database",
+			roles: RoleSet{roleDevStage, roleDevProd},
+			access: []access{
+				{server: dbCockroachProd, dbUser: "dev", access: true},
+				{server: dbCockroachProd, dbUser: "DEV", access: true},
+				{server: dbCockroachProd, dbUser: "superuser", access: false},
+				{server: dbCockroachProd, dbUser: "Superuser", access: false},
 			},
 		},
 	}


### PR DESCRIPTION
backport of https://github.com/gravitational/teleport/pull/41822 to branch/v13

changelog: Fixed a security issue denied CockroachDB users can be accessed with case-insensitive variants