### PR TITLE
Do not overwrite an existing cluster when adding it again

### DIFF
--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
@@ -105,6 +105,35 @@ test('add cluster', async () => {
   );
 });
 
+test('add cluster does not overwrite the existing cluster', async () => {
+  const { addCluster } = getClientMocks();
+  const service = createService({
+    addCluster,
+  });
+  service.state.clusters.set(clusterUri, {
+    ...clusterMock,
+    features: { advancedAccessWorkflows: true, isUsageBasedBilling: true },
+  });
+
+  await service.addRootCluster(clusterUri);
+
+  expect(addCluster).toHaveBeenCalledWith({ name: clusterUri });
+  expect(service.state.clusters).toStrictEqual(
+    new Map([
+      [
+        clusterUri,
+        {
+          ...clusterMock,
+          features: {
+            advancedAccessWorkflows: true,
+            isUsageBasedBilling: true,
+          },
+        },
+      ],
+    ])
+  );
+});
+
 test('remove cluster', async () => {
   const { removeGateway } = getClientMocks();
   const service = createService({ removeGateway });

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -75,12 +75,18 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
 
   async addRootCluster(addr: string) {
     const { response: cluster } = await this.client.addCluster({ name: addr });
-    this.setState(draft => {
-      draft.clusters.set(
-        cluster.uri as uri.RootClusterUri,
-        this.removeInternalLoginsFromCluster(cluster)
-      );
-    });
+    // Do not overwrite the existing cluster;
+    // otherwise we may lose properties fetched from the auth server.
+    // Consider separating properties read from profile and those
+    // fetched from the auth server at the RPC message level.
+    if (!this.state.clusters.has(cluster.uri)) {
+      this.setState(draft => {
+        draft.clusters.set(
+          cluster.uri,
+          this.removeInternalLoginsFromCluster(cluster)
+        );
+      });
+    }
 
     return cluster;
   }


### PR DESCRIPTION
If you try to re-add a cluster that you already have in the state, you may accidentally clear cluster properties fetched from the auth server. This happens because `AddCluster` only returns properties that don't require logging in.

Overall, extending the `Cluster` message with properties that sometimes may be empty wasn't a good decision. We should rather keep them separately, so that: 
1. we can model the loading, error and success states correctly, 
2. there will be no risk of overwriting them with "empty" values.  