### PR TITLE
docs: Update Windows troubleshooting

### DIFF
--- a/docs/pages/desktop-access/troubleshooting.mdx
+++ b/docs/pages/desktop-access/troubleshooting.mdx
@@ -273,6 +273,9 @@ First, generate a client certificate with `tctl`, being sure to replace the
 appropriate for your environment:
 
 ```
+# NOTE: To issue Windows certificates, you must run 'tctl auth sign' locally
+# on the same machine as the Teleport auth_service. Running this command remotely
+# with an identity issued by 'tsh' will result in 'ERROR: access denied'
 $  tctl auth sign \
     --windows-user=svc-teleport \
     --windows-sid=S-1-5-21-3788279871-1068139173-3054872986-500 \

--- a/docs/pages/desktop-access/troubleshooting.mdx
+++ b/docs/pages/desktop-access/troubleshooting.mdx
@@ -272,11 +272,11 @@ First, generate a client certificate with `tctl`, being sure to replace the
 `--windows-user`, `--windows-sid`, and `--windows-domain` flags with values
 appropriate for your environment:
 
-```
+```code
 # NOTE: To issue Windows certificates, you must run 'tctl auth sign' locally
 # on the same machine as the Teleport auth_service. Running this command remotely
 # with an identity issued by 'tsh' will result in 'ERROR: access denied'
-$  tctl auth sign \
+$ tctl auth sign \
     --windows-user=svc-teleport \
     --windows-sid=S-1-5-21-3788279871-1068139173-3054872986-500 \
     --windows-domain=domain.example.com \


### PR DESCRIPTION
Running `tctl auth sign` to get Windows certs requires `RoleAdmin`:

https://github.com/gravitational/teleport/blob/cb51e5f428cd30c86e591c90317648e95b057adb/lib/auth/auth_with_roles.go#L6563-L6572

A community user hit this error: https://goteleport.slack.com/archives/CEZH6UL64/p1718232443084519

This nuance does unfortunately mean that it isn't possible to use this step to debug Windows desktops connected to a Teleport Cloud cluster.