### PR TITLE
improve unified resource cache perf

### DIFF
--- a/lib/services/access_request_cache.go
+++ b/lib/services/access_request_cache.go
@@ -355,29 +355,31 @@ func (c *AccessRequestCache) getResourcesAndUpdateCurrent(ctx context.Context) e
 	return nil
 }
 
-// processEventAndUpdateCurrent is part of the resourceCollector interface and is used to update the
+// processEventsAndUpdateCurrent is part of the resourceCollector interface and is used to update the
 // primary cache state when modification events occur.
-func (c *AccessRequestCache) processEventAndUpdateCurrent(ctx context.Context, event types.Event) {
+func (c *AccessRequestCache) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
 	c.rw.RLock()
 	cache := c.primaryCache
 	c.rw.RUnlock()
 
-	switch event.Type {
-	case types.OpPut:
-		req, ok := event.Resource.(*types.AccessRequestV3)
-		if !ok {
-			slog.WarnContext(ctx, "unexpected resource type in event", "expected", logutils.TypeAttr(req), "got", logutils.TypeAttr(event.Resource))
-			return
+	for _, event := range events {
+		switch event.Type {
+		case types.OpPut:
+			req, ok := event.Resource.(*types.AccessRequestV3)
+			if !ok {
+				slog.WarnContext(ctx, "unexpected resource type in event", "expected", logutils.TypeAttr(req), "got", logutils.TypeAttr(event.Resource))
+				continue
+			}
+			if evicted := cache.Put(req); evicted > 1 {
+				// this warning, if it appears, means that we configured our indexes incorrectly and one access request is overwriting another.
+				// the most likely explanation is that one of our indexes is missing the request id suffix we typically use.
+				slog.WarnContext(ctx, "request put event resulted in multiple cache evictions (this is a bug)", "id", req.GetName(), "evicted", evicted)
+			}
+		case types.OpDelete:
+			cache.Delete(accessRequestID, event.Resource.GetName())
+		default:
+			slog.WarnContext(ctx, "unexpected event variant", "op", logutils.StringerAttr(event.Type), "resource", logutils.TypeAttr(event.Resource))
 		}
-		if evicted := cache.Put(req); evicted > 1 {
-			// this warning, if it appears, means that we configured our indexes incorrectly and one access request is overwriting another.
-			// the most likely explanation is that one of our indexes is missing the request id suffix we typically use.
-			slog.WarnContext(ctx, "request put event resulted in multiple cache evictions (this is a bug)", "id", req.GetName(), "evicted", evicted)
-		}
-	case types.OpDelete:
-		cache.Delete(accessRequestID, event.Resource.GetName())
-	default:
-		slog.WarnContext(ctx, "unexpected event variant", "op", logutils.StringerAttr(event.Type), "resource", logutils.TypeAttr(event.Resource))
 	}
 }
 

--- a/lib/services/notifications_cache.go
+++ b/lib/services/notifications_cache.go
@@ -442,62 +442,69 @@ func (c *GlobalNotificationCache) getResourcesAndUpdateCurrent(ctx context.Conte
 	return nil
 }
 
-// processEventAndUpdateCurrent is part of the resourceCollector interface and is used to update the
+// processEventsAndUpdateCurrent is part of the resourceCollector interface and is used to update the
 // primary cache state when modification events occur.
-func (c *UserNotificationCache) processEventAndUpdateCurrent(ctx context.Context, event types.Event) {
+func (c *UserNotificationCache) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
 	c.rw.RLock()
 	cache := c.primaryCache
 	c.rw.RUnlock()
-	switch event.Type {
-	case types.OpPut:
-		// Since the EventsService watcher currently only supports legacy resources, we had to use types.Resource153ToLegacy() when parsing the event
-		// to transform the notification into a legacy resource. We now have to use Unwrap() to get the original RFD153-style notification out and add it to the cache.
-		resource153, ok := event.Resource.(types.Resource153Unwrapper)
-		if !ok {
-			slog.WarnContext(ctx, "Unexpected resource type in event (expected types.Resource153Unwrapper)", "resource_type", reflect.TypeOf(resource153))
-			return
-		}
-		resource := resource153.Unwrap()
 
-		notification, ok := resource.(*notificationsv1.Notification)
-		if !ok {
-			slog.WarnContext(ctx, "Unexpected resource type in event (expected *notificationsv1.Notification)", "resource_type", reflect.TypeOf(resource))
-			return
+	for _, event := range events {
+		switch event.Type {
+		case types.OpPut:
+			// Since the EventsService watcher currently only supports legacy resources, we had to use types.Resource153ToLegacy() when parsing the event
+			// to transform the notification into a legacy resource. We now have to use Unwrap() to get the original RFD153-style notification out and add it to the cache.
+			resource153, ok := event.Resource.(types.Resource153Unwrapper)
+			if !ok {
+				slog.WarnContext(ctx, "Unexpected resource type in event (expected types.Resource153Unwrapper)", "resource_type", reflect.TypeOf(resource153))
+				continue
+			}
+			resource := resource153.Unwrap()
+
+			notification, ok := resource.(*notificationsv1.Notification)
+			if !ok {
+				slog.WarnContext(ctx, "Unexpected resource type in event (expected *notificationsv1.Notification)", "resource_type", reflect.TypeOf(resource))
+				continue
+			}
+			if evicted := cache.Put(notification); evicted > 1 {
+				slog.WarnContext(ctx, "Processing of put event for notification resulted in multiple cache evictions (this is a bug).", "notification", notification.GetMetadata().GetName())
+			}
+		case types.OpDelete:
+			cache.Delete(notificationID, event.Resource.GetName())
+		default:
+			slog.WarnContext(ctx, "Unexpected event variant", "event", event.Type)
 		}
-		if evicted := cache.Put(notification); evicted > 1 {
-			slog.WarnContext(ctx, "Processing of put event for notification resulted in multiple cache evictions (this is a bug).", "notification", notification.GetMetadata().GetName())
-		}
-	case types.OpDelete:
-		cache.Delete(notificationID, event.Resource.GetName())
-	default:
-		slog.WarnContext(ctx, "Unexpected event variant", "event", event.Type)
 	}
 }
-func (c *GlobalNotificationCache) processEventAndUpdateCurrent(ctx context.Context, event types.Event) {
+
+func (c *GlobalNotificationCache) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
 	c.rw.RLock()
 	cache := c.primaryCache
 	c.rw.RUnlock()
-	switch event.Type {
-	case types.OpPut:
-		resource153, ok := event.Resource.(types.Resource153Unwrapper)
-		if !ok {
-			slog.WarnContext(ctx, "Unexpected resource type in event (expected types.Resource153Unwrapper)", "resource_type", reflect.TypeOf(resource153))
-			return
-		}
-		resource := resource153.Unwrap()
 
-		globalNotification, ok := resource.(*notificationsv1.GlobalNotification)
-		if !ok {
-			slog.WarnContext(ctx, "Unexpected resource type in event (expected *notificationsv1.GlobalNotification)", "resource_type", reflect.TypeOf(resource))
-			return
+	for _, event := range events {
+		switch event.Type {
+		case types.OpPut:
+			resource153, ok := event.Resource.(types.Resource153Unwrapper)
+			if !ok {
+				slog.WarnContext(ctx, "Unexpected resource type in event (expected types.Resource153Unwrapper)", "resource_type", reflect.TypeOf(resource153))
+				continue
+			}
+			resource := resource153.Unwrap()
+
+			globalNotification, ok := resource.(*notificationsv1.GlobalNotification)
+			if !ok {
+				slog.WarnContext(ctx, "Unexpected resource type in event (expected *notificationsv1.GlobalNotification)", "resource_type", reflect.TypeOf(resource))
+				continue
+			}
+			if evicted := cache.Put(globalNotification); evicted > 1 {
+				slog.WarnContext(ctx, "Processing of put event for notification resulted in multiple cache evictions (this is a bug).", "notification", globalNotification.GetMetadata().GetName())
+			}
+		case types.OpDelete:
+			cache.Delete(notificationID, event.Resource.GetName())
+		default:
+			slog.WarnContext(ctx, "Unexpected event variant", "event", event.Type)
 		}
-		if evicted := cache.Put(globalNotification); evicted > 1 {
-			slog.WarnContext(ctx, "Processing of put event for notification resulted in multiple cache evictions (this is a bug).", "notification", globalNotification.GetMetadata().GetName())
-		}
-	case types.OpDelete:
-		cache.Delete(notificationID, event.Resource.GetName())
-	default:
-		slog.WarnContext(ctx, "Unexpected event variant", "event", event.Type)
 	}
 }
 

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -41,6 +41,11 @@ const (
 	// smallFanoutCapacity is the default capacity used for the circular event buffer allocated by
 	// resource watchers that implement event fanout.
 	smallFanoutCapacity = 128
+
+	// eventBufferMaxSize is the maximum size of the event buffer used by resource watchers to
+	// batch events that arrive in quick succession. In practice the event buffer should never
+	// grow this large unless we're dealing with a truly massive teleport cluster.
+	eventBufferMaxSize = 2048
 )
 
 // resourceCollector is a generic interface for maintaining an up-to-date view
@@ -51,8 +56,11 @@ type resourceCollector interface {
 	// getResourcesAndUpdateCurrent is called when the resources should be
 	// (re-)fetched directly.
 	getResourcesAndUpdateCurrent(context.Context) error
-	// processEventAndUpdateCurrent is called when a watcher event is received.
-	processEventAndUpdateCurrent(context.Context, types.Event)
+	// processEventsAndUpdateCurrent is called when a watcher events are received. The event buffer
+	// may be reused so implementers must not retain it, but implementers may mutate the buffer
+	// in place during the call, e.g. in order to filter out undesired events before passing them
+	// to a subsideary bulk-processor such as a fanout.
+	processEventsAndUpdateCurrent(context.Context, []types.Event)
 	// notifyStale is called when the maximum acceptable staleness (if specified)
 	// is exceeded.
 	notifyStale()
@@ -335,6 +343,8 @@ func (p *resourceWatcher) watch() error {
 	p.retry.Reset()
 	p.failureStartedAt = time.Time{}
 
+	// start out with a modestly sized event buffer
+	eventBuf := make([]types.Event, 0, 16)
 	for {
 		select {
 		case <-watcher.Done():
@@ -342,7 +352,23 @@ func (p *resourceWatcher) watch() error {
 		case <-p.ctx.Done():
 			return trace.ConnectionProblem(p.ctx.Err(), "context is closing")
 		case event := <-watcher.Events():
-			p.collector.processEventAndUpdateCurrent(p.ctx, event)
+			// resource collectors want to process events in batches
+			// when possible in order to reduce contention on their locks.
+			// we therefore optimistically try to gather a large number of
+			// events without blocking.
+			eventBuf = append(eventBuf, event)
+		CollectEvents:
+			for len(eventBuf) < eventBufferMaxSize {
+				select {
+				case additionalEvent := <-watcher.Events():
+					eventBuf = append(eventBuf, additionalEvent)
+				default:
+					break CollectEvents
+				}
+			}
+			p.collector.processEventsAndUpdateCurrent(p.ctx, eventBuf)
+			clear(eventBuf)
+			eventBuf = eventBuf[:0]
 		case p.LoopC <- struct{}{}:
 			// Used in tests to detect the watch loop is running.
 		case <-p.StaleC:
@@ -460,34 +486,42 @@ func (p *proxyCollector) defineCollectorAsInitialized() {
 	})
 }
 
-// processEventAndUpdateCurrent is called when a watcher event is received.
-func (p *proxyCollector) processEventAndUpdateCurrent(ctx context.Context, event types.Event) {
-	if event.Resource == nil || event.Resource.GetKind() != types.KindProxy {
-		p.Log.Warningf("Unexpected event: %v.", event)
-		return
-	}
-
+// processEventsAndUpdateCurrent is called when a watcher event is received.
+func (p *proxyCollector) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
 	p.rw.Lock()
 	defer p.rw.Unlock()
 
-	switch event.Type {
-	case types.OpDelete:
-		delete(p.current, event.Resource.GetName())
-		// Always broadcast when a proxy is deleted.
+	var updated bool
+
+	for _, event := range events {
+		if event.Resource == nil || event.Resource.GetKind() != types.KindProxy {
+			p.Log.Warningf("Unexpected event: %v.", event)
+			continue
+		}
+
+		switch event.Type {
+		case types.OpDelete:
+			delete(p.current, event.Resource.GetName())
+			// Always broadcast when a proxy is deleted.
+			updated = true
+		case types.OpPut:
+			server, ok := event.Resource.(types.Server)
+			if !ok {
+				p.Log.Warningf("Unexpected type %T.", event.Resource)
+				continue
+			}
+			current, exists := p.current[server.GetName()]
+			p.current[server.GetName()] = server
+			if !exists || (p.ProxyDiffer != nil && p.ProxyDiffer(current, server)) {
+				updated = true
+			}
+		default:
+			p.Log.Warningf("Skipping unsupported event type %s.", event.Type)
+		}
+	}
+
+	if updated {
 		p.broadcastUpdate(ctx)
-	case types.OpPut:
-		server, ok := event.Resource.(types.Server)
-		if !ok {
-			p.Log.Warningf("Unexpected type %T.", event.Resource)
-			return
-		}
-		current, exists := p.current[server.GetName()]
-		p.current[server.GetName()] = server
-		if !exists || (p.ProxyDiffer != nil && p.ProxyDiffer(current, server)) {
-			p.broadcastUpdate(ctx)
-		}
-	default:
-		p.Log.Warningf("Skipping unsupported event type %s.", event.Type)
 	}
 }
 
@@ -706,34 +740,38 @@ func (p *lockCollector) defineCollectorAsInitialized() {
 	})
 }
 
-// processEventAndUpdateCurrent is called when a watcher event is received.
-func (p *lockCollector) processEventAndUpdateCurrent(ctx context.Context, event types.Event) {
-	if event.Resource == nil || event.Resource.GetKind() != types.KindLock {
-		p.Log.Warningf("Unexpected event: %v.", event)
-		return
-	}
-
+// processEventsAndUpdateCurrent is called when a watcher event is received.
+func (p *lockCollector) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
 	p.currentRW.Lock()
 	defer p.currentRW.Unlock()
-	switch event.Type {
-	case types.OpDelete:
-		delete(p.current, event.Resource.GetName())
-		p.fanout.Emit(event)
-	case types.OpPut:
-		lock, ok := event.Resource.(types.Lock)
-		if !ok {
-			p.Log.Warningf("Unexpected resource type %T.", event.Resource)
-			return
+	eventsToEmit := events[:0]
+	for _, event := range events {
+		if event.Resource == nil || event.Resource.GetKind() != types.KindLock {
+			p.Log.Warningf("Unexpected event: %v.", event)
+			continue
 		}
-		if lock.IsInForce(p.Clock.Now()) {
-			p.current[lock.GetName()] = lock
-			p.fanout.Emit(event)
-		} else {
-			delete(p.current, lock.GetName())
+
+		switch event.Type {
+		case types.OpDelete:
+			delete(p.current, event.Resource.GetName())
+			eventsToEmit = append(eventsToEmit, event)
+		case types.OpPut:
+			lock, ok := event.Resource.(types.Lock)
+			if !ok {
+				p.Log.Warningf("Unexpected resource type %T.", event.Resource)
+				continue
+			}
+			if lock.IsInForce(p.Clock.Now()) {
+				p.current[lock.GetName()] = lock
+				eventsToEmit = append(eventsToEmit, event)
+			} else {
+				delete(p.current, lock.GetName())
+			}
+		default:
+			p.Log.Warningf("Skipping unsupported event type %s.", event.Type)
 		}
-	default:
-		p.Log.Warningf("Skipping unsupported event type %s.", event.Type)
 	}
+	p.fanout.Emit(eventsToEmit...)
 }
 
 // notifyStale is called when the maximum acceptable staleness (if specified)
@@ -883,36 +921,39 @@ func (p *databaseCollector) defineCollectorAsInitialized() {
 	})
 }
 
-// processEventAndUpdateCurrent is called when a watcher event is received.
-func (p *databaseCollector) processEventAndUpdateCurrent(ctx context.Context, event types.Event) {
-	if event.Resource == nil || event.Resource.GetKind() != types.KindDatabase {
-		p.Log.Warnf("Unexpected event: %v.", event)
-		return
-	}
+// processEventsAndUpdateCurrent is called when a watcher event is received.
+func (p *databaseCollector) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	switch event.Type {
-	case types.OpDelete:
-		delete(p.current, event.Resource.GetName())
-		select {
-		case <-ctx.Done():
-		case p.DatabasesC <- resourcesToSlice(p.current):
-		}
-	case types.OpPut:
-		database, ok := event.Resource.(types.Database)
-		if !ok {
-			p.Log.Warnf("Unexpected resource type %T.", event.Resource)
-			return
-		}
-		p.current[database.GetName()] = database
-		select {
-		case <-ctx.Done():
-		case p.DatabasesC <- resourcesToSlice(p.current):
-		}
 
-	default:
-		p.Log.Warnf("Unsupported event type %s.", event.Type)
-		return
+	var updated bool
+	for _, event := range events {
+		if event.Resource == nil || event.Resource.GetKind() != types.KindDatabase {
+			p.Log.Warnf("Unexpected event: %v.", event)
+			continue
+		}
+		switch event.Type {
+		case types.OpDelete:
+			delete(p.current, event.Resource.GetName())
+			updated = true
+		case types.OpPut:
+			database, ok := event.Resource.(types.Database)
+			if !ok {
+				p.Log.Warnf("Unexpected resource type %T.", event.Resource)
+				continue
+			}
+			p.current[database.GetName()] = database
+			updated = true
+		default:
+			p.Log.Warnf("Unsupported event type %s.", event.Type)
+		}
+	}
+
+	if updated {
+		select {
+		case <-ctx.Done():
+		case p.DatabasesC <- resourcesToSlice(p.current):
+		}
 	}
 }
 
@@ -1021,39 +1062,40 @@ func (p *appCollector) defineCollectorAsInitialized() {
 	})
 }
 
-// processEventAndUpdateCurrent is called when a watcher event is received.
-func (p *appCollector) processEventAndUpdateCurrent(ctx context.Context, event types.Event) {
-	if event.Resource == nil || event.Resource.GetKind() != types.KindApp {
-		p.Log.Warnf("Unexpected event: %v.", event)
-		return
-	}
+// processEventsAndUpdateCurrent is called when a watcher event is received.
+func (p *appCollector) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	switch event.Type {
-	case types.OpDelete:
-		delete(p.current, event.Resource.GetName())
-		p.AppsC <- resourcesToSlice(p.current)
-
-		select {
-		case <-ctx.Done():
-		case p.AppsC <- resourcesToSlice(p.current):
+	for _, event := range events {
+		if event.Resource == nil || event.Resource.GetKind() != types.KindApp {
+			p.Log.Warnf("Unexpected event: %v.", event)
+			continue
 		}
+		switch event.Type {
+		case types.OpDelete:
+			delete(p.current, event.Resource.GetName())
+			p.AppsC <- resourcesToSlice(p.current)
 
-	case types.OpPut:
-		app, ok := event.Resource.(types.Application)
-		if !ok {
-			p.Log.Warnf("Unexpected resource type %T.", event.Resource)
-			return
-		}
-		p.current[app.GetName()] = app
+			select {
+			case <-ctx.Done():
+			case p.AppsC <- resourcesToSlice(p.current):
+			}
 
-		select {
-		case <-ctx.Done():
-		case p.AppsC <- resourcesToSlice(p.current):
+		case types.OpPut:
+			app, ok := event.Resource.(types.Application)
+			if !ok {
+				p.Log.Warnf("Unexpected resource type %T.", event.Resource)
+				continue
+			}
+			p.current[app.GetName()] = app
+
+			select {
+			case <-ctx.Done():
+			case p.AppsC <- resourcesToSlice(p.current):
+			}
+		default:
+			p.Log.Warnf("Unsupported event type %s.", event.Type)
 		}
-	default:
-		p.Log.Warnf("Unsupported event type %s.", event.Type)
-		return
 	}
 }
 
@@ -1172,39 +1214,40 @@ func (k *kubeCollector) defineCollectorAsInitialized() {
 	})
 }
 
-// processEventAndUpdateCurrent is called when a watcher event is received.
-func (k *kubeCollector) processEventAndUpdateCurrent(ctx context.Context, event types.Event) {
-	if event.Resource == nil || event.Resource.GetKind() != types.KindKubernetesCluster {
-		k.Log.Warnf("Unexpected event: %v.", event)
-		return
-	}
+// processEventsAndUpdateCurrent is called when a watcher event is received.
+func (k *kubeCollector) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	switch event.Type {
-	case types.OpDelete:
-		delete(k.current, event.Resource.GetName())
-		k.KubeClustersC <- resourcesToSlice(k.current)
-
-		select {
-		case <-ctx.Done():
-		case k.KubeClustersC <- resourcesToSlice(k.current):
+	for _, event := range events {
+		if event.Resource == nil || event.Resource.GetKind() != types.KindKubernetesCluster {
+			k.Log.Warnf("Unexpected event: %v.", event)
+			continue
 		}
+		switch event.Type {
+		case types.OpDelete:
+			delete(k.current, event.Resource.GetName())
+			k.KubeClustersC <- resourcesToSlice(k.current)
 
-	case types.OpPut:
-		cluster, ok := event.Resource.(types.KubeCluster)
-		if !ok {
-			k.Log.Warnf("Unexpected resource type %T.", event.Resource)
-			return
-		}
-		k.current[cluster.GetName()] = cluster
+			select {
+			case <-ctx.Done():
+			case k.KubeClustersC <- resourcesToSlice(k.current):
+			}
 
-		select {
-		case <-ctx.Done():
-		case k.KubeClustersC <- resourcesToSlice(k.current):
+		case types.OpPut:
+			cluster, ok := event.Resource.(types.KubeCluster)
+			if !ok {
+				k.Log.Warnf("Unexpected resource type %T.", event.Resource)
+				continue
+			}
+			k.current[cluster.GetName()] = cluster
+
+			select {
+			case <-ctx.Done():
+			case k.KubeClustersC <- resourcesToSlice(k.current):
+			}
+		default:
+			k.Log.Warnf("Unsupported event type %s.", event.Type)
 		}
-	default:
-		k.Log.Warnf("Unsupported event type %s.", event.Type)
-		return
 	}
 }
 
@@ -1375,39 +1418,40 @@ func (k *kubeServerCollector) defineCollectorAsInitialized() {
 	})
 }
 
-// processEventAndUpdateCurrent is called when a watcher event is received.
-func (k *kubeServerCollector) processEventAndUpdateCurrent(ctx context.Context, event types.Event) {
-	if event.Resource == nil || event.Resource.GetKind() != types.KindKubeServer {
-		k.Log.Warnf("Unexpected event: %v.", event)
-		return
-	}
-
-	server, ok := event.Resource.(types.KubeServer)
-	if !ok {
-		k.Log.Warnf("Unexpected resource type %T.", event.Resource)
-		return
-	}
-
+// processEventsAndUpdateCurrent is called when a watcher event is received.
+func (k *kubeServerCollector) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
 	k.lock.Lock()
 	defer k.lock.Unlock()
 
-	switch event.Type {
-	case types.OpDelete:
-		key := kubeServersKey{
-			// On delete events, the server description is populated with the host ID.
-			hostID:       server.GetMetadata().Description,
-			resourceName: server.GetName(),
+	for _, event := range events {
+		if event.Resource == nil || event.Resource.GetKind() != types.KindKubeServer {
+			k.Log.Warnf("Unexpected event: %v.", event)
+			continue
 		}
-		delete(k.current, key)
-	case types.OpPut:
-		key := kubeServersKey{
-			hostID:       server.GetHostID(),
-			resourceName: server.GetName(),
+
+		server, ok := event.Resource.(types.KubeServer)
+		if !ok {
+			k.Log.Warnf("Unexpected resource type %T.", event.Resource)
+			continue
 		}
-		k.current[key] = server
-	default:
-		k.Log.Warnf("Unsupported event type %s.", event.Type)
-		return
+
+		switch event.Type {
+		case types.OpDelete:
+			key := kubeServersKey{
+				// On delete events, the server description is populated with the host ID.
+				hostID:       server.GetMetadata().Description,
+				resourceName: server.GetName(),
+			}
+			delete(k.current, key)
+		case types.OpPut:
+			key := kubeServersKey{
+				hostID:       server.GetHostID(),
+				resourceName: server.GetName(),
+			}
+			k.current[key] = server
+		default:
+			k.Log.Warnf("Unsupported event type %s.", event.Type)
+		}
 	}
 }
 
@@ -1600,45 +1644,51 @@ func (c *caCollector) defineCollectorAsInitialized() {
 	})
 }
 
-// processEventAndUpdateCurrent is called when a watcher event is received.
-func (c *caCollector) processEventAndUpdateCurrent(ctx context.Context, event types.Event) {
-	if event.Resource == nil || event.Resource.GetKind() != types.KindCertAuthority {
-		c.Log.Warnf("Unexpected event: %v.", event)
-		return
-	}
+// processEventsAndUpdateCurrent is called when a watcher event is received.
+func (c *caCollector) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	switch event.Type {
-	case types.OpDelete:
-		caType := types.CertAuthType(event.Resource.GetSubKind())
-		if !c.watchingType(caType) {
-			return
-		}
 
-		delete(c.cas[caType], event.Resource.GetName())
-		c.fanout.Emit(event)
-	case types.OpPut:
-		ca, ok := event.Resource.(types.CertAuthority)
-		if !ok {
-			c.Log.Warnf("Unexpected resource type %T.", event.Resource)
-			return
-		}
+	eventsToEmit := events[:0]
 
-		if !c.watchingType(ca.GetType()) {
-			return
+	for _, event := range events {
+		if event.Resource == nil || event.Resource.GetKind() != types.KindCertAuthority {
+			c.Log.Warnf("Unexpected event: %v.", event)
+			continue
 		}
+		switch event.Type {
+		case types.OpDelete:
+			caType := types.CertAuthType(event.Resource.GetSubKind())
+			if !c.watchingType(caType) {
+				continue
+			}
 
-		authority, ok := c.cas[ca.GetType()][ca.GetName()]
-		if ok && CertAuthoritiesEquivalent(authority, ca) {
-			return
+			delete(c.cas[caType], event.Resource.GetName())
+			eventsToEmit = append(eventsToEmit, event)
+		case types.OpPut:
+			ca, ok := event.Resource.(types.CertAuthority)
+			if !ok {
+				c.Log.Warnf("Unexpected resource type %T.", event.Resource)
+				continue
+			}
+
+			if !c.watchingType(ca.GetType()) {
+				continue
+			}
+
+			authority, ok := c.cas[ca.GetType()][ca.GetName()]
+			if ok && CertAuthoritiesEquivalent(authority, ca) {
+				continue
+			}
+
+			c.cas[ca.GetType()][ca.GetName()] = ca
+			eventsToEmit = append(eventsToEmit, event)
+		default:
+			c.Log.Warnf("Unsupported event type %s.", event.Type)
 		}
-
-		c.cas[ca.GetType()][ca.GetName()] = ca
-		c.fanout.Emit(event)
-	default:
-		c.Log.Warnf("Unsupported event type %s.", event.Type)
-		return
 	}
+
+	c.fanout.Emit(eventsToEmit...)
 }
 
 func (c *caCollector) watchingType(t types.CertAuthType) bool {
@@ -1883,30 +1933,31 @@ func (n *nodeCollector) defineCollectorAsInitialized() {
 	})
 }
 
-// processEventAndUpdateCurrent is called when a watcher event is received.
-func (n *nodeCollector) processEventAndUpdateCurrent(ctx context.Context, event types.Event) {
-	if event.Resource == nil || event.Resource.GetKind() != types.KindNode {
-		n.Log.Warningf("Unexpected event: %v.", event)
-		return
-	}
+// processEventsAndUpdateCurrent is called when a watcher event is received.
+func (n *nodeCollector) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
+	n.rw.Lock()
+	defer n.rw.Unlock()
 
-	switch event.Type {
-	case types.OpDelete:
-		n.rw.Lock()
-		delete(n.current, event.Resource.GetName())
-		n.rw.Unlock()
-	case types.OpPut:
-		server, ok := event.Resource.(types.Server)
-		if !ok {
-			n.Log.Warningf("Unexpected type %T.", event.Resource)
-			return
+	for _, event := range events {
+		if event.Resource == nil || event.Resource.GetKind() != types.KindNode {
+			n.Log.Warningf("Unexpected event: %v.", event)
+			continue
 		}
 
-		n.rw.Lock()
-		n.current[server.GetName()] = server
-		n.rw.Unlock()
-	default:
-		n.Log.Warningf("Skipping unsupported event type %s.", event.Type)
+		switch event.Type {
+		case types.OpDelete:
+			delete(n.current, event.Resource.GetName())
+		case types.OpPut:
+			server, ok := event.Resource.(types.Server)
+			if !ok {
+				n.Log.Warningf("Unexpected type %T.", event.Resource)
+				continue
+			}
+
+			n.current[server.GetName()] = server
+		default:
+			n.Log.Warningf("Skipping unsupported event type %s.", event.Type)
+		}
 	}
 }
 
@@ -2027,36 +2078,38 @@ func (p *accessRequestCollector) defineCollectorAsInitialized() {
 	})
 }
 
-// processEventAndUpdateCurrent is called when a watcher event is received.
-func (p *accessRequestCollector) processEventAndUpdateCurrent(ctx context.Context, event types.Event) {
-	if event.Resource == nil || event.Resource.GetKind() != types.KindAccessRequest {
-		p.Log.Warnf("Unexpected event: %v.", event)
-		return
-	}
+// processEventsAndUpdateCurrent is called when a watcher event is received.
+func (p *accessRequestCollector) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	switch event.Type {
-	case types.OpDelete:
-		delete(p.current, event.Resource.GetName())
-		select {
-		case <-ctx.Done():
-		case p.AccessRequestsC <- resourcesToSlice(p.current):
-		}
-	case types.OpPut:
-		accessRequest, ok := event.Resource.(types.AccessRequest)
-		if !ok {
-			p.Log.Warnf("Unexpected resource type %T.", event.Resource)
-			return
-		}
-		p.current[accessRequest.GetName()] = accessRequest
-		select {
-		case <-ctx.Done():
-		case p.AccessRequestsC <- resourcesToSlice(p.current):
-		}
 
-	default:
-		p.Log.Warnf("Unsupported event type %s.", event.Type)
-		return
+	for _, event := range events {
+		if event.Resource == nil || event.Resource.GetKind() != types.KindAccessRequest {
+			p.Log.Warnf("Unexpected event: %v.", event)
+			continue
+		}
+		switch event.Type {
+		case types.OpDelete:
+			delete(p.current, event.Resource.GetName())
+			select {
+			case <-ctx.Done():
+			case p.AccessRequestsC <- resourcesToSlice(p.current):
+			}
+		case types.OpPut:
+			accessRequest, ok := event.Resource.(types.AccessRequest)
+			if !ok {
+				p.Log.Warnf("Unexpected resource type %T.", event.Resource)
+				continue
+			}
+			p.current[accessRequest.GetName()] = accessRequest
+			select {
+			case <-ctx.Done():
+			case p.AccessRequestsC <- resourcesToSlice(p.current):
+			}
+
+		default:
+			p.Log.Warnf("Unsupported event type %s.", event.Type)
+		}
 	}
 }
 
@@ -2200,42 +2253,41 @@ func (c *oktaAssignmentCollector) defineCollectorAsInitialized() {
 	})
 }
 
-// processEventAndUpdateCurrent is called when a watcher event is received.
-func (c *oktaAssignmentCollector) processEventAndUpdateCurrent(ctx context.Context, event types.Event) {
-	if event.Resource == nil || event.Resource.GetKind() != types.KindOktaAssignment {
-		c.log.Warnf("Unexpected event: %v.", event)
-		return
-	}
-	switch event.Type {
-	case types.OpDelete:
-		c.mu.Lock()
-		delete(c.current, event.Resource.GetName())
-		resources := resourcesToSlice(c.current)
-		c.mu.Unlock()
+// processEventsAndUpdateCurrent is called when a watcher event is received.
+func (c *oktaAssignmentCollector) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-		select {
-		case <-ctx.Done():
-		case c.cfg.OktaAssignmentsC <- resources:
+	for _, event := range events {
+		if event.Resource == nil || event.Resource.GetKind() != types.KindOktaAssignment {
+			c.log.Warnf("Unexpected event: %v.", event)
+			continue
 		}
-	case types.OpPut:
-		oktaAssignment, ok := event.Resource.(types.OktaAssignment)
-		if !ok {
-			c.log.Warnf("Unexpected resource type %T.", event.Resource)
-			return
-		}
-		c.mu.Lock()
-		c.current[oktaAssignment.GetName()] = oktaAssignment
-		resources := resourcesToSlice(c.current)
-		c.mu.Unlock()
+		switch event.Type {
+		case types.OpDelete:
+			delete(c.current, event.Resource.GetName())
+			resources := resourcesToSlice(c.current)
+			select {
+			case <-ctx.Done():
+			case c.cfg.OktaAssignmentsC <- resources:
+			}
+		case types.OpPut:
+			oktaAssignment, ok := event.Resource.(types.OktaAssignment)
+			if !ok {
+				c.log.Warnf("Unexpected resource type %T.", event.Resource)
+				continue
+			}
+			c.current[oktaAssignment.GetName()] = oktaAssignment
+			resources := resourcesToSlice(c.current)
 
-		select {
-		case <-ctx.Done():
-		case c.cfg.OktaAssignmentsC <- resources:
-		}
+			select {
+			case <-ctx.Done():
+			case c.cfg.OktaAssignmentsC <- resources:
+			}
 
-	default:
-		c.log.Warnf("Unsupported event type %s.", event.Type)
-		return
+		default:
+			c.log.Warnf("Unsupported event type %s.", event.Type)
+		}
 	}
 }
 


### PR DESCRIPTION
Auth servers in very large clusters experiencing very high load on the unified resource cache can experience significant contention, leading to poor client performance and a large number of client API calls blocking and unable to make progress.  This PR makes two changes intended to reduce contention/blocking in such circumstances:

- The unified resource cache (and all other resource watchers in `lib/service`) have been modified to perform batch-processing of backend events. This is intended to minimize the number of lock acquisition due to writes in scenarios where there is very high event load (namely, when there are hundreds or thousands of agent heartbeats per second).
- The internal lock of the unified resource cache has been switched from a standard mutex to a read-write mutex, allowing the unified resource cache to now support concurrent reads.

A prototype of these changes was validated in a cluster with ~60k agents and ~1k unified resource API calls per second.

changelog: improved search and predicate/label based dialing performance in large clusters under very high load.