### PR TITLE
docs: include tcp uri format in app access ref

### DIFF
--- a/docs/pages/includes/config-reference/app-service.yaml
+++ b/docs/pages/includes/config-reference/app-service.yaml
@@ -22,7 +22,8 @@ app_service:
       # Optional: For access to cloud provider APIs, specify the cloud
       # provider. Allowed values are "AWS", "Azure", and "GCP".
       cloud: ""
-      # URI and Port of Application.
+      # URI and Port of Application. For TCP applications
+      # use tcp, ex: tcp://localhost:5432.
       uri: "http://10.0.1.27:8000"
       # Optionally skip TLS verification. default false
       # insecure_skip_verify: true

--- a/docs/pages/includes/config-reference/app-service.yaml
+++ b/docs/pages/includes/config-reference/app-service.yaml
@@ -22,7 +22,7 @@ app_service:
       # Optional: For access to cloud provider APIs, specify the cloud
       # provider. Allowed values are "AWS", "Azure", and "GCP".
       cloud: ""
-      # URI and Port of Application. For TCP applications
+      # URI of Application. For TCP applications
       # use tcp, ex: tcp://localhost:5432.
       uri: "http://10.0.1.27:8000"
       # Optionally skip TLS verification. default false


### PR DESCRIPTION
A TCP example wasn't included.