### PR TITLE
Add note about upgrades to IP list page

### DIFF
--- a/docs/pages/choose-an-edition/teleport-cloud/ips.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/ips.mdx
@@ -46,6 +46,14 @@ When this list is modified, we will provide at least two weeks notice by:
 If you are Teleport Enterprise customer and plan to employ this allowlist, please let us know by opening a support ticket.
 </Notice>
 
+Additionally, to receive Teleport agent updates, nodes must be able to reach the following domains via HTTPS during the update.
+
+```
+apt.releases.teleport.dev
+yum.releases.teleport.dev
+cdn.teleport.dev
+```
+
 ## Changelog
 
 - 2024-06-06: List published


### PR DESCRIPTION
This PR clarifies that customers who apply the IP list from https://github.com/gravitational/teleport/pull/42593 may need to make additional adjustments to ensure Teleport updates are available.