### PR TITLE
Improve role fetching and unmarshaling

### DIFF
--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
@@ -91,7 +90,9 @@ func (s *AccessService) ListRoles(ctx context.Context, req *proto.ListRolesReque
 	limit := int(req.Limit)
 
 	if limit == 0 {
-		limit = apidefaults.DefaultChunkSize
+		// it can take a lot of effort to parse roles and until a page is done
+		// parsing, it will be held in memory - so keep this reasonably small
+		limit = 100
 	}
 
 	if limit > maxPageSize {

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -20,7 +20,6 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -34,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	jsoniter "github.com/json-iterator/go"
 	log "github.com/sirupsen/logrus"
 	"github.com/vulcand/predicate"
 	"golang.org/x/crypto/ssh"
@@ -3307,47 +3307,38 @@ func UnmarshalRole(bytes []byte, opts ...MarshalOption) (types.Role, error) {
 
 // UnmarshalRoleV6 unmarshals the RoleV6 resource from JSON.
 func UnmarshalRoleV6(bytes []byte, opts ...MarshalOption) (*types.RoleV6, error) {
-	var h types.ResourceHeader
-	err := json.Unmarshal(bytes, &h)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	switch h.Version {
-	case types.V7:
-		fallthrough
-	case types.V6:
-		fallthrough
-	case types.V5:
-		fallthrough
-	case types.V4:
-		// V4 roles are identical to V3 except for their defaults
-		fallthrough
-	case types.V3:
-		var role types.RoleV6
-		if err := utils.FastUnmarshal(bytes, &role); err != nil {
-			return nil, trace.BadParameter(err.Error())
-		}
-
-		if err := ValidateRole(&role); err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		if cfg.Revision != "" {
-			role.SetRevision(cfg.Revision)
-		}
-		if !cfg.Expires.IsZero() {
-			role.SetExpiry(cfg.Expires)
-		}
-		return &role, nil
+	version := jsoniter.Get(bytes, "version").ToString()
+	switch version {
+	// these are all backed by the same shape of data, they just have different semantics and defaults
+	case types.V3, types.V4, types.V5, types.V6, types.V7:
+	default:
+		return nil, trace.BadParameter("role version %q is not supported", version)
 	}
 
-	return nil, trace.BadParameter("role version %q is not supported", h.Version)
+	var role types.RoleV6
+	if err := utils.FastUnmarshal(bytes, &role); err != nil {
+		return nil, trace.BadParameter(err.Error())
+	}
+	if role.Version != version {
+		return nil, trace.BadParameter("inconsistent version in role data, got %q and %q", role.Version, version)
+	}
+
+	if err := ValidateRole(&role); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if cfg.Revision != "" {
+		role.SetRevision(cfg.Revision)
+	}
+	if !cfg.Expires.IsZero() {
+		role.SetExpiry(cfg.Expires)
+	}
+	return &role, nil
 }
 
 // MarshalRole marshals the Role resource to JSON.


### PR DESCRIPTION
This PR changes the default page size for `ListRoles` (that the API client uses by default, and by extent the cache initialization process) from 1000 to 100; roles can require a lot of effort during unmarshaling (as we validate expressions, which requires parsing them) and after a cluster event such as an auth server restart, a lot of nodes will all connect at the same time and get roles 1000 at a time, which can spike the memory used by the auth server. The default iteration page size of 1000 was picked somewhat arbitrarily and works well for resources that are just data with very little effort required during unmarshaling, but roles can be pretty big and hang around for a while, so tuning the page size down can help mitigate these memory requirement bursts.

In addition, this PR changes the version checking for roles to use `jsoniter.Get` to access the one field we need, rather than using `encoding/json`'s unmarshaler for a whole resource header. A simple benchmark that unmarshals a reasonably "average" role with one `where` expression shows a 28% improvement in time spent in `services.UnmarshalRoleV6`, with a tiny reduction in allocations as well.

<details>
<summary>Benchmark result:</summary>

```
current
BenchmarkUnmarshalRole    210998             27651 ns/op           17377 B/op        331 allocs/op

new
BenchmarkUnmarshalRole    293476             19791 ns/op           16521 B/op        320 allocs/op
```
</details>


<details>

<summary>CPU profile flame graph for a relative comparison (with FastUnmarshal and ValidateRole being the same in both):</summary>

<img width="1911" alt="Screenshot 2024-05-24 alle 12 31 06" src="https://github.com/gravitational/teleport/assets/886075/0b5c1d09-bf1c-43ed-b75b-c4d85d6a6ae7">
<img width="1917" alt="Screenshot 2024-05-24 alle 12 31 26" src="https://github.com/gravitational/teleport/assets/886075/b9251dad-4763-43f0-81d6-e6e2617cb5b7">
</details>

changelog: reduced memory and cpu usage after control plane restarts in clusters with a high number of roles