### PR TITLE
Add access list owner IneligibleStatus to ignored fields

### DIFF
--- a/lib/services/compare.go
+++ b/lib/services/compare.go
@@ -45,8 +45,11 @@ func CompareResources[T any](resA, resB T) int {
 			cmpopts.IgnoreFields(accesslist.AccessList{}, "Status"),
 			cmpopts.IgnoreFields(header.Metadata{}, "ID", "Revision"),
 			cmpopts.IgnoreUnexported(headerv1.Metadata{}),
+
 			// Managed by IneligibleStatusReconciler, ignored by all others.
 			cmpopts.IgnoreFields(accesslist.AccessListMemberSpec{}, "IneligibleStatus"),
+			cmpopts.IgnoreFields(accesslist.Owner{}, "IneligibleStatus"),
+
 			cmpopts.EquateEmpty(),
 		)
 	}

--- a/lib/services/compare_test.go
+++ b/lib/services/compare_test.go
@@ -44,6 +44,17 @@ func TestCompareResources(t *testing.T) {
 	compareTestCase(t, "cmp equal with equal IneligibleStatus", newAccessListMemberSpec("status1", "accessList1"), newAccessListMemberSpec("status1", "accessList1"), Equal)
 	compareTestCase(t, "cmp equal with different IneligibleStatus", newAccessListMemberSpec("status1", "accessList1"), newAccessListMemberSpec("status2", "accessList1"), Equal)
 	compareTestCase(t, "cmp not equal", newAccessListMemberSpec("status1", "accessList1"), newAccessListMemberSpec("status1", "accessList2"), Different)
+
+	// These results compare the IneligibleStatus field in accesslist.Owner, which should be ignored.
+	newAccessListOwner := func(ineligibleStatus, name string) accesslist.Owner {
+		return accesslist.Owner{
+			Name:             name,
+			IneligibleStatus: ineligibleStatus,
+		}
+	}
+	compareTestCase(t, "cmp equal with equal IneligibleStatus", newAccessListOwner("status1", "alice"), newAccessListOwner("status1", "alice"), Equal)
+	compareTestCase(t, "cmp equal with different IneligibleStatus", newAccessListOwner("status1", "alice"), newAccessListOwner("status2", "alice"), Equal)
+	compareTestCase(t, "cmp different when name differs", newAccessListOwner("status1", "alice"), newAccessListOwner("status1", "bob"), Different)
 }
 
 func compareTestCase[T any](t *testing.T, name string, resA, resB T, expected int) {


### PR DESCRIPTION
This replicates what was done for `AccessListMember` in https://github.com/gravitational/teleport/pull/41039 . As these statuses are taken care off by a dedicated reconciler, other reconcilers should ignore this field to reduce unnecessary updates.