### PR TITLE
docs: update helm install for db and app labels

### DIFF
--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -169,7 +169,7 @@ $ helm install teleport-kube-agent teleport/teleport-kube-agent \
   --set authToken=${JOIN_TOKEN?} \
   --set "apps[0].name=grafana" \
   --set "apps[0].uri=http://example-grafana.example-grafana.svc.cluster.local" \
-  --set "labels.env=dev" \
+  --set "apps[0].labels.env=dev" \
   --version (=teleport.version=)
 ```
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
@@ -220,8 +220,8 @@ To configure the Teleport Database Service to trust a custom CA:
         protocol: <Var name="protocol" />
   +     tls:
   +       ca_cert_file: "/etc/teleport-tls-db/db-ca/ca.pem"
-    labels:
-      env: dev
+        static_labels:
+          env: dev
   + extraVolumes:
   +   - name: db-ca
   +     secret:

--- a/docs/pages/includes/database-access/db-helm-install.mdx
+++ b/docs/pages/includes/database-access/db-helm-install.mdx
@@ -15,7 +15,7 @@ $ helm install teleport-kube-agent teleport/teleport-kube-agent \
   --set "databases[0].name={{ dbName }}" \
   --set "databases[0].uri={{ databaseAddress }}" \
   --set "databases[0].protocol={{ dbProtocol }}" \
-  --set "labels.env=dev" \
+  --set "databases[0].static_labels.env=dev" \
   --version (=teleport.version=)
 ```
 
@@ -35,7 +35,7 @@ $ helm install teleport-kube-agent teleport/teleport-kube-agent \
   --set "databases[0].name={{ dbName }}" \
   --set "databases[0].uri={{ databaseAddress }}" \
   --set "databases[0].protocol={{ dbProtocol }}" \
-  --set "labels.env=dev" \
+  --set "databases[0].static_labels.env=dev" \
   --version (=cloud.version=)
 ```
 

--- a/docs/pages/includes/database-access/self-hosted-db-helm-install.mdx
+++ b/docs/pages/includes/database-access/self-hosted-db-helm-install.mdx
@@ -11,13 +11,13 @@ roles: db
 proxyAddr: <Var name="example.teleport.sh" />
 # Set to false if using Teleport Community Edition
 enterprise: true
-authToken: <Var name="JOIN_TOKEN" />
+authToken: "<Var name="JOIN_TOKEN" />"
 databases:
   - name: {{ dbName }}
     uri: {{ databaseAddress }}
     protocol: {{ dbProtocol }}
-labels:
-  env: dev
+    static_labels:
+      env: dev
 ```
 
 To configure the Teleport Database Service to trust a custom CA:
@@ -46,8 +46,8 @@ To configure the Teleport Database Service to trust a custom CA:
          protocol: {{ dbProtocol }}
    +     tls:
    +       ca_cert_file: "/etc/teleport-tls-db/db-ca/ca.pem"
-     labels:
-       env: dev
+         static_labels:
+           env: dev
    + extraVolumes:
    +   - name: db-ca
    +     secret:


### PR DESCRIPTION
The `labels` included in db helm installations were meant for k8s resources, not dbs.