### PR TITLE
[v15] allow setting TLS material in event-handler helm chart

### DIFF
--- a/examples/chart/event-handler/.lint/existing-tls-secret-with-ca.yaml
+++ b/examples/chart/event-handler/.lint/existing-tls-secret-with-ca.yaml
@@ -1,0 +1,2 @@
+tls:
+  existingCASecretName: "helm-lint-existing-tls-secret-ca"

--- a/examples/chart/event-handler/templates/deployment.yaml
+++ b/examples/chart/event-handler/templates/deployment.yaml
@@ -42,6 +42,10 @@ spec:
           env:
             - name: "TELEPORT_PLUGIN_FAIL_FAST"
               value: "true"
+          {{- if .Values.tls.existingCASecretName }}
+            - name: SSL_CERT_FILE
+              value: /etc/teleport-tls-ca/ca.pem
+          {{- end }}
           ports:
             - name: http
               containerPort: 80
@@ -63,6 +67,11 @@ spec:
             - name: certificate
               mountPath: /var/lib/teleport/plugins/event-handler/client.key
               subPath: {{ .Values.fluentd.certificate.keyPath }}
+           {{- if .Values.tls.existingCASecretName }}
+            - mountPath: /etc/teleport-tls-ca
+              name: "teleport-tls-ca"
+              readOnly: true
+           {{- end }}
             {{- if or .Values.persistentVolumeClaim.enabled .Values.persistentVolumeClaim.existingClaim }}
             - name: "{{ .Values.persistentVolumeClaim.volumeName }}"
               mountPath: "{{ .Values.eventHandler.storagePath }}"
@@ -95,6 +104,11 @@ spec:
           secret:
             secretName: "{{ .Values.fluentd.certificate.secretName }}"
             defaultMode: 0600
+        {{- if .Values.tls.existingCASecretName }}
+        - name: "teleport-tls-ca"
+          secret:
+            secretName: {{ .Values.tls.existingCASecretName }}
+        {{- end }}
         {{- if .Values.persistentVolumeClaim.enabled }}
         - name: "{{ .Values.persistentVolumeClaim.volumeName }}"
           persistentVolumeClaim:

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -69,3 +69,60 @@ should match the snapshot:
             secret:
               defaultMode: 384
               secretName: ""
+should mount tls.existingCASecretName and set environment when set in values:
+  1: |
+    containers:
+    - command:
+      - /usr/local/bin/teleport-event-handler
+      - start
+      - --config
+      - /etc/teleport-event-handler.toml
+      env:
+      - name: TELEPORT_PLUGIN_FAIL_FAST
+        value: "true"
+      - name: SSL_CERT_FILE
+        value: /etc/teleport-tls-ca/ca.pem
+      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:17.0.0-dev
+      imagePullPolicy: IfNotPresent
+      name: teleport-plugin-event-handler
+      ports:
+      - containerPort: 80
+        name: http
+        protocol: TCP
+      resources: {}
+      securityContext: {}
+      volumeMounts:
+      - mountPath: /etc/teleport-event-handler.toml
+        name: config
+        subPath: teleport-event-handler.toml
+      - mountPath: /var/lib/teleport/plugins/event-handler/teleport-identity
+        name: teleport-identity
+      - mountPath: /var/lib/teleport/plugins/event-handler/ca.crt
+        name: certificate
+        subPath: ca.crt
+      - mountPath: /var/lib/teleport/plugins/event-handler/client.crt
+        name: certificate
+        subPath: client.crt
+      - mountPath: /var/lib/teleport/plugins/event-handler/client.key
+        name: certificate
+        subPath: client.key
+      - mountPath: /etc/teleport-tls-ca
+        name: teleport-tls-ca
+        readOnly: true
+    securityContext: {}
+    volumes:
+    - configMap:
+        defaultMode: 384
+        name: RELEASE-NAME-teleport-plugin-event-handler
+      name: config
+    - name: teleport-identity
+      secret:
+        defaultMode: 384
+        secretName: ""
+    - name: certificate
+      secret:
+        defaultMode: 384
+        secretName: ""
+    - name: teleport-tls-ca
+      secret:
+        secretName: helm-lint-existing-tls-secret-ca

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -82,7 +82,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:17.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:15.4.5
       imagePullPolicy: IfNotPresent
       name: teleport-plugin-event-handler
       ports:

--- a/examples/chart/event-handler/tests/deployment_test.yaml
+++ b/examples/chart/event-handler/tests/deployment_test.yaml
@@ -18,3 +18,27 @@ tests:
       - equal:
           path: spec.strategy.type
           value: Recreate
+  - it: should mount tls.existingCASecretName and set environment when set in values
+    template: deployment.yaml
+    values:
+      - ../.lint/existing-tls-secret-with-ca.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: teleport-tls-ca
+            secret:
+              secretName: helm-lint-existing-tls-secret-ca
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /etc/teleport-tls-ca
+            name: teleport-tls-ca
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SSL_CERT_FILE
+            value: /etc/teleport-tls-ca/ca.pem
+      - matchSnapshot:
+          path: spec.template.spec

--- a/examples/chart/event-handler/values.schema.json
+++ b/examples/chart/event-handler/values.schema.json
@@ -225,6 +225,20 @@
             "default": {},
             "additionalProperties": true
         },
+        "tls": {
+            "$id": "#/properties/tls",
+            "type": "object",
+            "required": [
+                "existingCASecretName"
+            ],
+            "properties": {
+                "existingCASecretName": {
+                    "$id": "#/properties/tls/properties/existingCASecretName",
+                    "type": "string",
+                    "default": ""
+                }
+            }
+        },        
         "tolerations": {
             "$id": "#/properties/tolerations",
             "type": "array",

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -60,6 +60,21 @@ resources: {}
 
 nodeSelector: {}
 
+# tls -- contains settings for mounting your own TLS material in the event-handler pod.
+# The event-handler does not expose a TLS server, so this is only used to trust CAs.
+tls:
+  # tls.existingCASecretName(string) -- sets the `SSL_CERT_FILE` environment
+  # variable to load a trusted CA or bundle in PEM format into Teleport pods.
+  # The injected CA will be used to validate TLS communications with the Proxy
+  # Service.
+  #
+  # You must create a secret containing the CA certs in the same namespace as Teleport using a command like:
+  #
+  # $ kubectl create secret generic my-root-ca --from-file=ca.pem=/path/to/root-ca.pem
+  #
+  #   The key containing the root CA in the secret must be `ca.pem`.
+  existingCASecretName: ""
+
 tolerations: []
 
 affinity: {}


### PR DESCRIPTION
Backport #43330 to branch/v15

changelog: Add configuration for custom CAs in the event-handler helm chart.
