### PR TITLE
docs: correct traits reference in login rules

### DIFF
--- a/docs/pages/includes/login-rule-spec.mdx
+++ b/docs/pages/includes/login-rule-spec.mdx
@@ -37,7 +37,7 @@ spec:
   #
   # Exactly one of traits_map or traits_expression must be set.
   traits_map:
-    logins:
+    groups:
       - external.groups
     logins:
       - strings.lower(external.username)


### PR DESCRIPTION
This should have been `groups`, not `logins`.