### PR TITLE
[v16] Search bar should show requestable resources for leaves if the root cluster allows it

### DIFF
--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -104,7 +104,7 @@ export const makeLeafCluster = (
   authClusterId: '',
   loggedInUser: makeLoggedInUser(),
   proxyVersion: '',
-  showResources: ShowResources.REQUESTABLE,
+  showResources: ShowResources.UNSPECIFIED,
   ...props,
 });
 

--- a/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
@@ -272,7 +272,7 @@ describe('useResourceSearch', () => {
     expect(appContext.resourcesService.searchResources).not.toHaveBeenCalled();
   });
 
-  it('requestable resources should be fetched for leaves if the root cluster allows it', async () => {
+  it('fetches requestable resources for leaves if the root cluster allows it', async () => {
     const appContext = new MockAppContext();
     const rootCluster = makeRootCluster({
       showResources: ShowResources.REQUESTABLE,

--- a/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
@@ -19,6 +19,8 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react';
 
+import { ShowResources } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
+
 import { ServerUri } from 'teleterm/ui/uri';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { SearchResult } from 'teleterm/ui/services/resources';
@@ -27,6 +29,7 @@ import {
   makeKube,
   makeLabelsList,
   makeRootCluster,
+  makeLeafCluster,
 } from 'teleterm/services/tshd/testHelpers';
 
 import { MockAppContextProvider } from '../fixtures/MockAppContextProvider';
@@ -267,6 +270,49 @@ describe('useResourceSearch', () => {
     });
     await result.current('foo', [], true);
     expect(appContext.resourcesService.searchResources).not.toHaveBeenCalled();
+  });
+
+  it('requestable resources should be fetched for leaves if the root cluster allows it', async () => {
+    const appContext = new MockAppContext();
+    const rootCluster = makeRootCluster({
+      showResources: ShowResources.REQUESTABLE,
+    });
+    const leafCluster = makeLeafCluster({
+      showResources: ShowResources.UNSPECIFIED,
+    });
+    appContext.clustersService.setState(draftState => {
+      draftState.clusters.set(rootCluster.uri, rootCluster);
+      draftState.clusters.set(leafCluster.uri, leafCluster);
+    });
+    jest
+      .spyOn(appContext.resourcesService, 'searchResources')
+      .mockResolvedValue([]);
+
+    const { result } = renderHook(() => useResourceSearch(), {
+      wrapper: ({ children }) => (
+        <MockAppContextProvider appContext={appContext}>
+          {children}
+        </MockAppContextProvider>
+      ),
+    });
+    await result.current('foo', [], false);
+    expect(appContext.resourcesService.searchResources).toHaveBeenCalledTimes(
+      2
+    );
+    expect(appContext.resourcesService.searchResources).toHaveBeenCalledWith({
+      clusterUri: rootCluster.uri,
+      filters: [],
+      includeRequestable: true,
+      limit: 100,
+      search: 'foo',
+    });
+    expect(appContext.resourcesService.searchResources).toHaveBeenCalledWith({
+      clusterUri: leafCluster.uri,
+      filters: [],
+      includeRequestable: true,
+      limit: 100,
+      search: 'foo',
+    });
   });
 });
 

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -127,7 +127,8 @@ export function useResourceSearch() {
             filters: resourceTypeSearchFilters.map(f => f.resourceType),
             limit,
             includeRequestable:
-              cluster.showResources === ShowResources.REQUESTABLE,
+              clustersService.findRootClusterByResource(cluster.uri)
+                ?.showResources === ShowResources.REQUESTABLE,
           })
         )
       );


### PR DESCRIPTION
Backport #42568 to branch/v16