### PR TITLE
build: Bump buildbox version for master to teleport17

### DIFF
--- a/build.assets/images.mk
+++ b/build.assets/images.mk
@@ -5,7 +5,7 @@ DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(DIR)arch.mk
 endif
 
-BUILDBOX_VERSION ?= teleport16
+BUILDBOX_VERSION ?= teleport17
 BUILDBOX_BASE_NAME ?= ghcr.io/gravitational/teleport-buildbox
 
 BUILDBOX = $(BUILDBOX_BASE_NAME):$(BUILDBOX_VERSION)


### PR DESCRIPTION
Now that branch/v16 has been cut, master should use `teleport17` as the
buildbox version.