### PR TITLE
`oneoff` script: Use user directory instead of /tmp for downloading teleport

### DIFF
--- a/lib/web/scripts/oneoff/oneoff.sh
+++ b/lib/web/scripts/oneoff/oneoff.sh
@@ -5,14 +5,16 @@ cdnBaseURL='{{.CDNBaseURL}}'
 teleportVersion='{{.TeleportVersion}}'
 teleportFlavor='{{.TeleportFlavor}}' # teleport or teleport-ent
 successMessage='{{.SuccessMessage}}'
+teleportArgs='{{.TeleportArgs}}'
 
 # shellcheck disable=all
-tempDir=$({{.BinMktemp}} -d)
+# Use $HOME or / as base dir
+tempDir=$({{.BinMktemp}} -d -p ${HOME:-}/)
 OS=$({{.BinUname}} -s)
 ARCH=$({{.BinUname}} -m)
 # shellcheck enable=all
 
-teleportArgs='{{.TeleportArgs}}'
+trap 'rm -rf -- "$tempDir"' EXIT
 
 teleportTarballName() {
     if [ ${OS} = "Darwin" ]; then
@@ -36,19 +38,14 @@ teleportTarballName() {
 }
 
 main() {
-    cd $tempDir
-
     tarballName=$(teleportTarballName)
-    curl --show-error --fail --location --remote-name ${cdnBaseURL}/${tarballName}
-    echo "Extracting teleport to $tempDir ..."
-    tar -xzf ${tarballName}
+    echo "Downloading from ${cdnBaseURL}/${tarballName} and extracting teleport to ${tempDir} ..."
+    curl --show-error --fail --location ${cdnBaseURL}/${tarballName} | tar xzf - -C ${tempDir} ${teleportFlavor}/teleport
 
-    mkdir -p ./bin
-    mv ./${teleportFlavor}/teleport ./bin/teleport
-    echo "> ./bin/teleport ${teleportArgs} $@"
-    ./bin/teleport ${teleportArgs} $@ && echo $successMessage
-
-    cd -
+    mkdir -p ${tempDir}/bin
+    mv ${tempDir}/${teleportFlavor}/teleport ${tempDir}/bin/teleport
+    echo "> ${tempDir}/bin/teleport ${teleportArgs} $@"
+    ${tempDir}/bin/teleport ${teleportArgs} $@ && echo $successMessage
 }
 
 main $@

--- a/lib/web/scripts/oneoff/oneoff_test.go
+++ b/lib/web/scripts/oneoff/oneoff_test.go
@@ -42,6 +42,10 @@ func TestOneOffScript(t *testing.T) {
 	teleportVersionOutput := "Teleport v13.1.0 git:api/v13.1.0-0-gd83ec74 go1.20.4"
 	scriptName := "oneoff.sh"
 
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+	homeDir = homeDir + "/"
+
 	unameMock, err := bintest.NewMock("uname")
 	require.NoError(t, err)
 	defer func() {
@@ -96,7 +100,7 @@ func TestOneOffScript(t *testing.T) {
 
 		unameMock.Expect("-s").AndWriteToStdout("Linux")
 		unameMock.Expect("-m").AndWriteToStdout("x86_64")
-		mktempMock.Expect("-d").AndWriteToStdout(testWorkingDir)
+		mktempMock.Expect("-d", "-p", homeDir).AndWriteToStdout(testWorkingDir)
 		teleportMock.Expect("version").AndWriteToStdout(teleportVersionOutput)
 
 		err = os.WriteFile(scriptLocation, []byte(script), 0700)
@@ -112,9 +116,12 @@ func TestOneOffScript(t *testing.T) {
 		require.True(t, mktempMock.Check(t))
 		require.True(t, teleportMock.Check(t))
 
-		require.Contains(t, string(out), "> ./bin/teleport version")
+		require.Contains(t, string(out), "teleport version")
 		require.Contains(t, string(out), teleportVersionOutput)
 		require.Contains(t, string(out), "Test was a success.")
+
+		// Script should remove the temporary directory.
+		require.NoDirExists(t, testWorkingDir)
 	})
 
 	t.Run("command can be executed with extra arguments", func(t *testing.T) {
@@ -151,7 +158,7 @@ func TestOneOffScript(t *testing.T) {
 
 		unameMock.Expect("-s").AndWriteToStdout("Linux")
 		unameMock.Expect("-m").AndWriteToStdout("x86_64")
-		mktempMock.Expect("-d").AndWriteToStdout(testWorkingDir)
+		mktempMock.Expect("-d", "-p", homeDir).AndWriteToStdout(testWorkingDir)
 		teleportMock.Expect("help", "start").AndWriteToStdout(teleportHelpStart)
 
 		err = os.WriteFile(scriptLocation, []byte(script), 0700)
@@ -167,9 +174,12 @@ func TestOneOffScript(t *testing.T) {
 		require.True(t, mktempMock.Check(t))
 		require.True(t, teleportMock.Check(t))
 
-		require.Contains(t, string(out), "> ./bin/teleport help start")
+		require.Contains(t, string(out), "/bin/teleport help start")
 		require.Contains(t, string(out), teleportHelpStart)
 		require.Contains(t, string(out), "Test was a success.")
+
+		// Script should remove the temporary directory.
+		require.NoDirExists(t, testWorkingDir)
 	})
 
 	t.Run("invalid OS", func(t *testing.T) {
@@ -179,7 +189,7 @@ func TestOneOffScript(t *testing.T) {
 
 		unameMock.Expect("-s").AndWriteToStdout("Windows")
 		unameMock.Expect("-m").AndWriteToStdout("x86_64")
-		mktempMock.Expect("-d").AndWriteToStdout(testWorkingDir)
+		mktempMock.Expect("-d", "-p", homeDir).AndWriteToStdout(testWorkingDir)
 
 		err = os.WriteFile(scriptLocation, []byte(script), 0700)
 		require.NoError(t, err)
@@ -199,7 +209,7 @@ func TestOneOffScript(t *testing.T) {
 
 		unameMock.Expect("-s").AndWriteToStdout("Linux")
 		unameMock.Expect("-m").AndWriteToStdout("apple-silicon")
-		mktempMock.Expect("-d").AndWriteToStdout(testWorkingDir)
+		mktempMock.Expect("-d", "-p", homeDir).AndWriteToStdout(testWorkingDir)
 
 		err = os.WriteFile(scriptLocation, []byte(script), 0700)
 		require.NoError(t, err)
@@ -261,7 +271,7 @@ func TestOneOffScript(t *testing.T) {
 
 		unameMock.Expect("-s").AndWriteToStdout("Linux")
 		unameMock.Expect("-m").AndWriteToStdout("x86_64")
-		mktempMock.Expect("-d").AndWriteToStdout(testWorkingDir)
+		mktempMock.Expect("-d", "-p", homeDir).AndWriteToStdout(testWorkingDir)
 		teleportMock.Expect("version").AndWriteToStdout(teleportVersionOutput)
 
 		err = os.WriteFile(scriptLocation, []byte(script), 0700)
@@ -277,7 +287,7 @@ func TestOneOffScript(t *testing.T) {
 		require.True(t, mktempMock.Check(t))
 		require.True(t, teleportMock.Check(t))
 
-		require.Contains(t, string(out), "> ./bin/teleport version")
+		require.Contains(t, string(out), "/bin/teleport version")
 		require.Contains(t, string(out), teleportVersionOutput)
 		require.Contains(t, string(out), "Test was a success.")
 	})


### PR DESCRIPTION
Some systems have a very restricted size in `/tmp`. When doing some tests, we found out that Amazon Linux 2023 EC2 instance only has 475MB (possibly related to using an instance with 1GB of RAM?), and that's not enough to download and uncompress the tarball. We tried to optimize that and only extract the `teleport/teleport` binary, but there's not enough space for that as well.

So, instead, we are now storing the teleport binary in the user's cache dir.

Another change is that we also remove the created folder when the script exits.