### PR TITLE
Remove outdated per-session MFA limitations from docs

### DIFF
--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -10,6 +10,7 @@ when starting new:
 - SSH connections (a single `tsh ssh` call, Web UI SSH session or Teleport Connect SSH session)
 - Kubernetes sessions (a single `kubectl` call)
 - Database sessions (a single `tsh db connect` call)
+- Application sessions
 - Desktop sessions
 
 This is an advanced security feature that protects users against compromises of
@@ -262,11 +263,4 @@ Current limitations for this feature are:
 - For SSH connections besides the Web UI, the `tsh` or Teleport Connect client must be used for per-session MFA.
   (The OpenSSH `ssh` client does not work with per-session MFA).
 - Only `kubectl` supports per-session WebAuthn authentication for Kubernetes.
-- Database access with per-session MFA only works with `tsh db connect` or `tsh proxy db --tunnel`.
-  Per-session MFA for databases is not supported in Teleport Connect.
-- Application access clients don't support per-session MFA
-  authentication yet, although cluster and role configuration applies to them.
-  If you enable per-session MFA checks cluster-wide, you will not be able to
-  use Application access. We're working on integrating per-session
-  MFA checks for these clients.
 - For desktop access, only WebAuthn devices are supported.


### PR DESCRIPTION
Teleport Connect will support per-session MFA for databases in v16.
So I think we will have all kinds of clients supported now.

To my best knowledge, the same applies to apps. 
(@Joerger please confirm)