### PR TITLE
[v16] Fix wrong context usage for reissuing expired certificate for tsh proxy kube.

### DIFF
--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -567,6 +567,7 @@ func mustCreateKubeLocalProxyMiddleware(t *testing.T, teleportCluster, kubeClust
 		CertReissuer: func(ctx context.Context, teleportCluster, kubeCluster string) (tls.Certificate, error) {
 			return tls.Certificate{}, nil
 		},
+		CloseContext: context.Background(),
 	})
 }
 

--- a/lib/srv/alpnproxy/kube.go
+++ b/lib/srv/alpnproxy/kube.go
@@ -81,7 +81,8 @@ type KubeMiddleware struct {
 	// headless controls whether proxy is working in headless login mode.
 	headless bool
 
-	logger logrus.FieldLogger
+	logger  logrus.FieldLogger
+	context context.Context
 
 	// isCertReissuingRunning is used to only ever have one concurrent cert reissuing session requiring user input.
 	isCertReissuingRunning atomic.Bool
@@ -97,6 +98,7 @@ type KubeMiddlewareConfig struct {
 	Headless     bool
 	Clock        clockwork.Clock
 	Logger       logrus.FieldLogger
+	Context      context.Context
 }
 
 // NewKubeMiddleware creates a new KubeMiddleware.
@@ -107,6 +109,7 @@ func NewKubeMiddleware(cfg KubeMiddlewareConfig) LocalProxyHTTPMiddleware {
 		headless:     cfg.Headless,
 		clock:        cfg.Clock,
 		logger:       cfg.Logger,
+		context:      cfg.Context,
 	}
 }
 
@@ -120,6 +123,9 @@ func (m *KubeMiddleware) CheckAndSetDefaults() error {
 	}
 	if m.logger == nil {
 		m.logger = logrus.WithField(teleport.ComponentKey, "local_proxy_kube")
+	}
+	if m.context == nil {
+		m.context = context.Background()
 	}
 	return nil
 }
@@ -245,7 +251,7 @@ func (m *KubeMiddleware) reissueCertIfExpired(ctx context.Context, cert tls.Cert
 			if identity.RouteToCluster != "" {
 				cluster = identity.RouteToCluster
 			}
-			newCert, err := m.certReissuer(ctx, cluster, identity.KubernetesCluster)
+			newCert, err := m.certReissuer(m.context, cluster, identity.KubernetesCluster)
 			if err == nil {
 				m.certsMu.Lock()
 				m.certs[serverName] = newCert

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -540,11 +540,14 @@ func TestKubeMiddleware(t *testing.T) {
 		require.Equal(t, http.StatusInternalServerError, rw.Status())
 		require.Contains(t, rw.Buffer().String(), "context deadline exceeded")
 
+		// just let the reissuing goroutine some time to replace certs.
+		time.Sleep(10 * time.Millisecond)
+
 		// but certificate still was reissued.
 		certs, err := km.OverwriteClientCerts(req)
 		require.NoError(t, err)
 		require.Len(t, certs, 1)
-		require.Equal(t, newCert, certs[0])
+		require.Equal(t, newCert, certs[0], "certificate was not reissued")
 	})
 
 	testCases := []struct {

--- a/lib/teleterm/gateway/kube.go
+++ b/lib/teleterm/gateway/kube.go
@@ -131,8 +131,9 @@ func (k *kube) makeKubeMiddleware() (alpnproxy.LocalProxyHTTPMiddleware, error) 
 			cert, err := k.cfg.OnExpiredCert(ctx, k)
 			return cert, trace.Wrap(err)
 		},
-		Clock:  k.cfg.Clock,
-		Logger: k.cfg.Log,
+		Clock:   k.cfg.Clock,
+		Logger:  k.cfg.Log,
+		Context: k.closeContext,
 	}), nil
 }
 

--- a/lib/teleterm/gateway/kube.go
+++ b/lib/teleterm/gateway/kube.go
@@ -131,9 +131,9 @@ func (k *kube) makeKubeMiddleware() (alpnproxy.LocalProxyHTTPMiddleware, error) 
 			cert, err := k.cfg.OnExpiredCert(ctx, k)
 			return cert, trace.Wrap(err)
 		},
-		Clock:   k.cfg.Clock,
-		Logger:  k.cfg.Log,
-		Context: k.closeContext,
+		Clock:        k.cfg.Clock,
+		Logger:       k.cfg.Log,
+		CloseContext: k.closeContext,
 	}), nil
 }
 

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -342,6 +342,7 @@ func makeKubeLocalProxy(cf *CLIConf, tc *client.TeleportClient, clusters kubecon
 		CertReissuer: kubeProxy.getCertReissuer(tc),
 		Headless:     cf.Headless,
 		Logger:       log,
+		Context:      cf.Context,
 	})
 
 	localProxy, err := alpnproxy.NewLocalProxy(

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -342,7 +342,7 @@ func makeKubeLocalProxy(cf *CLIConf, tc *client.TeleportClient, clusters kubecon
 		CertReissuer: kubeProxy.getCertReissuer(tc),
 		Headless:     cf.Headless,
 		Logger:       log,
-		Context:      cf.Context,
+		CloseContext: cf.Context,
 	})
 
 	localProxy, err := alpnproxy.NewLocalProxy(


### PR DESCRIPTION
Backport #43374 to branch/v16

changelog: Wait for user MFA input when reissuing expired certificates for a kube proxy.
