### PR TITLE
Remove Node mentions from architecture guides

### DIFF
--- a/docs/pages/architecture/authentication.mdx
+++ b/docs/pages/architecture/authentication.mdx
@@ -141,8 +141,8 @@ services and rotates SSH and X.509 certificates.
 
 ### Internal certificates
 
-Teleport internal services - Auth, Proxy and Nodes use certificates to identify themselves
-within a cluster. To join proxies and nodes to the cluster and receive certificates, admins should use
+Teleport internal services - the Auth Service, Proxy Service, Agents, and Machine ID Bots - use certificates to identify themselves
+within a cluster. To join services to the cluster and receive certificates, admins should use
 [short-lived tokens or cloud identity services](../agents/join-services-to-your-cluster/join-token.mdx).
 
 Unlike users and services, internal services receive long-lived certificates.
@@ -163,5 +163,5 @@ cluster certificates, use node [session and identity locking](../access-controls
 
 - [Architecture Overview](../core-concepts.mdx)
 - [Authorization](authorization.mdx)
-- [Teleport Nodes](agents.mdx)
+- [Teleport Agents](agents.mdx)
 - [Teleport Proxy](proxy.mdx)

--- a/docs/pages/architecture/authorization.mdx
+++ b/docs/pages/architecture/authorization.mdx
@@ -397,6 +397,6 @@ spec:
 - [Access Requests Guides](../access-controls/access-requests.mdx)
 - [Architecture Overview](../core-concepts.mdx)
 - [Teleport Auth](authentication.mdx)
-- [Teleport Nodes](agents.mdx)
+- [Teleport Agents](agents.mdx)
 - [Teleport Proxy](proxy.mdx)
 

--- a/docs/pages/architecture/introduction.mdx
+++ b/docs/pages/architecture/introduction.mdx
@@ -13,7 +13,6 @@ works.
 - [Teleport Agents](./agents.mdx)
 - [The Teleport Proxy Service](./proxy.mdx)
 - [Trusted Clusters](./trustedclusters.mdx)
-- [Teleport Nodes](./agents.mdx)
 - [Session Recording](./session-recording.mdx)
 - [TLS Routing](./tls-routing.mdx)
 - [Proxy Peering](./proxy-peering.mdx)

--- a/docs/pages/architecture/session-recording.mdx
+++ b/docs/pages/architecture/session-recording.mdx
@@ -123,7 +123,7 @@ Auth Service.
 ### Synchronous recording
 
 When synchronous recording is enabled, the Teleport component doing the recording
-(which may be the Node or the Proxy Service instance depending on your configuration)
+(which may be the Teleport SSH Service or the Proxy Service instance depending on your configuration)
 submits each recording event to Teleport's Auth Server as it occurs. In this mode,
 failure to emit a recording event is considered fatal - the session will be terminated
 if an event cannot be recorded. This makes synchronous recording best suited for highly
@@ -135,8 +135,9 @@ or terminated due to temporary connection loss.
 In synchronous recording modes, the Auth Server receives a stream of recording
 events and is responsible for assembling them into the final artifact and uploading
 it to the storage backend. Since data is streamed directly to the Auth Server,
-Teleport administrators don't need to be concerned with disk space on their Nodes
-and Proxy Service instances, as no recording data is written to those disks.
+Teleport administrators don't need to be concerned with disk space on their
+Teleport SSH Service and Proxy Service instances, as no recording data is
+written to those disks.
 
 ### Asynchronous recording
 

--- a/docs/pages/architecture/trustedclusters.mdx
+++ b/docs/pages/architecture/trustedclusters.mdx
@@ -10,7 +10,7 @@ is a group of Teleport connected resources. Each cluster
 manages a set of certificate authorities (CAs) for its users and resources.
 
 Trusted Clusters allow the users of one cluster, the **root cluster**, to
-seamlessly SSH into the Nodes of another cluster, the **leaf cluster**, while
+access resources registered with another cluster, the **leaf cluster**, while
 remaining authenticated with only a single Auth Service. The leaf cluster can
 be running behind a firewall without any ingress ports open.
 


### PR DESCRIPTION
Closes #13364

Update mentions of Teleport Nodes, which are outdated, to reflect our new terminology.