### PR TITLE
[v13] web: use cdn.teleport.dev for download links

### DIFF
--- a/web/packages/teleport/src/services/links.ts
+++ b/web/packages/teleport/src/services/links.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const DOWNLOAD_BASE_URL = 'https://get.gravitational.com/';
+const DOWNLOAD_BASE_URL = 'https://cdn.teleport.dev/';
 
 export default function getDownloadLink(
   type: Arch,


### PR DESCRIPTION
Backport #42034 to branch/v13