### PR TITLE
chore: Bump Buf to v1.34.0

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -17,7 +17,7 @@ LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 DEVTOOLSET ?= devtoolset-12
 
 # Protogen related versions.
-BUF_VERSION ?= v1.33.0
+BUF_VERSION ?= v1.34.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4


### PR DESCRIPTION
Update to the latest release.

* https://github.com/bufbuild/buf/releases/tag/v1.34.0