### PR TITLE
docs: update enforce device trust notice

### DIFF
--- a/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
@@ -5,12 +5,13 @@ videoBanner: gBQyj_X1LVw
 ---
 
 <Admonition type="notice" title="Supported Resources">
-Device trust fully supports SSH, Database and Kubernetes resources.
+Device trust fully supports SSH, Database and Kubernetes resources using
+cluster-wide or role-based enforcement.
 
-Apps may enforce trusted devices using role-based enforcement. See the [App
-Access support](#app-access-support) section.
+Apps and Desktops may enforce trusted devices using role-based enforcement. See the [App
+Access support](#app-access-support) and the [Desktop Access support](#desktop-access-support)
+sections for further details.
 
-Support for other resources is planned for upcoming Teleport versions.
 </Admonition>
 
 Resources protected by the device mode "required" will enforce the use of a


### PR DESCRIPTION
Including desktop for role-based advisement and slight wording update. Only applies to V16 for backport