### PR TITLE
Propagate clocks to auth transport credentials

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5041,6 +5041,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		TransportCredentials: &httplib.TLSCreds{Config: cfg.TLS},
 		UserGetter:           cfg.Middleware,
 		GetAuthPreference:    cfg.AuthServer.Cache.GetAuthPreference,
+		Clock:                cfg.AuthServer.clock,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/transport_credentials.go
+++ b/lib/auth/transport_credentials.go
@@ -320,5 +320,6 @@ func (c *TransportCredentials) Clone() credentials.TransportCredentials {
 		authorizer:           c.authorizer,
 		enforcer:             c.enforcer,
 		TransportCredentials: c.TransportCredentials.Clone(),
+		clock:                c.clock,
 	}
 }


### PR DESCRIPTION
Not setting the clock results in test code using a fake clock and the transport credentials using a real clock. Fixes issues with tests resulting in `connection error: desc = "error reading server preface: EOF"` errors.