### PR TITLE
[docs] fix redshift serverless include

### DIFF
--- a/docs/pages/database-access/enroll-aws-databases/redshift-serverless.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/redshift-serverless.mdx
@@ -134,7 +134,7 @@ role 'redshift-serverless-access' has been created
 
 ## Step 3/4. Install and start the Teleport Database Service
 
-(!docs/pages/includes/database-access/token.mdx!)
+(!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
 (!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 


### PR DESCRIPTION
Fixes a missing partial file in the redshift serverless guide.
The partial was was moved in https://github.com/gravitational/teleport/pull/43137