### PR TITLE
docs: Add 502 Bad Gateway to the list of potential errors

### DIFF
--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -677,8 +677,6 @@ $ aws route53 get-change --id "${CHANGEID?}" | jq '.ChangeInfo.Status'
 Create a user to be able to log into Teleport. This needs to be done on the Teleport auth server,
 so we can run the command using `kubectl`:
 
-<Tabs>
-<TabItem scope={["oss"]} label="Teleport Community Edition">
 ```code
 $ kubectl --namespace <Var name="namespace" /> exec deploy/<Var name="release-name" />-auth -- tctl users add test --roles=access,editor
 
@@ -687,19 +685,6 @@ https://teleport.example.com:443/web/invite/91cfbd08bc89122275006e48b516cc68
 
 NOTE: Make sure teleport.example.com:443 points at a Teleport proxy that users can access.
 ```
-</TabItem>
-<TabItem scope={["enterprise", "cloud"]} label="Commercial">
-```code
-$ kubectl --namespace teleport exec deploy/teleport-auth -- tctl users add test --roles=access,editor,reviewer
-
-User "test" has been created but requires a password. Share this URL with the user to complete user setup, link is valid for 1h:
-https://teleport.example.com:443/web/invite/91cfbd08bc89122275006e48b516cc68
-
-NOTE: Make sure teleport.example.com:443 points at a Teleport proxy that users can access.
-```
-</TabItem>
-
-</Tabs>
 
 Load the user creation link to create a password and set up multi-factor authentication for the Teleport user via the web UI.
 

--- a/docs/pages/management/admin/troubleshooting.mdx
+++ b/docs/pages/management/admin/troubleshooting.mdx
@@ -37,7 +37,7 @@ To change the instance log level use the `teleport debug set-log-level` command:
 $ teleport debug set-log-level DEBUG
 Changed log level from "INFO" to "DEBUG".
 
-$ kubectl -n teleport exec my-pod -- teleport set-log-level DEBUG 
+$ kubectl -n teleport exec my-pod -- teleport set-log-level DEBUG
 Changed log level from "INFO" to "DEBUG".
 ```
 
@@ -177,7 +177,7 @@ Teleport v9.0.4 git: go1.18
 
 <Tabs>
 <TabItem scope={["cloud", "enterprise","team"]} label="Commercial Teleport Editions">
-If you have a question or need assistance please submit a request 
+If you have a question or need assistance please submit a request
 through the [Teleport support portal](https://support.goteleport.com).
 
 </TabItem>
@@ -224,7 +224,7 @@ tunnel via the Proxy Service. This means that `teleport.cluster.local` appears
 in log messages that show the URL of a request made to the Auth Service, and
 does not explicitly indicate that something is misconfigured.
 
-### `ssh: overflow reading version string`
+### `ssh: overflow reading version string` and/or `502: Bad Gateway` errors
 
 (!docs/pages/includes/tls-multiplexing-warnings.mdx!)
 


### PR DESCRIPTION
While debugging with a prospect, I realised that a common cause of `502 Bad Gateway` errors is a reverse proxy attempting to speak HTTP to an HTTPS backend. Adding this message to the header here should make the error more easily searchable/Googleable.

The same prospect also pointed out that the provided name for the Teleport auth pod in the "Commercial" tab is incorrect. The OSS instructions are more correct and will work for both editions, so I just removed the tab list.