### PR TITLE
[v14] Remove `libfido2 found, setting FIDO2=dynamic` message from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,6 @@ export C_ARCH
 ifeq ("$(shell pkg-config libfido2 2>/dev/null; echo $$?)", "0")
 LIBFIDO2_TEST_TAG := libfido2
 ifeq ($(FIDO2),)
-$(info libfido2 found, setting FIDO2=dynamic)
 FIDO2 ?= dynamic
 endif
 endif


### PR DESCRIPTION
Backport #43458 to branch/v14