### PR TITLE
load EnvironmentFile for standalone and ha auth

### DIFF
--- a/assets/aws/files/system/teleport-auth.service
+++ b/assets/aws/files/system/teleport-auth.service
@@ -10,6 +10,7 @@ Type=simple
 Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
+EnvironmentFile=/etc/teleport.d/conf
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
 # systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"

--- a/assets/aws/files/system/teleport.service
+++ b/assets/aws/files/system/teleport.service
@@ -10,6 +10,7 @@ Type=simple
 Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
+EnvironmentFile=/etc/teleport.d/conf
 ExecStartPre=/usr/local/bin/teleport-all-pre-start
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
 # systemd before 239 needs an absolute path


### PR DESCRIPTION
`/etc/teleport.d/conf` can be set by user data for custom environment variables, but only the `teleport-proxy.service` and `teleport-proxy-acm.service` units loaded this. This allows those same custom env vars to be seen by `teleport-auth.service` and `teleport.service`.