### PR TITLE
[v15] JIRA plugin: ensure Summary is less than 255 chars

### DIFF
--- a/integrations/access/jira/client.go
+++ b/integrations/access/jira/client.go
@@ -163,6 +163,18 @@ func statusFromStatusCode(httpCode int) types.PluginStatus {
 	return &types.PluginStatusV1{Code: code}
 }
 
+// buildSummary creates the Issue's summary by using the user name and roles.
+// No official docs seem to exist, but it's _known_ that summary field must be less than 255 chars:
+// Eg https://community.atlassian.com/t5/Jira-questions/Summary-must-be-less-than-255-characters/qaq-p/989632
+func buildSummary(reqData RequestData) string {
+	summary := fmt.Sprintf("%s requested %s", reqData.User, strings.Join(reqData.Roles, ", "))
+	if len(summary) <= 254 {
+		return summary
+	}
+
+	return summary[:strings.LastIndexAny(summary[:254], ",")]
+}
+
 // HealthCheck checks Jira endpoint for validity and also checks the project permissions.
 func (j *Jira) HealthCheck(ctx context.Context) error {
 	log := logger.Get(ctx)
@@ -244,7 +256,7 @@ func (j *Jira) CreateIssue(ctx context.Context, reqID string, reqData RequestDat
 		Fields: IssueFieldsInput{
 			Type:        &IssueType{Name: j.issueType},
 			Project:     &Project{Key: j.project},
-			Summary:     fmt.Sprintf("%s requested %s", reqData.User, strings.Join(reqData.Roles, ", ")),
+			Summary:     buildSummary(reqData),
 			Description: description,
 		},
 	}

--- a/integrations/access/jira/client.go
+++ b/integrations/access/jira/client.go
@@ -171,8 +171,7 @@ func buildSummary(reqData RequestData) string {
 	if len(summary) <= 254 {
 		return summary
 	}
-
-	return summary[:strings.LastIndexAny(summary[:254], ",")]
+	return fmt.Sprintf("%s requested access to %d roles", reqData.User, len(reqData.Roles))
 }
 
 // HealthCheck checks Jira endpoint for validity and also checks the project permissions.

--- a/integrations/access/jira/client_test.go
+++ b/integrations/access/jira/client_test.go
@@ -1,0 +1,69 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package jira
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSummary(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		reqData     RequestData
+		expected    string
+		expectedLen int
+	}{
+		{
+			name: "single role",
+			reqData: RequestData{
+				Roles: []string{"editor"},
+				User:  "my-user",
+			},
+			expected:    "my-user requested editor",
+			expectedLen: 24,
+		},
+		{
+			name: "lots of roles that exceed the field size are truncated",
+			reqData: RequestData{
+				Roles: strings.Split(strings.Repeat("editor,", 1000), ","),
+				User:  "my-user",
+			},
+			expected:    "my-user requested " + strings.Repeat("editor, ", 28) + "editor",
+			expectedLen: 248,
+		},
+		{
+			name: "small role names should not cause an exceeding number of chars",
+			reqData: RequestData{
+				Roles: strings.Split(strings.Repeat("r,", 1000), ","),
+				User:  "my-user",
+			},
+			expected:    "my-user requested " + strings.Repeat("r, ", 78) + "r",
+			expectedLen: 253,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildSummary(tt.reqData)
+			require.Equal(t, tt.expected, got)
+			require.Len(t, got, tt.expectedLen)
+		})
+	}
+}

--- a/integrations/access/jira/client_test.go
+++ b/integrations/access/jira/client_test.go
@@ -27,10 +27,9 @@ import (
 
 func TestBuildSummary(t *testing.T) {
 	for _, tt := range []struct {
-		name        string
-		reqData     RequestData
-		expected    string
-		expectedLen int
+		name     string
+		reqData  RequestData
+		expected string
 	}{
 		{
 			name: "single role",
@@ -38,32 +37,20 @@ func TestBuildSummary(t *testing.T) {
 				Roles: []string{"editor"},
 				User:  "my-user",
 			},
-			expected:    "my-user requested editor",
-			expectedLen: 24,
+			expected: "my-user requested editor",
 		},
 		{
 			name: "lots of roles that exceed the field size are truncated",
 			reqData: RequestData{
-				Roles: strings.Split(strings.Repeat("editor,", 1000), ","),
+				Roles: strings.Split(strings.TrimRight(strings.Repeat("editor,", 1000), ","), ","),
 				User:  "my-user",
 			},
-			expected:    "my-user requested " + strings.Repeat("editor, ", 28) + "editor",
-			expectedLen: 248,
-		},
-		{
-			name: "small role names should not cause an exceeding number of chars",
-			reqData: RequestData{
-				Roles: strings.Split(strings.Repeat("r,", 1000), ","),
-				User:  "my-user",
-			},
-			expected:    "my-user requested " + strings.Repeat("r, ", 78) + "r",
-			expectedLen: 253,
+			expected: "my-user requested access to 1000 roles",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := buildSummary(tt.reqData)
 			require.Equal(t, tt.expected, got)
-			require.Len(t, got, tt.expectedLen)
 		})
 	}
 }


### PR DESCRIPTION
Backport #42825 to branch/v15

changelog: Fix Jira Issue creation when Summary exceeds the max allowed size 
