### PR TITLE
[v15] event-handler: Fix link to docs in README

### DIFF
--- a/examples/chart/event-handler/README.md
+++ b/examples/chart/event-handler/README.md
@@ -4,7 +4,7 @@ This chart sets up and configures a Deployment for the Event Handler plugin.
 
 ## Installation
 
-See the [Access Requests with Slack guide](https://goteleport.com/docs/access-controls/access-request-plugins/ssh-approval-slack/).
+See the [Export Events with FluentD Guide](https://goteleport.com/docs/management/export-audit-events/fluentd/).
 
 ## Settings
 


### PR DESCRIPTION
Backport #43236 to branch/v15