### PR TITLE
[v14] Allow headless auth when local auth is disabled

### DIFF
--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -1454,20 +1454,6 @@ func TestServer_Authenticate_headless(t *testing.T) {
 			mfa := configureForMFA(t, srv)
 			username := mfa.User
 
-			// Fail a login attempt so we have a non-empty list of attempts.
-			_, err = proxyClient.AuthenticateSSHUser(ctx, authclient.AuthenticateSSHRequest{
-				AuthenticateUserRequest: authclient.AuthenticateUserRequest{
-					Username:  username,
-					Webauthn:  &wantypes.CredentialAssertionResponse{}, // bad response
-					PublicKey: []byte(sshPubKey),
-				},
-				TTL: 24 * time.Hour,
-			})
-			require.True(t, trace.IsAccessDenied(err), "got err = %v, want AccessDenied", err)
-			attempts, err := srv.Auth().GetUserLoginAttempts(username)
-			require.NoError(t, err)
-			require.NotEmpty(t, attempts, "Want at least one failed login attempt")
-
 			ctx, cancel := context.WithTimeout(ctx, tc.timeout)
 			defer cancel()
 
@@ -1518,18 +1504,8 @@ func TestServer_Authenticate_headless(t *testing.T) {
 
 			if tc.expectErr {
 				require.Error(t, err)
-				// Verify login attempts unchanged. This is a proxy for various other user
-				// checks (locked, etc).
-				updatedAttempts, err := srv.Auth().GetUserLoginAttempts(username)
-				require.NoError(t, err)
-				require.Equal(t, attempts, updatedAttempts, "Login attempts unexpectedly changed")
 			} else {
 				require.NoError(t, err)
-				// Verify zeroed login attempts. This is a proxy for various other user
-				// checks (locked, etc).
-				updatedAttempts, err := srv.Auth().GetUserLoginAttempts(username)
-				require.NoError(t, err)
-				require.Empty(t, updatedAttempts, "Login attempts not reset")
 			}
 		})
 	}

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -275,6 +275,16 @@ func (a *Server) authenticateUserInternal(ctx context.Context, req authclient.Au
 	user = req.Username
 	passwordless := user == ""
 
+	// Handle headless authentication as a special case separate from local auth methods below.
+	if req.HeadlessAuthenticationID != "" {
+		mfaDev, err = a.authenticateHeadless(ctx, req)
+		if err != nil {
+			log.Debugf("Headless Authentication for user %q failed while waiting for approval: %v", user, err)
+			return nil, "", trace.Wrap(err)
+		}
+		return mfaDev, user, nil
+	}
+
 	// Only one path if passwordless, other variants shouldn't see an empty user.
 	if passwordless {
 		return a.authenticatePasswordless(ctx, req)
@@ -301,18 +311,6 @@ func (a *Server) authenticateUserInternal(ctx context.Context, req authclient.Au
 	var authErr error // error message kept obscure on purpose, use logging for details
 	switch {
 	// cases in order of preference
-	case req.HeadlessAuthenticationID != "":
-		// handle authentication before the user lock to prevent locking out users
-		// due to timed-out/canceled headless authentication attempts.
-		mfaDevice, err := a.authenticateHeadless(ctx, req)
-		if err != nil {
-			log.Debugf("Headless Authentication for user %q failed while waiting for approval: %v", user, err)
-			return nil, "", trace.Wrap(authenticateHeadlessError)
-		}
-		authenticateFn = func() (*types.MFADevice, error) {
-			return mfaDevice, nil
-		}
-		authErr = authenticateHeadlessError
 	case req.Webauthn != nil:
 		authenticateFn = func() (*types.MFADevice, error) {
 			if req.Pass != nil {
@@ -496,6 +494,14 @@ func (a *Server) authenticateHeadless(ctx context.Context, req authclient.Authen
 		return nil, trace.AccessDenied("headless authentication public key mismatch")
 	}
 
+	// Only grab user lock on successful headless auth to perform normal login
+	// checks, like whether the user is locked. Failed headless login attempts
+	// won't lock out the user.
+	if err := a.WithUserLock(ctx, req.Username, func() error { return nil }); err != nil {
+		log.Debugf("WithUserLock for user %q failed during headless authentication: %v", req.Username, err)
+		return nil, trace.Wrap(authenticateHeadlessError)
+	}
+
 	return approvedHeadlessAuthn.MfaDevice, nil
 }
 
@@ -609,7 +615,9 @@ func (a *Server) AuthenticateSSHUser(ctx context.Context, req authclient.Authent
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if !authPref.GetAllowLocalAuth() {
+
+	// Disable all local auth requests, except headless requests.
+	if !authPref.GetAllowLocalAuth() && req.HeadlessAuthenticationID == "" {
 		a.emitNoLocalAuthEvent(username)
 		return nil, trace.AccessDenied(noLocalAuth)
 	}

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -275,7 +275,9 @@ func (a *Server) authenticateUserInternal(ctx context.Context, req authclient.Au
 	user = req.Username
 	passwordless := user == ""
 
-	// Handle headless authentication as a special case separate from local auth methods below.
+	// Headless auth is treated more like sso login or access requests than local login,
+	// meaning it should be allowed for non-local users and failed headless auth attempts
+	// should not lock out the user (we skip the WithUserLock wrapper).
 	if req.HeadlessAuthenticationID != "" {
 		mfaDev, err = a.authenticateHeadless(ctx, req)
 		if err != nil {
@@ -492,14 +494,6 @@ func (a *Server) authenticateHeadless(ctx context.Context, req authclient.Authen
 	}
 	if !bytes.Equal(req.PublicKey, ha.PublicKey) {
 		return nil, trace.AccessDenied("headless authentication public key mismatch")
-	}
-
-	// Only grab user lock on successful headless auth to perform normal login
-	// checks, like whether the user is locked. Failed headless login attempts
-	// won't lock out the user.
-	if err := a.WithUserLock(ctx, req.Username, func() error { return nil }); err != nil {
-		log.Debugf("WithUserLock for user %q failed during headless authentication: %v", req.Username, err)
-		return nil, trace.Wrap(authenticateHeadlessError)
 	}
 
 	return approvedHeadlessAuthn.MfaDevice, nil

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -189,9 +189,6 @@ func (a *Server) emitAuthAuditEvent(ctx context.Context, props authAuditProps) e
 }
 
 var (
-	// authenticateHeadlessError is the generic error returned for failed headless
-	// authentication attempts.
-	authenticateHeadlessError = &trace.AccessDeniedError{Message: "headless authentication failed"}
 	// authenticateWebauthnError is the generic error returned for failed WebAuthn
 	// authentication attempts.
 	authenticateWebauthnError = &trace.AccessDeniedError{Message: "invalid Webauthn response"}


### PR DESCRIPTION
Backport #41933 to branch/v14

changelog: Fixed Headless auth for SSO users, including when local auth is disabled.
