### PR TITLE
Add Bot Instance heartbeating to `tbot`

### DIFF
--- a/lib/tbot/service_heartbeat_test.go
+++ b/lib/tbot/service_heartbeat_test.go
@@ -1,0 +1,111 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/gravitational/teleport"
+	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+type fakeHeartbeatSubmitter struct {
+	ch chan *machineidv1pb.SubmitHeartbeatRequest
+}
+
+func (f *fakeHeartbeatSubmitter) SubmitHeartbeat(
+	ctx context.Context, in *machineidv1pb.SubmitHeartbeatRequest, opts ...grpc.CallOption,
+) (*machineidv1pb.SubmitHeartbeatResponse, error) {
+	f.ch <- in
+	return &machineidv1pb.SubmitHeartbeatResponse{}, nil
+}
+
+func TestHeartbeatService(t *testing.T) {
+	t.Parallel()
+
+	log := utils.NewSlogLoggerForTests()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	fhs := &fakeHeartbeatSubmitter{
+		ch: make(chan *machineidv1pb.SubmitHeartbeatRequest, 2),
+	}
+	svc := heartbeatService{
+		now: func() time.Time {
+			return time.Date(2024, time.April, 1, 12, 0, 0, 0, time.UTC)
+		},
+		log: log,
+		botCfg: &config.BotConfig{
+			Oneshot: false,
+			Onboarding: config.OnboardingConfig{
+				JoinMethod: types.JoinMethodGitHub,
+			},
+		},
+		startedAt:          time.Date(2024, time.April, 1, 11, 0, 0, 0, time.UTC),
+		heartbeatSubmitter: fhs,
+		interval:           time.Second,
+		retryLimit:         3,
+	}
+
+	hostName, err := os.Hostname()
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- svc.Run(ctx)
+	}()
+
+	got := <-fhs.ch
+	want := &machineidv1pb.SubmitHeartbeatRequest{
+		Heartbeat: &machineidv1pb.BotInstanceStatusHeartbeat{
+			RecordedAt:   timestamppb.New(svc.now()),
+			Hostname:     hostName,
+			IsStartup:    true,
+			OneShot:      false,
+			Uptime:       durationpb.New(time.Hour),
+			Version:      teleport.Version,
+			Architecture: runtime.GOARCH,
+			Os:           runtime.GOOS,
+			JoinMethod:   string(types.JoinMethodGitHub),
+		},
+	}
+	assert.Empty(t, cmp.Diff(want, got, protocmp.Transform()))
+
+	got = <-fhs.ch
+	want.Heartbeat.IsStartup = false
+	assert.Empty(t, cmp.Diff(want, got, protocmp.Transform()))
+
+	cancel()
+	assert.NoError(t, <-errCh)
+}

--- a/lib/tbot/service_heatbeat.go
+++ b/lib/tbot/service_heatbeat.go
@@ -1,0 +1,125 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/gravitational/teleport"
+	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/lib/tbot/config"
+)
+
+type heartbeatSubmitter interface {
+	SubmitHeartbeat(
+		ctx context.Context, in *machineidv1pb.SubmitHeartbeatRequest, opts ...grpc.CallOption,
+	) (*machineidv1pb.SubmitHeartbeatResponse, error)
+}
+
+type heartbeatService struct {
+	now                func() time.Time
+	log                *slog.Logger
+	botCfg             *config.BotConfig
+	startedAt          time.Time
+	heartbeatSubmitter heartbeatSubmitter
+	interval           time.Duration
+	retryLimit         int
+}
+
+func (s *heartbeatService) heartbeat(ctx context.Context, isStartup bool) error {
+	s.log.DebugContext(ctx, "Sending heartbeat")
+	hostName, err := os.Hostname()
+	if err != nil {
+		s.log.WarnContext(ctx, "Failed to determine hostname for heartbeat", "error", err)
+	}
+
+	hb := &machineidv1pb.BotInstanceStatusHeartbeat{
+		RecordedAt:   timestamppb.New(s.now()),
+		Hostname:     hostName,
+		IsStartup:    isStartup,
+		Uptime:       durationpb.New(s.now().Sub(s.startedAt)),
+		OneShot:      s.botCfg.Oneshot,
+		JoinMethod:   string(s.botCfg.Onboarding.JoinMethod),
+		Version:      teleport.Version,
+		Architecture: runtime.GOARCH,
+		Os:           runtime.GOOS,
+	}
+
+	_, err = s.heartbeatSubmitter.SubmitHeartbeat(ctx, &machineidv1pb.SubmitHeartbeatRequest{
+		Heartbeat: hb,
+	})
+	if err != nil {
+		return trace.Wrap(err, "submitting heartbeat")
+	}
+
+	s.log.InfoContext(ctx, "Sent heartbeat", "data", hb.String())
+	return nil
+}
+
+func (s *heartbeatService) OneShot(ctx context.Context) error {
+	err := s.heartbeat(ctx, true)
+	// Ignore not implemented as this is likely confusing.
+	// TODO(noah): Remove NotImplemented check at V18 assuming V17 first major
+	// with heartbeating.
+	if err != nil && !trace.IsNotImplemented(err) {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func (s *heartbeatService) Run(ctx context.Context) error {
+	isStartup := true
+	err := runOnInterval(ctx, runOnIntervalConfig{
+		name:       "submit-heartbeat",
+		log:        s.log,
+		interval:   s.interval,
+		retryLimit: s.retryLimit,
+		f: func(ctx context.Context) error {
+			err := s.heartbeat(ctx, isStartup)
+			// TODO(noah): Remove NotImplemented check at V18 assuming V17 first
+			// major with heartbeating.
+			if trace.IsNotImplemented(err) {
+				s.log.DebugContext(
+					ctx,
+					"Cluster does not support Bot Instance heartbeats",
+				)
+				return nil
+			}
+			if err != nil {
+				return trace.Wrap(err, "submitting heartbeat")
+			}
+			isStartup = false
+			return nil
+		},
+	})
+	return trace.Wrap(err)
+}
+
+func (s *heartbeatService) String() string {
+	return "heartbeat"
+}

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -38,10 +38,12 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/webclient"
+	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	experiment "github.com/gravitational/teleport/lib/auth/machineid/machineidv1/bot_instance_experiment"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -127,6 +129,7 @@ func (b *Bot) BotIdentity() *identity.Identity {
 func (b *Bot) Run(ctx context.Context) (err error) {
 	ctx, span := tracer.Start(ctx, "Bot/Run")
 	defer func() { apitracing.EndSpan(span, err) }()
+	startedAt := time.Now()
 
 	if err := metrics.RegisterPrometheusCollectors(clientMetrics); err != nil {
 		return trace.Wrap(err)
@@ -237,6 +240,24 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 			),
 		})
 	}
+
+	// Gate heartbeating behind the workload identity experiment for now.
+	if experiment.Enabled() {
+		services = append(services, &heartbeatService{
+			now:       time.Now,
+			botCfg:    b.cfg,
+			startedAt: startedAt,
+			log: b.log.With(
+				teleport.ComponentKey, teleport.Component(componentTBot, "heartbeat"),
+			),
+			heartbeatSubmitter: machineidv1pb.NewBotInstanceServiceClient(
+				b.botIdentitySvc.GetClient().GetConnection(),
+			),
+			interval:   time.Minute * 30,
+			retryLimit: 5,
+		})
+	}
+
 	services = append(services, &outputsService{
 		authPingCache:    authPingCache,
 		proxyPingCache:   proxyPingCache,


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/41456

Adds heartbeating functionality into `tbot` itself - this will not work until the backend has been implemented.
