### PR TITLE
[docs] flush privileges after updating roles_mapping

### DIFF
--- a/docs/pages/database-access/auto-user-provisioning/mariadb.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/mariadb.mdx
@@ -61,6 +61,7 @@ automatically designates the admin user as "Admin" of those roles.
 Alternatively, you can assign the admin user as the "Admin" of existing roles:
 ```sql
 UPDATE mysql.roles_mapping SET User ='teleport-admin' WHERE Admin_option='Y' AND Role='role1';
+FLUSH PRIVILEGES;
 ```
 
 Replace `role1` with the name of the role that will be granted to
@@ -98,6 +99,7 @@ CREATE ROLE role1 WITH ADMIN 'teleport-admin';
 Alternatively, you can assign the admin user as the "Admin" of existing roles:
 ```sql
 UPDATE mysql.roles_mapping SET User ='teleport-admin' WHERE Admin_option='Y' AND Role='role1';
+FLUSH PRIVILEGES;
 ```
 
 Replace `role1` with the name of the role that will be granted to


### PR DESCRIPTION
If you don't flush privileges after manually updating the `mysql.roles_mapping` table, then the changes don't take effect. This tripped me up when I was following the guide, so it seems worth it even though it might be obvious to some.