### PR TITLE
[vnet] clean up osconfig on startup

### DIFF
--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -130,11 +130,9 @@ func (c *osConfigurator) updateOSConfiguration(ctx context.Context) error {
 	return trace.Wrap(err, "configuring OS")
 }
 
-func (c *osConfigurator) deconfigureOS() error {
+func (c *osConfigurator) deconfigureOS(ctx context.Context) error {
 	// configureOS is meant to be called with an empty config to deconfigure anything necessary.
-	// Pass context.Background() because we are likely deconfiguring because we received a signal to terminate
-	// and all contexts have been canceled.
-	return trace.Wrap(configureOS(context.Background(), &osConfig{}))
+	return trace.Wrap(configureOS(ctx, &osConfig{}))
 }
 
 func (c *osConfigurator) setTunIPv4FromCIDR(cidrRange string) error {


### PR DESCRIPTION
This PR cleans up any stale vnet OS configuration (particularly /etc/resolver DNS configuration files) on startup. the VNet admin process may fail to clean these up if it was killed with SIGKILL or e.g. the laptop was hard shutdown/rebooted. It's necessary to clean them up because the admin process also needs to be able to reach the proxy address in order to read the cluster `vnet_config`, and since VNet is not running yet, DNS resolution will time out.