### PR TITLE
chore: Bump golangci-lint to v1.59.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -166,6 +166,11 @@ linters-settings:
     context: all
     key-naming-case: snake
     static-msg: true
+    forbidden-keys:
+      - level
+      - msg
+      - source
+      - time
   testifylint:
     disable-all: true
     enable:

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.22.4
-GOLANGCI_LINT_VERSION ?= v1.58.1
+GOLANGCI_LINT_VERSION ?= v1.59.1
 
 NODE_VERSION ?= 20.13.0
 

--- a/integrations/access/email/testlib/suite.go
+++ b/integrations/access/email/testlib/suite.go
@@ -102,8 +102,8 @@ func (s *EmailBaseSuite) SetupTest() {
 
 // startApp starts the email plugin, waits for it to become ready and returns.
 func (s *EmailBaseSuite) startApp() {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
 
 	app, err := email.NewApp(s.appConfig)
 	require.NoError(t, err)

--- a/integrations/access/jira/testlib/helpers.go
+++ b/integrations/access/jira/testlib/helpers.go
@@ -73,8 +73,8 @@ func (s *JiraBaseSuite) postWebhook(ctx context.Context, url, issueID, status st
 }
 
 func (s *JiraBaseSuite) postWebhookAndCheck(ctx context.Context, url, issueID, status string) {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
 
 	resp, err := s.postWebhook(ctx, url, issueID, status)
 	require.NoError(t, err)

--- a/integrations/access/jira/testlib/suite.go
+++ b/integrations/access/jira/testlib/suite.go
@@ -89,8 +89,8 @@ func (s *JiraBaseSuite) SetupTest() {
 
 // startApp starts the discord plugin, waits for it to become ready and returns,
 func (s *JiraBaseSuite) startApp() {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
 
 	app, err := jira.NewApp(s.appConfig)
 	require.NoError(t, err)

--- a/integrations/access/msteams/testlib/suite.go
+++ b/integrations/access/msteams/testlib/suite.go
@@ -82,8 +82,8 @@ func (s *MsTeamsBaseSuite) SetupTest() {
 
 // startApp starts the Slack plugin, waits for it to become ready and returns.
 func (s *MsTeamsBaseSuite) startApp() {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
 
 	app, err := msteams.NewApp(*s.appConfig)
 	require.NoError(t, err)

--- a/integrations/access/opsgenie/testlib/suite.go
+++ b/integrations/access/opsgenie/testlib/suite.go
@@ -97,8 +97,8 @@ func (s *OpsgenieBaseSuite) SetupTest() {
 
 // startApp starts the OpsGenie plugin, waits for it to become ready and returns.
 func (s *OpsgenieBaseSuite) startApp() {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
 
 	app, err := opsgenie.NewOpsgenieApp(context.Background(), &s.appConfig)
 	require.NoError(t, err)

--- a/integrations/access/pagerduty/testlib/suite.go
+++ b/integrations/access/pagerduty/testlib/suite.go
@@ -123,8 +123,8 @@ func (s *PagerdutyBaseSuite) SetupTest() {
 
 // startApp starts the Pagerduty plugin, waits for it to become ready and returns.
 func (s *PagerdutyBaseSuite) startApp() {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
 
 	app, err := pagerduty.NewApp(s.appConfig)
 	require.NoError(t, err)
@@ -451,8 +451,8 @@ func (s *PagerdutyBaseSuite) assertNoNewEvents(ctx context.Context, watcher type
 }
 
 func (s *PagerdutyBaseSuite) assertReviewSubmitted(ctx context.Context, userName string) {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
 
 	watcher, err := s.Ruler().NewWatcher(ctx, types.Watch{
 		Kinds: []types.WatchKind{{Kind: types.KindAccessRequest}},
@@ -481,8 +481,8 @@ func (s *PagerdutyBaseSuite) assertReviewSubmitted(ctx context.Context, userName
 }
 
 func (s *PagerdutyBaseSuite) assertNoReviewSubmitted(ctx context.Context, userName string) {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
 
 	watcher, err := s.Ruler().NewWatcher(ctx, types.Watch{
 		Kinds: []types.WatchKind{{Kind: types.KindAccessRequest}},

--- a/integrations/access/servicenow/testlib/suite.go
+++ b/integrations/access/servicenow/testlib/suite.go
@@ -83,8 +83,9 @@ func (s *ServiceNowBaseSuite) SetupTest() {
 
 // startApp starts the ServiceNow plugin, waits for it to become ready and returns.
 func (s *ServiceNowBaseSuite) startApp() {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 

--- a/integrations/access/slack/testlib/helpers.go
+++ b/integrations/access/slack/testlib/helpers.go
@@ -135,6 +135,8 @@ func channelsToMessages(channels ...string) (messages []slack.Message) {
 type slackCheckMessage func(context.Context) (slack.Message, error)
 
 func (s *SlackBaseSuite) matchAndCallFn(t *testing.T, ctx context.Context, matchMessages []slack.Message, matchBy matchFn, testFns []checkMsgTestFn, slackCall slackCheckMessage) []slack.Message {
+	s.T().Helper()
+
 	matchingTimestamps := map[string]slack.Message{}
 
 	for _, matchMessage := range matchMessages {

--- a/integrations/access/slack/testlib/suite.go
+++ b/integrations/access/slack/testlib/suite.go
@@ -886,6 +886,7 @@ func (s *SlackSuiteEnterprise) TestAccessListReminder() {
 }
 
 func (s *SlackBaseSuite) requireReminderMsgEqual(ctx context.Context, id, text string) {
+	s.T().Helper()
 	t := s.T()
 
 	msg, err := s.fakeSlack.CheckNewMessage(ctx)

--- a/integrations/event-handler/event_handler_test.go
+++ b/integrations/event-handler/event_handler_test.go
@@ -127,6 +127,7 @@ func (s *EventHandlerSuite) SetupTest() {
 }
 
 func (s *EventHandlerSuite) startApp() {
+	s.T().Helper()
 	t := s.T()
 	t.Helper()
 

--- a/integrations/lib/testing/integration/accessrequestsuite.go
+++ b/integrations/lib/testing/integration/accessrequestsuite.go
@@ -259,6 +259,7 @@ func (s *AccessRequestSuite) SetupSuite() {
 // newClientForUser creates a teleport client for a give user.
 // The user must be created beforehand.
 func (s *AccessRequestSuite) newClientForUser(ctx context.Context, user types.User) *client.Client {
+	s.T().Helper()
 	t := s.T()
 	creds := s.AuthHelper.CredentialsForUser(t, ctx, user)
 	clientConfig := client.Config{
@@ -314,6 +315,7 @@ func (s *AccessRequestSuite) ClientByName(name string) *Client {
 // The access request reason can be padded with "A" by setting
 // SetReasonPadding.
 func (s *AccessRequestSuite) NewAccessRequest(userName string, suggestedReviewers []string, padding int) types.AccessRequest {
+	s.T().Helper()
 	t := s.T()
 	t.Helper()
 
@@ -332,8 +334,8 @@ func (s *AccessRequestSuite) NewAccessRequest(userName string, suggestedReviewer
 
 // CreateAccessRequest creates a new access request and submits it.
 func (s *AccessRequestSuite) CreateAccessRequest(ctx context.Context, userName string, suggestedReviewers []string) types.AccessRequest {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
 
 	req := s.NewAccessRequest(userName, suggestedReviewers, s.requestPadding)
 	out, err := s.ClientByName(userName).CreateAccessRequestV2(ctx, req)

--- a/integrations/lib/testing/integration/suite.go
+++ b/integrations/lib/testing/integration/suite.go
@@ -108,8 +108,8 @@ func (s *Suite) initContexts(oldT *testing.T, newT *testing.T) {
 
 // SetContextTimeout limits the lifetime of test and app contexts.
 func (s *Suite) SetContextTimeout(timeout time.Duration) context.Context {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
 
 	contexts, ok := s.contexts[t]
 	require.True(t, ok)
@@ -129,8 +129,8 @@ func (s *Suite) SetContextTimeout(timeout time.Duration) context.Context {
 
 // Context returns a current test context.
 func (s *Suite) Context() context.Context {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
 	contexts, ok := s.contexts[t]
 	require.True(t, ok)
 	return contexts.testCtx
@@ -138,8 +138,8 @@ func (s *Suite) Context() context.Context {
 
 // NewTmpFile creates a new temporary file.
 func (s *Suite) NewTmpFile(pattern string) *os.File {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
 
 	file, err := os.CreateTemp("", pattern)
 	require.NoError(t, err)
@@ -152,8 +152,8 @@ func (s *Suite) NewTmpFile(pattern string) *os.File {
 
 // StartApp spawns an app in parallel with the running test/suite.
 func (s *Suite) StartApp(app AppI) {
+	s.T().Helper()
 	t := s.T()
-	t.Helper()
 
 	contexts, ok := s.contexts[t]
 	require.True(t, ok)

--- a/integrations/terraform/testlib/main_test.go
+++ b/integrations/terraform/testlib/main_test.go
@@ -164,6 +164,8 @@ func (s *TerraformBaseSuite) SetupSuite() {
 }
 
 func (s *TerraformBaseSuite) getTLSCreds(ctx context.Context, user types.User, outputPath string) {
+	s.T().Helper()
+
 	key, err := libclient.GenerateRSAKey()
 	require.NoError(s.T(), err)
 
@@ -200,6 +202,7 @@ func (s *TerraformBaseSuite) SetupTest() {
 }
 
 func (s *TerraformBaseSuite) closeClient() {
+	s.T().Helper()
 	p, ok := s.terraformProvider.(*provider.Provider)
 	require.True(s.T(), ok)
 	if p != nil && p.Client != nil {

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -896,7 +896,7 @@ func TestFormatConnectToProxyErr(t *testing.T) {
 			}
 
 			if tt.wantUserMessage != "" {
-				require.NotNil(t, traceErr)
+				require.Error(t, traceErr)
 				require.Contains(t, traceErr.Messages, tt.wantUserMessage)
 			}
 		})

--- a/lib/integrations/awsoidc/idp_iam_config.go
+++ b/lib/integrations/awsoidc/idp_iam_config.go
@@ -345,7 +345,7 @@ func ConfigureIdPIAM(ctx context.Context, clt IdPIAMConfigureClient, req IdPIAMC
 	}
 	log := slog.With(
 		"bucket", req.s3Bucket,
-		"bucket-prefix", req.s3BucketPrefix,
+		"bucket_prefix", req.s3BucketPrefix,
 	)
 
 	log.InfoContext(ctx, "Creating bucket in region", "region", clt.RegionForCreateBucket())

--- a/lib/integrations/samlidp/gcpworkforce.go
+++ b/lib/integrations/samlidp/gcpworkforce.go
@@ -108,7 +108,7 @@ func (s *GCPWorkforceService) CreateWorkforcePoolAndProvider(ctx context.Context
 		if err := waitForPoolStatus(pollCtx, workforceService, poolFullName, s.APIParams.PoolName); err != nil {
 			return trace.Wrap(err)
 		}
-		slog.With("pool_name", s.APIParams.PoolName, "Pool ready for use.")
+		slog.With("pool_name", s.APIParams.PoolName).InfoContext(ctx, "Pool ready for use.")
 	}
 
 	return s.createWorkforceProvider(ctx, workforceService, poolFullName)

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1179,7 +1179,7 @@ func (process *TeleportProcess) newClient(identity *state.Identity) (*authclient
 	// for config v1 and v2, attempt to directly connect to the auth server and fall back to tunneling
 	case defaults.TeleportConfigVersionV1, defaults.TeleportConfigVersionV2:
 		// if we don't have a proxy address, try to connect to the auth server directly
-		logger := process.logger.With("auth-addrs", utils.NetAddrsToStrings(authServers))
+		logger := process.logger.With("auth_addrs", utils.NetAddrsToStrings(authServers))
 
 		directClient, resp, directErr := connectToAuthServer(logger)
 		if directErr == nil {
@@ -1218,7 +1218,7 @@ func (process *TeleportProcess) newClient(identity *state.Identity) (*authclient
 	case defaults.TeleportConfigVersionV3:
 		proxyServer := process.Config.ProxyServer
 		if !proxyServer.IsEmpty() {
-			logger := process.logger.With("proxy-server", proxyServer.String())
+			logger := process.logger.With("proxy_server", proxyServer.String())
 			logger.DebugContext(process.ExitContext(), "Attempting to connect to Auth Server through tunnel.")
 
 			tunnelClient, pingResponse, err := process.newClientThroughTunnel(tlsConfig, sshClientConfig, identity.ID.Role)
@@ -1232,7 +1232,7 @@ func (process *TeleportProcess) newClient(identity *state.Identity) (*authclient
 		}
 
 		// if we don't have a proxy address, try to connect to the auth server directly
-		logger := process.logger.With("auth-server", utils.NetAddrsToStrings(authServers))
+		logger := process.logger.With("auth_server", utils.NetAddrsToStrings(authServers))
 
 		return connectToAuthServer(logger)
 	}

--- a/lib/srv/desktop/rdp/rdpclient/client_common.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_common.go
@@ -91,7 +91,7 @@ func (c *Config) checkAndSetDefaults() error {
 	if c.Encoder == nil {
 		c.Encoder = tdp.PNGEncoder()
 	}
-	c.Logger = c.Logger.With("rdp-addr", c.Addr)
+	c.Logger = c.Logger.With("rdp_addr", c.Addr)
 	return nil
 }
 

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -710,7 +710,7 @@ func (s *WindowsService) handleConnection(proxyConn *tls.Conn) {
 		sendTDPError("Internal error.")
 		return
 	}
-	log = log.With("client-ip", remoteAddr)
+	log = log.With("client_ip", remoteAddr)
 	if err := s.cfg.ConnLimiter.AcquireConnection(remoteAddr); err != nil {
 		log.WarnContext(context.Background(), "Connection limit exceeded, rejecting connection")
 		sendTDPError("Connection limit exceeded.")
@@ -736,7 +736,7 @@ func (s *WindowsService) handleConnection(proxyConn *tls.Conn) {
 
 	// Fetch the target desktop info. Name of the desktop is passed via SNI.
 	desktopName := strings.TrimSuffix(proxyConn.ConnectionState().ServerName, SNISuffix)
-	log = log.With("desktop-name", desktopName)
+	log = log.With("desktop_name", desktopName)
 
 	desktops, err := s.cfg.AccessPoint.GetWindowsDesktops(ctx,
 		types.WindowsDesktopFilter{HostID: s.cfg.Heartbeat.HostUUID, Name: desktopName})
@@ -752,7 +752,7 @@ func (s *WindowsService) handleConnection(proxyConn *tls.Conn) {
 	}
 	desktop := desktops[0]
 
-	log = log.With("desktop-addr", desktop.GetAddr())
+	log = log.With("desktop_addr", desktop.GetAddr())
 	log.DebugContext(ctx, "Connecting to Windows desktop")
 	defer log.DebugContext(ctx, "Windows desktop disconnected")
 


### PR DESCRIPTION
Update to the latest release.

* https://github.com/golangci/golangci-lint/releases/tag/v1.59.1
* https://github.com/golangci/golangci-lint/releases/tag/v1.59.0
* https://github.com/golangci/golangci-lint/releases/tag/v1.58.2