### PR TITLE
[v15] docs: Clarify that app public_addr cannot be changed on Cloud

### DIFF
--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -181,6 +181,17 @@ The dumper app will dump all the request headers in the response.
 
 ### Customize public address
 
+<Admonition
+  type="note"
+  title="For self-hosted environments only"
+>
+  The public address of apps cannot be changed or overridden on cloud-hosted Teleport tenants, due to TLS
+  certificate limitations.
+
+  For cloud-hosted customers, apps will always be available at `https://<app-name>.example.teleport.sh`, where `example`
+  is the name chosen for your cloud-hosted Teleport tenant.
+</Admonition>
+
 By default applications are available at `<app-name>.<proxy-host>:<proxy-port>`
 address. To override the public address, specify the `public_addr` field:
 


### PR DESCRIPTION
Backport #42060 to branch/v15