### PR TITLE
[v14] Add AppArmor profile for Connect

### DIFF
--- a/web/packages/teleterm/build_resources/linux/after-install.tpl
+++ b/web/packages/teleterm/build_resources/linux/after-install.tpl
@@ -64,17 +64,31 @@ else
   fi
 fi
 
-APPARMOR_PROFILE_DEST="/etc/apparmor.d/teleport-connect"
+APPARMOR_PROFILE_SOURCE="$APP/resources/apparmor-profile"
+APPARMOR_PROFILE_TARGET="/etc/apparmor.d/teleport-connect"
 
 # Install apparmor profile.
-if [ -d "/etc/apparmor.d" ]; then
-  cp -f "$APP/resources/apparmor-profile" "$APPARMOR_PROFILE_DEST"
+# First check if the version of AppArmor running on the device supports our profile.
+# This is in order to keep backwards compatibility with Ubuntu 22.04 which does not support abi/4.0.
+# In that case, we just skip installing the profile since the app runs fine without it on 22.04.
+#
+# Those apparmor_parser flags are akin to performing a dry run of loading a profile.
+# https://wiki.debian.org/AppArmor/HowToUse#Dumping_profiles
+#
+# Unfortunately, at the moment AppArmor doesn't have a good story for backwards compatibility.
+# https://askubuntu.com/questions/1517272/writing-a-backwards-compatible-apparmor-profile
+if test -d "/etc/apparmor.d"; then
+  if apparmor_parser --skip-kernel-load --debug "$APPARMOR_PROFILE_SOURCE" > /dev/null 2>&1; then
+    cp -f "$APPARMOR_PROFILE_SOURCE" "$APPARMOR_PROFILE_TARGET"
 
-  if hash apparmor_parser 2>/dev/null; then
-    # Extra flags taken from dh_apparmor:
-    # > By using '-W -T' we ensure that any abstraction updates are also pulled in.
-    # https://wiki.debian.org/AppArmor/Contribute/FirstTimeProfileImport
-    apparmor_parser --replace --write-cache --skip-read-cache "$APPARMOR_PROFILE_DEST"
+    if hash apparmor_parser 2>/dev/null; then
+      # Extra flags taken from dh_apparmor:
+      # > By using '-W -T' we ensure that any abstraction updates are also pulled in.
+      # https://wiki.debian.org/AppArmor/Contribute/FirstTimeProfileImport
+      apparmor_parser --replace --write-cache --skip-read-cache "$APPARMOR_PROFILE_TARGET"
+    fi
+  else
+    echo "Skipping the installation of the AppArmor profile as this version of AppArmor does not seem to support the profile bundled with Teleport Connect."
   fi
 fi
 

--- a/web/packages/teleterm/build_resources/linux/after-install.tpl
+++ b/web/packages/teleterm/build_resources/linux/after-install.tpl
@@ -64,4 +64,18 @@ else
   fi
 fi
 
+APPARMOR_PROFILE_DEST="/etc/apparmor.d/teleport-connect"
+
+# Install apparmor profile.
+if [ -d "/etc/apparmor.d" ]; then
+  cp -f "$APP/resources/apparmor-profile" "$APPARMOR_PROFILE_DEST"
+
+  if hash apparmor_parser 2>/dev/null; then
+    # Extra flags taken from dh_apparmor:
+    # > By using '-W -T' we ensure that any abstraction updates are also pulled in.
+    # https://wiki.debian.org/AppArmor/Contribute/FirstTimeProfileImport
+    apparmor_parser --replace --write-cache --skip-read-cache "$APPARMOR_PROFILE_DEST"
+  fi
+fi
+
 # vim: syntax=sh

--- a/web/packages/teleterm/build_resources/linux/after-remove.tpl
+++ b/web/packages/teleterm/build_resources/linux/after-remove.tpl
@@ -46,4 +46,11 @@ if [ -L "$TSH_SYMLINK_TARGET" ] && [ ! -e "$TSH_SYMLINK_TARGET" ]; then
   rm -f "$TSH_SYMLINK_TARGET"
 fi
 
+APPARMOR_PROFILE_DEST="/etc/apparmor.d/teleport-connect"
+
+# Remove apparmor profile.
+if [ -f "$APPARMOR_PROFILE_DEST" ]; then
+  rm -f "$APPARMOR_PROFILE_DEST"
+fi
+
 # vim: syntax=sh

--- a/web/packages/teleterm/build_resources/linux/apparmor-profile
+++ b/web/packages/teleterm/build_resources/linux/apparmor-profile
@@ -1,0 +1,9 @@
+abi <abi/4.0>,
+include <tunables/global>
+
+profile teleport-connect /opt/Teleport\ Connect/teleport-connect flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/teleport-connect>
+}

--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -204,6 +204,10 @@ module.exports = {
         from: env.CONNECT_TSH_BIN_PATH,
         to: './bin/tsh',
       },
+      {
+        from: 'build_resources/linux/apparmor-profile',
+        to: './apparmor-profile',
+      },
     ].filter(Boolean),
   },
   directories: {


### PR DESCRIPTION
Backport #43595 to branch/v14

changelog: Fixed startup crash of Teleport Connect on Ubuntu 24.04 by adding an AppArmor profile
