### PR TITLE
Allow arguments for the oneoff script

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -38,7 +38,7 @@ const (
 
 	// PackageNameOSS is the teleport package name for the OSS version.
 	PackageNameOSS = "teleport"
-	// PackageNameOSS is the teleport package name for the Enterprise version.
+	// PackageNameEnt is the teleport package name for the Enterprise version.
 	PackageNameEnt = "teleport-ent"
 
 	// ActionRead grants read access (get, list)
@@ -545,6 +545,9 @@ const (
 	V1 = "v1"
 )
 
+// PackageNameKinds is the list of valid teleport package names.
+var PackageNameKinds = []string{PackageNameOSS, PackageNameEnt}
+
 // WebSessionSubKinds lists subkinds of web session resources
 var WebSessionSubKinds = []string{KindAppSession, KindWebSession, KindSnowflakeSession, KindSAMLIdPSession}
 
@@ -667,7 +670,7 @@ const (
 	// id found via automatic discovery, to avoid re-running
 	// installation commands on the node.
 	ProjectIDLabel = TeleportInternalLabelPrefix + "project-id"
-	// ZoneLabek is used to identify virtual machines by GCP zone
+	// ZoneLabel is used to identify virtual machines by GCP zone
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.
 	ZoneLabel = TeleportInternalLabelPrefix + "zone"

--- a/lib/web/scripts/oneoff/oneoff.go
+++ b/lib/web/scripts/oneoff/oneoff.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/modules"
 )
@@ -82,8 +82,6 @@ type OneOffScriptParams struct {
 	SuccessMessage string
 }
 
-var validPackageNames = []string{types.PackageNameOSS, types.PackageNameEnt}
-
 // CheckAndSetDefaults checks if the required params ara present.
 func (p *OneOffScriptParams) CheckAndSetDefaults() error {
 	if p.TeleportArgs == "" {
@@ -103,7 +101,7 @@ func (p *OneOffScriptParams) CheckAndSetDefaults() error {
 	}
 
 	if p.TeleportVersion == "" {
-		p.TeleportVersion = "v" + teleport.Version
+		p.TeleportVersion = "v" + api.Version
 	}
 
 	if p.TeleportFlavor == "" {
@@ -112,8 +110,8 @@ func (p *OneOffScriptParams) CheckAndSetDefaults() error {
 			p.TeleportFlavor = types.PackageNameEnt
 		}
 	}
-	if !slices.Contains(validPackageNames, p.TeleportFlavor) {
-		return trace.BadParameter("invalid teleport flavor, only %v are supported", validPackageNames)
+	if !slices.Contains(types.PackageNameKinds, p.TeleportFlavor) {
+		return trace.BadParameter("invalid teleport flavor, only %v are supported", types.PackageNameKinds)
 	}
 
 	if p.SuccessMessage == "" {

--- a/lib/web/scripts/oneoff/oneoff.sh
+++ b/lib/web/scripts/oneoff/oneoff.sh
@@ -45,10 +45,10 @@ main() {
 
     mkdir -p ./bin
     mv ./${teleportFlavor}/teleport ./bin/teleport
-    echo "> ./bin/teleport ${teleportArgs}"
-    ./bin/teleport ${teleportArgs} && echo $successMessage
+    echo "> ./bin/teleport ${teleportArgs} $@"
+    ./bin/teleport ${teleportArgs} $@ && echo $successMessage
 
     cd -
 }
 
-main
+main $@

--- a/lib/web/scripts/oneoff/oneoff_test.go
+++ b/lib/web/scripts/oneoff/oneoff_test.go
@@ -117,6 +117,61 @@ func TestOneOffScript(t *testing.T) {
 		require.Contains(t, string(out), "Test was a success.")
 	})
 
+	t.Run("command can be executed with extra arguments", func(t *testing.T) {
+		teleportHelpStart := "Use teleport start --config teleport.yaml"
+		// set up
+		testWorkingDir := t.TempDir()
+		require.NoError(t, os.Mkdir(testWorkingDir+"/bin/", 0o755))
+		scriptLocation := testWorkingDir + "/" + scriptName
+
+		teleportMock, err := bintest.NewMock(testWorkingDir + "/bin/teleport")
+		require.NoError(t, err)
+		defer func() {
+			assert.NoError(t, teleportMock.Close())
+		}()
+
+		teleportBinTarball, err := utils.CompressTarGzArchive([]string{"teleport/teleport"}, singleFileFS{file: teleportMock.Path})
+		require.NoError(t, err)
+
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, "/teleport-v13.1.0-linux-amd64-bin.tar.gz", req.URL.Path)
+			http.ServeContent(w, req, "teleport-v13.1.0-linux-amd64-bin.tar.gz", time.Now(), bytes.NewReader(teleportBinTarball.Bytes()))
+		}))
+		defer func() { testServer.Close() }()
+
+		script, err := BuildScript(OneOffScriptParams{
+			BinUname:        unameMock.Path,
+			BinMktemp:       mktempMock.Path,
+			CDNBaseURL:      testServer.URL,
+			TeleportArgs:    "help",
+			TeleportVersion: "v13.1.0",
+			SuccessMessage:  "Test was a success.",
+		})
+		require.NoError(t, err)
+
+		unameMock.Expect("-s").AndWriteToStdout("Linux")
+		unameMock.Expect("-m").AndWriteToStdout("x86_64")
+		mktempMock.Expect("-d").AndWriteToStdout(testWorkingDir)
+		teleportMock.Expect("help", "start").AndWriteToStdout(teleportHelpStart)
+
+		err = os.WriteFile(scriptLocation, []byte(script), 0700)
+		require.NoError(t, err)
+
+		// execute script
+		out, err := exec.Command("bash", scriptLocation, "start").CombinedOutput()
+
+		// validate
+		require.NoError(t, err, string(out))
+
+		require.True(t, unameMock.Check(t))
+		require.True(t, mktempMock.Check(t))
+		require.True(t, teleportMock.Check(t))
+
+		require.Contains(t, string(out), "> ./bin/teleport help start")
+		require.Contains(t, string(out), teleportHelpStart)
+		require.Contains(t, string(out), "Test was a success.")
+	})
+
 	t.Run("invalid OS", func(t *testing.T) {
 		// set up
 		testWorkingDir := t.TempDir()


### PR DESCRIPTION
The oneoff script downloads teleport and runs a teleport command. In order to use the oneoff script for Server Auto Discover we must allow it to receive a token as an argument.
You can see how the script is meant to be executed:
https://github.com/gravitational/teleport/blob/737cbdd0c4b74fe1d4775fbe2e09b4571a806a46/lib/cloud/aws/ssm_documents.go#L56