### PR TITLE
[vnet] add read permissions for vnet_config to default implicit role

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -73,6 +73,7 @@ var DefaultImplicitRules = []types.Rule{
 	types.NewRule(types.KindWindowsDesktop, RO()),
 	types.NewRule(types.KindKubernetesCluster, RO()),
 	types.NewRule(types.KindUsageEvent, []string{types.VerbCreate}),
+	types.NewRule(types.KindVnetConfig, RO()),
 }
 
 // DefaultCertAuthorityRules provides access the minimal set of resources


### PR DESCRIPTION
Changelog: allows all authenticated users to read the cluster `vnet_config`.