### PR TITLE
[v14] Fix azure join when filtering by resource group

### DIFF
--- a/lib/auth/join_azure.go
+++ b/lib/auth/join_azure.go
@@ -303,7 +303,7 @@ func azureResourceGroupIsAllowed(allowedResourceGroups []string, vmResourceGroup
 	// Converting everything to the same case will ensure a proper comparison.
 	resourceGroup := strings.ToUpper(vmResourceGroup)
 	for _, allowedResourceGroup := range allowedResourceGroups {
-		if resourceGroup == strings.ToUpper(allowedResourceGroup) {
+		if strings.EqualFold(resourceGroup, allowedResourceGroup) {
 			return true
 		}
 	}

--- a/lib/auth/join_azure.go
+++ b/lib/auth/join_azure.go
@@ -23,6 +23,7 @@ import (
 	"encoding/pem"
 	"net/url"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -284,14 +285,30 @@ func checkAzureAllowRules(vm *azure.VirtualMachine, token string, allowRules []*
 		if rule.Subscription != vm.Subscription {
 			continue
 		}
-		if len(rule.ResourceGroups) > 0 {
-			if !slices.Contains(rule.ResourceGroups, vm.ResourceGroup) {
-				continue
-			}
+		if !azureResourceGroupIsAllowed(rule.ResourceGroups, vm.ResourceGroup) {
+			continue
 		}
 		return nil
 	}
 	return trace.AccessDenied("instance %v did not match any allow rules in token %v", vm.Name, token)
+}
+func azureResourceGroupIsAllowed(allowedResourceGroups []string, vmResourceGroup string) bool {
+	if len(allowedResourceGroups) == 0 {
+		return true
+	}
+
+	// ResourceGroups are case insensitive.
+	// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/frequently-asked-questions#are-resource-group-names-case-sensitive
+	// The API returns them using capital case, but docs don't mention a specific case.
+	// Converting everything to the same case will ensure a proper comparison.
+	resourceGroup := strings.ToUpper(vmResourceGroup)
+	for _, allowedResourceGroup := range allowedResourceGroups {
+		if resourceGroup == strings.ToUpper(allowedResourceGroup) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (a *Server) checkAzureRequest(ctx context.Context, challenge string, req *proto.RegisterUsingAzureMethodRequest, cfg *azureRegisterConfig) error {

--- a/lib/auth/join_azure_test.go
+++ b/lib/auth/join_azure_test.go
@@ -188,7 +188,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			subscription:     subID,
-			resourceGroup:    "rg",
+			resourceGroup:    "RG",
 			tokenSpec: types.ProvisionTokenSpecV2{
 				Roles: []types.SystemRole{types.RoleNode},
 				Azure: &types.ProvisionTokenSpecV2Azure{
@@ -210,7 +210,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			tokenName:        "test-token",
 			requestTokenName: "wrong-token",
 			subscription:     subID,
-			resourceGroup:    "rg",
+			resourceGroup:    "RG",
 			tokenSpec: types.ProvisionTokenSpecV2{
 				Roles: []types.SystemRole{types.RoleNode},
 				Azure: &types.ProvisionTokenSpecV2Azure{
@@ -231,7 +231,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			subscription:     subID,
-			resourceGroup:    "rg",
+			resourceGroup:    "RG",
 			tokenSpec: types.ProvisionTokenSpecV2{
 				Roles: []types.SystemRole{types.RoleNode},
 				Azure: &types.ProvisionTokenSpecV2Azure{
@@ -253,7 +253,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			subscription:     "some-junk",
-			resourceGroup:    "rg",
+			resourceGroup:    "RG",
 			tokenSpec: types.ProvisionTokenSpecV2{
 				Roles: []types.SystemRole{types.RoleNode},
 				Azure: &types.ProvisionTokenSpecV2Azure{
@@ -274,7 +274,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			subscription:     subID,
-			resourceGroup:    "wrong-rg",
+			resourceGroup:    "WRONG-RG",
 			tokenSpec: types.ProvisionTokenSpecV2{
 				Roles: []types.SystemRole{types.RoleNode},
 				Azure: &types.ProvisionTokenSpecV2Azure{
@@ -296,7 +296,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			subscription:     subID,
-			resourceGroup:    "rg",
+			resourceGroup:    "RG",
 			tokenSpec: types.ProvisionTokenSpecV2{
 				Roles: []types.SystemRole{types.RoleNode},
 				Azure: &types.ProvisionTokenSpecV2Azure{
@@ -320,7 +320,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			subscription:     subID,
-			resourceGroup:    "rg",
+			resourceGroup:    "RG",
 			tokenSpec: types.ProvisionTokenSpecV2{
 				Roles: []types.SystemRole{types.RoleNode},
 				Azure: &types.ProvisionTokenSpecV2Azure{
@@ -341,7 +341,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			subscription:     subID,
-			resourceGroup:    "rg",
+			resourceGroup:    "RG",
 			vmID:             "vm-id",
 			tokenSpec: types.ProvisionTokenSpecV2{
 				Roles: []types.SystemRole{types.RoleNode},
@@ -356,7 +356,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			},
 			vmResult: &azure.VirtualMachine{
 				Subscription:  subID,
-				ResourceGroup: "rg",
+				ResourceGroup: "RG",
 				VMID:          "different-id",
 			},
 			verify:      mockVerifyToken(nil),

--- a/lib/auth/join_azure_test.go
+++ b/lib/auth/join_azure_test.go
@@ -206,6 +206,28 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			assertError: require.NoError,
 		},
 		{
+			name:             "resource group is case insensitive",
+			tokenName:        "test-token",
+			requestTokenName: "test-token",
+			subscription:     subID,
+			resourceGroup:    "my-RESOURCE-GROUP",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Azure: &types.ProvisionTokenSpecV2Azure{
+					Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+						{
+							Subscription:   subID,
+							ResourceGroups: []string{"MY-resource-group"},
+						},
+					},
+				},
+				JoinMethod: types.JoinMethodAzure,
+			},
+			verify:      mockVerifyToken(nil),
+			certs:       []*x509.Certificate{tlsConfig.Certificate},
+			assertError: require.NoError,
+		},
+		{
 			name:             "wrong token",
 			tokenName:        "test-token",
 			requestTokenName: "wrong-token",


### PR DESCRIPTION
Backport #42128 to branch/v14

changelog: Fix Azure join method when using Resource Groups in the allow section.
