### PR TITLE
Machine ID: Agent based SSH auth for multiplexer

### DIFF
--- a/lib/config/openssh/openssh.go
+++ b/lib/config/openssh/openssh.go
@@ -35,17 +35,19 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+// proxyCommandQuote prepares a string for insertion into the ssh_config
+func proxyCommandQuote(s string) string {
+	s = `'` + strings.ReplaceAll(s, `'`, `'"'"'`) + `'`
+	// escape any percent signs which could trigger the percent expansion
+	// for ProxyCommand.
+	s = strings.ReplaceAll(s, `%`, `%%`)
+	// escape any newlines which could impact the parsing of ssh_config
+	s = strings.ReplaceAll(s, "\n", `'"\n"'`)
+	return s
+}
+
 var sshConfigTemplate = template.Must(template.New("ssh-config").Funcs(template.FuncMap{
-	// proxyCommandQuote prepares a string for insertion into the ssh_config
-	"proxyCommandQuote": func(s string) string {
-		s = `'` + strings.ReplaceAll(s, `'`, `'"'"'`) + `'`
-		// escape any percent signs which could trigger the percent expansion
-		// for ProxyCommand.
-		s = strings.ReplaceAll(s, `%`, `%%`)
-		// escape any newlines which could impact the parsing of ssh_config
-		s = strings.ReplaceAll(s, "\n", `'"\n"'`)
-		return s
-	},
+	"proxyCommandQuote": proxyCommandQuote,
 }).Parse(
 	`# Begin generated Teleport configuration for {{ .ProxyHost }} by {{ .AppName }}
 {{$dot := . }}
@@ -69,9 +71,6 @@ Host *.{{ $clusterName }} !{{ $dot.ProxyHost }}
 {{- if eq $dot.AppName "tbot" }}
 {{- if $dot.PureTBotProxyCommand }}
     ProxyCommand {{ proxyCommandQuote $dot.ExecutablePath }} ssh-proxy-command --destination-dir={{ proxyCommandQuote $dot.DestinationDir }} --proxy-server={{ proxyCommandQuote (print $dot.ProxyHost ":" $dot.ProxyPort) }} --cluster={{ proxyCommandQuote $clusterName }} {{ if $dot.TLSRouting }}--tls-routing{{ else }}--no-tls-routing{{ end }} {{ if $dot.ConnectionUpgrade }}--connection-upgrade{{ else }}--no-connection-upgrade{{ end }} {{ if $dot.Resume }}--resume{{ else }}--no-resume{{ end }} --user=%r --host=%h --port=%p
-{{- else if $dot.TBotMux }}
-    ProxyCommand {{range $v := $dot.TBotMuxProxyCommand}}{{ proxyCommandQuote $v }} {{end}}{{ proxyCommandQuote $dot.TBotMuxSocketPath }} '{{ $dot.TBotMuxData }}'
-    ProxyUseFdpass true
 {{- else }}
     ProxyCommand "{{ $dot.ExecutablePath }}" proxy --destination-dir={{ $dot.DestinationDir }} --proxy-server={{ $dot.ProxyHost }}:{{ $dot.ProxyPort }} ssh --cluster={{ $clusterName }}  %r@%h:%p
 {{- end }}
@@ -107,13 +106,6 @@ type SSHConfigParameters struct {
 	Insecure             bool
 	FIPS                 bool
 	Resume               bool
-
-	// TBotMuxCommand enables the `ssh-multiplexer-proxy-command` operating mode
-	// when generating the ssh_config for tbot.
-	TBotMux             bool
-	TBotMuxProxyCommand []string
-	TBotMuxSocketPath   string
-	TBotMuxData         string
 }
 
 type sshTmplParams struct {
@@ -260,6 +252,70 @@ func (c *SSHConfig) GetSSHConfig(sb *strings.Builder, config *SSHConfigParameter
 	if err := sshConfigTemplate.Execute(sb, sshTmplParams{
 		SSHConfigParameters: *config,
 		sshConfigOptions:    *sshOptions,
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+var muxedSSHConfigTemplate = template.Must(template.New("muxed-ssh-config").Funcs(template.FuncMap{
+	"proxyCommandQuote": proxyCommandQuote,
+}).Parse(
+	`# Begin generated Teleport configuration by {{ .AppName }} for the ssh-multiplexer service
+{{$dot := . }}
+{{- range $clusterName := .ClusterNames }}
+Host *.{{ $clusterName }}
+    Port {{ $dot.Port }}
+    UserKnownHostsFile {{ proxyCommandQuote $dot.KnownHostsPath }}
+    HostKeyAlgorithms {{ if $dot.NewerHostKeyAlgorithmsSupported }}rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,{{ end }}ssh-rsa-cert-v01@openssh.com
+    IdentityFile none
+    IdentityAgent {{ proxyCommandQuote $dot.AgentSocketPath }}    
+    ProxyCommand {{range $v := $dot.ProxyCommand}}{{ proxyCommandQuote $v }} {{end}}{{ proxyCommandQuote $dot.MuxSocketPath }} '{{ $dot.Data }}'
+    ProxyUseFDPass yes
+{{- end }}
+# End generated Teleport configuration
+`))
+
+// MuxedSSHConfigParameters is a set of SSH related parameters used to generate
+// a ssh_config file for the ssh-multiplexer service.
+type MuxedSSHConfigParameters struct {
+	AppName         SSHConfigApps
+	ClusterNames    []string
+	KnownHostsPath  string
+	ProxyCommand    []string
+	MuxSocketPath   string
+	AgentSocketPath string
+	Data            string
+	// Port is the node port to use, defaulting to 3022, if not specified by flag
+	Port int
+}
+
+type muxedSSHTmplParams struct {
+	MuxedSSHConfigParameters
+	sshConfigOptions
+}
+
+// GetMuxedSSHConfig generates a ssh_config file for the ssh-multiplexer service.
+func (c *SSHConfig) GetMuxedSSHConfig(sb *strings.Builder, config *MuxedSSHConfigParameters) error {
+	var sshOptions *sshConfigOptions
+	version, err := c.getSSHVersion()
+	if err != nil {
+		c.log.WithError(err).Debugf("Could not determine SSH version, using default SSH config")
+		sshOptions = getDefaultSSHConfigOptions()
+	} else {
+		c.log.Debugf("Found OpenSSH version %s", version)
+		sshOptions = getSSHConfigOptions(version)
+	}
+	if config.Port == 0 {
+		config.Port = defaults.SSHServerListenPort
+	}
+
+	c.log.Debugf("Using SSH options: %s", sshOptions)
+
+	if err := muxedSSHConfigTemplate.Execute(sb, muxedSSHTmplParams{
+		MuxedSSHConfigParameters: *config,
+		sshConfigOptions:         *sshOptions,
 	}); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/config/openssh/openssh_test.go
+++ b/lib/config/openssh/openssh_test.go
@@ -174,3 +174,70 @@ func TestSSHConfig_GetSSHConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestSSHConfig_GetMuxedSSHConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		sshVersion string
+		config     *MuxedSSHConfigParameters
+	}{
+		{
+			name:       "legacy OpenSSH - single cluster",
+			sshVersion: "7.4.0",
+			config: &MuxedSSHConfigParameters{
+				AppName:         TbotApp,
+				ClusterNames:    []string{"example.com"},
+				KnownHostsPath:  "/opt/machine-id/known_hosts",
+				MuxSocketPath:   "/opt/machine-id/v1.sock",
+				AgentSocketPath: "/opt/machine-id/agent.sock",
+				ProxyCommand:    []string{"/bin/fdpass-teleport", "foo"},
+				Data:            `%h:%p`,
+			},
+		},
+		{
+			name:       "modern OpenSSH - single cluster",
+			sshVersion: "9.0.0",
+			config: &MuxedSSHConfigParameters{
+				AppName:         TbotApp,
+				ClusterNames:    []string{"example.com"},
+				KnownHostsPath:  "/opt/machine-id/known_hosts",
+				MuxSocketPath:   "/opt/machine-id/v1.sock",
+				AgentSocketPath: "/opt/machine-id/agent.sock",
+				ProxyCommand:    []string{"/bin/fdpass-teleport", "foo"},
+				Data:            `%h:%p`,
+			},
+		},
+		{
+			name:       "modern OpenSSH - multiple clusters",
+			sshVersion: "9.0.0",
+			config: &MuxedSSHConfigParameters{
+				AppName:         TbotApp,
+				ClusterNames:    []string{"example.com", "example.org"},
+				KnownHostsPath:  "/opt/machine-id/known_hosts",
+				MuxSocketPath:   "/opt/machine-id/v1.sock",
+				AgentSocketPath: "/opt/machine-id/agent.sock",
+				ProxyCommand:    []string{"/bin/fdpass-teleport", "foo"},
+				Data:            `%h:%p`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &SSHConfig{
+				getSSHVersion: func() (*semver.Version, error) {
+					return semver.New(tt.sshVersion), nil
+				},
+				log: logrus.New(),
+			}
+
+			sb := &strings.Builder{}
+			err := c.GetMuxedSSHConfig(sb, tt.config)
+			if golden.ShouldSet() {
+				golden.Set(t, []byte(sb.String()))
+			}
+			require.NoError(t, err)
+			require.Equal(t, string(golden.Get(t)), sb.String())
+		})
+	}
+}

--- a/lib/config/openssh/testdata/TestSSHConfig_GetMuxedSSHConfig/legacy_OpenSSH_-_single_cluster.golden
+++ b/lib/config/openssh/testdata/TestSSHConfig_GetMuxedSSHConfig/legacy_OpenSSH_-_single_cluster.golden
@@ -1,0 +1,10 @@
+# Begin generated Teleport configuration by tbot for the ssh-multiplexer service
+
+Host *.example.com
+    Port 3022
+    UserKnownHostsFile '/opt/machine-id/known_hosts'
+    HostKeyAlgorithms ssh-rsa-cert-v01@openssh.com
+    IdentityFile none
+	IdentityAgent '/opt/machine-id/agent.sock'    
+	ProxyCommand '/bin/fdpass-teleport' 'foo' '/opt/machine-id/v1.sock' '%h:%p'
+# End generated Teleport configuration

--- a/lib/config/openssh/testdata/TestSSHConfig_GetMuxedSSHConfig/legacy_OpenSSH_-_single_cluster.golden
+++ b/lib/config/openssh/testdata/TestSSHConfig_GetMuxedSSHConfig/legacy_OpenSSH_-_single_cluster.golden
@@ -5,6 +5,7 @@ Host *.example.com
     UserKnownHostsFile '/opt/machine-id/known_hosts'
     HostKeyAlgorithms ssh-rsa-cert-v01@openssh.com
     IdentityFile none
-	IdentityAgent '/opt/machine-id/agent.sock'    
-	ProxyCommand '/bin/fdpass-teleport' 'foo' '/opt/machine-id/v1.sock' '%h:%p'
+    IdentityAgent '/opt/machine-id/agent.sock'    
+    ProxyCommand '/bin/fdpass-teleport' 'foo' '/opt/machine-id/v1.sock' '%h:%p'
+    ProxyUseFDPass yes
 # End generated Teleport configuration

--- a/lib/config/openssh/testdata/TestSSHConfig_GetMuxedSSHConfig/modern_OpenSSH_-_multiple_clusters.golden
+++ b/lib/config/openssh/testdata/TestSSHConfig_GetMuxedSSHConfig/modern_OpenSSH_-_multiple_clusters.golden
@@ -5,13 +5,15 @@ Host *.example.com
     UserKnownHostsFile '/opt/machine-id/known_hosts'
     HostKeyAlgorithms rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com
     IdentityFile none
-	IdentityAgent '/opt/machine-id/agent.sock'    
-	ProxyCommand '/bin/fdpass-teleport' 'foo' '/opt/machine-id/v1.sock' '%h:%p'
+    IdentityAgent '/opt/machine-id/agent.sock'    
+    ProxyCommand '/bin/fdpass-teleport' 'foo' '/opt/machine-id/v1.sock' '%h:%p'
+    ProxyUseFDPass yes
 Host *.example.org
     Port 3022
     UserKnownHostsFile '/opt/machine-id/known_hosts'
     HostKeyAlgorithms rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com
     IdentityFile none
-	IdentityAgent '/opt/machine-id/agent.sock'    
-	ProxyCommand '/bin/fdpass-teleport' 'foo' '/opt/machine-id/v1.sock' '%h:%p'
+    IdentityAgent '/opt/machine-id/agent.sock'    
+    ProxyCommand '/bin/fdpass-teleport' 'foo' '/opt/machine-id/v1.sock' '%h:%p'
+    ProxyUseFDPass yes
 # End generated Teleport configuration

--- a/lib/config/openssh/testdata/TestSSHConfig_GetMuxedSSHConfig/modern_OpenSSH_-_multiple_clusters.golden
+++ b/lib/config/openssh/testdata/TestSSHConfig_GetMuxedSSHConfig/modern_OpenSSH_-_multiple_clusters.golden
@@ -1,0 +1,17 @@
+# Begin generated Teleport configuration by tbot for the ssh-multiplexer service
+
+Host *.example.com
+    Port 3022
+    UserKnownHostsFile '/opt/machine-id/known_hosts'
+    HostKeyAlgorithms rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com
+    IdentityFile none
+	IdentityAgent '/opt/machine-id/agent.sock'    
+	ProxyCommand '/bin/fdpass-teleport' 'foo' '/opt/machine-id/v1.sock' '%h:%p'
+Host *.example.org
+    Port 3022
+    UserKnownHostsFile '/opt/machine-id/known_hosts'
+    HostKeyAlgorithms rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com
+    IdentityFile none
+	IdentityAgent '/opt/machine-id/agent.sock'    
+	ProxyCommand '/bin/fdpass-teleport' 'foo' '/opt/machine-id/v1.sock' '%h:%p'
+# End generated Teleport configuration

--- a/lib/config/openssh/testdata/TestSSHConfig_GetMuxedSSHConfig/modern_OpenSSH_-_single_cluster.golden
+++ b/lib/config/openssh/testdata/TestSSHConfig_GetMuxedSSHConfig/modern_OpenSSH_-_single_cluster.golden
@@ -1,0 +1,10 @@
+# Begin generated Teleport configuration by tbot for the ssh-multiplexer service
+
+Host *.example.com
+    Port 3022
+    UserKnownHostsFile '/opt/machine-id/known_hosts'
+    HostKeyAlgorithms rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com
+    IdentityFile none
+	IdentityAgent '/opt/machine-id/agent.sock'    
+	ProxyCommand '/bin/fdpass-teleport' 'foo' '/opt/machine-id/v1.sock' '%h:%p'
+# End generated Teleport configuration

--- a/lib/config/openssh/testdata/TestSSHConfig_GetMuxedSSHConfig/modern_OpenSSH_-_single_cluster.golden
+++ b/lib/config/openssh/testdata/TestSSHConfig_GetMuxedSSHConfig/modern_OpenSSH_-_single_cluster.golden
@@ -5,6 +5,7 @@ Host *.example.com
     UserKnownHostsFile '/opt/machine-id/known_hosts'
     HostKeyAlgorithms rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com
     IdentityFile none
-	IdentityAgent '/opt/machine-id/agent.sock'    
-	ProxyCommand '/bin/fdpass-teleport' 'foo' '/opt/machine-id/v1.sock' '%h:%p'
+    IdentityAgent '/opt/machine-id/agent.sock'    
+    ProxyCommand '/bin/fdpass-teleport' 'foo' '/opt/machine-id/v1.sock' '%h:%p'
+    ProxyUseFDPass yes
 # End generated Teleport configuration

--- a/lib/tbot/identity/identity_facade.go
+++ b/lib/tbot/identity/identity_facade.go
@@ -176,7 +176,7 @@ func (f *Facade) SSHClientConfig() (*ssh.ClientConfig, error) {
 			ssh.PublicKeysCallback(func() (signers []ssh.Signer, err error) {
 				f.mu.RLock()
 				defer f.mu.RUnlock()
-				return []ssh.Signer{f.identity.KeySigner}, nil
+				return []ssh.Signer{f.identity.CertSigner}, nil
 			}),
 		},
 		HostKeyCallback: hostKeyCallback,


### PR DESCRIPTION
One of the current problems is that TBot does not write to destinations atomically and OpenSSH does not read from destinations atomically - this means that OpenSSH could read during an identity renewal and receive a mismatched certificate and private key. We can solve this problem by offering an agent - with the added benefit that we avoid writing the private key to disk.

Additionally, I tidied up some logging to be less verbose when the connection closes.