### PR TITLE
Move `@types/google-protobuf` from teleterm to build

### DIFF
--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -46,6 +46,7 @@
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.2",
+    "@types/google-protobuf": "^3.15.12",
     "@types/jest": "^29.5.12",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^20.12.11",
@@ -108,3 +109,4 @@
     "ts-loader": "^9.4.2"
   }
 }
+

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -39,7 +39,6 @@
     "@protobuf-ts/grpc-transport": "^2.9.4",
     "@protobuf-ts/runtime": "^2.9.4",
     "@protobuf-ts/runtime-rpc": "^2.9.4",
-    "@types/google-protobuf": "^3.15.12",
     "@types/node-forge": "^1.0.4",
     "@types/tar-fs": "^2.0.4",
     "@types/whatwg-url": "^11.0.5",


### PR DESCRIPTION
`@types/google-protobuf` was used by teleport.e, which suggests it might be a better idea to just move it to the `build` package which is used by both teleterm and teleport.e.