### PR TITLE
[v14] kube: fix data race caused by improper usage of `sync.WaitGroup`

### DIFF
--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -1563,10 +1563,7 @@ func (c *weakWaitGroup) Done() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.count--
-	if c.cond.L == nil {
-		c.cond.L = &c.mu
-	}
-	if c.count == 0 {
+	if c.count == 0 && c.cond.L != nil {
 		c.cond.Broadcast()
 	}
 }

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -1534,7 +1534,7 @@ func (s *session) retrieveEphemeralContainerCommand(ctx context.Context, usernam
 // various parts of the codebase concurrently and need to be awaited only if they started before
 // a certain point in time, specifically before session.Close() is called. If a goroutine
 // is initiated after session.Close() has been invoked, it will not be included in the wait process.
-// It's the caller responsability to ensure that all goroutines started after Wait() returns end
+// It's the caller responsibility to ensure that all goroutines started after Wait() returns end
 // up being a no-op.
 //
 // Important Considerations:

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -372,7 +372,7 @@ type session struct {
 
 	// eventsWaiter is used to wait for events to be emitted and goroutines closed
 	// when a session is closed.
-	eventsWaiter sync.WaitGroup
+	eventsWaiter concurrentWaitGroup
 
 	streamContext       context.Context
 	streamContextCancel context.CancelFunc
@@ -437,6 +437,7 @@ func newSession(ctx authContext, forwarder *Forwarder, req *http.Request, params
 		recorder: events.WithNoOpPreparer(
 			events.NewDiscardRecorder(),
 		),
+		eventsWaiter: newConcurrentWaitGroup(),
 	}
 
 	s.io.OnWriteError = s.disconnectPartyOnErr
@@ -1518,4 +1519,41 @@ func (s *session) retrieveEphemeralContainerCommand(ctx context.Context, usernam
 
 	}
 	return nil
+}
+
+// concurrentWaitGroup is a wait group that can be used concurrently.
+// It exits when the count reaches 0 for the first time.
+type concurrentWaitGroup struct {
+	cond  *sync.Cond
+	count int
+}
+
+func newConcurrentWaitGroup() concurrentWaitGroup {
+	return concurrentWaitGroup{
+		cond:  sync.NewCond(&sync.Mutex{}),
+		count: 0,
+	}
+}
+
+func (c *concurrentWaitGroup) Add(delta int) {
+	c.cond.L.Lock()
+	defer c.cond.L.Unlock()
+	c.count += delta
+}
+
+func (c *concurrentWaitGroup) Done() {
+	c.cond.L.Lock()
+	defer c.cond.L.Unlock()
+	c.count--
+	if c.count == 0 {
+		c.cond.Broadcast()
+	}
+}
+
+func (c *concurrentWaitGroup) Wait() {
+	c.cond.L.Lock()
+	defer c.cond.L.Unlock()
+	for c.count > 0 {
+		c.cond.Wait()
+	}
 }


### PR DESCRIPTION
Backport #42669 to branch/v14