### PR TITLE
Allow headless auth when local auth is disabled

### DIFF
--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -301,6 +301,16 @@ func (a *Server) authenticateUserInternal(
 	user = req.Username
 	passwordless := user == ""
 
+	// Handle headless authentication as a special case separate from local auth methods below.
+	if req.HeadlessAuthenticationID != "" {
+		mfaDev, err = a.authenticateHeadless(ctx, req)
+		if err != nil {
+			log.Debugf("Headless Authentication for user %q failed while waiting for approval: %v", user, err)
+			return nil, "", trace.Wrap(err)
+		}
+		return mfaDev, user, nil
+	}
+
 	// Only one path if passwordless, other variants shouldn't see an empty user.
 	if passwordless {
 		if requiredExt.Scope != mfav1.ChallengeScope_CHALLENGE_SCOPE_LOGIN {
@@ -331,18 +341,6 @@ func (a *Server) authenticateUserInternal(
 	var authErr error // error message kept obscure on purpose, use logging for details
 	switch {
 	// cases in order of preference
-	case req.HeadlessAuthenticationID != "":
-		// handle authentication before the user lock to prevent locking out users
-		// due to timed-out/canceled headless authentication attempts.
-		mfaDevice, err := a.authenticateHeadless(ctx, req)
-		if err != nil {
-			log.Debugf("Headless Authentication for user %q failed while waiting for approval: %v", user, err)
-			return nil, "", trace.Wrap(authenticateHeadlessError)
-		}
-		authenticateFn = func() (*types.MFADevice, error) {
-			return mfaDevice, nil
-		}
-		authErr = authenticateHeadlessError
 	case req.Webauthn != nil:
 		authenticateFn = func() (*types.MFADevice, error) {
 			if req.Pass != nil {
@@ -540,6 +538,14 @@ func (a *Server) authenticateHeadless(ctx context.Context, req authclient.Authen
 		return nil, trace.AccessDenied("headless authentication public key mismatch")
 	}
 
+	// Only grab user lock on successful headless auth to perform normal login
+	// checks, like whether the user is locked. Failed headless login attempts
+	// won't lock out the user.
+	if err := a.WithUserLock(ctx, req.Username, func() error { return nil }); err != nil {
+		log.Debugf("WithUserLock for user %q failed during headless authentication: %v", req.Username, err)
+		return nil, trace.Wrap(authenticateHeadlessError)
+	}
+
 	return approvedHeadlessAuthn.MfaDevice, nil
 }
 
@@ -675,7 +681,9 @@ func (a *Server) AuthenticateSSHUser(ctx context.Context, req authclient.Authent
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if !authPref.GetAllowLocalAuth() {
+
+	// Disable all local auth requests, except headless requests.
+	if !authPref.GetAllowLocalAuth() && req.HeadlessAuthenticationID == "" {
 		a.emitNoLocalAuthEvent(username)
 		return nil, trace.AccessDenied(noLocalAuth)
 	}

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -198,9 +198,6 @@ func (a *Server) emitAuthAuditEvent(ctx context.Context, props authAuditProps) e
 }
 
 var (
-	// authenticateHeadlessError is the generic error returned for failed headless
-	// authentication attempts.
-	authenticateHeadlessError = &trace.AccessDeniedError{Message: "headless authentication failed"}
 	// authenticateWebauthnError is the generic error returned for failed WebAuthn
 	// authentication attempts.
 	authenticateWebauthnError = &trace.AccessDeniedError{Message: "invalid credentials"}


### PR DESCRIPTION
changelog: Fix Headless auth for sso users, including when local auth is disabled.

Note: In addition to the issue below, this fixes a regression in headless auth for sso users caused by https://github.com/gravitational/teleport/pull/41196.

Closes https://github.com/gravitational/teleport/issues/37063
Closes https://github.com/gravitational/customer-sensitive-requests/issues/260