### PR TITLE
[docs] generalize tctl token partial

### DIFF
--- a/docs/pages/auto-discovery/databases.mdx
+++ b/docs/pages/auto-discovery/databases.mdx
@@ -33,7 +33,7 @@ Auth Service and save it in `/tmp/token` on the host that will run the
 Discovery Service.
 
 ```code
-$ tctl tokens add --type=discovery
+$ tctl tokens add --type=discovery --format=text
 ```
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)

--- a/docs/pages/auto-discovery/databases.mdx
+++ b/docs/pages/auto-discovery/databases.mdx
@@ -26,15 +26,7 @@ discover AWS-hosted databases automatically.
 
 ## Step 1/4. Generate a join token
 
-The Discovery Service requires a valid join token to connect to the cluster.
-
-Generate a join token by running the following command against your Teleport
-Auth Service and save it in `/tmp/token` on the host that will run the
-Discovery Service.
-
-```code
-$ tctl tokens add --type=discovery --format=text
-```
+(!docs/pages/includes/tctl-token.mdx serviceName="Discovery" tokenType="discovery" tokenFile="/tmp/token" !)
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 

--- a/docs/pages/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
@@ -30,7 +30,7 @@ description: How to configure Teleport database access with Amazon Keyspaces (Ap
 
 ## Step 1/5. Set up the Teleport Database Service
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 

--- a/docs/pages/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
@@ -30,7 +30,7 @@ description: How to configure Teleport database access with Amazon Keyspaces (Ap
 
 ## Step 1/5. Set up the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 

--- a/docs/pages/database-access/enroll-aws-databases/aws-dynamodb.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-dynamodb.mdx
@@ -155,7 +155,7 @@ the correct STS endpoint.
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 ### Install and start Teleport
 

--- a/docs/pages/database-access/enroll-aws-databases/aws-dynamodb.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-dynamodb.mdx
@@ -155,7 +155,7 @@ the correct STS endpoint.
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 ### Install and start Teleport
 

--- a/docs/pages/database-access/enroll-aws-databases/aws-opensearch.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-opensearch.mdx
@@ -190,7 +190,7 @@ Teleport:
 
 </Details>
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 Use the token provided by the output of this command in the next step.
 

--- a/docs/pages/database-access/enroll-aws-databases/aws-opensearch.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-opensearch.mdx
@@ -190,7 +190,7 @@ Teleport:
 
 </Details>
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 Use the token provided by the output of this command in the next step.
 

--- a/docs/pages/database-access/enroll-aws-databases/postgres-redshift.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/postgres-redshift.mdx
@@ -42,7 +42,7 @@ automatically enroll all AWS databases in your infrastructure.
 
 ## Step 2/6. Create a Database Service configuration
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 

--- a/docs/pages/database-access/enroll-aws-databases/postgres-redshift.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/postgres-redshift.mdx
@@ -42,7 +42,7 @@ automatically enroll all AWS databases in your infrastructure.
 
 ## Step 2/6. Create a Database Service configuration
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 

--- a/docs/pages/database-access/enroll-aws-databases/redis-aws.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/redis-aws.mdx
@@ -58,7 +58,7 @@ databases in your infrastructure.
 
 ## Step 2/6. Create a Database Service configuration
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 

--- a/docs/pages/database-access/enroll-aws-databases/redis-aws.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/redis-aws.mdx
@@ -58,7 +58,7 @@ databases in your infrastructure.
 
 ## Step 2/6. Create a Database Service configuration
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 

--- a/docs/pages/database-access/enroll-aws-databases/sql-server-ad.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/sql-server-ad.mdx
@@ -205,7 +205,7 @@ KVNO Principal
 
 ## Step 4/7. Set up the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 (!docs/pages/includes/install-linux.mdx!)
 

--- a/docs/pages/database-access/enroll-aws-databases/sql-server-ad.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/sql-server-ad.mdx
@@ -205,7 +205,7 @@ KVNO Principal
 
 ## Step 4/7. Set up the Teleport Database Service
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 (!docs/pages/includes/install-linux.mdx!)
 

--- a/docs/pages/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
@@ -37,7 +37,7 @@ database.
 
 ## Step 1/5. Install the Teleport Database Service
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 Install Teleport on the host where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
@@ -37,7 +37,7 @@ database.
 
 ## Step 1/5. Install the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 Install Teleport on the host where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
@@ -122,7 +122,7 @@ Cloud documentation for more info.
 
 ### Create a join token
 
-(!docs/pages/includes/database-access/token.mdx tokenFile="/tmp/token" !)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token" !)
 
 ### (Optional) Download the Cloud SQL CA certificate
 

--- a/docs/pages/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
@@ -78,7 +78,7 @@ in Google Cloud documentation for more info.
 
 ### Create a join token
 
-(!docs/pages/includes/database-access/token.mdx tokenFile="/tmp/token"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 ### (Optional) Download the Cloud SQL CA certificate
 

--- a/docs/pages/database-access/enroll-google-cloud-databases/spanner.mdx
+++ b/docs/pages/database-access/enroll-google-cloud-databases/spanner.mdx
@@ -110,7 +110,7 @@ Select the "Service Account Token Creator" role and save the change:
 
 ## Step 4/8. Configure the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx tokenFile="/tmp/token" !)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token" !)
 
 Provide the following information and then generate a configuration file for the
 Teleport Database Service:

--- a/docs/pages/database-access/enroll-managed-databases/mongodb-atlas.mdx
+++ b/docs/pages/database-access/enroll-managed-databases/mongodb-atlas.mdx
@@ -36,7 +36,7 @@ forwards user traffic to MongoDB Atlas.
 
 ## Step 1/4. Set up the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 Install Teleport on the host where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-managed-databases/mongodb-atlas.mdx
+++ b/docs/pages/database-access/enroll-managed-databases/mongodb-atlas.mdx
@@ -36,7 +36,7 @@ forwards user traffic to MongoDB Atlas.
 
 ## Step 1/4. Set up the Teleport Database Service
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 Install Teleport on the host where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-managed-databases/snowflake.mdx
+++ b/docs/pages/database-access/enroll-managed-databases/snowflake.mdx
@@ -39,7 +39,7 @@ forwards the user's requests to Snowflake as Teleport-authenticated messages.
 
 ## Step 1/5. Set up the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-managed-databases/snowflake.mdx
+++ b/docs/pages/database-access/enroll-managed-databases/snowflake.mdx
@@ -39,7 +39,7 @@ forwards the user's requests to Snowflake as Teleport-authenticated messages.
 
 ## Step 1/5. Set up the Teleport Database Service
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
@@ -31,7 +31,7 @@ description: How to configure Teleport database access with Cassandra and Scylla
 
 ## Step 1/5. Set up the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
@@ -31,7 +31,7 @@ description: How to configure Teleport database access with Cassandra and Scylla
 
 ## Step 1/5. Set up the Teleport Database Service
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
@@ -58,7 +58,7 @@ choose:
 
 ## Step 1/5. Create a Teleport token and user
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 (!docs/pages/includes/database-access/create-user.mdx!)
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
@@ -58,7 +58,7 @@ choose:
 
 ## Step 1/5. Create a Teleport token and user
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 (!docs/pages/includes/database-access/create-user.mdx!)
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted.mdx
@@ -37,7 +37,7 @@ description: How to configure Teleport database access with self-hosted Cockroac
 
 ## Step 1/4. Set up the Teleport Database Service
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted.mdx
@@ -37,7 +37,7 @@ description: How to configure Teleport database access with self-hosted Cockroac
 
 ## Step 1/4. Set up the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/elastic.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/elastic.mdx
@@ -26,7 +26,7 @@ description: How to configure Teleport database access with Elasticsearch.
 
 ## Step 1/5. Set up the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/elastic.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/elastic.mdx
@@ -26,7 +26,7 @@ description: How to configure Teleport database access with Elasticsearch.
 
 ## Step 1/5. Set up the Teleport Database Service
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
@@ -44,7 +44,7 @@ videoBanner: 6lgVObxoLkc
 
 ### Set up the Teleport Database service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
@@ -44,7 +44,7 @@ videoBanner: 6lgVObxoLkc
 
 ### Set up the Teleport Database service
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
@@ -32,7 +32,7 @@ description: How to configure Teleport database access with self-hosted MySQL/Ma
 
 ## Step 1/4. Create the Teleport Database Token
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 ## Step 2/4. Create a certificate/key pair
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
@@ -32,7 +32,7 @@ description: How to configure Teleport database access with self-hosted MySQL/Ma
 
 ## Step 1/4. Create the Teleport Database Token
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 ## Step 2/4. Create a certificate/key pair
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
@@ -30,7 +30,7 @@ description: How to configure Teleport database access with Oracle.
 
 ## Step 1/6. Create a Teleport token and user
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 <Admonition type="tip">
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
@@ -30,7 +30,7 @@ description: How to configure Teleport database access with Oracle.
 
 ## Step 1/6. Create a Teleport token and user
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 <Admonition type="tip">
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
@@ -33,7 +33,7 @@ description: How to configure Teleport database access with self-hosted PostgreS
 
 ## Step 1/5. Create a Teleport token and user
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 ### Create a Teleport user
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
@@ -33,7 +33,7 @@ description: How to configure Teleport database access with self-hosted PostgreS
 
 ## Step 1/5. Create a Teleport token and user
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 ### Create a Teleport user
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/redis-cluster.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/redis-cluster.mdx
@@ -44,7 +44,7 @@ If you want to configure Redis Standalone, please read [Database Access with Red
 
 ## Step 1/6. Set up the Teleport Database Service
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/redis-cluster.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/redis-cluster.mdx
@@ -44,7 +44,7 @@ If you want to configure Redis Standalone, please read [Database Access with Red
 
 ## Step 1/6. Set up the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/redis.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/redis.mdx
@@ -44,7 +44,7 @@ If you want to configure Redis Cluster, please read [Database Access with Redis 
 
 ## Step 1/5. Set up the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/redis.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/redis.mdx
@@ -44,7 +44,7 @@ If you want to configure Redis Cluster, please read [Database Access with Redis 
 
 ## Step 1/5. Set up the Teleport Database Service
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 Install and configure Teleport where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/sql-server-ad-pkinit.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/sql-server-ad-pkinit.mdx
@@ -208,7 +208,7 @@ from there, you can copy and use it on your database configuration.
 
 ## Step 4/7. Set up the Teleport Database Service
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 Install Teleport on the host where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/sql-server-ad-pkinit.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/sql-server-ad-pkinit.mdx
@@ -208,7 +208,7 @@ from there, you can copy and use it on your database configuration.
 
 ## Step 4/7. Set up the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 Install Teleport on the host where you will run the Teleport Database Service:
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/vitess.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/vitess.mdx
@@ -37,7 +37,7 @@ description: How to configure Teleport database access for Vitess (MySQL protoco
 
 ## Step 1/4. Create the Teleport Database Token
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 ## Step 2/4. Create a certificate/key pair
 

--- a/docs/pages/database-access/enroll-self-hosted-databases/vitess.mdx
+++ b/docs/pages/database-access/enroll-self-hosted-databases/vitess.mdx
@@ -37,7 +37,7 @@ description: How to configure Teleport database access for Vitess (MySQL protoco
 
 ## Step 1/4. Create the Teleport Database Token
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 ## Step 2/4. Create a certificate/key pair
 

--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -87,7 +87,7 @@ See the [Automatic User Provisioning](./rbac.mdx) guide for how to configure Tel
 
 ## Step 2/5. Configure the Teleport Database Service
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 

--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -87,7 +87,7 @@ See the [Automatic User Provisioning](./rbac.mdx) guide for how to configure Tel
 
 ## Step 2/5. Configure the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 

--- a/docs/pages/includes/database-access/rds-proxy.mdx
+++ b/docs/pages/includes/database-access/rds-proxy.mdx
@@ -40,7 +40,7 @@ automatically enroll all AWS databases in your infrastructure.
 
 ## Step 2/7. Create a Teleport Database Service configuration
 
-(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 

--- a/docs/pages/includes/database-access/rds-proxy.mdx
+++ b/docs/pages/includes/database-access/rds-proxy.mdx
@@ -40,7 +40,7 @@ automatically enroll all AWS databases in your infrastructure.
 
 ## Step 2/7. Create a Teleport Database Service configuration
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db"!)
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 

--- a/docs/pages/includes/database-access/token.mdx
+++ b/docs/pages/includes/database-access/token.mdx
@@ -1,9 +1,0 @@
-{{ tokenFile="/tmp/token" }}
-
-The Database Service requires a valid join token to join your Teleport cluster.
-Run the following `tctl` command and save the token output in `{{ tokenFile }}`
-on the server that will run the Database Service:
-
-```code
-$ tctl tokens add --type=db --format=text
-```

--- a/docs/pages/includes/tctl-token.mdx
+++ b/docs/pages/includes/tctl-token.mdx
@@ -1,5 +1,3 @@
-{{ tokenFile="/tmp/token" }}
-
 The {{ serviceName }} Service requires a valid join token to join your Teleport cluster.
 Run the following `tctl` command and save the token output in `{{ tokenFile }}`
 on the server that will run the {{ serviceName }} Service:

--- a/docs/pages/includes/tctl-token.mdx
+++ b/docs/pages/includes/tctl-token.mdx
@@ -1,0 +1,10 @@
+{{ tokenFile="/tmp/token" }}
+
+The {{ serviceName }} Service requires a valid join token to join your Teleport cluster.
+Run the following `tctl` command and save the token output in `{{ tokenFile }}`
+on the server that will run the {{ serviceName }} Service:
+
+```code
+$ tctl tokens add --type={{ tokenType }} --format=text
+(=presets.tokens.first=)
+```


### PR DESCRIPTION
This is a docs only PR that moves the join token partial from `includes/database-access/token.mdx` to `includes/tctl-token.mdx` and generalizes the partial by teleport service.
I then use the same token in the discovery guide.

I extracted this from the larger docs work I'm doing because it touches a lot of files.

Related:
- https://github.com/gravitational/teleport/issues/41004

