### PR TITLE
Rename AccessGraphAccessPathChanged

### DIFF
--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -765,6 +765,8 @@ const (
 	// AccessGraphAccessPathChangedEvent is emitted when an access path is changed in the access graph
 	// and an identity/resource is affected.
 	AccessGraphAccessPathChangedEvent = "access_graph.access_path_changed"
+	// TODO(jakule): Remove once e is updated to the new name.
+	AccessGraphAccessPathChanged = AccessGraphAccessPathChangedEvent
 )
 
 const (


### PR DESCRIPTION
#42029 in Teleport renamed AccessGraphAccessPathChanged to AccessGraphAccessPathChangedEvent. This change fixed the build error caused by that.