### PR TITLE
fix: drop reserved `source` key in `slog.Logger`

### DIFF
--- a/lib/vnet/dns/osnameservers_darwin.go
+++ b/lib/vnet/dns/osnameservers_darwin.go
@@ -96,6 +96,6 @@ func (s *OSUpstreamNameserverSource) upstreamNameservers(ctx context.Context) ([
 		nameservers = append(nameservers, nameserver)
 	}
 
-	slog.DebugContext(ctx, "Loaded host upstream nameservers.", "nameservers", nameservers, "source", confFilePath)
+	slog.DebugContext(ctx, "Loaded host upstream nameservers.", "nameservers", nameservers, "config_file", confFilePath)
 	return nameservers, nil
 }


### PR DESCRIPTION
The `source` key in slog.Logger is a reserved key and should not be used because it causes a panic. This commit removes the `source` key from the logger.

Note: We already enforce the forbidden keys as per https://github.com/gravitational/teleport/pull/42049. However, our lint jobs currently only run on Ubuntu runners, while the code in question compiles for Darwin targets only.