### PR TITLE
[v16] Include SAML IdP service provider `preset` value in unified resource view response

### DIFF
--- a/lib/web/ui/app.go
+++ b/lib/web/ui/app.go
@@ -56,6 +56,9 @@ type App struct {
 	UserGroups []UserGroupAndDescription `json:"userGroups,omitempty"`
 	// SAMLApp if true, indicates that the app is a SAML Application (SAML IdP Service Provider)
 	SAMLApp bool `json:"samlApp,omitempty"`
+	// SAMLAppPreset is the preset value of SAML IdP service provider. The SAML service provider
+	// preset value is used to process custom configuration for the service provider.
+	SAMLAppPreset string `json:"samlAppPreset,omitempty"`
 	// RequireRequest indicates if a returned resource is only accessible after an access request
 	RequiresRequest bool `json:"requiresRequest,omitempty"`
 	// Integration is the integration name that must be used to access this Application.
@@ -163,6 +166,7 @@ func MakeAppTypeFromSAMLApp(app types.SAMLIdPServiceProvider, c MakeAppsConfig) 
 		ClusterID:       c.AppClusterName,
 		FriendlyName:    types.FriendlyName(app),
 		SAMLApp:         true,
+		SAMLAppPreset:   app.GetPreset(),
 		RequiresRequest: c.RequiresRequest,
 	}
 

--- a/lib/web/ui/app_test.go
+++ b/lib/web/ui/app_test.go
@@ -270,9 +270,7 @@ func TestMakeAppTypeFromSAMLApp(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-
 			apps := MakeAppTypeFromSAMLApp(&test.sp, MakeAppsConfig{})
-
 			require.Empty(t, cmp.Diff(test.expected, apps))
 		})
 	}

--- a/lib/web/ui/app_test.go
+++ b/lib/web/ui/app_test.go
@@ -223,6 +223,61 @@ func newApp(t *testing.T, name, publicAddr, description string, labels map[strin
 	return app
 }
 
+func TestMakeAppTypeFromSAMLApp(t *testing.T) {
+	tests := []struct {
+		name             string
+		sp               types.SAMLIdPServiceProviderV1
+		appsToUserGroups map[string]types.UserGroups
+		expected         App
+	}{
+		{
+			name: "empty",
+			expected: App{
+				Kind:          types.KindApp,
+				Name:          "",
+				Description:   "SAML Application",
+				PublicAddr:    "",
+				Labels:        []Label{},
+				SAMLApp:       true,
+				SAMLAppPreset: "",
+			},
+		},
+		{
+			name: "saml idp service provider",
+			sp: types.SAMLIdPServiceProviderV1{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "test_app",
+					},
+				},
+				Spec: types.SAMLIdPServiceProviderSpecV1{
+					Preset: "test_preset",
+				},
+			},
+			expected: App{
+				Kind:          types.KindApp,
+				Name:          "test_app",
+				Description:   "SAML Application",
+				PublicAddr:    "",
+				Labels:        []Label{},
+				SAMLApp:       true,
+				SAMLAppPreset: "test_preset",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			apps := MakeAppTypeFromSAMLApp(&test.sp, MakeAppsConfig{})
+
+			require.Empty(t, cmp.Diff(test.expected, apps))
+		})
+	}
+}
+
 // createAppServerOrSPFromApp returns a AppServerOrSAMLIdPServiceProvider given an App.
 //
 //nolint:staticcheck // SA1019. Kept to be deleted along with the API in 16.0.


### PR DESCRIPTION
Backport #43446 to branch/v16

Part of https://github.com/gravitational/teleport.e/issues/4458