### PR TITLE
fix: Do not DNS resolve on TestJoinServiceClient_RegisterUsingTPMMethod

### DIFF
--- a/api/client/joinservice_test.go
+++ b/api/client/joinservice_test.go
@@ -116,9 +116,14 @@ func TestJoinServiceClient_RegisterUsingTPMMethod(t *testing.T) {
 		cancel()
 	}()
 
-	c, err := grpc.NewClient("unused.com", grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-		return lis.DialContext(ctx)
-	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	// grpc.NewClient attempts to DNS resolve addr, whereas grpc.Dial doesn't.
+	c, err := grpc.Dial(
+		"bufconn",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	require.NoError(t, err)
 
 	joinClient := NewJoinServiceClient(proto.NewJoinServiceClient(c))


### PR DESCRIPTION
Fixes the current CI breakage.

There is another possible solution where we keep grpc.NewClient and use a [manual resolver][1], but this is much simpler.

[1]: https://pkg.go.dev/google.golang.org/grpc@v1.64.0/resolver/manual#NewBuilderWithScheme