### PR TITLE
[v16] AWS OIDC: Remove App Server that uses the integration credentials

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -932,7 +932,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	// The Integration DELETE endpoint already sets the expected named param after `/integrations/`
 	// It must be re-used here, otherwise the router will not start.
 	// See https://github.com/julienschmidt/httprouter/issues/364
-	h.DELETE("/webapi/sites/:site/integrations/:name_or_subkind/:name/aws-app-access", h.WithClusterAuth(h.awsOIDCDeleteAWSAppAccess))
+	h.DELETE("/webapi/sites/:site/integrations/:name_or_subkind/aws-app-access/:name", h.WithClusterAuth(h.awsOIDCDeleteAWSAppAccess))
 	h.GET("/webapi/scripts/integrations/configure/ec2-ssm-iam.sh", h.WithLimiter(h.awsOIDCConfigureEC2SSMIAM))
 
 	// SAML IDP integration endpoints

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -908,7 +908,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.POST("/webapi/sites/:site/integrations", h.WithClusterAuth(h.integrationsCreate))
 	h.GET("/webapi/sites/:site/integrations/:name", h.WithClusterAuth(h.integrationsGet))
 	h.PUT("/webapi/sites/:site/integrations/:name", h.WithClusterAuth(h.integrationsUpdate))
-	h.DELETE("/webapi/sites/:site/integrations/:name", h.WithClusterAuth(h.integrationsDelete))
+	h.DELETE("/webapi/sites/:site/integrations/:name_or_subkind", h.WithClusterAuth(h.integrationsDelete))
 
 	// AWS OIDC Integration Actions
 	h.GET("/webapi/scripts/integrations/configure/awsoidc-idp.sh", h.WithLimiter(h.awsOIDCConfigureIdP))
@@ -929,6 +929,10 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/scripts/integrations/configure/access-graph-cloud-sync-iam.sh", h.WithLimiter(h.accessGraphCloudSyncOIDC))
 	h.GET("/webapi/scripts/integrations/configure/aws-app-access-iam.sh", h.WithLimiter(h.awsOIDCConfigureAWSAppAccessIAM))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/aws-app-access", h.WithClusterAuth(h.awsOIDCCreateAWSAppAccess))
+	// The Integration DELETE endpoint already sets the expected named param after `/integrations/`
+	// It must be re-used here, otherwise the router will not start.
+	// See https://github.com/julienschmidt/httprouter/issues/364
+	h.DELETE("/webapi/sites/:site/integrations/:name_or_subkind/:name/aws-app-access", h.WithClusterAuth(h.awsOIDCDeleteAWSAppAccess))
 	h.GET("/webapi/scripts/integrations/configure/ec2-ssm-iam.sh", h.WithLimiter(h.awsOIDCConfigureEC2SSMIAM))
 
 	// SAML IDP integration endpoints

--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -152,7 +152,7 @@ func (h *Handler) integrationsUpdate(w http.ResponseWriter, r *http.Request, p h
 
 // integrationsDelete removes an Integration based on its name
 func (h *Handler) integrationsDelete(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
-	integrationName := p.ByName("name")
+	integrationName := p.ByName("name_or_subkind")
 	if integrationName == "" {
 		return nil, trace.BadParameter("an integration name is required")
 	}

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -951,14 +951,16 @@ func TestAWSOIDCSecurityGroupsRulesConverter(t *testing.T) {
 	}
 }
 
-func TestAWSOIDCAppAccessAppServerCreation(t *testing.T) {
+func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 	env := newWebPack(t, 1)
+	ctx := context.Background()
 
 	roleTokenCRD, err := types.NewRole(services.RoleNameForUser("my-user"), types.RoleSpecV6{
 		Allow: types.RoleConditions{
+			AppLabels: types.Labels{"*": []string{"*"}},
 			Rules: []types.Rule{
 				types.NewRule(types.KindIntegration, []string{types.VerbRead}),
-				types.NewRule(types.KindAppServer, []string{types.VerbCreate, types.VerbUpdate}),
+				types.NewRule(types.KindAppServer, []string{types.VerbCreate, types.VerbUpdate, types.VerbList, types.VerbDelete}),
 				types.NewRule(types.KindUserGroup, []string{types.VerbList, types.VerbRead}),
 			},
 		},
@@ -976,16 +978,22 @@ func TestAWSOIDCAppAccessAppServerCreation(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = env.server.Auth().CreateIntegration(context.Background(), myIntegration)
+	_, err = env.server.Auth().CreateIntegration(ctx, myIntegration)
 	require.NoError(t, err)
+
+	// Deleting the AWS App Access should return an error because it was not created yet.
+	deleteEndpoint := pack.clt.Endpoint("webapi", "sites", "localhost", "integrations", "aws-oidc", "my-integration", "aws-app-access")
+	_, err = pack.clt.Delete(ctx, deleteEndpoint)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "not found")
 
 	// Create the AWS App Access for the current integration.
 	endpoint := pack.clt.Endpoint("webapi", "sites", "localhost", "integrations", "aws-oidc", "my-integration", "aws-app-access")
-	_, err = pack.clt.PostJSON(context.Background(), endpoint, nil)
+	_, err = pack.clt.PostJSON(ctx, endpoint, nil)
 	require.NoError(t, err)
 
 	// Ensure the AppServer was correctly created.
-	appServers, err := env.server.Auth().GetApplicationServers(context.Background(), "default")
+	appServers, err := env.server.Auth().GetApplicationServers(ctx, "default")
 	require.NoError(t, err)
 	require.Len(t, appServers, 1)
 
@@ -1019,4 +1027,11 @@ func TestAWSOIDCAppAccessAppServerCreation(t *testing.T) {
 		appServers[0],
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision", "Namespace"),
 	))
+
+	// After deleting the application, it should be removed from the backend.
+	_, err = pack.clt.Delete(ctx, deleteEndpoint)
+	require.NoError(t, err)
+	appServers, err = env.server.Auth().GetApplicationServers(ctx, "default")
+	require.NoError(t, err)
+	require.Empty(t, appServers)
 }

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -982,7 +982,7 @@ func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 	require.NoError(t, err)
 
 	// Deleting the AWS App Access should return an error because it was not created yet.
-	deleteEndpoint := pack.clt.Endpoint("webapi", "sites", "localhost", "integrations", "aws-oidc", "my-integration", "aws-app-access")
+	deleteEndpoint := pack.clt.Endpoint("webapi", "sites", "localhost", "integrations", "aws-oidc", "aws-app-access", "my-integration")
 	_, err = pack.clt.Delete(ctx, deleteEndpoint)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "not found")


### PR DESCRIPTION
Backport #42012 to branch/v16