### PR TITLE
[v16] fix: Do not DNS resolve on TestJoinServiceClient_RegisterUsingTPMMethod

### DIFF
--- a/api/client/joinservice_test.go
+++ b/api/client/joinservice_test.go
@@ -116,9 +116,14 @@ func TestJoinServiceClient_RegisterUsingTPMMethod(t *testing.T) {
 		cancel()
 	}()
 
-	c, err := grpc.NewClient("unused.com", grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-		return lis.DialContext(ctx)
-	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	// grpc.NewClient attempts to DNS resolve addr, whereas grpc.Dial doesn't.
+	c, err := grpc.Dial(
+		"bufconn",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	require.NoError(t, err)
 
 	joinClient := NewJoinServiceClient(proto.NewJoinServiceClient(c))


### PR DESCRIPTION
Backport #42513 to branch/v16