### PR TITLE
Move MongoDB IAM auth to aws-sdk-go-v2

### DIFF
--- a/lib/cloud/aws.go
+++ b/lib/cloud/aws.go
@@ -1,0 +1,184 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cloud
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/gravitational/trace"
+
+	cloudaws "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// AWSV2Clients is an interface for providing AWS API clients.
+type AWSClientsV2 interface {
+	// GetAWSConfigV2 returns AWS config for the specified region, optionally
+	// assuming AWS IAM Roles.
+	GetAWSConfigV2(ctx context.Context, region string, opts ...AWSOptionsFn) (*aws.Config, error)
+	// GetAWSSTSClientV2 returns AWS STS client for the specified region.
+	GetAWSSTSClientV2(ctx context.Context, region string, opts ...AWSOptionsFn) (cloudaws.STSAPI, error)
+}
+
+type awsConfigCacheKey struct {
+	region      string
+	integration string
+	roleARN     string
+	externalID  string
+}
+
+type awsClientsV2 struct {
+	// configsCache is a cache of AWS configs, where the cache key is an
+	// instance of awsConfigCacheKey.
+	configsCache *utils.FnCache
+}
+
+func newAWSClientsV2() (*awsClientsV2, error) {
+	configsCache, err := utils.NewFnCache(utils.FnCacheConfig{
+		TTL: 15 * time.Minute,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &awsClientsV2{
+		configsCache: configsCache,
+	}, nil
+}
+
+// GetAWSConfigV2 returns AWS config for the specified region, optionally
+// assuming AWS IAM Roles.
+func (c *awsClientsV2) GetAWSConfigV2(ctx context.Context, region string, opts ...AWSOptionsFn) (*aws.Config, error) {
+	var options awsOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	var err error
+	if options.baseConfigV2 == nil {
+		options.baseConfigV2, err = c.getAWSConfigV2ForRegion(ctx, region, options)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	if options.assumeRoleARN == "" {
+		return options.baseConfigV2, nil
+	}
+	return c.getAWSConfigV2ForRole(ctx, region, options)
+}
+
+// GetAWSSTSClientV2 returns AWS STS client for the specified region.
+func (c *awsClientsV2) GetAWSSTSClientV2(ctx context.Context, region string, opts ...AWSOptionsFn) (cloudaws.STSAPI, error) {
+	config, err := c.GetAWSConfigV2(ctx, region, opts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return cloudaws.NewSTSClient(*config), nil
+}
+
+// getAWSConfigV2ForRegion returns AWS config for the specified region.
+func (c *awsClientsV2) getAWSConfigV2ForRegion(ctx context.Context, region string, opts awsOptions) (*aws.Config, error) {
+	if err := opts.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cacheKey := awsConfigCacheKey{
+		region:      region,
+		integration: opts.integration,
+	}
+
+	config, err := utils.FnCacheGet(ctx, c.configsCache, cacheKey, func(ctx context.Context) (*aws.Config, error) {
+		// TODO support integration.
+		if opts.credentialsSource == credentialsSourceIntegration {
+			return nil, trace.NotImplemented("missing aws integration config provider")
+		}
+
+		slog.DebugContext(ctx, "Initializing AWS config using ambient credentials.", "region", region)
+		config, err := awsAmbientConfigV2Provider(ctx, region, nil /*credProvider*/)
+		return config, trace.Wrap(err)
+	})
+	// TODO handle opts.customRetryer and opts.maxRetries
+	return config, trace.Wrap(err)
+}
+
+// getAWSConfigV2ForRole returns AWS config for the specified region and role.
+func (c *awsClientsV2) getAWSConfigV2ForRole(ctx context.Context, region string, options awsOptions) (*aws.Config, error) {
+	if err := options.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if options.baseConfigV2 == nil {
+		return nil, trace.BadParameter("missing base config")
+	}
+
+	cacheKey := awsConfigCacheKey{
+		region:      region,
+		integration: options.integration,
+		roleARN:     options.assumeRoleARN,
+		externalID:  options.assumeRoleExternalID,
+	}
+	return utils.FnCacheGet(ctx, c.configsCache, cacheKey, func(ctx context.Context) (*aws.Config, error) {
+		config, err := newAWSConfigForRole(ctx, cloudaws.NewSTSClient(*options.baseConfigV2), region, options)
+		return config, trace.Wrap(err)
+	})
+}
+
+func newAWSConfigForRole(ctx context.Context, client cloudaws.STSAPI, region string, options awsOptions) (*aws.Config, error) {
+	provider := stscreds.NewAssumeRoleProvider(client, options.assumeRoleARN, func(o *stscreds.AssumeRoleOptions) {
+		if options.assumeRoleExternalID != "" {
+			o.ExternalID = aws.String(options.assumeRoleExternalID)
+		}
+	})
+
+	if _, err := provider.Retrieve(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	config, err := awsAmbientConfigV2Provider(ctx, region, provider)
+	return config, trace.Wrap(err)
+}
+
+// awsAmbientConfigV2Provider loads a new config using the environment variables.
+func awsAmbientConfigV2Provider(ctx context.Context, region string, credProvider aws.CredentialsProvider) (*aws.Config, error) {
+	opts := []func(*awsconfig.LoadOptions) error{
+		awsConfigFipsOption(),
+	}
+	if region != "" {
+		opts = append(opts, awsconfig.WithRegion(region))
+	}
+	if credProvider != nil {
+		opts = append(opts, awsconfig.WithCredentialsProvider(credProvider))
+	}
+	config, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &config, nil
+}
+
+func awsConfigFipsOption() awsconfig.LoadOptionsFunc {
+	if modules.GetModules().IsBoringBinary() {
+		return awsconfig.WithUseFIPSEndpoint(aws.FIPSEndpointStateEnabled)
+	}
+	return awsconfig.WithUseFIPSEndpoint(aws.FIPSEndpointStateUnset)
+}

--- a/lib/cloud/aws/errors.go
+++ b/lib/cloud/aws/errors.go
@@ -109,6 +109,14 @@ func ConvertIAMv2Error(err error) error {
 		return trace.BadParameter(*malformedPolicyDocument.Message)
 	}
 
+	return convertGenericSDKV2error(err)
+}
+
+func convertGenericSDKV2error(err error) error {
+	if err == nil {
+		return nil
+	}
+
 	var re *awshttp.ResponseError
 	if errors.As(err, &re) {
 		return convertRequestFailureErrorFromStatusCode(re.HTTPStatusCode(), re.Err)

--- a/lib/cloud/aws/identity.go
+++ b/lib/cloud/aws/identity.go
@@ -117,6 +117,17 @@ func GetIdentityWithClient(ctx context.Context, stsClient stsiface.STSAPI) (Iden
 	return IdentityFromArn(aws.StringValue(out.Arn))
 }
 
+// GetIdentityFromSTSAPI determines AWS identity of this Teleport process using
+// the provided STS API client.
+func GetIdentityFromSTSAPI(ctx context.Context, client STSAPI) (Identity, error) {
+	out, err := client.GetCallerIdentity(ctx, nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return IdentityFromArn(aws.StringValue(out.Arn))
+}
+
 // IdentityFromArn returns an `Identity` interface based on the provided ARN.
 func IdentityFromArn(arnString string) (Identity, error) {
 	parsedARN, err := arn.Parse(arnString)

--- a/lib/cloud/aws/sts.go
+++ b/lib/cloud/aws/sts.go
@@ -1,0 +1,134 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package aws
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	smithyendpoints "github.com/aws/smithy-go/endpoints"
+	"github.com/gravitational/trace"
+)
+
+// STSAPI defines an interface for sts.Client.
+type STSAPI interface {
+	stscreds.AssumeRoleAPIClient
+
+	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
+type stsClient struct {
+	client *sts.Client
+}
+
+// NewSTSClient returns a new STS client.
+func NewSTSClient(config aws.Config) *stsClient {
+	return &stsClient{
+		client: sts.NewFromConfig(
+			config,
+			sts.WithEndpointResolverV2(newSTSEndpointResolver()),
+		),
+	}
+}
+
+func (c *stsClient) AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	output, err := c.client.AssumeRole(ctx, params, optFns...)
+	if err != nil {
+		return nil, trace.Wrap(convertSTSError(err))
+	}
+	return output, nil
+}
+
+func (c *stsClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	output, err := c.client.GetCallerIdentity(ctx, params, optFns...)
+	if err != nil {
+		return nil, trace.Wrap(convertSTSError(err))
+	}
+	return output, nil
+}
+
+// convertSTSError converts aws-sdk-go-v2/service/sts errors.
+func convertSTSError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		switch awsErr.Code() {
+		case "ExpiredTokenException":
+			return trace.AccessDenied(awsErr.Error())
+		case "IDPCommunicationError":
+			return trace.ConnectionProblem(awsErr, awsErr.Error())
+		case "IDPRejectedClaim":
+			return trace.AccessDenied(awsErr.Error())
+		case "InvalidAuthorizationMessageException":
+			return trace.BadParameter(awsErr.Error())
+		case "InvalidIdentityToken":
+			return trace.AccessDenied(awsErr.Error())
+		case "MalformedPolicyDocument":
+			return trace.BadParameter(awsErr.Error())
+		case "PackedPolicyTooLarge":
+			return trace.BadParameter(awsErr.Error())
+		case "RegionDisabledException":
+			return trace.BadParameter(awsErr.Error())
+		}
+	}
+
+	return convertGenericSDKV2error(err)
+}
+
+// stsEndpointResolver implements sts.EndpointResolverV2 to find the STS
+// endpoint.
+//
+// Note that aws-sdk-go-v2 always uses regional endpoint by default. This
+// custom endpoint resolver makes sure that we fall back to global endpoint if
+// no region is available.
+type stsEndpointResolver struct {
+	defaultResolver sts.EndpointResolverV2
+}
+
+func newSTSEndpointResolver() stsEndpointResolver {
+	return stsEndpointResolver{
+		defaultResolver: sts.NewDefaultEndpointResolverV2(),
+	}
+}
+
+// ResolveEndpoint implements sts.EndpointResolverV2 to find the STS endpoint.
+func (r stsEndpointResolver) ResolveEndpoint(ctx context.Context, params sts.EndpointParameters) (smithyendpoints.Endpoint, error) {
+	// Use the global endpoint when region is empty.
+	if aws.ToString(params.Region) == "" {
+		// A region is still required for passing basic validation and selecting
+		// partition. Defaulting to "us-east-1".
+		//
+		// Note that for other partitions like US Gov, users are required to
+		// specify region through env var like AWS_REGION. This was required
+		// with aws-sdk-go as well otherwise the legacy SDK would fallback to
+		// the global endpoint in the standard partition.
+		params.Region = aws.String("us-east-1")
+		params.UseGlobalEndpoint = aws.Bool(true)
+		slog.DebugContext(ctx, "No region provided when resolving STS endpoint. Falling back to global endpoint.")
+	}
+	endpoint, err := r.defaultResolver.ResolveEndpoint(ctx, params)
+	return endpoint, trace.Wrap(err)
+}

--- a/lib/cloud/aws/sts.go
+++ b/lib/cloud/aws/sts.go
@@ -73,6 +73,9 @@ func convertSTSError(err error) error {
 		return nil
 	}
 
+	// TODO(greedy52) is there any way to prevent aws-sdk-go-v2 to translate
+	// HTTP error codes to these specific types? Is it possible to
+	// automatically generate these so CI can catch new error types?
 	var awsErr awserr.Error
 	if errors.As(err, &awsErr) {
 		switch awsErr.Code() {

--- a/lib/cloud/aws/sts_test.go
+++ b/lib/cloud/aws/sts_test.go
@@ -36,7 +36,7 @@ func Test_convertSTSError(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       error
-		wantErrorAs error
+		wantErrorAs interface{}
 	}{
 		{
 			name:        "no error",

--- a/lib/cloud/aws/sts_test.go
+++ b/lib/cloud/aws/sts_test.go
@@ -1,0 +1,128 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/aws/aws-sdk-go/aws"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_convertSTSError(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       error
+		wantErrorAs error
+	}{
+		{
+			name:        "no error",
+			input:       nil,
+			wantErrorAs: nil,
+		},
+		{
+			name:        "IDPCommunicationErrorException",
+			input:       &ststypes.IDPCommunicationErrorException{},
+			wantErrorAs: new(trace.ConnectionProblemError),
+		},
+		{
+			name: "no permission to assume role",
+			input: &awshttp.ResponseError{
+				ResponseError: &smithyhttp.ResponseError{
+					Response: &smithyhttp.Response{Response: &http.Response{
+						StatusCode: http.StatusForbidden,
+					}},
+					Err: trace.Errorf("User: arn:aws:sts::123456789012:assumed-role/alice/i-00112233445566778 is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::123456789012:role/bob"),
+				},
+			},
+			wantErrorAs: new(trace.AccessDeniedError),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := convertSTSError(test.input)
+			if test.wantErrorAs == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorAs(t, err, &test.wantErrorAs)
+			}
+		})
+	}
+}
+
+func Test_stsEndpointResolver(t *testing.T) {
+	resolver := newSTSEndpointResolver()
+	tests := []struct {
+		name         string
+		params       sts.EndpointParameters
+		wantEndpoint string
+	}{
+		{
+			name:         "global (no region)",
+			params:       sts.EndpointParameters{},
+			wantEndpoint: "https://sts.amazonaws.com",
+		},
+		{
+			name: "ca-central-1",
+			params: sts.EndpointParameters{
+				Region: aws.String("ca-central-1"),
+			},
+			wantEndpoint: "https://sts.ca-central-1.amazonaws.com",
+		},
+		{
+			name: "us-west-2 fips",
+			params: sts.EndpointParameters{
+				Region:  aws.String("us-west-2"),
+				UseFIPS: aws.Bool(true),
+			},
+			wantEndpoint: "https://sts-fips.us-west-2.amazonaws.com",
+		},
+		{
+			name: "us-gov-east-1 fips",
+			params: sts.EndpointParameters{
+				Region:  aws.String("us-gov-east-1"),
+				UseFIPS: aws.Bool(true),
+			},
+			wantEndpoint: "https://sts.us-gov-east-1.amazonaws.com",
+		},
+		{
+			name: "cn-northwest-1",
+			params: sts.EndpointParameters{
+				Region: aws.String("cn-northwest-1"),
+			},
+			wantEndpoint: "https://sts.cn-northwest-1.amazonaws.com.cn",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			endpoint, err := resolver.ResolveEndpoint(context.Background(), test.params)
+			require.NoError(t, err)
+			require.Equal(t, test.wantEndpoint, endpoint.URI.String())
+		})
+	}
+}

--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -32,6 +32,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription"
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	awscredentialsv2 "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
@@ -73,6 +75,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/gravitational/teleport/api/types"
+	cloudaws "github.com/gravitational/teleport/lib/cloud/aws"
 	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
@@ -93,6 +96,8 @@ type Clients interface {
 	GCPClients
 	// AWSClients is an interface for providing AWS API clients.
 	AWSClients
+	// AWSClientsV2 is an interface for providing AWS API clients.
+	AWSClientsV2
 	// AzureClients is an interface for Azure-specific API clients
 	AzureClients
 	// Closer closes all initialized clients.
@@ -112,6 +117,7 @@ type GCPClients interface {
 }
 
 // AWSClients is an interface for providing AWS API clients.
+// TODO DELETE when migrated to AWSV2Clients.
 type AWSClients interface {
 	// GetAWSSession returns AWS session for the specified region and any role(s).
 	GetAWSSession(ctx context.Context, region string, opts ...AWSOptionsFn) (*awssession.Session, error)
@@ -261,6 +267,10 @@ func NewClients(opts ...ClientsOption) (Clients, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	awsClientsV2, err := newAWSClientsV2()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	cloudClients := &cloudClients{
 		awsSessionsCache: awsSessionsCache,
 		gcpClients: gcpClients{
@@ -269,6 +279,7 @@ func NewClients(opts ...ClientsOption) (Clients, error) {
 			gcpInstances: newClientCache[gcp.InstancesClient](gcp.NewInstancesClient),
 		},
 		azureClients: azClients,
+		awsClientsV2: awsClientsV2,
 	}
 
 	for _, opt := range opts {
@@ -293,12 +304,7 @@ func WithAWSIntegrationSessionProvider(sessionProvider AWSIntegrationSessionProv
 // This is used to generate aws sessions for clients that must use an Integration instead of ambient credentials.
 type AWSIntegrationSessionProvider func(ctx context.Context, region string, integration string) (*awssession.Session, error)
 
-type awsSessionCacheKey struct {
-	region      string
-	integration string
-	roleARN     string
-	externalID  string
-}
+type awsSessionCacheKey = awsConfigCacheKey
 
 type cloudClients struct {
 	// awsSessionsCache is a cache of AWS sessions, where the cache key is
@@ -312,6 +318,8 @@ type cloudClients struct {
 	gcpClients
 	// azureClients contains Azure-specific clients.
 	*azureClients
+	// awsClientsV2 contains AWS-specific clients using aws-=sdk-go-v2.
+	*awsClientsV2
 	// mtx is used for locking.
 	mtx sync.RWMutex
 }
@@ -377,6 +385,9 @@ type awsOptions struct {
 	// baseSession is a session to use instead of the default session for an
 	// AWS region, which is used to enable role chaining.
 	baseSession *awssession.Session
+	// baseConfigV2 is a AWS config to use instead of the default config for an
+	// AWS region, which is used to enable role chaining.
+	baseConfigV2 *awsv2.Config
 	// assumeRoleARN is the AWS IAM Role ARN to assume.
 	assumeRoleARN string
 	// assumeRoleExternalID is used to assume an external AWS IAM Role.
@@ -432,9 +443,14 @@ func WithAssumeRoleFromAWSMeta(meta types.AWS) AWSOptionsFn {
 
 // WithChainedAssumeRole sets a role to assume with a base session to use
 // for assuming the role, which enables role chaining.
-func WithChainedAssumeRole(session *awssession.Session, roleARN, externalID string) AWSOptionsFn {
+func WithChainedAssumeRole[Base *awssession.Session | *awsv2.Config](base Base, roleARN, externalID string) AWSOptionsFn {
 	return func(options *awsOptions) {
-		options.baseSession = session
+		switch v := any(base).(type) {
+		case *awssession.Session:
+			options.baseSession = v
+		case *awsv2.Config:
+			options.baseConfigV2 = v
+		}
 		options.assumeRoleARN = roleARN
 		options.assumeRoleExternalID = externalID
 	}
@@ -1010,25 +1026,30 @@ var _ Clients = (*TestCloudClients)(nil)
 
 // TestCloudClients are used in tests.
 type TestCloudClients struct {
-	RDS                     rdsiface.RDSAPI
-	RDSPerRegion            map[string]rdsiface.RDSAPI
-	Redshift                redshiftiface.RedshiftAPI
-	RedshiftServerless      redshiftserverlessiface.RedshiftServerlessAPI
-	ElastiCache             elasticacheiface.ElastiCacheAPI
-	OpenSearch              opensearchserviceiface.OpenSearchServiceAPI
-	MemoryDB                memorydbiface.MemoryDBAPI
-	SecretsManager          secretsmanageriface.SecretsManagerAPI
-	IAM                     iamiface.IAMAPI
-	STS                     stsiface.STSAPI
-	GCPSQL                  gcp.SQLAdminClient
-	GCPGKE                  gcp.GKEClient
-	GCPInstances            gcp.InstancesClient
-	EC2                     ec2iface.EC2API
-	SSM                     ssmiface.SSMAPI
-	InstanceMetadata        imds.Client
-	EKS                     eksiface.EKSAPI
-	KMS                     kmsiface.KMSAPI
-	S3                      s3iface.S3API
+	STSAPI cloudaws.STSAPI
+
+	// TODO remove legacy AWS clients.
+	RDS                rdsiface.RDSAPI
+	RDSPerRegion       map[string]rdsiface.RDSAPI
+	Redshift           redshiftiface.RedshiftAPI
+	RedshiftServerless redshiftserverlessiface.RedshiftServerlessAPI
+	ElastiCache        elasticacheiface.ElastiCacheAPI
+	OpenSearch         opensearchserviceiface.OpenSearchServiceAPI
+	MemoryDB           memorydbiface.MemoryDBAPI
+	SecretsManager     secretsmanageriface.SecretsManagerAPI
+	IAM                iamiface.IAMAPI
+	STS                stsiface.STSAPI
+	EC2                ec2iface.EC2API
+	SSM                ssmiface.SSMAPI
+	InstanceMetadata   imds.Client
+	EKS                eksiface.EKSAPI
+	KMS                kmsiface.KMSAPI
+	S3                 s3iface.S3API
+
+	GCPSQL       gcp.SQLAdminClient
+	GCPGKE       gcp.GKEClient
+	GCPInstances gcp.InstancesClient
+
 	AzureMySQL              azure.DBServersClient
 	AzureMySQLPerSub        map[string]azure.DBServersClient
 	AzurePostgres           azure.DBServersClient
@@ -1044,6 +1065,30 @@ type TestCloudClients struct {
 	AzureMySQLFlex          azure.MySQLFlexServersClient
 	AzurePostgresFlex       azure.PostgresFlexServersClient
 	AzureRunCommand         azure.RunCommandClient
+}
+
+func (c *TestCloudClients) GetAWSConfigV2(ctx context.Context, region string, opts ...AWSOptionsFn) (*awsv2.Config, error) {
+	var options awsOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	if options.baseConfigV2 == nil {
+		options.baseConfigV2 = &awsv2.Config{
+			Region:      region,
+			Credentials: awscredentialsv2.NewStaticCredentialsProvider("fakeClientKeyID", "fakeClientSecret", ""),
+		}
+	}
+	if options.assumeRoleARN == "" {
+		return options.baseConfigV2, nil
+	}
+	return newAWSConfigForRole(ctx, c.STSAPI, region, options)
+}
+
+func (c *TestCloudClients) GetAWSSTSClientV2(ctx context.Context, region string, opts ...AWSOptionsFn) (cloudaws.STSAPI, error) {
+	if _, err := c.GetAWSConfigV2(ctx, region, opts...); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return c.STSAPI, nil
 }
 
 // GetAWSSession returns AWS session for the specified region, optionally

--- a/lib/cloud/mocks/aws_sts.go
+++ b/lib/cloud/mocks/aws_sts.go
@@ -1,0 +1,85 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mocks
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+
+	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
+)
+
+type STSAPIMock struct {
+	libcloudaws.STSAPI
+
+	CallerIdentityARN string
+
+	assumedRoleARNs        []string
+	assumedRoleExternalIDs []string
+	mu                     sync.Mutex
+}
+
+func (m *STSAPIMock) GetAssumedRoleARNs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.assumedRoleARNs
+}
+
+func (m *STSAPIMock) GetAssumedRoleExternalIDs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.assumedRoleExternalIDs
+}
+
+func (m *STSAPIMock) ResetAssumeRoleHistory() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.assumedRoleARNs = nil
+	m.assumedRoleExternalIDs = nil
+}
+
+func (m *STSAPIMock) GetCallerIdentity(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{
+		Arn: aws.String(m.CallerIdentityARN),
+	}, nil
+}
+
+func (m *STSAPIMock) AssumeRole(_ context.Context, in *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !slices.Contains(m.assumedRoleARNs, aws.ToString(in.RoleArn)) {
+		m.assumedRoleARNs = append(m.assumedRoleARNs, aws.ToString(in.RoleArn))
+		m.assumedRoleExternalIDs = append(m.assumedRoleExternalIDs, aws.ToString(in.ExternalId))
+	}
+	expiry := time.Now().Add(60 * time.Minute)
+	return &sts.AssumeRoleOutput{
+		Credentials: &ststypes.Credentials{
+			AccessKeyId:     in.RoleArn,
+			SecretAccessKey: aws.String("secret"),
+			SessionToken:    aws.String("token"),
+			Expiration:      &expiry,
+		},
+	}, nil
+}


### PR DESCRIPTION
related:
- https://github.com/gravitational/teleport/issues/14142
- https://github.com/gravitational/teleport/pull/37770

changes:
- new `cloud.AWSClientsV2` interaface
- have to define an interface for sts.client as the SDK does not provide one
- have to implement an endpoint resolver to make sure we fall back to global STS endpoint when region is not available
- have to implement a custom error conversion function 
