### PR TITLE
refactor keystore config

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -115,11 +115,6 @@ func newTestPack(
 		Authority:              testauthority.New(),
 		Emitter:                p.mockEmitter,
 		SkipPeriodicOperations: true,
-		KeyStoreConfig: keystore.Config{
-			Software: keystore.SoftwareConfig{
-				RSAKeyPairSource: testauthority.New().GenerateKeyPair,
-			},
-		},
 	}
 	p.a, err = NewServer(authConfig, opts...)
 	if err != nil {
@@ -979,11 +974,6 @@ func TestUpdateConfig(t *testing.T) {
 		Backend:                s.bk,
 		Authority:              testauthority.New(),
 		SkipPeriodicOperations: true,
-		KeyStoreConfig: keystore.Config{
-			Software: keystore.SoftwareConfig{
-				RSAKeyPairSource: testauthority.New().GenerateKeyPair,
-			},
-		},
 	}
 	authServer, err := NewServer(authConfig)
 	require.NoError(t, err)
@@ -3763,15 +3753,15 @@ func TestCAGeneration(t *testing.T) {
 		clusterName = "cluster1"
 		HostUUID    = "0000-000-000-0000"
 	)
-	native.PrecomputeKeys()
 	// Cache key for better performance as we don't care about the value being unique.
 	privKey, pubKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
 
-	rsaKeyPairSource := func() (priv []byte, pub []byte, err error) {
-		return privKey, pubKey, nil
-	}
-	keyStore := keystore.NewSoftwareKeystoreForTests(t, keystore.WithRSAKeyPairSource(rsaKeyPairSource))
+	keyStore := keystore.NewSoftwareKeystoreForTests(t,
+		keystore.WithRSAKeyPairSource(func() (priv []byte, pub []byte, err error) {
+			return privKey, pubKey, nil
+		}),
+	)
 
 	for _, caType := range types.CertAuthTypes {
 		t.Run(string(caType), func(t *testing.T) {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -5687,7 +5687,7 @@ func TestGenerateHostCert(t *testing.T) {
 // the first available identity.
 func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 	srv, err := NewTestAuthServer(TestAuthServerConfig{Dir: t.TempDir()})
-	require.NoError(t, err)
+	require.NoError(t, err, trace.DebugReport(err))
 
 	roles := types.LocalServiceMappings()
 	for _, role := range roles {

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/auth/keystore"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
@@ -82,11 +81,6 @@ func setupGithubContext(ctx context.Context, t *testing.T) *githubContext {
 		Backend:                tt.b,
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
-		KeyStoreConfig: keystore.Config{
-			Software: keystore.SoftwareConfig{
-				RSAKeyPairSource: authority.New().GenerateKeyPair,
-			},
-		},
 	}
 	tt.a, err = NewServer(authConfig)
 	require.NoError(t, err)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -57,6 +57,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/srv/db/common/databaseobjectimportrule"
@@ -80,7 +81,7 @@ type InitConfig struct {
 
 	// KeyStoreConfig is the config for the KeyStore which handles private CA
 	// keys that may be held in an HSM.
-	KeyStoreConfig keystore.Config
+	KeyStoreConfig servicecfg.KeystoreConfig
 
 	// HostUUID is a UUID of this host
 	HostUUID string

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
-	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend"
@@ -1027,12 +1026,7 @@ func setupConfig(t *testing.T) InitConfig {
 		StaticTokens:            types.DefaultStaticTokens(),
 		AuthPreference:          types.DefaultAuthPreference(),
 		SkipPeriodicOperations:  true,
-		KeyStoreConfig: keystore.Config{
-			Software: keystore.SoftwareConfig{
-				RSAKeyPairSource: testauthority.New().GenerateKeyPair,
-			},
-		},
-		Tracer: tracing.NoopTracer(teleport.ComponentAuth),
+		Tracer:                  tracing.NoopTracer(teleport.ComponentAuth),
 	}
 }
 

--- a/lib/auth/integration/integrationv1/service_test.go
+++ b/lib/auth/integration/integrationv1/service_test.go
@@ -428,13 +428,6 @@ func initSvc(t *testing.T, ca types.CertAuthority, clusterName string, proxyPubl
 	cacheResourceService, err := local.NewIntegrationsService(backend, local.WithIntegrationsServiceCacheMode(true))
 	require.NoError(t, err)
 
-	keystoreManager, err := keystore.NewManager(ctx, keystore.Config{
-		Software: keystore.SoftwareConfig{
-			RSAKeyPairSource: testauthority.New().GenerateKeyPair,
-		},
-	})
-	require.NoError(t, err)
-
 	cache := &mockCache{
 		domainName: clusterName,
 		ca:         ca,
@@ -450,7 +443,7 @@ func initSvc(t *testing.T, ca types.CertAuthority, clusterName string, proxyPubl
 		Backend:         localResourceService,
 		Authorizer:      authorizer,
 		Cache:           cache,
-		KeyStoreManager: keystoreManager,
+		KeyStoreManager: keystore.NewSoftwareKeystoreForTests(t),
 	})
 	require.NoError(t, err)
 

--- a/lib/auth/keystore/aws_kms.go
+++ b/lib/auth/keystore/aws_kms.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"slices"
 	"strings"
 	"sync"
@@ -36,13 +37,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/cloud"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
 const (
@@ -61,48 +62,17 @@ type CloudClientProvider interface {
 	GetAWSKMSClient(ctx context.Context, region string, opts ...cloud.AWSOptionsFn) (kmsiface.KMSAPI, error)
 }
 
-// AWSKMSConfig holds configuration parameters specific to AWS KMS keystores.
-type AWSKMSConfig struct {
-	Cluster    string
-	AWSAccount string
-	AWSRegion  string
-
-	CloudClients CloudClientProvider
-	clock        clockwork.Clock
-}
-
-// CheckAndSetDefaults checks that required parameters of the config are
-// properly set and sets defaults.
-func (c *AWSKMSConfig) CheckAndSetDefaults() error {
-	if c.Cluster == "" {
-		return trace.BadParameter("cluster is required")
-	}
-	if c.AWSAccount == "" {
-		return trace.BadParameter("AWS account is required")
-	}
-	if c.AWSRegion == "" {
-		return trace.BadParameter("AWS region is required")
-	}
-	if c.CloudClients == nil {
-		return trace.BadParameter("CloudClients is required")
-	}
-	if c.clock == nil {
-		c.clock = clockwork.NewRealClock()
-	}
-	return nil
-}
-
 type awsKMSKeystore struct {
-	kms        kmsiface.KMSAPI
-	cluster    string
-	awsAccount string
-	awsRegion  string
-	clock      clockwork.Clock
-	logger     logrus.FieldLogger
+	kms         kmsiface.KMSAPI
+	clusterName types.ClusterName
+	awsAccount  string
+	awsRegion   string
+	clock       clockwork.Clock
+	logger      *slog.Logger
 }
 
-func newAWSKMSKeystore(ctx context.Context, cfg *AWSKMSConfig, logger logrus.FieldLogger) (*awsKMSKeystore, error) {
-	stsClient, err := cfg.CloudClients.GetAWSSTSClient(ctx, cfg.AWSRegion, cloud.WithAmbientCredentials())
+func newAWSKMSKeystore(ctx context.Context, cfg *servicecfg.AWSKMSConfig, opts *Options) (*awsKMSKeystore, error) {
+	stsClient, err := opts.CloudClients.GetAWSSTSClient(ctx, cfg.AWSRegion, cloud.WithAmbientCredentials())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -114,17 +84,21 @@ func newAWSKMSKeystore(ctx context.Context, cfg *AWSKMSConfig, logger logrus.Fie
 		return nil, trace.BadParameter("configured AWS KMS account %q does not match AWS account of ambient credentials %q",
 			cfg.AWSAccount, aws.StringValue(id.Account))
 	}
-	kmsClient, err := cfg.CloudClients.GetAWSKMSClient(ctx, cfg.AWSRegion, cloud.WithAmbientCredentials())
+	kmsClient, err := opts.CloudClients.GetAWSKMSClient(ctx, cfg.AWSRegion, cloud.WithAmbientCredentials())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	clock := opts.clockworkOverride
+	if clock == nil {
+		clock = clockwork.NewRealClock()
+	}
 	return &awsKMSKeystore{
-		cluster:    cfg.Cluster,
-		awsAccount: cfg.AWSAccount,
-		awsRegion:  cfg.AWSRegion,
-		kms:        kmsClient,
-		clock:      cfg.clock,
-		logger:     logger,
+		clusterName: opts.ClusterName,
+		awsAccount:  cfg.AWSAccount,
+		awsRegion:   cfg.AWSRegion,
+		kms:         kmsClient,
+		clock:       clock,
+		logger:      opts.Logger,
 	}, nil
 }
 
@@ -134,10 +108,9 @@ func (a *awsKMSKeystore) keyTypeDescription() string {
 	return fmt.Sprintf("AWS KMS keys in account %s and region %s", a.awsAccount, a.awsRegion)
 }
 
-// generateRSA creates a new RSA private key and returns its identifier and
-// a crypto.Signer. The returned identifier can be passed to getSigner
-// later to get the same crypto.Signer.
-func (a *awsKMSKeystore) generateRSA(ctx context.Context, opts ...RSAKeyOption) ([]byte, crypto.Signer, error) {
+// generateRSA creates a new RSA private key and returns its identifier and a crypto.Signer. The returned
+// identifier can be passed to getSigner later to get an equivalent crypto.Signer.
+func (a *awsKMSKeystore) generateRSA(ctx context.Context, _ ...rsaKeyOption) ([]byte, crypto.Signer, error) {
 	output, err := a.kms.CreateKey(&kms.CreateKeyInput{
 		Description: aws.String("Teleport CA key"),
 		KeySpec:     aws.String("RSA_2048"),
@@ -145,7 +118,7 @@ func (a *awsKMSKeystore) generateRSA(ctx context.Context, opts ...RSAKeyOption) 
 		Tags: []*kms.Tag{
 			{
 				TagKey:   aws.String(clusterTagKey),
-				TagValue: aws.String(a.cluster),
+				TagValue: aws.String(a.clusterName.GetClusterName()),
 			},
 		},
 	})
@@ -235,7 +208,7 @@ func (a *awsKMSKeystore) getPublicKeyDER(ctx context.Context, keyARN string) ([]
 		startedWaiting := a.clock.Now()
 		select {
 		case t := <-retry.After():
-			a.logger.Debugf("Failed to fetch public key for %q, retrying after waiting %v", keyARN, t.Sub(startedWaiting))
+			a.logger.DebugContext(ctx, "Failed to fetch public key, retrying", "key_arn", keyARN, "retry_interval", t.Sub(startedWaiting))
 			retry.Inc()
 		case <-ctx.Done():
 			return nil, trace.Wrap(ctx.Err())
@@ -372,7 +345,7 @@ func (a *awsKMSKeystore) deleteUnusedKeys(ctx context.Context, activeKeys [][]by
 			return trace.Wrap(err, "failed to fetch tags for AWS KMS key %q", keyARN)
 		}
 		if !slices.ContainsFunc(output.Tags, func(tag *kms.Tag) bool {
-			return aws.StringValue(tag.TagKey) == clusterTagKey && aws.StringValue(tag.TagValue) == a.cluster
+			return aws.StringValue(tag.TagKey) == clusterTagKey && aws.StringValue(tag.TagValue) == a.clusterName.GetClusterName()
 		}) {
 			// This key was not created by this Teleport cluster, never delete it.
 			return nil
@@ -389,10 +362,8 @@ func (a *awsKMSKeystore) deleteUnusedKeys(ctx context.Context, activeKeys [][]by
 			return trace.Errorf("failed to describe AWS KMS key %q", keyARN)
 		}
 		if keyState := aws.StringValue(describeOutput.KeyMetadata.KeyState); keyState != "Enabled" {
-			a.logger.WithFields(logrus.Fields{
-				"key_arn":   keyARN,
-				"key_state": keyState,
-			}).Info("deleteUnusedKeys skipping AWS KMS key which is not in enabled state.")
+			a.logger.InfoContext(ctx, "deleteUnusedKeys skipping AWS KMS key which is not in enabled state.",
+				"key_arn", keyARN, "key_state", keyState)
 			return nil
 		}
 		creationDate := aws.TimeValue(describeOutput.KeyMetadata.CreationDate)
@@ -400,9 +371,8 @@ func (a *awsKMSKeystore) deleteUnusedKeys(ctx context.Context, activeKeys [][]by
 			// Never delete keys created in the last 5 minutes in case they were
 			// created by a different auth server and just haven't been added to
 			// the backend CA yet (which is why they don't appear in activeKeys).
-			a.logger.WithFields(logrus.Fields{
-				"key_arn": keyARN,
-			}).Info("deleteUnusedKeys skipping AWS KMS key which was created in the past 5 minutes.")
+			a.logger.InfoContext(ctx, "deleteUnusedKeys skipping AWS KMS key which was created in the past 5 minutes.",
+				"key_arn", keyARN)
 			return nil
 		}
 
@@ -427,7 +397,7 @@ func (a *awsKMSKeystore) deleteUnusedKeys(ctx context.Context, activeKeys [][]by
 	}
 
 	for _, keyARN := range keysToDelete {
-		a.logger.WithField("key_arn", keyARN).Info("Deleting unused AWS KMS key.")
+		a.logger.InfoContext(ctx, "Deleting unused AWS KMS key.", "key_arn", keyARN)
 		if _, err := a.kms.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
 			KeyId:               aws.String(keyARN),
 			PendingWindowInDays: aws.Int64(7),

--- a/lib/auth/keystore/aws_kms_test.go
+++ b/lib/auth/keystore/aws_kms_test.go
@@ -39,7 +39,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -55,21 +58,26 @@ func TestAWSKMS_DeleteUnusedKeys(t *testing.T) {
 
 	const pageSize int = 4
 	fakeKMS := newFakeAWSKMSService(t, clock, "123456789012", "us-west-2", pageSize)
-	cfg := Config{
-		AWSKMS: AWSKMSConfig{
-			Cluster:    "test-cluster",
+	cfg := servicecfg.KeystoreConfig{
+		AWSKMS: servicecfg.AWSKMSConfig{
 			AWSAccount: "123456789012",
 			AWSRegion:  "us-west-2",
-			CloudClients: &cloud.TestCloudClients{
-				KMS: fakeKMS,
-				STS: &fakeAWSSTSClient{
-					account: "123456789012",
-				},
-			},
-			clock: clock,
 		},
 	}
-	keyStore, err := NewManager(ctx, cfg)
+	clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{ClusterName: "test-cluster"})
+	require.NoError(t, err)
+	opts := &Options{
+		ClusterName: clusterName,
+		HostUUID:    "uuid",
+		CloudClients: &cloud.TestCloudClients{
+			KMS: fakeKMS,
+			STS: &fakeAWSSTSClient{
+				account: "123456789012",
+			},
+		},
+		clockworkOverride: clock,
+	}
+	keyStore, err := NewManager(ctx, &cfg, opts)
 	require.NoError(t, err)
 
 	totalKeys := pageSize * 3
@@ -120,20 +128,25 @@ func TestAWSKMS_DeleteUnusedKeys(t *testing.T) {
 
 func TestAWSKMS_WrongAccount(t *testing.T) {
 	clock := clockwork.NewFakeClock()
-	cfg := Config{
-		AWSKMS: AWSKMSConfig{
-			Cluster:    "test-cluster",
+	cfg := &servicecfg.KeystoreConfig{
+		AWSKMS: servicecfg.AWSKMSConfig{
 			AWSAccount: "111111111111",
 			AWSRegion:  "us-west-2",
-			CloudClients: &cloud.TestCloudClients{
-				KMS: newFakeAWSKMSService(t, clock, "222222222222", "us-west-2", 1000),
-				STS: &fakeAWSSTSClient{
-					account: "222222222222",
-				},
+		},
+	}
+	clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{ClusterName: "test-cluster"})
+	require.NoError(t, err)
+	opts := &Options{
+		ClusterName: clusterName,
+		HostUUID:    "uuid",
+		CloudClients: &cloud.TestCloudClients{
+			KMS: newFakeAWSKMSService(t, clock, "222222222222", "us-west-2", 1000),
+			STS: &fakeAWSSTSClient{
+				account: "222222222222",
 			},
 		},
 	}
-	_, err := NewManager(context.Background(), cfg)
+	_, err = NewManager(context.Background(), cfg, opts)
 	require.ErrorIs(t, err, trace.BadParameter(`configured AWS KMS account "111111111111" does not match AWS account of ambient credentials "222222222222"`))
 }
 
@@ -147,21 +160,26 @@ func TestAWSKMS_RetryWhilePending(t *testing.T) {
 		region:    "us-west-2",
 		pageLimit: 1000,
 	}
-	cfg := Config{
-		AWSKMS: AWSKMSConfig{
-			Cluster:    "test-cluster",
+	cfg := &servicecfg.KeystoreConfig{
+		AWSKMS: servicecfg.AWSKMSConfig{
 			AWSAccount: "111111111111",
 			AWSRegion:  "us-west-2",
-			CloudClients: &cloud.TestCloudClients{
-				KMS: kms,
-				STS: &fakeAWSSTSClient{
-					account: "111111111111",
-				},
-			},
-			clock: clock,
 		},
 	}
-	manager, err := NewManager(context.Background(), cfg)
+	clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{ClusterName: "test-cluster"})
+	require.NoError(t, err)
+	opts := &Options{
+		ClusterName: clusterName,
+		HostUUID:    "uuid",
+		CloudClients: &cloud.TestCloudClients{
+			KMS: kms,
+			STS: &fakeAWSSTSClient{
+				account: "111111111111",
+			},
+		},
+		clockworkOverride: clock,
+	}
+	manager, err := NewManager(ctx, cfg, opts)
 	require.NoError(t, err)
 
 	// Test with one retry required.

--- a/lib/auth/keystore/gcp_kms.go
+++ b/lib/auth/keystore/gcp_kms.go
@@ -56,8 +56,8 @@ type pendingRetryTag struct{}
 
 var (
 	gcpKMSProtectionLevels = map[string]kmspb.ProtectionLevel{
-		"SOFTWARE": kmspb.ProtectionLevel_SOFTWARE,
-		"HSM":      kmspb.ProtectionLevel_HSM,
+		servicecfg.GCPKMSProtectionLevelHSM:      kmspb.ProtectionLevel_HSM,
+		servicecfg.GCPKMSProtectionLevelSoftware: kmspb.ProtectionLevel_SOFTWARE,
 	}
 )
 

--- a/lib/auth/keystore/gcp_kms.go
+++ b/lib/auth/keystore/gcp_kms.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -33,12 +34,11 @@ import (
 	"cloud.google.com/go/kms/apiv1/kmspb"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/keystore/internal/faketime"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
 const (
@@ -61,54 +61,21 @@ var (
 	}
 )
 
-// GCPKMS holds configuration parameters specific to GCP KMS keystores.
-type GCPKMSConfig struct {
-	// KeyRing is the fully qualified name of the GCP KMS keyring.
-	KeyRing string
-	// ProtectionLevel specifies how cryptographic operations are performed.
-	// For more information, see https://cloud.google.com/kms/docs/algorithms#protection_levels
-	// Supported options are "HSM" and "SOFTWARE".
-	ProtectionLevel string
-	// HostUUID is the UUID of the teleport host (auth server) running this
-	// keystore. Used to label keys so that they can be queried and deleted per
-	// server without races when multiple auth servers are configured with the
-	// same KeyRing.
-	HostUUID string
-
-	kmsClientOverride *kms.KeyManagementClient
-	clockOverride     faketime.Clock
-}
-
-func (cfg *GCPKMSConfig) CheckAndSetDefaults() error {
-	if cfg.KeyRing == "" {
-		return trace.BadParameter("must provide a valid KeyRing to GCPKMSConfig")
-	}
-	if _, ok := gcpKMSProtectionLevels[cfg.ProtectionLevel]; !ok {
-		return trace.BadParameter("unsupported ProtectionLevel %s", cfg.ProtectionLevel)
-	}
-	if cfg.HostUUID == "" {
-		return trace.BadParameter("must provide a valid HostUUID to GCPKMSConfig")
-	}
-	return nil
-}
-
 type gcpKMSKeyStore struct {
 	hostUUID        string
 	keyRing         string
 	protectionLevel kmspb.ProtectionLevel
 	kmsClient       *kms.KeyManagementClient
-	log             logrus.FieldLogger
+	log             *slog.Logger
 	clock           faketime.Clock
 	waiting         chan struct{}
 }
 
 // newGCPKMSKeyStore returns a new keystore configured to use a GCP KMS keyring
 // to manage all key material.
-func newGCPKMSKeyStore(ctx context.Context, cfg *GCPKMSConfig, logger logrus.FieldLogger) (*gcpKMSKeyStore, error) {
-	var kmsClient *kms.KeyManagementClient
-	if cfg.kmsClientOverride != nil {
-		kmsClient = cfg.kmsClientOverride
-	} else {
+func newGCPKMSKeyStore(ctx context.Context, cfg *servicecfg.GCPKMSConfig, opts *Options) (*gcpKMSKeyStore, error) {
+	kmsClient := opts.kmsClient
+	if kmsClient == nil {
 		var err error
 		kmsClient, err = kms.NewKeyManagementClient(ctx)
 		if err != nil {
@@ -116,21 +83,17 @@ func newGCPKMSKeyStore(ctx context.Context, cfg *GCPKMSConfig, logger logrus.Fie
 		}
 	}
 
-	var clock faketime.Clock
-	if cfg.clockOverride == nil {
+	clock := opts.faketimeOverride
+	if clock == nil {
 		clock = faketime.NewRealClock()
-	} else {
-		clock = cfg.clockOverride
 	}
 
-	logger = logger.WithFields(logrus.Fields{teleport.ComponentKey: "GCPKMSKeyStore"})
-
 	return &gcpKMSKeyStore{
-		hostUUID:        cfg.HostUUID,
+		hostUUID:        opts.HostUUID,
 		keyRing:         cfg.KeyRing,
 		protectionLevel: gcpKMSProtectionLevels[cfg.ProtectionLevel],
 		kmsClient:       kmsClient,
-		log:             logger,
+		log:             opts.Logger,
 		clock:           clock,
 		waiting:         make(chan struct{}),
 	}, nil
@@ -146,20 +109,20 @@ func (g *gcpKMSKeyStore) keyTypeDescription() string {
 // crypto.Signer. The returned identifier for gcpKMSKeyStore encoded the full
 // GCP KMS key version name, and can be passed to getSigner later to get the same
 // crypto.Signer.
-func (g *gcpKMSKeyStore) generateRSA(ctx context.Context, opts ...RSAKeyOption) ([]byte, crypto.Signer, error) {
-	options := &RSAKeyOptions{}
+func (g *gcpKMSKeyStore) generateRSA(ctx context.Context, opts ...rsaKeyOption) ([]byte, crypto.Signer, error) {
+	options := &rsaKeyOptions{}
 	for _, opt := range opts {
 		opt(options)
 	}
 
 	var alg kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm
-	switch options.DigestAlgorithm {
+	switch options.digestAlgorithm {
 	case crypto.SHA256, 0:
 		alg = kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_2048_SHA256
 	case crypto.SHA512:
 		alg = kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA512
 	default:
-		return nil, nil, trace.BadParameter("unsupported digest algorithm: %v", options.DigestAlgorithm)
+		return nil, nil, trace.BadParameter("unsupported digest algorithm: %v", options.digestAlgorithm)
 	}
 
 	keyUUID := uuid.NewString()
@@ -325,7 +288,7 @@ func (g *gcpKMSKeyStore) deleteUnusedKeys(ctx context.Context, activeKeys [][]by
 	}
 
 	for _, unusedKey := range keysToDelete {
-		g.log.WithFields(logrus.Fields{"key_version": unusedKey.keyVersionName}).Info("Deleting unused GCP KMS key.")
+		g.log.InfoContext(ctx, "Deleting unused GCP KMS key.", "key_version", unusedKey.keyVersionName)
 		err := g.deleteKey(ctx, unusedKey.marshal())
 		// Ignore errors where we can't destroy because the state is already
 		// DESTROYED or DESTROY_SCHEDULED

--- a/lib/auth/keystore/keystore_test.go
+++ b/lib/auth/keystore/keystore_test.go
@@ -35,8 +35,9 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -250,7 +251,7 @@ func TestManager(t *testing.T) {
 
 	for _, backendDesc := range pack.backends {
 		t.Run(backendDesc.name, func(t *testing.T) {
-			manager, err := NewManager(ctx, backendDesc.config)
+			manager, err := NewManager(ctx, &backendDesc.config, pack.opts)
 			require.NoError(t, err)
 
 			// Delete all keys to clean up the test.
@@ -390,13 +391,14 @@ func TestManager(t *testing.T) {
 }
 
 type testPack struct {
+	opts     *Options
 	backends []*backendDesc
 	clock    clockwork.FakeClock
 }
 
 type backendDesc struct {
 	name                string
-	config              Config
+	config              servicecfg.KeystoreConfig
 	backend             backend
 	expectedKeyType     types.PrivateKeyType
 	unusedRawKey        []byte
@@ -408,7 +410,7 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 	var backends []*backendDesc
 
 	hostUUID := uuid.NewString()
-	logger := utils.NewLoggerForTests()
+	logger := utils.NewSlogLoggerForTests()
 
 	unusedPKCS11Key, err := keyID{
 		HostID: hostUUID,
@@ -416,32 +418,43 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 	}.marshal()
 	require.NoError(t, err)
 
-	softwareConfig := Config{Software: SoftwareConfig{
-		RSAKeyPairSource: native.GenerateKeyPair,
-	}}
-	softwareBackend := newSoftwareKeyStore(&softwareConfig.Software)
+	_, gcpKMSDialer := newTestGCPKMSService(t)
+	testGCPKMSClient := newTestGCPKMSClient(t, gcpKMSDialer)
+
+	clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
+		ClusterName: "test-cluster",
+	})
+	require.NoError(t, err)
+
+	opts := &Options{
+		ClusterName: clusterName,
+		HostUUID:    hostUUID,
+		Logger:      logger,
+		CloudClients: &cloud.TestCloudClients{
+			KMS: newFakeAWSKMSService(t, clock, "123456789012", "us-west-2", 100),
+			STS: &fakeAWSSTSClient{
+				account: "123456789012",
+			},
+		},
+		kmsClient:         testGCPKMSClient,
+		clockworkOverride: clock,
+	}
+
+	softwareBackend := newSoftwareKeyStore(&softwareConfig{})
 	backends = append(backends, &backendDesc{
 		name:                "software",
-		config:              softwareConfig,
+		config:              servicecfg.KeystoreConfig{},
 		backend:             softwareBackend,
 		unusedRawKey:        testRawPrivateKey,
 		deletionDoesNothing: true,
 	})
 
 	if config, ok := softHSMTestConfig(t); ok {
-		cfg := PKCS11Config{
-			Path:       config.PKCS11.Path,
-			SlotNumber: config.PKCS11.SlotNumber,
-			TokenLabel: config.PKCS11.TokenLabel,
-			Pin:        config.PKCS11.Pin,
-			HostUUID:   hostUUID,
-		}
-
-		backend, err := newPKCS11KeyStore(&cfg, logger)
+		backend, err := newPKCS11KeyStore(&config.PKCS11, opts)
 		require.NoError(t, err)
 		backends = append(backends, &backendDesc{
 			name:            "softhsm",
-			config:          Config{PKCS11: cfg},
+			config:          config,
 			backend:         backend,
 			expectedKeyType: types.PrivateKeyType_PKCS11,
 			unusedRawKey:    unusedPKCS11Key,
@@ -449,19 +462,11 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 	}
 
 	if config, ok := yubiHSMTestConfig(t); ok {
-		cfg := PKCS11Config{
-			Path:       config.PKCS11.Path,
-			SlotNumber: config.PKCS11.SlotNumber,
-			TokenLabel: config.PKCS11.TokenLabel,
-			Pin:        config.PKCS11.Pin,
-			HostUUID:   hostUUID,
-		}
-
-		backend, err := newPKCS11KeyStore(&cfg, logger)
+		backend, err := newPKCS11KeyStore(&config.PKCS11, opts)
 		require.NoError(t, err)
 		backends = append(backends, &backendDesc{
 			name:            "yubihsm",
-			config:          Config{PKCS11: cfg},
+			config:          config,
 			backend:         backend,
 			expectedKeyType: types.PrivateKeyType_PKCS11,
 			unusedRawKey:    unusedPKCS11Key,
@@ -469,18 +474,11 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 	}
 
 	if config, ok := cloudHSMTestConfig(t); ok {
-		cfg := PKCS11Config{
-			Path:       config.PKCS11.Path,
-			SlotNumber: config.PKCS11.SlotNumber,
-			TokenLabel: config.PKCS11.TokenLabel,
-			Pin:        config.PKCS11.Pin,
-			HostUUID:   hostUUID,
-		}
-		backend, err := newPKCS11KeyStore(&cfg, logger)
+		backend, err := newPKCS11KeyStore(&config.PKCS11, opts)
 		require.NoError(t, err)
 		backends = append(backends, &backendDesc{
 			name:            "yubihsm",
-			config:          Config{PKCS11: cfg},
+			config:          config,
 			backend:         backend,
 			expectedKeyType: types.PrivateKeyType_PKCS11,
 			unusedRawKey:    unusedPKCS11Key,
@@ -488,17 +486,11 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 	}
 
 	if config, ok := gcpKMSTestConfig(t); ok {
-		cfg := GCPKMSConfig{
-			KeyRing:         config.GCPKMS.KeyRing,
-			ProtectionLevel: config.GCPKMS.ProtectionLevel,
-			HostUUID:        hostUUID,
-		}
-
-		backend, err := newGCPKMSKeyStore(ctx, &cfg, logger)
+		backend, err := newGCPKMSKeyStore(ctx, &config.GCPKMS, opts)
 		require.NoError(t, err)
 		backends = append(backends, &backendDesc{
 			name:            "gcp_kms",
-			config:          Config{GCPKMS: cfg},
+			config:          config,
 			backend:         backend,
 			expectedKeyType: types.PrivateKeyType_GCP_KMS,
 			unusedRawKey: gcpKMSKeyID{
@@ -506,17 +498,13 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 			}.marshal(),
 		})
 	}
-	_, gcpKMSDialer := newTestGCPKMSService(t)
-	testGCPKMSClient := newTestGCPKMSClient(t, gcpKMSDialer)
-	fakeGCPKMSConfig := Config{
-		GCPKMS: GCPKMSConfig{
-			HostUUID:          hostUUID,
-			ProtectionLevel:   "HSM",
-			KeyRing:           "test-keyring",
-			kmsClientOverride: testGCPKMSClient,
+	fakeGCPKMSConfig := servicecfg.KeystoreConfig{
+		GCPKMS: servicecfg.GCPKMSConfig{
+			ProtectionLevel: "HSM",
+			KeyRing:         "test-keyring",
 		},
 	}
-	fakeGCPKMSBackend, err := newGCPKMSKeyStore(ctx, &fakeGCPKMSConfig.GCPKMS, logger)
+	fakeGCPKMSBackend, err := newGCPKMSKeyStore(ctx, &fakeGCPKMSConfig.GCPKMS, opts)
 	require.NoError(t, err)
 	backends = append(backends, &backendDesc{
 		name:            "fake_gcp_kms",
@@ -529,18 +517,11 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 	})
 
 	if config, ok := awsKMSTestConfig(t); ok {
-		cfg := AWSKMSConfig{
-			Cluster:    config.AWSKMS.Cluster,
-			AWSAccount: config.AWSKMS.AWSAccount,
-			AWSRegion:  config.AWSKMS.AWSRegion,
-			clock:      clock,
-		}
-
-		backend, err := newAWSKMSKeystore(ctx, &cfg, logger)
+		backend, err := newAWSKMSKeystore(ctx, &config.AWSKMS, opts)
 		require.NoError(t, err)
 		backends = append(backends, &backendDesc{
 			name:            "aws_kms",
-			config:          Config{AWSKMS: cfg},
+			config:          config,
 			backend:         backend,
 			expectedKeyType: types.PrivateKeyType_AWS_KMS,
 			unusedRawKey: awsKMSKeyID{
@@ -557,21 +538,13 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 		})
 	}
 
-	fakeAWSKMSConfig := Config{
-		AWSKMS: AWSKMSConfig{
-			Cluster:    "test-cluster",
+	fakeAWSKMSConfig := servicecfg.KeystoreConfig{
+		AWSKMS: servicecfg.AWSKMSConfig{
 			AWSAccount: "123456789012",
 			AWSRegion:  "us-west-2",
-			CloudClients: &cloud.TestCloudClients{
-				KMS: newFakeAWSKMSService(t, clock, "123456789012", "us-west-2", 100),
-				STS: &fakeAWSSTSClient{
-					account: "123456789012",
-				},
-			},
-			clock: clock,
 		},
 	}
-	fakeAWSKMSBackend, err := newAWSKMSKeystore(ctx, &fakeAWSKMSConfig.AWSKMS, logger)
+	fakeAWSKMSBackend, err := newAWSKMSKeystore(ctx, &fakeAWSKMSConfig.AWSKMS, opts)
 	require.NoError(t, err)
 	backends = append(backends, &backendDesc{
 		name:            "fake_aws_kms",
@@ -592,6 +565,7 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 	})
 
 	return &testPack{
+		opts:     opts,
 		backends: backends,
 		clock:    clock,
 	}

--- a/lib/auth/keystore/pkcs11.go
+++ b/lib/auth/keystore/pkcs11.go
@@ -53,7 +53,7 @@ func newPKCS11KeyStore(config *servicecfg.PKCS11Config, opts *Options) (*pkcs11K
 		Path:       config.Path,
 		TokenLabel: config.TokenLabel,
 		SlotNumber: config.SlotNumber,
-		Pin:        config.Pin,
+		Pin:        config.PIN,
 	}
 
 	ctx, err := crypto11.Configure(cryptoConfig)

--- a/lib/auth/keystore/software.go
+++ b/lib/auth/keystore/software.go
@@ -36,20 +36,20 @@ type softwareKeyStore struct {
 // RSAKeyPairSource is a function type which returns new RSA keypairs.
 type RSAKeyPairSource func() (priv []byte, pub []byte, err error)
 
-type SoftwareConfig struct {
-	RSAKeyPairSource RSAKeyPairSource
+type softwareConfig struct {
+	rsaKeyPairSource RSAKeyPairSource
 }
 
-func (cfg *SoftwareConfig) CheckAndSetDefaults() error {
-	if cfg.RSAKeyPairSource == nil {
-		cfg.RSAKeyPairSource = native.GenerateKeyPair
+func (cfg *softwareConfig) checkAndSetDefaults() {
+	if cfg.rsaKeyPairSource == nil {
+		cfg.rsaKeyPairSource = native.GenerateKeyPair
 	}
-	return nil
 }
 
-func newSoftwareKeyStore(config *SoftwareConfig) *softwareKeyStore {
+func newSoftwareKeyStore(config *softwareConfig) *softwareKeyStore {
+	config.checkAndSetDefaults()
 	return &softwareKeyStore{
-		rsaKeyPairSource: config.RSAKeyPairSource,
+		rsaKeyPairSource: config.rsaKeyPairSource,
 	}
 }
 
@@ -63,7 +63,7 @@ func (s *softwareKeyStore) keyTypeDescription() string {
 // crypto.Signer. The returned identifier for softwareKeyStore is a pem-encoded
 // private key, and can be passed to getSigner later to get the same
 // crypto.Signer.
-func (s *softwareKeyStore) generateRSA(ctx context.Context, _ ...RSAKeyOption) ([]byte, crypto.Signer, error) {
+func (s *softwareKeyStore) generateRSA(ctx context.Context, _ ...rsaKeyOption) ([]byte, crypto.Signer, error) {
 	priv, _, err := s.rsaKeyPairSource()
 	if err != nil {
 		return nil, nil, err

--- a/lib/auth/keystore/testhelpers.go
+++ b/lib/auth/keystore/testhelpers.go
@@ -96,7 +96,6 @@ func awsKMSTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
 	}
 	return servicecfg.KeystoreConfig{
 		AWSKMS: servicecfg.AWSKMSConfig{
-			Cluster:    "test-cluster",
 			AWSAccount: awsKMSAccount,
 			AWSRegion:  awsKMSRegion,
 		},
@@ -209,7 +208,7 @@ func NewSoftwareKeystoreForTests(_ *testing.T, opts ...TestKeystoreOption) *Mana
 	for _, opt := range opts {
 		opt(&options)
 	}
-	softwareBackend := newSoftwareKeyStore(&SoftwareConfig{RSAKeyPairSource: options.rsaKeyPairSource})
+	softwareBackend := newSoftwareKeyStore(&softwareConfig{rsaKeyPairSource: options.rsaKeyPairSource})
 	return &Manager{
 		backendForNewKeys:     softwareBackend,
 		usableSigningBackends: []backend{softwareBackend},

--- a/lib/auth/keystore/testhelpers.go
+++ b/lib/auth/keystore/testhelpers.go
@@ -69,7 +69,7 @@ func yubiHSMTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
 		PKCS11: servicecfg.PKCS11Config{
 			Path:       yubiHSMPath,
 			SlotNumber: &slotNumber,
-			Pin:        yubiHSMPin,
+			PIN:        yubiHSMPin,
 		},
 	}, true
 }
@@ -83,7 +83,7 @@ func cloudHSMTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
 		PKCS11: servicecfg.PKCS11Config{
 			Path:       "/opt/cloudhsm/lib/libcloudhsm_pkcs11.so",
 			TokenLabel: "cavium",
-			Pin:        cloudHSMPin,
+			PIN:        cloudHSMPin,
 		},
 	}, true
 }
@@ -183,7 +183,7 @@ func softHSMTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
 		PKCS11: servicecfg.PKCS11Config{
 			Path:       path,
 			TokenLabel: tokenLabel,
-			Pin:        "password",
+			PIN:        "password",
 		},
 	}
 	return *cachedSoftHSMConfig, true

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -41,7 +41,6 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	wanpb "github.com/gravitational/teleport/api/types/webauthn"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/auth/keystore"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -83,11 +82,6 @@ func setupPasswordSuite(t *testing.T) *passwordSuite {
 		Backend:                s.bk,
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
-		KeyStoreConfig: keystore.Config{
-			Software: keystore.SoftwareConfig{
-				RSAKeyPairSource: authority.New().GenerateKeyPair,
-			},
-		},
 	}
 	s.a, err = NewServer(authConfig)
 	require.NoError(t, err)

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/auth/keystore"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
@@ -417,11 +416,6 @@ func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *Serve
 		Backend:                bk,
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
-		KeyStoreConfig: keystore.Config{
-			Software: keystore.SoftwareConfig{
-				RSAKeyPairSource: authority.New().GenerateKeyPair,
-			},
-		},
 	}
 	a, err := NewServer(authConfig)
 	require.NoError(t, err)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1084,13 +1084,13 @@ func applyPKCS11Config(pkcs11Config *PKCS11, cfg *servicecfg.Config) error {
 	cfg.Auth.KeyStore.PKCS11.TokenLabel = pkcs11Config.TokenLabel
 	cfg.Auth.KeyStore.PKCS11.SlotNumber = pkcs11Config.SlotNumber
 
-	cfg.Auth.KeyStore.PKCS11.Pin = pkcs11Config.Pin
-	if pkcs11Config.PinPath != "" {
-		if pkcs11Config.Pin != "" {
+	cfg.Auth.KeyStore.PKCS11.PIN = pkcs11Config.PIN
+	if pkcs11Config.PINPath != "" {
+		if pkcs11Config.PIN != "" {
 			return trace.BadParameter("can not set both pin and pin_path")
 		}
 
-		fi, err := utils.StatFile(pkcs11Config.PinPath)
+		fi, err := utils.StatFile(pkcs11Config.PINPath)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1099,16 +1099,16 @@ func applyPKCS11Config(pkcs11Config *PKCS11, cfg *servicecfg.Config) error {
 		if fi.Mode().Perm()&worldReadableBits != 0 {
 			return trace.Errorf(
 				"HSM pin file (%s) must not be world-readable",
-				pkcs11Config.PinPath,
+				pkcs11Config.PINPath,
 			)
 		}
 
-		pinBytes, err := os.ReadFile(pkcs11Config.PinPath)
+		pinBytes, err := os.ReadFile(pkcs11Config.PINPath)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		pin := strings.TrimRight(string(pinBytes), "\r\n")
-		cfg.Auth.KeyStore.PKCS11.Pin = pin
+		cfg.Auth.KeyStore.PKCS11.PIN = pin
 	}
 	return nil
 }

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -837,7 +837,7 @@ SREzU8onbBsjMg9QDiSf5oJLKvd/Ren+zGY7
 	require.Equal(t, pkcs11LibPath, cfg.Auth.KeyStore.PKCS11.Path)
 	require.Equal(t, "example_token", cfg.Auth.KeyStore.PKCS11.TokenLabel)
 	require.Equal(t, 1, *cfg.Auth.KeyStore.PKCS11.SlotNumber)
-	require.Equal(t, "example_pin", cfg.Auth.KeyStore.PKCS11.Pin)
+	require.Equal(t, "example_pin", cfg.Auth.KeyStore.PKCS11.PIN)
 	require.ElementsMatch(t, []string{"ca-pin-from-string", "ca-pin-from-file1", "ca-pin-from-file2"}, cfg.CAPins)
 
 	require.True(t, cfg.Databases.Enabled)
@@ -3041,7 +3041,7 @@ func TestApplyKeyStoreConfig(t *testing.T) {
 						ModulePath: securePKCS11LibPath,
 						TokenLabel: "foo",
 						SlotNumber: &slotNumber,
-						Pin:        "pin",
+						PIN:        "pin",
 					},
 				},
 			},
@@ -3049,7 +3049,7 @@ func TestApplyKeyStoreConfig(t *testing.T) {
 				PKCS11: servicecfg.PKCS11Config{
 					TokenLabel: "foo",
 					SlotNumber: &slotNumber,
-					Pin:        "pin",
+					PIN:        "pin",
 					Path:       securePKCS11LibPath,
 				},
 			},
@@ -3062,7 +3062,7 @@ func TestApplyKeyStoreConfig(t *testing.T) {
 						ModulePath: securePKCS11LibPath,
 						TokenLabel: "foo",
 						SlotNumber: &slotNumber,
-						PinPath:    securePinFilePath,
+						PINPath:    securePinFilePath,
 					},
 				},
 			},
@@ -3070,7 +3070,7 @@ func TestApplyKeyStoreConfig(t *testing.T) {
 				PKCS11: servicecfg.PKCS11Config{
 					TokenLabel: "foo",
 					SlotNumber: &slotNumber,
-					Pin:        "secure-pin-file",
+					PIN:        "secure-pin-file",
 					Path:       securePKCS11LibPath,
 				},
 			},
@@ -3080,8 +3080,8 @@ func TestApplyKeyStoreConfig(t *testing.T) {
 			auth: Auth{
 				CAKeyParams: &CAKeyParams{
 					PKCS11: &PKCS11{
-						Pin:     "oops",
-						PinPath: securePinFilePath,
+						PIN:     "oops",
+						PINPath: securePinFilePath,
 					},
 				},
 			},
@@ -3106,7 +3106,7 @@ func TestApplyKeyStoreConfig(t *testing.T) {
 			auth: Auth{
 				CAKeyParams: &CAKeyParams{
 					PKCS11: &PKCS11{
-						PinPath: worldReadablePinFilePath,
+						PINPath: worldReadablePinFilePath,
 					},
 				},
 			},

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -883,13 +883,13 @@ type PKCS11 struct {
 	// SlotNumber is the slot number of the HSM token to use. Set this or
 	// TokenLabel to select a token.
 	SlotNumber *int `yaml:"slot_number,omitempty"`
-	// Pin is the raw pin for connecting to the HSM. Set this or PinPath to set
+	// PIN is the raw pin for connecting to the HSM. Set this or PINPath to set
 	// the pin.
-	Pin string `yaml:"pin,omitempty"`
-	// PinPath is a path to a file containing a pin for connecting to the HSM.
+	PIN string `yaml:"pin,omitempty"`
+	// PINPath is a path to a file containing a pin for connecting to the HSM.
 	// Trailing newlines will be removed, other whitespace will be left. Set
 	// this or Pin to set the pin.
-	PinPath string `yaml:"pin_path,omitempty"`
+	PINPath string `yaml:"pin_path,omitempty"`
 }
 
 // GoogleCloudKMS configures Google Cloud Key Management Service to to be used for

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -86,7 +86,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/accesspoint"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keygen"
-	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/authz"
@@ -1902,31 +1901,6 @@ func (process *TeleportProcess) initAuthService() error {
 		return trace.Wrap(err)
 	}
 
-	keystoreConfig := keystore.Config{
-		PKCS11: keystore.PKCS11Config{
-			Path:       cfg.Auth.KeyStore.PKCS11.Path,
-			SlotNumber: cfg.Auth.KeyStore.PKCS11.SlotNumber,
-			TokenLabel: cfg.Auth.KeyStore.PKCS11.TokenLabel,
-			Pin:        cfg.Auth.KeyStore.PKCS11.Pin,
-			HostUUID:   cfg.Auth.KeyStore.PKCS11.HostUUID,
-		},
-		GCPKMS: keystore.GCPKMSConfig{
-			KeyRing:         cfg.Auth.KeyStore.GCPKMS.KeyRing,
-			ProtectionLevel: cfg.Auth.KeyStore.GCPKMS.ProtectionLevel,
-			HostUUID:        cfg.Auth.KeyStore.GCPKMS.HostUUID,
-		},
-		AWSKMS: keystore.AWSKMSConfig{
-			Cluster:    cfg.Auth.KeyStore.AWSKMS.Cluster,
-			AWSAccount: cfg.Auth.KeyStore.AWSKMS.AWSAccount,
-			AWSRegion:  cfg.Auth.KeyStore.AWSKMS.AWSRegion,
-		},
-		Logger: process.log,
-	}
-
-	if (keystoreConfig.AWSKMS != keystore.AWSKMSConfig{}) {
-		keystoreConfig.AWSKMS.CloudClients = cloudClients
-	}
-
 	// first, create the AuthServer
 	authServer, err := auth.Init(
 		process.ExitContext(),
@@ -1959,7 +1933,7 @@ func (process *TeleportProcess) initAuthService() error {
 			OIDCConnectors:          cfg.OIDCConnectors,
 			AuditLog:                process.auditLog,
 			CipherSuites:            cfg.CipherSuites,
-			KeyStoreConfig:          keystoreConfig,
+			KeyStoreConfig:          cfg.Auth.KeyStore,
 			Emitter:                 checkingEmitter,
 			Streamer:                events.NewReportingStreamer(streamer, process.Config.Testing.UploadEventsC),
 			TraceClient:             traceClt,

--- a/lib/service/servicecfg/auth.go
+++ b/lib/service/servicecfg/auth.go
@@ -225,8 +225,8 @@ type PKCS11Config struct {
 	SlotNumber *int
 	// TokenLabel is the label of the PKCS11 token to use.
 	TokenLabel string
-	// Pin is the PKCS11 pin for the given token.
-	Pin string
+	// PIN is the PKCS11 PIN for the given token.
+	PIN string
 }
 
 // CheckAndSetDefaults checks that required parameters of the config are

--- a/lib/service/servicecfg/auth.go
+++ b/lib/service/servicecfg/auth.go
@@ -254,7 +254,9 @@ type GCPKMSConfig struct {
 }
 
 const (
-	GCPKMSProtectionLevelHSM      = "HSM"
+	// GCPKMSProtectionLevelHSM represents the HSM protection level in GCP KMS.
+	GCPKMSProtectionLevelHSM = "HSM"
+	// GCPKMSProtectionLevelSoftware represents the SOFTWARE protection level in GCP KMS.
 	GCPKMSProtectionLevelSoftware = "SOFTWARE"
 )
 

--- a/lib/service/servicecfg/auth.go
+++ b/lib/service/servicecfg/auth.go
@@ -189,22 +189,98 @@ type KeystoreConfig struct {
 	AWSKMS AWSKMSConfig
 }
 
+// CheckAndSetDefaults checks that required parameters of the config are
+// properly set and sets defaults.
+func (cfg *KeystoreConfig) CheckAndSetDefaults() error {
+	count := 0
+	if cfg.PKCS11 != (PKCS11Config{}) {
+		if err := cfg.PKCS11.CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err, "validating pkcs11 config")
+		}
+		count++
+	}
+	if cfg.GCPKMS != (GCPKMSConfig{}) {
+		if err := cfg.GCPKMS.CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err, "validating gcp_kms config")
+		}
+		count++
+	}
+	if cfg.AWSKMS != (AWSKMSConfig{}) {
+		if err := cfg.AWSKMS.CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err, "validating aws_kms config")
+		}
+		count++
+	}
+	if count > 1 {
+		return trace.BadParameter("must configure at most one of pkcs11, gcp_kms, or aws_kms")
+	}
+	return nil
+}
+
+// PKCS11Config holds static configuration options for a PKCS#11 HSM.
 type PKCS11Config struct {
-	Path       string
+	// Path is the path to the PKCS11 module.
+	Path string
+	// SlotNumber is the PKCS11 slot to use.
 	SlotNumber *int
+	// TokenLabel is the label of the PKCS11 token to use.
 	TokenLabel string
-	Pin        string
-	HostUUID   string
+	// Pin is the PKCS11 pin for the given token.
+	Pin string
 }
 
+// CheckAndSetDefaults checks that required parameters of the config are
+// properly set and sets defaults.
+func (cfg *PKCS11Config) CheckAndSetDefaults() error {
+	if cfg.Path == "" {
+		return trace.BadParameter("must provide Path")
+	}
+	if cfg.SlotNumber == nil && cfg.TokenLabel == "" {
+		return trace.BadParameter("must provide one of SlotNumber or TokenLabel")
+	}
+	return nil
+}
+
+// GCPKMSConfig holds static configuration options for GCP KMS.
 type GCPKMSConfig struct {
-	KeyRing         string
+	// KeyRing is the fully qualified name of the GCP KMS keyring.
+	KeyRing string
+	// ProtectionLevel specifies how cryptographic operations are performed.
+	// For more information, see https://cloud.google.com/kms/docs/algorithms#protection_levels
+	// Supported options are "HSM" and "SOFTWARE".
 	ProtectionLevel string
-	HostUUID        string
 }
 
+// CheckAndSetDefaults checks that required parameters of the config are
+// properly set and sets defaults.
+func (cfg *GCPKMSConfig) CheckAndSetDefaults() error {
+	if cfg.KeyRing == "" {
+		return trace.BadParameter("must provide a valid KeyRing")
+	}
+	switch cfg.ProtectionLevel {
+	case "SOFTWARE", "HSM":
+	default:
+		return trace.BadParameter("unsupported ProtectionLevel %s", cfg.ProtectionLevel)
+	}
+	return nil
+}
+
+// AWSKMSConfig holds static configuration options for AWS KMS.
 type AWSKMSConfig struct {
-	Cluster    string
+	// AWSAccount is the AWS account ID where the keys will reside.
 	AWSAccount string
-	AWSRegion  string
+	// AWSRegion is the AWS region where the keys will reside.
+	AWSRegion string
+}
+
+// CheckAndSetDefaults checks that required parameters of the config are
+// properly set and sets defaults.
+func (c *AWSKMSConfig) CheckAndSetDefaults() error {
+	if c.AWSAccount == "" {
+		return trace.BadParameter("AWS account is required")
+	}
+	if c.AWSRegion == "" {
+		return trace.BadParameter("AWS region is required")
+	}
+	return nil
 }

--- a/lib/service/servicecfg/auth.go
+++ b/lib/service/servicecfg/auth.go
@@ -19,6 +19,8 @@
 package servicecfg
 
 import (
+	"slices"
+
 	"github.com/coreos/go-oidc/oauth2"
 	"github.com/dustin/go-humanize"
 	"github.com/gravitational/trace"
@@ -251,15 +253,18 @@ type GCPKMSConfig struct {
 	ProtectionLevel string
 }
 
+const (
+	GCPKMSProtectionLevelHSM      = "HSM"
+	GCPKMSProtectionLevelSoftware = "SOFTWARE"
+)
+
 // CheckAndSetDefaults checks that required parameters of the config are
 // properly set and sets defaults.
 func (cfg *GCPKMSConfig) CheckAndSetDefaults() error {
 	if cfg.KeyRing == "" {
 		return trace.BadParameter("must provide a valid KeyRing")
 	}
-	switch cfg.ProtectionLevel {
-	case "SOFTWARE", "HSM":
-	default:
+	if !slices.Contains([]string{GCPKMSProtectionLevelHSM, GCPKMSProtectionLevelSoftware}, cfg.ProtectionLevel) {
 		return trace.BadParameter("unsupported ProtectionLevel %s", cfg.ProtectionLevel)
 	}
 	return nil

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -38,7 +38,6 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/bpf"
@@ -134,11 +133,6 @@ func newMockServer(t *testing.T) *mockServer {
 		Authority:    testauthority.New(),
 		ClusterName:  clusterName,
 		StaticTokens: staticTokens,
-		KeyStoreConfig: keystore.Config{
-			Software: keystore.SoftwareConfig{
-				RSAKeyPairSource: testauthority.New().GenerateKeyPair,
-			},
-		},
 	}
 
 	authServer, err := auth.NewServer(authCfg, auth.WithClock(clock))


### PR DESCRIPTION
We recently duplicated most fields of `(lib/auth/keystore).Config` types to `(lib/service/servicecfg).KeystoreConfig` to break some dependencies on cloud SDKs in our client binaries.

This PR deletes `(lib/auth/keystore).Config` to unify on `(lib/service/servicecfg).KeystoreConfig`. It adds a new `keystore.Options` struct to hold runtime options for the keystore, in contrast to `KeystoreConfig` which holds mostly static options coming from the config file.

No functional changes are made here.

Depends on https://github.com/gravitational/teleport/pull/43153 and https://github.com/gravitational/teleport.e/pull/4425

I made these changes while prepping the keystore to support configurable signature algorithms for the implementation of RFD 136.