### PR TITLE
[branch/v16] Added multiarch image support to teleport plugins images (#42001)

### DIFF
--- a/integrations/access/Dockerfile
+++ b/integrations/access/Dockerfile
@@ -1,44 +1,18 @@
-ARG BUILDBOX
 ARG BASE_IMAGE=gcr.io/distroless/static-debian12
 
 # BUILDPLATFORM is provided by Docker/buildx
-FROM --platform=$BUILDPLATFORM $BUILDBOX as builder
+# Extract the built tarball to reduce the final image size
+FROM --platform=${BUILDPLATFORM} alpine:3.20.0 as extractor
 
-WORKDIR /go/src/github.com/gravitational/teleport/
-
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-
-# We have to copy the API before `go mod download` because go.mod has a replace directive for it
-COPY api/ api/
-
-RUN go mod download
-
-# Copy in code
-COPY version.go constants.go ./
-COPY lib/ ./lib/
-COPY build.assets/images.mk build.assets/arch.mk ./build.assets/
-COPY integrations/lib/ ./integrations/lib/
-COPY integrations/access/ ./integrations/access/
-
-RUN pwd && ls -la
-
-ARG TARGETOS
-ARG TARGETARCH
-ARG ACCESS_PLUGIN
-ARG VERSION
-
-WORKDIR /go/src/github.com/gravitational/teleport/integrations/access/$ACCESS_PLUGIN
-
-# Build the program. We rely on golang's cross-compilation capabilities for multiarch building.
-RUN make build/teleport-$ACCESS_PLUGIN VERSION=$VERSION
+WORKDIR /extraction
+COPY *${TARGETARCH}*.tar.gz /plugin.tar.gz
+RUN tar -xzvf /plugin.tar.gz && \
+    find . -type f -executable -name 'teleport-*' -exec mv {} /teleport-plugin \;
 
 # Create the image with the build operator on the $TARGETPLATFORM
 # TARGETPLATFORM is provided by Docker/buildx
-FROM --platform=$TARGETPLATFORM $BASE_IMAGE
+FROM --platform=${TARGETPLATFORM} ${BASE_IMAGE}
 WORKDIR /
-ARG ACCESS_PLUGIN
-COPY --from=builder /go/src/github.com/gravitational/teleport/integrations/access/$ACCESS_PLUGIN/build/teleport-$ACCESS_PLUGIN /usr/local/bin/teleport-plugin
+COPY --from=extractor /teleport-plugin /usr/local/bin/teleport-plugin
 
 ENTRYPOINT ["/usr/local/bin/teleport-plugin"]

--- a/integrations/access/common.mk
+++ b/integrations/access/common.mk
@@ -12,7 +12,7 @@ CGOFLAG ?= CGO_ENABLED=0
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
 RELEASE_NAME=teleport-access-$(ACCESS_PLUGIN)
-RELEASE=$(RELEASE_NAME)-$(VERSION)-$(OS)-$(ARCH)-bin
+RELEASE=$(RELEASE_NAME)-v$(VERSION)-$(OS)-$(ARCH)-bin
 
 RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
@@ -23,7 +23,7 @@ DOCKER_IMAGE_BASE = $(DOCKER_PRIVATE_REGISTRY)/gravitational
 DOCKER_IMAGE = $(DOCKER_IMAGE_BASE)/$(DOCKER_NAME):$(DOCKER_VERSION)
 DOCKER_ECR_PUBLIC_REGISTRY = public.ecr.aws/gravitational
 DOCKER_IMAGE_ECR_PUBLIC = $(DOCKER_ECR_PUBLIC_REGISTRY)/$(DOCKER_NAME):$(DOCKER_VERSION)
-DOCKER_BUILD_ARGS = --load --platform="$(OS)/$(ARCH)" --build-arg ACCESS_PLUGIN=$(ACCESS_PLUGIN) --build-arg VERSION=$(VERSION) --build-arg BUILDBOX=$(BUILDBOX)
+DOCKER_BUILD_ARGS = --load --platform="$(OS)/$(ARCH)"
 # In staging
 # DOCKER_PRIVATE_REGISTRY = 603330915152.dkr.ecr.us-west-2.amazonaws.com
 # DOCKER_ECR_PUBLIC_REGISTRY = public.ecr.aws/gravitational-staging
@@ -44,7 +44,7 @@ clean:
 	rm -rf *.gz
 
 .PHONY: release
-release: clean $(BINARY)
+release: $(BINARY)
 	@echo "---> $(RELEASE_MESSAGE)"
 	mkdir build/$(RELEASE_NAME)
 	cp -rf $(BINARY) \
@@ -57,8 +57,9 @@ release: clean $(BINARY)
 	@echo "---> Created build/$(RELEASE).tar.gz."
 
 .PHONY: docker-build
-docker-build: ## Build docker image with the plugin.
-	docker buildx build ${DOCKER_BUILD_ARGS} -t ${DOCKER_IMAGE} -f ../Dockerfile ../../..
+docker-build: OS = linux
+docker-build: release ## Build docker image with the plugin.
+	docker buildx build ${DOCKER_BUILD_ARGS} -t ${DOCKER_IMAGE} -f ../Dockerfile ./build
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the plugin.

--- a/integrations/event-handler/Dockerfile
+++ b/integrations/event-handler/Dockerfile
@@ -1,39 +1,18 @@
-ARG BUILDBOX
 ARG BASE_IMAGE=gcr.io/distroless/static-debian12
 
 # BUILDPLATFORM is provided by Docker/buildx
-FROM --platform=$BUILDPLATFORM $BUILDBOX as builder
+# Extract the built tarball to reduce the final image size
+FROM --platform=${BUILDPLATFORM} alpine:3.20.0 as extractor
 
-WORKDIR /go/src/github.com/gravitational/teleport/
-
-# Copy dependencies and go.mod
-COPY api/ api/
-COPY version.go constants.go go.mod go.sum ./
-COPY lib/ ./lib/
-COPY build.assets/images.mk build.assets/arch.mk ./build.assets/
-COPY integrations/lib/ ./integrations/lib/
-
-COPY integrations/event-handler/go.mod ./integrations/event-handler/go.mod
-COPY integrations/event-handler/go.sum ./integrations/event-handler/go.sum
-
-RUN cd integrations/event-handler && go mod download
-
-COPY integrations/event-handler ./integrations/event-handler
-
-ARG TARGETOS
-ARG TARGETARCH
-ARG GITREF
-ARG VERSION
-
-WORKDIR /go/src/github.com/gravitational/teleport/integrations/event-handler
-
-# Build the program. We rely on golang's cross-compilation capabilities for multiarch building.
-RUN make build GITREF=$GITREF VERSION=$VERSION
+WORKDIR /extraction
+COPY *${TARGETARCH}*.tar.gz /plugin.tar.gz
+RUN tar -xzvf /plugin.tar.gz && \
+    find . -type f -executable -name 'teleport-*' -exec mv {} /teleport-plugin \;
 
 # Create the image with the build operator on the $TARGETPLATFORM
 # TARGETPLATFORM is provided by Docker/buildx
-FROM --platform=$TARGETPLATFORM $BASE_IMAGE
+FROM --platform=${TARGETPLATFORM} ${BASE_IMAGE}
 WORKDIR /
-COPY --from=builder /go/src/github.com/gravitational/teleport/integrations/event-handler/build/teleport-event-handler /usr/local/bin/teleport-event-handler
+COPY --from=extractor /teleport-plugin /usr/local/bin/teleport-plugin
 
-ENTRYPOINT ["/usr/local/bin/teleport-event-handler"]
+ENTRYPOINT ["/usr/local/bin/teleport-plugin"]

--- a/integrations/event-handler/Makefile
+++ b/integrations/event-handler/Makefile
@@ -15,7 +15,7 @@ GENTERRAFORMPATH := $(shell go env GOPATH)/bin
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-event-handler
 
-GITREF ?= $(shell git describe --dirty --long --tags --match '*event-handler*')
+GITREF ?= $(shell git describe --dirty --long --tags --match '$(VERSION)')
 ADDFLAGS ?=
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags "-w -s -X main.Gitref=$(GITREF) -X main.Version=$(VERSION)"
 CGOFLAG ?= CGO_ENABLED=0
@@ -34,7 +34,7 @@ DOCKER_IMAGE_BASE = $(DOCKER_PRIVATE_REGISTRY)/gravitational
 DOCKER_IMAGE = $(DOCKER_IMAGE_BASE)/$(DOCKER_NAME):$(DOCKER_VERSION)
 DOCKER_ECR_PUBLIC_REGISTRY = public.ecr.aws/gravitational
 DOCKER_IMAGE_ECR_PUBLIC = $(DOCKER_ECR_PUBLIC_REGISTRY)/$(DOCKER_NAME):$(DOCKER_VERSION)
-DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg GITREF=$(GITREF) --build-arg VERSION=$(VERSION) --build-arg VERSION=$(VERSION) --load --platform="$(OS)/$(ARCH)" --build-arg BUILDBOX=$(BUILDBOX)
+DOCKER_BUILD_ARGS = --load --platform="$(OS)/$(ARCH)"
 RELEASE_NAME = teleport-event-handler
 RELEASE = $(RELEASE_NAME)-v$(VERSION)-$(OS)-$(ARCH)-bin
 RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
@@ -43,7 +43,7 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 # DOCKER_ECR_PUBLIC_REGISTRY = public.ecr.aws/gravitational-staging
 
 .PHONY: build
-build: clean
+build:
 	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -o $(BUILDDIR)/teleport-event-handler $(BUILDFLAGS)
 
 .PHONY: release
@@ -65,8 +65,9 @@ clean:
 	go clean
 
 .PHONY: docker-build
-docker-build: ## Build docker image with the plugin.
-	docker build ${DOCKER_BUILD_ARGS} -t ${DOCKER_IMAGE} -f ./Dockerfile ../..
+docker-build: OS = linux
+docker-build: release ## Build docker image with the plugin.
+	docker build ${DOCKER_BUILD_ARGS} -t ${DOCKER_IMAGE} -f ./Dockerfile .
 
 .PHONY: docker-push
 docker-push:


### PR DESCRIPTION
Backports #42001. Must be merged in sync with https://github.com/gravitational/teleport.e/pull/4264 to prevent breakage.

changelog: Added support for amd64 and arm64 ISAs for both Linux and macOs on all Teleport plugins binaries.
changelog: Added multiarch images for all Teleport plugins container images.
changelog: All Teleport plugins container images are now signed.
changelog: Added rolling major/minor tags for all Teleport plugins container images. For example, pulling `public.ecr.aws/gravitational/teleport-plugin-email:16` will now always pull the latest v16 `teleport-plugin-email` image.