### PR TITLE
Update min macOS version to 10.15

### DIFF
--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -11,7 +11,7 @@
 # Written mainly for macOS builders.
 set -eu
 
-readonly MACOS_VERSION_MIN=10.13
+readonly MACOS_VERSION_MIN=10.15
 
 # Cross-architecture building
 # Set C_ARCH to $(uname -m) if unset, and validate supported architecture

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -43,7 +43,7 @@
 		<key>DTXcodeBuild</key>
 		<string>13C100</string>
 		<key>LSMinimumSystemVersion</key>
-		<string>10.12.0</string>
+		<string>10.15.0</string>
 		<key>NSHumanReadableCopyright</key>
 		<string/>
 		<key>NSMainStoryboardFile</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -41,7 +41,7 @@
 		<key>DTXcodeBuild</key>
 		<string>13C100</string>
 		<key>LSMinimumSystemVersion</key>
-		<string>10.12.0</string>
+		<string>10.15.0</string>
 		<key>NSHumanReadableCopyright</key>
 		<string/>
 		<key>NSMainStoryboardFile</key>

--- a/docs/pages/access-controls/guides/passwordless.mdx
+++ b/docs/pages/access-controls/guides/passwordless.mdx
@@ -226,7 +226,7 @@ standalone version of `tsh`. [Download the macOS tsh installer](
 ../../installation.mdx#macos).
 
 Touch ID support requires Macs with a Touch ID sensor and Secure Enclave. It also
-requires macOS >= 10.13 (macOS High Sierra).
+requires macOS >= 10.15 (macOS Catalina).
 
 You can run the `tsh touchid diag` command to verify requirements. A capable
 device and `tsh` binary should show an output similar to the one below:

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -33,7 +33,7 @@ running Teleport on UNIX variants other than Linux \[1].
 | Operating System | `teleport` Daemon | `tctl` Admin Tool | `tsh` and Teleport Connect User Clients [2] | Web UI (via the browser) | `tbot` Daemon |
 | - | - | - | - | - | - |
 | Linux v2.6.23+ (RHEL/CentOS 7+, Amazon Linux 2+, Amazon Linux 2023+, Ubuntu 16.04+, Debian 9+, SLES 12 SP 5+, and SLES 15 SP 5+) \[3] | yes | yes | yes | yes | yes |
-| macOS v10.13+  (High Sierra)| yes | yes | yes | yes | yes |
+| macOS v10.15+  (Catalina)| yes | yes | yes | yes | yes |
 | Windows 10+ (rev. 1607) \[4] | no | no | yes | yes | no |
 
 \[1] *Teleport is written in Go and many of these system requirements are due to the requirements
@@ -126,7 +126,7 @@ Download and run the installation script on the server where you want to install
 Teleport:
 
 ```code
-$ curl https://goteleport.com/static/install.sh | bash -s ${TELEPORT_VERSION?} ${TELEPORT_EDITION?} 
+$ curl https://goteleport.com/static/install.sh | bash -s ${TELEPORT_VERSION?} ${TELEPORT_EDITION?}
 ```
 
 ### Package repositories
@@ -145,21 +145,21 @@ repositories.
 
    <Tabs>
    <TabItem label="Teleport Community Edition">
-   
+
    ```code
    $ export TELEPORT_PKG=teleport
    $ export TELEPORT_VERSION=v(=teleport.major_version=)
    $ export TELEPORT_CHANNEL=stable/${TELEPORT_VERSION?}
    ```
-   
+
    </TabItem>
    <TabItem label="Teleport Cloud">
-   
+
    Teleport Cloud installations must include the automatic agent updater. The
    following commands show you how to determine the Teleport version to install
    by querying your Teleport Cloud account. This way, the Teleport installation
    has the same major version as the service that conducts automatic updates:
-   
+
    ```code
    $ export TELEPORT_DOMAIN=<Var name="example.teleport.com" />
    $ export TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/channel/stable/cloud/version | sed 's/v//')"
@@ -176,19 +176,19 @@ repositories.
 
    </TabItem>
    <TabItem label="Teleport Enterprise (Self-Hosted)">
-   
+
    ```code
    $ export TELEPORT_PKG=teleport-ent
    $ export TELEPORT_VERSION=v(=teleport.major_version=)
    $ export TELEPORT_CHANNEL=stable/${TELEPORT_VERSION?}
    ```
-   
+
    For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
-   
+
    ```code
    $ export TELEPORT_PKG=teleport-ent-fips
    ```
-   
+
    </TabItem>
    </Tabs>
 
@@ -206,9 +206,9 @@ repositories.
    distribution variants. When installing Teleport using RPM repositories, you
    may need to replace the `ID` variable set in `/etc/os-release` with `ID_LIKE`
    to install packages of the closest supported distribution.
-   
+
    Currently supported distributions (and `ID` values) are:
-   
+
    | Distribution | Version              | `ID` value in `/etc/os-release` |
    |--------------|----------------------|---------------------------------|
    | Amazon Linux | 2 and 2023           | `amzn`                          |
@@ -217,12 +217,12 @@ repositories.
    | RHEL         | >= 7                 | `rhel`                          |
    | SLES         | >= 12 SP5, >= 15 SP5 | `sles`                          |
    | Ubuntu       | >= 16.04             | `ubuntu`                        |
-   
+
    Note that [Enhanced Session
    Recording](./server-access/guides/bpf-session-recording.mdx) requires Linux
    kernel version 5.8+. This means that it requires more recent OS versions than
    other Teleport features:
-   
+
    | Distribution | Version                  |
    |--------------|--------------------------|
    | Amazon Linux | 2 (post 11/2021), 2023   |
@@ -236,7 +236,7 @@ repositories.
 
    <Tabs>
    <TabItem label="apt">
-   
+
    ```code
    # Download the Teleport PGP public key
    $ sudo curl https://apt.releases.teleport.dev/gpg \
@@ -247,15 +247,15 @@ repositories.
    https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} \
    ${TELEPORT_CHANNEL?}" \
    | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
-   
+
    $ sudo apt-get update
    $ sudo apt-get install ${TELEPORT_PKG?}
    ```
-   
+
    </TabItem>
-   
+
    <TabItem label="yum">
-   
+
    ```code
    # Add the Teleport YUM repository. You'll need to update this file for each
    # major release of Teleport.
@@ -269,11 +269,11 @@ repositories.
    # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
    # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
    ```
-   
+
    </TabItem>
-   
+
    <TabItem label="zypper">
-   
+
    ```code
    # Add the Teleport Zypper repository. You'll need to update this file for each
    # major release of Teleport.
@@ -288,11 +288,11 @@ repositories.
    # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
    # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
    ```
-   
+
    </TabItem>
-   
+
    <TabItem label="dnf">
-   
+
    ```code
    # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
    # file for each major release of Teleport.
@@ -303,14 +303,14 @@ repositories.
    $ sudo yum install -y yum-utils
    # Use the dnf config manager plugin to add the teleport RPM repo
    $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/${TELEPORT_CHANNEL?}/teleport.repo")"
-   
+
    # Install teleport
    $ sudo dnf install ${TELEPORT_PKG}
-   
+
    # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
    # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
    ```
-   
+
    </TabItem>
    </Tabs>
 
@@ -349,7 +349,7 @@ script](#one-line-installation-script) or manually install Teleport from a
    $ SYSTEM_ARCH=""
    ```
 
-   The following architecture values are available:   
+   The following architecture values are available:
 
    - `amd64`
    - `arm64`

--- a/lib/auth/touchid/api_darwin.go
+++ b/lib/auth/touchid/api_darwin.go
@@ -21,7 +21,7 @@
 
 package touchid
 
-// #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=10.13
+// #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=10.15
 // #cgo LDFLAGS: -framework CoreFoundation -framework Foundation -framework LocalAuthentication -framework Security
 // #include <stdlib.h>
 // #include "authenticate.h"

--- a/lib/devicetrust/native/device_darwin.go
+++ b/lib/devicetrust/native/device_darwin.go
@@ -18,7 +18,7 @@
 
 package native
 
-// #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=10.13
+// #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=10.15
 // #cgo LDFLAGS: -framework CoreFoundation -framework Foundation -framework IOKit -framework Security
 // #include <stdint.h>
 // #include <stdlib.h>

--- a/lib/web/scripts/node-join/README.md
+++ b/lib/web/scripts/node-join/README.md
@@ -41,11 +41,11 @@ Things it doesn't do (yet):
   - Any other distribution
     - uses `.tar.gz` tarball package
 
-- MacOS
+- macOS
   - Architectures
     - x86_64
-    - aarch64 (no Teleport binaries available yet)
-  - MacOS 10.12+
+    - aarch64
+  - MacOS 10.15+
     - uses `.tar.gz` tarball package
 
 ## Arguments


### PR DESCRIPTION
Teleport 16 will be built with Go 1.22, which requires macOS 10.15 (Catalina) or later.

changelog: Teleport now requires macOS 10.15 (Catalina) or later.