### PR TITLE
[v15] Web: Add alternate EC2 auto discover flow using AWS Systems Manager (SSM)

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
+++ b/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
@@ -437,7 +437,7 @@ exports[`render with URL loc state set to "server" 1`] = `
           <div
             class="c22"
           >
-            EC2 Instance
+            EC2 Auto Enrollment
           </div>
         </div>
       </div>
@@ -1297,7 +1297,7 @@ exports[`render with all access 1`] = `
           <div
             class="c16"
           >
-            EC2 Instance
+            EC2 Auto Enrollment
           </div>
         </div>
       </div>
@@ -3618,7 +3618,7 @@ exports[`render with no access 1`] = `
           <div
             class="c17"
           >
-            EC2 Instance
+            EC2 Auto Enrollment
           </div>
         </div>
       </div>
@@ -5387,7 +5387,7 @@ exports[`render with partial access 1`] = `
           <div
             class="c16"
           >
-            EC2 Instance
+            EC2 Auto Enrollment
           </div>
         </div>
       </div>

--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -20,7 +20,10 @@ import { Platform } from 'design/platform';
 
 import { assertUnreachable } from 'shared/utils/assertUnreachable';
 
-import { DiscoverEventResource } from 'teleport/services/userEvent';
+import {
+  DiscoverDiscoveryConfigMethod,
+  DiscoverEventResource,
+} from 'teleport/services/userEvent';
 
 import { ResourceKind } from '../Shared/ResourceKind';
 
@@ -87,7 +90,22 @@ export const SERVERS: ResourceSpec[] = [
       baseServerKeywords + 'ec2 instance connect endpoint aws amazon eice',
     icon: 'Aws',
     event: DiscoverEventResource.Ec2Instance,
-    nodeMeta: { location: ServerLocation.Aws },
+    nodeMeta: {
+      location: ServerLocation.Aws,
+      discoveryConfigMethod: DiscoverDiscoveryConfigMethod.AwsEc2Eice,
+    },
+  },
+  {
+    name: 'EC2 Auto Discover with SSM',
+    kind: ResourceKind.Server,
+    keywords:
+      baseServerKeywords + 'ec2 instance aws amazon simple systems manager ssm',
+    icon: 'Aws',
+    event: DiscoverEventResource.Ec2Instance,
+    nodeMeta: {
+      location: ServerLocation.Aws,
+      discoveryConfigMethod: DiscoverDiscoveryConfigMethod.AwsEc2Ssm,
+    },
   },
   {
     name: 'Connect My Computer',

--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -84,22 +84,11 @@ export const SERVERS: ResourceSpec[] = [
     platform: Platform.macOS,
   },
   {
-    name: 'EC2 Instance',
+    name: 'EC2 Auto Enrollment',
     kind: ResourceKind.Server,
     keywords:
-      baseServerKeywords + 'ec2 instance connect endpoint aws amazon eice',
-    icon: 'Aws',
-    event: DiscoverEventResource.Ec2Instance,
-    nodeMeta: {
-      location: ServerLocation.Aws,
-      discoveryConfigMethod: DiscoverDiscoveryConfigMethod.AwsEc2Eice,
-    },
-  },
-  {
-    name: 'EC2 Auto Discover with SSM',
-    kind: ResourceKind.Server,
-    keywords:
-      baseServerKeywords + 'ec2 instance aws amazon simple systems manager ssm',
+      baseServerKeywords +
+      'ec2 instance aws amazon simple systems manager ssm auto enrollment',
     icon: 'Aws',
     event: DiscoverEventResource.Ec2Instance,
     nodeMeta: {

--- a/web/packages/teleport/src/Discover/SelectResource/types.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/types.ts
@@ -24,7 +24,10 @@ import { AuthType } from 'teleport/services/user';
 
 import { ResourceKind } from '../Shared/ResourceKind';
 
-import type { DiscoverEventResource } from 'teleport/services/userEvent';
+import type {
+  DiscoverDiscoveryConfigMethod,
+  DiscoverEventResource,
+} from 'teleport/services/userEvent';
 
 import type { ResourceIconName } from 'design/ResourceIcon';
 
@@ -77,8 +80,11 @@ export enum SamlServiceProviderPreset {
 
 export interface ResourceSpec {
   dbMeta?: { location: DatabaseLocation; engine: DatabaseEngine };
-  nodeMeta?: { location: ServerLocation };
   appMeta?: { awsConsole?: boolean };
+  nodeMeta?: {
+    location: ServerLocation;
+    discoveryConfigMethod: DiscoverDiscoveryConfigMethod;
+  };
   kubeMeta?: { location: KubeLocation };
   samlMeta?: { preset: SamlServiceProviderPreset };
   name: string;

--- a/web/packages/teleport/src/Discover/Server/ConfigureDiscoveryService/ConfigureDiscoveryService.story.tsx
+++ b/web/packages/teleport/src/Discover/Server/ConfigureDiscoveryService/ConfigureDiscoveryService.story.tsx
@@ -1,0 +1,115 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+import { ContextProvider } from 'teleport';
+import cfg from 'teleport/config';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import {
+  DiscoverProvider,
+  DiscoverContextState,
+} from 'teleport/Discover/useDiscover';
+import {
+  IntegrationKind,
+  IntegrationStatusCode,
+} from 'teleport/services/integrations';
+import { ResourceKind } from 'teleport/Discover/Shared';
+import {
+  DiscoverDiscoveryConfigMethod,
+  DiscoverEventResource,
+} from 'teleport/services/userEvent';
+import { ServerLocation } from 'teleport/Discover/SelectResource';
+
+import { ConfigureDiscoveryService as Comp } from './ConfigureDiscoveryService';
+
+export default {
+  title: 'Teleport/Discover/Server',
+};
+
+export const ConfigureDiscoveryService = () => {
+  return <Component />;
+};
+
+const Component = () => {
+  const ctx = createTeleportContext();
+  const discoverCtx: DiscoverContextState = {
+    agentMeta: {
+      resourceName: 'aws-console',
+      agentMatcherLabels: [],
+      awsRegion: 'ap-south-1',
+      awsIntegration: {
+        kind: IntegrationKind.AwsOidc,
+        name: 'some-oidc-name',
+        resourceType: 'integration',
+        spec: {
+          roleArn: 'arn:aws:iam::123456789012:role/test-role-arn',
+          issuerS3Bucket: '',
+          issuerS3Prefix: '',
+        },
+        statusCode: IntegrationStatusCode.Running,
+      },
+      autoDiscovery: {
+        config: {
+          name: 'discovery-config-name',
+          discoveryGroup: 'discovery-group-name',
+          aws: [],
+        },
+      },
+    },
+    currentStep: 0,
+    nextStep: () => null,
+    prevStep: () => null,
+    onSelectResource: () => null,
+    resourceSpec: {
+      name: '',
+      kind: ResourceKind.Application,
+      icon: null,
+      keywords: '',
+      event: DiscoverEventResource.Ec2Instance,
+      nodeMeta: {
+        location: ServerLocation.Aws,
+        discoveryConfigMethod: DiscoverDiscoveryConfigMethod.AwsEc2Ssm,
+      },
+    },
+    exitFlow: () => null,
+    viewConfig: null,
+    indexedViews: [],
+    setResourceSpec: () => null,
+    updateAgentMeta: () => null,
+    emitErrorEvent: () => null,
+    emitEvent: () => null,
+    eventState: null,
+  };
+
+  cfg.proxyCluster = 'localhost';
+  return (
+    <MemoryRouter
+      initialEntries={[
+        { pathname: cfg.routes.discover, state: { entity: 'application' } },
+      ]}
+    >
+      <ContextProvider ctx={ctx}>
+        <DiscoverProvider mockCtx={discoverCtx}>
+          <Comp />
+        </DiscoverProvider>
+      </ContextProvider>
+    </MemoryRouter>
+  );
+};

--- a/web/packages/teleport/src/Discover/Server/ConfigureDiscoveryService/ConfigureDiscoveryService.story.tsx
+++ b/web/packages/teleport/src/Discover/Server/ConfigureDiscoveryService/ConfigureDiscoveryService.story.tsx
@@ -40,7 +40,7 @@ import { ServerLocation } from 'teleport/Discover/SelectResource';
 import { ConfigureDiscoveryService as Comp } from './ConfigureDiscoveryService';
 
 export default {
-  title: 'Teleport/Discover/Server',
+  title: 'Teleport/Discover/Server/EC2',
 };
 
 export const ConfigureDiscoveryService = () => {

--- a/web/packages/teleport/src/Discover/Server/ConfigureDiscoveryService/ConfigureDiscoveryService.tsx
+++ b/web/packages/teleport/src/Discover/Server/ConfigureDiscoveryService/ConfigureDiscoveryService.tsx
@@ -26,6 +26,7 @@ import { SelfHostedAutoDiscoverDirections } from 'teleport/Discover/Shared/AutoD
 import { DEFAULT_DISCOVERY_GROUP_NON_CLOUD } from 'teleport/services/discovery';
 
 import { ActionButtons, Header } from '../../Shared';
+import { SingleEc2InstanceInstallation } from '../Shared';
 
 export function ConfigureDiscoveryService() {
   const { nextStep, agentMeta, updateAgentMeta } = useDiscover();
@@ -53,6 +54,7 @@ export function ConfigureDiscoveryService() {
         The Teleport Discovery Service can connect to Amazon EC2 and
         automatically discover and enroll EC2 instances.
       </Text>
+      <SingleEc2InstanceInstallation />
       <SelfHostedAutoDiscoverDirections
         showSubHeader={false}
         clusterPublicUrl={storeUser.state.cluster.publicURL}

--- a/web/packages/teleport/src/Discover/Server/ConfigureDiscoveryService/ConfigureDiscoveryService.tsx
+++ b/web/packages/teleport/src/Discover/Server/ConfigureDiscoveryService/ConfigureDiscoveryService.tsx
@@ -1,0 +1,65 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useState } from 'react';
+import { Box, Text } from 'design';
+
+import { useDiscover } from 'teleport/Discover/useDiscover';
+import useTeleport from 'teleport/useTeleport';
+
+import { SelfHostedAutoDiscoverDirections } from 'teleport/Discover/Shared/AutoDiscovery/SelfHostedAutoDiscoverDirections';
+import { DEFAULT_DISCOVERY_GROUP_NON_CLOUD } from 'teleport/services/discovery';
+
+import { ActionButtons, Header } from '../../Shared';
+
+export function ConfigureDiscoveryService() {
+  const { nextStep, agentMeta, updateAgentMeta } = useDiscover();
+
+  const [discoveryGroupName, setDiscoveryGroupName] = useState(
+    DEFAULT_DISCOVERY_GROUP_NON_CLOUD
+  );
+
+  const { storeUser } = useTeleport();
+
+  function handleNextStep() {
+    updateAgentMeta({
+      ...agentMeta,
+      autoDiscovery: {
+        config: { name: '', aws: [], discoveryGroup: discoveryGroupName },
+      },
+    });
+    nextStep();
+  }
+
+  return (
+    <Box maxWidth="1000px">
+      <Header>Configure Teleport Discovery Service</Header>
+      <Text mb={4}>
+        The Teleport Discovery Service can connect to Amazon EC2 and
+        automatically discover and enroll EC2 instances.
+      </Text>
+      <SelfHostedAutoDiscoverDirections
+        showSubHeader={false}
+        clusterPublicUrl={storeUser.state.cluster.publicURL}
+        discoveryGroupName={discoveryGroupName}
+        setDiscoveryGroupName={setDiscoveryGroupName}
+      />
+      <ActionButtons onProceed={handleNextStep} />
+    </Box>
+  );
+}

--- a/web/packages/teleport/src/Discover/Server/ConfigureDiscoveryService/ConfigureDiscoveryService.tsx
+++ b/web/packages/teleport/src/Discover/Server/ConfigureDiscoveryService/ConfigureDiscoveryService.tsx
@@ -29,7 +29,7 @@ import { ActionButtons, Header } from '../../Shared';
 import { SingleEc2InstanceInstallation } from '../Shared';
 
 export function ConfigureDiscoveryService() {
-  const { nextStep, agentMeta, updateAgentMeta } = useDiscover();
+  const { nextStep, prevStep, agentMeta, updateAgentMeta } = useDiscover();
 
   const [discoveryGroupName, setDiscoveryGroupName] = useState(
     DEFAULT_DISCOVERY_GROUP_NON_CLOUD
@@ -61,7 +61,7 @@ export function ConfigureDiscoveryService() {
         discoveryGroupName={discoveryGroupName}
         setDiscoveryGroupName={setDiscoveryGroupName}
       />
-      <ActionButtons onProceed={handleNextStep} />
+      <ActionButtons onProceed={handleNextStep} onPrev={prevStep} />
     </Box>
   );
 }

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigCreatedDialog.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigCreatedDialog.tsx
@@ -38,6 +38,10 @@ export function DiscoveryConfigCreatedDialog({
           <Icons.Check size="small" ml={1} mr={2} color="success.main" />
           <Box>
             <Text>Discovery configuration successfully created.</Text>
+            <Text>
+              The discovery service can take a few minutes to finish
+              auto-enrolling resources.
+            </Text>
           </Box>
         </Flex>
         <ButtonPrimary width="100%" onClick={() => toNextStep()}>

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigCreatedDialog.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigCreatedDialog.tsx
@@ -21,8 +21,6 @@ import { Text, Flex, ButtonPrimary, Box } from 'design';
 import * as Icons from 'design/Icon';
 import Dialog, { DialogContent } from 'design/DialogConfirmation';
 
-import cfg from 'teleport/config';
-
 export function DiscoveryConfigCreatedDialog({
   toNextStep,
 }: {
@@ -40,12 +38,6 @@ export function DiscoveryConfigCreatedDialog({
           <Icons.Check size="small" ml={1} mr={2} color="success.main" />
           <Box>
             <Text>Discovery configuration successfully created.</Text>
-            {cfg.isCloud && (
-              <Text mt={2}>
-                It can take up to 30 minutes for the instances to be discovered
-                and listed in Teleport.
-              </Text>
-            )}
           </Box>
         </Flex>
         <ButtonPrimary width="100%" onClick={() => toNextStep()}>

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigCreatedDialog.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigCreatedDialog.tsx
@@ -1,0 +1,57 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { Text, Flex, ButtonPrimary, Box } from 'design';
+import * as Icons from 'design/Icon';
+import Dialog, { DialogContent } from 'design/DialogConfirmation';
+
+import cfg from 'teleport/config';
+
+export function DiscoveryConfigCreatedDialog({
+  toNextStep,
+}: {
+  toNextStep: () => void;
+}) {
+  return (
+    <Dialog disableEscapeKeyDown={false} open={true}>
+      <DialogContent
+        width="460px"
+        alignItems="center"
+        mb={0}
+        textAlign="center"
+      >
+        <Flex mb={5}>
+          <Icons.Check size="small" ml={1} mr={2} color="success.main" />
+          <Box>
+            <Text>Discovery configuration successfully created.</Text>
+            {cfg.isCloud && (
+              <Text mt={2}>
+                It can take up to 30 minutes for the instances to be discovered
+                and listed in Teleport.
+              </Text>
+            )}
+          </Box>
+        </Flex>
+        <ButtonPrimary width="100%" onClick={() => toNextStep()}>
+          Next
+        </ButtonPrimary>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.story.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.story.tsx
@@ -1,0 +1,187 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useEffect } from 'react';
+import { MemoryRouter } from 'react-router';
+import { initialize, mswLoader } from 'msw-storybook-addon';
+import { rest } from 'msw';
+import { Info } from 'design/Alert';
+
+import { ContextProvider } from 'teleport';
+import cfg from 'teleport/config';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import {
+  DiscoverProvider,
+  DiscoverContextState,
+} from 'teleport/Discover/useDiscover';
+import {
+  IntegrationKind,
+  IntegrationStatusCode,
+} from 'teleport/services/integrations';
+import { ResourceKind } from 'teleport/Discover/Shared';
+import {
+  DiscoverDiscoveryConfigMethod,
+  DiscoverEventResource,
+} from 'teleport/services/userEvent';
+import { ServerLocation } from 'teleport/Discover/SelectResource';
+
+import { DiscoveryConfigSsm } from './DiscoveryConfigSsm';
+
+initialize();
+
+const defaultIsCloud = cfg.isCloud;
+export default {
+  title: 'Teleport/Discover/Server/EC2/DiscoveryConfigSsm',
+  loaders: [mswLoader],
+  decorators: [
+    Story => {
+      useEffect(() => {
+        // Clean up
+        return () => {
+          cfg.isCloud = defaultIsCloud;
+        };
+      }, []);
+      return <Story />;
+    },
+  ],
+};
+
+export const SuccessCloud = () => {
+  cfg.isCloud = true;
+  return <Component />;
+};
+SuccessCloud.parameters = {
+  msw: {
+    handlers: [
+      rest.post(cfg.api.joinTokenPath, (req, res, ctx) =>
+        res(ctx.json({ id: 'token-id' }))
+      ),
+      rest.post(cfg.api.discoveryConfigPath, (req, res, ctx) =>
+        res(ctx.json({ name: 'discovery-cfg-name' }))
+      ),
+    ],
+  },
+};
+
+export const SuccessSelfHosted = () => <Component />;
+SuccessSelfHosted.parameters = {
+  msw: {
+    handlers: [
+      rest.post(cfg.api.joinTokenPath, (req, res, ctx) =>
+        res(ctx.json({ id: 'token-id' }))
+      ),
+      rest.post(cfg.api.discoveryConfigPath, (req, res, ctx) =>
+        res(ctx.json({ name: 'discovery-cfg-name' }))
+      ),
+    ],
+  },
+};
+
+export const Loading = () => {
+  cfg.isCloud = true;
+  return <Component />;
+};
+Loading.parameters = {
+  msw: {
+    handlers: [
+      rest.post(cfg.api.joinTokenPath, (req, res, ctx) =>
+        res(ctx.json({ id: 'token-id' }))
+      ),
+      rest.post(cfg.api.discoveryConfigPath, (req, res, ctx) =>
+        res(ctx.delay('infinite'))
+      ),
+    ],
+  },
+};
+
+export const Failed = () => <Component />;
+Failed.parameters = {
+  msw: {
+    handlers: [
+      rest.post(cfg.api.joinTokenPath, (req, res, ctx) =>
+        res(ctx.json({ id: 'token-id' }))
+      ),
+      rest.post(cfg.api.discoveryConfigPath, (req, res, ctx) =>
+        res(
+          ctx.status(403),
+          ctx.json({ message: 'Some kind of error message' })
+        )
+      ),
+    ],
+  },
+};
+
+const Component = () => {
+  const ctx = createTeleportContext();
+  const discoverCtx: DiscoverContextState = {
+    agentMeta: {
+      resourceName: 'aws-console',
+      agentMatcherLabels: [],
+      awsIntegration: {
+        kind: IntegrationKind.AwsOidc,
+        name: 'some-oidc-name',
+        resourceType: 'integration',
+        spec: {
+          roleArn: 'arn:aws:iam::123456789012:role/test-role-arn',
+          issuerS3Bucket: '',
+          issuerS3Prefix: '',
+        },
+        statusCode: IntegrationStatusCode.Running,
+      },
+    },
+    currentStep: 0,
+    nextStep: () => null,
+    prevStep: () => null,
+    onSelectResource: () => null,
+    resourceSpec: {
+      name: '',
+      kind: ResourceKind.Application,
+      icon: null,
+      keywords: '',
+      event: DiscoverEventResource.Ec2Instance,
+      nodeMeta: {
+        location: ServerLocation.Aws,
+        discoveryConfigMethod: DiscoverDiscoveryConfigMethod.AwsEc2Ssm,
+      },
+    },
+    exitFlow: () => null,
+    viewConfig: null,
+    indexedViews: [],
+    setResourceSpec: () => null,
+    updateAgentMeta: () => null,
+    emitErrorEvent: () => null,
+    emitEvent: () => null,
+    eventState: null,
+  };
+
+  cfg.proxyCluster = 'localhost';
+  return (
+    <MemoryRouter
+      initialEntries={[
+        { pathname: cfg.routes.discover, state: { entity: 'application' } },
+      ]}
+    >
+      <ContextProvider ctx={ctx}>
+        <DiscoverProvider mockCtx={discoverCtx}>
+          <Info>Devs: Click next to see next state</Info>
+          <DiscoveryConfigSsm />
+        </DiscoverProvider>
+      </ContextProvider>
+    </MemoryRouter>
+  );
+};

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
@@ -51,6 +51,8 @@ import useStickyClusterId from 'teleport/useStickyClusterId';
 
 import { ActionButtons, Header, Mark, StyledBox } from '../../Shared';
 
+import { SingleEc2InstanceInstallation } from '../Shared';
+
 import { DiscoveryConfigCreatedDialog } from './DiscoveryConfigCreatedDialog';
 
 const IAM_POLICY_NAME = 'EC2DiscoverWithSSM';
@@ -155,6 +157,7 @@ export function DiscoveryConfigSsm() {
           automatically discover and register instances. <SharedText />
         </Text>
       )}
+      {cfg.isCloud && <SingleEc2InstanceInstallation />}
       {attempt.status === 'error' && (
         <Danger mt={3}>{attempt.statusText}</Danger>
       )}

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
@@ -1,0 +1,372 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useState } from 'react';
+import {
+  Box,
+  Link as ExternalLink,
+  Text,
+  Flex,
+  ButtonSecondary,
+  Link,
+} from 'design';
+import styled from 'styled-components';
+import { Danger, Info } from 'design/Alert';
+import TextEditor from 'shared/components/TextEditor';
+import { ToolTipInfo } from 'shared/components/ToolTip';
+import FieldInput from 'shared/components/FieldInput';
+import { Rule } from 'shared/components/Validation/rules';
+import Validation, { Validator } from 'shared/components/Validation';
+import { makeEmptyAttempt, useAsync } from 'shared/hooks/useAsync';
+import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
+
+import cfg from 'teleport/config';
+import { useDiscover } from 'teleport/Discover/useDiscover';
+import { Regions } from 'teleport/services/integrations';
+import { AwsRegionSelector } from 'teleport/Discover/Shared/AwsRegionSelector';
+import JoinTokenService, { JoinToken } from 'teleport/services/joinToken';
+
+import {
+  DISCOVERY_GROUP_CLOUD,
+  createDiscoveryConfig,
+  InstallParamEnrollMode,
+} from 'teleport/services/discovery';
+import { splitAwsIamArn } from 'teleport/services/integrations/aws';
+import useStickyClusterId from 'teleport/useStickyClusterId';
+
+import { ActionButtons, Header, Mark, StyledBox } from '../../Shared';
+
+import { DiscoveryConfigCreatedDialog } from './DiscoveryConfigCreatedDialog';
+
+const IAM_POLICY_NAME = 'EC2DiscoverWithSSM';
+
+export function DiscoveryConfigSsm() {
+  const { agentMeta, emitErrorEvent, nextStep, updateAgentMeta } =
+    useDiscover();
+
+  const { arnResourceName, awsAccountId } = splitAwsIamArn(
+    agentMeta.awsIntegration.spec.roleArn
+  );
+
+  const { clusterId } = useStickyClusterId();
+
+  const [selectedRegion, setSelectedRegion] = useState<Regions>();
+  const [ssmDocumentName, setSsmDocumentName] = useState(
+    'TeleportDiscoveryInstaller'
+  );
+  const [scriptUrl, setScriptUrl] = useState('');
+  const [createdToken, setCreatedToken] = useState<JoinToken>();
+  const [showRestOfSteps, setShowRestOfSteps] = useState(false);
+
+  const [attempt, createJoinTokenAndDiscoveryConfig, setAttempt] = useAsync(
+    async () => {
+      try {
+        const joinTokenService = new JoinTokenService();
+        // Don't create another token if token was already created.
+        // This can happen if creating discovery config attempt failed
+        // and the user retries.
+        let joinToken = createdToken;
+        if (!joinToken) {
+          joinToken = await joinTokenService.fetchJoinToken({
+            roles: ['Node'],
+            method: 'iam',
+            rules: [{ awsAccountId }],
+          });
+          setCreatedToken(joinToken);
+        }
+
+        const config = await createDiscoveryConfig(clusterId, {
+          name: crypto.randomUUID(),
+          discoveryGroup: cfg.isCloud
+            ? DISCOVERY_GROUP_CLOUD
+            : agentMeta.autoDiscovery.config.discoveryGroup,
+          aws: [
+            {
+              types: ['ec2'],
+              regions: [selectedRegion],
+              tags: { '*': ['*'] },
+              integration: agentMeta.awsIntegration.name,
+              ssm: { documentName: ssmDocumentName },
+              install: {
+                enrollMode: InstallParamEnrollMode.Script,
+                installTeleport: true,
+                joinToken: joinToken.id,
+              },
+            },
+          ],
+        });
+
+        updateAgentMeta({
+          ...agentMeta,
+          awsRegion: selectedRegion,
+          autoDiscovery: {
+            config,
+          },
+        });
+      } catch (err) {
+        emitErrorEvent(err.message);
+        throw err;
+      }
+    }
+  );
+
+  function generateScriptUrl(validator: Validator) {
+    if (!validator.validate()) return;
+
+    const scriptUrl = cfg.getAwsIamConfigureScriptEc2AutoDiscoverWithSsmUrl({
+      iamRoleName: arnResourceName,
+      region: selectedRegion,
+      ssmDocument: ssmDocumentName,
+    });
+    setScriptUrl(scriptUrl);
+  }
+
+  function clear() {
+    setAttempt(makeEmptyAttempt);
+    setCreatedToken(null);
+  }
+
+  return (
+    <Box maxWidth="1000px">
+      <Header>Setup Discovery Config for Teleport Discovery Service</Header>
+      {cfg.isCloud ? (
+        <Text>
+          The Teleport Discovery Service can connect to Amazon EC2 and
+          automatically discover and enroll EC2 instances. <SharedText />
+        </Text>
+      ) : (
+        <Text>
+          Discovery config defines the setup that enables Teleport to
+          automatically discover and register instances. <SharedText />
+        </Text>
+      )}
+      {attempt.status === 'error' && (
+        <Danger mt={3}>{attempt.statusText}</Danger>
+      )}
+      <StyledBox mt={4}>
+        <Text bold>Step 1</Text>
+        <Box mb={-5}>
+          <Text typography="subtitle1">
+            Select the AWS Region that contains the EC2 instances that you would
+            like to enroll:
+          </Text>
+          <AwsRegionSelector
+            onFetch={(region: Regions) => setSelectedRegion(region)}
+            clear={clear}
+            disableSelector={!!scriptUrl}
+          />
+        </Box>
+        {!showRestOfSteps && (
+          <ButtonSecondary
+            onClick={() => setShowRestOfSteps(true)}
+            disabled={!selectedRegion}
+            mt={3}
+          >
+            Next
+          </ButtonSecondary>
+        )}
+        {scriptUrl && (
+          <ButtonSecondary onClick={() => setScriptUrl('')} mt={3}>
+            Edit
+          </ButtonSecondary>
+        )}
+      </StyledBox>
+      {showRestOfSteps && (
+        <>
+          <StyledBox mt={4}>
+            <Text bold>Step 2</Text>
+            <Text typography="subtitle1">
+              Attach AWS managed{' '}
+              <Link
+                target="_blank"
+                href="https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html"
+              >
+                AmazonSSMManagedInstanceCore
+              </Link>{' '}
+              policy to EC2 instances IAM profile. The policy enables EC2
+              instances to use SSM core functionality.
+            </Text>
+          </StyledBox>
+          <StyledBox mt={4}>
+            <Text bold>Step 3</Text>
+            Each EC2 instance requires{' '}
+            <Link
+              target="_blank"
+              href="https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent-status-and-restart.html"
+            >
+              SSM Agent
+            </Link>{' '}
+            to be running. The SSM{' '}
+            <Link
+              target="_blank"
+              href={`https://${selectedRegion}.console.aws.amazon.com/systems-manager/fleet-manager/managed-nodes?region=${selectedRegion}`}
+            >
+              Nodes Manager dashboard
+            </Link>{' '}
+            will list all instances that have SSM agent already running. Ensure
+            ping statuses are <Mark>Online</Mark>.
+            <Info mt={3} mb={0}>
+              If you do not see your instances listed in the dashboard, it might
+              take up to 30 minutes for your instances to use the IAM
+              credentials you updated in step 2.
+            </Info>
+          </StyledBox>
+          <Validation>
+            {({ validator }) => (
+              <StyledBox mt={4}>
+                <Text bold>Step 4</Text>
+                <Box>
+                  <Text typography="subtitle1" mb={1}>
+                    Give a name for the{' '}
+                    <Link
+                      target="_blank"
+                      href="https://docs.aws.amazon.com/systems-manager/latest/userguide/documents.html"
+                    >
+                      AWS SSM Document
+                    </Link>{' '}
+                    that will be created on your behalf. Required to run the
+                    installer script on each discovered instances.
+                  </Text>
+                  <FieldInput
+                    rule={requiredSsmDocument}
+                    label="SSM Document Name"
+                    value={ssmDocumentName}
+                    onChange={e => setSsmDocumentName(e.target.value)}
+                    placeholder="ssm-document-name"
+                    disabled={!!scriptUrl}
+                  />
+                </Box>
+                <ButtonSecondary
+                  onClick={() =>
+                    scriptUrl ? setScriptUrl('') : generateScriptUrl(validator)
+                  }
+                  disabled={!selectedRegion}
+                >
+                  {scriptUrl ? 'Edit' : 'Next'}
+                </ButtonSecondary>
+              </StyledBox>
+            )}
+          </Validation>
+          {scriptUrl && (
+            <StyledBox mt={4}>
+              <Text bold>Step 5</Text>
+              <Flex alignItems="center" gap={1} mb={2}>
+                <Text typography="subtitle1">
+                  Run the command below on your{' '}
+                  <ExternalLink
+                    href="https://console.aws.amazon.com/cloudshell/home"
+                    target="_blank"
+                  >
+                    AWS CloudShell
+                  </ExternalLink>{' '}
+                  to configure your IAM permissions.
+                </Text>
+                <ToolTipInfo sticky={true} maxWidth={450}>
+                  The following IAM permissions will be added as an inline
+                  policy named <Mark>{IAM_POLICY_NAME}</Mark> to IAM role{' '}
+                  <Mark>{arnResourceName}</Mark>
+                  <Box mb={2}>
+                    <EditorWrapper $height={350}>
+                      <TextEditor
+                        readOnly={true}
+                        data={[{ content: inlinePolicyJson, type: 'json' }]}
+                        bg="levels.deep"
+                      />
+                    </EditorWrapper>
+                  </Box>
+                </ToolTipInfo>
+              </Flex>
+              <TextSelectCopyMulti
+                lines={[{ text: `bash -c "$(curl '${scriptUrl}')"` }]}
+              />
+            </StyledBox>
+          )}
+        </>
+      )}
+
+      {attempt.status === 'success' && (
+        <DiscoveryConfigCreatedDialog toNextStep={nextStep} />
+      )}
+
+      <ActionButtons
+        onProceed={createJoinTokenAndDiscoveryConfig}
+        disableProceed={attempt.status === 'processing' || !scriptUrl}
+      />
+    </Box>
+  );
+}
+
+const EditorWrapper = styled(Flex)`
+  flex-directions: column;
+  height: ${p => p.$height}px;
+  margin-top: ${p => p.theme.space[3]}px;
+  width: 450px;
+`;
+
+const inlinePolicyJson = `{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+              "ec2:DescribeInstances",
+              "ssm:DescribeInstanceInformation",
+              "ssm:GetCommandInvocation",
+              "ssm:ListCommandInvocations",
+              "ssm:SendCommand"
+          ],
+          "Resource": "*"
+      }
+  ]
+}`;
+
+const SSM_DOCUMENT_NAME_REGEX = new RegExp('^[0-9A-Za-z._-]*$');
+const requiredSsmDocument: Rule = name => () => {
+  if (!name || name.length < 3 || name.length > 128) {
+    return {
+      valid: false,
+      message: 'name must be between 3 and 128 characters',
+    };
+  }
+
+  const match = name.match(SSM_DOCUMENT_NAME_REGEX);
+  if (!match) {
+    return {
+      valid: false,
+      message: 'valid characters are a-z, A-Z, 0-9, and _, -, and . only',
+    };
+  }
+
+  return {
+    valid: true,
+  };
+};
+
+const SharedText = () => (
+  <>
+    The service will execute an install script on these discovered instances
+    using{' '}
+    <ExternalLink
+      target="_blank"
+      href="https://docs.aws.amazon.com/systems-manager/latest/userguide/what-is-systems-manager.html"
+    >
+      AWS Systems Manager
+    </ExternalLink>{' '}
+    that will install Teleport, start it and join the cluster.
+  </>
+);

--- a/web/packages/teleport/src/Discover/Server/Shared.tsx
+++ b/web/packages/teleport/src/Discover/Server/Shared.tsx
@@ -1,0 +1,49 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { Link as InternalLink } from 'react-router-dom';
+import { OutlineInfo } from 'design/Alert/Alert';
+import { Box } from 'design';
+
+import cfg from 'teleport/config';
+
+import { InfoIcon } from '../Shared/InfoIcon';
+import { Mark } from '../Shared';
+
+export const SingleEc2InstanceInstallation = () => (
+  <OutlineInfo mt={3} linkColor="buttons.link.default">
+    <Box>
+      <InfoIcon />
+    </Box>
+    <Box>
+      Auto discovery will enroll all EC2 instances found in a region. If you
+      want to enroll a <Mark>single</Mark> EC2 instance instead, consider
+      following the{' '}
+      <InternalLink
+        to={{
+          pathname: cfg.routes.discover,
+          state: { searchKeywords: 'linux' },
+        }}
+      >
+        Teleport service installation
+      </InternalLink>{' '}
+      flow instead.
+    </Box>
+  </OutlineInfo>
+);

--- a/web/packages/teleport/src/Discover/Server/Shared.tsx
+++ b/web/packages/teleport/src/Discover/Server/Shared.tsx
@@ -43,7 +43,7 @@ export const SingleEc2InstanceInstallation = () => (
       >
         Teleport service installation
       </InternalLink>{' '}
-      flow instead.
+      flow.
     </Box>
   </OutlineInfo>
 );

--- a/web/packages/teleport/src/Discover/Shared/AutoDiscovery/SelfHostedAutoDiscoverDirections.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AutoDiscovery/SelfHostedAutoDiscoverDirections.tsx
@@ -38,10 +38,12 @@ export const SelfHostedAutoDiscoverDirections = ({
   clusterPublicUrl,
   discoveryGroupName,
   setDiscoveryGroupName,
+  showSubHeader = true,
 }: {
   clusterPublicUrl: string;
   discoveryGroupName: string;
   setDiscoveryGroupName(n: string): void;
+  showSubHeader?: boolean;
 }) => {
   const yamlContent = `version: v3
 teleport:
@@ -61,14 +63,18 @@ discovery_service:
 
   return (
     <Box mt={2}>
-      <Flex alignItems="center">
-        <Text>
-          Auto-enrolling requires you to configure a{' '}
-          <Mark>Discovery Service</Mark>
-        </Text>
-        <ToolTipInfo children={discoveryServiceToolTip} />
-      </Flex>
-      <br />
+      {showSubHeader && (
+        <>
+          <Flex alignItems="center">
+            <Text>
+              Auto-enrolling requires you to configure a{' '}
+              <Mark>Discovery Service</Mark>
+            </Text>
+            <ToolTipInfo children={discoveryServiceToolTip} />
+          </Flex>
+          <br />
+        </>
+      )}
       <StyledBox mb={5}>
         <Text bold>Step 1: Create a Join Token</Text>
         <Text mb={2}>

--- a/web/packages/teleport/src/Discover/Shared/AwsRegionSelector/AwsRegionSelector.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AwsRegionSelector/AwsRegionSelector.tsx
@@ -30,7 +30,7 @@ export function AwsRegionSelector({
   clear,
 }: {
   onFetch(region: Regions): void;
-  onRefresh(): void;
+  onRefresh?(): void;
   disableSelector: boolean;
   clear(): void;
 }) {
@@ -58,22 +58,24 @@ export function AwsRegionSelector({
             isDisabled={disableSelector}
           />
         </Box>
-        <ButtonSecondary
-          onClick={onRefresh}
-          mt={1}
-          title="Refresh database table"
-          height="40px"
-          width="30px"
-          css={`
-            &:disabled {
-              opacity: 0.35;
-              pointer-events: none;
-            }
-          `}
-          disabled={disableSelector || !selectedRegion}
-        >
-          <RefreshIcon size="medium" />
-        </ButtonSecondary>
+        {onRefresh && (
+          <ButtonSecondary
+            onClick={onRefresh}
+            mt={1}
+            title="Refresh database table"
+            height="40px"
+            width="30px"
+            css={`
+              &:disabled {
+                opacity: 0.35;
+                pointer-events: none;
+              }
+            `}
+            disabled={disableSelector || !selectedRegion}
+          >
+            <RefreshIcon size="medium" />
+          </ButtonSecondary>
+        )}
       </Flex>
     </Box>
   );

--- a/web/packages/teleport/src/Discover/Shared/InfoIcon.tsx
+++ b/web/packages/teleport/src/Discover/Shared/InfoIcon.tsx
@@ -1,0 +1,29 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+import { Info } from 'design/Icon';
+
+export const InfoIcon = styled(Info)`
+  background-color: ${p => p.theme.colors.link};
+  border-radius: 100px;
+  height: 32px;
+  width: 32px;
+  color: ${p => p.theme.colors.text.primaryInverse};
+  margin-right: ${p => p.theme.space[2]}px;
+`;

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -317,6 +317,9 @@ const cfg = {
     awsConfigureIamAppAccessPath:
       '/v1/webapi/scripts/integrations/configure/aws-app-access-iam.sh?role=:iamRoleName',
 
+    awsConfigureIamEc2AutoDiscoverWithSsmPath:
+      '/v1/webapi/scripts/integrations/configure/ec2-ssm-iam.sh?role=:iamRoleName&awsRegion=:region&ssmDocument=:ssmDocument',
+
     eksClustersListPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/eksclusters',
     eksEnrollClustersPath:
@@ -1092,6 +1095,17 @@ const cfg = {
     );
   },
 
+  getAwsIamConfigureScriptEc2AutoDiscoverWithSsmUrl(
+    params: UrlAwsConfigureIamEc2AutoDiscoverWithSsmScriptParams
+  ) {
+    return (
+      cfg.baseUrl +
+      generatePath(cfg.api.awsConfigureIamEc2AutoDiscoverWithSsmPath, {
+        ...params,
+      })
+    );
+  },
+
   getAwsConfigureIamScriptListDatabasesUrl(
     params: UrlAwsConfigureIamScriptParams
   ) {
@@ -1240,6 +1254,12 @@ export interface UrlAwsOidcConfigureIdp {
 export interface UrlAwsConfigureIamScriptParams {
   region: Regions;
   iamRoleName: string;
+}
+
+export interface UrlAwsConfigureIamEc2AutoDiscoverWithSsmScriptParams {
+  region: Regions;
+  iamRoleName: string;
+  ssmDocument: string;
 }
 
 export interface UrlGcpWorkforceConfigParam {

--- a/web/packages/teleport/src/services/discovery/discovery.ts
+++ b/web/packages/teleport/src/services/discovery/discovery.ts
@@ -73,5 +73,13 @@ function makeAwsMatchersReq(inputMatchers: AwsMatcher[]) {
     tags: a.tags || {},
     integration: a.integration,
     kube_app_discovery: !!a.kubeAppDiscovery,
+    ssm: a.ssm ? { document_name: a.ssm.documentName } : undefined,
+    install: a.install
+      ? {
+          enroll_mode: a.install.enrollMode,
+          install_teleport: a.install.installTeleport,
+          join_token: a.install.joinToken,
+        }
+      : undefined,
   }));
 }

--- a/web/packages/teleport/src/services/discovery/types.ts
+++ b/web/packages/teleport/src/services/discovery/types.ts
@@ -29,6 +29,12 @@ export type DiscoveryConfig = {
 
 type AwsMatcherTypes = 'rds' | 'eks' | 'ec2';
 
+export enum InstallParamEnrollMode {
+  'Unspecified' = 0,
+  'Script' = 1,
+  'Eice' = 2,
+}
+
 // AWSMatcher matches AWS EC2 instances, AWS EKS clusters and AWS Databases
 export type AwsMatcher = {
   // types are AWS types to match, "ec2", "eks", "rds", "redshift", "elasticache",
@@ -43,6 +49,30 @@ export type AwsMatcher = {
   integration: string;
   // kubeAppDiscovery specifies if Kubernetes App Discovery should be enabled for a discovered cluster.
   kubeAppDiscovery?: boolean;
+  /**
+   * InstallParams sets the join method when installing on
+   * discovered EC2 nodes
+   */
+  install?: {
+    /**
+     *  EnrollMode indicates the mode used to enroll the node into Teleport.
+     * Valid values: script, eice.
+     */
+    enrollMode: InstallParamEnrollMode;
+    /**
+     * InstallTeleport disables agentless discovery
+     */
+    installTeleport: boolean;
+    /**
+     * JoinToken is the token to use when joining the cluster
+     */
+    joinToken: string;
+  };
+  /**
+   * SSM provides options to use when sending a document command to
+   * an EC2 node
+   */
+  ssm?: { documentName: string };
 };
 
 type Labels = Record<string, string[]>;

--- a/web/packages/teleport/src/services/discovery/types.ts
+++ b/web/packages/teleport/src/services/discovery/types.ts
@@ -30,9 +30,8 @@ export type DiscoveryConfig = {
 type AwsMatcherTypes = 'rds' | 'eks' | 'ec2';
 
 export enum InstallParamEnrollMode {
-  'Unspecified' = 0,
-  'Script' = 1,
-  'Eice' = 2,
+  Script = 1,
+  Eice = 2,
 }
 
 // AWSMatcher matches AWS EC2 instances, AWS EKS clusters and AWS Databases
@@ -50,26 +49,25 @@ export type AwsMatcher = {
   // kubeAppDiscovery specifies if Kubernetes App Discovery should be enabled for a discovered cluster.
   kubeAppDiscovery?: boolean;
   /**
-   * InstallParams sets the join method when installing on
+   * install sets the join method when installing on
    * discovered EC2 nodes
    */
   install?: {
     /**
-     *  EnrollMode indicates the mode used to enroll the node into Teleport.
-     * Valid values: script, eice.
+     * enrollMode indicates the mode used to enroll the node into Teleport.
      */
     enrollMode: InstallParamEnrollMode;
     /**
-     * InstallTeleport disables agentless discovery
+     * installTeleport disables agentless discovery
      */
     installTeleport: boolean;
     /**
-     * JoinToken is the token to use when joining the cluster
+     * joinToken is the token to use when joining the cluster
      */
     joinToken: string;
   };
   /**
-   * SSM provides options to use when sending a document command to
+   * ssm provides options to use when sending a document command to
    * an EC2 node
    */
   ssm?: { documentName: string };


### PR DESCRIPTION
Backport #42038 to branch/v15

changelog: Added an alternate EC2 auto discover flow using AWS Systems Manager as a more scalable method than EICE in the "Enroll New Resource" view in the web UI
