### PR TITLE
[v16] Include BuildCommunity in built type checks (#42391)

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1285,7 +1285,7 @@ func (a *Server) runPeriodicOperations() {
 	defer instancePeriodics.Stop()
 
 	var ossDesktopsCheck <-chan time.Time
-	if modules.GetModules().BuildType() == modules.BuildOSS {
+	if modules.GetModules().IsOSSBuild() {
 		ossDesktopsCheck = interval.New(interval.Config{
 			Duration:      OSSDesktopsCheckPeriod,
 			FirstDuration: utils.HalfJitter(time.Second * 10),
@@ -5521,7 +5521,7 @@ func (a *Server) syncDesktopsLimitAlert(ctx context.Context) {
 
 // desktopsLimitExceeded checks if number of non-AD desktops exceeds limit for OSS distribution. Returns always false for Enterprise.
 func (a *Server) desktopsLimitExceeded(ctx context.Context) (bool, error) {
-	if modules.GetModules().BuildType() != modules.BuildOSS {
+	if modules.GetModules().IsEnterpriseBuild() {
 		return false, nil
 	}
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4427,7 +4427,7 @@ func (a *ServerWithRoles) DeleteRole(ctx context.Context, name string) error {
 	// It's OK to delete this code alongside migrateOSS code in auth.
 	// It prevents 6.0 from migrating resources multiple times
 	// and the role is used for `tctl users add` code too.
-	if modules.GetModules().BuildType() == modules.BuildOSS && name == teleport.AdminRoleName {
+	if modules.GetModules().IsOSSBuild() && name == teleport.AdminRoleName {
 		return trace.AccessDenied("can not delete system role %q", name)
 	}
 

--- a/lib/devicetrust/config/config.go
+++ b/lib/devicetrust/config/config.go
@@ -30,7 +30,7 @@ import (
 // `dt` and the current modules.
 func GetEffectiveMode(dt *types.DeviceTrust) string {
 	// OSS doesn't support device trust.
-	if modules.GetModules().BuildType() == modules.BuildOSS {
+	if modules.GetModules().IsOSSBuild() {
 		return constants.DeviceTrustModeOff
 	}
 

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -293,6 +293,10 @@ type Modules interface {
 	SetFeatures(Features)
 	// BuildType returns build type (OSS, Community or Enterprise)
 	BuildType() string
+	// IsEnterpriseBuild returns if the binary was built with enterprise modules
+	IsEnterpriseBuild() bool
+	// IsOSSBuild returns if the binary was built without enterprise modules
+	IsOSSBuild() bool
 	// AttestHardwareKey attests a hardware key and returns its associated private key policy.
 	AttestHardwareKey(context.Context, interface{}, *keys.AttestationStatement, crypto.PublicKey, time.Duration) (*keys.AttestationData, error)
 	// GenerateAccessRequestPromotions generates a list of valid promotions for given access request.
@@ -377,6 +381,16 @@ var teleportBuildType = BuildOSS
 // BuildType returns build type (OSS, Community or Enterprise)
 func (p *defaultModules) BuildType() string {
 	return teleportBuildType
+}
+
+// IsEnterpriseBuild returns false for [defaultModules].
+func (p *defaultModules) IsEnterpriseBuild() bool {
+	return false
+}
+
+// IsOSSBuild returns true for [defaultModules].
+func (p *defaultModules) IsOSSBuild() bool {
+	return true
 }
 
 // PrintVersion prints the Teleport version.

--- a/lib/modules/test.go
+++ b/lib/modules/test.go
@@ -93,6 +93,14 @@ func (m *TestModules) BuildType() string {
 	return m.TestBuildType
 }
 
+func (m *TestModules) IsEnterpriseBuild() bool {
+	return m.BuildType() == BuildEnterprise
+}
+
+func (m *TestModules) IsOSSBuild() bool {
+	return m.BuildType() != BuildEnterprise
+}
+
 // AttestHardwareKey attests a hardware key.
 func (m *TestModules) AttestHardwareKey(ctx context.Context, obj interface{}, as *keys.AttestationStatement, pk crypto.PublicKey, d time.Duration) (*keys.AttestationData, error) {
 	if m.MockAttestationData != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1345,7 +1345,7 @@ func (process *TeleportProcess) enterpriseServicesEnabled() bool {
 // enterpriseServicesEnabledWithCommunityBuild will return true if any
 // enterprise services are enabled with an OSS teleport build.
 func (process *TeleportProcess) enterpriseServicesEnabledWithCommunityBuild() bool {
-	return modules.GetModules().BuildType() == modules.BuildOSS &&
+	return modules.GetModules().IsOSSBuild() &&
 		(process.Config.Okta.Enabled || process.Config.Jamf.Enabled())
 }
 

--- a/lib/services/github.go
+++ b/lib/services/github.go
@@ -179,7 +179,7 @@ func MarshalOSSGithubConnector(githubConnector types.GithubConnector, opts ...Ma
 		// Only return an error if the endpoint url is set and the build is OSS
 		// so that the enterprise marshaler can call this marshaler to produce
 		// the final output without receiving an error.
-		if modules.GetModules().BuildType() == modules.BuildOSS &&
+		if modules.GetModules().IsOSSBuild() &&
 			githubConnector.Spec.EndpointURL != "" {
 			return nil, fmt.Errorf("GitHub endpoint URL is set: %w", ErrRequiresEnterprise)
 		}

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -786,7 +786,7 @@ func onConfigDump(flags dumpFlags) error {
 		return nil
 	}
 
-	if modules.GetModules().BuildType() != modules.BuildOSS {
+	if modules.GetModules().IsEnterpriseBuild() {
 		flags.LicensePath = filepath.Join(flags.DataDir, "license.pem")
 	}
 
@@ -847,7 +847,7 @@ func onConfigDump(flags dumpFlags) error {
 		requiresRoot := !canWriteToDataDir || !canWriteToConfDir
 
 		fmt.Fprintf(flags.stdout, "\nA Teleport configuration file has been created at %q.\n", configPath)
-		if modules.GetModules().BuildType() != modules.BuildOSS {
+		if modules.GetModules().IsEnterpriseBuild() {
 			fmt.Fprintf(flags.stdout, "Add your Teleport license file to %q.\n", flags.LicensePath)
 		}
 		fmt.Fprintf(flags.stdout, "To start Teleport with this configuration file, run:\n\n")

--- a/tool/teleport/testenv/test_server.go
+++ b/tool/teleport/testenv/test_server.go
@@ -393,6 +393,16 @@ func (p *cliModules) BuildType() string {
 	return "CLI"
 }
 
+// IsEnterpriseBuild returns false for [cliModules].
+func (p *cliModules) IsEnterpriseBuild() bool {
+	return false
+}
+
+// IsOSSBuild returns false for [cliModules].
+func (p *cliModules) IsOSSBuild() bool {
+	return false
+}
+
 // PrintVersion prints the Teleport version.
 func (p *cliModules) PrintVersion() {
 	fmt.Println("Teleport CLI")

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -208,6 +208,16 @@ func (p *cliModules) BuildType() string {
 	return "CLI"
 }
 
+// IsEnterpriseBuild returns false for [cliModules].
+func (p *cliModules) IsEnterpriseBuild() bool {
+	return false
+}
+
+// IsOSSBuild returns false for [cliModules].
+func (p *cliModules) IsOSSBuild() bool {
+	return false
+}
+
 // PrintVersion prints the Teleport version.
 func (p *cliModules) PrintVersion() {
 	fmt.Printf("Teleport CLI\n")


### PR DESCRIPTION
Backport #42391 

Updated `e` manually (tip of e branch/v16), rest is clean backport