### PR TITLE
Update version check to permit pre-releases

### DIFF
--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -730,6 +730,22 @@ func TestValidateClientVersion(t *testing.T) {
 				require.True(t, trace.IsAccessDenied(err), "got %T, expected access denied error", err)
 			},
 		},
+		{
+			name:          "pre-release client allowed",
+			middleware:    &Middleware{OldestSupportedVersion: &teleport.MinClientSemVersion},
+			clientVersion: semver.Version{Major: teleport.SemVersion.Major - 1, PreRelease: "dev.abcd.123"}.String(),
+			errAssertion: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:          "pre-release client rejected",
+			middleware:    &Middleware{OldestSupportedVersion: &teleport.MinClientSemVersion},
+			clientVersion: semver.Version{Major: teleport.SemVersion.Major - 2, PreRelease: "dev.abcd.123"}.String(),
+			errAssertion: func(t *testing.T, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got %T, expected access denied error", err)
+			},
+		},
 	}
 
 	for _, tt := range cases {

--- a/version.go
+++ b/version.go
@@ -33,8 +33,10 @@ var (
 	// Per https://github.com/gravitational/teleport/blob/master/rfd/0012-teleport-versioning.md,
 	// only one major version backwards is supported for clients.
 	MinClientVersion = MinClientSemVersion.String()
-	// MinClientSemVersion is the MinClientVersion represented as a [semver.Version].
-	MinClientSemVersion = semver.Version{Major: SemVersion.Major - 1}
+	// MinClientSemVersion is the MinClientVersion represented as a [semver.Version]. The
+	// [semver.Version.PreRelease] is set to "aa" so that the minimum client version comes before
+	// <version>-alpha so that alpha, beta, rc, and dev builds are permitted.
+	MinClientSemVersion = semver.Version{Major: SemVersion.Major - 1, PreRelease: "aa"}
 )
 
 // Gitref is set to the output of "git describe" during the build process.


### PR DESCRIPTION
The minimum client version was updated to set the prerelease to "aa" so that it appears before any alpha, beta, rc, or dev builds. This is a similar hack to the one used by utils.VersionBeforeAlpha.

Fixes https://github.com/gravitational/teleport/issues/43184.