### PR TITLE
Fix meta description clash

### DIFF
--- a/docs/pages/machine-id/workload-identity.mdx
+++ b/docs/pages/machine-id/workload-identity.mdx
@@ -1,6 +1,6 @@
 ---
 title: Workload Identity
-description: Teleport's Workload Identity for SPIFFE
+description: Describes Teleport Workload Identity, which issues flexible, short-lived identities to secure workload-to-workload communications.
 ---
 
 <Admonition type="tip" title="Preview">

--- a/docs/pages/machine-id/workload-identity/best-practices.mdx
+++ b/docs/pages/machine-id/workload-identity/best-practices.mdx
@@ -1,6 +1,6 @@
 ---
 title: Best Practices for Teleport Workload Identity
-description: Teleport's Workload Identity for SPIFFE
+description: Answers common questions and describes best practices for using Teleport Workload Identity in production.
 ---
 
 This page covers common questions and best practices for using Teleport's


### PR DESCRIPTION
Two Workload Identity pages have the same meta description, which can be harmful for SEO. This change gives each page a different meta description.