### PR TITLE
Mark Discovery service healthy on startup

### DIFF
--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -128,6 +128,11 @@ func (process *TeleportProcess) initDiscoveryService() error {
 	}
 	logger.InfoContext(process.ExitContext(), "Discovery service has successfully started")
 
+	// The Discovery service doesn't have heartbeats so we cannot use them to check health.
+	// For now, we just mark ourselves ready all the time on startup.
+	// If we don't, a process only running the Discovery service will never report ready.
+	process.OnHeartbeat(teleport.ComponentDiscovery)(nil)
+
 	if err := discoveryService.Wait(); err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/35808

Changelog: Fix a bug where a Teleport instance running only Jamf or Discovery service would never have a healthy  `/readyz` endpoint.

This PR is similar to the Jamf service one in teleport.e: https://github.com/gravitational/teleport.e/pull/4445

The Teleport readiness relies on Teleport heartbeats. As the Discovery service doesn't have heartbeats, it was never seen healthy by the readiness checker, and the readiness always failed.

This PR marks the Discovery service ready on startup. We [discussed on Slack](https://gravitational.slack.com/archives/C01TYKHFVTQ/p1718720682298219?thread_ts=1718714491.889579&cid=C01TYKHFVTQ) and concluded that service readiness should not depend on the health of external APIs. For such services, a better approach might be to define a heartbeat replacement testing Teleport connectivity and use this instead. Readiness and process lifecycle management can be discussed in a future RFD.

### Context for reviewers:
- `<Service>ReadyEvent` is used by the process supervisor to wait for the service to startup
- `TeleportOKEvent{Component: <Service>}` is emitted by `process.OnHeartbeat()` and is used to answer the readiness probe