### PR TITLE
Use `sh` in `oneoff` script

### DIFF
--- a/lib/web/scripts/oneoff/oneoff.sh
+++ b/lib/web/scripts/oneoff/oneoff.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
 cdnBaseURL='{{.CDNBaseURL}}'
 teleportVersion='{{.TeleportVersion}}'
@@ -14,29 +14,29 @@ ARCH=$({{.BinUname}} -m)
 
 teleportArgs='{{.TeleportArgs}}'
 
-function teleportTarballName(){
-    if [[ ${OS} == "Darwin" ]]; then
+teleportTarballName() {
+    if [ ${OS} = "Darwin" ]; then
         echo ${teleportFlavor}-${teleportVersion}-darwin-universal-bin.tar.gz
         return 0
     fi;
 
-    if [[ ${OS} != "Linux" ]]; then
+    if [ ${OS} != "Linux" ]; then
         echo "Only MacOS and Linux are supported." >&2
         return 1
     fi;
 
-    if [[ ${ARCH} == "armv7l" ]]; then echo "${teleportFlavor}-${teleportVersion}-linux-arm-bin.tar.gz"
-    elif [[ ${ARCH} == "aarch64" ]]; then echo "${teleportFlavor}-${teleportVersion}-linux-arm64-bin.tar.gz"
-    elif [[ ${ARCH} == "x86_64" ]]; then echo "${teleportFlavor}-${teleportVersion}-linux-amd64-bin.tar.gz"
-    elif [[ ${ARCH} == "i686" ]]; then echo "${teleportFlavor}-${teleportVersion}-linux-386-bin.tar.gz"
+    if [ ${ARCH} = "armv7l" ]; then echo "${teleportFlavor}-${teleportVersion}-linux-arm-bin.tar.gz"
+    elif [ ${ARCH} = "aarch64" ]; then echo "${teleportFlavor}-${teleportVersion}-linux-arm64-bin.tar.gz"
+    elif [ ${ARCH} = "x86_64" ]; then echo "${teleportFlavor}-${teleportVersion}-linux-amd64-bin.tar.gz"
+    elif [ ${ARCH} = "i686" ]; then echo "${teleportFlavor}-${teleportVersion}-linux-386-bin.tar.gz"
     else
         echo "Invalid Linux architecture ${ARCH}." >&2
         return 1
     fi;
 }
 
-function main() {
-    pushd $tempDir > /dev/null
+main() {
+    cd $tempDir
 
     tarballName=$(teleportTarballName)
     curl --show-error --fail --location --remote-name ${cdnBaseURL}/${tarballName}
@@ -48,7 +48,7 @@ function main() {
     echo "> ./bin/teleport ${teleportArgs}"
     ./bin/teleport ${teleportArgs} && echo $successMessage
 
-    popd > /dev/null    
+    cd -
 }
 
 main

--- a/lib/web/scripts/oneoff/oneoff_test.go
+++ b/lib/web/scripts/oneoff/oneoff_test.go
@@ -103,7 +103,7 @@ func TestOneOffScript(t *testing.T) {
 		require.NoError(t, err)
 
 		// execute script
-		out, err := exec.Command("bash", scriptLocation).CombinedOutput()
+		out, err := exec.Command("sh", scriptLocation).CombinedOutput()
 
 		// validate
 		require.NoError(t, err, string(out))
@@ -130,7 +130,7 @@ func TestOneOffScript(t *testing.T) {
 		require.NoError(t, err)
 
 		// execute script
-		out, err := exec.Command("bash", scriptLocation).CombinedOutput()
+		out, err := exec.Command("sh", scriptLocation).CombinedOutput()
 
 		// validate
 		require.Error(t, err, string(out))
@@ -150,7 +150,7 @@ func TestOneOffScript(t *testing.T) {
 		require.NoError(t, err)
 
 		// execute script
-		out, err := exec.Command("bash", scriptLocation).CombinedOutput()
+		out, err := exec.Command("sh", scriptLocation).CombinedOutput()
 
 		// validate
 		require.Error(t, err, string(out))
@@ -213,7 +213,7 @@ func TestOneOffScript(t *testing.T) {
 		require.NoError(t, err)
 
 		// execute script
-		out, err := exec.Command("bash", scriptLocation).CombinedOutput()
+		out, err := exec.Command("sh", scriptLocation).CombinedOutput()
 
 		// validate
 		require.NoError(t, err, string(out))


### PR DESCRIPTION
`oneoff` script intends to be as simple and compatible as possible.
Using `sh` allows us to be even more compatible, not only with more specific systems but also allows it to be used by the teleport discovery script.

Teleport discovery script uses `/bin/sh <my-script.sh>`
Some systems might be using bash as `/bin/sh`, but other ones, notably Ubuntu ones, use `dash`.
`dash` has less features than bash, so the `oneoff` script now only uses features that are present on both.
https://github.com/gravitational/teleport/blob/737cbdd0c4b74fe1d4775fbe2e09b4571a806a46/lib/cloud/aws/ssm_documents.go#L56