### PR TITLE
Add an optional limit for concurrent `CreateAuditStream` operations

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5193,6 +5193,9 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 			log.Error("Failed to parse the TELEPORT_UNSTABLE_CREATEAUDITSTREAM_INFLIGHT_LIMIT envvar, limit will not be enforced.")
 			inflightLimit = -1
 		}
+		if inflightLimit == 0 {
+			log.Warn("TELEPORT_UNSTABLE_CREATEAUDITSTREAM_INFLIGHT_LIMIT is set to 0, no CreateAuditStream RPCs will be allowed.")
+		}
 		metrics.RegisterPrometheusCollectors(
 			createAuditStreamAcceptedTotalMetric,
 			createAuditStreamRejectedTotalMetric,

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -137,6 +139,24 @@ var (
 		},
 		[]string{teleport.TagType},
 	)
+
+	createAuditStreamAcceptedTotalMetric = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: teleport.MetricNamespace,
+		Name:      "unstable_createauditstream_accepted_total",
+		Help:      "CreateAuditStream RPCs accepted by the concurrency limiter",
+	})
+
+	createAuditStreamRejectedTotalMetric = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: teleport.MetricNamespace,
+		Name:      "unstable_createauditstream_rejected_total",
+		Help:      "CreateAuditStream RPCs rejected by the concurrency limiter",
+	})
+
+	createAuditStreamLimitMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: teleport.MetricNamespace,
+		Name:      "unstable_createauditstream_limit",
+		Help:      "Configured limit of in-flight CreateAuditStream RPCs",
+	})
 )
 
 // GRPCServer is gRPC Auth Server API
@@ -164,6 +184,11 @@ type GRPCServer struct {
 	// TraceServiceServer exposes the exporter server so that the auth server may
 	// collect and forward spans
 	collectortracepb.TraceServiceServer
+
+	// createAuditStreamSemaphore, if not nil, is used to limit the amount of
+	// in-flight CreateAuditStream RPCs, by sending a value in at the beginning
+	// of the RPC and pulling one out before returning.
+	createAuditStreamSemaphore chan struct{}
 }
 
 // Export forwards OTLP traces to the upstream collector configured in the tracing service. This allows for
@@ -264,6 +289,21 @@ func (g *GRPCServer) CreateAuditStream(stream authpb.AuthService_CreateAuditStre
 	auth, err := g.authenticate(stream.Context())
 	if err != nil {
 		return trace.Wrap(err)
+	}
+
+	if sem := g.createAuditStreamSemaphore; sem != nil {
+		select {
+		case sem <- struct{}{}:
+			createAuditStreamAcceptedTotalMetric.Inc()
+			defer func() { <-sem }()
+		default:
+			createAuditStreamRejectedTotalMetric.Inc()
+			// [trace.ConnectionProblemError] is rendered with a gRPC
+			// "unavailable" error code, which is the correct error if the
+			// client can just back off and retry with no further changes to the
+			// request
+			return trace.ConnectionProblem(nil, "too many concurrent CreateAuditStream operations, try again later")
+		}
 	}
 
 	var eventStream apievents.Stream
@@ -5145,6 +5185,19 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		usersService:    usersService,
 		botService:      botService,
 		presenceService: presenceService,
+	}
+
+	if en := os.Getenv("TELEPORT_UNSTABLE_CREATEAUDITSTREAM_INFLIGHT_LIMIT"); en != "" {
+		inflightLimit, _ := strconv.ParseInt(en, 10, 64)
+		metrics.RegisterPrometheusCollectors(
+			createAuditStreamAcceptedTotalMetric,
+			createAuditStreamRejectedTotalMetric,
+			createAuditStreamLimitMetric,
+		)
+		createAuditStreamLimitMetric.Set(float64(inflightLimit))
+		if inflightLimit >= 0 {
+			authServer.createAuditStreamSemaphore = make(chan struct{}, inflightLimit)
+		}
 	}
 
 	authpb.RegisterAuthServiceServer(server, authServer)

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5188,7 +5188,11 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	}
 
 	if en := os.Getenv("TELEPORT_UNSTABLE_CREATEAUDITSTREAM_INFLIGHT_LIMIT"); en != "" {
-		inflightLimit, _ := strconv.ParseInt(en, 10, 64)
+		inflightLimit, err := strconv.ParseInt(en, 10, 64)
+		if err != nil {
+			log.Error("Failed to parse the TELEPORT_UNSTABLE_CREATEAUDITSTREAM_INFLIGHT_LIMIT envvar, limit will not be enforced.")
+			inflightLimit = -1
+		}
 		metrics.RegisterPrometheusCollectors(
 			createAuditStreamAcceptedTotalMetric,
 			createAuditStreamRejectedTotalMetric,


### PR DESCRIPTION
This PR adds an unstable envvar (`TELEPORT_UNSTABLE_CREATEAUDITSTREAM_INFLIGHT_LIMIT`) to limit the allowed in-flight `CreateAuditStream` RPCs on the Auth Service's gRPC server. Rejected streams are immediately closed with a `trace.ConnectionProblemError`, which results in a gRPC `unavailable` code. Current agents attempting to upload sessions will not even notice the error, they'll just get a (short) timeout while waiting for the upload status, and then they'll back off (linearly, from 5 to 500 seconds). The circuit breaker on the clients only checks that the stream is established correctly (which it's going to be, in the case of this sort of manual rejection of the stream), so the rest of Teleport will keep working as usual.

This change is motivated by an outage that hit a large cluster with burst activity of hundreds of thousands of SSH sessions at once - the peripheral nodes tried uploading the newly created session recordings all at once, and memory consumption skyrocketed to the point of going out of memory. With a manually configured limit, memory consumption is going to be limited.

This is going to be unsupported and undocumented (thus the `TELEPORT_UNSTABLE_` envvar) until we figure out a better strategy to limit concurrent operations in general. Teleport 15+ only, as Teleport 14 control planes have to support v13 agents, which rely on the audit stream to also emit audit log events.