### PR TITLE
[v16] transform `services.SemaphoreLock` to satisfy `context.Context`

### DIFF
--- a/lib/services/semaphore.go
+++ b/lib/services/semaphore.go
@@ -81,6 +81,10 @@ func (l *SemaphoreLockConfig) CheckAndSetDefaults() error {
 // SemaphoreLock provides a convenient interface for managing
 // semaphore lease keepalive operations.
 type SemaphoreLock struct {
+	// ctx is the parent context for the lease keepalive operation.
+	// it's used to propagate deadline cancellations from the parent
+	// context and to carry values for the context interface.
+	ctx       context.Context
 	cfg       SemaphoreLockConfig
 	lease0    types.SemaphoreLease
 	retry     retryutils.Retry
@@ -107,8 +111,27 @@ func (l *SemaphoreLock) finish(err error) {
 
 // Done signals that lease keepalive operations
 // have stopped.
+// If the parent context is canceled, the lease
+// will be released and done will be closed.
 func (l *SemaphoreLock) Done() <-chan struct{} {
 	return l.doneC
+}
+
+// Deadline returns the deadline of the parent context if it exists.
+func (l *SemaphoreLock) Deadline() (time.Time, bool) {
+	return l.ctx.Deadline()
+}
+
+// Value returns the value associated with the key in the parent context.
+func (l *SemaphoreLock) Value(key interface{}) interface{} {
+	return l.ctx.Value(key)
+}
+
+// Error returns the final error value.
+func (l *SemaphoreLock) Err() error {
+	l.cond.L.Lock()
+	defer l.cond.L.Unlock()
+	return l.err
 }
 
 // Wait blocks until the final result is available.  Note that
@@ -268,6 +291,7 @@ func AcquireSemaphoreLock(ctx context.Context, cfg SemaphoreLockConfig) (*Semaph
 		return nil, trace.Wrap(err)
 	}
 	lock := &SemaphoreLock{
+		ctx:      ctx,
 		cfg:      cfg,
 		lease0:   *lease,
 		retry:    retry,

--- a/lib/services/semaphore.go
+++ b/lib/services/semaphore.go
@@ -80,6 +80,25 @@ func (l *SemaphoreLockConfig) CheckAndSetDefaults() error {
 
 // SemaphoreLock provides a convenient interface for managing
 // semaphore lease keepalive operations.
+// SemaphoreLock implements the [context.Context] interface
+// and can be used to propagate cancellation when the parent
+// context is canceled or when the lease expires.
+//
+//		lease,err := AcquireSemaphoreLock(ctx, cfg)
+//		if err != nil {
+//			... handle error ...
+//		}
+//		defer func(){
+//			lease.Stop()
+//			err := lease.Wait()
+//			if err != nil {
+//				... handle error ...
+//			}
+//		}()
+//
+//	 newCtx,cancel := context.WithCancel(ctx)
+//	 defer cancel()
+//	 ... do work with newCtx ...
 type SemaphoreLock struct {
 	// ctx is the parent context for the lease keepalive operation.
 	// it's used to propagate deadline cancellations from the parent


### PR DESCRIPTION
Backport #42607 to branch/v16