### PR TITLE
docs: networking proxy update

### DIFF
--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -29,7 +29,7 @@ public_addr: ["service1.example.com", "service2.example.com"]
 Specifying a public address for a Teleport service may be useful in the
 following use cases:
 
-- You have multiple identical services, e.g., DB Service instances, behind a
+- You have multiple identical services, e.g., Proxy Service instances, behind a
   load balancer.
 - You want Teleport to issue an SSH certificate for the service with additional
   principals, e.g., host names.

--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -14,13 +14,22 @@ configuration file. The public address can take an IP or a DNS name. It can also
 be a list of values:
 
 ```yaml
-public_addr: ["proxy-one.example.com", "proxy-two.example.com"]
+public_addr: ["service1.example.com", "service2.example.com"]
 ```
+
+<Admonition
+  type="warning"
+  title="Note"
+>
+  Only a single Proxy Service `public_addr` should be configured. Attempting
+  to have multiple addresses can result in redirects to the first listed address
+  that may not be available to the client.
+</Admonition>
 
 Specifying a public address for a Teleport service may be useful in the
 following use cases:
 
-- You have multiple identical services, e.g., Proxy Service instances, behind a
+- You have multiple identical services, e.g., DB Service instances, behind a
   load balancer.
 - You want Teleport to issue an SSH certificate for the service with additional
   principals, e.g., host names.


### PR DESCRIPTION
Multiple proxy public addresses are not fully supported. Providing warning to only have a single public address.