### PR TITLE
move `requiredAll` rule to shared validation package 

### DIFF
--- a/web/packages/shared/components/Validation/rules.ts
+++ b/web/packages/shared/components/Validation/rules.ts
@@ -194,6 +194,34 @@ const requiredEmailLike: Rule<string, EmailValidationResult> = email => () => {
   };
 };
 
+/**
+ * A rule function that combines multiple inner rule functions. All rules must
+ * return `valid`, otherwise it returns a comma separated string containing all
+ * invalid rule messages.
+ * @param rules a list of rule functions to apply
+ * @returns a rule function that ANDs all input rules
+ */
+const requiredAll =
+  <T>(...rules: Rule<T | string | string[], ValidationResult>[]): Rule<T> =>
+  (value: T) =>
+  () => {
+    let messages = [];
+    for (let r of rules) {
+      let result = r(value)();
+      if (!result.valid) {
+        messages.push(result.message);
+      }
+    }
+
+    if (messages.length > 0) {
+      return {
+        valid: false,
+        message: messages.join('. '),
+      };
+    }
+    return { valid: true };
+  };
+
 export {
   requiredToken,
   requiredPassword,
@@ -202,4 +230,5 @@ export {
   requiredRoleArn,
   requiredIamRoleName,
   requiredEmailLike,
+  requiredAll
 };

--- a/web/packages/shared/components/Validation/rules.ts
+++ b/web/packages/shared/components/Validation/rules.ts
@@ -230,5 +230,5 @@ export {
   requiredRoleArn,
   requiredIamRoleName,
   requiredEmailLike,
-  requiredAll
+  requiredAll,
 };


### PR DESCRIPTION
`requiredAll` rule wraps multiple input validation rule

Moved from https://github.com/gravitational/teleport.e/blob/47993f90488593ca48b3c207621702ed987fac4b/web/teleport/src/InviteCollaborators/rules.ts#L135 as the rule will be used in https://github.com/gravitational/teleport/pull/42620 and in scenarious where case where multiple validation rules needs to be wrapped. 