### PR TITLE
docs: Add more methods to set Origin/Host headers

### DIFF
--- a/docs/pages/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/application-access/troubleshooting-apps.mdx
@@ -37,49 +37,17 @@ traffic isn't being permitted, or application logs that indicate CORS or CSRF er
 In most cases, you can fix these types of issues by adding explicit `rewrite` settings for the Origin and Host headers
 in the Teleport configuration for each application.
 
-<Tabs>
-<TabItem label="/etc/teleport.yaml">
-  To fix CSRF or CORS issues if you use statically configured apps in `/etc/teleport.yaml`:
+### Solution 1: Application Service configuration file
 
-  1. Open the `/etc/teleport.yaml` file that contains the application configuration in a text editor.
+To fix CSRF or CORS issues if you use statically configured apps in `/etc/teleport.yaml`:
 
-  2. Add a `rewrite.headers` section similar to the following `grafana` example:
+1. Open the `/etc/teleport.yaml` file that contains the application configuration in a text editor.
 
-    ```yaml
-    app_service:
-      enabled: true
-      apps:
-      - name: grafana
-        uri: http://localhost:3000
-        public_addr: grafana.teleport.example.com
-        rewrite:
-          headers:
-          - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
-          - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
-    ```
+1. Add a `rewrite.headers` section similar to the following `grafana` example:
 
-  3. Save your changes and restart the Teleport service.
-</TabItem>
-
-<TabItem label="teleport-kube-agent">
-  To fix CSRF or CORS issues if you deploy applications using Kubernetes and `teleport-kube-agent`:
-
-  1. Open the `teleport/examples/chart/teleport-kube-agent/values.yaml` file that contains the application
-    configuration in a text editor.
-
-  2. Locate the `apps` section in the `values.yaml` file.
-
-    ```yaml
-    # Details of at least one app to be proxied. Example:
-    # apps:
-    #  - name: grafana
-    #    uri: http://localhost:3000
-    apps: []
-    ```
-
-  3. Add a `rewrite.headers` section similar to the following `grafana` example:
-
-    ```yaml
+  ```yaml
+  app_service:
+    enabled: true
     apps:
     - name: grafana
       uri: http://localhost:3000
@@ -88,53 +56,82 @@ in the Teleport configuration for each application.
         headers:
         - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
         - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
-    ```
-</TabItem>
+  ```
 
-<TabItem label="Dynamic app configuration">
-  To fix CSRF or CORS issues if you deploy applications with dynamic configuration:
+1. Save your changes and restart the Teleport service.
 
-  1. Edit your dynamic app configuration to include the `rewrite.headers` section:
+### Solution 2: `teleport-kube-agent` values file
 
-    ```yaml
-    kind: app
-    version: v3
-    metadata:
-      name: grafana
-      labels:
-        env: dev
-    spec:
-      uri: http://localhost:3000
-      public_addr: grafana.teleport.example.com
-      rewrite:
+To fix CSRF or CORS issues if you deploy applications using Kubernetes and `teleport-kube-agent`:
+
+1. Open the `teleport/examples/chart/teleport-kube-agent/values.yaml` file that contains the application
+  configuration in a text editor.
+
+1. Locate the `apps` section in the `values.yaml` file.
+
+  ```yaml
+  # Details of at least one app to be proxied. Example:
+  # apps:
+  #  - name: grafana
+  #    uri: http://localhost:3000
+  apps: []
+  ```
+
+1. Add a `rewrite.headers` section similar to the following `grafana` example:
+
+  ```yaml
+  apps:
+  - name: grafana
+    uri: http://localhost:3000
+    public_addr: grafana.teleport.example.com
+    rewrite:
+      headers:
+      - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+      - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
+  ```
+
+### Solution 3: Dynamic app configuration
+
+To fix CSRF or CORS issues if you deploy applications with dynamic configuration:
+
+1. Edit your dynamic app configuration to include the `rewrite.headers` section:
+
+  ```yaml
+  kind: app
+  version: v3
+  metadata:
+    name: grafana
+    labels:
+      env: dev
+  spec:
+    uri: http://localhost:3000
+    public_addr: grafana.teleport.example.com
+    rewrite:
+      headers:
+      - name: "Origin"
+        value: "https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+      - name: "Host"
+        value: "grafana.teleport.example.com" # Teleport application subdomain itself
+  ```
+
+### Solution 4: Kubernetes app autodiscovery
+
+To fix CSRF or CORS issues if you deploy applications using Kubernetes autodiscovery:
+
+1. Edit your Kubernetes `Service` configuration to include the `rewrite.headers` section:
+
+  ```yaml
+  apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      teleport.dev/app-rewrite: |
         headers:
         - name: "Origin"
           value: "https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
         - name: "Host"
           value: "grafana.teleport.example.com" # Teleport application subdomain itself
-    ```
-</TabItem>
-
-<TabItem label="Kubernetes app autodiscovery">
-  To fix CSRF or CORS issues if you deploy applications using Kubernetes autodiscovery:
-
-  1. Edit your Kubernetes `Service` configuration to include the `rewrite.headers` section:
-
-    ```yaml
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations:
-        teleport.dev/app-rewrite: |
-          headers:
-          - name: "Origin"
-            value: "https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
-          - name: "Host"
-            value: "grafana.teleport.example.com" # Teleport application subdomain itself
-    ```
-</TabItem>
-</Tabs>
-
+  ```
 
 ## Untrusted certificate errors
 

--- a/docs/pages/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/application-access/troubleshooting-apps.mdx
@@ -35,58 +35,106 @@ traffic isn't being permitted, or application logs that indicate CORS or CSRF er
 ### Solution
 
 In most cases, you can fix these types of issues by adding explicit `rewrite` settings for the Origin and Host headers
-in the Teleport configuration file for each application.
+in the Teleport configuration for each application.
 
-To fix CSRF or CORS issues:
+<Tabs>
+<TabItem label="/etc/teleport.yaml">
+  To fix CSRF or CORS issues if you use statically configured apps in `/etc/teleport.yaml`:
 
-1. Open the `/etc/teleport.yaml` file that contains the application configuration in a text editor.
+  1. Open the `/etc/teleport.yaml` file that contains the application configuration in a text editor.
 
-1. Add a `rewrite.headers` section similar to the following `grafana` example:
+  2. Add a `rewrite.headers` section similar to the following `grafana` example:
 
-   ```yaml
-   app_service:
-     enabled: true
-     apps:
-     - name: grafana
-       uri: http://localhost:3000
-       public_addr: grafana.teleport.example.com
-       rewrite:
-         headers:
-         - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
-         - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
-   ```
+    ```yaml
+    app_service:
+      enabled: true
+      apps:
+      - name: grafana
+        uri: http://localhost:3000
+        public_addr: grafana.teleport.example.com
+        rewrite:
+          headers:
+          - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+          - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
+    ```
 
-1. Save your changes and restart the Teleport service.
+  3. Save your changes and restart the Teleport service.
+</TabItem>
 
-To fix CSRF or CORS issues if you deploy applications using Kubernetes and `teleport-kube-agent`:
+<TabItem label="teleport-kube-agent">
+  To fix CSRF or CORS issues if you deploy applications using Kubernetes and `teleport-kube-agent`:
 
-1. Open the `teleport/examples/chart/teleport-kube-agent/values.yaml` file that contains the application
-   configuration in a text editor.
+  1. Open the `teleport/examples/chart/teleport-kube-agent/values.yaml` file that contains the application
+    configuration in a text editor.
 
-1. Locate the `apps` section in the `values.yaml` file.
+  2. Locate the `apps` section in the `values.yaml` file.
 
-   ```yaml
-   # Details of at least one app to be proxied. Example:
-   # apps:
-   #  - name: grafana
-   #    uri: http://localhost:3000
-   apps: []
-   ```
+    ```yaml
+    # Details of at least one app to be proxied. Example:
+    # apps:
+    #  - name: grafana
+    #    uri: http://localhost:3000
+    apps: []
+    ```
 
-1. Add a `rewrite.headers` section similar to the following `grafana` example:
+  3. Add a `rewrite.headers` section similar to the following `grafana` example:
 
-   ```yaml
-   app_service:
-     enabled: true
-     apps:
-     - name: grafana
-       uri: http://localhost:3000
-       public_addr: grafana.teleport.example.com
-       rewrite:
-         headers:
-         - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
-         - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
-   ```
+    ```yaml
+    apps:
+    - name: grafana
+      uri: http://localhost:3000
+      public_addr: grafana.teleport.example.com
+      rewrite:
+        headers:
+        - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+        - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
+    ```
+</TabItem>
+
+<TabItem label="Dynamic app configuration">
+  To fix CSRF or CORS issues if you deploy applications with dynamic configuration:
+
+  1. Edit your dynamic app configuration to include the `rewrite.headers` section:
+
+    ```yaml
+    kind: app
+    version: v3
+    metadata:
+      name: grafana
+      labels:
+        env: dev
+    spec:
+      uri: http://localhost:3000
+      public_addr: grafana.teleport.example.com
+      rewrite:
+        headers:
+        - name: "Origin"
+          value: "https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+        - name: "Host"
+          value: "grafana.teleport.example.com" # Teleport application subdomain itself
+    ```
+</TabItem>
+
+<TabItem label="Kubernetes app autodiscovery">
+  To fix CSRF or CORS issues if you deploy applications using Kubernetes autodiscovery:
+
+  1. Edit your Kubernetes `Service` configuration to include the `rewrite.headers` section:
+
+    ```yaml
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        teleport.dev/app-rewrite: |
+          headers:
+          - name: "Origin"
+            value: "https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+          - name: "Host"
+            value: "grafana.teleport.example.com" # Teleport application subdomain itself
+    ```
+</TabItem>
+</Tabs>
+
 
 ## Untrusted certificate errors
 

--- a/docs/pages/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/application-access/troubleshooting-apps.mdx
@@ -41,6 +41,7 @@ To fix CSRF or CORS issues if you use statically configured apps in `/etc/telepo
 
 1. Open the `/etc/teleport.yaml` file that contains the application configuration in a text editor.
 
+{/*lint ignore ordered-list-marker-value*/}
 2. Add a `rewrite.headers` section similar to the following `grafana` example:
 
   ```yaml
@@ -65,6 +66,7 @@ To fix CSRF or CORS issues if you deploy applications using Kubernetes and `tele
 1. Open the `teleport/examples/chart/teleport-kube-agent/values.yaml` file that contains the application
   configuration in a text editor.
 
+{/*lint ignore ordered-list-marker-value*/}
 2. Locate the `apps` section in the `values.yaml` file.
 
   ```yaml

--- a/docs/pages/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/application-access/troubleshooting-apps.mdx
@@ -41,22 +41,22 @@ To fix CSRF or CORS issues if you use statically configured apps in `/etc/telepo
 
 1. Open the `/etc/teleport.yaml` file that contains the application configuration in a text editor.
 
-1. Add a `rewrite.headers` section similar to the following `grafana` example:
+2. Add a `rewrite.headers` section similar to the following `grafana` example:
 
-```yaml
-app_service:
-  enabled: true
-  apps:
-  - name: grafana
-    uri: http://localhost:3000
-    public_addr: grafana.teleport.example.com
-    rewrite:
-      headers:
-      - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
-      - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
-```
+  ```yaml
+  app_service:
+    enabled: true
+    apps:
+    - name: grafana
+      uri: http://localhost:3000
+      public_addr: grafana.teleport.example.com
+      rewrite:
+        headers:
+        - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+        - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
+  ```
 
-1. Save your changes and restart the Teleport service.
+3. Save your changes and restart the Teleport service.
 
 ### Solution 2: `teleport-kube-agent` values file
 
@@ -65,28 +65,28 @@ To fix CSRF or CORS issues if you deploy applications using Kubernetes and `tele
 1. Open the `teleport/examples/chart/teleport-kube-agent/values.yaml` file that contains the application
   configuration in a text editor.
 
-1. Locate the `apps` section in the `values.yaml` file.
+2. Locate the `apps` section in the `values.yaml` file.
 
-```yaml
-# Details of at least one app to be proxied. Example:
-# apps:
-#  - name: grafana
-#    uri: http://localhost:3000
-apps: []
-```
+  ```yaml
+  # Details of at least one app to be proxied. Example:
+  # apps:
+  #  - name: grafana
+  #    uri: http://localhost:3000
+  apps: []
+  ```
 
-1. Add a `rewrite.headers` section similar to the following `grafana` example:
+3. Add a `rewrite.headers` section similar to the following `grafana` example:
 
-```yaml
-apps:
-- name: grafana
-  uri: http://localhost:3000
-  public_addr: grafana.teleport.example.com
-  rewrite:
-    headers:
-    - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
-    - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
-```
+  ```yaml
+  apps:
+  - name: grafana
+    uri: http://localhost:3000
+    public_addr: grafana.teleport.example.com
+    rewrite:
+      headers:
+      - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+      - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
+  ```
 
 ### Solution 3: Dynamic app configuration
 
@@ -94,23 +94,23 @@ To fix CSRF or CORS issues if you deploy applications with dynamic configuration
 
 1. Edit your dynamic app configuration to include the `rewrite.headers` section:
 
-```yaml
-kind: app
-version: v3
-metadata:
-  name: grafana
-  labels:
-    env: dev
-spec:
-  uri: http://localhost:3000
-  public_addr: grafana.teleport.example.com
-  rewrite:
-    headers:
-    - name: "Origin"
-      value: "https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
-    - name: "Host"
-      value: "grafana.teleport.example.com" # Teleport application subdomain itself
-```
+  ```yaml
+  kind: app
+  version: v3
+  metadata:
+    name: grafana
+    labels:
+      env: dev
+  spec:
+    uri: http://localhost:3000
+    public_addr: grafana.teleport.example.com
+    rewrite:
+      headers:
+      - name: "Origin"
+        value: "https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+      - name: "Host"
+        value: "grafana.teleport.example.com" # Teleport application subdomain itself
+  ```
 
 ### Solution 4: Kubernetes app autodiscovery
 
@@ -118,18 +118,18 @@ To fix CSRF or CORS issues if you deploy applications using Kubernetes autodisco
 
 1. Edit your Kubernetes `Service` configuration to include the `rewrite.headers` section:
 
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  annotations:
-    teleport.dev/app-rewrite: |
-      headers:
-      - name: "Origin"
-        value: "https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
-      - name: "Host"
-        value: "grafana.teleport.example.com" # Teleport application subdomain itself
-```
+  ```yaml
+  apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      teleport.dev/app-rewrite: |
+        headers:
+        - name: "Origin"
+          value: "https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+        - name: "Host"
+          value: "grafana.teleport.example.com" # Teleport application subdomain itself
+  ```
 
 ## Untrusted certificate errors
 

--- a/docs/pages/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/application-access/troubleshooting-apps.mdx
@@ -32,8 +32,6 @@ Issues with Cross-Site Request Forgery (CSRF) or Cross-Origin Resource Sharing (
 result in a loss of application functionality, errors in the application itself indicating that
 traffic isn't being permitted, or application logs that indicate CORS or CSRF errors.
 
-### Solution
-
 In most cases, you can fix these types of issues by adding explicit `rewrite` settings for the Origin and Host headers
 in the Teleport configuration for each application.
 
@@ -45,18 +43,18 @@ To fix CSRF or CORS issues if you use statically configured apps in `/etc/telepo
 
 1. Add a `rewrite.headers` section similar to the following `grafana` example:
 
-  ```yaml
-  app_service:
-    enabled: true
-    apps:
-    - name: grafana
-      uri: http://localhost:3000
-      public_addr: grafana.teleport.example.com
-      rewrite:
-        headers:
-        - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
-        - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
-  ```
+```yaml
+app_service:
+  enabled: true
+  apps:
+  - name: grafana
+    uri: http://localhost:3000
+    public_addr: grafana.teleport.example.com
+    rewrite:
+      headers:
+      - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+      - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
+```
 
 1. Save your changes and restart the Teleport service.
 
@@ -69,26 +67,26 @@ To fix CSRF or CORS issues if you deploy applications using Kubernetes and `tele
 
 1. Locate the `apps` section in the `values.yaml` file.
 
-  ```yaml
-  # Details of at least one app to be proxied. Example:
-  # apps:
-  #  - name: grafana
-  #    uri: http://localhost:3000
-  apps: []
-  ```
+```yaml
+# Details of at least one app to be proxied. Example:
+# apps:
+#  - name: grafana
+#    uri: http://localhost:3000
+apps: []
+```
 
 1. Add a `rewrite.headers` section similar to the following `grafana` example:
 
-  ```yaml
-  apps:
-  - name: grafana
-    uri: http://localhost:3000
-    public_addr: grafana.teleport.example.com
-    rewrite:
-      headers:
-      - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
-      - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
-  ```
+```yaml
+apps:
+- name: grafana
+  uri: http://localhost:3000
+  public_addr: grafana.teleport.example.com
+  rewrite:
+    headers:
+    - "Origin: https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+    - "Host: grafana.teleport.example.com" # Teleport application subdomain itself
+```
 
 ### Solution 3: Dynamic app configuration
 
@@ -96,23 +94,23 @@ To fix CSRF or CORS issues if you deploy applications with dynamic configuration
 
 1. Edit your dynamic app configuration to include the `rewrite.headers` section:
 
-  ```yaml
-  kind: app
-  version: v3
-  metadata:
-    name: grafana
-    labels:
-      env: dev
-  spec:
-    uri: http://localhost:3000
-    public_addr: grafana.teleport.example.com
-    rewrite:
-      headers:
-      - name: "Origin"
-        value: "https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
-      - name: "Host"
-        value: "grafana.teleport.example.com" # Teleport application subdomain itself
-  ```
+```yaml
+kind: app
+version: v3
+metadata:
+  name: grafana
+  labels:
+    env: dev
+spec:
+  uri: http://localhost:3000
+  public_addr: grafana.teleport.example.com
+  rewrite:
+    headers:
+    - name: "Origin"
+      value: "https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+    - name: "Host"
+      value: "grafana.teleport.example.com" # Teleport application subdomain itself
+```
 
 ### Solution 4: Kubernetes app autodiscovery
 
@@ -120,18 +118,18 @@ To fix CSRF or CORS issues if you deploy applications using Kubernetes autodisco
 
 1. Edit your Kubernetes `Service` configuration to include the `rewrite.headers` section:
 
-  ```yaml
-  apiVersion: v1
-  kind: Service
-  metadata:
-    annotations:
-      teleport.dev/app-rewrite: |
-        headers:
-        - name: "Origin"
-          value: "https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
-        - name: "Host"
-          value: "grafana.teleport.example.com" # Teleport application subdomain itself
-  ```
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    teleport.dev/app-rewrite: |
+      headers:
+      - name: "Origin"
+        value: "https://grafana.teleport.example.com" # Teleport application subdomain prepended with "https://"
+      - name: "Host"
+        value: "grafana.teleport.example.com" # Teleport application subdomain itself
+```
 
 ## Untrusted certificate errors
 


### PR DESCRIPTION
Added a tabbed list to show the way to set Origin/Host headers in 4 different scenarios.