### PR TITLE
[v13] Propagate clocks to auth transport credentials

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5484,6 +5484,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		TransportCredentials: &httplib.TLSCreds{Config: cfg.TLS},
 		UserGetter:           cfg.Middleware,
 		GetAuthPreference:    cfg.AuthServer.Cache.GetAuthPreference,
+		Clock:                cfg.AuthServer.clock,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/transport_credentials.go
+++ b/lib/auth/transport_credentials.go
@@ -316,5 +316,6 @@ func (c *TransportCredentials) Clone() credentials.TransportCredentials {
 		authorizer:           c.authorizer,
 		enforcer:             c.enforcer,
 		TransportCredentials: c.TransportCredentials.Clone(),
+		clock:                c.clock,
 	}
 }


### PR DESCRIPTION
Backport #41898 to branch/v13