### PR TITLE
[v16] Fix kubernetes-access redirect

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2384,7 +2384,7 @@
     },
     {
       "source": "/kubernetes-access/getting-started/local/",
-      "destination": "/kubernetes-access/",
+      "destination": "/kubernetes-access/introduction/",
       "permanent": true
     },
     {


### PR DESCRIPTION
This redirect points to a nonexistent page. The broken redirect was removed in an earlier commit but restored in
cbe65e3c4a2f2bd5cdad18b4addaffd9af31038b.