### PR TITLE
Clean up after client redirect fix

### DIFF
--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -1177,23 +1177,3 @@ var GithubScopes = []string{
 	// read:org grants read-only access to user's team memberships
 	"read:org",
 }
-
-var OIDCAuthRequestHook = func(_ context.Context, req *types.OIDCAuthRequest, connector types.OIDCConnector) error {
-	// see CreateGithubAuthRequest
-	if !req.CreateWebSession {
-		if err := ValidateClientRedirect(req.ClientRedirectURL, req.SSOTestFlow, connector.GetClientRedirectSettings()); err != nil {
-			return trace.Wrap(err, InvalidClientRedirectErrorMessage)
-		}
-	}
-	return nil
-}
-
-var SAMLAuthRequestHook = func(_ context.Context, req *types.SAMLAuthRequest, connector types.SAMLConnector) error {
-	// see CreateGithubAuthRequest
-	if !req.CreateWebSession {
-		if err := ValidateClientRedirect(req.ClientRedirectURL, req.SSOTestFlow, connector.GetClientRedirectSettings()); err != nil {
-			return trace.Wrap(err, InvalidClientRedirectErrorMessage)
-		}
-	}
-	return nil
-}


### PR DESCRIPTION
This PR cleans up unused code that was added in gravitational/teleport#41833 for the sake of enterprise code; this code is no longer necessary as of gravitational/teleport.e#4471 and so it can be removed.