### PR TITLE
[v14] build: Build mac arm64 binaries with -extldflags=-ld_classic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,9 +249,15 @@ endif
 
 # Add -debugtramp=2 to work around 24 bit CALL/JMP instruction offset.
 # Add "-extldflags -Wl,--long-plt" to avoid ld assertion failure on large binaries
-GO_LDFLAGS += -extldflags -Wl,--long-plt -debugtramp=2
+GO_LDFLAGS += -extldflags=-Wl,--long-plt -debugtramp=2
 endif
 endif # OS == linux
+
+ifeq ("$(OS)-$(ARCH)","darwin-arm64")
+# Temporary link flags due to changes in Apple's linker
+# https://github.com/golang/go/issues/67854
+GO_LDFLAGS += -extldflags=-ld_classic
+endif
 
 # Windows requires extra parameters to cross-compile with CGO.
 ifeq ("$(OS)","windows")

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,8 @@ CC=arm-linux-gnueabihf-gcc
 endif
 
 # Add -debugtramp=2 to work around 24 bit CALL/JMP instruction offset.
-BUILDFLAGS = $(ADDFLAGS) -ldflags '-extldflags "-Wl,--long-plt" -w -s -debugtramp=2 $(KUBECTL_SETVERSION)' -trimpath
+# Add "-extldflags -Wl,--long-plt" to avoid ld assertion failure on large binaries
+GO_LDFLAGS += -extldflags -Wl,--long-plt -debugtramp=2
 endif
 endif # OS == linux
 

--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,14 @@ CGOFLAG ?= CGO_ENABLED=1
 # should be an absolute directory as it is used by e/Makefile too, from the e/ directory.
 RELEASE_DIR := $(CURDIR)/$(BUILDDIR)/artifacts
 
+GO_LDFLAGS ?= -w -s $(KUBECTL_SETVERSION)
+
 # When TELEPORT_DEBUG is true, set flags to produce
 # debugger-friendly builds.
 ifeq ("$(TELEPORT_DEBUG)","true")
 BUILDFLAGS ?= $(ADDFLAGS) -gcflags=all="-N -l"
 else
-BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s $(KUBECTL_SETVERSION)' -trimpath
+BUILDFLAGS ?= $(ADDFLAGS) -ldflags '$(GO_LDFLAGS)' -trimpath
 endif
 
 GO_ENV_OS := $(shell go env GOOS)


### PR DESCRIPTION
Add the flag `-extldflags=-ld_classic` to the Go build command line when 
building the teleport binaries. This is needed to get around a new issue 
with the xcode linker on macOS when building enterprise `build/teleport` 
emitting the error:

   ld: B/BL out of range -153903124 (max +/-128MB) to '_runtime.memequal'

This change has not been added to the enterprise makefile as the vars are
propagated when we build enterprise from the OSS makefile.

This requires first backporting part of the PR that added the GO_LDFLAGS
make variable as well as a follow-up fix. Some small merge conflicts due
to v14 not having `-buildmode=pie` were easily resolved.

Backport: https://github.com/gravitational/teleport/pull/42732
Backport: https://github.com/gravitational/teleport/pull/42116
Backport: https://github.com/gravitational/teleport/pull/41294 (partial)