### PR TITLE
Fix setting request reason for automatic ssh access requests.

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3374,28 +3374,29 @@ func retryWithAccessRequest(
 }
 
 func promptUserForAccessRequestDetails(cf *CLIConf, req types.AccessRequest) error {
-	if cf.RequestMode != accessRequestModeRole {
-		return nil
-	}
-	// If this is a role access request, ensure that it only has one role.
-	switch len(req.GetRoles()) {
-	case 0:
-		return trace.AccessDenied("no roles to request that would grant access")
-	case 1:
-		return nil
-	default:
-		selectedRole, err := prompt.PickOne(
-			cf.Context, os.Stdout, prompt.NewContextReader(os.Stdin),
-			"Choose role to request",
-			req.GetRoles())
-		if err != nil {
-			return trace.Wrap(err)
+	if cf.RequestMode == accessRequestModeRole {
+		// If this is a role access request, ensure that it only has one role.
+		switch len(req.GetRoles()) {
+		case 0:
+			return trace.AccessDenied("no roles to request that would grant access")
+		case 1:
+			// No need to choose a role, just set request reason.
+		default:
+			selectedRole, err := prompt.PickOne(
+				cf.Context, os.Stdout, prompt.NewContextReader(os.Stdin),
+				"Choose role to request",
+				req.GetRoles())
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			req.SetRoles([]string{selectedRole})
 		}
-		req.SetRoles([]string{selectedRole})
 	}
+
 	if err := setAccessRequestReason(cf, req); err != nil {
 		return trace.Wrap(err)
 	}
+
 	return nil
 }
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -2011,15 +2011,9 @@ func TestSSHAccessRequest(t *testing.T) {
 
 			requests, err := rootAuth.GetAuthServer().GetAccessRequests(ctx, types.AccessRequestFilter{})
 			require.NoError(t, err)
-
-			found := false
-			for _, r := range requests {
-				if r.GetRequestReason() == requestReason {
-					found = true
-					break
-				}
-			}
-			require.True(t, found, "access request with the specified reason was not found")
+			require.True(t, slices.ContainsFunc(requests, func(request types.AccessRequest) bool {
+				return request.GetRequestReason() == requestReason
+			}), "access request with the specified reason was not found")
 
 			// now that we have an approved access request, it should work without
 			// prompting for a request reason

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1975,6 +1976,20 @@ func TestSSHAccessRequest(t *testing.T) {
 			_, err = rootAuth.GetAuthServer().UpsertUser(ctx, alice)
 			require.NoError(t, err)
 
+			err = Run(ctx, []string{
+				"logout",
+			}, setHomePath(tmpHomePath))
+			require.NoError(t, err)
+
+			err = Run(ctx, []string{
+				"login",
+				"--insecure",
+				"--proxy", proxyAddr.String(),
+				"--user", "alice",
+			}, setHomePath(tmpHomePath), setMockSSOLogin(rootAuth.GetAuthServer(), alice, connector.GetName()))
+			require.NoError(t, err)
+
+			requestReason := uuid.New().String()
 			// the first ssh request can fail if the proxy node watcher doesn't know
 			// about the nodes yet, retry a few times until it works
 			require.Eventually(t, func() bool {
@@ -1984,7 +1999,7 @@ func TestSSHAccessRequest(t *testing.T) {
 					"--debug",
 					"--insecure",
 					"--request-mode", tc.requestMode,
-					"--request-reason", "reason here to bypass prompt",
+					"--request-reason", requestReason,
 					fmt.Sprintf("%s@%s", user.Username, sshHostname),
 					"echo", "test",
 				}, setHomePath(tmpHomePath))
@@ -1993,6 +2008,18 @@ func TestSSHAccessRequest(t *testing.T) {
 				}
 				return err == nil
 			}, 10*time.Second, 100*time.Millisecond, "failed to ssh with retries")
+
+			requests, err := rootAuth.GetAuthServer().GetAccessRequests(ctx, types.AccessRequestFilter{})
+			require.NoError(t, err)
+
+			found := false
+			for _, r := range requests {
+				if r.GetRequestReason() == requestReason {
+					found = true
+					break
+				}
+			}
+			require.True(t, found, "access request with the specified reason was not found")
 
 			// now that we have an approved access request, it should work without
 			// prompting for a request reason


### PR DESCRIPTION
It seems that after adding automatic role access requests ( #39003 ) , request reason functionality got broken - in tsh codepath we never set reason for resource requests and only set reason for role requests if there's more than one role. This PR fixes that, so we again get request reason from the flag or prompt user for it. 
I also added tsh logout/login in the tests, I think second test case didn't actually work because we had approved access request from the first one.

Changelog: Fix setting request reason for automatic ssh access requests.

Fixes #42634