### PR TITLE
[v14] Machine ID: Render kubernetes template without exec plugin when using non-directory destination

### DIFF
--- a/lib/tbot/bot/destination.go
+++ b/lib/tbot/bot/destination.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package bot
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // Destination can persist renewable certificates.
 type Destination interface {
@@ -51,4 +54,8 @@ type Destination interface {
 	// MarshalYAML enables the yaml package to correctly marshal the Destination
 	// as YAML including the type header.
 	MarshalYAML() (interface{}, error)
+
+	// Stringer so that Destination's implements fmt.Stringer which allows for
+	// better logging.
+	fmt.Stringer
 }

--- a/lib/tbot/config/template_kubernetes.go
+++ b/lib/tbot/config/template_kubernetes.go
@@ -202,7 +202,7 @@ func (t *templateKubernetes) render(
 	destinationDir, isDirectoryDest := destination.(*DestinationDirectory)
 	if !t.disableExecPlugin {
 		if !isDirectoryDest {
-			log.WarnContext(ctx, "Kubernetes template will be rendered without exec plugin because destination is not a directory. Explicitly set `disable_exec_plugin: true` in the output to suppress this message")
+			log.InfoContext(ctx, "Kubernetes template will be rendered without exec plugin because destination is not a directory. Explicitly set `disable_exec_plugin: true` in the output to suppress this message")
 			t.disableExecPlugin = true
 		}
 	}

--- a/lib/tbot/config/template_kubernetes.go
+++ b/lib/tbot/config/template_kubernetes.go
@@ -199,6 +199,14 @@ func (t *templateKubernetes) render(
 		kubernetesClusterName: t.clusterName,
 	}
 
+	destinationDir, isDirectoryDest := destination.(*DestinationDirectory)
+	if !t.disableExecPlugin {
+		if !isDirectoryDest {
+			log.WarnContext(ctx, "Kubernetes template will be rendered without exec plugin because destination is not a directory. Explicitly set `disable_exec_plugin: true` in the output to suppress this message")
+			t.disableExecPlugin = true
+		}
+	}
+
 	var cfg *clientcmdapi.Config
 	if t.disableExecPlugin {
 		// If they've disabled the exec plugin, we just write the credentials
@@ -214,14 +222,6 @@ func (t *templateKubernetes) render(
 		// We only support directory mode for this since the exec plugin needs
 		// to know the path to read the credentials from, and this is
 		// unpredictable with other types of destination.
-		destinationDir, ok := destination.(*DestinationDirectory)
-		if !ok {
-			return trace.BadParameter(
-				"Destination %s must be a directory in exec plugin mode",
-				destination,
-			)
-		}
-
 		executablePath, err := t.executablePathGetter()
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/tbot/config/template_kubernetes.go
+++ b/lib/tbot/config/template_kubernetes.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 const defaultKubeconfigPath = "kubeconfig.yaml"
@@ -199,14 +200,22 @@ func (t *templateKubernetes) render(
 		kubernetesClusterName: t.clusterName,
 	}
 
+	// In exec plugin mode, we write the credentials to disk and write a
+	// kubeconfig that execs `tbot` to load those credentials.
+
+	// We only support directory mode for this since the exec plugin needs
+	// to know the path to read the credentials from, and this is
+	// unpredictable with other types of destination.
 	destinationDir, isDirectoryDest := destination.(*DestinationDirectory)
 	if !t.disableExecPlugin {
 		if !isDirectoryDest {
-			log.InfoContext(ctx, "Kubernetes template will be rendered without exec plugin because destination is not a directory. Explicitly set `disable_exec_plugin: true` in the output to suppress this message", "destination", destination)
+			log.InfoContext(
+				ctx,
+				"Kubernetes template will be rendered without exec plugin because destination is not a directory. Explicitly set `disable_exec_plugin: true` in the output to suppress this message",
+				"destination", logutils.StringerAttr(destination))
 			t.disableExecPlugin = true
 		}
 	}
-
 	var cfg *clientcmdapi.Config
 	if t.disableExecPlugin {
 		// If they've disabled the exec plugin, we just write the credentials
@@ -216,12 +225,6 @@ func (t *templateKubernetes) render(
 			return trace.Wrap(err)
 		}
 	} else {
-		// In exec plugin mode, we write the credentials to disk and write a
-		// kubeconfig that execs `tbot` to load those credentials.
-
-		// We only support directory mode for this since the exec plugin needs
-		// to know the path to read the credentials from, and this is
-		// unpredictable with other types of destination.
 		executablePath, err := t.executablePathGetter()
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/tbot/config/template_kubernetes.go
+++ b/lib/tbot/config/template_kubernetes.go
@@ -202,7 +202,7 @@ func (t *templateKubernetes) render(
 	destinationDir, isDirectoryDest := destination.(*DestinationDirectory)
 	if !t.disableExecPlugin {
 		if !isDirectoryDest {
-			log.InfoContext(ctx, "Kubernetes template will be rendered without exec plugin because destination is not a directory. Explicitly set `disable_exec_plugin: true` in the output to suppress this message")
+			log.InfoContext(ctx, "Kubernetes template will be rendered without exec plugin because destination is not a directory. Explicitly set `disable_exec_plugin: true` in the output to suppress this message", "destination", destination)
 			t.disableExecPlugin = true
 		}
 	}


### PR DESCRIPTION
Backport #43401 to branch/v14

changelog: Machine ID defaults to disabling the use of the Kubernetes exec plugin when writing a Kubeconfig to a directory destination. This removes the need to manually configure `disable_exec_plugin`.
