### PR TITLE
[v16] Move `@types/google-protobuf` from teleterm to build

### DIFF
--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -46,6 +46,7 @@
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.1",
+    "@types/google-protobuf": "^3.10.0",
     "@types/jest": "^29.5.10",
     "@types/jsdom": "^21.1.6",
     "@types/node": "^20.12.11",

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -39,7 +39,6 @@
     "@protobuf-ts/grpc-transport": "^2.9.3",
     "@protobuf-ts/runtime": "^2.9.3",
     "@protobuf-ts/runtime-rpc": "^2.9.3",
-    "@types/google-protobuf": "^3.10.0",
     "@types/node-forge": "^1.0.4",
     "@types/tar-fs": "^2.0.1",
     "@types/whatwg-url": "^11.0.1",


### PR DESCRIPTION
Backport #43106.