### PR TITLE
[v15] MockedUnaryCall.then: Handle onrejected not being defined

### DIFF
--- a/web/packages/teleterm/src/services/tshd/cloneableClient.ts
+++ b/web/packages/teleterm/src/services/tshd/cloneableClient.ts
@@ -404,9 +404,17 @@ export class MockedUnaryCall<Response extends object>
     onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>
   ): Promise<TResult1 | TResult2> {
     if (this.error) {
-      // Despite this being an error branch, it needs to use Promise.resolve. Otherwise we'd get
-      // uncaught errors. See https://www.promisejs.org/implementing/#then
-      return Promise.resolve(onrejected(this.error));
+      if (typeof onrejected === 'function') {
+        try {
+          // Despite this being an error branch, it needs to use Promise.resolve. Otherwise we'd get
+          // uncaught errors. See https://www.promisejs.org/implementing/#then
+          return Promise.resolve(onrejected(this.error));
+        } catch (ex) {
+          return Promise.reject(ex);
+        }
+      } else {
+        return Promise.reject(this.error);
+      }
     }
 
     return Promise.resolve(


### PR DESCRIPTION
While working on a v16 feature, I discovered that `MockedUnaryCall` behaves incorrectly when returned from a non-async function (which should be perfectly valid) https://github.com/gravitational/teleport/pull/43195#discussion_r1645964540.

Since that PR won't be backported to v15, I'm pushing just this single fix to v15.

I copied the error branch implementation from https://www.promisejs.org/implementing/#then. It's like the second time I'm fixing this class that I wrote myself, hopefully this is the last time! 🤞