### PR TITLE
Avoid deadlocks during app shutdown

### DIFF
--- a/api/client/inventory.go
+++ b/api/client/inventory.go
@@ -361,6 +361,10 @@ func (i *downstreamICS) runSendLoop(stream proto.AuthService_InventoryControlStr
 }
 
 func (i *downstreamICS) Send(ctx context.Context, msg proto.UpstreamInventoryMessage) error {
+	if err := ctx.Err(); err != nil {
+		return trace.Wrap(err)
+	}
+
 	errC := make(chan error, 1)
 	select {
 	case i.sendC <- upstreamSend{msg: msg, errC: errC}:
@@ -530,6 +534,10 @@ func (i *upstreamICS) runSendLoop(stream proto.AuthService_InventoryControlStrea
 }
 
 func (i *upstreamICS) Send(ctx context.Context, msg proto.DownstreamInventoryMessage) error {
+	if err := ctx.Err(); err != nil {
+		return trace.Wrap(err)
+	}
+
 	errC := make(chan error, 1)
 	select {
 	case i.sendC <- downstreamSend{msg: msg, errC: errC}:

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -460,14 +460,19 @@ func (s *Server) Shutdown(ctx context.Context) error {
 }
 
 func (s *Server) close(ctx context.Context) error {
-	// Stop all proxied apps.
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	shouldDeleteApps := services.ShouldDeleteServerHeartbeatsOnShutdown(ctx)
 
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(100)
+
+	// Hold the READ lock while iterating the applications here to prevent
+	// deadlocking in flight heartbeats. The heartbeat announce acquires
+	// the lock to build the app resource to send. If the WRITE lock is
+	// held during the shutdown procedure below, any in flight heartbeats
+	// will block acquiring the mutex until shutdown completes, at which
+	// point the heartbeat will be emitted and the removal of the app
+	// server below would be undone.
+	s.mu.RLock()
 	for name := range s.apps {
 		name := name
 		heartbeat := s.heartbeats[name]
@@ -480,7 +485,7 @@ func (s *Server) close(ctx context.Context) error {
 			log := s.log.WithField("app", name)
 			log.Debug("Stopping app")
 			if err := heartbeat.Close(); err != nil {
-				s.log.WithError(err).Warnf("Failed to stop app %q.", name)
+				log.WithError(err).Warn("Failed to stop app.")
 			} else {
 				log.Debug("Stopped app")
 			}
@@ -489,23 +494,26 @@ func (s *Server) close(ctx context.Context) error {
 				g.Go(func() error {
 					log.Debug("Deleting app")
 					if err := s.removeAppServer(gctx, name); err != nil {
-						log.WithError(err).Warnf("Failed to delete app %q.", name)
+						log.WithError(err).Warn("Failed to delete app.")
 					} else {
-						log.Debugf("Deleted app")
+						log.Debug("Deleted app")
 					}
 					return nil
 				})
 			}
 		}
 	}
+	s.mu.RUnlock()
 
 	if err := g.Wait(); err != nil {
 		s.log.WithError(err).Warn("Deleting all apps failed")
 	}
 
+	s.mu.Lock()
 	clear(s.apps)
 	clear(s.dynamicLabels)
 	clear(s.heartbeats)
+	s.mu.Unlock()
 
 	errs := s.c.ConnectionsHandler.Close(ctx)
 


### PR DESCRIPTION
TestShutdown was flaky because of a deadlock with inflight heartbeat attempts and app server shutdown. When building the app to heartbeat the app.Server mutex is held to populate dynamic labels. The same mutex is held for the duration of app.Shutdown, which caused heartbeats attempting to announce during shutdown being blocked until shutdown completed. This resulted in one last heartbeat for an app to be sent even though shutdown just attempted to stop all heartbeats and delete all app servers.

The Send operations of the inventory control stream have also been updated to better respect contexts to reduce raciness that can lead to sending messages after the handle was closed. 

Fixes https://github.com/gravitational/teleport/issues/42807.