### PR TITLE
[v14] Fix wrong context usage for reissuing expired certificate for tsh proxy kube.

### DIFF
--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -570,6 +570,7 @@ func mustCreateKubeLocalProxyMiddleware(t *testing.T, teleportCluster, kubeClust
 		CertReissuer: func(ctx context.Context, teleportCluster, kubeCluster string) (tls.Certificate, error) {
 			return tls.Certificate{}, nil
 		},
+		CloseContext: context.Background(),
 	})
 }
 

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -502,8 +502,51 @@ func TestKubeMiddleware(t *testing.T) {
 	)
 
 	certReissuer = func(ctx context.Context, teleportCluster, kubeCluster string) (tls.Certificate, error) {
-		return newCert, nil
+		select {
+		case <-ctx.Done():
+			return tls.Certificate{}, ctx.Err()
+		default:
+			return newCert, nil
+		}
 	}
+
+	t.Run("expired certificate is still reissued if request context expires", func(t *testing.T) {
+		req := &http.Request{
+			TLS: &tls.ConnectionState{
+				ServerName: "kube1",
+			},
+		}
+		// we set request context to a context that will expired immediately.
+		reqCtx, cancel := context.WithDeadline(context.Background(), time.Now())
+		defer cancel()
+		req = req.WithContext(reqCtx)
+
+		km := NewKubeMiddleware(KubeMiddlewareConfig{
+			Certs:        KubeClientCerts{"kube1": kube1Cert},
+			CertReissuer: certReissuer,
+			Clock:        clockwork.NewFakeClockAt(now.Add(time.Hour * 2)),
+			CloseContext: context.Background(),
+		})
+		err := km.CheckAndSetDefaults()
+		require.NoError(t, err)
+
+		rw := responsewriters.NewMemoryResponseWriter()
+		// HandleRequest will reissue certificate if needed.
+		km.HandleRequest(rw, req)
+
+		// request timed out.
+		require.Equal(t, http.StatusInternalServerError, rw.Status())
+		require.Contains(t, rw.Buffer().String(), "context deadline exceeded")
+
+		// just let the reissuing goroutine some time to replace certs.
+		time.Sleep(10 * time.Millisecond)
+
+		// but certificate still was reissued.
+		certs, err := km.OverwriteClientCerts(req)
+		require.NoError(t, err)
+		require.Len(t, certs, 1)
+		require.Equal(t, newCert, certs[0], "certificate was not reissued")
+	})
 
 	testCases := []struct {
 		name            string
@@ -557,6 +600,7 @@ func TestKubeMiddleware(t *testing.T) {
 				Certs:        tt.startCerts,
 				CertReissuer: certReissuer,
 				Clock:        tt.clock,
+				CloseContext: context.Background(),
 			})
 
 			// HandleRequest will reissue certificate if needed

--- a/lib/teleterm/gateway/kube.go
+++ b/lib/teleterm/gateway/kube.go
@@ -142,6 +142,7 @@ func (k *kube) makeKubeMiddleware() (alpnproxy.LocalProxyHTTPMiddleware, error) 
 		CertReissuer: certReissuer.reissueCert,
 		Clock:        k.cfg.Clock,
 		Logger:       k.cfg.Log,
+		CloseContext: k.closeContext,
 	}), nil
 }
 

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -339,6 +339,7 @@ func makeKubeLocalProxy(cf *CLIConf, tc *client.TeleportClient, clusters kubecon
 		CertReissuer: kubeProxy.getCertReissuer(tc),
 		Headless:     cf.Headless,
 		Logger:       log,
+		CloseContext: cf.Context,
 	})
 
 	localProxy, err := alpnproxy.NewLocalProxy(


### PR DESCRIPTION
Backport #43374 to branch/v14

Manual backport because of a phantom conflict on neighbouring lines.

changelog: Wait for user MFA input when reissuing expired certificates for a kube proxy.
