### PR TITLE
[v16] Introduce long-lived SSH proxy for Machine ID (#42592)

### DIFF
--- a/api/client/proxy/client.go
+++ b/api/client/proxy/client.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/client"
-	authpb "github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/proxy/transport/transportv1"
 	"github.com/gravitational/teleport/api/defaults"
 	transportv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/transport/v1"
@@ -431,10 +430,7 @@ func (c *Client) ClusterDetails(ctx context.Context) (ClusterDetails, error) {
 func (c *Client) Ping(ctx context.Context) error {
 	// TODO(tross): Update to call Ping when it is added to the transport service.
 	// For now we don't really care what method is used we just want to measure
-	// how long it takes to get a reply. This will always fail with a not implemented
-	// error since the Proxy gRPC server doesn't serve the auth service proto. However,
-	// we use it because it's already imported in the api package.
-	clt := authpb.NewAuthServiceClient(c.grpcConn)
-	_, _ = clt.Ping(ctx, &authpb.PingRequest{})
+	// how long it takes to get a reply.
+	_, _ = c.transport.ClusterDetails(ctx)
 	return nil
 }

--- a/lib/config/openssh/openssh.go
+++ b/lib/config/openssh/openssh.go
@@ -69,6 +69,9 @@ Host *.{{ $clusterName }} !{{ $dot.ProxyHost }}
 {{- if eq $dot.AppName "tbot" }}
 {{- if $dot.PureTBotProxyCommand }}
     ProxyCommand {{ proxyCommandQuote $dot.ExecutablePath }} ssh-proxy-command --destination-dir={{ proxyCommandQuote $dot.DestinationDir }} --proxy-server={{ proxyCommandQuote (print $dot.ProxyHost ":" $dot.ProxyPort) }} --cluster={{ proxyCommandQuote $clusterName }} {{ if $dot.TLSRouting }}--tls-routing{{ else }}--no-tls-routing{{ end }} {{ if $dot.ConnectionUpgrade }}--connection-upgrade{{ else }}--no-connection-upgrade{{ end }} {{ if $dot.Resume }}--resume{{ else }}--no-resume{{ end }} --user=%r --host=%h --port=%p
+{{- else if $dot.TBotMux }}
+    ProxyCommand {{range $v := $dot.TBotMuxProxyCommand}}{{ proxyCommandQuote $v }} {{end}}{{ proxyCommandQuote $dot.TBotMuxSocketPath }} '{{ $dot.TBotMuxData }}'
+    ProxyUseFdpass true
 {{- else }}
     ProxyCommand "{{ $dot.ExecutablePath }}" proxy --destination-dir={{ $dot.DestinationDir }} --proxy-server={{ $dot.ProxyHost }}:{{ $dot.ProxyPort }} ssh --cluster={{ $clusterName }}  %r@%h:%p
 {{- end }}
@@ -104,6 +107,13 @@ type SSHConfigParameters struct {
 	Insecure             bool
 	FIPS                 bool
 	Resume               bool
+
+	// TBotMuxCommand enables the `ssh-multiplexer-proxy-command` operating mode
+	// when generating the ssh_config for tbot.
+	TBotMux             bool
+	TBotMuxProxyCommand []string
+	TBotMuxSocketPath   string
+	TBotMuxData         string
 }
 
 type sshTmplParams struct {

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -484,6 +484,12 @@ func (o *ServiceConfigs) UnmarshalYAML(node *yaml.Node) error {
 				return trace.Wrap(err)
 			}
 			out = append(out, v)
+		case SSHMultiplexerServiceType:
+			v := &SSHMultiplexerService{}
+			if err := node.Decode(v); err != nil {
+				return trace.Wrap(err)
+			}
+			out = append(out, v)
 		default:
 			return trace.BadParameter("unrecognized service type (%s)", header.Type)
 		}

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -283,6 +283,11 @@ func TestBotConfig_YAML(t *testing.T) {
 					&ExampleService{
 						Message: "llama",
 					},
+					&SSHMultiplexerService{
+						Destination: &DestinationDirectory{
+							Path: "/bot/output",
+						},
+					},
 				},
 			},
 		},

--- a/lib/tbot/config/service_ssh_multiplexer.go
+++ b/lib/tbot/config/service_ssh_multiplexer.go
@@ -1,0 +1,95 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package config
+
+import (
+	"github.com/gravitational/trace"
+	"gopkg.in/yaml.v3"
+
+	"github.com/gravitational/teleport/lib/tbot/bot"
+)
+
+// SSHMultiplexerServiceType is the type of the `ssh-proxy` service.
+const SSHMultiplexerServiceType = "ssh-multiplexer"
+
+// SSHMultiplexerService is the configuration for the `ssh-proxy` service
+type SSHMultiplexerService struct {
+	// Destination is where the config and tunnel should be written to. It
+	// should be a DestinationDirectory.
+	Destination bot.Destination `yaml:"destination"`
+	// EnableResumption controls whether to enable session resumption for the
+	// SSH proxy.
+	// Call `SessionResumptionEnabled` to get the value with defaults applied.
+	EnableResumption *bool `yaml:"enable_resumption"`
+	// ProxyTemplatesPath is the path to the directory containing the templates
+	// for the SSH proxy.
+	// This field is optional, if not provided, no templates will be used.
+	// This file is loaded once on start, so changes to the templates will
+	// require a restart of tbot.
+	ProxyTemplatesPath string `yaml:"proxy_templates_path"`
+	// ProxyCommand is the base command to configure OpenSSH to invoke to
+	// connect to the SSH multiplexer. The path to the socket and the target
+	// will be automatically appended.
+	// Optional: If not provided, it will default to the `tbot` binary.
+	ProxyCommand []string `yaml:"proxy_command,omitempty"`
+}
+
+func (s *SSHMultiplexerService) SessionResumptionEnabled() bool {
+	if s.EnableResumption == nil {
+		return true
+	}
+	return *s.EnableResumption
+}
+
+func (s *SSHMultiplexerService) Type() string {
+	return SSHMultiplexerServiceType
+}
+
+func (s *SSHMultiplexerService) MarshalYAML() (interface{}, error) {
+	type raw SSHMultiplexerService
+	return withTypeHeader((*raw)(s), SSHMultiplexerServiceType)
+}
+
+func (s *SSHMultiplexerService) UnmarshalYAML(node *yaml.Node) error {
+	dest, err := extractOutputDestination(node)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Alias type to remove UnmarshalYAML to avoid recursion
+	type raw SSHMultiplexerService
+	if err := node.Decode((*raw)(s)); err != nil {
+		return trace.Wrap(err)
+	}
+	s.Destination = dest
+	return nil
+}
+
+func (s *SSHMultiplexerService) CheckAndSetDefaults() error {
+	if s.Destination == nil {
+		return trace.BadParameter("destination: must be specified")
+	}
+	_, ok := s.Destination.(*DestinationDirectory)
+	if !ok {
+		return trace.BadParameter("destination: must be of type `directory`")
+	}
+	if err := validateOutputDestination(s.Destination); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}

--- a/lib/tbot/config/service_ssh_multiplexer_test.go
+++ b/lib/tbot/config/service_ssh_multiplexer_test.go
@@ -1,0 +1,82 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package config
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/lib/tbot/botfs"
+)
+
+func TestSSHMultiplexerService_YAML(t *testing.T) {
+	t.Parallel()
+
+	tests := []testYAMLCase[SSHMultiplexerService]{
+		{
+			name: "full",
+			in: SSHMultiplexerService{
+				Destination: &DestinationDirectory{
+					Path: "/opt/machine-id",
+				},
+				EnableResumption:   ptr[bool](true),
+				ProxyTemplatesPath: "/etc/teleport/templates",
+				ProxyCommand:       []string{"rusty-boi"},
+			},
+		},
+	}
+	testYAML(t, tests)
+}
+
+func TestSSHMultiplexerService_CheckAndSetDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []testCheckAndSetDefaultsCase[*SSHMultiplexerService]{
+		{
+			name: "valid",
+			in: func() *SSHMultiplexerService {
+				return &SSHMultiplexerService{
+					Destination: &DestinationDirectory{
+						Path:     "/opt/machine-id",
+						ACLs:     botfs.ACLOff,
+						Symlinks: botfs.SymlinksInsecure,
+					},
+				}
+			},
+		},
+		{
+			name: "missing destination",
+			in: func() *SSHMultiplexerService {
+				return &SSHMultiplexerService{
+					Destination: nil,
+				}
+			},
+			wantErr: "destination: must be specified",
+		},
+		{
+			name: "wrong destination type",
+			in: func() *SSHMultiplexerService {
+				return &SSHMultiplexerService{
+					Destination: &DestinationMemory{},
+				}
+			},
+			wantErr: "destination: must be of type `directory`",
+		},
+	}
+	testCheckAndSetDefaults(t, tests)
+}

--- a/lib/tbot/config/template_ssh_client_test.go
+++ b/lib/tbot/config/template_ssh_client_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gravitational/teleport/lib/tbot/botfs"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/ssh"
 	"github.com/gravitational/teleport/lib/utils/golden"
 )
 
@@ -111,10 +112,10 @@ func TestTemplateSSHClient_Render(t *testing.T) {
 				return bytes.ReplaceAll(b, []byte(dir), []byte("/test/dir"))
 			}
 
-			knownHostBytes, err := os.ReadFile(filepath.Join(dir, knownHostsName))
+			knownHostBytes, err := os.ReadFile(filepath.Join(dir, ssh.KnownHostsName))
 			require.NoError(t, err)
 			knownHostBytes = replaceTestDir(knownHostBytes)
-			sshConfigBytes, err := os.ReadFile(filepath.Join(dir, sshConfigName))
+			sshConfigBytes, err := os.ReadFile(filepath.Join(dir, ssh.ConfigName))
 			require.NoError(t, err)
 			sshConfigBytes = replaceTestDir(sshConfigBytes)
 			if golden.ShouldSet() {

--- a/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
+++ b/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
@@ -39,6 +39,12 @@ services:
               pid: 100
   - type: example
     message: llama
+  - type: ssh-multiplexer
+    destination:
+      type: directory
+      path: /bot/output
+    enable_resumption: null
+    proxy_templates_path: ""
 debug: true
 auth_server: example.teleport.sh:443
 certificate_ttl: 1m0s

--- a/lib/tbot/config/testdata/TestSSHMultiplexerService_YAML/full.golden
+++ b/lib/tbot/config/testdata/TestSSHMultiplexerService_YAML/full.golden
@@ -1,0 +1,8 @@
+type: ssh-multiplexer
+destination:
+  type: directory
+  path: /opt/machine-id
+enable_resumption: true
+proxy_templates_path: /etc/teleport/templates
+proxy_command:
+  - rusty-boi

--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -1,0 +1,752 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/prometheus/client_golang/prometheus"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+
+	proxyclient "github.com/gravitational/teleport/api/client/proxy"
+	"github.com/gravitational/teleport/api/observability/tracing"
+	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	libclient "github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/config/openssh"
+	"github.com/gravitational/teleport/lib/observability/metrics"
+	"github.com/gravitational/teleport/lib/resumption"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/ssh"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const sshMuxSocketName = "v1.sock"
+
+var (
+	muxReqsStartedCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "tbot_ssh_multiplexer_requests_started_total",
+			Help: "Number of requests completed by the multiplexer",
+		},
+	)
+	muxReqsHandledCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tbot_ssh_multiplexer_requests_handled_total",
+			Help: "Number of requests completed by the multiplexer",
+		}, []string{"status"},
+	)
+	muxReqsInflightGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "tbot_ssh_multiplexer_requests_in_flight",
+			Help: "Number of SSH connections currently being handled by the multiplexer",
+		},
+	)
+)
+
+// SSHMultiplexerService is a long-lived local SSH proxy. It listens on a local Unix
+// socket and has a special client with support for FDPassing with OpenSSH.
+// It places an emphasis on high performance.
+type SSHMultiplexerService struct {
+	alpnUpgradeCache *alpnProxyConnUpgradeRequiredCache
+	// botAuthClient should be an auth client using the bots internal identity.
+	// This will not have any roles impersonated and should only be used to
+	// fetch CAs.
+	botAuthClient     *authclient.Client
+	botCfg            *config.BotConfig
+	cfg               *config.SSHMultiplexerService
+	getBotIdentity    getBotIdentityFn
+	log               *slog.Logger
+	proxyPingCache    *proxyPingCache
+	reloadBroadcaster *channelBroadcaster
+	resolver          reversetunnelclient.Resolver
+
+	// Fields below here are initialized by the service itself on startup.
+	identity *identity.Facade
+}
+
+func (s *SSHMultiplexerService) writeArtifacts(ctx context.Context, proxyHost string, id *identity.Identity) error {
+	dest := s.cfg.Destination.(*config.DestinationDirectory)
+
+	// TODO(noah): identity.SaveIdentity outputs artifacts we don't necessarily
+	// want. For now, I've just manually output them here but we may want to
+	// revisit how this is implemented.
+	if err := dest.Write(ctx, identity.SSHCertKey, id.CertBytes); err != nil {
+		return trace.Wrap(err, "writing %s", identity.SSHCertKey)
+	}
+	if err := dest.Write(ctx, identity.PrivateKeyKey, id.PrivateKeyBytes); err != nil {
+		return trace.Wrap(err, "writing %s", identity.PrivateKeyKey)
+	}
+	if err := dest.Write(ctx, identity.PublicKeyKey, id.PublicKeyBytes); err != nil {
+		return trace.Wrap(err, "writing %s", identity.PublicKeyKey)
+	}
+
+	// Generate known hosts
+	knownHosts, err := ssh.GenerateKnownHosts(
+		ctx,
+		s.botAuthClient,
+		[]string{id.ClusterName},
+		proxyHost,
+	)
+	if err != nil {
+		return trace.Wrap(err, "generating known hosts")
+	}
+	if err := dest.Write(ctx, ssh.KnownHostsName, []byte(knownHosts)); err != nil {
+		return trace.Wrap(err, "writing %s", ssh.KnownHostsName)
+	}
+
+	// Generate SSH config
+	proxyCommand := s.cfg.ProxyCommand
+	if len(proxyCommand) == 0 {
+		executablePath, err := os.Executable()
+		if err != nil {
+			return trace.Wrap(err, "determining executable path")
+		}
+		proxyCommand = []string{
+			executablePath,
+			"ssh-multiplexer-proxy-command",
+		}
+	}
+
+	absPath, err := filepath.Abs(dest.Path)
+	if err != nil {
+		return trace.Wrap(err, "determining absolute path for destination")
+	}
+
+	var sshConfigBuilder strings.Builder
+	sshConf := openssh.NewSSHConfig(openssh.GetSystemSSHVersion, nil)
+	err = sshConf.GetSSHConfig(&sshConfigBuilder, &openssh.SSHConfigParameters{
+		AppName:             openssh.TbotApp,
+		ClusterNames:        []string{id.ClusterName},
+		KnownHostsPath:      filepath.Join(absPath, ssh.KnownHostsName),
+		IdentityFilePath:    filepath.Join(absPath, identity.PrivateKeyKey),
+		CertificateFilePath: filepath.Join(absPath, identity.SSHCertKey),
+		ProxyHost:           proxyHost,
+
+		TBotMux:             true,
+		TBotMuxProxyCommand: proxyCommand,
+		TBotMuxData:         `%h:%p`,
+		TBotMuxSocketPath:   filepath.Join(absPath, sshMuxSocketName),
+	})
+	if err != nil {
+		return trace.Wrap(err, "generating SSH config")
+	}
+	if err := dest.Write(ctx, ssh.ConfigName, []byte(sshConfigBuilder.String())); err != nil {
+		return trace.Wrap(err, "writing %s", ssh.ConfigName)
+	}
+
+	return nil
+}
+
+func (s *SSHMultiplexerService) setup(ctx context.Context) (
+	_ *authclient.Client,
+	_ *cyclingHostDialClient,
+	proxyHost string,
+	_ *libclient.TSHConfig,
+	_ error,
+) {
+	// Register service metrics. Expected to always work.
+	if err := metrics.RegisterPrometheusCollectors(
+		muxReqsStartedCounter,
+		muxReqsHandledCounter,
+		muxReqsInflightGauge,
+	); err != nil {
+		return nil, nil, "", nil, trace.Wrap(err)
+	}
+
+	if err := s.cfg.Destination.Init(ctx, []string{}); err != nil {
+		return nil, nil, "", nil, trace.Wrap(err, "initializing destination")
+	}
+
+	// Load in any proxy templates if a path to them has been provided.
+	tshConfig := &libclient.TSHConfig{}
+	if s.cfg.ProxyTemplatesPath != "" {
+		s.log.InfoContext(ctx, "Loading proxy templates", "path", s.cfg.ProxyTemplatesPath)
+		var err error
+		tshConfig, err = libclient.LoadTSHConfig(s.cfg.ProxyTemplatesPath)
+		if err != nil {
+			return nil, nil, "", nil, trace.Wrap(err, "loading proxy templates")
+		}
+	}
+
+	// Generate our initial identity and write the artifacts to the destination.
+	id, err := s.generateIdentity(ctx)
+	if err != nil {
+		return nil, nil, "", nil, trace.Wrap(err, "generating initial identity")
+	}
+	s.identity = identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
+
+	sshConfig, err := s.identity.SSHClientConfig()
+	if err != nil {
+		return nil, nil, "", nil, trace.Wrap(err)
+	}
+
+	// Ping the proxy and determine if we need to upgrade the connection.
+	proxyPing, err := s.proxyPingCache.ping(ctx)
+	if err != nil {
+		return nil, nil, "", nil, trace.Wrap(err)
+	}
+	proxyAddr := proxyPing.Proxy.SSH.PublicAddr
+	proxyHost, _, err = net.SplitHostPort(proxyPing.Proxy.SSH.PublicAddr)
+	if err != nil {
+		return nil, nil, "", nil, trace.Wrap(err)
+	}
+	connUpgradeRequired := false
+	if proxyPing.Proxy.TLSRoutingEnabled {
+		connUpgradeRequired, err = s.alpnUpgradeCache.isUpgradeRequired(
+			ctx, proxyAddr, s.botCfg.Insecure,
+		)
+		if err != nil {
+			return nil, nil, "", nil, trace.Wrap(err, "determining if ALPN upgrade is required")
+		}
+	}
+
+	// Create Proxy and Auth clients
+	proxyClient := newCyclingHostDialClient(100, proxyclient.ClientConfig{
+		ProxyAddress:      proxyAddr,
+		TLSRoutingEnabled: proxyPing.Proxy.TLSRoutingEnabled,
+		TLSConfigFunc: func(cluster string) (*tls.Config, error) {
+			cfg, err := s.identity.TLSConfig()
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			// The facade TLS config is tailored toward connections to the Auth service.
+			// Override the server name to be the proxy and blank out the next protos to
+			// avoid hitting the proxy web listener.
+			cfg.ServerName = proxyHost
+			cfg.NextProtos = nil
+			return cfg, nil
+		},
+		UnaryInterceptors: []grpc.UnaryClientInterceptor{
+			clientMetrics.UnaryClientInterceptor(),
+			interceptors.GRPCClientUnaryErrorInterceptor,
+		},
+		StreamInterceptors: []grpc.StreamClientInterceptor{
+			clientMetrics.StreamClientInterceptor(),
+			interceptors.GRPCClientStreamErrorInterceptor,
+		},
+		SSHConfig:               sshConfig,
+		InsecureSkipVerify:      s.botCfg.Insecure,
+		ALPNConnUpgradeRequired: connUpgradeRequired,
+	})
+
+	authClient, err := clientForFacade(
+		ctx, s.log, s.botCfg, s.identity, s.resolver,
+	)
+	if err != nil {
+		return nil, nil, "", nil, trace.Wrap(err)
+	}
+
+	return authClient, proxyClient, proxyHost, tshConfig, nil
+}
+
+// generateIdentity generates our impersonated identity which we will write to
+// the destination.
+func (s *SSHMultiplexerService) generateIdentity(ctx context.Context) (*identity.Identity, error) {
+	roles, err := fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
+	if err != nil {
+		return nil, trace.Wrap(err, "fetching default roles")
+	}
+
+	ident, err := generateIdentity(
+		ctx,
+		s.botAuthClient,
+		s.getBotIdentity(),
+		roles,
+		s.botCfg.CertificateTTL,
+		nil,
+	)
+	return ident, err
+}
+
+func (s *SSHMultiplexerService) identityRenewalLoop(ctx context.Context, proxyHost string) error {
+	reloadCh, unsubscribe := s.reloadBroadcaster.subscribe()
+	defer unsubscribe()
+
+	ticker := time.NewTicker(s.botCfg.RenewalInterval)
+	jitter := retryutils.NewJitter()
+	defer ticker.Stop()
+	for {
+		var err error
+		for attempt := 1; attempt <= renewalRetryLimit; attempt++ {
+			s.log.InfoContext(
+				ctx,
+				"Attempting to renew identity",
+				"attempt", attempt,
+				"retry_limit", renewalRetryLimit,
+			)
+			var id *identity.Identity
+			id, err = s.generateIdentity(ctx)
+			if err == nil {
+				s.identity.Set(id)
+				err = s.writeArtifacts(ctx, proxyHost, id)
+				if err == nil {
+					break
+				}
+			}
+
+			if attempt != renewalRetryLimit {
+				// exponentially back off with jitter, starting at 1 second.
+				backoffTime := time.Second * time.Duration(math.Pow(2, float64(attempt-1)))
+				backoffTime = jitter(backoffTime)
+				s.log.WarnContext(
+					ctx,
+					"Identity renewal attempt failed. Waiting to retry",
+					"attempt", attempt,
+					"retry_limit", renewalRetryLimit,
+					"backoff", backoffTime,
+					"error", err,
+				)
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-time.After(backoffTime):
+				}
+			}
+		}
+		if err != nil {
+			s.log.WarnContext(
+				ctx,
+				"All retry attempts exhausted renewing identity. Waiting for next normal renewal cycle",
+				"retry_limit", renewalRetryLimit,
+				"interval", s.botCfg.RenewalInterval,
+			)
+		} else {
+			s.log.InfoContext(
+				ctx,
+				"Renewed identity. Waiting for next identity renewal",
+				"interval", s.botCfg.RenewalInterval,
+			)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			continue
+		case <-reloadCh:
+			continue
+		}
+	}
+}
+
+func (s *SSHMultiplexerService) Run(ctx context.Context) (err error) {
+	ctx, span := tracer.Start(
+		ctx,
+		"SSHMultiplexerService/Run",
+	)
+	defer func() { tracing.EndSpan(span, err) }()
+
+	authClient, hostDialer, proxyHost, tshConfig, err := s.setup(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer authClient.Close()
+
+	dest := s.cfg.Destination.(*config.DestinationDirectory)
+	absPath, err := filepath.Abs(dest.Path)
+	if err != nil {
+		return trace.Wrap(err, "determining absolute path for destination")
+	}
+	listenerURL := url.URL{Scheme: "unix", Path: filepath.Join(absPath, sshMuxSocketName)}
+	l, err := createListener(
+		ctx,
+		s.log,
+		listenerURL.String(),
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer l.Close()
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		defer context.AfterFunc(egCtx, func() { _ = l.Close() })()
+		for {
+			downstream, err := l.Accept()
+			if err != nil {
+				if utils.IsUseOfClosedNetworkError(err) {
+					return nil
+				}
+
+				s.log.WarnContext(
+					egCtx,
+					"Error encountered accepting connection, sleeping and continuing",
+					"error",
+					err,
+				)
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-time.After(50 * time.Millisecond):
+				}
+
+				continue
+			}
+
+			go func() {
+				muxReqsStartedCounter.Inc()
+				muxReqsInflightGauge.Inc()
+				defer muxReqsInflightGauge.Dec()
+
+				err := s.handleConn(
+					egCtx, tshConfig, authClient, hostDialer, proxyHost, downstream,
+				)
+
+				var status string
+				switch {
+				case utils.IsOKNetworkError(err):
+					// We reduce the verbosity here since these are to be
+					// expected and are not usually indicative of a problem.
+					status = "OK_NETWORK_ERROR"
+					s.log.DebugContext(egCtx, "Handler exited with a network error", "error", err)
+				case err != nil && !errors.Is(err, context.Canceled):
+					status = "ERROR"
+					s.log.WarnContext(egCtx, "Handler exited with error", "error", err)
+				default:
+					status = "OK"
+				}
+				muxReqsHandledCounter.WithLabelValues(status).Inc()
+			}()
+		}
+	})
+	eg.Go(func() error {
+		return s.identityRenewalLoop(egCtx, proxyHost)
+	})
+
+	return eg.Wait()
+}
+
+func (s *SSHMultiplexerService) handleConn(
+	ctx context.Context,
+	tshConfig *libclient.TSHConfig,
+	authClient *authclient.Client,
+	hostDialer *cyclingHostDialClient,
+	proxyHost string,
+	downstream net.Conn,
+) (err error) {
+	ctx, span := tracer.Start(
+		ctx,
+		"SSHMultiplexerService/handleConn",
+		oteltrace.WithNewRoot(),
+	)
+	defer func() { tracing.EndSpan(span, err) }()
+	defer func() {
+		if err := downstream.Close(); err != nil {
+			s.log.DebugContext(ctx, "Error closing downstream connection", "error", err)
+		}
+	}()
+
+	// The first thing downstream will send is the multiplexing request which is
+	// the "[host]:[port]\x00" format.
+	buf := bufio.NewReader(downstream)
+	req, err := buf.ReadString('\x00')
+	if err != nil {
+		return trace.Wrap(err, "reading request")
+	}
+	req = req[:len(req)-1] // Drop the NUL.
+	host, port, err := utils.SplitHostPort(req)
+	if err != nil {
+		return trace.Wrap(err, "malformed request %q", req)
+	}
+
+	log := s.log.With(
+		slog.Group("req",
+			"host", host,
+			"port", port,
+		),
+	)
+	log.InfoContext(ctx, "Received multiplexing request")
+
+	clusterName := s.identity.Get().ClusterName
+	expanded, matched := tshConfig.ProxyTemplates.Apply(
+		net.JoinHostPort(host, port),
+	)
+	if matched {
+		log.DebugContext(
+			ctx,
+			"Proxy templated matched",
+			"populated_template", expanded,
+		)
+		if expanded.Cluster != "" {
+			clusterName = expanded.Cluster
+		}
+
+		if expanded.Host != "" {
+			host = expanded.Host
+		}
+	}
+
+	var target string
+	if expanded == nil || (len(expanded.Search) == 0 && expanded.Query == "") {
+		host = cleanTargetHost(host, proxyHost, clusterName)
+		target = net.JoinHostPort(host, port)
+	} else {
+		node, err := resolveTargetHostWithClient(ctx, authClient, expanded.Search, expanded.Query)
+		if err != nil {
+			return trace.Wrap(err, "resolving target host")
+		}
+
+		log.DebugContext(
+			ctx,
+			"Found matching SSH host",
+			"host_uuid", node.GetName(),
+			"host_name", node.GetHostname(),
+		)
+
+		target = net.JoinHostPort(node.GetName(), "0")
+	}
+
+	upstream, _, err := hostDialer.DialHost(ctx, target, clusterName, nil)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if s.cfg.SessionResumptionEnabled() {
+		log.DebugContext(ctx, "Enabling session resumption")
+		upstream, err = resumption.WrapSSHClientConn(
+			ctx,
+			upstream,
+			func(ctx context.Context, hostID string) (net.Conn, error) {
+				log.DebugContext(ctx, "Resuming connection")
+				// if the connection is being resumed, it means that
+				// we didn't need the agent in the first place
+				var noAgent agent.ExtendedAgent
+				conn, _, err := hostDialer.DialHost(
+					ctx, net.JoinHostPort(hostID, "0"), clusterName, noAgent,
+				)
+				return conn, err
+			})
+		if err != nil {
+			return trace.Wrap(err, "wrapping conn for session resumption")
+		}
+	}
+	defer func() {
+		if err := upstream.Close(); err != nil {
+			s.log.DebugContext(ctx, "Error closing upstream connection", "error", err)
+		}
+	}()
+
+	defer context.AfterFunc(ctx, func() {
+		if err := trace.NewAggregate(
+			upstream.Close(),
+			downstream.Close(),
+		); err != nil {
+			s.log.DebugContext(ctx, "Error closing connections", "error", err)
+		}
+	})()
+
+	log.InfoContext(ctx, "Proxying connection for multiplexing request")
+	startedProxying := time.Now()
+
+	errCh := make(chan error, 2)
+	go func() {
+		defer upstream.Close()
+		defer downstream.Close()
+		// Drain the buffer we used to read in the request in case it read in more
+		// than just the initial request.
+		drained, _ := buf.Peek(buf.Buffered())
+		if _, err := upstream.Write(drained); err != nil {
+			errCh <- trace.Wrap(err, "draining request buffer upstream")
+			return
+		}
+		_, err = io.Copy(upstream, downstream)
+		errCh <- trace.Wrap(err, "downstream->upstream")
+	}()
+
+	go func() {
+		defer upstream.Close()
+		defer downstream.Close()
+		_, err := io.Copy(downstream, upstream)
+		errCh <- trace.Wrap(err, "upstream->downstream")
+	}()
+
+	err = trace.NewAggregate(<-errCh, <-errCh)
+	log.InfoContext(
+		ctx,
+		"Finished proxying connection multiplexing request",
+		"proxied_duration", time.Since(startedProxying),
+	)
+	return err
+}
+
+func (s *SSHMultiplexerService) String() string {
+	return config.SSHMultiplexerServiceType
+}
+
+type hostDialer interface {
+	DialHost(ctx context.Context, target string, cluster string, keyring agent.ExtendedAgent) (net.Conn, proxyclient.ClusterDetails, error)
+	Close() error
+}
+
+// cyclingHostDialClient handles cycling through proxy clients every configured
+// number of connections. This prevents a single client being overwhelmed.
+type cyclingHostDialClient struct {
+	max          int32
+	hostDialerFn func(ctx context.Context) (hostDialer, error)
+
+	mu         sync.Mutex
+	started    int32
+	currentClt *refCountProxyClient
+}
+
+type refCountProxyClient struct {
+	clt      hostDialer
+	refCount atomic.Int32
+}
+
+func (r *refCountProxyClient) release() {
+	if r == nil {
+		return
+	}
+	if r.refCount.Add(-1) <= 0 {
+		go r.clt.Close()
+	}
+}
+
+type refCountConn struct {
+	net.Conn
+	parent atomic.Pointer[refCountProxyClient]
+}
+
+func (r *refCountConn) Close() error {
+	// Swap operation ensures that this conn only releases the ref to its
+	// underlying client once, even if Close is called multiple times.
+	defer r.parent.Swap(nil).release()
+	return trace.Wrap(r.Conn.Close())
+}
+
+func newCyclingHostDialClient(max int32, config proxyclient.ClientConfig) *cyclingHostDialClient {
+	return &cyclingHostDialClient{
+		max: max,
+		hostDialerFn: func(ctx context.Context) (hostDialer, error) {
+			return proxyclient.NewClient(ctx, config)
+		},
+	}
+}
+
+func (s *cyclingHostDialClient) DialHost(ctx context.Context, target string, cluster string, keyring agent.ExtendedAgent) (net.Conn, proxyclient.ClusterDetails, error) {
+	s.mu.Lock()
+	if s.currentClt == nil {
+		clt, err := s.hostDialerFn(ctx)
+		if err != nil {
+			s.mu.Unlock()
+			return nil, proxyclient.ClusterDetails{}, trace.Wrap(err)
+		}
+		s.currentClt = &refCountProxyClient{clt: clt}
+		// cyclingHostDialClient holds a reference while the refCountProxyClient
+		// is "live"
+		s.currentClt.refCount.Add(1)
+		s.started = 0
+	}
+
+	currentClt := s.currentClt
+	s.started++
+	if s.started >= s.max {
+		// the reference owned by cyclingHostDialClient is transferred to currentClt
+		s.currentClt = nil
+	} else {
+		currentClt.refCount.Add(1)
+	}
+	s.mu.Unlock()
+
+	innerConn, details, err := currentClt.clt.DialHost(ctx, target, cluster, keyring)
+	if err != nil {
+		currentClt.release()
+		return nil, details, trace.Wrap(err)
+	}
+
+	wrappedConn := &refCountConn{
+		Conn: innerConn,
+	}
+	wrappedConn.parent.Store(currentClt)
+	return wrappedConn, details, nil
+}
+
+// ConnectToSSHMultiplex connects to the SSH multiplexer and sends the target
+// to the multiplexer. It then returns the connection to the SSH multiplexer
+// over stdout.
+func ConnectToSSHMultiplex(ctx context.Context, socketPath string, target string, stdout *os.File) error {
+	outConn, err := net.FileConn(stdout)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer outConn.Close()
+	outUnix, ok := outConn.(*net.UnixConn)
+	if !ok {
+		return trace.BadParameter("expected stdout to be %T, got %T", outUnix, outConn)
+	}
+
+	c, err := new(net.Dialer).DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer c.Close()
+
+	if _, err := fmt.Fprint(c, target, "\x00"); err != nil {
+		return trace.Wrap(err)
+	}
+
+	rawC, err := c.(*net.UnixConn).SyscallConn()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var innerErr error
+	if controlErr := rawC.Control(func(fd uintptr) {
+		// We have to write something in order to send a control message so
+		// we just write NUL.
+		_, _, innerErr = outUnix.WriteMsgUnix(
+			[]byte{0},
+			syscall.UnixRights(int(fd)),
+			nil,
+		)
+	}); controlErr != nil {
+		return trace.Wrap(controlErr)
+	}
+	if innerErr != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}

--- a/lib/tbot/service_ssh_multiplexer_test.go
+++ b/lib/tbot/service_ssh_multiplexer_test.go
@@ -1,0 +1,179 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ssh/agent"
+
+	proxyclient "github.com/gravitational/teleport/api/client/proxy"
+)
+
+type mockConn struct {
+	mu     sync.Mutex
+	closed bool
+	net.Conn
+}
+
+func (mc *mockConn) Close() error {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	mc.closed = true
+	mc.Conn.Close()
+	return nil
+}
+
+type mockHostDialer struct {
+	t      *testing.T
+	mu     sync.Mutex
+	closed bool
+	conns  []*mockConn
+}
+
+func (m *mockHostDialer) DialHost(
+	_ context.Context, _ string, _ string, _ agent.ExtendedAgent,
+) (net.Conn, proxyclient.ClusterDetails, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		m.t.Errorf("attempt to dial on closed host dialer")
+		return nil, proxyclient.ClusterDetails{}, fmt.Errorf("closed")
+	}
+	conn := &mockConn{
+		Conn: &net.TCPConn{},
+	}
+	m.conns = append(m.conns, conn)
+	return conn, proxyclient.ClusterDetails{}, nil
+}
+
+func (m *mockHostDialer) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+type mockHostDialerTracker struct {
+	t           *testing.T
+	mu          sync.Mutex
+	hostDialers []*mockHostDialer
+}
+
+func (m *mockHostDialerTracker) New(_ context.Context) (hostDialer, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	hostDialer := &mockHostDialer{t: m.t}
+	m.hostDialers = append(m.hostDialers, hostDialer)
+	return hostDialer, nil
+}
+
+func (m *mockHostDialerTracker) count() (open int, closed int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, conn := range m.hostDialers {
+		conn.mu.Lock()
+		connClosed := conn.closed
+		conn.mu.Unlock()
+
+		if connClosed {
+			closed++
+		} else {
+			open++
+		}
+	}
+	return open, closed
+
+}
+
+func TestCyclingHostDialClient(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tracker := &mockHostDialerTracker{}
+	cycler := &cyclingHostDialClient{
+		max:          5,
+		hostDialerFn: tracker.New,
+	}
+
+	var conns []net.Conn
+	for i := 0; i < 10; i++ {
+		conn, _, err := cycler.DialHost(ctx, "", "", nil)
+		assert.NoError(t, err)
+		conns = append(conns, conn)
+	}
+
+	openDialers, closedDialers := tracker.count()
+	assert.Equal(t, 2, openDialers)
+	assert.Equal(t, 0, closedDialers)
+
+	// Close the first connection, it should not close any dialer.
+	_ = conns[0].Close()
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		openDialers, closedDialers = tracker.count()
+		assert.Equal(t, 2, openDialers)
+		assert.Equal(t, 0, closedDialers)
+	}, time.Second, 100*time.Millisecond)
+
+	// Close the next 4 connections, it should close the first dialer.
+	for i := 1; i < 5; i++ {
+		_ = conns[i].Close()
+	}
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		openDialers, closedDialers = tracker.count()
+		assert.Equal(t, 1, openDialers)
+		assert.Equal(t, 1, closedDialers)
+	}, time.Second, 100*time.Millisecond)
+
+	// Close the next 5 connections, it should close the second dialer.
+	for i := 5; i < 10; i++ {
+		_ = conns[i].Close()
+	}
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		openDialers, closedDialers = tracker.count()
+		assert.Equal(t, 0, openDialers)
+		assert.Equal(t, 2, closedDialers)
+	}, time.Second, 100*time.Millisecond)
+
+	// Now we want to validate a weirder case, let's create 4 connections,
+	// close them and then create a fifth.
+	for i := 0; i < 4; i++ {
+		conn, _, err := cycler.DialHost(ctx, "", "", nil)
+		assert.NoError(t, err)
+		_ = conn.Close()
+	}
+	conn, _, err := cycler.DialHost(ctx, "", "", nil)
+	assert.NoError(t, err)
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		openDialers, closedDialers = tracker.count()
+		assert.Equal(t, 1, openDialers)
+		assert.Equal(t, 2, closedDialers)
+	}, time.Second, 100*time.Millisecond)
+	_ = conn.Close()
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		openDialers, closedDialers = tracker.count()
+		assert.Equal(t, 0, openDialers)
+		assert.Equal(t, 3, closedDialers)
+	}, time.Second, 100*time.Millisecond)
+}

--- a/lib/tbot/ssh/ssh.go
+++ b/lib/tbot/ssh/ssh.go
@@ -1,0 +1,86 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+)
+
+const (
+	// ConfigName is the name of the ssh_config file on disk
+	ConfigName = "ssh_config"
+
+	// KnownHostsName is the name of the known_hosts file on disk
+	KnownHostsName = "known_hosts"
+)
+
+type certAuthorityGetter interface {
+	GetCertAuthority(
+		ctx context.Context,
+		id types.CertAuthID,
+		includeSigningKeys bool,
+	) (types.CertAuthority, error)
+}
+
+// GenerateKnownHosts generates a known_hosts file for the provided cluster
+// names and proxy hosts.
+func GenerateKnownHosts(
+	ctx context.Context,
+	bot certAuthorityGetter,
+	clusterNames []string,
+	proxyHosts string,
+) (string, error) {
+	certAuthorities := make([]types.CertAuthority, 0, len(clusterNames))
+	for _, cn := range clusterNames {
+		ca, err := bot.GetCertAuthority(ctx, types.CertAuthID{
+			Type:       types.HostCA,
+			DomainName: cn,
+		}, false)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+		certAuthorities = append(certAuthorities, ca)
+	}
+
+	var sb strings.Builder
+	for _, auth := range authclient.AuthoritiesToTrustedCerts(certAuthorities) {
+		pubKeys, err := auth.SSHCertPublicKeys()
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		for _, pubKey := range pubKeys {
+			bytes := ssh.MarshalAuthorizedKey(pubKey)
+			fmt.Fprintf(&sb,
+				"@cert-authority %s,%s,*.%s %s type=host\n",
+				proxyHosts, auth.ClusterName, auth.ClusterName, strings.TrimSpace(string(bytes)),
+			)
+		}
+	}
+
+	return sb.String(), nil
+}

--- a/lib/tbot/ssh_proxy.go
+++ b/lib/tbot/ssh_proxy.go
@@ -214,6 +214,14 @@ func resolveTargetHost(ctx context.Context, cfg client.Config, search, query str
 	}
 	defer apiClient.Close()
 
+	return resolveTargetHostWithClient(ctx, apiClient, search, query)
+}
+
+// resolveTargetHostWithClient resolves the target host using the provided
+// client and search and query parameters.
+func resolveTargetHostWithClient(
+	ctx context.Context, apiClient client.GetResourcesClient, search, query string,
+) (types.Server, error) {
 	nodes, err := client.GetAllResources[types.Server](ctx, apiClient, &proto.ListResourcesRequest{
 		ResourceType:        types.KindNode,
 		SearchKeywords:      libclient.ParseSearchKeywords(search, ','),
@@ -222,15 +230,12 @@ func resolveTargetHost(ctx context.Context, cfg client.Config, search, query str
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	if len(nodes) == 0 {
 		return nil, trace.NotFound("no matching SSH hosts found for search terms or query expression")
 	}
-
 	if len(nodes) > 1 {
 		return nil, trace.BadParameter("found multiple matching SSH hosts %v", nodes[:2])
 	}
-
 	return nodes[0], nil
 }
 

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -25,7 +25,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/user"
 	"path"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -35,12 +37,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
@@ -52,6 +56,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/testhelpers"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
 func TestMain(m *testing.M) {
@@ -723,9 +728,9 @@ func TestBotSPIFFEWorkloadAPI(t *testing.T) {
 	require.NoError(t, err)
 
 	// SVID has successfully been issued. We can now assert that it's correct.
-	require.Equal(t, "spiffe://localhost/foo", svid.ID.String())
+	require.Equal(t, "spiffe://test-cluster.local/foo", svid.ID.String())
 	cert := svid.Certificates[0]
-	require.Equal(t, "spiffe://localhost/foo", cert.URIs[0].String())
+	require.Equal(t, "spiffe://test-cluster.local/foo", cert.URIs[0].String())
 	require.True(t, net.IPv4(10, 0, 0, 1).Equal(cert.IPAddresses[0]))
 	require.Equal(t, []string{"example.com"}, cert.DNSNames)
 	require.WithinRange(
@@ -842,4 +847,131 @@ func TestBotDatabaseTunnel(t *testing.T) {
 	// Shut down bot and make sure it exits.
 	cancel()
 	wg.Wait()
+}
+
+func TestBotSSHMultiplexer(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := utils.NewSlogLoggerForTests()
+
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	// 104 length limit on UDS on MacOS forces us to use a custom tmpdir.
+	tmpDir := path.Join(os.TempDir(), t.Name())
+	require.NoError(t, os.RemoveAll(tmpDir))
+	require.NoError(t, os.Mkdir(tmpDir, 0777))
+	t.Cleanup(func() {
+		assert.NoError(t, os.RemoveAll(tmpDir))
+	})
+
+	// Make a new auth server with SSH agent
+	fc, fds := testhelpers.DefaultConfig(t)
+	fc.SSH.EnabledFlag = "true"
+	fc.SSH.ListenAddress = testenv.NewTCPListener(t, service.ListenerNodeSSH, &fds)
+	_ = testhelpers.MakeAndRunTestAuthServer(t, log, fc, fds)
+	rootClient := testhelpers.MakeDefaultAuthClient(t, fc)
+
+	// Create role that allows the bot to access the database.
+	role, err := types.NewRole("ssh-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			NodeLabels: types.Labels{
+				"*": apiutils.Strings{"*"},
+			},
+			Logins: []string{currentUser.Username},
+		},
+	})
+	require.NoError(t, err)
+	role, err = rootClient.UpsertRole(ctx, role)
+	require.NoError(t, err)
+
+	// Prepare the bot config
+	onboarding, _ := testhelpers.MakeBot(t, rootClient, "test", role.GetName())
+	botConfig := testhelpers.DefaultBotConfig(
+		t, fc, onboarding, []config.Output{},
+		testhelpers.DefaultBotConfigOpts{
+			UseAuthServer: true,
+			Insecure:      true,
+			ServiceConfigs: []config.ServiceConfig{
+				&config.SSHMultiplexerService{
+					Destination: &config.DestinationDirectory{
+						Path: tmpDir,
+					},
+				},
+			},
+		},
+	)
+	botConfig.Oneshot = false
+	b := New(botConfig, log)
+
+	// Spin up goroutine for bot to run in
+	ctx, cancel := context.WithCancel(ctx)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := b.Run(ctx)
+		assert.NoError(t, err, "bot should not exit with error")
+		cancel()
+	}()
+	t.Cleanup(func() {
+		// Shut down bot and make sure it exits.
+		cancel()
+		wg.Wait()
+	})
+
+	// Wait for files to be output
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for _, fileName := range []string{
+			"key",
+			"key.pub",
+			"key-cert.pub",
+			"known_hosts",
+			"ssh_config",
+		} {
+			_, err := os.Stat(filepath.Join(tmpDir, fileName))
+			assert.NoError(t, err)
+		}
+	}, 10*time.Second, 100*time.Millisecond)
+
+	privateKeyBytes, err := os.ReadFile(filepath.Join(tmpDir, "key"))
+	require.NoError(t, err)
+	certBytes, err := os.ReadFile(filepath.Join(tmpDir, "key-cert.pub"))
+	require.NoError(t, err)
+	signer, err := ssh.ParsePrivateKey(privateKeyBytes)
+	require.NoError(t, err)
+	cert, _, _, _, err := ssh.ParseAuthorizedKey(certBytes)
+	require.NoError(t, err)
+	certSigner, err := ssh.NewCertSigner(cert.(*ssh.Certificate), signer)
+	require.NoError(t, err)
+	callback, err := knownhosts.New(filepath.Join(tmpDir, "known_hosts"))
+	require.NoError(t, err)
+	sshConfig := &ssh.ClientConfig{
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(certSigner),
+		},
+		User:            currentUser.Username,
+		HostKeyCallback: callback,
+	}
+	conn, err := net.Dial("unix", filepath.Join(tmpDir, "v1.sock"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		conn.Close()
+	})
+	_, err = fmt.Fprint(conn, "test.test-cluster.local:0\x00")
+	require.NoError(t, err)
+	sshConn, sshChan, sshReq, err := ssh.NewClientConn(conn, "test.test-cluster.local:22", sshConfig)
+	require.NoError(t, err)
+	sshClient := ssh.NewClient(sshConn, sshChan, sshReq)
+	t.Cleanup(func() {
+		sshClient.Close()
+	})
+	sshSess, err := sshClient.NewSession()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		sshSess.Close()
+	})
+	out, err := sshSess.CombinedOutput("echo hello")
+	require.NoError(t, err)
+	require.Equal(t, "hello\n", string(out))
 }

--- a/lib/tbot/testhelpers/srv.go
+++ b/lib/tbot/testhelpers/srv.go
@@ -64,7 +64,8 @@ func DefaultConfig(t *testing.T) (*config.FileConfig, []*servicecfg.FileDescript
 
 	fc := &config.FileConfig{
 		Global: config.Global{
-			DataDir: t.TempDir(),
+			DataDir:  t.TempDir(),
+			NodeName: "test",
 		},
 		Proxy: config.Proxy{
 			Service: config.Service{
@@ -77,7 +78,7 @@ func DefaultConfig(t *testing.T) (*config.FileConfig, []*servicecfg.FileDescript
 			PublicAddr: []string{"localhost"}, // ListenerProxyWeb port will be appended
 		},
 		Auth: config.Auth{
-			ClusterName: "localhost",
+			ClusterName: "test-cluster.local",
 			Service: config.Service{
 				EnabledFlag:   "true",
 				ListenAddress: testenv.NewTCPListener(t, service.ListenerAuth, &fds),

--- a/tool/tbot/proxy_ssh.go
+++ b/tool/tbot/proxy_ssh.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/gravitational/trace"
 
@@ -55,4 +56,10 @@ func onSSHProxyCommand(ctx context.Context, cf *config.CLIConf) error {
 	}
 
 	return trace.Wrap(tbot.ProxySSH(ctx, proxySSHConfig))
+}
+
+// onSSHMultiplexProxyCommand connects to an existing long-lived SSH multiplexer
+// service as opposed to onSSHProxyCommand which completes this on-the-fly.
+func onSSHMultiplexProxyCommand(ctx context.Context, socketPath string, target string) error {
+	return trace.Wrap(tbot.ConnectToSSHMultiplex(ctx, socketPath, target, os.Stdout))
 }


### PR DESCRIPTION
Backports #42592

changelog: Introduces the new Machine ID `ssh-multiplexer` service for significant improvements in SSH performance.