### PR TITLE
Fix interleaved output from `tsh ssh` on multiple nodes

### DIFF
--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -304,14 +304,15 @@ func (l wrappedListener) Accept() (net.Conn, error) {
 func TestLineLabeledWriter(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name     string
-		inputs   []string
-		expected string
+		name       string
+		inputs     []string
+		lineLength int
+		expected   string
 	}{
 		{
 			name:     "typical input",
 			inputs:   []string{"this is\nsome test\ninput"},
-			expected: "[label] this is\n[label] some test\n[label] input",
+			expected: "[label] this is\n[label] some test\n[label] input\n",
 		},
 		{
 			name:     "don't add empty line at end",
@@ -321,7 +322,7 @@ func TestLineLabeledWriter(t *testing.T) {
 		{
 			name:     "blank lines in middle",
 			inputs:   []string{"this\n\nis\n\nsome input"},
-			expected: "[label] this\n[label] \n[label] is\n[label] \n[label] some input",
+			expected: "[label] this\n[label] \n[label] is\n[label] \n[label] some input\n",
 		},
 		{
 			name:     "line break between writes",
@@ -331,18 +332,31 @@ func TestLineLabeledWriter(t *testing.T) {
 		{
 			name:     "line break immediately on second write",
 			inputs:   []string{"line 1", "\nline 2"},
-			expected: "[label] line 1\n[label] line 2",
+			expected: "[label] line 1\n[label] line 2\n",
 		},
 		{
 			name:     "line continues between writes",
-			inputs:   []string{"this is all ", "one continuous line"},
-			expected: "[label] this is all one continuous line",
+			inputs:   []string{"this is all ", "one continuous line ", "until\nnow"},
+			expected: "[label] this is all one continuous line until\n[label] now\n",
+		},
+		{
+			name:       "long lines wrapped",
+			inputs:     []string{"1234\nabcdefghijklmnopqrstuvwxyz\n1234"},
+			lineLength: 16,
+			expected:   "[label] 1234\n[label] abcdefgh\n[label] ijklmnop\n[label] qrstuvwx\n[label] yz\n[label] 1234\n",
+		},
+		{
+			name:       "exact length lines",
+			inputs:     []string{"abcdefgh", "\nijklmnop"},
+			lineLength: 16,
+			expected:   "[label] abcdefgh\n[label] ijklmnop\n",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			w := newLineLabeledWriter(&buf, "label")
+			w, err := newLineLabeledWriter(&buf, "label", tc.lineLength)
+			require.NoError(t, err)
 
 			totalBytes := 0
 			expectedBytes := 0
@@ -352,6 +366,7 @@ func TestLineLabeledWriter(t *testing.T) {
 				totalBytes += n
 				expectedBytes += len(line)
 			}
+			assert.NoError(t, w.Close())
 			assert.Equal(t, expectedBytes, totalBytes)
 			assert.Equal(t, tc.expected, buf.String())
 		})


### PR DESCRIPTION
This change fixes an occasional bug where output from a command run on multiple nodes would interleave, making it harder to read. The client now:
- buffers output from each node and only prints complete lines (under a lock)
- wraps lines to the width of the terminal when possible so we don't buffer an arbitrarily large amount of output

Resolves #21089.