### PR TITLE
Add /etc/default/teleport as EnvironmentFile to Teleport AMIs

### DIFF
--- a/assets/aws/files/system/teleport-acm.service
+++ b/assets/aws/files/system/teleport-acm.service
@@ -10,6 +10,7 @@ Type=simple
 Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
+EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
 # systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"

--- a/assets/aws/files/system/teleport-auth.service
+++ b/assets/aws/files/system/teleport-auth.service
@@ -10,6 +10,7 @@ Type=simple
 Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
+EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
 # systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"

--- a/assets/aws/files/system/teleport-proxy-acm.service
+++ b/assets/aws/files/system/teleport-proxy-acm.service
@@ -10,6 +10,8 @@ Type=simple
 Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
+EnvironmentFile=-/etc/default/teleport
+# TODO(gus): REMOVE IN 17.0.0 - /etc/default/teleport should be used instead
 EnvironmentFile=/etc/teleport.d/conf
 ExecStartPre=/usr/local/bin/teleport-ssm-get-token
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid

--- a/assets/aws/files/system/teleport-proxy.service
+++ b/assets/aws/files/system/teleport-proxy.service
@@ -10,6 +10,8 @@ Type=simple
 Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
+EnvironmentFile=-/etc/default/teleport
+# TODO(gus): REMOVE IN 17.0.0 - /etc/default/teleport should be used instead
 EnvironmentFile=/etc/teleport.d/conf
 ExecStartPre=/usr/local/bin/teleport-ssm-get-token
 ExecStartPre=/bin/aws s3 sync s3://${TELEPORT_S3_BUCKET}/live/${TELEPORT_DOMAIN_NAME} /var/lib/teleport

--- a/assets/aws/files/system/teleport.service
+++ b/assets/aws/files/system/teleport.service
@@ -10,6 +10,7 @@ Type=simple
 Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
+EnvironmentFile=-/etc/default/teleport
 ExecStartPre=/usr/local/bin/teleport-all-pre-start
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
 # systemd before 239 needs an absolute path


### PR DESCRIPTION
All Teleport unit files in AMIs should load environment variable overrides from `/etc/default/teleport` in the same way as regular Teleport package installations.

Updates #43616

changelog: Teleport AMIs now optionally source environment variables from `/etc/default/teleport` as regular Teleport package installations do.