### PR TITLE
Reduce log level on TOTP failures

### DIFF
--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -263,7 +263,10 @@ func (a *Server) checkOTP(user string, otpToken string) (*types.MFADevice, error
 		}
 
 		if err := a.checkTOTP(ctx, user, otpToken, dev); err != nil {
-			log.WithError(err).Errorf("Using TOTP device %q", dev.GetName())
+			log.
+				WithError(err).
+				WithField("device", dev.GetName()).
+				Debug("TOTP device failed verification. This is expected if the user has multiple TOTP devices.")
 			continue
 		}
 		return dev, nil


### PR DESCRIPTION
Reduce log level on TOTP failures for a couple of reasons:

1. Failures are expected to happen for various conditions (for example, the user mis-types the code)
2. Failures are expected and normal if the user has multiple TOTP devices (as only one can succeed)

Neither of those is actionable, but it can still be interesting debug information.

Fixes #42131.