### PR TITLE
[v15] kube: fix missing exit code and Error from session.end events

### DIFF
--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -552,8 +552,7 @@ func (s *session) launch(isEphemeralCont bool) (returnErr error) {
 		return trace.Wrap(err)
 	}
 	defer func() {
-		// The closure captures the err variable pointer so that the variable can
-		// be changed by the code below, but when defer runs, it gets the last value.
+		// call onFinished to emit the session.end and exec events.
 		onFinished(returnErr)
 	}()
 

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -514,7 +514,7 @@ func (s *session) checkPresence() error {
 
 // launch waits until the session meets access requirements and then transitions the session
 // to a running state.
-func (s *session) launch(isEphemeralCont bool) error {
+func (s *session) launch(isEphemeralCont bool) (returnErr error) {
 	defer func() {
 		err := s.Close()
 		if err != nil {
@@ -554,7 +554,7 @@ func (s *session) launch(isEphemeralCont bool) error {
 	defer func() {
 		// The closure captures the err variable pointer so that the variable can
 		// be changed by the code below, but when defer runs, it gets the last value.
-		onFinished(err)
+		onFinished(returnErr)
 	}()
 
 	termParams := tsession.TerminalParams{


### PR DESCRIPTION
Backport #42134 to branch/v15

changelog: Fixed a regression where Kubernetes Exec audit events were not properly populated and lacked error details.
