### PR TITLE
Add yarn ecosystem to dependabot.yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -228,6 +228,84 @@ updates:
       - "rust"
       - "no-changelog"
 
+  - package-ecosystem: npm
+    directory: "/web/packages/build"
+    schedule:
+      interval: monthly
+      day: "sunday"
+      time: "09:00" # 9am UTC
+    open-pull-requests-limit: 20
+    reviewers:
+      - avatus
+      - ryanclark
+    labels:
+      - "dependencies"
+      - "ui"
+      - "no-changelog"
+  - package-ecosystem: npm
+    directory: "/web/packages/design"
+    schedule:
+      interval: monthly
+      day: "sunday"
+      time: "09:00" # 9am UTC
+    open-pull-requests-limit: 20
+    reviewers:
+      - avatus
+      - kimlisa
+      - rudream
+      - bl-nero
+    labels:
+      - "dependencies"
+      - "ui"
+      - "no-changelog"
+  - package-ecosystem: npm
+    directory: "/web/packages/shared"
+    schedule:
+      interval: monthly
+      day: "sunday"
+      time: "09:00" # 9am UTC
+    open-pull-requests-limit: 20
+    reviewers:
+      - avatus
+      - kimlisa
+      - rudream
+      - bl-nero
+    labels:
+      - "dependencies"
+      - "ui"
+      - "no-changelog"
+  - package-ecosystem: npm
+    directory: "/web/packages/teleport"
+    schedule:
+      interval: monthly
+      day: "sunday"
+      time: "09:00" # 9am UTC
+    open-pull-requests-limit: 20
+    reviewers:
+      - avatus
+      - kimlisa
+      - rudream
+      - bl-nero
+    labels:
+      - "dependencies"
+      - "ui"
+      - "no-changelog"
+  - package-ecosystem: npm
+    directory: "/web/packages/teleterm"
+    schedule:
+      interval: monthly
+      day: "sunday"
+      time: "09:00" # 9am UTC
+    open-pull-requests-limit: 20
+    reviewers:
+      - avatus
+      - ravicious
+      - gzdunek
+    labels:
+      - "dependencies"
+      - "ui"
+      - "teleport-connect"
+      - "no-changelog"
   - package-ecosystem: github-actions
     directory: "/.github/workflows"
     schedule:


### PR DESCRIPTION
This PR should enable dependabot to check our web UI ecosystem. We use yarn workspaces so (I believe) we have to target each individual package.json in order for it to be updated. As far as I'm aware, I haven't found a way to [validate a dependabot.yaml file before letting it run](https://github.com/dependabot/dependabot-core/issues/4605) so this may need to be iterated on (validate in the sense of, "hey this is going to work as we expect", not syntactically).

I've tried to split up the responsibility for each package around the web team (connect team takes /teleterm, ryan helps with /build).

I suspect we will get quite a bit of noise at the start since most of our deps are out of date (some more than others) but after the initial push, it should be minimal as time goes on.