### PR TITLE
[v14] Only include system annotations that are present in the requested roles in an access request 

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -204,7 +204,7 @@ spec:
   allow:
     rules:
       - resources: ['access_request']
-        verbs: ['list', 'read', 'update']
+        verbs: ['list', 'read']
       - resources: ['access_plugin_data']
         verbs: ['update']
     review_requests:

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -7083,6 +7083,18 @@ func TestAccessRequestNonGreedyAnnotations(t *testing.T) {
 	require.NoError(t, err)
 	idServer.SetStaticLabels(map[string]string{"service": "payments"})
 
+	ctx := context.Background()
+	srv := newTestTLSServer(t)
+	for _, role := range roles {
+		err := srv.Auth().CreateRole(ctx, role)
+		require.NoError(t, err)
+	}
+
+	for _, server := range []types.Server{paymentsServer, idServer} {
+		_, err := srv.Auth().UpsertNode(ctx, server)
+		require.NoError(t, err)
+	}
+
 	for _, tc := range []struct {
 		name                 string
 		roles                []string
@@ -7124,7 +7136,7 @@ func TestAccessRequestNonGreedyAnnotations(t *testing.T) {
 			errfn:                require.Error,
 		},
 		{
-			name:           "identity-requester requests role, receives payment annotations",
+			name:           "identity-requester requests role, receives identity annotations",
 			roles:          []string{"identity-requester"},
 			requestedRoles: []string{"identity-access"},
 			expectedAnnotations: map[string][]string{
@@ -7133,7 +7145,7 @@ func TestAccessRequestNonGreedyAnnotations(t *testing.T) {
 			},
 		},
 		{
-			name:                 "identity-resource-requester requests resource, receives payment annotations",
+			name:                 "identity-resource-requester requests resource, receives identity annotations",
 			roles:                []string{"identity-resource-requester"},
 			requestedRoles:       []string{"identity-access"},
 			requestedResourceIDs: []string{"server-identity"},
@@ -7143,13 +7155,13 @@ func TestAccessRequestNonGreedyAnnotations(t *testing.T) {
 			},
 		},
 		{
-			name:           "identity-requester requests identity role, receives error",
+			name:           "identity-requester requests paymen role, receives error",
 			roles:          []string{"identity-requester"},
 			requestedRoles: []string{"payments-access"},
 			errfn:          require.Error,
 		},
 		{
-			name:                 "identity-resource-requester requests identity resource, receives error",
+			name:                 "identity-resource-requester requests payment resource, receives error",
 			roles:                []string{"identity-resource-requester"},
 			requestedRoles:       []string{"payment-access"},
 			requestedResourceIDs: []string{"server-identity"},
@@ -7172,24 +7184,48 @@ func TestAccessRequestNonGreedyAnnotations(t *testing.T) {
 				"any-requestor": {"true"},
 			},
 		},
+		{
+			name:           "both payments and identity-requester requests payments role, receives payments annotations",
+			roles:          []string{"identity-requester", "payments-requester"},
+			requestedRoles: []string{"payments-access"},
+			expectedAnnotations: map[string][]string{
+				"requesting": {"role"},
+				"services":   {"payments"},
+			},
+		},
+		{
+			name: "all requester roles, requests payments role, receives payments and any annotations",
+			roles: []string{
+				"identity-requester", "payments-requester",
+				"identity-resource-requester", "payments-resource-requester",
+				"any-requester"},
+			requestedRoles: []string{"payments-access"},
+			expectedAnnotations: map[string][]string{
+				"requesting":    {"role"},
+				"services":      {"payments"},
+				"any-requestor": {"true"},
+			},
+		},
+		{
+			name: "all requester roles, requests payments resource, receives payments and any annotations",
+			roles: []string{
+				"identity-requester", "payments-requester",
+				"identity-resource-requester", "payments-resource-requester",
+				"any-requester"},
+			requestedRoles:       []string{"payments-access"},
+			requestedResourceIDs: []string{"server-payments"},
+			expectedAnnotations: map[string][]string{
+				"requesting":    {"resources"},
+				"services":      {"payments"},
+				"any-requestor": {"true"},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			srv := newTestTLSServer(t)
-			for _, role := range roles {
-				_, err := srv.Auth().CreateRole(ctx, role)
-				require.NoError(t, err)
-			}
-
-			for _, server := range []types.Server{paymentsServer, idServer} {
-				_, err := srv.Auth().UpsertNode(ctx, server)
-				require.NoError(t, err)
-			}
-
 			user, err := types.NewUser("requester")
 			require.NoError(t, err)
 			user.SetRoles(tc.roles)
-			_, err = srv.Auth().CreateUser(ctx, user)
+			err = srv.Auth().UpsertUser(user)
 			require.NoError(t, err)
 
 			var req types.AccessRequest

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -6976,6 +6976,88 @@ func TestCreateAccessRequest(t *testing.T) {
 	}
 }
 
+func TestAccessRequestNonGreedyAnnotations(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	srv := newTestTLSServer(t)
+	paymentRequestReviewer, identityRequestReviewer, _ := createSessionTestUsers(t, srv.Auth())
+	requester, _, err := CreateUserAndRole(srv.Auth(), "requester", nil, []types.Rule{})
+	require.NoError(t, err)
+
+	paymentsRole, err := types.NewRole("paymentsRole", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				Roles: []string{"requestRole"},
+				Annotations: map[string][]string{
+					"pagerduty_services": {"payments"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	paymentsReviewRole, err := types.NewRole("paymentsReviewRole", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{types.NewRule(types.KindAccessRequest, []string{"update"})},
+		},
+	})
+	require.NoError(t, err)
+	identityReviewRole, err := types.NewRole("identityReviewRole", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{types.NewRule(types.KindAccessRequest, []string{"update"})},
+		},
+	})
+	require.NoError(t, err)
+
+	requestRole, err := types.NewRole("requestRole", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				Roles: []string{"requestRole"},
+				Annotations: map[string][]string{
+					"pagerduty_services": {"identity"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	srv.Auth().CreateRole(ctx, requestRole)
+	srv.Auth().CreateRole(ctx, paymentsRole)
+	srv.Auth().CreateRole(ctx, paymentsReviewRole)
+	srv.Auth().CreateRole(ctx, identityReviewRole)
+
+	user, err := srv.Auth().GetUser(ctx, paymentRequestReviewer, true)
+	require.NoError(t, err)
+	user.AddRole(paymentsReviewRole.GetName())
+	_, err = srv.Auth().UpsertUser(ctx, user)
+	require.NoError(t, err)
+
+	user, err = srv.Auth().GetUser(ctx, identityRequestReviewer, true)
+	require.NoError(t, err)
+	user.AddRole(identityReviewRole.GetName())
+	_, err = srv.Auth().UpsertUser(ctx, user)
+	require.NoError(t, err)
+
+	user, err = srv.Auth().GetUser(ctx, requester.GetName(), true)
+	require.NoError(t, err)
+	user.AddRole(paymentsRole.GetName())
+	_, err = srv.Auth().UpsertUser(ctx, user)
+	require.NoError(t, err)
+
+	client, err := srv.NewClient(TestUser(requester.GetName()))
+	require.NoError(t, err)
+
+	paymentsAccessRequest, err := types.NewAccessRequest(uuid.NewString(), requester.GetName(), "requestRole")
+	require.NoError(t, err)
+	req, err := client.CreateAccessRequestV2(ctx, paymentsAccessRequest)
+	require.NoError(t, err)
+
+	// system annotations should only contain annotations from the requested role
+	require.Equal(t, map[string][]string{"pagerduty_services": {"payments"}}, req.GetSystemAnnotations())
+
+	require.NoError(t, err)
+}
+
 func mustAccessRequest(t *testing.T, user string, state types.RequestState, created, expires time.Time, roles []string, resourceIDs []types.ResourceID) types.AccessRequest {
 	t.Helper()
 

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1611,6 +1611,8 @@ Outer:
 func (m *RequestValidator) SystemAnnotations(req types.AccessRequest) (map[string][]string, error) {
 	annotations := make(map[string][]string)
 
+	// allowedAnnotations keeps track of annotations an access request
+	// can be granted by the roles requested.
 	allowedAnnotations := make(map[string][]string)
 	for _, userRole := range m.userState.GetRoles() {
 		role, err := m.getter.GetRole(context.Background(), userRole)
@@ -1621,6 +1623,9 @@ func (m *RequestValidator) SystemAnnotations(req types.AccessRequest) (map[strin
 		acr := role.GetAccessRequestConditions(types.Allow)
 
 		for _, reqRole := range req.GetRoles() {
+			// if the requested role is a resource request, the roles
+			// granted in `search_as_roles` must be used to make the
+			// access request and so only annotations from those roles should be included
 			roles := acr.Roles
 			if len(req.GetRequestedResourceIDs()) != 0 {
 				roles = acr.SearchAsRoles

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1633,7 +1633,7 @@ func (m *RequestValidator) SystemAnnotations(req types.AccessRequest) (map[strin
 			if slices.Contains(roles, reqRole) {
 				for k, v := range acr.Annotations {
 					vals := allowedAnnotations[k]
-					allowedAnnotations[k] = slices.Concat(vals, v)
+					allowedAnnotations[k] = append(vals, v...)
 				}
 			}
 		}
@@ -1653,7 +1653,8 @@ func (m *RequestValidator) SystemAnnotations(req types.AccessRequest) (map[strin
 		if len(filtered) == 0 {
 			continue
 		}
-		annotations[k] = filtered
+		slices.Sort(filtered)
+		annotations[k] = slices.Compact(filtered)
 	}
 	return annotations, nil
 }

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1171,7 +1171,11 @@ func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest
 		// incoming requests must have system annotations attached
 		// before being inserted into the backend. this is how the
 		// RBAC system propagates sideband information to plugins.
-		req.SetSystemAnnotations(m.SystemAnnotations())
+		systemAnnotations, err := m.SystemAnnotations(req.GetRoles())
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		req.SetSystemAnnotations(systemAnnotations)
 
 		// if no suggested reviewers were provided by the user then
 		// use the defaults suggested by the user's static roles.
@@ -1604,21 +1608,44 @@ Outer:
 
 // SystemAnnotations calculates the system annotations for a pending
 // access request.
-func (m *RequestValidator) SystemAnnotations() map[string][]string {
+func (m *RequestValidator) SystemAnnotations(requestedRoles []string) (map[string][]string, error) {
 	annotations := make(map[string][]string)
+
+	allowedAnnotations := make(map[string][]string)
+	for _, userRole := range m.userState.GetRoles() {
+		role, err := m.getter.GetRole(context.Background(), userRole)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		acr := role.GetAccessRequestConditions(types.Allow)
+
+		for _, reqRole := range requestedRoles {
+			if slices.Contains(acr.Roles, reqRole) {
+				for k, v := range acr.Annotations {
+					vals := allowedAnnotations[k]
+					allowedAnnotations[k] = slices.Concat(vals, v)
+				}
+			}
+		}
+	}
+
 	for k, va := range m.Annotations.Allow {
 		var filtered []string
 		for _, v := range va {
-			if !slices.Contains(m.Annotations.Deny[k], v) {
-				filtered = append(filtered, v)
+			if slices.Contains(m.Annotations.Deny[k], v) {
+				continue
 			}
+			if !slices.Contains(allowedAnnotations[k], v) {
+				continue
+			}
+			filtered = append(filtered, v)
 		}
 		if len(filtered) == 0 {
 			continue
 		}
 		annotations[k] = filtered
 	}
-	return annotations
+	return annotations, nil
 }
 
 type ValidateRequestOption func(*RequestValidator)

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1171,7 +1171,7 @@ func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest
 		// incoming requests must have system annotations attached
 		// before being inserted into the backend. this is how the
 		// RBAC system propagates sideband information to plugins.
-		systemAnnotations, err := m.SystemAnnotations(req.GetRoles())
+		systemAnnotations, err := m.SystemAnnotations(req)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1608,7 +1608,7 @@ Outer:
 
 // SystemAnnotations calculates the system annotations for a pending
 // access request.
-func (m *RequestValidator) SystemAnnotations(requestedRoles []string) (map[string][]string, error) {
+func (m *RequestValidator) SystemAnnotations(req types.AccessRequest) (map[string][]string, error) {
 	annotations := make(map[string][]string)
 
 	allowedAnnotations := make(map[string][]string)
@@ -1617,10 +1617,15 @@ func (m *RequestValidator) SystemAnnotations(requestedRoles []string) (map[strin
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+
 		acr := role.GetAccessRequestConditions(types.Allow)
 
-		for _, reqRole := range requestedRoles {
-			if slices.Contains(acr.Roles, reqRole) {
+		for _, reqRole := range req.GetRoles() {
+			roles := acr.Roles
+			if len(req.GetRequestedResourceIDs()) != 0 {
+				roles = acr.SearchAsRoles
+			}
+			if slices.Contains(roles, reqRole) {
 				for k, v := range acr.Annotations {
 					vals := allowedAnnotations[k]
 					allowedAnnotations[k] = slices.Concat(vals, v)

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -222,6 +222,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindSecurityReport, nil
 	case types.KindServerInfo:
 		return types.KindServerInfo, nil
+	case types.KindAccessRequest, types.KindAccessRequest + "s", "accessrequest", "accessrequests":
+		return types.KindAccessRequest, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }

--- a/lib/services/resource_test.go
+++ b/lib/services/resource_test.go
@@ -165,6 +165,11 @@ func TestParseShortcut(t *testing.T) {
 
 		"SamL_IDP_sERVICe_proVidER": {expectedOutput: types.KindSAMLIdPServiceProvider},
 
+		"access_request":  {expectedOutput: types.KindAccessRequest},
+		"access_requests": {expectedOutput: types.KindAccessRequest},
+		"accessrequest":   {expectedOutput: types.KindAccessRequest},
+		"accessrequests":  {expectedOutput: types.KindAccessRequest},
+
 		"unknown_type": {expectedErr: true},
 	}
 

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1347,3 +1347,40 @@ func (c *accessListCollection) writeText(w io.Writer, verbose bool) error {
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)
 }
+
+type accessRequestCollection struct {
+	accessRequests []types.AccessRequest
+}
+
+func (c *accessRequestCollection) resources() []types.Resource {
+	r := make([]types.Resource, len(c.accessRequests))
+	for i, resource := range c.accessRequests {
+		r[i] = resource
+	}
+	return r
+}
+
+func (c *accessRequestCollection) writeText(w io.Writer, verbose bool) error {
+	var t asciitable.Table
+	var rows [][]string
+	for _, al := range c.accessRequests {
+		var annotations []string
+		for k, v := range al.GetSystemAnnotations() {
+			annotations = append(annotations, fmt.Sprintf("%s/%s", k, strings.Join(v, ",")))
+		}
+		rows = append(rows, []string{
+			al.GetName(),
+			al.GetUser(),
+			strings.Join(al.GetRoles(), ", "),
+			strings.Join(annotations, ", "),
+		})
+	}
+	if verbose {
+		t = asciitable.MakeTable([]string{"Name", "User", "Roles", "Annotations"}, rows...)
+	} else {
+		t = asciitable.MakeTableWithTruncatedColumn([]string{"Name", "User", "Roles", "Annotations"}, rows, "Annotations")
+	}
+
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -2377,6 +2377,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		accessLists, err := client.AccessListClient().GetAccessLists(ctx)
 		return &accessListCollection{accessLists: accessLists}, trace.Wrap(err)
+	case types.KindAccessRequest:
+		resource, err := client.GetAccessRequests(ctx, types.AccessRequestFilter{ID: rc.ref.Name})
+		return &accessRequestCollection{accessRequests: resource}, trace.Wrap(err)
 	}
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/41821

changelog: Only include system annotations that are present in the requested roles in an access request 