### PR TITLE
[v14] Improve recording upload backoff

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -525,7 +525,7 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 			}
 
 			// wait for the upload of the right session to complete
-			timeoutC := time.After(10 * time.Second)
+			timeoutC := time.After(20 * time.Second)
 		loop:
 			for {
 				select {
@@ -1269,7 +1269,7 @@ func testLeafProxySessionRecording(t *testing.T, suite *integrationTestSuite) {
 
 			// Wait for the session recording to be uploaded and available
 			var uploaded bool
-			timeoutC := time.After(10 * time.Second)
+			timeoutC := time.After(20 * time.Second)
 			for !uploaded {
 				select {
 				case event := <-uploadChan:

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -319,7 +319,7 @@ func testExec(t *testing.T, suite *KubeSuite, pinnedIP string, clientError strin
 
 	// verify traffic capture and upload, wait for the upload to hit
 	var sessionID string
-	timeoutC := time.After(10 * time.Second)
+	timeoutC := time.After(20 * time.Second)
 loop:
 	for {
 		select {
@@ -754,7 +754,7 @@ func testKubeTrustedClustersClientCert(t *testing.T, suite *KubeSuite) {
 
 	// verify traffic capture and upload, wait for the upload to hit
 	var sessionID string
-	timeoutC := time.After(10 * time.Second)
+	timeoutC := time.After(20 * time.Second)
 loop:
 	for {
 		select {
@@ -1028,7 +1028,7 @@ func testKubeTrustedClustersSNI(t *testing.T, suite *KubeSuite) {
 
 	// verify traffic capture and upload, wait for the upload to hit
 	var sessionID string
-	timeoutC := time.After(10 * time.Second)
+	timeoutC := time.After(20 * time.Second)
 loop:
 	for {
 		select {

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -483,16 +483,17 @@ func TestUploadBadSession(t *testing.T) {
 // uploaderPack reduces boilerplate required
 // to create a test
 type uploaderPack struct {
-	scanPeriod  time.Duration
-	clock       clockwork.FakeClock
-	eventsC     chan events.UploadEvent
-	memEventsC  chan events.UploadEvent
-	memUploader *eventstest.MemoryUploader
-	streamer    events.Streamer
-	scanDir     string
-	uploader    *Uploader
-	ctx         context.Context
-	cancel      context.CancelFunc
+	scanPeriod       time.Duration
+	initialScanDelay time.Duration
+	clock            clockwork.FakeClock
+	eventsC          chan events.UploadEvent
+	memEventsC       chan events.UploadEvent
+	memUploader      *eventstest.MemoryUploader
+	streamer         events.Streamer
+	scanDir          string
+	uploader         *Uploader
+	ctx              context.Context
+	cancel           context.CancelFunc
 }
 
 func (u *uploaderPack) Close(t *testing.T) {
@@ -505,13 +506,14 @@ func newUploaderPack(t *testing.T, wrapStreamer wrapStreamerFn) uploaderPack {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	pack := uploaderPack{
-		clock:      clockwork.NewFakeClock(),
-		eventsC:    make(chan events.UploadEvent, 100),
-		memEventsC: make(chan events.UploadEvent, 100),
-		ctx:        ctx,
-		cancel:     cancel,
-		scanDir:    scanDir,
-		scanPeriod: 10 * time.Second,
+		clock:            clockwork.NewFakeClock(),
+		eventsC:          make(chan events.UploadEvent, 100),
+		memEventsC:       make(chan events.UploadEvent, 100),
+		ctx:              ctx,
+		cancel:           cancel,
+		scanDir:          scanDir,
+		scanPeriod:       10 * time.Second,
+		initialScanDelay: 10 * time.Millisecond,
 	}
 	pack.memUploader = eventstest.NewMemoryUploader(pack.memEventsC)
 
@@ -527,12 +529,13 @@ func newUploaderPack(t *testing.T, wrapStreamer wrapStreamerFn) uploaderPack {
 	}
 
 	uploader, err := NewUploader(UploaderConfig{
-		ScanDir:      pack.scanDir,
-		CorruptedDir: corruptedDir,
-		ScanPeriod:   pack.scanPeriod,
-		Streamer:     pack.streamer,
-		Clock:        pack.clock,
-		EventsC:      pack.eventsC,
+		ScanDir:          pack.scanDir,
+		CorruptedDir:     corruptedDir,
+		InitialScanDelay: pack.initialScanDelay,
+		ScanPeriod:       pack.scanPeriod,
+		Streamer:         pack.streamer,
+		Clock:            pack.clock,
+		EventsC:          pack.eventsC,
 	})
 	require.NoError(t, err)
 	pack.uploader = uploader
@@ -564,12 +567,13 @@ func runResume(t *testing.T, testCase resumeTestCase) {
 
 	scanPeriod := 10 * time.Second
 	uploader, err := NewUploader(UploaderConfig{
-		EventsC:      eventsC,
-		ScanDir:      scanDir,
-		CorruptedDir: corruptedDir,
-		ScanPeriod:   scanPeriod,
-		Streamer:     test.streamer,
-		Clock:        clock,
+		EventsC:          eventsC,
+		ScanDir:          scanDir,
+		CorruptedDir:     corruptedDir,
+		InitialScanDelay: 10 * time.Millisecond,
+		ScanPeriod:       scanPeriod,
+		Streamer:         test.streamer,
+		Clock:            clock,
 	})
 	require.Nil(t, err)
 	go uploader.Serve(ctx)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3008,10 +3008,11 @@ func (process *TeleportProcess) initUploaderService() error {
 	corruptedDir := filepath.Join(paths[1]...)
 
 	fileUploader, err := filesessions.NewUploader(filesessions.UploaderConfig{
-		Streamer:     uploaderClient,
-		ScanDir:      uploadsDir,
-		CorruptedDir: corruptedDir,
-		EventsC:      process.Config.Testing.UploadEventsC,
+		Streamer:         uploaderClient,
+		ScanDir:          uploadsDir,
+		CorruptedDir:     corruptedDir,
+		EventsC:          process.Config.Testing.UploadEventsC,
+		InitialScanDelay: 15 * time.Second,
 	})
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Backport #42718 to branch/v14

changelog: Improve backoff of session recording uploads by teleport agents