### PR TITLE
Fix the Back button on change password wizard

### DIFF
--- a/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.test.tsx
+++ b/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.test.tsx
@@ -118,6 +118,24 @@ describe('with passwordless reauthentication', () => {
     expect(onSuccess).toHaveBeenCalled();
   });
 
+  it('cancels changing password', async () => {
+    await reauthenticate();
+    const changePasswordStep = within(
+      screen.getByTestId('change-password-step')
+    );
+    await user.type(
+      changePasswordStep.getByLabelText('New Password'),
+      'new-pass1234'
+    );
+    await user.type(
+      changePasswordStep.getByLabelText('Confirm Password'),
+      'new-pass1234'
+    );
+    await user.click(changePasswordStep.getByText('Back'));
+    expect(auth.changePassword).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
   it('validates the password form', async () => {
     await reauthenticate();
     const changePasswordStep = within(
@@ -191,6 +209,24 @@ describe('with WebAuthn MFA reauthentication', () => {
       credential: dummyCredential,
     });
     expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('cancels changing password', async () => {
+    await reauthenticate();
+    const changePasswordStep = within(
+      screen.getByTestId('change-password-step')
+    );
+    await user.type(
+      changePasswordStep.getByLabelText('New Password'),
+      'new-pass1234'
+    );
+    await user.type(
+      changePasswordStep.getByLabelText('Confirm Password'),
+      'new-pass1234'
+    );
+    await user.click(changePasswordStep.getByText('Back'));
+    expect(auth.changePassword).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
   });
 
   it('validates the password form', async () => {
@@ -275,6 +311,24 @@ describe('with OTP MFA reauthentication', () => {
     expect(onSuccess).toHaveBeenCalled();
   });
 
+  it('cancels changing password', async () => {
+    await reauthenticate();
+    const changePasswordStep = within(
+      screen.getByTestId('change-password-step')
+    );
+    await user.type(
+      changePasswordStep.getByLabelText('New Password'),
+      'new-pass1234'
+    );
+    await user.type(
+      changePasswordStep.getByLabelText('Confirm Password'),
+      'new-pass1234'
+    );
+    await user.click(changePasswordStep.getByText('Back'));
+    expect(auth.changePassword).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
   it('validates the password form', async () => {
     await reauthenticate();
     const changePasswordStep = within(
@@ -350,6 +404,25 @@ describe('without reauthentication', () => {
       secondFactorToken: '',
     });
     expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('cancels changing password', async () => {
+    render(<TestWizard auth2faType="off" passwordlessEnabled={false} />);
+
+    const changePasswordStep = within(
+      screen.getByTestId('change-password-step')
+    );
+    await user.type(
+      changePasswordStep.getByLabelText('New Password'),
+      'new-pass1234'
+    );
+    await user.type(
+      changePasswordStep.getByLabelText('Confirm Password'),
+      'new-pass1234'
+    );
+    await user.click(changePasswordStep.getByText('Cancel'));
+    expect(auth.changePassword).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
   });
 
   it('validates the password form', async () => {

--- a/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
+++ b/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
@@ -340,11 +340,11 @@ export function ChangePasswordStep({
                 Save Changes
               </ButtonPrimary>
               {stepIndex === 0 ? (
-                <ButtonSecondary block={true} onClick={onClose}>
+                <ButtonSecondary type="button" block={true} onClick={onClose}>
                   Cancel
                 </ButtonSecondary>
               ) : (
-                <ButtonSecondary block={true} onClick={prev}>
+                <ButtonSecondary type="button" block={true} onClick={prev}>
                   Back
                 </ButtonSecondary>
               )}


### PR DESCRIPTION
If the password form was filled out, the back button accidentally used the default form submit handler, thus actually submitting the form. This change fixes this behavior.

Tested manually:
- Change password with MFA verification
- Change password with OTP verification
- Cancel change with MFA verification
- Cancel change with OTP verification