### PR TITLE
[docs] remove instructions for serviceAccountUser bind

### DIFF
--- a/docs/pages/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/application-access/cloud-apis/google-cloud.mdx
@@ -94,15 +94,6 @@ $ gcloud iam service-accounts create teleport-google-cloud-cli \
   --display-name="teleport-google-cloud-cli"
 ```
 
-Enable your service account to act as other service accounts by assigning it the
-predefined "Service Account User" role:
-
-```code
-$ gcloud projects add-iam-policy-binding <Var name="google-cloud-project" /> \
-   --member="serviceAccount:teleport-google-cloud-cli@<Var name="google-cloud-project" />.iam.gserviceaccount.com" \
-   --role="roles/iam.serviceAccountUser"
-```
-
 ### Set up a service account that Teleport users can access
 
 When a Teleport user executes a Google Cloud CLI command against the Teleport


### PR DESCRIPTION
This binding is not necessary:
https://cloud.google.com/iam/docs/service-account-permissions#user-role
> The Service Account User role (roles/iam.serviceAccountUser) lets a principal [attach a service account to a resource](https://cloud.google.com/iam/docs/attach-service-accounts). When the code running on that resource needs to authenticate, it can get credentials for the attached service account.
> 
> This role does not allow principals to [create short-lived credentials](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct) for service accounts, or to use the [--impersonate-service-account flag](https://cloud.google.com/sdk/gcloud/reference#--impersonate-service-account) for the Google Cloud CLI. To complete these tasks, you need the [Service Account Token Creator role](https://cloud.google.com/iam/docs/service-account-permissions#token-creator-role) on the service account.

We already document adding the "service account token creator" role below this, so it's just an unneeded step we can remove.
