### PR TITLE
[v16] Backport all `master` docs diffs to v16

### DIFF
--- a/docs/pages/choose-an-edition/teleport-cloud/ips.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/ips.mdx
@@ -1,0 +1,51 @@
+---
+title: Public IP Address Allowlist
+description: Restrict outbound network connections from your infrastructure to cloud-hosted Teleport Enterprise.
+tocDepth: 3
+---
+
+Teleport Agents connected to cloud-hosted Teleport Enterprise clusters must be allowed to connect to the following IP addresses in order to join the Teleport cluster.
+
+```
+3.7.23.103/32
+3.67.31.207/32
+3.109.188.166/32
+13.215.3.254/32
+18.136.170.204/32
+18.197.230.105/32
+18.228.73.158/32
+35.82.240.238/32
+44.198.252.22/32
+44.213.172.215/32
+44.217.250.22/32
+50.112.183.104/32
+52.59.15.95/32
+52.66.6.236/32
+52.67.142.215/32
+52.220.247.39/32
+54.94.211.77/32
+54.185.13.106/32
+```
+
+This list may be used to allowlist outbound network connections from Teleport Agents to cloud-hosted Teleport Enterprise.
+
+Allowlisting these IPs is not a required or recommended configuration for Teleport Agents, but it may be useful in environments that require restrictions to outbound network connections.
+For example, this list may be used to configure firewalls that sit in front of Teleport Agents, when those firewalls block access to the public internet by default.
+
+<Notice type="warning">
+Note that IP addresses may be added or removed from the above list over time.
+</Notice>
+
+When this list is modified, we will provide at least two weeks notice by:
+1. Updating the Changelog below.
+1. Notifying cloud-hosted Teleport Enterprise customers via email.
+1. Providing a [Status Page](https://status.teleport.sh/) update.
+1. Reaching out directly to Enterprise customers that have requested advanced notice.
+
+<Notice type="warning">
+If you are Teleport Enterprise customer and plan to employ this allowlist, please let us know by opening a support ticket.
+</Notice>
+
+## Changelog
+
+- 2024-06-06: List published

--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -242,21 +242,16 @@ Service, Kubernetes Service, and other services that protect resources in your
 infrastructure, there is no need to open ports on the machines running the
 agents to the public internet. 
 
-Some Teleport services listen for traffic to one of their proxied resources,
-meaning that you can expose ports on that service's host directly to clients.
-This is useful when you need to connect to resources directly if the Proxy
-Service becomes unavailable. 
+<Details title="Direct connections to agents">
 
-<Admonition
-  type="tip"
-  title="Note"
->
-  In Teleport Cloud, the Auth and Proxy Services run in Teleport-owned infrastructure.
-For this reason, Teleport Cloud customers must connect their resources via reverse tunnels.
-Exposing ports for direct dial is only supported in self-hosted deployments.
-</Admonition>
+If you run a self-hosted Teleport cluster, you can join an agent [directly to
+the Teleport Auth
+Service](../agents/join-services-to-your-cluster/join-token.mdx#start-your-teleport-process-with-the-invite-token).
+In this setup, certain Teleport services open their own listeners rather than
+accepting connections via reverse tunnel. The Proxy Service connects to these
+agent services by dialing them directly.
 
-The table below describes the ports that each Teleport Service opens for proxied
+The table below describes the ports that each Teleport service opens for proxied
 traffic:
 
 | Port | Service | Traffic Type |
@@ -265,6 +260,9 @@ traffic:
 | 3026 | Kubernetes Service | HTTPS traffic to a Kubernetes API server.| 
 | 3028 | Windows Desktop Service | Teleport Desktop Protocol traffic from Teleport clients.|
 
-You can only access enrolled applications and databases through the Teleport Proxy Service.
-The Teleport Application Service and Teleport Database Service use reverse tunnel
-connections through the Teleport Proxy Service and cannot expose ports directly.
+You can only access enrolled applications and desktops through the Teleport
+Proxy Service. The Teleport Application Service and Teleport Database Service
+use reverse tunnel connections through the Teleport Proxy Service and cannot
+expose ports directly.
+
+</Details>


### PR DESCRIPTION
Since we are releasing v16, all docs changes present in `master` should also be present in the v16 release branch. This change brings the v16 release branch up to date with `master`.

This branch is based on running the following command:

```
$ git checkout origin/master -- docs/pages
```