### PR TITLE
Reload teleport config and process after an upgrade

### DIFF
--- a/examples/systemd/post-upgrade
+++ b/examples/systemd/post-upgrade
@@ -8,4 +8,5 @@ set -eu
 # testing in a container.
 if [ -d /run/systemd/system ]; then
     systemctl --system daemon-reload >/dev/null || true
+    systemctl reload teleport.service || true
 fi


### PR DESCRIPTION
Closes #10154 

This PR modifies the post install script of the teleport package. This post install script runs systemctl reload teleport.service to update the teleport process and reload the yaml config

changelog: teleport service is now reloaded on upgrades