### PR TITLE
docs: remove sudo usage in troubleshooting

### DIFF
--- a/docs/pages/machine-id/troubleshooting.mdx
+++ b/docs/pages/machine-id/troubleshooting.mdx
@@ -135,8 +135,8 @@ server-side data and issues a new joining token.
 Remove and recreate the bot, replacing the name and role list as desired:
 
 ```code
-$ sudo tctl bots rm example
-$ sudo tctl bots add example --roles=access
+$ tctl bots rm example
+$ tctl bots add example --roles=access
 ```
 
 Copy the resulting join token into the existing bot config—either the


### PR DESCRIPTION
`sudo` should be avoided unless required for examples.  