### PR TITLE
fix: Address macOS build deprecation warning

### DIFF
--- a/lib/auth/touchid/register.m
+++ b/lib/auth/touchid/register.m
@@ -31,10 +31,9 @@
 
 int Register(CredentialInfo req, char **pubKeyB64Out, char **errOut) {
   CFErrorRef error = NULL;
-  // kSecAccessControlTouchIDAny is used for compatibility with macOS 10.12.
   SecAccessControlRef access = SecAccessControlCreateWithFlags(
       kCFAllocatorDefault, kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-      kSecAccessControlPrivateKeyUsage | kSecAccessControlTouchIDAny, &error);
+      kSecAccessControlPrivateKeyUsage | kSecAccessControlBiometryAny, &error);
   if (error) {
     NSError *nsError = CFBridgingRelease(error);
     *errOut = CopyNSString([nsError localizedDescription]);


### PR DESCRIPTION
Replace kSecAccessControlTouchIDAny, which was used for macOS 10.12 compatibility, with kSecAccessControlBiometryAny. 

"BiometryAny" allows for Face ID, but otherwise behaves the same as "TouchIDAny". This is a noop for macOS devices, therefore a noop to us. Existing `tsh` Touch ID keys are not affected.

Follow up from #42017.

* https://developer.apple.com/documentation/security/secaccesscontrolcreateflags/ksecaccesscontroltouchidany
* https://developer.apple.com/documentation/security/secaccesscontrolcreateflags/ksecaccesscontrolbiometryany