### PR TITLE
Refactor story decorators to enable use of useTheme within decorators

### DIFF
--- a/web/.storybook/preview.js
+++ b/web/.storybook/preview.js
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import { rest, setupWorker } from 'msw';
-import { addDecorator, addParameters } from '@storybook/react';
+import { addParameters } from '@storybook/react';
 import {
   darkTheme,
   lightTheme,
@@ -48,7 +48,7 @@ if (typeof global.process === 'undefined') {
 history.init();
 
 // wrap each story with theme provider
-const ThemeDecorator = (storyFn, meta) => {
+const ThemeDecorator = (Story, meta) => {
   let ThemeProvider;
   let theme;
 
@@ -75,27 +75,29 @@ const ThemeDecorator = (storyFn, meta) => {
 
   return (
     <ThemeProvider theme={theme}>
-      <Box p={3}>{storyFn()}</Box>
+      <Box p={3}>
+        <Story />
+      </Box>
     </ThemeProvider>
   );
 };
 
 // wrap stories with an argument of {userContext: true} with user context provider
-const UserDecorator = (storyFn, meta) => {
+const UserDecorator = (Story, meta) => {
   if (meta.args.userContext) {
     const UserProvider = UserContextProvider;
     return (
       <UserProvider>
-        <Box p={3}>{storyFn()}</Box>
+        <Story />
       </UserProvider>
     );
   }
 
-  return <Box p={3}>{storyFn()}</Box>;
+  return <Story />;
 };
 
-addDecorator(UserDecorator);
-addDecorator(ThemeDecorator);
+export const decorators = [UserDecorator, ThemeDecorator];
+
 addParameters({
   options: {
     showPanel: false,


### PR DESCRIPTION
The way our decorators were written made it so that calling `useTheme` within a decorator resulted in no theme being returned, likely because it wasn't able to read the theme from the context. 

I wanted to write a decorator which wrapped all of my stories in a `<Box>` of certain width and background color. In the end I realized that I can write just `<Box bg="levels.elevated" />` and that works too. But I decided to push a fix anyway.

[According to the docs](https://storybook.js.org/docs/6.5/writing-stories/decorators#decorator-inheritance), first the global decorators are executed and only then decorators defined within stories, so in theory it should all work.

What caught my attention was the fact that we defined decorators as components executing a story function instead of rendering a story component. I don't know exactly why this helps, but I've found https://github.com/storybookjs/storybook/issues/21777 and decided to give it a try. I think it works because now that stories are rendered as proper components, the contexts work as expected too within decorators themselves.

To verify this, apply the patch below and run `yarn storybook` on master and open the first story. It should fail because `theme` is undefined. Now check out to this branch, run `yarn storybook` again and verify that the story works as expected.

<details>
<summary>Patch</summary>

```diff
diff --git a/web/packages/teleport/src/AccessRequests/AccessRequests.story.tsx b/web/packages/teleport/src/AccessRequests/AccessRequests.story.tsx
index 30e8c2a52b5..f0b40888b9d 100644
--- a/web/packages/teleport/src/AccessRequests/AccessRequests.story.tsx
+++ b/web/packages/teleport/src/AccessRequests/AccessRequests.story.tsx
@@ -17,6 +17,9 @@
  */
 
 import React from 'react';
+import { useTheme } from 'styled-components';
+
+import { Box } from 'design';
 
 import { LockedAccessRequests } from 'teleport/AccessRequests/LockedAccessRequests/LockedAccessRequests';
 import { ContextProvider } from 'teleport';
@@ -24,6 +27,16 @@ import { createTeleportContext } from 'teleport/mocks/contexts';
 
 export default {
   title: 'Teleport/Access Requests',
+  decorators: [
+    Story => {
+      const theme = useTheme();
+      return (
+        <Box bg={theme.colors.success.main}>
+          <Story />
+        </Box>
+      );
+    },
+  ],
 };
 
 export const Locked = () => {

```
</details>

---

I also removed `<Box>` from `UserDecorator` as I deemed it unnecessary – `ThemeDecorator` already adds a box with padding.