### PR TITLE
omit dns lookups on uuid-like targets

### DIFF
--- a/api/utils/route.go
+++ b/api/utils/route.go
@@ -88,7 +88,10 @@ func newSSHRouteMatcher(cfg SSHRouteMatcherConfig) SSHRouteMatcher {
 	_, err := uuid.Parse(cfg.Host)
 	dialByID := err == nil || aws.IsEC2NodeID(cfg.Host)
 
-	ips, _ := cfg.Resolver.LookupHost(context.Background(), cfg.Host)
+	var ips []string
+	if !dialByID {
+		ips, _ = cfg.Resolver.LookupHost(context.Background(), cfg.Host)
+	}
 
 	return SSHRouteMatcher{
 		cfg:            cfg,


### PR DESCRIPTION
Teleport SSH host routing logic performs a DNS lookup in order to help determine potential indirect matches (e.g. when a node advertises its IP address, but not its hostname, and the user dialed it by hostname).  In many environments, however, dialing is done almost exclusively by UUID (or ec2 node ID).  This is how all dials originating from the web UI work, as well as any dials based on predicates/selectors.  In these cases, the DNS lookup is unnecessary and may even be detrimental (e.g. overwhelming coredns pods serving particularly heavily loaded teleport proxies).

This PR changes the routing logic to omit the DNS lookup for id-like targets.  Since id-like targets never contain `.`, this shouldn't have any real drawbacks unless someone is serving id-like TLDs to their proxies, something that we judge to be unlikely and not worth supporting.

changelog: omit unnecessary DNS lookup in proxies when routing to nodes by ID.