### PR TITLE
Fix panic in app dialing

### DIFF
--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -388,7 +388,7 @@ func (t *transport) DialContext(ctx context.Context, _, _ string) (conn net.Conn
 
 	// eliminate any servers from the head of the list that were unreachable
 	t.mu.Lock()
-	if i < len(servers) {
+	if i < len(t.c.servers) {
 		t.c.servers = t.c.servers[i:]
 	} else {
 		t.c.servers = nil


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/35501 incorrectly checked the length on the local servers variable instead of `t.c.servers` which could lead to panics like the one below.

```bash

panic: runtime error: slice bounds out of range [1:0]
goroutine 6558252 [running]:
github.com/gravitational/teleport/lib/web/app.(*transport).DialContext(0xc00296d5f0, {0xae8bbd8, 0xc002596a20}, {0x42c525?, 0xc001dc4d80?}, {0x120?, 0x118?})
    github.com/gravitational/teleport/lib/web/app/transport.go:264 +0x5dc
net/http.(*Transport).dial(0xc002596a20?, {0xae8bbd8?, 0xc002596a20?}, {0x92ff0a2?, 0x4e4fc13?}, {0xc000b8dfc0?, 0xc00226f000?})
    net/http/transport.go:1183 +0xd2
net/http.(*Transport).dialConn(0xc002f9cb40, {0xae8bbd8, 0xc002596a20}, {{}, 0x0, {0x9301a85, 0x5}, {0xc000b8dfc0, 0x1a}, 0x0})
    net/http/transport.go:1625 +0x7e8
net/http.(*Transport).dialConnFor(0xae8bc10?, 0xc003340370)
    net/http/transport.go:1467 +0x9f
created by net/http.(*Transport).queueForDial in goroutine 6562349
    net/http/transport.go:1436 +0x3cb

```


changelog: Prevent a panic in the Proxy when accessing an offline application