### PR TITLE
List DNS zones of connected clusters only in VNet in Connect

### DIFF
--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -42,7 +42,9 @@ export const VnetSliderStep = (props: StepComponentProps) => {
     'clustersService',
     useCallback(state => state.clusters, [])
   );
-  const rootClusters = [...clusters.values()].filter(cluster => !cluster.leaf);
+  const rootClusters = [...clusters.values()].filter(
+    cluster => !cluster.leaf && cluster.connected
+  );
   const rootProxyHostnames = rootClusters.map(
     cluster => new whatwg.URL(`https://${cluster.proxyHost}`).hostname
   );


### PR DESCRIPTION
When a cluster is added to the app but the user is yet to log in to it, the cluster exists in the state with an empty `proxyHost` field. This PR makes it so that we don't list DNS zones of clusters to which the user is yet to log in or those with expired certs.

I'm not adding a changelog for this fix, since I have a PR in the works that completely changes how DNS zones are fetched anyway – we won't be doing any URL parsing there.


https://github.com/gravitational/teleport/assets/27113/a072cf0c-9506-42fa-8533-159b86107259

https://github.com/gravitational/teleport/assets/27113/32079daf-4a58-4f24-b5e2-df3c12fb8907