### PR TITLE
[v14] Strip debug info from Windows builds

### DIFF
--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -343,7 +343,10 @@ function Build-Tsh {
     $CommandDuration = Measure-Block {
         Write-Host "::group::Building tsh..."
         $UnsignedBinaryPath = "$BuildDirectory\unsigned-$BinaryName"
-        go build -tags piv -o "$UnsignedBinaryPath" "$TeleportSourceDirectory\tool\tsh"
+        go build -tags piv -trimpath -ldflags "-s -w" -o "$UnsignedBinaryPath" "$TeleportSourceDirectory\tool\tsh"
+        if ($LastExitCode -ne 0) {
+           exit $LastExitCode
+        }
         Write-Host "::endgroup::"
 
         Write-Host "::group::Signing tsh..."


### PR DESCRIPTION
Backport #41787 to branch/v14

changelog: Debug symbols are now stripped from Windows builds, resulting in smaller tsh and tctl binaries.
