### PR TITLE
[v14] Fix CRD field name generation for new fields (partial backport)

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_githubconnectors.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_githubconnectors.yaml
@@ -48,7 +48,7 @@ spec:
                   localhost ones.
                 nullable: true
                 properties:
-                  allowedHttpsHostnames:
+                  allowed_https_hostnames:
                     description: a list of hostnames allowed for https client redirect
                       URLs
                     items:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_oidcconnectors.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_oidcconnectors.yaml
@@ -73,7 +73,7 @@ spec:
                   localhost ones.
                 nullable: true
                 properties:
-                  allowedHttpsHostnames:
+                  allowed_https_hostnames:
                     description: a list of hostnames allowed for https client redirect
                       URLs
                     items:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_samlconnectors.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_samlconnectors.yaml
@@ -88,7 +88,7 @@ spec:
                   localhost ones.
                 nullable: true
                 properties:
-                  allowedHttpsHostnames:
+                  allowed_https_hostnames:
                     description: a list of hostnames allowed for https client redirect
                       URLs
                     items:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_githubconnectors.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_githubconnectors.yaml
@@ -48,7 +48,7 @@ spec:
                   localhost ones.
                 nullable: true
                 properties:
-                  allowedHttpsHostnames:
+                  allowed_https_hostnames:
                     description: a list of hostnames allowed for https client redirect
                       URLs
                     items:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_oidcconnectors.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_oidcconnectors.yaml
@@ -73,7 +73,7 @@ spec:
                   localhost ones.
                 nullable: true
                 properties:
-                  allowedHttpsHostnames:
+                  allowed_https_hostnames:
                     description: a list of hostnames allowed for https client redirect
                       URLs
                     items:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_samlconnectors.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_samlconnectors.yaml
@@ -88,7 +88,7 @@ spec:
                   localhost ones.
                 nullable: true
                 properties:
-                  allowedHttpsHostnames:
+                  allowed_https_hostnames:
                     description: a list of hostnames allowed for https client redirect
                       URLs
                     items:

--- a/integrations/operator/crdgen/tree.go
+++ b/integrations/operator/crdgen/tree.go
@@ -222,8 +222,8 @@ func (field Field) JSONName() string {
 	if res := gogoproto.GetJsonTag(field.desc); res != nil {
 		return strings.Split(*res, ",")[0]
 	}
-	if field.desc.JsonName != nil {
-		return *field.desc.JsonName
+	if field.desc.Name != nil {
+		return *field.desc.Name
 	}
 	return ""
 }


### PR DESCRIPTION
Changelog: Fix the field `allowed_https_hostnames` in the Teleport Operator resources: SAML, OIDC, and GitHub Connector.

This PR backports two lines from https://github.com/gravitational/teleport/pull/31771 that change the way `crdgen` figures out the field name. This ensures the new fields are following snake case, like in other IaC manifests (`tctl`, and TF provider).