### PR TITLE
Add support for SAML SLO in `tsh`

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -446,6 +446,8 @@ type SAMLSettings struct {
 	Name string `json:"name"`
 	// Display is the display name for the connector.
 	Display string `json:"display"`
+	// SingleLogoutEnabled is whether SAML SLO (single logout) is enabled for this auth connector.
+	SingleLogoutEnabled bool `json:"singleLogoutEnabled,omitempty"`
 }
 
 // OIDCSettings contains the Name and Display string for OIDC.

--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -110,6 +110,10 @@ type Profile struct {
 	// MissingClusterDetails means this profile was created with limited cluster details.
 	// Missing cluster details should be loaded into the profile by pinging the proxy.
 	MissingClusterDetails bool
+
+	// SAMLSingleLogoutEnabled is whether SAML SLO (single logout) is enabled, this can only be true if this is a SAML SSO session
+	// using an auth connector with a SAML SLO URL configured.
+	SAMLSingleLogoutEnabled bool `yaml:"saml_slo_enabled,omitempty"`
 }
 
 // Copy returns a shallow copy of p, or nil if p is nil.

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -1328,6 +1328,8 @@ type SSHLoginResponse struct {
 	TLSCert []byte `json:"tls_cert"`
 	// HostSigners is a list of signing host public keys trusted by proxy
 	HostSigners []TrustedCerts `json:"host_signers"`
+	// SAMLSingleLogoutEnabled is whether SAML SLO (single logout) is enabled for the SAML auth connector being used, if applicable.
+	SAMLSingleLogoutEnabled bool `json:"samlSingleLogoutEnabled"`
 }
 
 // TrustedCerts contains host certificates, it preserves backwards compatibility

--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -195,7 +195,8 @@ func (s *Store) ReadProfileStatus(profileName string) (*ProfileStatus, error) {
 				Cluster:     profile.SiteName,
 				KubeEnabled: profile.KubeProxyAddr != "",
 				// Set ValidUntil to now to show that the keys are not available.
-				ValidUntil: time.Now(),
+				ValidUntil:              time.Now(),
+				SAMLSingleLogoutEnabled: profile.SAMLSingleLogoutEnabled,
 			}, nil
 		}
 		return nil, trace.Wrap(err)
@@ -204,13 +205,14 @@ func (s *Store) ReadProfileStatus(profileName string) (*ProfileStatus, error) {
 	_, onDisk := s.KeyStore.(*FSKeyStore)
 
 	return profileStatusFromKey(key, profileOptions{
-		ProfileName:   profileName,
-		ProfileDir:    profile.Dir,
-		WebProxyAddr:  profile.WebProxyAddr,
-		Username:      profile.Username,
-		SiteName:      profile.SiteName,
-		KubeProxyAddr: profile.KubeProxyAddr,
-		IsVirtual:     !onDisk,
+		ProfileName:             profileName,
+		ProfileDir:              profile.Dir,
+		WebProxyAddr:            profile.WebProxyAddr,
+		Username:                profile.Username,
+		SiteName:                profile.SiteName,
+		KubeProxyAddr:           profile.KubeProxyAddr,
+		SAMLSingleLogoutEnabled: profile.SAMLSingleLogoutEnabled,
+		IsVirtual:               !onDisk,
 	})
 }
 

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -238,18 +238,23 @@ type ProfileStatus struct {
 	// files on disk - must be accompanied by fallback logic when those paths
 	// do not exist.
 	IsVirtual bool
+
+	// SAMLSingleLogoutEnabled is whether SAML SLO (single logout) is enabled, this can only be true if this is a SAML SSO session
+	// using an auth connector with a SAML SLO URL configured.
+	SAMLSingleLogoutEnabled bool
 }
 
 // profileOptions contains fields needed to initialize a profile beyond those
 // derived directly from a Key.
 type profileOptions struct {
-	ProfileName   string
-	ProfileDir    string
-	WebProxyAddr  string
-	Username      string
-	SiteName      string
-	KubeProxyAddr string
-	IsVirtual     bool
+	ProfileName             string
+	ProfileDir              string
+	WebProxyAddr            string
+	Username                string
+	SiteName                string
+	KubeProxyAddr           string
+	IsVirtual               bool
+	SAMLSingleLogoutEnabled bool
 }
 
 // profileFromkey returns a ProfileStatus for the given key and options.
@@ -350,25 +355,26 @@ func profileStatusFromKey(key *Key, opts profileOptions) (*ProfileStatus, error)
 			Scheme: "https",
 			Host:   opts.WebProxyAddr,
 		},
-		Username:           opts.Username,
-		Logins:             sshCert.ValidPrincipals,
-		ValidUntil:         validUntil,
-		Extensions:         extensions,
-		CriticalOptions:    sshCert.CriticalOptions,
-		Roles:              roles,
-		Cluster:            opts.SiteName,
-		Traits:             traits,
-		ActiveRequests:     activeRequests,
-		KubeEnabled:        opts.KubeProxyAddr != "",
-		KubeUsers:          tlsID.KubernetesUsers,
-		KubeGroups:         tlsID.KubernetesGroups,
-		Databases:          databases,
-		Apps:               apps,
-		AWSRolesARNs:       tlsID.AWSRoleARNs,
-		AzureIdentities:    tlsID.AzureIdentities,
-		GCPServiceAccounts: tlsID.GCPServiceAccounts,
-		IsVirtual:          opts.IsVirtual,
-		AllowedResourceIDs: allowedResourceIDs,
+		Username:                opts.Username,
+		Logins:                  sshCert.ValidPrincipals,
+		ValidUntil:              validUntil,
+		Extensions:              extensions,
+		CriticalOptions:         sshCert.CriticalOptions,
+		Roles:                   roles,
+		Cluster:                 opts.SiteName,
+		Traits:                  traits,
+		ActiveRequests:          activeRequests,
+		KubeEnabled:             opts.KubeProxyAddr != "",
+		KubeUsers:               tlsID.KubernetesUsers,
+		KubeGroups:              tlsID.KubernetesGroups,
+		Databases:               databases,
+		Apps:                    apps,
+		AWSRolesARNs:            tlsID.AWSRoleARNs,
+		AzureIdentities:         tlsID.AzureIdentities,
+		GCPServiceAccounts:      tlsID.GCPServiceAccounts,
+		IsVirtual:               opts.IsVirtual,
+		AllowedResourceIDs:      allowedResourceIDs,
+		SAMLSingleLogoutEnabled: opts.SAMLSingleLogoutEnabled,
 	}, nil
 }
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1202,8 +1202,9 @@ func samlSettings(connector types.SAMLConnector, cap types.AuthPreference) webcl
 	return webclient.AuthenticationSettings{
 		Type: constants.SAML,
 		SAML: &webclient.SAMLSettings{
-			Name:    connector.GetName(),
-			Display: connector.GetDisplay(),
+			Name:                connector.GetName(),
+			Display:             connector.GetDisplay(),
+			SingleLogoutEnabled: connector.GetSingleLogoutURL() != "",
 		},
 		// Local fallback / MFA.
 		SecondFactor:      cap.GetSecondFactor(),

--- a/web/packages/design/src/CardError/CardError.jsx
+++ b/web/packages/design/src/CardError/CardError.jsx
@@ -113,7 +113,7 @@ LoginFailed.propTypes = {
 
 export const LogoutFailed = ({ message, loginUrl }) => (
   <CardError>
-    <Header>Login Unsuccessful</Header>
+    <Header>Logout Unsuccessful</Header>
     <Content
       message={message}
       desc={


### PR DESCRIPTION
## Purpose

Part of #41076

This PR adds SAML SLO (single logout) functionality to `tsh`. When a user runs `tsh logout`, if they were logged in via a SAML auth connector with SLO configured, they will also be logged out of the identity provider.