### PR TITLE
Fix removing resources from access request when they share the same name

### DIFF
--- a/web/packages/design/src/DataTable/types.ts
+++ b/web/packages/design/src/DataTable/types.ts
@@ -105,7 +105,7 @@ export type ServersideProps = {
 
 // Makes it so either key or altKey is required
 type TableColumnWithKey<T> = TableColumnBase<T> & {
-  key: Extract<keyof T, string>;
+  key: keyof T & string;
   // altSortKey is the alternative field to sort column by,
   // if provided. Otherwise it falls back to sorting by field
   // "key".

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -244,6 +244,11 @@ export function RequestCheckout<T extends PendingListItem>({
                 data={data}
                 columns={[
                   {
+                    key: 'clusterName',
+                    headerText: 'Cluster Name',
+                    isNonRender: !showClusterNameColumn,
+                  },
+                  {
                     key: 'kind',
                     headerText: 'Type',
                     render: item => (
@@ -253,11 +258,6 @@ export function RequestCheckout<T extends PendingListItem>({
                   {
                     key: 'name',
                     headerText: 'Name',
-                  },
-                  {
-                    key: 'clusterName',
-                    headerText: 'Cluster Name',
-                    isNonRender: !showClusterNameColumn,
                   },
                   {
                     altKey: 'delete-btn',

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -61,10 +61,9 @@ import type { TransitionStatus } from 'react-transition-group';
 import type { AccessRequest } from 'shared/services/accessRequests';
 import type { ResourceKind } from '../resource';
 
-export function RequestCheckoutWithSlider({
-  transitionState,
-  ...props
-}: RequestCheckoutWithSliderProps) {
+export function RequestCheckoutWithSlider<
+  T extends PendingListItem = PendingListItem,
+>({ transitionState, ...props }: RequestCheckoutWithSliderProps<T>) {
   const ref = useRef<HTMLDivElement>();
 
   // Listeners are attached to enable overflow on the parent container after
@@ -120,7 +119,7 @@ export function RequestCheckoutWithSlider({
   );
 }
 
-export function RequestCheckout({
+export function RequestCheckout<T extends PendingListItem>({
   toggleResource,
   onClose,
   reset,
@@ -148,7 +147,7 @@ export function RequestCheckout({
   isResourceRequest,
   selectedResourceRequestRoles,
   Header,
-}: RequestCheckoutProps) {
+}: RequestCheckoutProps<T>) {
   // Specifies the start date/time a requestor requested for.
   const [start, setStart] = useState<Date>();
   const [reason, setReason] = useState('');
@@ -261,11 +260,7 @@ export function RequestCheckout({
                           p={2}
                           onClick={() => {
                             clearAttempt();
-                            toggleResource(
-                              resource.kind,
-                              resource.id,
-                              resource.name
-                            );
+                            toggleResource(resource);
                           }}
                           disabled={createAttempt.status === 'processing'}
                           css={`
@@ -687,49 +682,51 @@ const StyledTable = styled(Table)`
   overflow: hidden;
 ` as typeof Table;
 
-export type RequestCheckoutWithSliderProps = {
+export type RequestCheckoutWithSliderProps<
+  T extends PendingListItem = PendingListItem,
+> = {
   transitionState: TransitionStatus;
-} & RequestCheckoutProps;
+} & RequestCheckoutProps<T>;
 
-export type RequestCheckoutProps = {
-  onClose(): void;
-  toggleResource: (
-    kind: ResourceKind,
-    resourceId: string,
-    resourceName?: string
-  ) => void;
-  appsGrantedByUserGroup?: string[];
-  userGroupFetchAttempt?: Attempt;
-  reset: () => void;
-  SuccessComponent?: (params: SuccessComponentParams) => JSX.Element;
-  isResourceRequest: boolean;
-  requireReason: boolean;
-  selectedReviewers: ReviewerOption[];
-  data: {
-    kind: ResourceKind;
-    /** Name of the resource, for presentation purposes only. */
-    name: string;
-    /** Identifier of the resource. Should be sent in requests. */
-    id: string;
-  }[];
-  setRequestTTL: (value: Option<number>) => void;
-  createRequest: (req: CreateRequest) => void;
-  fetchStatus: 'loading' | 'loaded';
-  fetchResourceRequestRolesAttempt: Attempt;
-  requestTTL: Option<number>;
-  resourceRequestRoles: string[];
-  reviewers: string[];
-  setSelectedReviewers: (value: ReviewerOption[]) => void;
-  setMaxDuration: (value: Option<number>) => void;
-  clearAttempt: () => void;
-  createAttempt: Attempt;
-  setSelectedResourceRequestRoles: (value: string[]) => void;
-  numRequestedResources: number;
-  selectedResourceRequestRoles: string[];
-  dryRunResponse: AccessRequest;
-  maxDuration: Option<number>;
-  Header?: () => JSX.Element;
-};
+export interface PendingListItem {
+  kind: ResourceKind;
+  /** Name of the resource, for presentation purposes only. */
+  name: string;
+  /** Identifier of the resource. Should be sent in requests. */
+  id: string;
+  clusterName?: string;
+}
+
+export type RequestCheckoutProps<T extends PendingListItem = PendingListItem> =
+  {
+    onClose(): void;
+    toggleResource: (resource: T) => void;
+    appsGrantedByUserGroup?: string[];
+    userGroupFetchAttempt?: Attempt;
+    reset: () => void;
+    SuccessComponent?: (params: SuccessComponentParams) => JSX.Element;
+    isResourceRequest: boolean;
+    requireReason: boolean;
+    selectedReviewers: ReviewerOption[];
+    data: T[];
+    setRequestTTL: (value: Option<number>) => void;
+    createRequest: (req: CreateRequest) => void;
+    fetchStatus: 'loading' | 'loaded';
+    fetchResourceRequestRolesAttempt: Attempt;
+    requestTTL: Option<number>;
+    resourceRequestRoles: string[];
+    reviewers: string[];
+    setSelectedReviewers: (value: ReviewerOption[]) => void;
+    setMaxDuration: (value: Option<number>) => void;
+    clearAttempt: () => void;
+    createAttempt: Attempt;
+    setSelectedResourceRequestRoles: (value: string[]) => void;
+    numRequestedResources: number;
+    selectedResourceRequestRoles: string[];
+    dryRunResponse: AccessRequest;
+    maxDuration: Option<number>;
+    Header?: () => JSX.Element;
+  };
 
 type SuccessComponentParams = {
   reset: () => void;

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -647,6 +647,7 @@ function getPrettyResourceKind(kind: ResourceKind): string {
       return 'Desktop';
     default:
       kind satisfies never;
+      return kind;
   }
 }
 

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -137,6 +137,7 @@ export function RequestCheckout<T extends PendingListItem>({
   setRequestTTL,
   dryRunResponse,
   data,
+  showClusterNameColumn,
   createAttempt,
   fetchResourceRequestRolesAttempt,
   createRequest,
@@ -249,6 +250,11 @@ export function RequestCheckout<T extends PendingListItem>({
                   {
                     key: 'name',
                     headerText: 'Name',
+                  },
+                  {
+                    key: 'clusterName',
+                    headerText: 'Cluster Name',
+                    isNonRender: !showClusterNameColumn,
                   },
                   {
                     altKey: 'delete-btn',
@@ -709,6 +715,7 @@ export type RequestCheckoutProps<T extends PendingListItem = PendingListItem> =
     requireReason: boolean;
     selectedReviewers: ReviewerOption[];
     data: T[];
+    showClusterNameColumn?: boolean;
     setRequestTTL: (value: Option<number>) => void;
     createRequest: (req: CreateRequest) => void;
     fetchStatus: 'loading' | 'loaded';

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -246,6 +246,9 @@ export function RequestCheckout<T extends PendingListItem>({
                   {
                     key: 'kind',
                     headerText: 'Type',
+                    render: item => (
+                      <Cell>{getPrettyResourceKind(item.kind)}</Cell>
+                    ),
                   },
                   {
                     key: 'name',
@@ -622,6 +625,29 @@ function TextBox({
       />
     </LabelInput>
   );
+}
+
+function getPrettyResourceKind(kind: ResourceKind): string {
+  switch (kind) {
+    case 'role':
+      return 'Role';
+    case 'app':
+      return 'Application';
+    case 'node':
+      return 'Server';
+    case 'resource':
+      return 'Resource';
+    case 'db':
+      return 'Database';
+    case 'kube_cluster':
+      return 'Kubernetes';
+    case 'user_group':
+      return 'User Group';
+    case 'windows_desktop':
+      return 'Desktop';
+    default:
+      kind satisfies never;
+  }
 }
 
 const requireText = (value: string, requireReason: boolean) => () => {

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/__snapshots__/RequestCheckout.story.test.tsx.snap
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/__snapshots__/RequestCheckout.story.test.tsx.snap
@@ -928,7 +928,7 @@ exports[`failed state 1`] = `
           <tbody>
             <tr>
               <td>
-                app
+                Application
               </td>
               <td>
                 app-name
@@ -954,7 +954,7 @@ exports[`failed state 1`] = `
             </tr>
             <tr>
               <td>
-                db
+                Database
               </td>
               <td>
                 app-name
@@ -980,7 +980,7 @@ exports[`failed state 1`] = `
             </tr>
             <tr>
               <td>
-                kube_cluster
+                Kubernetes
               </td>
               <td>
                 kube-name
@@ -1006,7 +1006,7 @@ exports[`failed state 1`] = `
             </tr>
             <tr>
               <td>
-                user_group
+                User Group
               </td>
               <td>
                 user-group-name
@@ -1032,7 +1032,7 @@ exports[`failed state 1`] = `
             </tr>
             <tr>
               <td>
-                windows_desktop
+                Desktop
               </td>
               <td>
                 desktop-name
@@ -2394,7 +2394,7 @@ exports[`loaded state 1`] = `
           <tbody>
             <tr>
               <td>
-                app
+                Application
               </td>
               <td>
                 app-name
@@ -2420,7 +2420,7 @@ exports[`loaded state 1`] = `
             </tr>
             <tr>
               <td>
-                db
+                Database
               </td>
               <td>
                 app-name
@@ -2446,7 +2446,7 @@ exports[`loaded state 1`] = `
             </tr>
             <tr>
               <td>
-                kube_cluster
+                Kubernetes
               </td>
               <td>
                 kube-name
@@ -2472,7 +2472,7 @@ exports[`loaded state 1`] = `
             </tr>
             <tr>
               <td>
-                user_group
+                User Group
               </td>
               <td>
                 user-group-name
@@ -2498,7 +2498,7 @@ exports[`loaded state 1`] = `
             </tr>
             <tr>
               <td>
-                windows_desktop
+                Desktop
               </td>
               <td>
                 desktop-name

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/index.ts
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/index.ts
@@ -17,7 +17,7 @@
  */
 
 export { RequestCheckoutWithSlider, RequestCheckout } from './RequestCheckout';
-export type { RequestCheckoutProps } from './RequestCheckout';
+export type { RequestCheckoutProps, PendingListItem } from './RequestCheckout';
 
 export * from './utils';
 export type { ReviewerOption } from './types';

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
@@ -86,6 +86,7 @@ export function AccessRequestCheckout() {
     setSelectedResourceRequestRoles,
     clearCreateAttempt,
     data,
+    shouldShowClusterNameColumn,
     suggestedReviewers,
     selectedReviewers,
     setSelectedReviewers,
@@ -232,6 +233,7 @@ export function AccessRequestCheckout() {
             }
             reset={reset}
             data={data}
+            showClusterNameColumn={shouldShowClusterNameColumn}
             createAttempt={createRequestAttempt}
             resourceRequestRoles={resourceRequestRoles}
             fetchResourceRequestRolesAttempt={fetchResourceRolesAttempt}

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
@@ -138,7 +138,11 @@ export function AccessRequestCheckout() {
                 {data
                   .slice(0, MAX_RESOURCES_IN_BAR_TO_SHOW)
                   .map(c => {
-                    let resource = { name: c.name, Icon: undefined };
+                    let resource = {
+                      name: c.name,
+                      key: `${c.clusterName}-${c.kind}-${c.id}`,
+                      Icon: undefined,
+                    };
                     switch (c.kind) {
                       case 'app':
                         resource.Icon = Icon.Application;
@@ -162,7 +166,7 @@ export function AccessRequestCheckout() {
                   .map(c => (
                     <Label
                       kind="secondary"
-                      key={c.name}
+                      key={c.key}
                       css={`
                         display: flex;
                         align-items: center;

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
@@ -160,7 +160,7 @@ export function AccessRequestCheckout() {
                       case 'role':
                         break;
                       default:
-                        c.kind satisfies never;
+                        c satisfies never;
                     }
                     return resource;
                   })

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
@@ -170,10 +170,6 @@ export default function useAccessRequestCheckout() {
             id: role,
             name: role,
             clusterName,
-            originalItem: {
-              kind: 'role',
-              role: role,
-            },
           });
         });
         break;
@@ -186,7 +182,7 @@ export default function useAccessRequestCheckout() {
             kind,
             id,
             name,
-            originalItem: { kind: 'resource', resource: resourceRequest },
+            originalItem: resourceRequest,
             clusterName: ctx.clustersService.findClusterByResource(
               resourceRequest.resource.uri
             )?.name,
@@ -204,15 +200,17 @@ export default function useAccessRequestCheckout() {
     return workspaceAccessRequest.getCollapsed();
   }
 
-  async function toggleResource({
-    originalItem,
-  }: PendingListItemWithOriginalItem) {
-    if (originalItem.kind === 'role') {
-      await workspaceAccessRequest.addOrRemoveRole(originalItem.role);
+  async function toggleResource(
+    pendingListItem: PendingListItemWithOriginalItem
+  ) {
+    if (pendingListItem.kind === 'role') {
+      await workspaceAccessRequest.addOrRemoveRole(pendingListItem.id);
       return;
     }
 
-    await workspaceAccessRequest.addOrRemoveResource(originalItem.resource);
+    await workspaceAccessRequest.addOrRemoveResource(
+      pendingListItem.originalItem
+    );
   }
 
   function getAssumedRequests() {
@@ -385,12 +383,13 @@ export default function useAccessRequestCheckout() {
   };
 }
 
-type PendingListItemWithOriginalItem = Omit<PendingListItem, 'kind'> & {
-  kind: ResourceKind;
-  originalItem:
+type PendingListItemWithOriginalItem = Omit<PendingListItem, 'kind'> &
+  (
+    | {
+        kind: Exclude<ResourceKind, 'role'>;
+        originalItem: ResourceRequest;
+      }
     | {
         kind: 'role';
-        role: string;
       }
-    | { kind: 'resource'; resource: ResourceRequest };
-};
+  );

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
@@ -345,7 +345,7 @@ export default function useAccessRequestCheckout() {
   }
 
   const shouldShowClusterNameColumn =
-    pendingAccessRequest.kind === 'resource' &&
+    pendingAccessRequest?.kind === 'resource' &&
     Array.from(pendingAccessRequest.resources.values()).some(a =>
       routing.isLeafCluster(a.resource.uri)
     );

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
@@ -43,6 +43,8 @@ import {
   AccessRequest as TeletermAccessRequest,
 } from 'teleterm/services/tshd/types';
 
+import { routing } from 'teleterm/ui/uri';
+
 import { ResourceKind } from '../DocumentAccessRequests/NewRequest/useNewRequest';
 
 import { makeUiAccessRequest } from '../DocumentAccessRequests/useAccessRequests';
@@ -344,12 +346,19 @@ export default function useAccessRequestCheckout() {
     }
   }
 
+  const shouldShowClusterNameColumn =
+    pendingAccessRequest.kind === 'resource' &&
+    Array.from(pendingAccessRequest.resources.values()).some(a =>
+      routing.isLeafCluster(a.resource.uri)
+    );
+
   return {
     showCheckout,
     isCollapsed,
     assumedRequests: getAssumedRequests(),
     toggleResource,
     data: getPendingAccessRequestsPerResource(pendingAccessRequest),
+    shouldShowClusterNameColumn,
     createRequest,
     reset,
     setHasExited,

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
@@ -24,6 +24,7 @@ import useAttempt from 'shared/hooks/useAttemptNext';
 import {
   ReviewerOption,
   getDryRunMaxDuration,
+  PendingListItem,
 } from 'shared/components/AccessRequests/NewRequest';
 
 import { CreateRequest } from 'shared/components/AccessRequests/Shared/types';
@@ -34,7 +35,7 @@ import { useAppContext } from 'teleterm/ui/appContextProvider';
 import {
   PendingAccessRequest,
   extractResourceRequestProperties,
-  toResourceRequest,
+  ResourceRequest,
 } from 'teleterm/ui/services/workspacesService/accessRequestsService';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 import {
@@ -151,20 +152,8 @@ export default function useAccessRequestCheckout() {
 
   function getPendingAccessRequestsPerResource(
     pendingRequest: PendingAccessRequest
-  ): {
-    kind: ResourceKind;
-    clusterName: string;
-    id: string;
-    name: string;
-  }[] {
-    const data: {
-      kind: ResourceKind;
-      clusterName: string;
-      /** Identifier of the resource. Should be sent in requests. */
-      id: string;
-      /** Name of the resource, for presentation purposes only. */
-      name: string;
-    }[] = [];
+  ): PendingListItemWithOriginalItem[] {
+    const data: PendingListItemWithOriginalItem[] = [];
     if (!workspaceAccessRequest) {
       return data;
     }
@@ -173,8 +162,17 @@ export default function useAccessRequestCheckout() {
       case 'role': {
         const clusterName =
           ctx.clustersService.findCluster(rootClusterUri)?.name;
-        pendingRequest.roles.forEach(r => {
-          data.push({ kind: 'role', id: r, name: r, clusterName });
+        pendingRequest.roles.forEach(role => {
+          data.push({
+            kind: 'role',
+            id: role,
+            name: role,
+            clusterName,
+            originalItem: {
+              kind: 'role',
+              role: role,
+            },
+          });
         });
         break;
       }
@@ -186,6 +184,7 @@ export default function useAccessRequestCheckout() {
             kind,
             id,
             name,
+            originalItem: { kind: 'resource', resource: resourceRequest },
             clusterName: ctx.clustersService.findClusterByResource(
               resourceRequest.resource.uri
             )?.name,
@@ -203,24 +202,15 @@ export default function useAccessRequestCheckout() {
     return workspaceAccessRequest.getCollapsed();
   }
 
-  async function toggleResource(
-    kind: ResourceKind,
-    resourceId: string,
-    resourceName: string
-  ) {
-    if (kind === 'role') {
-      await workspaceAccessRequest.addOrRemoveRole(resourceId);
+  async function toggleResource({
+    originalItem,
+  }: PendingListItemWithOriginalItem) {
+    if (originalItem.kind === 'role') {
+      await workspaceAccessRequest.addOrRemoveRole(originalItem.role);
       return;
     }
 
-    await workspaceAccessRequest.addOrRemoveResource(
-      toResourceRequest({
-        kind,
-        resourceId,
-        resourceName,
-        clusterUri,
-      })
-    );
+    await workspaceAccessRequest.addOrRemoveResource(originalItem.resource);
   }
 
   function getAssumedRequests() {
@@ -385,3 +375,13 @@ export default function useAccessRequestCheckout() {
     setRequestTTL,
   };
 }
+
+type PendingListItemWithOriginalItem = Omit<PendingListItem, 'kind'> & {
+  kind: ResourceKind;
+  originalItem:
+    | {
+        kind: 'role';
+        role: string;
+      }
+    | { kind: 'resource'; resource: ResourceRequest };
+};


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/42352

Removing resources with the same name did not work, because when converting a “shared” access request to a “Connect” access request, we always passed the active cluster URI, not the URI of the cluster to which the resource belonged.
To fix this, I allowed extending the object passed to `data` in `RequestCheckout`, so we can keep the original items there. 
Another benefit of that is that we no longer have to convert the "shared" request to "Connect" request.

I also added some improvements:
* cluster name is shown in the checkout if there's a resource from a leaf cluster,
* we no longer show an unformatted resource kind in the checkout. 