### PR TITLE
Add `runOnInterval` helper for `tbot`

### DIFF
--- a/lib/tbot/loop.go
+++ b/lib/tbot/loop.go
@@ -1,0 +1,129 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/utils/retryutils"
+)
+
+type runOnIntervalConfig struct {
+	name                 string
+	f                    func(ctx context.Context) error
+	reloadCh             chan struct{}
+	log                  *slog.Logger
+	interval             time.Duration
+	retryLimit           int
+	exitOnRetryExhausted bool
+	waitBeforeFirstRun   bool
+}
+
+// runOnInterval runs a function on a given interval, with retries and jitter.
+//
+// TODO(noah): Emit Prometheus metrics for:
+// - Success/Failure of attempts
+// - Time taken to execute attempt
+// - Time of next attempt
+func runOnInterval(ctx context.Context, cfg runOnIntervalConfig) error {
+	ticker := time.NewTicker(cfg.interval)
+	jitter := retryutils.NewJitter()
+
+	// If no reload channel is provided, create one that never yields a value.
+	if cfg.reloadCh == nil {
+		cfg.reloadCh = make(chan struct{})
+	}
+	log := cfg.log.With("task", cfg.name)
+
+	firstRun := true
+
+	defer ticker.Stop()
+	for {
+		if !firstRun || (firstRun && cfg.waitBeforeFirstRun) {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-ticker.C:
+			case <-cfg.reloadCh:
+			}
+		}
+		firstRun = false
+
+		var err error
+		for attempt := 1; attempt <= cfg.retryLimit; attempt++ {
+			log.InfoContext(
+				ctx,
+				"Attempting task",
+				"attempt", attempt,
+				"retry_limit", cfg.retryLimit,
+			)
+			err = cfg.f(ctx)
+			if err == nil {
+				break
+			}
+
+			if attempt != cfg.retryLimit {
+				// exponentially back off with jitter, starting at 1 second.
+				backoffTime := time.Second * time.Duration(math.Pow(2, float64(attempt-1)))
+				backoffTime = jitter(backoffTime)
+				cfg.log.WarnContext(
+					ctx,
+					"Task failed. Backing off and retrying",
+					"attempt", attempt,
+					"retry_limit", cfg.retryLimit,
+					"backoff", backoffTime,
+					"error", err,
+				)
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-time.After(backoffTime):
+				}
+			}
+		}
+		if err != nil {
+			if cfg.exitOnRetryExhausted {
+				log.ErrorContext(
+					ctx,
+					"All retry attempts exhausted. Exiting",
+					"error", err,
+					"retry_limit", cfg.retryLimit,
+				)
+				return trace.Wrap(err)
+			}
+			log.WarnContext(
+				ctx,
+				"All retry attempts exhausted. Will wait for next interval",
+				"retry_limit", cfg.retryLimit,
+				"interval", cfg.interval,
+			)
+		} else {
+			log.InfoContext(
+				ctx,
+				"Task succeeded. Waiting interval",
+				"interval", cfg.interval,
+			)
+		}
+	}
+}

--- a/lib/tbot/loop_test.go
+++ b/lib/tbot/loop_test.go
@@ -27,18 +27,23 @@ import (
 
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func Test_runOnInterval(t *testing.T) {
 	t.Parallel()
-	clock := clockwork.NewFakeClock()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
+	log := utils.NewSlogLoggerForTests()
+	clock := clockwork.NewFakeClock()
 	callCount := atomic.Int64{}
 	cfg := runOnIntervalConfig{
 		name:  "test",
 		clock: clock,
+		log:   log,
 		f: func(ctx context.Context) error {
 			callCount.Add(1)
 			return nil
@@ -75,10 +80,12 @@ func Test_runOnInterval_failureExit(t *testing.T) {
 
 	callCount := atomic.Int64{}
 
+	log := utils.NewSlogLoggerForTests()
 	testErr := fmt.Errorf("test error")
 	cfg := runOnIntervalConfig{
 		name:  "test",
 		clock: clockwork.NewRealClock(),
+		log:   log,
 		f: func(ctx context.Context) error {
 			callCount.Add(1)
 			return testErr

--- a/lib/tbot/loop_test.go
+++ b/lib/tbot/loop_test.go
@@ -1,0 +1,99 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_runOnInterval(t *testing.T) {
+	t.Parallel()
+	clock := clockwork.NewFakeClock()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	callCount := atomic.Int64{}
+	cfg := runOnIntervalConfig{
+		name:  "test",
+		clock: clock,
+		f: func(ctx context.Context) error {
+			callCount.Add(1)
+			return nil
+		},
+		retryLimit:           3,
+		interval:             time.Minute * 10,
+		exitOnRetryExhausted: true,
+	}
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- runOnInterval(ctx, cfg)
+	}()
+
+	// Wait for three iterations to have been completed.
+	clock.BlockUntil(1)
+	clock.Advance(time.Minute * 11)
+	clock.BlockUntil(1)
+	clock.Advance(time.Minute * 11)
+	clock.BlockUntil(1)
+
+	// Cancel the ctx and make sure runOnInterval returns
+	cancel()
+	gotErr := <-errCh
+	assert.NoError(t, gotErr)
+	assert.Equal(t, int64(3), callCount.Load())
+}
+
+func Test_runOnInterval_failureExit(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	callCount := atomic.Int64{}
+
+	testErr := fmt.Errorf("test error")
+	cfg := runOnIntervalConfig{
+		name:  "test",
+		clock: clockwork.NewRealClock(),
+		f: func(ctx context.Context) error {
+			callCount.Add(1)
+			return testErr
+		},
+		retryLimit:           3,
+		interval:             time.Second,
+		exitOnRetryExhausted: true,
+	}
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- runOnInterval(ctx, cfg)
+	}()
+
+	gotErr := <-errCh
+	assert.ErrorIs(t, gotErr, testErr)
+	assert.Equal(t, int64(3), callCount.Load())
+}

--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -350,7 +350,7 @@ func (s *SSHMultiplexerService) identityRenewalLoop(ctx context.Context, proxyHo
 	defer unsubscribe()
 
 	err := runOnInterval(ctx, runOnIntervalConfig{
-		name: "output-renewal",
+		name: "identity-renewal",
 		f: func(ctx context.Context) error {
 			id, err := s.generateIdentity(ctx)
 			if err != nil {

--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
 	"net"
 	"net/url"
 	"os"
@@ -48,7 +47,6 @@ import (
 	proxyclient "github.com/gravitational/teleport/api/client/proxy"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
-	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/config/openssh"
@@ -351,71 +349,22 @@ func (s *SSHMultiplexerService) identityRenewalLoop(ctx context.Context, proxyHo
 	reloadCh, unsubscribe := s.reloadBroadcaster.subscribe()
 	defer unsubscribe()
 
-	ticker := time.NewTicker(s.botCfg.RenewalInterval)
-	jitter := retryutils.NewJitter()
-	defer ticker.Stop()
-	for {
-		var err error
-		for attempt := 1; attempt <= renewalRetryLimit; attempt++ {
-			s.log.InfoContext(
-				ctx,
-				"Attempting to renew identity",
-				"attempt", attempt,
-				"retry_limit", renewalRetryLimit,
-			)
-			var id *identity.Identity
-			id, err = s.generateIdentity(ctx)
-			if err == nil {
-				s.identity.Set(id)
-				err = s.writeArtifacts(ctx, proxyHost, id)
-				if err == nil {
-					break
-				}
+	err := runOnInterval(ctx, runOnIntervalConfig{
+		name: "output-renewal",
+		f: func(ctx context.Context) error {
+			id, err := s.generateIdentity(ctx)
+			if err != nil {
+				return trace.Wrap(err, "generating identity")
 			}
-
-			if attempt != renewalRetryLimit {
-				// exponentially back off with jitter, starting at 1 second.
-				backoffTime := time.Second * time.Duration(math.Pow(2, float64(attempt-1)))
-				backoffTime = jitter(backoffTime)
-				s.log.WarnContext(
-					ctx,
-					"Identity renewal attempt failed. Waiting to retry",
-					"attempt", attempt,
-					"retry_limit", renewalRetryLimit,
-					"backoff", backoffTime,
-					"error", err,
-				)
-				select {
-				case <-ctx.Done():
-					return nil
-				case <-time.After(backoffTime):
-				}
-			}
-		}
-		if err != nil {
-			s.log.WarnContext(
-				ctx,
-				"All retry attempts exhausted renewing identity. Waiting for next normal renewal cycle",
-				"retry_limit", renewalRetryLimit,
-				"interval", s.botCfg.RenewalInterval,
-			)
-		} else {
-			s.log.InfoContext(
-				ctx,
-				"Renewed identity. Waiting for next identity renewal",
-				"interval", s.botCfg.RenewalInterval,
-			)
-		}
-
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-ticker.C:
-			continue
-		case <-reloadCh:
-			continue
-		}
-	}
+			s.identity.Set(id)
+			return s.writeArtifacts(ctx, proxyHost, id)
+		},
+		interval:   s.botCfg.RenewalInterval,
+		retryLimit: renewalRetryLimit,
+		log:        s.log,
+		reloadCh:   reloadCh,
+	})
+	return trace.Wrap(err)
 }
 
 func (s *SSHMultiplexerService) Run(ctx context.Context) (err error) {


### PR DESCRIPTION
We had 4-5 implementations of the same style of loop throughout `tbot` that handled some kind of recurring task with retries and backoff on failure. This PR introduces a single implementation of this which can be reused.

By doing so:

- I can add an individual unit test to make sure this loop backs off correctly.
- We can introduce more advanced forms of backoff.
- Reduce the amount of code that distracts from the actual implementation of other services.
- We can add metrics in a single place to keep track of recurring tasks.

Blocked on https://github.com/gravitational/teleport/pull/42909 merging since that adds another loop which should be refactored to use this.

