### PR TITLE
[v15] Include SAML IdP service provider `preset` value in unified resource view response

### DIFF
--- a/lib/web/ui/app.go
+++ b/lib/web/ui/app.go
@@ -56,6 +56,9 @@ type App struct {
 	UserGroups []UserGroupAndDescription `json:"userGroups,omitempty"`
 	// SAMLApp if true, indicates that the app is a SAML Application (SAML IdP Service Provider)
 	SAMLApp bool `json:"samlApp,omitempty"`
+	// SAMLAppPreset is the preset value of SAML IdP service provider. The SAML service provider
+	// preset value is used to process custom configuration for the service provider.
+	SAMLAppPreset string `json:"samlAppPreset,omitempty"`
 	// Integration is the integration name that must be used to access this Application.
 	// Only applicable to AWS App Access.
 	Integration string `json:"integration,omitempty"`
@@ -150,14 +153,15 @@ func MakeApp(app types.Application, c MakeAppsConfig) App {
 func MakeSAMLApp(app types.SAMLIdPServiceProvider, c MakeAppsConfig) App {
 	labels := makeLabels(app.GetAllLabels())
 	resultApp := App{
-		Kind:         types.KindApp,
-		Name:         app.GetName(),
-		Description:  "SAML Application",
-		PublicAddr:   "",
-		Labels:       labels,
-		ClusterID:    c.AppClusterName,
-		FriendlyName: types.FriendlyName(app),
-		SAMLApp:      true,
+		Kind:          types.KindApp,
+		Name:          app.GetName(),
+		Description:   "SAML Application",
+		PublicAddr:    "",
+		Labels:        labels,
+		ClusterID:     c.AppClusterName,
+		FriendlyName:  types.FriendlyName(app),
+		SAMLApp:       true,
+		SAMLAppPreset: app.GetPreset(),
 	}
 
 	return resultApp

--- a/lib/web/ui/app_test.go
+++ b/lib/web/ui/app_test.go
@@ -210,7 +210,7 @@ func TestMakeApps(t *testing.T) {
 	}
 }
 
-func TestMakeAppTypeFromSAMLApp(t *testing.T) {
+func TestMakeSAMLApp(t *testing.T) {
 	tests := []struct {
 		name             string
 		sp               types.SAMLIdPServiceProviderV1

--- a/lib/web/ui/app_test.go
+++ b/lib/web/ui/app_test.go
@@ -210,6 +210,59 @@ func TestMakeApps(t *testing.T) {
 	}
 }
 
+func TestMakeAppTypeFromSAMLApp(t *testing.T) {
+	tests := []struct {
+		name             string
+		sp               types.SAMLIdPServiceProviderV1
+		appsToUserGroups map[string]types.UserGroups
+		expected         App
+	}{
+		{
+			name: "empty",
+			expected: App{
+				Kind:          types.KindApp,
+				Name:          "",
+				Description:   "SAML Application",
+				PublicAddr:    "",
+				Labels:        []Label{},
+				SAMLApp:       true,
+				SAMLAppPreset: "",
+			},
+		},
+		{
+			name: "saml idp service provider",
+			sp: types.SAMLIdPServiceProviderV1{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "test_app",
+					},
+				},
+				Spec: types.SAMLIdPServiceProviderSpecV1{
+					Preset: "test_preset",
+				},
+			},
+			expected: App{
+				Kind:          types.KindApp,
+				Name:          "test_app",
+				Description:   "SAML Application",
+				PublicAddr:    "",
+				Labels:        []Label{},
+				SAMLApp:       true,
+				SAMLAppPreset: "test_preset",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			apps := MakeSAMLApp(&test.sp, MakeAppsConfig{})
+			require.Empty(t, cmp.Diff(test.expected, apps))
+		})
+	}
+}
+
 func newApp(t *testing.T, name, publicAddr, description string, labels map[string]string) types.Application {
 	app, err := types.NewAppV3(types.Metadata{
 		Name:        name,


### PR DESCRIPTION
Backport #43446 to branch/v15

Part of https://github.com/gravitational/teleport.e/issues/4458