### PR TITLE
[v16] build: Build mac arm64 binaries with -extldflags=-ld_classic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,9 +246,15 @@ endif
 
 # Add -debugtramp=2 to work around 24 bit CALL/JMP instruction offset.
 # Add "-extldflags -Wl,--long-plt" to avoid ld assertion failure on large binaries
-GO_LDFLAGS += -extldflags -Wl,--long-plt -debugtramp=2
+GO_LDFLAGS += -extldflags=-Wl,--long-plt -debugtramp=2
 endif
 endif # OS == linux
+
+ifeq ("$(OS)-$(ARCH)","darwin-arm64")
+# Temporary link flags due to changes in Apple's linker
+# https://github.com/golang/go/issues/67854
+GO_LDFLAGS += -extldflags=-ld_classic
+endif
 
 # Windows requires extra parameters to cross-compile with CGO.
 ifeq ("$(OS)","windows")


### PR DESCRIPTION
Add the flag `-extldflags=-ld_classic` to the Go build command line when
building the teleport binaries. This is needed to get around a new issue
with the xcode linker on macOS when building enterprise `build/teleport`
emitting the error:

    ld: B/BL out of range -153903124 (max +/-128MB) to '_runtime.memequal'

This change has not been added to the enterprise makefile as the vars
are propagated when we build enterprise from the OSS makefile.

Backport: https://github.com/gravitational/teleport/pull/42732