### PR TITLE
Update electron, node-pty and Node.js

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -6,7 +6,7 @@
 GOLANG_VERSION ?= go1.22.4
 GOLANGCI_LINT_VERSION ?= v1.59.1
 
-NODE_VERSION ?= 20.13.0
+NODE_VERSION ?= 20.14.0
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.77.0

--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -48,7 +48,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.12",
     "@types/jsdom": "^21.1.7",
-    "@types/node": "^20.12.11",
+    "@types/node": "^20.14.2",
     "@types/react": "^18.2.39",
     "@types/react-dom": "^18.2.17",
     "@types/react-router-dom": "^5.1.1",

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.8.22",
     "node-forge": "^1.3.1",
-    "node-pty": "1.1.0-beta12",
+    "node-pty": "1.1.0-beta14",
     "ring-buffer-ts": "^1.2.0",
     "split2": "4.1.0",
     "strip-ansi": "^7.1.0",
@@ -43,7 +43,7 @@
     "@types/node-forge": "^1.0.4",
     "@types/tar-fs": "^2.0.4",
     "@types/whatwg-url": "^11.0.5",
-    "electron": "30.0.3",
+    "electron": "31.0.1",
     "electron-notarize": "^1.2.2",
     "electron-vite": "^2.0.0",
     "google-protobuf": "^3.21.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4173,10 +4173,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^20.12.11", "@types/node@^20.9.0":
-  version "20.12.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.11.tgz#c4ef00d3507000d17690643278a60dc55a9dc9be"
-  integrity sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==
+"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^20.14.2", "@types/node@^20.9.0":
+  version "20.14.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.2.tgz#a5f4d2bcb4b6a87bffcaa717718c5a0f208f4a18"
+  integrity sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==
   dependencies:
     undici-types "~5.26.4"
 
@@ -7511,10 +7511,10 @@ electron-vite@^2.0.0:
     magic-string "^0.30.5"
     picocolors "^1.0.0"
 
-electron@30.0.3:
-  version "30.0.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-30.0.3.tgz#7c25ddb12ba89fd117991d010f1b274b1bafcb73"
-  integrity sha512-h+suwx6e0fnv/9wi0/cmCMtG+4LrPzJZa+3DEEpxcPcP+pcWnBI70t8QspxgMNIh2wzXLMD9XVqrLkEbiBAInw==
+electron@31.0.1:
+  version "31.0.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-31.0.1.tgz#0039524f8f38c24da802c3b18a42c3951acb5897"
+  integrity sha512-2eBcp4iqLkTsml6mMq+iqrS5u3kJ/2mpOLP7Mj7lo0uNK3OyfNqRS9z1ArsHjBF2/HV250Te/O9nKrwQRTX/+g==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"
@@ -11988,10 +11988,10 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
-node-pty@1.1.0-beta12:
-  version "1.1.0-beta12"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.1.0-beta12.tgz#702f8c05ac1d175dcbc17901f1c66ee5d67b27cd"
-  integrity sha512-xhWrczF9AN+TnIZoHcSiclt4dkD1IcncUOzcdgx3by0jwctt54ZgWEp68O0lE0D8ydxa/bk3nA9sWEDhDNJuwg==
+node-pty@1.1.0-beta14:
+  version "1.1.0-beta14"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.1.0-beta14.tgz#e6e9eeb3ac7186144d17902977f9da011e513563"
+  integrity sha512-w/o/q6UL95azHQhrKvMnIojs1AGiqxnjNgcH3138H/RIRkIpE8S5GvT4dpvQT+ZVbTJxoBFt/DnaBAT1PAN7WQ==
   dependencies:
     node-addon-api "^7.1.0"
 


### PR DESCRIPTION
No breaking changes that would affect us in electron 31 https://www.electronjs.org/blog#breaking-changes
Full release notes: https://releases.electronjs.org/releases/stable

Tag build: 16.0.0-dev.gzdunek.2 (tested on macOS, Windows and Ubuntu).

