### PR TITLE
fix: fix `nextKey` values when using multiple prefixes

### DIFF
--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -78,7 +78,6 @@ func (c *ServiceConfig[T]) CheckAndSetDefaults() error {
 	if c.UnmarshalFunc == nil {
 		return trace.BadParameter("unmarshal func is missing")
 	}
-
 	return nil
 }
 
@@ -167,17 +166,17 @@ func (s *Service[T]) GetResources(ctx context.Context) ([]T, error) {
 
 // ListResources returns a paginated list of resources.
 func (s *Service[T]) ListResources(ctx context.Context, pageSize int, pageToken string) ([]T, string, error) {
-	resources, next, err := s.ListResourcesReturnNextResource(ctx, pageSize, pageToken)
-	var nextKey string
-	if next != nil {
-		nextKey = backend.GetPaginationKey(*next)
-	}
+	resources, _, nextKey, err := s.listResourcesReturnNextResourceWithKey(ctx, pageSize, pageToken)
 	return resources, nextKey, trace.Wrap(err)
 }
 
 // ListResourcesReturnNextResource returns a paginated list of resources. The next resource is returned, which allows consumers to construct
 // the next pagination key as appropriate.
 func (s *Service[T]) ListResourcesReturnNextResource(ctx context.Context, pageSize int, pageToken string) ([]T, *T, error) {
+	resources, next, _, err := s.listResourcesReturnNextResourceWithKey(ctx, pageSize, pageToken)
+	return resources, next, trace.Wrap(err)
+}
+func (s *Service[T]) listResourcesReturnNextResourceWithKey(ctx context.Context, pageSize int, pageToken string) ([]T, *T, string, error) {
 	rangeStart := backend.Key(s.backendPrefix, pageToken)
 	rangeEnd := backend.RangeEnd(backend.ExactKey(s.backendPrefix))
 
@@ -191,26 +190,32 @@ func (s *Service[T]) ListResourcesReturnNextResource(ctx context.Context, pageSi
 	// no filter provided get the range directly
 	result, err := s.backend.GetRange(ctx, rangeStart, rangeEnd, limit)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, nil, "", trace.Wrap(err)
 	}
 
 	out := make([]T, 0, len(result.Items))
+	var lastKey []byte
 	for _, item := range result.Items {
 		resource, err := s.unmarshalFunc(item.Value, services.WithRevision(item.Revision))
 		if err != nil {
-			return nil, nil, trace.Wrap(err)
+			return nil, nil, "", trace.Wrap(err)
 		}
 		out = append(out, resource)
+		lastKey = item.Key
 	}
 
-	var next *T
+	var (
+		next    *T
+		nextKey string
+	)
 	if len(out) > pageSize {
 		next = &out[pageSize]
 		// Truncate the last item that was used to determine next row existence.
 		out = out[:pageSize]
+		nextKey = trimLastKey(string(lastKey), s.backendPrefix)
 	}
 
-	return out, next, nil
+	return out, next, nextKey, nil
 }
 
 // ListResourcesWithFilter returns a paginated list of resources that match the given filter.
@@ -226,6 +231,7 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 	limit := pageSize + 1
 
 	var resources []T
+	var lastKey []byte
 	if err := backend.IterateRange(
 		ctx,
 		s.backend,
@@ -239,6 +245,7 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 					return false, trace.Wrap(err)
 				}
 				if matcher(resource) {
+					lastKey = item.Key
 					resources = append(resources, resource)
 				}
 				if len(resources) == pageSize {
@@ -252,7 +259,7 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 
 	var nextKey string
 	if len(resources) > pageSize {
-		nextKey = backend.GetPaginationKey(resources[pageSize])
+		nextKey = trimLastKey(string(lastKey), s.backendPrefix)
 		// Truncate the last item that was used to determine next row existence.
 		resources = resources[:pageSize]
 	}
@@ -453,4 +460,14 @@ func (s *Service[T]) RunWhileLocked(ctx context.Context, lockName string, ttl ti
 		}, func(ctx context.Context) error {
 			return fn(ctx, s.backend)
 		}))
+}
+
+func trimLastKey(lastKey, prefix string) string {
+	if !strings.HasSuffix(prefix, string(backend.Separator)) {
+		prefix += string(backend.Separator)
+	}
+	if !strings.HasPrefix(prefix, string(backend.Separator)) {
+		prefix = string(backend.Separator) + prefix
+	}
+	return strings.TrimPrefix(lastKey, prefix)
 }

--- a/lib/services/local/generic/generic_wrapper.go
+++ b/lib/services/local/generic/generic_wrapper.go
@@ -33,8 +33,8 @@ func NewServiceWrapper[T types.ResourceMetadata](
 	resourceKind string,
 	backendPrefix string,
 	marshalFunc MarshalFunc[T],
-	unmarshalFunc UnmarshalFunc[T]) (*ServiceWrapper[T], error) {
-
+	unmarshalFunc UnmarshalFunc[T],
+) (*ServiceWrapper[T], error) {
 	cfg := &ServiceConfig[resourceMetadataAdapter[T]]{
 		Backend:       backend,
 		ResourceKind:  resourceKind,


### PR DESCRIPTION
This PR makes `generic.Service` correctly implementing `List*` functions when multiple key prefixes are defined