### PR TITLE
Update access graph version and add Docker deployment warning

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1912,7 +1912,7 @@
       "nodeIP": "ip-172-31-35-170"
     },
     "access_graph": {
-      "version": "1.20.1"
+      "version": "1.20.4"
     },
     "ansible": {
       "min_version": "2.9.6"

--- a/docs/pages/access-controls/access-graph/self-hosted.mdx
+++ b/docs/pages/access-controls/access-graph/self-hosted.mdx
@@ -31,6 +31,12 @@ to Teleport Enterprise customers.
     and must list the IP or DNS name of the TAG service in an X.509 v3 `subjectAltName` extension.
 - The node running the Access Graph service must be reachable from Teleport Auth Service and Proxy Service.
 
+<Notice type="warning">
+    The deployment with Docker is suitable for testing and development purposes. For production deployments,
+    consider using a container orchestration system like Kubernetes and Helm.
+    Refer to [Helm chart for Access Graph](self-hosted-helm.mdx) for instructions.
+</Notice>
+
 ## Step 1/3. Set up the Teleport Access Graph service
 
 You will need a copy of your Teleport cluster's host certificate authority (CA) on the machine that hosts the Access Graph service.
@@ -43,7 +49,8 @@ The host CA can be retrieved and saved into a file in one of the following ways:
 ```code
 $ sudo mkdir /etc/access_graph
 $ curl -s 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=tls-host' | sudo tee /etc/access_graph/teleport_host_ca.pem
-```
+$ sudo chmod +r /etc/access_graph/teleport_host_ca.pem # Set the correct permissions for the file so that the TAG service can read it.
+    ```
 </TabItem>
 
 <TabItem label="Via tctl">
@@ -53,6 +60,7 @@ $ tsh login --proxy=<Var name="teleport.example.com" />
 $ tctl get cert_authorities --format=json \
     | jq -r '.[] | select(.spec.type == "host") | .spec.active_keys.tls[].cert' \
     | base64 -d | sudo tee /etc/access_graph/teleport_host_ca.pem
+$ sudo chmod +r /etc/access_graph/teleport_host_ca.pem # Set the correct permissions for the file so that the TAG service can read it.
 ```
 </TabItem>
 </Tabs>

--- a/docs/pages/access-controls/access-graph/self-hosted.mdx
+++ b/docs/pages/access-controls/access-graph/self-hosted.mdx
@@ -29,10 +29,10 @@ to Teleport Enterprise customers.
 - A TLS certificate for the Access Graph service
   - The TLS certificate must be issued for "server authentication" key usage,
     and must list the IP or DNS name of the TAG service in an X.509 v3 `subjectAltName` extension.
-  - Starting from version 1.20.4 of the Access Graph service, the container by default runs as a non-root user.
+  - Starting from version 1.20.4 of the Access Graph service, the container runs as a non-root user by default.
     Make sure the certificate files are readable by the user running the container. You can set correct permissions with the following command:
     ```console
-    $ sudo chown 65532 /path/to/tls.key
+    $ sudo chown 65532 /etc/access_graph/tls.key
     ```
 - The node running the Access Graph service must be reachable from Teleport Auth Service and Proxy Service.
 
@@ -54,7 +54,7 @@ The host CA can be retrieved and saved into a file in one of the following ways:
 ```code
 $ sudo mkdir /etc/access_graph
 $ curl -s 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=tls-host' | sudo tee /etc/access_graph/teleport_host_ca.pem
-    ```
+```
 </TabItem>
 
 <TabItem label="Via tctl">

--- a/docs/pages/access-controls/access-graph/self-hosted.mdx
+++ b/docs/pages/access-controls/access-graph/self-hosted.mdx
@@ -29,6 +29,11 @@ to Teleport Enterprise customers.
 - A TLS certificate for the Access Graph service
   - The TLS certificate must be issued for "server authentication" key usage,
     and must list the IP or DNS name of the TAG service in an X.509 v3 `subjectAltName` extension.
+  - Starting from version 1.20.4 of the Access Graph service, the container by default runs as a non-root user.
+    Make sure the certificate files are readable by the user running the container. You can set correct permissions with the following command:
+    ```console
+    $ sudo chown 65532 /path/to/tls.key
+    ```
 - The node running the Access Graph service must be reachable from Teleport Auth Service and Proxy Service.
 
 <Notice type="warning">
@@ -49,7 +54,6 @@ The host CA can be retrieved and saved into a file in one of the following ways:
 ```code
 $ sudo mkdir /etc/access_graph
 $ curl -s 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=tls-host' | sudo tee /etc/access_graph/teleport_host_ca.pem
-$ sudo chmod +r /etc/access_graph/teleport_host_ca.pem # Set the correct permissions for the file so that the TAG service can read it.
     ```
 </TabItem>
 
@@ -60,7 +64,6 @@ $ tsh login --proxy=<Var name="teleport.example.com" />
 $ tctl get cert_authorities --format=json \
     | jq -r '.[] | select(.spec.type == "host") | .spec.active_keys.tls[].cert' \
     | base64 -d | sudo tee /etc/access_graph/teleport_host_ca.pem
-$ sudo chmod +r /etc/access_graph/teleport_host_ca.pem # Set the correct permissions for the file so that the TAG service can read it.
 ```
 </TabItem>
 </Tabs>

--- a/docs/pages/access-controls/access-graph/self-hosted.mdx
+++ b/docs/pages/access-controls/access-graph/self-hosted.mdx
@@ -31,14 +31,14 @@ to Teleport Enterprise customers.
     and must list the IP or DNS name of the TAG service in an X.509 v3 `subjectAltName` extension.
   - Starting from version 1.20.4 of the Access Graph service, the container runs as a non-root user by default.
     Make sure the certificate files are readable by the user running the container. You can set correct permissions with the following command:
-    ```console
+    ```code
     $ sudo chown 65532 /etc/access_graph/tls.key
     ```
 - The node running the Access Graph service must be reachable from Teleport Auth Service and Proxy Service.
 
 <Notice type="warning">
     The deployment with Docker is suitable for testing and development purposes. For production deployments,
-    consider using a container orchestration system like Kubernetes and Helm.
+    consider using the Teleport Access Graph Helm chart to deploy this service on Kubernetes.
     Refer to [Helm chart for Access Graph](self-hosted-helm.mdx) for instructions.
 </Notice>
 


### PR DESCRIPTION
The access graph version in the config.json file has been updated from 1.20.1 to 1.20.4. Also, a warning notice about Docker deployment suitability for testing and development purposes only has been added in the Docker deployment page.
Included instruction to make the tls keys readable after the default docker user has been changed.