### PR TITLE
docs: add Bot resource to Terraform role

### DIFF
--- a/docs/pages/management/dynamic-resources/terraform-provider.mdx
+++ b/docs/pages/management/dynamic-resources/terraform-provider.mdx
@@ -66,6 +66,7 @@ authority to manage resources in the cluster. To prepare credentials using a loc
        rules:
          - resources:
            - app
+           - bot
            - cluster_auth_preference
            - cluster_networking_config
            - db


### PR DESCRIPTION
Documentation for New Resource in Teleport 16, needed for Teleport 16 Cluster. 