### PR TITLE
Extract more information from `/etc/os-release`

### DIFF
--- a/lib/linux/os_release.go
+++ b/lib/linux/os_release.go
@@ -29,11 +29,13 @@ import (
 
 // OSRelease represents the information contained in the /etc/os-release file.
 type OSRelease struct {
-	PrettyName string
-	Name       string
-	VersionID  string
-	Version    string
-	ID         string
+	PrettyName      string
+	Name            string
+	VersionID       string
+	Version         string
+	VersionCodename string
+	ID              string
+	IDLike          string
 }
 
 // ParseOSRelease reads the /etc/os-release contents.
@@ -54,13 +56,24 @@ func ParseOSReleaseFromReader(in io.Reader) (*OSRelease, error) {
 	scan := bufio.NewScanner(in)
 	for scan.Scan() {
 		line := scan.Text()
-		vals := strings.Split(line, "=")
-		if len(vals) != 2 {
-			continue // Skip unexpected line
+
+		line = strings.TrimSpace(line) // Remove spaces from start and end.
+
+		if len(line) == 0 {
+			continue // Skip empty lines.
 		}
 
-		key := vals[0]
-		val := strings.Trim(vals[1], `"'`)
+		if line[0] == '#' {
+			continue // Skip comments.
+		}
+
+		vals := strings.Split(line, "=")
+		if len(vals) != 2 {
+			continue // Skip unexpected line.
+		}
+
+		key := strings.TrimSpace(vals[0])
+		val := strings.Trim(vals[1], `"' `)
 		m[key] = val
 	}
 	if err := scan.Err(); err != nil {
@@ -68,10 +81,12 @@ func ParseOSReleaseFromReader(in io.Reader) (*OSRelease, error) {
 	}
 
 	return &OSRelease{
-		PrettyName: m["PRETTY_NAME"],
-		Name:       m["NAME"],
-		VersionID:  m["VERSION_ID"],
-		Version:    m["VERSION"],
-		ID:         m["ID"],
+		PrettyName:      m["PRETTY_NAME"],
+		Name:            m["NAME"],
+		VersionID:       m["VERSION_ID"],
+		Version:         m["VERSION"],
+		VersionCodename: m["VERSION_CODENAME"],
+		ID:              m["ID"],
+		IDLike:          m["ID_LIKE"],
 	}, nil
 }

--- a/lib/linux/os_release_test.go
+++ b/lib/linux/os_release_test.go
@@ -51,11 +51,13 @@ PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-poli
 UBUNTU_CODENAME=jammy
 `),
 			want: &linux.OSRelease{
-				PrettyName: "Ubuntu 22.04.3 LTS",
-				Name:       "Ubuntu",
-				VersionID:  "22.04",
-				Version:    "22.04.3 LTS (Jammy Jellyfish)",
-				ID:         "ubuntu",
+				PrettyName:      "Ubuntu 22.04.3 LTS",
+				Name:            "Ubuntu",
+				VersionID:       "22.04",
+				Version:         "22.04.3 LTS (Jammy Jellyfish)",
+				ID:              "ubuntu",
+				VersionCodename: "jammy",
+				IDLike:          "debian",
 			},
 		},
 		{
@@ -68,6 +70,8 @@ ID=fake
 not supposed to be here either
 
 a=b=c
+
+# a comment
 
 VERSION=1.0
 `),


### PR DESCRIPTION
We will create a new package that installs teleport in the local system. In order to do so, we'll need to read `/etc/os-release`. This PR adds the required fields for detecting the distro if it is based on a popuplar distro.