### PR TITLE
[v14] kube: fix missing exit code and Error from session.end events

### DIFF
--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -24,7 +24,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +37,8 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 
 	"github.com/gravitational/teleport"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 )
 
@@ -308,6 +312,7 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 		name           string
 		errorMessage   string
 		errorInspector func(*testing.T, error)
+		interactive    bool
 	}{
 		{
 			name:         "missing get permission",
@@ -323,9 +328,27 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 				require.NotContains(t, err.Error(), kubernetes130BreakingChangeHint)
 			},
 		},
+		{
+			name:         "missing get permission interactive session",
+			errorMessage: fmt.Sprintf(errorMessage, "get"),
+			errorInspector: func(t *testing.T, err error) {
+				require.Contains(t, err.Error(), kubernetes130BreakingChangeHint)
+			},
+			interactive: true,
+		},
+		{
+			name:         "missing create permission interactive session",
+			errorMessage: fmt.Sprintf(errorMessage, "create"),
+			errorInspector: func(t *testing.T, err error) {
+				require.NotContains(t, err.Error(), kubernetes130BreakingChangeHint)
+			},
+			interactive: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			const errorCode = http.StatusForbidden
 
 			kubeMock, err := testingkubemock.NewKubeAPIMock(
@@ -340,6 +363,10 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 			)
 			require.NoError(t, err)
 			t.Cleanup(func() { kubeMock.Close() })
+			var (
+				execEvent  *apievents.Exec
+				eventsLock sync.Mutex
+			)
 
 			// creates a Kubernetes service with a configured cluster pointing to mock api server
 			testCtx := SetupTestContext(
@@ -347,6 +374,13 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 				t,
 				TestConfig{
 					Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+					OnEvent: func(evt apievents.AuditEvent) {
+						eventsLock.Lock()
+						defer eventsLock.Unlock()
+						if exec, ok := evt.(*apievents.Exec); ok {
+							execEvent = exec
+						}
+					},
 				},
 			)
 
@@ -369,14 +403,24 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 				user.GetName(),
 				kubeCluster,
 			)
-
-			streamOpts := remotecommand.StreamOptions{
-				Stdin:  nil,
-				Stdout: &bytes.Buffer{},
-				Stderr: &bytes.Buffer{},
-				Tty:    false,
+			var streamOpts remotecommand.StreamOptions
+			if !tt.interactive {
+				streamOpts = remotecommand.StreamOptions{
+					Stdin:  nil,
+					Stdout: &bytes.Buffer{},
+					Stderr: &bytes.Buffer{},
+					Tty:    false,
+				}
+			} else {
+				stdinReader, _ := io.Pipe()
+				t.Cleanup(func() { stdinReader.Close() })
+				streamOpts = remotecommand.StreamOptions{
+					Stdin:  stdinReader,
+					Stdout: &bytes.Buffer{},
+					Stderr: nil,
+					Tty:    true,
+				}
 			}
-
 			req, err := generateExecRequest(
 				generateExecRequestConfig{
 					addr:          testCtx.KubeProxyAddress(),
@@ -394,6 +438,18 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 			err = exec.StreamWithContext(testCtx.Context, streamOpts)
 			require.Error(t, err)
 			tt.errorInspector(t, err)
+
+			require.Eventually(t, func() bool {
+				eventsLock.Lock()
+				defer eventsLock.Unlock()
+				return execEvent != nil
+			}, 5*time.Second, 100*time.Millisecond, "expected exec event to be recorded")
+
+			eventsLock.Lock()
+			require.Equal(t, events.ExecFailureCode, execEvent.Code)
+			require.Equal(t, "403", execEvent.ExitCode)
+			require.NotEmpty(t, execEvent.Error)
+			eventsLock.Unlock()
 		})
 	}
 }

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -509,7 +509,7 @@ func (s *session) checkPresence() error {
 
 // launch waits until the session meets access requirements and then transitions the session
 // to a running state.
-func (s *session) launch(isEphemeralCont bool) error {
+func (s *session) launch(isEphemeralCont bool) (returnErr error) {
 	defer func() {
 		err := s.Close()
 		if err != nil {
@@ -549,7 +549,7 @@ func (s *session) launch(isEphemeralCont bool) error {
 	defer func() {
 		// The closure captures the err variable pointer so that the variable can
 		// be changed by the code below, but when defer runs, it gets the last value.
-		onFinished(err)
+		onFinished(returnErr)
 	}()
 
 	termParams := tsession.TerminalParams{

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -547,8 +547,7 @@ func (s *session) launch(isEphemeralCont bool) (returnErr error) {
 		return trace.Wrap(err)
 	}
 	defer func() {
-		// The closure captures the err variable pointer so that the variable can
-		// be changed by the code below, but when defer runs, it gets the last value.
+		// call onFinished to emit the session.end and exec events.
 		onFinished(returnErr)
 	}()
 


### PR DESCRIPTION
Backport #42134 to branch/v14

changelog: Fixed a regression where Kubernetes Exec audit events were not properly populated and lacked error details.
