### PR TITLE
Use UnifiedResources API when resolving proxy templates for Machine ID SSH

### DIFF
--- a/lib/tbot/ssh_proxy.go
+++ b/lib/tbot/ssh_proxy.go
@@ -232,6 +232,7 @@ func resolveTargetHostWithClient(
 		Kinds:               []string{types.KindNode},
 		SearchKeywords:      libclient.ParseSearchKeywords(search, ','),
 		PredicateExpression: query,
+		SortBy:              types.SortBy{Field: types.ResourceKind},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -240,7 +241,11 @@ func resolveTargetHostWithClient(
 		return nil, trace.NotFound("no matching SSH hosts found for search terms or query expression")
 	}
 	if len(resources) > 1 {
-		return nil, trace.BadParameter("found multiple matching SSH hosts %v", resources[:2])
+		names := make([]string, len(resources))
+		for i, res := range resources {
+			names[i] = res.GetName()
+		}
+		return nil, trace.BadParameter("found multiple matching SSH hosts %v", names)
 	}
 	node := resources[0].ResourceWithLabels.(*types.ServerV2)
 	if node == nil {


### PR DESCRIPTION
When searching by a predicate, the old ListResources RPC will cause every resource within your Teleport cluster to be unmarshalled. The UnifiedResources API is superior because it leverages an in-memory cache of the unmarshaled resources. This should reduce the CPU and memory consumption associated with a large number of connections being established.

changelog: Use more efficient API when querying SSH nodes to resolve Proxy Templates in `tbot`.