### PR TITLE
[v14] [docs] fix broken include in postgres guide

### DIFF
--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -163,4 +163,5 @@ $ tsh db logout
 ## Next steps
 
 - Set up [automatic database user provisioning](../auto-user-provisioning/postgres.mdx).
+
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)


### PR DESCRIPTION
This PR moves the partial onto its own line to render it properly, otherwise it doesn't render at all.
Only on v14 branch, seems we fixed on v15+ already.