### PR TITLE
Instruments pgevents to report metrics

### DIFF
--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -59,6 +59,12 @@
 | `teleport_audit_parquetlog_last_processed_timestamp`     | gauge     | Teleport Audit Log  | Number of last processing time in Parquet-format audit log.                                        |
 | `teleport_audit_parquetlog_age_oldest_processed_message` | gauge     | Teleport Audit Log  | Number of age of oldest event in Parquet-format audit log.                                         |
 | `teleport_audit_parquetlog_errors_from_collect_count`    | counter   | Teleport Audit Log  | Number of collect failures in Parquet-format audit log.                                            |
+| `teleport_postgres_events_backend_write_requests`        | counter   | Postgres (Events)   | Number of write requests to postgres events, labelled with the request `status` (success or failure). |
+| `teleport_postgres_events_backend_batch_read_requests`   | counter   | Postgres (Events)   | Number of batch read requests to postgres events, labelled with the request `status` (success or failure). |
+| `teleport_postgres_events_backend_batch_delete_requests` | counter   | Postgres (Events)   | Number of batch delete requests to postgres events, labelled with the request `status` (success or failure). |
+| `teleport_postgres_events_backend_write_seconds`         | histogram | Postgres (Events)   | Latency for postgres events write operations, in seconds.                                          |
+| `teleport_postgres_events_backend_batch_read_seconds`    | histogram | Postgres (Events)   | Latency for postgres events batch read operations, in seconds.                                     |
+| `teleport_postgres_events_backend_batch_delete_seconds`  | histogram | Postgres (Events)   | Latency for postgres events batch delete operations, in seconds.                                   |
 | `teleport_connected_resources`                           | gauge     | Teleport Auth       | Number and type of resources connected via keepalives.                                             |
 | `teleport_registered_servers`                            | gauge     | Teleport Auth       | The number of Teleport services that are connected to an Auth Service instance grouped by version. |
 | `teleport_registered_servers_by_install_methods`         | gauge     | Teleport Auth       | The number of Teleport services that are connected to an Auth Service instance grouped by install methods. |

--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -59,9 +59,9 @@
 | `teleport_audit_parquetlog_last_processed_timestamp`     | gauge     | Teleport Audit Log  | Number of last processing time in Parquet-format audit log.                                        |
 | `teleport_audit_parquetlog_age_oldest_processed_message` | gauge     | Teleport Audit Log  | Number of age of oldest event in Parquet-format audit log.                                         |
 | `teleport_audit_parquetlog_errors_from_collect_count`    | counter   | Teleport Audit Log  | Number of collect failures in Parquet-format audit log.                                            |
-| `teleport_postgres_events_backend_write_requests`        | counter   | Postgres (Events)   | Number of write requests to postgres events, labelled with the request `status` (success or failure). |
-| `teleport_postgres_events_backend_batch_read_requests`   | counter   | Postgres (Events)   | Number of batch read requests to postgres events, labelled with the request `status` (success or failure). |
-| `teleport_postgres_events_backend_batch_delete_requests` | counter   | Postgres (Events)   | Number of batch delete requests to postgres events, labelled with the request `status` (success or failure). |
+| `teleport_postgres_events_backend_write_requests`        | counter   | Postgres (Events)   | Number of write requests to postgres events, labeled with the request `status` (success or failure). |
+| `teleport_postgres_events_backend_batch_read_requests`   | counter   | Postgres (Events)   | Number of batch read requests to postgres events, labeled with the request `status` (success or failure). |
+| `teleport_postgres_events_backend_batch_delete_requests` | counter   | Postgres (Events)   | Number of batch delete requests to postgres events, labeled with the request `status` (success or failure). |
 | `teleport_postgres_events_backend_write_seconds`         | histogram | Postgres (Events)   | Latency for postgres events write operations, in seconds.                                          |
 | `teleport_postgres_events_backend_batch_read_seconds`    | histogram | Postgres (Events)   | Latency for postgres events batch read operations, in seconds.                                     |
 | `teleport_postgres_events_backend_batch_delete_seconds`  | histogram | Postgres (Events)   | Latency for postgres events batch delete operations, in seconds.                                   |

--- a/lib/events/pgevents/metrics.go
+++ b/lib/events/pgevents/metrics.go
@@ -34,7 +34,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: teleport.MetricNamespace,
 			Name:      "postgres_events_backend_write_requests",
-			Help:      "Number of write requests to postgres events, labelled with the request `status` (success or failure).",
+			Help:      "Number of write requests to postgres events, labeled with the request `status` (success or failure).",
 		},
 		labels,
 	)
@@ -42,7 +42,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: teleport.MetricNamespace,
 			Name:      "postgres_events_backend_batch_read_requests",
-			Help:      "Number of batch read requests to postgres events, labelled with the request `status` (success or failure).",
+			Help:      "Number of batch read requests to postgres events, labeled with the request `status` (success or failure).",
 		},
 		labels,
 	)
@@ -50,7 +50,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: teleport.MetricNamespace,
 			Name:      "postgres_events_backend_batch_delete_requests",
-			Help:      "Number of batch delete requests to postgres events, labelled with the request `status` (success or failure).",
+			Help:      "Number of batch delete requests to postgres events, labeled with the request `status` (success or failure).",
 		},
 		labels,
 	)

--- a/lib/events/pgevents/metrics.go
+++ b/lib/events/pgevents/metrics.go
@@ -34,7 +34,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: teleport.MetricNamespace,
 			Name:      "postgres_events_backend_write_requests",
-			Help:      "Number of write requests to postgres events",
+			Help:      "Number of write requests to postgres events, labelled with the request `status` (success or failure).",
 		},
 		labels,
 	)
@@ -42,15 +42,15 @@ var (
 		prometheus.CounterOpts{
 			Namespace: teleport.MetricNamespace,
 			Name:      "postgres_events_backend_batch_read_requests",
-			Help:      "Number of batch read requests to postgres events",
+			Help:      "Number of batch read requests to postgres events, labelled with the request `status` (success or failure).",
 		},
 		labels,
 	)
-	cleanupRequests = prometheus.NewCounterVec(
+	batchDeleteRequests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: teleport.MetricNamespace,
-			Name:      "postgres_events_backend_cleanup_requests",
-			Help:      "Number of cleanup requests to postgres events",
+			Name:      "postgres_events_backend_batch_delete_requests",
+			Help:      "Number of batch delete requests to postgres events, labelled with the request `status` (success or failure).",
 		},
 		labels,
 	)
@@ -58,7 +58,7 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: teleport.MetricNamespace,
 			Name:      "postgres_events_backend_write_seconds",
-			Help:      "Latency for postgres events write operations",
+			Help:      "Latency for postgres events write operations, in seconds.",
 			// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
 			// highest bucket start of 0.001 sec * 2^15 == 32.768 sec
 			Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
@@ -68,32 +68,32 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: teleport.MetricNamespace,
 			Name:      "postgres_events_backend_batch_read_seconds",
-			Help:      "Latency for postgres events batch read operations",
+			Help:      "Latency for postgres events batch read operations, in seconds.",
 			// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
 			// highest bucket start of 0.001 sec * 2^15 == 32.768 sec
 			Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
 		},
 	)
-	cleanupLatencies = prometheus.NewHistogram(
+	batchDeleteLatencies = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: teleport.MetricNamespace,
-			Name:      "postgres_events_backend_cleanup_seconds",
-			Help:      "Latency for postgres events cleanup operations",
+			Name:      "postgres_events_backend_batch_delete_seconds",
+			Help:      "Latency for postgres events cleanup operations, in seconds.",
 			// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
 			// highest bucket start of 0.001 sec * 2^17 == 131 sec
 			Buckets: prometheus.ExponentialBuckets(0.001, 2, 18),
 		},
 	)
 
-	writeRequestsSuccess     = writeRequests.With(successLabels)
-	writeRequestsFailure     = writeRequests.With(failureLabels)
-	batchReadRequestsSuccess = batchReadRequests.With(successLabels)
-	batchReadRequestsFailure = batchReadRequests.With(failureLabels)
-	cleanupRequestsSuccess   = cleanupRequests.With(successLabels)
-	cleanupRequestsFailure   = cleanupRequests.With(failureLabels)
+	writeRequestsSuccess       = writeRequests.With(successLabels)
+	writeRequestsFailure       = writeRequests.With(failureLabels)
+	batchReadRequestsSuccess   = batchReadRequests.With(successLabels)
+	batchReadRequestsFailure   = batchReadRequests.With(failureLabels)
+	batchDeleteRequestsSuccess = batchDeleteRequests.With(successLabels)
+	batchDeleteRequestsFailure = batchDeleteRequests.With(failureLabels)
 
 	prometheusCollectors = []prometheus.Collector{
-		writeRequests, batchReadRequests, cleanupRequests,
-		writeLatencies, batchReadLatencies, cleanupLatencies,
+		writeRequests, batchReadRequests, batchDeleteRequests,
+		writeLatencies, batchReadLatencies, batchDeleteLatencies,
 	}
 )

--- a/lib/events/pgevents/metrics.go
+++ b/lib/events/pgevents/metrics.go
@@ -28,6 +28,7 @@ var (
 
 	writeRequests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
+			Namespace: teleport.MetricNamespace,
 			Name: "postgres_events_backend_write_requests",
 			Help: "Number of write requests to postgres events",
 		},
@@ -35,6 +36,7 @@ var (
 	)
 	batchReadRequests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
+			Namespace: teleport.MetricNamespace,
 			Name: "postgres_events_backend_batch_read_requests",
 			Help: "Number of batch read requests to postgres events",
 		},
@@ -42,6 +44,7 @@ var (
 	)
 	cleanupRequests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
+			Namespace: teleport.MetricNamespace,
 			Name: "postgres_events_backend_cleanup_requests",
 			Help: "Number of cleanup requests to postgres events",
 		},
@@ -49,6 +52,7 @@ var (
 	)
 	writeLatencies = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
+			Namespace: teleport.MetricNamespace,
 			Name: "postgres_events_backend_write_seconds",
 			Help: "Latency for postgres events write operations",
 			// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
@@ -58,6 +62,7 @@ var (
 	)
 	batchReadLatencies = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
+			Namespace: teleport.MetricNamespace,
 			Name: "postgres_events_backend_batch_read_seconds",
 			Help: "Latency for postgres events batch read operations",
 			// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
@@ -67,10 +72,11 @@ var (
 	)
 	cleanupLatencies = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
+			Namespace: teleport.MetricNamespace,
 			Name: "postgres_events_backend_cleanup_seconds",
 			Help: "Latency for postgres events cleanup operations",
 			// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
-			// highest bucket start of 0.001 sec * 2^15 == 32.768 sec
+			// highest bucket start of 0.001 sec * 2^17 == 131 sec
 			Buckets: prometheus.ExponentialBuckets(0.001, 2, 18),
 		},
 	)

--- a/lib/events/pgevents/metrics.go
+++ b/lib/events/pgevents/metrics.go
@@ -18,7 +18,11 @@
 
 package pgevents
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gravitational/teleport"
+)
 
 var (
 	statusLabel   = "status"
@@ -29,32 +33,32 @@ var (
 	writeRequests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: teleport.MetricNamespace,
-			Name: "postgres_events_backend_write_requests",
-			Help: "Number of write requests to postgres events",
+			Name:      "postgres_events_backend_write_requests",
+			Help:      "Number of write requests to postgres events",
 		},
 		labels,
 	)
 	batchReadRequests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: teleport.MetricNamespace,
-			Name: "postgres_events_backend_batch_read_requests",
-			Help: "Number of batch read requests to postgres events",
+			Name:      "postgres_events_backend_batch_read_requests",
+			Help:      "Number of batch read requests to postgres events",
 		},
 		labels,
 	)
 	cleanupRequests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: teleport.MetricNamespace,
-			Name: "postgres_events_backend_cleanup_requests",
-			Help: "Number of cleanup requests to postgres events",
+			Name:      "postgres_events_backend_cleanup_requests",
+			Help:      "Number of cleanup requests to postgres events",
 		},
 		labels,
 	)
 	writeLatencies = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: teleport.MetricNamespace,
-			Name: "postgres_events_backend_write_seconds",
-			Help: "Latency for postgres events write operations",
+			Name:      "postgres_events_backend_write_seconds",
+			Help:      "Latency for postgres events write operations",
 			// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
 			// highest bucket start of 0.001 sec * 2^15 == 32.768 sec
 			Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
@@ -63,8 +67,8 @@ var (
 	batchReadLatencies = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: teleport.MetricNamespace,
-			Name: "postgres_events_backend_batch_read_seconds",
-			Help: "Latency for postgres events batch read operations",
+			Name:      "postgres_events_backend_batch_read_seconds",
+			Help:      "Latency for postgres events batch read operations",
 			// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
 			// highest bucket start of 0.001 sec * 2^15 == 32.768 sec
 			Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
@@ -73,8 +77,8 @@ var (
 	cleanupLatencies = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: teleport.MetricNamespace,
-			Name: "postgres_events_backend_cleanup_seconds",
-			Help: "Latency for postgres events cleanup operations",
+			Name:      "postgres_events_backend_cleanup_seconds",
+			Help:      "Latency for postgres events cleanup operations",
 			// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
 			// highest bucket start of 0.001 sec * 2^17 == 131 sec
 			Buckets: prometheus.ExponentialBuckets(0.001, 2, 18),
@@ -93,4 +97,3 @@ var (
 		writeLatencies, batchReadLatencies, cleanupLatencies,
 	}
 )
-

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -293,13 +293,13 @@ func (l *Log) periodicCleanup(ctx context.Context, cleanupInterval, retentionPer
 
 			return tag.RowsAffected(), nil
 		})
-		cleanupLatencies.Observe(time.Since(start).Seconds())
+		batchDeleteLatencies.Observe(time.Since(start).Seconds())
 
 		if err != nil {
-			cleanupRequestsFailure.Inc()
+			batchDeleteRequestsFailure.Inc()
 			l.log.WithError(err).Error("Failed to execute periodic cleanup.")
 		} else {
-			cleanupRequestsSuccess.Inc()
+			batchDeleteRequestsSuccess.Inc()
 			l.log.WithField("deleted_rows", deleted).Debug("Executed periodic cleanup.")
 		}
 	}

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -189,7 +189,10 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
+
+	if err := metrics.RegisterPrometheusCollectors(prometheusCollectors...); err != nil {
+		return nil, trace.Wrap(err, "registering prometheus collectors")
+	}
 
 	if cfg.AuthMode == AzureADAuth {
 		bc, err := pgcommon.AzureBeforeConnect(cfg.Log)

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -39,6 +39,7 @@ import (
 	pgcommon "github.com/gravitational/teleport/lib/backend/pgbk/common"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -188,6 +189,7 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
 
 	if cfg.AuthMode == AzureADAuth {
 		bc, err := pgcommon.AzureBeforeConnect(cfg.Log)
@@ -276,6 +278,7 @@ func (l *Log) periodicCleanup(ctx context.Context, cleanupInterval, retentionPer
 		}
 
 		l.log.Debug("Executing periodic cleanup.")
+		start := time.Now()
 		deleted, err := pgcommon.RetryIdempotent(ctx, l.log, func() (int64, error) {
 			tag, err := l.pool.Exec(ctx,
 				"DELETE FROM events WHERE creation_time < (now() - $1::interval)",
@@ -287,9 +290,13 @@ func (l *Log) periodicCleanup(ctx context.Context, cleanupInterval, retentionPer
 
 			return tag.RowsAffected(), nil
 		})
+		cleanupLatencies.Observe(time.Since(start).Seconds())
+
 		if err != nil {
+			cleanupRequestsFailure.Inc()
 			l.log.WithError(err).Error("Failed to execute periodic cleanup.")
 		} else {
+			cleanupRequestsSuccess.Inc()
 			l.log.WithField("deleted_rows", deleted).Debug("Executed periodic cleanup.")
 		}
 	}
@@ -316,9 +323,10 @@ func (l *Log) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) er
 
 	eventID := uuid.New()
 
+	start := time.Now()
 	// if an event with the same event_id exists, it means that we inserted it
 	// and then failed to receive the success reply from the commit
-	if _, err := pgcommon.RetryIdempotent(ctx, l.log, func() (struct{}, error) {
+	_, err = pgcommon.RetryIdempotent(ctx, l.log, func() (struct{}, error) {
 		_, err := l.pool.Exec(ctx,
 			"INSERT INTO events (event_time, event_id, event_type, session_id, event_data)"+
 				" VALUES ($1, $2, $3, $4, $5)"+
@@ -326,9 +334,15 @@ func (l *Log) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) er
 			event.GetTime().UTC(), eventID, event.GetType(), sessionID, eventJSON,
 		)
 		return struct{}{}, trace.Wrap(err)
-	}); err != nil {
+	})
+
+	writeLatencies.Observe(time.Since(start).Seconds())
+
+	if err != nil {
+		writeRequestsFailure.Inc()
 		return trace.Wrap(err)
 	}
+	writeRequestsSuccess.Inc()
 
 	return nil
 }
@@ -424,8 +438,9 @@ func (l *Log) searchEvents(
 	var endTime time.Time
 	var endID uuid.UUID
 
+	transactionStart := time.Now()
 	const idempotent = true
-	if err := pgcommon.RetryTx(ctx, l.log, l.pool, pgx.TxOptions{
+	err := pgcommon.RetryTx(ctx, l.log, l.pool, pgx.TxOptions{
 		AccessMode: pgx.ReadOnly,
 	}, idempotent, func(tx pgx.Tx) error {
 		evs = nil
@@ -491,9 +506,14 @@ func (l *Log) searchEvents(
 			}
 		}
 		return nil
-	}); err != nil {
+	})
+	batchReadLatencies.Observe(time.Since(transactionStart).Seconds())
+
+	if err != nil {
+		batchReadRequestsFailure.Inc()
 		return nil, "", trace.Wrap(err)
 	}
+	batchReadRequestsSuccess.Inc()
 
 	var nextKey string
 	if len(evs) > 0 && (len(evs) >= limit || sizeLimit) {


### PR DESCRIPTION
Most event backends provide no or few metrics, I needed to measure those when testing the cockroachDB event backend so here they are.

Once you are happy with this PR I can send similar ones for most popular event backends (especially DyamoDB).

I copied most of the logic from the existing firestore metrics with the following changes:
- ~I turned `batchWrite` into `cleanup` as this was the only use case and found that `batchWrite` might be confusing. Maybe `batchDelete` is more appropriate, I'll take any suggestion~ switched to batchDelete.
- I added a `status: success|failure` label to the counters because we had no visibility on the request failure (are we failing the call? getting rate-limited?). When observing a system it's a good practice to measure at least [Rate Errors and Duration](https://grafana.com/blog/2018/08/02/the-red-method-how-to-instrument-your-services/), so this PR adds the "Errors" part.

Changelog: add Prometheus metrics for the Postgres event backend.