### PR TITLE
[v16] fix: drop reserved `source` key in `slog.Logger`

### DIFF
--- a/lib/vnet/dns/osnameservers_darwin.go
+++ b/lib/vnet/dns/osnameservers_darwin.go
@@ -96,6 +96,6 @@ func (s *OSUpstreamNameserverSource) upstreamNameservers(ctx context.Context) ([
 		nameservers = append(nameservers, nameserver)
 	}
 
-	slog.DebugContext(ctx, "Loaded host upstream nameservers.", "nameservers", nameservers, "source", confFilePath)
+	slog.DebugContext(ctx, "Loaded host upstream nameservers.", "nameservers", nameservers, "config_file", confFilePath)
 	return nameservers, nil
 }


### PR DESCRIPTION
Backport #43388 to branch/v16