### PR TITLE
reenable redshift serverless e2e test

### DIFF
--- a/e2e/aws/redshift_test.go
+++ b/e2e/aws/redshift_test.go
@@ -37,7 +37,6 @@ import (
 )
 
 func testRedshiftServerless(t *testing.T) {
-	t.Skip("skipped until we fix the spacelift stack")
 	t.Parallel()
 	accessRole := mustGetEnv(t, rssAccessRoleARNEnv)
 	discoveryRole := mustGetEnv(t, rssDiscoveryRoleARNEnv)


### PR DESCRIPTION
This PR re-enables the skipped redshift serverless e2e test.

for context: The spacelift stack broke weeks ago during the weekly `terraform destroy; terraform apply`. We have since enabled stack task approvers for fixing that quickly, and it hasn't happened since. If it happens again I will at least be able to go into the CI account to poke around and see why, and then unblock CI by retrying the task.

Not backporting this just yet though - I'd like to see if the recreate failure comes back after re-enabling this first