### PR TITLE
Add status icons to VNet panel, adjust empty state copy & start notification

### DIFF
--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator.tsx
@@ -23,15 +23,17 @@ type Status = 'on' | 'off' | 'error';
 
 export const ConnectionStatusIndicator = (props: {
   status: Status;
+  inline?: boolean;
   [key: string]: any;
 }) => {
-  const { status, ...styles } = props;
+  const { status, inline, ...styles } = props;
 
-  return <StyledStatus {...styles} $status={status} />;
+  return <StyledStatus {...styles} $status={status} $inline={inline} />;
 };
 
 const StyledStatus = styled(Box)`
   position: relative;
+  ${props => props.$inline && `display: inline-block;`}
   width: 8px;
   height: 8px;
   border-radius: 50%;
@@ -60,11 +62,13 @@ const StyledStatus = styled(Box)`
           color: ${theme.colors.error.main};
           &:after {
             content: '𐄂';
-            position: absolute;
+            font-size: 19px;
+
+            ${!props.$inline &&
+            `position: absolute;
             top: -3px;
             left: -1px;
-            line-height: 8px;
-            font-size: 19px;
+            line-height: 8px;`}
           }
         `;
       }

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useCallback } from 'react';
+import { PropsWithChildren, useCallback } from 'react';
 import { StepComponentProps } from 'design/StepSlider';
 import { Box, Flex, Text } from 'design';
 import { mergeRefs } from 'shared/libs/mergeRefs';
@@ -24,6 +24,7 @@ import { useRefAutoFocus } from 'shared/hooks';
 import * as whatwg from 'whatwg-url';
 
 import { useStoreSelector } from 'teleterm/ui/hooks/useStoreSelector';
+import { ConnectionStatusIndicator } from 'teleterm/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator';
 
 import { useVnetContext } from './vnetContext';
 import { VnetSliderStepHeader } from './VnetConnectionItem';
@@ -64,7 +65,7 @@ export const VnetSliderStep = (props: StepComponentProps) => {
       <VnetSliderStepHeader goBack={props.prev} />
       <Flex
         p={textSpacing}
-        gap={1}
+        gap={3}
         flexDirection="column"
         css={`
           &:empty {
@@ -73,20 +74,20 @@ export const VnetSliderStep = (props: StepComponentProps) => {
         `}
       >
         {startAttempt.status === 'error' && (
-          <Text>Could not start VNet: {startAttempt.statusText}</Text>
+          <ErrorText>Could not start VNet: {startAttempt.statusText}</ErrorText>
         )}
         {stopAttempt.status === 'error' && (
-          <Text>Could not stop VNet: {stopAttempt.statusText}</Text>
+          <ErrorText>Could not stop VNet: {stopAttempt.statusText}</ErrorText>
         )}
 
         {status.value === 'stopped' &&
           (status.reason.value === 'unexpected-shutdown' ? (
-            <Text>
+            <ErrorText>
               VNet unexpectedly shut down:{' '}
               {status.reason.errorMessage ||
                 'no direct reason was given, please check logs'}
               .
-            </Text>
+            </ErrorText>
           ) : (
             <>
               <Text>
@@ -112,7 +113,8 @@ export const VnetSliderStep = (props: StepComponentProps) => {
             {/* TODO(ravicious): Add leaf clusters and custom DNS zones when support for them
                 lands in VNet. */}
             <Text p={textSpacing}>
-              Proxying TCP connections to {rootProxyHostnames.join(', ')}
+              <ConnectionStatusIndicator status="on" inline mr={1} /> Proxying
+              TCP connections to {rootProxyHostnames.join(', ')}
             </Text>
           </>
         ))}
@@ -121,3 +123,10 @@ export const VnetSliderStep = (props: StepComponentProps) => {
 };
 
 const textSpacing = 1;
+
+const ErrorText = (props: PropsWithChildren) => (
+  <Text>
+    <ConnectionStatusIndicator status="error" inline mr={2} />
+    {props.children}
+  </Text>
+);

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -89,17 +89,16 @@ export const VnetSliderStep = (props: StepComponentProps) => {
               .
             </ErrorText>
           ) : (
-            <>
+            <Flex flexDirection="column" gap={1}>
               <Text>
                 VNet enables any program to connect to TCP applications
                 protected by Teleport.
               </Text>
               <Text>
-                Just start VNet and connect to any TCP app over its public
-                address – VNet authenticates the connection for you under the
-                hood.
+                Start VNet and connect to any TCP app over its public address –
+                VNet authenticates the connection for you under the hood.
               </Text>
-            </>
+            </Flex>
           ))}
       </Flex>
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.ts
@@ -159,11 +159,16 @@ export async function connectToAppWithVnet(
     // prompt, the Electron app throws an error about clipboard write permission being denied.
     if (error['name'] === 'NotAllowedError') {
       console.error(error);
+      ctx.notificationsService.notifyInfo(
+        `Connect via VNet by using ${addrToCopy}.`
+      );
       return;
     }
     throw error;
   }
-  ctx.notificationsService.notifyInfo(`Copied ${addrToCopy} to clipboard`);
+  ctx.notificationsService.notifyInfo(
+    `Connect via VNet by using ${addrToCopy} (copied to clipboard).`
+  );
 }
 
 /**


### PR DESCRIPTION
This PR adds some icons so that it's easier to see what state VNet is in. "Just" has been removed from the empty state copy. After clicking "Connect" next to a TCP app, the notification is always shown, even if we failed to copy the address to the clipboard.

| Before | After |
| --- | --- |
| ![image](https://github.com/gravitational/teleport/assets/27113/3d6bb893-8116-42a7-bfaa-93821dcde8c3) | ![image](https://github.com/gravitational/teleport/assets/27113/c7e982ce-e9d6-4148-a151-28926378cc3a) |
| ![image](https://github.com/gravitational/teleport/assets/27113/c55d14d2-da4e-4584-8c53-41e7a14407ea) | ![image](https://github.com/gravitational/teleport/assets/27113/4b55ca8f-ce7e-4c40-b6ad-4e2eba15151c) |
