### PR TITLE
Reorganize the color palette

### DIFF
--- a/web/packages/design/src/Checkbox/Checkbox.tsx
+++ b/web/packages/design/src/Checkbox/Checkbox.tsx
@@ -166,7 +166,7 @@ export const StyledCheckboxInternal = styled.input.attrs(props => ({
     &:hover,
     .teleport-checkbox__force-hover & {
       background-color: ${props =>
-        props.theme.colors.interactive.tonal.neutral[0]};
+        props.theme.colors.interactive.tonal.neutral[0].background};
       border-color: ${props => props.theme.colors.text.slightlyMuted};
 
       &:checked {
@@ -182,7 +182,7 @@ export const StyledCheckboxInternal = styled.input.attrs(props => ({
     &:focus-visible,
     .teleport-checkbox__force-focus-visible & {
       background-color: ${props =>
-        props.theme.colors.interactive.tonal.neutral[0]};
+        props.theme.colors.interactive.tonal.neutral[0].background};
       border-color: ${props => props.theme.colors.buttons.primary.default};
       outline: none;
       border-width: 2px;
@@ -200,7 +200,7 @@ export const StyledCheckboxInternal = styled.input.attrs(props => ({
     &:active,
     .teleport-checkbox__force-active & {
       background-color: ${props =>
-        props.theme.colors.interactive.tonal.neutral[1]};
+        props.theme.colors.interactive.tonal.neutral[1].background};
       border-color: ${props => props.theme.colors.text.slightlyMuted};
 
       &:checked {
@@ -212,7 +212,7 @@ export const StyledCheckboxInternal = styled.input.attrs(props => ({
 
   &:disabled {
     background-color: ${props =>
-      props.theme.colors.interactive.tonal.neutral[0]};
+      props.theme.colors.interactive.tonal.neutral[0].background};
     border-color: transparent;
   }
 

--- a/web/packages/design/src/MultiRowBox/MultiRowBox.tsx
+++ b/web/packages/design/src/MultiRowBox/MultiRowBox.tsx
@@ -39,7 +39,7 @@ type MultiRowBoxProps = {
  */
 export const MultiRowBox = styled(Box)`
   border: ${props =>
-    `${props.theme.borders[1]} ${props.theme.colors.interactive.tonal.neutral[2]}`};
+    `${props.theme.borders[1]} ${props.theme.colors.interactive.tonal.neutral[2].background}`};
   border-radius: ${props => props.theme.radii[2]}px;
 `;
 
@@ -48,7 +48,7 @@ export const Row = styled(Box)`
   padding: ${props => props.theme.space[4]}px;
   &:not(:last-child) {
     border-bottom: ${props =>
-      `${props.theme.borders[1]} ${props.theme.colors.interactive.tonal.neutral[2]}`};
+      `${props.theme.borders[1]} ${props.theme.colors.interactive.tonal.neutral[2].background}`};
   }
 `;
 

--- a/web/packages/design/src/Toggle/Toggle.tsx
+++ b/web/packages/design/src/Toggle/Toggle.tsx
@@ -160,6 +160,7 @@ const StyledInput = styled.input.attrs({ type: 'checkbox' })<SizeProps>`
   }
 
   &:disabled:checked + ${StyledSlider} {
-    background: ${props => props.theme.colors.interactive.tonal.success[2]};
+    background: ${props =>
+      props.theme.colors.interactive.tonal.success[2].background};
   }
 `;

--- a/web/packages/design/src/theme/themeColors.story.tsx
+++ b/web/packages/design/src/theme/themeColors.story.tsx
@@ -358,7 +358,7 @@ function ColorsBox({ colors, themeType = null, ...styles }) {
 function SingleColorBox({ bg, color, path, ...styles }) {
   return (
     <Box width="150px" height="150px" p={3} mr={3} bg={bg} {...styles}>
-      <Text color={color} css={``}>
+      <Text color={color}>
         {/* Path, potentially broken along the periods. */}
         {path.split('.').map((word, i, arr) => (
           <>

--- a/web/packages/design/src/theme/themeColors.story.tsx
+++ b/web/packages/design/src/theme/themeColors.story.tsx
@@ -33,7 +33,7 @@ const ColorsComponent = () => {
   return (
     <Flex flexDirection="column" p="4">
       <Flex flexDirection="column">
-        <Text mb="2" typography="h4">
+        <Text mb="2" typography="h3">
           Levels
         </Text>
         <Text mb="2">
@@ -54,50 +54,73 @@ const ColorsComponent = () => {
           </Link>
         </Text>
         <ColorsBox mb="4" colors={theme.colors.levels} themeType="levels" />
-        <Text mb="1" typography="h4">
-          Spot Backgrounds
+        <Text mb="2" typography="h3">
+          Interactive Colors
         </Text>
         <Text mb="2">
-          Spot backgrounds are used as highlights or accents. They are not solid
-          colours, instead, they are a slightly transparent mask that highlights
-          the colour behind it. This makes them quite versatile and they can be
-          used to accentuate or highlight components on any background.
-          <br />
-          They may be used for things such as indicating a hover or active state
-          for an item in a menu, or for minor accents such as dividers. <br />
+          <p>
+            Interactive colors are used for hover states, indicators, etc. An
+            example of this in use currently would be unified resource cards in
+            the Pinned and Pinned (Hovered) states.
+          </p>
+          <p>
+            All interactive colors have separate fields for background and text.
+          </p>
         </Text>
-        <Flex>
-          <SingleColorBox
-            mb="4"
-            mr={0}
-            color={theme.colors.spotBackground[0]}
-            themeType="levels"
-            path="theme.colors.spotBackground[0]"
-          />
-          <SingleColorBox
-            mb="4"
-            mr={0}
-            color={theme.colors.spotBackground[1]}
-            themeType="levels"
-            path="theme.colors.spotBackground[1]"
-          />
-          <SingleColorBox
-            mb="4"
-            mr={0}
-            color={theme.colors.spotBackground[2]}
-            themeType="levels"
-            path="theme.colors.spotBackground[2]"
-          />
+        <Flex flexDirection="column" gap={4}>
+          {Object.entries(theme.colors.interactive.solid).map(
+            ([intent, colorGroup]) => (
+              <Flex gap={4}>
+                {Object.entries(colorGroup).map(
+                  ([state, { background, text }]) => (
+                    <SingleColorBox
+                      mb="2"
+                      path={`theme.colors.interactive.solid.${intent}.${state}`}
+                      bg={background}
+                      color={text}
+                    />
+                  )
+                )}
+              </Flex>
+            )
+          )}
         </Flex>
-        <Text mb="2" typography="h4">
+        <Text mb="1" typography="h4">
+          Tonal color variants
+        </Text>
+        <Text mb="2">
+          Tonal color variants are used as highlights or accents. They are not
+          solid colours, instead, they are a slightly transparent mask that
+          highlights the colour behind it. This makes them quite versatile and
+          they can be used to accentuate or highlight components on any
+          background.
+        </Text>
+        <Flex flexDirection="column" gap={4}>
+          {Object.entries(theme.colors.interactive.tonal).map(
+            ([intent, colorGroup]) => (
+              <Flex gap={4}>
+                {colorGroup.map(({ background, text }, i) => (
+                  <SingleColorBox
+                    mb="2"
+                    path={`theme.colors.interactive.tonal.${intent}[${i}]`}
+                    bg={background}
+                    color={text}
+                  />
+                ))}
+              </Flex>
+            )
+          )}
+        </Flex>
+        <Text mb="2" typography="h3">
           Brand
         </Text>
         <SingleColorBox
           mb="4"
           path="theme.colors.brand"
-          color={theme.colors.brand}
+          bg={theme.colors.brand}
+          color={theme.colors.text.primaryInverse}
         />
-        <Text mb="2" typography="h4">
+        <Text mb="2" typography="h3">
           Shadows
         </Text>
         <Flex>
@@ -153,7 +176,7 @@ const ColorsComponent = () => {
             <Text>theme.boxShadow[2]</Text>
           </Box>
         </Flex>
-        <Text mb="2" typography="h4">
+        <Text mb="2" typography="h3">
           Text Colors
         </Text>
         <Flex width="fit-content" flexDirection="row" mb={4}>
@@ -291,31 +314,6 @@ const ColorsComponent = () => {
             </Text>
           </Flex>
         </Flex>
-        <Text mb="2" typography="h3">
-          Interactive Colors
-        </Text>
-        <Text mb="2">
-          Interactive colors are used for hover states, indicators, etc. An
-          example of this in use currently would be unified resource cards in
-          the Pinned and Pinned(Hovered) states.
-        </Text>
-        <Flex gap={4}>
-          <SingleColorBox
-            mb="2"
-            path="theme.colors.interactive.tonal.primary[0]"
-            color={theme.colors.interactive.tonal.primary[0]}
-          />
-          <SingleColorBox
-            mb="2"
-            path="theme.colors.interactive.tonal.primary[1]"
-            color={theme.colors.interactive.tonal.primary[1]}
-          />
-          <SingleColorBox
-            mb="2"
-            path="theme.colors.interactive.tonal.primary[2]"
-            color={theme.colors.interactive.tonal.primary[2]}
-          />
-        </Flex>
       </Flex>
     </Flex>
   );
@@ -357,17 +355,20 @@ function ColorsBox({ colors, themeType = null, ...styles }) {
   );
 }
 
-function SingleColorBox({ color, path, ...styles }) {
+function SingleColorBox({ bg, color, path, ...styles }) {
   return (
-    <Flex flexWrap="wrap" key={path} width="260px" mb={3}>
-      <Box
-        css={`
-          color: ${props => props.theme.colors.text.slightlyMuted};
-        `}
-      >
-        {path}
-      </Box>
-      <Box width="100%" height="50px" p={3} mr={3} bg={color} {...styles} />
-    </Flex>
+    <Box width="150px" height="150px" p={3} mr={3} bg={bg} {...styles}>
+      <Text color={color} css={``}>
+        {/* Path, potentially broken along the periods. */}
+        {path.split('.').map((word, i, arr) => (
+          <>
+            {word}
+            {i < arr.length - 1 ? '.' : ''}
+            {/*potential line break*/}
+            <wbr />
+          </>
+        ))}
+      </Text>
+    </Box>
   );
 }

--- a/web/packages/design/src/theme/themes/bblpTheme.ts
+++ b/web/packages/design/src/theme/themes/bblpTheme.ts
@@ -91,34 +91,66 @@ const colors: ThemeColors = {
   brand: '#FFA028',
 
   interactive: {
+    solid: {
+      primary: {
+        default: { text: '#000000', background: '#FFA028' },
+        hover: { text: '#000000', background: '#FFB04C' },
+        active: { text: '#000000', background: '#DB8922' },
+      },
+      success: {
+        default: { text: '#000000', background: '#00A223' },
+        hover: { text: '#000000', background: '#35D655' },
+        active: { text: '#000000', background: '#00851C' },
+      },
+      accent: {
+        default: { text: '#000000', background: '#66ABFF' },
+        hover: { text: '#000000', background: '#99C7FF' },
+        active: { text: '#000000', background: '#2B8EFF' },
+      },
+      danger: {
+        default: { text: '#FFFFFF', background: '#E51E3C' },
+        hover: { text: '#FFFFFF', background: '#FD2D4A' },
+        active: { text: '#FFFFFF', background: '#C31834' },
+      },
+      alert: {
+        default: { text: '#000000', background: '#FA5A28' },
+        hover: { text: '#000000', background: '#FB754C' },
+        active: { text: '#000000', background: '#D64D22' },
+      },
+    },
+
     tonal: {
       primary: [
-        'rgba(255,160,40, 0.1)',
-        'rgba(255,160,40, 0.18)',
-        'rgba(255,160,40, 0.25)',
+        { text: '#FFB04C', background: 'rgba(255,160,40, 0.1)' },
+        { text: '#DB8922', background: 'rgba(255,160,40, 0.18)' },
+        { text: '#DB8922', background: 'rgba(255,160,40, 0.25)' },
       ],
       success: [
-        'rgba(0, 162, 35, 0.1)',
-        'rgba(0, 162, 35, 0.18)',
-        'rgba(0, 162, 35, 0.25)',
+        { text: '#35D655', background: 'rgba(0, 162, 35, 0.1)' },
+        { text: '#35D655', background: 'rgba(0, 162, 35, 0.18)' },
+        { text: '#00851C', background: 'rgba(0, 162, 35, 0.25)' },
       ],
       // TODO rudream: update bblp interactive tonal colors.
       danger: [
-        'rgba(255, 98, 87, 0.1)',
-        'rgba(255, 98, 87, 0.18)',
-        'rgba(255, 98, 87, 0.25)',
+        { text: '#FD2D4A', background: 'rgba(255, 98, 87, 0.1)' },
+        { text: '#FD2D4A', background: 'rgba(255, 98, 87, 0.18)' },
+        { text: '#C31834', background: 'rgba(255, 98, 87, 0.25)' },
       ],
       alert: [
-        'rgba(255, 171, 0, 0.1)',
-        'rgba(255, 171, 0, 0.18)',
-        'rgba(255, 171, 0, 0.25)',
+        { text: '#D64D22', background: 'rgba(255, 171, 0, 0.1)' },
+        { text: '#D64D22', background: 'rgba(255, 171, 0, 0.18)' },
+        { text: '#D64D22', background: 'rgba(255, 171, 0, 0.25)' },
       ],
       informational: [
-        'rgba(0, 158, 255, 0.1)',
-        'rgba(0, 158, 255, 0.18)',
-        'rgba(0, 158, 255, 0.25)',
+        { text: '#2B8EFF', background: 'rgba(0, 158, 255, 0.1)' },
+        { text: '#2B8EFF', background: 'rgba(0, 158, 255, 0.18)' },
+        { text: '#2B8EFF', background: 'rgba(0, 158, 255, 0.25)' },
       ],
-      neutral: neutralColors,
+      neutral: [
+        { text: '#FFFFFF', background: neutralColors[0] },
+        { text: '#FFFFFF', background: neutralColors[1] },
+        { text: '#FFFFFF', background: neutralColors[2] },
+      ],
     },
   },
 

--- a/web/packages/design/src/theme/themes/darkTheme.ts
+++ b/web/packages/design/src/theme/themes/darkTheme.ts
@@ -91,33 +91,65 @@ const colors: ThemeColors = {
   brand: '#9F85FF',
 
   interactive: {
+    solid: {
+      primary: {
+        default: { text: '#000000', background: '#9F85FF' },
+        hover: { text: '#000000', background: '#B29DFF' },
+        active: { text: '#000000', background: '#C5B6FF' },
+      },
+      success: {
+        default: { text: '#000000', background: '#00BFA6' },
+        hover: { text: '#000000', background: '#33CCB8' },
+        active: { text: '#000000', background: '#66D9CA' },
+      },
+      accent: {
+        default: { text: '#000000', background: '#009EFF' },
+        hover: { text: '#000000', background: '#33B1FF' },
+        active: { text: '#000000', background: '#66C5FF' },
+      },
+      danger: {
+        default: { text: '#000000', background: '#FF6257' },
+        hover: { text: '#000000', background: '#FF8179' },
+        active: { text: '#000000', background: '#FFA19A' },
+      },
+      alert: {
+        default: { text: '#000000', background: '#FFAB00' },
+        hover: { text: '#000000', background: '#FFBC33' },
+        active: { text: '#000000', background: '#FFCD66' },
+      },
+    },
+
     tonal: {
       primary: [
-        'rgba(159,133,255, 0.1)',
-        'rgba(159,133,255, 0.18)',
-        'rgba(159,133,255, 0.25)',
+        { text: '#B29DFF', background: 'rgba(159,133,255, 0.1)' },
+        { text: '#C5B6FF', background: 'rgba(159,133,255, 0.18)' },
+        { text: '#C5B6FF', background: 'rgba(159,133,255, 0.25)' },
       ],
       success: [
-        'rgba(0, 191, 166, 0.1)',
-        'rgba(0, 191, 166, 0.18)',
-        'rgba(0, 191, 166, 0.25)',
+        { text: '#33CCB8', background: 'rgba(0, 191, 166, 0.1)' },
+        { text: '#33CCB8', background: 'rgba(0, 191, 166, 0.18)' },
+        { text: '#66D9CA', background: 'rgba(0, 191, 166, 0.25)' },
       ],
       danger: [
-        'rgba(255, 98, 87, 0.1)',
-        'rgba(255, 98, 87, 0.18)',
-        'rgba(255, 98, 87, 0.25)',
+        { text: '#FF8179', background: 'rgba(255, 98, 87, 0.1)' },
+        { text: '#FF8179', background: 'rgba(255, 98, 87, 0.18)' },
+        { text: '#FFA19A', background: 'rgba(255, 98, 87, 0.25)' },
       ],
       alert: [
-        'rgba(255, 171, 0, 0.1)',
-        'rgba(255, 171, 0, 0.18)',
-        'rgba(255, 171, 0, 0.25)',
+        { text: '#FFCD66', background: 'rgba(255, 171, 0, 0.1)' },
+        { text: '#FFCD66', background: 'rgba(255, 171, 0, 0.18)' },
+        { text: '#FFCD66', background: 'rgba(255, 171, 0, 0.25)' },
       ],
       informational: [
-        'rgba(0, 158, 255, 0.1)',
-        'rgba(0, 158, 255, 0.18)',
-        'rgba(0, 158, 255, 0.25)',
+        { text: '#66C5FF', background: 'rgba(0, 158, 255, 0.1)' },
+        { text: '#66C5FF', background: 'rgba(0, 158, 255, 0.18)' },
+        { text: '#66C5FF', background: 'rgba(0, 158, 255, 0.25)' },
       ],
-      neutral: neutralColors,
+      neutral: [
+        { text: '#FFFFFF', background: neutralColors[0] },
+        { text: '#FFFFFF', background: neutralColors[1] },
+        { text: '#FFFFFF', background: neutralColors[2] },
+      ],
     },
   },
 

--- a/web/packages/design/src/theme/themes/lightTheme.ts
+++ b/web/packages/design/src/theme/themes/lightTheme.ts
@@ -90,33 +90,65 @@ const colors: ThemeColors = {
   brand: '#512FC9',
 
   interactive: {
+    solid: {
+      primary: {
+        default: { text: '#FFFFFF', background: '#512FC9' },
+        hover: { text: '#FFFFFF', background: '#4126A1' },
+        active: { text: '#FFFFFF', background: '#311C79' },
+      },
+      success: {
+        default: { text: '#FFFFFF', background: '#007D6B' },
+        hover: { text: '#FFFFFF', background: '#006456' },
+        active: { text: '#FFFFFF', background: '#004B40' },
+      },
+      accent: {
+        default: { text: '#FFFFFF', background: '#0073BA' },
+        hover: { text: '#FFFFFF', background: '#005C95' },
+        active: { text: '#FFFFFF', background: '#004570' },
+      },
+      danger: {
+        default: { text: '#FFFFFF', background: '#CC372D' },
+        hover: { text: '#FFFFFF', background: '#A32C24' },
+        active: { text: '#FFFFFF', background: '#7A211B' },
+      },
+      alert: {
+        default: { text: '#000000', background: '#FFAB00' },
+        hover: { text: '#000000', background: '#CC8900' },
+        active: { text: '#000000', background: '#996700' },
+      },
+    },
+
     tonal: {
       primary: [
-        'rgba(81,47,201, 0.1)',
-        'rgba(81,47,201, 0.18)',
-        'rgba(81,47,201, 0.25)',
+        { text: '#4126A1', background: 'rgba(81,47,201, 0.1)' },
+        { text: '#311C79', background: 'rgba(81,47,201, 0.18)' },
+        { text: '#311C79', background: 'rgba(81,47,201, 0.25)' },
       ],
       success: [
-        'rgba(0, 125, 107, 0.1)',
-        'rgba(0, 125, 107, 0.18)',
-        'rgba(0, 125, 107, 0.25)',
+        { text: '#006456', background: 'rgba(0, 125, 107, 0.1)' },
+        { text: '#006456', background: 'rgba(0, 125, 107, 0.18)' },
+        { text: '#004B40', background: 'rgba(0, 125, 107, 0.25)' },
       ],
       danger: [
-        'rgba(204, 55, 45, 0.1)',
-        'rgba(204, 55, 45, 0.18)',
-        'rgba(204, 55, 45, 0.25)',
+        { text: '#A32C24', background: 'rgba(204, 55, 45, 0.1)' },
+        { text: '#A32C24', background: 'rgba(204, 55, 45, 0.18)' },
+        { text: '#7A211B', background: 'rgba(204, 55, 45, 0.25)' },
       ],
       alert: [
-        'rgba(255, 171, 0, 0.1)',
-        'rgba(255, 171, 0, 0.18)',
-        'rgba(255, 171, 0, 0.25)',
+        { text: '#996700', background: 'rgba(255, 171, 0, 0.1)' },
+        { text: '#996700', background: 'rgba(255, 171, 0, 0.18)' },
+        { text: '#996700', background: 'rgba(255, 171, 0, 0.25)' },
       ],
       informational: [
-        'rgba(0, 115, 186, 0.1)',
-        'rgba(0, 115, 186, 0.18)',
-        'rgba(0, 115, 186, 0.25)',
+        { text: '#004570', background: 'rgba(0, 115, 186, 0.1)' },
+        { text: '#004570', background: 'rgba(0, 115, 186, 0.18)' },
+        { text: '#004570', background: 'rgba(0, 115, 186, 0.25)' },
       ],
-      neutral: neutralColors,
+      neutral: [
+        { text: '#000000', background: neutralColors[0] },
+        { text: '#000000', background: neutralColors[1] },
+        { text: '#000000', background: neutralColors[2] },
+      ],
     },
   },
 

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -20,6 +20,17 @@ import { fonts } from '../fonts';
 import { blueGrey } from '../palette';
 import typography, { fontSizes, fontWeights } from '../typography';
 
+export type TextAndBackgroundColors = {
+  text: string;
+  background: string;
+};
+
+type InteractiveColorGroup = {
+  default: TextAndBackgroundColors;
+  hover: TextAndBackgroundColors;
+  active: TextAndBackgroundColors;
+};
+
 export type ThemeColors = {
   /**
     Colors in `levels` are used to reflect the perceived depth of elements in the UI.
@@ -52,17 +63,23 @@ export type ThemeColors = {
    * Interactive colors are used to highlight different actions or states
    * based on intent.
    *
-   * For example, primary would be used for as selected states,
-   * or hover over primary intent actions.
+   * For example, primary would be used for as selected states.
    */
   interactive: {
+    solid: {
+      primary: InteractiveColorGroup;
+      success: InteractiveColorGroup;
+      accent: InteractiveColorGroup;
+      danger: InteractiveColorGroup;
+      alert: InteractiveColorGroup;
+    };
     tonal: {
-      primary: string[];
-      neutral: string[];
-      success: string[];
-      danger: string[];
-      alert: string[];
-      informational: string[];
+      primary: TextAndBackgroundColors[];
+      neutral: TextAndBackgroundColors[];
+      success: TextAndBackgroundColors[];
+      danger: TextAndBackgroundColors[];
+      alert: TextAndBackgroundColors[];
+      informational: TextAndBackgroundColors[];
     };
   };
 
@@ -87,6 +104,7 @@ export type ThemeColors = {
     textDisabled: string;
     bgDisabled: string;
 
+    /** @deprecated Use `interactive.solid.primary` instead. */
     primary: {
       text: string;
       default: string;
@@ -94,6 +112,7 @@ export type ThemeColors = {
       active: string;
     };
 
+    /** @deprecated Use `interactive.tonal.neutral` instead. */
     secondary: {
       default: string;
       hover: string;
@@ -107,6 +126,7 @@ export type ThemeColors = {
       border: string;
     };
 
+    /** @deprecated Use `interactive.solid.danger` instead. */
     warning: {
       text: string;
       default: string;
@@ -116,6 +136,7 @@ export type ThemeColors = {
 
     trashButton: { default: string; hover: string };
 
+    /** @deprecated Use `interactive.solid.accent` instead. */
     link: {
       default: string;
       hover: string;
@@ -129,23 +150,28 @@ export type ThemeColors = {
 
   progressBarColor: string;
 
+  /** @deprecated Use `interactive.solid.danger` instead. */
   error: {
     main: string;
     hover: string;
     active: string;
   };
+
+  /** @deprecated Use `interactive.solid.alert` instead. */
   warning: {
     main: string;
     hover: string;
     active: string;
   };
 
+  /** @deprecated Use `interactive.solid.success` instead. */
   success: {
     main: string;
     hover: string;
     active: string;
   };
 
+  /** @deprecated Use `interactive.solid.accent` instead. */
   accent: {
     main: string;
     hover: string;

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -20,7 +20,7 @@ import { fonts } from '../fonts';
 import { blueGrey } from '../palette';
 import typography, { fontSizes, fontWeights } from '../typography';
 
-export type TextAndBackgroundColors = {
+type TextAndBackgroundColors = {
   text: string;
   background: string;
 };

--- a/web/packages/design/src/theme/utils/colorManipulator.js
+++ b/web/packages/design/src/theme/utils/colorManipulator.js
@@ -133,9 +133,9 @@ export function decomposeColor(color) {
 /**
  * Converts a color object with type and values to a string.
  *
- * @param {object} color - Decomposed color
- * @param {string} color.type - One of: 'rgb', 'rgba', 'hsl', 'hsla'
- * @param {array} color.values - [n,n,n] or [n,n,n,n]
+ * @param {object} bgColor - Decomposed color
+ * @param {string} bgColor.type - One of: 'rgb', 'rgba', 'hsl', 'hsla'
+ * @param {array} bgColor.values - [n,n,n] or [n,n,n,n]
  * @returns {string} A CSS color string
  */
 export function recomposeColor(color) {

--- a/web/packages/design/src/theme/utils/colorManipulator.js
+++ b/web/packages/design/src/theme/utils/colorManipulator.js
@@ -133,9 +133,9 @@ export function decomposeColor(color) {
 /**
  * Converts a color object with type and values to a string.
  *
- * @param {object} bgColor - Decomposed color
- * @param {string} bgColor.type - One of: 'rgb', 'rgba', 'hsl', 'hsla'
- * @param {array} bgColor.values - [n,n,n] or [n,n,n,n]
+ * @param {object} color - Decomposed color
+ * @param {string} color.type - One of: 'rgb', 'rgba', 'hsl', 'hsla'
+ * @param {array} color.values - [n,n,n] or [n,n,n,n]
  * @returns {string} A CSS color string
  */
 export function recomposeColor(color) {

--- a/web/packages/shared/components/UnifiedResources/shared/getBackgroundColor.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/getBackgroundColor.ts
@@ -27,16 +27,16 @@ export interface BackgroundColorProps {
 
 export const getBackgroundColor = (props: BackgroundColorProps) => {
   if (props.requiresRequest && props.pinned) {
-    return props.theme.colors.interactive.tonal.primary[0];
+    return props.theme.colors.interactive.tonal.primary[0].background;
   }
   if (props.requiresRequest) {
     return props.theme.colors.spotBackground[0];
   }
   if (props.selected) {
-    return props.theme.colors.interactive.tonal.primary[2];
+    return props.theme.colors.interactive.tonal.primary[2].background;
   }
   if (props.pinned) {
-    return props.theme.colors.interactive.tonal.primary[1];
+    return props.theme.colors.interactive.tonal.primary[1].background;
   }
   return 'transparent';
 };

--- a/web/packages/teleport/src/Account/Account.tsx
+++ b/web/packages/teleport/src/Account/Account.tsx
@@ -348,7 +348,7 @@ function PasskeysHeader({
     return (
       <Flex flexDirection="column" alignItems="center">
         <Box
-          bg={theme.colors.interactive.tonal.neutral[0]}
+          bg={theme.colors.interactive.tonal.neutral[0].background}
           lineHeight={0}
           p={2}
           borderRadius={3}

--- a/web/packages/teleport/src/Account/Header.tsx
+++ b/web/packages/teleport/src/Account/Header.tsx
@@ -48,7 +48,7 @@ export function Header({
       {/* lineHeight=0 prevents the icon background from being larger than
           required by the icon itself. */}
       <Box
-        bg={theme.colors.interactive.tonal.neutral[0]}
+        bg={theme.colors.interactive.tonal.neutral[0].background}
         lineHeight={0}
         p={2}
         borderRadius={3}

--- a/web/packages/teleport/src/Account/ManageDevices/wizards/AddAuthDeviceWizard.tsx
+++ b/web/packages/teleport/src/Account/ManageDevices/wizards/AddAuthDeviceWizard.tsx
@@ -276,7 +276,7 @@ function QrCodeBox({ privilegeToken }: { privilegeToken: string }) {
       gap={4}
       p={4}
       mb={4}
-      bg="interactive.tonal.neutral.0"
+      bg="interactive.tonal.neutral.0.background"
     >
       <Flex height="168px" justifyContent="center" alignItems="center">
         {fetchQrCodeAttempt.status === 'error' && (

--- a/web/packages/teleport/src/Account/StatePill.tsx
+++ b/web/packages/teleport/src/Account/StatePill.tsx
@@ -57,13 +57,13 @@ function statePillStyles({ state }: StatePillProps): ReturnType<typeof css> {
     case 'active':
       return css`
         background-color: ${props =>
-          props.theme.colors.interactive.tonal.success[0]};
+          props.theme.colors.interactive.tonal.success[0].background};
         color: ${props => props.theme.colors.success.main};
       `;
     case 'inactive':
       return css`
         background-color: ${props =>
-          props.theme.colors.interactive.tonal.neutral[0]};
+          props.theme.colors.interactive.tonal.neutral[0].background};
         color: ${props => props.theme.colors.text.disabled};
       `;
     default:

--- a/web/packages/teleport/src/Notifications/Notification.tsx
+++ b/web/packages/teleport/src/Notifications/Notification.tsx
@@ -261,17 +261,19 @@ const Container = styled.div<{ clicked?: boolean }>`
   border-radius: ${props => props.theme.radii[3]}px;
   cursor: pointer;
 
-  background: ${props => props.theme.colors.interactive.tonal.primary[0]};
+  background: ${props =>
+    props.theme.colors.interactive.tonal.primary[0].background};
   &:hover {
-    background: ${props => props.theme.colors.interactive.tonal.primary[1]};
+    background: ${props =>
+      props.theme.colors.interactive.tonal.primary[1].background};
   }
 
   ${props =>
     props.clicked &&
     `
-    background: ${props.theme.colors.interactive.tonal.neutral[0]};
+    background: ${props.theme.colors.interactive.tonal.neutral[0].background};
     &:hover {
-      background: ${props.theme.colors.interactive.tonal.neutral[1]};
+      background: ${props.theme.colors.interactive.tonal.neutral[1].background};
     }
     `}
 `;
@@ -322,27 +324,27 @@ function getIconColors(
     case 'success':
       return {
         primary: theme.colors.success.main,
-        secondary: theme.colors.interactive.tonal.success[0],
+        secondary: theme.colors.interactive.tonal.success[0].background,
       };
     case 'success-alt':
       return {
         primary: theme.colors.accent.main,
-        secondary: theme.colors.interactive.tonal.informational[0],
+        secondary: theme.colors.interactive.tonal.informational[0].background,
       };
     case 'informational':
       return {
         primary: theme.colors.brand,
-        secondary: theme.colors.interactive.tonal.primary[0],
+        secondary: theme.colors.interactive.tonal.primary[0].background,
       };
     case `warning`:
       return {
         primary: theme.colors.warning.main,
-        secondary: theme.colors.interactive.tonal.alert[0],
+        secondary: theme.colors.interactive.tonal.alert[0].background,
       };
     case 'failure':
       return {
         primary: theme.colors.error.main,
-        secondary: theme.colors.interactive.tonal.danger[0],
+        secondary: theme.colors.interactive.tonal.danger[0].background,
       };
   }
 }

--- a/web/packages/teleport/src/Notifications/Notifications.tsx
+++ b/web/packages/teleport/src/Notifications/Notifications.tsx
@@ -287,7 +287,7 @@ function Header({
           box-sizing: border-box;
           gap: 12px;
           border-bottom: 1px solid
-            ${p => p.theme.colors.interactive.tonal.neutral[2]};
+            ${p => p.theme.colors.interactive.tonal.neutral[2].background};
           padding-bottom: ${p => p.theme.space[3]}px;
           margin-bottom: ${p => p.theme.space[3]}px;
         `}
@@ -326,9 +326,11 @@ function EmptyState() {
           justify-content: center;
           height: 88px;
           width: 88px;
-          background-color: ${p => p.theme.colors.interactive.tonal.neutral[0]};
+          background-color: ${p =>
+            p.theme.colors.interactive.tonal.neutral[0].background};
           border-radius: ${p => p.theme.radii[7]}px;
-          border: 1px solid ${p => p.theme.colors.interactive.tonal.neutral[1]};
+          border: 1px solid
+            ${p => p.theme.colors.interactive.tonal.neutral[1].background};
         `}
       >
         <BellRinging size={40} />
@@ -511,7 +513,8 @@ const NotificationsList = styled.div`
   padding-right: ${p => `${p.theme.space[3] - 8}px`};
 
   ::-webkit-scrollbar-thumb {
-    background-color: ${p => p.theme.colors.interactive.tonal.neutral[2]};
+    background-color: ${p =>
+      p.theme.colors.interactive.tonal.neutral[2].background};
     border-radius: ${p => p.theme.radii[2]}px;
     // Trick to make the scrollbar thumb 2px narrower than the track.
     border: 2px solid transparent;
@@ -522,7 +525,8 @@ const NotificationsList = styled.div`
     width: 8px;
     border-radius: ${p => p.theme.radii[2]}px;
     border-radius: ${p => p.theme.radii[2]}px;
-    background-color: ${p => p.theme.colors.interactive.tonal.neutral[0]};
+    background-color: ${p =>
+      p.theme.colors.interactive.tonal.neutral[0].background};
   }
 
   .notification {

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -261,7 +261,7 @@ const TeleportLogo = ({ CustomLogo }: TopBarProps) => {
           transition: background-color 0.1s linear;
           &:hover {
             background-color: ${p =>
-              p.theme.colors.interactive.tonal.primary[0]};
+              p.theme.colors.interactive.tonal.primary[0].background};
           }
           align-items: center;
         `}
@@ -312,7 +312,8 @@ const NavigationButton = ({
 }) => {
   const theme = useTheme();
   const selectedBorder = `2px solid ${theme.colors.brand}`;
-  const selectedBackground = theme.colors.interactive.tonal.neutral[0];
+  const selectedBackground =
+    theme.colors.interactive.tonal.neutral[0].background;
 
   return (
     <HoverTooltip

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
@@ -159,7 +159,7 @@ const Passwordless = ({
       <Flex
         flexDirection="column"
         border={1}
-        borderColor="interactive.tonal.neutral.2"
+        borderColor="interactive.tonal.neutral.2.background"
         borderRadius={3}
         p={3}
         gap={3}

--- a/web/packages/teleport/src/components/NewMfaDeviceForm/NewMfaDeviceForm.tsx
+++ b/web/packages/teleport/src/components/NewMfaDeviceForm/NewMfaDeviceForm.tsx
@@ -186,7 +186,7 @@ export function NewMfaDeviceForm({
             {mfaType?.value === 'webauthn' && (
               <Box
                 border={1}
-                borderColor="interactive.tonal.neutral.2"
+                borderColor="interactive.tonal.neutral.2.background"
                 borderRadius={3}
                 p={3}
               >
@@ -214,7 +214,7 @@ export function NewMfaDeviceForm({
             {mfaType?.value === 'otp' && (
               <Flex
                 border={1}
-                borderColor="interactive.tonal.neutral.2"
+                borderColor="interactive.tonal.neutral.2.background"
                 borderRadius={3}
                 p={3}
                 gap={3}

--- a/web/packages/teleport/src/components/Passkeys/PasskeyBlurb.tsx
+++ b/web/packages/teleport/src/components/Passkeys/PasskeyBlurb.tsx
@@ -25,7 +25,7 @@ export function PasskeyBlurb() {
   return (
     <Box
       border={1}
-      borderColor="interactive.tonal.neutral.2"
+      borderColor="interactive.tonal.neutral.2.background"
       borderRadius={3}
       p={3}
     >

--- a/web/packages/teleport/src/components/Passkeys/PasskeyIcons.tsx
+++ b/web/packages/teleport/src/components/Passkeys/PasskeyIcons.tsx
@@ -43,7 +43,8 @@ const OverlappingChip = styled.span`
   display: inline-block;
   background: ${props => props.theme.colors.levels.surface};
   border: ${props => props.theme.borders[1]};
-  border-color: ${props => props.theme.colors.interactive.tonal.neutral[2]};
+  border-color: ${props =>
+    props.theme.colors.interactive.tonal.neutral[2].background};
   border-radius: 50%;
   margin-right: -6px;
 `;


### PR DESCRIPTION
This change puts together color combinations that are defined by the [new design system](https://www.figma.com/design/Gpjs9vjhzUKF1GDbeG9JGE/Application-Design-System?node-id=6786-30523&t=32pdAkte34JyVzTw-0). Most of these colors were already there, but scattered and disorganized. This change deprecates the old fields and introduces new ones that have text and background colors grouped together and are intended to serve as the source of truth.

This is a preparation step for the upcoming change that implements the new button system.

There are no visible changes expected.

Note: This change is coupled with https://github.com/gravitational/teleport.e/pull/4457, but (hopefully) not enough to break the build or tests.