### PR TITLE
Clarify the style rule for Teleport editions

### DIFF
--- a/.github/vale-styles/messaging/edition-names.yml
+++ b/.github/vale-styles/messaging/edition-names.yml
@@ -2,7 +2,7 @@ extends: existence
 scope:
   # Using the raw scope so we can catch instances in TabItem labels.
   - raw
-message: '"%s" is no longer a recognized Teleport edition. Use "Teleport Enterprise" instead, and clarify the hosting type in parentheses rather than including it in the name of the product, e.g., "Teleport Enterprise (self-hosted)" or "Teleport Enterprise (cloud-hosted)".'
+message: '"%s" is no longer a recognized Teleport edition. Use "Teleport Enterprise" instead, and clarify the hosting type rather than including it in the name of the product. For example, you could say, "For managed Teleport Enterprise...", "Teleport Enterprise (managed)", "self-hosted Teleport Enterprise," etc., as long as the implication is that Teleport Enterprise is a single product that users can host in two ways. If the hosting type is not important in a given sentence, there is no need to specify it.'
 level: error
 ignorecase: false
 tokens:


### PR DESCRIPTION
Encourage authors to take a more flexible approach to mentioning cloud-hosted and self-hosted Teleport Enterprise. In the current vale style rule for Teleport editions, the alternative to "Teleport Enterprise Cloud" seemed to be a more rigid suggestion to use "Teleport Enterprise (cloud-hosted)", which is usually not the smoothest way to express this information.