### PR TITLE
Reword "Preview" admonition in Workload Identity documentation to remove Production warning.

### DIFF
--- a/docs/pages/machine-id/workload-identity.mdx
+++ b/docs/pages/machine-id/workload-identity.mdx
@@ -5,8 +5,9 @@ description: Describes Teleport Workload Identity, which issues flexible, short-
 
 <Admonition type="tip" title="Preview">
 Teleport Workload Identity is currently in Preview. This means that some
-features may be missing. We are actively working on improving the Workload
-Identity and would love to [hear your feedback](mailto:product@goteleport.com).
+features may be missing. We're actively looking for design partners to help us
+shape the future of Workload Identity and would love to
+[hear your feedback](mailto:product@goteleport.com).
 </Admonition>
 
 Teleport's Workload Identity issues flexible short-lived identities intended

--- a/docs/pages/machine-id/workload-identity.mdx
+++ b/docs/pages/machine-id/workload-identity.mdx
@@ -4,9 +4,9 @@ description: Describes Teleport Workload Identity, which issues flexible, short-
 ---
 
 <Admonition type="tip" title="Preview">
-Teleport Workload Identity is currently in Preview. We are actively working on
-improving the feature and would love to [hear your feedback](mailto:product@goteleport.com).
-We currently do not recommend using this feature in production.
+Teleport Workload Identity is currently in Preview. This means that some
+features may be missing. We are actively working on improving the Workload
+Identity and would love to [hear your feedback](mailto:product@goteleport.com).
 </Admonition>
 
 Teleport's Workload Identity issues flexible short-lived identities intended

--- a/docs/pages/machine-id/workload-identity/aws-roles-anywhere.mdx
+++ b/docs/pages/machine-id/workload-identity/aws-roles-anywhere.mdx
@@ -3,6 +3,13 @@ title: Configuring Workload ID and AWS Roles Anywhere
 description: Configuring AWS to accept Workload ID certificates as authentication using AWS Roles Anywhere
 ---
 
+<Admonition type="tip" title="Preview">
+Teleport Workload Identity is currently in Preview. This means that some
+features may be missing. We're actively looking for design partners to help us
+shape the future of Workload Identity and would love to
+[hear your feedback](mailto:product@goteleport.com).
+</Admonition>
+
 Teleport Workload Identity issues flexible short-lived identities in X.509
 certificates. AWS Roles Anywhere allows you to use these certificates to
 authenticate to AWS services.

--- a/docs/pages/machine-id/workload-identity/best-practices.mdx
+++ b/docs/pages/machine-id/workload-identity/best-practices.mdx
@@ -3,6 +3,13 @@ title: Best Practices for Teleport Workload Identity
 description: Answers common questions and describes best practices for using Teleport Workload Identity in production.
 ---
 
+<Admonition type="tip" title="Preview">
+Teleport Workload Identity is currently in Preview. This means that some
+features may be missing. We're actively looking for design partners to help us
+shape the future of Workload Identity and would love to
+[hear your feedback](mailto:product@goteleport.com).
+</Admonition>
+
 This page covers common questions and best practices for using Teleport's
 Workload Identity feature in production.
 

--- a/docs/pages/machine-id/workload-identity/getting-started.mdx
+++ b/docs/pages/machine-id/workload-identity/getting-started.mdx
@@ -5,8 +5,9 @@ description: Getting started with Teleport Workload Identity for SPIFFE and Mach
 
 <Admonition type="tip" title="Preview">
 Teleport Workload Identity is currently in Preview. This means that some
-features may be missing. We are actively working on improving the Workload
-Identity and would love to [hear your feedback](mailto:product@goteleport.com).
+features may be missing. We're actively looking for design partners to help us
+shape the future of Workload Identity and would love to
+[hear your feedback](mailto:product@goteleport.com).
 </Admonition>
 
 Teleport's Workload Identity issues flexible short-lived identities intended

--- a/docs/pages/machine-id/workload-identity/getting-started.mdx
+++ b/docs/pages/machine-id/workload-identity/getting-started.mdx
@@ -4,9 +4,9 @@ description: Getting started with Teleport Workload Identity for SPIFFE and Mach
 ---
 
 <Admonition type="tip" title="Preview">
-Teleport Workload Identity is currently in Preview. We are actively working on
-improving the feature and would love to [hear your feedback](mailto:product@goteleport.com).
-We currently do not recommend using this feature in production.
+Teleport Workload Identity is currently in Preview. This means that some
+features may be missing. We are actively working on improving the Workload
+Identity and would love to [hear your feedback](mailto:product@goteleport.com).
 </Admonition>
 
 Teleport's Workload Identity issues flexible short-lived identities intended

--- a/docs/pages/machine-id/workload-identity/tsh.mdx
+++ b/docs/pages/machine-id/workload-identity/tsh.mdx
@@ -4,9 +4,9 @@ description: Issuing SPIFFE SVIDs using Workload Identity and tsh
 ---
 
 <Admonition type="tip" title="Preview">
-Teleport Workload Identity is currently in Preview. We are actively working on
-improving the feature and would love to [hear your feedback](mailto:product@goteleport.com).
-We currently do not recommend using this feature in production.
+Teleport Workload Identity is currently in Preview. This means that some
+features may be missing. We are actively working on improving the Workload
+Identity and would love to [hear your feedback](mailto:product@goteleport.com).
 </Admonition>
 
 In some scenarios, you may wish to issue a SPIFFE SVID manually, without using

--- a/docs/pages/machine-id/workload-identity/tsh.mdx
+++ b/docs/pages/machine-id/workload-identity/tsh.mdx
@@ -5,8 +5,9 @@ description: Issuing SPIFFE SVIDs using Workload Identity and tsh
 
 <Admonition type="tip" title="Preview">
 Teleport Workload Identity is currently in Preview. This means that some
-features may be missing. We are actively working on improving the Workload
-Identity and would love to [hear your feedback](mailto:product@goteleport.com).
+features may be missing. We're actively looking for design partners to help us
+shape the future of Workload Identity and would love to
+[hear your feedback](mailto:product@goteleport.com).
 </Admonition>
 
 In some scenarios, you may wish to issue a SPIFFE SVID manually, without using


### PR DESCRIPTION
When we initially released the feature, we went with a rather foreboding warning of "We currently do not recommend using this feature in production" - this was because we initially didn't have significant evidence of stability. Since the release, we've run Workload Identity on a number of platforms for extended periods, and I'm now happy that stability/reliability is not a concern.

Whilst Workload Identity may not have enough features to be considered out of preview yet, I do think it's worth removing this warning as it could be discouraging adoption - which is what we need to continue improving the product.