### PR TITLE
Add entitlements model to GetFeatures

### DIFF
--- a/api/types/license.go
+++ b/api/types/license.go
@@ -105,7 +105,7 @@ type License interface {
 
 	// GetSupportsFeatureHiding returns feature hiding support flag.
 	GetSupportsFeatureHiding() Bool
-	// GetSupportsFeatureHiding sets feature hiding support flag.
+	// SetSupportsFeatureHiding sets feature hiding support flag.
 	SetSupportsFeatureHiding(Bool)
 
 	// GetTrial returns the trial flag.
@@ -156,8 +156,24 @@ type License interface {
 
 	// GetSupportsPolicy returns Teleport Policy support flag.
 	GetSupportsPolicy() Bool
-	//SGetSupportsPolicy sets Teleport Policy support flag.
+	// SetSupportsPolicy sets Teleport Policy support flag.
 	SetSupportsPolicy(Bool)
+
+	// GetEntitlements returns the Entitlements object
+	GetEntitlements() map[string]EntitlementInfo
+	// SetEntitlements sets the Entitlements object
+	SetEntitlements(map[string]EntitlementInfo)
+}
+
+// EntitlementInfo is the state and limits of a particular entitlement; Example for feature X:
+// { Enabled: true,  Limit: 0 }   => unlimited access to feature X
+// { Enabled: true,  Limit: >0 }  => limited access to feature X
+// { Enabled: false, Limit: >=0 } => no access to feature X
+type EntitlementInfo struct {
+	// Enabled indicates the feature is 'on' if true; feature is disabled if false
+	Enabled Bool
+	// Limit indicates the allotted amount of use when limited; if 0 use is unlimited
+	Limit int32
 }
 
 // FeatureSource defines where the list of features enabled
@@ -494,6 +510,16 @@ func (c *LicenseV3) SetSupportsPolicy(value Bool) {
 	c.Spec.SupportsPolicy = value
 }
 
+// GetEntitlements returns Entitlements
+func (c *LicenseV3) GetEntitlements() map[string]EntitlementInfo {
+	return c.Spec.Entitlements
+}
+
+// SetEntitlements sets Entitlements
+func (c *LicenseV3) SetEntitlements(value map[string]EntitlementInfo) {
+	c.Spec.Entitlements = value
+}
+
 // String represents a human readable version of license enabled features
 func (c *LicenseV3) String() string {
 	var features []string
@@ -601,4 +627,7 @@ type LicenseSpecV3 struct {
 	AnonymizationKey string `json:"anonymization_key,omitempty"`
 	// SupportsPolicy turns Teleport Policy features on or off.
 	SupportsPolicy Bool `json:"policy,omitempty"`
+
+	// entitlements define a customer’s access to a specific features
+	Entitlements map[string]EntitlementInfo `json:"entitlements,omitempty"`
 }

--- a/entitlements/entitlements.go
+++ b/entitlements/entitlements.go
@@ -1,0 +1,48 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package entitlements
+
+type EntitlementKind string
+
+// The EntitlementKind list should be 1:1 with the Features & FeatureStrings in salescenter/product/product.go,
+// except CustomTheme which is dropped. CustomTheme entitlement only toggles the ability to "set" a theme;
+// the value of that theme, if set, is stored and accessed outside of entitlements.
+const (
+	AccessLists            EntitlementKind = "AccessLists"
+	AccessMonitoring       EntitlementKind = "AccessMonitoring"
+	AccessRequests         EntitlementKind = "AccessRequests"
+	App                    EntitlementKind = "App"
+	CloudAuditLogRetention EntitlementKind = "CloudAuditLogRetention"
+	DB                     EntitlementKind = "DB"
+	Desktop                EntitlementKind = "Desktop"
+	DeviceTrust            EntitlementKind = "DeviceTrust"
+	ExternalAuditStorage   EntitlementKind = "ExternalAuditStorage"
+	FeatureHiding          EntitlementKind = "FeatureHiding"
+	HSM                    EntitlementKind = "HSM"
+	Identity               EntitlementKind = "Identity"
+	JoinActiveSessions     EntitlementKind = "JoinActiveSessions"
+	K8s                    EntitlementKind = "K8s"
+	MobileDeviceManagement EntitlementKind = "MobileDeviceManagement"
+	OIDC                   EntitlementKind = "OIDC"
+	OktaSCIM               EntitlementKind = "OktaSCIM"
+	OktaUserSync           EntitlementKind = "OktaUserSync"
+	Policy                 EntitlementKind = "Policy"
+	SAML                   EntitlementKind = "SAML"
+	SessionLocks           EntitlementKind = "SessionLocks"
+	UpsellAlert            EntitlementKind = "UpsellAlert"
+	UsageReporting         EntitlementKind = "UsageReporting"
+)

--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
@@ -265,7 +266,9 @@ func testClientCert(p *Pack, t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
-			App: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.App: {Enabled: true},
+			},
 		},
 	})
 	evilUser, _ := p.CreateUser(t)

--- a/integration/db/db_integration_test.go
+++ b/integration/db/db_integration_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -108,7 +109,11 @@ func TestDatabaseAccessSeparateListeners(t *testing.T) {
 func (p *DatabasePack) testIPPinning(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
-		TestFeatures:  modules.Features{DB: true},
+		TestFeatures: modules.Features{
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.DB: {Enabled: true},
+			},
+		},
 	})
 
 	type testCase struct {

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/state"
@@ -56,7 +57,9 @@ func TestMain(m *testing.M) {
 	modules.SetModules(&modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
-			HSM: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.HSM: {Enabled: true},
+			},
 		},
 	})
 

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -72,6 +72,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/integration/kube"
 	"github.com/gravitational/teleport/lib"
@@ -1345,7 +1346,9 @@ func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
-			Kubernetes: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.K8s: {Enabled: true},
+			},
 		},
 	})
 

--- a/integration/proxy/proxy_tunnel_strategy_test.go
+++ b/integration/proxy/proxy_tunnel_strategy_test.go
@@ -33,6 +33,7 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
@@ -158,7 +159,11 @@ func TestProxyTunnelStrategyProxyPeering(t *testing.T) {
 	// This test cannot run in parallel as set module changes the global state.
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
-		TestFeatures:  modules.Features{DB: true},
+		TestFeatures: modules.Features{
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.DB: {Enabled: true},
+			},
+		},
 	})
 
 	p := newProxyTunnelStrategy(t, "proxy-tunnel-proxy-peer",

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integration/helpers"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	resourcesv2 "github.com/gravitational/teleport/integrations/operator/apis/resources/v2"
@@ -99,8 +100,10 @@ func defaultTeleportServiceConfig(t *testing.T) (*helpers.TeleInstance, string) 
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
-			OIDC: true,
-			SAML: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.OIDC: {Enabled: true},
+				entitlements.SAML: {Enabled: true},
+			},
 		},
 	})
 

--- a/integrations/terraform/testlib/terraform_enterprise_test.go
+++ b/integrations/terraform/testlib/terraform_enterprise_test.go
@@ -26,6 +26,7 @@ import (
 
 	eintegration "github.com/gravitational/teleport/e/integration"
 	eauth "github.com/gravitational/teleport/e/lib/auth"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integrations/lib/testing/integration"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/modules"
@@ -35,10 +36,12 @@ import (
 func TestTerraformEnterprise(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			OIDC:                    true,
-			SAML:                    true,
 			AdvancedAccessWorkflows: true,
-			DeviceTrust:             modules.DeviceTrustFeature{Enabled: true},
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.OIDC:        {Enabled: true},
+				entitlements.SAML:        {Enabled: true},
+				entitlements.DeviceTrust: {Enabled: true},
+			},
 		},
 	})
 

--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -1543,7 +1544,9 @@ func TestUpdateAccessRequestWithAdditionalReviewers(t *testing.T) {
 
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			IdentityGovernanceSecurity: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.Identity: {Enabled: true},
+			},
 		},
 	})
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -79,6 +79,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/native"
@@ -350,15 +351,15 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		AuthPreferenceGetter: cfg.ClusterConfiguration,
 	}
 	if cfg.KeyStoreConfig.PKCS11 != (servicecfg.PKCS11Config{}) {
-		if !modules.GetModules().Features().HSM {
+		if !modules.GetModules().Features().GetEntitlement(entitlements.HSM).Enabled {
 			return nil, fmt.Errorf("PKCS11 HSM support requires a license with the HSM feature enabled: %w", ErrRequiresEnterprise)
 		}
 	} else if cfg.KeyStoreConfig.GCPKMS != (servicecfg.GCPKMSConfig{}) {
-		if !modules.GetModules().Features().HSM {
+		if !modules.GetModules().Features().GetEntitlement(entitlements.HSM).Enabled {
 			return nil, fmt.Errorf("Google Cloud KMS support requires a license with the HSM feature enabled: %w", ErrRequiresEnterprise)
 		}
 	} else if cfg.KeyStoreConfig.AWSKMS != (servicecfg.AWSKMSConfig{}) {
-		if !modules.GetModules().Features().HSM {
+		if !modules.GetModules().Features().GetEntitlement(entitlements.HSM).Enabled {
 			return nil, fmt.Errorf("AWS KMS support requires a license with the HSM feature enabled: %w", ErrRequiresEnterprise)
 		}
 	} else {
@@ -5358,7 +5359,7 @@ func (a *Server) UpsertNode(ctx context.Context, server types.Server) (*types.Ke
 func enforceLicense(t string) error {
 	switch t {
 	case types.KindKubeServer, types.KindKubernetesCluster:
-		if !modules.GetModules().Features().Kubernetes {
+		if !modules.GetModules().Features().GetEntitlement(entitlements.K8s).Enabled {
 			return trace.AccessDenied(
 				"this Teleport cluster is not licensed for Kubernetes, please contact the cluster administrator")
 		}
@@ -6882,10 +6883,13 @@ func (a *Server) getAccessRequestMonthlyUsage(ctx context.Context) (int, error) 
 // If so, it returns an error. This is only applicable on usage-based billing plans.
 func (a *Server) verifyAccessRequestMonthlyLimit(ctx context.Context) error {
 	f := modules.GetModules().Features()
-	if f.IsLegacy() || f.IGSEnabled() {
-		return nil // unlimited
+	accessRequestsEntitlement := f.GetEntitlement(entitlements.AccessRequests)
+
+	if accessRequestsEntitlement.Limit == 0 {
+		return nil // unlimited access
 	}
-	monthlyLimit := f.AccessRequests.MonthlyRequestLimit
+
+	monthlyLimit := accessRequestsEntitlement.Limit
 
 	const limitReachedMessage = "cluster has reached its monthly access request limit, please contact the cluster administrator"
 
@@ -6893,7 +6897,7 @@ func (a *Server) verifyAccessRequestMonthlyLimit(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if usage >= monthlyLimit {
+	if usage >= int(monthlyLimit) {
 		return trace.AccessDenied(limitReachedMessage)
 	}
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/clusterconfig/clusterconfigv1"
 	"github.com/gravitational/teleport/lib/auth/okta"
@@ -3487,7 +3488,7 @@ func (a *ServerWithRoles) UpsertOIDCConnector(ctx context.Context, connector typ
 	if err := a.authConnectorAction(apidefaults.Namespace, types.KindOIDC, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if !modules.GetModules().Features().OIDC {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.OIDC).Enabled {
 		// TODO(zmb3): ideally we would wrap ErrRequiresEnterprise here, but
 		// we can't currently propagate wrapped errors across the gRPC boundary,
 		// and we want tctl to display a clean user-facing message in this case
@@ -3508,7 +3509,7 @@ func (a *ServerWithRoles) UpdateOIDCConnector(ctx context.Context, connector typ
 	if err := a.authConnectorAction(apidefaults.Namespace, types.KindOIDC, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if !modules.GetModules().Features().OIDC {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.OIDC).Enabled {
 		// TODO(zmb3): ideally we would wrap ErrRequiresEnterprise here, but
 		// we can't currently propagate wrapped errors across the gRPC boundary,
 		// and we want tctl to display a clean user-facing message in this case
@@ -3528,7 +3529,7 @@ func (a *ServerWithRoles) CreateOIDCConnector(ctx context.Context, connector typ
 	if err := a.authConnectorAction(apidefaults.Namespace, types.KindOIDC, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if !modules.GetModules().Features().OIDC {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.OIDC).Enabled {
 		// TODO(zmb3): ideally we would wrap ErrRequiresEnterprise here, but
 		// we can't currently propagate wrapped errors across the gRPC boundary,
 		// and we want tctl to display a clean user-facing message in this case
@@ -3572,7 +3573,7 @@ func (a *ServerWithRoles) GetOIDCConnectors(ctx context.Context, withSecrets boo
 }
 
 func (a *ServerWithRoles) CreateOIDCAuthRequest(ctx context.Context, req types.OIDCAuthRequest) (*types.OIDCAuthRequest, error) {
-	if !modules.GetModules().Features().OIDC {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.OIDC).Enabled {
 		// TODO(zmb3): ideally we would wrap ErrRequiresEnterprise here, but
 		// we can't currently propagate wrapped errors across the gRPC boundary,
 		// and we want tctl to display a clean user-facing message in this case
@@ -3646,7 +3647,7 @@ func (a *ServerWithRoles) DeleteOIDCConnector(ctx context.Context, connectorID s
 
 // UpsertSAMLConnector creates or updates a SAML connector.
 func (a *ServerWithRoles) UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error) {
-	if !modules.GetModules().Features().SAML {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.SAML).Enabled {
 		return nil, trace.Wrap(ErrSAMLRequiresEnterprise)
 	}
 
@@ -3669,7 +3670,7 @@ func (a *ServerWithRoles) UpsertSAMLConnector(ctx context.Context, connector typ
 
 // CreateSAMLConnector creates a new SAML connector.
 func (a *ServerWithRoles) CreateSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error) {
-	if !modules.GetModules().Features().SAML {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.SAML).Enabled {
 		return nil, trace.Wrap(ErrSAMLRequiresEnterprise)
 	}
 
@@ -3687,7 +3688,7 @@ func (a *ServerWithRoles) CreateSAMLConnector(ctx context.Context, connector typ
 
 // UpdateSAMLConnector updates an existing SAML connector
 func (a *ServerWithRoles) UpdateSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error) {
-	if !modules.GetModules().Features().SAML {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.SAML).Enabled {
 		return nil, trace.Wrap(ErrSAMLRequiresEnterprise)
 	}
 
@@ -3733,7 +3734,7 @@ func (a *ServerWithRoles) GetSAMLConnectors(ctx context.Context, withSecrets boo
 }
 
 func (a *ServerWithRoles) CreateSAMLAuthRequest(ctx context.Context, req types.SAMLAuthRequest) (*types.SAMLAuthRequest, error) {
-	if !modules.GetModules().Features().SAML {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.SAML).Enabled {
 		return nil, trace.Wrap(ErrSAMLRequiresEnterprise)
 	}
 

--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -26,6 +26,7 @@ import (
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/authz"
 	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
 	"github.com/gravitational/teleport/lib/events"
@@ -902,7 +903,7 @@ func (s *Service) GetClusterAccessGraphConfig(ctx context.Context, _ *clustercon
 	}
 
 	// If the policy feature is disabled in the license, return a disabled response.
-	if !modules.GetModules().Features().Policy.Enabled && !modules.GetModules().Features().AccessGraph {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.Policy).Enabled && !modules.GetModules().Features().AccessGraph {
 		return &clusterconfigpb.GetClusterAccessGraphConfigResponse{
 			AccessGraph: &clusterconfigpb.AccessGraphConfig{
 				Enabled: false,

--- a/lib/auth/clusterconfig/clusterconfigv1/service_test.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service_test.go
@@ -33,6 +33,7 @@ import (
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/clusterconfig/clusterconfigv1"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -1825,8 +1826,8 @@ func TestGetAccessGraphConfig(t *testing.T) {
 			testSetup: func(t *testing.T) {
 				m := modules.TestModules{
 					TestFeatures: modules.Features{
-						Policy: modules.PolicyFeature{
-							Enabled: true,
+						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+							entitlements.Policy: {Enabled: true},
 						},
 					},
 				}
@@ -1849,8 +1850,8 @@ func TestGetAccessGraphConfig(t *testing.T) {
 			testSetup: func(t *testing.T) {
 				m := modules.TestModules{
 					TestFeatures: modules.Features{
-						Policy: modules.PolicyFeature{
-							Enabled: true,
+						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+							entitlements.Policy: {Enabled: true},
 						},
 					},
 				}

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -38,6 +38,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/modules"
@@ -201,7 +202,7 @@ func getServerNames(req *proto.DatabaseCertRequest) []string {
 // SignDatabaseCSR generates a client certificate used by proxy when talking
 // to a remote database service.
 func (a *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequest) (*proto.DatabaseCSRResponse, error) {
-	if !modules.GetModules().Features().DB {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.DB).Enabled {
 		return nil, trace.AccessDenied(
 			"this Teleport cluster is not licensed for database access, please contact the cluster administrator")
 	}
@@ -290,7 +291,7 @@ func (a *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 
 // GenerateSnowflakeJWT generates JWT in the format required by Snowflake.
 func (a *Server) GenerateSnowflakeJWT(ctx context.Context, req *proto.SnowflakeJWTRequest) (*proto.SnowflakeJWTResponse, error) {
-	if !modules.GetModules().Features().DB {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.DB).Enabled {
 		return nil, trace.AccessDenied(
 			"this Teleport cluster is not licensed for database access, please contact the cluster administrator")
 	}

--- a/lib/auth/desktop.go
+++ b/lib/auth/desktop.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -43,7 +44,7 @@ import (
 // GenerateWindowsDesktopCert generates client certificate for Windows RDP
 // authentication.
 func (a *Server) GenerateWindowsDesktopCert(ctx context.Context, req *proto.WindowsDesktopCertRequest) (*proto.WindowsDesktopCertResponse, error) {
-	if !modules.GetModules().Features().Desktop {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.Desktop).Enabled {
 		return nil, trace.AccessDenied(
 			"this Teleport cluster is not licensed for desktop access, please contact the cluster administrator")
 	}

--- a/lib/auth/desktop_test.go
+++ b/lib/auth/desktop_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/modules"
 )
 
@@ -33,7 +34,9 @@ import (
 func TestDesktopAccessDisabled(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			Desktop: false, // Explicily turn off desktop access.
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.Desktop: {Enabled: false}, // Explicitly turn off desktop access.
+			},
 		},
 	})
 

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -64,6 +64,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -855,7 +856,9 @@ func TestGenerateUserCerts_deviceAuthz(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise, // required for Device Trust.
 		TestFeatures: modules.Features{
-			App: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.App: {Enabled: true},
+			},
 		},
 	})
 
@@ -4187,7 +4190,11 @@ func TestExport(t *testing.T) {
 // a SAML connector.
 func TestSAMLValidation(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
-		TestFeatures: modules.Features{SAML: true},
+		TestFeatures: modules.Features{
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.SAML: {Enabled: true},
+			},
+		},
 	})
 
 	// minimal entity_descriptor to pass validation. not actually valid
@@ -4459,8 +4466,8 @@ func TestUpsertApplicationServerOrigin(t *testing.T) {
 func TestGetAccessGraphConfig(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			Policy: modules.PolicyFeature{
-				Enabled: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.Policy: {Enabled: true},
 			},
 		},
 	})

--- a/lib/auth/kube_test.go
+++ b/lib/auth/kube_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -39,7 +40,9 @@ import (
 func TestProcessKubeCSR(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			Kubernetes: true, // test requires kube feature is enabled
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.K8s: {Enabled: true}, // test requires kube feature is enabled
+			},
 		},
 	})
 

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -30,6 +30,7 @@ import (
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/jwt"
@@ -266,7 +267,7 @@ type NewAppSessionRequest struct {
 // The certificate is used for all access requests, which is where access
 // control is enforced.
 func (a *Server) CreateAppSession(ctx context.Context, req *proto.CreateAppSessionRequest, identity tlsca.Identity, checker services.AccessChecker) (types.WebSession, error) {
-	if !modules.GetModules().Features().App {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.App).Enabled {
 		return nil, trace.AccessDenied(
 			"this Teleport cluster is not licensed for application access, please contact the cluster administrator")
 	}
@@ -327,7 +328,7 @@ func (a *Server) CreateAppSession(ctx context.Context, req *proto.CreateAppSessi
 }
 
 func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionRequest) (types.WebSession, error) {
-	if !modules.GetModules().Features().App {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.App).Enabled {
 		return nil, trace.AccessDenied(
 			"this Teleport cluster is not licensed for application access, please contact the cluster administrator")
 	}
@@ -512,7 +513,7 @@ func (a *Server) CreateSessionCert(userState services.UserState, sessionTTL time
 func (a *Server) CreateSnowflakeSession(ctx context.Context, req types.CreateSnowflakeSessionRequest,
 	identity tlsca.Identity, checker services.AccessChecker,
 ) (types.WebSession, error) {
-	if !modules.GetModules().Features().DB {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.DB).Enabled {
 		return nil, trace.AccessDenied(
 			"this Teleport cluster is not licensed for database access, please contact the cluster administrator")
 	}

--- a/lib/auth/usage_test.go
+++ b/lib/auth/usage_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/events"
 	eventstest "github.com/gravitational/teleport/lib/events/test"
 	"github.com/gravitational/teleport/lib/modules"
@@ -72,8 +73,8 @@ func TestAccessRequest_WithAndWithoutLimit(t *testing.T) {
 	_, err = s.testpack.a.CreateAccessRequestV2(ctx, req, tlsca.Identity{})
 	require.Error(t, err, "expected access request creation to fail due to the monthly limit")
 
-	// Lift limit with IGS, expect no limit error.
-	s.features.IdentityGovernanceSecurity = true
+	// Lift limit, expect no limit error.
+	s.features.Entitlements[entitlements.AccessRequests] = modules.EntitlementInfo{Enabled: true, Limit: 0}
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: s.features,
 	})
@@ -81,20 +82,12 @@ func TestAccessRequest_WithAndWithoutLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	// Put back limit, expect limit error.
-	s.features.IdentityGovernanceSecurity = false
+	s.features.Entitlements[entitlements.AccessRequests] = modules.EntitlementInfo{Enabled: true, Limit: 1}
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: s.features,
 	})
 	_, err = s.testpack.a.CreateAccessRequestV2(ctx, req, tlsca.Identity{})
 	require.Error(t, err, "expected access request creation to fail due to the monthly limit")
-
-	// Lift limit with legacy non-usage based, expect no limit error.
-	s.features.IsUsageBasedBilling = false
-	modules.SetTestModules(t, &modules.TestModules{
-		TestFeatures: s.features,
-	})
-	_, err = s.testpack.a.CreateAccessRequestV2(ctx, req, tlsca.Identity{})
-	require.NoError(t, err)
 }
 
 type setupAccessRequestLimist struct {
@@ -105,7 +98,7 @@ type setupAccessRequestLimist struct {
 }
 
 func setUpAccessRequestLimitForJulyAndAugust(t *testing.T, username string, rolename string) setupAccessRequestLimist {
-	monthlyLimit := 3
+	monthlyLimit := int32(3)
 
 	makeEvent := func(eventType string, id string, timestamp time.Time) apievents.AuditEvent {
 		return &apievents.AccessRequestCreate{
@@ -119,7 +112,7 @@ func setUpAccessRequestLimitForJulyAndAugust(t *testing.T, username string, role
 
 	features := modules.GetModules().Features()
 	features.IsUsageBasedBilling = true
-	features.AccessRequests.MonthlyRequestLimit = monthlyLimit
+	features.Entitlements[entitlements.AccessRequests] = modules.EntitlementInfo{Limit: monthlyLimit, Enabled: true}
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: features,
 	})
@@ -182,7 +175,7 @@ func setUpAccessRequestLimitForJulyAndAugust(t *testing.T, username string, role
 
 	return setupAccessRequestLimist{
 		testpack:     p,
-		monthlyLimit: monthlyLimit,
+		monthlyLimit: int(monthlyLimit),
 		features:     features,
 		clock:        clock,
 	}

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/trait"
 	"github.com/gravitational/teleport/api/types/userloginstate"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
@@ -398,8 +399,10 @@ func TestAccessLists(t *testing.T) {
 			modules.SetTestModules(t, &modules.TestModules{
 				TestBuildType: modules.BuildEnterprise,
 				TestFeatures: modules.Features{
-					Cloud:                      test.cloud,
-					IdentityGovernanceSecurity: true,
+					Cloud: test.cloud,
+					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+						entitlements.Identity: {Enabled: true},
+					},
 				},
 			})
 

--- a/lib/integrations/externalauditstorage/configurator.go
+++ b/lib/integrations/externalauditstorage/configurator.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -182,7 +183,7 @@ func NewDraftConfigurator(ctx context.Context, ecaSvc ExternalAuditStorageGetter
 
 func newConfigurator(ctx context.Context, spec *externalauditstorage.ExternalAuditStorageSpec, integrationSvc services.IntegrationsGetter, alertService ClusterAlertService, optFns ...func(*Options)) (*Configurator, error) {
 	// ExternalAuditStorage is only available in Cloud Enterprise
-	if !modules.GetModules().Features().Cloud || !modules.GetModules().Features().ExternalAuditStorage {
+	if !modules.GetModules().Features().Cloud || !modules.GetModules().Features().GetEntitlement(entitlements.ExternalAuditStorage).Enabled {
 		return &Configurator{isUsed: false}, nil
 	}
 

--- a/lib/integrations/externalauditstorage/configurator_test.go
+++ b/lib/integrations/externalauditstorage/configurator_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -102,8 +103,10 @@ func TestConfiguratorIsUsed(t *testing.T) {
 			name: "cloud enterprise without config",
 			modules: &modules.TestModules{
 				TestFeatures: modules.Features{
-					Cloud:                true,
-					ExternalAuditStorage: true,
+					Cloud: true,
+					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+						entitlements.ExternalAuditStorage: {Enabled: true},
+					},
 				},
 			},
 			wantIsUsed: false,
@@ -112,8 +115,10 @@ func TestConfiguratorIsUsed(t *testing.T) {
 			name: "cloud enterprise with only draft",
 			modules: &modules.TestModules{
 				TestFeatures: modules.Features{
-					Cloud:                true,
-					ExternalAuditStorage: true,
+					Cloud: true,
+					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+						entitlements.ExternalAuditStorage: {Enabled: true},
+					},
 				},
 			},
 			// Just create draft, External Audit Storage should be disabled, it's
@@ -129,8 +134,10 @@ func TestConfiguratorIsUsed(t *testing.T) {
 			name: "cloud enterprise with cluster config",
 			modules: &modules.TestModules{
 				TestFeatures: modules.Features{
-					Cloud:                true,
-					ExternalAuditStorage: true,
+					Cloud: true,
+					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+						entitlements.ExternalAuditStorage: {Enabled: true},
+					},
 				},
 			},
 			// Create draft and promote it to cluster.
@@ -178,8 +185,10 @@ func TestCredentialsCache(t *testing.T) {
 
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			Cloud:                true,
-			ExternalAuditStorage: true,
+			Cloud: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.ExternalAuditStorage: {Enabled: true},
+			},
 		},
 	})
 
@@ -338,8 +347,10 @@ func TestDraftConfigurator(t *testing.T) {
 
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			Cloud:                true,
-			ExternalAuditStorage: true,
+			Cloud: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.ExternalAuditStorage: {Enabled: true},
+			},
 		},
 	})
 

--- a/lib/kube/proxy/moderated_sessions_test.go
+++ b/lib/kube/proxy/moderated_sessions_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/events"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/modules"
@@ -49,7 +50,11 @@ import (
 
 func TestModeratedSessions(t *testing.T) {
 	// enable enterprise features to have access to ModeratedSessions.
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise, TestFeatures: modules.Features{Kubernetes: true}})
+	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise, TestFeatures: modules.Features{
+		Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+			entitlements.K8s: {Enabled: true},
+		},
+	}})
 	const (
 		moderatorUsername       = "moderator_user"
 		moderatorRoleName       = "mod_role"
@@ -496,7 +501,11 @@ func validateSessionTracker(testCtx *TestContext, sessionID string, reason strin
 // Lock watcher connection to be stale and it takes ~5 minutes to happen.
 func TestInteractiveSessionsNoAuth(t *testing.T) {
 	// enable enterprise features to have access to ModeratedSessions.
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise, TestFeatures: modules.Features{Kubernetes: true}})
+	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise, TestFeatures: modules.Features{
+		Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+			entitlements.K8s: {Enabled: true},
+		},
+	}})
 	const (
 		moderatorUsername       = "moderator_user"
 		moderatorRoleName       = "mod_role"

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -45,177 +46,122 @@ import (
 
 // Features provides supported and unsupported features
 type Features struct {
-	// Kubernetes enables Kubernetes Access product
-	Kubernetes bool
-	// App enables Application Access product
-	App bool
-	// DB enables database access product
-	DB bool
-	// OIDC enables OIDC connectors
-	OIDC bool
-	// SAML enables SAML connectors
-	SAML bool
-	// AccessControls enables FIPS access controls
-	AccessControls bool
-	// Currently this flag is to gate actions from OSS clusters.
-	//
-	// Determining support for access request is currently determined by:
-	//   1) Enterprise + [Features.IdentityGovernanceSecurity] == true, new flag
-	//   introduced with Enterprise Usage Based (EUB) product.
-	//   2) Enterprise + [Features.IsUsageBasedBilling] == false, legacy support
-	//   where before EUB, it was unlimited.
-	//
-	// AdvancedAccessWorkflows is currently set to true for all
-	// enterprise editions (team, cloud, on-prem). Historically, access request
-	// was only available for enterprise cloud and enterprise on-prem.
-	AdvancedAccessWorkflows bool
+	// --------------- Cloud Settings
 	// Cloud enables some cloud-related features
 	Cloud bool
-	// HSM enables PKCS#11 HSM support
-	HSM bool
-	// Desktop enables desktop access product
-	Desktop bool
+	// CustomTheme holds the name of WebUI custom theme.
+	CustomTheme string
+	// IsStripeManaged indicates if the cluster billing is managed via Stripe
+	IsStripeManaged bool
+	// IsUsageBasedBilling enables some usage-based billing features
+	IsUsageBasedBilling bool
+	// Questionnaire indicates whether cluster users should get an onboarding questionnaire
+	Questionnaire bool
+	// SupportType indicates the type of customer's support
+	SupportType proto.SupportType
+	// Entitlements reflect Cloud Entitlements including access and limits
+	Entitlements map[entitlements.EntitlementKind]EntitlementInfo
+
+	// todo (michellescripts) have the following fields evaluated for deprecation, consolidation, or fetch from Cloud
+	// AdvancedAccessWorkflows is currently set to the value of the Cloud Access Requests entitlement
+	AdvancedAccessWorkflows bool
 	// RecoveryCodes enables account recovery codes
 	RecoveryCodes bool
 	// Plugins enables hosted plugins
 	Plugins bool
 	// AutomaticUpgrades enables automatic upgrades of agents/services.
 	AutomaticUpgrades bool
-	// IsUsageBasedBilling enables some usage-based billing features
-	IsUsageBasedBilling bool
-	// DeviceTrust holds its namesake feature settings.
-	DeviceTrust DeviceTrustFeature
-	// FeatureHiding enables hiding features from being discoverable for users who don't have the necessary permissions.
-	FeatureHiding bool
-	// AccessRequests holds its namesake feature settings.
-	AccessRequests AccessRequestsFeature
-	// CustomTheme holds the name of WebUI custom theme.
-	CustomTheme string
-
 	// AccessGraph enables the usage of access graph.
 	// NOTE: this is a legacy flag that is currently used to signal
 	// that Access Graph integration is *enabled* on a cluster.
 	// *Access* to the feature is gated on the `Policy` flag.
 	// TODO(justinas): remove this field once "TAG enabled" status is moved to a resource in the backend.
 	AccessGraph bool
-	// IdentityGovernanceSecurity indicates whether IGS related features are enabled:
-	// access list, access request, access monitoring, device trust.
-	IdentityGovernanceSecurity bool
-	// AccessList holds its namesake feature settings.
-	AccessList AccessListFeature
-	// AccessMonitoring holds its namesake feature settings.
-	AccessMonitoring AccessMonitoringFeature
+	// AccessMonitoringConfigured contributes to the enablement of access monitoring.
+	// NOTE: this flag is used to signal that Access Monitoring is *enabled* on a cluster.
+	// *Access* to the feature is gated on the `AccessMonitoring` entitlement.
+	AccessMonitoringConfigured bool
+	// --------------- Deprecated Fields
+	// AccessControls enables FIPS access controls
+	// Deprecated
+	AccessControls bool
+	// Assist enables Assistant feature
+	// Deprecated
+	Assist bool
 	// ProductType describes the product being used.
+	// Deprecated
 	ProductType ProductType
-	// Policy holds settings for the Teleport Policy feature set.
-	// At the time of writing, this includes Teleport Access Graph (TAG).
-	Policy PolicyFeature
-	// Questionnaire indicates whether cluster users should get an onboarding questionnaire
-	Questionnaire bool
-	// IsStripeManaged indicates if the cluster billing is managed via Stripe
-	IsStripeManaged bool
-	// ExternalAuditStorage indicates whether the EAS feature is enabled in the cluster.
-	ExternalAuditStorage bool
-	// SupportType indicates the type of customer's support
-	SupportType proto.SupportType
-	// JoinActiveSessions indicates whether joining active sessions via web UI is enabled
-	JoinActiveSessions bool
-	// MobileDeviceManagement indicates whether endpoints management (like Jamf Plugin) can be used in the cluster
-	MobileDeviceManagement bool
 }
 
-// DeviceTrustFeature holds the Device Trust feature general and usage-based
-// settings.
-// Limits have no affect if [Feature.IdentityGovernanceSecurity] is enabled.
-type DeviceTrustFeature struct {
-	// Currently this flag is to gate actions from OSS clusters.
-	//
-	// Determining support for device trust is currently determined by:
-	//   1) Enterprise + [Features.IdentityGovernanceSecurity] == true, new flag
-	//   introduced with Enterprise Usage Based (EUB) product.
-	//   2) Enterprise + [Features.IsUsageBasedBilling] == false, legacy support
-	//   where before EUB, it was unlimited.
+// EntitlementInfo is the state and limits of a particular entitlement
+type EntitlementInfo struct {
+	// Enabled indicates the feature is 'on' if true; feature is disabled if false
 	Enabled bool
-	// DevicesUsageLimit is the usage-based limit for the number of
-	// registered/enrolled devices, at the implementation's discretion.
-	DevicesUsageLimit int
-}
-
-// AccessRequestsFeature holds the Access Requests feature general and usage-based settings.
-// Limits have no affect if [Feature.IdentityGovernanceSecurity] is enabled.
-type AccessRequestsFeature struct {
-	// MonthlyRequestLimit is the usage-based limit for the number of
-	// access requests created in a calendar month.
-	MonthlyRequestLimit int
-}
-
-// AccessListFeature holds the Access List feature settings.
-// Limits have no affect if feature is enabled.
-type AccessListFeature struct {
-	// Limit for the number of access list creatable when feature is
-	// not enabled.
-	CreateLimit int
-}
-
-// AccessMonitoring holds the Access Monitoring feature settings.
-// Limits have no affect if [Feature.IdentityGovernanceSecurity] is enabled.
-type AccessMonitoringFeature struct {
-	// True if enabled in the auth service config: [auth_service.access_monitoring.enabled].
-	Enabled bool
-	// Defines the max number of days to include in an access report.
-	MaxReportRangeLimit int
-}
-
-type PolicyFeature struct {
-	// Enabled is set to `true` if Teleport Policy is enabled in the license.
-	Enabled bool
+	// Limit indicates the allotted amount of use when limited; if 0 use is unlimited
+	Limit int32
 }
 
 // ToProto converts Features into proto.Features
+// todo (michellescripts) phase 2 entitlements: update auth service
 func (f Features) ToProto() *proto.Features {
 	return &proto.Features{
-		ProductType:             proto.ProductType(f.ProductType),
-		Kubernetes:              f.Kubernetes,
-		App:                     f.App,
-		DB:                      f.DB,
-		OIDC:                    f.OIDC,
-		SAML:                    f.SAML,
-		AccessControls:          f.AccessControls,
-		AdvancedAccessWorkflows: f.AdvancedAccessWorkflows,
-		Cloud:                   f.Cloud,
-		HSM:                     f.HSM,
-		Desktop:                 f.Desktop,
-		RecoveryCodes:           f.RecoveryCodes,
-		Plugins:                 f.Plugins,
-		AutomaticUpgrades:       f.AutomaticUpgrades,
-		IsUsageBased:            f.IsUsageBasedBilling,
-		FeatureHiding:           f.FeatureHiding,
-		CustomTheme:             f.CustomTheme,
-		AccessGraph:             f.AccessGraph,
-		DeviceTrust: &proto.DeviceTrustFeature{
-			Enabled:           f.DeviceTrust.Enabled,
-			DevicesUsageLimit: int32(f.DeviceTrust.DevicesUsageLimit),
+		// Settings
+		Cloud:           f.Cloud,
+		CustomTheme:     f.CustomTheme,
+		IsStripeManaged: f.IsStripeManaged,
+		IsUsageBased:    f.IsUsageBasedBilling,
+		Questionnaire:   f.Questionnaire,
+		SupportType:     f.SupportType,
+
+		// todo (michellescripts) update this api to use new entitlements; typed as Entitlement
+		AccessList: &proto.AccessListFeature{
+			CreateLimit: f.GetEntitlement(entitlements.AccessLists).Limit,
+		},
+		// todo (michellescripts) in phase 2, break out AccessMonitoringConfigured and AccessMonitoringEntitlement
+		AccessMonitoring: &proto.AccessMonitoringFeature{
+			Enabled:             f.AccessMonitoringConfigured, // currently for backwards compatibility until we can separate enabled and entitled
+			MaxReportRangeLimit: f.GetEntitlement(entitlements.AccessMonitoring).Limit,
 		},
 		AccessRequests: &proto.AccessRequestsFeature{
-			MonthlyRequestLimit: int32(f.AccessRequests.MonthlyRequestLimit),
+			MonthlyRequestLimit: f.GetEntitlement(entitlements.AccessRequests).Limit,
 		},
-		IdentityGovernance: f.IdentityGovernanceSecurity,
-		AccessMonitoring: &proto.AccessMonitoringFeature{
-			Enabled:             f.AccessMonitoring.Enabled,
-			MaxReportRangeLimit: int32(f.AccessMonitoring.MaxReportRangeLimit),
+		DeviceTrust: &proto.DeviceTrustFeature{
+			Enabled:           f.GetEntitlement(entitlements.DeviceTrust).Enabled,
+			DevicesUsageLimit: f.GetEntitlement(entitlements.DeviceTrust).Limit,
 		},
-		AccessList: &proto.AccessListFeature{
-			CreateLimit: int32(f.AccessList.CreateLimit),
-		},
-		Policy: &proto.PolicyFeature{
-			Enabled: f.Policy.Enabled,
-		},
-		Questionnaire:          f.Questionnaire,
-		IsStripeManaged:        f.IsStripeManaged,
-		ExternalAuditStorage:   f.ExternalAuditStorage,
-		SupportType:            f.SupportType,
-		JoinActiveSessions:     f.JoinActiveSessions,
-		MobileDeviceManagement: f.MobileDeviceManagement,
+
+		AccessControls:          f.AccessControls,
+		AccessGraph:             f.AccessGraph,
+		AdvancedAccessWorkflows: f.AdvancedAccessWorkflows,
+		App:                     f.GetEntitlement(entitlements.App).Enabled,
+		AutomaticUpgrades:       f.AutomaticUpgrades,
+		DB:                      f.GetEntitlement(entitlements.DB).Enabled,
+		Desktop:                 f.GetEntitlement(entitlements.Desktop).Enabled,
+		ExternalAuditStorage:    f.GetEntitlement(entitlements.ExternalAuditStorage).Enabled,
+		FeatureHiding:           f.GetEntitlement(entitlements.FeatureHiding).Enabled,
+		HSM:                     f.GetEntitlement(entitlements.HSM).Enabled,
+		IdentityGovernance:      f.GetEntitlement(entitlements.Identity).Enabled,
+		JoinActiveSessions:      f.GetEntitlement(entitlements.JoinActiveSessions).Enabled,
+		Kubernetes:              f.GetEntitlement(entitlements.K8s).Enabled,
+		MobileDeviceManagement:  f.GetEntitlement(entitlements.MobileDeviceManagement).Enabled,
+		OIDC:                    f.GetEntitlement(entitlements.OIDC).Enabled,
+		Plugins:                 f.Plugins,
+		Policy:                  &proto.PolicyFeature{Enabled: f.GetEntitlement(entitlements.Policy).Enabled},
+		ProductType:             proto.ProductType(f.ProductType),
+		RecoveryCodes:           f.RecoveryCodes,
+		SAML:                    f.GetEntitlement(entitlements.SAML).Enabled,
+	}
+}
+
+func (f Features) GetEntitlement(e entitlements.EntitlementKind) EntitlementInfo {
+	al, ok := f.Entitlements[e]
+	if !ok {
+		return EntitlementInfo{}
+	}
+
+	return EntitlementInfo{
+		Enabled: al.Enabled,
+		Limit:   al.Limit,
 	}
 }
 
@@ -229,23 +175,6 @@ const (
 	// ProductTypeEUB is Teleport Enterprise Usage Based product.
 	ProductTypeEUB ProductType = 2
 )
-
-// IsLegacy describes the legacy enterprise product that existed before the
-// usage-based product was introduced. Some features (Device Trust, for example)
-// require the IGS add-on in usage-based products but are included for legacy
-// licenses.
-func (f Features) IsLegacy() bool {
-	return !f.IsUsageBasedBilling
-}
-
-func (f Features) IGSEnabled() bool {
-	return f.IdentityGovernanceSecurity
-}
-
-// TODO(mcbattirola): remove isTeam when it is no longer used
-func (f Features) IsTeam() bool {
-	return f.ProductType == ProductTypeTeam
-}
 
 // AccessResourcesGetter is a minimal interface that is used to get access lists
 // and related resources from the backend.
@@ -398,20 +327,23 @@ func (p *defaultModules) PrintVersion() {
 	fmt.Printf("Teleport v%s git:%s %s\n", teleport.Version, teleport.Gitref, runtime.Version())
 }
 
-// Features returns supported features
+// Features returns supported features for default modules which is applied for OSS users
+// todo (michellescripts) remove deprecated features
 func (p *defaultModules) Features() Features {
 	p.loadDynamicValues.Do(func() {
 		p.automaticUpgrades = automaticupgrades.IsEnabled()
 	})
 
 	return Features{
-		Kubernetes:         true,
-		DB:                 true,
-		App:                true,
-		Desktop:            true,
-		AutomaticUpgrades:  p.automaticUpgrades,
-		JoinActiveSessions: true,
-		SupportType:        proto.SupportType_SUPPORT_TYPE_FREE,
+		AutomaticUpgrades: p.automaticUpgrades,
+		SupportType:       proto.SupportType_SUPPORT_TYPE_FREE,
+		Entitlements: map[entitlements.EntitlementKind]EntitlementInfo{
+			entitlements.App:                {Enabled: true, Limit: 0},
+			entitlements.DB:                 {Enabled: true, Limit: 0},
+			entitlements.Desktop:            {Enabled: true, Limit: 0},
+			entitlements.JoinActiveSessions: {Enabled: true, Limit: 0},
+			entitlements.K8s:                {Enabled: true, Limit: 0},
+		},
 	}
 }
 

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -25,8 +25,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/modules"
 )
@@ -85,4 +87,108 @@ func TestValidateSessionRecordingConfigOnCloud(t *testing.T) {
 	recConfig.SetMode(types.RecordAtProxy)
 	_, err = testServer.AuthServer.UpsertSessionRecordingConfig(ctx, recConfig)
 	require.EqualError(t, err, "cannot set proxy recording mode on Cloud")
+}
+
+func TestFeatures_ToProto(t *testing.T) {
+	expected := &proto.Features{
+		Assist:                  false,
+		CustomTheme:             "dark",
+		ProductType:             1,
+		SupportType:             1,
+		AccessControls:          true,
+		AccessGraph:             true,
+		AdvancedAccessWorkflows: true,
+		App:                     true,
+		AutomaticUpgrades:       true,
+		Cloud:                   true,
+		DB:                      true,
+		Desktop:                 true,
+		ExternalAuditStorage:    true,
+		FeatureHiding:           true,
+		HSM:                     true,
+		IdentityGovernance:      true,
+		IsStripeManaged:         true,
+		IsUsageBased:            true,
+		JoinActiveSessions:      true,
+		Kubernetes:              true,
+		MobileDeviceManagement:  true,
+		OIDC:                    true,
+		Plugins:                 true,
+		Questionnaire:           true,
+		RecoveryCodes:           true,
+		SAML:                    true,
+
+		AccessList:       &proto.AccessListFeature{CreateLimit: 111},
+		AccessMonitoring: &proto.AccessMonitoringFeature{Enabled: false, MaxReportRangeLimit: 2113}, // todo (michellescripts) this is due to the backwards compatibility claus, update in phase 2
+		AccessRequests:   &proto.AccessRequestsFeature{MonthlyRequestLimit: 39},
+		DeviceTrust:      &proto.DeviceTrustFeature{Enabled: true, DevicesUsageLimit: 103},
+		Policy:           &proto.PolicyFeature{Enabled: true},
+	}
+
+	f := modules.Features{
+		CustomTheme:             "dark",
+		ProductType:             1,
+		SupportType:             1,
+		AccessControls:          true,
+		AccessGraph:             true,
+		AdvancedAccessWorkflows: true,
+		Assist:                  true,
+		AutomaticUpgrades:       true,
+		Cloud:                   true,
+		IsStripeManaged:         true,
+		IsUsageBasedBilling:     true,
+		Plugins:                 true,
+		Questionnaire:           true,
+		RecoveryCodes:           true,
+		Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+			entitlements.AccessLists:            {Enabled: true, Limit: 111},
+			entitlements.AccessMonitoring:       {Enabled: true, Limit: 2113},
+			entitlements.AccessRequests:         {Enabled: true, Limit: 39},
+			entitlements.App:                    {Enabled: true, Limit: 3},
+			entitlements.CloudAuditLogRetention: {Enabled: true, Limit: 3},
+			entitlements.DB:                     {Enabled: true, Limit: 3},
+			entitlements.Desktop:                {Enabled: true, Limit: 3},
+			entitlements.DeviceTrust:            {Enabled: true, Limit: 103},
+			entitlements.ExternalAuditStorage:   {Enabled: true, Limit: 3},
+			entitlements.FeatureHiding:          {Enabled: true, Limit: 3},
+			entitlements.HSM:                    {Enabled: true, Limit: 3},
+			entitlements.Identity:               {Enabled: true, Limit: 3},
+			entitlements.JoinActiveSessions:     {Enabled: true, Limit: 3},
+			entitlements.K8s:                    {Enabled: true, Limit: 3},
+			entitlements.MobileDeviceManagement: {Enabled: true, Limit: 3},
+			entitlements.OIDC:                   {Enabled: true, Limit: 3},
+			entitlements.OktaSCIM:               {Enabled: true, Limit: 3},
+			entitlements.OktaUserSync:           {Enabled: true, Limit: 3},
+			entitlements.Policy:                 {Enabled: true, Limit: 3},
+			entitlements.SAML:                   {Enabled: true, Limit: 3},
+			entitlements.SessionLocks:           {Enabled: true, Limit: 3},
+			entitlements.UpsellAlert:            {Enabled: true, Limit: 3},
+			entitlements.UsageReporting:         {Enabled: true, Limit: 3},
+		},
+	}
+
+	actual := f.ToProto()
+	require.Equal(t, expected, actual)
+}
+
+func TestFeatures_GetEntitlement(t *testing.T) {
+	f := modules.Features{
+		Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+			entitlements.AccessLists: {Enabled: true, Limit: 111},
+			entitlements.K8s:         {Enabled: false},
+			entitlements.SAML:        {},
+		},
+	}
+
+	actual := f.GetEntitlement(entitlements.AccessLists)
+	require.Equal(t, modules.EntitlementInfo{Enabled: true, Limit: 111}, actual)
+
+	actual = f.GetEntitlement(entitlements.K8s)
+	require.Equal(t, modules.EntitlementInfo{Enabled: false}, actual)
+
+	actual = f.GetEntitlement(entitlements.SAML)
+	require.Equal(t, modules.EntitlementInfo{}, actual)
+
+	actual = f.GetEntitlement(entitlements.UsageReporting)
+	require.Equal(t, modules.EntitlementInfo{}, actual)
 }

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -477,8 +478,10 @@ func TestAthenaAuditLogSetup(t *testing.T) {
 	ctx := context.Background()
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			Cloud:                true,
-			ExternalAuditStorage: true,
+			Cloud: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.ExternalAuditStorage: {Enabled: true},
+			},
 		},
 	})
 

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
@@ -195,7 +196,7 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 	// the AccessList feature
 
 	action := updateAccessList
-	if !modules.GetModules().Features().IGSEnabled() {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.Identity).Enabled {
 		action = func() error {
 			err := a.service.RunWhileLocked(ctx, createAccessListLimitLockName, accessListLockTTL,
 				func(ctx context.Context, _ backend.Backend) error {
@@ -463,7 +464,7 @@ func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, acc
 	// AccessList feature
 
 	action := reconcileMembers
-	if !modules.GetModules().Features().IGSEnabled() {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.Identity).Enabled {
 		action = func() error {
 			return a.service.RunWhileLocked(ctx, createAccessListLimitLockName, 2*accessListLockTTL,
 				func(ctx context.Context, _ backend.Backend) error {
@@ -659,8 +660,8 @@ func lockName(accessListName string) string {
 // access list name matches the ones we retrieved.
 // Returns error if limit has been reached.
 func (a *AccessListService) VerifyAccessListCreateLimit(ctx context.Context, targetAccessListName string) error {
-	feature := modules.GetModules().Features()
-	if feature.IGSEnabled() {
+	f := modules.GetModules().Features()
+	if f.GetEntitlement(entitlements.Identity).Enabled {
 		return nil // unlimited
 	}
 
@@ -681,7 +682,7 @@ func (a *AccessListService) VerifyAccessListCreateLimit(ctx context.Context, tar
 		}
 	}
 
-	if len(lists) < feature.AccessList.CreateLimit {
+	if int32(len(lists)) < f.GetEntitlement(entitlements.AccessLists).Limit {
 		return nil
 	}
 

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/trait"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
@@ -1167,9 +1168,9 @@ func newAccessListService(t *testing.T, mem *memory.Memory, clock clockwork.Cloc
 
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			IdentityGovernanceSecurity: igsEnabled,
-			AccessList: modules.AccessListFeature{
-				CreateLimit: 1,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.Identity:    {Enabled: igsEnabled},
+				entitlements.AccessLists: {Enabled: true, Limit: 1},
 			},
 		},
 	})

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
@@ -1076,7 +1077,9 @@ func TestMongoDBMaxMessageSize(t *testing.T) {
 func TestAccessDisabled(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			DB: false,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.DB: {Enabled: false},
+			},
 		},
 	})
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1649,6 +1649,7 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 
 	policy := clusterFeatures.GetPolicy()
 
+	// todo (michellescripts) entitlements phase 3: update webCfg
 	webCfg := webclient.WebConfig{
 		Edition:                        modules.GetModules().BuildType(),
 		Auth:                           authSettings,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -94,6 +94,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/agentless"
 	"github.com/gravitational/teleport/lib/auth"
@@ -4412,7 +4413,9 @@ func TestClusterAppsGet(t *testing.T) {
 func TestApplicationAccessDisabled(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			App: false,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.App: {Enabled: false},
+			},
 		},
 	})
 
@@ -4663,17 +4666,15 @@ func TestGetWebConfig_IGSFeatureLimits(t *testing.T) {
 
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			ProductType:                modules.ProductTypeTeam,
-			IdentityGovernanceSecurity: true,
-			AccessList: modules.AccessListFeature{
-				CreateLimit: 5,
-			},
-			AccessMonitoring: modules.AccessMonitoringFeature{
-				MaxReportRangeLimit: 10,
-			},
+			ProductType:         modules.ProductTypeTeam,
 			IsUsageBasedBilling: true,
 			IsStripeManaged:     true,
 			Questionnaire:       true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.Identity:         {Enabled: true},
+				entitlements.AccessLists:      {Enabled: true, Limit: 5},
+				entitlements.AccessMonitoring: {Enabled: true, Limit: 10},
+			},
 		},
 	})
 

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
@@ -954,8 +955,10 @@ func newAdminActionTestSuite(t *testing.T) *adminActionTestSuite {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
-			OIDC: true,
-			SAML: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.OIDC: {Enabled: true},
+				entitlements.SAML: {Enabled: true},
+			},
 		},
 	})
 

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/modules"
@@ -333,8 +334,10 @@ func TestEditEnterpriseResources(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
-			OIDC: true,
-			SAML: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.OIDC: {Enabled: true},
+				entitlements.SAML: {Enabled: true},
+			},
 		},
 	})
 	log := utils.NewSlogLoggerForTests()

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/config"
@@ -2020,8 +2021,10 @@ func TestCreateEnterpriseResources(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
-			OIDC: true,
-			SAML: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.OIDC: {Enabled: true},
+				entitlements.SAML: {Enabled: true},
+			},
 		},
 	})
 

--- a/tool/teleport/testenv/test_server.go
+++ b/tool/teleport/testenv/test_server.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/utils/keys"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -435,9 +436,11 @@ func (p *cliModules) PrintVersion() {
 // Features returns supported features
 func (p *cliModules) Features() modules.Features {
 	return modules.Features{
-		Kubernetes:              true,
-		DB:                      true,
-		App:                     true,
+		Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+			entitlements.K8s: {Enabled: true},
+			entitlements.DB:  {Enabled: true},
+			entitlements.App: {Enabled: true},
+		},
 		AdvancedAccessWorkflows: true,
 		AccessControls:          true,
 	}

--- a/tool/tsh/common/access_request_test.go
+++ b/tool/tsh/common/access_request_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/modules"
@@ -40,7 +41,9 @@ func TestAccessRequestSearch(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
-			Kubernetes: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.K8s: {Enabled: true},
+			},
 		},
 	},
 	)

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -40,6 +40,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -76,7 +77,9 @@ func TestTshDB(t *testing.T) {
 		&modules.TestModules{
 			TestBuildType: modules.BuildEnterprise,
 			TestFeatures: modules.Features{
-				DB: true,
+				Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+					entitlements.DB: {Enabled: true},
+				},
 			},
 		},
 	)

--- a/tool/tsh/common/hardware_key_test.go
+++ b/tool/tsh/common/hardware_key_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
@@ -292,7 +293,9 @@ func TestHardwareKeyApp(t *testing.T) {
 	testModules := &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
-			App: true,
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.App: {Enabled: true},
+			},
 		},
 	}
 	modules.SetTestModules(t, testModules)

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keypaths"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -320,7 +321,9 @@ func TestKubeSelection(t *testing.T) {
 		&modules.TestModules{
 			TestBuildType: modules.BuildEnterprise,
 			TestFeatures: modules.Features{
-				Kubernetes: true,
+				Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+					entitlements.K8s: {Enabled: true},
+				},
 			},
 		},
 	)

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -70,6 +70,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keypaths"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/prompt"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integration/kube"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
@@ -227,9 +228,11 @@ func (p *cliModules) PrintVersion() {
 // Features returns supported features
 func (p *cliModules) Features() modules.Features {
 	return modules.Features{
-		Kubernetes:              true,
-		DB:                      true,
-		App:                     true,
+		Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+			entitlements.K8s: {Enabled: true},
+			entitlements.DB:  {Enabled: true},
+			entitlements.App: {Enabled: true},
+		},
 		AdvancedAccessWorkflows: true,
 		AccessControls:          true,
 	}

--- a/web/packages/teleport/src/services/storageService/types.ts
+++ b/web/packages/teleport/src/services/storageService/types.ts
@@ -41,7 +41,7 @@ export const KeysEnum = {
 export type SurveyRequest = {
   companyName: string;
   employeeCount: string;
-  resourcesList: Array<string>;
+  resources: Array<string>;
   role: string;
   team: string;
 };


### PR DESCRIPTION
### What

![image](https://github.com/gravitational/teleport.e/assets/11967646/7b71ab53-4683-4305-9b68-e071e14adc18)

This is the first set of PRs in a series of PRs to surface [entitlements](https://www.notion.so/goteleport/Entitlement-System-73406dd32fa543ab9a4d67f19a1805d3?pm=c) in Teleport. Entitlements define a customers access to a particular feature, and the source of truth for entitlements is Cloud (sales center / license).

In this PR set we're updating the `GetCloudFeatures` method (previously `FetchFromCloud`) and the `getSelfHostedLicenseFeatures` method (previously `getLicenseFeatures`) to set a new field called `Entitlements.` Entitlements are a map of features to information:

```
AccessRequests: {Enabled: true, Limited: false, Limit: 0}
```

The keys for entitlements are located in `teleport/entitlements.go`

This PR does not propagate any changes past **ClusterFeatures**; future PRs will make similar changes to auth & web config features (reference above image).

**Note** that Identity business logic for enabling and limiting features was added in [Cloud](https://github.com/gravitational/cloud/pull/8783), and features read from cloud should be trusted wrt Identity groupings.

### License

This PR updates the license spec to add a new Entitlements section. Once released, we will be able to update the Cloud repo to start issuing licenses with the new entitlements model.

In [Teleport.E](https://github.com/gravitational/teleport.e/pull/4317
), the `getSelfHostedLicenseFeatures` method is backwards compatible, all the original logic persists and is applied. Entitlements will only be set if they are present on the license (i.e. the instance has a modern license).

### Related

Supports https://github.com/gravitational/cloud/issues/9022
Cloud PR: https://github.com/gravitational/cloud/pull/8783
E PR: https://github.com/gravitational/teleport.e/pull/4317

