### PR TITLE
Edit DynamoDB link in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,7 @@ in the SSH Web Terminal and Audit Monitoring.
 #### DynamoDB permission requirements have changed
 
 Teleport clusters using the dynamodb backend must now have the `dynamodb:ConditionCheckItem`
-permission. For a full list of all required permissions see the dynamo backend iam
-policy [example](docs/pages/includes/dynamodb-iam-policy.mdx).
+permission. For a full list of all required permissions see the Teleport [Backend Reference](docs/pages/reference/backends.mdx#dynamodb).
 
 #### Disabling second factor authentication_type
 


### PR DESCRIPTION
Linking to a partial won't work in the docs engine we are migrating to. Instead, link to the sectionof a page that includes the partial.