### PR TITLE
Fix getting chart url for non standard releases during EKS enrollment.

### DIFF
--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -541,11 +541,7 @@ func getChartURL(version string) (*url.URL, error) {
 	if ver.PreRelease != "" {
 		repo = agentStagingRepoURL
 	}
-	return &url.URL{
-		Scheme: repo.Scheme,
-		Host:   repo.Host,
-		Path:   fmt.Sprintf("%s-%s.tgz", agentName, version),
-	}, nil
+	return repo.JoinPath(fmt.Sprintf("%s-%s.tgz", agentName, version)), nil
 }
 
 // getChartData returns kube agent Helm chart data ready to be used by Helm SDK. We don't use native Helm

--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -34,6 +34,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	eksTypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/coreos/go-semver/semver"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -69,6 +70,7 @@ const (
 )
 
 var agentRepoURL = url.URL{Scheme: "https", Host: "charts.releases.teleport.dev"}
+var agentStagingRepoURL = url.URL{Scheme: "https", Host: "charts.releases.development.teleport.dev"}
 
 // EnrollEKSClusterResult contains result for a single EKS cluster enrollment, if it was successful 'Error' will be nil
 // otherwise it will contain an error happened during enrollment.
@@ -528,18 +530,31 @@ type installKubeAgentParams struct {
 	req          EnrollEKSClustersRequest
 }
 
-func getChartURL(version string) *url.URL {
-	return &url.URL{
-		Scheme: agentRepoURL.Scheme,
-		Host:   agentRepoURL.Host,
-		Path:   fmt.Sprintf("%s-%s.tgz", agentName, version),
+func getChartURL(version string) (*url.URL, error) {
+	repo := agentRepoURL
+	ver, err := semver.NewVersion(version)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse chart version %q", version)
 	}
+
+	// pre release tagged charts are located in the staging repo.
+	if ver.PreRelease != "" {
+		repo = agentStagingRepoURL
+	}
+	return &url.URL{
+		Scheme: repo.Scheme,
+		Host:   repo.Host,
+		Path:   fmt.Sprintf("%s-%s.tgz", agentName, version),
+	}, nil
 }
 
 // getChartData returns kube agent Helm chart data ready to be used by Helm SDK. We don't use native Helm
 // chart downloading because it tends to save temporary files and here we do everything just in memory.
 func getChartData(version string) (*chart.Chart, error) {
-	chartURL := getChartURL(version)
+	chartURL, err := getChartURL(version)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	g, err := getter.All(helmCli.New()).ByScheme(chartURL.Scheme)
 	if err != nil {

--- a/lib/integrations/awsoidc/eks_enroll_clusters_test.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters_test.go
@@ -45,6 +45,7 @@ func TestGetChartUrl(t *testing.T) {
 	testCases := []struct {
 		version  string
 		expected string
+		error    string
 	}{
 		{
 			version:  "14.3.3",
@@ -56,12 +57,22 @@ func TestGetChartUrl(t *testing.T) {
 		},
 		{
 			version:  "15.0.0-alpha.5",
-			expected: "https://charts.releases.teleport.dev/teleport-kube-agent-15.0.0-alpha.5.tgz",
+			expected: "https://charts.releases.development.teleport.dev/teleport-kube-agent-15.0.0-alpha.5.tgz",
+		},
+		{
+			version: "abc",
+			error:   "failed to parse chart version",
 		},
 	}
 
 	for _, tt := range testCases {
-		require.Equal(t, tt.expected, getChartURL(tt.version).String())
+		res, err := getChartURL(tt.version)
+		if tt.error != "" {
+			require.ErrorContains(t, err, tt.error)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, res.String())
+		}
 	}
 }
 


### PR DESCRIPTION
Because of recent changes in release policy non standard releases go to the staging repo, so we need to amend the way we get kube chart url for the EKS enrollment.

Fixes #42335 