### PR TITLE
Use correct fingerprint for gcp instances

### DIFF
--- a/lib/cloud/gcp/vm.go
+++ b/lib/cloud/gcp/vm.go
@@ -178,7 +178,7 @@ func toInstance(origInstance *computepb.Instance, projectID string) *gcpimds.Ins
 		Labels:            origInstance.GetLabels(),
 		InternalIPAddress: internalIP,
 		ExternalIPAddress: externalIP,
-		Fingerprint:       origInstance.GetFingerprint(),
+		Fingerprint:       origInstance.GetMetadata().GetFingerprint(),
 		MetadataItems:     items,
 	}
 	// GCP VMs can have at most one service account.

--- a/lib/cloud/gcp/vm_test.go
+++ b/lib/cloud/gcp/vm_test.go
@@ -21,17 +21,23 @@ package gcp
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	compute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -253,4 +259,58 @@ func TestRunCommand(t *testing.T) {
 		},
 	}))
 	require.Equal(t, 1, mock.execCount)
+}
+
+func TestGetInstance(t *testing.T) {
+	ctx := context.Background()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/compute/v1/projects/{project}/zones/{zone}/instances/{id}", func(w http.ResponseWriter, r *http.Request) {
+		out, err := json.Marshal(&computepb.Instance{
+			Name:        googleapi.String("Test"),
+			Zone:        googleapi.String("TestZone"),
+			Fingerprint: googleapi.String("9876"),
+			NetworkInterfaces: []*computepb.NetworkInterface{
+				{NetworkIP: googleapi.String("10.20.30.40")},
+			},
+			Metadata: &computepb.Metadata{
+				Fingerprint: googleapi.String("1234"),
+				Items: []*computepb.Items{
+					{Key: googleapi.String("animal"), Value: googleapi.String("llama")},
+				},
+			},
+		})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Write(out)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	clt, err := compute.NewInstancesRESTClient(ctx, option.WithEndpoint(srv.URL), option.WithoutAuthentication(), option.WithHTTPClient(srv.Client()))
+	require.NoError(t, err)
+
+	instanceClient := instancesClient{InstancesClientConfig{InstanceClient: clt}}
+
+	actual, err := instanceClient.GetInstance(ctx, &gcpimds.InstanceRequest{
+		ProjectID:       "TestProject",
+		Zone:            "TestZone",
+		Name:            "llama",
+		ID:              123,
+		WithoutHostKeys: true,
+	})
+	require.NoError(t, err)
+
+	expected := &gcpimds.Instance{
+		Name:              "Test",
+		ProjectID:         "TestProject",
+		Zone:              "TestZone",
+		Fingerprint:       "1234",
+		InternalIPAddress: "10.20.30.40",
+		MetadataItems:     map[string]string{"animal": "llama"},
+	}
+	require.Empty(t, cmp.Diff(expected, actual))
+
 }


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/43122 incorrectly pulled the fingerprint from the compute instance object instead of the compute instance object metadata.

This resulted in errors updating resources due to fingerprint mismatches.

```
2024-06-18T16:35:53Z ERRO [DISCOVERY] Failed to enroll discovered GCP VMs. error:[
ERROR REPORT:
Original Error: *apierror.APIError googleapi: Error 412: Supplied fingerprint does not match current metadata fingerprint.
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:407 github.com/gravitational/teleport/lib/cloud/gcp.(*instancesClient).AddSSHKey
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:548 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:76 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.7.0/errgroup/errgroup.go:78 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_amd64.s:1695 runtime.goexit
User Message: googleapi: Error 412: Supplied fingerprint does not match current metadata fingerprint.] pid:1121.1 discovery/discovery.go:1206
```