### PR TITLE
Web: Fix not being able to logout from session invalidation error

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2230,7 +2230,17 @@ func (h *Handler) deleteWebSession(w http.ResponseWriter, r *http.Request, _ htt
 
 func (h *Handler) logout(ctx context.Context, w http.ResponseWriter, sctx *SessionContext) error {
 	if err := sctx.Invalidate(ctx); err != nil {
-		return trace.Wrap(err)
+		h.log.
+			WithError(err).
+			WithField("user", sctx.GetUser()).
+			Warn("Failed to invalidate sessions")
+	}
+
+	if err := h.auth.releaseResources(sctx.GetUser(), sctx.GetSessionID()); err != nil {
+		h.log.
+			WithError(err).
+			WithField("session_id", sctx.GetSessionID()).
+			Debug("sessionCache: Failed to release web session")
 	}
 	clearSessionCookies(w)
 

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -1038,14 +1038,7 @@ func (s *sessionCache) invalidateSession(ctx context.Context, sctx *SessionConte
 		sessionDeletionErrs = errors.Join(sessionDeletionErrs, err)
 	}
 
-	if sessionDeletionErrs != nil {
-		return trace.Wrap(sessionDeletionErrs)
-	}
-
-	if err := s.releaseResources(sctx.GetUser(), sctx.GetSessionID()); err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
+	return trace.Wrap(sessionDeletionErrs)
 }
 
 func (s *sessionCache) getContext(key string) (*SessionContext, bool) {


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/42209
fixes https://github.com/gravitational/teleport/issues/41651

When trying to logout from the web UI and [invalidation](https://github.com/gravitational/teleport/blob/99256a34c1b4eaeefa6bbaf8fbdc61762917f2c3/lib/web/apiserver.go#L2241) returns an error (mainly from trying to [delete sessions](https://github.com/gravitational/teleport/blob/99256a34c1b4eaeefa6bbaf8fbdc61762917f2c3/lib/web/sessions.go#L1011) for app, web, and samlidp), we return an error without deleting the cookie, keeping the user in a logged in state with an error.

There are certain scenarios where the user is locked in this logged in state (as explained in the linked issues) despite retrying and the only way for the user to get out of this state was to:
 1) manually delete the cookies from the browser
 2) close the browser

Worse case it kept the user in a [infinite redirect loop](https://gravitational.slack.com/archives/C02DQ1C2BMW/p1717547115744499?thread_ts=1717522548.807559&cid=C02DQ1C2BMW)

This PR will delete the cookies and release session from cache, regardless of any errors from trying to invalidate sessions.

The consequence of this is that sessions related to user (app, samlidp, and web) will remain until it expires, but don't think that's in scope of this PR (also i wasn't sure how to resolve that issue, if it's an issue...) 

changelog: Fix not being able to logout from the web UI when session invalidation errors

part of https://github.com/gravitational/teleport/issues/42119