### PR TITLE
docs: Add disable_exec_plugin to Machine ID troubleshooting steps

### DIFF
--- a/docs/pages/machine-id/troubleshooting.mdx
+++ b/docs/pages/machine-id/troubleshooting.mdx
@@ -38,7 +38,7 @@ backend, and embeds a copy of the counter in the certificate.
 
 If the counter embedded in your bot certificate doesn't match the counter
 stored in Teleport's Auth Server, the renewal will fail and the bot user will
-be automatically [locked](../access-controls/guides/locking.mdx). 
+be automatically [locked](../access-controls/guides/locking.mdx).
 
 Renewable certificates are exclusively stored in the bot's internal data
 directory, by default `/var/lib/teleport/bot`. It's possible to trigger this by
@@ -52,7 +52,7 @@ with old certificates and trigger a lock.
 ### Resolution
 
 Before unlocking the bot, try to determine if either of the two scenarios
-described above apply. If the certificates were stolen, there may be 
+described above apply. If the certificates were stolen, there may be
 underlying security concerns that need to be addressed.
 
 Otherwise, first ensure only one bot instance is using the internal data
@@ -218,8 +218,8 @@ However, the database exists and can be seen by regular users via `tsh`:
 
 ```code
 $ tsh db ls
-Name       Description Allowed Users Labels  Connect 
----------- ----------- ------------- ------- ------- 
+Name       Description Allowed Users Labels  Connect
+---------- ----------- ------------- ------- -------
 example                [alice]       env=dev
 ```
 
@@ -292,3 +292,31 @@ flag:
 $ tctl bots rm example
 $ tctl bots add example --roles=foo,bar,machine-id-db
 ```
+
+## Destination kubernetes_secret: `identity-output` must be a directory in exec plugin mode
+
+By default, when outputting a Kubernetes identity, `tbot` outputs make use of a Kubernetes exec
+plugin to always provide the "latest" version of the credentials.
+
+When outputting a Kubernetes identity to a Kubernetes secret, however, it is important to disable
+the use of the `exec` plugin by adding `disable_exec_plugin: true` to the output. This means that
+a static `kubeconfig` file with embedded short-lived credentials is written instead:
+
+```yaml
+outputs:
+  - type: kubernetes
+    # Specify the name of the Kubernetes cluster you wish the credentials to
+    # grant access to.
+    kubernetes_cluster: example-k8s-cluster
+    # Required when outputting a Kubernetes identity to a Kubernetes secret.
+    disable_exec_plugin: true
+    destination:
+      type: kubernetes_secret
+      # For this guide, identity-output is used as the secret name.
+      # You may wish to customize this. Multiple outputs cannot share the same
+      # destination.
+      name: identity-output
+```
+
+Failure to add the `disable_exec_plugin` flag will result in a warning being displayed:
+`Destination kubernetes_secret: identity-output must be a directory in exec plugin mode`

--- a/docs/pages/machine-id/troubleshooting.mdx
+++ b/docs/pages/machine-id/troubleshooting.mdx
@@ -296,7 +296,7 @@ $ tctl bots add example --roles=foo,bar,machine-id-db
 ## Destination kubernetes_secret: `identity-output` must be a directory in exec plugin mode
 
 By default, when outputting a Kubernetes identity, `tbot` outputs make use of a Kubernetes exec
-plugin to always provide the "latest" version of the credentials.
+plugin to always provide the latest version of the credentials.
 
 When outputting a Kubernetes identity to a Kubernetes secret, however, it is important to disable
 the use of the `exec` plugin by adding `disable_exec_plugin: true` to the output. This means that

--- a/docs/pages/machine-id/troubleshooting.mdx
+++ b/docs/pages/machine-id/troubleshooting.mdx
@@ -319,4 +319,4 @@ outputs:
 ```
 
 Failure to add the `disable_exec_plugin` flag will result in a warning being displayed:
-`Destination kubernetes_secret: identity-output must be a directory in exec plugin mode`
+`Destination kubernetes_secret: identity-output must be a directory in exec plugin mode`.


### PR DESCRIPTION
While we wait for https://github.com/gravitational/teleport/issues/40610 to be completed or addressed alternatively, this PR adds a mention of the error shown when `disable_exec_plugin: true` is not set while it should be. This should help with discoverability, as several prospects have hit this issue in the last week or two.