### PR TITLE
Add missing return to FileStorage.write

### DIFF
--- a/web/packages/teleterm/src/services/fileStorage/fileStorage.ts
+++ b/web/packages/teleterm/src/services/fileStorage/fileStorage.ts
@@ -97,7 +97,7 @@ export function createFileStorage(opts: {
       return;
     }
     const text = stringify(state);
-    writeFile(filePath, text);
+    return writeFile(filePath, text);
   }
 
   function replace(json: any): void {


### PR DESCRIPTION
Ever since we switched to Vite and started using electron-vite to automatically restart the Electron app on changes in dev mode, I sometimes noticed my `app_state.json` getting corrupted and the app starting in a pristine state, showing modals as if it was launched for the first time.

I attributed this to `app_state.json` getting corrupted. I looked for a relevant error in my logs and sure enough there it was:

```
[23-05-24 10:35:16] [FileStorage] error: Cannot read /Users/rav/Library/Application Support/Electron/app_state.json file SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at loadStateSync (/Users/rav/src/teleport/web/packages/teleterm/build/app/main/index.js:909:15)
    at createFileStorage (/Users/rav/src/teleport/web/packages/teleterm/build/app/main/index.js:857:13)
    at createFileStorages (/Users/rav/src/teleport/web/packages/teleterm/build/app/main/index.js:75420:26)
    at initializeApp (/Users/rav/src/teleport/web/packages/teleterm/build/app/main/index.js:75246:7)
```

I suspected that it might be due to electron-vite sending a sigkill to the Electron app and the app getting killed while it's writing to the file. I asked Grzegorz if he ever ran into that, and he confirmed that he did run into that too.

Grzegorz said, "I wonder if changing `appStateFileStorage.write()` to a sync write instead of async-based one would help here", and I said, "I don't think so, it's already awaited for…"

https://github.com/gravitational/teleport/blob/c7d2830bf63f9cfa1d5e92d836ba13fd6d41f165/web/packages/teleterm/src/main.ts#L119-L132

Well, turns out it wasn't, because we failed to return a promise from `FileStorage.write`! This is one of the things that no-floating-promises would have caught (https://github.com/gravitational/teleport/issues/41945).