### PR TITLE
Add capitalization rules

### DIFF
--- a/.github/vale-styles/messaging/capitalization.yml
+++ b/.github/vale-styles/messaging/capitalization.yml
@@ -22,3 +22,5 @@ tokens:
   - kubernetes service
   - machine id
   - ssh service
+  - Teleport agent
+  - '[Dd]evice trust'


### PR DESCRIPTION
Fixes #41428
Fixes #41485

Add vale linter rules to standardize capitalizing "Teleport Agent" and "Device Trust". This is because these are names of Teleport features and components.