### PR TITLE
Support requesting resources from the search bar

### DIFF
--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
@@ -16,7 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useState, useRef, useCallback, MutableRefObject } from 'react';
+import {
+  useState,
+  useRef,
+  useCallback,
+  MutableRefObject,
+  useEffect,
+} from 'react';
 
 import { ResourcesResponse } from 'teleport/services/agents';
 import { ApiError } from 'teleport/services/api/parseError';
@@ -57,6 +63,11 @@ export function useKeyBasedPagination<T>({
   // cause rerenders.
   const abortController = useRef<AbortController | null>(null);
   const pendingPromise = useRef<Promise<ResourcesResponse<T>> | null>(null);
+
+  useEffect(() => {
+    // Abort a pending request when the hook unmounts.
+    return () => abortController.current?.abort();
+  }, []);
 
   const clear = useCallback(() => {
     abortController.current?.abort();

--- a/web/packages/shared/utils/wait.ts
+++ b/web/packages/shared/utils/wait.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** Resolves after a given duration */
+/** Resolves after a given duration. */
 export function wait(ms: number, abortSignal?: AbortSignal): Promise<void> {
   if (abortSignal?.aborted) {
     return Promise.reject(new DOMException('Wait was aborted.', 'AbortError'));
@@ -34,5 +34,20 @@ export function wait(ms: number, abortSignal?: AbortSignal): Promise<void> {
 
     const timeout = setTimeout(done, ms);
     abortSignal?.addEventListener('abort', abort, { once: true });
+  });
+}
+
+/** Blocks until the signal is aborted. */
+export function waitForever(abortSignal: AbortSignal): Promise<never> {
+  if (abortSignal.aborted) {
+    return Promise.reject(new DOMException('Wait was aborted.', 'AbortError'));
+  }
+
+  return new Promise((_, reject) => {
+    const abort = () => {
+      reject(new DOMException('Wait was aborted.', 'AbortError'));
+    };
+
+    abortSignal.addEventListener('abort', abort, { once: true });
   });
 }

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
@@ -80,6 +80,7 @@ export function AccessRequestCheckout() {
     toggleResource,
     selectedResourceRequestRoles,
     createRequest,
+    reset,
     resourceRequestRoles,
     fetchResourceRolesAttempt,
     setSelectedResourceRequestRoles,
@@ -225,7 +226,7 @@ export function AccessRequestCheckout() {
                 goToRequests: goToRequestsList,
               })
             }
-            reset={closeCheckout}
+            reset={reset}
             data={data}
             createAttempt={createRequestAttempt}
             resourceRequestRoles={resourceRequestRoles}

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -43,6 +43,7 @@ import { ShowResources } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb'
 import { DefaultTab } from 'gen-proto-ts/teleport/userpreferences/v1/unified_resource_preferences_pb';
 
 import { NodeSubKind } from 'shared/services';
+import { waitForever } from 'shared/utils/wait';
 
 import { UserPreferences } from 'teleterm/services/tshd/types';
 import { UnifiedResourceResponse } from 'teleterm/ui/services/resources';
@@ -510,18 +511,4 @@ function NoResources(props: {
       {$content}
     </Flex>
   );
-}
-
-function waitForever(abortSignal: AbortSignal): Promise<never> {
-  if (abortSignal.aborted) {
-    return Promise.reject(new DOMException('Wait was aborted.', 'AbortError'));
-  }
-
-  return new Promise((_, reject) => {
-    const abort = () => {
-      reject(new DOMException('Wait was aborted.', 'AbortError'));
-    };
-
-    abortSignal.addEventListener('abort', abort, { once: true });
-  });
 }

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -230,8 +230,6 @@ const Resources = memo(
     const { fetch, resources, attempt, clear } = useUnifiedResourcesFetch({
       fetchFunc: useCallback(
         async (paginationParams, signal) => {
-          const showRequestableResources =
-            props.showResources === ShowResources.REQUESTABLE;
           const response = await retryWithRelogin(
             appContext,
             props.clusterUri,
@@ -239,7 +237,7 @@ const Resources = memo(
               appContext.resourcesService.listUnifiedResources(
                 {
                   clusterUri: props.clusterUri,
-                  searchAsRoles: showRequestableResources,
+                  searchAsRoles: false,
                   sortBy: {
                     isDesc: props.queryParams.sort.dir === 'DESC',
                     field: props.queryParams.sort.fieldName,
@@ -250,7 +248,8 @@ const Resources = memo(
                   pinnedOnly: props.queryParams.pinnedOnly,
                   startKey: paginationParams.startKey,
                   limit: paginationParams.limit,
-                  includeRequestable: showRequestableResources,
+                  includeRequestable:
+                    props.showResources === ShowResources.REQUESTABLE,
                 },
                 signal
               )

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -204,7 +204,7 @@ export function UnifiedResources(props: {
       discoverUrl={discoverUrl}
       // Reset the component state when query params object change.
       // JSON.stringify on the same object will always produce the same string.
-      key={JSON.stringify(mergedParams)}
+      key={`${JSON.stringify(mergedParams)}-${rootCluster.showResources}`}
     />
   );
 }
@@ -230,6 +230,10 @@ const Resources = memo(
     const { fetch, resources, attempt, clear } = useUnifiedResourcesFetch({
       fetchFunc: useCallback(
         async (paginationParams, signal) => {
+          // Do not make the call if we don't know what resources we should show.
+          if (props.showResources === ShowResources.UNSPECIFIED) {
+            return { startKey: '', agents: [] };
+          }
           const response = await retryWithRelogin(
             appContext,
             props.clusterUri,
@@ -258,7 +262,6 @@ const Resources = memo(
           return {
             startKey: response.nextKey,
             agents: response.resources,
-            totalCount: response.resources.length,
           };
         },
         [

--- a/web/packages/teleterm/src/ui/Search/actions.tsx
+++ b/web/packages/teleterm/src/ui/Search/actions.tsx
@@ -29,6 +29,7 @@ import {
 } from 'teleterm/ui/services/workspacesService';
 import { retryWithRelogin, assertUnreachable } from 'teleterm/ui/utils';
 import { routing } from 'teleterm/ui/uri';
+import { ResourceRequest } from 'teleterm/ui/services/workspacesService/accessRequestsService';
 
 export interface SimpleAction {
   type: 'simple-action';
@@ -76,6 +77,14 @@ export function mapToAction(
 ): SearchAction {
   switch (result.kind) {
     case 'server': {
+      if (result.requiresRequest) {
+        return {
+          type: 'simple-action',
+          searchResult: result,
+          perform: () => addResourceToRequest(ctx, result),
+        };
+      }
+
       return {
         type: 'parametrized-action',
         searchResult: result,
@@ -104,6 +113,14 @@ export function mapToAction(
       };
     }
     case 'kube': {
+      if (result.requiresRequest) {
+        return {
+          type: 'simple-action',
+          searchResult: result,
+          perform: () => addResourceToRequest(ctx, result),
+        };
+      }
+
       return {
         type: 'simple-action',
         searchResult: result,
@@ -120,6 +137,14 @@ export function mapToAction(
       };
     }
     case 'app': {
+      if (result.requiresRequest) {
+        return {
+          type: 'simple-action',
+          searchResult: result,
+          perform: () => addResourceToRequest(ctx, result),
+        };
+      }
+
       if (result.resource.awsConsole) {
         return {
           type: 'parametrized-action',
@@ -156,6 +181,14 @@ export function mapToAction(
       };
     }
     case 'database': {
+      if (result.requiresRequest) {
+        return {
+          type: 'simple-action',
+          searchResult: result,
+          perform: () => addResourceToRequest(ctx, result),
+        };
+      }
+
       return {
         type: 'parametrized-action',
         searchResult: result,
@@ -259,5 +292,19 @@ export function mapToAction(
     }
     default:
       assertUnreachable(result);
+  }
+}
+
+async function addResourceToRequest(
+  ctx: IAppContext,
+  resource: ResourceRequest
+): Promise<void> {
+  const rootClusterUri = routing.ensureRootClusterUri(resource.resource.uri);
+  const { isAtDesiredWorkspace } =
+    await ctx.workspacesService.setActiveWorkspace(rootClusterUri);
+  if (isAtDesiredWorkspace) {
+    await ctx.workspacesService
+      .getWorkspaceAccessRequestsService(rootClusterUri)
+      .addResource(resource);
   }
 }

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -608,7 +608,11 @@ export function ServerItem(props: SearchResultItem<SearchResultServer>) {
   );
 
   return (
-    <IconAndContent Icon={icons.Server} iconColor="brand">
+    <IconAndContent
+      Icon={icons.Server}
+      iconColor="brand"
+      iconOpacity={getRequestableResourceIconOpacity(props.searchResult)}
+    >
       <Flex
         justifyContent="space-between"
         alignItems="center"
@@ -616,7 +620,9 @@ export function ServerItem(props: SearchResultItem<SearchResultServer>) {
         gap={1}
       >
         <Text typography="body1">
-          Connect over SSH to{' '}
+          {props.searchResult.requiresRequest
+            ? 'Request access to server '
+            : 'Connect over SSH to '}
           <strong>
             <HighlightField field="hostname" searchResult={searchResult} />
           </strong>
@@ -682,7 +688,11 @@ export function DatabaseItem(props: SearchResultItem<SearchResultDatabase>) {
   );
 
   return (
-    <IconAndContent Icon={icons.Database} iconColor="brand">
+    <IconAndContent
+      Icon={icons.Database}
+      iconColor="brand"
+      iconOpacity={getRequestableResourceIconOpacity(props.searchResult)}
+    >
       <Flex
         justifyContent="space-between"
         alignItems="center"
@@ -690,7 +700,9 @@ export function DatabaseItem(props: SearchResultItem<SearchResultDatabase>) {
         gap={1}
       >
         <Text typography="body1">
-          Set up a db connection to{' '}
+          {props.searchResult.requiresRequest
+            ? 'Request access to db '
+            : 'Set up a db connection to '}
           <strong>
             <HighlightField field="name" searchResult={searchResult} />
           </strong>
@@ -759,14 +771,20 @@ export function AppItem(props: SearchResultItem<SearchResultApp>) {
   );
 
   return (
-    <IconAndContent Icon={icons.Application} iconColor="brand">
+    <IconAndContent
+      Icon={icons.Application}
+      iconColor="brand"
+      iconOpacity={getRequestableResourceIconOpacity(props.searchResult)}
+    >
       <Flex
         justifyContent="space-between"
         alignItems="center"
         flexWrap="wrap"
         gap={1}
       >
-        <Text typography="body1">{getAppItemCopy($appName, app)}</Text>
+        <Text typography="body1">
+          {getAppItemCopy($appName, app, searchResult.requiresRequest)}
+        </Text>
         <Box ml="auto">
           <Text typography="body2" fontSize={0}>
             {props.getOptionalClusterName(app.uri)}
@@ -789,7 +807,14 @@ export function AppItem(props: SearchResultItem<SearchResultApp>) {
   );
 }
 
-function getAppItemCopy($appName: React.JSX.Element, app: tsh.App) {
+function getAppItemCopy(
+  $appName: React.JSX.Element,
+  app: tsh.App,
+  requiresRequest: boolean
+) {
+  if (requiresRequest) {
+    return <>Request access to app {$appName}</>;
+  }
   if (app.samlApp) {
     return <>Log in to {$appName} in the browser</>;
   }
@@ -803,7 +828,11 @@ export function KubeItem(props: SearchResultItem<SearchResultKube>) {
   const { searchResult } = props;
 
   return (
-    <IconAndContent Icon={icons.Kubernetes} iconColor="brand">
+    <IconAndContent
+      Icon={icons.Kubernetes}
+      iconColor="brand"
+      iconOpacity={getRequestableResourceIconOpacity(props.searchResult)}
+    >
       <Flex
         justifyContent="space-between"
         alignItems="center"
@@ -811,7 +840,9 @@ export function KubeItem(props: SearchResultItem<SearchResultKube>) {
         gap={1}
       >
         <Text typography="body1">
-          Log in to Kubernetes cluster{' '}
+          {props.searchResult.requiresRequest
+            ? 'Request access to Kubernetes cluster '
+            : 'Log in to Kubernetes cluster '}
           <strong>
             <HighlightField field="name" searchResult={searchResult} />
           </strong>
@@ -1122,4 +1153,9 @@ function ContentAndAdvancedSearch(
       )}
     </Flex>
   );
+}
+
+function getRequestableResourceIconOpacity(args: { requiresRequest: boolean }) {
+  // Unified resources use 0.5 opacity for the requestable resources.
+  return args.requiresRequest ? 0.5 : 1;
 }

--- a/web/packages/teleterm/src/ui/Search/pickers/ResultList.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ResultList.tsx
@@ -197,13 +197,20 @@ export function IconAndContent(
   props: React.PropsWithChildren<{
     Icon: React.ComponentType<IconProps>;
     iconColor: string;
+    iconOpacity?: number;
   }>
 ) {
   return (
     <Flex alignItems="flex-start" gap={2}>
       {/* lineHeight of the icon needs to match the line height of the first row of props.children */}
       <Flex height="24px">
-        <props.Icon color={props.iconColor} size="medium" />
+        <props.Icon
+          color={props.iconColor}
+          size="medium"
+          style={{
+            opacity: props.iconOpacity,
+          }}
+        />
       </Flex>
       <Flex flexDirection="column" gap={1} minWidth={0} flex="1">
         {props.children}

--- a/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
@@ -175,6 +175,22 @@ const SearchResultItems = () => {
       }),
     }),
     makeResourceResult({
+      kind: 'server',
+      requiresRequest: true,
+      resource: makeServer({
+        hostname: 'long-label-list',
+        uri: `${clusterUri}/servers/2f96e498-88ec-442f-a25b-569fa915041c`,
+        name: '2f96e498-88ec-442f-a25b-569fa915041c',
+        labels: makeLabelsList({
+          arch: 'aarch64',
+          external: '32.192.113.93',
+          internal: '10.0.0.175',
+          kernel: '5.13.0-1234-aws',
+          service: 'ansible',
+        }),
+      }),
+    }),
+    makeResourceResult({
       kind: 'app',
       resource: makeAppWithAddr({
         uri: `${clusterUri}/apps/web-app`,
@@ -284,6 +300,23 @@ const SearchResultItems = () => {
     }),
 
     makeResourceResult({
+      kind: 'app',
+      requiresRequest: true,
+      resource: makeAppWithAddr({
+        uri: `${clusterUri}/apps/web-app`,
+        name: 'web-app',
+        endpointUri: 'http://localhost:3000',
+        desc: '',
+        labels: makeLabelsList({
+          access: 'cloudwatch-metrics,ec2,s3,cloudtrail',
+          'aws/Environment': 'demo-13-biz',
+          'aws/Owner': 'foobar',
+          env: 'dev',
+          'teleport.dev/origin': 'config-file',
+        }),
+      }),
+    }),
+    makeResourceResult({
       kind: 'database',
       resource: makeDatabase({
         uri: `${clusterUri}/dbs/no-desc`,
@@ -373,6 +406,25 @@ const SearchResultItems = () => {
       }),
     }),
     makeResourceResult({
+      kind: 'database',
+      requiresRequest: true,
+      resource: makeDatabase({
+        uri: `${clusterUri}/dbs/no-desc`,
+        name: 'no-desc',
+        desc: '',
+        labels: makeLabelsList({
+          'aws/Accounting': 'dev-ops',
+          'aws/Environment': 'demo-13-biz',
+          'aws/Name': 'db-bastion-4-13biz',
+          'aws/Owner': 'foobar',
+          'aws/Service': 'teleport-db',
+          engine: '🐘',
+          env: 'dev',
+          'teleport.dev/origin': 'config-file',
+        }),
+      }),
+    }),
+    makeResourceResult({
       kind: 'kube',
       resource: makeKube({
         name: 'short-label-list',
@@ -402,6 +454,18 @@ const SearchResultItems = () => {
       resource: makeKube({
         name: 'super-long-kube-name-with-uuid-2f96e498-88ec-442f-a25b-569fa915041c',
         uri: `/clusters/teleport-very-long-cluster-name-with-uuid-2f96e498-88ec-442f-a25b-569fa915041c/kubes/super-long-desc`,
+        labels: makeLabelsList({
+          'im-just-a-smol': 'kube',
+          kube: 'kubersson',
+          with: 'little-to-no-labels',
+        }),
+      }),
+    }),
+    makeResourceResult({
+      kind: 'kube',
+      requiresRequest: true,
+      resource: makeKube({
+        name: 'short-label-list',
         labels: makeLabelsList({
           'im-just-a-smol': 'kube',
           kube: 'kubersson',

--- a/web/packages/teleterm/src/ui/Search/testHelpers.ts
+++ b/web/packages/teleterm/src/ui/Search/testHelpers.ts
@@ -27,5 +27,6 @@ export const makeResourceResult = (
   score: 0,
   labelMatches: [],
   resourceMatches: [],
+  requiresRequest: false,
   ...props,
 });

--- a/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
@@ -54,6 +54,33 @@ describe('rankResults', () => {
     expect(sortedResults[1]).toEqual(server);
   });
 
+  it('prefers accessible resources over requestable ones', () => {
+    const serverAccessible = makeResourceResult({
+      kind: 'server',
+      resource: makeServer({ hostname: 'sales-foo' }),
+    });
+    const serverRequestable = makeResourceResult({
+      kind: 'server',
+      resource: makeServer({ hostname: 'sales-bar' }),
+      requiresRequest: true,
+    });
+    const labelMatch = makeResourceResult({
+      kind: 'server',
+      resource: makeServer({
+        hostname: 'lorem-ipsum',
+        labels: makeLabelsList({ foo: 'sales' }),
+      }),
+    });
+    const sortedResults = rankResults(
+      [labelMatch, serverRequestable, serverAccessible],
+      'sales'
+    );
+
+    expect(sortedResults[0].resource).toEqual(serverAccessible.resource);
+    expect(sortedResults[1].resource).toEqual(serverRequestable.resource);
+    expect(sortedResults[2].resource).toEqual(labelMatch.resource);
+  });
+
   it('saves individual label match scores', () => {
     const server = makeResourceResult({
       kind: 'server',

--- a/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
@@ -140,6 +140,7 @@ describe('useResourceSearch', () => {
       .map(() => ({
         kind: 'server' as const,
         resource: makeServer({}),
+        requiresRequest: false,
       }));
     jest
       .spyOn(appContext.resourcesService, 'searchResources')
@@ -160,6 +161,7 @@ describe('useResourceSearch', () => {
       search: 'foo',
       filters: [],
       limit: 100,
+      includeRequestable: true,
     });
     expect(appContext.resourcesService.searchResources).toHaveBeenCalledTimes(
       1
@@ -191,6 +193,7 @@ describe('useResourceSearch', () => {
       search: '',
       filters: [],
       limit: 10,
+      includeRequestable: true,
     });
     expect(appContext.resourcesService.searchResources).toHaveBeenCalledTimes(
       1

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -364,9 +364,9 @@ function calculateScore(
     searchResultScore += resourceMatchScore;
   }
 
-  // Show resources that require access at the bottom.
+  // Show resources that require access lower in the results.
   if (searchResult.requiresRequest) {
-    searchResultScore *= 0.1;
+    searchResultScore *= 0.95;
   }
 
   return { ...searchResult, labelMatches, score: searchResultScore };

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -18,6 +18,8 @@
 
 import { useCallback } from 'react';
 
+import { ShowResources } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
+
 import { assertUnreachable } from 'teleterm/ui/utils';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 
@@ -124,6 +126,8 @@ export function useResourceSearch() {
             search,
             filters: resourceTypeSearchFilters.map(f => f.resourceType),
             limit,
+            includeRequestable:
+              cluster.showResources === ShowResources.REQUESTABLE,
           })
         )
       );
@@ -358,6 +362,11 @@ function calculateScore(
 
     const resourceMatchScore = getLengthScore(searchTerm, field) * weight;
     searchResultScore += resourceMatchScore;
+  }
+
+  // Show resources that require access at the bottom.
+  if (searchResult.requiresRequest) {
+    searchResultScore *= 0.1;
   }
 
   return { ...searchResult, labelMatches, score: searchResultScore };

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
@@ -139,6 +139,7 @@ describe('searchResources', () => {
       search: '',
       filters: [],
       limit: 10,
+      includeRequestable: true,
     });
     expect(searchResults).toHaveLength(4);
 
@@ -167,6 +168,7 @@ describe('searchResources', () => {
       search: '',
       filters: [],
       limit: 10,
+      includeRequestable: true,
     });
     await expect(searchResults).rejects.toThrow(
       new ResourceSearchError('/clusters/foo', expectedCause)

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -126,7 +126,7 @@ export class ResourcesService {
         limit,
         search,
         query: '',
-        searchAsRoles: includeRequestable,
+        searchAsRoles: false,
         pinnedOnly: false,
         startKey: '',
         sortBy: { field: 'name', isDesc: true },

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -111,11 +111,13 @@ export class ResourcesService {
     search,
     filters,
     limit,
+    includeRequestable,
   }: {
     clusterUri: uri.ClusterUri;
     search: string;
     filters: ResourceTypeFilter[];
     limit: number;
+    includeRequestable: boolean;
   }): Promise<SearchResult[]> {
     try {
       const { resources } = await this.listUnifiedResources({
@@ -124,11 +126,11 @@ export class ResourcesService {
         limit,
         search,
         query: '',
-        searchAsRoles: false,
+        searchAsRoles: includeRequestable,
         pinnedOnly: false,
         startKey: '',
         sortBy: { field: 'name', isDesc: true },
-        includeRequestable: false, //TODO(gzdunek): Support requestable resources in the search bar.
+        includeRequestable,
       });
       return resources.map(r => {
         if (r.kind === 'app') {
@@ -238,15 +240,25 @@ export class ResourceSearchError extends Error {
   }
 }
 
-export type SearchResultServer = { kind: 'server'; resource: types.Server };
+export type SearchResultServer = {
+  kind: 'server';
+  resource: types.Server;
+  requiresRequest: boolean;
+};
 export type SearchResultDatabase = {
   kind: 'database';
   resource: types.Database;
+  requiresRequest: boolean;
 };
-export type SearchResultKube = { kind: 'kube'; resource: types.Kube };
+export type SearchResultKube = {
+  kind: 'kube';
+  resource: types.Kube;
+  requiresRequest: boolean;
+};
 export type SearchResultApp = {
   kind: 'app';
   resource: types.App & { addrWithProtocol: string };
+  requiresRequest: boolean;
 };
 
 export type SearchResult =

--- a/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.test.ts
@@ -298,3 +298,36 @@ test('updates the request when the user tries to mix roles with resources and ag
     },
   });
 });
+
+test('adding the same resource twice with addResource does not toggle it', async () => {
+  const { accessRequestsService } = getTestSetup(
+    getMockPendingResourceAccessRequest()
+  );
+
+  const server = makeServer({
+    uri: `/clusters/${rootClusterUri}/servers/foo1`,
+    hostname: 'foo1',
+  });
+
+  // Try to add the same resource twice.
+  await accessRequestsService.addResource({
+    kind: 'server',
+    resource: server,
+  });
+  await accessRequestsService.addResource({
+    kind: 'server',
+    resource: server,
+  });
+
+  const pendingRequest = accessRequestsService.getPendingAccessRequest();
+  expect(
+    pendingRequest.kind === 'resource' &&
+      pendingRequest.resources.get(server.uri)
+  ).toStrictEqual({
+    kind: 'server',
+    resource: {
+      hostname: server.hostname,
+      uri: server.uri,
+    },
+  });
+});

--- a/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
@@ -112,6 +112,9 @@ export class AccessRequestsService {
 
       const { resources } = draftState.pending;
 
+      if (resources.has(request.resource.uri)) {
+        return;
+      }
       resources.set(request.resource.uri, getRequiredProperties(request));
     });
   }

--- a/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
@@ -76,10 +76,7 @@ export class AccessRequestsService {
     }
   }
 
-  async addOrRemoveResource({
-    kind,
-    resource,
-  }: ResourceRequest): Promise<void> {
+  async addOrRemoveResource(request: ResourceRequest): Promise<void> {
     if (!(await this.canUpdateRequest('resource'))) {
       return;
     }
@@ -93,22 +90,29 @@ export class AccessRequestsService {
 
       const { resources } = draftState.pending;
 
-      if (resources.has(resource.uri)) {
-        resources.delete(resource.uri);
+      if (resources.has(request.resource.uri)) {
+        resources.delete(request.resource.uri);
       } else {
-        // Store only properties required by the type.
-        if (kind === 'server') {
-          resources.set(resource.uri, {
-            kind,
-            resource: { uri: resource.uri, hostname: resource.hostname },
-          });
-        } else {
-          resources.set(resource.uri, {
-            kind,
-            resource: { uri: resource.uri },
-          });
-        }
+        resources.set(request.resource.uri, getRequiredProperties(request));
       }
+    });
+  }
+
+  async addResource(request: ResourceRequest): Promise<void> {
+    if (!(await this.canUpdateRequest('resource'))) {
+      return;
+    }
+    this.setState(draftState => {
+      if (draftState.pending.kind !== 'resource') {
+        draftState.pending = {
+          kind: 'resource',
+          resources: new Map(),
+        };
+      }
+
+      const { resources } = draftState.pending;
+
+      resources.set(request.resource.uri, getRequiredProperties(request));
     });
   }
 
@@ -156,6 +160,23 @@ export class AccessRequestsService {
     }
     return shouldProceed;
   }
+}
+
+/** Returns only the properties required by the type. */
+function getRequiredProperties({
+  kind,
+  resource,
+}: ResourceRequest): ResourceRequest {
+  if (kind === 'server') {
+    return {
+      kind,
+      resource: { uri: resource.uri, hostname: resource.hostname },
+    };
+  }
+  return {
+    kind,
+    resource: { uri: resource.uri },
+  };
 }
 
 /** Returns an empty access request. We default to the resource access request. */


### PR DESCRIPTION
In addition to requesting resources from the unified view, we can do this also from the search bar.

<img width="1272" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/6e28b62c-cd2d-405b-8081-baf031ed068c">

To keep the search bar simple, I always show `Request access to...` for requestable resources, even if they were already added to the request. I didn't want to make the search bar more complex with additional states.



