### PR TITLE
Add docs for web_idle_timeout

### DIFF
--- a/docs/pages/connect-your-client/web-ui.mdx
+++ b/docs/pages/connect-your-client/web-ui.mdx
@@ -50,7 +50,7 @@ Use `tctl` to edit the `cluster_networking_config` value:
 $ tctl edit cluster_networking_config
 ```
 
-Change the value of `spec.web_idle_timeout` to `saml`:
+Change the value of `spec.web_idle_timeout`:
 
 ```yaml
 kind: cluster_networking_config

--- a/docs/pages/connect-your-client/web-ui.mdx
+++ b/docs/pages/connect-your-client/web-ui.mdx
@@ -30,3 +30,54 @@ From the active sessions list, click **Join** and select a participant mode to j
 You must have the `join_sessions` allow policy in a role you've been assigned to join sessions in any participant mode. 
 For information about how to configure the `join_sessions` allow policy and participant modes for a role, see 
 [Configure an allow policy](../access-controls/guides/moderated-sessions.mdx#configure-an-allow-policy).
+
+## Idle timeout
+
+After the user logs in, the Teleport Web UI checks every 30 seconds if the session is inactive. If
+so, it logs out the user. A session is considered inactive if more than 10 minutes have passed since
+the user last interacted with any Web UI browser tab, either through keyboard input or mouse
+movement and clicks.
+
+The default idle timeout of 10 minutes can be adjusted in the Auth Service configuration through the
+`web_idle_timeout` setting.
+
+<Tabs>
+<TabItem scope={["cloud", "team"]} label="Dynamic Resources (All Editions)">
+
+Use `tctl` to edit the `cluster_networking_config` value:
+
+```code
+$ tctl edit cluster_networking_config
+```
+
+Change the value of `spec.web_idle_timeout` to `saml`:
+
+```yaml
+kind: cluster_networking_config
+metadata:
+  ...
+spec:
+  ...
+  web_idle_timeout: 10m0s
+  ...
+version: v2
+```
+
+After you save and exit the editor, `tctl` will update the resource:
+
+```text
+cluster networking configuration has been updated
+```
+
+</TabItem>
+<TabItem label="Static Config (Self-Hosted)" scope={["oss", "enterprise"]}>
+
+Update `/etc/teleport.yaml` in the `auth_service` section and restart the `teleport` daemon.
+
+```yaml
+auth_service:
+  web_idle_timeout: 10m0s
+```
+
+</TabItem>
+</Tabs>

--- a/docs/pages/connect-your-client/web-ui.mdx
+++ b/docs/pages/connect-your-client/web-ui.mdx
@@ -33,13 +33,12 @@ For information about how to configure the `join_sessions` allow policy and part
 
 ## Idle timeout
 
-After the user logs in, the Teleport Web UI checks every 30 seconds if the session is inactive. If
-so, it logs out the user. A session is considered inactive if more than 10 minutes have passed since
-the user last interacted with any Web UI browser tab, either through keyboard input or mouse
-movement and clicks.
+After you log in, the Teleport Web UI checks every 30 seconds if your session is inactive. If so, it
+logs you out. A session is considered inactive if more than 10 minutes have passed since you last
+interacted with any Web UI browser tab, either through keyboard input or mouse movement and clicks.
 
-The default idle timeout of 10 minutes can be adjusted in the Auth Service configuration through the
-`web_idle_timeout` setting.
+To change the default idle timeout of 10 minutes, ask your cluster admin to adjust the
+`web_idle_timeout` setting in the Auth Service configuration.
 
 <Tabs>
 <TabItem scope={["cloud", "team"]} label="Dynamic Resources (All Editions)">


### PR DESCRIPTION
[Preview](https://docs-3mzv1opjc-goteleport.vercel.app/docs/connect-your-client/web-ui/#idle-timeout)

We got [a ticket from a customer](https://gravitational.zendesk.com/agent/tickets/10685) who asked if it's possible to increase the timeout in Cloud.

It's not easy to figure this out since the idle timeout is not mentioned explicitly anywhere, other than in the config reference. And even if you find it there, then you need to know that that part of auth service config maps to `cluster_networking_config` in Cloud. On top of that, editing `cluster_networking_config` in Cloud clusters used to not work, but this has been fixed a while ago (https://github.com/gravitational/teleport/issues/18829).

I added tabs for dynamic and static config which I copied from the Okta SSO guide. I know we want to remove them from how-to guides (https://github.com/gravitational/teleport/issues/38931), but I think they're fine here? It feels important to show how it can be done in both environments. Let me know if I should replace the tabs with something else.

The docs are based on the relevant piece of code in the Web UI:

https://github.com/gravitational/teleport/blob/dd33d8d5c0ce41eac1d036631aa51418effaeaae/web/packages/teleport/src/components/Authenticated/Authenticated.tsx#L116-L155

https://github.com/gravitational/teleport/blob/dd33d8d5c0ce41eac1d036631aa51418effaeaae/web/packages/teleport/src/components/Authenticated/Authenticated.tsx#L37-L47

Related issues:
* https://github.com/gravitational/teleport/issues/32855