### PR TITLE
add `services.AcquireSemaphoreLockWithRetry`

### DIFF
--- a/lib/services/semaphore.go
+++ b/lib/services/semaphore.go
@@ -81,6 +81,10 @@ func (l *SemaphoreLockConfig) CheckAndSetDefaults() error {
 // SemaphoreLock provides a convenient interface for managing
 // semaphore lease keepalive operations.
 type SemaphoreLock struct {
+	// ctx is the parent context for the lease keepalive operation.
+	// it's used to propagate deadline cancellations from the parent
+	// context and to carry values for the context interface.
+	ctx       context.Context
 	cfg       SemaphoreLockConfig
 	lease0    types.SemaphoreLease
 	retry     retryutils.Retry
@@ -107,8 +111,27 @@ func (l *SemaphoreLock) finish(err error) {
 
 // Done signals that lease keepalive operations
 // have stopped.
+// If the parent context is canceled, the lease
+// will be released and done will be closed.
 func (l *SemaphoreLock) Done() <-chan struct{} {
 	return l.doneC
+}
+
+// Deadline returns the deadline of the parent context if it exists.
+func (l *SemaphoreLock) Deadline() (time.Time, bool) {
+	return l.ctx.Deadline()
+}
+
+// Value returns the value associated with the key in the parent context.
+func (l *SemaphoreLock) Value(key interface{}) interface{} {
+	return l.ctx.Value(key)
+}
+
+// Error returns the final error value.
+func (l *SemaphoreLock) Err() error {
+	l.cond.L.Lock()
+	defer l.cond.L.Unlock()
+	return l.err
 }
 
 // Wait blocks until the final result is available.  Note that
@@ -268,6 +291,7 @@ func AcquireSemaphoreLock(ctx context.Context, cfg SemaphoreLockConfig) (*Semaph
 		return nil, trace.Wrap(err)
 	}
 	lock := &SemaphoreLock{
+		ctx:      ctx,
 		cfg:      cfg,
 		lease0:   *lease,
 		retry:    retry,

--- a/lib/services/semaphore.go
+++ b/lib/services/semaphore.go
@@ -312,7 +312,7 @@ type SemaphoreLockConfigWithRetry struct {
 	Retry retryutils.LinearConfig
 }
 
-// AcquireSemaphoreLock attempts to acquire and hold a semaphore lease. If successfully acquired,
+// AcquireSemaphoreLockWithRetry attempts to acquire and hold a semaphore lease. If successfully acquired,
 // background keepalive processes are started and an associated lock handle is returned.
 // If the lease cannot be acquired, the operation is retried according to the retry schedule until
 // it succeeds or the context expires.  Canceling the supplied context releases the semaphore.

--- a/lib/services/semaphore.go
+++ b/lib/services/semaphore.go
@@ -304,6 +304,34 @@ func AcquireSemaphoreLock(ctx context.Context, cfg SemaphoreLockConfig) (*Semaph
 	return lock, nil
 }
 
+// SemaphoreLockConfigWithRetry contains parameters for acquiring a semaphore lock
+// until it succeeds or context expires.
+type SemaphoreLockConfigWithRetry struct {
+	SemaphoreLockConfig
+	// Retry is the retry configuration.
+	Retry retryutils.LinearConfig
+}
+
+// AcquireSemaphoreLock attempts to acquire and hold a semaphore lease. If successfully acquired,
+// background keepalive processes are started and an associated lock handle is returned.
+// If the lease cannot be acquired, the operation is retried according to the retry schedule until
+// it succeeds or the context expires.  Canceling the supplied context releases the semaphore.
+func AcquireSemaphoreLockWithRetry(ctx context.Context, cfg SemaphoreLockConfigWithRetry) (*SemaphoreLock, error) {
+	retry, err := retryutils.NewLinear(cfg.Retry)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var lease *SemaphoreLock
+	err = retry.For(ctx, func() (err error) {
+		lease, err = AcquireSemaphoreLock(ctx, cfg.SemaphoreLockConfig)
+		return trace.Wrap(err)
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return lease, nil
+}
+
 // UnmarshalSemaphore unmarshals the Semaphore resource from JSON.
 func UnmarshalSemaphore(bytes []byte, opts ...MarshalOption) (types.Semaphore, error) {
 	var semaphore types.SemaphoreV3


### PR DESCRIPTION
This PR introduces `services.AcquireSemaphoreLockWithRetry` function that only returns if it sucessfully acquired the lock or if the parent context is cancelled. This function will retry until it sucessfully acquires the lock before returning.