### PR TITLE
[v15] Docs: add transition text between role definition and `tctl create`

### DIFF
--- a/docs/pages/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/access-controls/device-trust/device-management.mdx
@@ -238,8 +238,7 @@ management.
 </Admonition>
 
 Following is an example of a role that grants permissions for the `device` resource is necessary to manage
-the inventory. Save the yaml below as `device-admin.yaml` and create it in your
-cluster:
+the inventory. Save the yaml below as `device-admin.yaml`:
 
 ```yaml
 version: v7
@@ -259,6 +258,8 @@ spec:
       - create_enroll_token
       - enroll
 ```
+
+Create the role:
 
 ```code
 $ tctl create -f device-admin.yaml

--- a/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
@@ -67,6 +67,8 @@ spec:
 
 ```
 
+Update the role:
+
 ```code
 $ tctl create -f device-enforcement.yaml
 ```

--- a/docs/pages/access-controls/guides/impersonation.mdx
+++ b/docs/pages/access-controls/guides/impersonation.mdx
@@ -215,6 +215,8 @@ spec:
       '*': '*'
 ```
 
+Create the resources:
+
 ```code
 $ tctl create -f security-impersonator.yaml
 $ tctl users update alice --set-roles=security-impersonator,access

--- a/docs/pages/access-controls/guides/locking.mdx
+++ b/docs/pages/access-controls/guides/locking.mdx
@@ -97,7 +97,7 @@ a lock:
 ERROR: access denied to perform action "create" on "lock"
 ```
 
-Create a role `locksmith`:
+Define a role `locksmith`:
 
 ```yaml
 kind: role
@@ -110,6 +110,8 @@ spec:
       - resources: [lock]
         verbs: [list, create, read, update, delete]
 ```
+
+Create the role:
 
 ```code
 $ tctl create -f locksmith.yaml

--- a/docs/pages/access-controls/sso/one-login.mdx
+++ b/docs/pages/access-controls/sso/one-login.mdx
@@ -144,6 +144,8 @@ spec:
 
 **Notice:** Replace `ubuntu` with linux login available on your servers!
 
+Create the role:
+
 ```code
 $ tctl create -f dev.yaml
 ```

--- a/docs/pages/includes/server-access/custom-installer.mdx
+++ b/docs/pages/includes/server-access/custom-installer.mdx
@@ -14,6 +14,8 @@ spec:
         verbs: [list, create, read, update]
 ```
 
+Create the role:
+
 ```code
 $ tctl create -f installer-manager.yaml
 # role 'installer-manager' has been created


### PR DESCRIPTION
Backport #41941 to branch/v15