### PR TITLE
Fix fetching requestable roles for servers in access requests

### DIFF
--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -705,7 +705,13 @@ export type RequestCheckoutProps = {
   isResourceRequest: boolean;
   requireReason: boolean;
   selectedReviewers: ReviewerOption[];
-  data: { kind: ResourceKind; name: string; id: string }[];
+  data: {
+    kind: ResourceKind;
+    /** Name of the resource, for presentation purposes only. */
+    name: string;
+    /** Identifier of the resource. Should be sent in requests. */
+    id: string;
+  }[];
   setRequestTTL: (value: Option<number>) => void;
   createRequest: (req: CreateRequest) => void;
   fetchStatus: 'loading' | 'loaded';

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.test.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+
+import {
+  makeRootCluster,
+  makeServer,
+  rootClusterUri,
+} from 'teleterm/services/tshd/testHelpers';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+
+import useAccessRequestCheckout from './useAccessRequestCheckout';
+
+test('fetching requestable roles for servers uses UUID, not hostname', async () => {
+  const server = makeServer();
+  const cluster = makeRootCluster();
+  const appContext = new MockAppContext();
+  appContext.clustersService.setState(draftState => {
+    draftState.clusters.set(rootClusterUri, cluster);
+  });
+  await appContext.workspacesService.setActiveWorkspace(rootClusterUri);
+  appContext.workspacesService
+    .getWorkspaceAccessRequestsService(rootClusterUri)
+    .addOrRemoveResource('node', server.name, server.hostname);
+
+  jest.spyOn(appContext.tshd, 'getRequestableRoles');
+
+  const wrapper = ({ children }) => (
+    <MockAppContextProvider appContext={appContext}>
+      {children}
+    </MockAppContextProvider>
+  );
+
+  renderHook(useAccessRequestCheckout, { wrapper });
+
+  await waitFor(() =>
+    expect(appContext.tshd.getRequestableRoles).toHaveBeenCalledWith({
+      clusterUri: rootClusterUri,
+      resourceIds: [
+        {
+          clusterName: 'teleport-local',
+          kind: 'node',
+          name: '1234abcd-1234-abcd-1234-abcd1234abcd',
+          subResourceName: '',
+        },
+      ],
+    })
+  );
+});

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
@@ -113,7 +113,7 @@ export default function useAccessRequestCheckout() {
           resourceIds: data
             .filter(d => d.kind !== 'role')
             .map(d => ({
-              name: d.name,
+              name: d.id,
               kind: d.kind,
               clusterName: d.clusterName,
               subResourceName: '',

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
@@ -113,6 +113,9 @@ export default function useAccessRequestCheckout() {
           resourceIds: data
             .filter(d => d.kind !== 'role')
             .map(d => ({
+              // We have to use id, not name.
+              // These fields are the same for all resources except servers,
+              // where id is UUID and name is the hostname.
               name: d.id,
               kind: d.kind,
               clusterName: d.clusterName,
@@ -148,7 +151,9 @@ export default function useAccessRequestCheckout() {
     const data: {
       kind: ResourceKind;
       clusterName: string;
+      /** Identifier of the resource. Should be sent in requests. */
       id: string;
+      /** Name of the resource, for presentation purposes only. */
       name: string;
     }[] = [];
     if (!workspaceAccessRequest) {


### PR DESCRIPTION
When fetching requestable roles, we should use `id` not `name`. These fields are the same for all resources except servers, where `id` is UUID and `name` is the hostname.

Using hostname caused errors like below: 
<img width="495" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/9f9916fc-70c8-49e7-a880-c2fc7e99f184">

Changelog: Fixed creating access requests for servers in Teleport Connect that were blocked due to a "no roles configured" error