### PR TITLE
[v16] Move @types/google-protobuf from teleterm to build

### DIFF
--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -46,6 +46,7 @@
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.1",
+    "@types/google-protobuf": "^3.15.12",
     "@types/jest": "^29.5.10",
     "@types/jsdom": "^21.1.6",
     "@types/node": "^20.12.11",

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -39,7 +39,6 @@
     "@protobuf-ts/grpc-transport": "^2.9.3",
     "@protobuf-ts/runtime": "^2.9.3",
     "@protobuf-ts/runtime-rpc": "^2.9.3",
-    "@types/google-protobuf": "^3.10.0",
     "@types/node-forge": "^1.0.4",
     "@types/tar-fs": "^2.0.1",
     "@types/whatwg-url": "^11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3990,10 +3990,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/google-protobuf@^3.10.0":
-  version "3.15.6"
-  resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.15.6.tgz#674a69493ef2c849b95eafe69167ea59079eb504"
-  integrity sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw==
+"@types/google-protobuf@^3.15.12":
+  version "3.15.12"
+  resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.15.12.tgz#eb2ba0eddd65712211a2b455dc6071d665ccf49b"
+  integrity sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ==
 
 "@types/graceful-fs@^4.1.3":
   version "4.1.8"


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/43106/files

I had to update the `yarn.lock` file 