### PR TITLE
feat: improve error message when RBAC misses `get` verb

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -936,7 +936,8 @@
     "yubishm",
     "znmqk",
     "zxvf",
-    "zztop"
+    "zztop",
+    "SPDY"
   ],
   "flagWords": [
     "hte"

--- a/docs/pages/kubernetes-access/troubleshooting.mdx
+++ b/docs/pages/kubernetes-access/troubleshooting.mdx
@@ -221,3 +221,54 @@ spec:
 
 Once the roles are created, you can assign them to users as usual, but
 to be effective immediately, they must logout and login again.
+
+## Unable to exec into a Pod with kubectl 1.30+
+
+```text
+pods "<pod_name>" is forbidden: User "<user>" cannot get resource "pods/exec" in API group "" in the namespace "<namespace>"
+```
+
+### Symptoms
+
+After upgrading `kubectl` to version 1.30 or later, attempts to exec into a Pod
+fail with an error similar to:
+
+```text
+pods "<pod_name>" is forbidden: User "<user>" cannot get resource "pods/exec" in API group "" in the namespace "<namespace>"
+```
+
+### Explanation
+
+Starting with Kubernetes 1.30, the `kubectl exec` command switched from using
+the SPDY protocol to the WebSocket protocol for communicating with the Kubernetes
+API server. This change was made to enhance the performance and reliability of
+the `kubectl exec` command, as the SPDY protocol was deprecated.
+
+Although WebSocket was intended to be a drop-in replacement for SPDY, it introduced
+a breaking change for Kubernetes clusters where RBAC was configured to restrict
+access to the `pods/exec` resource using only the `create` verb. Previously,
+the SPDY protocol allowed creating a connection using either
+`GET` (mapped to `get` in Kubernetes RBAC) or
+`POST` (mapped to `create` in Kubernetes RBAC).
+
+With the WebSocket protocol, the `kubectl exec` command always uses the `GET`
+method to create a connection. This means that if the RBAC policy permits only
+the `create` verb, the connection will be denied.
+
+### Resolution
+
+To resolve this issue, update the RBAC policy to allow the `get` verb for
+the `pods/exec` (sub)resource. This can be done by modifying the `ClusterRole`
+or `Role` that grants access to the user.
+
+For example, if you have a `ClusterRole` that grants access to the `pods/exec`
+resource with the `create` verb, update it to allow the `get` verb as well:
+
+```yaml
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create", "get"]
+```
+
+Once the `ClusterRole` is updated, you should be able to exec into Pods using
+`kubectl` version 1.30 or later.

--- a/lib/kube/proxy/constants.go
+++ b/lib/kube/proxy/constants.go
@@ -81,3 +81,16 @@ const (
 	// in the role.
 	kubernetesResourcesKey = "kubernetes_resources"
 )
+
+const (
+	// kubernete130BreakingChangeHint is a hint to help users fix the issue when
+	// they are unable to exec into a pod due to RBAC rules not allowing the user
+	// to access the pods/exec using  "get" verbs.
+	kubernetes130BreakingChangeHint = "\n\n Kubernetes 1.30 switched to a new exec API that uses websockets.\n" +
+		"To fix the issue, please ensure that your Kubernetes RBAC rules allow" +
+		" the user to access the pods/exec using \"create\" and \"get\" verbs.\n" +
+		"Please update your Kubernetes RBAC Roles and ClusterRoles with the following rule:\n" +
+		`- apiGroups: [""]
+resources: ["pods/exec"]
+verbs: ["create", "get"]` + "\n"
+)

--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
@@ -296,4 +297,105 @@ func generateExecRequest(cfg generateExecRequestConfig) (*rest.Request, error) {
 		Param(teleport.KubeSessionReasonQueryParam, cfg.reason)
 
 	return req, nil
+}
+
+func TestExecMissingGETPermissionError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		errorMessage = "pods \"api-1\" is forbidden: User \"bar\" cannot %s resource " +
+			"\"pods/exec\" in API group \"\" in the namespace \"ns\""
+	)
+	tests := []struct {
+		name           string
+		errorMessage   string
+		errorInspector func(*testing.T, error)
+	}{
+		{
+			name:         "missing get permission",
+			errorMessage: fmt.Sprintf(errorMessage, "get"),
+			errorInspector: func(t *testing.T, err error) {
+				require.Contains(t, err.Error(), kubernetes130BreakingChangeHint)
+			},
+		},
+		{
+			name:         "missing create permission",
+			errorMessage: fmt.Sprintf(errorMessage, "create"),
+			errorInspector: func(t *testing.T, err error) {
+				require.NotContains(t, err.Error(), kubernetes130BreakingChangeHint)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const errorCode = http.StatusForbidden
+
+			kubeMock, err := testingkubemock.NewKubeAPIMock(
+				testingkubemock.WithExecError(
+					metav1.Status{
+						Status:  metav1.StatusFailure,
+						Message: tt.errorMessage,
+						Reason:  metav1.StatusReasonForbidden,
+						Code:    errorCode,
+					},
+				),
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() { kubeMock.Close() })
+
+			// creates a Kubernetes service with a configured cluster pointing to mock api server
+			testCtx := SetupTestContext(
+				context.Background(),
+				t,
+				TestConfig{
+					Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+				},
+			)
+
+			t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+
+			// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+			user, _ := testCtx.CreateUserAndRole(
+				testCtx.Context,
+				t,
+				username,
+				RoleSpec{
+					Name:       roleName,
+					KubeUsers:  roleKubeUsers,
+					KubeGroups: roleKubeGroups,
+				})
+
+			// generate a kube client with user certs for auth
+			_, userRestConfig := testCtx.GenTestKubeClientTLSCert(
+				t,
+				user.GetName(),
+				kubeCluster,
+			)
+
+			streamOpts := remotecommand.StreamOptions{
+				Stdin:  nil,
+				Stdout: &bytes.Buffer{},
+				Stderr: &bytes.Buffer{},
+				Tty:    false,
+			}
+
+			req, err := generateExecRequest(
+				generateExecRequestConfig{
+					addr:          testCtx.KubeProxyAddress(),
+					podName:       podName,
+					podNamespace:  podNamespace,
+					containerName: podContainerName,
+					cmd:           containerCommmandExecute, // placeholder for commands to execute in the dummy pod
+					options:       streamOpts,
+				},
+			)
+			require.NoError(t, err)
+
+			exec, err := remotecommand.NewSPDYExecutor(userRestConfig, http.MethodPost, req.URL())
+			require.NoError(t, err)
+			err = exec.StreamWithContext(testCtx.Context, streamOpts)
+			require.Error(t, err)
+			tt.errorInspector(t, err)
+		})
+	}
 }

--- a/lib/kube/proxy/remotecommand.go
+++ b/lib/kube/proxy/remotecommand.go
@@ -275,7 +275,7 @@ func (s *remoteCommandProxy) sendStatus(err error) error {
 				Status:  metav1.StatusFailure,
 				Code:    http.StatusForbidden,
 				Reason:  metav1.StatusReasonForbidden,
-				Message: err.Error(),
+				Message: formatExecForbiddenErrorMessage(err),
 			},
 		})
 	} else if isSessionTerminatedError(err) {
@@ -284,6 +284,28 @@ func (s *remoteCommandProxy) sendStatus(err error) error {
 
 	err = trace.BadParameter("error executing command in container: %v", err)
 	return s.writeStatus(apierrors.NewInternalError(err))
+}
+
+// formatExecForbiddenErrorMessage formats the error message for the forbidden error
+// when trying to exec into a pod in Kubernetes 1.30.
+func formatExecForbiddenErrorMessage(err error) string {
+	message := err.Error()
+	// forbiddenGetResource is the error message that is returned when the user is forbidden to exec into a pod.
+	// This error message is returned when the user does not have the necessary RBAC rules to exec into a pod.
+	const forbiddenGetResource = "cannot get resource \"pods/exec\" in API group"
+	// Kubernetes 1.30 switched to a new exec API that uses a different protocol.
+	// Previously, the exec API used SPDY. The new exec API uses websockets.
+	// SPDY allowed the client to send the request as GET or POST, but websockets
+	// only allow GET per definition.
+	// This means that most clients that used kubectl version 1.29 or older can
+	// suddenly get a forbidden error when trying to exec into a pod in Kubernetes 1.30
+	// because the RBAC rules are not allowing the user to access the pods/exec resource
+	// using the GET verb.
+	// This error message is a hint to the user that they need to update their RBAC rules.
+	if strings.Contains(message, forbiddenGetResource) {
+		message += kubernetes130BreakingChangeHint
+	}
+	return message
 }
 
 // streamAndReply holds both a Stream and a channel that is closed when the stream's reply frame is


### PR DESCRIPTION
Prior to kubectl v1.30, the exec API used SPDY protocol but new versions use websockets. SPDY allowed the client to send the request as GET or POST, but websockets only allow GET per definition.

This means that most clients that used kubectl version 1.29 or older can suddenly get a forbidden error when trying to exec into a pod in Kubernetes 1.30 because the RBAC rules are not allowing the user to access the pods/exec resource using the GET verb.

This commit updates the error message to hint to the user that they need to update their RBAC rules.

Changelog: Enhanced error messaging for clients using `kubectl exec` v1.30+ to include warnings about a breaking change in Kubernetes.