### PR TITLE
[v14] Mark Discovery service healthy on startup

### DIFF
--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -127,6 +127,11 @@ func (process *TeleportProcess) initDiscoveryService() error {
 	}
 	log.Infof("Discovery service has successfully started")
 
+	// The Discovery service doesn't have heartbeats so we cannot use them to check health.
+	// For now, we just mark ourselves ready all the time on startup.
+	// If we don't, a process only running the Discovery service will never report ready.
+	process.OnHeartbeat(teleport.ComponentDiscovery)(nil)
+
 	if err := discoveryService.Wait(); err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport #43278 to branch/v14

changelog: Fix a bug where a Teleport instance running only Jamf or Discovery service would never have a healthy  `/readyz` endpoint.
