### PR TITLE
Update rejected connections alert description based on user agent

### DIFF
--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -772,28 +772,44 @@ func TestRejectedClientClusterAlert(t *testing.T) {
 	// Assert that only a single alert was created based on the above rejections.
 	require.Len(t, alerts, 1)
 	require.Equal(t, "rejected-unsupported-connection", alerts[0].GetName())
+	require.Contains(t, alerts[0].Spec.Message, "agents")
 
-	// Reset the last alert time to a time beyond the rate limit, allowing the next
-	// rejection to trigger another alert.
-	mw.lastRejectedAlertTime.Store(time.Now().Add(-25 * time.Hour).UnixNano())
+	for _, tool := range []string{"tsh", "tctl", "tbot"} {
+		t.Run(tool, func(t *testing.T) {
+			// Reset the test alerts.
+			alerts = nil
 
-	// Validate two unsupported clients in parallel to verify that concurrent attempts
-	// to create an alert are prevented.
-	var wg sync.WaitGroup
-	for i := 0; i < 2; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			err := mw.ValidateClientVersion(ctx, IdentityInfo{Conn: &fakeConn{}, IdentityGetter: TestBuiltin(types.RoleNode).I})
-			assert.Error(t, err)
-		}()
+			// Reset the last alert time to a time beyond the rate limit, allowing the next
+			// rejection to trigger another alert.
+			mw.lastRejectedAlertTime.Store(time.Now().Add(-25 * time.Hour).UnixNano())
+
+			// Create a new context with the user-agent set to a client tool. This should alter the
+			// text in the alert to indicate the connection was from a client tool and not an agent.
+			ctx = metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				"version":    semver.Version{Major: teleport.SemVersion.Major - 20}.String(),
+				"user-agent": tool + "/" + teleport.Version,
+			}))
+
+			// Validate two unsupported clients in parallel to verify that concurrent attempts
+			// to create an alert are prevented.
+			var wg sync.WaitGroup
+			for i := 0; i < 2; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					err := mw.ValidateClientVersion(ctx, IdentityInfo{Conn: &fakeConn{}, IdentityGetter: TestBuiltin(types.RoleNode).I})
+					assert.Error(t, err)
+				}()
+			}
+
+			wg.Wait()
+
+			// Assert that only a single additional alert was created and that
+			// it was created for clients and not agents.
+			require.Len(t, alerts, 1)
+			assert.Equal(t, "rejected-unsupported-connection", alerts[0].GetName())
+			require.Contains(t, alerts[0].Spec.Message, tool)
+		})
 	}
 
-	wg.Wait()
-
-	// Assert that only a single additional alert was created.
-	require.Len(t, alerts, 2)
-	for _, alert := range alerts {
-		assert.Equal(t, "rejected-unsupported-connection", alert.GetName())
-	}
 }


### PR DESCRIPTION
Modifies the rejected-unsupported-connection alert description to replace the word "agents" with the appropriate client tool if the user agent is populated. User agents of client tools did not get set prior to https://github.com/gravitational/teleport/pull/37726, so any clients running without that change will still result in the alert containing "agents".