### PR TITLE
[buddy] Prevent unnecessary Jamf service validation when it is disabled

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -671,10 +671,10 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		}
 	}
 
-	// Apply regardless of Jamf being enabled.
-	// If a config is present, we want it to be valid.
-	if err := applyJamfConfig(fc, cfg); err != nil {
-		return trace.Wrap(err)
+	if fc.Jamf.Enabled() {
+		if err := applyJamfConfig(fc, cfg); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	return nil

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -3518,13 +3518,12 @@ jamf_service:
 			yaml: `jamf_service: {}`,
 		},
 		{
-			name: "disabled config is validated",
+			name: "disabled config ignored",
 			yaml: `
 jamf_service:
   enabled: false
   api_endpoint: https://yourtenant.jamfcloud.com
   username: llama`,
-			wantErr: "password",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Disables validation of `jamf_service` when the service is disabled.

Changelog: Skip `jamf_service` validation when the service is not enabled.

Buddies #42958
Fixes: #42956