### PR TITLE
Script oneoff: add optional command prefix (sudo)

### DIFF
--- a/lib/web/scripts/oneoff/oneoff.go
+++ b/lib/web/scripts/oneoff/oneoff.go
@@ -62,6 +62,9 @@ type OneOffScriptParams struct {
 	// TeleportCommandPrefix is a prefix command to use when calling teleport command.
 	// Acceptable values are: "sudo"
 	TeleportCommandPrefix string
+	// binSudo contains the location for the sudo binary.
+	// Used for testing.
+	binSudo string
 
 	// TeleportArgs is the arguments to pass to the teleport binary.
 	// Eg, 'version'
@@ -106,6 +109,10 @@ func (p *OneOffScriptParams) CheckAndSetDefaults() error {
 		p.BinMktemp = binMktemp
 	}
 
+	if p.binSudo == "" {
+		p.binSudo = "sudo"
+	}
+
 	if p.CDNBaseURL == "" {
 		p.CDNBaseURL = teleportCDNLocation
 	}
@@ -128,10 +135,12 @@ func (p *OneOffScriptParams) CheckAndSetDefaults() error {
 		p.SuccessMessage = "Completed successfully."
 	}
 
-	if p.TeleportCommandPrefix != "" {
-		if !slices.Contains(allowedCommandPrefix, p.TeleportCommandPrefix) {
-			return trace.BadParameter("invalid command prefix, only %v are supported", allowedCommandPrefix)
-		}
+	switch p.TeleportCommandPrefix {
+	case PrefixSUDO:
+		p.TeleportCommandPrefix = p.binSudo
+	case "":
+	default:
+		return trace.BadParameter("invalid command prefix %q, only %v are supported", p.TeleportCommandPrefix, allowedCommandPrefix)
 	}
 
 	return nil

--- a/lib/web/scripts/oneoff/oneoff.go
+++ b/lib/web/scripts/oneoff/oneoff.go
@@ -41,7 +41,13 @@ const (
 
 	// binMktemp is the default binary name for creating temporary directories.
 	binMktemp = "mktemp"
+
+	// PrefixSUDO is a Teleport Command Prefix that executes with higher privileges
+	// Use with caution.
+	PrefixSUDO = "sudo"
 )
+
+var allowedCommandPrefix = []string{PrefixSUDO}
 
 var (
 	//go:embed oneoff.sh
@@ -53,6 +59,10 @@ var (
 
 // OneOffScriptParams contains the required params to create a script that downloads and executes teleport binary.
 type OneOffScriptParams struct {
+	// TeleportCommandPrefix is a prefix command to use when calling teleport command.
+	// Acceptable values are: "sudo"
+	TeleportCommandPrefix string
+
 	// TeleportArgs is the arguments to pass to the teleport binary.
 	// Eg, 'version'
 	TeleportArgs string
@@ -116,6 +126,12 @@ func (p *OneOffScriptParams) CheckAndSetDefaults() error {
 
 	if p.SuccessMessage == "" {
 		p.SuccessMessage = "Completed successfully."
+	}
+
+	if p.TeleportCommandPrefix != "" {
+		if !slices.Contains(allowedCommandPrefix, p.TeleportCommandPrefix) {
+			return trace.BadParameter("invalid command prefix, only %v are supported", allowedCommandPrefix)
+		}
 	}
 
 	return nil

--- a/lib/web/scripts/oneoff/oneoff.sh
+++ b/lib/web/scripts/oneoff/oneoff.sh
@@ -45,7 +45,7 @@ main() {
     mkdir -p ${tempDir}/bin
     mv ${tempDir}/${teleportFlavor}/teleport ${tempDir}/bin/teleport
     echo "> ${tempDir}/bin/teleport ${teleportArgs} $@"
-    ${tempDir}/bin/teleport ${teleportArgs} $@ && echo $successMessage
+    {{.TeleportCommandPrefix}} ${tempDir}/bin/teleport ${teleportArgs} $@ && echo $successMessage
 }
 
 main $@


### PR DESCRIPTION
We are converting the installer script used for Server Auto Discover to use go instead of shell script.

As an example, in EC2 Auto Discover, the script runs as `ssm-user` which has access to using `sudo`.

This script is currently using `sudo` to change system wide configurations (adding repos, installing packages, create file locks, ....):
https://github.com/gravitational/teleport/blob/master/api/types/installers/installer.sh.tmpl
In order to convert this script into go code, we must also run with elevated privileges.

This PR changes the `oneoff` script to optionally run with a prefix. This prefix can only be `sudo`.