### PR TITLE
Show cloud commands as default installation instructions

### DIFF
--- a/docs/pages/includes/install-windows-clients.mdx
+++ b/docs/pages/includes/install-windows-clients.mdx
@@ -2,28 +2,28 @@
   # Set the TLS level to TLS 1.2 (required on Windows Server 2016 and lower)
   $ [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
   # Get the expected checksum for the Windows tsh package
-  $ $Resp = Invoke-WebRequest https://cdn.teleport.dev/teleport-v{{ version }}-windows-amd64-bin.zip.sha256
+  $ $Resp = Invoke-WebRequest https://cdn.teleport.dev/teleport-v$TELEPORT_VERSION-windows-amd64-bin.zip.sha256
   # PowerShell will return the binary representation of the response content
   # by default, so you need to convert it to a string
   $ [System.Text.Encoding]::UTF8.getstring($Resp.Content)
   # <checksum> <filename>
-  $ Invoke-WebRequest -OutFile teleport-v{{ version }}-windows-amd64-bin.zip -Uri https://cdn.teleport.dev/teleport-v{{ version }}-windows-amd64-bin.zip
-  $ certUtil -hashfile teleport-v{{ version }}-windows-amd64-bin.zip SHA256
-  # SHA256 hash of teleport-v{{ version }}-windows-amd64-bin.zip:
+  $ Invoke-WebRequest -OutFile teleport-v$TELEPORT_VERSION-windows-amd64-bin.zip -Uri https://cdn.teleport.dev/teleport-v$TELEPORT_VERSION-windows-amd64-bin.zip
+  $ certUtil -hashfile teleport-v$TELEPORT_VERSION-windows-amd64-bin.zip SHA256
+  # SHA256 hash of teleport-v$TELEPORT_VERSION-windows-amd64-bin.zip:
   # <checksum>
   # CertUtil: -hashfile command completed successfully.
   ```
 
   After you have verified that the checksums match, you can extract the archive.
-  The executables will be available at `teleport-v{{ version }}-windows-amd64-bin\`.
+  The executables will be available at `teleport-v$TELEPORT_VERSION-windows-amd64-bin\`.
 
   ```code
-  $ Expand-Archive teleport-v{{ version }}-windows-amd64-bin.zip
-  $ cd teleport-v{{ version }}-windows-amd64-bin
+  $ Expand-Archive teleport-v$TELEPORT_VERSION-windows-amd64-bin.zip
+  $ cd teleport-v$TELEPORT_VERSION-windows-amd64-bin
   $ .\tsh.exe version
-  Teleport v{{ version }} git:v{{ version }} go(=teleport.golang=)
+  Teleport v$TELEPORT_VERSION git:v$TELEPORT_VERSION go(=teleport.golang=)
   $ .\tctl.exe version
-  Teleport v{{ version }} git:v{{ version }} go(=teleport.golang=)
+  Teleport v$TELEPORT_VERSION git:v$TELEPORT_VERSION go(=teleport.golang=)
   ```
 
   Make sure to move `tsh.exe` and `tctl.exe` into your PATH.

--- a/docs/pages/includes/install-windows.mdx
+++ b/docs/pages/includes/install-windows.mdx
@@ -31,3 +31,5 @@ To install `tsh` and `tctl` on Windows, run the following commands in
 
 </TabItem>
 </Tabs>
+
+(!docs/pages/includes/install-windows-clients.mdx!)

--- a/docs/pages/includes/install-windows.mdx
+++ b/docs/pages/includes/install-windows.mdx
@@ -10,7 +10,7 @@ To install `tsh` and `tctl` on Windows, run the following commands in
 
   ```code
   # Set the desired teleport version
-  $TELEPORT_VERSION="(=cloud.version=)"
+  $ $TELEPORT_VERSION="(=cloud.version=)"
   ```
 
 </TabItem>
@@ -18,7 +18,7 @@ To install `tsh` and `tctl` on Windows, run the following commands in
 
   ```code
   # Set the desired teleport version
-  $TELEPORT_VERSION="(=teleport.version=)"
+  $ $TELEPORT_VERSION="(=teleport.version=)"
   ```
 
 </TabItem>
@@ -26,7 +26,7 @@ To install `tsh` and `tctl` on Windows, run the following commands in
 
   ```code
   # Set the desired teleport version
-  $TELEPORT_VERSION="(=teleport.version=)"
+  $ $TELEPORT_VERSION="(=teleport.version=)"
   ```
 
 </TabItem>

--- a/docs/pages/includes/install-windows.mdx
+++ b/docs/pages/includes/install-windows.mdx
@@ -8,18 +8,26 @@ To install `tsh` and `tctl` on Windows, run the following commands in
 <Tabs>
 <TabItem label="Teleport Enterprise (Managed)" scope="cloud">
 
-
-  (!docs/pages/includes/install-windows-clients.mdx version="(=cloud.version=)" !)
+  ```code
+  # Set the desired teleport version
+  $TELEPORT_VERSION="(=cloud.version=)"
+  ```
 
 </TabItem>
 <TabItem label="Teleport Enterprise (Self-Hosted)" scope="enterprise">
 
-  (!docs/pages/includes/install-windows-clients.mdx version="(=teleport.version=)" !)
+  ```code
+  # Set the desired teleport version
+  $TELEPORT_VERSION="(=teleport.version=)"
+  ```
 
 </TabItem>
 <TabItem label="Teleport Community Edition" scope="oss">
 
-  (!docs/pages/includes/install-windows-clients.mdx version="(=teleport.version=)" !)
+  ```code
+  # Set the desired teleport version
+  $TELEPORT_VERSION="(=teleport.version=)"
+  ```
 
 </TabItem>
 </Tabs>

--- a/docs/pages/includes/install-windows.mdx
+++ b/docs/pages/includes/install-windows.mdx
@@ -4,13 +4,15 @@ can be run under `cmd.exe`, PowerShell, and Windows Terminal.
 To install `tsh` and `tctl` on Windows, run the following commands in
 **PowerShell** (these commands will not work in `cmd.exe`):
 
+
 <Tabs>
-<TabItem label="Teleport Enterprise Cloud" scope="cloud">
+<TabItem label="Teleport Enterprise (Managed)" scope="cloud">
+
 
   (!docs/pages/includes/install-windows-clients.mdx version="(=cloud.version=)" !)
 
 </TabItem>
-<TabItem label="Teleport Enterprise" scope="enterprise">
+<TabItem label="Teleport Enterprise (Self-Hosted)" scope="enterprise">
 
   (!docs/pages/includes/install-windows-clients.mdx version="(=teleport.version=)" !)
 

--- a/docs/pages/includes/install-windows.mdx
+++ b/docs/pages/includes/install-windows.mdx
@@ -5,9 +5,9 @@ To install `tsh` and `tctl` on Windows, run the following commands in
 **PowerShell** (these commands will not work in `cmd.exe`):
 
 <Tabs>
-<TabItem label="Teleport Community Edition" scope="oss">
+<TabItem label="Teleport Enterprise Cloud" scope="cloud">
 
-  (!docs/pages/includes/install-windows-clients.mdx version="(=teleport.version=)" !)
+  (!docs/pages/includes/install-windows-clients.mdx version="(=cloud.version=)" !)
 
 </TabItem>
 <TabItem label="Teleport Enterprise" scope="enterprise">
@@ -15,10 +15,9 @@ To install `tsh` and `tctl` on Windows, run the following commands in
   (!docs/pages/includes/install-windows-clients.mdx version="(=teleport.version=)" !)
 
 </TabItem>
+<TabItem label="Teleport Community Edition" scope="oss">
 
-<TabItem  label="Teleport Enterprise Cloud" scope="cloud">
-
-  (!docs/pages/includes/install-windows-clients.mdx version="(=cloud.version=)" !)
+  (!docs/pages/includes/install-windows-clients.mdx version="(=teleport.version=)" !)
 
 </TabItem>
 </Tabs>

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -91,14 +91,6 @@ and install Teleport.
 First, assign environment variables based on your edition:
 
 <Tabs>
-<TabItem label="Teleport Community Edition">
-
-```code
-$ TELEPORT_EDITION="oss"
-$ TELEPORT_VERSION="(=teleport.version=)"
-```
-
-</TabItem>
 <TabItem label="Teleport Cloud">
 
 The following commands show you how to determine the Teleport version to install
@@ -116,6 +108,14 @@ $ TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/
 
 ```code
 $ TELEPORT_EDITION="enterprise"
+$ TELEPORT_VERSION="(=teleport.version=)"
+```
+
+</TabItem>
+<TabItem label="Teleport Community Edition">
+
+```code
+$ TELEPORT_EDITION="oss"
 $ TELEPORT_VERSION="(=teleport.version=)"
 ```
 
@@ -144,15 +144,6 @@ repositories.
    install:
 
    <Tabs>
-   <TabItem label="Teleport Community Edition">
-
-   ```code
-   $ export TELEPORT_PKG=teleport
-   $ export TELEPORT_VERSION=v(=teleport.major_version=)
-   $ export TELEPORT_CHANNEL=stable/${TELEPORT_VERSION?}
-   ```
-
-   </TabItem>
    <TabItem label="Teleport Cloud">
 
    Teleport Cloud installations must include the automatic agent updater. The
@@ -187,6 +178,15 @@ repositories.
 
    ```code
    $ export TELEPORT_PKG=teleport-ent-fips
+   ```
+
+   </TabItem>
+   <TabItem label="Teleport Community Edition">
+
+   ```code
+   $ export TELEPORT_PKG=teleport
+   $ export TELEPORT_VERSION=v(=teleport.major_version=)
+   $ export TELEPORT_CHANNEL=stable/${TELEPORT_VERSION?}
    ```
 
    </TabItem>
@@ -439,15 +439,15 @@ either:
   `(=teleport.version=)`.
 
 <Tabs>
-<TabItem label="Teleport Community Edition" scope={["oss"]}>
+<TabItem label="Teleport Enterprise Cloud" scope={["team", "cloud"]}>
 
-|Image name|Troubleshooting Tools?|Image base|
-|-|-|-|
-|`(=teleport.latest_oss_docker_image=)`|No|[Distroless Debian 12](https://github.com/GoogleContainerTools/distroless)|
-|`(=teleport.latest_oss_debug_docker_image=)`|Yes|[Distroless Debian 12](https://github.com/GoogleContainerTools/distroless)|
+| Image name | Includes troubleshooting tools | Image base |
+| - | - | - |
+| `public.ecr.aws/gravitational/teleport-ent-distroless:(=cloud.version=)` | No | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
+| `public.ecr.aws/gravitational/teleport-ent-distroless-debug:(=cloud.version=)` | Yes | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
 
-For testing, we always recommend that you use the latest release version of
-Teleport, which is currently `(=teleport.latest_oss_docker_image=)`.
+For testing, we always recommend that you use the latest Cloud release version of
+Teleport Enterprise, which is currently `public.ecr.aws/gravitational/teleport-ent-distroless:(=cloud.version=)`.
 
 </TabItem>
 <TabItem label="Teleport Enterprise" scope={["enterprise"]}>
@@ -468,15 +468,15 @@ For testing, we always recommend that you use the latest release version of
 Teleport Enterprise, which is currently `(=teleport.latest_ent_docker_image=)`.
 
 </TabItem>
-<TabItem label="Teleport Enterprise Cloud" scope={["team", "cloud"]}>
+<TabItem label="Teleport Community Edition" scope={["oss"]}>
 
-| Image name | Includes troubleshooting tools | Image base |
-| - | - | - |
-| `public.ecr.aws/gravitational/teleport-ent-distroless:(=cloud.version=)` | No | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
-| `public.ecr.aws/gravitational/teleport-ent-distroless-debug:(=cloud.version=)` | Yes | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
+|Image name|Troubleshooting Tools?|Image base|
+|-|-|-|
+|`(=teleport.latest_oss_docker_image=)`|No|[Distroless Debian 12](https://github.com/GoogleContainerTools/distroless)|
+|`(=teleport.latest_oss_debug_docker_image=)`|Yes|[Distroless Debian 12](https://github.com/GoogleContainerTools/distroless)|
 
-For testing, we always recommend that you use the latest Cloud release version of
-Teleport Enterprise, which is currently `public.ecr.aws/gravitational/teleport-ent-distroless:(=cloud.version=)`.
+For testing, we always recommend that you use the latest release version of
+Teleport, which is currently `(=teleport.latest_oss_docker_image=)`.
 
 </TabItem>
 </Tabs>
@@ -767,6 +767,16 @@ chart.
 ## macOS
 
 <Tabs>
+<TabItem label="Cloud-Hosted Enterprise">
+
+(!docs/pages/includes/cloud/install-macos.mdx!)
+
+</TabItem>
+<TabItem label="Self-Hosted Enterprise">
+
+(!docs/pages/includes/enterprise/install-macos.mdx!)
+
+</TabItem>
 <TabItem label="Community Edition">
 
 You can download one of the following .pkg installers for macOS:
@@ -797,16 +807,6 @@ Homebrew is not maintained by Teleport and we can't guarantee its reliability or
 security.
 
 </Notice>
-
-</TabItem>
-<TabItem label="Self-Hosted Enterprise">
-
-(!docs/pages/includes/enterprise/install-macos.mdx!)
-
-</TabItem>
-<TabItem label="Cloud-Hosted Enterprise">
-
-(!docs/pages/includes/cloud/install-macos.mdx!)
 
 </TabItem>
 </Tabs>

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -91,7 +91,7 @@ and install Teleport.
 First, assign environment variables based on your edition:
 
 <Tabs>
-<TabItem label="Teleport Cloud">
+<TabItem label="Teleport Enterprise (Managed)">
 
 The following commands show you how to determine the Teleport version to install
 by querying your Teleport Cloud account. This way, the Teleport installation has
@@ -104,7 +104,7 @@ $ TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/
 ```
 
 </TabItem>
-<TabItem label="Teleport Enterprise">
+<TabItem label="Teleport Enterprise (Self-Hosted)">
 
 ```code
 $ TELEPORT_EDITION="enterprise"
@@ -144,7 +144,7 @@ repositories.
    install:
 
    <Tabs>
-   <TabItem label="Teleport Cloud">
+   <TabItem label="Teleport Enterprise (Managed)">
 
    Teleport Cloud installations must include the automatic agent updater. The
    following commands show you how to determine the Teleport version to install
@@ -439,7 +439,7 @@ either:
   `(=teleport.version=)`.
 
 <Tabs>
-<TabItem label="Teleport Enterprise Cloud" scope={["team", "cloud"]}>
+<TabItem label="Teleport Enterprise (Managed)" scope={["team", "cloud"]}>
 
 | Image name | Includes troubleshooting tools | Image base |
 | - | - | - |
@@ -450,7 +450,7 @@ For testing, we always recommend that you use the latest Cloud release version o
 Teleport Enterprise, which is currently `public.ecr.aws/gravitational/teleport-ent-distroless:(=cloud.version=)`.
 
 </TabItem>
-<TabItem label="Teleport Enterprise" scope={["enterprise"]}>
+<TabItem label="Teleport Enterprise (Self-Hosted)" scope={["enterprise"]}>
 
 | Image name | Includes troubleshooting tools | Image base |
 | - | - | - |
@@ -767,17 +767,17 @@ chart.
 ## macOS
 
 <Tabs>
-<TabItem label="Cloud-Hosted Enterprise">
+<TabItem label="Teleport Enterprise (Managed)">
 
 (!docs/pages/includes/cloud/install-macos.mdx!)
 
 </TabItem>
-<TabItem label="Self-Hosted Enterprise">
+<TabItem label="Teleport Enterprise (Self-Hosted)">
 
 (!docs/pages/includes/enterprise/install-macos.mdx!)
 
 </TabItem>
-<TabItem label="Community Edition">
+<TabItem label="Teleport Community Edition">
 
 You can download one of the following .pkg installers for macOS:
 


### PR DESCRIPTION
This PR reorganizes the installation documentation to show Cloud Enterprise specific instructions as the default instead of the Community Edition instructions.