### PR TITLE
[v15] Fixes error propagation and resizes during MFA

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -148,6 +148,9 @@ type Client struct {
 
 	clientActivityMu sync.RWMutex
 	clientLastActive time.Time
+
+	// mouseX and mouseY are the last mouse coordinates sent to the client.
+	mouseX, mouseY uint32
 }
 
 // New creates and connects a new Client based on cfg.
@@ -364,8 +367,7 @@ func (c *Client) startInputStreaming(stopCh chan struct{}) error {
 	c.cfg.Log.Info("TDP input streaming starting")
 	defer c.cfg.Log.Info("TDP input streaming finished")
 
-	// Remember mouse coordinates to send them with all CGOPointer events.
-	var mouseX, mouseY uint32
+	var withheldResize *tdp.ClientScreenSpec
 	for {
 		select {
 		case <-stopCh:
@@ -385,283 +387,313 @@ func (c *Client) startInputStreaming(stopCh chan struct{}) error {
 		}
 
 		if atomic.LoadUint32(&c.readyForInput) == 0 {
-			// Input not allowed yet, drop the message.
-			c.cfg.Log.Debugf("Dropping TDP input message: %T", msg)
+			switch m := msg.(type) {
+			case tdp.ClientScreenSpec:
+				// Withhold the latest screen size until the client is ready for input. This ensures
+				// that the client receives the correct screen size when it is ready.
+				withheldResize = &m
+				c.cfg.Log.Debugf("Withholding screen size until client is ready for input: %dx%d", m.Width, m.Height)
+			default:
+				// Ignore all messages except ClientScreenSpec until the client is ready for input.
+				c.cfg.Log.Debugf("Dropping TDP input message, not ready for input: %T", msg)
+			}
+
 			continue
 		}
 
 		c.UpdateClientActivity()
 
-		switch m := msg.(type) {
-		case tdp.ClientScreenSpec:
-			// If the client has specified a fixed screen size, we don't
-			// need to send a screen resize event.
-			if c.cfg.hasSizeOverride() {
-				continue
+		if withheldResize != nil {
+			c.cfg.Log.Debug("Sending withheld screen size to client")
+			if err := c.handleTDPInput(*withheldResize); err != nil {
+				return trace.Wrap(err)
 			}
+			withheldResize = nil
+		}
 
-			c.cfg.Log.Debugf("Client changed screen size: %d x %d", m.Width, m.Height)
-			if errCode := C.client_write_screen_resize(
-				C.ulong(c.handle),
-				C.uint32_t(m.Width),
-				C.uint32_t(m.Height),
-			); errCode != C.ErrCodeSuccess {
-				return trace.Errorf("ClientScreenSpec: client_write_screen_resize: %v", errCode)
-			}
-		case tdp.MouseMove:
-			mouseX, mouseY = m.X, m.Y
-			if errCode := C.client_write_rdp_pointer(
-				C.ulong(c.handle),
-				C.CGOMousePointerEvent{
-					x:      C.uint16_t(m.X),
-					y:      C.uint16_t(m.Y),
-					button: C.PointerButtonNone,
-					wheel:  C.PointerWheelNone,
-				},
-			); errCode != C.ErrCodeSuccess {
-				return trace.Errorf("MouseMove: client_write_rdp_pointer: %v", errCode)
-			}
-		case tdp.MouseButton:
-			// Map the button to a C enum value.
-			var button C.CGOPointerButton
-			switch m.Button {
-			case tdp.LeftMouseButton:
-				button = C.PointerButtonLeft
-			case tdp.RightMouseButton:
-				button = C.PointerButtonRight
-			case tdp.MiddleMouseButton:
-				button = C.PointerButtonMiddle
-			default:
-				button = C.PointerButtonNone
-			}
-			if errCode := C.client_write_rdp_pointer(
-				C.ulong(c.handle),
-				C.CGOMousePointerEvent{
-					x:      C.uint16_t(mouseX),
-					y:      C.uint16_t(mouseY),
-					button: uint32(button),
-					down:   m.State == tdp.ButtonPressed,
-					wheel:  C.PointerWheelNone,
-				},
-			); errCode != C.ErrCodeSuccess {
-				return trace.Errorf("MouseButton: client_write_rdp_pointer: %v", errCode)
-			}
-		case tdp.MouseWheel:
-			var wheel C.CGOPointerWheel
-			switch m.Axis {
-			case tdp.VerticalWheelAxis:
-				wheel = C.PointerWheelVertical
-			case tdp.HorizontalWheelAxis:
-				wheel = C.PointerWheelHorizontal
-				// TDP positive scroll deltas move towards top-left.
-				// RDP positive scroll deltas move towards top-right.
-				//
-				// Fix the scroll direction to match TDP, it's inverted for
-				// horizontal scroll in RDP.
-				m.Delta = -m.Delta
-			default:
-				wheel = C.PointerWheelNone
-			}
-			if errCode := C.client_write_rdp_pointer(
-				C.ulong(c.handle),
-				C.CGOMousePointerEvent{
-					x:           C.uint16_t(mouseX),
-					y:           C.uint16_t(mouseY),
-					button:      C.PointerButtonNone,
-					wheel:       uint32(wheel),
-					wheel_delta: C.int16_t(m.Delta),
-				},
-			); errCode != C.ErrCodeSuccess {
-				return trace.Errorf("MouseWheel: client_write_rdp_pointer: %v", errCode)
-			}
-		case tdp.KeyboardButton:
-			if errCode := C.client_write_rdp_keyboard(
-				C.ulong(c.handle),
-				C.CGOKeyboardEvent{
-					code: C.uint16_t(m.KeyCode),
-					down: m.State == tdp.ButtonPressed,
-				},
-			); errCode != C.ErrCodeSuccess {
-				return trace.Errorf("KeyboardButton: client_write_rdp_keyboard: %v", errCode)
-			}
-		case tdp.SyncKeys:
-			if errCode := C.client_write_rdp_sync_keys(C.ulong(c.handle),
-				C.CGOSyncKeys{
-					scroll_lock_down: m.ScrollLockState == tdp.ButtonPressed,
-					num_lock_down:    m.NumLockState == tdp.ButtonPressed,
-					caps_lock_down:   m.CapsLockState == tdp.ButtonPressed,
-					kana_lock_down:   m.KanaLockState == tdp.ButtonPressed,
-				}); errCode != C.ErrCodeSuccess {
-				return trace.Errorf("SyncKeys: client_write_rdp_sync_keys: %v", errCode)
-			}
-		case tdp.ClipboardData:
-			if !c.cfg.AllowClipboard {
-				continue
-			}
-			if len(m) > 0 {
-				if errCode := C.client_update_clipboard(
-					C.ulong(c.handle),
-					(*C.uint8_t)(unsafe.Pointer(&m[0])),
-					C.uint32_t(len(m)),
-				); errCode != C.ErrCodeSuccess {
-					return trace.Errorf("ClipboardData: client_update_clipboard (len=%v): %v", len(m), errCode)
-				}
-			} else {
-				c.cfg.Log.Warning("Received an empty clipboard message")
-			}
-		case tdp.SharedDirectoryAnnounce:
-			if c.cfg.AllowDirectorySharing {
-				driveName := C.CString(m.Name)
-				defer C.free(unsafe.Pointer(driveName))
-				if errCode := C.client_handle_tdp_sd_announce(C.ulong(c.handle), C.CGOSharedDirectoryAnnounce{
-					directory_id: C.uint32_t(m.DirectoryID),
-					name:         driveName,
-				}); errCode != C.ErrCodeSuccess {
-					return trace.Errorf("SharedDirectoryAnnounce: failed with %v", errCode)
-				}
-			}
-		case tdp.SharedDirectoryInfoResponse:
-			if c.cfg.AllowDirectorySharing {
-				path := C.CString(m.Fso.Path)
-				defer C.free(unsafe.Pointer(path))
-				if errCode := C.client_handle_tdp_sd_info_response(C.ulong(c.handle), C.CGOSharedDirectoryInfoResponse{
-					completion_id: C.uint32_t(m.CompletionID),
-					err_code:      m.ErrCode,
-					fso: C.CGOFileSystemObject{
-						last_modified: C.uint64_t(m.Fso.LastModified),
-						size:          C.uint64_t(m.Fso.Size),
-						file_type:     m.Fso.FileType,
-						is_empty:      C.uint8_t(m.Fso.IsEmpty),
-						path:          path,
-					},
-				}); errCode != C.ErrCodeSuccess {
-					return trace.Errorf("SharedDirectoryInfoResponse failed: %v", errCode)
-				}
-			}
-		case tdp.SharedDirectoryCreateResponse:
-			if c.cfg.AllowDirectorySharing {
-				path := C.CString(m.Fso.Path)
-				defer C.free(unsafe.Pointer(path))
-				if errCode := C.client_handle_tdp_sd_create_response(C.ulong(c.handle), C.CGOSharedDirectoryCreateResponse{
-					completion_id: C.uint32_t(m.CompletionID),
-					err_code:      m.ErrCode,
-					fso: C.CGOFileSystemObject{
-						last_modified: C.uint64_t(m.Fso.LastModified),
-						size:          C.uint64_t(m.Fso.Size),
-						file_type:     m.Fso.FileType,
-						is_empty:      C.uint8_t(m.Fso.IsEmpty),
-						path:          path,
-					},
-				}); errCode != C.ErrCodeSuccess {
-					return trace.Errorf("SharedDirectoryCreateResponse failed: %v", errCode)
-				}
-			}
-		case tdp.SharedDirectoryDeleteResponse:
-			if c.cfg.AllowDirectorySharing {
-				if errCode := C.client_handle_tdp_sd_delete_response(C.ulong(c.handle), C.CGOSharedDirectoryDeleteResponse{
-					completion_id: C.uint32_t(m.CompletionID),
-					err_code:      m.ErrCode,
-				}); errCode != C.ErrCodeSuccess {
-					return trace.Errorf("SharedDirectoryDeleteResponse failed: %v", errCode)
-				}
-			}
-		case tdp.SharedDirectoryListResponse:
-			if c.cfg.AllowDirectorySharing {
-				fsoList := make([]C.CGOFileSystemObject, 0, len(m.FsoList))
-
-				for _, fso := range m.FsoList {
-					path := C.CString(fso.Path)
-					defer C.free(unsafe.Pointer(path))
-
-					fsoList = append(fsoList, C.CGOFileSystemObject{
-						last_modified: C.uint64_t(fso.LastModified),
-						size:          C.uint64_t(fso.Size),
-						file_type:     fso.FileType,
-						is_empty:      C.uint8_t(fso.IsEmpty),
-						path:          path,
-					})
-				}
-
-				fsoListLen := len(fsoList)
-				var cgoFsoList *C.CGOFileSystemObject
-
-				if fsoListLen > 0 {
-					cgoFsoList = (*C.CGOFileSystemObject)(unsafe.Pointer(&fsoList[0]))
-				} else {
-					cgoFsoList = (*C.CGOFileSystemObject)(unsafe.Pointer(&fsoList))
-				}
-
-				if errCode := C.client_handle_tdp_sd_list_response(C.ulong(c.handle), C.CGOSharedDirectoryListResponse{
-					completion_id:   C.uint32_t(m.CompletionID),
-					err_code:        m.ErrCode,
-					fso_list_length: C.uint32_t(fsoListLen),
-					fso_list:        cgoFsoList,
-				}); errCode != C.ErrCodeSuccess {
-					return trace.Errorf("SharedDirectoryListResponse failed: %v", errCode)
-				}
-			}
-		case tdp.SharedDirectoryReadResponse:
-			if c.cfg.AllowDirectorySharing {
-				var readData *C.uint8_t
-				if m.ReadDataLength > 0 {
-					readData = (*C.uint8_t)(unsafe.Pointer(&m.ReadData[0]))
-				} else {
-					readData = (*C.uint8_t)(unsafe.Pointer(&m.ReadData))
-				}
-
-				if errCode := C.client_handle_tdp_sd_read_response(C.ulong(c.handle), C.CGOSharedDirectoryReadResponse{
-					completion_id:    C.uint32_t(m.CompletionID),
-					err_code:         m.ErrCode,
-					read_data_length: C.uint32_t(m.ReadDataLength),
-					read_data:        readData,
-				}); errCode != C.ErrCodeSuccess {
-					return trace.Errorf("SharedDirectoryReadResponse failed: %v", errCode)
-				}
-			}
-		case tdp.SharedDirectoryWriteResponse:
-			if c.cfg.AllowDirectorySharing {
-				if errCode := C.client_handle_tdp_sd_write_response(C.ulong(c.handle), C.CGOSharedDirectoryWriteResponse{
-					completion_id: C.uint32_t(m.CompletionID),
-					err_code:      m.ErrCode,
-					bytes_written: C.uint32_t(m.BytesWritten),
-				}); errCode != C.ErrCodeSuccess {
-					return trace.Errorf("SharedDirectoryWriteResponse failed: %v", errCode)
-				}
-			}
-		case tdp.SharedDirectoryMoveResponse:
-			if c.cfg.AllowDirectorySharing {
-				if errCode := C.client_handle_tdp_sd_move_response(C.ulong(c.handle), C.CGOSharedDirectoryMoveResponse{
-					completion_id: C.uint32_t(m.CompletionID),
-					err_code:      m.ErrCode,
-				}); errCode != C.ErrCodeSuccess {
-					return trace.Errorf("SharedDirectoryMoveResponse failed: %v", errCode)
-				}
-			}
-		case tdp.SharedDirectoryTruncateResponse:
-			if c.cfg.AllowDirectorySharing {
-				if errCode := C.client_handle_tdp_sd_truncate_response(C.ulong(c.handle), C.CGOSharedDirectoryTruncateResponse{
-					completion_id: C.uint32_t(m.CompletionID),
-					err_code:      m.ErrCode,
-				}); errCode != C.ErrCodeSuccess {
-					return trace.Errorf("SharedDirectoryTruncateResponse failed: %v", errCode)
-				}
-			}
-		case tdp.RDPResponsePDU:
-			pduLen := uint32(len(m))
-			if pduLen == 0 {
-				c.cfg.Log.Error("response PDU empty")
-			}
-			rdpResponsePDU := (*C.uint8_t)(unsafe.SliceData(m))
-
-			if errCode := C.client_handle_tdp_rdp_response_pdu(
-				C.ulong(c.handle), rdpResponsePDU, C.uint32_t(pduLen),
-			); errCode != C.ErrCodeSuccess {
-				return trace.Errorf("RDPResponsePDU failed: %v", errCode)
-			}
-		default:
-			c.cfg.Log.Warningf("Skipping unimplemented TDP message type %T", msg)
+		if err := c.handleTDPInput(msg); err != nil {
+			return trace.Wrap(err)
 		}
 	}
+}
+
+// handleTDPInput handles a single TDP message sent to us from the browser.
+func (c *Client) handleTDPInput(msg tdp.Message) error {
+	switch m := msg.(type) {
+	case tdp.ClientScreenSpec:
+		// If the client has specified a fixed screen size, we don't
+		// need to send a screen resize event.
+		if c.cfg.hasSizeOverride() {
+			return nil
+		}
+
+		c.cfg.Log.Debugf("Client changed screen size: %dx%d", m.Width, m.Height)
+		if errCode := C.client_write_screen_resize(
+			C.ulong(c.handle),
+			C.uint32_t(m.Width),
+			C.uint32_t(m.Height),
+		); errCode != C.ErrCodeSuccess {
+			return trace.Errorf("ClientScreenSpec: client_write_screen_resize: %v", errCode)
+		}
+	case tdp.MouseMove:
+		c.mouseX, c.mouseY = m.X, m.Y
+		if errCode := C.client_write_rdp_pointer(
+			C.ulong(c.handle),
+			C.CGOMousePointerEvent{
+				x:      C.uint16_t(m.X),
+				y:      C.uint16_t(m.Y),
+				button: C.PointerButtonNone,
+				wheel:  C.PointerWheelNone,
+			},
+		); errCode != C.ErrCodeSuccess {
+			return trace.Errorf("MouseMove: client_write_rdp_pointer: %v", errCode)
+		}
+	case tdp.MouseButton:
+		// Map the button to a C enum value.
+		var button C.CGOPointerButton
+		switch m.Button {
+		case tdp.LeftMouseButton:
+			button = C.PointerButtonLeft
+		case tdp.RightMouseButton:
+			button = C.PointerButtonRight
+		case tdp.MiddleMouseButton:
+			button = C.PointerButtonMiddle
+		default:
+			button = C.PointerButtonNone
+		}
+		if errCode := C.client_write_rdp_pointer(
+			C.ulong(c.handle),
+			C.CGOMousePointerEvent{
+				x:      C.uint16_t(c.mouseX),
+				y:      C.uint16_t(c.mouseY),
+				button: uint32(button),
+				down:   m.State == tdp.ButtonPressed,
+				wheel:  C.PointerWheelNone,
+			},
+		); errCode != C.ErrCodeSuccess {
+			return trace.Errorf("MouseButton: client_write_rdp_pointer: %v", errCode)
+		}
+	case tdp.MouseWheel:
+		var wheel C.CGOPointerWheel
+		switch m.Axis {
+		case tdp.VerticalWheelAxis:
+			wheel = C.PointerWheelVertical
+		case tdp.HorizontalWheelAxis:
+			wheel = C.PointerWheelHorizontal
+			// TDP positive scroll deltas move towards top-left.
+			// RDP positive scroll deltas move towards top-right.
+			//
+			// Fix the scroll direction to match TDP, it's inverted for
+			// horizontal scroll in RDP.
+			m.Delta = -m.Delta
+		default:
+			wheel = C.PointerWheelNone
+		}
+		if errCode := C.client_write_rdp_pointer(
+			C.ulong(c.handle),
+			C.CGOMousePointerEvent{
+				x:           C.uint16_t(c.mouseX),
+				y:           C.uint16_t(c.mouseY),
+				button:      C.PointerButtonNone,
+				wheel:       uint32(wheel),
+				wheel_delta: C.int16_t(m.Delta),
+			},
+		); errCode != C.ErrCodeSuccess {
+			return trace.Errorf("MouseWheel: client_write_rdp_pointer: %v", errCode)
+		}
+	case tdp.KeyboardButton:
+		if errCode := C.client_write_rdp_keyboard(
+			C.ulong(c.handle),
+			C.CGOKeyboardEvent{
+				code: C.uint16_t(m.KeyCode),
+				down: m.State == tdp.ButtonPressed,
+			},
+		); errCode != C.ErrCodeSuccess {
+			return trace.Errorf("KeyboardButton: client_write_rdp_keyboard: %v", errCode)
+		}
+	case tdp.SyncKeys:
+		if errCode := C.client_write_rdp_sync_keys(C.ulong(c.handle),
+			C.CGOSyncKeys{
+				scroll_lock_down: m.ScrollLockState == tdp.ButtonPressed,
+				num_lock_down:    m.NumLockState == tdp.ButtonPressed,
+				caps_lock_down:   m.CapsLockState == tdp.ButtonPressed,
+				kana_lock_down:   m.KanaLockState == tdp.ButtonPressed,
+			}); errCode != C.ErrCodeSuccess {
+			return trace.Errorf("SyncKeys: client_write_rdp_sync_keys: %v", errCode)
+		}
+	case tdp.ClipboardData:
+		if !c.cfg.AllowClipboard {
+			c.cfg.Log.Debug("Received clipboard data, but clipboard is disabled")
+			return nil
+		}
+		if len(m) > 0 {
+			if errCode := C.client_update_clipboard(
+				C.ulong(c.handle),
+				(*C.uint8_t)(unsafe.Pointer(&m[0])),
+				C.uint32_t(len(m)),
+			); errCode != C.ErrCodeSuccess {
+				return trace.Errorf("ClipboardData: client_update_clipboard (len=%v): %v", len(m), errCode)
+			}
+		} else {
+			c.cfg.Log.Warn("Received an empty clipboard message")
+		}
+	case tdp.SharedDirectoryAnnounce:
+		if c.cfg.AllowDirectorySharing {
+			driveName := C.CString(m.Name)
+			defer C.free(unsafe.Pointer(driveName))
+			if errCode := C.client_handle_tdp_sd_announce(C.ulong(c.handle), C.CGOSharedDirectoryAnnounce{
+				directory_id: C.uint32_t(m.DirectoryID),
+				name:         driveName,
+			}); errCode != C.ErrCodeSuccess {
+				return trace.Errorf("SharedDirectoryAnnounce: failed with %v", errCode)
+			}
+		}
+	case tdp.SharedDirectoryInfoResponse:
+		if c.cfg.AllowDirectorySharing {
+			path := C.CString(m.Fso.Path)
+			defer C.free(unsafe.Pointer(path))
+			if errCode := C.client_handle_tdp_sd_info_response(C.ulong(c.handle), C.CGOSharedDirectoryInfoResponse{
+				completion_id: C.uint32_t(m.CompletionID),
+				err_code:      m.ErrCode,
+				fso: C.CGOFileSystemObject{
+					last_modified: C.uint64_t(m.Fso.LastModified),
+					size:          C.uint64_t(m.Fso.Size),
+					file_type:     m.Fso.FileType,
+					is_empty:      C.uint8_t(m.Fso.IsEmpty),
+					path:          path,
+				},
+			}); errCode != C.ErrCodeSuccess {
+				return trace.Errorf("SharedDirectoryInfoResponse failed: %v", errCode)
+			}
+		}
+	case tdp.SharedDirectoryCreateResponse:
+		if c.cfg.AllowDirectorySharing {
+			path := C.CString(m.Fso.Path)
+			defer C.free(unsafe.Pointer(path))
+			if errCode := C.client_handle_tdp_sd_create_response(C.ulong(c.handle), C.CGOSharedDirectoryCreateResponse{
+				completion_id: C.uint32_t(m.CompletionID),
+				err_code:      m.ErrCode,
+				fso: C.CGOFileSystemObject{
+					last_modified: C.uint64_t(m.Fso.LastModified),
+					size:          C.uint64_t(m.Fso.Size),
+					file_type:     m.Fso.FileType,
+					is_empty:      C.uint8_t(m.Fso.IsEmpty),
+					path:          path,
+				},
+			}); errCode != C.ErrCodeSuccess {
+				return trace.Errorf("SharedDirectoryCreateResponse failed: %v", errCode)
+			}
+		}
+	case tdp.SharedDirectoryDeleteResponse:
+		if c.cfg.AllowDirectorySharing {
+			if errCode := C.client_handle_tdp_sd_delete_response(C.ulong(c.handle), C.CGOSharedDirectoryDeleteResponse{
+				completion_id: C.uint32_t(m.CompletionID),
+				err_code:      m.ErrCode,
+			}); errCode != C.ErrCodeSuccess {
+				return trace.Errorf("SharedDirectoryDeleteResponse failed: %v", errCode)
+			}
+		}
+	case tdp.SharedDirectoryListResponse:
+		if c.cfg.AllowDirectorySharing {
+			fsoList := make([]C.CGOFileSystemObject, 0, len(m.FsoList))
+
+			for _, fso := range m.FsoList {
+				path := C.CString(fso.Path)
+				defer C.free(unsafe.Pointer(path))
+
+				fsoList = append(fsoList, C.CGOFileSystemObject{
+					last_modified: C.uint64_t(fso.LastModified),
+					size:          C.uint64_t(fso.Size),
+					file_type:     fso.FileType,
+					is_empty:      C.uint8_t(fso.IsEmpty),
+					path:          path,
+				})
+			}
+
+			fsoListLen := len(fsoList)
+			var cgoFsoList *C.CGOFileSystemObject
+
+			if fsoListLen > 0 {
+				cgoFsoList = (*C.CGOFileSystemObject)(unsafe.Pointer(&fsoList[0]))
+			} else {
+				cgoFsoList = (*C.CGOFileSystemObject)(unsafe.Pointer(&fsoList))
+			}
+
+			if errCode := C.client_handle_tdp_sd_list_response(C.ulong(c.handle), C.CGOSharedDirectoryListResponse{
+				completion_id:   C.uint32_t(m.CompletionID),
+				err_code:        m.ErrCode,
+				fso_list_length: C.uint32_t(fsoListLen),
+				fso_list:        cgoFsoList,
+			}); errCode != C.ErrCodeSuccess {
+				return trace.Errorf("SharedDirectoryListResponse failed: %v", errCode)
+			}
+		}
+	case tdp.SharedDirectoryReadResponse:
+		if c.cfg.AllowDirectorySharing {
+			var readData *C.uint8_t
+			if m.ReadDataLength > 0 {
+				readData = (*C.uint8_t)(unsafe.Pointer(&m.ReadData[0]))
+			} else {
+				readData = (*C.uint8_t)(unsafe.Pointer(&m.ReadData))
+			}
+
+			if errCode := C.client_handle_tdp_sd_read_response(C.ulong(c.handle), C.CGOSharedDirectoryReadResponse{
+				completion_id:    C.uint32_t(m.CompletionID),
+				err_code:         m.ErrCode,
+				read_data_length: C.uint32_t(m.ReadDataLength),
+				read_data:        readData,
+			}); errCode != C.ErrCodeSuccess {
+				return trace.Errorf("SharedDirectoryReadResponse failed: %v", errCode)
+			}
+		}
+	case tdp.SharedDirectoryWriteResponse:
+		if c.cfg.AllowDirectorySharing {
+			if errCode := C.client_handle_tdp_sd_write_response(C.ulong(c.handle), C.CGOSharedDirectoryWriteResponse{
+				completion_id: C.uint32_t(m.CompletionID),
+				err_code:      m.ErrCode,
+				bytes_written: C.uint32_t(m.BytesWritten),
+			}); errCode != C.ErrCodeSuccess {
+				return trace.Errorf("SharedDirectoryWriteResponse failed: %v", errCode)
+			}
+		}
+	case tdp.SharedDirectoryMoveResponse:
+		if c.cfg.AllowDirectorySharing {
+			if errCode := C.client_handle_tdp_sd_move_response(C.ulong(c.handle), C.CGOSharedDirectoryMoveResponse{
+				completion_id: C.uint32_t(m.CompletionID),
+				err_code:      m.ErrCode,
+			}); errCode != C.ErrCodeSuccess {
+				return trace.Errorf("SharedDirectoryMoveResponse failed: %v", errCode)
+			}
+		}
+	case tdp.SharedDirectoryTruncateResponse:
+		if c.cfg.AllowDirectorySharing {
+			if errCode := C.client_handle_tdp_sd_truncate_response(C.ulong(c.handle), C.CGOSharedDirectoryTruncateResponse{
+				completion_id: C.uint32_t(m.CompletionID),
+				err_code:      m.ErrCode,
+			}); errCode != C.ErrCodeSuccess {
+				return trace.Errorf("SharedDirectoryTruncateResponse failed: %v", errCode)
+			}
+		}
+	case tdp.RDPResponsePDU:
+		pduLen := uint32(len(m))
+		if pduLen == 0 {
+			c.cfg.Log.Error("response PDU empty")
+		}
+		rdpResponsePDU := (*C.uint8_t)(unsafe.SliceData(m))
+
+		if errCode := C.client_handle_tdp_rdp_response_pdu(
+			C.ulong(c.handle), rdpResponsePDU, C.uint32_t(pduLen),
+		); errCode != C.ErrCodeSuccess {
+			return trace.Errorf("RDPResponsePDU failed: %v", errCode)
+		}
+	default:
+		c.cfg.Log.Warnf(
+			"Skipping unimplemented TDP message: %T", msg,
+
+		)
+	}
+
+	return nil
 }
 
 // asRustBackedSlice creates a Go slice backed by data managed in Rust

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -95,6 +95,7 @@ import (
 	"github.com/gravitational/teleport/lib/secret"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/web/app"
@@ -172,6 +173,10 @@ type Handler struct {
 	// an authenticated websocket so unauthenticated sockets dont get left
 	// open.
 	wsIODeadline time.Duration
+
+	// withheldMessages is a list of any messages that came from the browser which were
+	// withheld while the user was performing MFA.
+	withheldMessages []tdp.Message
 }
 
 // HandlerOption is a functional argument - an option that can be passed

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -76,7 +76,7 @@ func (h *Handler) desktopConnectHandle(
 	log := sctx.cfg.Log.WithField("desktop-name", desktopName).WithField("cluster-name", site.GetName())
 	log.Debug("New desktop access websocket connection")
 
-	if err := h.createDesktopConnection(w, r, desktopName, site.GetName(), log, sctx, site, ws); err != nil {
+	if err := h.createDesktopConnection(r, desktopName, site.GetName(), log, sctx, site, ws); err != nil {
 		// createDesktopConnection makes a best effort attempt to send an error to the user
 		// (via websocket) before terminating the connection. We log the error here, but
 		// return nil because our HTTP middleware will try to write the returned error in JSON
@@ -88,7 +88,6 @@ func (h *Handler) desktopConnectHandle(
 }
 
 func (h *Handler) createDesktopConnection(
-	w http.ResponseWriter,
 	r *http.Request,
 	desktopName string,
 	clusterName string,
@@ -98,6 +97,7 @@ func (h *Handler) createDesktopConnection(
 	ws *websocket.Conn,
 ) error {
 	defer ws.Close()
+	ctx := r.Context()
 
 	sendTDPError := func(err error) error {
 		sendErr := sendTDPNotification(ws, err, tdp.SeverityError)
@@ -140,11 +140,11 @@ func (h *Handler) createDesktopConnection(
 	//
 	// In the future, we may want to do something smarter like latency-based
 	// routing.
-	clt, err := sctx.GetUserClient(r.Context(), site)
+	clt, err := sctx.GetUserClient(ctx, site)
 	if err != nil {
 		return sendTDPError(trace.Wrap(err))
 	}
-	winDesktops, err := clt.GetWindowsDesktops(r.Context(), types.WindowsDesktopFilter{Name: desktopName})
+	winDesktops, err := clt.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{Name: desktopName})
 	if err != nil {
 		return sendTDPError(trace.Wrap(err, "cannot get Windows desktops"))
 	}
@@ -164,13 +164,31 @@ func (h *Handler) createDesktopConnection(
 		validServiceIDs[i], validServiceIDs[j] = validServiceIDs[j], validServiceIDs[i]
 	})
 
-	// Issue certificate for TLS config and pass MFA check if required.
-	tlsConfig, err := h.desktopTLSConfig(r.Context(), ws, clt, sctx, desktopName, username, site.GetName())
+	// Parse the private key of the user from the session context.
+	pk, err := keys.ParsePrivateKey(sctx.cfg.Session.GetPriv())
 	if err != nil {
 		return sendTDPError(err)
 	}
 
-	clientSrcAddr, clientDstAddr := authz.ClientAddrsFromContext(r.Context())
+	// Check if MFA is required and create a UserCertsRequest.
+	mfaRequired, certsReq, err := h.prepareForCertIssuance(ctx, sctx, site, pk, desktopName, username)
+	if err != nil {
+		return sendTDPError(err)
+	}
+
+	// Issue certificate for the user/desktop combination and perform MFA ceremony if required.
+	certs, err := h.issueCerts(ctx, ws, sctx, mfaRequired, certsReq)
+	if err != nil {
+		return sendTDPError(err)
+	}
+
+	// Create a TLS config for connecting to the Windows Desktop Service.
+	tlsConfig, err := h.createDesktopTLSConfig(ctx, sctx, desktopName, pk, certs)
+	if err != nil {
+		return sendTDPError(err)
+	}
+
+	clientSrcAddr, clientDstAddr := authz.ClientAddrsFromContext(ctx)
 
 	c := &connector{
 		log:           log,
@@ -187,12 +205,16 @@ func (h *Handler) createDesktopConnection(
 
 	serviceConnTLS := tls.Client(serviceConn, tlsConfig)
 
-	if err := serviceConnTLS.HandshakeContext(r.Context()); err != nil {
+	if err := serviceConnTLS.HandshakeContext(ctx); err != nil {
 		return sendTDPError(err)
 	}
 	log.Debug("Connected to windows_desktop_service")
 
 	tdpConn := tdp.NewConn(serviceConnTLS)
+
+	// Now that we have a connection to the Windows Desktop Service, we can
+	// send the username and screen spec to the service, and any withheld
+	// messages that were received before the MFA ceremony was completed.
 	err = tdpConn.WriteMessage(tdp.ClientUsername{Username: username})
 	if err != nil {
 		return sendTDPError(err)
@@ -200,6 +222,11 @@ func (h *Handler) createDesktopConnection(
 	err = tdpConn.WriteMessage(screenSpec)
 	if err != nil {
 		return sendTDPError(err)
+	}
+	for _, msg := range h.withheldMessages {
+		if err := tdpConn.WriteMessage(msg); err != nil {
+			return sendTDPError(err)
+		}
 	}
 
 	// proxyWebsocketConn hangs here until connection is closed
@@ -219,34 +246,17 @@ const (
 	SNISuffix = ".desktop." + constants.APIDomain
 )
 
-func (h *Handler) desktopTLSConfig(ctx context.Context, ws *websocket.Conn, clusterClient authclient.ClientI, sessCtx *SessionContext, desktopName, username, siteName string) (_ *tls.Config, err error) {
-	ctx, span := h.tracer.Start(ctx, "desktop/TLSConfig")
-	defer func() {
-		span.RecordError(err)
-		span.End()
-	}()
-
-	pk, err := keys.ParsePrivateKey(sessCtx.cfg.Session.GetPriv())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	mfaRequiredResp, err := clusterClient.IsMFARequired(ctx, &proto.IsMFARequiredRequest{
-		Target: &proto.IsMFARequiredRequest_WindowsDesktop{
-			WindowsDesktop: &proto.RouteToWindowsDesktop{
-				WindowsDesktop: desktopName,
-				Login:          username,
-			},
-		},
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+func createUserCertsRequest(
+	sctx *SessionContext,
+	pk *keys.PrivateKey,
+	desktopName,
+	username,
+	siteName string,
+) (*proto.UserCertsRequest, error) {
 	key := &client.Key{
 		PrivateKey: pk,
-		Cert:       sessCtx.cfg.Session.GetPub(),
-		TLSCert:    sessCtx.cfg.Session.GetTLSCert(),
+		Cert:       sctx.cfg.Session.GetPub(),
+		TLSCert:    sctx.cfg.Session.GetTLSCert(),
 	}
 
 	tlsCert, err := key.TeleportTLSCertificate()
@@ -266,27 +276,76 @@ func (h *Handler) desktopTLSConfig(ctx context.Context, ws *websocket.Conn, clus
 		},
 	}
 
-	var certPEMBlock []byte
-	if mfaRequiredResp.Required {
-		certPEMBlock, err = h.performMFACeremony(ctx, sessCtx.cfg.RootClient, ws, &certsReq)
+	return &certsReq, nil
+}
+
+// prepareForCertIssuance prepares for certificate issuance by checking if MFA
+// is required for the user/desktop combination and creating a UserCertsRequest.
+func (h *Handler) prepareForCertIssuance(
+	ctx context.Context,
+	sctx *SessionContext,
+	site reversetunnelclient.RemoteSite,
+	pk *keys.PrivateKey,
+	desktopName, username string,
+) (mfaRequired bool, certsReq *proto.UserCertsRequest, err error) {
+	// Check if MFA is required for this user/desktop combination.
+	mfaRequired, err = h.checkMFARequired(ctx, &isMFARequiredRequest{
+		WindowsDesktop: &isMFARequiredWindowsDesktop{
+			DesktopName: desktopName,
+			Login:       username,
+		},
+	}, sctx, site)
+	if err != nil {
+		return false, nil, trace.Wrap(err)
+	}
+
+	certsReq, err = createUserCertsRequest(sctx, pk, desktopName, username, site.GetName())
+	if err != nil {
+		return false, nil, trace.Wrap(err)
+	}
+
+	return mfaRequired, certsReq, nil
+}
+
+// issueCerts issues certificates for the user/desktop combination, performing
+// the MFA ceremony if required.
+func (h *Handler) issueCerts(
+	ctx context.Context,
+	ws *websocket.Conn,
+	sctx *SessionContext,
+	mfaRequired bool,
+	certsReq *proto.UserCertsRequest,
+) (certs *proto.Certs, err error) {
+	if mfaRequired {
+		certs, err = h.performMFACeremony(ctx, ws, sctx, certsReq)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 	} else {
-		certs, err := sessCtx.cfg.RootClient.GenerateUserCerts(ctx, certsReq)
+		certs, err = sctx.cfg.RootClient.GenerateUserCerts(ctx, *certsReq)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		certPEMBlock = certs.TLS
 	}
 
-	certConf, err := pk.TLSCertificate(certPEMBlock)
+	return certs, nil
+}
+
+// createDesktopTLSConfig creates a TLS config for connecting to a Windows Desktop Service
+// using the user's private key and the issued certificates.
+func (h *Handler) createDesktopTLSConfig(
+	ctx context.Context,
+	sctx *SessionContext,
+	desktopName string,
+	pk *keys.PrivateKey,
+	certs *proto.Certs,
+) (*tls.Config, error) {
+	certConf, err := pk.TLSCertificate(certs.TLS)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	tlsConfig, err := sessCtx.ClientTLSConfig(ctx)
+	tlsConfig, err := sctx.ClientTLSConfig(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -300,7 +359,12 @@ func (h *Handler) desktopTLSConfig(ctx context.Context, ws *websocket.Conn, clus
 // performMFACeremony completes the mfa ceremony and returns the raw TLS certificate
 // on success. The user will be prompted to tap their security key by the UI
 // in order to perform the assertion.
-func (h *Handler) performMFACeremony(ctx context.Context, authClient authclient.ClientI, ws *websocket.Conn, certsReq *proto.UserCertsRequest) (_ []byte, err error) {
+func (h *Handler) performMFACeremony(
+	ctx context.Context,
+	ws *websocket.Conn,
+	sctx *SessionContext,
+	certsReq *proto.UserCertsRequest,
+) (_ *proto.Certs, err error) {
 	ctx, span := h.tracer.Start(ctx, "desktop/performMFACeremony")
 	defer func() {
 		span.RecordError(err)
@@ -326,13 +390,35 @@ func (h *Handler) performMFACeremony(ctx context.Context, authClient authclient.
 		}
 
 		span.AddEvent("waiting for user to complete mfa ceremony")
-		ty, buf, err := ws.ReadMessage()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+		var buf []byte
+		// Loop through incoming messages until we receive an MFA message that lets us
+		// complete the ceremony. Non-MFA messages (e.g. ClientScreenSpecs representing
+		// screen resizes) are withheld for later.
+		for {
+			var ty int
+			ty, buf, err = ws.ReadMessage()
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if ty != websocket.BinaryMessage {
+				return nil, trace.BadParameter("received unexpected web socket message type %d", ty)
+			}
+			if len(buf) == 0 {
+				return nil, trace.BadParameter("empty message received")
+			}
 
-		if ty != websocket.BinaryMessage {
-			return nil, trace.BadParameter("received unexpected web socket message type %d", ty)
+			if tdp.MessageType(buf[0]) != tdp.TypeMFA {
+				// This is not an MFA message, withhold it for later.
+				msg, err := tdp.Decode(buf)
+				h.log.Debugf("Received non-MFA message, withholding:", msg)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+				h.withheldMessages = append(h.withheldMessages, msg)
+				continue
+			}
+
+			break
 		}
 
 		assertion, err := codec.decodeResponse(buf, defaults.WebsocketWebauthnChallenge)
@@ -346,7 +432,7 @@ func (h *Handler) performMFACeremony(ctx context.Context, authClient authclient.
 
 	_, newCerts, err := client.PerformMFACeremony(ctx, client.PerformMFACeremonyParams{
 		CurrentAuthClient: nil, // Only RootAuthClient is used.
-		RootAuthClient:    authClient,
+		RootAuthClient:    sctx.cfg.RootClient,
 		MFAPrompt:         promptMFA,
 		MFAAgainstRoot:    true,
 		MFARequiredReq:    nil, // No need to verify.
@@ -360,7 +446,7 @@ func (h *Handler) performMFACeremony(ctx context.Context, authClient authclient.
 		return nil, trace.Wrap(err)
 	}
 
-	return newCerts.TLS, nil
+	return newCerts, nil
 }
 
 func readUsername(r *http.Request) (string, error) {
@@ -610,8 +696,10 @@ func (h *Handler) desktopAccessScriptConfigureHandle(w http.ResponseWriter, r *h
 		return "", trace.BadParameter("invalid token")
 	}
 
+	ctx := r.Context()
+
 	// verify that the token exists
-	token, err := h.GetProxyClient().GetToken(r.Context(), tokenStr)
+	token, err := h.GetProxyClient().GetToken(ctx, tokenStr)
 	if err != nil {
 		return "", trace.BadParameter("invalid token")
 	}
@@ -625,13 +713,13 @@ func (h *Handler) desktopAccessScriptConfigureHandle(w http.ResponseWriter, r *h
 		return "", trace.NotFound("no proxy servers found")
 	}
 
-	clusterName, err := h.GetProxyClient().GetDomainName(r.Context())
+	clusterName, err := h.GetProxyClient().GetDomainName(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	certAuthority, err := h.GetProxyClient().GetCertAuthority(
-		r.Context(),
+		ctx,
 		types.CertAuthID{Type: types.UserCA, DomainName: clusterName},
 		false,
 	)

--- a/lib/web/mfa.go
+++ b/lib/web/mfa.go
@@ -19,6 +19,7 @@
 package web
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -153,7 +154,7 @@ func (h *Handler) createAuthenticateChallengeHandle(w http.ResponseWriter, r *ht
 
 	var mfaRequiredCheckProto *proto.IsMFARequiredRequest
 	if req.IsMFARequiredRequest != nil {
-		mfaRequiredCheckProto, err = req.IsMFARequiredRequest.checkAndGetProtoRequest()
+		mfaRequiredCheckProto, err = h.checkAndGetProtoRequest(r.Context(), c, req.IsMFARequiredRequest)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -308,10 +309,10 @@ type isMFARequiredRequest struct {
 	// requires MFA check.
 	Kube *isMFARequiredKube `json:"kube,omitempty"`
 	// AdminAction is the name of the admin action RPC to check if MFA is required.
-	AdminAction *isMFARequiredAdminAction `json:"admin_action"`
+	AdminAction *isMFARequiredAdminAction `json:"admin_action,omitempty"`
 }
 
-func (r *isMFARequiredRequest) checkAndGetProtoRequest() (*proto.IsMFARequiredRequest, error) {
+func (h *Handler) checkAndGetProtoRequest(ctx context.Context, scx *SessionContext, r *isMFARequiredRequest) (*proto.IsMFARequiredRequest, error) {
 	numRequests := 0
 	var protoReq *proto.IsMFARequiredRequest
 
@@ -417,7 +418,7 @@ func (h *Handler) isMFARequired(w http.ResponseWriter, r *http.Request, p httpro
 		return nil, trace.Wrap(err)
 	}
 
-	protoReq, err := httpReq.checkAndGetProtoRequest()
+	protoReq, err := h.checkAndGetProtoRequest(r.Context(), sctx, httpReq)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/mfa.go
+++ b/lib/web/mfa.go
@@ -412,28 +412,39 @@ type isMfaRequiredResponse struct {
 	Required bool `json:"required"`
 }
 
+// isMFARequired is the [ClusterHandler] implementer for checking if MFA is required for a given target.
 func (h *Handler) isMFARequired(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	var httpReq *isMFARequiredRequest
 	if err := httplib.ReadJSON(r, &httpReq); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	protoReq, err := h.checkAndGetProtoRequest(r.Context(), sctx, httpReq)
+	required, err := h.checkMFARequired(r.Context(), httpReq, sctx, site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := sctx.GetUserClient(r.Context(), site)
+	return isMfaRequiredResponse{Required: required}, nil
+}
+
+// checkMFARequired checks if MFA is required for the target specified in the [isMFARequiredRequest].
+func (h *Handler) checkMFARequired(ctx context.Context, req *isMFARequiredRequest, sctx *SessionContext, site reversetunnelclient.RemoteSite) (bool, error) {
+	protoReq, err := h.checkAndGetProtoRequest(ctx, sctx, req)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return false, trace.Wrap(err)
 	}
 
-	res, err := clt.IsMFARequired(r.Context(), protoReq)
+	clt, err := sctx.GetUserClient(ctx, site)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return false, trace.Wrap(err)
 	}
 
-	return isMfaRequiredResponse{Required: res.GetRequired()}, nil
+	res, err := clt.IsMFARequired(ctx, protoReq)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	return res.GetRequired(), nil
 }
 
 // makeAuthenticateChallenge converts proto to JSON format.

--- a/lib/web/mfa_codec.go
+++ b/lib/web/mfa_codec.go
@@ -106,7 +106,7 @@ func (tdpMFACodec) decodeResponse(buf []byte, envelopeType string) (*authproto.M
 		return nil, trace.BadParameter("empty MFA message received")
 	}
 	if tdp.MessageType(buf[0]) != tdp.TypeMFA {
-		return nil, trace.BadParameter("expected MFA message type %v, got %v", tdp.TypeMFA, buf[0])
+		return nil, trace.BadParameter("decodeResponse: expected MFA message type %v, got %v", tdp.TypeMFA, buf[0])
 	}
 	msg, err := tdp.DecodeMFA(bytes.NewReader(buf[1:]))
 	if err != nil {
@@ -120,7 +120,7 @@ func (tdpMFACodec) decodeChallenge(buf []byte, envelopeType string) (*authproto.
 		return nil, trace.BadParameter("empty MFA message received")
 	}
 	if tdp.MessageType(buf[0]) != tdp.TypeMFA {
-		return nil, trace.BadParameter("expected MFA message type %v, got %v", tdp.TypeMFA, buf[0])
+		return nil, trace.BadParameter("decodeChallenge: expected MFA message type %v, got %v", tdp.TypeMFA, buf[0])
 	}
 	msg, err := tdp.DecodeMFAChallenge(bytes.NewReader(buf[1:]))
 	if err != nil {

--- a/web/packages/teleport/src/DesktopSession/useTdpClientCanvas.tsx
+++ b/web/packages/teleport/src/DesktopSession/useTdpClientCanvas.tsx
@@ -157,9 +157,18 @@ export default function useTdpClientCanvas(props: Props) {
   const clientOnTdpError = (error: Error) => {
     setDirectorySharingState(defaultDirectorySharingState);
     setClipboardSharingState(defaultClipboardSharingState);
-    setTdpConnection({
-      status: 'failed',
-      statusText: error.message || error.toString(),
+    setTdpConnection(prevState => {
+      // Sometimes when a connection closes due to an error, we get a cascade of
+      // errors. Here we update the status only if it's not already 'failed', so
+      // that the first error message (which is usually the most informative) is
+      // displayed to the user.
+      if (prevState.status !== 'failed') {
+        return {
+          status: 'failed',
+          statusText: error.message || error.toString(),
+        };
+      }
+      return prevState;
     });
   };
 

--- a/web/packages/teleport/src/lib/tdp/client.ts
+++ b/web/packages/teleport/src/lib/tdp/client.ts
@@ -602,10 +602,7 @@ export default class Client extends EventEmitterWebAuthnSender {
       return;
     }
 
-    this.handleError(
-      new Error('websocket unavailable'),
-      TdpClientEvent.CLIENT_ERROR
-    );
+    this.logger.warn('websocket is not open');
   }
 
   sendClientScreenSpec(spec: ClientScreenSpec) {


### PR DESCRIPTION
backport #41570 to branch/v15

Also backports a required piece of `mfa.go` from https://github.com/gravitational/teleport/pull/40077

changelog: Solved a bug that was causing Windows Desktop sessions to fail when the screen was resized during an MFA ceremony