### PR TITLE
[v14] Display websocket errors in the UI

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3821,6 +3821,7 @@ func (h *Handler) writeErrToWebSocket(ws *websocket.Conn, err error) {
 		return
 	}
 	errEnvelope := terminal.Envelope{
+		Version: defaults.WebsocketVersion,
 		Type:    defaults.WebsocketError,
 		Payload: trace.UserMessage(err),
 	}

--- a/web/packages/teleport/src/lib/term/protobuf.js
+++ b/web/packages/teleport/src/lib/term/protobuf.js
@@ -30,6 +30,7 @@ export const MessageTypeEnum = {
   FILE_TRANSFER_REQUEST: 'f',
   FILE_TRANSFER_DECISION: 't',
   WEBAUTHN_CHALLENGE: 'n',
+  ERROR: 'e',
   LATENCY: 'l',
 };
 
@@ -58,6 +59,7 @@ export const messageFields = {
       event: MessageTypeEnum.AUDIT.charCodeAt(0),
       close: MessageTypeEnum.SESSION_END.charCodeAt(0),
       challengeResponse: MessageTypeEnum.WEBAUTHN_CHALLENGE.charCodeAt(0),
+      error: MessageTypeEnum.ERROR.charCodeAt(0),
     },
   },
 };

--- a/web/packages/teleport/src/lib/term/tty.ts
+++ b/web/packages/teleport/src/lib/term/tty.ts
@@ -200,6 +200,9 @@ class Tty extends EventEmitterWebAuthnSender {
             this.emit(TermEvent.DATA, msg.payload);
           }
           break;
+        case MessageTypeEnum.ERROR:
+          this.emit(TermEvent.DATA, msg.payload + '\n');
+          break;
         case MessageTypeEnum.LATENCY:
           this.emit(TermEvent.LATENCY, msg.payload);
           break;


### PR DESCRIPTION
We never implemented UI support for the websocket error message, so errors were never surfaced to users.

This also uncovered one case where we were sending invalid data (due to a missing version number).

Closes #42626
Backports #43433

Changelog: Display errors in the web UI console for SSH sessions.