### PR TITLE
Update the Docs Test Plan

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-plan-docs.md
+++ b/.github/ISSUE_TEMPLATE/test-plan-docs.md
@@ -80,17 +80,9 @@ to select "Version 12.0" in the documentation version switcher.
 
 ### Getting started
 
-- [ ] [Community Edition](../../docs/pages/index.mdx)
-- [ ] [Teleport Team](../../docs/pages/choose-an-edition/teleport-team.mdx)
-  (this also serves as the getting started guide for Teleport Enterprise Cloud).
-- [ ] [Teleport Enterprise with
+- [ ] [Teleport Community Edition](../../docs/pages/index.mdx)
+- [ ] [Teleport Enterprise (Cloud)](../../docs/pages/choose-an-edition/teleport-cloud/get-started.mdx).
+- [ ] [Teleport Enterprise (Self-Hosted) with
   Helm](../../docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx)
-- [ ] [Teleport Enterprise with
+- [ ] [Teleport Enterprise (Self-Hosted) with
   Terraform](../../docs/pages/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx)
-
-### New feature docs
-
-- [ ] Review the roadmap for the major version we are releasing and verify that
-  you can complete all how-to guides for new features successfully. Consult the
-  [Upcoming Releases Page](../../docs/pages/upcoming-releases.mdx) for a list of
-  features in the next major release.


### PR DESCRIPTION
Anticipate the v16 release by refreshing the Docs Test Plan:

- Update getting started guide links for the different Teleport editions.
- Remove the step to verify the accuracy of new feature docs, since (a) these are already tested when authors write these pages and (b) to reduce bandwidth requirements for executing the test plan.