### PR TITLE
Rotate Connect logs in ascending order

### DIFF
--- a/web/packages/teleterm/src/services/logger/loggerService.ts
+++ b/web/packages/teleterm/src/services/logger/loggerService.ts
@@ -89,7 +89,7 @@ export function createFileLoggerService(
     transports: [
       new transports.File({
         maxsize: 4194304, // 4 MB - max size of a single file
-        maxFiles: 5,
+        maxFiles: opts.dev ? 5 : 3,
         dirname: opts.dir,
         filename: `${opts.name}.log`,
         tailable: true,

--- a/web/packages/teleterm/src/services/logger/loggerService.ts
+++ b/web/packages/teleterm/src/services/logger/loggerService.ts
@@ -92,6 +92,7 @@ export function createFileLoggerService(
         maxFiles: 5,
         dirname: opts.dir,
         filename: `${opts.name}.log`,
+        tailable: true,
       }),
     ],
   });


### PR DESCRIPTION
By default, winston rotates logs in this really annoying manner. When `tshd.log` reaches `maxsize`, it creates `tshd1.log` and starts writing logs there. This means that before you jump to inspect the logs, you have to look at the full list of them to check which one is the current logfile.

It turns out this behavior can be changed with [the `tailable` option](https://github.com/winstonjs/winston/blob/7f5f014d56f646bd96b989922d69e60c91f6f664/docs/transports.md#file-transport) which makes winston rotate logs just like other unix tools do. Now `tshd.log` is always the current file.

I also limited the number of logfiles in the packaged app. 5 seems like a lot, especially since debug logs are turned off by default. There's no need to store all of those logs on the devices of our users.

---

Here's the directory with my logs before and after launching a packaged version of Connect with the changes from this PR:

```
$ date -Iminutes
2024-06-17T11:13+02:00
$ ls -lh -D "%FT%T" ~/Library/Application\ Support/Teleport\ Connect/logs
total 42456
-rw-r--r--@ 1 rav  staff   5.7K 2024-06-14T13:39:36 agent-cleanup.log
-rw-r--r--@ 1 rav  staff   1.3M 2024-06-17T11:12:10 main.log
-rw-r--r--@ 1 rav  staff   4.0M 2024-06-04T13:41:30 renderer.log
-rw-r--r--@ 1 rav  staff   1.2M 2024-06-17T11:12:08 renderer1.log
-rw-r--r--@ 1 rav  staff    92K 2024-06-17T11:12:07 shared.log
-rw-r--r--@ 1 rav  staff   4.0M 2024-01-29T16:41:09 tshd.log
-rw-r--r--@ 1 rav  staff   4.0M 2024-05-29T15:34:39 tshd1.log
-rw-r--r--@ 1 rav  staff   3.1M 2024-06-17T11:12:10 tshd2.log
$ ls -lh -D "%FT%T" ~/Library/Application\ Support/Teleport\ Connect/logs
total 34112
-rw-r--r--@ 1 rav  staff   5.7K 2024-06-14T13:39:36 agent-cleanup.log
-rw-r--r--@ 1 rav  staff   1.3M 2024-06-17T11:13:43 main.log
-rw-r--r--  1 rav  staff   1.9K 2024-06-17T11:13:41 renderer.log
-rw-r--r--@ 1 rav  staff   4.0M 2024-06-04T13:41:30 renderer1.log
-rw-r--r--@ 1 rav  staff   1.2M 2024-06-17T11:12:08 renderer2.log
-rw-r--r--@ 1 rav  staff    92K 2024-06-17T11:13:41 shared.log
-rw-r--r--  1 rav  staff   4.5K 2024-06-17T11:13:43 tshd.log
-rw-r--r--@ 1 rav  staff   4.0M 2024-01-29T16:41:09 tshd1.log
-rw-r--r--@ 1 rav  staff   4.0M 2024-05-29T15:34:39 tshd2.log
```

`renderer1.log` was the current log before launching the new version. After launching the new version, winston rotates all renderer logs and began writing to `renderer.log`. When users upgrade the app to use the new rotation logic, it should result in a loss of logs only in rare cases.

changelog: Improved log rotation logic in Teleport Connect; now the non-numbered files always contain recent logs.