### PR TITLE
Remove random no-login- set on auditor role

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -21,7 +21,6 @@ package services
 import (
 	"slices"
 
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 
@@ -287,7 +286,6 @@ func NewPresetAuditorRole() types.Role {
 			},
 		},
 	}
-	role.SetLogins(types.Allow, []string{"no-login-" + uuid.New().String()})
 	return role
 }
 


### PR DESCRIPTION
There is nothing that consumes or requires the randomly generated login applied to the preset auditor role, and nothing that prevents a user from removing it. This login was determined to be vestigial and serve no purpose anymore.

Closes #25840