### PR TITLE
Add example scripts for creating self-hosted Redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,8 @@ web/certs/
 
 # Files produced by tests
 *.avi
+
+# Files produced by examples/self-hosted-databases scripts
+examples/self-hosted-databases/**/*.cas
+examples/self-hosted-databases/**/*.key
+examples/self-hosted-databases/**/*.crt

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,3 +33,8 @@
 ### Trusted Cluster
 * [Trusted Cluster Resource](https://github.com/gravitational/teleport/blob/master/examples/resources/trusted_cluster.yaml)
 * [Trusted Cluster Resource - With RBAC (Enterprise Only)](https://github.com/gravitational/teleport/blob/master/examples/resources/trusted_cluster_enterprise.yaml)
+
+### Configure Self-hosted Database Examples
+
+* [Self-hosted Redis (single instance)](https://github.com/gravitational/teleport/blob/master/examples/self-hosted-databases/redis-single)
+* [Self-hosted Redis (cluster setup)](https://github.com/gravitational/teleport/blob/master/examples/self-hosted-databases/redis-cluster/)

--- a/examples/self-hosted-databases/redis-cluster/Makefile
+++ b/examples/self-hosted-databases/redis-cluster/Makefile
@@ -1,0 +1,30 @@
+self-signed:
+	openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout self-signed.key -out self-signed.crt -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP.1:127.0.0.1" -addext "extendedKeyUsage = serverAuth, clientAuth"
+
+init: self-signed
+	cp self-signed.crt node.crt
+	cp self-signed.key node.key
+	cp self-signed.crt node.cas
+	tctl auth export --type db-client >> node.cas
+	chmod a+r node*
+up:
+	docker-compose up -d
+down:
+	docker-compose down
+
+dump:
+	@printf "%s\n" \
+      'db_service:' \
+      '  enabled: "yes"' \
+      '  databases:' \
+      '  - name: "self-hosted-redis-cluster"' \
+      '    protocol: "redis"'\
+      '    uri: "rediss://127.0.0.1:17000?mode=cluster"' \
+      '    tls:' \
+      '      ca_cert_file: $(CURDIR)/self-signed.crt' \
+      '    static_labels: ' \
+	  '      "env": "teleport-examples" '
+
+.PHONY: clean
+clean: down
+	rm -rf node*.crt node*.cas node*.key

--- a/examples/self-hosted-databases/redis-cluster/Makefile
+++ b/examples/self-hosted-databases/redis-cluster/Makefile
@@ -1,10 +1,17 @@
 self-signed:
+	# This example uses openssl to generate a "shared" cert for all Redis
+	# nodes.
+	#
+	# In production, a cert should be generated per Redis node and signed by
+	# the same CA. Here is a blog post on that:
+	# https://medium.com/@ozcankasal/setting-up-a-redis-cluster-with-tls-e02d53d9faa7
 	openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout self-signed.key -out self-signed.crt -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP.1:127.0.0.1" -addext "extendedKeyUsage = serverAuth, clientAuth"
 
 init: self-signed
 	cp self-signed.crt node.crt
 	cp self-signed.key node.key
 	cp self-signed.crt node.cas
+	# IMPORTANT! Export Teleport database client CA for Redis to trust.
 	tctl auth export --type db-client >> node.cas
 	chmod a+r node*
 up:
@@ -13,6 +20,8 @@ down:
 	docker-compose down
 
 dump:
+	# IMPORTANT! Teleport must trust the self-signed cert through
+	# `ca_cert_file`.
 	@printf "%s\n" \
       'db_service:' \
       '  enabled: "yes"' \

--- a/examples/self-hosted-databases/redis-cluster/README.md
+++ b/examples/self-hosted-databases/redis-cluster/README.md
@@ -1,0 +1,62 @@
+# Redis cluster
+
+The make script manages a Redis cluster using `docker-compose` on the same host
+of the database service.
+
+The Redis servers use self-signed certficates for internal communications and
+incoming client connections.
+
+It is assumed that you already have a running Teleport cluster, a running
+database service, and approriate roles for database access.
+
+It is assumed that `tctl` can be run either with a logged in `tsh` profile or
+has direct access to Teleport Auth through `/etc/teleport.yaml`.
+
+The script was tested on Amazon Linux and MacOS.
+
+## To setup
+1. `make init` to generate self-hosted certs and export Teleport database client CA.
+1. `make up` to launch the docker containers with `docker-compose`.
+1. `make dump` to see a sample database definition. Add this to your database service.
+
+## To connect
+```bash
+$ tsh db connect self-hosted-redis-cluster
+localhost:65120> auth teleport
+OK
+localhost:65120> set name "self-hosted-cluster"
+OK
+localhost:65120> 
+
+$ tsh db connect --db-user alice self-hosted-redis-cluster
+localhost:65137> auth alice f7ca53a40f56ec7ff6a235d9136431c6104a1769eed13d18a2d68f388325f305
+OK
+localhost:65137> get name
+"self-hosted-cluster"
+localhost:65137> get a
+(nil)
+localhost:65137> get b
+(nil)
+localhost:65137> 
+```
+
+Note `teleport` is the password for the default user, `alice`'s password is
+shown as above. `users.acl` contains the sha256 hash of `alice`'s password.
+
+## To teardown
+`make clean`
+
+## Sample Teleport role
+
+```yaml
+kind: role
+version: v5
+metadata:
+  name: redis-access
+spec:
+  allow:
+    db_labels:
+      env: ["teleport-examples"]
+
+    db_users: ["default", "alice"]
+```

--- a/examples/self-hosted-databases/redis-cluster/README.md
+++ b/examples/self-hosted-databases/redis-cluster/README.md
@@ -1,13 +1,14 @@
 # Redis cluster
 
 The make script manages a Redis cluster using `docker-compose` on the same host
-of the database service.
+of the Database service.
 
 The Redis servers use self-signed certficates for internal communications and
-incoming client connections.
+incoming client connections. mTLS is configured on both Redis and Teleport side
+to trust each other's CA.
 
 It is assumed that you already have a running Teleport cluster, a running
-database service, and approriate roles for database access.
+Database service, and approriate roles for database access.
 
 It is assumed that `tctl` can be run either with a logged in `tsh` profile or
 has direct access to Teleport Auth through `/etc/teleport.yaml`.
@@ -17,7 +18,7 @@ The script was tested on Amazon Linux and MacOS.
 ## To setup
 1. `make init` to generate self-hosted certs and export Teleport database client CA.
 1. `make up` to launch the docker containers with `docker-compose`.
-1. `make dump` to see a sample database definition. Add this to your database service.
+1. `make dump` to see a sample database definition. Add this to your Database service.
 
 ## To connect
 ```bash

--- a/examples/self-hosted-databases/redis-cluster/docker-compose.yml
+++ b/examples/self-hosted-databases/redis-cluster/docker-compose.yml
@@ -1,0 +1,85 @@
+services:
+  redis-node-0:
+    image: redis:7.0
+    volumes:
+      - "./:/opt/redis"
+    command: ["redis-server", "/opt/redis/redis.conf", "--tls-port", "17000"]
+    ports:
+      - '17000:17000'
+      - '17001:17001'
+      - '17002:17002'
+      - '17003:17003'
+      - '17004:17004'
+      - '17005:17005'
+
+  redis-node-1:
+    image: redis:7.0
+    volumes:
+      - "./:/opt/redis"
+    command: ["redis-server", "/opt/redis/redis.conf", "--tls-port", "17001", "--port", "0"]
+    network_mode: "service:redis-node-0"
+
+  redis-node-2:
+    image: redis:7.0
+    volumes:
+      - "./:/opt/redis"
+    command: ["redis-server", "/opt/redis/redis.conf", "--tls-port", "17002", "--port", "0"]
+    network_mode: "service:redis-node-0"
+
+  redis-node-3:
+    image: redis:7.0
+    volumes:
+      - "./:/opt/redis"
+    command: ["redis-server", "/opt/redis/redis.conf", "--tls-port", "17003", "--port", "0"]
+    network_mode: "service:redis-node-0"
+
+  redis-node-4:
+    image: redis:7.0
+    volumes:
+      - "./:/opt/redis"
+    command: ["redis-server", "/opt/redis/redis.conf", "--tls-port", "17004", "--port", "0"]
+    network_mode: "service:redis-node-0"
+
+  redis-node-5:
+    image: redis:7.0
+    volumes:
+      - "./:/opt/redis"
+    command: ["redis-server", "/opt/redis/redis.conf", "--tls-port", "17005", "--port", "0"]
+    network_mode: "service:redis-node-0"
+
+  redis-cluster:
+    image: redis:7.0
+    volumes:
+      - "./:/opt/redis"
+    network_mode: "service:redis-node-0"
+    command:
+      - "redis-cli"
+      - "--cluster"
+      - "create"
+      - "127.0.0.1:17000"
+      - "127.0.0.1:17001"
+      - "127.0.0.1:17002"
+      - "127.0.0.1:17003"
+      - "127.0.0.1:17004"
+      - "127.0.0.1:17005"
+      - "--cluster-replicas"
+      - "1"
+      - "--cluster-yes"
+      - "--user"
+      - "alice"
+      - "--pass"
+      - "f7ca53a40f56ec7ff6a235d9136431c6104a1769eed13d18a2d68f388325f305"
+      - "--tls"
+      - "--cacert"
+      - "/opt/redis/node.cas"
+      - "--key"
+      - "/opt/redis/node.key"
+      - "--cert"
+      - "/opt/redis/node.crt"
+    depends_on:
+      - redis-node-0
+      - redis-node-1
+      - redis-node-2
+      - redis-node-3
+      - redis-node-4
+      - redis-node-5

--- a/examples/self-hosted-databases/redis-cluster/redis.conf
+++ b/examples/self-hosted-databases/redis-cluster/redis.conf
@@ -1,0 +1,10 @@
+cluster-enabled yes
+tls-replication yes
+tls-cluster yes
+aclfile /opt/redis/users.acl
+masterauth replica-user-password
+masteruser replica-user
+tls-cert-file /opt/redis/node.crt
+tls-key-file /opt/redis/node.key
+tls-ca-cert-file /opt/redis/node.cas
+tls-protocols "TLSv1.2 TLSv1.3"

--- a/examples/self-hosted-databases/redis-cluster/users.acl
+++ b/examples/self-hosted-databases/redis-cluster/users.acl
@@ -1,0 +1,2 @@
+user default on >teleport allcommands allkeys
+user alice on #1e224a37b85835463f66a36b127c3743a6d25d138e65ad7bc60d4e4805da4d3e allcommands allkeys

--- a/examples/self-hosted-databases/redis-single/Makefile
+++ b/examples/self-hosted-databases/redis-single/Makefile
@@ -1,0 +1,23 @@
+init:
+	tctl auth sign --format=redis --host=localhost --out=single --ttl=2190h
+	chmod a+r single*
+up:
+	docker run -d --name redis -v $(PWD):/opt/redis -p 6379:6379 redis:7.0 redis-server /opt/redis/single.conf
+
+down:
+	docker rm -f redis
+
+dump:
+	@printf "%s\n" \
+      'db_service:' \
+      '  enabled: "yes"' \
+      '  databases:' \
+      '  - name: "self-hosted-redis"' \
+      '    protocol: "redis"'\
+      '    uri: "localhost:6379"' \
+      '    static_labels: ' \
+	  '      "env": "teleport-examples" '
+
+.PHONY: clean
+clean: down
+	rm -rf single*.crt single*.cas single*.key

--- a/examples/self-hosted-databases/redis-single/README.md
+++ b/examples/self-hosted-databases/redis-single/README.md
@@ -1,10 +1,10 @@
 # Redis single instance
 
 The make script manages a single Redis instance in a docker container on the
-same host of the database service.
+same host of the Database service.
 
 It is assumed that you already have a running Teleport cluster, a running
-database service, and approriate roles for database access.
+Database service, and approriate roles for database access.
 
 It is assumed that `tctl` can be run either with a logged in `tsh` profile or
 has direct access to Teleport Auth through `/etc/teleport.yaml`.
@@ -14,7 +14,7 @@ The script was tested on Amazon Linux and MacOS.
 ## To setup
 1. `make init` to generate Teleport database certs.
 1. `make up` to launch the docker container.
-1. `make dump` to see a sample database definition. Add this to your database service.
+1. `make dump` to see a sample database definition. Add this to your Database service.
 
 ## To connect
 ```bash

--- a/examples/self-hosted-databases/redis-single/README.md
+++ b/examples/self-hosted-databases/redis-single/README.md
@@ -1,0 +1,55 @@
+# Redis single instance
+
+The make script manages a single Redis instance in a docker container on the
+same host of the database service.
+
+It is assumed that you already have a running Teleport cluster, a running
+database service, and approriate roles for database access.
+
+It is assumed that `tctl` can be run either with a logged in `tsh` profile or
+has direct access to Teleport Auth through `/etc/teleport.yaml`.
+
+The script was tested on Amazon Linux and MacOS.
+
+## To setup
+1. `make init` to generate Teleport database certs.
+1. `make up` to launch the docker container.
+1. `make dump` to see a sample database definition. Add this to your database service.
+
+## To connect
+```bash
+$ tsh db connect self-hosted-redis 
+localhost:63152> auth teleport
+OK
+localhost:63152> set name "self-hosted-redis"
+OK
+localhost:63152>
+
+$ tsh db connect --db-user alice self-hosted-redis
+localhost:63458> auth alice f7ca53a40f56ec7ff6a235d9136431c6104a1769eed13d18a2d68f388325f305
+OK
+localhost:63458> get name
+"self-hosted-redis"
+localhost:63458>
+```
+
+Note `teleport` is the password for the default user, `alice`'s password is
+shown as above. `users.acl` contains the sha256 hash of `alice`'s password.
+
+## To teardown
+`make clean`
+
+## Sample Teleport role
+
+```yaml
+kind: role
+version: v5
+metadata:
+  name: redis-access
+spec:
+  allow:
+    db_labels:
+      env: ["teleport-examples"]
+
+    db_users: ["default", "alice"]
+```

--- a/examples/self-hosted-databases/redis-single/single.conf
+++ b/examples/self-hosted-databases/redis-single/single.conf
@@ -1,0 +1,7 @@
+tls-port 6379
+port 0
+aclfile /opt/redis/users.acl
+tls-ca-cert-file /opt/redis/single.cas
+tls-cert-file /opt/redis/single.crt
+tls-key-file /opt/redis/single.key
+tls-protocols "TLSv1.2 TLSv1.3"

--- a/examples/self-hosted-databases/redis-single/users.acl
+++ b/examples/self-hosted-databases/redis-single/users.acl
@@ -1,0 +1,2 @@
+user default on >teleport allcommands allkeys
+user alice on #1e224a37b85835463f66a36b127c3743a6d25d138e65ad7bc60d4e4805da4d3e allcommands allkeys


### PR DESCRIPTION
Sample scripts to set up self-hosted databases. I use these scripts for release testing.