### PR TITLE
Invoke signing function for Windows Connect binary

### DIFF
--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -35,7 +35,7 @@ function New-TempDirectory {
     string
     #>
 
-    $TempDirectoryPath = Join-Path -Path "$([System.IO.Path]::GetTempPath())" -ChildPath "$($(New-Guid).Guid)"
+    $TempDirectoryPath = Join-Path -Path "$([System.IO.Path]::GetTempPath())" -ChildPath "$([guid]::newguid().Guid)"
     New-Item -ItemType Directory -Path "$TempDirectoryPath" | Out-Null
 
     return "$TempDirectoryPath"
@@ -304,7 +304,7 @@ function Invoke-SignBinary {
     )
 
     if (! $SignedBinaryPath) {
-        $ShouldMoveSignedBinary = true
+        $ShouldMoveSignedBinary = $true
         $SignedBinaryPath = Join-Path -Path $(New-TempDirectory) -ChildPath "signed.exe"
     }
 
@@ -312,7 +312,7 @@ function Invoke-SignBinary {
     wsl-ubuntu-command sign-binary "$UnsignedBinaryPath" "$SignedBinaryPath"
 
     if ($ShouldMoveSignedBinary) {
-        Move-Item -Path $SignedBinaryPath -Destination $UnsignedBinaryPath
+        Move-Item -Path $SignedBinaryPath -Destination $UnsignedBinaryPath -Force
     }
 }
 

--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -142,6 +142,8 @@ module.exports = {
   },
   win: {
     target: ['nsis'],
+    // The algorithm passed here is not used, it only prevents the signing function from being called twice for each file. 
+    // https://github.com/electron-userland/electron-builder/issues/3995#issuecomment-505725704
     signingHashAlgorithms: ['sha256'],
     sign: customSign => {
       if (process.env.CI !== 'true') {

--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -142,7 +142,7 @@ module.exports = {
   },
   win: {
     target: ['nsis'],
-    // The algorithm passed here is not used, it only prevents the signing function from being called twice for each file. 
+    // The algorithm passed here is not used, it only prevents the signing function from being called twice for each file.
     // https://github.com/electron-userland/electron-builder/issues/3995#issuecomment-505725704
     signingHashAlgorithms: ['sha256'],
     sign: customSign => {

--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -1,6 +1,6 @@
 const { env, platform } = require('process');
 const fs = require('fs');
-
+const { spawnSync } = require('child_process');
 const isMac = platform === 'darwin';
 
 // The following checks make no sense when cross-building because they check the platform of the
@@ -142,6 +142,28 @@ module.exports = {
   },
   win: {
     target: ['nsis'],
+    signingHashAlgorithms: ['sha256'],
+    sign: customSign => {
+      if (process.env.CI !== 'true') {
+        console.warn('Not running in CI pipeline: signing will be skipped');
+        return;
+      }
+
+      spawnSync(
+        'powershell',
+        [
+          '-noprofile',
+          '-executionpolicy',
+          'bypass',
+          '-c',
+          "$ProgressPreference = 'SilentlyContinue'; " +
+            "$ErrorActionPreference = 'Stop'; " +
+            '. ../../../build.assets/windows/build.ps1; ' +
+            `Invoke-SignBinary -UnsignedBinaryPath "${customSign.path}"`,
+        ],
+        { stdio: 'inherit' }
+      );
+    },
     artifactName: '${productName} Setup-${version}.${ext}',
     icon: 'build_resources/icon-win.ico',
     extraResources: [


### PR DESCRIPTION
The Windows Teleport Connect binary is not currently signed, only the installer. This PR invokes the Powershell signing function that we use to sign all other Windows binaries.

changelog: Teleport Connect binaries for Windows are now signed.