### PR TITLE
[v16] build: Set arm ldflags via GO_LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,8 @@ CC=arm-linux-gnueabihf-gcc
 endif
 
 # Add -debugtramp=2 to work around 24 bit CALL/JMP instruction offset.
-BUILDFLAGS = $(ADDFLAGS) -ldflags '-extldflags "-Wl,--long-plt" -w -s -debugtramp=2 $(KUBECTL_SETVERSION)' -trimpath -buildmode=pie
+# Add "-extldflags -Wl,--long-plt" to avoid ld assertion failure on large binaries
+GO_LDFLAGS += -extldflags -Wl,--long-plt -debugtramp=2
 endif
 endif # OS == linux
 


### PR DESCRIPTION
Set the arm-specific ldflags via the new `GO_LDFLAGS` var that was added
in 265b58cb7e1 instead of overriding `BUILDFLAGS`. Without this, the arm
ldflags were being overridden when building teleport on CI as that needs
to set extra ldflags for the community-licensed build.

Backport: https://github.com/gravitational/teleport/pull/42116
Test-run: https://github.com/gravitational/teleport.e/actions/runs/9278341029