### PR TITLE
[v16] docs: Include CHANGELOG.md in eligible paths for linter

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -27,6 +27,7 @@ jobs:
           filters: |
             changed:
               - '.github/workflows/doc-tests.yaml'
+              - 'CHANGELOG.md'
               - 'docs/**'
               - 'examples/**'
 


### PR DESCRIPTION
Backport #43035 to branch/v16