### PR TITLE
docs: add `window-size` setting to the Teleport `event-handler`

### DIFF
--- a/docs/pages/includes/plugins/finish-event-handler-config.mdx
+++ b/docs/pages/includes/plugins/finish-event-handler-config.mdx
@@ -9,6 +9,12 @@ storage = "./storage"
 timeout = "10s"
 batch = 20
 namespace = "default"
+# The window size configures the duration of the time window for the event handler
+# to request events from Teleport. By default, this is set to 24 hours.
+# Reduce the window size if the events backend cannot manage the event volume 
+# for the default window size.
+# The window size should be specified as a duration string, parsed by Go's time.ParseDuration.
+window-size = "24h"
 
 [forward.fluentd]
 ca = "/home/bob/event-handler/ca.crt"
@@ -36,6 +42,12 @@ eventHandler:
   timeout: "10s"
   batch: 20
   namespace: "default"
+  # The window size configures the duration of the time window for the event handler
+  # to request events from Teleport. By default, this is set to 24 hours.
+  # Reduce the window size if the events backend cannot manage the event volume 
+  # for the default window size.
+  # The window size should be specified as a duration string, parsed by Go's time.ParseDuration.
+  windowSize: "24h"
 
 teleport:
   address: "example.teleport.com:443"

--- a/examples/chart/event-handler/templates/configmap.yaml
+++ b/examples/chart/event-handler/templates/configmap.yaml
@@ -9,6 +9,7 @@ data:
     storage = {{ .Values.eventHandler.storagePath | toJson }}
     timeout = {{ .Values.eventHandler.timeout | toJson }}
     batch = {{ .Values.eventHandler.batch }}
+    window-size = {{ default "24h" .Values.eventHandler.windowSize | quote }}
 
     [teleport]
     addr = "{{ .Values.teleport.address }}"

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -6,6 +6,7 @@ should match the snapshot:
         storage = "/var/lib/teleport/plugins/event-handler/storage"
         timeout = "10s"
         batch = 20
+        window-size = "24h"
 
         [teleport]
         addr = "teleport.example.com:1234"

--- a/examples/chart/event-handler/values.schema.json
+++ b/examples/chart/event-handler/values.schema.json
@@ -307,13 +307,15 @@
             "default": {
                 "storagePath": "/var/lib/teleport/plugins/event-handler/storage",
                 "timeout": "10s",
-                "batch": 20
+                "batch": 20,
+                "window-size": "24h"
             },
             "examples": [
                 {
                     "storagePath": "/var/lib/teleport/plugins/event-handler/storage",
                     "timeout": "10s",
-                    "batch": 20
+                    "batch": 20,
+                    "window-size": "12h"
                 }
             ],
             "required": [
@@ -339,6 +341,11 @@
                     "$id": "#/properties/eventHandler/properties/batch",
                     "type": "number",
                     "default": 20
+                },
+                "window-size": {
+                    "$id": "#/properties/eventHandler/properties/window-size",
+                    "type": "string",
+                    "default": "24h"
                 }
             },
             "additionalProperties": true

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -14,6 +14,12 @@ eventHandler:
   storagePath: "/var/lib/teleport/plugins/event-handler/storage"
   timeout: "10s"
   batch: 20
+  # The window size configures the duration of the time window for the event handler
+  # to request events from Teleport. By default, this is set to 24 hours.
+  # Reduce the window size if the events backend cannot manage the event volume 
+  # for the default window size.
+  # The window size should be specified as a duration string, parsed by Go's time.ParseDuration.
+  windowSize: "24h"
 
 fluentd:
   url: ""


### PR DESCRIPTION
This PR adds documentation on how to tune the log ingestion window size.