### PR TITLE
Remove rate limiting on webapi/ping and webapi/connectionupgrade

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -665,7 +665,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	// endpoint returns the default authentication method and configuration that
 	// the server supports. the /webapi/ping/:connector endpoint can be used to
 	// query the authentication configuration for a specific connector.
-	h.GET("/webapi/ping", h.WithUnauthenticatedHighLimiter(h.ping))
+	h.GET("/webapi/ping", httplib.MakeHandler(h.ping))
 	h.GET("/webapi/ping/:connector", h.WithUnauthenticatedHighLimiter(h.pingWithConnector))
 
 	// Unauthenticated access to JWT public keys.
@@ -920,7 +920,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.DELETE("/webapi/sites/:site/discoveryconfig/:name", h.WithClusterAuth(h.discoveryconfigDelete))
 
 	// Connection upgrades.
-	h.GET("/webapi/connectionupgrade", h.WithHighLimiter(h.connectionUpgrade))
+	h.GET("/webapi/connectionupgrade", httplib.MakeHandler(h.connectionUpgrade))
 
 	// create user events.
 	h.POST("/webapi/precapture", h.WithUnauthenticatedLimiter(h.createPreUserEventHandle))


### PR DESCRIPTION
The limits on these endpoints can cause issues with legitimate use cases trying to establish large numbers of connections from a single host(i.e. Ansible Tower). Extending the limits would likely result in a bar that constantly needs to be raised as clusters with this workflow become larger. Instead the limits were removed entirely.

changelog: Remote rate limits on endpoints used extensively to connect to the cluster