### PR TITLE
[v15] Fix unintended `trace.Wrap(nil)` in `playFromFileStreamer`

### DIFF
--- a/lib/client/player.go
+++ b/lib/client/player.go
@@ -63,7 +63,7 @@ func (p *playFromFileStreamer) StreamSessionEvents(
 				select {
 				case evts <- evt:
 				case <-ctx.Done():
-					errs <- trace.Wrap(err)
+					errs <- trace.Wrap(ctx.Err())
 					return
 				}
 			}


### PR DESCRIPTION
Backport #42088 to branch/v15