### PR TITLE
[v15] Debug service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 gitref.go
 .data
 debug
+!/lib/srv/debug
+!/lib/client/debug
 default.etcd
 /darwin
 

--- a/constants.go
+++ b/constants.go
@@ -145,6 +145,10 @@ const (
 	// ComponentDiagnostic is a diagnostic service
 	ComponentDiagnostic = "diag"
 
+	// ComponentDebug is the debug service, which exposes debugging
+	// configuration over a Unix socket.
+	ComponentDebug = "debug"
+
 	// ComponentClient is a client
 	ComponentClient = "client"
 
@@ -921,4 +925,10 @@ const (
 	// KubeLegacyProxySuffix is the suffix used for legacy proxy services when
 	// generating their names Server names.
 	KubeLegacyProxySuffix = "-proxy_service"
+)
+
+const (
+	// DebugServiceSocketName represents the Unix domain socket name of the
+	// debug service.
+	DebugServiceSocketName = "debug.sock"
 )

--- a/lib/client/debug/debug.go
+++ b/lib/client/debug/debug.go
@@ -1,0 +1,160 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package debug
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/gravitational/trace"
+
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+)
+
+// SupportedProfiles list of supported pprof profiles that can be collected.
+// This list is composed by runtime/pprof.Profile and http/pprof definitions.
+var SupportedProfiles = map[string]struct{}{
+	"allocs":       {},
+	"block":        {},
+	"cmdline":      {},
+	"goroutine":    {},
+	"heap":         {},
+	"mutex":        {},
+	"profile":      {},
+	"threadcreate": {},
+	"trace":        {},
+}
+
+// Client represents the debug service client.
+type Client struct {
+	clt *http.Client
+}
+
+// NewClient generates a new debug service client.
+func NewClient(socketPath string) *Client {
+	return &Client{
+		clt: &http.Client{
+			Timeout: apidefaults.DefaultIOTimeout,
+			Transport: &http.Transport{
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return net.Dial("unix", socketPath)
+				},
+			},
+		},
+	}
+}
+
+// SetLogLevel changes the application's log level and a change status message.
+func (c *Client) SetLogLevel(ctx context.Context, level string) (string, error) {
+	resp, err := c.do(ctx, http.MethodPut, url.URL{Path: "/log-level"}, []byte(level))
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	defer resp.Body.Close()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", trace.BadParameter("Unable to change log level: %s", respBody)
+	}
+
+	return string(respBody), nil
+}
+
+// GetLogLevel fetches the current log level.
+func (c *Client) GetLogLevel(ctx context.Context) (string, error) {
+	resp, err := c.do(ctx, http.MethodGet, url.URL{Path: "/log-level"}, nil)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	defer resp.Body.Close()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", trace.BadParameter("Unable to fetch log level: %s", respBody)
+	}
+
+	return string(respBody), nil
+}
+
+// CollectProfile collects a pprof profile.
+func (c *Client) CollectProfile(ctx context.Context, profileName string, seconds int) ([]byte, error) {
+	u := url.URL{
+		Path: "/debug/pprof/" + profileName,
+	}
+
+	if _, ok := SupportedProfiles[profileName]; !ok {
+		return nil, trace.BadParameter("%q profile not supported", profileName)
+	}
+
+	if seconds > 0 {
+		qs := url.Values{}
+		qs.Add("seconds", strconv.Itoa(seconds))
+		u.RawQuery = qs.Encode()
+	}
+
+	resp, err := c.do(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	result, err := io.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, trace.BadParameter("Unable to collect profile %q: %s", profileName, result)
+	}
+
+	return result, nil
+}
+
+func (c *Client) do(ctx context.Context, method string, u url.URL, body []byte) (*http.Response, error) {
+	u.Scheme = "http"
+	u.Host = "debug"
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewBuffer(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), bodyReader)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resp, err := c.clt.Do(req)
+	if err != nil {
+		return nil, trace.Wrap(trace.ConvertSystemError(err))
+	}
+
+	return resp, nil
+}

--- a/lib/client/debug/debug_test.go
+++ b/lib/client/debug/debug_test.go
@@ -1,0 +1,149 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package debug
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+)
+
+func TestSetLogLevel(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success", func(t *testing.T) {
+		socketPath, _ := newSocketMockService(t, http.StatusOK, []byte{})
+		clt := NewClient(socketPath)
+
+		// The validation is done on the server side, here our server always
+		// return success.
+		_, err := clt.SetLogLevel(ctx, "INFO")
+		require.NoError(t, err)
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		socketPath, _ := newSocketMockService(t, http.StatusUnprocessableEntity, []byte{})
+		clt := NewClient(socketPath)
+
+		// The validation is done on the server side, here our server always
+		// return failure.
+		_, err := clt.SetLogLevel(ctx, "RANDOM")
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err))
+	})
+}
+
+func TestCollectProfile(t *testing.T) {
+	ctx := context.Background()
+
+	for _, test := range []struct {
+		desc         string
+		profile      string
+		seconds      int
+		expectErr    bool
+		expectedArgs string
+	}{
+		{
+			desc:    "profile",
+			profile: "goroutine",
+		},
+		{
+			desc:         "profile with seconds flag",
+			profile:      "block",
+			seconds:      10,
+			expectedArgs: "seconds=10",
+		},
+		{
+			desc:      "invalid profile",
+			profile:   "RANDOM",
+			expectErr: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			socketPath, closeFn := newSocketMockService(t, http.StatusOK, []byte("collected profile"))
+			defer closeFn()
+			clt := NewClient(socketPath)
+
+			_, err := clt.CollectProfile(ctx, test.profile, test.seconds)
+			if test.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			requestedPaths := closeFn()
+			require.Len(t, requestedPaths, 1)
+
+			path, args, _ := strings.Cut(requestedPaths[0], "?")
+			require.True(t, strings.HasPrefix(path, "/debug/pprof/"), "expected PProf request but got %q", path)
+			require.Equal(t, test.expectedArgs, args)
+			require.Equal(t, test.profile, strings.TrimPrefix(path, "/debug/pprof/"))
+		})
+	}
+}
+
+// newSocketMockService creates a unix socket that access HTTP requests and
+// always replies with success. Returns the path to the socket and `closeFn`,
+// which when called closes the socket and returns the requested paths.
+func newSocketMockService(t *testing.T, status int, contents []byte) (string, func() []string) {
+	t.Helper()
+
+	// We cannot simply use the `t.TempDir()` due to the size limit of UDS.
+	// Here, we place it inside the temporary directory, which will most likely
+	// give a smaller path.
+	// https://github.com/golang/go/issues/62614
+	socketDir, err := os.MkdirTemp("", "*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(socketDir) })
+
+	socketPath := filepath.Join(socketDir, teleport.DebugServiceSocketName)
+	require.Greater(t, 100, len(socketPath), "expected socket name to be smaller (less than 100 characters)"+
+		" due to Unix domain socket size limitation but got %q (%d).", socketPath, len(socketPath))
+
+	l, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+
+	var requests []string
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests = append(requests, r.URL.RequestURI())
+			w.WriteHeader(status)
+			w.Write(contents)
+		}),
+	}
+
+	go func() {
+		err := srv.Serve(l)
+		if err != nil && err != http.ErrServerClosed {
+			t.Log("Failed to start server", err)
+		}
+	}()
+
+	t.Cleanup(func() { srv.Shutdown(context.Background()) })
+	return socketPath, func() []string {
+		return requests
+	}
+}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -757,23 +757,23 @@ func applyLogConfig(loggerConfig Log, cfg *servicecfg.Config) error {
 		w = logFile
 	}
 
-	var level slog.Level
+	level := new(slog.LevelVar)
 	switch strings.ToLower(loggerConfig.Severity) {
 	case "", "info":
 		logger.SetLevel(log.InfoLevel)
-		level = slog.LevelInfo
+		level.Set(slog.LevelInfo)
 	case "err", "error":
 		logger.SetLevel(log.ErrorLevel)
-		level = slog.LevelError
+		level.Set(slog.LevelError)
 	case teleport.DebugLevel:
 		logger.SetLevel(log.DebugLevel)
-		level = slog.LevelDebug
+		level.Set(slog.LevelDebug)
 	case "warn", "warning":
 		logger.SetLevel(log.WarnLevel)
-		level = slog.LevelWarn
+		level.Set(slog.LevelWarn)
 	case "trace":
 		logger.SetLevel(log.TraceLevel)
-		level = logutils.TraceLevel
+		level.Set(logutils.TraceLevel)
 	default:
 		return trace.BadParameter("unsupported logger severity: %q", loggerConfig.Severity)
 	}
@@ -848,6 +848,7 @@ func applyLogConfig(loggerConfig Log, cfg *servicecfg.Config) error {
 
 	cfg.Log = logger
 	cfg.Logger = slogLogger
+	cfg.LoggerLevel = level
 	return nil
 }
 
@@ -2319,8 +2320,7 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 		// log level right away. Otherwise allow the command line flag to override
 		// logger severity in file configuration.
 		if fileConf == nil {
-			log.SetLevel(log.DebugLevel)
-			cfg.Log.SetLevel(log.DebugLevel)
+			cfg.SetLogLevel(slog.LevelDebug)
 		} else {
 			if strings.ToLower(fileConf.Logger.Severity) != "trace" {
 				fileConf.Logger.Severity = teleport.DebugLevel
@@ -2636,8 +2636,7 @@ func ConfigureOpenSSH(clf *CommandLineFlags, cfg *servicecfg.Config) error {
 
 	// Apply command line --debug flag to override logger severity.
 	if clf.Debug {
-		log.SetLevel(log.DebugLevel)
-		cfg.Log.SetLevel(log.DebugLevel)
+		cfg.SetLogLevel(slog.LevelDebug)
 		cfg.Debug = clf.Debug
 	}
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -245,6 +245,15 @@ type CommandLineFlags struct {
 	// IntegrationConfSAMLIdPGCPWorkforceArguments contains the arguments of
 	// `teleport integration configure samlidp gcp-workforce` command
 	IntegrationConfSAMLIdPGCPWorkforceArguments samlidpconfig.GCPWorkforceAPIParams
+
+	// LogLevel is the new application's log level.
+	LogLevel string
+
+	// Profiles comma-separated list of pprof profiles to be collected.
+	Profiles string
+
+	// ProfileSeconds defines the time the pprof will be collected.
+	ProfileSeconds int
 }
 
 // IntegrationConfAccessGraphAWSSync contains the arguments of
@@ -432,6 +441,9 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	}
 	if fc.WindowsDesktop.Disabled() {
 		cfg.WindowsDesktop.Enabled = false
+	}
+	if fc.Debug.Enabled() {
+		cfg.DebugService.Enabled = true
 	}
 
 	if fc.AccessGraph.Enabled {

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -544,6 +544,12 @@ func TestConfigReading(t *testing.T) {
 			GRPCServerLatency: true,
 			GRPCClientLatency: true,
 		},
+		Debug: DebugService{
+			Service: Service{
+				defaultEnabled: true,
+				EnabledFlag:    "yes",
+			},
+		},
 		WindowsDesktop: WindowsDesktopService{
 			Service: Service{
 				EnabledFlag:   "yes",
@@ -579,6 +585,8 @@ func TestConfigReading(t *testing.T) {
 	require.True(t, conf.Databases.Enabled())
 	require.True(t, conf.Metrics.Configured())
 	require.True(t, conf.Metrics.Enabled())
+	require.True(t, conf.Debug.Configured())
+	require.True(t, conf.Debug.Enabled())
 	require.True(t, conf.WindowsDesktop.Configured())
 	require.True(t, conf.WindowsDesktop.Enabled())
 	require.True(t, conf.Tracing.Enabled())
@@ -939,6 +947,7 @@ func TestApplyConfigNoneEnabled(t *testing.T) {
 	require.False(t, cfg.Apps.Enabled)
 	require.False(t, cfg.Databases.Enabled)
 	require.False(t, cfg.Metrics.Enabled)
+	require.True(t, cfg.DebugService.Enabled)
 	require.False(t, cfg.WindowsDesktop.Enabled)
 	require.Empty(t, cfg.Proxy.PostgresPublicAddrs)
 	require.Empty(t, cfg.Proxy.MySQLPublicAddrs)
@@ -1657,6 +1666,9 @@ func makeConfigFixture() string {
 			Certificate: "/etc/teleport/proxy.crt",
 		},
 	}
+
+	// Debug service.
+	conf.Debug.EnabledFlag = "yes"
 
 	// Windows Desktop Service
 	conf.WindowsDesktop = WindowsDesktopService{

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -80,6 +80,10 @@ type FileConfig struct {
 	// that defines the metrics service configuration
 	Metrics Metrics `yaml:"metrics_service,omitempty"`
 
+	// Debug is the "debug_service" section that defines the configuration for
+	// the Debug service.
+	Debug DebugService `yaml:"debug_service,omitempty"`
+
 	// WindowsDesktop is the "windows_desktop_service" that defines the
 	// configuration for Windows Desktop Access.
 	WindowsDesktop WindowsDesktopService `yaml:"windows_desktop_service,omitempty"`
@@ -466,6 +470,7 @@ func (conf *FileConfig) CheckAndSetDefaults() error {
 	conf.SSH.defaultEnabled = true
 	conf.Kube.defaultEnabled = false
 	conf.Okta.defaultEnabled = false
+	conf.Debug.defaultEnabled = true
 	if conf.Version == "" {
 		conf.Version = defaults.TeleportConfigVersionV1
 	}
@@ -2316,6 +2321,12 @@ type Metrics struct {
 // MTLSEnabled returns whether mtls is enabled or not in the metrics service config.
 func (m *Metrics) MTLSEnabled() bool {
 	return len(m.KeyPairs) > 0 && len(m.CACerts) > 0
+}
+
+// DebugService is a `debug_service` section of the config file.
+type DebugService struct {
+	// Service is a generic service configuration section
+	Service `yaml:",inline"`
 }
 
 // WindowsDesktopService contains configuration for windows_desktop_service.

--- a/lib/service/listeners.go
+++ b/lib/service/listeners.go
@@ -36,6 +36,7 @@ var (
 	ListenerDiagnostic = ListenerType(teleport.ComponentDiagnostic)
 	ListenerProxyKube  = ListenerType(teleport.Component(teleport.ComponentProxy, "kube"))
 	ListenerKube       = ListenerType(teleport.ComponentKube)
+	ListenerDebug      = ListenerType(teleport.ComponentDebug)
 	// Proxy can use the same listener for tunnels and web interface
 	// (multiplexing the requests).
 	ListenerProxyTunnelAndWeb = ListenerType(teleport.Component(teleport.ComponentProxy, "tunnel", "web"))
@@ -48,6 +49,16 @@ var (
 	ListenerMetrics           = ListenerType(teleport.ComponentMetrics)
 	ListenerWindowsDesktop    = ListenerType(teleport.ComponentWindowsDesktop)
 )
+
+// Network returns the network used by the listener.
+func (l ListenerType) Network() string {
+	switch l {
+	case ListenerDebug:
+		return "unix"
+	default:
+		return "tcp"
+	}
+}
 
 // AuthAddr returns auth server endpoint, if configured and started.
 func (process *TeleportProcess) AuthAddr() (*utils.NetAddr, error) {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3361,8 +3361,14 @@ func (process *TeleportProcess) initDebugService() error {
 		Handler:           debug.NewServeMux(logger, process.Config),
 		ReadTimeout:       apidefaults.DefaultIOTimeout,
 		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
-		WriteTimeout:      apidefaults.DefaultIOTimeout,
-		IdleTimeout:       apidefaults.DefaultIdleTimeout,
+		// pprof endpoints support delta profiles and cpu and trace profiling
+		// over time, both of which can be effectively unbounded in time; care
+		// should be taken when adding more endpoints to this server, however,
+		// and if necessary, a timeout can be either added to some more
+		// sensitive endpoint, or the timeout can be removed from the more lax
+		// ones
+		WriteTimeout: 0,
+		IdleTimeout:  apidefaults.DefaultIdleTimeout,
 	}
 
 	process.RegisterFunc("debug.service", func() error {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -143,6 +143,7 @@ import (
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/srv/app"
 	"github.com/gravitational/teleport/lib/srv/db"
+	"github.com/gravitational/teleport/lib/srv/debug"
 	"github.com/gravitational/teleport/lib/srv/desktop"
 	"github.com/gravitational/teleport/lib/srv/ingress"
 	"github.com/gravitational/teleport/lib/srv/regular"
@@ -1108,6 +1109,14 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		if err := process.initTracingService(); err != nil {
 			return nil, trace.Wrap(err)
 		}
+	}
+
+	if cfg.DebugService.Enabled {
+		if err := process.initDebugService(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		warnOnErr(process.ExitContext(), process.closeImportedDescriptors(teleport.ComponentDebug), process.logger)
 	}
 
 	// Create a process wide key generator that will be shared. This is so the
@@ -3324,6 +3333,47 @@ func (process *TeleportProcess) initDiagnosticService() error {
 
 	process.OnExit("diagnostic.shutdown", func(payload interface{}) {
 		warnOnErr(process.ExitContext(), muxListener.Close(), logger)
+		if payload == nil {
+			logger.InfoContext(process.ExitContext(), "Shutting down immediately.")
+			warnOnErr(process.ExitContext(), server.Close(), logger)
+		} else {
+			logger.InfoContext(process.ExitContext(), "Shutting down gracefully.")
+			ctx := payloadContext(payload)
+			warnOnErr(process.ExitContext(), server.Shutdown(ctx), logger)
+		}
+		logger.InfoContext(process.ExitContext(), "Exited.")
+	})
+
+	return nil
+}
+
+// initDebugService starts debug service serving endpoints used for
+// troubleshooting the instance.
+func (process *TeleportProcess) initDebugService() error {
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDebug, process.id))
+
+	listener, err := process.importOrCreateListener(ListenerDebug, filepath.Join(process.Config.DataDir, teleport.DebugServiceSocketName))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	server := &http.Server{
+		Handler:           debug.NewServeMux(logger, process.Config),
+		ReadTimeout:       apidefaults.DefaultIOTimeout,
+		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+		WriteTimeout:      apidefaults.DefaultIOTimeout,
+		IdleTimeout:       apidefaults.DefaultIdleTimeout,
+	}
+
+	process.RegisterFunc("debug.service", func() error {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.WarnContext(process.ExitContext(), "Debug server exited with error.", "error", err)
+		}
+		return nil
+	})
+	warnOnErr(process.ExitContext(), process.closeImportedDescriptors(teleport.ComponentDebug), logger)
+
+	process.OnExit("debug.shutdown", func(payload interface{}) {
 		if payload == nil {
 			logger.InfoContext(process.ExitContext(), "Shutting down immediately.")
 			warnOnErr(process.ExitContext(), server.Close(), logger)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1570,3 +1570,48 @@ func TestSingleProcessModeResolver(t *testing.T) {
 		})
 	}
 }
+
+// TestDebugServiceStartSocket ensures the debug service socket starts
+// correctly, and is accessible.
+func TestDebugServiceStartSocket(t *testing.T) {
+	t.Parallel()
+	fakeClock := clockwork.NewFakeClock()
+
+	var err error
+	dataDir, err := os.MkdirTemp("", "*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dataDir) })
+
+	cfg := servicecfg.MakeDefaultConfig()
+	cfg.DebugService.Enabled = true
+	cfg.Clock = fakeClock
+	cfg.DataDir = dataDir
+	cfg.DiagnosticAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
+	cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"})
+	cfg.Auth.Enabled = true
+	cfg.Auth.StorageConfig.Params["path"] = dataDir
+	cfg.Auth.ListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
+	cfg.SSH.Enabled = false
+	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
+
+	process, err := NewTeleport(cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, process.Start())
+	t.Cleanup(func() { require.NoError(t, process.Close()) })
+
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", filepath.Join(process.Config.DataDir, teleport.DebugServiceSocketName))
+			},
+		},
+	}
+
+	// Fetch a random path, it should return 404 error.
+	req, err := httpClient.Get("http://debug/random")
+	require.NoError(t, err)
+	defer req.Body.Close()
+	require.Equal(t, http.StatusNotFound, req.StatusCode)
+}

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshca"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // Config contains the configuration for all services that Teleport can run.
@@ -222,6 +223,8 @@ type Config struct {
 	// Logger outputs messages using slog. The underlying handler respects
 	// the user supplied logging config.
 	Logger *slog.Logger
+	// LoggerLevel defines the Logger log level.
+	LoggerLevel *slog.LevelVar
 
 	// PluginRegistry allows adding enterprise logic to Teleport services
 	PluginRegistry plugin.Registry
@@ -516,6 +519,10 @@ func ApplyDefaults(cfg *Config) {
 		cfg.Logger = slog.Default()
 	}
 
+	if cfg.LoggerLevel == nil {
+		cfg.LoggerLevel = new(slog.LevelVar)
+	}
+
 	// Remove insecure and (borderline insecure) cryptographic primitives from
 	// default configuration. These can still be added back in file configuration by
 	// users, but not supported by default by Teleport. See #1856 for more
@@ -680,6 +687,10 @@ func applyDefaults(cfg *Config) {
 		cfg.Logger = slog.Default()
 	}
 
+	if cfg.LoggerLevel == nil {
+		cfg.LoggerLevel = new(slog.LevelVar)
+	}
+
 	if cfg.PollingPeriod == 0 {
 		cfg.PollingPeriod = defaults.LowResPollingPeriod
 	}
@@ -762,4 +773,13 @@ func verifyEnabledService(cfg *Config) error {
 
 	return trace.BadParameter(
 		"config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service, windows_desktop_service, discovery_service, okta_service or jamf_service")
+}
+
+// SetLogLevel changes the loggers log level.
+//
+// If called after `config.ApplyFileConfig` or `config.Configure` it will also
+// change the global loggers.
+func (c *Config) SetLogLevel(level slog.Level) {
+	c.Log.SetLevel(logutils.SlogLevelToLogrusLevel(level))
+	c.LoggerLevel.Set(level)
 }

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -106,6 +106,9 @@ type Config struct {
 	// Metrics defines the metrics service configuration.
 	Metrics MetricsConfig
 
+	// DebugService defines the debug service configuration.
+	DebugService DebugConfig
+
 	// WindowsDesktop defines the Windows desktop service configuration.
 	WindowsDesktop WindowsDesktopConfig
 
@@ -782,4 +785,9 @@ func verifyEnabledService(cfg *Config) error {
 func (c *Config) SetLogLevel(level slog.Level) {
 	c.Log.SetLevel(logutils.SlogLevelToLogrusLevel(level))
 	c.LoggerLevel.Set(level)
+}
+
+// GetLogLevel returns the current log level.
+func (c *Config) GetLogLevel() slog.Level {
+	return c.LoggerLevel.Level()
 }

--- a/lib/service/servicecfg/debug.go
+++ b/lib/service/servicecfg/debug.go
@@ -1,0 +1,23 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package servicecfg
+
+// DebugConfig specifies configuration for the debug service
+type DebugConfig struct {
+	// Enabled turns the debug service role on or off for this process.
+	Enabled bool
+}

--- a/lib/service/signals.go
+++ b/lib/service/signals.go
@@ -301,7 +301,17 @@ func (process *TeleportProcess) createListener(typ ListenerType, address string)
 		return nil, trace.BadParameter("listening is blocked")
 	}
 
-	listener, err := net.Listen("tcp", address)
+	// When the process exists, the socket files are left behind (to cover
+	// forking scenarios). To guarantee there won't be errors like "address
+	// already in use", delete the file before starting the listener.
+	if typ.Network() == "unix" {
+		process.logger.DebugContext(process.ExitContext(), "Deleting socket file", "path", address)
+		if err := trace.ConvertSystemError(os.Remove(address)); !trace.IsNotFound(err) {
+			warnOnErr(process.ExitContext(), err, process.logger)
+		}
+	}
+
+	listener, err := net.Listen(typ.Network(), address)
 	if err != nil {
 		process.Lock()
 		listener, ok := process.getListenerNeedsLock(typ, address)
@@ -312,6 +322,15 @@ func (process *TeleportProcess) createListener(typ ListenerType, address string)
 		}
 		return nil, trace.Wrap(err)
 	}
+
+	// The default behavior for unix listeners is to delete the file when the
+	// listener closes (unlinking). However, if the process forks, the file
+	// descriptor will be gone when its parent process exists, causing the new
+	// listener to have no socket file.
+	if unixListener, ok := listener.(*net.UnixListener); ok {
+		unixListener.SetUnlinkOnClose(false)
+	}
+
 	process.Lock()
 	defer process.Unlock()
 	// check this again in case we stopped allowing new listeners halfway

--- a/lib/srv/debug/handlers.go
+++ b/lib/srv/debug/handlers.go
@@ -45,26 +45,29 @@ func NewServeMux(logger *slog.Logger, leveler LogLeveler) *http.ServeMux {
 	mux.HandleFunc("/debug/pprof/profile", pprofMiddleware(logger, "profile", pprof.Profile))
 	mux.HandleFunc("/debug/pprof/symbol", pprofMiddleware(logger, "symbol", pprof.Symbol))
 	mux.HandleFunc("/debug/pprof/trace", pprofMiddleware(logger, "trace", pprof.Trace))
-	mux.HandleFunc("/debug/pprof/{profile}", func(w http.ResponseWriter, r *http.Request) {
-		pprofMiddleware(logger, r.PathValue("profile"), pprof.Index)(w, r)
+	mux.HandleFunc("/debug/pprof/", func(w http.ResponseWriter, r *http.Request) {
+		profile, _ := strings.CutPrefix(r.URL.Path, "/debug/pprof/")
+		pprofMiddleware(logger, profile, pprof.Index)(w, r)
 	})
-	mux.Handle("GET /log-level", handleGetLog(logger, leveler))
-	mux.Handle("PUT /log-level", handleSetLog(logger, leveler))
+	mux.Handle("/log-level", handleLog(logger, leveler))
 	return mux
 }
 
-// handleGetLog returns the http get log level handler.
-func handleGetLog(logger *slog.Logger, leveler LogLeveler) http.HandlerFunc {
+// handleLog returns the http log level handler.
+func handleLog(logger *slog.Logger, leveler LogLeveler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		level := leveler.GetLogLevel()
-		logger.InfoContext(r.Context(), "Log level requested", "log_level", level)
-		w.Write([]byte(marshalLogLevel(level)))
-	}
-}
+		if r.Method == http.MethodGet {
+			level := leveler.GetLogLevel()
+			logger.InfoContext(r.Context(), "Log level requested", "log_level", level)
+			w.Write([]byte(marshalLogLevel(level)))
+			return
+		}
 
-// handleSetLog returns the http set log level handler.
-func handleSetLog(logger *slog.Logger, leveler LogLeveler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
 		rawLevel, err := io.ReadAll(io.LimitReader(r.Body, 1024))
 		defer r.Body.Close()
 		if err != nil {

--- a/lib/srv/debug/handlers.go
+++ b/lib/srv/debug/handlers.go
@@ -1,0 +1,140 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package debug
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/pprof"
+	"slices"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	logutils "github.com/gravitational/teleport/lib/utils/log"
+)
+
+// LogLeveler defines a struct that can retrieve and set log levels.
+type LogLeveler interface {
+	// GetLogLevel returns the current log level.
+	GetLogLevel() slog.Level
+	// SetLogLevel sets the log level.
+	SetLogLevel(slog.Level)
+}
+
+// NewServeMux returns a http mux that handles all the debug service endpoints.
+func NewServeMux(logger *slog.Logger, leveler LogLeveler) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/cmdline", pprofMiddleware(logger, "cmdline", pprof.Cmdline))
+	mux.HandleFunc("/debug/pprof/profile", pprofMiddleware(logger, "profile", pprof.Profile))
+	mux.HandleFunc("/debug/pprof/symbol", pprofMiddleware(logger, "symbol", pprof.Symbol))
+	mux.HandleFunc("/debug/pprof/trace", pprofMiddleware(logger, "trace", pprof.Trace))
+	mux.HandleFunc("/debug/pprof/{profile}", func(w http.ResponseWriter, r *http.Request) {
+		pprofMiddleware(logger, r.PathValue("profile"), pprof.Index)(w, r)
+	})
+	mux.Handle("GET /log-level", handleGetLog(logger, leveler))
+	mux.Handle("PUT /log-level", handleSetLog(logger, leveler))
+	return mux
+}
+
+// handleGetLog returns the http get log level handler.
+func handleGetLog(logger *slog.Logger, leveler LogLeveler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		level := leveler.GetLogLevel()
+		logger.InfoContext(r.Context(), "Log level requested", "log_level", level)
+		w.Write([]byte(marshalLogLevel(level)))
+	}
+}
+
+// handleSetLog returns the http set log level handler.
+func handleSetLog(logger *slog.Logger, leveler LogLeveler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		rawLevel, err := io.ReadAll(io.LimitReader(r.Body, 1024))
+		defer r.Body.Close()
+		if err != nil {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.Write([]byte("Unable to read request body."))
+			return
+		}
+
+		level, err := unmarshalLogLevel(rawLevel)
+		if err != nil {
+			logger.WarnContext(r.Context(), "Failed to parse log level", "error", err)
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.Write([]byte("Invalid log level."))
+			return
+		}
+
+		currLevel := leveler.GetLogLevel()
+		message := fmt.Sprintf("Log level already set to %q.", level)
+		if level != currLevel {
+			message = fmt.Sprintf("Changed log level from %q to %q.", marshalLogLevel(currLevel), marshalLogLevel(level))
+			leveler.SetLogLevel(level)
+			logger.InfoContext(r.Context(), "Changed log level.", "old", marshalLogLevel(currLevel), "new", marshalLogLevel(level))
+		}
+
+		w.Write([]byte(message))
+	}
+}
+
+// pprofMiddleware logs pprof HTTP requests.
+func pprofMiddleware(logger *slog.Logger, profile string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		seconds := r.FormValue("seconds")
+		if seconds == "" {
+			seconds = "default"
+		}
+
+		logger.InfoContext(
+			r.Context(),
+			"Collecting pprof profile.",
+			"profile", profile,
+			"seconds", seconds,
+		)
+
+		next(w, r)
+	}
+}
+
+// unmarshalLogLevel unmarshals log level text representation to slog.Level.
+func unmarshalLogLevel(data []byte) (slog.Level, error) {
+	var level slog.Level
+	if contains := slices.Contains(logutils.SupportedLevelsText, strings.ToUpper(string(data))); !contains {
+		return level, trace.BadParameter("%q log level not supported", string(data))
+	}
+
+	if strings.EqualFold(string(data), logutils.TraceLevelText) {
+		return logutils.TraceLevel, nil
+	}
+
+	if err := level.UnmarshalText(data); err != nil {
+		return level, trace.Wrap(err)
+	}
+
+	return level, nil
+}
+
+// marshalLogLevel marshals log level to its text representation.
+func marshalLogLevel(level slog.Level) string {
+	if level == logutils.TraceLevel {
+		return logutils.TraceLevelText
+	}
+
+	return level.String()
+}

--- a/lib/srv/debug/handlers_test.go
+++ b/lib/srv/debug/handlers_test.go
@@ -1,0 +1,116 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package debug
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logutils "github.com/gravitational/teleport/lib/utils/log"
+)
+
+type mockLeveler struct {
+	currentLevel slog.Level
+}
+
+func (m *mockLeveler) GetLogLevel() slog.Level {
+	return m.currentLevel
+}
+
+func (m *mockLeveler) SetLogLevel(level slog.Level) {
+	m.currentLevel = level
+}
+
+func TestLogLevel(t *testing.T) {
+	leveler, ts := makeServer(t)
+	statusCode, logLevel := makeRequest(t, ts, http.MethodGet, "/log-level", "")
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Equal(t, leveler.GetLogLevel().String(), logLevel)
+
+	// Invalid log level
+	statusCode, _ = makeRequest(t, ts, http.MethodPut, "/log-level", "RANDOM")
+	require.Equal(t, http.StatusUnprocessableEntity, statusCode)
+
+	for _, logLevel := range logutils.SupportedLevelsText {
+		t.Run("Set"+logLevel, func(t *testing.T) {
+			statusCode, _ := makeRequest(t, ts, http.MethodPut, "/log-level", logLevel)
+			require.Equal(t, http.StatusOK, statusCode)
+
+			statusCode, retrievedLogLevel := makeRequest(t, ts, http.MethodGet, "/log-level", "")
+			require.Equal(t, http.StatusOK, statusCode)
+			require.Equal(t, logLevel, retrievedLogLevel)
+		})
+
+		t.Run("SetLower"+logLevel, func(t *testing.T) {
+			statusCode, _ := makeRequest(t, ts, http.MethodPut, "/log-level", strings.ToLower(logLevel))
+			require.Equal(t, http.StatusOK, statusCode)
+
+			statusCode, retrievedLogLevel := makeRequest(t, ts, http.MethodGet, "/log-level", "")
+			require.Equal(t, http.StatusOK, statusCode)
+			require.Equal(t, logLevel, retrievedLogLevel)
+		})
+	}
+
+	// Random or any other slog format should be rejected.
+	for _, level := range []string{"RANDOM", "DEBUG-1", "INFO+1", "INVALID"} {
+		t.Run("Set"+level, func(t *testing.T) {
+			statusCode, _ := makeRequest(t, ts, http.MethodPut, "/log-level", level)
+			require.Equal(t, http.StatusUnprocessableEntity, statusCode)
+		})
+
+		t.Run("SetLower"+level, func(t *testing.T) {
+			statusCode, _ := makeRequest(t, ts, http.MethodPut, "/log-level", strings.ToLower(level))
+			require.Equal(t, http.StatusUnprocessableEntity, statusCode)
+		})
+	}
+}
+
+func TestCollectProfiles(t *testing.T) {
+	_, ts := makeServer(t)
+	statusCode, body := makeRequest(t, ts, http.MethodGet, "/debug/pprof/goroutine", "")
+	require.Equal(t, http.StatusOK, statusCode)
+	require.NotEmpty(t, body)
+}
+
+func makeServer(t *testing.T) (*mockLeveler, *httptest.Server) {
+	leveler := &mockLeveler{}
+	ts := httptest.NewServer(NewServeMux(slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})), leveler))
+	t.Cleanup(func() { ts.Close() })
+	return leveler, ts
+}
+
+func makeRequest(t *testing.T, ts *httptest.Server, method, path, body string) (int, string) {
+	t.Helper()
+
+	req, err := http.NewRequest(method, ts.URL+path, bytes.NewBufferString(body))
+	require.NoError(t, err)
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(respBody)
+}

--- a/lib/utils/log/levels.go
+++ b/lib/utils/log/levels.go
@@ -24,6 +24,16 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// SupportedLevelsText lists the supported log levels in their text
+// representation. All strings are in uppercase.
+var SupportedLevelsText = []string{
+	TraceLevelText,
+	slog.LevelDebug.String(),
+	slog.LevelInfo.String(),
+	slog.LevelWarn.String(),
+	slog.LevelError.String(),
+}
+
 // SlogLevelToLogrusLevel converts a [slog.Level] to its equivalent
 // [logrus.Level].
 func SlogLevelToLogrusLevel(level slog.Level) logrus.Level {

--- a/lib/utils/log/slog_handler.go
+++ b/lib/utils/log/slog_handler.go
@@ -41,6 +41,9 @@ import (
 // TraceLevel is the logging level when set to Trace verbosity.
 const TraceLevel = slog.LevelDebug - 1
 
+// TraceLevelText is the text representation of Trace verbosity.
+const TraceLevelText = "TRACE"
+
 // SlogTextHandler is a [slog.Handler] that outputs messages in a textual
 // manner as configured by the Teleport configuration.
 type SlogTextHandler struct {

--- a/tool/teleport/common/debug.go
+++ b/tool/teleport/common/debug.go
@@ -1,0 +1,207 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	debugclient "github.com/gravitational/teleport/lib/client/debug"
+	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/lib/defaults"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
+)
+
+// DebugClient specifies the debug service client.
+type DebugClient interface {
+	// SetLogLevel changes the application's log level and a change status message.
+	SetLogLevel(context.Context, string) (string, error)
+	// GetLogLevel fetches the current log level.
+	GetLogLevel(context.Context) (string, error)
+	// CollectProfile collects a pprof profile.
+	CollectProfile(context.Context, string, int) ([]byte, error)
+}
+
+func onSetLogLevel(configPath string, level string) error {
+	ctx := context.Background()
+	clt, dataDir, socketPath, err := newDebugClient(configPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	setMessage, err := setLogLevel(ctx, clt, level)
+	if err != nil {
+		return convertToReadableErr(err, dataDir, socketPath)
+	}
+
+	fmt.Println(setMessage)
+	return nil
+}
+
+func setLogLevel(ctx context.Context, clt DebugClient, level string) (string, error) {
+	if contains := slices.Contains(logutils.SupportedLevelsText, strings.ToUpper(level)); !contains {
+		return "", trace.BadParameter("%q log level not supported", level)
+	}
+
+	return clt.SetLogLevel(ctx, level)
+}
+
+func onGetLogLevel(configPath string) error {
+	ctx := context.Background()
+	clt, dataDir, socketPath, err := newDebugClient(configPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	currentLogLevel, err := getLogLevel(ctx, clt)
+	if err != nil {
+		return convertToReadableErr(err, dataDir, socketPath)
+	}
+
+	fmt.Printf("Current log level %q\n", currentLogLevel)
+	return nil
+}
+
+func getLogLevel(ctx context.Context, clt DebugClient) (string, error) {
+	return clt.GetLogLevel(ctx)
+}
+
+// defaultCollectProfileSeconds defines the default collect profiles seconds
+// value.
+const defaultCollectProfileSeconds = 10
+
+// profilesWithoutSnapshotSupport list of profiles that DO NOT support taking
+// snapshots (seconds = 0).
+var profilesWithoutSnapshotSupport = map[string]struct{}{
+	"profile": {},
+	"trace":   {},
+}
+
+// defaultCollectProfiles defines the default profiles to be collected in case
+// none is provided.
+var defaultCollectProfiles = []string{"goroutine", "heap", "profile"}
+
+func onCollectProfiles(configPath string, rawProfiles string, seconds int) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
+	clt, dataDir, socketPath, err := newDebugClient(configPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var output bytes.Buffer
+	if err := collectProfiles(ctx, clt, &output, rawProfiles, seconds); err != nil {
+		return convertToReadableErr(err, dataDir, socketPath)
+	}
+
+	fmt.Print(output.String())
+	return nil
+}
+
+// collectProfiles collects the profiles and generate a compressed tarball
+// file.
+func collectProfiles(ctx context.Context, clt DebugClient, buf io.Writer, rawProfiles string, seconds int) error {
+	profiles := defaultCollectProfiles
+	if rawProfiles != "" {
+		profiles = slices.Compact(strings.Split(rawProfiles, ","))
+	}
+
+	fileTime := time.Now()
+	gw := gzip.NewWriter(buf)
+	tw := tar.NewWriter(gw)
+
+	for _, profile := range profiles {
+		profileSeconds := seconds
+		// When the profile doesn't support snapshot, we set a default seconds
+		// value to avoid blocking users when they consume those profiles.
+		if _, ok := profilesWithoutSnapshotSupport[profile]; seconds == 0 && ok {
+			profileSeconds = 10
+		}
+
+		contents, err := clt.CollectProfile(ctx, profile, profileSeconds)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		hd := &tar.Header{
+			Name:    profile + ".pprof",
+			Size:    int64(len(contents)),
+			Mode:    0600,
+			ModTime: fileTime,
+		}
+		if err := tw.WriteHeader(hd); err != nil {
+			return trace.Wrap(err)
+		}
+		if _, err := tw.Write(contents); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return trace.NewAggregate(tw.Close(), gw.Close())
+}
+
+// newDebugClient initializes the debug client based on the Teleport
+// configuration. It also returns the data dir and socket path used.
+func newDebugClient(configPath string) (DebugClient, string, string, error) {
+	cfg, err := config.ReadConfigFile(configPath)
+	if err != nil {
+		return nil, "", "", trace.Wrap(err)
+	}
+
+	// ReadConfigFile returns nil configuration if the file doesn't exists.
+	// In that case, fallback to default data dir path.
+	dataDir := defaults.DataDir
+	if cfg != nil {
+		dataDir = cfg.DataDir
+	}
+
+	socketPath := filepath.Join(dataDir, teleport.DebugServiceSocketName)
+	return debugclient.NewClient(socketPath), dataDir, socketPath, nil
+}
+
+// convertToReadableErr converts debug service client error into a more friendly
+// messages.
+func convertToReadableErr(err error, dataDir, socketPath string) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, context.Canceled):
+		return fmt.Errorf("Request canceled")
+	case trace.IsConnectionProblem(err):
+		return trace.BadParameter("Unable to reach debug service socket at %q."+
+			"\n\nVerify if you have enough permissions to open the socket and if the path"+
+			" to your data directory (%q) is correct. The command assumes the data"+
+			" directory from your configuration file, you can provide the path to it using the --config flag.", socketPath, dataDir)
+	default:
+		return err
+	}
+}

--- a/tool/teleport/common/debug_test.go
+++ b/tool/teleport/common/debug_test.go
@@ -1,0 +1,144 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+func TestCollectProfiles(t *testing.T) {
+	ctx := context.Background()
+
+	for _, test := range []struct {
+		desc             string
+		profilesInput    string
+		seconds          int
+		expectedProfiles map[string]int
+	}{
+		{
+			desc:             "single profile",
+			profilesInput:    "goroutine",
+			expectedProfiles: map[string]int{"goroutine": 0},
+		},
+		{
+			desc:             "profile with seconds flag",
+			profilesInput:    "block",
+			seconds:          15,
+			expectedProfiles: map[string]int{"block": 15},
+		},
+		{
+			desc:             "multiple profiles",
+			profilesInput:    "allocs,goroutine",
+			expectedProfiles: map[string]int{"allocs": 0, "goroutine": 0},
+		},
+		{
+			desc:             "profiles without snapshot support",
+			profilesInput:    "trace,profile",
+			expectedProfiles: map[string]int{"trace": defaultCollectProfileSeconds, "profile": defaultCollectProfileSeconds},
+		},
+		{
+			desc:             "profiles without snapshot support with seconds provided",
+			profilesInput:    "trace,profile",
+			seconds:          20,
+			expectedProfiles: map[string]int{"trace": 20, "profile": 20},
+		},
+		{
+			desc:             "duplicated profiles",
+			profilesInput:    "goroutine,goroutine",
+			expectedProfiles: map[string]int{"goroutine": 0},
+		},
+		{
+			desc:          "all valid profiles",
+			profilesInput: "allocs,block,cmdline,goroutine,heap,mutex,profile,threadcreate,trace",
+			expectedProfiles: map[string]int{
+				"allocs":       0,
+				"block":        0,
+				"cmdline":      0,
+				"goroutine":    0,
+				"heap":         0,
+				"mutex":        0,
+				"profile":      defaultCollectProfileSeconds,
+				"threadcreate": 0,
+				"trace":        defaultCollectProfileSeconds,
+			},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			clt := &mockDebugClient{profileContents: make([]byte, 0)}
+			var out bytes.Buffer
+			err := collectProfiles(ctx, clt, &out, test.profilesInput, test.seconds)
+			require.NoError(t, err)
+
+			var requestedProfiles []string
+			for _, profile := range clt.collectedProfiles {
+				expectedSeconds, ok := test.expectedProfiles[profile.name]
+				require.True(t, ok, "unexpected profile %q collected", profile.name)
+				require.Equal(t, expectedSeconds, profile.seconds)
+				requestedProfiles = append(requestedProfiles, profile.name)
+			}
+			require.Equal(t, len(test.expectedProfiles), len(requestedProfiles), "expected %d to be requested but got %d", len(test.expectedProfiles), len(requestedProfiles))
+
+			reader, err := gzip.NewReader(&out)
+			require.NoError(t, err)
+			var files []string
+			tarReader := tar.NewReader(reader)
+			for {
+				header, err := tarReader.Next()
+				if err == io.EOF {
+					break
+				}
+				require.NoError(t, err)
+				files = append(files, strings.TrimSuffix(header.Name, ".pprof"))
+			}
+
+			// We should have one file per profile collected.
+			require.ElementsMatch(t, maps.Keys(test.expectedProfiles), files)
+		})
+	}
+}
+
+type collectedProfile struct {
+	name    string
+	seconds int
+}
+
+type mockDebugClient struct {
+	DebugClient
+
+	profileContents   []byte
+	collectProfileErr error
+	collectedProfiles []collectedProfile
+}
+
+// CollectProfile implements debug.Client.
+func (m *mockDebugClient) CollectProfile(_ context.Context, name string, seconds int) ([]byte, error) {
+	if m.collectedProfiles == nil {
+		m.collectedProfiles = make([]collectedProfile, 0)
+	}
+
+	m.collectedProfiles = append(m.collectedProfiles, collectedProfile{name, seconds})
+	return m.profileContents, m.collectProfileErr
+}

--- a/tool/teleport/common/usage.go
+++ b/tool/teleport/common/usage.go
@@ -116,6 +116,21 @@ Examples:
   to using that label in addition to its name.
 %v
 %v`, appUsageExamples, dbUsageExamples)
+
+	collectProfileUsageExamples = `Examples:
+> teleport debug profile > pprof.tar.gz
+  Collect default profiles and stores the resulting tarball in a file.
+
+> teleport debug profile | tar xzv -C pprof/
+  Collects default profiles, decompress the results into pprof/ directory.
+
+> teleport debug profile heap,goroutine > pprof.tar.gz
+  Collects heap and goroutine profiles. Stores the results in a file.
+
+> teleport debug profile -s 0 goroutine > pprof.tar.gz
+  Collects a snapshot of goroutine profile. Stores the results in a file.
+  Note: Only allocs,block,goroutine,heap,mutex,threadcreate,trace,cmdline
+        supports snapshots.`
 )
 
 const (


### PR DESCRIPTION
Backport debug service PRs to `branch/v15`:
- #39416
- #39865
- #42077

Note: Since the debug service handlers were initially using the `ServeMux` new features present only on go1.22, it was required to update the handlers to work on go1.21 (The changes are all present on [this commit](https://github.com/gravitational/teleport/commit/2150c0c10cedaa7771dd420faa138d91e8d2538b))

Changelog: Added new `teleport debug set-log-level / profile` commands changing instance log level without a restart and collecting pprof profiles.