### PR TITLE
[POC] git proxy for AWS code commit

### DIFF
--- a/lib/srv/app/aws/codecommit.go
+++ b/lib/srv/app/aws/codecommit.go
@@ -1,0 +1,237 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package aws
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	apiawsutils "github.com/gravitational/teleport/api/utils/aws"
+	"github.com/gravitational/teleport/lib/srv/app/common"
+	libawsutils "github.com/gravitational/teleport/lib/utils/aws"
+	"github.com/gravitational/trace"
+)
+
+func (s *signerHandler) serveGitCodeCommitRequest(sessCtx *common.SessionContext, w http.ResponseWriter, req *http.Request) error {
+	s.Log.Infof("== code commit req URL %v", req.URL.String())
+	s.Log.Infof("== code commit original URL %v", req.Header.Get(common.TeleportOriginalGitURL))
+
+	originalURL, err := url.Parse(req.Header.Get(common.TeleportOriginalGitURL))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	region, err := getRegionFromCodeCommitEndpoint(originalURL.Host)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	credValue, err := s.getSessionCredentialValue(req.Context(), sessCtx, region)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	forwardReq, err := s.makeCodeCommitRequest(req, originalURL, credValue, region)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// TODO figure out why reverse proxy does not work
+	//recorder := httplib.NewResponseStatusRecorder(w)
+	//s.fwd.ServeHTTP(recorder, forwardReq)
+
+	response, err := http.DefaultClient.Do(forwardReq)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer response.Body.Close()
+
+	// TODO audit log
+	s.Log.Infof("== code commit response %v %v", response, err)
+
+	for key, values := range response.Header {
+		for _, value := range values {
+			w.Header().Set(key, value)
+		}
+	}
+	w.WriteHeader(response.StatusCode)
+	n, err := io.Copy(w, response.Body)
+	s.Log.Infof("== io.Copy %v %v", n, err)
+	return nil
+}
+
+func (s *signerHandler) getSessionCredentialValue(ctx context.Context, sessCtx *common.SessionContext, region string) (credentials.Value, error) {
+	awsSession, err := s.SessionProvider(ctx, region, sessCtx.App.GetIntegration())
+	if err != nil {
+		return credentials.Value{}, trace.Wrap(err)
+	}
+	credentials, err := s.CredentialsGetter.Get(ctx, libawsutils.GetCredentialsRequest{
+		Provider:    awsSession,
+		Expiry:      sessCtx.Identity.Expires,
+		SessionName: sessCtx.Identity.Username,
+		RoleARN:     sessCtx.Identity.RouteToApp.AWSRoleARN,
+	})
+	credValue, err := credentials.GetWithContext(ctx)
+	return credValue, trace.Wrap(err)
+}
+
+func (s *signerHandler) makeCodeCommitRequest(req *http.Request, originalURL *url.URL, credValue credentials.Value, region string) (*http.Request, error) {
+	signTime := s.Clock.Now()
+	signature, err := makeCodeCommitSignature(signTime, originalURL, region, credValue)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	forwardReq, err := cloneRequest(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	forwardReq.RequestURI = ""
+	forwardReq.URL.Scheme = "https"
+	forwardReq.Host = originalURL.Host
+	forwardReq.URL.Host = originalURL.Host
+	forwardReq.URL.User = url.UserPassword(
+		makeCodeCommitUser(credValue),
+		signTime.Format(libawsutils.AmzDateTimeFormat)+signature,
+	)
+	// TODO maybe clean up some headers before sending?
+	return forwardReq, nil
+}
+
+func makeCodeCommitUser(credValue credentials.Value) string {
+	if credValue.SessionToken == "" {
+		return credValue.AccessKeyID
+	}
+	return credValue.AccessKeyID + "%" + credValue.SessionToken
+}
+
+const (
+	awsShortDateFormat    = "20060102"
+	codeCommitServiceName = "codecommit"
+)
+
+func makeCodeCommitSignature(signTime time.Time, originalURL *url.URL, region string, credValue credentials.Value) (string, error) {
+	signer := &codeCommitSigV4Signer{
+		hostname:  originalURL.Hostname(),
+		path:      originalURL.Path,
+		region:    region,
+		signTime:  signTime,
+		credValue: credValue,
+	}
+	signature, err := signer.signature()
+	return signature, trace.Wrap(err)
+}
+
+// TODO move to lib/utils/aws?
+// https://github.com/aws/git-remote-codecommit/blob/master/git_remote_codecommit/__init__.py
+type codeCommitSigV4Signer struct {
+	hostname  string
+	path      string
+	region    string
+	signTime  time.Time
+	credValue credentials.Value
+}
+
+func (s *codeCommitSigV4Signer) canonicalRequest() string {
+	return fmt.Sprintf("GIT\n%s\n\nhost:%s\n\nhost\n", s.path, s.hostname)
+}
+
+func (s *codeCommitSigV4Signer) credentialScope() string {
+	parts := []string{
+		s.signTime.Format(awsShortDateFormat),
+		s.region,
+		codeCommitServiceName,
+		"aws4_request",
+	}
+	return strings.Join(parts, "/")
+}
+
+func (s *codeCommitSigV4Signer) stringToSign() (string, error) {
+	canonicalRequestHash := sha256.New()
+	if _, err := canonicalRequestHash.Write([]byte(s.canonicalRequest())); err != nil {
+		return "", trace.Wrap(err)
+	}
+	parts := []string{
+		"AWS4-HMAC-SHA256",
+		s.signTime.Format("20060102T150405"), // no "Z" suffix
+		s.credentialScope(),
+		hex.EncodeToString(canonicalRequestHash.Sum(nil)),
+	}
+	return strings.Join(parts, "\n"), nil
+}
+
+func (s *codeCommitSigV4Signer) hmac256(key []byte, data []byte) ([]byte, error) {
+	// this function is copyed from internal/v4/hmac.go
+	hash := hmac.New(sha256.New, key)
+	if _, err := hash.Write(data); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return hash.Sum(nil), nil
+}
+
+func (s *codeCommitSigV4Signer) signature() (string, error) {
+	stringToSign, err := s.stringToSign()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	rollingParts := []string{
+		"AWS4" + s.credValue.SecretAccessKey,
+		s.signTime.Format(awsShortDateFormat),
+		s.region,
+		codeCommitServiceName,
+		"aws4_request",
+		stringToSign,
+	}
+
+	rolling := []byte(rollingParts[0])
+	for _, v := range rollingParts[1:] {
+		rolling, err = s.hmac256(rolling, []byte(v))
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+	}
+	return hex.EncodeToString(rolling), nil
+}
+
+// TODO move it to api/utils/aws?
+// git-codecommit.ca-central-1.amazonaws.com
+func getRegionFromCodeCommitEndpoint(endpoint string) (string, error) {
+	if !apiawsutils.IsAWSEndpoint(endpoint) {
+		return "", trace.BadParameter("invalid AWS CodeCommit endpoint %v", endpoint)
+	}
+	if !strings.HasPrefix(endpoint, "git-codecommit.") {
+		return "", trace.BadParameter("invalid AWS CodeCommit endpoint %v", endpoint)
+	}
+	region, _, ok := strings.Cut(strings.TrimPrefix(endpoint, "git-codecommit."), ".")
+	if !ok {
+		return "", trace.BadParameter("invalid AWS CodeCommit endpoint %v", endpoint)
+	}
+	if err := apiawsutils.IsValidRegion(region); err != nil {
+		return "", trace.Wrap(err)
+	}
+	return region, nil
+}

--- a/lib/srv/app/aws/codecommit_test.go
+++ b/lib/srv/app/aws/codecommit_test.go
@@ -1,0 +1,69 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	libawsutils "github.com/gravitational/teleport/lib/utils/aws"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_codeCommitSigV4Signer(t *testing.T) {
+	date := "20220222T222222Z"
+	credValue := credentials.Value{
+		AccessKeyID:     "example-access-key-id",
+		SecretAccessKey: "example-secret-access-key",
+	}
+	signTime, err := libawsutils.ParseAmazonDateTime(date)
+	require.NoError(t, err)
+
+	signer := &codeCommitSigV4Signer{
+		region:    "ca-central-1",
+		hostname:  "git-codecommit.ca-central-1.amazonaws.com",
+		path:      "my-repo",
+		signTime:  signTime,
+		credValue: credValue,
+	}
+
+	// All expected values are calculated from using botocore lib:
+	// https://github.com/aws/git-remote-codecommit/blob/master/git_remote_codecommit/__init__.py
+	expectedCanonicalRequest := `GIT
+my-repo
+
+host:git-codecommit.ca-central-1.amazonaws.com
+
+host
+`
+	require.Equal(t, expectedCanonicalRequest, signer.canonicalRequest())
+
+	expectedStringToSign := `AWS4-HMAC-SHA256
+20220222T222222
+20220222/ca-central-1/codecommit/aws4_request
+d12655b601b13f5eb8eb058aa746e812881301ed96124748df87735142777fdf`
+	actualStringToSign, err := signer.stringToSign()
+	require.NoError(t, err)
+	require.Equal(t, expectedStringToSign, actualStringToSign)
+
+	expectedSignature := "46d2b6a9501b2738642bf0b2787de2397d2407d12cb55b3e6f61d7a169ca2872"
+	actualSignature, err := signer.signature()
+	require.NoError(t, err)
+	require.Equal(t, expectedSignature, actualSignature)
+}

--- a/lib/srv/app/aws/handler.go
+++ b/lib/srv/app/aws/handler.go
@@ -110,6 +110,7 @@ func NewAWSSignerHandler(ctx context.Context, config SignerHandlerConfig) (http.
 		reverseproxy.WithErrorHandler(handler.formatForwardResponseError),
 	)
 
+	reverseproxy.WithPassHostHeader
 	return handler, trace.Wrap(err)
 }
 
@@ -144,6 +145,11 @@ func (s *signerHandler) serveHTTP(w http.ResponseWriter, req *http.Request) erro
 	// AWS without re-signing.
 	if req.Header.Get(common.TeleportAWSAssumedRole) != "" {
 		return trace.Wrap(s.serveRequestByAssumedRole(sessCtx, w, req))
+	}
+
+	// TODO
+	if req.Header.Get(common.TeleportOriginalGitURL) != "" {
+		return trace.Wrap(s.serveGitCodeCommitRequest(sessCtx, w, req))
 	}
 
 	// Handle requests signed with the default local proxy credentials. The

--- a/lib/srv/app/common/header.go
+++ b/lib/srv/app/common/header.go
@@ -55,6 +55,8 @@ const (
 	// TeleportAWSAssumedRoleAuthorization contains the original authorization
 	// header for requests signed by assumed roles.
 	TeleportAWSAssumedRoleAuthorization = "X-Teleport-Aws-Assumed-Role-Authorization"
+	// TODO
+	TeleportOriginalGitURL = "X-Teleport-Original-Git-Url"
 )
 
 // ReservedHeaders is a list of headers injected by Teleport.
@@ -65,6 +67,7 @@ var ReservedHeaders = append([]string{
 	TeleportAPIInfoHeader,
 	TeleportAWSAssumedRole,
 	TeleportAWSAssumedRoleAuthorization,
+	TeleportOriginalGitURL,
 },
 	reverseproxy.XHeaders...,
 )

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -442,7 +442,11 @@ func (c *ConnectionsHandler) serveHTTP(w http.ResponseWriter, r *http.Request) e
 		//
 		// Also check header common.TeleportAWSAssumedRole which is added by
 		// the local proxy for AWS requests signed by assumed roles.
-		if awsutils.IsSignedByAWSSigV4(r) || r.Header.Get(common.TeleportAWSAssumedRole) != "" {
+		//
+		// TODO
+		if awsutils.IsSignedByAWSSigV4(r) ||
+			r.Header.Get(common.TeleportAWSAssumedRole) != "" ||
+			r.Header.Get(common.TeleportOriginalGitURL) != "" {
 			return c.serveSession(w, r, &identity, app, c.withAWSSigner)
 		}
 

--- a/lib/utils/aws/aws.go
+++ b/lib/utils/aws/aws.go
@@ -207,6 +207,12 @@ func VerifyAWSSignature(req *http.Request, credentials *credentials.Credentials)
 	return nil
 }
 
+// TODO
+func ParseAmazonDateTime(input string) (time.Time, error) {
+	t, err := time.Parse(AmzDateTimeFormat, input)
+	return t, trace.Wrap(err)
+}
+
 // NewSigner creates a new V4 signer.
 func NewSigner(credentials *credentials.Credentials, signingServiceName string) *v4.Signer {
 	options := func(s *v4.Signer) {

--- a/tool/git-test/main.go
+++ b/tool/git-test/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"io"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	cmd := exec.Command("git", "remote-http", "origin", "https://teleport.dev.aws.stevexin.me/v1/repos/steve-codecommit")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = io.MultiWriter(os.Stdout, os.Stderr)
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(),
+		"GIT_SSL_CERT=/Users/stevehuang/.tsh/keys/teleport.dev.aws.stevexin.me/STeve-app/teleport.dev.aws.stevexin.me/aws-dev-account-x509.pem",
+		"GIT_SSL_KEY=/Users/stevehuang/.tsh/keys/teleport.dev.aws.stevexin.me/STeve",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=http.extraHeader",
+		"GIT_CONFIG_VALUE_0=X-Teleport-Original-Git-Url: https://git-codecommit.ca-central-1.amazonaws.com/v1/repos/steve-codecommit",
+	)
+	cmd.Run()
+	os.Exit(cmd.ProcessState.ExitCode())
+}

--- a/tool/tsh/common/git.go
+++ b/tool/tsh/common/git.go
@@ -1,0 +1,191 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	apiawsutils "github.com/gravitational/teleport/api/utils/aws"
+)
+
+func onGitRemote(cf *CLIConf) error {
+	slog.InfoContext(cf.Context, "onGitRemote", "origin", cf.GitOrigin, "url", cf.GitURL)
+
+	gitURL, err := url.Parse(cf.GitURL)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if gitURL.User != nil {
+		cf.AppName = gitURL.User.Username()
+		if password, ok := gitURL.User.Password(); ok {
+			cf.SiteName = password
+		}
+		gitURL.User = nil
+	}
+
+	if isCodeCommitURL(gitURL) {
+		return trace.Wrap(onGitRemoteCodeCommit(cf, gitURL))
+	}
+	return trace.NotImplemented("unsupported %v", cf.GitURL)
+}
+
+func onGitRemoteCodeCommit(cf *CLIConf, codeCommitURL *url.URL) error {
+	// TODO local proxy for per-session MFA and proxy behind L7 load balancer?
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Check if app cert exists and prompt for app login if necessary.
+	if _, _, err := loadAppCertificate(tc, cf.AppName); err != nil {
+		return trace.Wrap(err)
+	}
+
+	profile, err := tc.ProfileStatus()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	gitConfigs := &gitConfigs{
+		sslCert:      profile.AppCertPath(tc.SiteName, cf.AppName),
+		sslKey:       profile.KeyPath(),
+		extraHeaders: []string{"X-Teleport-Original-Git-Url: " + codeCommitURL.String()},
+	}
+
+	runGitCommandAndExit(cf.Context, gitConfigs.envs(), "remote-http", cf.GitOrigin, "https://"+tc.WebProxyAddr+codeCommitURL.Path)
+	return nil
+}
+
+func runGitCommandAndExit(ctx context.Context, extraEnv []string, commands ...string) {
+	// TODO investigate why os.Environ() is required
+	cmd := exec.Command("git", commands...)
+	cmd.Env = append(os.Environ(), extraEnv...)
+	slog.DebugContext(ctx, "Calling git.", "env", cmd.Env, "args", strings.Join(cmd.Args, " "))
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		slog.ErrorContext(ctx, "Git exited with error.", "error", err)
+	}
+	if cmd.ProcessState != nil {
+		os.Exit(cmd.ProcessState.ExitCode())
+	}
+}
+
+func onGitClone(cf *CLIConf) error {
+	slog.InfoContext(cf.Context, "onGitClone", "app", cf.AppName, "url", cf.GitURL)
+
+	gitURL, err := url.Parse(cf.GitURL)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	gitURL.User = url.UserPassword(cf.AppName, cf.SiteName)
+
+	if err := ensureGitRemoteIsInstalled(cf); err != nil {
+		return trace.Wrap(err)
+	}
+	runGitCommandAndExit(cf.Context, nil, "clone", "teleport::"+gitURL.String())
+	return nil
+}
+
+func ensureGitRemoteIsInstalled(cf *CLIConf) error {
+	existingPath, err := exec.LookPath("git-remote-teleport")
+	if err == nil {
+		slog.InfoContext(cf.Context, "Found git-remote-teleport", "path", existingPath)
+		return nil
+	}
+
+	myself, err := os.Executable()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	targetPath := path.Join(path.Dir(myself), "git-remote-teleport")
+	if err := os.Link(myself, targetPath); err != nil {
+		return trace.Wrap(err)
+	}
+
+	slog.InfoContext(cf.Context, "Installed git-remote-teleport", "path", targetPath)
+	return nil
+}
+
+// TODO move to api/utils/aws?
+// https://git-codecommit.ca-central-1.amazonaws.com/v1/repos/steve-codecommit
+func isCodeCommitURL(u *url.URL) bool {
+	return u.Scheme == "https" &&
+		apiawsutils.IsAWSEndpoint(u.Host) &&
+		strings.HasPrefix(u.Host, "git-codecommit")
+}
+
+// TODO move to a proper lib like lib/client/git
+type gitConfigs struct {
+	sslCert      string
+	sslKey       string
+	extraHeaders []string
+	// TODO insecure, local proxy
+}
+
+func (g *gitConfigs) envs() []string {
+	envs := []string{
+		"GIT_SSL_CERT=" + g.sslCert,
+		"GIT_SSL_KEY=" + g.sslKey,
+	}
+	envs = append(envs, fmt.Sprintf("GIT_CONFIG_COUNT=%d", len(g.extraHeaders)))
+	for i, header := range g.extraHeaders {
+		envs = append(envs,
+			fmt.Sprintf("GIT_CONFIG_KEY_%d=http.extraHeader", i),
+			fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", i, header),
+		)
+	}
+	return envs
+}
+
+/*
+func (g *gitConfigs) updateFile(path string) error {
+	iniFile, err := ini.Load(path)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	httpSection := iniFile.Section("http")
+	if httpSection == nil {
+		httpSection, err = iniFile.NewSection("http")
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	httpSection.NewKey("sslCert", g.sslCert)
+	httpSection.NewKey("sslKey", g.sslKey)
+	for _, header := range g.extraHeaders {
+		httpSection.NewKey("extraHeader", header)
+	}
+	return iniFile.SaveToIndent(path, "\t")
+}
+*/


### PR DESCRIPTION
How it works:
-  `tsh`
   - `tsh git clone` first copies itself (`tsh`) to `git-remote-teleport` then calls `git clone teleport::https://<app-name>:<cluster>@git-codecommit.ca-central-1.amazonaws.com/v1/repos/steve-codecommit`. [`gitremote` official doc](/Users/stevehuang/go/github.com/gravitational/teleport/build/git-remote-teleport)
   - `git-remote-teleport` adds a few `GIT_` env vars then calls `git remote-http <origin> https://<teleport-proxy-addr>/v1/repos/steve-codecommit`. The env vars load Teleport client cert and add the original code commit URL as a header.
- App agent
   - calculate user/password based on [git-remote-codecommit](https://github.com/aws/git-remote-codecommit/blob/master/git_remote_codecommit/__init__.py) then forwards it to AWS code commit. 

Sample:
```
$ tsh apps login aws-dev-account --aws-role steve-poweruser
Logged into AWS app "aws-dev-account".
...

$ tsh aws codecommit get-repository --repository-name steve-codecommit | jq -r .repositoryMetadata.cloneUrlHttp
https://git-codecommit.ca-central-1.amazonaws.com/v1/repos/steve-codecommit

$ tsh git clone --app aws-dev-account https://git-codecommit.ca-central-1.amazonaws.com/v1/repos/steve-codecommit
Cloning into 'steve-codecommit'...
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint: 	git branch -m <name>
remote: Counting objects: 6, done.
Unpacking objects: 100% (6/6), 425 bytes | 60.00 KiB/s, done.

$ cd steve-codecommit/
$ git remote show origin
* remote origin
  Fetch URL: teleport::https://aws-dev-account:@git-codecommit.ca-central-1.amazonaws.com/v1/repos/steve-codecommit
  Push  URL: teleport::https://aws-dev-account:@git-codecommit.ca-central-1.amazonaws.com/v1/repos/steve-codecommit
  HEAD branch: main
  Remote branch:
    main tracked
  Local branch configured for 'git pull':
    main merges with remote main
  Local ref configured for 'git push':
    main pushes to main (up to date)

$ git fetch

$ which git-remote-teleport
/Users/stevehuang/go/github.com/gravitational/teleport/build/git-remote-teleport
```