### PR TITLE
security: remove link to HackerOne program

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,5 @@ The list of supported versions can be found
 
 ## Reporting a Vulnerability
 
-To report a security vulnerability to us, visit our [HackerOne
-page](https://hackerone.com/teleport) and submit a report to us with full
-details, including steps to reproduce the issue.
+To report a security vulnerability to us, use the embedded form on our
+[security page](https://goteleport.com/security).


### PR DESCRIPTION
The program is now invite-only, so the link will 404 for most users.