### PR TITLE
add a trouble shooting for db auto-user provisioning issue for RDS blue/green deployment

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1272,7 +1272,7 @@
           "slug": "/database-access/auto-user-provisioning/",
           "entries": [
             {
-              "title": "AWS Redshift",
+              "title": "Amazon Redshift",
               "slug": "/database-access/auto-user-provisioning/aws-redshift/"
             },
             {

--- a/docs/pages/database-access/auto-user-provisioning.mdx
+++ b/docs/pages/database-access/auto-user-provisioning.mdx
@@ -6,10 +6,10 @@ description: Configure automatic user provisioning for databases.
 (!docs/pages/includes/database-access/auto-user-provisioning/intro.mdx!)
 
 Currently, automatic user provisioning is supported for the following databases:
-- [PostgreSQL databases (self-hosted and AWS RDS)](./auto-user-provisioning/postgres.mdx)
-- [MySQL databases (self-hosted and AWS RDS)](./auto-user-provisioning/mysql.mdx)
-- [MariaDB databases (self-hosted and AWS RDS)](./auto-user-provisioning/mariadb.mdx)
-- [AWS Redshift databases](./auto-user-provisioning/aws-redshift.mdx)
+- [PostgreSQL databases (self-hosted and Amazon RDS)](./auto-user-provisioning/postgres.mdx)
+- [MySQL databases (self-hosted and Amazon RDS)](./auto-user-provisioning/mysql.mdx)
+- [MariaDB databases (self-hosted and Amazon RDS)](./auto-user-provisioning/mariadb.mdx)
+- [Amazon Redshift databases](./auto-user-provisioning/aws-redshift.mdx)
 - [MongoDB databases (self-hosted)](./auto-user-provisioning/mongodb.mdx)
 
 

--- a/docs/pages/database-access/auto-user-provisioning/aws-redshift.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/aws-redshift.mdx
@@ -1,13 +1,13 @@
 ---
-title: AWS Redshift Automatic User Provisioning 
-description: Configure automatic user provisioning for AWS Redshift.
+title: Amazon Redshift Automatic User Provisioning
+description: Configure automatic user provisioning for Amazon Redshift.
 ---
 
 (!docs/pages/includes/database-access/auto-user-provisioning/intro.mdx!)
 
 ## Prerequisites
 
-- Teleport cluster v14.1.3 or higher with a configured [AWS
+- Teleport cluster v14.1.3 or higher with a configured [Amazon
   Redshift](../enroll-aws-databases/postgres-redshift.mdx) database.
 - Ability to connect to and create user accounts in the target database.
 

--- a/docs/pages/database-access/auto-user-provisioning/mysql.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/mysql.mdx
@@ -114,7 +114,7 @@ ERROR 1105 (HY000): ERROR 1044 (42000): Access denied for user '<your-teleport-u
 
 ### Table is read only error
 
-You may encounter the following error when connecting to an AWS RDS Aurora
+You may encounter the following error when connecting to an Amazon RDS Aurora
 reader endpoint:
 ```shell
 $ tsh db connect --db-name <database> example

--- a/docs/pages/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/postgres.mdx
@@ -192,7 +192,7 @@ GRANT CONNECT ON DATABASE <database> to "reader";
 
 ### Cannot execute in a read-only transaction error
 
-You may encounter the following error when connecting to an AWS RDS Aurora
+You may encounter the following error when connecting to an Amazon RDS Aurora
 reader endpoint:
 ```shell
 $ tsh db connect --db-name <database> example
@@ -246,6 +246,23 @@ GRANT rds_iam TO "teleport-admin" WITH ADMIN OPTION;
 (!docs/pages/includes/database-access/pg-cancel-request-limitation.mdx!)
 
 (!docs/pages/includes/database-access/psql-ssl-syscall-error.mdx!)
+
+### Amazon RDS Blue/Green deployment enters a state of "Replication degraded"
+
+Amazon RDS Blue/Green deployment may enter a state of "Replication degraded"
+when auto-user provisioning is used to connect to the database.
+
+This occurs due to a [limitation in PostgreSQL logical
+replication(https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments-overview.html#blue-green-deployments-limitations-postgres)
+for Blue/Green deployments as Data Definition Language (DDL) statements cannot
+be replicated. Consequently, Amazon RDS will enter the "Replication degraded"
+state when a DDL change is detected.
+
+It is recommended to disable database auto-user provisioning before starting
+the Blue/Green deployment. For example, you can temporarily remove the
+`teleport.dev/db-admin` resource tag from the auto-discovered RDS databases.
+Once Teleport detects the change and disables auto-user provisioning, you can
+still connect as the database admin user through Teleport.
 
 ## Next steps
 

--- a/docs/pages/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/postgres.mdx
@@ -259,10 +259,15 @@ be replicated. Consequently, Amazon RDS will enter the "Replication degraded"
 state when a DDL change is detected.
 
 It is recommended to disable database auto-user provisioning before starting
-the Blue/Green deployment. For example, you can temporarily remove the
-`teleport.dev/db-admin` resource tag from the auto-discovered RDS databases.
-Once Teleport detects the change and disables auto-user provisioning, you can
-still connect as the database admin user through Teleport.
+the Blue/Green deployment.
+
+If the database is auto-discovered by Teleport, you can temporarily remove the
+`teleport.dev/db-admin` AWS resource tag. For a database registered using
+either static config or a dynamic `db` resource, you can temporarily remove the
+`admin_user` setting.
+
+Once auto-user provisioning is disabled, you can still connect as the database
+admin user through Teleport.
 
 ## Next steps
 

--- a/docs/pages/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/postgres.mdx
@@ -253,7 +253,7 @@ Amazon RDS Blue/Green deployment may enter a state of "Replication degraded"
 when auto-user provisioning is used to connect to the database.
 
 This occurs due to a [limitation in PostgreSQL logical
-replication(https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments-overview.html#blue-green-deployments-limitations-postgres)
+replication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments-overview.html#blue-green-deployments-limitations-postgres)
 for Blue/Green deployments as Data Definition Language (DDL) statements cannot
 be replicated. Consequently, Amazon RDS will enter the "Replication degraded"
 state when a DDL change is detected.


### PR DESCRIPTION
A customer reported that using auto-user provisioning invalidates their blue/green deployment. adding a trouble shooting section on this.

also updated a few `AWX xxxx` to `Amazon xxx`