### PR TITLE
node-agent chart improvements

### DIFF
--- a/assets/loadtest/helm/node-agent/templates/config.yaml
+++ b/assets/loadtest/helm/node-agent/templates/config.yaml
@@ -24,14 +24,18 @@ data:
       enabled: false
     ssh_service:
       enabled: true
+      {{ if .Values.labels }}
+      labels: {{- toYaml .Values.labels | nindent 8 }}
+      {{- end }}
       commands:
         - name: fullname
-          command: ['bash', '-c', 'echo "$HOSTNAME-$REPLICA"']
+          command: ['sh', '-c', 'echo "$HOSTNAME-$REPLICA"']
       # listen_addr set at runtime to avoid conflicts in the same pod
       # listen_addr: 0.0.0.0:3022
   entrypoint.sh: |2
-    #!/bin/bash
+    #!/busybox/sh
     set -euxo pipefail
+    sed -i 's!/sbin/nologin!/busybox/sh!' /etc/passwd
     cp /etc/teleport-config/teleport.yaml /etc/teleport.yaml
     echo "  listen_addr: '0.0.0.0:30$REPLICA'" >> /etc/teleport.yaml
     HOST="$(hostname)-$REPLICA"

--- a/assets/loadtest/helm/node-agent/templates/config.yaml
+++ b/assets/loadtest/helm/node-agent/templates/config.yaml
@@ -40,4 +40,4 @@ data:
     echo "  listen_addr: '0.0.0.0:30$REPLICA'" >> /etc/teleport.yaml
     HOST="$(hostname)-$REPLICA"
     cat /etc/teleport.yaml
-    exec teleport start -c /etc/teleport.yaml --nodename $HOST
+    exec dumb-init --rewrite 15:3 -- teleport start -c /etc/teleport.yaml --nodename $HOST

--- a/assets/loadtest/helm/node-agent/templates/deployment.yaml
+++ b/assets/loadtest/helm/node-agent/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       containers:
@@ -20,14 +22,23 @@ spec:
         {{- $id := printf "%02d" $i }}
         - image: "{{ $.Values.image.repository }}:{{ default $.Chart.AppVersion $.Values.image.tag }}"
           name: agent-{{ $id }}
-          command: ["bash", "/etc/teleport-config/entrypoint.sh"]
+          command: ["/busybox/sh", "/etc/teleport-config/entrypoint.sh"]
           env:
             - name: REPLICA
               value: "{{ $id }}"
+            {{- if $.Values.tls.existingCASecretName }}
+            - name: SSL_CERT_FILE
+              value: /etc/teleport-tls-ca/ca.pem
+            {{- end }}
           volumeMounts:
             - mountPath: /etc/teleport-config
               name: config
               readOnly: true
+            {{- if $.Values.tls.existingCASecretName }}
+            - mountPath: /etc/teleport-tls-ca
+              name: "teleport-tls-ca"
+              readOnly: true
+            {{- end }}
           resources: {{- toYaml $.Values.resources | nindent 12 }}
         {{- end }}
       volumes:
@@ -35,6 +46,11 @@ spec:
             name: {{ .Release.Name }}
             defaultMode: 0766
           name: config
+        {{- if .Values.tls.existingCASecretName }}
+        - name: teleport-tls-ca
+          secret:
+            secretName: {{ .Values.tls.existingCASecretName }}
+        {{- end }}
       {{- if .Values.tolerations }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8}}
       {{- end }}

--- a/assets/loadtest/helm/node-agent/values.yaml
+++ b/assets/loadtest/helm/node-agent/values.yaml
@@ -17,8 +17,13 @@ joinParams:
   # the kubernetes join method is not currently suited for joining a large amount of nodes in a short time
   method: token
   # DO NOT USE THIS IN PRODUCTION
-  token_name: qwertyuiop
+  token_name: ""
 
 tolerations: []
 
 affinity: {}
+
+tls:
+  existingCASecretName: ""
+
+labels: {}


### PR DESCRIPTION
This PR contains a bunch of small fixes and improvements on the node-agent Helm chart used for loadtests:
- allow users to ssh into the nodes by removing the nologin (this broke when moving to distroless)
- change from bash to busybox/sh
- add tls.externalCASecretName support (custom CA)
- add custom ssh labels support