### PR TITLE
[docs] update discovery config references

### DIFF
--- a/docs/pages/auto-discovery/kubernetes.mdx
+++ b/docs/pages/auto-discovery/kubernetes.mdx
@@ -83,12 +83,12 @@ discovery_service:
        # This value is an optional AWS role ARN to assume when polling EKS clusters
        assume_role_arn: arn:aws:iam::123456789012:role/iam-discovery-role
        # External ID is an optional value that should be set when accessing
-	     # your AWS account from a third-party service (delegated access).
+       # your AWS account from a third-party service (delegated access).
        external_id: "example-external-id"
-       # Specifies the role for which the Discovery Service should create the EKS access entry.
-       # This is an optional parameter. If not set, the Discovery Service will attempt to create
-       # the access entry using its own identity.
-       # If used, the role must match the role configured for the Kubernetes Service.
+       # Optional role for which the Discovery Service should create the EKS access entry.
+       # If not set, the Discovery Service will attempt to create the access
+       # entry using its own identity.
+       # If used, the role must match the role configured for a Teleport Kubernetes Service.
        setup_access_for_arn: arn:aws:iam::123456789012:role/kube-service-role
     # Matchers for discovering Azure-hosted resources.
     azure:

--- a/docs/pages/includes/discovery/discovery-config.yaml
+++ b/docs/pages/includes/discovery/discovery-config.yaml
@@ -1,10 +1,13 @@
 discovery_service:
     enabled: "yes"
     # discovery_group is used to group discovered resources into different
-    # sets. This is useful when you have multiple Teleport Discovery services
-    # running in the same cluster but polling different cloud providers or cloud
-    # accounts. It prevents discovered services from colliding in Teleport when
+    # sets. This is required when you have multiple Teleport Discovery services
+    # running. It prevents discovered services from colliding in Teleport when
     # managing discovered resources.
+    # If two Discovery Services match the same resources, they must be in the
+    # same discovery group.
+    # If two Discovery Services match different resources, they must be in
+    # different discovery groups.
     discovery_group: "disc-group"
     # poll_interval is the cadence at which the discovery server will run each of its
     # discovery cycles. The default is 5m.
@@ -51,6 +54,11 @@ discovery_service:
         # executed when installing teleport on matching nodes
         # Optional, defaults to: "TeleportDiscoveryInstaller".
         document_name: "TeleportDiscoveryInstaller"
+      # Optional role for which the Discovery Service should create the EKS access entry.
+      # If not set, the Discovery Service will attempt to create the access
+      # entry using its own identity.
+      # If used, the role must match the role configured for a Teleport Kubernetes Service.
+      setup_access_for_arn: arn:aws:iam::123456789012:role/kube-service-role
     # Matchers for discovering Azure-hosted resources.
     azure:
       # Azure resource types. Valid options are:


### PR DESCRIPTION
This is a docs only PR that:
* adds more explanation for discovery_group
* document `setup_access_for_arn` for our EKS bootstrap

I'll be sure to remove the `setup_access_for_arn` reference when I backport this to v14, since that was added in v15.

Related to docs work for:
- https://github.com/gravitational/teleport/issues/41004