### PR TITLE
[v16] Add check to AMR watcher to handle subject removing requests

### DIFF
--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -241,16 +241,9 @@ func (a *App) handleAccessMonitoringRule(ctx context.Context, event types.Event)
 			return trace.BadParameter("expected AccessMonitoringRule resource type, got %T", event.Resource)
 		}
 
-		// If an Access Monitoring Rule with KindAccessRequest is already in the cache and the subjects
-		// change to no longer contain KindAccessRequest.
-		if ok := slices.ContainsFunc(req.Spec.Subjects, func(subject string) bool {
-			return subject == types.KindAccessRequest
-		}); !ok {
-			delete(a.accessMonitoringRules.rules, event.Resource.GetName())
-			return nil
-		}
-
+		// In the event an existing rule no longer applies we must remove it.
 		if !a.amrAppliesToThisPlugin(req) {
+			delete(a.accessMonitoringRules.rules, event.Resource.GetName())
 			return nil
 		}
 		a.accessMonitoringRules.rules[req.Metadata.Name] = req

--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -240,6 +240,16 @@ func (a *App) handleAccessMonitoringRule(ctx context.Context, event types.Event)
 		if !ok {
 			return trace.BadParameter("expected AccessMonitoringRule resource type, got %T", event.Resource)
 		}
+
+		// If an Access Monitoring Rule with KindAccessRequest is already in the cache and the subjects
+		// change to no longer contain KindAccessRequest.
+		if ok := slices.ContainsFunc(req.Spec.Subjects, func(subject string) bool {
+			return subject == types.KindAccessRequest
+		}); !ok {
+			delete(a.accessMonitoringRules.rules, event.Resource.GetName())
+			return nil
+		}
+
 		if !a.amrAppliesToThisPlugin(req) {
 			return nil
 		}

--- a/integrations/access/slack/testlib/suite.go
+++ b/integrations/access/slack/testlib/suite.go
@@ -311,6 +311,9 @@ func (s *SlackSuiteOSS) TestRecipientsFromAccessMonitoringRule() {
 	assert.Equal(t, s.requesterOSSSlackUser.ID, messages[0].Channel)
 	assert.Equal(t, s.reviewer1SlackUser.ID, messages[1].Channel)
 	assert.Equal(t, s.reviewer2SlackUser.ID, messages[2].Channel)
+
+	assert.NoError(t, s.ClientByName(integration.RulerUserName).
+		AccessMonitoringRulesClient().DeleteAccessMonitoringRule(ctx, "test-slack-amr"))
 }
 
 func (s *SlackSuiteOSS) TestRecipientsFromAccessMonitoringRuleAfterUpdate() {
@@ -334,7 +337,7 @@ func (s *SlackSuiteOSS) TestRecipientsFromAccessMonitoringRuleAfterUpdate() {
 			Kind:    types.KindAccessMonitoringRule,
 			Version: types.V1,
 			Metadata: &v1.Metadata{
-				Name: "test-slack-amr",
+				Name: "test-slack-amr-2",
 			},
 			Spec: &accessmonitoringrulesv1.AccessMonitoringRuleSpec{
 				Subjects:  []string{types.KindAccessRequest},
@@ -356,7 +359,7 @@ func (s *SlackSuiteOSS) TestRecipientsFromAccessMonitoringRuleAfterUpdate() {
 			Kind:    types.KindAccessMonitoringRule,
 			Version: types.V1,
 			Metadata: &v1.Metadata{
-				Name: "test-slack-amr",
+				Name: "test-slack-amr-2",
 			},
 			Spec: &accessmonitoringrulesv1.AccessMonitoringRuleSpec{
 				Subjects:  []string{"someOtherKind"},
@@ -401,6 +404,9 @@ func (s *SlackSuiteOSS) TestRecipientsFromAccessMonitoringRuleAfterUpdate() {
 	sort.Sort(SlackMessageSlice(messages))
 	assert.Equal(t, s.requesterOSSSlackUser.ID, messages[0].Channel)
 	assert.Equal(t, s.reviewer2SlackUser.ID, messages[1].Channel)
+
+	assert.NoError(t, s.ClientByName(integration.RulerUserName).
+		AccessMonitoringRulesClient().DeleteAccessMonitoringRule(ctx, "test-slack-amr-2"))
 }
 
 // TestApproval tests that when a request is approved, its corresponding message


### PR DESCRIPTION
Backport #42171 to branch/v16

changelog: Fix bug where the plugins AMR cache is not updated in the event Access requests are removed from the subject of an existing rule 
