### PR TITLE
Disable session recording for non-interactive sessions

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -48,9 +48,6 @@ const (
 
 	// SSHSessionID is the UUID of the current session.
 	SSHSessionID = "SSH_SESSION_ID"
-
-	// EnableNonInteractiveSessionRecording can be used to record non-interactive SSH session.
-	EnableNonInteractiveSessionRecording = "SSH_TELEPORT_RECORD_NON_INTERACTIVE"
 )
 
 const (

--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -299,6 +299,10 @@ func (s *Service) CloseSession(ctx *SessionContext) error {
 	return trace.NewAggregate(errs...)
 }
 
+func (s *Service) Enabled() bool {
+	return true
+}
+
 // processAccessEvents pulls events off the perf ring buffer, parses them, and emits them to
 // the audit log.
 func (s *Service) processAccessEvents() {

--- a/lib/bpf/common.go
+++ b/lib/bpf/common.go
@@ -42,6 +42,9 @@ type BPF interface {
 
 	// Close will stop any running BPF programs.
 	Close(restarting bool) error
+
+	// Enabled returns whether enhanced recording is active.
+	Enabled() bool
 }
 
 // SessionContext contains all the information needed to track and emit
@@ -99,6 +102,10 @@ func (s *NOP) OpenSession(_ *SessionContext) (uint64, error) {
 // CloseSession closes a NOP session. Note this function does nothing.
 func (s *NOP) CloseSession(_ *SessionContext) error {
 	return nil
+}
+
+func (s *NOP) Enabled() bool {
+	return false
 }
 
 // IsHostCompatible checks that BPF programs can run on this host.

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -411,12 +411,6 @@ type ServerContext struct {
 	killShellr *os.File
 	killShellw *os.File
 
-	// multiWriter is used to record non-interactive session output.
-	// Currently, used by Assist.
-	multiWriter io.Writer
-	// recordNonInteractiveSession enables non-interactive session recording. Used by Assist.
-	recordNonInteractiveSession bool
-
 	// ExecType holds the type of the channel or request. For example "session" or
 	// "direct-tcpip". Used to create correct subcommand during re-exec.
 	ExecType string

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -161,13 +161,7 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 
 	// Connect stdout and stderr to the channel so the user can interact with the command.
 	e.Cmd.Stderr = channel.Stderr()
-
-	if e.Ctx.recordNonInteractiveSession {
-		e.Ctx.Tracef("Starting local exec and recording non-interactive session")
-		e.Cmd.Stdout = io.MultiWriter(e.Ctx.multiWriter, channel)
-	} else {
-		e.Cmd.Stdout = channel
-	}
+	e.Cmd.Stdout = channel
 
 	// Copy from the channel (client input) into stdin of the process.
 	inputWriter, err := e.Cmd.StdinPipe()
@@ -380,13 +374,7 @@ func (e *remoteExec) Start(ctx context.Context, ch ssh.Channel) (*ExecResult, er
 	}
 
 	// hook up stdout/err the channel so the user can interact with the command
-	if e.ctx.recordNonInteractiveSession {
-		e.ctx.Tracef("Starting remote exec and recording non-interactive session")
-		e.session.Stdout = io.MultiWriter(e.ctx.multiWriter, ch)
-	} else {
-		e.session.Stdout = ch
-	}
-
+	e.session.Stdout = ch
 	e.session.Stderr = ch.Stderr()
 	inputWriter, err := e.session.StdinPipe()
 	if err != nil {

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1595,8 +1595,7 @@ func (s *Server) handlePuTTYWinadj(ch ssh.Channel, req *ssh.Request) error {
 // teleportVarPrefixes contains the list of prefixes used by Teleport environment
 // variables. Matching variables are saved in the session context when forwarding
 // the calls to a remote SSH server as they can contain Teleport-specific
-// information used to process the session properly (e.g. TELEPORT_SESSION or
-// SSH_TELEPORT_RECORD_NON_INTERACTIVE)
+// information used to process the session properly (e.g. TELEPORT_SESSION)
 var teleportVarPrefixes = []string{"TELEPORT_", "SSH_TELEPORT_"}
 
 func isTeleportEnv(varName string) bool {

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -158,6 +158,7 @@ type mockServer struct {
 	auth      *auth.Server
 	component string
 	clock     clockwork.FakeClock
+	bpf       bpf.BPF
 }
 
 // ID is the unique ID of the server.
@@ -252,6 +253,10 @@ func (m *mockServer) UseTunnel() bool {
 
 // GetBPF returns the BPF service used for enhanced session recording.
 func (m *mockServer) GetBPF() bpf.BPF {
+	if m.bpf != nil {
+		return m.bpf
+	}
+
 	return &bpf.NOP{}
 }
 
@@ -387,4 +392,24 @@ func (c *mockSSHChannel) SendRequest(name string, wantReply bool, payload []byte
 // Read and Write respectively.
 func (c *mockSSHChannel) Stderr() io.ReadWriter {
 	return c.stdErr
+}
+
+type fakeBPF struct {
+	bpf bpf.NOP
+}
+
+func (f fakeBPF) OpenSession(ctx *bpf.SessionContext) (uint64, error) {
+	return f.bpf.OpenSession(ctx)
+}
+
+func (f fakeBPF) CloseSession(ctx *bpf.SessionContext) error {
+	return f.bpf.CloseSession(ctx)
+}
+
+func (f fakeBPF) Close(restarting bool) error {
+	return f.bpf.Close(restarting)
+}
+
+func (f fakeBPF) Enabled() bool {
+	return true
 }

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -361,10 +361,6 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 		scx.Tracef("Session found, reusing it %s", sessionID)
 	}
 
-	if _, found := scx.GetEnv(teleport.EnableNonInteractiveSessionRecording); found {
-		scx.recordNonInteractiveSession = true
-	}
-
 	// This logic allows concurrent request to create a new session
 	// to fail, what is ok because we should never have this condition.
 	sess, _, err := newSession(ctx, sessionID, s, scx, channel)
@@ -1008,8 +1004,18 @@ func (s *session) emitSessionJoinEvent(ctx *ServerContext) {
 		sessionJoinEvent.ConnectionMetadata.LocalAddr = ctx.ServerConn.LocalAddr().String()
 	}
 
+	var notifyPartyPayload []byte
 	preparedEvent, err := s.Recorder().PrepareSessionEvent(sessionJoinEvent)
 	if err == nil {
+		// Try marshaling the event prior to emitting it to prevent races since
+		// the audit/recording machinery might try to set some fields while the
+		// marshal is underway.
+		if eventPayload, err := json.Marshal(preparedEvent); err != nil {
+			s.log.Warnf("Unable to marshal %v: %v.", events.SessionJoinEvent, err)
+		} else {
+			notifyPartyPayload = eventPayload
+		}
+
 		if err := s.recordEvent(ctx.srv.Context(), preparedEvent); err != nil {
 			s.log.WithError(err).Warn("Failed to record session join event.")
 		}
@@ -1023,12 +1029,15 @@ func (s *session) emitSessionJoinEvent(ctx *ServerContext) {
 	// Notify all members of the party that a new member has joined over the
 	// "x-teleport-event" channel.
 	for _, p := range s.parties {
-		eventPayload, err := json.Marshal(sessionJoinEvent)
-		if err != nil {
-			s.log.Warnf("Unable to marshal %v for %v: %v.", events.SessionJoinEvent, p.sconn.RemoteAddr(), err)
+		if len(notifyPartyPayload) == 0 {
+			s.log.Warnf("No join event to send to %v", p.sconn.RemoteAddr())
 			continue
 		}
-		_, _, err = p.sconn.SendRequest(teleport.SessionEvent, false, eventPayload)
+
+		payload := make([]byte, len(notifyPartyPayload))
+		copy(payload, notifyPartyPayload)
+
+		_, _, err = p.sconn.SendRequest(teleport.SessionEvent, false, payload)
 		if err != nil {
 			s.log.Warnf("Unable to send %v to %v: %v.", events.SessionJoinEvent, p.sconn.RemoteAddr(), err)
 			continue
@@ -1377,6 +1386,11 @@ func newRecorder(s *session, ctx *ServerContext) (events.SessionPreparerRecorder
 		return events.WithNoOpPreparer(events.NewDiscardRecorder()), nil
 	}
 
+	// Don't record non-interactive sessions when enhanced recording is disabled.
+	if ctx.GetTerm() == nil && !ctx.srv.GetBPF().Enabled() {
+		return events.WithNoOpPreparer(events.NewDiscardRecorder()), nil
+	}
+
 	rec, err := recorder.New(recorder.Config{
 		SessionID:    s.id,
 		ServerID:     s.serverMeta.ServerID,
@@ -1407,12 +1421,6 @@ func newRecorder(s *session, ctx *ServerContext) (events.SessionPreparerRecorder
 }
 
 func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *ServerContext) error {
-	if scx.recordNonInteractiveSession {
-		// enable recording.
-		s.io.AddWriter(sessionRecorderID, utils.WriteCloserWithContext(scx.srv.Context(), s.Recorder()))
-		s.scx.multiWriter = s.io
-	}
-
 	// Emit a session.start event for the exec session.
 	s.emitSessionStartEvent(scx)
 
@@ -1466,10 +1474,6 @@ func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *Serve
 
 	// Process has been placed in a cgroup, continue execution.
 	execRequest.Continue()
-
-	if scx.recordNonInteractiveSession {
-		s.io.On()
-	}
 
 	// Process is running, wait for it to stop.
 	go func() {

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net"
 	"os/user"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -266,6 +267,7 @@ func TestSession_newRecorder(t *testing.T) {
 			},
 			sctx: &ServerContext{
 				SessionRecordingConfig: proxyRecording,
+				term:                   &terminal{},
 			},
 			errAssertion: require.NoError,
 			recAssertion: isNotSessionWriter,
@@ -285,6 +287,7 @@ func TestSession_newRecorder(t *testing.T) {
 			},
 			sctx: &ServerContext{
 				SessionRecordingConfig: proxyRecordingSync,
+				term:                   &terminal{},
 			},
 			errAssertion: require.NoError,
 			recAssertion: isNotSessionWriter,
@@ -307,6 +310,7 @@ func TestSession_newRecorder(t *testing.T) {
 				srv: &mockServer{
 					component: teleport.ComponentNode,
 				},
+				term: &terminal{},
 				Identity: IdentityContext{
 					AccessChecker: services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
 						Roles: []string{"dev"},
@@ -363,6 +367,7 @@ func TestSession_newRecorder(t *testing.T) {
 						},
 					}),
 				},
+				term: &terminal{},
 			},
 			errAssertion: require.NoError,
 			recAssertion: func(t require.TestingT, i interface{}, _ ...interface{}) {
@@ -392,6 +397,7 @@ func TestSession_newRecorder(t *testing.T) {
 					MockRecorderEmitter: &eventstest.MockRecorderEmitter{},
 					datadir:             t.TempDir(),
 				},
+				term: &terminal{},
 			},
 			errAssertion: require.NoError,
 			recAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
@@ -460,12 +466,14 @@ func TestSession_emitAuditEvent(t *testing.T) {
 	})
 }
 
-// TestInteractiveSession tests interaction session lifecycles.
-// Multiple sessions are opened in parallel tests to test for
-// deadlocks between session registry, sessions, and parties.
+// TestInteractiveSession tests interactive session lifecycles
+// and validates audit events and session recordings are emitted.
 func TestInteractiveSession(t *testing.T) {
+	t.Parallel()
+
 	srv := newMockServer(t)
 	srv.component = teleport.ComponentNode
+	t.Cleanup(func() { require.NoError(t, srv.auth.Close()) })
 
 	reg, err := NewSessionRegistry(SessionRegistryConfig{
 		Srv:                   srv,
@@ -474,19 +482,217 @@ func TestInteractiveSession(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { reg.Close() })
 
-	t.Run("Stop", func(t *testing.T) {
-		t.Parallel()
-		sess, _ := testOpenSession(t, reg, nil)
+	// Create a server context with an overridden recording mode
+	// so that sessions are recorded with the test emitter.
+	scx := newTestServerContext(t, reg.Srv, nil)
+	rcfg := types.DefaultSessionRecordingConfig()
+	rcfg.SetMode(types.RecordAtNodeSync)
+	scx.SessionRecordingConfig = rcfg
 
-		// Stopping the session should trigger the session
-		// to end and cleanup in the background
-		sess.Stop()
+	// Allocate a terminal for the session so that
+	// events are properly recorded.
+	terminal, err := newLocalTerminal(scx)
+	require.NoError(t, err)
+	scx.term = terminal
 
-		sessionClosed := func() bool {
-			_, found := reg.findSession(sess.id)
-			return !found
+	// Open a new session
+	sshChanOpen := newMockSSHChannel()
+	go func() {
+		// Consume stdout sent to the channel
+		io.ReadAll(sshChanOpen)
+	}()
+	require.NoError(t, reg.OpenSession(context.Background(), sshChanOpen, scx))
+	require.NotNil(t, scx.session)
+
+	// Simulate changing window size to capture an additional event.
+	require.NoError(t, reg.NotifyWinChange(context.Background(), rsession.TerminalParams{W: 100, H: 100}, scx))
+
+	// Stopping the session should trigger the session
+	// to end and cleanup in the background
+	scx.session.Stop()
+
+	// Wait for the session to be removed from the registry.
+	require.Eventually(t, func() bool {
+		_, found := reg.findSession(scx.session.id)
+		return !found
+	}, time.Second*15, time.Millisecond*500)
+
+	// Validate that the expected audit events were emitted.
+	expectedEvents := []string{events.SessionStartEvent, events.ResizeEvent, events.SessionEndEvent, events.SessionLeaveEvent}
+	require.Eventually(t, func() bool {
+		actual := srv.MockRecorderEmitter.Events()
+
+		for _, evt := range expectedEvents {
+			contains := slices.ContainsFunc(actual, func(event apievents.AuditEvent) bool {
+				return event.GetType() == evt
+			})
+			if !contains {
+				return false
+			}
 		}
-		require.Eventually(t, sessionClosed, time.Second*15, time.Millisecond*500)
+		return true
+	}, 15*time.Second, 500*time.Millisecond)
+
+	// Validate that the expected recording events were emitted.
+	require.Eventually(t, func() bool {
+		actual := srv.MockRecorderEmitter.RecordedEvents()
+
+		for _, evt := range expectedEvents {
+			contains := slices.ContainsFunc(actual, func(event apievents.PreparedSessionEvent) bool {
+				return event.GetAuditEvent().GetType() == evt
+			})
+			if !contains {
+				return false
+			}
+		}
+
+		return true
+	}, 15*time.Second, 500*time.Millisecond)
+}
+
+// TestNonInteractiveSession tests non-interactive session lifecycles
+// and validates audit events and session recordings are emitted when
+// appropriate.
+func TestNonInteractiveSession(t *testing.T) {
+	t.Parallel()
+
+	t.Run("without BPF", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newMockServer(t)
+		srv.component = teleport.ComponentNode
+		t.Cleanup(func() { require.NoError(t, srv.auth.Close()) })
+
+		reg, err := NewSessionRegistry(SessionRegistryConfig{
+			Srv:                   srv,
+			SessionTrackerService: srv.auth,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { reg.Close() })
+
+		// Create a server context with an overridden recording mode
+		// so that sessions are recorded with the test emitter.
+		scx := newTestServerContext(t, reg.Srv, nil)
+		rcfg := types.DefaultSessionRecordingConfig()
+		rcfg.SetMode(types.RecordAtNodeSync)
+		scx.SessionRecordingConfig = rcfg
+
+		// Modify the execRequest to actually execute a command.
+		scx.execRequest = &localExec{Ctx: scx, Command: "true"}
+
+		// Open a new session
+		sshChanOpen := newMockSSHChannel()
+		go func() {
+			// Consume stdout sent to the channel
+			io.ReadAll(sshChanOpen)
+		}()
+		require.NoError(t, reg.OpenExecSession(context.Background(), sshChanOpen, scx))
+		require.NotNil(t, scx.session)
+
+		// Wait for the command execution to complete and the session to be terminated.
+		require.Eventually(t, func() bool {
+			_, found := reg.findSession(scx.session.id)
+			return !found
+		}, time.Second*15, time.Millisecond*500)
+
+		// Verify that all the expected audit events are eventually emitted.
+		expected := []string{events.SessionStartEvent, events.ExecEvent, events.SessionEndEvent, events.SessionLeaveEvent}
+		require.Eventually(t, func() bool {
+			actual := srv.MockRecorderEmitter.Events()
+
+			for _, evt := range expected {
+				contains := slices.ContainsFunc(actual, func(event apievents.AuditEvent) bool {
+					return event.GetType() == evt
+				})
+				if !contains {
+					return false
+				}
+			}
+
+			return true
+		}, 15*time.Second, 500*time.Millisecond)
+
+		// Verify that NO recordings were emitted
+		require.Empty(t, srv.MockRecorderEmitter.RecordedEvents())
+	})
+
+	t.Run("with BPF", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newMockServer(t)
+		srv.component = teleport.ComponentNode
+		// Modify bpf to "enable" enhanced recording. This should
+		// trigger recordings to be captured.
+		srv.bpf = fakeBPF{}
+		t.Cleanup(func() { require.NoError(t, srv.auth.Close()) })
+
+		reg, err := NewSessionRegistry(SessionRegistryConfig{
+			Srv:                   srv,
+			SessionTrackerService: srv.auth,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { reg.Close() })
+
+		// Create a server context with an overridden recording mode
+		// so that sessions are recorded with the test emitter.
+		scx := newTestServerContext(t, reg.Srv, nil)
+		rcfg := types.DefaultSessionRecordingConfig()
+		rcfg.SetMode(types.RecordAtNodeSync)
+		scx.SessionRecordingConfig = rcfg
+
+		// Modify the execRequest to actually execute a command.
+		scx.execRequest = &localExec{Ctx: scx, Command: "true"}
+
+		// Open a new session
+		sshChanOpen := newMockSSHChannel()
+		go func() {
+			// Consume stdout sent to the channel
+			io.ReadAll(sshChanOpen)
+		}()
+		require.NoError(t, reg.OpenExecSession(context.Background(), sshChanOpen, scx))
+		require.NotNil(t, scx.session)
+
+		// Wait for the command execution to complete and the session to be terminated.
+		require.Eventually(t, func() bool {
+			_, found := reg.findSession(scx.session.id)
+			return !found
+		}, time.Second*15, time.Millisecond*500)
+
+		// Verify that all the expected audit events are eventually emitted.
+		expectedEvents := []string{events.SessionStartEvent, events.ExecEvent, events.SessionEndEvent, events.SessionLeaveEvent}
+		require.Eventually(t, func() bool {
+			actual := srv.MockRecorderEmitter.Events()
+
+			for _, evt := range expectedEvents {
+				contains := slices.ContainsFunc(actual, func(event apievents.AuditEvent) bool {
+					return event.GetType() == evt
+				})
+				if !contains {
+					return false
+				}
+			}
+
+			return true
+		}, 15*time.Second, 500*time.Millisecond)
+
+		// Validate that the expected recording events were emitted.
+		require.Eventually(t, func() bool {
+			actual := srv.MockRecorderEmitter.RecordedEvents()
+
+			for _, evt := range expectedEvents {
+				if evt == events.ExecEvent {
+					continue
+				}
+				contains := slices.ContainsFunc(actual, func(event apievents.PreparedSessionEvent) bool {
+					return event.GetAuditEvent().GetType() == evt
+				})
+				if !contains {
+					return false
+				}
+			}
+
+			return true
+		}, 15*time.Second, 500*time.Millisecond)
 	})
 }
 


### PR DESCRIPTION
These recordings only contain session.start, session.end and session.leave events, all of which are already included in the audit log. Removing these recordings should produce no data loss but will greatly reduce the amount of work performed by the agents, the auth service, and storage costs.

The only case where non-interactive sessions are still recorded is when BPF is enabled. This is required, for now, because enhanced session recording can generate more events than the audit log has traditionally been able to ingest.


changelog: Disabled session recordings for non-interactive sessions when enhanced recording is disabled. There is no loss of auditing or impact on data fidelity because these recordings only contained session.start, session.end, and session.leave events which were already captured in the audit log. This will cause all teleport components to consume less resources and reduce storage costs.