### PR TITLE
[v14] Add --node-name to the teleport configure command

### DIFF
--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -403,6 +403,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dump.Flag("proxy", "Address of the proxy.").StringVar(&dumpFlags.ProxyAddress)
 	dump.Flag("app-name", "Name of the application to start when using app role.").StringVar(&dumpFlags.AppName)
 	dump.Flag("app-uri", "Internal address of the application to proxy.").StringVar(&dumpFlags.AppURI)
+	dump.Flag("node-name", "Name for the Teleport node.").StringVar(&dumpFlags.NodeName)
 	dump.Flag("node-labels", "Comma-separated list of labels to add to newly created nodes, for example env=staging,cloud=aws.").StringVar(&dumpFlags.NodeLabels)
 
 	ver.Flag("raw", "Print the raw teleport version string.").BoolVar(&rawVersion)


### PR DESCRIPTION
Backport #42156 to branch/v14

changelog: The `teleport configure` command now supports a `--node-name` flag for overriding the node's hostname.
