### PR TITLE
Web: Process SAML IdP service provider preset value in Apps type

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/types.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/types.ts
@@ -69,7 +69,8 @@ export enum KubeLocation {
   Aws,
 }
 
-/** SamlServiceProviderPreset defines SAML service provider preset types.
+/**
+ * SamlServiceProviderPreset defines SAML service provider preset types.
  * Used to define custom or pre-defined configuration flow.
  */
 export enum SamlServiceProviderPreset {

--- a/web/packages/teleport/src/services/apps/apps.test.ts
+++ b/web/packages/teleport/src/services/apps/apps.test.ts
@@ -47,6 +47,7 @@ test('correct formatting of apps fetch response', async () => {
         userGroups: [],
         samlApp: false,
         samlAppSsoUrl: '',
+        samlAppPreset: 'unspecified',
         integration: '',
       },
       {
@@ -68,6 +69,7 @@ test('correct formatting of apps fetch response', async () => {
         userGroups: [],
         samlApp: false,
         samlAppSsoUrl: '',
+        samlAppPreset: 'unspecified',
         integration: '',
       },
       {
@@ -89,6 +91,7 @@ test('correct formatting of apps fetch response', async () => {
         userGroups: [],
         samlApp: false,
         samlAppSsoUrl: '',
+        samlAppPreset: 'unspecified',
         integration: '',
       },
       {
@@ -110,6 +113,7 @@ test('correct formatting of apps fetch response', async () => {
         userGroups: [],
         samlApp: true,
         samlAppSsoUrl: 'http://localhost/enterprise/saml-idp/login/saml-app',
+        samlAppPreset: 'gcp-workforce',
         integration: '',
       },
     ],
@@ -168,6 +172,7 @@ const mockResponse = {
       name: 'saml-app',
       description: 'SAML Application',
       samlApp: true,
+      samlAppPreset: 'gcp-workforce',
     },
   ],
   startKey: 'mockKey',

--- a/web/packages/teleport/src/services/apps/apps.test.ts
+++ b/web/packages/teleport/src/services/apps/apps.test.ts
@@ -47,7 +47,6 @@ test('correct formatting of apps fetch response', async () => {
         userGroups: [],
         samlApp: false,
         samlAppSsoUrl: '',
-        samlAppPreset: 'unspecified',
         integration: '',
       },
       {
@@ -69,7 +68,6 @@ test('correct formatting of apps fetch response', async () => {
         userGroups: [],
         samlApp: false,
         samlAppSsoUrl: '',
-        samlAppPreset: 'unspecified',
         integration: '',
       },
       {
@@ -91,7 +89,6 @@ test('correct formatting of apps fetch response', async () => {
         userGroups: [],
         samlApp: false,
         samlAppSsoUrl: '',
-        samlAppPreset: 'unspecified',
         integration: '',
       },
       {

--- a/web/packages/teleport/src/services/apps/makeApps.ts
+++ b/web/packages/teleport/src/services/apps/makeApps.ts
@@ -20,6 +20,8 @@ import { AwsRole } from 'shared/services/apps';
 
 import cfg from 'teleport/config';
 
+import { SamlServiceProviderPreset } from 'teleport/Discover/SelectResource/types';
+
 import { App } from './types';
 
 export default function makeApp(json: any): App {
@@ -65,6 +67,9 @@ export default function makeApp(json: any): App {
   if (samlApp) {
     samlAppSsoUrl = `${cfg.baseUrl}/enterprise/saml-idp/login/${name}`;
   }
+  const samlAppPreset = json.samlAppPreset
+    ? json.samlAppPreset
+    : SamlServiceProviderPreset.Unspecified;
 
   return {
     kind: 'app',
@@ -84,6 +89,7 @@ export default function makeApp(json: any): App {
     friendlyName,
     userGroups,
     samlApp,
+    samlAppPreset,
     samlAppSsoUrl,
     requiresRequest,
     integration,

--- a/web/packages/teleport/src/services/apps/makeApps.ts
+++ b/web/packages/teleport/src/services/apps/makeApps.ts
@@ -20,8 +20,6 @@ import { AwsRole } from 'shared/services/apps';
 
 import cfg from 'teleport/config';
 
-import { SamlServiceProviderPreset } from 'teleport/Discover/SelectResource/types';
-
 import { App } from './types';
 
 export default function makeApp(json: any): App {
@@ -38,6 +36,7 @@ export default function makeApp(json: any): App {
     friendlyName = '',
     requiresRequest,
     integration = '',
+    samlAppPreset,
   } = json;
 
   const canCreateUrl = fqdn && clusterId && publicAddr;
@@ -67,9 +66,6 @@ export default function makeApp(json: any): App {
   if (samlApp) {
     samlAppSsoUrl = `${cfg.baseUrl}/enterprise/saml-idp/login/${name}`;
   }
-  const samlAppPreset = json.samlAppPreset
-    ? json.samlAppPreset
-    : SamlServiceProviderPreset.Unspecified;
 
   return {
     kind: 'app',

--- a/web/packages/teleport/src/services/apps/types.ts
+++ b/web/packages/teleport/src/services/apps/types.ts
@@ -20,6 +20,8 @@ import { AwsRole } from 'shared/services/apps';
 
 import { ResourceLabel } from 'teleport/services/agents';
 
+import type { SamlServiceProviderPreset } from 'teleport/Discover/SelectResource/types';
+
 export interface App {
   kind: 'app';
   id: string;
@@ -44,6 +46,8 @@ export interface App {
   samlApp: boolean;
   // samlAppSsoUrl is the URL that triggers IdP-initiated SSO for SAML Application;
   samlAppSsoUrl?: string;
+  // samlAppPreset is used to identify SAML service provider preset type.
+  samlAppPreset?: SamlServiceProviderPreset;
   // Integration is the integration name that must be used to access this Application.
   // Only applicable to AWS App Access.
   integration?: string;


### PR DESCRIPTION
In the unified resource response, the SAML app response now includes SAML IdP service provider preset type - https://github.com/gravitational/teleport/pull/43446

This PR updates the frontend `App` interface and `makeApps` function to process incoming `samlAppPreset` value. 

This PR just handles the value but actual usage will be added in subsequent PRs for  SAML app update flow.


Part of - https://github.com/gravitational/teleport.e/issues/4458