### PR TITLE
docs: Update role reference to be more inclusive to v7

### DIFF
--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -89,9 +89,9 @@ Teleport provides several pre-defined roles out-of-the-box:
 There are currently four supported role versions: `v3`, `v4`, `v5`, `v6` and `v7`. `v4`, `v5` and `v6` roles are
 completely backwards-compatible with `v3`, the only difference lies in the
 default values which will be applied to the role if they are not
-explicitly set. Additionally, roles `v5` or `v6` are required to use [Moderated Sessions](./guides/moderated-sessions.mdx).
+explicitly set. Additionally, roles with version `v5` or higher are required to use [Moderated Sessions](./guides/moderated-sessions.mdx).
 
-Label              | `v3` Default   | `v4`, `v5` and `v6` Default
+Label              | `v3` Default   | `v4` and higher Default
 ------------------ | -------------- | ---------------
 `node_labels`       | `[{"*": "*"}]` if the role has any logins, else `[]` | `[]`
 `app_labels`        | `[{"*": "*"}]` | `[]`

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -86,9 +86,9 @@ Teleport provides several pre-defined roles out-of-the-box:
 
 ### Role versions
 
-There are currently five supported role versions: `v3`, `v4`, `v5`, `v6` and `v7`.
+There are currently five supported role versions: `v3`, `v4`, `v5`, `v6`, and `v7`.
 
-`v4` and higher roles are completely backwards-compatible with `v3`, the only difference
+`v4` and higher roles are completely backwards compatible with `v3`. The only difference
 lies in the default values which will be applied to the role if they are not explicitly set.
 Additionally, roles with version `v5` or higher are required to use [Moderated Sessions](./guides/moderated-sessions.mdx).
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -86,10 +86,11 @@ Teleport provides several pre-defined roles out-of-the-box:
 
 ### Role versions
 
-There are currently four supported role versions: `v3`, `v4`, `v5`, `v6` and `v7`. `v4`, `v5` and `v6` roles are
-completely backwards-compatible with `v3`, the only difference lies in the
-default values which will be applied to the role if they are not
-explicitly set. Additionally, roles with version `v5` or higher are required to use [Moderated Sessions](./guides/moderated-sessions.mdx).
+There are currently five supported role versions: `v3`, `v4`, `v5`, `v6` and `v7`.
+
+`v4` and higher roles are completely backwards-compatible with `v3`, the only difference
+lies in the default values which will be applied to the role if they are not explicitly set.
+Additionally, roles with version `v5` or higher are required to use [Moderated Sessions](./guides/moderated-sessions.mdx).
 
 Label              | `v3` Default   | `v4` and higher Default
 ------------------ | -------------- | ---------------


### PR DESCRIPTION
We previously mentioned `v4`, `v5` and `v6` as special cases, but my understanding is that this is now true across the board for role versions `v4`+ in most cases.

No `branch/v13` backport is needed as `v7` was added in Teleport 14.