### PR TITLE
Added support for plugins debug images

### DIFF
--- a/integrations/access/Dockerfile
+++ b/integrations/access/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=gcr.io/distroless/static-debian12
+ARG BASE_IMAGE_TAG=latest
+ARG BASE_IMAGE=gcr.io/distroless/static-debian12:${BASE_IMAGE_TAG}
 
 # BUILDPLATFORM is provided by Docker/buildx
 # Extract the built tarball to reduce the final image size

--- a/integrations/event-handler/Dockerfile
+++ b/integrations/event-handler/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=gcr.io/distroless/static-debian12
+ARG BASE_IMAGE_TAG=latest
+ARG BASE_IMAGE=gcr.io/distroless/static-debian12:${BASE_IMAGE_TAG}
 
 # BUILDPLATFORM is provided by Docker/buildx
 # Extract the built tarball to reduce the final image size


### PR DESCRIPTION
This PR adds debug images for Teleport plugins. This needs to be merged together with https://github.com/gravitational/teleport.e/pull/4247. To make review easier, I'm pointing this PR at https://github.com/gravitational/teleport/tree/fred/multiarch-plugin-images-1, but I'll point it at master once https://github.com/gravitational/teleport/pull/42001 lands.

changelog: Added multiarch `debug` images for Teleport plugins. These can be accessed by appending `-debug` to the image name, e.x. `docker pull public.ecr.aws/gravitational/teleport-plugin-email-debug:15`.