### PR TITLE
Fix linting errors in install scripts

### DIFF
--- a/assets/install-scripts/install-connect.sh
+++ b/assets/install-scripts/install-connect.sh
@@ -208,7 +208,7 @@ install_teleport() {
 
   KERNEL_VERSION=$(uname -r)
   MIN_VERSION="2.6.23"
-  if [ $MIN_VERSION != $(echo -e "$MIN_VERSION\n$KERNEL_VERSION" | sort -V | head -n1) ]; then
+  if [ $MIN_VERSION != "$(echo -e "$MIN_VERSION\n$KERNEL_VERSION" | sort -V | head -n1)" ]; then
     echo "ERROR: Teleport Connect requires Linux kernel version $MIN_VERSION+"
     exit 1
   fi
@@ -261,6 +261,8 @@ install_teleport() {
   ID=""
   ID_LIKE=""
   if [[ -f "$OS_RELEASE" ]]; then
+    # Skip checking the os release file
+    # shellcheck source=/dev/null
     . $OS_RELEASE
   fi
 

--- a/assets/install-scripts/install.sh
+++ b/assets/install-scripts/install.sh
@@ -195,7 +195,7 @@ install_via_zypper() {
   fi
 
   $SUDO rpm --import https://zypper.releases.teleport.dev/gpg
-  $SUDO zypper addrepo --refresh --repo $(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/$CHANNEL/teleport-zypper.repo")
+  $SUDO zypper addrepo --refresh --repo "$(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/$CHANNEL/teleport-zypper.repo")"
   $SUDO zypper --gpg-auto-import-keys refresh teleport
   $SUDO zypper install -y "teleport$TELEPORT_SUFFIX"
 


### PR DESCRIPTION
This fixes the linting errors on the newly-migrated install scripts. These linter errors are blocking master branch merges. Not sure why they didn't trigger on the original PR.