### PR TITLE
support ECDSA JWTs and JWKs

### DIFF
--- a/integration/appaccess/jwt.go
+++ b/integration/appaccess/jwt.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types/wrappers"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/web"
 )
@@ -46,7 +45,6 @@ func verifyJWT(t *testing.T, pack *Pack, token, appURI string) {
 	// Verify JWT.
 	key, err := jwt.New(&jwt.Config{
 		PublicKey:   publicKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
 		ClusterName: pack.jwtAppClusterName,
 	})
 	require.NoError(t, err)

--- a/lib/auth/integration/integrationv1/awsoidc_test.go
+++ b/lib/auth/integration/integrationv1/awsoidc_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/authz"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -119,7 +118,6 @@ func TestGenerateAWSOIDCToken(t *testing.T) {
 
 	// Validate JWT against public key
 	key, err := jwt.New(&jwt.Config{
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
 		ClusterName: clusterName,
 		Clock:       resourceSvc.clock,
 		PublicKey:   publicKey,

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -4865,7 +4865,6 @@ func verifyJWT(clock clockwork.Clock, clusterName string, pairs []*types.JWTKeyP
 		key, err := jwt.New(&jwt.Config{
 			Clock:       clock,
 			PublicKey:   publicKey,
-			Algorithm:   defaults.ApplicationTokenAlgorithm,
 			ClusterName: clusterName,
 		})
 		if err != nil {
@@ -4899,7 +4898,6 @@ func verifyJWTAWSOIDC(clock clockwork.Clock, clusterName string, pairs []*types.
 		key, err := jwt.New(&jwt.Config{
 			Clock:       clock,
 			PublicKey:   publicKey,
-			Algorithm:   defaults.ApplicationTokenAlgorithm,
 			ClusterName: clusterName,
 		})
 		if err != nil {

--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -148,12 +148,11 @@ var (
 		DatabaseCATLS:       RSA2048,
 		DatabaseClientCATLS: RSA2048,
 		OpenSSHCASSH:        Ed25519,
-		// TODO(nklaassen): update JWT algorithms to ECDSAP256 once supported.
-		JWTCAJWT:     RSA2048,
-		OIDCIdPCAJWT: RSA2048,
-		SAMLIdPCATLS: ECDSAP256,
-		SPIFFECATLS:  ECDSAP256,
-		SPIFFECAJWT:  RSA2048,
+		JWTCAJWT:            ECDSAP256,
+		OIDCIdPCAJWT:        ECDSAP256,
+		SAMLIdPCATLS:        ECDSAP256,
+		SPIFFECATLS:         ECDSAP256,
+		SPIFFECAJWT:         ECDSAP256,
 		// TODO(nklaassen): subject key purposes.
 	}
 
@@ -168,12 +167,11 @@ var (
 		DatabaseCATLS:       RSA2048,
 		DatabaseClientCATLS: RSA2048,
 		OpenSSHCASSH:        ECDSAP256,
-		// TODO(nklaassen): update JWT algorithms to ECDSAP256 once supported.
-		JWTCAJWT:     RSA2048,
-		OIDCIdPCAJWT: RSA2048,
-		SAMLIdPCATLS: ECDSAP256,
-		SPIFFECATLS:  ECDSAP256,
-		SPIFFECAJWT:  RSA2048,
+		JWTCAJWT:            ECDSAP256,
+		OIDCIdPCAJWT:        ECDSAP256,
+		SAMLIdPCATLS:        ECDSAP256,
+		SPIFFECATLS:         ECDSAP256,
+		SPIFFECAJWT:         ECDSAP256,
 		// TODO(nklaassen): subject key purposes.
 	}
 
@@ -190,12 +188,11 @@ var (
 		DatabaseCATLS:       RSA2048,
 		DatabaseClientCATLS: RSA2048,
 		OpenSSHCASSH:        ECDSAP256,
-		// TODO(nklaassen): update JWT algorithms to ECDSAP256 once supported.
-		JWTCAJWT:     RSA2048,
-		OIDCIdPCAJWT: RSA2048,
-		SAMLIdPCATLS: ECDSAP256,
-		SPIFFECATLS:  ECDSAP256,
-		SPIFFECAJWT:  RSA2048,
+		JWTCAJWT:            ECDSAP256,
+		OIDCIdPCAJWT:        ECDSAP256,
+		SAMLIdPCATLS:        ECDSAP256,
+		SPIFFECATLS:         ECDSAP256,
+		SPIFFECAJWT:         ECDSAP256,
 		// TODO(nklaassen): subject key purposes.
 	}
 

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"golang.org/x/crypto/ssh"
@@ -738,13 +737,6 @@ const (
 )
 
 const (
-	// ApplicationTokenKeyType is the type of asymmetric key used to sign tokens.
-	// See https://tools.ietf.org/html/rfc7518#section-6.1 for possible values.
-	ApplicationTokenKeyType = "RSA"
-	// ApplicationTokenAlgorithm is the default algorithm used to sign
-	// application access tokens.
-	ApplicationTokenAlgorithm = jose.RS256
-
 	// JWTUse is the default usage of the JWT.
 	// See https://www.rfc-editor.org/rfc/rfc7517#section-4.2 for more information.
 	JWTUse = "sig"

--- a/lib/jwt/jwk.go
+++ b/lib/jwt/jwk.go
@@ -20,16 +20,24 @@ package jwt
 
 import (
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"math/big"
 
+	"github.com/go-jose/go-jose/v3"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/defaults"
+)
+
+const (
+	keyTypeRSA = "RSA"
+	keyTypeEC  = "EC"
 )
 
 // JWK is a JSON Web Key, described in detail in RFC 7517.
@@ -38,10 +46,19 @@ type JWK struct {
 	KeyType string `json:"kty"`
 	// Algorithm used to sign.
 	Algorithm string `json:"alg"`
-	// N is the modulus of the public key.
-	N string `json:"n"`
-	// E is the exponent of the public key.
-	E string `json:"e"`
+
+	// N is the modulus of an RSA public key.
+	N string `json:"n,omitempty"`
+	// E is the exponent of an RSA public key.
+	E string `json:"e,omitempty"`
+
+	// Curve identifies the cryptographic curve used with an ECDSA public key.
+	Curve string `json:"crv,omitempty"`
+	// X is the x coordinate parameter of an ECDSA public key.
+	X string `json:"x,omitempty"`
+	// Y is the y coordinate parameter of an ECDSA public key.
+	Y string `json:"y,omitempty"`
+
 	// Use identifies the intended use of the public key.
 	// This field is required for the AWS OIDC Integration.
 	// https://www.rfc-editor.org/rfc/rfc7517#section-4.2
@@ -53,41 +70,92 @@ type JWK struct {
 }
 
 // KeyID returns a key id derived from the public key.
-func KeyID(pub *rsa.PublicKey) string {
+func KeyID(pub crypto.PublicKey) (string, error) {
+	switch p := pub.(type) {
+	case *rsa.PublicKey:
+		return rsaKeyID(p), nil
+	default:
+		return genericKeyID(p)
+	}
+}
+
+func rsaKeyID(pub *rsa.PublicKey) string {
 	hash := sha256.Sum256(x509.MarshalPKCS1PublicKey(pub))
 	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+func genericKeyID(pub crypto.PublicKey) (string, error) {
+	pubKeyDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	hash := sha256.Sum256(pubKeyDER)
+	return base64.RawURLEncoding.EncodeToString(hash[:]), nil
 }
 
 // MarshalJWK will marshal a supported public key into JWK format.
 func MarshalJWK(bytes []byte) (JWK, error) {
 	// Parse the public key and validate type.
-	p, err := keys.ParsePublicKey(bytes)
+	pub, err := keys.ParsePublicKey(bytes)
 	if err != nil {
 		return JWK{}, trace.Wrap(err)
 	}
-	publicKey, ok := p.(*rsa.PublicKey)
-	if !ok {
-		return JWK{}, trace.BadParameter("unsupported key format %T", p)
-	}
 
-	// Marshal to JWK.
+	switch p := pub.(type) {
+	case *rsa.PublicKey:
+		return marshalRSAJWK(p), nil
+	case *ecdsa.PublicKey:
+		return marshalECDSAJWK(p)
+	default:
+		return JWK{}, trace.BadParameter("unsupported public type type %T", pub)
+	}
+}
+
+func marshalRSAJWK(pub *rsa.PublicKey) JWK {
 	return JWK{
-		KeyType:   string(defaults.ApplicationTokenKeyType),
-		Algorithm: string(defaults.ApplicationTokenAlgorithm),
-		N:         base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
-		E:         base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes()),
+		KeyType:   keyTypeRSA,
 		Use:       defaults.JWTUse,
-		KeyID:     KeyID(publicKey),
+		KeyID:     rsaKeyID(pub),
+		Algorithm: string(jose.RS256),
+		N:         base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+		E:         base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+	}
+}
+
+func marshalECDSAJWK(pub *ecdsa.PublicKey) (JWK, error) {
+	if pub.Curve != elliptic.P256() {
+		return JWK{}, trace.BadParameter("unsupported curve %T", pub.Curve)
+	}
+	keyID, err := genericKeyID(pub)
+	if err != nil {
+		return JWK{}, trace.Wrap(err)
+	}
+	return JWK{
+		KeyType:   keyTypeEC,
+		Use:       defaults.JWTUse,
+		KeyID:     keyID,
+		Algorithm: string(jose.ES256),
+		Curve:     pub.Curve.Params().Name,
+		X:         base64.RawURLEncoding.EncodeToString(pub.X.Bytes()),
+		Y:         base64.RawURLEncoding.EncodeToString(pub.Y.Bytes()),
 	}, nil
 }
 
 // UnmarshalJWK will unmarshal JWK into a crypto.PublicKey that can be used
 // to validate signatures.
 func UnmarshalJWK(jwk JWK) (crypto.PublicKey, error) {
-	if jwk.KeyType != string(defaults.ApplicationTokenKeyType) {
+	switch jwk.KeyType {
+	case keyTypeRSA:
+		return unmarshalRSAJWK(jwk)
+	case keyTypeEC:
+		return unmarshalECDSAJWK(jwk)
+	default:
 		return nil, trace.BadParameter("unsupported key type %v", jwk.KeyType)
 	}
-	if jwk.Algorithm != string(defaults.ApplicationTokenAlgorithm) {
+}
+
+func unmarshalRSAJWK(jwk JWK) (*rsa.PublicKey, error) {
+	if jwk.Algorithm != string(jose.RS256) {
 		return nil, trace.BadParameter("unsupported algorithm %v", jwk.Algorithm)
 	}
 
@@ -103,5 +171,29 @@ func UnmarshalJWK(jwk JWK) (crypto.PublicKey, error) {
 	return &rsa.PublicKey{
 		N: new(big.Int).SetBytes(n),
 		E: int(new(big.Int).SetBytes(e).Uint64()),
+	}, nil
+}
+
+func unmarshalECDSAJWK(jwk JWK) (*ecdsa.PublicKey, error) {
+	if jwk.Algorithm != string(jose.ES256) {
+		return nil, trace.BadParameter("unsupported algorithm %v", jwk.Algorithm)
+	}
+	if jwk.Curve != elliptic.P256().Params().Name {
+		return nil, trace.BadParameter("unsupported curve %v", jwk.Curve)
+	}
+
+	x, err := base64.RawURLEncoding.DecodeString(jwk.X)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	y, err := base64.RawURLEncoding.DecodeString(jwk.Y)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     new(big.Int).SetBytes(x),
+		Y:     new(big.Int).SetBytes(y),
 	}, nil
 }

--- a/lib/jwt/jwk_test.go
+++ b/lib/jwt/jwk_test.go
@@ -23,9 +23,10 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/cryptosuites"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMarshalJWK(t *testing.T) {

--- a/lib/jwt/jwk_test.go
+++ b/lib/jwt/jwk_test.go
@@ -19,67 +19,108 @@
 package jwt
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
-	"math/big"
 	"testing"
 
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMarshalJWK(t *testing.T) {
-	pubBytes, _, err := GenerateKeyPair()
-	require.NoError(t, err)
+	t.Parallel()
 
-	jwk, err := MarshalJWK(pubBytes)
-	require.NoError(t, err)
+	for _, alg := range supportedAlgorithms {
+		t.Run(alg.String(), func(t *testing.T) {
+			key, err := cryptosuites.GenerateKeyWithAlgorithm(alg)
+			require.NoError(t, err)
 
-	// Required for integrating with AWS OpenID Connect Identity Provider.
-	require.Equal(t, "sig", jwk.Use)
+			pubBytes, err := keys.MarshalPublicKey(key.Public())
+			require.NoError(t, err)
+
+			jwk, err := MarshalJWK(pubBytes)
+			require.NoError(t, err)
+
+			// Required for integrating with AWS OpenID Connect Identity Provider.
+			require.Equal(t, "sig", jwk.Use)
+		})
+	}
 }
 
 func TestKeyIDHasConsistentOutputForAnInput(t *testing.T) {
 	t.Parallel()
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
-	require.NoError(t, err)
-	publicKey := privateKey.Public().(*rsa.PublicKey)
-	id1 := KeyID(publicKey)
-	id2 := KeyID(publicKey)
-	require.NotEmpty(t, id1)
-	require.Equal(t, id1, id2)
+	for _, alg := range supportedAlgorithms {
+		t.Run(alg.String(), func(t *testing.T) {
+			key, err := cryptosuites.GenerateKeyWithAlgorithm(alg)
+			require.NoError(t, err)
+			id1, err := KeyID(key.Public())
+			require.NoError(t, err)
+			id2, err := KeyID(key.Public())
+			require.NoError(t, err)
+			require.NotEmpty(t, id1)
+			require.Equal(t, id1, id2)
 
-	expectedLength := base64.RawURLEncoding.EncodedLen(sha256.Size)
-	require.Len(t, id1, expectedLength, "expected key id to always be %d characters long", expectedLength)
+			expectedLength := base64.RawURLEncoding.EncodedLen(sha256.Size)
+			require.Len(t, id1, expectedLength, "expected key id to always be %d characters long", expectedLength)
+		})
+	}
 }
 
 func TestKeyIDHasDistinctOutputForDifferingInputs(t *testing.T) {
 	t.Parallel()
 
-	privateKey1, err := rsa.GenerateKey(rand.Reader, 1024)
-	require.NoError(t, err)
-	privateKey2, err := rsa.GenerateKey(rand.Reader, 1024)
-	require.NoError(t, err)
-	publicKey1 := privateKey1.Public().(*rsa.PublicKey)
-	publicKey2 := privateKey2.Public().(*rsa.PublicKey)
-	id1 := KeyID(publicKey1)
-	id2 := KeyID(publicKey2)
-	require.NotEmpty(t, id1)
-	require.NotEmpty(t, id2)
-	require.NotEqual(t, id1, id2)
+	for _, alg := range supportedAlgorithms {
+		t.Run(alg.String(), func(t *testing.T) {
+			privateKey1, err := cryptosuites.GenerateKeyWithAlgorithm(alg)
+			require.NoError(t, err)
+			privateKey2, err := cryptosuites.GenerateKeyWithAlgorithm(alg)
+			require.NoError(t, err)
+			id1, err := KeyID(privateKey1.Public())
+			require.NoError(t, err)
+			id2, err := KeyID(privateKey2.Public())
+			require.NoError(t, err)
+			require.NotEmpty(t, id1)
+			require.NotEmpty(t, id2)
+			require.NotEqual(t, id1, id2)
+		})
+	}
 }
 
 // TestKeyIDCompatibility ensures we do not introduce a change in the KeyID algorithm for existing keys.
 // It does so by ensuring that a pre-generated public key results in the expected value.
 func TestKeyIDCompatibility(t *testing.T) {
-	n, ok := new(big.Int).
-		SetString("10804584566601725083798733714540307814537881454603593919227265169397611763416631197061041949793088023127406259586903197568870611092333639226643589004457719", 10)
-	require.True(t, ok, "failed to create a bigint")
-	publicKey := &rsa.PublicKey{
-		E: 65537,
-		N: n,
+	for _, tc := range []struct {
+		desc       string
+		pubKeyPEM  string
+		expectedID string
+	}{
+		{
+			desc: "RSA",
+			pubKeyPEM: `-----BEGIN RSA PUBLIC KEY-----
+MEgCQQDOS7WRzZm+ADCp8dL/fNtJvKegWx0ShJ8jzenoIyK4i7KW8Y23/mr5EEul
++B3xNVX2pMu3WOsgH4kZ088x9vb3AgMBAAE=
+-----END RSA PUBLIC KEY-----`,
+			expectedID: "GDLHLDvPUYmNLVU3WgshDX7bAw8xEmML8ypeE9KRAEQ",
+		},
+		{
+			desc: "ECDSA",
+			pubKeyPEM: `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoqR1cHAPOWIhqbvXhBfQZq9jndZH
+PsPcvHNBFaa5GxTtwWFgzLEM17ERKDdBCbCf8oME2GRMKXlWOADlC3MYxg==
+-----END PUBLIC KEY-----`,
+			expectedID: "fLYYX_JCuFA6XuN6BVCeas1bbEWRd7clCTkr8QG6Djk",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			publicKey, err := keys.ParsePublicKey([]byte(tc.pubKeyPEM))
+			require.NoError(t, err)
+
+			kid, err := KeyID(publicKey)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectedID, kid)
+		})
 	}
-	require.Equal(t, "GDLHLDvPUYmNLVU3WgshDX7bAw8xEmML8ypeE9KRAEQ", KeyID(publicKey))
 }

--- a/lib/jwt/jwt.go
+++ b/lib/jwt/jwt.go
@@ -21,7 +21,8 @@ package jwt
 
 import (
 	"crypto"
-	"crypto/rand"
+	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
@@ -39,10 +40,8 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
-	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
-	"github.com/gravitational/teleport/api/utils/keys"
 )
 
 // Config defines the clock and PEM encoded bytes of a public and private
@@ -56,9 +55,6 @@ type Config struct {
 
 	// PrivateKey is used to sign and verify tokens.
 	PrivateKey crypto.Signer
-
-	// Algorithm is algorithm used to sign JWT tokens.
-	Algorithm jose.SignatureAlgorithm
 
 	// ClusterName is the name of the cluster that will be signing the JWT tokens.
 	ClusterName string
@@ -75,9 +71,6 @@ func (c *Config) CheckAndSetDefaults() error {
 
 	if c.PrivateKey == nil && c.PublicKey == nil {
 		return trace.BadParameter("public or private key is required")
-	}
-	if c.Algorithm == "" {
-		return trace.BadParameter("algorithm is required")
 	}
 	if c.ClusterName == "" {
 		return trace.BadParameter("cluster name is required")
@@ -159,13 +152,19 @@ func (k *Key) signAny(claims any, opts *jose.SignerOptions) (string, error) {
 	// Create a signer with configured private key and algorithm.
 	var signer interface{}
 	switch k.config.PrivateKey.(type) {
-	case *rsa.PrivateKey:
+	case *rsa.PrivateKey, *ecdsa.PrivateKey, ed25519.PrivateKey:
 		signer = k.config.PrivateKey
 	default:
 		signer = cryptosigner.Opaque(k.config.PrivateKey)
 	}
+
+	algorithm, err := joseAlgorithm(k.config.PrivateKey.Public())
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
 	signingKey := jose.SigningKey{
-		Algorithm: k.config.Algorithm,
+		Algorithm: algorithm,
 		Key:       signer,
 	}
 
@@ -183,6 +182,18 @@ func (k *Key) signAny(claims any, opts *jose.SignerOptions) (string, error) {
 		return "", trace.Wrap(err)
 	}
 	return token, nil
+}
+
+func joseAlgorithm(pub crypto.PublicKey) (jose.SignatureAlgorithm, error) {
+	switch pub.(type) {
+	case *rsa.PublicKey:
+		return jose.RS256, nil
+	case *ecdsa.PublicKey:
+		return jose.ES256, nil
+	case ed25519.PublicKey:
+		return jose.EdDSA, nil
+	}
+	return "", trace.BadParameter("unsupported public key type %T", pub)
 }
 
 func (k *Key) Sign(p SignParams) (string, error) {
@@ -266,11 +277,10 @@ func (k *Key) SignEntraOIDC(p SignParams) (string, error) {
 
 	// Azure expect a `kid` header to be present and non-empty,
 	// unlike e.g. AWS which accepts an empty `kid` string value.
-	publicKey, ok := k.config.PublicKey.(*rsa.PublicKey)
-	if !ok {
-		return "", trace.BadParameter("expected an RSA public key")
+	kid, err := KeyID(k.config.PublicKey)
+	if err != nil {
+		return "", trace.Wrap(err)
 	}
-	kid := KeyID(publicKey)
 	opts := (&jose.SignerOptions{}).
 		WithHeader(jose.HeaderKey("kid"), kid)
 	return k.sign(claims, opts)
@@ -549,26 +559,6 @@ type Claims struct {
 
 	// Traits returns the traits assigned to the user within Teleport.
 	Traits wrappers.Traits `json:"traits"`
-}
-
-// GenerateKeyPair generates and return a PEM encoded private and public
-// key in the format used by this package.
-func GenerateKeyPair() ([]byte, []byte, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, constants.RSAKeySize)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	public, err := keys.MarshalPublicKey(privateKey.Public())
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	private, err := keys.MarshalPrivateKey(privateKey)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	return public, private, nil
 }
 
 // CheckNotBefore ensures the token was not issued in the future.

--- a/lib/jwt/jwt_test.go
+++ b/lib/jwt/jwt_test.go
@@ -27,336 +27,348 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types/wrappers"
-	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 )
 
+var supportedAlgorithms = []cryptosuites.Algorithm{
+	cryptosuites.RSA2048,
+	cryptosuites.ECDSAP256,
+}
+
 func TestSignAndVerify(t *testing.T) {
-	_, privateBytes, err := GenerateKeyPair()
-	require.NoError(t, err)
-	privateKey, err := keys.ParsePrivateKey(privateBytes)
-	require.NoError(t, err)
+	t.Parallel()
+	for _, alg := range supportedAlgorithms {
+		t.Run(alg.String(), func(t *testing.T) {
+			privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(alg)
+			require.NoError(t, err)
 
-	clock := clockwork.NewFakeClockAt(time.Now())
+			clock := clockwork.NewFakeClockAt(time.Now())
 
-	// Create a new key that can sign and verify tokens.
-	key, err := New(&Config{
-		Clock:       clock,
-		PrivateKey:  privateKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
-		ClusterName: "example.com",
-	})
-	require.NoError(t, err)
+			// Create a new key that can sign and verify tokens.
+			key, err := New(&Config{
+				Clock:       clock,
+				PrivateKey:  privateKey,
+				ClusterName: "example.com",
+			})
+			require.NoError(t, err)
 
-	// Sign a token with the new key.
-	token, err := key.Sign(SignParams{
-		Username: "foo@example.com",
-		Roles:    []string{"foo", "bar"},
-		Expires:  clock.Now().Add(1 * time.Minute),
-		URI:      "http://127.0.0.1:8080",
-	})
-	require.NoError(t, err)
+			// Sign a token with the new key.
+			token, err := key.Sign(SignParams{
+				Username: "foo@example.com",
+				Roles:    []string{"foo", "bar"},
+				Expires:  clock.Now().Add(1 * time.Minute),
+				URI:      "http://127.0.0.1:8080",
+			})
+			require.NoError(t, err)
 
-	// Verify that the token can be validated and values match expected values.
-	claims, err := key.Verify(VerifyParams{
-		Username: "foo@example.com",
-		RawToken: token,
-		URI:      "http://127.0.0.1:8080",
-	})
-	require.NoError(t, err)
-	require.Equal(t, "foo@example.com", claims.Username)
-	require.Equal(t, []string{"foo", "bar"}, claims.Roles)
+			// Verify that the token can be validated and values match expected values.
+			claims, err := key.Verify(VerifyParams{
+				Username: "foo@example.com",
+				RawToken: token,
+				URI:      "http://127.0.0.1:8080",
+			})
+			require.NoError(t, err)
+			require.Equal(t, "foo@example.com", claims.Username)
+			require.Equal(t, []string{"foo", "bar"}, claims.Roles)
+		})
+	}
 }
 
 // TestPublicOnlyVerifyAzure checks that a non-signing key used to validate a JWT
 // can be created. Azure version.
 func TestPublicOnlyVerifyAzure(t *testing.T) {
-	publicBytes, privateBytes, err := GenerateKeyPair()
-	require.NoError(t, err)
-	privateKey, err := keys.ParsePrivateKey(privateBytes)
-	require.NoError(t, err)
-	publicKey, err := keys.ParsePublicKey(publicBytes)
-	require.NoError(t, err)
+	t.Parallel()
+	for _, alg := range supportedAlgorithms {
+		t.Run(alg.String(), func(t *testing.T) {
+			privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(alg)
+			require.NoError(t, err)
+			publicKey := privateKey.Public()
 
-	// Create a new key that can sign and verify tokens.
-	key, err := New(&Config{
-		PrivateKey:  privateKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
-		ClusterName: "example.com",
-	})
-	require.NoError(t, err)
+			// Create a new key that can sign and verify tokens.
+			key, err := New(&Config{
+				PrivateKey:  privateKey,
+				ClusterName: "example.com",
+			})
+			require.NoError(t, err)
 
-	// Sign a token with the new key.
-	token, err := key.SignAzureToken(AzureTokenClaims{
-		TenantID: "dummy-tenant-id",
-		Resource: "my-resource",
-	})
-	require.NoError(t, err)
+			// Sign a token with the new key.
+			token, err := key.SignAzureToken(AzureTokenClaims{
+				TenantID: "dummy-tenant-id",
+				Resource: "my-resource",
+			})
+			require.NoError(t, err)
 
-	// Create a new key that can only verify tokens and make sure the token
-	// values match the expected values.
-	key, err = New(&Config{
-		PublicKey:   publicKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
-		ClusterName: "example.com",
-	})
-	require.NoError(t, err)
-	claims, err := key.VerifyAzureToken(token)
-	require.NoError(t, err)
-	require.Equal(t, AzureTokenClaims{
-		TenantID: "dummy-tenant-id",
-		Resource: "my-resource",
-	}, *claims)
+			// Create a new key that can only verify tokens and make sure the token
+			// values match the expected values.
+			key, err = New(&Config{
+				PublicKey:   publicKey,
+				ClusterName: "example.com",
+			})
+			require.NoError(t, err)
+			claims, err := key.VerifyAzureToken(token)
+			require.NoError(t, err)
+			require.Equal(t, AzureTokenClaims{
+				TenantID: "dummy-tenant-id",
+				Resource: "my-resource",
+			}, *claims)
 
-	// Make sure this key returns an error when trying to sign.
-	_, err = key.SignAzureToken(*claims)
-	require.Error(t, err)
+			// Make sure this key returns an error when trying to sign.
+			_, err = key.SignAzureToken(*claims)
+			require.Error(t, err)
+		})
+	}
 }
 
 // TestPublicOnlyVerify checks that a non-signing key used to validate a JWT
 // can be created.
 func TestPublicOnlyVerify(t *testing.T) {
-	publicBytes, privateBytes, err := GenerateKeyPair()
-	require.NoError(t, err)
-	privateKey, err := keys.ParsePrivateKey(privateBytes)
-	require.NoError(t, err)
-	publicKey, err := keys.ParsePublicKey(publicBytes)
-	require.NoError(t, err)
+	t.Parallel()
+	for _, alg := range supportedAlgorithms {
+		t.Run(alg.String(), func(t *testing.T) {
+			privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(alg)
+			require.NoError(t, err)
+			publicKey := privateKey.Public()
 
-	clock := clockwork.NewFakeClockAt(time.Now())
+			clock := clockwork.NewFakeClockAt(time.Now())
 
-	// Create a new key that can sign and verify tokens.
-	key, err := New(&Config{
-		PrivateKey:  privateKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
-		ClusterName: "example.com",
-	})
-	require.NoError(t, err)
+			// Create a new key that can sign and verify tokens.
+			key, err := New(&Config{
+				PrivateKey:  privateKey,
+				ClusterName: "example.com",
+			})
+			require.NoError(t, err)
 
-	// Sign a token with the new key.
-	token, err := key.Sign(SignParams{
-		Username: "foo@example.com",
-		Roles:    []string{"foo", "bar"},
-		Traits: wrappers.Traits{
-			"trait1": []string{"value-1", "value-2"},
-		},
-		Expires: clock.Now().Add(1 * time.Minute),
-		URI:     "http://127.0.0.1:8080",
-	})
-	require.NoError(t, err)
+			// Sign a token with the new key.
+			token, err := key.Sign(SignParams{
+				Username: "foo@example.com",
+				Roles:    []string{"foo", "bar"},
+				Traits: wrappers.Traits{
+					"trait1": []string{"value-1", "value-2"},
+				},
+				Expires: clock.Now().Add(1 * time.Minute),
+				URI:     "http://127.0.0.1:8080",
+			})
+			require.NoError(t, err)
 
-	// Create a new key that can only verify tokens and make sure the token
-	// values match the expected values.
-	key, err = New(&Config{
-		PublicKey:   publicKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
-		ClusterName: "example.com",
-	})
-	require.NoError(t, err)
-	claims, err := key.Verify(VerifyParams{
-		Username: "foo@example.com",
-		URI:      "http://127.0.0.1:8080",
-		RawToken: token,
-	})
-	require.NoError(t, err)
-	require.Equal(t, "foo@example.com", claims.Username)
-	require.Equal(t, []string{"foo", "bar"}, claims.Roles)
+			// Create a new key that can only verify tokens and make sure the token
+			// values match the expected values.
+			key, err = New(&Config{
+				PublicKey:   publicKey,
+				ClusterName: "example.com",
+			})
+			require.NoError(t, err)
+			claims, err := key.Verify(VerifyParams{
+				Username: "foo@example.com",
+				URI:      "http://127.0.0.1:8080",
+				RawToken: token,
+			})
+			require.NoError(t, err)
+			require.Equal(t, "foo@example.com", claims.Username)
+			require.Equal(t, []string{"foo", "bar"}, claims.Roles)
 
-	// Make sure this key returns an error when trying to sign.
-	_, err = key.Sign(SignParams{
-		Username: "foo@example.com",
-		Roles:    []string{"foo", "bar"},
-		Expires:  clock.Now().Add(1 * time.Minute),
-		URI:      "http://127.0.0.1:8080",
-	})
-	require.Error(t, err)
+			// Make sure this key returns an error when trying to sign.
+			_, err = key.Sign(SignParams{
+				Username: "foo@example.com",
+				Roles:    []string{"foo", "bar"},
+				Expires:  clock.Now().Add(1 * time.Minute),
+				URI:      "http://127.0.0.1:8080",
+			})
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestKey_SignAndVerifyPROXY(t *testing.T) {
-	_, privateBytes, err := GenerateKeyPair()
-	require.NoError(t, err)
-	privateKey, err := keys.ParsePrivateKey(privateBytes)
-	require.NoError(t, err)
+	t.Parallel()
+	for _, alg := range supportedAlgorithms {
+		t.Run(alg.String(), func(t *testing.T) {
+			privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(alg)
+			require.NoError(t, err)
 
-	clock := clockwork.NewFakeClockAt(time.Now())
-	const clusterName = "teleport-test"
+			clock := clockwork.NewFakeClockAt(time.Now())
+			const clusterName = "teleport-test"
 
-	// Create a new key that can sign and verify tokens.
-	key, err := New(&Config{
-		PrivateKey:  privateKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
-		ClusterName: clusterName,
-		Clock:       clock,
-	})
-	require.NoError(t, err)
-	source := "1.2.3.4:555"
-	destination := "4.3.2.1:666:"
+			// Create a new key that can sign and verify tokens.
+			key, err := New(&Config{
+				PrivateKey:  privateKey,
+				ClusterName: clusterName,
+				Clock:       clock,
+			})
+			require.NoError(t, err)
+			source := "1.2.3.4:555"
+			destination := "4.3.2.1:666:"
 
-	// Sign a token with the new key.
-	token, err := key.SignPROXYJWT(PROXYSignParams{
-		ClusterName:        clusterName,
-		SourceAddress:      source,
-		DestinationAddress: destination,
-	})
-	require.NoError(t, err)
+			// Sign a token with the new key.
+			token, err := key.SignPROXYJWT(PROXYSignParams{
+				ClusterName:        clusterName,
+				SourceAddress:      source,
+				DestinationAddress: destination,
+			})
+			require.NoError(t, err)
 
-	// Successfully verify
-	_, err = key.VerifyPROXY(PROXYVerifyParams{
-		ClusterName:        clusterName,
-		SourceAddress:      source,
-		DestinationAddress: destination,
-		RawToken:           token,
-	})
-	require.NoError(t, err)
+			// Successfully verify
+			_, err = key.VerifyPROXY(PROXYVerifyParams{
+				ClusterName:        clusterName,
+				SourceAddress:      source,
+				DestinationAddress: destination,
+				RawToken:           token,
+			})
+			require.NoError(t, err)
 
-	// Check that if params don't match verification fails
-	_, err = key.VerifyPROXY(PROXYVerifyParams{
-		ClusterName:        clusterName + "1",
-		SourceAddress:      source,
-		DestinationAddress: destination,
-		RawToken:           token,
-	})
-	require.ErrorContains(t, err, "invalid issuer")
+			// Check that if params don't match verification fails
+			_, err = key.VerifyPROXY(PROXYVerifyParams{
+				ClusterName:        clusterName + "1",
+				SourceAddress:      source,
+				DestinationAddress: destination,
+				RawToken:           token,
+			})
+			require.ErrorContains(t, err, "invalid issuer")
 
-	_, err = key.VerifyPROXY(PROXYVerifyParams{
-		ClusterName:        clusterName,
-		SourceAddress:      destination,
-		DestinationAddress: source,
-		RawToken:           token,
-	})
-	require.ErrorContains(t, err, "invalid subject")
+			_, err = key.VerifyPROXY(PROXYVerifyParams{
+				ClusterName:        clusterName,
+				SourceAddress:      destination,
+				DestinationAddress: source,
+				RawToken:           token,
+			})
+			require.ErrorContains(t, err, "invalid subject")
 
-	// Rewind clock backward and verify that token is not valid yet
-	clock.Advance(time.Minute * -2)
-	_, err = key.VerifyPROXY(PROXYVerifyParams{
-		ClusterName:        clusterName,
-		SourceAddress:      source,
-		DestinationAddress: destination,
-		RawToken:           token,
-	})
-	require.ErrorContains(t, err, "token not valid yet")
+			// Rewind clock backward and verify that token is not valid yet
+			clock.Advance(time.Minute * -2)
+			_, err = key.VerifyPROXY(PROXYVerifyParams{
+				ClusterName:        clusterName,
+				SourceAddress:      source,
+				DestinationAddress: destination,
+				RawToken:           token,
+			})
+			require.ErrorContains(t, err, "token not valid yet")
 
-	// Advance clock and verify that token is expired now
-	clock.Advance(time.Minute*2 + expirationPROXY*2)
-	_, err = key.VerifyPROXY(PROXYVerifyParams{
-		ClusterName:        clusterName,
-		SourceAddress:      source,
-		DestinationAddress: destination,
-		RawToken:           token,
-	})
-	require.ErrorContains(t, err, "token is expired")
+			// Advance clock and verify that token is expired now
+			clock.Advance(time.Minute*2 + expirationPROXY*2)
+			_, err = key.VerifyPROXY(PROXYVerifyParams{
+				ClusterName:        clusterName,
+				SourceAddress:      source,
+				DestinationAddress: destination,
+				RawToken:           token,
+			})
+			require.ErrorContains(t, err, "token is expired")
+		})
+	}
 }
 
 func TestKey_SignAndVerifyAWSOIDC(t *testing.T) {
-	_, privateBytes, err := GenerateKeyPair()
-	require.NoError(t, err)
-	privateKey, err := keys.ParsePrivateKey(privateBytes)
-	require.NoError(t, err)
+	t.Parallel()
+	for _, alg := range supportedAlgorithms {
+		t.Run(alg.String(), func(t *testing.T) {
+			privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(alg)
+			require.NoError(t, err)
 
-	clock := clockwork.NewFakeClockAt(time.Now())
-	const clusterName = "teleport-test"
+			clock := clockwork.NewFakeClockAt(time.Now())
+			const clusterName = "teleport-test"
 
-	// Create a new key that can sign and verify tokens.
-	key, err := New(&Config{
-		PrivateKey:  privateKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
-		ClusterName: clusterName,
-		Clock:       clock,
-	})
-	require.NoError(t, err)
+			// Create a new key that can sign and verify tokens.
+			key, err := New(&Config{
+				PrivateKey:  privateKey,
+				ClusterName: clusterName,
+				Clock:       clock,
+			})
+			require.NoError(t, err)
 
-	// Sign a token with the new key.
-	expiresIn := time.Minute * 5
-	token, err := key.SignAWSOIDC(SignParams{
-		Username: "user",
-		Issuer:   "https://localhost/",
-		URI:      "https://localhost/",
-		Subject:  "system:proxy",
-		Audience: "discover.teleport",
-		Expires:  clock.Now().Add(expiresIn),
-	})
-	require.NoError(t, err)
+			// Sign a token with the new key.
+			expiresIn := time.Minute * 5
+			token, err := key.SignAWSOIDC(SignParams{
+				Username: "user",
+				Issuer:   "https://localhost/",
+				URI:      "https://localhost/",
+				Subject:  "system:proxy",
+				Audience: "discover.teleport",
+				Expires:  clock.Now().Add(expiresIn),
+			})
+			require.NoError(t, err)
 
-	// Successfully verify
-	_, err = key.VerifyAWSOIDC(AWSOIDCVerifyParams{
-		RawToken: token,
-		Issuer:   "https://localhost/",
-	})
-	require.NoError(t, err, token)
+			// Successfully verify
+			_, err = key.VerifyAWSOIDC(AWSOIDCVerifyParams{
+				RawToken: token,
+				Issuer:   "https://localhost/",
+			})
+			require.NoError(t, err, token)
 
-	// Check that if params don't match verification fails
-	_, err = key.VerifyAWSOIDC(AWSOIDCVerifyParams{
-		RawToken: token,
-		Issuer:   "https://localhost/" + "1",
-	})
-	require.ErrorContains(t, err, "invalid issuer")
+			// Check that if params don't match verification fails
+			_, err = key.VerifyAWSOIDC(AWSOIDCVerifyParams{
+				RawToken: token,
+				Issuer:   "https://localhost/" + "1",
+			})
+			require.ErrorContains(t, err, "invalid issuer")
 
-	// Rewind clock backward and verify that token is not valid yet
-	clock.Advance(time.Minute * -2)
-	_, err = key.VerifyAWSOIDC(AWSOIDCVerifyParams{
-		RawToken: token,
-		Issuer:   "https://localhost/",
-	})
-	require.ErrorContains(t, err, "token not valid yet")
-	// Revert time to before this sub-test.
-	clock.Advance(time.Minute * 2)
+			// Rewind clock backward and verify that token is not valid yet
+			clock.Advance(time.Minute * -2)
+			_, err = key.VerifyAWSOIDC(AWSOIDCVerifyParams{
+				RawToken: token,
+				Issuer:   "https://localhost/",
+			})
+			require.ErrorContains(t, err, "token not valid yet")
+			// Revert time to before this sub-test.
+			clock.Advance(time.Minute * 2)
 
-	// Advance clock and verify that token is expired now
-	clock.Advance(expiresIn + time.Minute)
-	_, err = key.VerifyAWSOIDC(AWSOIDCVerifyParams{
-		RawToken: token,
-		Issuer:   "https://localhost/",
-	})
-	require.ErrorContains(t, err, "token is expired")
+			// Advance clock and verify that token is expired now
+			clock.Advance(expiresIn + time.Minute)
+			_, err = key.VerifyAWSOIDC(AWSOIDCVerifyParams{
+				RawToken: token,
+				Issuer:   "https://localhost/",
+			})
+			require.ErrorContains(t, err, "token is expired")
+		})
+	}
 }
 
 // TestExpiry checks that token expiration works.
 func TestExpiry(t *testing.T) {
-	_, privateBytes, err := GenerateKeyPair()
-	require.NoError(t, err)
-	privateKey, err := keys.ParsePrivateKey(privateBytes)
-	require.NoError(t, err)
+	t.Parallel()
+	for _, alg := range supportedAlgorithms {
+		t.Run(alg.String(), func(t *testing.T) {
+			privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(alg)
+			require.NoError(t, err)
 
-	clock := clockwork.NewFakeClockAt(time.Now())
+			clock := clockwork.NewFakeClockAt(time.Now())
 
-	// Create a new key that can be used to sign and verify tokens.
-	key, err := New(&Config{
-		Clock:       clock,
-		PrivateKey:  privateKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
-		ClusterName: "example.com",
-	})
-	require.NoError(t, err)
+			// Create a new key that can be used to sign and verify tokens.
+			key, err := New(&Config{
+				Clock:       clock,
+				PrivateKey:  privateKey,
+				ClusterName: "example.com",
+			})
+			require.NoError(t, err)
 
-	// Sign a token with a 1 minute expiration.
-	token, err := key.Sign(SignParams{
-		Username: "foo@example.com",
-		Roles:    []string{"foo", "bar"},
-		Traits: wrappers.Traits{
-			"trait1": []string{"value-1", "value-2"},
-		},
-		Expires: clock.Now().Add(1 * time.Minute),
-		URI:     "http://127.0.0.1:8080",
-	})
-	require.NoError(t, err)
+			// Sign a token with a 1 minute expiration.
+			token, err := key.Sign(SignParams{
+				Username: "foo@example.com",
+				Roles:    []string{"foo", "bar"},
+				Traits: wrappers.Traits{
+					"trait1": []string{"value-1", "value-2"},
+				},
+				Expires: clock.Now().Add(1 * time.Minute),
+				URI:     "http://127.0.0.1:8080",
+			})
+			require.NoError(t, err)
 
-	// Verify that the token is still valid.
-	claims, err := key.Verify(VerifyParams{
-		Username: "foo@example.com",
-		URI:      "http://127.0.0.1:8080",
-		RawToken: token,
-	})
-	require.NoError(t, err)
-	require.Equal(t, "foo@example.com", claims.Username)
-	require.Equal(t, []string{"foo", "bar"}, claims.Roles)
-	require.Equal(t, josejwt.NewNumericDate(clock.Now()), claims.IssuedAt)
+			// Verify that the token is still valid.
+			claims, err := key.Verify(VerifyParams{
+				Username: "foo@example.com",
+				URI:      "http://127.0.0.1:8080",
+				RawToken: token,
+			})
+			require.NoError(t, err)
+			require.Equal(t, "foo@example.com", claims.Username)
+			require.Equal(t, []string{"foo", "bar"}, claims.Roles)
+			require.Equal(t, josejwt.NewNumericDate(clock.Now()), claims.IssuedAt)
 
-	// Advance time by two minutes and verify the token is no longer valid.
-	clock.Advance(2 * time.Minute)
-	_, err = key.Verify(VerifyParams{
-		Username: "foo@example.com",
-		URI:      "http://127.0.0.1:8080",
-		RawToken: token,
-	})
-	require.Error(t, err)
+			// Advance time by two minutes and verify the token is no longer valid.
+			clock.Advance(2 * time.Minute)
+			_, err = key.Verify(VerifyParams{
+				Username: "foo@example.com",
+				URI:      "http://127.0.0.1:8080",
+				RawToken: token,
+			})
+			require.Error(t, err)
+		})
+	}
 }

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -49,7 +49,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/native"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/jwt"
@@ -1225,7 +1224,6 @@ func getTestCertCAsGetterAndSigner(t testing.TB, clusterName string) ([]byte, Ce
 	clock := clockwork.NewFakeClockAt(time.Now())
 	jwtSigner, err := jwt.New(&jwt.Config{
 		Clock:       clock,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
 		ClusterName: clusterName,
 		PrivateKey:  proxyPriv,
 	})
@@ -1329,7 +1327,6 @@ func BenchmarkMux_ProxyV2Signature(b *testing.B) {
 			jwtVerifier, err := jwt.New(&jwt.Config{
 				Clock:       clock,
 				PublicKey:   cert.PublicKey,
-				Algorithm:   defaults.ApplicationTokenAlgorithm,
 				ClusterName: clusterName,
 			})
 			require.NoError(b, err, "Could not create JWT verifier")

--- a/lib/multiplexer/proxyline.go
+++ b/lib/multiplexer/proxyline.go
@@ -38,7 +38,6 @@ import (
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -520,7 +519,6 @@ func (p *ProxyLine) VerifySignature(ctx context.Context, caGetter CertAuthorityG
 	jwtVerifier, err := jwt.New(&jwt.Config{
 		Clock:       clock,
 		PublicKey:   signingCert.PublicKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
 		ClusterName: localClusterName,
 	})
 	if err != nil {

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -209,7 +208,6 @@ func checkJWTKeys(cai types.CertAuthority) error {
 			return trace.Wrap(err)
 		}
 		cfg := &jwt.Config{
-			Algorithm:   defaults.ApplicationTokenAlgorithm,
 			ClusterName: ca.GetClusterName(),
 			PrivateKey:  privateKey,
 			PublicKey:   publicKey,
@@ -257,7 +255,6 @@ func checkSAMLIDPCA(cai types.CertAuthority) error {
 func GetJWTSigner(signer crypto.Signer, clusterName string, clock clockwork.Clock) (*jwt.Key, error) {
 	key, err := jwt.New(&jwt.Config{
 		Clock:       clock,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
 		ClusterName: clusterName,
 		PrivateKey:  signer,
 	})

--- a/lib/srv/alpnproxy/azure_msi_middleware.go
+++ b/lib/srv/alpnproxy/azure_msi_middleware.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/jwt"
 )
 
@@ -178,7 +177,6 @@ func (m *AzureMSIMiddleware) toJWT(claims jwt.AzureTokenClaims) (string, error) 
 	key, err := jwt.New(&jwt.Config{
 		Clock:       m.Clock,
 		PrivateKey:  m.Key,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
 		ClusterName: types.TeleportAzureMSIEndpoint, // todo get cluster name
 	})
 	if err != nil {

--- a/lib/srv/alpnproxy/azure_msi_middleware_test.go
+++ b/lib/srv/alpnproxy/azure_msi_middleware_test.go
@@ -34,20 +34,25 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/jwt"
 )
 
 func TestAzureMSIMiddlewareHandleRequest(t *testing.T) {
+	t.Parallel()
+	for _, alg := range []cryptosuites.Algorithm{cryptosuites.RSA2048, cryptosuites.ECDSAP256} {
+		t.Run(alg.String(), func(t *testing.T) {
+			testAzureMSIMiddlewareHandleRequest(t, alg)
+		})
+	}
+}
+
+func testAzureMSIMiddlewareHandleRequest(t *testing.T, alg cryptosuites.Algorithm) {
 	newPrivateKey := func() crypto.Signer {
-		_, privateBytes, err := jwt.GenerateKeyPair()
-		require.NoError(t, err)
-		privateKey, err := keys.ParsePrivateKey(privateBytes)
+		privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(alg)
 		require.NoError(t, err)
 		return privateKey
 	}
-
 	m := &AzureMSIMiddleware{
 		Identity: "azureTestIdentity",
 		TenantID: "cafecafe-cafe-4aaa-cafe-cafecafecafe",
@@ -171,7 +176,6 @@ func TestAzureMSIMiddlewareHandleRequest(t *testing.T) {
 					key, err := jwt.New(&jwt.Config{
 						Clock:       m.Clock,
 						PrivateKey:  pk,
-						Algorithm:   defaults.ApplicationTokenAlgorithm,
 						ClusterName: types.TeleportAzureMSIEndpoint,
 					})
 					require.NoError(t, err)

--- a/lib/srv/app/azure/handler.go
+++ b/lib/srv/app/azure/handler.go
@@ -262,7 +262,6 @@ func (s *handler) parseAuthHeader(token string, pubKey crypto.PublicKey) (*jwt.A
 	key, err := jwt.New(&jwt.Config{
 		Clock:       s.Clock,
 		PublicKey:   pubKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
 		ClusterName: types.TeleportAzureMSIEndpoint,
 	})
 	if err != nil {

--- a/lib/srv/db/snowflake/test.go
+++ b/lib/srv/db/snowflake/test.go
@@ -213,7 +213,6 @@ func (s *TestServer) verifyJWT(ctx context.Context, accName, loginName, token st
 	key, err := jwt.New(&jwt.Config{
 		Clock:       clock,
 		PublicKey:   cert.PublicKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
 		ClusterName: clusterName,
 	})
 	if err != nil {

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -289,7 +289,6 @@ func (t *transport) resignAzureJWTCookie(r *http.Request) error {
 	clientJWTKey, err := jwt.New(&jwt.Config{
 		Clock:       t.c.clock,
 		PublicKey:   r.TLS.PeerCertificates[0].PublicKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
 		ClusterName: types.TeleportAzureMSIEndpoint,
 	})
 	if err != nil {
@@ -304,7 +303,6 @@ func (t *transport) resignAzureJWTCookie(r *http.Request) error {
 	wsJWTKey, err := jwt.New(&jwt.Config{
 		Clock:       t.c.clock,
 		PrivateKey:  wsPrivateKey,
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
 		ClusterName: types.TeleportAzureMSIEndpoint,
 	})
 	if err != nil {

--- a/lib/web/app/transport_test.go
+++ b/lib/web/app/transport_test.go
@@ -389,7 +389,6 @@ func Test_transport_rewriteRequest(t *testing.T) {
 				jwtKey, err := jwt.New(&jwt.Config{
 					Clock:       tr.c.clock,
 					PrivateKey:  tt.jwtPrivateKey,
-					Algorithm:   defaults.ApplicationTokenAlgorithm,
 					ClusterName: types.TeleportAzureMSIEndpoint,
 				})
 				require.NoError(t, err)
@@ -410,7 +409,6 @@ func Test_transport_rewriteRequest(t *testing.T) {
 				wsJWTKey, err := jwt.New(&jwt.Config{
 					Clock:       tr.c.clock,
 					PrivateKey:  wsPrivateKey,
-					Algorithm:   defaults.ApplicationTokenAlgorithm,
 					ClusterName: types.TeleportAzureMSIEndpoint,
 				})
 				require.NoError(t, err)


### PR DESCRIPTION
This PR continues the implementation of RFD 136 by adding support for ECDSA JWTs and JWKs, and updating the `balanced-dev`, `fips-dev`, and `hsm-dev` algorithm suites to use ECDSA for all newly generated JWT CA keys.