### PR TITLE
[v16] Fix getting initial version for installation kube agent for EKS Discover enrollment in the Teleport cloud.

### DIFF
--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -58,7 +58,7 @@ func (s *Server) startKubeIntegrationWatchers() error {
 	proxyPublicAddr := pingResponse.GetProxyPublicAddr()
 
 	releaseChannels := automaticupgrades.Channels{automaticupgrades.DefaultChannelName: &automaticupgrades.Channel{
-		ForwardURL: fmt.Sprintf("https://%s/webapi/automaticupgrades/channel/%s", proxyPublicAddr, automaticupgrades.DefaultCloudChannelName)}}
+		ForwardURL: fmt.Sprintf("https://%s/webapi/automaticupgrades/channel/%s", proxyPublicAddr, automaticupgrades.DefaultChannelName)}}
 	if err := releaseChannels.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -21,6 +21,7 @@ package discovery
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -50,7 +51,14 @@ func (s *Server) startKubeIntegrationWatchers() error {
 
 	clt := s.AccessPoint
 
-	releaseChannels := automaticupgrades.Channels{}
+	pingResponse, err := s.AccessPoint.Ping(s.ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	proxyPublicAddr := pingResponse.GetProxyPublicAddr()
+
+	releaseChannels := automaticupgrades.Channels{automaticupgrades.DefaultChannelName: &automaticupgrades.Channel{
+		ForwardURL: fmt.Sprintf("https://%s/webapi/automaticupgrades/channel/%s", proxyPublicAddr, automaticupgrades.DefaultCloudChannelName)}}
 	if err := releaseChannels.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -214,7 +222,7 @@ func (s *Server) getKubeAgentVersion(releaseChannels automaticupgrades.Channels)
 	agentVersion := pingResponse.ServerVersion
 
 	clusterFeatures := s.ClusterFeatures()
-	if clusterFeatures.GetAutomaticUpgrades() {
+	if clusterFeatures.GetAutomaticUpgrades() && clusterFeatures.GetCloud() {
 		defaultVersion, err := releaseChannels.DefaultVersion(s.ctx)
 		if err == nil {
 			agentVersion = defaultVersion

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -89,7 +89,7 @@ func TestGetAgentVersion(t *testing.T) {
 			ping: func(ctx context.Context) (proto.PingResponse, error) {
 				return proto.PingResponse{ServerVersion: "10"}, nil
 			},
-			clusterFeatures: proto.Features{AutomaticUpgrades: true},
+			clusterFeatures: proto.Features{AutomaticUpgrades: true, Cloud: true},
 			channelVersion:  "v1.2.3",
 			expectedVersion: "1.2.3",
 			errorAssert:     require.NoError,


### PR DESCRIPTION
Backport #43370 to branch/v16