### PR TITLE
docs: Add WinSCP troubleshooting step and tsh.exe path advice

### DIFF
--- a/docs/pages/connect-your-client/putty-winscp.mdx
+++ b/docs/pages/connect-your-client/putty-winscp.mdx
@@ -29,7 +29,7 @@ You will learn how to:
 
   <Admonition type="note">
     Do not place `tsh.exe` in the `System32` directory, as this can cause issues when using WinSCP.
-    You should use `%SystemRoot%` (e.g. `C:\Windows`) instead, which is already included in `%PATH`.
+    You should use `%SystemRoot%` (e.g. `C:\Windows`) instead, which is already included in `%PATH%`.
 
     If you do not have administrator rights on the Windows system you're using, you can use `%USERPROFILE%`
     (e.g. `C:\Users\<username>`) instead - but note that you will not be able to run `tsh` commands globally

--- a/docs/pages/connect-your-client/putty-winscp.mdx
+++ b/docs/pages/connect-your-client/putty-winscp.mdx
@@ -29,7 +29,11 @@ You will learn how to:
 
   <Admonition type="note">
     Do not place `tsh.exe` in the `System32` directory, as this can cause issues when using WinSCP.
-    You should use `%WINDIR%` (e.g. `C:\Windows`) or `%USERPROFILE%` (e.g. `C:\Users\<username>`) instead.
+    You should use `%SystemRoot%` (e.g. `C:\Windows`) instead, which is already included in `%PATH`.
+
+    If you do not have administrator rights on the Windows system you're using, you can use `%USERPROFILE%`
+    (e.g. `C:\Users\<username>`) instead - but note that you will not be able to run `tsh` commands globally
+    from the command line unless you are in the same directory as `tsh.exe`.
   </Admonition>
 
 - PuTTY for Windows version 0.78 or higher. You can download the latest version of PuTTY from the [PuTTY download page](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html).
@@ -300,10 +304,10 @@ Here are two locations where `tsh.exe` can be stored which are not affected by t
 - `%WINDIR%` (e.g. `C:\Windows` - requires administrator privileges)
 
 To fix this issue, follow these steps:
-- Place the `tsh.exe` application into a different directory, as detailed above.
-- Re-run `tsh puttyconfig` for each PuTTY session in order to replace the configured path to `tsh.exe` inside the session.
-- Delete each saved session inside WinSCP.
-- Re-import saved PuTTY sessions into WinSCP by following the process detailed in steps 2-3 above.
+1. Place the `tsh.exe` application into a different directory, as detailed above.
+1. Re-run `tsh puttyconfig` for each PuTTY session in order to replace the configured path to `tsh.exe` inside the session.
+1. Delete each saved session inside WinSCP.
+1. Re-import saved PuTTY sessions into WinSCP by following the process detailed in steps 2-3 above.
 
 ### `proxy: ERROR: access denied to <user> connecting to <proxy>`
 

--- a/docs/pages/connect-your-client/putty-winscp.mdx
+++ b/docs/pages/connect-your-client/putty-winscp.mdx
@@ -300,8 +300,8 @@ triggers a bug in WinSCP which causes the path to `tsh.exe` to be erroneously re
 failure. This bug does not seem to affect PuTTY sessions.
 
 Here are two locations where `tsh.exe` can be stored which are not affected by this bug:
+- `%SystemRoot%` (e.g. `C:\Windows` - requires administrator privileges, and is incuded in `%PATH%` by default)
 - `%USERPROFILE` (e.g. `C:\Users\<username>` - does not require administrator privileges)
-- `%WINDIR%` (e.g. `C:\Windows` - requires administrator privileges)
 
 To fix this issue, follow these steps:
 1. Place the `tsh.exe` application into a different directory, as detailed above.

--- a/docs/pages/connect-your-client/putty-winscp.mdx
+++ b/docs/pages/connect-your-client/putty-winscp.mdx
@@ -27,6 +27,11 @@ You will learn how to:
 
   You should then unzip the archive and move `tsh.exe` to your `%PATH%`.
 
+  <Admonition type="note">
+    Do not place `tsh.exe` in the `System32` directory, as this can cause issues when using WinSCP.
+    You should use `%WINDIR%` (e.g. `C:\Windows`) or `%USERPROFILE%` (e.g. `C:\Users\<username>`) instead.
+  </Admonition>
+
 - PuTTY for Windows version 0.78 or higher. You can download the latest version of PuTTY from the [PuTTY download page](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html).
 
 - (optional) WinSCP for Windows version 6.2 or higher. You can download the latest version of WinSCP from the [WinSCP download page](https://winscp.net/eng/download.php)
@@ -284,10 +289,34 @@ key. Note that if you re-run `tsh puttyconfig` for the given hostname, this comm
 
 ## Troubleshooting
 
+### WinSCP shows `Server unexpectedly closed network connection` or `Error 232: The pipe is being closed` when connecting
+
+This error is usually caused when the `tsh.exe` application is incorrectly placed in the `C:\Windows\System32` directory. This
+triggers a bug in WinSCP which causes the path to `tsh.exe` to be erroneously replaced at runtime, leading to a connection
+failure. This bug does not seem to affect PuTTY sessions.
+
+Here are two locations where `tsh.exe` can be stored which are not affected by this bug:
+- `%USERPROFILE` (e.g. `C:\Users\<username>` - does not require administrator privileges)
+- `%WINDIR%` (e.g. `C:\Windows` - requires administrator privileges)
+
+To fix this issue, follow these steps:
+- Place the `tsh.exe` application into a different directory, as detailed above
+- Re-run `tsh puttyconfig` for each PuTTY session in order to replace the configured path to `tsh.exe` inside the session
+- Delete each saved session inside WinSCP
+- Re-import saved PuTTY sessions into WinSCP by following the process detailed in steps 2-3 above.
+
 ### `proxy: ERROR: access denied to <user> connecting to <proxy>`
 
 You have provided an incorrect login username to the `tsh puttyconfig` command. Re-run the command with a login username
 that your Teleport user/role has permissions to use. Check the logins listed under the `logins` role specification or user trait.
+
+If you can log in successfully with `tsh ssh`, you should be able to use the name login/hostname with `tsh puttyconfig`.
+
+### `Connect failed [ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain]`
+
+You have provided an incorrect login username to the `tsh puttyconfig` command when attempting to connect to an OpenSSH server.
+Re-run the command with a login username that your Teleport user/role has permissions to use. Check the logins listed under the
+`logins` role specification or user trait.
 
 If you can log in successfully with `tsh ssh`, you should be able to use the name login/hostname with `tsh puttyconfig`.
 
@@ -299,6 +328,15 @@ successful, check the Teleport proxy logs for more detailed errors.
 
 If the node is running OpenSSH rather than Teleport, you must make sure to specify the `sshd` port when adding the session,
 for example using `tsh puttyconfig --port 22 user@host` or `tsh puttyconfig user@host:22`.
+
+### `proxy: direct dialing to nodes not found in inventory is not supported`
+
+This error usually means that you registered an agentless OpenSSH host (i.e. a host running sshd) without also providing the
+port while running `tsh puttyconfig`. Try re-adding the host with the correct port (22 in this example) by using
+`tsh puttyconfig --port 22 user@host`.
+
+If you still get this error after fixing the port, make sure that the host you are trying to connect to appears in the output
+of `tsh ls`. Hostnames which do not appear in the output of `tsh ls` are unavailable for connection.
 
 ### `Unable to use certificate file "C:\Users\<username>\.tsh\keys\<proxy>\<user>-ssh\<cluster>-cert.pub" (unable to open file)`
 

--- a/docs/pages/connect-your-client/putty-winscp.mdx
+++ b/docs/pages/connect-your-client/putty-winscp.mdx
@@ -300,9 +300,9 @@ Here are two locations where `tsh.exe` can be stored which are not affected by t
 - `%WINDIR%` (e.g. `C:\Windows` - requires administrator privileges)
 
 To fix this issue, follow these steps:
-- Place the `tsh.exe` application into a different directory, as detailed above
-- Re-run `tsh puttyconfig` for each PuTTY session in order to replace the configured path to `tsh.exe` inside the session
-- Delete each saved session inside WinSCP
+- Place the `tsh.exe` application into a different directory, as detailed above.
+- Re-run `tsh puttyconfig` for each PuTTY session in order to replace the configured path to `tsh.exe` inside the session.
+- Delete each saved session inside WinSCP.
 - Re-import saved PuTTY sessions into WinSCP by following the process detailed in steps 2-3 above.
 
 ### `proxy: ERROR: access denied to <user> connecting to <proxy>`

--- a/docs/pages/connect-your-client/putty-winscp.mdx
+++ b/docs/pages/connect-your-client/putty-winscp.mdx
@@ -300,7 +300,7 @@ triggers a bug in WinSCP which causes the path to `tsh.exe` to be erroneously re
 failure. This bug does not seem to affect PuTTY sessions.
 
 Here are two locations where `tsh.exe` can be stored which are not affected by this bug:
-- `%SystemRoot%` (e.g. `C:\Windows` - requires administrator privileges, and is incuded in `%PATH%` by default)
+- `%SystemRoot%` (e.g. `C:\Windows` - requires administrator privileges, and is included in `%PATH%` by default)
 - `%USERPROFILE` (e.g. `C:\Users\<username>` - does not require administrator privileges)
 
 To fix this issue, follow these steps:

--- a/docs/pages/includes/install-tsh.mdx
+++ b/docs/pages/includes/install-tsh.mdx
@@ -1,7 +1,7 @@
 <Tabs>
   <TabItem label="Mac">
     Download the signed macOS .pkg installer for `tsh`. In Finder double-click the `pkg` file to install it:
- 
+
     ```code
     $ curl -O https://cdn.teleport.dev/tsh-(=teleport.version=).pkg
     ```
@@ -28,6 +28,8 @@
     ```code
     $ curl.exe -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-windows-amd64-bin.zip
     # Unzip the archive and move `tsh.exe` to your %PATH%
+    # NOTE: Do not place tsh.exe in the System32 directory, as this can cause issues when using WinSCP.
+    # Use %WINDIR% (C:\Windows) or %USERPROFILE% (C:\Users\<username>) instead.
     ```
   </TabItem>
 

--- a/docs/pages/includes/install-tsh.mdx
+++ b/docs/pages/includes/install-tsh.mdx
@@ -29,7 +29,7 @@
     $ curl.exe -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-windows-amd64-bin.zip
     # Unzip the archive and move `tsh.exe` to your %PATH%
     # NOTE: Do not place tsh.exe in the System32 directory, as this can cause issues when using WinSCP.
-    # Use %WINDIR% (C:\Windows) or %USERPROFILE% (C:\Users\<username>) instead.
+    # Use %SystemRoot% (C:\Windows) or %USERPROFILE% (C:\Users\<username>) instead.
     ```
   </TabItem>
 

--- a/docs/pages/includes/install-windows-clients.mdx
+++ b/docs/pages/includes/install-windows-clients.mdx
@@ -30,5 +30,9 @@
 
   <Admonition type="note">
     Do not place `tsh.exe` in the `System32` directory, as this can cause issues when using WinSCP.
-    You should use `%WINDIR%` (e.g. `C:\Windows`) or `%USERPROFILE%` (e.g. `C:\Users\<username>`) instead.
+    You should use `%SystemRoot%` (e.g. `C:\Windows`) instead, which is already included in `%PATH%`.
+
+    If you do not have administrator rights on the Windows system you're using, you can use `%USERPROFILE%`
+    (e.g. `C:\Users\<username>`) instead - but note that you will not be able to run `tsh` commands globally
+    from the command line unless you are in the same directory as `tsh.exe`.
   </Admonition>

--- a/docs/pages/includes/install-windows-clients.mdx
+++ b/docs/pages/includes/install-windows-clients.mdx
@@ -27,3 +27,8 @@
   ```
 
   Make sure to move `tsh.exe` and `tctl.exe` into your PATH.
+
+  <Admonition type="note">
+    Do not place `tsh.exe` in the `System32` directory, as this can cause issues when using WinSCP.
+    You should use `%WINDIR%` (e.g. `C:\Windows`) or `%USERPROFILE%` (e.g. `C:\Users\<username>`) instead.
+  </Admonition>

--- a/docs/pages/server-access/guides/jetbrains-sftp.mdx
+++ b/docs/pages/server-access/guides/jetbrains-sftp.mdx
@@ -73,7 +73,7 @@ $ ssh user@[server name].[cluster name]
   $ ssh -p 22 user@[server name].[cluster name]
   ```
 </Admonition>
-  
+
 ## Step 2/3. Configure your JetBrains IDE
 
 After opening your IDE go to `Tools` -> `Deployment` -> `Browse Remote Host`.


### PR DESCRIPTION
While investigating a customer issue with using WinSCP, @programmerq discovered an interesting Windows/WinSCP bug relating to path replacement which is only triggered when `tsh.exe` is spawned from the `System32` directory.

This PR adds a troubleshooting step to the WinSCP docs explaining how to work around this issue, and adds information wherever the docs instruct people to install/extract `tsh.exe` to inform them not to use `System32` (which is pretty bad practice anyway, and requires administrator rights)