### PR TITLE
[v13] Web: fix notification dropdown from being too long with max height

### DIFF
--- a/web/packages/teleport/src/TopBar/Notifications/Notifications.tsx
+++ b/web/packages/teleport/src/TopBar/Notifications/Notifications.tsx
@@ -79,7 +79,12 @@ export function Notifications() {
 
       <Dropdown
         open={open}
-        style={{ width: '300px' }}
+        style={{
+          width: '300px',
+          maxHeight: '80vh',
+          overflowY: 'auto',
+          overflowX: 'hidden',
+        }}
         data-testid="tb-note-dropdown"
       >
         {items.length ? (


### PR DESCRIPTION
manual backport of https://github.com/gravitational/teleport/pull/42336

changelog: Fix web UI notification dropdown menu height from growing too long from many notifications