### PR TITLE
docs: cloud faq update on versions

### DIFF
--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -151,7 +151,7 @@ described in [Teleport Upcoming Releases](../../upcoming-releases.mdx).
 - Minor updates and patches typically occur between one day and a week after a release.
 - Teleport Auth Service and Teleport Proxy Service updates are pushed to Teleport cloud accounts
   during your scheduled maintenance window.
-- Teleport Auth and Proxy service will not be automatically upgraded to the next major version with
+- The Teleport Auth Service and Proxy Service will not be automatically upgraded to the next major version with
   Teleport agents on older major versions. An example would be the Teleport Auth and Proxy service are on
   version 16 and agents are still on version 15 or older. That would prevent Teleport Auth and Proxy
   being updated to version 17 automatically.
@@ -168,9 +168,9 @@ connected agents?](#how-can-i-find-version-information-on-connected-agents).
 For more information about automatic updates and compatibility issues, contact
 [Teleport support](https://goteleport.com/support/).
 
-### Why wasn't my Teleport Enterprise Cloud instance upgraded to the latest major version?
+### Why wasn't my managed Teleport Enterprise instance upgraded to the latest major version?
 
-The Teleport Control plane supports agents that are on the same major version or one major version behind.
+The Teleport control plane supports Agents that are on the same major version or one major version behind.
 If your agents are not up to date, we will withhold major version upgrades in order to prevent connectivity
 issues to your resources. For example, if your control plane is currently running Teleport 15 and you have agents
 running Teleport 14, we will not be able to upgrade your control plane to Teleport 16 until all agents are

--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -142,7 +142,7 @@ The ability to download recordings for offline viewing will be available in a fu
 
 ### Will Teleport be updated automatically?
 
-The Teleport Auth Service and Teleport Proxy Service for managed Teleport Enterprise instances
+The Teleport Auth Service and Teleport Proxy Service for managed Teleport Enterprise clusters
 are automatically kept up to date with patches and minor releases following the release schedule
 described in [Teleport Upcoming Releases](../../upcoming-releases.mdx).
 
@@ -152,10 +152,10 @@ described in [Teleport Upcoming Releases](../../upcoming-releases.mdx).
 - Teleport Auth Service and Teleport Proxy Service updates are pushed to Teleport cloud accounts
   during your scheduled maintenance window.
 - The Teleport Auth Service and Proxy Service will not be automatically upgraded to the next
-   major version with Teleport agents on older major versions. 
+   major version with Teleport Agents on older major versions. 
 - Teleport Agents are only updated automatically if you enroll them in automatic updates.
 
-If you have Teleport Agents connected to a managed Teleport Enterprise instance
+If you have Teleport Agents connected to a managed Teleport Enterprise cluster
 that are more than one major version behind, you might experience compatibility
 issues unless your Teleport Agents are enrolled in automatic updates. See the [Upgrading
 Overview](../../upgrading/overview.mdx) for more information.
@@ -166,7 +166,7 @@ connected agents?](#how-can-i-find-version-information-on-connected-agents).
 For more information about automatic updates and compatibility issues, contact
 [Teleport support](https://goteleport.com/support/).
 
-### Why wasn't my managed Teleport Enterprise instance upgraded to the latest major version?
+### Why wasn't my managed Teleport Enterprise cluster upgraded to the latest major version?
 
 The Teleport control plane supports Teleport Agents that are on the same major version or one major version behind.
 If your Teleport Agents are not up to date, we will withhold major version upgrades in order to prevent connectivity

--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -142,7 +142,7 @@ The ability to download recordings for offline viewing will be available in a fu
 
 ### Will Teleport be updated automatically?
 
-The Teleport Auth Service and Teleport Proxy Service for Teleport Enterprise Cloud
+The Teleport Auth Service and Teleport Proxy Service for managed Teleport Enterprise instances
 are automatically kept up to date with patches and minor releases following the release schedule
 described in [Teleport Upcoming Releases](../../upcoming-releases.mdx).
 
@@ -151,18 +151,16 @@ described in [Teleport Upcoming Releases](../../upcoming-releases.mdx).
 - Minor updates and patches typically occur between one day and a week after a release.
 - Teleport Auth Service and Teleport Proxy Service updates are pushed to Teleport cloud accounts
   during your scheduled maintenance window.
-- The Teleport Auth Service and Proxy Service will not be automatically upgraded to the next major version with
-  Teleport agents on older major versions. An example would be the Teleport Auth and Proxy service are on
-  version 16 and agents are still on version 15 or older. That would prevent Teleport Auth and Proxy
-  being updated to version 17 automatically.
-- Teleport agents are only updated automatically if you enroll them in automatic updates.
+- The Teleport Auth Service and Proxy Service will not be automatically upgraded to the next
+   major version with Teleport agents on older major versions. 
+- Teleport Agents are only updated automatically if you enroll them in automatic updates.
 
-If you have Teleport agents connected to a Teleport Enterprise Cloud cluster
+If you have Teleport Agents connected to a managed Teleport Enterprise instance
 that are more than one major version behind, you might experience compatibility
-issues unless your agents are enrolled in automatic updates. See the [Upgrading
+issues unless your Teleport Agents are enrolled in automatic updates. See the [Upgrading
 Overview](../../upgrading/overview.mdx) for more information.
 
-To get version information for your agents, see [How can I find version information on
+To get version information for your Teleport Agents, see [How can I find version information on
 connected agents?](#how-can-i-find-version-information-on-connected-agents).
 
 For more information about automatic updates and compatibility issues, contact
@@ -170,13 +168,13 @@ For more information about automatic updates and compatibility issues, contact
 
 ### Why wasn't my managed Teleport Enterprise instance upgraded to the latest major version?
 
-The Teleport control plane supports Agents that are on the same major version or one major version behind.
-If your agents are not up to date, we will withhold major version upgrades in order to prevent connectivity
-issues to your resources. For example, if your control plane is currently running Teleport 15 and you have agents
-running Teleport 14, we will not be able to upgrade your control plane to Teleport 16 until all agents are
+The Teleport control plane supports Teleport Agents that are on the same major version or one major version behind.
+If your Teleport Agents are not up to date, we will withhold major version upgrades in order to prevent connectivity
+issues to your resources. For example, if your control plane is currently running Teleport 15 and you have Teleport Agents
+running Teleport 14, we will not be able to upgrade your control plane to Teleport 16 until all Teleport Agents are
 running Teleport 15.
 
-You can check the status of your agent versions from the `tctl inventory ls` command. `Auth` and `Proxy` 
+You can check the status of your Teleport Agent versions from the `tctl inventory ls` command. `Auth` and `Proxy` 
 services are those managed by Teleport. See [How can I find version information on
 connected agents?](#how-can-i-find-version-information-on-connected-agents) for further detail.
 

--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -152,6 +152,10 @@ described in [Teleport Upcoming Releases](../../upcoming-releases.mdx).
 - Teleport Auth Service and Teleport Proxy Service updates are pushed to Teleport cloud accounts
   during your scheduled maintenance window.
 - Teleport agents are only updated automatically if you enroll them in automatic updates.
+- Teleport Auth and Proxy service will not be automatically upgraded to the next major version with
+  Teleport agents on older major versions. An example would be the Teleport Auth and Proxy service are on
+  version 16 and agents are still on version 15 or older. That would prevent Teleport Auth and Proxy
+  being updated to version 17 automatically.
 
 If you have Teleport agents connected to a Teleport Enterprise Cloud cluster
 that are more than one major version behind, you might experience compatibility
@@ -163,6 +167,17 @@ connected agents?](#how-can-i-find-version-information-on-connected-agents).
 
 For more information about automatic updates and compatibility issues, contact
 [Teleport support](https://goteleport.com/support/).
+
+### Why wasn't my Teleport Enterprise Cloud instance upgraded to the latest version?
+
+Teleport Auth and Proxy service will not be automatically upgraded to the next major version with
+Teleport agents on older major versions. An example would be the Teleport Auth and Proxy service are on
+version 16 and agents are still on version 15 or older. That would prevent Teleport Auth and Proxy
+being updated to version 17 automatically.
+
+You can check the status of your versions from the `tctl inventory ls` command. `Auth` and `Proxy` 
+services are those managed by Teleport. See [How can I find version information on
+connected agents?](#how-can-i-find-version-information-on-connected-agents) for further detail.
 
 ### Are updates times configurable for Teleport Enterprise Cloud?
 
@@ -201,26 +216,16 @@ period. For more information, read one of the following guides:
 
 ### How can I find version information on connected agents?
 
-To find the version of Teleport agent is attached to your cluster, run the
-following commands for the different protocols we support.
+You can check the status of your agents' version from the `tctl inventory ls` command. `Auth` and `Proxy` 
+services are those managed by Teleport.
 
-```code
-$ tctl get nodes --format=text
-$ tctl get kube_server --format=text
-$ tctl get app_server --format=text
-$ tctl get db_server --format=text
-$ tctl get windows_desktop_service --format=text
-```
-
-Below you can see sample output of `tctl get nodes --format=text`. Note the
-`Version` column will contain the version of the attached agent.
-
-```code
-$ tctl get nodes --format=text
-Host     UUID                                 Public Address Labels Version
--------- ------------------------------------ -------------- ------ ----------
-server01 46d8cad0-8967-4815-a01a-77aae62c34fe                       (=teleport.version=)
-server02 c33b5513-a9eb-463b-8f1b-1f209afe5b4f                       (=teleport.version=)
+```bash
+tctl inventory ls
+Server ID                            Hostname              Services        Agent Version Upgrader Upgrader Version
+------------------------------------ --------------------- --------------- ------------- -------- ----------------
+065ab336-1ac2-4314-8b16-32fc06a172a7 example-1             Node,App        v(=cloud.version=)      unit     v(=cloud.version=)
+065ab336-1ac2-4314-8b16-f00uj04004db example-2             Node,Db         v(=cloud.version=)      unit     v(=cloud.version=)
+3de21e67-845a-4be1-a024-908829718d27 teleport-kube-0       Kube            v(=cloud.version=)      kube     v(=cloud.version=)
 ```
 
 ## Architecture and networking

--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -151,11 +151,11 @@ described in [Teleport Upcoming Releases](../../upcoming-releases.mdx).
 - Minor updates and patches typically occur between one day and a week after a release.
 - Teleport Auth Service and Teleport Proxy Service updates are pushed to Teleport cloud accounts
   during your scheduled maintenance window.
-- Teleport agents are only updated automatically if you enroll them in automatic updates.
 - Teleport Auth and Proxy service will not be automatically upgraded to the next major version with
   Teleport agents on older major versions. An example would be the Teleport Auth and Proxy service are on
   version 16 and agents are still on version 15 or older. That would prevent Teleport Auth and Proxy
   being updated to version 17 automatically.
+- Teleport agents are only updated automatically if you enroll them in automatic updates.
 
 If you have Teleport agents connected to a Teleport Enterprise Cloud cluster
 that are more than one major version behind, you might experience compatibility
@@ -170,12 +170,13 @@ For more information about automatic updates and compatibility issues, contact
 
 ### Why wasn't my Teleport Enterprise Cloud instance upgraded to the latest major version?
 
-Teleport Auth and Proxy service will not be automatically upgraded to the next major version with
-Teleport agents on older major versions. An example would be the Teleport Auth and Proxy service are on
-version 16 and agents are still on version 15 or older. That would prevent Teleport Auth and Proxy
-being updated to version 17 automatically.
+The Teleport Control plane supports agents that are on the same major version or one major version behind.
+If your agents are not up to date, we will withhold major version upgrades in order to prevent connectivity
+issues to your resources. For example, if your control plane is currently running Teleport 15 and you have agents
+running Teleport 14, we will not be able to upgrade your control plane to Teleport 16 until all agents are
+running Teleport 15.
 
-You can check the status of your versions from the `tctl inventory ls` command. `Auth` and `Proxy` 
+You can check the status of your agent versions from the `tctl inventory ls` command. `Auth` and `Proxy` 
 services are those managed by Teleport. See [How can I find version information on
 connected agents?](#how-can-i-find-version-information-on-connected-agents) for further detail.
 

--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -168,7 +168,7 @@ connected agents?](#how-can-i-find-version-information-on-connected-agents).
 For more information about automatic updates and compatibility issues, contact
 [Teleport support](https://goteleport.com/support/).
 
-### Why wasn't my Teleport Enterprise Cloud instance upgraded to the latest version?
+### Why wasn't my Teleport Enterprise Cloud instance upgraded to the latest major version?
 
 Teleport Auth and Proxy service will not be automatically upgraded to the next major version with
 Teleport agents on older major versions. An example would be the Teleport Auth and Proxy service are on


### PR DESCRIPTION
That instances are not upgraded automatically on agent versions was not provided. Also updated `tctl inventory ls` instead of multiple commands.