### PR TITLE
[v15] prevent session id reuse

### DIFF
--- a/api/observability/tracing/ssh/client.go
+++ b/api/observability/tracing/ssh/client.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 
 	"github.com/gravitational/trace"
 	"go.opentelemetry.io/otel/attribute"
@@ -164,6 +165,18 @@ func (c *Client) OpenChannel(
 // NewSession creates a new SSH session that is passed tracing context
 // so that spans may be correlated properly over the ssh connection.
 func (c *Client) NewSession(ctx context.Context) (*Session, error) {
+	return c.newSession(ctx, nil)
+}
+
+// NewSessionWithRequestCallback creates a new SSH session that is passed
+// tracing context so that spans may be correlated properly over the ssh
+// connection. The handling of channel requests from the underlying SSH
+// session can be controlled with chanReqCallback.
+func (c *Client) NewSessionWithRequestCallback(ctx context.Context, chanReqCallback ChannelRequestCallback) (*Session, error) {
+	return c.newSession(ctx, chanReqCallback)
+}
+
+func (c *Client) newSession(ctx context.Context, chanReqCallback ChannelRequestCallback) (*Session, error) {
 	tracer := tracing.NewConfig(c.opts).TracerProvider.Tracer(instrumentationName)
 
 	ctx, span := tracer.Start(
@@ -191,7 +204,7 @@ func (c *Client) NewSession(ctx context.Context) (*Session, error) {
 	}
 
 	// get a session from the wrapper
-	session, err := wrapper.NewSession()
+	session, err := wrapper.NewSession(chanReqCallback)
 	return session, trace.Wrap(err)
 }
 
@@ -216,8 +229,13 @@ type clientWrapper struct {
 	contexts map[string][]context.Context
 }
 
+// ChannelRequestCallback allows the handling of channel requests
+// to be customized. nil can be returned if you don't want
+// golang/x/crypto/ssh to handle the request.
+type ChannelRequestCallback func(req *ssh.Request) *ssh.Request
+
 // NewSession opens a new Session for this client.
-func (c *clientWrapper) NewSession() (*Session, error) {
+func (c *clientWrapper) NewSession(callback ChannelRequestCallback) (*Session, error) {
 	// create a client that will defer to us when
 	// opening the "session" channel so that we
 	// can add an Envelope to the request
@@ -225,9 +243,40 @@ func (c *clientWrapper) NewSession() (*Session, error) {
 		Conn: c,
 	}
 
-	session, err := client.NewSession()
-	if err != nil {
-		return nil, trace.Wrap(err)
+	var session *ssh.Session
+	var err error
+	if callback != nil {
+		// open a session manually so we can take ownership of the
+		// requests chan
+		ch, originalReqs, openChannelErr := client.OpenChannel("session", nil)
+		if openChannelErr != nil {
+			return nil, trace.Wrap(openChannelErr)
+		}
+
+		// pass the channel requests to the provided callback and
+		// forward them to another chan so golang.org/x/crypto/ssh
+		// can handle Session exiting correctly
+		reqs := make(chan *ssh.Request, cap(originalReqs))
+		go func() {
+			defer close(reqs)
+
+			for req := range originalReqs {
+				if req := callback(req); req != nil {
+					reqs <- req
+				}
+			}
+		}()
+
+		session, err = newCryptoSSHSession(ch, reqs)
+		if err != nil {
+			_ = ch.Close()
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		session, err = client.NewSession()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	// wrap the session so all session requests on the channel
@@ -236,6 +285,39 @@ func (c *clientWrapper) NewSession() (*Session, error) {
 		Session: session,
 		wrapper: c,
 	}, nil
+}
+
+// wrappedSSHConn allows an SSH session to be created while also allowing
+// callers to take ownership of the SSH channel requests chan.
+type wrappedSSHConn struct {
+	ssh.Conn
+
+	channelOpened atomic.Bool
+
+	ch   ssh.Channel
+	reqs <-chan *ssh.Request
+}
+
+func (f *wrappedSSHConn) OpenChannel(_ string, _ []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+	if !f.channelOpened.CompareAndSwap(false, true) {
+		panic("wrappedSSHConn OpenChannel called more than once")
+	}
+
+	return f.ch, f.reqs, nil
+}
+
+// newCryptoSSHSession allows callers to take ownership of the SSH
+// channel requests chan and allow callers to handle SSH channel requests.
+// golang.org/x/crypto/ssh.(Client).NewSession takes ownership of all
+// SSH channel requests and doesn't allow the caller to view or reply
+// to them, so this workaround is needed.
+func newCryptoSSHSession(ch ssh.Channel, reqs <-chan *ssh.Request) (*ssh.Session, error) {
+	return (&ssh.Client{
+		Conn: &wrappedSSHConn{
+			ch:   ch,
+			reqs: reqs,
+		},
+	}).NewSession()
 }
 
 // Dial initiates a connection to the addr from the remote host.

--- a/api/observability/tracing/ssh/client_test.go
+++ b/api/observability/tracing/ssh/client_test.go
@@ -242,3 +242,29 @@ func TestSetEnvs(t *testing.T) {
 	default:
 	}
 }
+
+type mockSSHChannel struct {
+	ssh.Channel
+}
+
+func TestWrappedSSHConn(t *testing.T) {
+	sshCh := new(mockSSHChannel)
+	reqs := make(<-chan *ssh.Request)
+
+	// ensure that OpenChannel returns the same SSH channel and requests
+	// chan that wrappedSSHConn was given
+	wrappedConn := &wrappedSSHConn{
+		ch:   sshCh,
+		reqs: reqs,
+	}
+	retCh, retReqs, err := wrappedConn.OpenChannel("", nil)
+	require.NoError(t, err)
+	require.Equal(t, sshCh, retCh)
+	require.Equal(t, reqs, retReqs)
+
+	// ensure the wrapped SSH conn will panic if OpenChannel is called
+	// twice
+	require.Panics(t, func() {
+		wrappedConn.OpenChannel("", nil)
+	})
+}

--- a/constants.go
+++ b/constants.go
@@ -724,6 +724,14 @@ const (
 	// version they are running.
 	VersionRequest = "x-teleport-version"
 
+	// CurrentSessionIDRequest is sent by servers to inform clients of
+	// the session ID that is being used.
+	CurrentSessionIDRequest = "current-session-id@goteleport.com"
+
+	// SessionIDQueryRequest is sent by clients to ask servers if they
+	// will generate their own session ID when a new session is created.
+	SessionIDQueryRequest = "session-id-query@goteleport.com"
+
 	// ForceTerminateRequest is an SSH request to forcefully terminate a session.
 	ForceTerminateRequest = "x-teleport-force-terminate"
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1237,7 +1237,7 @@ func testLeafProxySessionRecording(t *testing.T, suite *integrationTestSuite) {
 				)
 				assert.NoError(t, err)
 
-				errCh <- nodeClient.RunInteractiveShell(ctx, types.SessionPeerMode, nil, nil)
+				errCh <- nodeClient.RunInteractiveShell(ctx, types.SessionPeerMode, nil, nil, nil)
 				assert.NoError(t, nodeClient.Close())
 			}()
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -5546,7 +5546,7 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 			}
 
 			t.Run("GetSessionTracker", func(t *testing.T) {
-				sid := session.ID("test-session")
+				sid := session.NewID()
 				tracker, err := s.CreateSessionTracker(ctx, &types.SessionTrackerV1{
 					ResourceHeader: types.ResourceHeader{
 						Metadata: types.Metadata{

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1077,6 +1077,10 @@ type TeleportClient struct {
 	Config
 	localAgent *LocalKeyAgent
 
+	// OnChannelRequest gets called when SSH channel requests are
+	// received. It's safe to keep it nil.
+	OnChannelRequest tracessh.ChannelRequestCallback
+
 	// OnShellCreated gets called when the shell is created. It's
 	// safe to keep it nil.
 	OnShellCreated ShellCreatedCallback
@@ -1916,7 +1920,7 @@ func (tc *TeleportClient) runShellOrCommandOnSingleNode(ctx context.Context, clt
 		// Reuse the existing nodeClient we connected above.
 		return nodeClient.RunCommand(ctx, command)
 	}
-	return trace.Wrap(nodeClient.RunInteractiveShell(ctx, types.SessionPeerMode, nil, nil))
+	return trace.Wrap(nodeClient.RunInteractiveShell(ctx, types.SessionPeerMode, nil, tc.OnChannelRequest, nil))
 }
 
 func (tc *TeleportClient) runShellOrCommandOnMultipleNodes(ctx context.Context, clt *ClusterClient, nodes []targetNode, command []string) error {
@@ -2075,7 +2079,7 @@ func (tc *TeleportClient) Join(ctx context.Context, mode types.SessionParticipan
 	fmt.Printf("Joining session with participant mode: %v. \n\n", mode)
 
 	// running shell with a given session means "join" it:
-	err = nc.RunInteractiveShell(ctx, mode, session, beforeStart)
+	err = nc.RunInteractiveShell(ctx, mode, session, tc.OnChannelRequest, beforeStart)
 	return trace.Wrap(err)
 }
 

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -248,7 +248,6 @@ func TestListenAndForwardCancel(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func newTestListener(t *testing.T, handle func(net.Conn)) net.Listener {

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -157,6 +157,10 @@ func newSession(ctx context.Context,
 		}
 		// new session!
 	} else {
+		// TODO(capnspacehook): DELETE IN 17.0.0
+		// clients shouldn't set TELEPORT_SESSION when they aren't joining
+		// a session, and won't need to once all supported Proxy/Node
+		// versions set the session ID for new sessions
 		sid, ok := ns.env[sshutils.SessionEnvVar]
 		if !ok {
 			sid = string(session.NewID())
@@ -188,7 +192,7 @@ func (ns *NodeSession) NodeClient() *NodeClient {
 	return ns.nodeClient
 }
 
-func (ns *NodeSession) regularSession(ctx context.Context, callback func(s *tracessh.Session) error) error {
+func (ns *NodeSession) regularSession(ctx context.Context, chanReqCallback tracessh.ChannelRequestCallback, sessionCallback func(s *tracessh.Session) error) error {
 	ctx, span := ns.nodeClient.Tracer.Start(
 		ctx,
 		"nodeClient/regularSession",
@@ -196,19 +200,19 @@ func (ns *NodeSession) regularSession(ctx context.Context, callback func(s *trac
 	)
 	defer span.End()
 
-	session, err := ns.createServerSession(ctx)
+	session, err := ns.createServerSession(ctx, chanReqCallback)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	session.Stdout = ns.terminal.Stdout()
 	session.Stderr = ns.terminal.Stderr()
 	session.Stdin = ns.terminal.Stdin()
-	return trace.Wrap(callback(session))
+	return trace.Wrap(sessionCallback(session))
 }
 
 type interactiveCallback func(serverSession *tracessh.Session, shell io.ReadWriteCloser) error
 
-func (ns *NodeSession) createServerSession(ctx context.Context) (*tracessh.Session, error) {
+func (ns *NodeSession) createServerSession(ctx context.Context, chanReqCallback tracessh.ChannelRequestCallback) (*tracessh.Session, error) {
 	ctx, span := ns.nodeClient.Tracer.Start(
 		ctx,
 		"nodeClient/createServerSession",
@@ -216,7 +220,7 @@ func (ns *NodeSession) createServerSession(ctx context.Context) (*tracessh.Sessi
 	)
 	defer span.End()
 
-	sess, err := ns.nodeClient.Client.NewSession(ctx)
+	sess, err := ns.nodeClient.Client.NewSessionWithRequestCallback(ctx, chanReqCallback)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -284,7 +288,7 @@ func selectKeyAgent(tc *TeleportClient) agent.ExtendedAgent {
 
 // interactiveSession creates an interactive session on the remote node, executes
 // the given callback on it, and waits for the session to end
-func (ns *NodeSession) interactiveSession(ctx context.Context, mode types.SessionParticipantMode, callback interactiveCallback) error {
+func (ns *NodeSession) interactiveSession(ctx context.Context, mode types.SessionParticipantMode, chanReqCallback tracessh.ChannelRequestCallback, sessionCallback interactiveCallback) error {
 	ctx, span := ns.nodeClient.Tracer.Start(
 		ctx,
 		"nodeClient/interactiveSession",
@@ -298,7 +302,7 @@ func (ns *NodeSession) interactiveSession(ctx context.Context, mode types.Sessio
 		termType = teleport.SafeTerminalType
 	}
 	// create the server-side session:
-	sess, err := ns.createServerSession(ctx)
+	sess, err := ns.createServerSession(ctx, chanReqCallback)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -311,7 +315,7 @@ func (ns *NodeSession) interactiveSession(ctx context.Context, mode types.Sessio
 
 	// call the passed callback and give them the established
 	// ssh session:
-	if err := callback(sess, remoteTerm); err != nil {
+	if err := sessionCallback(sess, remoteTerm); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -514,8 +518,8 @@ func (s *sessionWriter) Write(p []byte) (int, error) {
 }
 
 // runShell executes user's shell on the remote node under an interactive session
-func (ns *NodeSession) runShell(ctx context.Context, mode types.SessionParticipantMode, beforeStart func(io.Writer), callback ShellCreatedCallback) error {
-	return ns.interactiveSession(ctx, mode, func(s *tracessh.Session, shell io.ReadWriteCloser) error {
+func (ns *NodeSession) runShell(ctx context.Context, mode types.SessionParticipantMode, chanReqCallback tracessh.ChannelRequestCallback, beforeStart func(io.Writer), shellCallback ShellCreatedCallback) error {
+	return ns.interactiveSession(ctx, mode, chanReqCallback, func(s *tracessh.Session, shell io.ReadWriteCloser) error {
 		w := &sessionWriter{
 			tshOut:  ns.nodeClient.TC.Stdout,
 			session: s,
@@ -531,8 +535,8 @@ func (ns *NodeSession) runShell(ctx context.Context, mode types.SessionParticipa
 		}
 
 		// call the client-supplied callback
-		if callback != nil {
-			exit, err := callback(s, ns.nodeClient.Client, shell)
+		if shellCallback != nil {
+			exit, err := shellCallback(s, ns.nodeClient.Client, shell)
 			if exit {
 				return trace.Wrap(err)
 			}
@@ -543,7 +547,7 @@ func (ns *NodeSession) runShell(ctx context.Context, mode types.SessionParticipa
 
 // runCommand executes a "exec" request either in interactive mode (with a
 // TTY attached) or non-intractive mode (no TTY).
-func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionParticipantMode, cmd []string, callback ShellCreatedCallback, interactive bool) error {
+func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionParticipantMode, cmd []string, chanReqCallback tracessh.ChannelRequestCallback, shellCallback ShellCreatedCallback, interactive bool) error {
 	ctx, span := ns.nodeClient.Tracer.Start(
 		ctx,
 		"nodeClient/runCommand",
@@ -564,13 +568,13 @@ func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionPartici
 	// keyboard based signals will be propogated to the TTY on the server which is
 	// where all signal handling will occur.
 	if interactive {
-		return ns.interactiveSession(ctx, mode, func(s *tracessh.Session, term io.ReadWriteCloser) error {
+		return ns.interactiveSession(ctx, mode, chanReqCallback, func(s *tracessh.Session, term io.ReadWriteCloser) error {
 			err := s.Start(ctx, strings.Join(cmd, " "))
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			if callback != nil {
-				exit, err := callback(s, ns.NodeClient().Client, term)
+			if shellCallback != nil {
+				exit, err := shellCallback(s, ns.NodeClient().Client, term)
 				if exit {
 					return trace.Wrap(err)
 				}
@@ -591,7 +595,7 @@ func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionPartici
 	// Unfortunately at the moment the Go SSH library Teleport uses does not
 	// support sending SSH_MSG_DISCONNECT. Instead we close the SSH channel and
 	// SSH client, and try and exit as gracefully as possible.
-	return ns.regularSession(ctx, func(s *tracessh.Session) error {
+	return ns.regularSession(ctx, chanReqCallback, func(s *tracessh.Session) error {
 		errCh := make(chan error, 1)
 		go func() {
 			errCh <- s.Run(ctx, strings.Join(cmd, " "))

--- a/lib/services/local/sessiontracker.go
+++ b/lib/services/local/sessiontracker.go
@@ -192,7 +192,7 @@ func (s *sessionTracker) CreateSessionTracker(ctx context.Context, tracker types
 		Value:   json,
 		Expires: tracker.Expiry(),
 	}
-	_, err = s.bk.Put(ctx, item)
+	_, err = s.bk.Create(ctx, item)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -54,17 +54,22 @@ func (s *ID) Check() error {
 
 // ParseID parses ID and checks if it's correct.
 func ParseID(id string) (*ID, error) {
-	_, err := uuid.Parse(id)
+	parsed, err := uuid.Parse(id)
 	if err != nil {
 		return nil, trace.BadParameter("%v is not a valid UUID", id)
 	}
-	uid := ID(id)
+	// use the parsed UUID to build the ID instead of the string that
+	// was passed in. id is user controlled and uuid.Parse accepts
+	// several UUID formats that are not supported correctly across
+	// Teleport. (uuid.UUID).String always uses the same format that
+	// is supported by Teleport everywhere, so use that.
+	uid := ID(parsed.String())
 	return &uid, nil
 }
 
 // NewID returns new session ID. The session ID is based on UUIDv4.
 func NewID() ID {
-	return ID(uuid.New().String())
+	return ID(uuid.NewString())
 }
 
 // Session is a session of any kind (SSH, Kubernetes, Desktop, etc)

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -319,6 +319,10 @@ type ServerContext struct {
 	// term holds PTY if it was requested by the session.
 	term Terminal
 
+	// sessionID holds the session ID that will be used when a new
+	// session is created.
+	sessionID rsession.ID
+
 	// session holds the active session (if there's an active one).
 	session *session
 
@@ -628,7 +632,7 @@ func (c *ServerContext) SessionID() rsession.ID {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.session == nil {
-		return ""
+		return c.sessionID
 	}
 	return c.session.id
 }
@@ -647,19 +651,31 @@ func (c *ServerContext) CreateOrJoinSession(reg *SessionRegistry) error {
 	// its ID will be added to the environment
 	ssid, found := c.getEnvLocked(sshutils.SessionEnvVar)
 	if !found {
+		c.sessionID = rsession.NewID()
+		c.Logger.Debugf("Will create new session for SSH connection %v.", c.ServerConn.RemoteAddr())
 		return nil
 	}
+
 	// make sure whatever session is requested is a valid session
 	id, err := rsession.ParseID(ssid)
 	if err != nil {
-		return trace.BadParameter("invalid session id")
+		return trace.BadParameter("invalid session ID")
 	}
 
 	// update ctx with the session if it exists
 	if sess, found := reg.findSession(*id); found {
+		c.sessionID = *id
 		c.session = sess
 		c.Logger.Debugf("Will join session %v for SSH connection %v.", c.session.id, c.ServerConn.RemoteAddr())
 	} else {
+		// TODO(capnspacehook): DELETE IN 17.0.0 - by then all supported
+		// clients should only set TELEPORT_SESSION when they want to
+		// join a session. Always return an error instead of using a
+		// new ID.
+		//
+		// to prevent the user from controlling the session ID, generate
+		// a new one
+		c.sessionID = rsession.NewID()
 		c.Logger.Debugf("Will create new session for SSH connection %v.", c.ServerConn.RemoteAddr())
 	}
 
@@ -731,10 +747,20 @@ func (c *ServerContext) getEnvLocked(key string) (string, bool) {
 }
 
 // setSession sets the context's session
-func (c *ServerContext) setSession(sess *session) {
+func (c *ServerContext) setSession(sess *session, ch ssh.Channel) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.session = sess
+
+	// inform the client of the session ID that is being used in a new
+	// goroutine to reduce latency
+	go func() {
+		c.Logger.Debug("Sending current session ID.")
+		_, err := ch.SendRequest(teleport.CurrentSessionIDRequest, false, []byte(sess.ID()))
+		if err != nil {
+			c.Logger.WithError(err).Debug("Failed to send the current session ID.")
+		}
+	}()
 }
 
 // getSession returns the context's session

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -967,6 +967,13 @@ func (s *Server) handleGlobalRequest(ctx context.Context, req *ssh.Request) {
 			return
 		}
 		// Pass request on unchanged.
+	case teleport.SessionIDQueryRequest:
+		// Reply true to session ID query requests, we will set new
+		// session IDs for new sessions
+		if err := req.Reply(true, nil); err != nil {
+			s.log.WithError(err).Warnf("Failed to reply to session ID query request")
+		}
+		return
 	case teleport.KeepAliveReqType:
 	default:
 		s.log.Debugf("Rejecting unknown global request %q.", req.Type)

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
+	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -65,16 +66,16 @@ func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet) *S
 	recConfig := types.DefaultSessionRecordingConfig()
 	recConfig.SetMode(types.RecordOff)
 	clusterName := "localhost"
+	_, connCtx := sshutils.NewConnectionContext(ctx, nil, &ssh.ServerConn{Conn: sshConn})
 	scx := &ServerContext{
-		Entry: logrus.NewEntry(logrus.StandardLogger()),
-		ConnectionContext: &sshutils.ConnectionContext{
-			ServerConn: &ssh.ServerConn{Conn: sshConn},
-		},
+		Entry:                  logrus.NewEntry(logrus.StandardLogger()),
+		ConnectionContext:      connCtx,
 		env:                    make(map[string]string),
 		SessionRecordingConfig: recConfig,
 		IsTestStub:             true,
 		ClusterName:            clusterName,
 		srv:                    srv,
+		sessionID:              rsession.NewID(),
 		Identity: IdentityContext{
 			Login:        usr.Username,
 			TeleportUser: "teleportUser",

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1413,6 +1413,13 @@ func (s *Server) HandleRequest(ctx context.Context, ccx *sshutils.ConnectionCont
 				s.Logger.Warnf("Failed to reply to %q request: %v", r.Type, err)
 			}
 		}
+	case teleport.SessionIDQueryRequest:
+		// Reply true to session ID query requests, we will set new
+		// session IDs for new sessions
+		if err := r.Reply(true, nil); err != nil {
+			s.Logger.WithError(err).Warnf("Failed to reply to session ID query request")
+		}
+		return
 	default:
 		if r.WantReply {
 			if err := r.Reply(false, nil); err != nil {

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -811,10 +811,10 @@ func TestParties(t *testing.T) {
 
 func testJoinSession(t *testing.T, reg *SessionRegistry, sess *session) {
 	scx := newTestServerContext(t, reg.Srv, nil)
-	scx.setSession(sess)
+	sshChanOpen := newMockSSHChannel()
+	scx.setSession(sess, sshChanOpen)
 
 	// Open a new session
-	sshChanOpen := newMockSSHChannel()
 	go func() {
 		// Consume stdout sent to the channel
 		io.ReadAll(sshChanOpen)

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -55,6 +56,7 @@ import (
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/session"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -843,7 +845,6 @@ func (s *sessionCache) getOrCreateSession(ctx context.Context, user, sessionID s
 	}
 
 	return sctx, nil
-
 }
 
 func (s *sessionCache) invalidateSession(ctx context.Context, sctx *SessionContext) error {
@@ -1157,4 +1158,85 @@ func (c *remoteClientCache) Close() error {
 	c.clients = nil
 
 	return trace.NewAggregate(errors...)
+}
+
+// sessionIDStatus indicates whether the session ID was received from
+// the server or not, and if not why
+type sessionIDStatus int
+
+const (
+	// sessionIDReceived indicates the the session ID was received
+	sessionIDReceived sessionIDStatus = iota + 1
+	// sessionIDNotSent indicates that the server set the session ID
+	// but didn't send it to us
+	sessionIDNotSent
+	// sessionIDNotModified indicates that the server used the session
+	// ID that was set by us
+	sessionIDNotModified
+)
+
+// prepareToReceiveSessionID configures the TeleportClient to listen for
+// the server to send the session ID it's using. The returned function
+// will return the current session ID from the server or a reason why
+// one wasn't received.
+func prepareToReceiveSessionID(ctx context.Context, log *logrus.Entry, nc *client.NodeClient) func() (session.ID, sessionIDStatus) {
+	// send the session ID received from the server
+	var gotSessionID atomic.Bool
+	sessionIDFromServer := make(chan session.ID, 1)
+	nc.TC.OnChannelRequest = func(req *ssh.Request) *ssh.Request {
+		// ignore unrelated requests and handle only the first session
+		// ID request
+		if req.Type != teleport.CurrentSessionIDRequest || gotSessionID.Load() {
+			return req
+		}
+
+		sid, err := session.ParseID(string(req.Payload))
+		if err != nil {
+			log.WithError(err).Warn("Unable to parse session ID.")
+			return nil
+		}
+
+		if gotSessionID.CompareAndSwap(false, true) {
+			sessionIDFromServer <- *sid
+		}
+
+		return nil
+	}
+
+	// If the session is about to close and we haven't received a session
+	// ID yet, ask if the server even supports sending one. Send the
+	// request in a new goroutine so session establishment won't be
+	// blocked on making this request
+	serverWillSetSessionID := make(chan bool, 1)
+	go func() {
+		resp, _, err := nc.Client.SendRequest(ctx, teleport.SessionIDQueryRequest, true, nil)
+		if err != nil {
+			log.WithError(err).Warn("Failed to send session ID query request")
+			serverWillSetSessionID <- false
+		} else {
+			serverWillSetSessionID <- resp
+		}
+	}()
+
+	return func() (session.ID, sessionIDStatus) {
+		timer := time.NewTimer(10 * time.Second)
+		defer timer.Stop()
+
+		for {
+			select {
+			case sessionID := <-sessionIDFromServer:
+				return sessionID, sessionIDReceived
+			case sessionIDIsComing := <-serverWillSetSessionID:
+				if !sessionIDIsComing {
+					return session.ID(""), sessionIDNotModified
+				}
+				// the server will send the session ID, continue
+				// waiting for it
+			case <-ctx.Done():
+				return session.ID(""), sessionIDNotSent
+			case <-timer.C:
+				return session.ID(""), sessionIDNotSent
+			}
+		}
+	}
 }


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/42123.

changelog: Fixed session recordings getting overwritten or not uploaded