### PR TITLE
[v16] event-handler chart: re-create pods when a PV is mounted

### DIFF
--- a/examples/chart/event-handler/templates/deployment.yaml
+++ b/examples/chart/event-handler/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- include "event-handler.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  {{- if or .Values.persistentVolumeClaim.enabled .Values.persistentVolumeClaim.existingClaim }}
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "event-handler.selectorLabels" . | nindent 6 }}

--- a/examples/chart/event-handler/tests/deployment_test.yaml
+++ b/examples/chart/event-handler/tests/deployment_test.yaml
@@ -9,3 +9,12 @@ tests:
         tag: v98.76.54
     asserts:
       - matchSnapshot: {}
+
+  - it: uses the recreate strategy if a PV is mounted
+    set:
+      persistentVolumeClaim:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate


### PR DESCRIPTION
Backport #42331 to branch/v16

changelog: Fix the event-handler Helm chart causing stuck rollouts when using a PVC
