### PR TITLE
docs: update for tctl Windows support

### DIFF
--- a/docs/pages/access-controls/guides/headless.mdx
+++ b/docs/pages/access-controls/guides/headless.mdx
@@ -1,5 +1,5 @@
 ---
-title: Headless WebAuthn 
+title: Headless WebAuthn
 description: Headless WebAuthn
 ---
 
@@ -9,13 +9,13 @@ features which are usually not usable in WebAuthn-incompatible environments.
 For example:
 
 - Logging into Teleport with WebAuthn from a remote dev box
-- Connecting to a Teleport SSH Service from a remote dev box with per-session MFA 
+- Connecting to a Teleport SSH Service from a remote dev box with per-session MFA
 - Performing `tsh scp` from one Teleport SSH Service to another with per-session MFA
 - Logging into Teleport on a machine without a WebAuthn-compatible browser
 
 <Admonition type="note" title="Headless WebAuthn Support">
   Headless WebAuthn only supports the following `tsh` commands:
-  
+
   - `tsh ls`
   - `tsh ssh`
   - `tsh scp`
@@ -28,7 +28,7 @@ For example:
 - A v12.2+ Teleport cluster with WebAuthn configured.
   See the [Second Factor: WebAuthn](./webauthn.mdx) guide.
 - WebAuthn hardware device, such as YubiKey.
-- Machines for Headless WebAuthn activities have [Linux](../../installation.mdx#linux), [macOS](../../installation.mdx#macos) or [Windows](../../installation.mdx#windows-tsh-client-only) `tsh` binary v12.2+ installed.
+- Machines for Headless WebAuthn activities have [Linux](../../installation.mdx#linux), [macOS](../../installation.mdx#macos) or [Windows](../../installation.mdx#windows-tsh-and-tctl-clients-only) `tsh` binary v12.2+ installed.
 - Machines used to approve Headless WebAuthn requests have a Web browser with [WebAuthn support](
   https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/) or `tsh` binary v12.2+ installed.
 - Optional: Teleport Connect v13.3.1+ for [seamless Headless WebAuthn approval](#optional-teleport-connect).
@@ -100,7 +100,7 @@ $ tctl create -f cap.yaml
 
 ## Step 2/3. Initiate Headless WebAuthn
 
-First open a terminal on the remote machine and confirm the `tsh` binary 
+First open a terminal on the remote machine and confirm the `tsh` binary
 is v12.2+ with `tsh version`.
 
 ```code
@@ -114,11 +114,11 @@ headless authentication, printing a URL and `tsh` command.
 ```code
 $ tsh ls --headless --proxy=proxy.example.com --user=alice
 # Complete headless authentication in your local web browser:
-# 
+#
 # https://proxy.example.com:3080/web/headless/86172f78-af7c-5935-a7c1-ed06b94f17dc
-# 
+#
 # or execute this command in your local terminal:
-# 
+#
 # tsh headless approve --user=alice --proxy=proxy.example.com 86172f78-af7c-5935-a7c1-ed06b94f17dc
 ```
 
@@ -134,17 +134,17 @@ lifetime of a single `tsh` request. This means that for each `tsh --headless`
 command, you will need to go through the Headless WebAuthn flow:
 
 ### Example: Listing SSH servers
-```code 
+```code
 $ tsh ls --headless --proxy=proxy.example.com --user=alice
 # Complete headless authentication in your local web browser:
-# 
+#
 # https://proxy.example.com:3080/web/headless/86172f78-af7c-5935-a7c1-ed06b94f17dc
-# 
+#
 # or execute this command in your local terminal:
-# 
+#
 # tsh headless approve --user=alice --proxy=proxy.example.com 86172f78-af7c-5935-a7c1-ed06b94f17dc
 # # User approves through link
-# Node Name Address        Labels                                                                             
+# Node Name Address        Labels
 # --------- -------------- -----------
 # server01  127.0.0.1:3022 arch=x86_64
 ```
@@ -153,23 +153,23 @@ $ tsh ls --headless --proxy=proxy.example.com --user=alice
 ```code
 $ tsh ssh --headless --proxy=proxy.example.com --user=alice alice@server01
 # Complete headless authentication in your local web browser:
-# 
+#
 # https://proxy.example.com:3080/web/headless/864cccd9-2425-46d9-a9f2-636387e66ebf
-# 
+#
 # or execute this command in your local terminal:
-# 
+#
 # tsh headless approve --user=alice --proxy=proxy.example.com 864cccd9-2425-46d9-a9f2-636387e66ebf
 # # User approves through link and a ssh terminal starts
 alice@server01 $
 ```
 
 <Notice type="note">
-  The Teleport user, `--user` parameter, is the Teleport user requesting Headless WebAuthn activity. 
+  The Teleport user, `--user` parameter, is the Teleport user requesting Headless WebAuthn activity.
   If no `--user` parameter or environment variables set the OS user in the machine terminal is used.
 
   The login username, `--login` parameter or login@hostname, for `tsh ssh` commands is the user
-  to open a SSH session as. If no login username for the SSH session is set the OS terminal username is used. 
-  A Teleport user must have access to that login user for that server or they will receive 
+  to open a SSH session as. If no login username for the SSH session is set the OS terminal username is used.
+  A Teleport user must have access to that login user for that server or they will receive
   an access denied message. The user could receive an access denied message after being approved
   for their Headless WebAuthn activity since the same access rights are granted or denied as if running from
   your local terminal.
@@ -201,7 +201,7 @@ You will be prompted to tap your MFA key to complete the approval process.
 
 When using Headless WebAuthn, `tsh` does not write private key and certificate data
 to disk(`~/.tsh`). Instead, `tsh` holds these secrets in memory for the duration of
-the request. Additionally, it will try to lock the process memory to further protect 
+the request. Additionally, it will try to lock the process memory to further protect
 the secrets from being stolen by other users on a shared machine.
 
 Below are some of the specific warning messages you may run into and how to fix them:

--- a/docs/pages/includes/device-trust/prereqs.mdx
+++ b/docs/pages/includes/device-trust/prereqs.mdx
@@ -4,7 +4,7 @@
 - To enroll a Windows device, you need:
   - A device with TPM 2.0.
   - A user with administrator privileges. This is only required during enrollment.
-  - `tsh` v13.1.2 or newer. [Download the Windows tsh installer](../../installation.mdx#windows-tsh-client-only).
+  - `tsh` v13.1.2 or newer. [Download the Windows tsh installer](../../installation.mdx#windows-tsh-and-tctl-clients-only).
 - To enroll a Linux device, you need:
   - A device with TPM 2.0.
   - A user with permissions to use the /dev/tpmrm0 device (typically done by

--- a/docs/pages/includes/install-windows-clients.mdx
+++ b/docs/pages/includes/install-windows-clients.mdx
@@ -15,14 +15,15 @@
   ```
 
   After you have verified that the checksums match, you can extract the archive.
-  The executable will be available at
-  `teleport-v{{ version }}-windows-amd64-bin\tsh.exe`.
+  The executables will be available at `teleport-v{{ version }}-windows-amd64-bin\`.
 
   ```code
   $ Expand-Archive teleport-v{{ version }}-windows-amd64-bin.zip
   $ cd teleport-v{{ version }}-windows-amd64-bin
   $ .\tsh.exe version
   Teleport v{{ version }} git:v{{ version }} go(=teleport.golang=)
+  $ .\tctl.exe version
+  Teleport v{{ version }} git:v{{ version }} go(=teleport.golang=)
   ```
 
-  Make sure to move `tsh.exe` into your PATH.
+  Make sure to move `tsh.exe` and `tctl.exe` into your PATH.

--- a/docs/pages/includes/install-windows.mdx
+++ b/docs/pages/includes/install-windows.mdx
@@ -1,23 +1,24 @@
 Most `tsh` features are supported for Windows 10 1607+. The `tsh ssh` command
 can be run under `cmd.exe`, PowerShell, and Windows Terminal.
 
-To install `tsh` on Windows, run the following commands in **PowerShell** (these commands will not work in `cmd.exe`):
+To install `tsh` and `tctl` on Windows, run the following commands in
+**PowerShell** (these commands will not work in `cmd.exe`):
 
-<Tabs dropdownView dropdownCaption="Teleport Edition">
+<Tabs>
 <TabItem label="Teleport Community Edition" scope="oss">
 
-  (!docs/pages/includes/install-windows-tsh.mdx version="(=teleport.version=)" !)
- 
+  (!docs/pages/includes/install-windows-clients.mdx version="(=teleport.version=)" !)
+
 </TabItem>
 <TabItem label="Teleport Enterprise" scope="enterprise">
 
-  (!docs/pages/includes/install-windows-tsh.mdx version="(=teleport.version=)" !)
- 
+  (!docs/pages/includes/install-windows-clients.mdx version="(=teleport.version=)" !)
+
 </TabItem>
 
 <TabItem  label="Teleport Enterprise Cloud" scope="cloud">
- 
-  (!docs/pages/includes/install-windows-tsh.mdx version="(=cloud.version=)" !)
- 
+
+  (!docs/pages/includes/install-windows-clients.mdx version="(=cloud.version=)" !)
+
 </TabItem>
 </Tabs>

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -44,8 +44,8 @@ of the [Go toolchain](https://github.com/golang/go/wiki/MinimumRequirements)*.
 
 \[3] *Enhanced Session Recording requires Linux kernel v5.8+*.
 
-\[4] *Teleport server does not run on Windows yet, but `tsh` and Teleport Connect (the Teleport desktop clients)
-supports most features on Windows 10 and later.*
+\[4] *Teleport server does not run on Windows yet, but `tsh`, `tctl`, and Teleport Connect (the Teleport desktop clients)
+support most features on Windows 10 and later.*
 
 ## Linux
 
@@ -126,7 +126,7 @@ Download and run the installation script on the server where you want to install
 Teleport:
 
 ```code
-$ curl https://goteleport.com/static/install.sh | bash -s ${TELEPORT_VERSION?} ${TELEPORT_EDITION?} 
+$ curl https://goteleport.com/static/install.sh | bash -s ${TELEPORT_VERSION?} ${TELEPORT_EDITION?}
 ```
 
 ### Package repositories
@@ -145,21 +145,21 @@ repositories.
 
    <Tabs>
    <TabItem label="Teleport Community Edition">
-   
+
    ```code
    $ export TELEPORT_PKG=teleport
    $ export TELEPORT_VERSION=v(=teleport.major_version=)
    $ export TELEPORT_CHANNEL=stable/${TELEPORT_VERSION?}
    ```
-   
+
    </TabItem>
    <TabItem label="Teleport Cloud">
-   
+
    Teleport Cloud installations must include the automatic agent updater. The
    following commands show you how to determine the Teleport version to install
    by querying your Teleport Cloud account. This way, the Teleport installation
    has the same major version as the service that conducts automatic updates:
-   
+
    ```code
    $ export TELEPORT_DOMAIN=<Var name="example.teleport.com" />
    $ export TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/channel/stable/cloud/version | sed 's/v//')"
@@ -176,19 +176,19 @@ repositories.
 
    </TabItem>
    <TabItem label="Teleport Enterprise (Self-Hosted)">
-   
+
    ```code
    $ export TELEPORT_PKG=teleport-ent
    $ export TELEPORT_VERSION=v(=teleport.major_version=)
    $ export TELEPORT_CHANNEL=stable/${TELEPORT_VERSION?}
    ```
-   
+
    For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
-   
+
    ```code
    $ export TELEPORT_PKG=teleport-ent-fips
    ```
-   
+
    </TabItem>
    </Tabs>
 
@@ -206,9 +206,9 @@ repositories.
    distribution variants. When installing Teleport using RPM repositories, you
    may need to replace the `ID` variable set in `/etc/os-release` with `ID_LIKE`
    to install packages of the closest supported distribution.
-   
+
    Currently supported distributions (and `ID` values) are:
-   
+
    | Distribution | Version              | `ID` value in `/etc/os-release` |
    |--------------|----------------------|---------------------------------|
    | Amazon Linux | 2 and 2023           | `amzn`                          |
@@ -217,12 +217,12 @@ repositories.
    | RHEL         | >= 7                 | `rhel`                          |
    | SLES         | >= 12 SP5, >= 15 SP5 | `sles`                          |
    | Ubuntu       | >= 16.04             | `ubuntu`                        |
-   
+
    Note that [Enhanced Session
    Recording](./server-access/guides/bpf-session-recording.mdx) requires Linux
    kernel version 5.8+. This means that it requires more recent OS versions than
    other Teleport features:
-   
+
    | Distribution | Version                  |
    |--------------|--------------------------|
    | Amazon Linux | 2 (post 11/2021), 2023   |
@@ -236,7 +236,7 @@ repositories.
 
    <Tabs>
    <TabItem label="apt">
-   
+
    ```code
    # Download the Teleport PGP public key
    $ sudo curl https://apt.releases.teleport.dev/gpg \
@@ -247,15 +247,15 @@ repositories.
    https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} \
    ${TELEPORT_CHANNEL?}" \
    | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
-   
+
    $ sudo apt-get update
    $ sudo apt-get install ${TELEPORT_PKG?}
    ```
-   
+
    </TabItem>
-   
+
    <TabItem label="yum">
-   
+
    ```code
    # Add the Teleport YUM repository. You'll need to update this file for each
    # major release of Teleport.
@@ -269,11 +269,11 @@ repositories.
    # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
    # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
    ```
-   
+
    </TabItem>
-   
+
    <TabItem label="zypper">
-   
+
    ```code
    # Add the Teleport Zypper repository. You'll need to update this file for each
    # major release of Teleport.
@@ -288,11 +288,11 @@ repositories.
    # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
    # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
    ```
-   
+
    </TabItem>
-   
+
    <TabItem label="dnf">
-   
+
    ```code
    # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
    # file for each major release of Teleport.
@@ -303,14 +303,14 @@ repositories.
    $ sudo yum install -y yum-utils
    # Use the dnf config manager plugin to add the teleport RPM repo
    $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/${TELEPORT_CHANNEL?}/teleport.repo")"
-   
+
    # Install teleport
    $ sudo dnf install ${TELEPORT_PKG}
-   
+
    # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
    # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
    ```
-   
+
    </TabItem>
    </Tabs>
 
@@ -349,7 +349,7 @@ script](#one-line-installation-script) or manually install Teleport from a
    $ SYSTEM_ARCH=""
    ```
 
-   The following architecture values are available:   
+   The following architecture values are available:
 
    - `amd64`
    - `arm64`
@@ -809,7 +809,7 @@ security.
 </TabItem>
 </Tabs>
 
-## Windows (tsh client only)
+## Windows (`tsh` and `tctl` clients only)
 
 (!docs/pages/includes/install-windows.mdx!)
 


### PR DESCRIPTION
Teleport 16 will ship tctl.exe for Windows.

Updates #36457