### PR TITLE
[Web] Update notification card styles

### DIFF
--- a/web/packages/teleport/src/Notifications/Notification.story.tsx
+++ b/web/packages/teleport/src/Notifications/Notification.story.tsx
@@ -22,7 +22,7 @@ import { subSeconds, subMinutes, subHours, subDays } from 'date-fns';
 import { initialize, mswLoader } from 'msw-storybook-addon';
 import { rest } from 'msw';
 
-import { Flex } from 'design';
+import { Flex, Text } from 'design';
 
 import {
   NotificationSubKind,
@@ -43,6 +43,55 @@ export default {
 };
 
 initialize();
+
+export const NotificationCard = () => {
+  const ctx = createTeleportContext();
+
+  return (
+    <MemoryRouter>
+      <ContextProvider ctx={ctx}>
+        <Flex
+          mt={4}
+          p={4}
+          gap={4}
+          css={`
+            background: ${props => props.theme.colors.levels.surface};
+            width: 450px;
+            height: fit-content;
+            flex-direction: column;
+          `}
+        >
+          <Flex flexDirection="column">
+            <Text typography="h4" textAlign="center" mb={1}>
+              Visited: Yes
+            </Text>
+            <Notification
+              notification={mockNotifications[5]}
+              closeNotificationsList={() => null}
+              markNotificationAsClicked={() => null}
+              removeNotification={() => null}
+            />
+          </Flex>
+          <Flex flexDirection="column">
+            <Text typography="h4" textAlign="center" mb={1}>
+              Visited: No
+            </Text>
+            <Notification
+              notification={{
+                ...mockNotifications[5],
+                clicked: false,
+                id: '2',
+              }}
+              closeNotificationsList={() => null}
+              markNotificationAsClicked={() => null}
+              removeNotification={() => null}
+            />
+          </Flex>
+        </Flex>
+      </ContextProvider>
+    </MemoryRouter>
+  );
+};
 
 export const NotificationTypes = () => {
   const ctx = createTeleportContext();

--- a/web/packages/teleport/src/Notifications/Notification.tsx
+++ b/web/packages/teleport/src/Notifications/Notification.tsx
@@ -133,14 +133,18 @@ export function Notification({
     // Prevents this from being triggered when the user is just clicking away from
     // an open "mark as read/hide this notification" menu popover.
     if (e.currentTarget.contains(e.target as HTMLElement)) {
-      if (content.kind === 'text') {
-        setShowTextContentDialog(true);
-        return;
-      }
-      onMarkAsClicked();
-      closeNotificationsList();
-      history.push(content.redirectRoute);
+      onClick();
     }
+  }
+
+  function onClick() {
+    if (content.kind === 'text') {
+      setShowTextContentDialog(true);
+      return;
+    }
+    onMarkAsClicked();
+    closeNotificationsList();
+    history.push(content.redirectRoute);
   }
 
   const isClicked =
@@ -153,6 +157,12 @@ export function Notification({
         clicked={isClicked}
         onClick={onNotificationClick}
         className="notification"
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === 'Enter') {
+            onClick();
+          }
+        }}
       >
         <GraphicContainer>
           <MainIconContainer type={content.type}>
@@ -261,22 +271,40 @@ const Container = styled.div<{ clicked?: boolean }>`
   border-radius: ${props => props.theme.radii[3]}px;
   cursor: pointer;
 
-  background: ${props =>
-    props.theme.colors.interactive.tonal.primary[0].background};
-  &:hover {
-    background: ${props =>
-      props.theme.colors.interactive.tonal.primary[1].background};
+  ${props => getInteractiveStateStyles(props.theme, props.clicked)}
+`;
+
+function getInteractiveStateStyles(theme: Theme, clicked: boolean): string {
+  if (clicked) {
+    return `
+        background: transparent;
+        &:hover {
+          background: ${theme.colors.interactive.tonal.neutral[0].background};
+        }
+        &:active {
+          outline: none;
+          background: ${theme.colors.interactive.tonal.neutral[1].background};
+        }
+        &:focus {
+          outline: ${theme.borders[2]} ${theme.colors.text.slightlyMuted};
+        }
+        `;
   }
 
-  ${props =>
-    props.clicked &&
-    `
-    background: ${props.theme.colors.interactive.tonal.neutral[0].background};
+  return `
+    background: ${theme.colors.interactive.tonal.primary[0].background};
     &:hover {
-      background: ${props.theme.colors.interactive.tonal.neutral[1].background};
+      background: ${theme.colors.interactive.tonal.primary[1].background};
     }
-    `}
-`;
+    &:active {
+      outline: none;
+      background: ${theme.colors.interactive.tonal.primary[2].background};
+    }
+    &:focus {
+      outline: ${theme.borders[2]} ${theme.colors.interactive.solid.primary.default.background};
+    }
+    `;
+}
 
 const ContentContainer = styled.div`
   display: flex;
@@ -323,12 +351,12 @@ function getIconColors(
   switch (type) {
     case 'success':
       return {
-        primary: theme.colors.success.main,
+        primary: theme.colors.interactive.solid.success.active.background,
         secondary: theme.colors.interactive.tonal.success[0].background,
       };
     case 'success-alt':
       return {
-        primary: theme.colors.accent.main,
+        primary: theme.colors.interactive.solid.accent.active.background,
         secondary: theme.colors.interactive.tonal.informational[0].background,
       };
     case 'informational':
@@ -338,7 +366,7 @@ function getIconColors(
       };
     case `warning`:
       return {
-        primary: theme.colors.warning.main,
+        primary: theme.colors.interactive.solid.alert.active.background,
         secondary: theme.colors.interactive.tonal.alert[0].background,
       };
     case 'failure':

--- a/web/packages/teleport/src/Notifications/Notifications.tsx
+++ b/web/packages/teleport/src/Notifications/Notifications.tsx
@@ -508,7 +508,7 @@ const NotificationsList = styled.div`
   max-height: 100%;
   overflow-y: auto;
   padding: ${p => p.theme.space[3]}px;
-  padding-top: 0px;
+  padding-top: 2px;
   // Subtract the width of the scrollbar from the right padding.
   padding-right: ${p => `${p.theme.space[3] - 8}px`};
 


### PR DESCRIPTION
## Purpose

This PR updates the notification card interactive states to be in line with updated designs in Figma. This PR also adds the ability to select notifications using tab and pressing enter to open them, making use of the new `focus` state.

[Figma designs](https://www.figma.com/design/Gpjs9vjhzUKF1GDbeG9JGE/Application-Design-System?node-id=14944-13080&t=BpHlv0OnLEnLUEP0-1)

## Demo

### Visited: Yes (user has previously opened this notification)

#### Dark Theme

##### Default

<img width="416" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/b979b622-a779-4a1f-b51f-1d767afdc5f4">

#### Hover

<img width="416" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/b0c99ee6-6075-4006-9f4e-deddf4edd159">

#### Active

<img width="416" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/80538fc0-a8f6-4cfe-9074-664d09b8ad4e">

#### Focus

![image](https://github.com/gravitational/teleport/assets/56373201/85306c49-cfa4-4860-be21-412beb1760e8)

#### Light Theme

##### Default

<img width="416" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/731ac2a8-14fd-48b7-a0dc-378f63b9bded">

##### Hover

<img width="416" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/909628ba-8237-41fe-bf74-b0856b82137e">

##### Active

<img width="416" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/ec806eb7-feb4-4fe0-985e-d17c0d2c72cc">

##### Focus

![image](https://github.com/gravitational/teleport/assets/56373201/9ea42731-1cd5-4481-943e-f277b7bc6d47)

### Visited: No

#### Dark Theme

##### Default

<img width="416" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/786d2c48-58df-4ae7-bfb8-8d5b0c3ccb00">

#### Hover

<img width="416" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/4a1241ec-0346-4d89-bcdd-e5beda37268b">

#### Active

<img width="416" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/8770be08-4fc0-49f5-b3f0-a8fac5423e7d">

#### Focus

![image](https://github.com/gravitational/teleport/assets/56373201/1998e268-9293-4f8d-b812-4417ee6e9d6c)

#### Light Theme

##### Default

<img width="416" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/64fcf7b7-4d8c-4eed-81cf-7df35cdf08b1">

##### Hover

<img width="416" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/65bee28f-8568-4e44-a5e6-edb9d3faf355">

##### Active

<img width="416" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/6adb3f3d-62ab-463f-9160-27ba924844c6">

##### Focus

![image](https://github.com/gravitational/teleport/assets/56373201/c0689211-4e01-45e0-84e6-15a6abc61e55)









