### PR TITLE
Use String Representation For Latency Log

### DIFF
--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -772,7 +772,7 @@ func (s *localSite) handleHeartbeat(rconn *remoteConn, ch ssh.Channel, reqC <-ch
 
 			log := logger
 			if roundtrip != 0 {
-				log = logger.WithField("latency", roundtrip)
+				log = logger.WithField("latency", roundtrip.String())
 			}
 			log.Debugf("Ping <- %v", rconn.conn.RemoteAddr())
 


### PR DESCRIPTION
Why: Use the `String()` function on `time.Duration` to have the `latency` log field emit as a formatted duration string, instead of the raw NS figure. This would assist with human consumption of these logs, being able to more quickly eyeball the emitted latency.

Resolves: https://github.com/gravitational/teleport/issues/41921