### PR TITLE
[v16] audit: populate `server_version` in `ServerMetadata`

### DIFF
--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/gravitational/ttlmap"
 
+	ossteleport "github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	controlgroup "github.com/gravitational/teleport/lib/cgroup"
@@ -388,6 +389,7 @@ func (s *Service) emitCommandEvent(eventBytes []byte) {
 				Code: events.SessionCommandCode,
 			},
 			ServerMetadata: apievents.ServerMetadata{
+				ServerVersion:   ossteleport.Version,
 				ServerID:        ctx.ServerID,
 				ServerHostname:  ctx.ServerHostname,
 				ServerNamespace: ctx.Namespace,
@@ -446,6 +448,7 @@ func (s *Service) emitDiskEvent(eventBytes []byte) {
 			Code: events.SessionDiskCode,
 		},
 		ServerMetadata: apievents.ServerMetadata{
+			ServerVersion:   ossteleport.Version,
 			ServerID:        ctx.ServerID,
 			ServerHostname:  ctx.ServerHostname,
 			ServerNamespace: ctx.Namespace,
@@ -500,6 +503,7 @@ func (s *Service) emit4NetworkEvent(eventBytes []byte) {
 			Code: events.SessionNetworkCode,
 		},
 		ServerMetadata: apievents.ServerMetadata{
+			ServerVersion:   ossteleport.Version,
 			ServerID:        ctx.ServerID,
 			ServerHostname:  ctx.ServerHostname,
 			ServerNamespace: ctx.Namespace,
@@ -556,6 +560,7 @@ func (s *Service) emit6NetworkEvent(eventBytes []byte) {
 			Code: events.SessionNetworkCode,
 		},
 		ServerMetadata: apievents.ServerMetadata{
+			ServerVersion:   ossteleport.Version,
 			ServerID:        ctx.ServerID,
 			ServerHostname:  ctx.ServerHostname,
 			ServerNamespace: ctx.Namespace,

--- a/lib/events/eventstest/generate.go
+++ b/lib/events/eventstest/generate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 
+	"github.com/gravitational/teleport"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 )
@@ -73,7 +74,8 @@ func GenerateTestSession(params SessionParams) []apievents.AuditEvent {
 			ClusterName: params.ClusterName,
 		},
 		ServerMetadata: apievents.ServerMetadata{
-			ServerID: params.ServerID,
+			ServerVersion: teleport.Version,
+			ServerID:      params.ServerID,
 			ServerLabels: map[string]string{
 				"kernel": "5.3.0-42-generic",
 				"date":   "Mon Mar 30 08:58:54 PDT 2020",
@@ -105,6 +107,7 @@ func GenerateTestSession(params SessionParams) []apievents.AuditEvent {
 			Time:  params.Clock.Now().UTC().Add(time.Hour + time.Second + 7*time.Millisecond),
 		},
 		ServerMetadata: apievents.ServerMetadata{
+			ServerVersion:   teleport.Version,
 			ServerID:        params.ServerID,
 			ServerNamespace: "default",
 		},

--- a/lib/srv/app/common/audit.go
+++ b/lib/srv/app/common/audit.go
@@ -106,6 +106,7 @@ func (a *audit) OnSessionStart(ctx context.Context, serverID string, identity *t
 			ClusterName: identity.RouteToApp.ClusterName,
 		},
 		ServerMetadata: apievents.ServerMetadata{
+			ServerVersion:   teleport.Version,
 			ServerID:        serverID,
 			ServerNamespace: apidefaults.Namespace,
 		},
@@ -132,6 +133,7 @@ func (a *audit) OnSessionEnd(ctx context.Context, serverID string, identity *tls
 			ClusterName: identity.RouteToApp.ClusterName,
 		},
 		ServerMetadata: apievents.ServerMetadata{
+			ServerVersion:   teleport.Version,
 			ServerID:        serverID,
 			ServerNamespace: apidefaults.Namespace,
 		},
@@ -158,6 +160,7 @@ func (a *audit) OnSessionChunk(ctx context.Context, serverID, chunkID string, id
 			ClusterName: identity.RouteToApp.ClusterName,
 		},
 		ServerMetadata: apievents.ServerMetadata{
+			ServerVersion:   teleport.Version,
 			ServerID:        serverID,
 			ServerNamespace: apidefaults.Namespace,
 		},

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -1398,6 +1398,7 @@ func (c *ServerContext) GetExecRequest() (Exec, error) {
 
 func (c *ServerContext) GetServerMetadata() apievents.ServerMetadata {
 	return apievents.ServerMetadata{
+		ServerVersion:   teleport.Version,
 		ServerID:        c.srv.HostUUID(),
 		ServerHostname:  c.srv.GetInfo().GetHostname(),
 		ServerNamespace: c.srv.GetNamespace(),

--- a/lib/srv/db/common/audit.go
+++ b/lib/srv/db/common/audit.go
@@ -272,6 +272,7 @@ func MakeEventMetadata(session *Session, eventType, eventCode string) events.Met
 // MakeServerMetadata returns common server metadata for database session.
 func MakeServerMetadata(session *Session) events.ServerMetadata {
 	return events.ServerMetadata{
+		ServerVersion:   teleport.Version,
 		ServerID:        session.HostID,
 		ServerNamespace: apidefaults.Namespace,
 	}

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -409,6 +409,7 @@ func (s *Server) TargetMetadata() apievents.ServerMetadata {
 	}
 
 	return apievents.ServerMetadata{
+		ServerVersion:   teleport.Version,
 		ServerNamespace: s.GetNamespace(),
 		ServerID:        s.targetID,
 		ServerAddr:      s.targetAddr,

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -31,6 +31,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -457,7 +458,8 @@ func (w *Monitor) emitDisconnectEvent(reason string) error {
 			RemoteAddr: w.Conn.RemoteAddr().String(),
 		},
 		ServerMetadata: apievents.ServerMetadata{
-			ServerID: w.ServerID,
+			ServerVersion: teleport.Version,
+			ServerID:      w.ServerID,
 		},
 		Reason: reason,
 	}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -245,6 +245,7 @@ type Server struct {
 // TargetMetadata returns metadata about the server.
 func (s *Server) TargetMetadata() apievents.ServerMetadata {
 	return apievents.ServerMetadata{
+		ServerVersion:   teleport.Version,
 		ServerNamespace: s.GetNamespace(),
 		ServerID:        s.ID(),
 		ServerAddr:      s.Addr(),
@@ -1479,6 +1480,7 @@ func (s *Server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 						RemoteAddr: ccx.ServerConn.RemoteAddr().String(),
 					},
 					ServerMetadata: apievents.ServerMetadata{
+						ServerVersion:   teleport.Version,
 						ServerID:        s.uuid,
 						ServerNamespace: s.GetNamespace(),
 					},

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -882,6 +882,7 @@ func TestTrackingSession(t *testing.T) {
 					},
 				},
 				serverMeta: apievents.ServerMetadata{
+					ServerVersion:  teleport.Version,
 					ServerHostname: "test",
 					ServerID:       "123",
 				},

--- a/lib/srv/session_control.go
+++ b/lib/srv/session_control.go
@@ -335,6 +335,7 @@ func (s *SessionController) emitRejection(ctx context.Context, userMetadata apie
 			RemoteAddr: remoteAddr,
 		},
 		ServerMetadata: apievents.ServerMetadata{
+			ServerVersion:   teleport.Version,
 			ServerID:        s.cfg.ServerID,
 			ServerNamespace: apidefaults.Namespace,
 		},

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -287,6 +288,7 @@ func (h *Handler) createAppSession(w http.ResponseWriter, r *http.Request, p htt
 			ClusterName: identity.RouteToApp.ClusterName,
 		},
 		ServerMetadata: apievents.ServerMetadata{
+			ServerVersion:   teleport.Version,
 			ServerID:        h.cfg.HostUUID,
 			ServerNamespace: apidefaults.Namespace,
 		},


### PR DESCRIPTION
Backport #42159 to branch/v16