### PR TITLE
tweak the node-agent loadtest chart

### DIFF
--- a/assets/loadtest/helm/node-agent/templates/config.yaml
+++ b/assets/loadtest/helm/node-agent/templates/config.yaml
@@ -9,8 +9,8 @@ data:
     teleport:
       log:
         severity: DEBUG
-      storage:
-        type: dir
+        format:
+          output: json
       {{- if .Values.authServer }}
       auth_server: {{ .Values.authServer }}
       {{- end }}
@@ -24,20 +24,15 @@ data:
       enabled: false
     ssh_service:
       enabled: true
-      {{ if .Values.labels }}
-      labels: {{- toYaml .Values.labels | nindent 8 }}
-      {{- end }}
-      commands:
-        - name: fullname
-          command: ['sh', '-c', 'echo "$HOSTNAME-$REPLICA"']
-      # listen_addr set at runtime to avoid conflicts in the same pod
-      # listen_addr: 0.0.0.0:3022
+      labels:{{- if .Values.labels }}{{- toYaml .Values.labels | nindent 8 }}{{- end }}
   entrypoint.sh: |2
     #!/busybox/sh
     set -euxo pipefail
     sed -i 's!/sbin/nologin!/busybox/sh!' /etc/passwd
     cp /etc/teleport-config/teleport.yaml /etc/teleport.yaml
+    nodename="$( hostname )-$REPLICA"
+    echo "    NODENAME: ${nodename}" >> /etc/teleport.yaml
+    echo "    POD: $( hostname )" >> /etc/teleport.yaml
     echo "  listen_addr: '0.0.0.0:30$REPLICA'" >> /etc/teleport.yaml
-    HOST="$(hostname)-$REPLICA"
     cat /etc/teleport.yaml
-    exec dumb-init --rewrite 15:3 -- teleport start -c /etc/teleport.yaml --nodename $HOST
+    exec dumb-init --rewrite 15:3 -- teleport start --nodename "${nodename}"


### PR DESCRIPTION
This PR adds `POD` and `NODENAME` labels - containing the name of the pod running the agent and the nodename of the specific agent (the pod name plus a numerical suffix), respectively - to each agent in the node-agent loadtest chart, in addition to the ones configured in the chart values, to help test label filtering.

This also gets rid of the command label (which updates every second (!)) and sets the log format to json.