### PR TITLE
fix web server shutdown panic

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -10376,3 +10376,17 @@ func TestWebSocketClosedBeforeSSHSessionCreated(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, out)
 }
+
+func TestUnstartedServerShutdown(t *testing.T) {
+	t.Parallel()
+	s := newWebSuite(t)
+	srv, err := NewServer(ServerConfig{
+		Server:  &http.Server{},
+		Handler: s.webHandler,
+	})
+
+	require.NoError(t, err)
+
+	// Shutdown the server before starting it shouldn't panic.
+	require.NoError(t, srv.Shutdown(context.Background()))
+}

--- a/lib/web/server.go
+++ b/lib/web/server.go
@@ -70,8 +70,9 @@ func (c *ServerConfig) CheckAndSetDefaults() error {
 type Server struct {
 	cfg ServerConfig
 
-	mu sync.Mutex
-	ln net.Listener
+	mu     sync.Mutex
+	ln     net.Listener
+	closed bool
 }
 
 // NewServer constructs a [Server] from the provided [ServerConfig].
@@ -89,12 +90,25 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 func (s *Server) Serve(l net.Listener) error {
 	s.mu.Lock()
 	s.ln = l
+	closed := s.closed
+	if closed {
+		s.ln.Close()
+	}
 	s.mu.Unlock()
+	if closed {
+		return trace.Errorf("serve called on previously closed server")
+	}
 	return trace.Wrap(s.cfg.Server.Serve(l))
 }
 
 // Close immediately closes the [http.Server].
 func (s *Server) Close() error {
+	s.mu.Lock()
+	s.closed = true
+	if s.ln != nil {
+		s.ln.Close()
+	}
+	s.mu.Unlock()
 	return trace.NewAggregate(s.cfg.Handler.Close(), s.cfg.Server.Close())
 }
 
@@ -111,7 +125,11 @@ func (s *Server) HandleConnection(ctx context.Context, conn net.Conn) error {
 // web UI will not prevent the [http.Server] from shutting down.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.mu.Lock()
-	err := s.ln.Close()
+	var err error
+	s.closed = true
+	if s.ln != nil {
+		err = s.ln.Close()
+	}
 	s.mu.Unlock()
 
 	activeConnections := s.cfg.Handler.handler.userConns.Load()


### PR DESCRIPTION
Fixes a niche case where a `web.Server` could panic if a teleport process starts to exit before all of its startup logic has completed (e.g. due to one or more required startup steps failing).  This is a comparatively minor issue since no running teleport instance is going to hit this case, but it can make debugging the actual cause of the failed startup more difficult.