### PR TITLE
[v16] Add UI changes for kube exec functionality. (#41466)

### DIFF
--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -77,6 +77,7 @@ import (
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/modules"
@@ -1675,25 +1676,44 @@ func testKubeExecWeb(t *testing.T, suite *KubeSuite) {
 
 	// Login and run the tests.
 	webPack := helpers.LoginWebClient(t, proxyAddr.String(), testUser, userPassword)
-	endpoint, err := url.JoinPath("sites", "$site", "kube", kubeClusterName, "connect/ws") // :site/kube/:clusterName/connect/ws
-	require.NoError(t, err)
+	endpoint := "sites/$site/kube/exec/ws"
 
 	openWebsocketAndReadSession := func(t *testing.T, endpoint string, req web.PodExecRequest) *websocket.Conn {
-		ws, resp, err := webPack.OpenWebsocket(t, endpoint, req)
+		termSize := struct {
+			Term session.TerminalParams `json:"term"`
+		}{
+			Term: session.TerminalParams{W: req.Term.W, H: req.Term.H},
+		}
+		ws, resp, err := webPack.OpenWebsocket(t, endpoint, termSize)
 		require.NoError(t, err)
 		require.NoError(t, resp.Body.Close())
 
-		_, data, err := ws.ReadMessage()
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		reqEnvelope := &terminal.Envelope{
+			Version: defaults.WebsocketVersion,
+			Type:    defaults.WebsocketKubeExec,
+			Payload: string(data),
+		}
+
+		envelopeBytes, err := proto.Marshal(reqEnvelope)
+		require.NoError(t, err)
+
+		err = ws.WriteMessage(websocket.BinaryMessage, envelopeBytes)
+		require.NoError(t, err)
+
+		_, data, err = ws.ReadMessage()
 		require.NoError(t, err)
 		require.Equal(t, `{"type":"create_session_response","status":"ok"}`+"\n", string(data))
 
 		execSocket := executionWebsocketReader{ws}
 
 		// First message: session metadata
-		envelope, err := execSocket.Read()
+		sessionEnvelope, err := execSocket.Read()
 		require.NoError(t, err)
 		var sessionMetadata sessionMetadataResponse
-		require.NoError(t, json.Unmarshal([]byte(envelope.Payload), &sessionMetadata))
+		require.NoError(t, json.Unmarshal([]byte(sessionEnvelope.Payload), &sessionMetadata))
 
 		return ws
 	}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -723,6 +723,9 @@ const (
 
 	// WebsocketLatency provides latency information for a session.
 	WebsocketLatency = "l"
+
+	// WebsocketKubeExec provides latency information for a session.
+	WebsocketKubeExec = "k"
 )
 
 // The following are cryptographic primitives Teleport does not support in

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -40,6 +40,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	gogoproto "github.com/gogo/protobuf/proto"
 	"github.com/google/safetext/shsprintf"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -774,7 +775,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/connect/ws", h.WithClusterAuthWebSocket(h.siteNodeConnect))         // connect to an active session (via websocket, with auth over websocket)
 	h.GET("/webapi/sites/:site/sessions", h.WithClusterAuth(h.clusterActiveAndPendingSessionsGet)) // get list of active and pending sessions
 
-	h.GET("/webapi/sites/:site/kube/:clusterName/connect/ws", h.WithClusterAuthWebSocket(h.podConnect)) // connect to a pod with exec (via websocket, with auth over websocket)
+	h.GET("/webapi/sites/:site/kube/exec/ws", h.WithClusterAuthWebSocket(h.podConnect)) // connect to a pod with exec (via websocket, with auth over websocket)
 
 	// Audit events handlers.
 	h.GET("/webapi/sites/:site/events/search", h.WithClusterAuth(h.clusterSearchEvents))                 // search site events
@@ -3358,6 +3359,11 @@ func (h *Handler) siteNodeConnect(
 	return nil, nil
 }
 
+type podConnectParams struct {
+	// Term is the initial PTY size.
+	Term session.TerminalParams `json:"term"`
+}
+
 func (h *Handler) podConnect(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -3367,13 +3373,29 @@ func (h *Handler) podConnect(
 	ws *websocket.Conn,
 ) (interface{}, error) {
 	q := r.URL.Query()
-	params := q.Get("params")
-	if params == "" {
+	if q.Get("params") == "" {
 		return nil, trace.BadParameter("missing params")
 	}
+	var params podConnectParams
+	if err := json.Unmarshal([]byte(q.Get("params")), &params); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
-	var execReq PodExecRequest
-	if err := json.Unmarshal([]byte(params), &execReq); err != nil {
+	execReq, err := readPodExecRequestFromWS(ws)
+	if err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) || terminal.IsOKWebsocketCloseError(trace.Unwrap(err)) {
+			return nil, nil
+		}
+		var netError net.Error
+		if errors.As(trace.Unwrap(err), &netError) && netError.Timeout() {
+			return nil, trace.BadParameter("timed out waiting for pod exec request data on websocket connection")
+		}
+
+		return nil, trace.Wrap(err)
+	}
+	execReq.Term = params.Term
+
+	if err := execReq.Validate(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -3393,7 +3415,7 @@ func (h *Handler) podConnect(
 
 	sess := session.Session{
 		Kind:                  types.KubernetesSessionKind,
-		Login:                 sctx.GetUser(),
+		Login:                 "root",
 		ClusterName:           clusterName,
 		KubernetesClusterName: execReq.KubeCluster,
 		Moderated:             accessEvaluator.IsModerated(),
@@ -3402,6 +3424,7 @@ func (h *Handler) podConnect(
 		LastActive:            h.clock.Now().UTC(),
 		Namespace:             apidefaults.Namespace,
 		Owner:                 sctx.GetUser(),
+		Command:               execReq.Command,
 	}
 
 	h.log.Debugf("New kube exec request for namespace=%s pod=%s container=%s, sid=%s, websid=%s.",
@@ -3448,6 +3471,42 @@ func (h *Handler) podConnect(
 
 	ph.ServeHTTP(w, r)
 	return nil, nil
+}
+
+// KubeExecDataWaitTimeout is how long server would wait for user to send pod exec data (namespace, pod name etc)
+// on websocket connection, after user initiated the exec into pod flow.
+const KubeExecDataWaitTimeout = defaults.HeadlessLoginTimeout
+
+func readPodExecRequestFromWS(ws *websocket.Conn) (*PodExecRequest, error) {
+	err := ws.SetReadDeadline(time.Now().Add(KubeExecDataWaitTimeout))
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to set read deadline for websocket connection")
+	}
+
+	messageType, bytes, err := ws.ReadMessage()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := ws.SetReadDeadline(time.Time{}); err != nil {
+		return nil, trace.Wrap(err, "failed to set read deadline for websocket connection")
+	}
+
+	if messageType != websocket.BinaryMessage {
+		return nil, trace.BadParameter("Expected binary message of type websocket.BinaryMessage, got %v", messageType)
+	}
+
+	var envelope terminal.Envelope
+	if err := gogoproto.Unmarshal(bytes, &envelope); err != nil {
+		return nil, trace.BadParameter("Failed to parse envelope: %v", err)
+	}
+
+	var req PodExecRequest
+	if err := json.Unmarshal([]byte(envelope.Payload), &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &req, nil
 }
 
 func (h *Handler) getKubeExecClusterData(netConfig types.ClusterNetworkingConfig) (string, string, error) {

--- a/lib/web/terminal/terminal.go
+++ b/lib/web/terminal/terminal.go
@@ -124,7 +124,7 @@ func (t *WSStream) SetReadDeadline(deadline time.Time) error {
 	return t.WSConn.SetReadDeadline(deadline)
 }
 
-func isOKWebsocketCloseError(err error) bool {
+func IsOKWebsocketCloseError(err error) bool {
 	return websocket.IsCloseError(err,
 		websocket.CloseAbnormalClosure,
 		websocket.CloseGoingAway,
@@ -145,7 +145,7 @@ func (t *WSStream) processMessages(ctx context.Context) {
 		default:
 			ty, bytes, err := t.WSConn.ReadMessage()
 			if err != nil {
-				if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) || isOKWebsocketCloseError(err) {
+				if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) || IsOKWebsocketCloseError(err) {
 					return
 				}
 

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -136,6 +136,13 @@ export function createViteConfig(
             secure: false,
             ws: true,
           },
+        // /webapi/sites/:site/kube/exec
+        [`^\\/v1\\/webapi\\/sites\\/${siteName}\\/kube/exec`]: {
+          target: `wss://${target}`,
+          changeOrigin: false,
+          secure: false,
+          ws: true,
+        },
         // /webapi/sites/:site/desktopplayback/:sid
         '^\\/v1\\/webapi\\/sites\\/(.*?)\\/desktopplayback\\/(.*?)': {
           target: `wss://${target}`,

--- a/web/packages/teleport/src/Console/Console.tsx
+++ b/web/packages/teleport/src/Console/Console.tsx
@@ -31,6 +31,7 @@ import Tabs from './Tabs';
 import ActionBar from './ActionBar';
 import DocumentSsh from './DocumentSsh';
 import DocumentNodes from './DocumentNodes';
+import DocumentKubeExec from './DocumentKubeExec';
 import DocumentBlank from './DocumentBlank';
 import usePageTitle from './usePageTitle';
 import useTabRouting from './useTabRouting';
@@ -141,6 +142,8 @@ function MemoizedDocument(props: { doc: stores.Document; visible: boolean }) {
         return <DocumentSsh doc={doc} visible={visible} />;
       case 'nodes':
         return <DocumentNodes doc={doc} visible={visible} />;
+      case 'kubeExec':
+        return <DocumentKubeExec doc={doc} visible={visible} />;
       default:
         return <DocumentBlank doc={doc} visible={visible} />;
     }

--- a/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.story.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.story.tsx
@@ -1,0 +1,136 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import ConsoleCtx from 'teleport/Console/consoleContext';
+
+import { ContextProvider } from 'teleport';
+import { TestLayout } from 'teleport/Console/Console.story';
+import TeleportContext from 'teleport/teleportContext';
+import * as stores from 'teleport/Console/stores/types';
+
+import DocumentKubeExec from './DocumentKubeExec';
+
+import type { Session } from 'teleport/services/session';
+
+export default {
+  title: 'Teleport/Console/DocumentKubeExec',
+};
+
+export const Connected = () => {
+  const { ctx, consoleCtx } = getContexts();
+
+  return (
+    <DocumentKubeExecWrapper ctx={ctx} consoleCtx={consoleCtx} doc={baseDoc} />
+  );
+};
+
+export const NotFound = () => {
+  const { ctx, consoleCtx } = getContexts();
+
+  const disconnectedDoc = {
+    ...baseDoc,
+    status: 'disconnected' as const,
+  };
+
+  return (
+    <DocumentKubeExecWrapper
+      ctx={ctx}
+      consoleCtx={consoleCtx}
+      doc={disconnectedDoc}
+    />
+  );
+};
+
+export const ServerError = () => {
+  const { ctx, consoleCtx } = getContexts();
+
+  const noSidDoc = {
+    ...baseDoc,
+    sid: '',
+  };
+
+  return (
+    <DocumentKubeExecWrapper ctx={ctx} consoleCtx={consoleCtx} doc={noSidDoc} />
+  );
+};
+
+type Props = {
+  ctx: TeleportContext;
+  consoleCtx: ConsoleCtx;
+  doc: stores.DocumentKubeExec;
+};
+
+const DocumentKubeExecWrapper = ({ ctx, consoleCtx, doc }: Props) => {
+  return (
+    <ContextProvider ctx={ctx}>
+      <TestLayout ctx={consoleCtx}>
+        <DocumentKubeExec doc={doc} visible={true} />
+      </TestLayout>
+    </ContextProvider>
+  );
+};
+
+function getContexts() {
+  const ctx = createTeleportContext();
+  const consoleCtx = new ConsoleCtx();
+  const tty = consoleCtx.createTty(session);
+  tty.connect = () => null;
+  consoleCtx.createTty = () => tty;
+  consoleCtx.storeUser = ctx.storeUser;
+
+  return { ctx, consoleCtx };
+}
+
+const baseDoc = {
+  kind: 'kubeExec',
+  status: 'connected',
+  sid: 'sid-value',
+  clusterId: 'clusterId-value',
+  serverId: 'serverId-value',
+  login: 'login-value',
+  kubeCluster: 'kubeCluster1',
+  kubeNamespace: 'namespace1',
+  pod: 'pod1',
+  container: '',
+  id: 3,
+  url: 'fd',
+  created: new Date(),
+  command: '/bin/bash',
+  isInteractive: true,
+} as const;
+
+const session: Session = {
+  kind: 'k8s',
+  login: '123',
+  sid: '456',
+  namespace: '',
+  created: new Date(),
+  durationText: '',
+  serverId: '',
+  resourceName: '',
+  clusterId: '',
+  parties: [],
+  addr: '',
+  participantModes: [],
+  moderated: false,
+  isInteractive: true,
+  command: '/bin/bash',
+};

--- a/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.test.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import '@testing-library/jest-dom';
+
+import { ThemeProvider } from 'styled-components';
+import 'jest-canvas-mock';
+import { darkTheme } from 'design/theme';
+
+import { act } from 'design/utils/testing';
+
+import { ContextProvider } from 'teleport';
+import { TestLayout } from 'teleport/Console/Console.story';
+import ConsoleCtx from 'teleport/Console/consoleContext';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+
+import Tty from 'teleport/lib/term/tty';
+
+import useKubeExecSession, { Status } from './useKubeExecSession';
+
+import DocumentKubeExec from './DocumentKubeExec';
+
+import type { Session } from 'teleport/services/session';
+
+jest.mock('./useKubeExecSession');
+
+const mockUseKubeExecSession = useKubeExecSession as jest.MockedFunction<
+  typeof useKubeExecSession
+>;
+
+describe('DocumentKubeExec', () => {
+  const setup = (status: Status) => {
+    mockUseKubeExecSession.mockReturnValue({
+      tty: {
+        sendKubeExecData: jest.fn(),
+        on: jest.fn(),
+        removeListener: jest.fn(),
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+        removeAllListeners: jest.fn(),
+      } as unknown as Tty,
+      status,
+      closeDocument: jest.fn(),
+      sendKubeExecData: jest.fn(),
+      session: baseSession,
+    });
+
+    const { ctx, consoleCtx } = getContexts();
+
+    render(
+      <ThemeProvider theme={darkTheme}>
+        <ContextProvider ctx={ctx}>
+          <TestLayout ctx={consoleCtx}>
+            <DocumentKubeExec doc={baseDoc} visible={true} />
+          </TestLayout>
+        </ContextProvider>
+      </ThemeProvider>
+    );
+  };
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(), // Deprecated
+      removeListener: jest.fn(), // Deprecated
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+
+  test('renders loading indicator when status is loading', async () => {
+    jest.useFakeTimers();
+    setup('loading');
+
+    act(() => jest.runAllTimers());
+    expect(screen.getByTestId('indicator')).toBeInTheDocument();
+  });
+
+  test('renders terminal window when status is initialized', () => {
+    setup('initialized');
+
+    expect(screen.getByTestId('terminal')).toBeInTheDocument();
+  });
+
+  test('renders data dialog when status is waiting-for-exec-data', () => {
+    setup('waiting-for-exec-data');
+
+    expect(screen.getByText('Exec into a pod')).toBeInTheDocument();
+  });
+
+  test('does not render data dialog when status is initialized', () => {
+    setup('initialized');
+
+    expect(screen.queryByText('Exec into a pod')).not.toBeInTheDocument();
+  });
+});
+
+function getContexts() {
+  const ctx = createTeleportContext();
+  const consoleCtx = new ConsoleCtx();
+  const tty = consoleCtx.createTty(baseSession);
+  tty.connect = () => null;
+  consoleCtx.createTty = () => tty;
+  consoleCtx.storeUser = ctx.storeUser;
+
+  return { ctx, consoleCtx };
+}
+
+const baseDoc = {
+  kind: 'kubeExec',
+  status: 'connected',
+  sid: 'sid-value',
+  clusterId: 'clusterId-value',
+  serverId: 'serverId-value',
+  login: 'login-value',
+  kubeCluster: 'kubeCluster1',
+  kubeNamespace: 'namespace1',
+  pod: 'pod1',
+  container: '',
+  id: 3,
+  url: 'fd',
+  created: new Date(),
+  command: '/bin/bash',
+  isInteractive: true,
+} as const;
+
+const baseSession: Session = {
+  kind: 'k8s',
+  login: '123',
+  sid: '456',
+  namespace: '',
+  created: new Date(),
+  durationText: '',
+  serverId: '',
+  resourceName: '',
+  clusterId: '',
+  parties: [],
+  addr: '',
+  participantModes: [],
+  moderated: false,
+  isInteractive: true,
+  command: '/bin/bash',
+};

--- a/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.tsx
@@ -1,0 +1,80 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import React, { useRef, useEffect } from 'react';
+
+import { useTheme } from 'styled-components';
+import { Box, Indicator } from 'design';
+
+import * as stores from 'teleport/Console/stores/types';
+import { Terminal, TerminalRef } from 'teleport/Console/DocumentSsh/Terminal';
+import useWebAuthn from 'teleport/lib/useWebAuthn';
+import useKubeExecSession from 'teleport/Console/DocumentKubeExec/useKubeExecSession';
+
+import Document from 'teleport/Console/Document';
+import AuthnDialog from 'teleport/components/AuthnDialog';
+
+import KubeExecData from './KubeExecDataDialog';
+
+type Props = {
+  visible: boolean;
+  doc: stores.DocumentKubeExec;
+};
+
+export default function DocumentKubeExec({ doc, visible }: Props) {
+  const terminalRef = useRef<TerminalRef>();
+  const { tty, status, closeDocument, sendKubeExecData } =
+    useKubeExecSession(doc);
+  const webauthn = useWebAuthn(tty);
+  useEffect(() => {
+    // when switching tabs or closing tabs, focus on visible terminal
+    terminalRef.current?.focus();
+  }, [visible, webauthn.requested]);
+  const theme = useTheme();
+
+  const terminal = (
+    <Terminal
+      ref={terminalRef}
+      tty={tty}
+      fontFamily={theme.fonts.mono}
+      theme={theme.colors.terminal}
+      convertEol={!doc.isInteractive}
+    />
+  );
+
+  return (
+    <Document visible={visible} flexDirection="column">
+      {status === 'loading' && (
+        <Box textAlign="center" m={10}>
+          <Indicator />
+        </Box>
+      )}
+      {webauthn.requested && (
+        <AuthnDialog
+          onContinue={webauthn.authenticate}
+          onCancel={closeDocument}
+          errorText={webauthn.errorText}
+        />
+      )}
+
+      {status === 'waiting-for-exec-data' && (
+        <KubeExecData onExec={sendKubeExecData} onClose={closeDocument} />
+      )}
+      {status !== 'loading' && terminal}
+    </Document>
+  );
+}

--- a/web/packages/teleport/src/Console/DocumentKubeExec/KubeExecDataDialog.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/KubeExecDataDialog.tsx
@@ -1,0 +1,171 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useState } from 'react';
+import Dialog, {
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from 'design/Dialog';
+import {
+  Box,
+  ButtonPrimary,
+  ButtonSecondary,
+  Flex,
+  Text,
+  Toggle,
+} from 'design';
+
+import Validation from 'shared/components/Validation';
+import FieldInput from 'shared/components/FieldInput';
+import { requiredField } from 'shared/components/Validation/rules';
+import { ToolTipInfo } from 'shared/components/ToolTip';
+
+type Props = {
+  onClose(): void;
+  onExec(
+    namespace: string,
+    pod: string,
+    container: string,
+    command: string,
+    isInteractive: boolean
+  ): void;
+};
+
+function KubeExecDataDialog({ onClose, onExec }: Props) {
+  const [namespace, setNamespace] = useState('');
+  const [pod, setPod] = useState('');
+  const [container, setContainer] = useState('');
+  const [execCommand, setExecCommand] = useState('');
+  const [execInteractive, setExecInteractive] = useState(true);
+
+  const podExec = () => {
+    onExec(namespace, pod, container, execCommand, execInteractive);
+  };
+
+  return (
+    <Dialog
+      dialogCss={dialogCss}
+      disableEscapeKeyDown={false}
+      onClose={onClose}
+      open={true}
+    >
+      <Validation>
+        {({ validator }) => (
+          <form>
+            <DialogHeader>
+              <DialogTitle>Exec into a pod</DialogTitle>
+            </DialogHeader>
+            <DialogContent>
+              <Box mb={4}>
+                <Flex gap={3}>
+                  <FieldInput
+                    value={namespace}
+                    placeholder="namespace"
+                    label="Namespace"
+                    autoFocus
+                    rule={requiredField('Namespace is required')}
+                    width="33%"
+                    onChange={e => setNamespace(e.target.value.trim())}
+                  />
+                  <FieldInput
+                    value={pod}
+                    placeholder="pod"
+                    label="Pod"
+                    rule={requiredField('Pod is required')}
+                    width="33%"
+                    onChange={e => setPod(e.target.value.trim())}
+                  />
+                  <FieldInput
+                    value={container}
+                    placeholder="container"
+                    label="Container (optional)"
+                    width="33%"
+                    onChange={e => setContainer(e.target.value.trim())}
+                  />
+                </Flex>
+                <Flex justifyContent="space-between" gap={3}>
+                  <FieldInput
+                    rule={requiredField('Command to execute is required')}
+                    value={execCommand}
+                    placeholder="/bin/bash"
+                    label="Command to execute"
+                    width="66%"
+                    onChange={e => setExecCommand(e.target.value)}
+                    toolTipContent={
+                      <Text>
+                        The command that will be executed inside the target pod.
+                      </Text>
+                    }
+                  />
+                  <Toggle
+                    isToggled={execInteractive}
+                    onToggle={() => {
+                      setExecInteractive(b => !b);
+                    }}
+                  >
+                    <Box ml={2} mr={1}>
+                      Interactive shell
+                    </Box>
+                    <ToolTipInfo>
+                      You can start an interactive shell and have a
+                      bidirectional communication with the target pod, or you
+                      can run one-off command and see its output.
+                    </ToolTipInfo>
+                  </Toggle>
+                </Flex>
+              </Box>
+            </DialogContent>
+            <DialogFooter>
+              <Flex justifyContent="space-between">
+                <ButtonSecondary
+                  type="button"
+                  width="45%"
+                  size="large"
+                  onClick={onClose}
+                >
+                  Close
+                </ButtonSecondary>
+                <ButtonPrimary
+                  type="submit"
+                  width="45%"
+                  size="large"
+                  onClick={e => {
+                    e.preventDefault();
+                    validator.validate() && podExec();
+                  }}
+                >
+                  Exec
+                </ButtonPrimary>
+              </Flex>
+            </DialogFooter>
+          </form>
+        )}
+      </Validation>
+    </Dialog>
+  );
+}
+
+const dialogCss = () => `
+  min-height: 200px;
+  max-width: 600px;
+  width: 100%;
+`;
+
+export default KubeExecDataDialog;

--- a/web/packages/teleport/src/Console/DocumentKubeExec/index.ts
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import DocumentKubeExec from './DocumentKubeExec';
+export default DocumentKubeExec;

--- a/web/packages/teleport/src/Console/DocumentSsh/Terminal/Terminal.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/Terminal/Terminal.tsx
@@ -41,6 +41,9 @@ export interface TerminalProps {
   tty: Tty;
   fontFamily: string;
   theme: ITheme;
+  // convertEol when set to true cursor will be set to the beginning of the next line with every received new line symbol.
+  // This is equivalent to replacing each '\n' with '\r\n'.
+  convertEol?: boolean;
 }
 
 export const Terminal = forwardRef<TerminalRef, TerminalProps>((props, ref) => {
@@ -64,6 +67,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>((props, ref) => {
       fontFamily: props.fontFamily,
       fontSize,
       theme: props.theme,
+      convertEol: props.convertEol,
     });
     termCtrlRef.current = termCtrl;
 
@@ -92,6 +96,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>((props, ref) => {
       width="100%"
       px="2"
       style={{ overflow: 'auto' }}
+      data-testid="terminal"
     >
       <StyledXterm ref={elementRef} />
     </Flex>

--- a/web/packages/teleport/src/Console/stores/storeDocs.ts
+++ b/web/packages/teleport/src/Console/stores/storeDocs.ts
@@ -85,7 +85,7 @@ export default class StoreDocs extends Store<State> {
   }
 
   findByUrl(url: string) {
-    return this.state.items.find(i => i.url === encodeURI(url));
+    return this.state.items.find(i => encodeURI(i.url.split('?')[0]) === url);
   }
 
   getNodeDocuments() {

--- a/web/packages/teleport/src/Console/stores/types.ts
+++ b/web/packages/teleport/src/Console/stores/types.ts
@@ -23,7 +23,7 @@ interface DocumentBase {
   title?: string;
   clusterId?: string;
   url: string;
-  kind: 'terminal' | 'nodes' | 'blank';
+  kind: 'terminal' | 'nodes' | 'kubeExec' | 'blank';
   created: Date;
 }
 
@@ -34,6 +34,7 @@ export interface DocumentBlank extends DocumentBase {
 export interface DocumentSsh extends DocumentBase {
   status: 'connected' | 'disconnected';
   kind: 'terminal';
+  kubeExec?: boolean;
   sid?: string;
   mode?: ParticipantMode;
   serverId: string;
@@ -50,6 +51,23 @@ export interface DocumentNodes extends DocumentBase {
   kind: 'nodes';
 }
 
-export type Document = DocumentNodes | DocumentSsh | DocumentBlank;
+export interface DocumentKubeExec extends DocumentBase {
+  status: 'connected' | 'disconnected';
+  kind: 'kubeExec';
+  sid?: string;
+  mode?: ParticipantMode;
+  kubeCluster: string;
+  kubeNamespace: string;
+  pod: string;
+  container: string;
+  isInteractive: boolean;
+  command: string;
+}
+
+export type Document =
+  | DocumentNodes
+  | DocumentSsh
+  | DocumentKubeExec
+  | DocumentBlank;
 
 export type Parties = Record<string, Participant[]>;

--- a/web/packages/teleport/src/Console/useTabRouting.test.tsx
+++ b/web/packages/teleport/src/Console/useTabRouting.test.tsx
@@ -65,6 +65,30 @@ test('handling of join ssh session route', async () => {
   expect(docs).toHaveLength(2);
 });
 
+test('handling of init kubeExec session route', async () => {
+  const ctx = new ConsoleContext();
+  const wrapper = makeWrapper(
+    '/web/cluster/localhost/console/kube/exec/kubeCluster/'
+  );
+  const { current } = renderHook(() => useTabRouting(ctx), { wrapper });
+  const docs = ctx.getDocuments();
+  expect(docs[1].kind).toBe('kubeExec');
+  expect(docs[1].id).toBe(current.activeDocId);
+  expect(docs).toHaveLength(2);
+});
+
+test('handling of init kubeExec session route with container', async () => {
+  const ctx = new ConsoleContext();
+  const wrapper = makeWrapper(
+    '/web/cluster/localhost/console/kube/exec/kubeCluster/'
+  );
+  const { current } = renderHook(() => useTabRouting(ctx), { wrapper });
+  const docs = ctx.getDocuments();
+  expect(docs[1].kind).toBe('kubeExec');
+  expect(docs[1].id).toBe(current.activeDocId);
+  expect(docs).toHaveLength(2);
+});
+
 test('active document id', async () => {
   const ctx = new ConsoleContext();
   const doc = ctx.addSshDocument({
@@ -75,6 +99,21 @@ test('active document id', async () => {
 
   const countBefore = ctx.getDocuments();
   const wrapper = makeWrapper('/web/cluster/two/console/node/server-123/root');
+  const { current } = renderHook(() => useTabRouting(ctx), { wrapper });
+  const countAfter = ctx.getDocuments();
+  expect(doc.id).toBe(current.activeDocId);
+  expect(countAfter).toBe(countBefore);
+});
+
+test('active document id, document url with query parameters', async () => {
+  const ctx = new ConsoleContext();
+  const doc = ctx.addKubeExecDocument({
+    clusterId: 'cluster1',
+    kubeId: 'kube1',
+  });
+
+  const countBefore = ctx.getDocuments();
+  const wrapper = makeWrapper('/web/cluster/cluster1/console/kube/exec/kube1/');
   const { current } = renderHook(() => useTabRouting(ctx), { wrapper });
   const countAfter = ctx.getDocuments();
   expect(doc.id).toBe(current.activeDocId);

--- a/web/packages/teleport/src/Console/useTabRouting.ts
+++ b/web/packages/teleport/src/Console/useTabRouting.ts
@@ -19,7 +19,7 @@
 import React from 'react';
 import { useRouteMatch, useParams, useLocation } from 'react-router';
 
-import cfg, { UrlSshParams } from 'teleport/config';
+import cfg, { UrlKubeExecParams, UrlSshParams } from 'teleport/config';
 import { ParticipantMode } from 'teleport/services/session';
 
 import ConsoleContext from './consoleContext';
@@ -28,6 +28,9 @@ export default function useRouting(ctx: ConsoleContext) {
   const { pathname, search } = useLocation();
   const { clusterId } = useParams<{ clusterId: string }>();
   const sshRouteMatch = useRouteMatch<UrlSshParams>(cfg.routes.consoleConnect);
+  const kubeExecRouteMatch = useRouteMatch<UrlKubeExecParams>(
+    cfg.routes.kubeExec
+  );
   const nodesRouteMatch = useRouteMatch(cfg.routes.consoleNodes);
   const joinSshRouteMatch = useRouteMatch<UrlSshParams>(
     cfg.routes.consoleSession
@@ -53,6 +56,8 @@ export default function useRouting(ctx: ConsoleContext) {
       ctx.addSshDocument(joinSshRouteMatch.params);
     } else if (nodesRouteMatch) {
       ctx.addNodeDocument(clusterId);
+    } else if (kubeExecRouteMatch) {
+      ctx.addKubeExecDocument(kubeExecRouteMatch.params);
     }
   }, [ctx, pathname]);
 

--- a/web/packages/teleport/src/Kubes/ConnectDialog/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Kubes/ConnectDialog/ConnectDialog.tsx
@@ -23,11 +23,12 @@ import Dialog, {
   DialogTitle,
   DialogContent,
 } from 'design/Dialog';
-import { Text, Box, ButtonSecondary } from 'design';
+import { Text, Box, ButtonSecondary, ButtonPrimary, Flex } from 'design';
 
-import TextSelectCopy from 'teleport/components/TextSelectCopy';
+import { generateTshLoginCommand, openNewTab } from 'teleport/lib/util';
 import { AuthType } from 'teleport/services/user';
-import { generateTshLoginCommand } from 'teleport/lib/util';
+import TextSelectCopy from 'teleport/components/TextSelectCopy';
+import cfg from 'teleport/config';
 
 function ConnectDialog(props: Props) {
   const {
@@ -38,6 +39,15 @@ function ConnectDialog(props: Props) {
     clusterId,
     accessRequestId,
   } = props;
+
+  const startKubeExecSession = () => {
+    const url = cfg.getKubeExecConnectRoute({
+      clusterId,
+      kubeId: kubeConnectName,
+    });
+
+    openNewTab(url);
+  };
 
   return (
     <Dialog
@@ -51,6 +61,9 @@ function ConnectDialog(props: Props) {
       </DialogHeader>
       <DialogContent>
         <Box mb={4}>
+          <Text mt={1} mb={2} bold>
+            Connect in the CLI using tsh and kubectl
+          </Text>
           <Text bold as="span">
             Step 1
           </Text>
@@ -99,6 +112,14 @@ function ConnectDialog(props: Props) {
             <TextSelectCopy mt="2" text={`tsh request drop`} />
           </Box>
         )}
+        <Box borderTop={1} mb={4} mt={4}>
+          <Flex mt={4} flex-direction="row" justifyContent="space-between">
+            <Text mt={1} bold>
+              Or exec into a pod on this Kubernetes cluster in Web UI
+            </Text>
+            <ButtonPrimary onClick={startKubeExecSession}>Exec</ButtonPrimary>
+          </Flex>
+        </Box>
       </DialogContent>
       <DialogFooter>
         <ButtonSecondary onClick={onClose}>Close</ButtonSecondary>

--- a/web/packages/teleport/src/Kubes/ConnectDialog/__snapshots__/ConnectDialog.story.test.tsx.snap
+++ b/web/packages/teleport/src/Kubes/ConnectDialog/__snapshots__/ConnectDialog.story.test.tsx.snap
@@ -67,6 +67,23 @@ exports[`kube connect dialogue local 1`] = `
   text-overflow: ellipsis;
   font-weight: 600;
   margin: 0px;
+  margin-bottom: 8px;
+  margin-top: 4px;
+}
+
+.c11 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  margin: 0px;
+}
+
+.c22 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  margin: 0px;
+  margin-top: 4px;
 }
 
 .c4 {
@@ -86,7 +103,7 @@ exports[`kube connect dialogue local 1`] = `
   margin-bottom: 24px;
 }
 
-.c11 {
+.c12 {
   box-sizing: border-box;
   margin-top: 8px;
   padding: 8px;
@@ -95,22 +112,34 @@ exports[`kube connect dialogue local 1`] = `
   border-radius: 4px;
 }
 
-.c13 {
+.c14 {
   box-sizing: border-box;
   margin-right: 8px;
 }
 
-.c15 {
+.c16 {
   box-sizing: border-box;
   margin-right: 4px;
 }
 
-.c17 {
+.c18 {
   box-sizing: border-box;
   margin-bottom: 4px;
 }
 
-.c18 {
+.c19 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  margin-top: 24px;
+  border-top: 1px solid;
+}
+
+.c20 {
+  box-sizing: border-box;
+  margin-top: 24px;
+}
+
+.c23 {
   box-sizing: border-box;
 }
 
@@ -124,17 +153,22 @@ exports[`kube connect dialogue local 1`] = `
   flex-direction: column;
 }
 
-.c12 {
+.c13 {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
-.c14 {
+.c15 {
   display: flex;
 }
 
-.c16 {
+.c21 {
+  display: flex;
+  justify-content: space-between;
+}
+
+.c17 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -160,22 +194,22 @@ exports[`kube connect dialogue local 1`] = `
   padding: 0px 24px;
 }
 
-.c16:hover,
-.c16:focus {
+.c17:hover,
+.c17:focus {
   background: #B29DFF;
 }
 
-.c16:active {
+.c17:active {
   background: #C5B6FF;
 }
 
-.c16:disabled {
+.c17:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
 }
 
-.c19 {
+.c24 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -201,16 +235,16 @@ exports[`kube connect dialogue local 1`] = `
   padding: 0px 24px;
 }
 
-.c19:hover,
-.c19:focus {
+.c24:hover,
+.c24:focus {
   background: rgba(255,255,255,0.13);
 }
 
-.c19:active {
+.c24:active {
   background: rgba(255,255,255,0.18);
 }
 
-.c19:disabled {
+.c24:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
@@ -250,22 +284,27 @@ exports[`kube connect dialogue local 1`] = `
           <div
             class="c9"
           >
-            <span
+            <div
               class="c10"
+            >
+              Connect in the CLI using tsh and kubectl
+            </div>
+            <span
+              class="c11"
             >
               Step 1
             </span>
              - Login to Teleport
             <div
-              class="c11 c12"
+              class="c12 c13"
               color="light"
             >
               <div
-                class="c13 c14"
+                class="c14 c15"
                 style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   style="user-select: none;"
                 >
                   $
@@ -275,7 +314,7 @@ exports[`kube connect dialogue local 1`] = `
                 </div>
               </div>
               <button
-                class="c16"
+                class="c17"
                 kind="primary"
                 style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
               >
@@ -287,22 +326,22 @@ exports[`kube connect dialogue local 1`] = `
             class="c9"
           >
             <span
-              class="c10"
+              class="c11"
             >
               Optional
             </span>
              
             - To write kubectl configuration to a separate file instead of having your global kubectl configuration modified, run the following command:
             <div
-              class="c11 c12"
+              class="c12 c13"
               color="light"
             >
               <div
-                class="c13 c14"
+                class="c14 c15"
                 style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   style="user-select: none;"
                 >
                   $
@@ -312,7 +351,7 @@ exports[`kube connect dialogue local 1`] = `
                 </div>
               </div>
               <button
-                class="c16"
+                class="c17"
                 kind="primary"
                 style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
               >
@@ -324,21 +363,21 @@ exports[`kube connect dialogue local 1`] = `
             class="c9"
           >
             <span
-              class="c10"
+              class="c11"
             >
               Step 2
             </span>
              - Select the Kubernetes cluster
             <div
-              class="c11 c12"
+              class="c12 c13"
               color="light"
             >
               <div
-                class="c13 c14"
+                class="c14 c15"
                 style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   style="user-select: none;"
                 >
                   $
@@ -348,7 +387,7 @@ exports[`kube connect dialogue local 1`] = `
                 </div>
               </div>
               <button
-                class="c16"
+                class="c17"
                 kind="primary"
                 style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
               >
@@ -357,24 +396,24 @@ exports[`kube connect dialogue local 1`] = `
             </div>
           </div>
           <div
-            class="c17"
+            class="c18"
           >
             <span
-              class="c10"
+              class="c11"
             >
               Step 3
             </span>
              - Connect to the Kubernetes cluster
             <div
-              class="c11 c12"
+              class="c12 c13"
               color="light"
             >
               <div
-                class="c13 c14"
+                class="c14 c15"
                 style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   style="user-select: none;"
                 >
                   $
@@ -384,7 +423,7 @@ exports[`kube connect dialogue local 1`] = `
                 </div>
               </div>
               <button
-                class="c16"
+                class="c17"
                 kind="primary"
                 style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
               >
@@ -392,12 +431,31 @@ exports[`kube connect dialogue local 1`] = `
               </button>
             </div>
           </div>
+          <div
+            class="c19"
+          >
+            <div
+              class="c20 c21"
+            >
+              <div
+                class="c22"
+              >
+                Or exec into a pod on this Kubernetes cluster in Web UI
+              </div>
+              <button
+                class="c17"
+                kind="primary"
+              >
+                Exec
+              </button>
+            </div>
+          </div>
         </div>
         <div
-          class="c18"
+          class="c23"
         >
           <button
-            class="c19"
+            class="c24"
             kind="secondary"
           >
             Close
@@ -476,6 +534,23 @@ exports[`kube connect dialogue local with requestId 1`] = `
   text-overflow: ellipsis;
   font-weight: 600;
   margin: 0px;
+  margin-bottom: 8px;
+  margin-top: 4px;
+}
+
+.c11 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  margin: 0px;
+}
+
+.c23 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  margin: 0px;
+  margin-top: 4px;
 }
 
 .c4 {
@@ -495,7 +570,7 @@ exports[`kube connect dialogue local with requestId 1`] = `
   margin-bottom: 24px;
 }
 
-.c11 {
+.c12 {
   box-sizing: border-box;
   margin-top: 8px;
   padding: 8px;
@@ -504,28 +579,40 @@ exports[`kube connect dialogue local with requestId 1`] = `
   border-radius: 4px;
 }
 
-.c13 {
+.c14 {
   box-sizing: border-box;
   margin-right: 8px;
 }
 
-.c15 {
+.c16 {
   box-sizing: border-box;
   margin-right: 4px;
-}
-
-.c17 {
-  box-sizing: border-box;
-  margin-bottom: 4px;
 }
 
 .c18 {
   box-sizing: border-box;
   margin-bottom: 4px;
-  margin-top: 16px;
 }
 
 .c19 {
+  box-sizing: border-box;
+  margin-bottom: 4px;
+  margin-top: 16px;
+}
+
+.c20 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  margin-top: 24px;
+  border-top: 1px solid;
+}
+
+.c21 {
+  box-sizing: border-box;
+  margin-top: 24px;
+}
+
+.c24 {
   box-sizing: border-box;
 }
 
@@ -539,17 +626,22 @@ exports[`kube connect dialogue local with requestId 1`] = `
   flex-direction: column;
 }
 
-.c12 {
+.c13 {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
-.c14 {
+.c15 {
   display: flex;
 }
 
-.c16 {
+.c22 {
+  display: flex;
+  justify-content: space-between;
+}
+
+.c17 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -575,22 +667,22 @@ exports[`kube connect dialogue local with requestId 1`] = `
   padding: 0px 24px;
 }
 
-.c16:hover,
-.c16:focus {
+.c17:hover,
+.c17:focus {
   background: #B29DFF;
 }
 
-.c16:active {
+.c17:active {
   background: #C5B6FF;
 }
 
-.c16:disabled {
+.c17:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
 }
 
-.c20 {
+.c25 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -616,16 +708,16 @@ exports[`kube connect dialogue local with requestId 1`] = `
   padding: 0px 24px;
 }
 
-.c20:hover,
-.c20:focus {
+.c25:hover,
+.c25:focus {
   background: rgba(255,255,255,0.13);
 }
 
-.c20:active {
+.c25:active {
   background: rgba(255,255,255,0.18);
 }
 
-.c20:disabled {
+.c25:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
@@ -665,22 +757,27 @@ exports[`kube connect dialogue local with requestId 1`] = `
           <div
             class="c9"
           >
-            <span
+            <div
               class="c10"
+            >
+              Connect in the CLI using tsh and kubectl
+            </div>
+            <span
+              class="c11"
             >
               Step 1
             </span>
              - Login to Teleport
             <div
-              class="c11 c12"
+              class="c12 c13"
               color="light"
             >
               <div
-                class="c13 c14"
+                class="c14 c15"
                 style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   style="user-select: none;"
                 >
                   $
@@ -690,7 +787,7 @@ exports[`kube connect dialogue local with requestId 1`] = `
                 </div>
               </div>
               <button
-                class="c16"
+                class="c17"
                 kind="primary"
                 style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
               >
@@ -702,22 +799,22 @@ exports[`kube connect dialogue local with requestId 1`] = `
             class="c9"
           >
             <span
-              class="c10"
+              class="c11"
             >
               Optional
             </span>
              
             - To write kubectl configuration to a separate file instead of having your global kubectl configuration modified, run the following command:
             <div
-              class="c11 c12"
+              class="c12 c13"
               color="light"
             >
               <div
-                class="c13 c14"
+                class="c14 c15"
                 style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   style="user-select: none;"
                 >
                   $
@@ -727,7 +824,7 @@ exports[`kube connect dialogue local with requestId 1`] = `
                 </div>
               </div>
               <button
-                class="c16"
+                class="c17"
                 kind="primary"
                 style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
               >
@@ -739,21 +836,21 @@ exports[`kube connect dialogue local with requestId 1`] = `
             class="c9"
           >
             <span
-              class="c10"
+              class="c11"
             >
               Step 2
             </span>
              - Select the Kubernetes cluster
             <div
-              class="c11 c12"
+              class="c12 c13"
               color="light"
             >
               <div
-                class="c13 c14"
+                class="c14 c15"
                 style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   style="user-select: none;"
                 >
                   $
@@ -763,43 +860,7 @@ exports[`kube connect dialogue local with requestId 1`] = `
                 </div>
               </div>
               <button
-                class="c16"
-                kind="primary"
-                style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
-              >
-                Copy
-              </button>
-            </div>
-          </div>
-          <div
-            class="c17"
-          >
-            <span
-              class="c10"
-            >
-              Step 3
-            </span>
-             - Connect to the Kubernetes cluster
-            <div
-              class="c11 c12"
-              color="light"
-            >
-              <div
-                class="c13 c14"
-                style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
-              >
-                <div
-                  class="c15"
-                  style="user-select: none;"
-                >
-                  $
-                </div>
-                <div>
-                  kubectl get pods
-                </div>
-              </div>
-              <button
-                class="c16"
+                class="c17"
                 kind="primary"
                 style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
               >
@@ -811,21 +872,57 @@ exports[`kube connect dialogue local with requestId 1`] = `
             class="c18"
           >
             <span
-              class="c10"
+              class="c11"
+            >
+              Step 3
+            </span>
+             - Connect to the Kubernetes cluster
+            <div
+              class="c12 c13"
+              color="light"
+            >
+              <div
+                class="c14 c15"
+                style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
+              >
+                <div
+                  class="c16"
+                  style="user-select: none;"
+                >
+                  $
+                </div>
+                <div>
+                  kubectl get pods
+                </div>
+              </div>
+              <button
+                class="c17"
+                kind="primary"
+                style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
+              >
+                Copy
+              </button>
+            </div>
+          </div>
+          <div
+            class="c19"
+          >
+            <span
+              class="c11"
             >
               Step 4 (Optional)
             </span>
              - When finished, drop the assumed role
             <div
-              class="c11 c12"
+              class="c12 c13"
               color="light"
             >
               <div
-                class="c13 c14"
+                class="c14 c15"
                 style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   style="user-select: none;"
                 >
                   $
@@ -835,7 +932,7 @@ exports[`kube connect dialogue local with requestId 1`] = `
                 </div>
               </div>
               <button
-                class="c16"
+                class="c17"
                 kind="primary"
                 style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
               >
@@ -843,12 +940,31 @@ exports[`kube connect dialogue local with requestId 1`] = `
               </button>
             </div>
           </div>
+          <div
+            class="c20"
+          >
+            <div
+              class="c21 c22"
+            >
+              <div
+                class="c23"
+              >
+                Or exec into a pod on this Kubernetes cluster in Web UI
+              </div>
+              <button
+                class="c17"
+                kind="primary"
+              >
+                Exec
+              </button>
+            </div>
+          </div>
         </div>
         <div
-          class="c19"
+          class="c24"
         >
           <button
-            class="c20"
+            class="c25"
             kind="secondary"
           >
             Close
@@ -927,6 +1043,23 @@ exports[`kube connect dialogue sso 1`] = `
   text-overflow: ellipsis;
   font-weight: 600;
   margin: 0px;
+  margin-bottom: 8px;
+  margin-top: 4px;
+}
+
+.c11 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  margin: 0px;
+}
+
+.c22 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  margin: 0px;
+  margin-top: 4px;
 }
 
 .c4 {
@@ -946,7 +1079,7 @@ exports[`kube connect dialogue sso 1`] = `
   margin-bottom: 24px;
 }
 
-.c11 {
+.c12 {
   box-sizing: border-box;
   margin-top: 8px;
   padding: 8px;
@@ -955,22 +1088,34 @@ exports[`kube connect dialogue sso 1`] = `
   border-radius: 4px;
 }
 
-.c13 {
+.c14 {
   box-sizing: border-box;
   margin-right: 8px;
 }
 
-.c15 {
+.c16 {
   box-sizing: border-box;
   margin-right: 4px;
 }
 
-.c17 {
+.c18 {
   box-sizing: border-box;
   margin-bottom: 4px;
 }
 
-.c18 {
+.c19 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  margin-top: 24px;
+  border-top: 1px solid;
+}
+
+.c20 {
+  box-sizing: border-box;
+  margin-top: 24px;
+}
+
+.c23 {
   box-sizing: border-box;
 }
 
@@ -984,17 +1129,22 @@ exports[`kube connect dialogue sso 1`] = `
   flex-direction: column;
 }
 
-.c12 {
+.c13 {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
-.c14 {
+.c15 {
   display: flex;
 }
 
-.c16 {
+.c21 {
+  display: flex;
+  justify-content: space-between;
+}
+
+.c17 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -1020,22 +1170,22 @@ exports[`kube connect dialogue sso 1`] = `
   padding: 0px 24px;
 }
 
-.c16:hover,
-.c16:focus {
+.c17:hover,
+.c17:focus {
   background: #B29DFF;
 }
 
-.c16:active {
+.c17:active {
   background: #C5B6FF;
 }
 
-.c16:disabled {
+.c17:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
 }
 
-.c19 {
+.c24 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -1061,16 +1211,16 @@ exports[`kube connect dialogue sso 1`] = `
   padding: 0px 24px;
 }
 
-.c19:hover,
-.c19:focus {
+.c24:hover,
+.c24:focus {
   background: rgba(255,255,255,0.13);
 }
 
-.c19:active {
+.c24:active {
   background: rgba(255,255,255,0.18);
 }
 
-.c19:disabled {
+.c24:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
@@ -1110,22 +1260,27 @@ exports[`kube connect dialogue sso 1`] = `
           <div
             class="c9"
           >
-            <span
+            <div
               class="c10"
+            >
+              Connect in the CLI using tsh and kubectl
+            </div>
+            <span
+              class="c11"
             >
               Step 1
             </span>
              - Login to Teleport
             <div
-              class="c11 c12"
+              class="c12 c13"
               color="light"
             >
               <div
-                class="c13 c14"
+                class="c14 c15"
                 style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   style="user-select: none;"
                 >
                   $
@@ -1135,7 +1290,7 @@ exports[`kube connect dialogue sso 1`] = `
                 </div>
               </div>
               <button
-                class="c16"
+                class="c17"
                 kind="primary"
                 style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
               >
@@ -1147,22 +1302,22 @@ exports[`kube connect dialogue sso 1`] = `
             class="c9"
           >
             <span
-              class="c10"
+              class="c11"
             >
               Optional
             </span>
              
             - To write kubectl configuration to a separate file instead of having your global kubectl configuration modified, run the following command:
             <div
-              class="c11 c12"
+              class="c12 c13"
               color="light"
             >
               <div
-                class="c13 c14"
+                class="c14 c15"
                 style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   style="user-select: none;"
                 >
                   $
@@ -1172,7 +1327,7 @@ exports[`kube connect dialogue sso 1`] = `
                 </div>
               </div>
               <button
-                class="c16"
+                class="c17"
                 kind="primary"
                 style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
               >
@@ -1184,21 +1339,21 @@ exports[`kube connect dialogue sso 1`] = `
             class="c9"
           >
             <span
-              class="c10"
+              class="c11"
             >
               Step 2
             </span>
              - Select the Kubernetes cluster
             <div
-              class="c11 c12"
+              class="c12 c13"
               color="light"
             >
               <div
-                class="c13 c14"
+                class="c14 c15"
                 style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   style="user-select: none;"
                 >
                   $
@@ -1208,7 +1363,7 @@ exports[`kube connect dialogue sso 1`] = `
                 </div>
               </div>
               <button
-                class="c16"
+                class="c17"
                 kind="primary"
                 style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
               >
@@ -1217,24 +1372,24 @@ exports[`kube connect dialogue sso 1`] = `
             </div>
           </div>
           <div
-            class="c17"
+            class="c18"
           >
             <span
-              class="c10"
+              class="c11"
             >
               Step 3
             </span>
              - Connect to the Kubernetes cluster
             <div
-              class="c11 c12"
+              class="c12 c13"
               color="light"
             >
               <div
-                class="c13 c14"
+                class="c14 c15"
                 style="overflow: auto; white-space: pre; word-break: break-all; font-size: 12px; font-family: \\"Droid Sans Mono\\", \\"monospace\\", monospace, \\"Droid Sans Fallback\\";"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   style="user-select: none;"
                 >
                   $
@@ -1244,7 +1399,7 @@ exports[`kube connect dialogue sso 1`] = `
                 </div>
               </div>
               <button
-                class="c16"
+                class="c17"
                 kind="primary"
                 style="max-width: 48px; width: 100%; padding: 4px 8px; min-height: 10px; font-size: 10px;"
               >
@@ -1252,12 +1407,31 @@ exports[`kube connect dialogue sso 1`] = `
               </button>
             </div>
           </div>
+          <div
+            class="c19"
+          >
+            <div
+              class="c20 c21"
+            >
+              <div
+                class="c22"
+              >
+                Or exec into a pod on this Kubernetes cluster in Web UI
+              </div>
+              <button
+                class="c17"
+                kind="primary"
+              >
+                Exec
+              </button>
+            </div>
+          </div>
         </div>
         <div
-          class="c18"
+          class="c23"
         >
           <button
-            class="c19"
+            class="c24"
             kind="secondary"
           >
             Close

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -159,6 +159,8 @@ const cfg = {
     consoleNodes: '/web/cluster/:clusterId/console/nodes',
     consoleConnect: '/web/cluster/:clusterId/console/node/:serverId/:login',
     consoleSession: '/web/cluster/:clusterId/console/session/:sid',
+    kubeExec: '/web/cluster/:clusterId/console/kube/exec/:kubeId/',
+    kubeExecSession: '/web/cluster/:clusterId/console/kube/exec/:sid',
     player: '/web/cluster/:clusterId/session/:sid', // ?recordingType=ssh|desktop|k8s&durationMs=1234
     login: '/web/login',
     loginSuccess: '/web/msg/info/login_success',
@@ -230,6 +232,8 @@ const cfg = {
     desktopIsActive: '/v1/webapi/sites/:clusterId/desktops/:desktopName/active',
     ttyWsAddr:
       'wss://:fqdn/v1/webapi/sites/:clusterId/connect/ws?params=:params&traceparent=:traceparent',
+    ttyKubeExecWsAddr:
+      'wss://:fqdn/v1/webapi/sites/:clusterId/kube/exec/ws?params=:params&traceparent=:traceparent',
     ttyPlaybackWsAddr:
       'wss://:fqdn/v1/webapi/sites/:clusterId/ttyplayback/:sid?access_token=:token', // TODO(zmb3): get token out of URL
     activeAndPendingSessionsPath: '/v1/webapi/sites/:clusterId/sessions',
@@ -558,12 +562,30 @@ const cfg = {
     });
   },
 
+  getKubeExecConnectRoute(params: UrlKubeExecParams) {
+    return generatePath(cfg.routes.kubeExec, { ...params });
+  },
+
   getDesktopRoute({ clusterId, username, desktopName }) {
     return generatePath(cfg.routes.desktop, {
       clusterId,
       desktopName,
       username,
     });
+  },
+
+  getKubeExecSessionRoute(
+    { clusterId, sid }: UrlParams,
+    mode?: ParticipantMode
+  ) {
+    const basePath = generatePath(cfg.routes.kubeExecSession, {
+      clusterId,
+      sid,
+    });
+    if (mode) {
+      return `${basePath}?mode=${mode}`;
+    }
+    return basePath;
   },
 
   getSshSessionRoute({ clusterId, sid }: UrlParams, mode?: ParticipantMode) {
@@ -1106,6 +1128,11 @@ export interface UrlSshParams {
   sid?: string;
   mode?: ParticipantMode;
   clusterId: string;
+}
+
+export interface UrlKubeExecParams {
+  clusterId: string;
+  kubeId: string;
 }
 
 export interface UrlSessionRecordingsParams {

--- a/web/packages/teleport/src/lib/term/enums.ts
+++ b/web/packages/teleport/src/lib/term/enums.ts
@@ -38,6 +38,7 @@ export enum TermEvent {
   CONN_CLOSE = 'connection.close',
   WEBAUTHN_CHALLENGE = 'terminal.webauthn',
   LATENCY = 'terminal.latency',
+  KUBE_EXEC = 'terminal.kube_exec',
 }
 
 // Websocket connection close codes.

--- a/web/packages/teleport/src/lib/term/protobuf.js
+++ b/web/packages/teleport/src/lib/term/protobuf.js
@@ -33,6 +33,7 @@ export const MessageTypeEnum = {
   FILE_TRANSFER_DECISION: 't',
   WEBAUTHN_CHALLENGE: 'n',
   LATENCY: 'l',
+  KUBE_EXEC: 'k',
 };
 
 export const messageFields = {
@@ -60,6 +61,7 @@ export const messageFields = {
       event: MessageTypeEnum.AUDIT.charCodeAt(0),
       close: MessageTypeEnum.SESSION_END.charCodeAt(0),
       challengeResponse: MessageTypeEnum.WEBAUTHN_CHALLENGE.charCodeAt(0),
+      kubeExec: MessageTypeEnum.KUBE_EXEC.charCodeAt(0),
     },
   },
 };
@@ -87,6 +89,10 @@ export class Protobuf {
 
   encodeFileTransferDecision(message) {
     return this.encode(messageFields.type.values.fileTransferDecision, message);
+  }
+
+  encodeKubeExecData(message) {
+    return this.encode(messageFields.type.values.kubeExec, message);
   }
 
   encodeRawMessage(message) {

--- a/web/packages/teleport/src/lib/term/terminal.ts
+++ b/web/packages/teleport/src/lib/term/terminal.ts
@@ -47,6 +47,7 @@ export default class TtyTerminal {
   _scrollBack: number;
   _fontFamily: string;
   _fontSize: number;
+  _convertEol: boolean;
   _debouncedResize: DebouncedFunc<() => void>;
   _fitAddon = new FitAddon();
   _webLinksAddon = new WebLinksAddon();
@@ -57,13 +58,14 @@ export default class TtyTerminal {
     tty: Tty,
     private options: Options
   ) {
-    const { el, scrollBack, fontFamily, fontSize } = options;
+    const { el, scrollBack, fontFamily, fontSize, convertEol } = options;
     this._el = el;
     this._fontFamily = fontFamily || undefined;
     this._fontSize = fontSize || 14;
     // Passing scrollback will overwrite the default config. This is to support ttyplayer.
     // Default to the config when not passed anything, which is the normal usecase
     this._scrollBack = scrollBack || cfg.ui.scrollbackLines;
+    this._convertEol = convertEol || false;
     this.tty = tty;
     this.term = null;
 
@@ -78,6 +80,7 @@ export default class TtyTerminal {
       fontFamily: this._fontFamily,
       fontSize: this._fontSize,
       scrollback: this._scrollBack,
+      convertEol: this._convertEol,
       cursorBlink: false,
       minimumContrastRatio: 4.5, // minimum for WCAG AA compliance
       theme: this.options.theme,
@@ -233,4 +236,5 @@ type Options = {
   scrollBack?: number;
   fontFamily?: string;
   fontSize?: number;
+  convertEol?: boolean;
 };

--- a/web/packages/teleport/src/lib/term/tty.ts
+++ b/web/packages/teleport/src/lib/term/tty.ts
@@ -86,6 +86,12 @@ class Tty extends EventEmitterWebAuthnSender {
     this.socket.send(bytearray);
   }
 
+  sendKubeExecData(data: KubeExecData) {
+    const encoded = this._proto.encodeKubeExecData(JSON.stringify(data));
+    const bytearray = new Uint8Array(encoded);
+    this.socket.send(bytearray);
+  }
+
   _sendFileTransferRequest(message: string) {
     const encoded = this._proto.encodeFileTransferRequest(message);
     const bytearray = new Uint8Array(encoded);
@@ -257,5 +263,14 @@ class Tty extends EventEmitterWebAuthnSender {
     return this._pendingUploads[location];
   }
 }
+
+export type KubeExecData = {
+  kubeCluster: string;
+  namespace: string;
+  pod: string;
+  container: string;
+  command: string;
+  isInteractive: boolean;
+};
 
 export default Tty;

--- a/web/packages/teleport/src/services/session/types.ts
+++ b/web/packages/teleport/src/services/session/types.ts
@@ -31,6 +31,7 @@ export interface Session {
   clusterId: string;
   parties: Participant[];
   addr: string;
+  kubeExec?: boolean;
   // resourceName depending on the "kind" field, is the name
   // of resource that the session is running in:
   //  - ssh: is referring to the hostname
@@ -45,6 +46,7 @@ export interface Session {
   moderated: boolean;
   // command is the command that was run to start this session.
   command: string;
+  isInteractive?: boolean;
 }
 
 export type SessionMetadata = {


### PR DESCRIPTION
Backport #41466 to branch v16.

Manual backport because assist removal touched some neighbouring lines in `Terminal.tsx`

Changelog: Add ability to exec into a pod on a Kubernetes cluster using Web UI.