### PR TITLE
Fix shellcheck for loadtest/ansible-like

### DIFF
--- a/assets/loadtest/ansible-like/gen_inventory.sh
+++ b/assets/loadtest/ansible-like/gen_inventory.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-cd $( dirname -- ${0} )
+cd "$( dirname -- "${0}" )" || exit 1
 
 tsh -i tbot_destdir_id/identity --proxy PROXYHOST:443 ls --format=json > inventory.json
 # jq -r '.[] | select(.metadata.expires > (now | strftime("%Y-%m-%dT%H:%M:%SZ"))) | .metadata.name + ".CLUSTERNAME"' < inventory.json | sort -R > inventory

--- a/assets/loadtest/ansible-like/run.sh
+++ b/assets/loadtest/ansible-like/run.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-cd $( dirname -- ${0} )
+cd "$( dirname -- "${0}" )" || exit 1
 
 mkdir -p /run/user/1000/ssh-control
 

--- a/assets/loadtest/ansible-like/run_node.sh
+++ b/assets/loadtest/ansible-like/run_node.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-cd $( dirname -- ${0} )
+cd "$( dirname -- "${0}" )" || exit 1
 
-sleep $( echo "90 * $(od -An -N4 -tu4 /dev/urandom) / 4294967295" | bc -l )
+sleep "$( echo "90 * $(od -An -N4 -tu4 /dev/urandom) / 4294967295" | bc -l )"
 
 ssh_opts="-qn -F tbot_destdir_mux/ssh_config -S /run/user/1000/ssh-control/%C -o ControlMaster=auto -o ControlPersist=60s -o Ciphers=^aes128-gcm@openssh.com -l root"
 

--- a/assets/loadtest/ansible-like/tbot_install.sh
+++ b/assets/loadtest/ansible-like/tbot_install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-cd $( dirname -- ${0} )
+cd "$( dirname -- "${0}" )" || exit 1
 
 sudo loginctl enable-linger
 


### PR DESCRIPTION
This fixes the shellcheck lint breakage added in #42921 (see https://github.com/gravitational/teleport/actions/runs/9521050130/job/26247659423?pr=43033 ).