### PR TITLE
[v13] Update updater inventory reporting after removal

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1018,6 +1018,9 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 
 	upgraderKind := os.Getenv("TELEPORT_EXT_UPGRADER")
 	upgraderVersion := automaticupgrades.GetUpgraderVersion(process.GracefulExitContext())
+	if upgraderVersion == "" {
+		upgraderKind = ""
+	}
 
 	// note: we must create the inventory handle *after* registerExpectedServices because that function determines
 	// the list of services (instance roles) to be included in the heartbeat.


### PR DESCRIPTION
Backport #43371 to branch/v13

changelog: Fixes an issue preventing accurate inventory reporting of the updater after it is removed
