### PR TITLE
Move the Access Request Plugins index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3144,7 +3144,7 @@ Other updates:
 
 * We now provide local user management via `https://[cluster-url]/web/users`, providing the ability to easily edit, reset and delete local users.
 * Teleport Node & App Install scripts. This is currently an Enterprise-only feature that provides customers with an easy 'auto-magic' installer script. Enterprise customers can enable this feature by modifying the 'token' resource. See note above.
-* We've added a Waiting Room for customers using Access Workflows. [Docs](./docs/pages/access-controls/access-request-plugins/index.mdx)
+* We've added a Waiting Room for customers using Access Workflows. [Docs](docs/pages/access-controls/access-request-plugins.mdx)
 
 ##### Signed RPM and Releases
 
@@ -3407,7 +3407,7 @@ Teleport's Web UI now exposes Teleport’s Audit log, letting auditors and admin
 
 ##### Teleport Plugins
 
-Teleport 4.3 introduces four new plugins that work out of the box with [Approval Workflow](./docs/pages/access-controls/access-request-plugins/index.mdx). These plugins allow you to automatically support role escalation with commonly used third party services. The built-in plugins are listed below.
+Teleport 4.3 introduces four new plugins that work out of the box with [Approval Workflow](docs/pages/access-controls/access-request-plugins.mdx). These plugins allow you to automatically support role escalation with commonly used third party services. The built-in plugins are listed below.
 
 *   [PagerDuty](./docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx)
 *   [Jira](./docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx)

--- a/docs/pages/access-controls/access-request-plugins.mdx
+++ b/docs/pages/access-controls/access-request-plugins.mdx
@@ -55,4 +55,4 @@ workflows by reading our setup guides:
 
 To read more about the architecture of an Access Request plugin, and start
 writing your own, read our [Access Request plugin development
-guide](../../api/access-plugin.mdx).
+guide](../api/access-plugin.mdx).

--- a/docs/pages/access-controls/introduction.mdx
+++ b/docs/pages/access-controls/introduction.mdx
@@ -61,7 +61,7 @@ You can integrate Teleport with your existing communication tool, e.g., Slack,
 PagerDuty, or Microsoft Teams, so Teleport users can easily create and approve
 Access Requests.
 
-[Get started with Access Request plugins](./access-request-plugins/index.mdx).
+[Get started with Access Request plugins](access-request-plugins.mdx).
 
 ## Achieve compliance
 

--- a/docs/pages/api/access-plugin.mdx
+++ b/docs/pages/api/access-plugin.mdx
@@ -8,7 +8,7 @@ assign Teleport users to less privileged roles by default and allow them to
 temporarily escalate their privileges. Reviewers can grant or deny Access
 Requests within your organization's existing communication workflows (e.g.,
 Slack, email, and PagerDuty) using [Access Request
-plugins](../access-controls/access-request-plugins/index.mdx).
+plugins](../access-controls/access-request-plugins.mdx).
 
 You can use Teleport's API client library to build an Access Request plugin that
 integrates with your organization's unique workflows. 

--- a/docs/pages/api/introduction.mdx
+++ b/docs/pages/api/introduction.mdx
@@ -17,7 +17,7 @@ the same API.
 Here is what you can do with the Go Client:
 
  - Integrate with external tools, e.g., to write an [Access Request
-   plugin](../access-controls/access-request-plugins/index.mdx). Teleport
+   plugin](../access-controls/access-request-plugins.mdx). Teleport
    maintains Access Request plugins for tools like Slack, Jira, and Mattermost.
  - Perform CRUD actions on resources, such as roles, authentication connectors,
    and provisioning tokens.

--- a/docs/pages/application-access/cloud-apis/azure-aks-workload-id.mdx
+++ b/docs/pages/application-access/cloud-apis/azure-aks-workload-id.mdx
@@ -222,7 +222,7 @@ teleport-azure-access-agent-0   1/1     Running   0          99s
   longstanding admin roles for attackers to hijack. View our documentation on
   [Role Access
   Requests](../../access-controls/access-requests/role-requests.mdx) and
-  [Access Request plugins](../../access-controls/access-request-plugins/index.mdx).
+  [Access Request plugins](../../access-controls/access-request-plugins.mdx).
 - Consult the Azure documentation for information about [Azure managed
   identities](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview)
   and how to [manage user-assigned managed

--- a/docs/pages/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/application-access/cloud-apis/azure.mdx
@@ -224,7 +224,7 @@ Application Service host.
   longstanding admin roles for attackers to hijack. View our documentation on
   [Role Access
   Requests](../../access-controls/access-requests/role-requests.mdx) and
-  [Access Request plugins](../../access-controls/access-request-plugins/index.mdx).
+  [Access Request plugins](../../access-controls/access-request-plugins.mdx).
 - Consult the Azure documentation for information about [Azure managed
   identities](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview)
   and how to [manage user-assigned managed

--- a/docs/pages/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/application-access/cloud-apis/google-cloud.mdx
@@ -631,7 +631,7 @@ command.
   temporarily, with no longstanding admin roles for attackers to hijack. View
   our documentation on [Role Access
   Requests](../../access-controls/access-requests/role-requests.mdx) and [Access
-  Request plugins](../../access-controls/access-request-plugins/index.mdx).
+  Request plugins](../../access-controls/access-request-plugins.mdx).
 - You can proxy any `gcloud` or `gsutil` command via Teleport. For a full
   reference of commands, view the Google Cloud documentation for
   [`gcloud`](https://cloud.google.com/sdk/gcloud/reference) and

--- a/docs/pages/choose-an-edition/migrate-to-cloud.mdx
+++ b/docs/pages/choose-an-edition/migrate-to-cloud.mdx
@@ -279,7 +279,7 @@ In general, you can migrate Teleport plugins using the following steps:
 
 For specific plugins running in your infrastructure, read the full documentation
 on:
-- [Access Request plugins](../access-controls/access-request-plugins/index.mdx)
+- [Access Request plugins](../access-controls/access-request-plugins.mdx)
 - The [Teleport Event Handler](../management/export-audit-events.mdx)
 
 ## Step 4/4. Verify end user access and performance

--- a/docs/pages/kubernetes-access/manage-access.mdx
+++ b/docs/pages/kubernetes-access/manage-access.mdx
@@ -450,6 +450,6 @@ Now that you know how to configure Teleport's RBAC system to control access to
 Kubernetes clusters, learn how to set up [Resource Access
 Requests](../access-controls/access-requests/resource-requests.mdx)
 for just-in-time access and [Access Request
-plugins](../access-controls/access-request-plugins/index.mdx) so you can manage
+plugins](../access-controls/access-request-plugins.mdx) so you can manage
 access with your communication workflow of choice.
 


### PR DESCRIPTION
The new docs engine we're moving to does not work well with pages called `index.mdx` aside from the main one. This change renames the only index page in a subdirectory, which does not affect the navigation menu.