### PR TITLE
prep for auth keystore config changes

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -3768,15 +3768,10 @@ func TestCAGeneration(t *testing.T) {
 	privKey, pubKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
 
-	ksConfig := keystore.Config{
-		Software: keystore.SoftwareConfig{
-			RSAKeyPairSource: func() (priv []byte, pub []byte, err error) {
-				return privKey, pubKey, nil
-			},
-		},
+	rsaKeyPairSource := func() (priv []byte, pub []byte, err error) {
+		return privKey, pubKey, nil
 	}
-	keyStore, err := keystore.NewManager(ctx, ksConfig)
-	require.NoError(t, err)
+	keyStore := keystore.NewSoftwareKeystoreForTests(t, keystore.WithRSAKeyPairSource(rsaKeyPairSource))
 
 	for _, caType := range types.CertAuthTypes {
 		t.Run(string(caType), func(t *testing.T) {

--- a/lib/auth/keystore/keystore_test.go
+++ b/lib/auth/keystore/keystore_test.go
@@ -419,7 +419,7 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 	softwareConfig := Config{Software: SoftwareConfig{
 		RSAKeyPairSource: native.GenerateKeyPair,
 	}}
-	softwareBackend := newSoftwareKeyStore(&softwareConfig.Software, logger)
+	softwareBackend := newSoftwareKeyStore(&softwareConfig.Software)
 	backends = append(backends, &backendDesc{
 		name:                "software",
 		config:              softwareConfig,

--- a/lib/auth/keystore/manager.go
+++ b/lib/auth/keystore/manager.go
@@ -142,7 +142,7 @@ func NewManager(ctx context.Context, cfg Config) (*Manager, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	softwareBackend := newSoftwareKeyStore(&cfg.Software, cfg.Logger)
+	softwareBackend := newSoftwareKeyStore(&cfg.Software)
 
 	if (cfg.PKCS11 != PKCS11Config{}) {
 		pkcs11Backend, err := newPKCS11KeyStore(&cfg.PKCS11, cfg.Logger)

--- a/lib/auth/keystore/software.go
+++ b/lib/auth/keystore/software.go
@@ -23,7 +23,6 @@ import (
 	"crypto"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/native"
@@ -48,7 +47,7 @@ func (cfg *SoftwareConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
-func newSoftwareKeyStore(config *SoftwareConfig, logger logrus.FieldLogger) *softwareKeyStore {
+func newSoftwareKeyStore(config *SoftwareConfig) *softwareKeyStore {
 	return &softwareKeyStore{
 		rsaKeyPairSource: config.RSAKeyPairSource,
 	}

--- a/lib/auth/keystore/testhelpers.go
+++ b/lib/auth/keystore/testhelpers.go
@@ -189,3 +189,29 @@ func softHSMTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
 	}
 	return *cachedSoftHSMConfig, true
 }
+
+type testKeystoreOptions struct {
+	rsaKeyPairSource RSAKeyPairSource
+}
+
+type TestKeystoreOption func(*testKeystoreOptions)
+
+func WithRSAKeyPairSource(rsaKeyPairSource RSAKeyPairSource) TestKeystoreOption {
+	return func(opts *testKeystoreOptions) {
+		opts.rsaKeyPairSource = rsaKeyPairSource
+	}
+}
+
+// NewSoftwareKeystoreForTests returns a new *Manager that is valid for tests not specifically testing the
+// keystore functionality.
+func NewSoftwareKeystoreForTests(_ *testing.T, opts ...TestKeystoreOption) *Manager {
+	var options testKeystoreOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	softwareBackend := newSoftwareKeyStore(&SoftwareConfig{RSAKeyPairSource: options.rsaKeyPairSource})
+	return &Manager{
+		backendForNewKeys:     softwareBackend,
+		usableSigningBackends: []backend{softwareBackend},
+	}
+}


### PR DESCRIPTION
This PR prepares for upcoming changes to the auth keystore config, by providing a way to create a software keystore for use in tests without referencing `keystore.Config`. This is necessary so that those references can be removed from teleport.e before they are modified in a following PR.

e PR: https://github.com/gravitational/teleport.e/pull/4425