### PR TITLE
Add support for AWS + GCP discovery in teleport kube agent chart

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/_config.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_config.tpl
@@ -123,11 +123,14 @@ discovery_service:
 {{- if $discoveryEnabled }}
   enabled: true
   discovery_group: {{ required "kubeClusterName is required in chart values when kube or discovery role is enabled, see README" .Values.kubeClusterName }}
-  {{- if .Values.kubernetesDiscovery }}
-  kubernetes: {{- toYaml .Values.kubernetesDiscovery | nindent 4 }}
+  {{- if .Values.awsDiscovery }}
+  aws: {{- toYaml .Values.awsDiscovery | nindent 4 }}
   {{- end }}
   {{- if .Values.gcpDiscovery }}
   gcp: {{- toYaml .Values.gcpDiscovery | nindent 4 }}
+  {{- end }}
+  {{- if .Values.kubernetesDiscovery }}
+  kubernetes: {{- toYaml .Values.kubernetesDiscovery | nindent 4 }}
   {{- end }}
 {{- else }}
   enabled: false

--- a/examples/chart/teleport-kube-agent/templates/_config.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_config.tpl
@@ -123,7 +123,12 @@ discovery_service:
 {{- if $discoveryEnabled }}
   enabled: true
   discovery_group: {{ required "kubeClusterName is required in chart values when kube or discovery role is enabled, see README" .Values.kubeClusterName }}
+  {{- if .Values.kubernetesDiscovery }}
   kubernetes: {{- toYaml .Values.kubernetesDiscovery | nindent 4 }}
+  {{- end }}
+  {{- if .Values.gcpDiscovery }}
+  gcp: {{- toYaml .Values.gcpDiscovery | nindent 4 }}
+  {{- end }}
 {{- else }}
   enabled: false
 {{- end }}

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -408,6 +408,55 @@ kubernetesDiscovery:
     labels:
       "*": "*"
 
+
+################################################################
+# Values that must be provided for AWS Discovery
+################################################################
+
+awsDiscovery: []
+  # AWS resource types. Valid options are:
+  # 'ec2' - discovers and registers AWS EC2 instances.
+  # 'eks' - discovers and registers AWS EKS clusters.
+  # 'rds' - discovers and registers AWS RDS and Aurora databases.
+  # 'rdsproxy' - discovers and registers AWS RDS Proxy databases.
+  # 'redshift' - discovers and registers AWS Redshift databases.
+  # 'redshift-serverless' - discovers and registers AWS Redshift Serverless databases.
+  # 'elasticache' - discovers and registers AWS ElastiCache Redis databases.
+  # 'memorydb' - discovers and registers AWS MemoryDB Redis databases.
+  # 'opensearch' - discovers and registers AWS OpenSearch Redis databases.
+    # - types: ["ec2"]
+    #   # AWS regions to search for resources from
+    #   regions: ["us-east-1","us-west-1"]
+    #   # AWS resource tags to match when registering resources
+    #   # Optional section: Defaults to "*":"*"
+    #   tags:
+    #     "*": "*"
+    #   # Optional AWS role that the Discovery Service will assume to discover
+    #   # and register AWS-hosted databases and EKS clusters.
+    #   assume_role_arn: "arn:aws:iam::123456789012:role/example-role-name"
+    #   # Optional AWS external ID that the Discovery Service will use to assume
+    #   # a role in an external AWS account.
+    #   external_id: "example-external-id"
+    #   # Optional section: install is used to provide parameters to the AWS SSM document.
+    #   # If the install section isn't provided, the below defaults are used.
+    #   # Only applicable for EC2 discovery.
+    #   install:
+    #     join_params:
+    #       # token_name is the name of the Teleport invite token to use.
+    #       # Optional, defaults to: "aws-discovery-iam-token".
+    #       token_name:  "aws-discovery-iam-token"
+    #     # script_name is the name of the Teleport install script to use.
+    #     # Optional, defaults to: "default-installer".
+    #     script_name: "default-installer"
+    #   # Optional section: ssm is used to configure which AWS SSM document to use
+    #   # If the ssm section isnt provided the below defaults are used.
+    #   ssm:
+    #     # document_name is the name of the SSM document that should be
+    #     # executed when installing teleport on matching nodes
+    #     # Optional, defaults to: "TeleportDiscoveryInstaller".
+    #     document_name: "TeleportDiscoveryInstaller"
+
+
 ################################################################
 # Values that must be provided for GCP Discovery
 ################################################################

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -409,6 +409,32 @@ kubernetesDiscovery:
       "*": "*"
 
 ################################################################
+# Values that must be provided for GCP Discovery
+################################################################
+
+gcpDiscovery: []
+  # GCP resource types. Valid options are:
+  # 'gke' - discovers and registers GKE Kubernetes clusters.
+  # 'gce' - discovers and registers GCP compute instances.
+  # - types: ["gce"]
+    # IDs of GCP projects to search for resources from.
+    # project_ids: ["project-id"]
+    #
+    # GCP locations to search for resources from. Valid options are:
+    # '*' - discovers resources in all locations.
+    # Any valid GCP region (e.g. "us-west1").
+    # Any valid GCP zone (e.g. "us-west1-b").
+    # locations: ["us-east2", "us-west1-b"]
+    #
+    # Email addresses of service accounts that instances can join with.
+    # If empty, any service account is allowed.
+    # service_accounts: []
+    #
+    # GCP resource label filters used to match resources.
+    # labels:
+    #   "*": "*"
+
+################################################################
 # Values that you may need to change.
 ################################################################
 


### PR DESCRIPTION
This PR adds two improvements for configuring the discovery service in the teleport-kube-agent chart:

- Add support for configuring AWS and GCP discovery when the discovery service is enabled
- Only populate the kubernetes discovery block if it was provided. This supports use cases where you might want AWS/GCP discovery without k8s discovery


