### PR TITLE
Fix `TestInitDatabaseService/enabled_invalid_databases` flakiness

### DIFF
--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1766,6 +1766,7 @@ func TestInitDatabaseService(t *testing.T) {
 			expectErr: false,
 		},
 	} {
+		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -1793,17 +1794,16 @@ func TestInitDatabaseService(t *testing.T) {
 			})
 			require.NoError(t, process.Start())
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			event, err := process.WaitForEvent(ctx, ServiceExitedWithErrorEvent)
 			if !test.expectErr {
-				// should timeout without the process exit event.
-				require.Error(t, err)
-				require.ErrorIs(t, err, context.DeadlineExceeded)
+				_, err := process.WaitForEvent(ctx, TeleportReadyEvent)
+				require.NoError(t, err)
 				return
 			}
 
+			event, err := process.WaitForEvent(ctx, ServiceExitedWithErrorEvent)
 			require.NoError(t, err)
 			require.NotNil(t, event)
 			exitPayload, ok := event.Payload.(ExitEventPayload)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1766,7 +1766,6 @@ func TestInitDatabaseService(t *testing.T) {
 			expectErr: false,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Attempt to fix test flakiness introduced at #42900. Related to #42963.

The flakiness on `TestInitDatabaseService/enabled_invalid_databases` was caused by the low timeout used while waiting for the service to exit. This value was set to low because tests that don't exit with an error would always require exceeding this timeout (causing a failure on the "Flaky Tests Detector" due to timeout).

This PR changes the assertion when no error is expected to wait for the Teleport ready event and increases the timeout while waiting for events, giving the instance enough time to transition between states.