### PR TITLE
Added Teleport plugins binaries to non-FIPS AMIs

### DIFF
--- a/assets/aws/single-ami.pkr.hcl
+++ b/assets/aws/single-ami.pkr.hcl
@@ -69,8 +69,8 @@ variable "teleport_fips" {
   default = false
 }
 
-variable "teleport_tarball" {
-  description = "Path to teleport tarball"
+variable "tarball_directory" {
+  description = "Path to directory containing Teleport tarballs"
   type = string
 }
 
@@ -187,7 +187,7 @@ build {
 
   provisioner "shell" {
     remote_folder = local.remote_folder
-    inline = ["mkdir /tmp/files"]
+    inline = ["mkdir -pv /tmp/files /tmp/tarballs"]
   }
 
   provisioner "file" {
@@ -196,8 +196,8 @@ build {
   }
 
   provisioner "file" {
-    source = var.teleport_tarball
-    destination = "/tmp/teleport.tar.gz"
+    source = var.tarball_directory
+    destination = "/tmp/tarballs"
   }
 
   provisioner "shell" {
@@ -206,6 +206,7 @@ build {
       "sudo cp /tmp/files/system/* /etc/systemd/system/",
       "sudo cp /tmp/files/bin/* /usr/local/bin/"
     ]
+
   }
 
   provisioner "shell" {


### PR DESCRIPTION
This PR adds Teleport plugins binaries to non-FIPS AMIs, addressing https://github.com/gravitational/teleport/issues/16244.

This must be merged at the same time as https://github.com/gravitational/teleport.e/pull/4309 to prevent breakage. This will need an e ref update prior to merge.

Note that this _only_ installs the plugins. It does not add tests for them, add services for them, or create config files for them. I'm not at all familiar with how access plugins run/operate, so if we want these then somebody else should probably add them in a follow-up PR.

Passing workflow run: https://github.com/gravitational/teleport.e/actions/runs/9359454718