### PR TITLE
provide users context error on secret retrieval attempt

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2740,7 +2740,7 @@ func (a *ServerWithRoles) GetUsers(ctx context.Context, withSecrets bool) ([]typ
 			}); err != nil {
 				log.WithError(err).Warn("Failed to emit local login failure event.")
 			}
-			return nil, trace.AccessDenied("this request can be only executed by an admin")
+			return nil, trace.AccessDenied("User secret information is not available from remote access")
 		}
 	} else {
 		if err := a.action(apidefaults.Namespace, types.KindUser, types.VerbList, types.VerbRead); err != nil {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2740,7 +2740,7 @@ func (a *ServerWithRoles) GetUsers(ctx context.Context, withSecrets bool) ([]typ
 			}); err != nil {
 				log.WithError(err).Warn("Failed to emit local login failure event.")
 			}
-			return nil, trace.AccessDenied("User secret information requires admin rights and is not available from remote access")
+			return nil, trace.AccessDenied("reading User secrets requires admin rights and is not available from remote access")
 		}
 	} else {
 		if err := a.action(apidefaults.Namespace, types.KindUser, types.VerbList, types.VerbRead); err != nil {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2740,7 +2740,7 @@ func (a *ServerWithRoles) GetUsers(ctx context.Context, withSecrets bool) ([]typ
 			}); err != nil {
 				log.WithError(err).Warn("Failed to emit local login failure event.")
 			}
-			return nil, trace.AccessDenied("User secret information is not available from remote access")
+			return nil, trace.AccessDenied("User secret information requires admin rights and is not available from remote access")
 		}
 	} else {
 		if err := a.action(apidefaults.Namespace, types.KindUser, types.VerbList, types.VerbRead); err != nil {

--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -186,7 +186,7 @@ func (s *Service) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*us
 			}); err != nil {
 				s.logger.WithError(err).Warn("Failed to emit local login failure event.")
 			}
-			return nil, trace.AccessDenied("User secret information is not available from remote access")
+			return nil, trace.AccessDenied("User secret information requires admin access and is not available from remote access")
 		}
 	} else {
 		// if secrets are not being accessed, let users always read
@@ -554,7 +554,7 @@ func (s *Service) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) 
 			}); err != nil {
 				s.logger.WithError(err).Warn("Failed to emit local login failure event.")
 			}
-			return nil, trace.AccessDenied("User secret information is not available from remote acces")
+			return nil, trace.AccessDenied("User secret information requires admin access and is not available from remote acces")
 		}
 	} else {
 		if err := authCtx.CheckAccessToKind(types.KindUser, types.VerbList, types.VerbRead); err != nil {

--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -186,7 +186,7 @@ func (s *Service) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*us
 			}); err != nil {
 				s.logger.WithError(err).Warn("Failed to emit local login failure event.")
 			}
-			return nil, trace.AccessDenied("User secret information requires admin access and is not available from remote access")
+			return nil, trace.AccessDenied("reading User secrets requires admin access and is not available from remote access")
 		}
 	} else {
 		// if secrets are not being accessed, let users always read
@@ -554,7 +554,7 @@ func (s *Service) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) 
 			}); err != nil {
 				s.logger.WithError(err).Warn("Failed to emit local login failure event.")
 			}
-			return nil, trace.AccessDenied("User secret information requires admin access and is not available from remote acces")
+			return nil, trace.AccessDenied("reading User secrets requires admin access and is not available from remote access")
 		}
 	} else {
 		if err := authCtx.CheckAccessToKind(types.KindUser, types.VerbList, types.VerbRead); err != nil {

--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -186,7 +186,7 @@ func (s *Service) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*us
 			}); err != nil {
 				s.logger.WithError(err).Warn("Failed to emit local login failure event.")
 			}
-			return nil, trace.AccessDenied("this request can be only executed by an admin")
+			return nil, trace.AccessDenied("User secret information is not available from remote access")
 		}
 	} else {
 		// if secrets are not being accessed, let users always read
@@ -554,7 +554,7 @@ func (s *Service) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) 
 			}); err != nil {
 				s.logger.WithError(err).Warn("Failed to emit local login failure event.")
 			}
-			return nil, trace.AccessDenied("this request can be only executed by an admin")
+			return nil, trace.AccessDenied("User secret information is not available from remote acces")
 		}
 	} else {
 		if err := authCtx.CheckAccessToKind(types.KindUser, types.VerbList, types.VerbRead); err != nil {


### PR DESCRIPTION
If a user attempts a `tctl get all` remotely they get a very generic error `this request can be only executed by an admin`.  You would not know this is an error related to user retrieval. 

This provides a more specific error to give this is due to attempting user secret information remotely. 