### PR TITLE
Add unstable envvar to disable server keepalives

### DIFF
--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -545,6 +545,18 @@ func TestInstanceHeartbeatDisabledEnv(t *testing.T) {
 	require.False(t, controller.instanceHBEnabled)
 }
 
+func TestServerKeepaliveDisabledEnv(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_DISABLE_SERVER_KEEPALIVE", "yes")
+
+	controller := NewController(
+		&fakeAuth{},
+		usagereporter.DiscardUsageReporter{},
+	)
+	defer controller.Close()
+
+	require.False(t, controller.serverKeepAliveEnabled)
+}
+
 // TestInstanceHeartbeat verifies basic expected behaviors for instance heartbeat.
 func TestInstanceHeartbeat(t *testing.T) {
 	const serverID = "test-instance"


### PR DESCRIPTION
This PR adds an unstable way (setting the `TELEPORT_UNSTABLE_DISABLE_SERVER_KEEPALIVE` envvar to `yes`) to disable the keepalive ticker in the inventory controller; this can be useful in large clusters to reduce the backend load in exchange for slightly less reliable UX (as the lack of keepalives will result in heartbeats potentially going missing sooner if the connection between a peripheral cluster component and the auth service is flaky).