### PR TITLE
[v15] chore: Bump Go toolchain to 1.22.4

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.21.11
+GOLANG_VERSION ?= go1.22.0
 GOLANGCI_LINT_VERSION ?= v1.58.1
 
 NODE_VERSION ?= 20.14.0

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.22.0
+GOLANG_VERSION ?= go1.22.4
 GOLANGCI_LINT_VERSION ?= v1.58.1
 
 NODE_VERSION ?= 20.14.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gravitational/teleport
 
 go 1.21
 
-toolchain go1.22.0
+toolchain go1.22.4
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gravitational/teleport
 
 go 1.21
 
-toolchain go1.21.11
+toolchain go1.22.0
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.9.0

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -2,7 +2,7 @@ module github.com/gravitational/teleport/integrations/event-handler
 
 go 1.21
 
-toolchain go1.21.11
+toolchain go1.22.4
 
 require (
 	github.com/alecthomas/kong v0.9.0

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -2,7 +2,7 @@ module github.com/gravitational/teleport/integrations/terraform
 
 go 1.21
 
-toolchain go1.21.11
+toolchain go1.22.4
 
 require (
 	github.com/gogo/protobuf v1.3.2


### PR DESCRIPTION
Update the Go toolchain to 1.22; Go 1.21 will EOL soon and Go 1.22 is already battle-tested by v16.

Changelog: Updated Go toolchain to 1.22.