### PR TITLE
Update etcd docker build

### DIFF
--- a/.github/services/Dockerfile.etcd
+++ b/.github/services/Dockerfile.etcd
@@ -1,7 +1,7 @@
 ARG BUILDARCH
 ARG ETCD_VERSION
 
-FROM alpine/openssl AS certgen
+FROM alpine/openssl:3.1.4 AS certgen
 ARG BUILDARCH
 ARG ETCD_VERSION
 WORKDIR /certs
@@ -12,7 +12,7 @@ FROM bitnami/etcd:${ETCD_VERSION}
 ARG BUILDARCH
 ARG ETCD_VERSION
 
-COPY --from=certgen /certs /certs
+COPY --from=certgen --chown=1001:1001 /certs /certs
 
 HEALTHCHECK CMD etcdctl --insecure-discovery --endpoint=https://etcd0:2379 --key-file /certs/client-key.pem --cert-file /certs/client-cert.pem --ca-file /certs/ca-cert.pem cluster-health
 

--- a/.github/services/Dockerfile.etcd
+++ b/.github/services/Dockerfile.etcd
@@ -1,9 +1,18 @@
 ARG BUILDARCH
 ARG ETCD_VERSION
 
-FROM bitnami/etcd:${ETCD_VERSION}
-
+FROM alpine/openssl AS certgen
+ARG BUILDARCH
+ARG ETCD_VERSION
+WORKDIR /certs
 COPY examples/etcd/certs /certs
+RUN apk add make && make
+
+FROM bitnami/etcd:${ETCD_VERSION}
+ARG BUILDARCH
+ARG ETCD_VERSION
+
+COPY --from=certgen /certs /certs
 
 HEALTHCHECK CMD etcdctl --insecure-discovery --endpoint=https://etcd0:2379 --key-file /certs/client-key.pem --cert-file /certs/client-cert.pem --ca-file /certs/ca-cert.pem cluster-health
 

--- a/.github/workflows/build-ci-service-images.yaml
+++ b/.github/workflows/build-ci-service-images.yaml
@@ -11,7 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: gravitational/ci-etcd
-  ETCD_VERSION: 3.3.9
+  ETCD_VERSION: 3.5.9
 
 jobs:
   build:


### PR DESCRIPTION
This commit updates the etcd image that we use for testing etcd in CI/CD to generate certs at image build time instead of storing them in the repo.

Additionally, we update the version of etcd used in GHA to match the version used in our makefile. In addition to being consistent, this is necessary because the etcd version is used to tag the image, and we want our build-ci-service-images workflow to push a new image with a new tag.

Updates gravitational/teleport-private#1497