### PR TITLE
Fix GCP label issues

### DIFF
--- a/lib/cloud/gcp/vm.go
+++ b/lib/cloud/gcp/vm.go
@@ -26,10 +26,7 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/url"
-	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -58,10 +55,6 @@ const sshUser = "teleport"
 // sshDefaultTimeout is the default timeout for dialing an instance.
 const sshDefaultTimeout = 10 * time.Second
 
-// urlErrorCodePattern is a regex for attempting to extract an HTTP error
-// code from a *url.Error.
-var urlErrorCodePattern = regexp.MustCompile(`\b[2-5]\d{2}\b`)
-
 // convertAPIError converts an error from the GCP API into a trace error.
 func convertAPIError(err error) error {
 	var googleError *googleapi.Error
@@ -74,15 +67,6 @@ func convertAPIError(err error) error {
 			return trace.ReadError(code, []byte(apiError.Reason()))
 		} else if apiError.GRPCStatus() != nil {
 			return trail.FromGRPC(apiError)
-		}
-	}
-	var urlError *url.Error
-	if errors.As(err, &urlError) {
-		if codeStr := urlErrorCodePattern.FindString(urlError.Error()); codeStr != "" {
-			code, err := strconv.Atoi(codeStr)
-			if err == nil {
-				return trace.ReadError(code, []byte(urlError.Error()))
-			}
 		}
 	}
 	return err

--- a/lib/cloud/gcp/vm_test.go
+++ b/lib/cloud/gcp/vm_test.go
@@ -21,10 +21,8 @@ package gcp
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -71,14 +69,6 @@ func TestConvertAPIError(t *testing.T) {
 		{
 			name: "api grpc error",
 			err:  fromError(t, status.Error(codes.PermissionDenied, "abcd1234")),
-		},
-		{
-			name: "url error",
-			err: &url.Error{
-				Op:  http.MethodGet,
-				URL: "https://example.com",
-				Err: fmt.Errorf("wrong code 99, wrong code 2007, wrong code 678, right code 403, wrong code 401 abcd1234"),
-			},
 		},
 	}
 	for _, tc := range tests {

--- a/lib/cloud/imds/gcp/imds_test.go
+++ b/lib/cloud/imds/gcp/imds_test.go
@@ -58,16 +58,44 @@ func (m *mockInstanceGetter) GetInstanceTags(ctx context.Context, req *gcp.Insta
 func TestIsInstanceMetadataAvailable(t *testing.T) {
 	t.Parallel()
 
-	t.Run("not available", func(t *testing.T) {
-		client := &InstanceMetadataClient{
+	tests := []struct {
+		name        string
+		getMetadata metadataGetter
+		assert      require.BoolAssertionFunc
+	}{
+		{
+			name: "not available",
 			getMetadata: func(ctx context.Context, path string) (string, error) {
 				return "", trace.NotFound("")
 			},
-		}
-		require.False(t, client.IsAvailable(context.Background()))
-	})
+			assert: require.False,
+		},
+		{
+			name: "not on gcp",
+			getMetadata: func(ctx context.Context, path string) (string, error) {
+				return "non-numeric id", nil
+			},
+			assert: require.False,
+		},
+		{
+			name: "on mocked gcp",
+			getMetadata: func(ctx context.Context, path string) (string, error) {
+				return "12345678", nil
+			},
+			assert: require.True,
+		},
+	}
 
-	t.Run("on gcp", func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &InstanceMetadataClient{
+				getMetadata: tc.getMetadata,
+			}
+			tc.assert(t, client.IsAvailable(context.Background()))
+		})
+	}
+
+	t.Run("on real gcp", func(t *testing.T) {
 		if os.Getenv("TELEPORT_TEST_GCP") == "" {
 			t.Skip("not on gcp")
 		}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -997,7 +997,7 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 			Clock:  cfg.Clock,
 		})
 		if err != nil {
-			cfg.Logger.ErrorContext(supervisor.ExitContext(), "Error creating cloud label importer.", "error", err)
+			cfg.Logger.ErrorContext(supervisor.ExitContext(), "Cloud labels will not be imported", "error", err)
 		}
 	}
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -997,7 +997,7 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 			Clock:  cfg.Clock,
 		})
 		if err != nil {
-			cfg.Logger.ErrorContext(supervisor.ExitContext(), "Cloud labels will not be imported", "error", err)
+			cfg.Logger.ErrorContext(supervisor.ExitContext(), "Cloud labels will not be imported.", "error", err)
 		}
 	}
 


### PR DESCRIPTION
This change:
- Fixes Teleport starting up on isolated cloud nodes.
- Changes imds errors to logs in lib/service, so an unexpected imds error doesn't prevent Teleport from starting.

Fixes #42312.

Changelog: Fixed crashes related to importing GCP labels