### PR TITLE
[v16] ami: Add install section to teleport-acm unit file

### DIFF
--- a/assets/aws/files/system/teleport-acm.service
+++ b/assets/aws/files/system/teleport-acm.service
@@ -15,3 +15,6 @@ ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Backport #43213 to branch/v16

changelog: Added a missing `[Install]` section to the `teleport-acm` systemd unit file as used by Teleport AMIs.
