### PR TITLE
Opsgenie team responders support

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -738,6 +738,8 @@ const (
 	ReqAnnotationApproveSchedulesLabel = "/schedules"
 	// ReqAnnotationNotifySchedulesLabel is the request annotation key at which notify schedules are stored for access plugins.
 	ReqAnnotationNotifySchedulesLabel = "/notify-services"
+	// ReqAnnotationTeamsLabel is the request annotation key at which teams are stored for access plugins.
+	ReqAnnotationTeamsLabel = "/teams"
 
 	// CloudAWS identifies that a resource was discovered in AWS.
 	CloudAWS = "AWS"

--- a/docs/pages/access-controls/access-request-plugins/opsgenie.mdx
+++ b/docs/pages/access-controls/access-request-plugins/opsgenie.mdx
@@ -80,7 +80,7 @@ spec:
 
 The `teleport.dev/notify-services` annotation specifies the schedules the alert will be created for.
 The `teleport.dev/teams` annotation specifies the teams the alert will be created for. This is useful when you
-have multiple schedules with escaltions or just an Opsgenie integrations that only works with teams.
+have multiple schedules with escalations or an Opsgenie integration that only works with teams.
 The `teleport.dev/schedules` annotation specifies the schedules the alert will check, and auto approve the
 Access Request if the requesting user is on-call.
 

--- a/docs/pages/access-controls/access-request-plugins/opsgenie.mdx
+++ b/docs/pages/access-controls/access-request-plugins/opsgenie.mdx
@@ -74,10 +74,13 @@ spec:
           deny: 1
       annotations:
         teleport.dev/notify-services: ['teleport-access-request-notifications']
+        teleport.dev/teams: ['teleport-team']
         teleport.dev/schedules: ['teleport-access-alert-schedules']
 ```
 
 The `teleport.dev/notify-services` annotation specifies the schedules the alert will be created for.
+The `teleport.dev/teams` annotation specifies the teams the alert will be created for. This is useful when you
+have multiple schedules with escaltions or just an Opsgenie integrations that only works with teams.
 The `teleport.dev/schedules` annotation specifies the schedules the alert will check, and auto approve the
 Access Request if the requesting user is on-call.
 

--- a/integrations/access/opsgenie/app.go
+++ b/integrations/access/opsgenie/app.go
@@ -274,9 +274,34 @@ func (a *App) onDeletedRequest(ctx context.Context, reqID string) error {
 	return a.resolveAlert(ctx, reqID, Resolution{Tag: ResolvedExpired})
 }
 
-func (a *App) getNotifyServiceNames(req types.AccessRequest) ([]string, error) {
-	annotationKey := types.TeleportNamespace + types.ReqAnnotationNotifySchedulesLabel
-	return common.GetServiceNamesFromAnnotations(req, annotationKey)
+// Get services to notify from both annotations: /notify-services and /teams
+// Return error if both are empty
+func (a *App) getNotifyServiceNames(ctx context.Context, req types.AccessRequest) ([]string, error) {
+	log := logger.Get(ctx)
+
+	var servicesNames []string
+
+	scheduleAnnotationKey := types.TeleportNamespace + types.ReqAnnotationNotifySchedulesLabel
+	schedules, err := common.GetServiceNamesFromAnnotations(req, scheduleAnnotationKey)
+	if err != nil {
+		log.Debugf("No schedules to notifiy in %s", scheduleAnnotationKey)
+	} else {
+		servicesNames = append(servicesNames, schedules...)
+	}
+
+	teamAnnotationKey := types.TeleportNamespace + types.ReqAnnotationTeamsLabel
+	teams, err := common.GetServiceNamesFromAnnotations(req, teamAnnotationKey)
+	if err != nil {
+		log.Debugf("No teams to notifiy in %s", teamAnnotationKey)
+	} else {
+		servicesNames = append(servicesNames, teams...)
+	}
+
+	if len(servicesNames) == 0 {
+		return nil, trace.NotFound("no services to notify")
+	}
+
+	return servicesNames, nil
 }
 
 func (a *App) getOnCallServiceNames(req types.AccessRequest) ([]string, error) {
@@ -287,8 +312,8 @@ func (a *App) getOnCallServiceNames(req types.AccessRequest) ([]string, error) {
 func (a *App) tryNotifyService(ctx context.Context, req types.AccessRequest) (bool, error) {
 	log := logger.Get(ctx)
 
-	serviceNames, err := a.getNotifyServiceNames(req)
-	if err != nil {
+	serviceNames, err := a.getNotifyServiceNames(ctx, req)
+	if err != nil || len(serviceNames) == 0 {
 		log.Debugf("Skipping the notification: %s", err)
 		return false, trace.Wrap(errMissingAnnotation)
 	}
@@ -318,12 +343,8 @@ func (a *App) tryNotifyService(ctx context.Context, req types.AccessRequest) (bo
 	}
 
 	if isNew {
-		for _, serviceName := range serviceNames {
-			alertCtx, _ := logger.WithField(ctx, "opsgenie_service_name", serviceName)
-
-			if err = a.createAlert(alertCtx, serviceName, reqID, reqData); err != nil {
-				return isNew, trace.Wrap(err, "creating Opsgenie alert")
-			}
+		if err = a.createAlert(ctx, reqID, reqData); err != nil {
+			return isNew, trace.Wrap(err, "creating Opsgenie alert")
 		}
 
 		if reqReviews := req.GetReviews(); len(reqReviews) > 0 {
@@ -336,7 +357,7 @@ func (a *App) tryNotifyService(ctx context.Context, req types.AccessRequest) (bo
 }
 
 // createAlert posts an alert with request information.
-func (a *App) createAlert(ctx context.Context, serviceID, reqID string, reqData RequestData) error {
+func (a *App) createAlert(ctx context.Context, reqID string, reqData RequestData) error {
 	data, err := a.opsgenie.CreateAlert(ctx, reqID, reqData)
 	if err != nil {
 		return trace.Wrap(err)

--- a/integrations/access/opsgenie/client.go
+++ b/integrations/access/opsgenie/client.go
@@ -221,13 +221,13 @@ func (og Client) getResponders(reqData RequestData) []Responder {
 	for _, s := range schedules {
 		responders = append(responders, Responder{
 			Type: ResponderTypeSchedule,
-			ID:   s,
+			Name: s,
 		})
 	}
 	for _, t := range teams {
 		responders = append(responders, Responder{
 			Type: ResponderTypeTeam,
-			ID:   t,
+			Name: t,
 		})
 	}
 	return responders

--- a/integrations/access/opsgenie/client.go
+++ b/integrations/access/opsgenie/client.go
@@ -45,6 +45,7 @@ const (
 	heartbeatName         = "teleport-access-heartbeat"
 	ResponderTypeSchedule = "schedule"
 	ResponderTypeUser     = "user"
+	ResponderTypeTeam     = "team"
 
 	ResolveAlertRequestRetryInterval = time.Second * 10
 	ResolveAlertRequestRetryTimeout  = time.Minute * 2
@@ -82,6 +83,8 @@ type ClientConfig struct {
 	APIEndpoint string
 	// DefaultSchedules are the default on-call schedules to check for auto approval
 	DefaultSchedules []string
+	// DefaultTeams are the default Opsgenie Teams to add as responders
+	DefaultTeams []string
 	// Priority is the priority alerts are to be created with
 	Priority string
 
@@ -142,7 +145,7 @@ func (og Client) CreateAlert(ctx context.Context, reqID string, reqData RequestD
 		Message:     fmt.Sprintf("Access request from %s", reqData.User),
 		Alias:       fmt.Sprintf("%s/%s", alertKeyPrefix, reqID),
 		Description: bodyDetails,
-		Responders:  og.getScheduleResponders(reqData),
+		Responders:  og.getResponders(reqData),
 		Priority:    og.Priority,
 	}
 
@@ -205,16 +208,26 @@ func (og Client) getAlertRequestResult(ctx context.Context, reqID string) (GetAl
 	return result, nil
 }
 
-func (og Client) getScheduleResponders(reqData RequestData) []Responder {
+func (og Client) getResponders(reqData RequestData) []Responder {
 	schedules := og.DefaultSchedules
 	if reqSchedules, ok := reqData.SystemAnnotations[types.TeleportNamespace+types.ReqAnnotationNotifySchedulesLabel]; ok {
 		schedules = reqSchedules
 	}
-	responders := make([]Responder, 0, len(schedules))
+	teams := og.DefaultTeams
+	if reqTeams, ok := reqData.SystemAnnotations[types.TeleportNamespace+types.ReqAnnotationTeamsLabel]; ok {
+		teams = reqTeams
+	}
+	responders := make([]Responder, 0, len(schedules)+len(teams))
 	for _, s := range schedules {
 		responders = append(responders, Responder{
 			Type: ResponderTypeSchedule,
 			ID:   s,
+		})
+	}
+	for _, t := range teams {
+		responders = append(responders, Responder{
+			Type: ResponderTypeTeam,
+			ID:   t,
 		})
 	}
 	return responders

--- a/integrations/access/opsgenie/client_test.go
+++ b/integrations/access/opsgenie/client_test.go
@@ -59,7 +59,7 @@ func TestCreateAlert(t *testing.T) {
 		Roles:         []string{"role1", "role2"},
 		RequestReason: "someReason",
 		SystemAnnotations: types.Labels{
-			types.TeleportNamespace + types.ReqAnnotationNotifySchedulesLabel: {"responder@teleport.com"},
+			types.TeleportNamespace + types.ReqAnnotationNotifySchedulesLabel: {"responder@example.com"},
 			types.TeleportNamespace + types.ReqAnnotationTeamsLabel:           {"MyOpsGenieTeam"},
 		},
 	})
@@ -70,7 +70,7 @@ func TestCreateAlert(t *testing.T) {
 		Alias:       "teleport-access-request/someRequestID",
 		Description: "someUser requested permissions for roles role1, role2 on Teleport at 01 Jan 01 00:00 UTC.\nReason: someReason\n\n",
 		Responders: []Responder{
-			{Type: "schedule", ID: "responder@teleport.com"},
+			{Type: "schedule", ID: "responder@example.com"},
 			{Type: "team", ID: "MyOpsGenieTeam"},
 		},
 		Priority: "somePriority",

--- a/integrations/access/opsgenie/client_test.go
+++ b/integrations/access/opsgenie/client_test.go
@@ -60,6 +60,7 @@ func TestCreateAlert(t *testing.T) {
 		RequestReason: "someReason",
 		SystemAnnotations: types.Labels{
 			types.TeleportNamespace + types.ReqAnnotationNotifySchedulesLabel: {"responder@teleport.com"},
+			types.TeleportNamespace + types.ReqAnnotationTeamsLabel:           {"MyOpsGenieTeam"},
 		},
 	})
 	assert.NoError(t, err)
@@ -68,8 +69,11 @@ func TestCreateAlert(t *testing.T) {
 		Message:     "Access request from someUser",
 		Alias:       "teleport-access-request/someRequestID",
 		Description: "someUser requested permissions for roles role1, role2 on Teleport at 01 Jan 01 00:00 UTC.\nReason: someReason\n\n",
-		Responders:  []Responder{{Type: "schedule", ID: "responder@teleport.com"}},
-		Priority:    "somePriority",
+		Responders: []Responder{
+			{Type: "schedule", ID: "responder@teleport.com"},
+			{Type: "team", ID: "MyOpsGenieTeam"},
+		},
+		Priority: "somePriority",
 	}
 	var got AlertBody
 	err = json.Unmarshal([]byte(recievedReq), &got)

--- a/integrations/access/opsgenie/testlib/suite.go
+++ b/integrations/access/opsgenie/testlib/suite.go
@@ -33,10 +33,13 @@ import (
 )
 
 const (
-	NotifyScheduleName         = "Teleport Notifications"
+	NotifyScheduleNameOne      = "Teleport Notifications One"
+	NotifyScheduleNameTwo      = "Teleport Notifications Two"
 	NotifyScheduleAnnotation   = types.TeleportNamespace + types.ReqAnnotationNotifySchedulesLabel
 	ApprovalScheduleName       = "Teleport Approval"
 	ApprovalScheduleAnnotation = types.TeleportNamespace + types.ReqAnnotationApproveSchedulesLabel
+	NotifyTeamName             = "My Team"
+	NotifyTeamAnnotation       = types.TeleportNamespace + types.ReqAnnotationTeamsLabel
 )
 
 // OpsgenieBaseSuite is the OpsGenie access plugin test suite.
@@ -69,12 +72,13 @@ func (s *OpsgenieBaseSuite) SetupTest() {
 
 	// This service should be notified for every access request.
 	s.ogNotifyResponder = s.fakeOpsgenie.StoreResponder(opsgenie.Responder{
-		Name: NotifyScheduleName,
+		Name: NotifyScheduleNameOne,
 	})
+
 	s.AnnotateRequesterRoleAccessRequests(
 		ctx,
 		NotifyScheduleAnnotation,
-		[]string{NotifyScheduleName},
+		[]string{NotifyScheduleNameOne, NotifyScheduleNameTwo},
 	)
 
 	// Responder 1 and 2 are on-call and should be automatically approved.
@@ -125,12 +129,43 @@ func (s *OpsgenieSuiteEnterprise) SetupTest() {
 	s.OpsgenieBaseSuite.SetupTest()
 }
 
-// TestAlertCreation validates that an alert is created to the service
-// specified in the role's annotation.
-func (s *OpsgenieSuiteOSS) TestAlertCreation() {
+// TestAlertCreationForSchedules validates that an alert is created to the service
+// specified in the role's annotation using /notify-services annotation
+func (s *OpsgenieSuiteOSS) TestAlertCreationForSchedules() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
+
+	s.startApp()
+
+	// Test execution: create an access request
+	req := s.CreateAccessRequest(ctx, integration.RequesterOSSUserName, nil)
+
+	// Validate the alert has been created in OpsGenie and its ID is stored in
+	// the plugin_data.
+	pluginData := s.checkPluginData(ctx, req.GetName(), func(data opsgenie.PluginData) bool {
+		return data.AlertID != ""
+	})
+
+	alert, err := s.fakeOpsgenie.CheckNewAlert(ctx)
+
+	require.NoError(t, err, "no new alerts stored")
+
+	assert.Equal(t, alert.ID, pluginData.AlertID)
+}
+
+// TestAlertCreationForTeams validates that an alert is created to the service
+// specified in the role's annotation using /teams annotation
+func (s *OpsgenieSuiteOSS) TestAlertCreationForTeams() {
+	t := s.T()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	s.AnnotateRequesterRoleAccessRequests(
+		ctx,
+		NotifyTeamAnnotation,
+		[]string{NotifyTeamName},
+	)
 
 	s.startApp()
 


### PR DESCRIPTION
Currently, when creating an Opsgenie alert with the Opsgenie integration, responders can only be of type `schedule`. 
However that are situations where type `teams` are required to work with Opsgenie integrations, as well, teams takes multiple schedules into consideration, such as escalations schedules.

Instead of changing the `teleport.dev/notify-services` annotation to support teams by default, I purpose adding a new annotation `teleport.dev/teams` that will contains the respective teams and the result will be a merge of both annotations to the responders payload. 

Teleport role:

```yaml
kind: role
metadata:
  name: prod-write-teaccess-request
spec:
  allow:
    request:
      annotations:
        teleport.dev/schedules:
        - MySchedule
        teleport.dev/teams:
        - MyTeam
      roles:
      - prod-write-role
```
will be converted into Opsgenie payload

```json
{
  "message": "Access request from ...",
  "alias": "....",
  "description":"....",
  "responders":[
  	{"name":"MySchedule", "type":"schedule"},
  	{"name":"MyTeam", "type":"team"}
  ],
  "priority":"P2"
}
```

**Update**

While adding the test in the suite, I found a couple of issues:
1. There was a redundant for loop, iterating all the schedules and creating an alert for each schedule/teams, as we can see from the example in the logs below.

```yaml
teleport-cluster-auth-5d9dbd496-vmrzd teleport {"ei":0,"event":"access_request.create","uid":"82ead604-b481-4e32-8e3e-f89fdc9e2bab","code":"T5000I","time":"2024-06-28T10:02:48.596Z","cluster_name":"teleport.test-hopeful-cobra.eu-dev.awsmmcn.private","user":"carlos.castro@example.com","user_kind":1,"expires":"2024-06-29T15:42:55Z","roles":["admin-server-access"],"id":"01905e4c-2b8e-72a5-9089-0a8b37c70d5b","state":"PENDING","annotations":{"teleport.dev/notify-services":["Primary - Access","Teleport JIT Testing_schedule"],"teleport.dev/schedules":["Teleport JIT Testing_schedule"]},"resource_ids":[{"cluster":"teleport.test-hopeful-cobra.eu-dev.awsmmcn.private","kind":"node","name":"3a2239b2-9abf-429b-b152-ba2933cd8e9a"},{"cluster":"teleport.test-hopeful-cobra.eu-dev.awsmmcn.private","kind":"node","name":"409ec5d0-f965-49a9-bbb0-0c5a4496503b"}],"max_duration":"2024-06-29T15:42:55Z"}

teleport-cluster-auth-5d9dbd496-slgqc teleport {"caller":"opsgenie/app.go:345","component":null,"level":"info","message":"Successfully created Opsgenie alert","opsgenie_alert_id":"5523ad71-4b13-42e1-a77f-1e8dea8286a1-1719568968975","opsgenie_service_name":"Primary - Access","request_id":"01905e4c-2b8e-72a5-9089-0a8b37c70d5b","request_op":"put","request_state":"PENDING","timestamp":"2024-06-28T10:02:49Z"}

teleport-cluster-auth-5d9dbd496-slgqc teleport {"caller":"opsgenie/app.go:345","component":null,"level":"info","message":"Successfully created Opsgenie alert","opsgenie_alert_id":"5523ad71-4b13-42e1-a77f-1e8dea8286a1-1719568968975","opsgenie_service_name":"Teleport JIT Testing_schedule","request_id":"01905e4c-2b8e-72a5-9089-0a8b37c70d5b","request_op":"put","request_state":"PENDING","timestamp":"2024-06-28T10:02:49Z"}
```

Since the alias is the same for all alerts, Opsgenie does not consider unique alerts, so it add a count instead of creating duplicate alerts (message below is from an alert activity log). Thats why I also think this was not caught by the tests.

```
Alert is received with same alias. Message: "Access request from carlos.castro@example.com". Count is increased to 2
```

However since the alert request already contains all the schedule in the responders fields, there is no need to create multiple alerts. 

2. The alert payload was using the schedule `ID`, but since we are actually using the name on the annotations, the alert is created with no responders, due to the ID (which is the name) did not exist. Updating to `Name` instead, fixes the issue.