### PR TITLE
Set default availability mode to ALL

### DIFF
--- a/lib/auth/userpreferences/userpreferencesv1/service_test.go
+++ b/lib/auth/userpreferences/userpreferencesv1/service_test.go
@@ -61,9 +61,10 @@ func TestService_GetUserPreferences(t *testing.T) {
 					},
 					Theme: userpreferencesv1.Theme_THEME_UNSPECIFIED,
 					UnifiedResourcePreferences: &userpreferencesv1.UnifiedResourcePreferences{
-						DefaultTab:     userpreferencesv1.DefaultTab_DEFAULT_TAB_ALL,
-						ViewMode:       userpreferencesv1.ViewMode_VIEW_MODE_CARD,
-						LabelsViewMode: userpreferencesv1.LabelsViewMode_LABELS_VIEW_MODE_COLLAPSED,
+						DefaultTab:            userpreferencesv1.DefaultTab_DEFAULT_TAB_ALL,
+						ViewMode:              userpreferencesv1.ViewMode_VIEW_MODE_CARD,
+						LabelsViewMode:        userpreferencesv1.LabelsViewMode_LABELS_VIEW_MODE_COLLAPSED,
+						AvailableResourceMode: userpreferencesv1.AvailableResourceMode_AVAILABLE_RESOURCE_MODE_ALL,
 					},
 					Onboard: &userpreferencesv1.OnboardUserPreferences{
 						PreferredResources: []userpreferencesv1.Resource{},

--- a/lib/services/local/userpreferences.go
+++ b/lib/services/local/userpreferences.go
@@ -42,9 +42,10 @@ func DefaultUserPreferences() *userpreferencesv1.UserPreferences {
 		},
 		Theme: userpreferencesv1.Theme_THEME_UNSPECIFIED,
 		UnifiedResourcePreferences: &userpreferencesv1.UnifiedResourcePreferences{
-			DefaultTab:     userpreferencesv1.DefaultTab_DEFAULT_TAB_ALL,
-			ViewMode:       userpreferencesv1.ViewMode_VIEW_MODE_CARD,
-			LabelsViewMode: userpreferencesv1.LabelsViewMode_LABELS_VIEW_MODE_COLLAPSED,
+			DefaultTab:            userpreferencesv1.DefaultTab_DEFAULT_TAB_ALL,
+			ViewMode:              userpreferencesv1.ViewMode_VIEW_MODE_CARD,
+			LabelsViewMode:        userpreferencesv1.LabelsViewMode_LABELS_VIEW_MODE_COLLAPSED,
+			AvailableResourceMode: userpreferencesv1.AvailableResourceMode_AVAILABLE_RESOURCE_MODE_ALL,
 		},
 		Onboard: &userpreferencesv1.OnboardUserPreferences{
 			PreferredResources: []userpreferencesv1.Resource{},

--- a/lib/services/local/userpreferences_test.go
+++ b/lib/services/local/userpreferences_test.go
@@ -109,6 +109,28 @@ func TestUserPreferencesCRUD(t *testing.T) {
 			},
 		},
 		{
+			name: "update the availability view only",
+			req: &userpreferencesv1.UpsertUserPreferencesRequest{
+				Preferences: &userpreferencesv1.UserPreferences{
+					UnifiedResourcePreferences: &userpreferencesv1.UnifiedResourcePreferences{
+						AvailableResourceMode: userpreferencesv1.AvailableResourceMode_AVAILABLE_RESOURCE_MODE_ACCESSIBLE,
+					},
+				},
+			},
+			expected: &userpreferencesv1.UserPreferences{
+				Assist:  defaultPref.Assist,
+				Onboard: defaultPref.Onboard,
+				Theme:   defaultPref.Theme,
+				UnifiedResourcePreferences: &userpreferencesv1.UnifiedResourcePreferences{
+					DefaultTab:            userpreferencesv1.DefaultTab_DEFAULT_TAB_ALL,
+					ViewMode:              userpreferencesv1.ViewMode_VIEW_MODE_CARD,
+					LabelsViewMode:        userpreferencesv1.LabelsViewMode_LABELS_VIEW_MODE_COLLAPSED,
+					AvailableResourceMode: userpreferencesv1.AvailableResourceMode_AVAILABLE_RESOURCE_MODE_ACCESSIBLE,
+				},
+				ClusterPreferences: defaultPref.ClusterPreferences,
+			},
+		},
+		{
 			name: "update the unified tab preference only",
 			req: &userpreferencesv1.UpsertUserPreferencesRequest{
 				Preferences: &userpreferencesv1.UserPreferences{
@@ -122,9 +144,10 @@ func TestUserPreferencesCRUD(t *testing.T) {
 				Onboard: defaultPref.Onboard,
 				Theme:   defaultPref.Theme,
 				UnifiedResourcePreferences: &userpreferencesv1.UnifiedResourcePreferences{
-					DefaultTab:     userpreferencesv1.DefaultTab_DEFAULT_TAB_PINNED,
-					ViewMode:       userpreferencesv1.ViewMode_VIEW_MODE_CARD,
-					LabelsViewMode: userpreferencesv1.LabelsViewMode_LABELS_VIEW_MODE_COLLAPSED,
+					DefaultTab:            userpreferencesv1.DefaultTab_DEFAULT_TAB_PINNED,
+					ViewMode:              userpreferencesv1.ViewMode_VIEW_MODE_CARD,
+					LabelsViewMode:        userpreferencesv1.LabelsViewMode_LABELS_VIEW_MODE_COLLAPSED,
+					AvailableResourceMode: userpreferencesv1.AvailableResourceMode_AVAILABLE_RESOURCE_MODE_ALL,
 				},
 				ClusterPreferences: defaultPref.ClusterPreferences,
 			},
@@ -233,9 +256,10 @@ func TestUserPreferencesCRUD(t *testing.T) {
 				Preferences: &userpreferencesv1.UserPreferences{
 					Theme: userpreferencesv1.Theme_THEME_LIGHT,
 					UnifiedResourcePreferences: &userpreferencesv1.UnifiedResourcePreferences{
-						DefaultTab:     userpreferencesv1.DefaultTab_DEFAULT_TAB_PINNED,
-						ViewMode:       userpreferencesv1.ViewMode_VIEW_MODE_LIST,
-						LabelsViewMode: userpreferencesv1.LabelsViewMode_LABELS_VIEW_MODE_COLLAPSED,
+						DefaultTab:            userpreferencesv1.DefaultTab_DEFAULT_TAB_PINNED,
+						ViewMode:              userpreferencesv1.ViewMode_VIEW_MODE_LIST,
+						LabelsViewMode:        userpreferencesv1.LabelsViewMode_LABELS_VIEW_MODE_COLLAPSED,
+						AvailableResourceMode: userpreferencesv1.AvailableResourceMode_AVAILABLE_RESOURCE_MODE_ALL,
 					},
 					Assist: &userpreferencesv1.AssistUserPreferences{
 						PreferredLogins: []string{"baz"},
@@ -260,9 +284,10 @@ func TestUserPreferencesCRUD(t *testing.T) {
 			expected: &userpreferencesv1.UserPreferences{
 				Theme: userpreferencesv1.Theme_THEME_LIGHT,
 				UnifiedResourcePreferences: &userpreferencesv1.UnifiedResourcePreferences{
-					DefaultTab:     userpreferencesv1.DefaultTab_DEFAULT_TAB_PINNED,
-					ViewMode:       userpreferencesv1.ViewMode_VIEW_MODE_LIST,
-					LabelsViewMode: userpreferencesv1.LabelsViewMode_LABELS_VIEW_MODE_COLLAPSED,
+					DefaultTab:            userpreferencesv1.DefaultTab_DEFAULT_TAB_PINNED,
+					ViewMode:              userpreferencesv1.ViewMode_VIEW_MODE_LIST,
+					LabelsViewMode:        userpreferencesv1.LabelsViewMode_LABELS_VIEW_MODE_COLLAPSED,
+					AvailableResourceMode: userpreferencesv1.AvailableResourceMode_AVAILABLE_RESOURCE_MODE_ALL,
 				},
 				Assist: &userpreferencesv1.AssistUserPreferences{
 					PreferredLogins: []string{"baz"},


### PR DESCRIPTION
Rather than letting the default mode be UNSPECIFIED, this sets the default mode to "ALL".
Note: this does not mean that a user can see all by default. It only reflects the "Availability filter" selection. If a cluster has showResources set to "accessible_only", the filter will reflect that value instead