### PR TITLE
Fix notifications infinite scroll bug

### DIFF
--- a/lib/auth/notification_test.go
+++ b/lib/auth/notification_test.go
@@ -282,7 +282,7 @@ func TestNotifications(t *testing.T) {
 
 	// Fetch the next 3 notifications, starting from the previously received startKeys.
 	// After this fetch, there should be no more global notifications for auditor, so the next page token
-	// for global notifications should be "end".
+	// for global notifications should be "".
 	resp, err = auditorClient.ListNotifications(ctx, &notificationsv1.ListNotificationsRequest{
 		PageSize:  3,
 		PageToken: resp.NextPageToken,
@@ -290,6 +290,16 @@ func TestNotifications(t *testing.T) {
 	require.NoError(t, err)
 	expectedNextKeys = fmt.Sprintf("%s,", notificationIdMap["auditor-2"])
 
+	require.Equal(t, expectedNextKeys, resp.NextPageToken)
+	finalOut = append(finalOut, resp.Notifications...)
+
+	// Fetch a page of 1 notification, starting from the previously received startKeys.
+	resp, err = auditorClient.ListNotifications(ctx, &notificationsv1.ListNotificationsRequest{
+		PageSize:  1,
+		PageToken: resp.NextPageToken,
+	})
+	require.NoError(t, err)
+	expectedNextKeys = fmt.Sprintf("%s,", notificationIdMap["auditor-1"])
 	require.Equal(t, expectedNextKeys, resp.NextPageToken)
 	finalOut = append(finalOut, resp.Notifications...)
 

--- a/lib/auth/notifications/notificationsv1/service.go
+++ b/lib/auth/notifications/notificationsv1/service.go
@@ -176,7 +176,12 @@ func (s *Service) ListNotifications(ctx context.Context, req *notificationsv1.Li
 			// If the last item in this page (ie. the current item in the stream) was a user-specific notification, then the userNotificationsNextKey should be the next item in the userNotifsStream, and
 			// the globalNotificationsNextKey should be the current (and unconsumed) item in the globalNotifsStream. And vice-versa.
 			if item.GetMetadata().GetLabels()[types.NotificationScope] == "user" {
-				nextGlobalKey = globalNotifsStream.Item().GetMetadata().GetName()
+				// If the provided globalKey was "", then return that as the nextGlobalKey again.
+				if globalKey != "" || !found {
+					nextGlobalKey = globalNotifsStream.Item().GetMetadata().GetName()
+				} else {
+					nextGlobalKey = ""
+				}
 				// Advance to the next user-specific notification.
 				ok := userNotifsStream.Next()
 				if ok {
@@ -186,7 +191,12 @@ func (s *Service) ListNotifications(ctx context.Context, req *notificationsv1.Li
 					nextUserKey = ""
 				}
 			} else {
-				nextUserKey = userNotifsStream.Item().GetMetadata().GetName()
+				// If the provided userKey was "", then return that as the nextUserKey again.
+				if userKey != "" || !found {
+					nextUserKey = userNotifsStream.Item().GetMetadata().GetName()
+				} else {
+					nextUserKey = ""
+				}
 				// Advance to the next global notification.
 				ok := globalNotifsStream.Next()
 				if ok {

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -360,7 +360,7 @@ const cfg = {
       '/webapi/scripts/integrations/configure/gcp-workforce-saml.sh?orgId=:orgId&poolName=:poolName&poolProviderName=:poolProviderName',
 
     notificationsPath:
-      '/v1/webapi/sites/:clusterId/notifications?limit=:limit?&startKeys=:startKey?',
+      '/v1/webapi/sites/:clusterId/notifications?limit=:limit?&startKey=:startKey?',
     notificationLastSeenTimePath:
       '/v1/webapi/sites/:clusterId/lastseennotification',
     notificationStatePath: '/v1/webapi/sites/:clusterId/notificationstate',


### PR DESCRIPTION
## Purpose

Fixes a bug I ran into causing infinite scrolling in the UI due to the URL query param being named `startKeys` instead of the expected `startKey`. Also fixes a bug in the logic for determining the `nextKeys`.