### PR TITLE
[v14] [branch/v16] Invoke signing function for Windows Connect binary (#41963)

### DIFF
--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -33,7 +33,7 @@ function New-TempDirectory {
     string
     #>
 
-    $TempDirectoryPath = Join-Path -Path "$([System.IO.Path]::GetTempPath())" -ChildPath "$($(New-Guid).Guid)"
+    $TempDirectoryPath = Join-Path -Path "$([System.IO.Path]::GetTempPath())" -ChildPath "$([guid]::newguid().Guid)"
     New-Item -ItemType Directory -Path "$TempDirectoryPath" | Out-Null
 
     return "$TempDirectoryPath"
@@ -296,8 +296,17 @@ function Invoke-SignBinary {
         [string] $SignedBinaryPath
     )
 
+    if (! $SignedBinaryPath) {
+        $ShouldMoveSignedBinary = $true
+        $SignedBinaryPath = Join-Path -Path $(New-TempDirectory) -ChildPath "signed.exe"
+    }
+
     Write-Host "Signing $UnsignedBinaryPath using WSL sign-binary script:"
     wsl-ubuntu-command sign-binary "$UnsignedBinaryPath" "$SignedBinaryPath"
+
+    if ($ShouldMoveSignedBinary) {
+        Move-Item -Path $SignedBinaryPath -Destination $UnsignedBinaryPath -Force
+    }
 }
 
 function Build-WindowsAuthenticationPackage {

--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -1,6 +1,6 @@
 const { env, platform } = require('process');
 const fs = require('fs');
-
+const { spawnSync } = require('child_process');
 const isMac = platform === 'darwin';
 
 // The following checks make no sense when cross-building because they check the platform of the
@@ -142,6 +142,30 @@ module.exports = {
   },
   win: {
     target: ['nsis'],
+    // The algorithm passed here is not used, it only prevents the signing function from being called twice for each file.
+    // https://github.com/electron-userland/electron-builder/issues/3995#issuecomment-505725704
+    signingHashAlgorithms: ['sha256'],
+    sign: customSign => {
+      if (process.env.CI !== 'true') {
+        console.warn('Not running in CI pipeline: signing will be skipped');
+        return;
+      }
+
+      spawnSync(
+        'powershell',
+        [
+          '-noprofile',
+          '-executionpolicy',
+          'bypass',
+          '-c',
+          "$ProgressPreference = 'SilentlyContinue'; " +
+            "$ErrorActionPreference = 'Stop'; " +
+            '. ../../../build.assets/windows/build.ps1; ' +
+            `Invoke-SignBinary -UnsignedBinaryPath "${customSign.path}"`,
+        ],
+        { stdio: 'inherit' }
+      );
+    },
     artifactName: '${productName} Setup-${version}.${ext}',
     icon: 'build_resources/icon-win.ico',
     extraResources: [


### PR DESCRIPTION
Backport #42459 to branch/v14

changelog: Teleport Connect binaries for Windows are now signed.
