### PR TITLE
Machine ID: Add Debug log on proxy template loading

### DIFF
--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -237,6 +237,18 @@ func (s *SSHMultiplexerService) setup(ctx context.Context) (
 		if err != nil {
 			return nil, nil, "", nil, trace.Wrap(err, "loading proxy templates")
 		}
+		for _, t := range tshConfig.ProxyTemplates {
+			s.log.DebugContext(
+				ctx,
+				"Loaded proxy template",
+				"template", t.Template,
+				"proxy", t.Proxy,
+				"host", t.Host,
+				"cluster", t.Cluster,
+				"query", t.Query,
+				"search", t.Search,
+			)
+		}
 	}
 
 	// Generate our initial identity and write the artifacts to the destination.


### PR DESCRIPTION
We encountered a customer who had a non-visible unicode character in their proxy template file and it was causing the regex to not match. It took ages to find this. This PR logs the loaded config in a way that should make this more obvious:

```
Loaded proxy template template:"\u00a0'^([\\w\\d-]+)\\.([\\w\\d\\.]+)\\.label:([0-9]+)$'" proxy: host: cluster:$2 query:labels.multiple == "$1" search: tbot/service_ssh_multiplexer.go:241
```