### PR TITLE
docs: remove tsh recording exports

### DIFF
--- a/docs/pages/desktop-access/reference/sessions.mdx
+++ b/docs/pages/desktop-access/reference/sessions.mdx
@@ -64,8 +64,18 @@ desktop icon in the first column to distinguish them from SSH recordings.
 
 ![Desktop Session Recording](../../../img/desktop-access/session-recording@2x.png)
 
-Click the play button to open the player in a new tab. To export desktop session
-recordings to video for playback outside of Teleport, use the
+Click the play button to open the player in a new tab.
+
+<Admonition
+  type="warning"
+  title="Note"
+>
+  Exported desktop session recordings are only currently available
+  for v14 Desktop Service agents. Desktop session recordings from v15+
+  are only available via the Web UI for playback.
+</Admonition>
+
+ To export desktop session recordings to video for playback outside of Teleport, use the
 `tsh recordings export` command:
 
 ```code

--- a/docs/pages/desktop-access/reference/sessions.mdx
+++ b/docs/pages/desktop-access/reference/sessions.mdx
@@ -66,28 +66,6 @@ desktop icon in the first column to distinguish them from SSH recordings.
 
 Click the play button to open the player in a new tab.
 
-<Admonition
-  type="warning"
-  title="Note"
->
-  Exported desktop session recordings are only currently available
-  for v14 Desktop Service agents. Desktop session recordings from v15+
-  are only available via the Web UI for playback.
-</Admonition>
-
- To export desktop session recordings to video for playback outside of Teleport, use the
-`tsh recordings export` command:
-
-```code
-$ tsh recordings export <SESSION_ID>
-```
-
-Note: video encoding is done client-side to avoid consuming server resources.
-
-<Admonition type="tip" title="Listing recordings">
-Use `tsh recordings ls` to list available recordings.
-</Admonition>
-
 ## Storage
 
 Be aware, desktop session recordings save PNGs of changing sections of the

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -837,27 +837,6 @@ $ tsh puttyconfig --leaf example.teleport.sh ec2-user@leaf-node
 
 See [full docs on `tsh puttyconfig` here](../../connect-your-client/putty-winscp.mdx).
 
-## tsh recordings export
-
-Export recorded desktop sessions to video.
-
-```code
-$ tsh recordings export <session_id> [<flags>]
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--out` | `<session_id>.avi` | a filename | Override the output file name. |
-
-### Examples
-
-```code
-$ tsh recordings export c8e1b2c5-322a-4095-89e3-391edfd2da9b --out=recording.avi
-wrote recording to recording.avi
-```
-
 ## tsh recordings ls
 
 List recorded sessions.


### PR DESCRIPTION
This is no longer applicable for v15+.