### PR TITLE
improve dynamodb permission error msg

### DIFF
--- a/lib/backend/dynamo/atomicwrite.go
+++ b/lib/backend/dynamo/atomicwrite.go
@@ -201,7 +201,7 @@ TxnLoop:
 			if !errors.As(err, &txnErr) {
 				if s := err.Error(); strings.Contains(s, "AccessDenied") && strings.Contains(s, "dynamodb:ConditionCheckItem") {
 					b.Warnf("AtomicWrite failed with error that may indicate dynamodb is missing the required dynamodb:ConditionCheckItem permission (this permission is now required for teleport v16 and later). Consider updating your IAM policy to include this permission.  Original error: %v", err)
-					return "", trace.Errorf("teleport is missing required permission dynamodb:ConditionCheckItem, please contact your administrator to update permissions")
+					return "", trace.Errorf("teleport is missing required AWS permission dynamodb:ConditionCheckItem, please contact your administrator to update permissions")
 				}
 				return "", trace.Errorf("unexpected error during atomic write: %v", err)
 			}

--- a/lib/backend/dynamo/atomicwrite.go
+++ b/lib/backend/dynamo/atomicwrite.go
@@ -199,6 +199,10 @@ TxnLoop:
 		if err != nil {
 			txnErr := &dynamodb.TransactionCanceledException{}
 			if !errors.As(err, &txnErr) {
+				if s := err.Error(); strings.Contains(s, "AccessDenied") && strings.Contains(s, "dynamodb:ConditionCheckItem") {
+					b.Warnf("AtomicWrite failed with error that may indicate dynamodb is missing the required dynamodb:ConditionCheckItem permission (this permission is now required for teleport v16 and later). Consider updating your IAM policy to include this permission.  Original error: %v", err)
+					return "", trace.Errorf("teleport is missing required permission dynamodb:ConditionCheckItem, please contact your administrator to update permissions")
+				}
 				return "", trace.Errorf("unexpected error during atomic write: %v", err)
 			}
 


### PR DESCRIPTION
v16+ has an additional dynamodb permission requirement.  This PR attempts to make the error a bit friendlier, so that anyone who misses the changelog entry can get things fixed quickly.