### PR TITLE
[branch/v16] Fixed plugins using arm64 binaries in all container images (#43031)

### DIFF
--- a/integrations/access/Dockerfile
+++ b/integrations/access/Dockerfile
@@ -4,8 +4,16 @@ ARG BASE_IMAGE=gcr.io/distroless/static-debian12
 # Extract the built tarball to reduce the final image size
 FROM --platform=${BUILDPLATFORM} alpine:3.20.0 as extractor
 
+ARG TARGETARCH
+ARG TARGETOS
+ARG ARTIFACT_NAME=plugin    # Should be something like 'access-slack' or 'event-handler'
+ARG TELEPORT_VERSION=0.0.0  # Should be the version without 'v' prefix
+ARG FILENAME=teleport-${ARTIFACT_NAME}-v${TELEPORT_VERSION}-${TARGETOS}-${TARGETARCH}-bin.tar.gz # Optional override
+
 WORKDIR /extraction
 COPY *${TARGETARCH}*.tar.gz /plugin.tar.gz
+COPY "${FILENAME}" /plugin.tar.gz
+
 RUN tar -xzvf /plugin.tar.gz && \
     find . -type f -executable -name 'teleport-*' -exec mv {} /teleport-plugin \;
 

--- a/integrations/event-handler/Dockerfile
+++ b/integrations/event-handler/Dockerfile
@@ -4,8 +4,16 @@ ARG BASE_IMAGE=gcr.io/distroless/static-debian12
 # Extract the built tarball to reduce the final image size
 FROM --platform=${BUILDPLATFORM} alpine:3.20.0 as extractor
 
+ARG TARGETARCH
+ARG TARGETOS
+ARG ARTIFACT_NAME=plugin    # Should be something like 'access-slack' or 'event-handler'
+ARG TELEPORT_VERSION=0.0.0  # Should be the version without 'v' prefix
+ARG FILENAME=teleport-${ARTIFACT_NAME}-v${TELEPORT_VERSION}-${TARGETOS}-${TARGETARCH}-bin.tar.gz # Optional override
+
 WORKDIR /extraction
 COPY *${TARGETARCH}*.tar.gz /plugin.tar.gz
+COPY "${FILENAME}" /plugin.tar.gz
+
 RUN tar -xzvf /plugin.tar.gz && \
     find . -type f -executable -name 'teleport-*' -exec mv {} /teleport-plugin \;
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/43031

changelog: Fix v16.0.0 amd64 Teleport plugin images using arm64 binaries