### PR TITLE
Move static database validation to only be executed on service start

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -922,6 +922,11 @@ func (d *DatabaseV3) CheckAndSetDefaults() error {
 		}
 	}
 
+	const defaultKRB5FilePath = "/etc/krb5.conf"
+	if d.Spec.AD.Domain != "" && d.Spec.AD.Krb5File == "" {
+		d.Spec.AD.Krb5File = defaultKRB5FilePath
+	}
+
 	return nil
 }
 

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -923,6 +923,8 @@ func (d *DatabaseV3) CheckAndSetDefaults() error {
 	}
 
 	const defaultKRB5FilePath = "/etc/krb5.conf"
+	// The presence of AD Domain indicates the AD configuration will be used.
+	// In those cases, set the default KRB5 file location if not present.
 	if d.Spec.AD.Domain != "" && d.Spec.AD.Krb5File == "" {
 		d.Spec.AD.Krb5File = defaultKRB5FilePath
 	}

--- a/api/types/database_test.go
+++ b/api/types/database_test.go
@@ -1064,3 +1064,59 @@ func TestDatabaseSpanner(t *testing.T) {
 		})
 	}
 }
+
+func TestDatabaseGCPCloudSQL(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		inputName   string
+		inputSpec   DatabaseSpecV3
+		expectError bool
+	}{
+		{
+			inputName: "gcp-valid-configuration",
+			inputSpec: DatabaseSpecV3{
+				Protocol: DatabaseProtocolPostgreSQL,
+				URI:      "localhost:5432",
+				GCP: GCPCloudSQL{
+					ProjectID:  "project-1",
+					InstanceID: "instance-1",
+				},
+			},
+			expectError: false,
+		},
+		{
+			inputName: "gcp-project-id-specified-without-instance-id",
+			inputSpec: DatabaseSpecV3{
+				Protocol: DatabaseProtocolPostgreSQL,
+				URI:      "localhost:5432",
+				GCP: GCPCloudSQL{
+					ProjectID: "project-1",
+				},
+			},
+			expectError: true,
+		},
+		{
+			inputName: "gcp-instance-id-specified-without-project-id",
+			inputSpec: DatabaseSpecV3{
+				Protocol: DatabaseProtocolPostgreSQL,
+				URI:      "localhost:5432",
+				GCP: GCPCloudSQL{
+					InstanceID: "instance-1",
+				},
+			},
+			expectError: true,
+		},
+	} {
+		t.Run(test.inputName, func(t *testing.T) {
+			_, err := NewDatabaseV3(Metadata{
+				Name: test.inputName,
+			}, test.inputSpec)
+			if test.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2576,11 +2576,12 @@ func TestAppsCLF(t *testing.T) {
 	}
 }
 
+// TestDatabaseConfig ensures reading database the configuration won't return
+// error.
 func TestDatabaseConfig(t *testing.T) {
 	tests := []struct {
 		inConfigString string
 		desc           string
-		outError       string
 	}{
 		{
 			desc: "valid database config",
@@ -2612,7 +2613,6 @@ db_service:
       command: ["uname", "-p"]
       period: 1h
 `,
-			outError: "",
 		},
 		{
 			desc: "missing database name",
@@ -2623,7 +2623,6 @@ db_service:
   - protocol: postgres
     uri: localhost:5432
 `,
-			outError: "empty database name",
 		},
 		{
 			desc: "unsupported database protocol",
@@ -2635,7 +2634,6 @@ db_service:
     protocol: unknown
     uri: localhost:5432
 `,
-			outError: `unsupported database "foo" protocol`,
 		},
 		{
 			desc: "missing database uri",
@@ -2646,7 +2644,6 @@ db_service:
   - name: foo
     protocol: postgres
 `,
-			outError: `database "foo" URI is empty`,
 		},
 		{
 			desc: "invalid database uri (missing port)",
@@ -2658,7 +2655,6 @@ db_service:
     protocol: postgres
     uri: 192.168.1.1
 `,
-			outError: `invalid database "foo" address`,
 		},
 	}
 	for _, tt := range tests {
@@ -2667,12 +2663,7 @@ db_service:
 				ConfigString: base64.StdEncoding.EncodeToString([]byte(tt.inConfigString)),
 			}
 			err := Configure(&clf, servicecfg.MakeDefaultConfig(), false)
-			if tt.outError != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.outError)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2687,7 +2687,6 @@ func TestDatabaseCLIFlags(t *testing.T) {
 		inFlags     CommandLineFlags
 		desc        string
 		outDatabase servicecfg.Database
-		outError    string
 	}{
 		{
 			desc: "valid database config",
@@ -2711,36 +2710,7 @@ func TestDatabaseCLIFlags(t *testing.T) {
 						Command: []string{"hostname"},
 					},
 				},
-				TLS: servicecfg.DatabaseTLS{
-					Mode: servicecfg.VerifyFull,
-				},
 			},
-		},
-		{
-			desc: "unsupported database protocol",
-			inFlags: CommandLineFlags{
-				DatabaseName:     "foo",
-				DatabaseProtocol: "unknown",
-				DatabaseURI:      "localhost:5432",
-			},
-			outError: `unsupported database "foo" protocol`,
-		},
-		{
-			desc: "missing database uri",
-			inFlags: CommandLineFlags{
-				DatabaseName:     "foo",
-				DatabaseProtocol: defaults.ProtocolPostgres,
-			},
-			outError: `database "foo" URI is empty`,
-		},
-		{
-			desc: "invalid database uri (missing port)",
-			inFlags: CommandLineFlags{
-				DatabaseName:     "foo",
-				DatabaseProtocol: defaults.ProtocolPostgres,
-				DatabaseURI:      "localhost",
-			},
-			outError: `invalid database "foo" address`,
 		},
 		{
 			desc: "RDS database",
@@ -2767,9 +2737,6 @@ func TestDatabaseCLIFlags(t *testing.T) {
 					types.OriginLabel: types.OriginConfigFile,
 				},
 				DynamicLabels: services.CommandLabels{},
-				TLS: servicecfg.DatabaseTLS{
-					Mode: servicecfg.VerifyFull,
-				},
 			},
 		},
 		{
@@ -2800,9 +2767,6 @@ func TestDatabaseCLIFlags(t *testing.T) {
 					types.OriginLabel: types.OriginConfigFile,
 				},
 				DynamicLabels: services.CommandLabels{},
-				TLS: servicecfg.DatabaseTLS{
-					Mode: servicecfg.VerifyFull,
-				},
 			},
 		},
 		{
@@ -2820,7 +2784,6 @@ func TestDatabaseCLIFlags(t *testing.T) {
 				Protocol: defaults.ProtocolPostgres,
 				URI:      "localhost:5432",
 				TLS: servicecfg.DatabaseTLS{
-					Mode:   servicecfg.VerifyFull,
 					CACert: fixtures.LocalhostCert,
 				},
 				GCP: servicecfg.DatabaseGCP{
@@ -2847,12 +2810,8 @@ func TestDatabaseCLIFlags(t *testing.T) {
 				Name:     "sqlserver",
 				Protocol: defaults.ProtocolSQLServer,
 				URI:      "sqlserver.example.com:1433",
-				TLS: servicecfg.DatabaseTLS{
-					Mode: servicecfg.VerifyFull,
-				},
 				AD: servicecfg.DatabaseAD{
 					KeytabFile: "/etc/keytab",
-					Krb5File:   defaults.Krb5FilePath,
 					Domain:     "EXAMPLE.COM",
 					SPN:        "MSSQLSvc/sqlserver.example.com:1433",
 				},
@@ -2876,9 +2835,6 @@ func TestDatabaseCLIFlags(t *testing.T) {
 				URI:      "localhost:3306",
 				MySQL: servicecfg.MySQLOptions{
 					ServerVersion: "8.0.28",
-				},
-				TLS: servicecfg.DatabaseTLS{
-					Mode: servicecfg.VerifyFull,
 				},
 				StaticLabels: map[string]string{
 					types.OriginLabel: types.OriginConfigFile,
@@ -2911,9 +2867,6 @@ func TestDatabaseCLIFlags(t *testing.T) {
 					types.OriginLabel: types.OriginConfigFile,
 				},
 				DynamicLabels: services.CommandLabels{},
-				TLS: servicecfg.DatabaseTLS{
-					Mode: servicecfg.VerifyFull,
-				},
 			},
 		},
 		{
@@ -2941,9 +2894,6 @@ func TestDatabaseCLIFlags(t *testing.T) {
 					types.OriginLabel: types.OriginConfigFile,
 				},
 				DynamicLabels: services.CommandLabels{},
-				TLS: servicecfg.DatabaseTLS{
-					Mode: servicecfg.VerifyFull,
-				},
 			},
 		},
 		{
@@ -2976,9 +2926,6 @@ func TestDatabaseCLIFlags(t *testing.T) {
 					types.OriginLabel: types.OriginConfigFile,
 				},
 				DynamicLabels: services.CommandLabels{},
-				TLS: servicecfg.DatabaseTLS{
-					Mode: servicecfg.VerifyFull,
-				},
 			},
 		},
 	}
@@ -2990,12 +2937,8 @@ func TestDatabaseCLIFlags(t *testing.T) {
 
 			config := servicecfg.MakeDefaultConfig()
 			err := Configure(&tt.inFlags, config, false)
-			if tt.outError != "" {
-				require.Contains(t, err.Error(), tt.outError)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, []servicecfg.Database{tt.outDatabase}, config.Databases.Databases)
-			}
+			require.NoError(t, err)
+			require.Equal(t, []servicecfg.Database{tt.outDatabase}, config.Databases.Databases)
 		})
 	}
 }

--- a/lib/config/database_test.go
+++ b/lib/config/database_test.go
@@ -224,7 +224,6 @@ func TestMakeDatabaseConfig(t *testing.T) {
 			flags             DatabaseSampleFlags
 			wantCommandLabels []CommandLabel
 			wantStaticLabels  map[string]string
-			requireFn         require.ErrorAssertionFunc
 		}{
 			"SelfHosted": {
 				flags: DatabaseSampleFlags{
@@ -244,7 +243,6 @@ func TestMakeDatabaseConfig(t *testing.T) {
 						Command: []string{"/bin/uname", "-m", `"p1 p2"`},
 					},
 				},
-				requireFn: require.NoError,
 			},
 			"AWSKeyspaces": {
 				flags: DatabaseSampleFlags{
@@ -257,7 +255,6 @@ func TestMakeDatabaseConfig(t *testing.T) {
 					DatabaseAWSAssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
 					DatabaseAWSExternalID:    "externalID123",
 				},
-				requireFn: require.NoError,
 			},
 			"AWSKeyspacesDeriveURIFromAWSRegion": {
 				flags: DatabaseSampleFlags{
@@ -270,7 +267,6 @@ func TestMakeDatabaseConfig(t *testing.T) {
 					DatabaseAWSAssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
 					DatabaseAWSExternalID:    "externalID123",
 				},
-				requireFn: require.NoError,
 			},
 			"AWSRedshift": {
 				flags: DatabaseSampleFlags{
@@ -282,7 +278,6 @@ func TestMakeDatabaseConfig(t *testing.T) {
 					DatabaseAWSAssumeRoleARN:     "arn:aws:iam::123456789012:role/DBDiscoverer",
 					DatabaseAWSExternalID:        "externalID123",
 				},
-				requireFn: require.NoError,
 			},
 			"AWSRDSInstance": {
 				flags: DatabaseSampleFlags{
@@ -294,7 +289,6 @@ func TestMakeDatabaseConfig(t *testing.T) {
 					DatabaseAWSAssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
 					DatabaseAWSExternalID:    "externalID123",
 				},
-				requireFn: require.NoError,
 			},
 			"AWSRDSCluster": {
 				flags: DatabaseSampleFlags{
@@ -306,7 +300,6 @@ func TestMakeDatabaseConfig(t *testing.T) {
 					DatabaseAWSAssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
 					DatabaseAWSExternalID:    "externalID123",
 				},
-				requireFn: require.NoError,
 			},
 			"AWSMemoryDB": {
 				flags: DatabaseSampleFlags{
@@ -318,7 +311,6 @@ func TestMakeDatabaseConfig(t *testing.T) {
 					DatabaseAWSAssumeRoleARN:       "arn:aws:iam::123456789012:role/DBDiscoverer",
 					DatabaseAWSExternalID:          "externalID123",
 				},
-				requireFn: require.NoError,
 			},
 			"AWSElastieCache": {
 				flags: DatabaseSampleFlags{
@@ -330,7 +322,6 @@ func TestMakeDatabaseConfig(t *testing.T) {
 					DatabaseAWSAssumeRoleARN:      "arn:aws:iam::123456789012:role/DBDiscoverer",
 					DatabaseAWSExternalID:         "externalID123",
 				},
-				requireFn: require.NoError,
 			},
 			"AD": {
 				flags: DatabaseSampleFlags{
@@ -341,7 +332,6 @@ func TestMakeDatabaseConfig(t *testing.T) {
 					DatabaseADSPN:          "MSSQLSvc/ec2amaz-4kn05du.dbadir.teleportdemo.net:1433",
 					DatabaseADKeytabFile:   keytabfile,
 				},
-				requireFn: require.NoError,
 			},
 			"GCP": {
 				flags: DatabaseSampleFlags{
@@ -351,7 +341,6 @@ func TestMakeDatabaseConfig(t *testing.T) {
 					DatabaseGCPProjectID:   "xxx-1234",
 					DatabaseGCPInstanceID:  "example",
 				},
-				requireFn: require.NoError,
 			},
 			"DynamoDBDeriveURIFromAWSRegion": {
 				flags: DatabaseSampleFlags{
@@ -362,114 +351,6 @@ func TestMakeDatabaseConfig(t *testing.T) {
 					DatabaseAWSAssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
 					DatabaseAWSExternalID:    "externalID123",
 				},
-				requireFn: require.NoError,
-			},
-			"MissingName": {
-				flags: DatabaseSampleFlags{
-					StaticDatabaseName:     "",
-					StaticDatabaseProtocol: "postgres",
-					StaticDatabaseURI:      "localhost:5432",
-				},
-				requireFn: require.Error,
-			},
-			"MissingProtocol": {
-				flags: DatabaseSampleFlags{
-					StaticDatabaseName:     "sample",
-					StaticDatabaseProtocol: "",
-					StaticDatabaseURI:      "localhost:5432",
-				},
-				requireFn: require.Error,
-			},
-			"MissingRequiredURI": {
-				flags: DatabaseSampleFlags{
-					StaticDatabaseName:     "sample",
-					StaticDatabaseProtocol: "postgres",
-					StaticDatabaseURI:      "",
-				},
-				requireFn: require.Error,
-			},
-			"BadURI": {
-				flags: DatabaseSampleFlags{
-					StaticDatabaseName:     "sample",
-					StaticDatabaseProtocol: "postgres",
-					StaticDatabaseURI:      "postgres://localhost:5432",
-				},
-				requireFn: require.Error,
-			},
-			"InvalidLabels": {
-				flags: DatabaseSampleFlags{
-					StaticDatabaseName:      "sample",
-					StaticDatabaseProtocol:  "postgres",
-					StaticDatabaseURI:       "localhost:5432",
-					StaticDatabaseRawLabels: "abc",
-				},
-				requireFn: require.Error,
-			},
-			"MissingRequiredAWSAccount": {
-				flags: DatabaseSampleFlags{
-					StaticDatabaseName:     "sample",
-					StaticDatabaseProtocol: "dynamodb",
-					StaticDatabaseURI:      "dynamodb.us-west-1.amazonaws.com",
-					DatabaseAWSRegion:      "us-west-1",
-					DatabaseAWSAccountID:   "",
-				},
-				requireFn: require.Error,
-			},
-			"MissingAWSRegionAndURI": {
-				flags: DatabaseSampleFlags{
-					StaticDatabaseName:     "sample",
-					StaticDatabaseProtocol: "dynamodb",
-					DatabaseAWSAccountID:   "123456789012",
-				},
-				requireFn: require.Error,
-			},
-			"AWSExternalIDMissingAWSRoleARN": {
-				flags: DatabaseSampleFlags{
-					StaticDatabaseName:       "sample",
-					StaticDatabaseProtocol:   "postgres",
-					StaticDatabaseURI:        "aurora-cluster-1.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432",
-					DatabaseAWSRegion:        "us-west-1",
-					DatabaseAWSRDSClusterID:  "aurora-cluster-1",
-					DatabaseAWSAssumeRoleARN: "", // missing role arn raises error because external id is set.
-					DatabaseAWSExternalID:    "externalID123",
-				},
-				requireFn: require.Error,
-			},
-			"MissingAWSRoleARNName": {
-				flags: DatabaseSampleFlags{
-					StaticDatabaseName:       "sample",
-					StaticDatabaseProtocol:   "postgres",
-					StaticDatabaseURI:        "aurora-cluster-1.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432",
-					DatabaseAWSRegion:        "us-west-1",
-					DatabaseAWSRDSClusterID:  "aurora-cluster-1",
-					DatabaseAWSAssumeRoleARN: "arn:aws:iam::123456789012:role", // missing role name
-					DatabaseAWSExternalID:    "externalID123",
-				},
-				requireFn: require.Error,
-			},
-			"InvalidAWSRoleARNFormat": {
-				flags: DatabaseSampleFlags{
-					StaticDatabaseName:       "sample",
-					StaticDatabaseProtocol:   "postgres",
-					StaticDatabaseURI:        "aurora-cluster-1.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432",
-					DatabaseAWSRegion:        "us-west-1",
-					DatabaseAWSRDSClusterID:  "aurora-cluster-1",
-					DatabaseAWSAssumeRoleARN: "foobar",
-					DatabaseAWSExternalID:    "externalID123",
-				},
-				requireFn: require.Error,
-			},
-			"InvalidAWSRoleARNResourceService": {
-				flags: DatabaseSampleFlags{
-					StaticDatabaseName:       "sample",
-					StaticDatabaseProtocol:   "postgres",
-					StaticDatabaseURI:        "aurora-cluster-1.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432",
-					DatabaseAWSRegion:        "us-west-1",
-					DatabaseAWSRDSClusterID:  "aurora-cluster-1",
-					DatabaseAWSAssumeRoleARN: "arn:aws:sts::123456789012:federated-user/Alice", // sts != iam
-					DatabaseAWSExternalID:    "externalID123",
-				},
-				requireFn: require.Error,
 			},
 		}
 
@@ -478,7 +359,7 @@ func TestMakeDatabaseConfig(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 				configString, err := MakeDatabaseAgentConfigString(tt.flags)
-				tt.requireFn(t, err)
+				require.NoError(t, err)
 				if err != nil {
 					return
 				}

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -81,6 +81,9 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+		if err := services.ValidateDatabase(db); err != nil {
+			return trace.Wrap(err)
+		}
 		databases = append(databases, db)
 	}
 

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1731,6 +1731,8 @@ func TestInstanceMetadata(t *testing.T) {
 }
 
 func TestInitDatabaseService(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct {
 		desc      string
 		enabled   bool
@@ -1791,7 +1793,7 @@ func TestInitDatabaseService(t *testing.T) {
 			})
 			require.NoError(t, process.Start())
 
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
 
 			event, err := process.WaitForEvent(ctx, ServiceExitedWithErrorEvent)

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -184,189 +183,45 @@ func TestCheckApp(t *testing.T) {
 	}
 }
 
-func TestCheckDatabase(t *testing.T) {
-	tests := []struct {
-		desc       string
-		inDatabase Database
-		outErr     bool
+// TestDatabaseStaticLabels ensures the static labels are set.
+func TestDatabaseStaticLabels(t *testing.T) {
+	db := Database{
+		Name:     "example",
+		Protocol: defaults.ProtocolPostgres,
+		URI:      "localhost:5432",
+	}
+	require.NoError(t, db.CheckAndSetDefaults())
+	require.Equal(t, types.OriginConfigFile, db.StaticLabels[types.OriginLabel])
+}
+
+func TestDatabaseAWSAccountID(t *testing.T) {
+	for _, test := range []struct {
+		desc              string
+		assumeRoleARN     string
+		expectedAccountID string
 	}{
 		{
-			desc: "ok",
-			inDatabase: Database{
-				Name:     "example",
-				Protocol: defaults.ProtocolPostgres,
-				URI:      "localhost:5432",
-			},
-			outErr: false,
+			desc:              "valid role arn",
+			assumeRoleARN:     "arn:aws:iam::123456789012:role/test-role",
+			expectedAccountID: "123456789012",
 		},
 		{
-			desc: "empty database name",
-			inDatabase: Database{
-				Protocol: defaults.ProtocolPostgres,
-				URI:      "localhost:5432",
-			},
-			outErr: true,
+			desc:              "invalid role arn",
+			assumeRoleARN:     "foobar",
+			expectedAccountID: "",
 		},
-		{
-			desc: "fails services.ValidateDatabase",
-			inDatabase: Database{
-				Name:     "??--++",
-				Protocol: defaults.ProtocolPostgres,
-				URI:      "localhost:5432",
-			},
-			outErr: true,
-		},
-		{
-			desc: "GCP valid configuration",
-			inDatabase: Database{
-				Name:     "example",
-				Protocol: defaults.ProtocolPostgres,
-				URI:      "localhost:5432",
-				GCP: DatabaseGCP{
-					ProjectID:  "project-1",
-					InstanceID: "instance-1",
-				},
-				TLS: DatabaseTLS{
-					CACert: fixtures.LocalhostCert,
-				},
-			},
-			outErr: false,
-		},
-		{
-			desc: "GCP project ID specified without instance ID",
-			inDatabase: Database{
-				Name:     "example",
-				Protocol: defaults.ProtocolPostgres,
-				URI:      "localhost:5432",
-				GCP: DatabaseGCP{
-					ProjectID: "project-1",
-				},
-				TLS: DatabaseTLS{
-					CACert: fixtures.LocalhostCert,
-				},
-			},
-			outErr: true,
-		},
-		{
-			desc: "GCP instance ID specified without project ID",
-			inDatabase: Database{
-				Name:     "example",
-				Protocol: defaults.ProtocolPostgres,
-				URI:      "localhost:5432",
-				GCP: DatabaseGCP{
-					InstanceID: "instance-1",
-				},
-				TLS: DatabaseTLS{
-					CACert: fixtures.LocalhostCert,
-				},
-			},
-			outErr: true,
-		},
-		{
-			desc: "SQL Server correct configuration",
-			inDatabase: Database{
-				Name:     "sqlserver",
-				Protocol: defaults.ProtocolSQLServer,
-				URI:      "sqlserver.example.com:1433",
-				AD: DatabaseAD{
-					KeytabFile: "/etc/keytab",
-					Domain:     "test-domain",
-					SPN:        "test-spn",
-				},
-			},
-			outErr: false,
-		},
-		{
-			desc: "SQL Server missing keytab",
-			inDatabase: Database{
-				Name:     "sqlserver",
-				Protocol: defaults.ProtocolSQLServer,
-				URI:      "localhost:1433",
-				AD: DatabaseAD{
-					Domain: "test-domain",
-					SPN:    "test-spn",
-				},
-			},
-			outErr: true,
-		},
-		{
-			desc: "SQL Server missing AD domain",
-			inDatabase: Database{
-				Name:     "sqlserver",
-				Protocol: defaults.ProtocolSQLServer,
-				URI:      "localhost:1433",
-				AD: DatabaseAD{
-					KeytabFile: "/etc/keytab",
-					SPN:        "test-spn",
-				},
-			},
-			outErr: true,
-		},
-		{
-			desc: "SQL Server missing SPN",
-			inDatabase: Database{
-				Name:     "sqlserver",
-				Protocol: defaults.ProtocolSQLServer,
-				URI:      "localhost:1433",
-				AD: DatabaseAD{
-					KeytabFile: "/etc/keytab",
-					Domain:     "test-domain",
-				},
-			},
-			outErr: true,
-		},
-		{
-			desc: "SQL Server missing LDAP Cert",
-			inDatabase: Database{
-				Name:     "sqlserver",
-				Protocol: defaults.ProtocolSQLServer,
-				URI:      "localhost:1433",
-				AD: DatabaseAD{
-					Domain:      "test-domain",
-					SPN:         "test-spn",
-					KDCHostName: "test-domain",
-				},
-			},
-			outErr: true,
-		},
-		{
-			desc: "SQL Server missing KDC Hostname",
-			inDatabase: Database{
-				Name:     "sqlserver",
-				Protocol: defaults.ProtocolSQLServer,
-				URI:      "localhost:1433",
-				AD: DatabaseAD{
-					Domain:   "test-domain",
-					SPN:      "test-spn",
-					LDAPCert: "random-content",
-				},
-			},
-			outErr: true,
-		},
-		{
-			desc: "MySQL with server version",
-			inDatabase: Database{
-				Name:     "mysql-foo",
-				Protocol: defaults.ProtocolMySQL,
-				URI:      "localhost:3306",
-				MySQL: MySQLOptions{
-					ServerVersion: "8.0.31",
-				},
-			},
-			outErr: false,
-		},
-	}
-	for _, test := range tests {
-		test := test
+	} {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
-
-			err := test.inDatabase.CheckAndSetDefaults()
-			if test.outErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+			db := Database{
+				Name:     "example",
+				Protocol: defaults.ProtocolPostgres,
+				AWS: DatabaseAWS{
+					AssumeRoleARN: test.assumeRoleARN,
+				},
 			}
+			require.NoError(t, db.CheckAndSetDefaults())
+			require.Equal(t, test.expectedAccountID, db.AWS.AccountID)
 		})
 	}
 }

--- a/lib/service/servicecfg/database.go
+++ b/lib/service/servicecfg/database.go
@@ -101,6 +101,7 @@ func (d *Database) CheckAndSetDefaults() error {
 
 	// If AWS account ID is missing, but assume role ARN is given,
 	// try to parse the role arn and set the account id to match.
+	// TODO(gabrielcorado): move this into the api package.
 	if d.AWS.AccountID == "" && d.AWS.AssumeRoleARN != "" {
 		parsed, err := awsutils.ParseRoleARN(d.AWS.AssumeRoleARN)
 		if err == nil {

--- a/lib/service/servicecfg/database.go
+++ b/lib/service/servicecfg/database.go
@@ -19,16 +19,9 @@
 package servicecfg
 
 import (
-	"strings"
-
-	"github.com/gravitational/trace"
-
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils/azure"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/srv/db/common/enterprise"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
@@ -100,53 +93,22 @@ type OracleOptions struct {
 
 // CheckAndSetDefaults validates the database proxy configuration.
 func (d *Database) CheckAndSetDefaults() error {
-	if err := enterprise.ProtocolValidation(d.Protocol); err != nil {
-		return trace.Wrap(err)
-	}
-	if d.Name == "" {
-		return trace.BadParameter("empty database name")
-	}
-
 	// Mark the database as coming from the static configuration.
 	if d.StaticLabels == nil {
 		d.StaticLabels = make(map[string]string)
 	}
 	d.StaticLabels[types.OriginLabel] = types.OriginConfigFile
 
-	if err := d.TLS.Mode.CheckAndSetDefaults(); err != nil {
-		return trace.Wrap(err)
-	}
-
-	// We support Azure AD authentication and Kerberos auth with AD for SQL
-	// Server. The first method doesn't require additional configuration since
-	// it assumes the environment’s Azure credentials
-	// (https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication).
-	// The second method requires additional information, validated by
-	// DatabaseAD.
-	if d.Protocol == defaults.ProtocolSQLServer &&
-		(d.AD.Domain != "" || !strings.Contains(d.URI, azure.MSSQLEndpointSuffix)) {
-		if err := d.AD.CheckAndSetDefaults(d.Name); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-
 	// If AWS account ID is missing, but assume role ARN is given,
 	// try to parse the role arn and set the account id to match.
 	if d.AWS.AccountID == "" && d.AWS.AssumeRoleARN != "" {
 		parsed, err := awsutils.ParseRoleARN(d.AWS.AssumeRoleARN)
-		if err != nil {
-			return trace.BadParameter("database %q invalid AWS assume_role_arn: %v",
-				d.Name, err)
+		if err == nil {
+			d.AWS.AccountID = parsed.AccountID
 		}
-		d.AWS.AccountID = parsed.AccountID
 	}
 
-	// Do a test run with extra validations.
-	db, err := d.ToDatabase()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return trace.Wrap(services.ValidateDatabase(db))
+	return nil
 }
 
 // ToDatabase converts Database to types.Database.
@@ -333,35 +295,6 @@ type DatabaseAD struct {
 	LDAPCert string
 	// KDCHostName is the Key Distribution Center Hostname for x509 authentication
 	KDCHostName string
-}
-
-// IsEmpty returns true if the database AD configuration is empty.
-func (d *DatabaseAD) IsEmpty() bool {
-	return d.KeytabFile == "" && d.Krb5File == "" && d.Domain == "" && d.SPN == ""
-}
-
-// CheckAndSetDefaults validates database Active Directory configuration.
-func (d *DatabaseAD) CheckAndSetDefaults(name string) error {
-	if d.KeytabFile == "" && d.KDCHostName == "" {
-		return trace.BadParameter("missing keytab file path or kdc_host_name for database %q", name)
-	}
-	if d.Krb5File == "" {
-		d.Krb5File = defaults.Krb5FilePath
-	}
-	if d.Domain == "" {
-		return trace.BadParameter("missing Active Directory domain for database %q", name)
-	}
-	if d.SPN == "" {
-		return trace.BadParameter("missing service principal name for database %q", name)
-	}
-
-	if d.KDCHostName != "" {
-		if d.LDAPCert == "" {
-			return trace.BadParameter("missing LDAP certificate for x509 authentication for database %q", name)
-		}
-	}
-
-	return nil
 }
 
 // DatabaseAzure contains Azure database configuration.

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -215,6 +215,11 @@ func ValidateDatabase(db types.Database) error {
 
 // needsADValidation returns whether a database AD configuration needs to
 // be validated.
+// We support Azure AD authentication and Kerberos auth with AD for SQL
+// Server. The first method doesn't require additional configuration since
+// it assumes the environment’s Azure credentials
+// (https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication).
+// AD configurations are only required for the second method.
 func needsADValidation(db types.Database) bool {
 	if db.GetProtocol() != defaults.ProtocolSQLServer {
 		return false

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -205,8 +205,13 @@ func testDatabaseLogin(t *testing.T) {
 				}, {
 					Name:         "mssql",
 					Protocol:     defaults.ProtocolSQLServer,
-					URI:          "localhost:1433",
+					URI:          "sqlserver.example.com:1433",
 					StaticLabels: map[string]string{"env": "dev"},
+					AD: servicecfg.DatabaseAD{
+						KeytabFile: "/etc/keytab",
+						Domain:     "EXAMPLE.COM",
+						SPN:        "MSSQLSvc/sqlserver.example.com:1433",
+					},
 				}, {
 					Name:         "dynamodb",
 					Protocol:     defaults.ProtocolDynamoDB,


### PR DESCRIPTION
Closes #42845.

Given that the `ApplyConfig` initializes all the configuration and sets default values, it also invokes the `services.ValidateDatabase` present at the `servicecfg.Database.CheckAndSetDefaults`, performing a full database validation every time the configuration was loaded. We're removing this call. The static database validation is now done directly on the DB service initialization.

In addition to this change, this PR simplifies the `servicecfg.Database.CheckAndSetDefaults` implementation, removing the duplicated validation (AD) and tests.

changelog: Fix cases where `tctl` commands could not be executed due to static database configuration errors.