### PR TITLE
configure: Don't try to run 'hostname' binary that doesn't exist

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -330,13 +330,6 @@ func makeSampleSSHConfig(conf *servicecfg.Config, flags SampleFlags, enabled boo
 	if enabled {
 		s.EnabledFlag = "yes"
 		s.ListenAddress = conf.SSH.Addr.Addr
-		s.Commands = []CommandLabel{
-			{
-				Name:    defaults.HostnameLabel,
-				Command: []string{"hostname"},
-				Period:  time.Minute,
-			},
-		}
 		labels, err := client.ParseLabelSpec(flags.NodeLabels)
 		if err != nil {
 			return s, trace.Wrap(err)


### PR DESCRIPTION
A community user reported that our sample config (generated by `teleport configure`) adds a sample `commands:` section which attempts to run the `hostname` binary every minute. However, our distroless images no longer include a `hostname` binary, meaning that Teleport logs one error per minute saying it's failed to execute the binary.

```
2024-05-27T12:24:38Z ERRO             Failed to run command and update label: exec: "hostname": executable file not found in $PATH. labels/labels.go:155
2024-05-27T12:24:38Z ERRO             "Error during temporary user cleanup: cant find getent binary\n\texec: \"getent\": executable file not found in $PATH" srv/usermgmt.go:469
2024-05-27T12:25:38Z ERRO             Failed to run command and update label: exec: "hostname": executable file not found in $PATH. labels/labels.go:155
2024-05-27T12:26:38Z ERRO             Failed to run command and update label: exec: "hostname": executable file not found in $PATH. labels/labels.go:155
2024-05-27T12:27:38Z ERRO             Failed to run command and update label: exec: "hostname": executable file not found in $PATH. labels/labels.go:155
2024-05-27T12:28:38Z ERRO             Failed to run command and update label: exec: "hostname": executable file not found in $PATH. labels/labels.go:155
2024-05-27T12:29:38Z ERRO             "Error during temporary user cleanup: cant find getent binary\n\texec: \"getent\": executable file not found in $PATH" srv/usermgmt.go:469
2024-05-27T12:29:38Z ERRO             Failed to run command and update label: exec: "hostname": executable file not found in $PATH. labels/labels.go:155
```

This PR removes the dynamic label and will avoid the error being printed in future.

```diff
$ teleport configure
#
# A Sample Teleport configuration file.
#
# Things to update:
#  1. license.pem: Retrieve a license from your Teleport account https://teleport.sh
#     if you are an Enterprise customer.
#
version: v3
teleport:
  nodename: ip-172-31-4-202
  data_dir: /var/lib/teleport
  log:
    output: stderr
    severity: INFO
    format:
      output: text
  ca_pin: ""
  diag_addr: ""
auth_service:
  enabled: "yes"
  listen_addr: 0.0.0.0:3025
  proxy_listener_mode: multiplex
ssh_service:
  enabled: "yes"
- commands:
- - name: hostname
-   command: [hostname]
-   period: 1m0s
proxy_service:
  enabled: "yes"
  https_keypairs: []
  https_keypairs_reload_interval: 0s
  acme: {}