### PR TITLE
[v16] kube: resolve Kubernetes cluster domain

### DIFF
--- a/docs/pages/reference/helm-reference/includes/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/includes/zz_generated.teleport-kube-agent.mdx
@@ -199,6 +199,17 @@ Once `appResources` is set, you can dynamically register application with
 `tsh` by following [the Dynamic App Registration guide](../../../application-access/guides/dynamic-registration.mdx).
 </Admonition>
 
+## `clusterDomain`
+
+| Type | Default |
+|------|---------|
+| `string` | `"cluster.local"` |
+
+`clusterDomain` sets the domain name used by the Kubernetes cluster. This value is used to build the
+FQDN application URIs. For example, if the cluster domain is `anything.local`, the agent will proxy the application
+`myapp` running in the `default` namespace at `http://myapp.default.svc.anything.local`. You must manually set this value
+to match your cluster domain if it is different from the default value `cluster.local`.
+
 ## `awsDatabases`
 
 | Type | Default |

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -141,6 +141,10 @@ spec:
         - name: TELEPORT_EXT_UPGRADER_VERSION
           value: {{ include "teleport-kube-agent.version" . }}
         {{- end }}
+        {{- if .Values.clusterDomain }}
+        - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+          value: {{ .Values.clusterDomain | quote }}
+        {{- end }}
         {{- if (gt (len .Values.extraEnv) 0) }}
           {{- toYaml .Values.extraEnv | nindent 8 }}
         {{- end }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -30,6 +30,8 @@ sets Deployment annotations when specified if action is Upgrade:
             env:
             - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
               value: "true"
+            - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+              value: cluster.local
             image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
             imagePullPolicy: IfNotPresent
             livenessProbe:
@@ -105,6 +107,8 @@ sets Deployment labels when specified if action is Upgrade:
           env:
           - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
             value: "true"
+          - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+            value: cluster.local
           image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -167,6 +171,8 @@ sets Pod annotations when specified if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -229,6 +235,8 @@ sets Pod labels when specified if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -312,6 +320,8 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -375,6 +385,8 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -437,6 +449,8 @@ should correctly configure existingDataVolume when set if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -497,6 +511,8 @@ should expose diag port if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -571,6 +587,8 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -645,6 +663,8 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -707,6 +727,8 @@ should have one replica when replicaCount is not set if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -769,6 +791,8 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -836,6 +860,8 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf an
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -904,6 +930,8 @@ should mount jamfCredentialsSecret.name when role is jamf and action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -972,6 +1000,8 @@ should mount tls.existingCASecretName and set environment when set in values if 
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
@@ -1042,6 +1072,8 @@ should mount tls.existingCASecretName and set extra environment when set in valu
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
@@ -1114,6 +1146,8 @@ should provision initContainer correctly when set in values if action is Upgrade
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1234,6 +1268,8 @@ should set affinity when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1296,6 +1332,8 @@ should set default serviceAccountName when not set in values if action is Upgrad
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1369,6 +1407,8 @@ should set environment when extraEnv set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
@@ -1433,6 +1473,8 @@ should set image and tag correctly if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:12.2.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1495,6 +1537,8 @@ should set imagePullPolicy when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: Always
       livenessProbe:
@@ -1557,6 +1601,8 @@ should set nodeSelector if set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1621,6 +1667,8 @@ should set not set priorityClassName when not set in values if action is Upgrade
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1695,6 +1743,8 @@ should set preferred affinity when more than one replica is used if action is Up
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1757,6 +1807,8 @@ should set priorityClassName when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1820,6 +1872,8 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1892,6 +1946,8 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1954,6 +2010,8 @@ should set resources when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -2023,6 +2081,8 @@ should set serviceAccountName when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -2085,6 +2145,8 @@ should set tolerations when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.3
       imagePullPolicy: IfNotPresent
       livenessProbe:

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -163,6 +163,12 @@ apps: []
 # </Admonition>
 appResources: []
 
+# clusterDomain(string) -- sets the domain name used by the Kubernetes cluster. This value is used to build the
+# FQDN application URIs. For example, if the cluster domain is `anything.local`, the agent will proxy the application
+# `myapp` running in the `default` namespace at `http://myapp.default.svc.anything.local`. You must manually set this value
+# to match your cluster domain if it is different from the default value `cluster.local`.
+clusterDomain: "cluster.local"
+
 ################################################################
 # Values that must be provided if Database access is enabled.
 ################################################################

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -22,7 +22,9 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
+	"sync"
 
 	"github.com/gravitational/trace"
 	corev1 "k8s.io/api/core/v1"
@@ -162,7 +164,7 @@ func UnmarshalAppServer(data []byte, opts ...MarshalOption) (types.AppServer, er
 // It transforms service fields and annotations into appropriate Teleport app fields.
 // Service labels are copied to app labels.
 func NewApplicationFromKubeService(service corev1.Service, clusterName, protocol string, port corev1.ServicePort) (types.Application, error) {
-	appURI := buildAppURI(protocol, getServiceFQDN(service), port.Port)
+	appURI := buildAppURI(protocol, GetServiceFQDN(service), port.Port)
 
 	rewriteConfig, err := getAppRewriteConfig(service.GetAnnotations())
 	if err != nil {
@@ -196,14 +198,15 @@ func NewApplicationFromKubeService(service corev1.Service, clusterName, protocol
 	return app, nil
 }
 
-func getServiceFQDN(s corev1.Service) string {
+// GetServiceFQDN returns the fully qualified domain name for the service.
+func GetServiceFQDN(service corev1.Service) string {
 	// If service type is ExternalName it points to external DNS name, to keep correct
 	// HOST for HTTP requests we return already final external DNS name.
 	// https://kubernetes.io/docs/concepts/services-networking/service/#externalname
-	if s.Spec.Type == corev1.ServiceTypeExternalName {
-		return s.Spec.ExternalName
+	if service.Spec.Type == corev1.ServiceTypeExternalName {
+		return service.Spec.ExternalName
 	}
-	return fmt.Sprintf("%s.%s.svc.cluster.local", s.GetName(), s.GetNamespace())
+	return fmt.Sprintf("%s.%s.svc.%s", service.GetName(), service.GetNamespace(), clusterDomainResolver())
 }
 
 func buildAppURI(protocol, serviceFQDN string, port int32) string {
@@ -273,4 +276,24 @@ func getAppLabels(serviceLabels map[string]string, clusterName string) (map[stri
 	result[types.KubernetesClusterLabel] = clusterName
 
 	return result, nil
+}
+
+var (
+	// clusterDomainResolver is a function that resolves the cluster domain once and caches the result.
+	// It's used to lazily resolve the cluster domain from the env var "TELEPORT_KUBE_CLUSTER_DOMAIN" or fallback to
+	// a default value.
+	// It's only used when agent is running in the Kubernetes cluster.
+	clusterDomainResolver = sync.OnceValue[string](getClusterDomain)
+)
+
+const (
+	// teleportKubeClusterDomain is the environment variable that specifies the cluster domain.
+	teleportKubeClusterDomain = "TELEPORT_KUBE_CLUSTER_DOMAIN"
+)
+
+func getClusterDomain() string {
+	if envDomain := os.Getenv(teleportKubeClusterDomain); envDomain != "" {
+		return envDomain
+	}
+	return "cluster.local"
 }

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -192,7 +192,7 @@ func (f *KubeAppFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, er
 				case protoHTTPS, protoHTTP, protoTCP:
 					portProtocols[port] = protocolAnnotation
 				default:
-					if p := autoProtocolDetection(getServiceFQDN(service), port, f.ProtocolChecker); p != protoTCP {
+					if p := autoProtocolDetection(services.GetServiceFQDN(service), port, f.ProtocolChecker); p != protoTCP {
 						portProtocols[port] = p
 					}
 				}
@@ -272,16 +272,6 @@ func autoProtocolDetection(serviceFQDN string, port v1.ServicePort, pc ProtocolC
 	}
 
 	return protoTCP
-}
-
-func getServiceFQDN(s v1.Service) string {
-	// If service type is ExternalName it points to external DNS name, to keep correct
-	// HOST for HTTP requests we return already final external DNS name.
-	// https://kubernetes.io/docs/concepts/services-networking/service/#externalname
-	if s.Spec.Type == v1.ServiceTypeExternalName {
-		return s.Spec.ExternalName
-	}
-	return fmt.Sprintf("%s.%s.svc.cluster.local", s.GetName(), s.GetNamespace())
 }
 
 // ProtocolChecker is an interface used to check what protocol uri serves


### PR DESCRIPTION
Backport of #43584 to branch/v16


Changelog: Extend Teleport ability to use non-default cluster domains in Kubernetes, avoiding the assumption of `cluster.local`.