### PR TITLE
 [v15] Only include system annotations that are present in the requested roles in an access request

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -204,7 +204,7 @@ spec:
   allow:
     rules:
       - resources: ['access_request']
-        verbs: ['list', 'read', 'update']
+        verbs: ['list', 'read']
       - resources: ['access_plugin_data']
         verbs: ['update']
     review_requests:

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -7081,6 +7081,88 @@ func TestCreateAccessRequest(t *testing.T) {
 	}
 }
 
+func TestAccessRequestNonGreedyAnnotations(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	srv := newTestTLSServer(t)
+	paymentRequestReviewer, identityRequestReviewer, _ := createSessionTestUsers(t, srv.Auth())
+	requester, _, err := CreateUserAndRole(srv.Auth(), "requester", nil, []types.Rule{})
+	require.NoError(t, err)
+
+	paymentsRole, err := types.NewRole("paymentsRole", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				Roles: []string{"requestRole"},
+				Annotations: map[string][]string{
+					"pagerduty_services": {"payments"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	paymentsReviewRole, err := types.NewRole("paymentsReviewRole", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{types.NewRule(types.KindAccessRequest, []string{"update"})},
+		},
+	})
+	require.NoError(t, err)
+	identityReviewRole, err := types.NewRole("identityReviewRole", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{types.NewRule(types.KindAccessRequest, []string{"update"})},
+		},
+	})
+	require.NoError(t, err)
+
+	requestRole, err := types.NewRole("requestRole", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				Roles: []string{"requestRole"},
+				Annotations: map[string][]string{
+					"pagerduty_services": {"identity"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	srv.Auth().CreateRole(ctx, requestRole)
+	srv.Auth().CreateRole(ctx, paymentsRole)
+	srv.Auth().CreateRole(ctx, paymentsReviewRole)
+	srv.Auth().CreateRole(ctx, identityReviewRole)
+
+	user, err := srv.Auth().GetUser(ctx, paymentRequestReviewer, true)
+	require.NoError(t, err)
+	user.AddRole(paymentsReviewRole.GetName())
+	_, err = srv.Auth().UpsertUser(ctx, user)
+	require.NoError(t, err)
+
+	user, err = srv.Auth().GetUser(ctx, identityRequestReviewer, true)
+	require.NoError(t, err)
+	user.AddRole(identityReviewRole.GetName())
+	_, err = srv.Auth().UpsertUser(ctx, user)
+	require.NoError(t, err)
+
+	user, err = srv.Auth().GetUser(ctx, requester.GetName(), true)
+	require.NoError(t, err)
+	user.AddRole(paymentsRole.GetName())
+	_, err = srv.Auth().UpsertUser(ctx, user)
+	require.NoError(t, err)
+
+	client, err := srv.NewClient(TestUser(requester.GetName()))
+	require.NoError(t, err)
+
+	paymentsAccessRequest, err := types.NewAccessRequest(uuid.NewString(), requester.GetName(), "requestRole")
+	require.NoError(t, err)
+	req, err := client.CreateAccessRequestV2(ctx, paymentsAccessRequest)
+	require.NoError(t, err)
+
+	// system annotations should only contain annotations from the requested role
+	require.Equal(t, map[string][]string{"pagerduty_services": {"payments"}}, req.GetSystemAnnotations())
+
+	require.NoError(t, err)
+}
+
 func mustAccessRequest(t *testing.T, user string, state types.RequestState, created, expires time.Time, roles []string, resourceIDs []types.ResourceID) types.AccessRequest {
 	t.Helper()
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -7101,6 +7101,17 @@ func TestAccessRequestNonGreedyAnnotations(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	nodeRole, err := types.NewRole("nodeRole", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				SearchAsRoles: []string{"resourceReqRole"},
+				Annotations: map[string][]string{
+					"requested": {"resource"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
 	paymentsReviewRole, err := types.NewRole("paymentsReviewRole", types.RoleSpecV6{
 		Allow: types.RoleConditions{
 			Rules: []types.Rule{types.NewRule(types.KindAccessRequest, []string{"update"})},
@@ -7126,10 +7137,28 @@ func TestAccessRequestNonGreedyAnnotations(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	resourceReqRole, err := types.NewRole("resourceReqRole", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			NodeLabels: types.Labels{"*": []string{"*"}},
+			Request: &types.AccessRequestConditions{
+				Annotations: map[string][]string{
+					"requested": {"resource"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
 	srv.Auth().CreateRole(ctx, requestRole)
+	srv.Auth().CreateRole(ctx, nodeRole)
 	srv.Auth().CreateRole(ctx, paymentsRole)
 	srv.Auth().CreateRole(ctx, paymentsReviewRole)
 	srv.Auth().CreateRole(ctx, identityReviewRole)
+	srv.Auth().CreateRole(ctx, resourceReqRole)
+
+	server, err := types.NewServer("server", types.KindNode, types.ServerSpecV2{})
+	require.NoError(t, err)
+	srv.Auth().UpsertNode(ctx, server)
 
 	user, err := srv.Auth().GetUser(ctx, paymentRequestReviewer, true)
 	require.NoError(t, err)
@@ -7146,6 +7175,7 @@ func TestAccessRequestNonGreedyAnnotations(t *testing.T) {
 	user, err = srv.Auth().GetUser(ctx, requester.GetName(), true)
 	require.NoError(t, err)
 	user.AddRole(paymentsRole.GetName())
+	user.AddRole(nodeRole.GetName())
 	_, err = srv.Auth().UpsertUser(ctx, user)
 	require.NoError(t, err)
 
@@ -7160,7 +7190,14 @@ func TestAccessRequestNonGreedyAnnotations(t *testing.T) {
 	// system annotations should only contain annotations from the requested role
 	require.Equal(t, map[string][]string{"pagerduty_services": {"payments"}}, req.GetSystemAnnotations())
 
+	resourceAccessRequest, err := types.NewAccessRequestWithResources(uuid.NewString(), requester.GetName(),
+		[]string{"resourceReqRole"},
+		[]types.ResourceID{{ClusterName: srv.ClusterName(), Kind: types.KindNode, Name: "server"}})
 	require.NoError(t, err)
+	req, err = client.CreateAccessRequestV2(ctx, resourceAccessRequest)
+	require.NoError(t, err)
+	require.Equal(t, map[string][]string{"requested": {"resource"}}, req.GetSystemAnnotations())
+
 }
 
 func mustAccessRequest(t *testing.T, user string, state types.RequestState, created, expires time.Time, roles []string, resourceIDs []types.ResourceID) types.AccessRequest {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -7083,120 +7083,248 @@ func TestCreateAccessRequest(t *testing.T) {
 
 func TestAccessRequestNonGreedyAnnotations(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
-	srv := newTestTLSServer(t)
-	paymentRequestReviewer, identityRequestReviewer, _ := createSessionTestUsers(t, srv.Auth())
-	requester, _, err := CreateUserAndRole(srv.Auth(), "requester", nil, []types.Rule{})
-	require.NoError(t, err)
-
-	paymentsRole, err := types.NewRole("paymentsRole", types.RoleSpecV6{
+	paymentsRequester, err := types.NewRole("payments-requester", types.RoleSpecV6{
 		Allow: types.RoleConditions{
 			Request: &types.AccessRequestConditions{
-				Roles: []string{"requestRole"},
 				Annotations: map[string][]string{
-					"pagerduty_services": {"payments"},
+					"services":   {"payments"},
+					"requesting": {"role"},
 				},
+				Roles: []string{"payments-access"},
 			},
 		},
 	})
 	require.NoError(t, err)
-	nodeRole, err := types.NewRole("nodeRole", types.RoleSpecV6{
+
+	paymentsResourceRequester, err := types.NewRole("payments-resource-requester", types.RoleSpecV6{
 		Allow: types.RoleConditions{
 			Request: &types.AccessRequestConditions{
-				SearchAsRoles: []string{"resourceReqRole"},
 				Annotations: map[string][]string{
-					"requested": {"resource"},
+					"services":   {"payments"},
+					"requesting": {"resources"},
 				},
+				SearchAsRoles: []string{"payments-access"},
 			},
 		},
 	})
 	require.NoError(t, err)
-	paymentsReviewRole, err := types.NewRole("paymentsReviewRole", types.RoleSpecV6{
-		Allow: types.RoleConditions{
-			Rules: []types.Rule{types.NewRule(types.KindAccessRequest, []string{"update"})},
-		},
-	})
-	require.NoError(t, err)
-	identityReviewRole, err := types.NewRole("identityReviewRole", types.RoleSpecV6{
-		Allow: types.RoleConditions{
-			Rules: []types.Rule{types.NewRule(types.KindAccessRequest, []string{"update"})},
-		},
-	})
-	require.NoError(t, err)
 
-	requestRole, err := types.NewRole("requestRole", types.RoleSpecV6{
+	paymentsAccess, err := types.NewRole("payments-access", types.RoleSpecV6{
 		Allow: types.RoleConditions{
+			NodeLabels: types.Labels{"service": []string{"payments"}},
 			Request: &types.AccessRequestConditions{
-				Roles: []string{"requestRole"},
 				Annotations: map[string][]string{
-					"pagerduty_services": {"identity"},
+					"never-get-this": {"true"},
 				},
 			},
 		},
 	})
 	require.NoError(t, err)
 
-	resourceReqRole, err := types.NewRole("resourceReqRole", types.RoleSpecV6{
+	identityRequester, err := types.NewRole("identity-requester", types.RoleSpecV6{
 		Allow: types.RoleConditions{
-			NodeLabels: types.Labels{"*": []string{"*"}},
 			Request: &types.AccessRequestConditions{
 				Annotations: map[string][]string{
-					"requested": {"resource"},
+					"services":   {"identity"},
+					"requesting": {"role"},
+				},
+				Roles: []string{"identity-access"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	identityResourceRequester, err := types.NewRole("identity-resource-requester", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				Annotations: map[string][]string{
+					"services":   {"identity"},
+					"requesting": {"resources"},
+				},
+				SearchAsRoles: []string{"identity-access"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	identityAccess, err := types.NewRole("identity-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			NodeLabels: types.Labels{"service": []string{"identity"}},
+			Request: &types.AccessRequestConditions{
+				Annotations: map[string][]string{
+					"never-get-this": {"true"},
 				},
 			},
 		},
 	})
 	require.NoError(t, err)
 
-	srv.Auth().CreateRole(ctx, requestRole)
-	srv.Auth().CreateRole(ctx, nodeRole)
-	srv.Auth().CreateRole(ctx, paymentsRole)
-	srv.Auth().CreateRole(ctx, paymentsReviewRole)
-	srv.Auth().CreateRole(ctx, identityReviewRole)
-	srv.Auth().CreateRole(ctx, resourceReqRole)
+	anyResourceRequester, err := types.NewRole("any-requester", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				Annotations: map[string][]string{
+					"any-requestor": {"true"},
+				},
+				SearchAsRoles: []string{"identity-access", "payments-access"},
+				Roles:         []string{"identity-access", "payments-access"},
+			},
+		},
+	})
 
-	server, err := types.NewServer("server", types.KindNode, types.ServerSpecV2{})
-	require.NoError(t, err)
-	srv.Auth().UpsertNode(ctx, server)
-
-	user, err := srv.Auth().GetUser(ctx, paymentRequestReviewer, true)
-	require.NoError(t, err)
-	user.AddRole(paymentsReviewRole.GetName())
-	_, err = srv.Auth().UpsertUser(ctx, user)
 	require.NoError(t, err)
 
-	user, err = srv.Auth().GetUser(ctx, identityRequestReviewer, true)
-	require.NoError(t, err)
-	user.AddRole(identityReviewRole.GetName())
-	_, err = srv.Auth().UpsertUser(ctx, user)
-	require.NoError(t, err)
+	roles := []types.Role{
+		paymentsRequester, paymentsResourceRequester, paymentsAccess,
+		identityRequester, identityResourceRequester, identityAccess,
+		anyResourceRequester,
+	}
 
-	user, err = srv.Auth().GetUser(ctx, requester.GetName(), true)
+	paymentsServer, err := types.NewServer("server-payments", types.KindNode, types.ServerSpecV2{})
 	require.NoError(t, err)
-	user.AddRole(paymentsRole.GetName())
-	user.AddRole(nodeRole.GetName())
-	_, err = srv.Auth().UpsertUser(ctx, user)
-	require.NoError(t, err)
+	paymentsServer.SetStaticLabels(map[string]string{"service": "payments"})
 
-	client, err := srv.NewClient(TestUser(requester.GetName()))
+	idServer, err := types.NewServer("server-identity", types.KindNode, types.ServerSpecV2{})
 	require.NoError(t, err)
+	idServer.SetStaticLabels(map[string]string{"service": "payments"})
 
-	paymentsAccessRequest, err := types.NewAccessRequest(uuid.NewString(), requester.GetName(), "requestRole")
-	require.NoError(t, err)
-	req, err := client.CreateAccessRequestV2(ctx, paymentsAccessRequest)
-	require.NoError(t, err)
+	for _, tc := range []struct {
+		name                 string
+		roles                []string
+		requestedRoles       []string
+		requestedResourceIDs []string
+		expectedAnnotations  map[string][]string
+		errfn                require.ErrorAssertionFunc
+	}{
+		{
+			name:           "payments-requester requests role, receives payment annotations",
+			roles:          []string{"payments-requester"},
+			requestedRoles: []string{"payments-access"},
+			expectedAnnotations: map[string][]string{
+				"services":   {"payments"},
+				"requesting": {"role"},
+			},
+		},
+		{
+			name:                 "payments-resource-requester requests resource, receives payment annotations",
+			roles:                []string{"payments-resource-requester"},
+			requestedRoles:       []string{"payments-access"},
+			requestedResourceIDs: []string{"server-payments"},
+			expectedAnnotations: map[string][]string{
+				"services":   {"payments"},
+				"requesting": {"resources"},
+			},
+		},
+		{
+			name:           "payments-requester requests identity role, receives error",
+			roles:          []string{"payments-requester"},
+			requestedRoles: []string{"identity-access"},
+			errfn:          require.Error,
+		},
+		{
+			name:                 "payments-resource-requester requests identity resource, receives error",
+			roles:                []string{"payments-resource-requester"},
+			requestedRoles:       []string{"identity-access"},
+			requestedResourceIDs: []string{"server-identity"},
+			errfn:                require.Error,
+		},
+		{
+			name:           "identity-requester requests role, receives payment annotations",
+			roles:          []string{"identity-requester"},
+			requestedRoles: []string{"identity-access"},
+			expectedAnnotations: map[string][]string{
+				"services":   {"identity"},
+				"requesting": {"role"},
+			},
+		},
+		{
+			name:                 "identity-resource-requester requests resource, receives payment annotations",
+			roles:                []string{"identity-resource-requester"},
+			requestedRoles:       []string{"identity-access"},
+			requestedResourceIDs: []string{"server-identity"},
+			expectedAnnotations: map[string][]string{
+				"services":   {"identity"},
+				"requesting": {"resources"},
+			},
+		},
+		{
+			name:           "identity-requester requests identity role, receives error",
+			roles:          []string{"identity-requester"},
+			requestedRoles: []string{"payments-access"},
+			errfn:          require.Error,
+		},
+		{
+			name:                 "identity-resource-requester requests identity resource, receives error",
+			roles:                []string{"identity-resource-requester"},
+			requestedRoles:       []string{"payment-access"},
+			requestedResourceIDs: []string{"server-identity"},
+			errfn:                require.Error,
+		},
+		{
+			name:           "any-requester requests role, receives annotations",
+			roles:          []string{"any-requester"},
+			requestedRoles: []string{"payments-access"},
+			expectedAnnotations: map[string][]string{
+				"any-requestor": {"true"},
+			},
+		},
+		{
+			name:                 "any-requester requests role, receives annotations",
+			roles:                []string{"any-requester"},
+			requestedRoles:       []string{"payments-access"},
+			requestedResourceIDs: []string{"server-payments"},
+			expectedAnnotations: map[string][]string{
+				"any-requestor": {"true"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			srv := newTestTLSServer(t)
+			for _, role := range roles {
+				_, err := srv.Auth().CreateRole(ctx, role)
+				require.NoError(t, err)
+			}
 
-	// system annotations should only contain annotations from the requested role
-	require.Equal(t, map[string][]string{"pagerduty_services": {"payments"}}, req.GetSystemAnnotations())
+			for _, server := range []types.Server{paymentsServer, idServer} {
+				_, err := srv.Auth().UpsertNode(ctx, server)
+				require.NoError(t, err)
+			}
 
-	resourceAccessRequest, err := types.NewAccessRequestWithResources(uuid.NewString(), requester.GetName(),
-		[]string{"resourceReqRole"},
-		[]types.ResourceID{{ClusterName: srv.ClusterName(), Kind: types.KindNode, Name: "server"}})
-	require.NoError(t, err)
-	req, err = client.CreateAccessRequestV2(ctx, resourceAccessRequest)
-	require.NoError(t, err)
-	require.Equal(t, map[string][]string{"requested": {"resource"}}, req.GetSystemAnnotations())
+			user, err := types.NewUser("requester")
+			require.NoError(t, err)
+			user.SetRoles(tc.roles)
+			_, err = srv.Auth().CreateUser(ctx, user)
+			require.NoError(t, err)
+
+			var req types.AccessRequest
+			if len(tc.requestedResourceIDs) == 0 {
+				req, err = types.NewAccessRequest(uuid.NewString(), user.GetName(), tc.requestedRoles...)
+			} else {
+				var resourceIds []types.ResourceID
+				for _, id := range tc.requestedResourceIDs {
+					resourceIds = append(resourceIds, types.ResourceID{
+						ClusterName: srv.ClusterName(),
+						Kind:        types.KindNode,
+						Name:        id,
+					})
+				}
+				req, err = types.NewAccessRequestWithResources(uuid.NewString(), user.GetName(), tc.requestedRoles, resourceIds)
+			}
+			require.NoError(t, err)
+
+			client, err := srv.NewClient(TestUser(user.GetName()))
+			require.NoError(t, err)
+			res, err := client.CreateAccessRequestV2(ctx, req)
+			if tc.errfn == nil {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedAnnotations, res.GetSystemAnnotations())
+			} else {
+				tc.errfn(t, err)
+			}
+
+		})
+	}
 
 }
 

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1728,7 +1728,7 @@ func (m *RequestValidator) SystemAnnotations(req types.AccessRequest) (map[strin
 			if slices.Contains(roles, reqRole) {
 				for k, v := range acr.Annotations {
 					vals := allowedAnnotations[k]
-					allowedAnnotations[k] = slices.Concat(vals, v)
+					allowedAnnotations[k] = append(vals, v...)
 				}
 			}
 		}
@@ -1748,7 +1748,8 @@ func (m *RequestValidator) SystemAnnotations(req types.AccessRequest) (map[strin
 		if len(filtered) == 0 {
 			continue
 		}
-		annotations[k] = filtered
+		slices.Sort(filtered)
+		annotations[k] = slices.Compact(filtered)
 	}
 	return annotations, nil
 }

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1706,6 +1706,8 @@ Outer:
 func (m *RequestValidator) SystemAnnotations(req types.AccessRequest) (map[string][]string, error) {
 	annotations := make(map[string][]string)
 
+	// allowedAnnotations keeps track of annotations an access request
+	// can be granted by the roles requested.
 	allowedAnnotations := make(map[string][]string)
 	for _, userRole := range m.userState.GetRoles() {
 		role, err := m.getter.GetRole(context.Background(), userRole)
@@ -1716,6 +1718,9 @@ func (m *RequestValidator) SystemAnnotations(req types.AccessRequest) (map[strin
 		acr := role.GetAccessRequestConditions(types.Allow)
 
 		for _, reqRole := range req.GetRoles() {
+			// if the requested role is a resource request, the roles
+			// granted in `search_as_roles` must be used to make the
+			// access request and so only annotations from those roles should be included
 			roles := acr.Roles
 			if len(req.GetRequestedResourceIDs()) != 0 {
 				roles = acr.SearchAsRoles

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -236,6 +236,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindAccessMonitoringRule, nil
 	case types.KindDatabaseObject, "database_object":
 		return types.KindDatabaseObject, nil
+	case types.KindAccessRequest, types.KindAccessRequest + "s", "accessrequest", "accessrequests":
+		return types.KindAccessRequest, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }

--- a/lib/services/resource_test.go
+++ b/lib/services/resource_test.go
@@ -167,6 +167,11 @@ func TestParseShortcut(t *testing.T) {
 
 		"SamL_IDP_sERVICe_proVidER": {expectedOutput: types.KindSAMLIdPServiceProvider},
 
+		"access_request":  {expectedOutput: types.KindAccessRequest},
+		"access_requests": {expectedOutput: types.KindAccessRequest},
+		"accessrequest":   {expectedOutput: types.KindAccessRequest},
+		"accessrequests":  {expectedOutput: types.KindAccessRequest},
+
 		"unknown_type": {expectedErr: true},
 	}
 

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1430,3 +1430,40 @@ func (c *accessListCollection) writeText(w io.Writer, verbose bool) error {
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)
 }
+
+type accessRequestCollection struct {
+	accessRequests []types.AccessRequest
+}
+
+func (c *accessRequestCollection) resources() []types.Resource {
+	r := make([]types.Resource, len(c.accessRequests))
+	for i, resource := range c.accessRequests {
+		r[i] = resource
+	}
+	return r
+}
+
+func (c *accessRequestCollection) writeText(w io.Writer, verbose bool) error {
+	var t asciitable.Table
+	var rows [][]string
+	for _, al := range c.accessRequests {
+		var annotations []string
+		for k, v := range al.GetSystemAnnotations() {
+			annotations = append(annotations, fmt.Sprintf("%s/%s", k, strings.Join(v, ",")))
+		}
+		rows = append(rows, []string{
+			al.GetName(),
+			al.GetUser(),
+			strings.Join(al.GetRoles(), ", "),
+			strings.Join(annotations, ", "),
+		})
+	}
+	if verbose {
+		t = asciitable.MakeTable([]string{"Name", "User", "Roles", "Annotations"}, rows...)
+	} else {
+		t = asciitable.MakeTableWithTruncatedColumn([]string{"Name", "User", "Roles", "Annotations"}, rows, "Annotations")
+	}
+
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -2711,6 +2711,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		accessLists, err := client.AccessListClient().GetAccessLists(ctx)
 		return &accessListCollection{accessLists: accessLists}, trace.Wrap(err)
+	case types.KindAccessRequest:
+		resource, err := client.GetAccessRequests(ctx, types.AccessRequestFilter{ID: rc.ref.Name})
+		return &accessRequestCollection{accessRequests: resource}, trace.Wrap(err)
 	}
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/41821

changelog: Only include system annotations that are present in the requested roles in an access request