### PR TITLE
[v15] Web: fix notification dropdown from being too long with max height

### DIFF
--- a/web/packages/teleport/src/TopBar/Notifications/Notifications.tsx
+++ b/web/packages/teleport/src/TopBar/Notifications/Notifications.tsx
@@ -94,7 +94,12 @@ export function Notifications({ iconSize = 24 }: { iconSize?: number }) {
 
         <Dropdown
           open={open}
-          style={{ width: '300px' }}
+          style={{
+            width: '300px',
+            maxHeight: '80vh',
+            overflowY: 'auto',
+            overflowX: 'hidden',
+          }}
           data-testid="tb-note-dropdown"
         >
           {items.length ? (


### PR DESCRIPTION
fix is only going in for v15/v14/v13, since a new notification system is introduced from v16

before, notification dropdown menu height grew without a max height, ruining the dashboard scrolling experience:
<img width="1728" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/661a01b7-f525-4717-9aa4-de321f3c2d6b">

after, adding a max-height:
<img width="1725" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/26af533b-fb06-4df2-8136-185427ded6cb">

changelog: Fixed web UI notification dropdown menu height from growing too long from many notifications