### PR TITLE
[v16] Properly load app certificates in `tsh proxy app` for virtual profiles

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2143,6 +2143,8 @@ type GenerateUserTestCertsRequest struct {
 	PinnedIP             string
 	MFAVerified          string
 	AttestationStatement *keys.AttestationStatement
+	AppName              string
+	AppSessionID         string
 }
 
 // GenerateUserTestCerts is used to generate user certificate, used internally for tests
@@ -2173,6 +2175,8 @@ func (a *Server) GenerateUserTestCerts(req GenerateUserTestCertsRequest) ([]byte
 		pinIP:                req.PinnedIP != "",
 		mfaVerified:          req.MFAVerified,
 		attestationStatement: req.AttestationStatement,
+		appName:              req.AppName,
+		appSessionID:         req.AppSessionID,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -406,6 +406,8 @@ func onProxyCommandApp(cf *CLIConf) error {
 	// Virtual profiles (e.g. indirect use via `tbot proxy app`) will attempt
 	// relogin which is not possible. For these, we'll need to load the app
 	// certificate manually and prepend the config option.
+	// TODO(timothyb89): Remove this workaround in favor of
+	// https://github.com/gravitational/teleport/pull/40985 once it is merged.
 	if profile.IsVirtual {
 		cert, needLogin, err := loadAppCertificate(tc, app.GetName())
 		if err != nil {

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -1569,10 +1569,11 @@ func TestProxyAppWithIdentity(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		r, err := http.Get(fmt.Sprintf("http://localhost:%s", port))
-
 		if err != nil {
 			return false
 		}
+
+		defer r.Body.Close()
 
 		if r.StatusCode != 200 {
 			return false

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -31,6 +31,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/user"
@@ -59,9 +60,11 @@ import (
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/db/dbcmd"
+	"github.com/gravitational/teleport/lib/client/identityfile"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/tlsca"
 	testserver "github.com/gravitational/teleport/tool/teleport/testenv"
@@ -1436,4 +1439,148 @@ func TestCheckProxyAWSFormatCompatibility(t *testing.T) {
 			test.checkError(t, checkProxyAWSFormatCompatibility(test.input))
 		})
 	}
+}
+
+// TestProxyAppWithIdentity ensures `tsh -i <identity> proxy app` works
+// correctly given a Machine ID-style identity with a valid RouteToApp.
+func TestProxyAppWithIdentity(t *testing.T) {
+	disableAgent(t)
+	lib.SetInsecureDevMode(true)
+	t.Cleanup(func() { lib.SetInsecureDevMode(false) })
+	ctx := context.Background()
+
+	const (
+		clusterName = "root"
+		appName     = "rootapp"
+		userName    = "admin"
+	)
+
+	appURI := startDummyHTTPServer(t, appName)
+
+	rootServerOpts := []testserver.TestServerOptFunc{
+		testserver.WithClusterName(t, clusterName),
+		testserver.WithConfig(func(cfg *servicecfg.Config) {
+			cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+			cfg.Apps = servicecfg.AppsConfig{
+				Enabled: true,
+				Apps: []servicecfg.App{{
+					Name: appName,
+					URI:  appURI,
+				}},
+			}
+		}),
+	}
+	process := testserver.MakeTestServer(t, rootServerOpts...)
+	authServer := process.GetAuthServer()
+
+	// create admin role and user.
+	adminRole, err := types.NewRole(userName, types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{
+				{
+					Resources: []string{types.Wildcard},
+					Verbs:     []string{types.Wildcard},
+				},
+			},
+			AppLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+		},
+	})
+	require.NoError(t, err)
+	adminRole, err = authServer.CreateRole(ctx, adminRole)
+	require.NoError(t, err)
+
+	user, err := types.NewUser(userName)
+	user.SetRoles([]string{adminRole.GetName()})
+	require.NoError(t, err)
+	_, err = authServer.CreateUser(ctx, user)
+	require.NoError(t, err)
+
+	// create an app session for the user
+	userState, err := authServer.GetUserOrLoginState(ctx, userName)
+	require.NoError(t, err)
+	accessInfo := services.AccessInfoFromUserState(userState)
+	ws, err := authServer.CreateAppSessionFromReq(ctx, auth.NewAppSessionRequest{
+		NewWebSessionRequest: auth.NewWebSessionRequest{
+			User:       userName,
+			Roles:      accessInfo.Roles,
+			Traits:     accessInfo.Traits,
+			SessionTTL: time.Hour,
+		},
+		PublicAddr:  fmt.Sprintf("%s.%s", appName, clusterName),
+		ClusterName: clusterName,
+	})
+	require.NoError(t, err)
+
+	key, err := client.GenerateRSAKey()
+	require.NoError(t, err)
+	key.ClusterName = clusterName
+
+	// generate user certs with a RouteToApp. note that unlike certs generated
+	// with `tsh app login`, this is intended to match Machine ID-type certs
+	// which are not usage restricted to apps only; this is required for tsh to
+	// make other auth API calls beyond just accessing the app.
+	sshCert, tlsCert, err := authServer.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+		Key:            key.MarshalSSHPublicKey(),
+		Username:       userName,
+		TTL:            time.Hour,
+		Compatibility:  constants.CertificateFormatStandard,
+		RouteToCluster: clusterName,
+		AppName:        appName,
+		AppSessionID:   ws.GetName(),
+	})
+	require.NoError(t, err)
+
+	key.Cert = sshCert
+	key.TLSCert = tlsCert
+
+	hostCAs, err := authServer.GetCertAuthorities(context.Background(), types.HostCA, false)
+	require.NoError(t, err)
+	key.TrustedCerts = authclient.AuthoritiesToTrustedCerts(hostCAs)
+
+	idPath := filepath.Join(t.TempDir(), "identity")
+	_, err = identityfile.Write(context.Background(), identityfile.WriteConfig{
+		OutputPath: idPath,
+		Key:        key,
+		Format:     identityfile.FormatFile,
+	})
+	require.NoError(t, err)
+
+	port := ports.Pop()
+
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errC := make(chan error)
+	go func() {
+		var tshArgs []string
+		if testing.Verbose() {
+			tshArgs = append(tshArgs, "--debug")
+		}
+
+		errC <- Run(cancelCtx, append(tshArgs,
+			"--debug",
+			"--insecure",
+			"--identity", idPath,
+			"--proxy", process.Config.Proxy.WebAddr.Addr,
+			"proxy", "app", appName,
+			"--port", port,
+		))
+	}()
+
+	require.Eventually(t, func() bool {
+		r, err := http.Get(fmt.Sprintf("http://localhost:%s", port))
+
+		if err != nil {
+			return false
+		}
+
+		if r.StatusCode != 200 {
+			return false
+		}
+
+		return true
+	}, time.Second*5, time.Millisecond*250, "a proxied app request must eventually succeed")
+
+	cancel()
+	require.NoError(t, <-errC)
 }

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -1575,11 +1575,7 @@ func TestProxyAppWithIdentity(t *testing.T) {
 
 		defer r.Body.Close()
 
-		if r.StatusCode != 200 {
-			return false
-		}
-
-		return true
+		return r.StatusCode == 200
 	}, time.Second*5, time.Millisecond*250, "a proxied app request must eventually succeed")
 
 	cancel()


### PR DESCRIPTION
Backport #42344 to branch/v16