### PR TITLE
kube: report errors back to user on every failure

### DIFF
--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"reflect"
 	"slices"
 	"strings"
@@ -425,7 +424,6 @@ func newSession(ctx authContext, forwarder *Forwarder, req *http.Request, params
 		log:                            log,
 		io:                             io,
 		accessEvaluator:                accessEvaluator,
-		emitter:                        events.NewDiscardEmitter(),
 		terminalSizeQueue:              newMultiResizeQueue(streamContext),
 		started:                        false,
 		sess:                           sess,
@@ -439,6 +437,12 @@ func newSession(ctx authContext, forwarder *Forwarder, req *http.Request, params
 		streamContext:                  streamContext,
 		streamContextCancel:            streamContextCancel,
 		partiesWg:                      sync.WaitGroup{},
+		// if session ever starts, emitter and recorder will be replaced
+		// by actual emitter and recorder.
+		emitter: events.NewDiscardEmitter(),
+		recorder: events.WithNoOpPreparer(
+			events.NewDiscardRecorder(),
+		),
 	}
 
 	s.io.OnWriteError = s.disconnectPartyOnErr
@@ -547,14 +551,20 @@ func (s *session) launch(isEphemeralCont bool) (returnErr error) {
 
 	eventPodMeta := request.eventPodMeta(request.context, s.sess.kubeAPICreds)
 
-	onFinished, err := s.lockedSetupLaunch(request, q, eventPodMeta)
+	onFinished, err := s.lockedSetupLaunch(request, eventPodMeta)
+	defer func() {
+		if returnErr != nil {
+			s.setTerminationErr(returnErr)
+			s.reportErrorToSessionRecorder(returnErr)
+			s.log.WithError(returnErr).Warning("Executor failed while streaming.")
+		}
+		// call onFinished to emit the session.end and exec events.
+		// onFinish is never nil.
+		onFinished(returnErr)
+	}()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer func() {
-		// call onFinished to emit the session.end and exec events.
-		onFinished(returnErr)
-	}()
 
 	termParams := tsession.TerminalParams{
 		W: 100,
@@ -636,14 +646,7 @@ func (s *session) launch(isEphemeralCont bool) (returnErr error) {
 
 	s.io.On()
 	if streamErr := executor.StreamWithContext(s.streamContext, options); streamErr != nil {
-		onErr := func(err error) {
-			s.setTerminationErr(err)
-			s.reportErrorToSessionRecorder(err)
-			s.log.WithError(err).Warning("Executor failed while streaming.")
-		}
-
 		if !isEphemeralCont {
-			onErr(streamErr)
 			return trace.Wrap(streamErr)
 		}
 
@@ -652,21 +655,18 @@ func (s *session) launch(isEphemeralCont bool) (returnErr error) {
 		// terminated or can't be found return the original error.
 		clientSet, _, err := s.forwarder.impersonatedKubeClient(&s.sess.authContext, s.req.Header)
 		if err != nil {
-			onErr(err)
 			return trace.Wrap(err)
 		}
 		podClient := clientSet.CoreV1().Pods(namespace)
 
 		pod, err := podClient.Get(s.forwarder.ctx, podName, metav1.GetOptions{})
 		if err != nil {
-			onErr(err)
 			return trace.Wrap(err)
 		}
 		status := getEphemeralContainerStatusByName(pod, container)
 		if status == nil {
 			// the container couldn't be found in the pod, return the
 			// original command streaming error
-			onErr(streamErr)
 			return trace.Wrap(streamErr)
 		}
 		if status.State.Terminated != nil {
@@ -676,14 +676,12 @@ func (s *session) launch(isEphemeralCont bool) (returnErr error) {
 				podName,
 				container,
 			); err != nil {
-				onErr(err)
 				return trace.Wrap(err)
 			}
 
 			return nil
 		}
 
-		onErr(streamErr)
 		return trace.Wrap(streamErr)
 	}
 
@@ -714,7 +712,7 @@ func (s *session) reportErrorToSessionRecorder(err error) {
 	}
 }
 
-func (s *session) lockedSetupLaunch(request *remoteCommandRequest, q url.Values, eventPodMeta apievents.KubernetesPodMetadata) (func(error), error) {
+func (s *session) lockedSetupLaunch(request *remoteCommandRequest, eventPodMeta apievents.KubernetesPodMetadata) (func(error), error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -772,62 +770,13 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, q url.Values,
 		s.terminalSizeQueue.callback = func(resize *remotecommand.TerminalSize) {}
 	}
 
-	recorder, err := recorder.New(recorder.Config{
-		SessionID:    tsession.ID(s.id.String()),
-		ServerID:     s.forwarder.cfg.HostID,
-		Namespace:    s.forwarder.cfg.Namespace,
-		Clock:        s.forwarder.cfg.Clock,
-		ClusterName:  s.forwarder.cfg.ClusterName,
-		RecordingCfg: s.ctx.recordingConfig,
-		SyncStreamer: s.forwarder.cfg.AuthClient,
-		DataDir:      s.forwarder.cfg.DataDir,
-		Component:    teleport.Component(teleport.ComponentSession, teleport.ComponentProxyKube),
-		// Session stream is using server context, not session context,
-		// to make sure that session is uploaded even after it is closed
-		Context: s.forwarder.ctx,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	s.recorder = recorder
-	s.emitter = s.forwarder.cfg.Emitter
-
-	s.io.AddWriter(sessionRecorderID, recorder)
-
-	// If the identity is verified with an MFA device, we enabled MFA-based presence for the session.
-	if s.PresenceEnabled {
-		s.eventsWaiter.Add(1)
-		go func() {
-			defer s.eventsWaiter.Done()
-			ticker := time.NewTicker(PresenceVerifyInterval)
-			defer ticker.Stop()
-
-			for {
-				select {
-				case <-ticker.C:
-					err := s.checkPresence()
-					if err != nil {
-						s.log.WithError(err).Error("Failed to check presence, closing session as a security measure")
-						err := s.Close()
-						if err != nil {
-							s.log.WithError(err).Error("Failed to close session")
-						}
-					}
-				case <-s.closeC:
-					return
-				}
-			}
-		}()
-	}
 	// If we get here, it means we are going to have a session.end event.
 	// This increments the waiter so that session.Close() guarantees that once called
 	// the events are emitted before closing the emitter/recorder.
 	// It might happen when a user disconnects or when a moderator forces an early
 	// termination.
 	s.eventsWaiter.Add(1)
-	// receive the exec error returned from API call to kube cluster
-	return func(errExec error) {
+	onFinish := func(errExec error) {
 		defer s.eventsWaiter.Done()
 		s.mu.Lock()
 		defer s.mu.Unlock()
@@ -921,7 +870,57 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, q url.Values,
 		} else {
 			s.forwarder.log.WithError(err).Warn("Failed to set up session end event - event will not be recorded")
 		}
-	}, nil
+	}
+
+	recorder, err := recorder.New(recorder.Config{
+		SessionID:    tsession.ID(s.id.String()),
+		ServerID:     s.forwarder.cfg.HostID,
+		Namespace:    s.forwarder.cfg.Namespace,
+		Clock:        s.forwarder.cfg.Clock,
+		ClusterName:  s.forwarder.cfg.ClusterName,
+		RecordingCfg: s.ctx.recordingConfig,
+		SyncStreamer: s.forwarder.cfg.AuthClient,
+		DataDir:      s.forwarder.cfg.DataDir,
+		Component:    teleport.Component(teleport.ComponentSession, teleport.ComponentProxyKube),
+		// Session stream is using server context, not session context,
+		// to make sure that session is uploaded even after it is closed
+		Context: s.forwarder.ctx,
+	})
+	if err != nil {
+		return onFinish, trace.Wrap(err)
+	}
+
+	s.recorder = recorder
+	s.emitter = s.forwarder.cfg.Emitter
+
+	s.io.AddWriter(sessionRecorderID, recorder)
+
+	// If the identity is verified with an MFA device, we enabled MFA-based presence for the session.
+	if s.PresenceEnabled {
+		s.eventsWaiter.Add(1)
+		go func() {
+			defer s.eventsWaiter.Done()
+			ticker := time.NewTicker(PresenceVerifyInterval)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-ticker.C:
+					err := s.checkPresence()
+					if err != nil {
+						s.log.WithError(err).Error("Failed to check presence, closing session as a security measure")
+						if err := s.Close(); err != nil {
+							s.log.WithError(err).Error("Failed to close session")
+						}
+						return
+					}
+				case <-s.closeC:
+					return
+				}
+			}
+		}()
+	}
+	return onFinish, nil
 }
 
 // join attempts to connect a party to the session.

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -559,7 +559,7 @@ func (s *session) launch(isEphemeralCont bool) (returnErr error) {
 			s.log.WithError(returnErr).Warning("Executor failed while streaming.")
 		}
 		// call onFinished to emit the session.end and exec events.
-		// onFinish is never nil.
+		// onFinished is never nil.
 		onFinished(returnErr)
 	}()
 	if err != nil {

--- a/lib/kube/proxy/sess_test.go
+++ b/lib/kube/proxy/sess_test.go
@@ -21,6 +21,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -52,14 +53,12 @@ import (
 
 func TestSessionEndError(t *testing.T) {
 	t.Parallel()
-	var (
-		eventsResult      []apievents.AuditEvent
-		eventsResultMutex sync.Mutex
-	)
 	const (
 		errorMessage = "request denied"
 		errorCode    = http.StatusForbidden
 	)
+	recordingErr := errors.New("recording err")
+
 	kubeMock, err := testingkubemock.NewKubeAPIMock(
 		testingkubemock.WithExecError(
 			metav1.Status{
@@ -73,99 +72,140 @@ func TestSessionEndError(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { kubeMock.Close() })
 
-	// creates a Kubernetes service with a configured cluster pointing to mock api server
-	testCtx := SetupTestContext(
-		context.Background(),
-		t,
-		TestConfig{
-			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-			// collect all audit events
-			OnEvent: func(event apievents.AuditEvent) {
-				eventsResultMutex.Lock()
-				defer eventsResultMutex.Unlock()
-				eventsResult = append(eventsResult, event)
-			},
+	tests := []struct {
+		name         string
+		recordingErr error
+		interactive  bool
+	}{
+		{
+			name:        "interactive without recording error",
+			interactive: true,
 		},
-	)
-
-	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
-
-	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
-	user, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		username,
-		RoleSpec{
-			Name:       roleName,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-		})
-
-	// generate a kube client with user certs for auth
-	_, userRestConfig := testCtx.GenTestKubeClientTLSCert(
-		t,
-		user.GetName(),
-		kubeCluster,
-	)
-	require.NoError(t, err)
-
-	var (
-		stdinWrite = &bytes.Buffer{}
-		stdout     = &bytes.Buffer{}
-		stderr     = &bytes.Buffer{}
-	)
-
-	_, err = stdinWrite.Write(stdinContent)
-	require.NoError(t, err)
-
-	streamOpts := remotecommand.StreamOptions{
-		Stdin:  io.NopCloser(stdinWrite),
-		Stdout: stdout,
-		Stderr: stderr,
-		Tty:    false,
+		{
+			name:        "non-interactive without recording error",
+			interactive: false,
+		},
+		{
+			name:         "interactive with recording error",
+			interactive:  true,
+			recordingErr: recordingErr,
+		},
 	}
 
-	req, err := generateExecRequest(
-		generateExecRequestConfig{
-			addr:          testCtx.KubeProxyAddress(),
-			podName:       podName,
-			podNamespace:  podNamespace,
-			containerName: podContainerName,
-			cmd:           containerCommmandExecute, // placeholder for commands to execute in the dummy pod
-			options:       streamOpts,
-		},
-	)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var (
+				eventsResult      []apievents.AuditEvent
+				eventsResultMutex sync.Mutex
+			)
+			// creates a Kubernetes service with a configured cluster pointing to mock api server
+			testCtx := SetupTestContext(
+				context.Background(),
+				t,
+				TestConfig{
+					Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+					// collect all audit events
+					OnEvent: func(event apievents.AuditEvent) {
+						eventsResultMutex.Lock()
+						defer eventsResultMutex.Unlock()
+						eventsResult = append(eventsResult, event)
+					},
+					CreateAuditStreamErr: tt.recordingErr,
+				},
+			)
 
-	exec, err := remotecommand.NewSPDYExecutor(userRestConfig, http.MethodPost, req.URL())
-	require.NoError(t, err)
-	err = exec.StreamWithContext(testCtx.Context, streamOpts)
-	require.Error(t, err)
+			t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	// check that the session is ended with an error in audit log.
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		eventsResultMutex.Lock()
-		defer eventsResultMutex.Unlock()
-		hasSessionEndEvent := false
-		hasSessionExecEvent := false
-		for _, event := range eventsResult {
-			if event.GetType() == events.SessionEndEvent {
-				hasSessionEndEvent = true
+			// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+			user, _ := testCtx.CreateUserAndRole(
+				testCtx.Context,
+				t,
+				username,
+				RoleSpec{
+					Name:       roleName,
+					KubeUsers:  roleKubeUsers,
+					KubeGroups: roleKubeGroups,
+				})
+
+			// generate a kube client with user certs for auth
+			_, userRestConfig := testCtx.GenTestKubeClientTLSCert(
+				t,
+				user.GetName(),
+				kubeCluster,
+			)
+			require.NoError(t, err)
+
+			var (
+				stdout         = &bytes.Buffer{}
+				stdinReader, _ = io.Pipe()
+			)
+
+			t.Cleanup(func() { stdinReader.Close() })
+			streamOpts := remotecommand.StreamOptions{
+				Stdin:  stdinReader,
+				Stdout: stdout,
+				Stderr: nil,
+				Tty:    tt.interactive,
 			}
-			if event.GetType() != events.ExecEvent {
-				continue
-			}
 
-			execEvent, ok := event.(*apievents.Exec)
-			assert.True(t, ok)
-			assert.Equal(t, events.ExecFailureCode, execEvent.GetCode())
-			assert.Equal(t, strconv.Itoa(errorCode), execEvent.ExitCode)
-			assert.Equal(t, errorMessage, execEvent.Error)
-			hasSessionExecEvent = true
-		}
-		assert.Truef(t, hasSessionEndEvent, "session end event not found in audit log")
-		assert.Truef(t, hasSessionExecEvent, "session exec event not found in audit log")
-	}, 10*time.Second, 1*time.Second)
+			req, err := generateExecRequest(
+				generateExecRequestConfig{
+					addr:          testCtx.KubeProxyAddress(),
+					podName:       podName,
+					podNamespace:  podNamespace,
+					containerName: podContainerName,
+					cmd:           containerCommmandExecute, // placeholder for commands to execute in the dummy pod
+					options:       streamOpts,
+				},
+			)
+			require.NoError(t, err)
+
+			exec, err := remotecommand.NewSPDYExecutor(userRestConfig, http.MethodPost, req.URL())
+			require.NoError(t, err)
+			err = exec.StreamWithContext(testCtx.Context, streamOpts)
+			require.Error(t, err)
+
+			if tt.recordingErr == nil {
+				// check that the session is ended with an error in audit log.
+				require.EventuallyWithT(t, func(t *assert.CollectT) {
+					eventsResultMutex.Lock()
+					defer eventsResultMutex.Unlock()
+					hasSessionEndEvent := false
+					hasSessionExecEvent := false
+					for _, event := range eventsResult {
+						if event.GetType() == events.SessionEndEvent {
+							hasSessionEndEvent = true
+						}
+						if event.GetType() != events.ExecEvent {
+							continue
+						}
+
+						execEvent, ok := event.(*apievents.Exec)
+						assert.True(t, ok)
+						assert.Equal(t, events.ExecFailureCode, execEvent.GetCode())
+						if tt.recordingErr == nil {
+							assert.Equal(t, strconv.Itoa(errorCode), execEvent.ExitCode)
+							assert.Equal(t, errorMessage, execEvent.Error)
+						} else {
+							assert.Empty(t, execEvent.ExitCode)
+							assert.Equal(t, tt.recordingErr.Error(), execEvent.Error)
+						}
+						hasSessionExecEvent = true
+					}
+					assert.Truef(t, hasSessionEndEvent, "session end event not found in audit log")
+					assert.Truef(t, hasSessionExecEvent, "session exec event not found in audit log")
+				}, 10*time.Second, 1*time.Second)
+			} else {
+				require.Never(t, func() bool {
+					eventsResultMutex.Lock()
+					defer eventsResultMutex.Unlock()
+					return len(eventsResult) > 0
+				}, 1*time.Second, 100*time.Millisecond)
+			}
+		})
+	}
 }
 
 func Test_session_trackSession(t *testing.T) {


### PR DESCRIPTION
This PR fixes an issue where the client could miss the exit error because the session was abruptly closed.

This PR adds coverage to ensure recorder failures force the session to be closed.