### PR TITLE
[v14] docs: updates to networking reference

### DIFF
--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -69,7 +69,7 @@ environment variables when running Teleport. You can also optionally set the
 specified hosts/netmasks/ports.
 
 By default, Teleport installations based on package managers (such as `apt` and
-`yum`) configure The `teleport` systemd unit to read environment variables from
+`yum`) configure the `teleport` systemd unit to read environment variables from
 the file `/etc/default/teleport`. 
 
 To configure HTTP CONNECT tunneling, you can assign these environment variables
@@ -109,7 +109,7 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
   type="warning"
   title="Note"
 >
-  The proxy service also respects `HTTPS_PROXY` and `HTTP_PROXY` when connecting to a local kubernetes cluster, which may not work. To fix this, add `kube.teleport.cluster.local` to `NO_PROXY`.
+  The Proxy Service also respects `HTTPS_PROXY` and `HTTP_PROXY` when connecting to a local Kubernetes cluster, which may not work. To fix this, add `kube.teleport.cluster.local` to `NO_PROXY`.
 </Admonition>
 
 ## Ports


### PR DESCRIPTION
backport #https://github.com/gravitational/teleport/pull/43578 to branch/v14