### PR TITLE
Disable debug service in agents ran by Connect My Computer

### DIFF
--- a/web/packages/teleterm/src/agentCleanupDaemon/agentCleanupDaemon.test.ts
+++ b/web/packages/teleterm/src/agentCleanupDaemon/agentCleanupDaemon.test.ts
@@ -1,4 +1,7 @@
 /**
+ * @jest-environment node
+ */
+/**
  * Teleport
  * Copyright (C) 2023  Gravitational, Inc.
  *

--- a/web/packages/teleterm/src/mainProcess/agentDownloader/fileDownloader.test.ts
+++ b/web/packages/teleterm/src/mainProcess/agentDownloader/fileDownloader.test.ts
@@ -1,5 +1,5 @@
 /**
- * @jest-environment jsdom
+ * @jest-environment node
  */
 /**
  * Teleport

--- a/web/packages/teleterm/src/mainProcess/createAgentConfigFile.test.ts
+++ b/web/packages/teleterm/src/mainProcess/createAgentConfigFile.test.ts
@@ -1,4 +1,7 @@
 /**
+ * @jest-environment node
+ */
+/**
  * Teleport
  * Copyright (C) 2023  Gravitational, Inc.
  *

--- a/web/packages/teleterm/src/mainProcess/createAgentConfigFile.test.ts
+++ b/web/packages/teleterm/src/mainProcess/createAgentConfigFile.test.ts
@@ -24,6 +24,7 @@ import { makeRuntimeSettings } from 'teleterm/mainProcess/fixtures/mocks';
 
 import {
   createAgentConfigFile,
+  disableDebugServiceStanza,
   generateAgentConfigPaths,
 } from './createAgentConfigFile';
 
@@ -34,10 +35,12 @@ beforeEach(() => {
   jest
     .spyOn(childProcess, 'execFile')
     .mockImplementation((command, args, options, callback) => {
-      callback(undefined, '', '');
-      return this;
+      callback(null, '', '');
+      return undefined;
     });
   jest.spyOn(fs, 'rm').mockImplementation(() => Promise.resolve());
+  jest.spyOn(fs, 'mkdir').mockImplementation(() => Promise.resolve(undefined));
+  jest.spyOn(fs, 'writeFile').mockImplementation(() => Promise.resolve());
 });
 
 test('teleport configure is called with proper arguments', async () => {
@@ -69,7 +72,7 @@ test('teleport configure is called with proper arguments', async () => {
     [
       'node',
       'configure',
-      `--output=${userDataDir}/agents/cluster.local/config.yaml`,
+      `--output=stdout`,
       `--data-dir=${userDataDir}/agents/cluster.local/data`,
       `--proxy=${proxy}`,
       `--token=${token}`,
@@ -79,6 +82,14 @@ test('teleport configure is called with proper arguments', async () => {
       timeout: 10_000, // 10 seconds
     },
     expect.anything()
+  );
+  expect(fs.writeFile).toHaveBeenCalledWith(
+    `${userDataDir}/agents/cluster.local/config.yaml`,
+    // It'd be nice to make childProcess.execFile return certain output and then verify that this
+    // argument includes that output + disableDebugServiceStanza. Alas, the promisified version of
+    // execFile isn't easily mockable – stdout in tests is just "undefined" for some reason.
+    expect.stringContaining(disableDebugServiceStanza),
+    expect.any(Object)
   );
 });
 

--- a/web/packages/teleterm/src/mainProcess/createAgentConfigFile.test.ts
+++ b/web/packages/teleterm/src/mainProcess/createAgentConfigFile.test.ts
@@ -91,8 +91,7 @@ test('teleport configure is called with proper arguments', async () => {
     // It'd be nice to make childProcess.execFile return certain output and then verify that this
     // argument includes that output + disableDebugServiceStanza. Alas, the promisified version of
     // execFile isn't easily mockable – stdout in tests is just "undefined" for some reason.
-    expect.stringContaining(disableDebugServiceStanza),
-    expect.any(Object)
+    expect.stringContaining(disableDebugServiceStanza)
   );
 });
 

--- a/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
+++ b/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
@@ -70,8 +70,6 @@ export async function createAgentConfigFile(
 
   try {
     await fs.mkdir(path.dirname(configFile), {
-      // Directories must be rwx, not just rw-.
-      mode: 0o744,
       // Create the agents dir too if it doesn't already exist.
       recursive: true,
     });
@@ -82,9 +80,7 @@ export async function createAgentConfigFile(
     }
   }
 
-  await fs.writeFile(configFile, stdout + disableDebugServiceStanza, {
-    mode: 0o644,
-  });
+  await fs.writeFile(configFile, stdout + disableDebugServiceStanza);
 }
 
 // The debug service is enabled by default. It starts when the teleport agent is launched and it

--- a/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
+++ b/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
@@ -52,12 +52,12 @@ export async function createAgentConfigFile(
     .map(keyAndValue => keyAndValue.join('='))
     .join(',');
 
-  await asyncExecFile(
+  const { stdout } = await asyncExecFile(
     runtimeSettings.agentBinaryPath,
     [
       'node',
       'configure',
-      `--output=${configFile}`,
+      '--output=stdout',
       `--data-dir=${dataDirectory}`,
       `--proxy=${args.proxy}`,
       `--token=${args.token}`,
@@ -67,7 +67,45 @@ export async function createAgentConfigFile(
       timeout: 10_000, // 10 seconds
     }
   );
+
+  try {
+    await fs.mkdir(path.dirname(configFile), {
+      // Directories must be rwx, not just rw-.
+      mode: 0o744,
+      // Create the agents dir too if it doesn't already exist.
+      recursive: true,
+    });
+  } catch (error) {
+    // Ignore error if directory already exists.
+    if (error['code'] !== 'EEXIST') {
+      throw error;
+    }
+  }
+
+  await fs.writeFile(configFile, stdout + disableDebugServiceStanza, {
+    mode: 0o644,
+  });
 }
+
+// The debug service is enabled by default. It starts when the teleport agent is launched and it
+// creates a debug.sock file in the data directory. Unfortunately, there's a length limit on the
+// socket path – 107 characters on Linux and 104 characters on macOS [1]. If exceeded, creating a
+// new listener fails with "bind: invalid argument".
+//
+// The default path for debug.sock for Connect My Computer on macOS is
+// /Users/<user>/Library/Application Support/Teleport Connect/agents/<proxy hostname>/data/debug.sock
+// The constant part is 76 characters which leaves just 28 characters for the hostname and user.
+//
+// As a workaround, we disable the debug service. This is going to work until someone adds another
+// socket which is crucial to run a Teleport agent.
+//
+// See the GitHub issue for more details: https://github.com/gravitational/teleport/issues/43250
+//
+// [1] https://unix.stackexchange.com/questions/367008/why-is-socket-path-length-limited-to-a-hundred-chars
+export const disableDebugServiceStanza = `
+debug_service:
+  enabled: false
+`;
 
 export async function removeAgentDirectory(
   runtimeSettings: RuntimeSettings,

--- a/web/packages/teleterm/src/mainProcess/terminateWithTimeout/terminateWithTimeout.test.ts
+++ b/web/packages/teleterm/src/mainProcess/terminateWithTimeout/terminateWithTimeout.test.ts
@@ -1,4 +1,7 @@
 /**
+ * @jest-environment node
+ */
+/**
  * Teleport
  * Copyright (C) 2023  Gravitational, Inc.
  *

--- a/web/packages/teleterm/src/services/grpcCredentials/makeCert/makeCert.test.ts
+++ b/web/packages/teleterm/src/services/grpcCredentials/makeCert/makeCert.test.ts
@@ -1,4 +1,7 @@
 /**
+ * @jest-environment node
+ */
+/**
  * (The MIT License)
  *
  * Copyright (c) 2019 Subash Pathak <subash@subash.me>


### PR DESCRIPTION
This is a workaround for #43250. In short, the debug service, which is [enabled by default](https://github.com/gravitational/teleport/blob/master/rfd/0167-debug-service.md#disabling), attempts to create a unix socket within the data directory. What we didn't know about is that there's a limit on how long the path of a unix socket can be. Since on macOS we store our agents pretty deep within `~/Library`, it's people are likely to exceed the limit if their username and proxy hostname are long enough.

As a workaround, we disable the debug service. Since we depend on `teleport node configure` to generate the config, we make it print the config to stdout, then we append the stanza that disables the debug service and save that to a file.

I tested the change on macOS and Linux in a VM. To reproduce the issue, add an extra suffix to the agent dir, long enough so that you exceed the limit listed in the issue. Remember to set the suffix in both JS and Go.

<details>
<summary>Patch</summary>

```diff
diff --git a/lib/teleterm/services/connectmycomputer/connectmycomputer.go b/lib/teleterm/services/connectmycomputer/connectmycomputer.go
index 1cc0f8914a..ec4dd60d53 100644
--- a/lib/teleterm/services/connectmycomputer/connectmycomputer.go
+++ b/lib/teleterm/services/connectmycomputer/connectmycomputer.go
@@ -380,7 +380,7 @@ func (n *NodeJoinWait) Run(ctx context.Context, accessAndIdentity AccessAndIdent
 }
 
 func (n *NodeJoinWait) getNodeNameFromHostUUIDFile(ctx context.Context, cluster *clusters.Cluster) (string, error) {
-	dataDir := getAgentDataDir(n.cfg.AgentsDir, cluster.ProfileName)
+	dataDir := getAgentDataDir(n.cfg.AgentsDir, fmt.Sprintf("%s-lorem-ipsum-dolor-sit-amet", cluster.ProfileName))
 
 	// NodeJoinWait gets executed when the agent is booting up, so the host UUID file might not exist
 	// on disk yet. Use a ticker to periodically check for its existence.
diff --git a/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts b/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
index bfe885a870..89ccbda107 100644
--- a/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
+++ b/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
@@ -199,5 +199,5 @@ function getAgentDirectoryOrThrow(
   if (!isValidPath) {
     throw new Error(`The agent config path is incorrect: ${resolved}`);
   }
-  return resolved;
+  return resolved + '-lorem-ipsum-dolor-sit-amet';
 }

```
</details>

changelog: Fixed Connect My Computer in Teleport Connect failing with "bind: invalid argument"