### PR TITLE
Docs: SAML IdP service provider RBAC reference

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -375,6 +375,11 @@
               "forScopes": ["enterprise", "cloud"]
             },
             {
+              "title": "SAML IdP RBAC",
+              "slug": "/access-controls/idps/saml-rbac/",
+              "forScopes": ["enterprise", "cloud"]
+            },
+            {
               "title": "SAML Attribute Mapping",
               "slug": "/access-controls/idps/saml-attribute-mapping/",
               "forScopes": ["enterprise", "cloud"]

--- a/docs/pages/access-controls/idps.mdx
+++ b/docs/pages/access-controls/idps.mdx
@@ -7,6 +7,7 @@ Since Teleport 12.1 users can authenticate to both internal and external applica
 through the use of a built in identity provider.
 
 - [SAML Guide](./idps/saml-guide.mdx): A guide for setting up an example application to integration with the SAML identity provider.
+- [SAML RBAC reference](./idps/saml-rbac): A reference on how to manage access to SAML IdP service provider resources.
 - [SAML Attribute Mapping](./idps/saml-attribute-mapping.mdx): A reference on how attribute mapping works in Teleport and how to
 use it to assert custom user attribute name and values in a SAML response.
 - [Use Teleport's SAML Provider to authenticate with Grafana](./idps/saml-grafana.mdx): Configure Grafana to authenticate using Teleport identities.

--- a/docs/pages/access-controls/idps.mdx
+++ b/docs/pages/access-controls/idps.mdx
@@ -7,7 +7,7 @@ Since Teleport 12.1 users can authenticate to both internal and external applica
 through the use of a built in identity provider.
 
 - [SAML Guide](./idps/saml-guide.mdx): A guide for setting up an example application to integration with the SAML identity provider.
-- [SAML RBAC reference](./idps/saml-rbac): A reference on how to manage access to SAML IdP service provider resources.
+- [SAML RBAC reference](./idps/saml-rbac.mdx): A reference on how to manage access to SAML IdP service provider resources.
 - [SAML Attribute Mapping](./idps/saml-attribute-mapping.mdx): A reference on how attribute mapping works in Teleport and how to
 use it to assert custom user attribute name and values in a SAML response.
 - [Use Teleport's SAML Provider to authenticate with Grafana](./idps/saml-grafana.mdx): Configure Grafana to authenticate using Teleport identities.

--- a/docs/pages/access-controls/idps/saml-guide.mdx
+++ b/docs/pages/access-controls/idps/saml-guide.mdx
@@ -187,44 +187,6 @@ federated by Teleport SAML IdP.
 
 This demonstrates adding a service provider to Teleport configured with a working idp-initiated SSO login flow.
 
-## Recommended: Creating dedicated role to manage service provider
-
-For production, we recommend creating a dedicated role to manage service provider.
-
-To create a dedicated role, first, ensure you are logged into Teleport as a user that has
-permissions to read and modify `saml_idp_service_provider` objects. The default `editor` role
-has access to this already, but in case you are using a more customized configuration,
-create a role called `sp-manager.yaml` with the following contents:
-
-```yaml
-kind: role
-metadata:
-  name: sp-manager
-spec:
-  allow:
-    rules:
-    - resources:
-      - saml_idp_service_provider
-      verbs:
-      - list
-      - create
-      - read
-      - update
-      - delete
-version: v7
-```
-
-Create the role with `tctl`:
-
-```code
-$ tctl create sp-manager.yaml
-role 'saml-idp-service-provider-manager' has been created
-```
-
-Next, add the role to your user.
-
-(!docs/pages/includes/add-role-to-user.mdx role="sp-manager"!)
-
-
 ## Next steps
+- Configure [access to SAML IdP protected resources](./saml-rbac.mdx).
 - Configure [SAML Attribute Mapping](./saml-attribute-mapping.mdx).

--- a/docs/pages/access-controls/idps/saml-rbac.mdx
+++ b/docs/pages/access-controls/idps/saml-rbac.mdx
@@ -1,0 +1,100 @@
+---
+title: Managing access to Teleport SAML IdP protected resources.
+description: Learn how SAML IdP service provider RBAC works.
+h1: Teleport SAML IdP service provider RBAC
+---
+
+To manage access to SAML IdP service provider, a role spec must target `saml_idp_service_provider`
+resource kind.
+
+Currently, SAML IdP only supports role-based access to `saml_idp_service_provider` resource.
+It does not support label-based resource filtering. User's can either have access to
+all the registered SAML IdP service provider's or they don't.
+
+This guide shows how to create roles that allow user's to access and manage SAML IdP protected
+resource in Teleport.
+
+## Prerequisites
+
+(!docs/pages/includes/commercial-prereqs-tabs.mdx!)
+
+- (!docs/pages/includes/tctl.mdx!)
+- If you're new to SAML, consider reviewing our [SAML Identity Provider
+  Reference](./saml-reference.mdx) before proceeding.
+- User with permission to read and modify `saml_idp_service_provider` resource. The preset `editor`
+role has this permission.
+
+
+
+## SAML IdP access role
+
+For non-administrative access to SAML IdP protected resources, a user should be assigned with
+a role that has `list` and `read` verbs defined for `saml_idp_service_provider` resource.
+
+Below is a reference role spec that enables accessing service provider's registered with Teleport
+SAML IdP.
+
+```yaml
+kind: role
+metadata:
+  name: saml-app-access
+spec:
+  allow:
+    rules:
+    - resources:
+      - saml_idp_service_provider
+      verbs:
+      - list
+      - read
+version: v7
+```
+
+Create the role with `tctl`:
+
+```code
+$ tctl create saml-app-access.yaml
+role 'saml-app-access' has been created
+```
+
+Next, add the role to your user.
+
+(!docs/pages/includes/add-role-to-user.mdx role="saml-app-access"!)
+
+
+## SAML IdP administrative role
+
+For administrative access to SAML IdP service provider, a user should be assigned with
+a role that has `list`, `read`, `create`, `update` and `delete` verbs defined for
+`saml_idp_service_provider` resource.
+
+Below is a reference role spec that enables creating and managing service provider's with Teleport
+SAML IdP.
+
+```yaml
+kind: role
+metadata:
+  name: saml-idp-manager
+spec:
+  allow:
+    rules:
+    - resources:
+      - saml_idp_service_provider
+      verbs:
+      - list
+      - create
+      - read
+      - update
+      - delete
+version: v7
+```
+
+Create the role with `tctl`:
+
+```code
+$ tctl create saml-idp-manager.yaml
+role 'saml-idp-manager' has been created
+```
+
+Next, add the role to your user.
+
+(!docs/pages/includes/add-role-to-user.mdx role="saml-idp-manager"!)

--- a/docs/pages/access-controls/idps/saml-rbac.mdx
+++ b/docs/pages/access-controls/idps/saml-rbac.mdx
@@ -4,7 +4,7 @@ description: Learn how SAML IdP service provider RBAC works.
 h1: Teleport SAML IdP service provider RBAC
 ---
 
-To manage access to SAML IdP service provider, a role spec must target `saml_idp_service_provider`
+To manage access to SAML IdP service provider resource, a role spec must target `saml_idp_service_provider`
 resource kind.
 
 Currently, SAML IdP only supports role-based access to `saml_idp_service_provider` resource.
@@ -23,7 +23,6 @@ resource in Teleport.
   Reference](./saml-reference.mdx) before proceeding.
 - User with permission to read and modify `saml_idp_service_provider` resource. The preset `editor`
 role has this permission.
-
 
 
 ## SAML IdP access role
@@ -98,3 +97,23 @@ role 'saml-idp-manager' has been created
 Next, add the role to your user.
 
 (!docs/pages/includes/add-role-to-user.mdx role="saml-idp-manager"!)
+
+
+## Deny access to enrolled SAML service providers
+
+By default, users are granted with an implicit access to the enrolled SAML service providers.
+To deny access, users must be assigned with a role that explicitly sets the
+`idp.saml.enabled` value to `false` in the role options. The value of `idp.saml.enabled`
+option is implicitly set to `true` in the default `access` role or when creating a new role.
+
+```yaml
+kind: role
+metadata:
+  name: access
+spec:
+  options:
+    ...
+    idp:
+      saml:
+        enabled: false
+```


### PR DESCRIPTION
Adds new SAML IdP service provider RBAC reference page explaining RBAC support for SAML service provider resource, along with examples to create access and admin roles.

This is in response to SAML papercut ticket - https://github.com/gravitational/teleport/issues/40927 and also based on feedback from a few Teleporters and customers who expressed confusion surrounding SAML IdP service provider.  Mainly because:
- The RBAC reference was buried into general SAML guide, so it was harder to discover from main navigation menu.
- Unlike other resources, SAML IdP currently does not support label based filtering. Most users expect it to be available with `app_labels` filter but sadly this is not the case. This was never mentioned in the docs, increasing support tickets. 