### PR TITLE
Fix file uploads/downloads when user doesn't have a home directory

### DIFF
--- a/lib/srv/usermgmt_linux.go
+++ b/lib/srv/usermgmt_linux.go
@@ -92,12 +92,8 @@ func (*HostUsersProvisioningBackend) CreateGroup(name string, gid string) error 
 }
 
 // CreateUser creates a user on a host
-func (*HostUsersProvisioningBackend) CreateUser(name string, groups []string, uid, gid string) error {
-	home, err := readDefaultHome(name)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = host.UserAdd(name, groups, home, uid, gid)
+func (*HostUsersProvisioningBackend) CreateUser(name string, groups []string, home, uid, gid string) error {
+	_, err := host.UserAdd(name, groups, home, uid, gid)
 	return trace.Wrap(err)
 }
 
@@ -214,17 +210,12 @@ func readDefaultSkel() (string, error) {
 	return skel, trace.Wrap(err)
 }
 
-func (u *HostUsersProvisioningBackend) CreateHomeDirectory(user string, uidS, gidS string) error {
+func (u *HostUsersProvisioningBackend) CreateHomeDirectory(userHome, uidS, gidS string) error {
 	uid, err := strconv.Atoi(uidS)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	gid, err := strconv.Atoi(gidS)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	userHome, err := readDefaultHome(user)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/usermgmt_other.go
+++ b/lib/srv/usermgmt_other.go
@@ -34,3 +34,7 @@ func newHostUsersBackend() (HostUsersBackend, error) {
 func newHostSudoersBackend(_ string) (HostSudoersBackend, error) {
 	return nil, trace.NotImplemented("Host user creation management is only supported on linux")
 }
+
+func readDefaultHome(user string) (string, error) {
+	return "", trace.NotImplemented("readDefaultHome is only supported on linux")
+}

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -106,7 +106,7 @@ func (tm *testHostUserBackend) CreateGroup(group, gid string) error {
 	return nil
 }
 
-func (tm *testHostUserBackend) CreateUser(user string, groups []string, uid, gid string) error {
+func (tm *testHostUserBackend) CreateUser(user string, groups []string, home, uid, gid string) error {
 	_, ok := tm.users[user]
 	if ok {
 		return trace.AlreadyExists("Group %q, already exists", user)
@@ -194,7 +194,7 @@ func TestUserMgmt_CreateTemporaryUser(t *testing.T) {
 	require.NotContains(t, backend.users, "bob")
 
 	backend.CreateGroup("testgroup", "")
-	backend.CreateUser("simon", []string{}, "", "")
+	backend.CreateUser("simon", []string{}, "", "", "")
 
 	// try to create a temporary user for simon
 	closer, err = users.CreateUser("simon", userinfo)
@@ -240,7 +240,7 @@ func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 		}
 		// test user already exists but teleport-service group has not yet
 		// been created
-		backend.CreateUser("testuser", nil, "", "")
+		backend.CreateUser("testuser", nil, "", "", "")
 		_, err := users.CreateUser("testuser", &services.HostUsersInfo{
 			Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
 		})
@@ -288,7 +288,7 @@ func TestUserMgmt_DeleteAllTeleportSystemUsers(t *testing.T) {
 		if slices.Contains(user.groups, types.TeleportServiceGroup) {
 			users.CreateUser(user.user, &services.HostUsersInfo{Groups: user.groups})
 		} else {
-			mgmt.CreateUser(user.user, user.groups, "", "")
+			mgmt.CreateUser(user.user, user.groups, "", "", "")
 		}
 	}
 	require.NoError(t, users.DeleteAllUsers())

--- a/lib/utils/host/hostusers.go
+++ b/lib/utils/host/hostusers.go
@@ -21,7 +21,9 @@ package host
 import (
 	"bytes"
 	"errors"
+	"os"
 	"os/exec"
+	"os/user"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -65,7 +67,8 @@ func UserAdd(username string, groups []string, home, uid, gid string) (exitCode 
 	}
 
 	if home == "" {
-		return -1, trace.BadParameter("home is a required parameter")
+		// Users without a home directory should land at the root, to match OpenSSH behavior.
+		home = string(os.PathSeparator)
 	}
 
 	// useradd ---no-create-home (username) (groups)...
@@ -111,8 +114,18 @@ func UserDel(username string) (exitCode int, err error) {
 	if err != nil {
 		return -1, trace.Wrap(err, "cant find userdel binary")
 	}
+	u, err := user.Lookup(username)
+	if err != nil {
+		return -1, trace.Wrap(err)
+	}
+	args := make([]string, 0, 2)
+	// Only remove the home dir if it exists and isn't the root.
+	if u.HomeDir != "" && u.HomeDir != string(os.PathSeparator) {
+		args = append(args, "--remove")
+	}
+	args = append(args, username)
 	// userdel --remove (remove home) username
-	cmd := exec.Command(userdelBin, "--remove", username)
+	cmd := exec.Command(userdelBin, args...)
 	output, err := cmd.CombinedOutput()
 	log.Debugf("%s output: %s", cmd.Path, string(output))
 	return cmd.ProcessState.ExitCode(), trace.Wrap(err)


### PR DESCRIPTION
This change fixes a bug where file uploads/downloads in the web UI would fail if the local user (provisioned by Teleport in `insecure-drop` mode) didn't have a home directory.

Fixes #41417.

Changelog: Fixed file upload/download for Teleport-created users in `insecure-drop` mode