### PR TITLE
fix: cleanup routine when semaphore lease is lost

### DIFF
--- a/lib/srv/discovery/access_graph_test.go
+++ b/lib/srv/discovery/access_graph_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
-	var testErr = "test error"
+	testErr := "test error"
 	clock := clockwork.NewFakeClock()
 	type args struct {
 		fetchers []aws_sync.AWSSync


### PR DESCRIPTION
This PR fixes an edge case where the semaphore lock can be lost due to a backend error and the routine can continue running.