### PR TITLE
[v14] Fix incorrect link in scaling docs

### DIFF
--- a/docs/pages/management/operations/scaling.mdx
+++ b/docs/pages/management/operations/scaling.mdx
@@ -14,7 +14,7 @@ self-hosted deployments of Teleport.
 
 ## Hardware recommendations
 
-Set up Teleport with a [High Availability configuration](../../reference/backends.mdx).
+Set up Teleport with a [High Availability configuration](../../deploy-a-cluster/high-availability.mdx).
 
 | Scenario                                                              | Max Recommended Count | Proxy Service         | Auth Service          | AWS Instance Types |
 |-----------------------------------------------------------------------|-----------------------|-----------------------|-----------------------|--------------------|


### PR DESCRIPTION
Backport #43570 to branch/v14