### PR TITLE
Fix userState forwarding in CreateSessionCert

### DIFF
--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -473,17 +473,12 @@ func (a *Server) generateAppToken(ctx context.Context, username string, roles []
 	return token, nil
 }
 
-func (a *Server) CreateSessionCert(user services.UserState, sessionTTL time.Duration, publicKey []byte, compatibility, routeToCluster, kubernetesCluster, loginIP string, attestationReq *keys.AttestationStatement) ([]byte, []byte, error) {
+func (a *Server) CreateSessionCert(userState services.UserState, sessionTTL time.Duration, publicKey []byte, compatibility, routeToCluster, kubernetesCluster, loginIP string, attestationReq *keys.AttestationStatement) ([]byte, []byte, error) {
 	// It's safe to extract the access info directly from services.User because
 	// this occurs during the initial login before the first certs have been
 	// generated, so there's no possibility of any active access requests.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-
-	userState, err := a.GetUserOrLoginState(ctx, user.GetName())
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
 
 	accessInfo := services.AccessInfoFromUserState(userState)
 	clusterName, err := a.GetClusterName()


### PR DESCRIPTION
### What


Fix user state forwarding. 

The CreateSessionCert takes a userState and fetches the users state. This is not needed. User state if fetched directly before CreateSessionCert is called. 
