### PR TITLE
tsh: remove redundant username check

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1116,10 +1116,7 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 		return nil, trace.BadParameter("No proxy address specified, missed --proxy flag?")
 	}
 	if c.HostLogin == "" {
-		c.HostLogin, err = Username()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+		c.HostLogin = c.Username
 		log.Infof("no host login given. defaulting to %s", c.HostLogin)
 	}
 


### PR DESCRIPTION
User lookups on AD-joined hosts can be slow (see #25014).

In the worst case, we were running the slow user lookup twice (once for the user, once for the login).

Fix this by defaulting login to the same value as user if unspecified, which has a similar result but only does one slow operation instead of two.

Updates #41922

Changelog: Speed up `tsh login` on AD-joined hosts.