### PR TITLE
Update device trust docs for v16

### DIFF
--- a/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
@@ -41,30 +41,34 @@ can be configured with the `spec.options.device_trust_mode` option and
 applies to the resources in its `allow` rules. It
 works similarly to [`require_session_mfa`](../guides/per-session-mfa.mdx).
 
-<Admonition type="tip" title="v13.3.6+">
-  Teleport version 13.3.6 and above has the preset `require-trusted-device` role.
-  Make sure you update the "allow" rules in the role according to your requirements.
+<Admonition type="warning" title="require-trusted-device role">
+  The preset `require-trusted-device` role does not enforce
+  [Apps](#app-access-support) or [Desktops](#desktop-access-support).
+  Refer to their corresponding sections for instructions.
 </Admonition>
 
-To enforce authenticated device checks for a specific role, update the role with
-the following:
+The role below is an example of full device trust enforcement. Alternatively,
+you may set options.device_trust_mode=required on an existing role for similar
+effects.
 
-```diff
+```yaml
 kind: role
 version: v7
 metadata:
   name: require-trusted-device
 spec:
   options:
-    # require authenticated device check for this role
-+   device_trust_mode: "required" # add this line
+    device_trust_mode: "required"
   allow:
-    logins: ['admin']
-    kubernetes_groups: ['edit']
+    logins: ["{{internal.logins}}"]
+    kubernetes_groups: ["{{internal.kubernetes_groups}}"]
     node_labels:
       '*': '*'
-    ...
-
+    app_labels:
+      '*': '*'
+    windows_desktop_labels:
+      '*': '*'
+    windows_desktop_logins: ["Administrator", "{{internal.windows_logins}}"]
 ```
 
 Update the role:

--- a/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
@@ -42,14 +42,14 @@ applies to the resources in its `allow` rules. It
 works similarly to [`require_session_mfa`](../guides/per-session-mfa.mdx).
 
 <Admonition type="warning" title="require-trusted-device role">
-  The preset `require-trusted-device` role does not enforce
-  [Apps](#app-access-support) or [Desktops](#desktop-access-support).
+  The preset `require-trusted-device` role does not enforce the use of a trusted
+  device for [Apps](#app-access-support) or [Desktops](#desktop-access-support).
   Refer to their corresponding sections for instructions.
 </Admonition>
 
-The role below is an example of full device trust enforcement. Alternatively,
-you may set options.device_trust_mode=required on an existing role for similar
-effects.
+The role below exemplifies trusted device enforcement for DB, K8s and SSH.
+Alternatively, you may set options.device_trust_mode=required on an existing
+role for similar effects.
 
 ```yaml
 kind: role
@@ -60,15 +60,23 @@ spec:
   options:
     device_trust_mode: "required"
   allow:
-    logins: ["{{internal.logins}}"]
-    kubernetes_groups: ["{{internal.kubernetes_groups}}"]
+    db_labels:
+      '*': '*'
+    db_names:
+    - '*'
+    db_users:
+    - '*'
+    kubernetes_groups:
+    - '{{internal.kubernetes_groups}}'
+    - system:masters
+    - developers
+    - viewers
+    kubernetes_labels:
+      '*': '*'
+    logins:
+    - '{{internal.logins}}'
     node_labels:
       '*': '*'
-    app_labels:
-      '*': '*'
-    windows_desktop_labels:
-      '*': '*'
-    windows_desktop_logins: ["Administrator", "{{internal.windows_logins}}"]
 ```
 
 Update the role:

--- a/docs/pages/includes/device-trust/troubleshooting.mdx
+++ b/docs/pages/includes/device-trust/troubleshooting.mdx
@@ -54,7 +54,8 @@ follow the steps below:
 1. Make sure your device is [registered and enrolled](
    ../../access-controls/device-trust/device-management.mdx#register-a-trusted-device)
 2. Install [Teleport Connect](
-   ../../connect-your-client/teleport-connect.mdx#installation--upgrade)
+   ../../connect-your-client/teleport-connect.mdx#installation--upgrade).
+   Use the DEB or RPM packages on Linux.
 3. Make sure Teleport Connect can access the same resource you are trying to
    access on the Web
 4. Ask your cluster administrator if device trust is enabled (cluster mode

--- a/docs/pages/includes/device-trust/troubleshooting.mdx
+++ b/docs/pages/includes/device-trust/troubleshooting.mdx
@@ -55,7 +55,8 @@ follow the steps below:
    ../../access-controls/device-trust/device-management.mdx#register-a-trusted-device)
 2. Install [Teleport Connect](
    ../../connect-your-client/teleport-connect.mdx#installation--upgrade).
-   Use the DEB or RPM packages on Linux.
+   Use the DEB or RPM packages on Linux (the tarball doesn't register the custom
+   URL handler).
 3. Make sure Teleport Connect can access the same resource you are trying to
    access on the Web
 4. Ask your cluster administrator if device trust is enabled (cluster mode


### PR DESCRIPTION
Apply a few small changes:

* Document limitations of the `require-trusted-device` role (and update its section)
* Document the need for DEB or RPM Connect packages on Linux