### PR TITLE
Add a FieldCheckbox component

### DIFF
--- a/web/packages/design/src/Checkbox/Checkbox.tsx
+++ b/web/packages/design/src/Checkbox/Checkbox.tsx
@@ -18,7 +18,7 @@
 
 import styled from 'styled-components';
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { Flex } from 'design';
 import { space } from 'design/system';
@@ -52,7 +52,7 @@ export const CheckboxInput = styled.input`
   ${space}
 `;
 
-type CheckboxSize = 'large' | 'small';
+export type CheckboxSize = 'large' | 'small';
 
 interface StyledCheckboxProps {
   size?: CheckboxSize;
@@ -79,27 +79,28 @@ interface StyledCheckboxProps {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-// TODO (bl-nero): Make this the default checkbox
-export function StyledCheckbox(props: StyledCheckboxProps) {
-  const { style, className, size, ...inputProps } = props;
-  return (
-    // The outer wrapper and inner wrapper are separate to allow using
-    // positioning CSS attributes on the checkbox while still maintaining its
-    // internal integrity that requires the internal wrapper to be positioned.
-    <OuterWrapper style={style} className={className}>
-      <InnerWrapper>
-        {/* The checkbox is rendered as two items placed on top of each other:
+export const StyledCheckbox = forwardRef<HTMLInputElement, StyledCheckboxProps>(
+  (props, ref) => {
+    const { style, className, size, ...inputProps } = props;
+    return (
+      // The outer wrapper and inner wrapper are separate to allow using
+      // positioning CSS attributes on the checkbox while still maintaining its
+      // internal integrity that requires the internal wrapper to be positioned.
+      <OuterWrapper style={style} className={className}>
+        <InnerWrapper>
+          {/* The checkbox is rendered as two items placed on top of each other:
             the actual checkbox, which is a native input control, and an SVG
             checkmark. Note that we avoid the usual "label with content" trick,
             because we want to be able to use this component both with and
             without surrounding labels. Instead, we use absolute positioning and
             an actually rendered input with a custom appearance. */}
-        <StyledCheckboxInternal cbSize={size} {...inputProps} />
-        <Checkmark />
-      </InnerWrapper>
-    </OuterWrapper>
-  );
-}
+          <CheckboxInternal ref={ref} cbSize={size} {...inputProps} />
+          <Checkmark />
+        </InnerWrapper>
+      </OuterWrapper>
+    );
+  }
+);
 
 const OuterWrapper = styled.span`
   line-height: 0;
@@ -132,7 +133,7 @@ const Checkmark = styled(Icon.CheckThick)`
   }
 `;
 
-export const StyledCheckboxInternal = styled.input.attrs(props => ({
+const CheckboxInternal = styled.input.attrs(props => ({
   // TODO(bl-nero): Make radio buttons a separate control.
   type: props.type || 'checkbox',
 }))`

--- a/web/packages/design/src/Checkbox/index.ts
+++ b/web/packages/design/src/Checkbox/index.ts
@@ -16,4 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { CheckboxInput, CheckboxWrapper, StyledCheckbox } from './Checkbox';
+export {
+  CheckboxInput,
+  CheckboxWrapper,
+  StyledCheckbox,
+  type CheckboxSize,
+} from './Checkbox';

--- a/web/packages/design/src/theme/typography.js
+++ b/web/packages/design/src/theme/typography.js
@@ -101,6 +101,26 @@ const typography = {
     fontSize: '14px',
     lineHeight: '20px',
   },
+
+  // TODO(bl-nero): Migrate everything to the new typography.
+  newBody1: {
+    fontSize: '16px',
+    fontWeight: light,
+    lineHeight: '24px',
+    letterSpacing: '0.08px',
+  },
+  newBody2: {
+    fontSize: '14px',
+    fontWeight: light,
+    lineHeight: '20px',
+    letterSpacing: '0.035px',
+  },
+  newBody3: {
+    fontSize: '12px',
+    fontWeight: regular,
+    lineHeight: '20px',
+    letterSpacing: '0.015px',
+  },
 };
 
 export default typography;

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -38,13 +38,14 @@ import {
   Cross,
 } from 'design/Icon';
 import Table, { Cell } from 'design/DataTable';
-import { CheckboxInput, CheckboxWrapper } from 'design/Checkbox';
 import { Danger } from 'design/Alert';
 
 import Validation, { useRule, Validator } from 'shared/components/Validation';
 import { Attempt } from 'shared/hooks/useAttemptNext';
 import { pluralize } from 'shared/utils/text';
 import { Option } from 'shared/components/Select';
+
+import { FieldCheckbox } from 'shared/components/FieldCheckbox';
 
 import { CreateRequest } from '../../Shared/types';
 import { AssumeStartTime } from '../../AssumeStartTime/AssumeStartTime';
@@ -521,34 +522,20 @@ function ResourceRequestRoles({
       {fetchAttempt.status === 'success' && expanded && (
         <Box mt={2}>
           {roles.map((roleName, index) => {
-            const id = `${roleName}${index}`;
+            const checked = selectedRoles.includes(roleName);
             return (
-              <CheckboxWrapper
-                key={index}
-                css={`
-                  width: 100%;
-                  cursor: pointer;
-                  background: ${({ theme }) => theme.colors.levels.surface};
-
-                  &:hover {
-                    border-color: ${({ theme }) =>
-                      theme.colors.levels.elevated};
-                  }
-                `}
-                as="label"
-                htmlFor={id}
-              >
-                <CheckboxInput
-                  type="checkbox"
+              <RoleRowContainer checked={checked}>
+                <StyledFieldCheckbox
+                  key={index}
                   name={roleName}
-                  id={id}
                   onChange={e => {
                     onInputChange(roleName, e);
                   }}
-                  checked={selectedRoles.includes(roleName)}
+                  checked={checked}
+                  label={roleName}
+                  size="small"
                 />
-                {roleName}
-              </CheckboxWrapper>
+              </RoleRowContainer>
             );
           })}
           {selectedRoles.length < roles.length && (
@@ -576,6 +563,45 @@ function ResourceRequestRoles({
     </Box>
   );
 }
+
+const RoleRowContainer = styled.div<{ checked?: boolean }>`
+  transition: all 150ms;
+  position: relative;
+
+  // TODO(bl-nero): That's the third place where we're copying these
+  // definitions. We need to make them reusable.
+  :hover {
+    background-color: ${props => props.theme.colors.levels.surface};
+
+    // We use a pseudo element for the shadow with position: absolute in order to prevent
+    // the shadow from increasing the size of the layout and causing scrollbar flicker.
+    :after {
+      box-shadow: ${props => props.theme.boxShadow[3]};
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      z-index: -1;
+      width: 100%;
+      height: 100%;
+    }
+  }
+`;
+
+const StyledFieldCheckbox = styled(FieldCheckbox)`
+  margin: 0;
+  padding: ${p => p.theme.space[2]}px;
+  background-color: ${props =>
+    props.checked
+      ? props.theme.colors.interactive.tonal.primary[2]
+      : 'transparent'};
+  border-bottom: ${props => props.theme.borders[2]}
+    ${props => props.theme.colors.interactive.tonal.neutral[0]};
+
+  & > label {
+    display: block; // make it full-width
+  }
+`;
 
 function TextBox({
   reason,

--- a/web/packages/shared/components/FieldCheckbox/FieldCheckbox.story.tsx
+++ b/web/packages/shared/components/FieldCheckbox/FieldCheckbox.story.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import Box from 'design/Box';
+
+import { FieldCheckbox } from '.';
+
+export default {
+  title: 'Shared',
+};
+
+export const FieldCheckboxStory = () => (
+  <Box width={600}>
+    <FieldCheckbox label="Unchecked checkbox" defaultChecked={false} />
+    <FieldCheckbox label="Checked checkbox" defaultChecked={true} />
+    <FieldCheckbox label="Disabled checkbox" disabled />
+    <FieldCheckbox size="small" label="Small checkbox" defaultChecked={true} />
+    <FieldCheckbox
+      label="Checkbox with helper text"
+      helperText="I'm a helpful helper text"
+      defaultChecked={true}
+    />
+    <FieldCheckbox
+      size="small"
+      label="Small checkbox with helper text"
+      helperText="Another helpful helper text"
+    />
+    <FieldCheckbox
+      disabled
+      label="Disabled checkbox with helper text"
+      helperText="There's nothing you can do here"
+      defaultChecked={true}
+    />
+    <FieldCheckbox
+      label="To check, or not to check: that is the question:
+      Whether 'tis nobler in the mind to suffer
+      The slings and arrows of outrageous fortune,
+      Or to take arms against a sea of troubles,
+      And by opposing end them?"
+      helperText="To uncheck: to sleep;
+      No more; and by a sleep to say we end
+      The heart-ache and the thousand natural shocks
+      That flesh is heir to, 'tis a consummation
+      Devoutly to be wish'd."
+    />
+  </Box>
+);
+
+FieldCheckboxStory.storyName = 'FieldCheckbox';

--- a/web/packages/shared/components/FieldCheckbox/FieldCheckbox.story.tsx
+++ b/web/packages/shared/components/FieldCheckbox/FieldCheckbox.story.tsx
@@ -1,3 +1,21 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import React from 'react';
 
 import Box from 'design/Box';

--- a/web/packages/shared/components/FieldCheckbox/FieldCheckbox.test.tsx
+++ b/web/packages/shared/components/FieldCheckbox/FieldCheckbox.test.tsx
@@ -1,3 +1,21 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { render, screen, userEvent } from 'design/utils/testing';
 import React, { useRef, useState } from 'react';
 

--- a/web/packages/shared/components/FieldCheckbox/FieldCheckbox.test.tsx
+++ b/web/packages/shared/components/FieldCheckbox/FieldCheckbox.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, userEvent } from 'design/utils/testing';
+import React, { useRef, useState } from 'react';
+
+import { FieldCheckbox } from './FieldCheckbox';
+
+test('controlled flow', async () => {
+  const onChange = jest.fn();
+
+  function TestField() {
+    const [checked, setChecked] = useState(false);
+    function onCbChange(e: React.ChangeEvent<HTMLInputElement>) {
+      const c = e.currentTarget.checked;
+      setChecked(c);
+      onChange(c);
+    }
+    return (
+      <FieldCheckbox label="I agree" checked={checked} onChange={onCbChange} />
+    );
+  }
+
+  const user = userEvent.setup();
+  render(<TestField />);
+
+  await user.click(screen.getByLabelText('I agree'));
+  expect(screen.getByLabelText('I agree')).toBeChecked();
+  expect(onChange).toHaveBeenLastCalledWith(true);
+
+  await user.click(screen.getByLabelText('I agree'));
+  expect(screen.getByLabelText('I agree')).not.toBeChecked();
+  expect(onChange).toHaveBeenLastCalledWith(false);
+});
+
+test('uncontrolled flow', async () => {
+  let checkboxRef;
+  function TestForm() {
+    const cbRefInternal = useRef();
+    checkboxRef = cbRefInternal;
+    return (
+      <form data-testid="form">
+        <FieldCheckbox ref={cbRefInternal} name="ack" label="Make it so" />
+      </form>
+    );
+  }
+
+  const user = userEvent.setup();
+  render(<TestForm />);
+  expect(screen.getByTestId('form')).toHaveFormValues({});
+
+  await user.click(screen.getByLabelText('Make it so'));
+  expect(screen.getByTestId('form')).toHaveFormValues({ ack: true });
+  expect(checkboxRef.current.checked).toBe(true);
+
+  await user.click(screen.getByLabelText('Make it so'));
+  expect(screen.getByTestId('form')).toHaveFormValues({});
+  expect(checkboxRef.current.checked).toBe(false);
+});

--- a/web/packages/shared/components/FieldCheckbox/FieldCheckbox.tsx
+++ b/web/packages/shared/components/FieldCheckbox/FieldCheckbox.tsx
@@ -1,0 +1,79 @@
+import Box from 'design/Box';
+import { CheckboxSize, StyledCheckbox } from 'design/Checkbox';
+import Flex from 'design/Flex';
+import LabelInput from 'design/LabelInput';
+import Text from 'design/Text';
+import { SpaceProps } from 'design/system';
+import React, { forwardRef } from 'react';
+import styled from 'styled-components';
+
+interface FieldCheckboxProps extends SpaceProps {
+  name?: string;
+  label?: React.ReactNode;
+  helperText?: React.ReactNode;
+  checked?: boolean;
+  defaultChecked?: boolean;
+  disabled?: boolean;
+  size?: CheckboxSize;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+/** Renders a checkbox with an associated label and an optional helper text. */
+export const FieldCheckbox = forwardRef<HTMLInputElement, FieldCheckboxProps>(
+  (
+    {
+      name,
+      label,
+      helperText,
+      checked,
+      defaultChecked,
+      disabled,
+      size,
+      onChange,
+      ...styles
+    },
+    ref
+  ) => {
+    const labelColor = disabled ? 'text.disabled' : 'text.main';
+    const helperColor = disabled ? 'text.disabled' : 'text.slightlyMuted';
+    const labelTypography = size === 'small' ? 'newBody2' : 'newBody1';
+    const helperTypography = size === 'small' ? 'newBody3' : 'newBody2';
+    return (
+      <Box mb={3} {...styles}>
+        <StyledLabel disabled={disabled}>
+          <Flex flexDirection="row" gap={2}>
+            <StyledCheckbox
+              size={size}
+              ref={ref}
+              checked={checked}
+              defaultChecked={defaultChecked}
+              disabled={disabled}
+              name={name}
+              onChange={onChange}
+            />
+            <Box>
+              <Text typography={labelTypography} color={labelColor}>
+                {label}
+              </Text>
+              <Text typography={helperTypography} color={helperColor}>
+                {helperText}
+              </Text>
+            </Box>
+          </Flex>
+        </StyledLabel>
+      </Box>
+    );
+  }
+);
+
+const StyledLabel = styled(LabelInput)<{ disabled?: boolean }>`
+  // Typically, a short label in a wide container means a lot of whitespace that
+  // acts as a click target for a checkbox. To avoid this, we use inline-flex to
+  // wrap the label around its content.
+  display: inline-flex;
+  width: auto;
+  gap: ${props => props.theme.space[2]}px;
+  margin-bottom: 0;
+  line-height: 0;
+  cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
+`;

--- a/web/packages/shared/components/FieldCheckbox/FieldCheckbox.tsx
+++ b/web/packages/shared/components/FieldCheckbox/FieldCheckbox.tsx
@@ -1,3 +1,21 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import Box from 'design/Box';
 import { CheckboxSize, StyledCheckbox } from 'design/Checkbox';
 import Flex from 'design/Flex';

--- a/web/packages/shared/components/FieldCheckbox/index.ts
+++ b/web/packages/shared/components/FieldCheckbox/index.ts
@@ -1,1 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 export { FieldCheckbox } from './FieldCheckbox';

--- a/web/packages/shared/components/FieldCheckbox/index.ts
+++ b/web/packages/shared/components/FieldCheckbox/index.ts
@@ -1,0 +1,1 @@
+export { FieldCheckbox } from './FieldCheckbox';

--- a/web/packages/teleport/src/Discover/Shared/SecurityGroupPicker/SecurityGroupPicker.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SecurityGroupPicker/SecurityGroupPicker.tsx
@@ -21,7 +21,7 @@ import React, { useState } from 'react';
 import { Flex, Link } from 'design';
 import Table, { Cell } from 'design/DataTable';
 import { Danger } from 'design/Alert';
-import { CheckboxInput } from 'design/Checkbox';
+import { StyledCheckbox } from 'design/Checkbox';
 import { FetchStatus } from 'design/DataTable/types';
 
 import { Attempt } from 'shared/hooks/useAttemptNext';
@@ -165,8 +165,7 @@ function CheckboxCell({
   return (
     <Cell width="20px">
       <Flex alignItems="center" my={2} justifyContent="center">
-        <CheckboxInput
-          type="checkbox"
+        <StyledCheckbox
           id={item.id}
           onChange={e => {
             onChange(item, e);

--- a/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.test.tsx
+++ b/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.test.tsx
@@ -47,7 +47,7 @@ test('user acknowledging script was ran when s3 bucket fields are edited', async
 
   // Initial state.
   expect(screen.queryByTestId('scriptbox')).not.toBeInTheDocument();
-  expect(screen.queryByTestId('checkbox')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText(/I ran the command/i)).not.toBeInTheDocument();
   expect(
     screen.queryByRole('button', { name: /generate command/i })
   ).not.toBeInTheDocument();
@@ -73,7 +73,7 @@ test('user acknowledging script was ran when s3 bucket fields are edited', async
   expect(
     screen.queryByRole('button', { name: /generate command/i })
   ).not.toBeInTheDocument();
-  expect(screen.getByTestId('checkbox')).toBeInTheDocument();
+  expect(screen.getByLabelText(/I ran the command/i)).toBeInTheDocument();
   expect(screen.getByTestId('scriptbox')).toBeInTheDocument();
 
   // Click on checkbox should enable save button and disable edit button.
@@ -120,7 +120,7 @@ test('render warning on save when leaving s3 fields empty', async () => {
 
   // Initial state.
   expect(screen.queryByTestId('scriptbox')).not.toBeInTheDocument();
-  expect(screen.queryByTestId('checkbox')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText(/I ran the command/i)).not.toBeInTheDocument();
   expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
   expect(
     screen.queryByRole('button', { name: /generate command/i })
@@ -136,14 +136,14 @@ test('render warning on save when leaving s3 fields empty', async () => {
     ).toBeEnabled()
   );
 
-  expect(screen.queryByTestId('checkbox')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText(/I ran the command/i)).not.toBeInTheDocument();
   expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
 
   userEvent.click(screen.getByRole('button', { name: /generate command/i }));
   await screen.findByRole('button', { name: /edit/i });
   expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
 
-  userEvent.click(screen.getByTestId('checkbox'));
+  userEvent.click(screen.getByLabelText(/I ran the command/i));
   await waitFor(() =>
     expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
   );
@@ -202,14 +202,14 @@ test('render warning on save when deleting existing s3 fields', async () => {
     ).toBeEnabled()
   );
 
-  expect(screen.queryByTestId('checkbox')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText(/I ran the command/i)).not.toBeInTheDocument();
   expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
 
   userEvent.click(screen.getByRole('button', { name: /generate command/i }));
   await screen.findByRole('button', { name: /edit/i });
   expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
 
-  userEvent.click(screen.getByTestId('checkbox'));
+  userEvent.click(screen.getByLabelText(/I ran the command/i));
   await waitFor(() =>
     expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
   );
@@ -286,7 +286,7 @@ test('edit submit called with proper fields', async () => {
   userEvent.click(screen.getByRole('button', { name: /generate command/i }));
   await screen.findByRole('button', { name: /edit/i });
 
-  userEvent.click(screen.getByTestId('checkbox'));
+  userEvent.click(screen.getByLabelText(/I ran the command/i));
   await waitFor(() =>
     expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
   );

--- a/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.tsx
+++ b/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.tsx
@@ -37,8 +37,9 @@ import useAttempt from 'shared/hooks/useAttemptNext';
 import FieldInput from 'shared/components/FieldInput';
 import Validation, { Validator } from 'shared/components/Validation';
 import { requiredRoleArn } from 'shared/components/Validation/rules';
-import { CheckboxInput } from 'design/Checkbox';
 import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
+
+import { FieldCheckbox } from 'shared/components/FieldCheckbox';
 
 import { Integration } from 'teleport/services/integrations';
 import cfg from 'teleport/config';
@@ -207,19 +208,14 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
           </DialogContent>
           <DialogFooter>
             {showGenerateCommand && scriptUrl && (
-              <Box mb={1}>
-                <CheckboxInput
-                  role="checkbox"
-                  type="checkbox"
-                  name="checkbox"
-                  data-testid="checkbox"
-                  checked={confirmed}
-                  onChange={e => {
-                    setConfirmed(e.target.checked);
-                  }}
-                />
-                I ran the command
-              </Box>
+              <FieldCheckbox
+                label="I ran the command"
+                name="checkbox"
+                checked={confirmed}
+                onChange={e => {
+                  setConfirmed(e.target.checked);
+                }}
+              />
             )}
 
             {requiresS3BucketWarning && showS3BucketWarning ? (

--- a/web/packages/teleport/src/Login/Login.tsx
+++ b/web/packages/teleport/src/Login/Login.tsx
@@ -20,7 +20,8 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { Box, Text, Link, Flex, ButtonPrimary } from 'design';
-import { StyledCheckbox } from 'design/Checkbox';
+
+import { FieldCheckbox } from 'shared/components/FieldCheckbox';
 
 import FormLogin from 'teleport/components/FormLogin';
 import { LogoHero } from 'teleport/components/LogoHero';
@@ -124,24 +125,26 @@ function LicenseAcknowledgement({
           </Link>{' '}
           to evaluate and use Teleport.
         </InfoText>
-        <Flex as="label" mt={3} gap={2} alignItems="center">
-          <StyledCheckbox
-            checked={checked}
-            onChange={e => {
-              setChecked(e.target.checked);
-            }}
-          />
-          <Text>
-            By clicking continue, you agree to our{' '}
-            <Link
-              href="https://github.com/gravitational/teleport/blob/master/LICENSE-community"
-              target="_blank"
-            >
-              Terms and Conditions
-            </Link>
-            .
-          </Text>
-        </Flex>
+        <FieldCheckbox
+          mt={3}
+          mb={0}
+          checked={checked}
+          onChange={e => {
+            setChecked(e.target.checked);
+          }}
+          label={
+            <>
+              By clicking continue, you agree to our{' '}
+              <Link
+                href="https://github.com/gravitational/teleport/blob/master/LICENSE-community"
+                target="_blank"
+              >
+                Terms and Conditions
+              </Link>
+              .
+            </>
+          }
+        />
         <ButtonPrimary
           disabled={!checked}
           onClick={() => {


### PR DESCRIPTION
This PR adds a component for labeled checkboxes, as specified in [Figma](https://www.figma.com/file/Gpjs9vjhzUKF1GDbeG9JGE/Application-Design-System?type=design&node-id=8543-42595&mode=design&t=lfboeNMENiqaZygH-4). It's the first in a chain of PRs that push this feature through our codebase without (hopefully) breaking the build on the OSS/Enterprise boundary.

![Screenshot 2024-06-18 at 13 47 04](https://github.com/gravitational/teleport/assets/9391503/5970d545-4b3e-4284-bb3c-d4fc084c5dfe)

![Screenshot 2024-06-18 at 13 29 07](https://github.com/gravitational/teleport/assets/9391503/0b8c9bc2-cadc-4130-810c-ef3a53c777e9)

Followed up by Enterprise PR https://github.com/gravitational/teleport.e/pull/4430
Followed up by OSS PR https://github.com/gravitational/teleport/pull/43173
Contributes to #42573

Manual tests:
- [x] Login dialog in the Community Edition mode
- [x] Unified Resources: interacting with tiles and the filter panel
- [x] Editing AWS OIDC integration
- [x] Security group picker (EC2 Ice or automatically deploying a database service)