### PR TITLE
Make `web/config.js` endpoint always available

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -525,7 +525,6 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		}
 
 		h.Handle("GET", "/robots.txt", httplib.MakeHandler(serveRobotsTxt))
-		h.Handle("GET", "/web/config.js", h.WithUnauthenticatedLimiter(h.getWebConfig))
 
 		etagFromAppHash, err := readEtagFromAppHash(cfg.StaticFS)
 		if err != nil {
@@ -534,6 +533,9 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 			etag = etagFromAppHash
 		}
 	}
+
+	// This endpoint is used both by Web UI and Connect.
+	h.Handle("GET", "/web/config.js", h.WithUnauthenticatedLimiter(h.getWebConfig))
 
 	if cfg.NodeWatcher != nil {
 		h.nodeWatcher = cfg.NodeWatcher


### PR DESCRIPTION
The `web/config.js` endpoint is used both by the Web UI and Connect. 
Recently we started use it [even more](https://github.com/gravitational/teleport/pull/41759/files#diff-5a07e732d8d3ce09f4de92529ce8626e7c91282d94f4a45ce41299262a59f8f5) and this [is breaking a few Connect's integration tests](https://github.com/gravitational/teleport/actions/runs/9221262400/job/25370939526?pr=41759), because the handler for it is added only if `staticFS` is set (and this is controlled by [`DisableWebService` and availability of webassets](https://github.com/gravitational/teleport/blob/08eaba07df10bced986b10ae5191b5aa6efbef06/lib/service/service.go#L4190)). 
Unfortunately, it is not easy to make it work in tests. Even if I set `Proxy.DisableWebInterface = false` the webassets can't be loaded (because I get `webAssetsMissingError`).

I could try to find a workaround for that, but since this API is used also by Connect, I I think it makes sense to have it available independently of Web UI.

Unblocks https://github.com/gravitational/teleport/pull/41759.