### PR TITLE
Docs: update mentions of the teleport-plugins repo

### DIFF
--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -87,9 +87,10 @@ We'll reference the exported file(s) later when configuring the plugin.
   To install from source you need `git` and `go >= (=teleport.golang=)` installed.
 
   ```code
-  # Checkout teleport-plugins
-  $ git clone https://github.com/gravitational/teleport-plugins.git
-  $ cd teleport-plugins/access/mattermost
+  # Checkout the Teleport repo and go in the mattermost access plugin directory
+  $ git clone https://github.com/gravitational/teleport.git
+  $ cd teleport/integrations/access/mattermost
+  $ git checkout (=teleport.plugin.version=)
   $ make
   ```
 </TabItem>

--- a/docs/pages/api/access-plugin.mdx
+++ b/docs/pages/api/access-plugin.mdx
@@ -52,7 +52,7 @@ plugin.
 
 The demo is a minimal working example, and you can see fully fledged plugins in
 the
-[`gravitational/teleport-plugins`](https://github.com/gravitational/teleport-plugins)
+[`gravitational/teleport`](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/integrations/access).
 repository on GitHub.
 
 </Admonition>
@@ -456,7 +456,7 @@ package to make it easier for your Access Request plugin to do this.
 ### Consult the examples
 
 Explore the
-[`gravitational/teleport-plugins`](https://github.com/gravitational/teleport-plugins)
+[`gravitational/teleport`](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/integrations/access).
 repository on GitHub for examples of plugins developed at Teleport. You can see
 how these plugins use the packages we discuss in this guide, as well as how they
 add more complete functionality like configuration validation and state

--- a/docs/pages/api/automatically-register-agents.mdx
+++ b/docs/pages/api/automatically-register-agents.mdx
@@ -955,12 +955,11 @@ Discovery Service, and you can [consult its
 source](https://github.com/gravitational/teleport/tree/master/lib/srv/discovery)
 to see how Teleport implements its discovery logic.
 
-The
-[`gravitational/teleport-plugins`](https://github.com/gravitational/teleport-plugins)
-repository contains examples of production-ready Teleport API clients. While we
-currently do not maintain plugins that auto-discover resources, you can use
-these examples to see how to implement configuration parsing, retries, and other
-tasks.
+The Teleport code repository contains [examples of production-ready Teleport API
+clients](https://github.com/gravitational/teleport/tree/(=teleport.version=)/examples/).
+While we currently do not maintain plugins that auto-discover resources, you
+can use these examples to see how to implement configuration parsing, retries,
+and other tasks.
 
 ### Provision the client application with short-lived credentials
 

--- a/docs/pages/api/rbac.mdx
+++ b/docs/pages/api/rbac.mdx
@@ -962,12 +962,11 @@ provider APIs:
 
 ### Consult examples
 
-The
-[`gravitational/teleport-plugins`](https://github.com/gravitational/teleport-plugins)
-repository contains examples of production-ready Teleport API clients. While we
-currently do not maintain plugins that generate Teleport roles, you can use
-these examples to see how to implement configuration parsing, retries, and other
-tasks.
+The Teleport code repository contains [examples of production-ready Teleport API
+clients](https://github.com/gravitational/teleport/tree/(=teleport.version=)/examples/).
+While we currently do not maintain plugins that generate Teleport
+roles, you can use these examples to see how to implement configuration
+parsing, retries, and other tasks.
 
 ### Provision the client application with short-lived credentials
 

--- a/docs/pages/includes/install-event-handler.mdx
+++ b/docs/pages/includes/install-event-handler.mdx
@@ -51,21 +51,6 @@ $ helm repo update
 ```
 
 </TabItem>
-<TabItem label="Build via Docker">
-Ensure that you have Docker installed and running.
-
-Run the following commands to build the plugin:
-
-```code
-$ git clone https://github.com/gravitational/teleport-plugins.git --depth 1
-$ cd teleport-plugins/event-handler/build.assets
-$ make build
-```
-
-You can find the compiled binary within your clone of the `teleport-plugins`
-repo, with the file path, `event-handler/build/teleport-event-handler`.
-
-</TabItem>
 <TabItem label="Build via Go">
 
 You will need Go >= (=teleport.golang=) installed.
@@ -73,9 +58,10 @@ You will need Go >= (=teleport.golang=) installed.
 Run the following commands on your Universal Forwarder host:
 
 ```code
-$ git clone https://github.com/gravitational/teleport-plugins.git --depth 1
-$ cd teleport-plugins/event-handler
-$ go build
+$ git clone https://github.com/gravitational/teleport.git --depth 1
+$ cd teleport/integrations/event-handler
+$ git checkout (=teleport.plugin.version=)
+$ make build
 ```
 
 The resulting executable will have the name `event-handler`. To follow the

--- a/docs/pages/includes/plugins/install-access-request.mdx
+++ b/docs/pages/includes/plugins/install-access-request.mdx
@@ -44,8 +44,9 @@ To install from source you need `git` and `go` installed. If you do not have Go
 installed, visit the Go [downloads page](https://go.dev/dl/).
 
 ```code
-$ git clone https://github.com/gravitational/teleport-plugins.git
-$ cd teleport-plugins/access/{{ name }}
+$ git clone https://github.com/gravitational/teleport
+$ cd teleport/integrations/access/{{ name }}
+$ git checkout (=teleport.plugin.version=)
 $ make
 ```
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-event-handler.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-event-handler.mdx
@@ -5,7 +5,7 @@ description: Values that can be set using the teleport-plugin-event-handler Helm
 
 The `teleport-plugin-event-handler` Helm chart is used to configure the Event Handler Teleport plugin which allows users to send events and session logs to a Fluentd instance for further processing or storage.
 
-You can [browse the source on GitHub](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/event-handler).
+You can [browse the source on GitHub](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/chart/event-handler).
 
 This reference details available values for the `teleport-plugin-event-handler` chart.
 
@@ -45,8 +45,6 @@ metadata:
 data:
   auth_id: ...
 ```
-
-Check out the [Event Handler Helm Chart documentation](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/event-handler/#prerequisites) for more information about how to acquire these credentials.
 
 `values.yaml` example:
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
@@ -6,8 +6,7 @@ description: Values that can be set using the teleport-plugin-jira Helm chart
 The `teleport-plugin-jira` Helm chart runs the Jira Teleport plugin, which
 allows users to receive and manage Access Requests as tasks in a Jira project.
 
-You can [browse the source on
-GitHub](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/access/jira).
+You can [browse the source on GitHub](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/chart/access/jira).
 
 This reference details available values for the `teleport-plugin-jira` chart.
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-mattermost.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-mattermost.mdx
@@ -7,7 +7,7 @@ The `teleport-plugin-mattermost` Helm chart is used to configure the
 Mattermost Teleport plugin, which allows users to receive Access
 Requests via channels or as direct messages in Mattermost.
 
-You can [browse the source on GitHub](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/access/mattermost).
+You can [browse the source on GitHub](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/chart/access/mattermost).
 
 This reference details available values for the `teleport-plugin-mattermost` chart.
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
@@ -5,7 +5,7 @@ description: Values that can be set using the teleport-plugin-pagerduty Helm cha
 
 The `teleport-plugin-pagerduty` Helm chart is used to configure the PagerDuty Teleport plugin, which allows users to receive Access Requests as pages via PagerDuty.
 
-You can [browse the source on GitHub](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/access/pagerduty).
+You can [browse the source on GitHub](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/chart/access/pagerduty).
 
 This reference details available values for the `teleport-plugin-pagerduty` chart.
 

--- a/docs/postrelease.md
+++ b/docs/postrelease.md
@@ -12,9 +12,6 @@ Our GitHub Actions workflows will create two PRs when a release is published:
 
 The AWS AMI ID PR can be merged right away.
 
-The docs version PR should be merged after the `gravitational/teleport-plugins` release
-is published, since the PR will include an update to the plugins version as well.
-
 ### Major releases only
 
 - [ ] Update support matrix in docs FAQ page


### PR DESCRIPTION
We are merging the teleport-plugins repo into teleport. This PR updates mentions of the teleport plugins repo in the docs to point to the new locations.