### PR TITLE
[v16] Rotate Connect logs in ascending order

### DIFF
--- a/web/packages/teleterm/src/services/logger/loggerService.ts
+++ b/web/packages/teleterm/src/services/logger/loggerService.ts
@@ -89,7 +89,7 @@ export function createFileLoggerService(
     transports: [
       new transports.File({
         maxsize: 4194304, // 4 MB - max size of a single file
-        maxFiles: 5,
+        maxFiles: opts.dev ? 5 : 3,
         dirname: opts.dir,
         filename: `${opts.name}.log`,
         tailable: true,

--- a/web/packages/teleterm/src/services/logger/loggerService.ts
+++ b/web/packages/teleterm/src/services/logger/loggerService.ts
@@ -92,6 +92,7 @@ export function createFileLoggerService(
         maxFiles: 5,
         dirname: opts.dir,
         filename: `${opts.name}.log`,
+        tailable: true,
       }),
     ],
   });


### PR DESCRIPTION
Backport #43082 to branch/v16

changelog: Improved log rotation logic in Teleport Connect; now the non-numbered files always contain recent logs.
