### PR TITLE
Azure IMDS: add location, vmid, subscription and group

### DIFF
--- a/lib/cloud/imds/azure/imds.go
+++ b/lib/cloud/imds/azure/imds.go
@@ -213,8 +213,8 @@ func (client *InstanceMetadataClient) GetHostname(ctx context.Context) (string, 
 }
 
 // InstanceInfo contains the current instance's metadata information.
-// Values obtained from
-// https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=linux#get-user-data
+// Values obtained from:
+// https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=linux#get-user-data.
 type InstanceInfo struct {
 	Location          string `json:"location"`
 	ResourceGroupName string `json:"resourceGroupName"`
@@ -223,7 +223,7 @@ type InstanceInfo struct {
 	ResourceID        string `json:"resourceId"`
 }
 
-// GetInstanceInfo gets the Azure Instance information
+// GetInstanceInfo gets the Azure Instance information.
 func (client *InstanceMetadataClient) GetInstanceInfo(ctx context.Context) (*InstanceInfo, error) {
 	body, err := client.getRawMetadata(ctx, "/instance/compute", url.Values{"format": []string{"json"}})
 	if err != nil {

--- a/lib/cloud/imds/azure/imds.go
+++ b/lib/cloud/imds/azure/imds.go
@@ -212,24 +212,43 @@ func (client *InstanceMetadataClient) GetHostname(ctx context.Context) (string, 
 	return value, nil
 }
 
+// InstanceInfo contains the current instance's metadata information.
+// Values obtained from
+// https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=linux#get-user-data
+type InstanceInfo struct {
+	Location          string `json:"location"`
+	ResourceGroupName string `json:"resourceGroupName"`
+	SubscriptionID    string `json:"subscriptionId"`
+	VMID              string `json:"vmId"`
+	ResourceID        string `json:"resourceId"`
+}
+
+// GetInstanceInfo gets the Azure Instance information
+func (client *InstanceMetadataClient) GetInstanceInfo(ctx context.Context) (*InstanceInfo, error) {
+	body, err := client.getRawMetadata(ctx, "/instance/compute", url.Values{"format": []string{"json"}})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var ret InstanceInfo
+	if err := utils.FastUnmarshal(body, &ret); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &ret, nil
+}
+
 // GetID gets the Azure resource ID of the cloud instance.
 func (client *InstanceMetadataClient) GetID(ctx context.Context) (string, error) {
-	compute := struct {
-		ResourceID string `json:"resourceId"`
-	}{}
-	body, err := client.getRawMetadata(ctx, "/instance/compute", url.Values{"format": []string{"json"}})
+	instanceInfo, err := client.GetInstanceInfo(ctx)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	if err := utils.FastUnmarshal(body, &compute); err != nil {
-		return "", trace.Wrap(err)
-	}
-
-	if compute.ResourceID == "" {
+	if instanceInfo.ResourceID == "" {
 		return "", trace.NotFound("instance resource ID not available")
 	}
 
-	return compute.ResourceID, nil
+	return instanceInfo.ResourceID, nil
 }
 
 // GetAttestedData gets attested data from the instance.

--- a/lib/cloud/imds/azure/imds_test.go
+++ b/lib/cloud/imds/azure/imds_test.go
@@ -205,14 +205,18 @@ func TestGetInstanceInfo(t *testing.T) {
 			errAssertion: require.NoError,
 		},
 		{
-			name:         "request error",
-			statusCode:   http.StatusNotFound,
-			errAssertion: require.Error,
+			name:       "request error",
+			statusCode: http.StatusNotFound,
+			errAssertion: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "not found")
+			},
 		},
 		{
-			name:         "empty body returns an error",
-			statusCode:   http.StatusOK,
-			errAssertion: require.Error,
+			name:       "empty body returns an error",
+			statusCode: http.StatusOK,
+			errAssertion: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "error found in #0 byte")
+			},
 		},
 	} {
 		tc := tc
@@ -256,9 +260,11 @@ func TestGetInstanceID(t *testing.T) {
 			errAssertion: require.Error,
 		},
 		{
-			name:         "request error",
-			statusCode:   http.StatusNotFound,
-			errAssertion: require.Error,
+			name:       "request error",
+			statusCode: http.StatusNotFound,
+			errAssertion: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "not found")
+			},
 		},
 	} {
 		tc := tc

--- a/lib/cloud/imds/azure/imds_test.go
+++ b/lib/cloud/imds/azure/imds_test.go
@@ -172,6 +172,59 @@ func TestParseMetadataClientError(t *testing.T) {
 	}
 }
 
+func TestGetInstanceInfo(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		stausCode            int
+		body                 []byte
+		expectedInstanceInfo *InstanceInfo
+		errAssertion         require.ErrorAssertionFunc
+	}{
+		{
+			name:      "with resource ID",
+			stausCode: http.StatusOK,
+			body:      []byte(`{"resourceId":"test-id"}`),
+			expectedInstanceInfo: &InstanceInfo{
+				ResourceID: "test-id",
+			},
+			errAssertion: require.NoError,
+		},
+		{
+			name:      "all fields",
+			stausCode: http.StatusOK,
+			body: []byte(`{"resourceId":"test-id", "location":"eastus", "resourceGroupName":"TestGroup", ` +
+				`"subscriptionId": "5187AF11-3581-4AB6-A654-59405CD40C44", "vmId":"ED7DAC09-6E73-447F-BD18-AF4D1196C1E4"}`),
+			expectedInstanceInfo: &InstanceInfo{
+				ResourceID:        "test-id",
+				Location:          "eastus",
+				ResourceGroupName: "TestGroup",
+				SubscriptionID:    "5187AF11-3581-4AB6-A654-59405CD40C44",
+				VMID:              "ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
+			},
+			errAssertion: require.NoError,
+		},
+		{
+			name:         "request error",
+			stausCode:    http.StatusNotFound,
+			errAssertion: require.Error,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write(tc.body)
+			}))
+
+			client := NewInstanceMetadataClient(WithBaseURL(server.URL))
+			instanceInfo, err := client.GetInstanceInfo(context.Background())
+			tc.errAssertion(t, err)
+			if tc.expectedInstanceInfo != nil {
+				require.Equal(t, tc.expectedInstanceInfo, instanceInfo)
+			}
+		})
+	}
+}
+
 func TestGetInstanceID(t *testing.T) {
 	for _, tc := range []struct {
 		name               string

--- a/lib/cloud/imds/azure/imds_test.go
+++ b/lib/cloud/imds/azure/imds_test.go
@@ -173,25 +173,26 @@ func TestParseMetadataClientError(t *testing.T) {
 }
 
 func TestGetInstanceInfo(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name                 string
-		stausCode            int
+		statusCode           int
 		body                 []byte
 		expectedInstanceInfo *InstanceInfo
 		errAssertion         require.ErrorAssertionFunc
 	}{
 		{
-			name:      "with resource ID",
-			stausCode: http.StatusOK,
-			body:      []byte(`{"resourceId":"test-id"}`),
+			name:       "with resource ID",
+			statusCode: http.StatusOK,
+			body:       []byte(`{"resourceId":"test-id"}`),
 			expectedInstanceInfo: &InstanceInfo{
 				ResourceID: "test-id",
 			},
 			errAssertion: require.NoError,
 		},
 		{
-			name:      "all fields",
-			stausCode: http.StatusOK,
+			name:       "all fields",
+			statusCode: http.StatusOK,
 			body: []byte(`{"resourceId":"test-id", "location":"eastus", "resourceGroupName":"TestGroup", ` +
 				`"subscriptionId": "5187AF11-3581-4AB6-A654-59405CD40C44", "vmId":"ED7DAC09-6E73-447F-BD18-AF4D1196C1E4"}`),
 			expectedInstanceInfo: &InstanceInfo{
@@ -205,13 +206,20 @@ func TestGetInstanceInfo(t *testing.T) {
 		},
 		{
 			name:         "request error",
-			stausCode:    http.StatusNotFound,
+			statusCode:   http.StatusNotFound,
+			errAssertion: require.Error,
+		},
+		{
+			name:         "empty body returns an error",
+			statusCode:   http.StatusOK,
 			errAssertion: require.Error,
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
+				w.WriteHeader(tc.statusCode)
 				w.Write(tc.body)
 			}))
 
@@ -226,35 +234,38 @@ func TestGetInstanceInfo(t *testing.T) {
 }
 
 func TestGetInstanceID(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name               string
-		stausCode          int
+		statusCode         int
 		body               []byte
 		expectedResourceID string
 		errAssertion       require.ErrorAssertionFunc
 	}{
 		{
 			name:               "with resource ID",
-			stausCode:          http.StatusOK,
+			statusCode:         http.StatusOK,
 			body:               []byte(`{"resourceId":"test-id"}`),
 			expectedResourceID: "test-id",
 			errAssertion:       require.NoError,
 		},
 		{
 			name:         "with error",
-			stausCode:    http.StatusOK,
+			statusCode:   http.StatusOK,
 			body:         []byte(`{"error":"test-error"}`),
 			errAssertion: require.Error,
 		},
 		{
 			name:         "request error",
-			stausCode:    http.StatusNotFound,
+			statusCode:   http.StatusNotFound,
 			errAssertion: require.Error,
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
+				w.WriteHeader(tc.statusCode)
 				w.Write(tc.body)
 			}))
 


### PR DESCRIPTION
This PR adds a new method to fetch instance metadata information. It will include the instance/metadata endpoint to retrieve them.

This is part of the work to move the node auto-discovery from shell script into go code.
This particular PR is used to do the same that it's done here:

https://github.com/gravitational/teleport/blob/c8362ed84311d245dadb2949fcee21a2a5c00b1a/api/types/installers/installer.sh.tmpl#L152-L158