### PR TITLE
Add launch daemon plist for VNet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -803,7 +803,7 @@ test-helm-update-snapshots: helmunit/installed
 # Runs all Go tests except integration, called by CI/CD.
 #
 .PHONY: test-go
-test-go: test-go-prepare test-go-unit test-go-touch-id test-go-tsh test-go-chaos
+test-go: test-go-prepare test-go-unit test-go-touch-id test-go-vnet-daemon test-go-tsh test-go-chaos
 
 #
 # Runs a test to ensure no environment variable leak into build binaries.
@@ -855,6 +855,17 @@ test-go-touch-id: FLAGS ?= -race -shuffle on
 test-go-touch-id: SUBJECT ?= ./lib/auth/touchid/...
 test-go-touch-id:
 ifneq ("$(TOUCHID_TAG)", "")
+	$(CGOFLAG) go test -cover -json $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
+		| tee $(TEST_LOG_DIR)/unit.json \
+		| gotestsum --raw-command -- cat
+endif
+
+# Make sure untagged vnetdaemon code build/tests.
+.PHONY: test-go-vnet-daemon
+test-go-vnet-daemon: FLAGS ?= -race -shuffle on
+test-go-vnet-daemon: SUBJECT ?= ./lib/vnet/daemon/...
+test-go-vnet-daemon:
+ifneq ("$(VNETDAEMON_TAG)", "")
 	$(CGOFLAG) go test -cover -json $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
 		| tee $(TEST_LOG_DIR)/unit.json \
 		| gotestsum --raw-command -- cat

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,15 @@ TOUCHID_MESSAGE := with-Touch-ID
 TOUCHID_TAG := touchid
 endif
 
+# Enable VNet daemon?
+# With VNETDAEMON=yes, tsh uses a Launch Daemon to start VNet.
+# This requires a signed and bundled tsh.
+VNETDAEMON_MESSAGE := without-VNet-daemon
+ifeq ("$(VNETDAEMON)", "yes")
+VNETDAEMON_MESSAGE := with-VNet-daemon
+VNETDAEMON_TAG := vnetdaemon
+endif
+
 # Enable PIV test packages for testing.
 # This test tag should never be used for builds/releases, only tests.
 PIV_TEST_TAG := pivtest
@@ -226,7 +235,7 @@ join-with = $(subst $(SPACE),$1,$(strip $2))
 
 # Separate TAG messages into comma-separated WITH and WITHOUT lists for readability.
 COMMA := ,
-MESSAGES := $(PAM_MESSAGE) $(FIPS_MESSAGE) $(BPF_MESSAGE) $(RDPCLIENT_MESSAGE) $(LIBFIDO2_MESSAGE) $(TOUCHID_MESSAGE) $(PIV_MESSAGE)
+MESSAGES := $(PAM_MESSAGE) $(FIPS_MESSAGE) $(BPF_MESSAGE) $(RDPCLIENT_MESSAGE) $(LIBFIDO2_MESSAGE) $(TOUCHID_MESSAGE) $(PIV_MESSAGE) $(VNETDAEMON_MESSAGE)
 WITH := $(subst -," ",$(call join-with,$(COMMA) ,$(subst with-,,$(filter with-%,$(MESSAGES)))))
 WITHOUT := $(subst -," ",$(call join-with,$(COMMA) ,$(subst without-,,$(filter without-%,$(MESSAGES)))))
 RELEASE_MESSAGE := "Building with GOOS=$(OS) GOARCH=$(ARCH) REPRODUCIBLE=$(REPRODUCIBLE) and with $(WITH) and without $(WITHOUT)."
@@ -348,7 +357,7 @@ $(BUILDDIR)/tsh:
 	@if [[ -z "$(LIBFIDO2_BUILD_TAG)" ]]; then \
 		echo 'Warning: Building tsh without libfido2. Install libfido2 to have access to MFA.' >&2; \
 	fi
-	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG_TSH) go build -tags "$(FIPS_TAG) $(LIBFIDO2_BUILD_TAG) $(TOUCHID_TAG) $(PIV_BUILD_TAG) $(KUSTOMIZE_NO_DYNAMIC_PLUGIN)" -o $(BUILDDIR)/tsh $(BUILDFLAGS) ./tool/tsh
+	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG_TSH) go build -tags "$(FIPS_TAG) $(LIBFIDO2_BUILD_TAG) $(TOUCHID_TAG) $(PIV_BUILD_TAG) $(VNETDAEMON_TAG) $(KUSTOMIZE_NO_DYNAMIC_PLUGIN)" -o $(BUILDDIR)/tsh $(BUILDFLAGS) ./tool/tsh
 
 .PHONY: $(BUILDDIR)/tbot
 $(BUILDDIR)/tbot: CGO_ENABLED ?= 0
@@ -828,7 +837,7 @@ test-go-prepare: ensure-webassets bpf-bytecode $(TEST_LOG_DIR) ensure-gotestsum 
 test-go-unit: FLAGS ?= -race -shuffle on
 test-go-unit: SUBJECT ?= $(shell go list ./... | grep -vE 'teleport/(e2e|integration|tool/tsh|integrations/operator|integrations/access|integrations/lib)')
 test-go-unit:
-	$(CGOFLAG) go test -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
+	$(CGOFLAG) go test -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG) $(VNETDAEMON_TAG)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
 		| tee $(TEST_LOG_DIR)/unit.json \
 		| gotestsum --raw-command -- cat
 
@@ -856,7 +865,7 @@ endif
 test-go-tsh: FLAGS ?= -race -shuffle on
 test-go-tsh: SUBJECT ?= github.com/gravitational/teleport/tool/tsh/...
 test-go-tsh:
-	$(CGOFLAG_TSH) go test -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
+	$(CGOFLAG_TSH) go test -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG) $(VNETDAEMON_TAG)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
 		| tee $(TEST_LOG_DIR)/unit.json \
 		| gotestsum --raw-command -- cat
 
@@ -954,7 +963,7 @@ FLAKY_TOP_N ?= 20
 FLAKY_SUMMARY_FILE ?= /tmp/flaky-report.txt
 test-go-flaky: FLAGS ?= -race -shuffle on
 test-go-flaky: SUBJECT ?= $(shell go list ./... | grep -v -e e2e -e integration -e tool/tsh -e integrations/operator -e integrations/access -e integrations/lib )
-test-go-flaky: GO_BUILD_TAGS ?= $(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG) $(LIBFIDO2_TEST_TAG)
+test-go-flaky: GO_BUILD_TAGS ?= $(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG) $(LIBFIDO2_TEST_TAG) $(VNETDAEMON_TAG)
 test-go-flaky: RENDER_FLAGS ?= -report-by flakiness -summary-file $(FLAKY_SUMMARY_FILE) -top $(FLAKY_TOP_N)
 test-go-flaky: test-go-prepare $(RENDER_TESTS) $(RERUN)
 	$(CGOFLAG) $(RERUN) -n $(FLAKY_RUNS) -t $(FLAKY_TIMEOUT) \
@@ -1083,7 +1092,7 @@ endif
 .PHONY: lint-go
 lint-go: GO_LINT_FLAGS ?=
 lint-go:
-	golangci-lint run -c .golangci.yml --build-tags='$(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_LINT_TAG)' $(GO_LINT_FLAGS)
+	golangci-lint run -c .golangci.yml --build-tags='$(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_LINT_TAG) $(VNETDAEMON_TAG)' $(GO_LINT_FLAGS)
 	$(MAKE) -C integrations/terraform lint
 	$(MAKE) -C integrations/event-handler lint
 

--- a/build.assets/macos/tsh/tsh.app/Contents/Library/LaunchDaemons/com.gravitational.teleport.tsh.vnetd.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Library/LaunchDaemons/com.gravitational.teleport.tsh.vnetd.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.gravitational.teleport.tsh.vnetd</string>
+	<key>BundleProgram</key>
+	<string>Contents/MacOS/tsh</string>
+  <key>ProgramArguments</key>
+  <array>
+      <string>tsh</string>
+      <string>vnet-daemon</string>
+  </array>
+	<key>MachServices</key>
+	<dict>
+    <key>com.gravitational.teleport.tsh.vnetd</key>
+		<true/>
+	</dict>
+  <key>StandardErrorPath</key>
+  <string>/var/log/vnet.log</string>
+  <key>StandardOutPath</key>
+  <string>/var/log/vnet.log</string>
+</dict>
+</plist>

--- a/build.assets/macos/tsh/tsh.app/Contents/Library/LaunchDaemons/com.gravitational.teleport.tsh.vnetd.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Library/LaunchDaemons/com.gravitational.teleport.tsh.vnetd.plist
@@ -6,19 +6,19 @@
 	<string>com.gravitational.teleport.tsh.vnetd</string>
 	<key>BundleProgram</key>
 	<string>Contents/MacOS/tsh</string>
-  <key>ProgramArguments</key>
-  <array>
-      <string>tsh</string>
-      <string>vnet-daemon</string>
-  </array>
+	<key>ProgramArguments</key>
+	<array>
+		<string>tsh</string>
+		<string>vnet-daemon</string>
+	</array>
 	<key>MachServices</key>
 	<dict>
-    <key>com.gravitational.teleport.tsh.vnetd</key>
+		<key>com.gravitational.teleport.tsh.vnetd</key>
 		<true/>
 	</dict>
-  <key>StandardErrorPath</key>
-  <string>/var/log/vnet.log</string>
-  <key>StandardOutPath</key>
-  <string>/var/log/vnet.log</string>
+	<key>StandardErrorPath</key>
+	<string>/var/log/vnet.log</string>
+	<key>StandardOutPath</key>
+	<string>/var/log/vnet.log</string>
 </dict>
 </plist>

--- a/build.assets/macos/tshdev/README.md
+++ b/build.assets/macos/tshdev/README.md
@@ -36,6 +36,8 @@ $skel/sign.sh tsh                  # sign tsh binary
 security find-identity -vp codesigning      # list codesign identities
 security cms -D -i /path/to/profile         # inspect provisioning profile
 codesign -d --entitlements /path/to/binary  # shows binary entitlements
+codesign --verify --verbose                 # verifies code signatures
+codesign -dv --verbose=4                    # verifies code signatures with verbose output
 
 # Extract plist and certificate from profile
 security cms -D -i /path/to/my.provisionprofile -o my.plist
@@ -79,3 +81,104 @@ through the steps here unless you are trying to recreate parts of the skeleton
 
     For example, click "build" and copy the app using "Product -> Show Build
     Folder in Finder".
+
+## Working with launch daemons
+
+tsh.app includes a launch daemon for VNet under `Contents/Library/LaunchDaemons`. tsh uses
+[`SMAppService`](https://developer.apple.com/documentation/servicemanagement/smappservice?language=objc)
+to register the daemon plist. Once the daemon is registered and is enabled under login items, it can
+be started by sending a message to the XPC service advertised under `MachServices` in plist. This is
+going to make launchd start the program listed under `BundleProgram`. Extra arguments are passed to
+the program are under `ProgramArguments`. See `man launchd.plist` for more details behind individual
+plist properties.
+
+### Recompiling daemon
+
+Once a login item is enabled, you are free to update the binary advertised under `BundleProgram` as
+much as you want. Just remember to sign it before calling the daemon.
+
+### Modifying plist
+
+The situation is more complicated for modifying the plist itself. In theory, macOS should pick up on
+any updates made to the plist. In practice, the mechanism for that seems to be spotty, especially on
+development machines where apps are being rebuilt many times:
+
+* [Unable to register loginItem via SMAppService - Status Error 78](https://developer.apple.com/forums/thread/726826)
+* [Login Item failing to launch with SMAppService. Error: 78, LastExitStatus: 19968](https://forums.developer.apple.com/forums/thread/727785)
+
+When working on a prototype of the launch daemon, we've ran into a situation where macOS
+aggressively cached information from plists. Despite `BundleProgram` being changed to another path,
+macOS did not picked up on that.
+
+To see how macOS interprets the plist, there are two helpful commands:
+
+To dump information from the database of Launch Services (search for the identifier of the bundle or
+the label of the XPC service):
+
+```
+sfltool dumpbtm
+```
+
+To see how launchd interprets the plist:
+
+```
+launchctl print system/com.goteleport.tshdev.vnetd
+```
+
+If you find that macOS doesn't have up to date info about the plist, then…
+
+### Refreshing cached plist information
+
+The method we had the most success with involves these steps:
+
+1. If you made any changes inside `tsh.app`, like modifying plists, make sure to stage those changes
+   in git first.
+1. Close system settings if they're open.
+1. Move `tsh.app` to the trash and then either empty the trash or delete that specific item from the
+   trash.
+1. Open Login Items in system settings.
+
+This forces the Launch Services database to get updated. After opening Login Items, you might be
+able to see the old login item for tsh.app for a split second after which it's removed from the
+list.
+
+This completely resets the state of the login item, meaning that the daemon will have to be
+registered and enabled again. Now restore deleted files from tsh.app in git and then rebuild and
+sign the app. Hopefully, this time macOS will pick up any new changes.
+
+If that doesn't work, as a last resort there's a **very destructive** `sfltool resetbtm`. This
+basically wipes the whole database of Launch Services, meaning that the status of all login items
+gets reset – this includes other software installed on your machine.
+
+After running it, you must restart the device. We found it to be the most helpful when switching
+between local signed builds and tag builds. For some reason, in that scenario macOS wouldn't want to
+launch the daemon with the following error:
+
+```
+2024-07-03 17:24:13.522640 (system/com.goteleport.tshdev.vnetd [70808]) <Warning>: Could not find and/or execute program specified by service: 3: No such process: Contents/MacOS/tsh
+2024-07-03 17:24:13.522662 (system/com.goteleport.tshdev.vnetd [70808]) <Error>: Service could not initialize: copy_bundle_path(<some binary data here>, ?pn-, 0, 0), error 0x6f - Invalid or missing Program/ProgramArguments
+```
+
+After resetting the db and restarting the device, everything seemed to be working again.
+
+### Daemon does not start
+
+List all jobs loaded into launchd. The second column is the status which you can then inspect.
+
+```
+$ sudo launchctl list | grep vnetd
+-   78   com.goteleport.tshdev.vnetd
+$ launchctl error 78
+78: Function not implemented
+```
+
+In that scenario, the `launchctl print` command above might return information that's of more use.
+Ultimately, you want to look at the logs from launchd – they seem to be the most helpful when
+debugging issues.
+
+```
+tail -f /var/log/com.apple.xpc.launchd/launchd.log
+```
+
+Capturing logs in Console.app might be useful too. However, the logs from launchd were sufficient
+for any debugging we had to do so far.

--- a/build.assets/macos/tshdev/README.md
+++ b/build.assets/macos/tshdev/README.md
@@ -36,8 +36,7 @@ $skel/sign.sh tsh                  # sign tsh binary
 security find-identity -vp codesigning      # list codesign identities
 security cms -D -i /path/to/profile         # inspect provisioning profile
 codesign -d --entitlements /path/to/binary  # shows binary entitlements
-codesign --verify --verbose                 # verifies code signatures
-codesign -dv --verbose=4                    # verifies code signatures with verbose output
+codesign -dv --verbose=4                    # verifies code signatures
 
 # Extract plist and certificate from profile
 security cms -D -i /path/to/my.provisionprofile -o my.plist

--- a/build.assets/macos/tshdev/README.md
+++ b/build.assets/macos/tshdev/README.md
@@ -91,6 +91,18 @@ going to make launchd start the program listed under `BundleProgram`. Extra argu
 the program are under `ProgramArguments`. See `man launchd.plist` for more details behind individual
 plist properties.
 
+When there's no login item for a daemon and an app attempts to register it for the first time, macOS
+shows a notification about it which says "tsh.app added items that can run in the background for all
+users. Do you want to allow this?". When working on a launch daemon, at some point macOS is going to
+stop showing the notification. In Console.app, you're going to see this:
+
+```
+Exceeded max notifications for tsh. Please file a Feedback report or contact the developer.
+item=uuid=4DF802A6-A9DE-4EF8-A6FB-4B046E50E1DE, name=tsh, type=daemon, disposition=[enabled,
+disallowed, visible, not notified], identifier=com.goteleport.tshdev.vnetd,
+url=Contents/Library/LaunchDaemons/com.goteleport.tshdev.vnetd.plist -- file:///
+```
+
 ### Recompiling daemon
 
 Once a login item is enabled, you are free to update the binary advertised under `BundleProgram` as

--- a/build.assets/macos/tshdev/tsh.app/Contents/Library/LaunchDaemons/com.goteleport.tshdev.vnetd.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Library/LaunchDaemons/com.goteleport.tshdev.vnetd.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.goteleport.tshdev.vnetd</string>
+	<key>BundleProgram</key>
+	<string>Contents/MacOS/tsh</string>
+  <key>ProgramArguments</key>
+  <array>
+      <string>tsh</string>
+      <string>vnet-daemon</string>
+  </array>
+	<key>MachServices</key>
+	<dict>
+    <key>com.goteleport.tshdev.vnetd</key>
+		<true/>
+	</dict>
+  <key>StandardErrorPath</key>
+  <string>/var/log/vnet.log</string>
+  <key>StandardOutPath</key>
+  <string>/var/log/vnet.log</string>
+</dict>
+</plist>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Library/LaunchDaemons/com.goteleport.tshdev.vnetd.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Library/LaunchDaemons/com.goteleport.tshdev.vnetd.plist
@@ -6,19 +6,19 @@
 	<string>com.goteleport.tshdev.vnetd</string>
 	<key>BundleProgram</key>
 	<string>Contents/MacOS/tsh</string>
-  <key>ProgramArguments</key>
-  <array>
-      <string>tsh</string>
-      <string>vnet-daemon</string>
-  </array>
+	<key>ProgramArguments</key>
+	<array>
+		<string>tsh</string>
+		<string>vnet-daemon</string>
+	</array>
 	<key>MachServices</key>
 	<dict>
-    <key>com.goteleport.tshdev.vnetd</key>
+		<key>com.goteleport.tshdev.vnetd</key>
 		<true/>
 	</dict>
-  <key>StandardErrorPath</key>
-  <string>/var/log/vnet.log</string>
-  <key>StandardOutPath</key>
-  <string>/var/log/vnet.log</string>
+	<key>StandardErrorPath</key>
+	<string>/var/log/vnet.log</string>
+	<key>StandardOutPath</key>
+	<string>/var/log/vnet.log</string>
 </dict>
 </plist>

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -94,16 +94,8 @@ func NormalizePath(path string, evaluateSymlinks bool) (string, error) {
 	if err != nil {
 		return "", trace.ConvertSystemError(err)
 	}
-
 	if evaluateSymlinks {
 		s, err = filepath.EvalSymlinks(s)
-		if err != nil {
-			return "", trace.ConvertSystemError(err)
-		}
-
-		// If the symlink is relative, filepath.EvalSymlinks returns a path relative to the current dir.
-		// Resolve it to an absolute path to stay true to the godoc.
-		s, err = filepath.Abs(s)
 		if err != nil {
 			return "", trace.ConvertSystemError(err)
 		}

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -94,8 +94,16 @@ func NormalizePath(path string, evaluateSymlinks bool) (string, error) {
 	if err != nil {
 		return "", trace.ConvertSystemError(err)
 	}
+
 	if evaluateSymlinks {
 		s, err = filepath.EvalSymlinks(s)
+		if err != nil {
+			return "", trace.ConvertSystemError(err)
+		}
+
+		// If the symlink is relative, filepath.EvalSymlinks returns a path relative to the current dir.
+		// Resolve it to an absolute path to stay true to the godoc.
+		s, err = filepath.Abs(s)
 		if err != nil {
 			return "", trace.ConvertSystemError(err)
 		}

--- a/lib/vnet/daemon/README.md
+++ b/lib/vnet/daemon/README.md
@@ -1,0 +1,14 @@
+# lib/vnet/daemon
+
+See [Working with launch
+daemons](../../../build.assets/macos/tshdev/README.md#working-with-launch-daemons) for general
+information on how to troubleshoot launch daemons.
+
+Useful resources:
+
+* https://developer.apple.com/documentation/xpc?language=objc
+* https://developer.apple.com/documentation/servicemanagement/smappservice?language=objc
+* https://www.objc.io/issues/14-mac/xpc/
+* https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/WorkingwithObjects/WorkingwithObjects.html
+* [Objective-C Memory Management for Swift Programmers](https://developer.apple.com/forums/thread/716261)
+* [XPC and App-to-App Communication](https://developer.apple.com/forums/thread/715338)

--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -18,6 +18,7 @@ package daemon
 
 // #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=10.15
 // #cgo LDFLAGS: -framework Foundation -framework ServiceManagement
+// #include <stdlib.h>
 // #include "client_darwin.h"
 import "C"
 

--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -157,10 +157,10 @@ type serviceStatus int
 
 // https://developer.apple.com/documentation/servicemanagement/smappservice/status-swift.enum?language=objc
 const (
-	serviceStatusNotRegistered serviceStatus = iota
-	serviceStatusEnabled
-	serviceStatusRequiresApproval
-	serviceStatusNotFound
+	serviceStatusNotRegistered    serviceStatus = 0
+	serviceStatusEnabled          serviceStatus = 1
+	serviceStatusRequiresApproval serviceStatus = 2
+	serviceStatusNotFound         serviceStatus = 3
 )
 
 func (s serviceStatus) String() string {

--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build darwin
-// +build darwin
-
 package daemon
 
 // #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=10.15

--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -1,0 +1,74 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build darwin
+// +build darwin
+
+package daemon
+
+// #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=10.15
+// #cgo LDFLAGS: -framework Foundation -framework ServiceManagement
+// #include "client_darwin.h"
+import "C"
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"unsafe"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
+)
+
+var log = logutils.NewPackageLogger(teleport.ComponentKey, "vnet:daemon")
+
+// Taken from manual for codesign.
+const codesignExitCodeVerificationFailed = 1
+
+func IsSigned(ctx context.Context) (bool, error) {
+	var result C.BundlePathResult
+	defer func() {
+		C.free(unsafe.Pointer(result.bundlePath))
+	}()
+	C.BundlePath(&result)
+
+	bundlePath := C.GoString(result.bundlePath)
+	if bundlePath == "" {
+		return false, nil
+	}
+
+	if err := exec.CommandContext(ctx, "codesign", "--verify", bundlePath).Run(); err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			log.DebugContext(ctx, "codesign --verify returned with non-zero exit code",
+				"exit_code", exitError.ExitCode(), "bundle_path", bundlePath)
+
+			if exitError.ExitCode() == codesignExitCodeVerificationFailed {
+				return false, nil
+			}
+
+			// Returning a custom error instead of wrapping err because err is just a cryptic "exit status 2".
+			return false, trace.Errorf("failed to check the signature of tsh, codesign returned with exit code %d", exitError.ExitCode())
+		}
+
+		return false, trace.Wrap(err, "failed to check the signature of tsh")
+	}
+
+	return true, nil
+}

--- a/lib/vnet/daemon/client_darwin.h
+++ b/lib/vnet/daemon/client_darwin.h
@@ -3,17 +3,6 @@
 
 #import <Foundation/Foundation.h>
 
-typedef struct BundlePathResult {
-  const char *bundlePath;
-} BundlePathResult;
-
-// BundlePath updates bundlePath of result with the path
-// to the bundle directory that contains the current executable.
-// bundlePath is an empty string if the bundle details could not be fetched.
-// It might return a path even for executables that are not in a bundle.
-// In that case, calling codesign --verify on that path will simply return with 1.
-void BundlePath(struct BundlePathResult *result);
-
 // Returns the label for the daemon by getting the identifier of the bundle
 // this executable is shipped in and appending ".vnetd" to it.
 //

--- a/lib/vnet/daemon/client_darwin.h
+++ b/lib/vnet/daemon/client_darwin.h
@@ -14,6 +14,32 @@ typedef struct BundlePathResult {
 // In that case, calling codesign --verify on that path will simply return with 1.
 void BundlePath(struct BundlePathResult *result);
 
+// Returns the label for the daemon by getting the identifier of the bundle
+// this executable is shipped in and appending ".vnetd" to it.
+//
+// The returned string might be empty if the executable is not in a bundle.
+//
+// The filename and the value of the Label key in the plist file and the Mach
+// service of of the daemon must match the string returned from this function.
+NSString * DaemonLabel(void);
+
+// DaemonPlist takes the result of DaemonLabel and appends ".plist" to it
+// if not empty.
+NSString * DaemonPlist(void);
+
+typedef struct RegisterDaemonResult {
+    bool ok;
+    // service_status is fetched even if [service registerAndReturnError] fails,
+    // for debugging purposes.
+    int service_status;
+    const char * error_description;
+} RegisterDaemonResult;
+
+// RegisterDaemon attempts to register the daemon. After the registration attempt,
+// it fetches the daemon status.
+// Pretty much a noop if the daemon is already registered and enabled.
+void RegisterDaemon(struct RegisterDaemonResult *result);
+
 // VNECopyNSString duplicates an NSString into an UTF-8 encoded C string.
 // The caller is expected to free the returned pointer.
 char *VNECopyNSString(NSString *val);

--- a/lib/vnet/daemon/client_darwin.h
+++ b/lib/vnet/daemon/client_darwin.h
@@ -4,7 +4,7 @@
 #import <Foundation/Foundation.h>
 
 typedef struct BundlePathResult {
-    const char * bundlePath;
+  const char *bundlePath;
 } BundlePathResult;
 
 // BundlePath updates bundlePath of result with the path
@@ -21,18 +21,18 @@ void BundlePath(struct BundlePathResult *result);
 //
 // The filename and the value of the Label key in the plist file and the Mach
 // service of of the daemon must match the string returned from this function.
-NSString * DaemonLabel(void);
+NSString *DaemonLabel(void);
 
 // DaemonPlist takes the result of DaemonLabel and appends ".plist" to it
 // if not empty.
-NSString * DaemonPlist(void);
+NSString *DaemonPlist(void);
 
 typedef struct RegisterDaemonResult {
-    bool ok;
-    // service_status is fetched even if [service registerAndReturnError] fails,
-    // for debugging purposes.
-    int service_status;
-    const char * error_description;
+  bool ok;
+  // service_status is fetched even if [service registerAndReturnError] fails,
+  // for debugging purposes.
+  int service_status;
+  const char *error_description;
 } RegisterDaemonResult;
 
 // RegisterDaemon attempts to register the daemon. After the registration attempt,

--- a/lib/vnet/daemon/client_darwin.h
+++ b/lib/vnet/daemon/client_darwin.h
@@ -1,20 +1,7 @@
-#ifndef client_darwin_h
-#define client_darwin_h
+#ifndef TELEPORT_LIB_VNET_DAEMON_CLIENT_DARWIN_H_
+#define TELEPORT_LIB_VNET_DAEMON_CLIENT_DARWIN_H_
 
 #import <Foundation/Foundation.h>
-
-// Returns the label for the daemon by getting the identifier of the bundle
-// this executable is shipped in and appending ".vnetd" to it.
-//
-// The returned string might be empty if the executable is not in a bundle.
-//
-// The filename and the value of the Label key in the plist file and the Mach
-// service of of the daemon must match the string returned from this function.
-NSString *DaemonLabel(void);
-
-// DaemonPlist takes the result of DaemonLabel and appends ".plist" to it
-// if not empty.
-NSString *DaemonPlist(void);
 
 typedef struct RegisterDaemonResult {
   bool ok;
@@ -27,16 +14,20 @@ typedef struct RegisterDaemonResult {
 // RegisterDaemon attempts to register the daemon. After the registration attempt,
 // it fetches the daemon status.
 // Pretty much a noop if the daemon is already registered and enabled.
-void RegisterDaemon(struct RegisterDaemonResult *result);
+//
+// The caller should check outResult.ok to see if the call succeeded.
+void RegisterDaemon(RegisterDaemonResult *outResult);
 
 // DaemonStatus returns the current status of the daemon's service in SMAppService.
 // Returns -1 if the given macOS version doesn't support SMAppService.
+// The rest of values directly corresponds to values from SMAppServiceStatus enum.
+// See client_darwin.go for a direct mapping.
+// https://developer.apple.com/documentation/servicemanagement/smappservice/status-swift.enum?language=objc
 int DaemonStatus(void);
 
+// OpenSystemSettingsLoginItems opens the Login Items section of system settings.
+// Should be used in conjunction with a message guiding the user towards enabling
+// the login item for the daemon.
 void OpenSystemSettingsLoginItems(void);
 
-// VNECopyNSString duplicates an NSString into an UTF-8 encoded C string.
-// The caller is expected to free the returned pointer.
-char *VNECopyNSString(NSString *val);
-
-#endif /* client_darwin_h */
+#endif /* TELEPORT_LIB_VNET_DAEMON_CLIENT_DARWIN_H_ */

--- a/lib/vnet/daemon/client_darwin.h
+++ b/lib/vnet/daemon/client_darwin.h
@@ -40,6 +40,12 @@ typedef struct RegisterDaemonResult {
 // Pretty much a noop if the daemon is already registered and enabled.
 void RegisterDaemon(struct RegisterDaemonResult *result);
 
+// DaemonStatus returns the current status of the daemon's service in SMAppService.
+// Returns -1 if the given macOS version doesn't support SMAppService.
+int DaemonStatus(void);
+
+void OpenSystemSettingsLoginItems(void);
+
 // VNECopyNSString duplicates an NSString into an UTF-8 encoded C string.
 // The caller is expected to free the returned pointer.
 char *VNECopyNSString(NSString *val);

--- a/lib/vnet/daemon/client_darwin.h
+++ b/lib/vnet/daemon/client_darwin.h
@@ -15,15 +15,19 @@ typedef struct RegisterDaemonResult {
 // it fetches the daemon status.
 // Pretty much a noop if the daemon is already registered and enabled.
 //
+// bundle_path must be an absolute path to the app bundle.
+//
 // The caller should check outResult.ok to see if the call succeeded.
-void RegisterDaemon(RegisterDaemonResult *outResult);
+void RegisterDaemon(const char *bundle_path, RegisterDaemonResult *outResult);
 
 // DaemonStatus returns the current status of the daemon's service in SMAppService.
 // Returns -1 if the given macOS version doesn't support SMAppService.
 // The rest of values directly corresponds to values from SMAppServiceStatus enum.
 // See client_darwin.go for a direct mapping.
 // https://developer.apple.com/documentation/servicemanagement/smappservice/status-swift.enum?language=objc
-int DaemonStatus(void);
+//
+// bundle_path must be an absolute path to the app bundle.
+int DaemonStatus(const char *bundle_path);
 
 // OpenSystemSettingsLoginItems opens the Login Items section of system settings.
 // Should be used in conjunction with a message guiding the user towards enabling

--- a/lib/vnet/daemon/client_darwin.h
+++ b/lib/vnet/daemon/client_darwin.h
@@ -1,0 +1,21 @@
+#ifndef client_darwin_h
+#define client_darwin_h
+
+#import <Foundation/Foundation.h>
+
+typedef struct BundlePathResult {
+    const char * bundlePath;
+} BundlePathResult;
+
+// BundlePath updates bundlePath of result with the path
+// to the bundle directory that contains the current executable.
+// bundlePath is an empty string if the bundle details could not be fetched.
+// It might return a path even for executables that are not in a bundle.
+// In that case, calling codesign --verify on that path will simply return with 1.
+void BundlePath(struct BundlePathResult *result);
+
+// VNECopyNSString duplicates an NSString into an UTF-8 encoded C string.
+// The caller is expected to free the returned pointer.
+char *VNECopyNSString(NSString *val);
+
+#endif /* client_darwin_h */

--- a/lib/vnet/daemon/client_darwin.m
+++ b/lib/vnet/daemon/client_darwin.m
@@ -19,9 +19,11 @@
 #import <Foundation/Foundation.h>
 #import <ServiceManagement/ServiceManagement.h>
 
+#include <string.h>
+
 // VNECopyNSString duplicates an NSString into an UTF-8 encoded C string.
 // The caller is expected to free the returned pointer.
-char *VNECopyNSString(NSString *val) {
+const char *VNECopyNSString(NSString *val) {
   if (val) {
     return strdup([val UTF8String]);
   }

--- a/lib/vnet/daemon/client_darwin.m
+++ b/lib/vnet/daemon/client_darwin.m
@@ -75,6 +75,22 @@ void RegisterDaemon(struct RegisterDaemonResult *result) {
     }
 }
 
+int DaemonStatus(void) {
+    if (@available(macOS 13, *)) {
+        SMAppService *service;
+        service = [SMAppService daemonServiceWithPlistName:(DaemonPlist())];
+        return (int) service.status;
+    } else {
+        return -1;
+    }
+}
+
+void OpenSystemSettingsLoginItems(void) {
+    if (@available(macOS 13, *)) {
+        [SMAppService openSystemSettingsLoginItems];
+    }
+}
+
 char *VNECopyNSString(NSString *val) {
     if (val) {
         return strdup([val UTF8String]);

--- a/lib/vnet/daemon/client_darwin.m
+++ b/lib/vnet/daemon/client_darwin.m
@@ -19,81 +19,81 @@
 #include "client_darwin.h"
 
 void BundlePath(struct BundlePathResult *result) {
-    // From the docs:
-    // > This method may return a valid bundle object even for unbundled apps.
-    // > It may also return nil if the bundle object could not be created,
-    // > so always check the return value.
-    NSBundle *main = [NSBundle mainBundle];
-    if (!main) {
-        result->bundlePath = strdup("");
-        return;
-    }
-    
-    result->bundlePath = VNECopyNSString([main bundlePath]);
+  // From the docs:
+  // > This method may return a valid bundle object even for unbundled apps.
+  // > It may also return nil if the bundle object could not be created,
+  // > so always check the return value.
+  NSBundle *main = [NSBundle mainBundle];
+  if (!main) {
+    result->bundlePath = strdup("");
+    return;
+  }
+
+  result->bundlePath = VNECopyNSString([main bundlePath]);
 }
 
-NSString * DaemonLabel(void) {
-    NSBundle *main = [NSBundle mainBundle];
-    if (!main) {
-        return @"";
-    }
-    
-    NSString *bundleIdentifier = [main bundleIdentifier];
-    if ([bundleIdentifier length] == 0) {
-        return bundleIdentifier;
-    }
-    
-    return [NSString stringWithFormat:@"%@.vnetd", bundleIdentifier];
+NSString *DaemonLabel(void) {
+  NSBundle *main = [NSBundle mainBundle];
+  if (!main) {
+    return @"";
+  }
+
+  NSString *bundleIdentifier = [main bundleIdentifier];
+  if ([bundleIdentifier length] == 0) {
+    return bundleIdentifier;
+  }
+
+  return [NSString stringWithFormat:@"%@.vnetd", bundleIdentifier];
 }
 
-NSString * DaemonPlist(void) {
-    NSString *label = DaemonLabel();
-    if ([label length] == 0) {
-        return label;
-    }
-    
-    return [NSString stringWithFormat:@"%@.plist", label];
+NSString *DaemonPlist(void) {
+  NSString *label = DaemonLabel();
+  if ([label length] == 0) {
+    return label;
+  }
+
+  return [NSString stringWithFormat:@"%@.plist", label];
 }
 
 void RegisterDaemon(struct RegisterDaemonResult *result) {
-    if (@available(macOS 13, *)) {
-        SMAppService *service;
-        NSError *error;
-        
-        service = [SMAppService daemonServiceWithPlistName:(DaemonPlist())];
-        
-        result->ok = [service registerAndReturnError:(&error)];
-        if (error) {
-            result->error_description = VNECopyNSString([error description]);
-        }
-        
-        // Grabbing the service status for debugging purposes, no matter if
-        // [service registerAndReturnError] succeeded or failed.
-        result->service_status = (int) service.status;
-    } else {
-        result->error_description = strdup("Service Management APIs are available on macOS 13.0+");
+  if (@available(macOS 13, *)) {
+    SMAppService *service;
+    NSError *error;
+
+    service = [SMAppService daemonServiceWithPlistName:(DaemonPlist())];
+
+    result->ok = [service registerAndReturnError:(&error)];
+    if (error) {
+      result->error_description = VNECopyNSString([error description]);
     }
+
+    // Grabbing the service status for debugging purposes, no matter if
+    // [service registerAndReturnError] succeeded or failed.
+    result->service_status = (int)service.status;
+  } else {
+    result->error_description = strdup("Service Management APIs are available on macOS 13.0+");
+  }
 }
 
 int DaemonStatus(void) {
-    if (@available(macOS 13, *)) {
-        SMAppService *service;
-        service = [SMAppService daemonServiceWithPlistName:(DaemonPlist())];
-        return (int) service.status;
-    } else {
-        return -1;
-    }
+  if (@available(macOS 13, *)) {
+    SMAppService *service;
+    service = [SMAppService daemonServiceWithPlistName:(DaemonPlist())];
+    return (int)service.status;
+  } else {
+    return -1;
+  }
 }
 
 void OpenSystemSettingsLoginItems(void) {
-    if (@available(macOS 13, *)) {
-        [SMAppService openSystemSettingsLoginItems];
-    }
+  if (@available(macOS 13, *)) {
+    [SMAppService openSystemSettingsLoginItems];
+  }
 }
 
 char *VNECopyNSString(NSString *val) {
-    if (val) {
-        return strdup([val UTF8String]);
-    }
-    return strdup("");
+  if (val) {
+    return strdup([val UTF8String]);
+  }
+  return strdup("");
 }

--- a/lib/vnet/daemon/client_darwin.m
+++ b/lib/vnet/daemon/client_darwin.m
@@ -13,6 +13,8 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#import <Foundation/Foundation.h>
+#import <ServiceManagement/ServiceManagement.h>
 
 #include "client_darwin.h"
 
@@ -20,7 +22,7 @@ void BundlePath(struct BundlePathResult *result) {
     // From the docs:
     // > This method may return a valid bundle object even for unbundled apps.
     // > It may also return nil if the bundle object could not be created,
-    // > so always check the return value. 
+    // > so always check the return value.
     NSBundle *main = [NSBundle mainBundle];
     if (!main) {
         result->bundlePath = strdup("");
@@ -28,6 +30,49 @@ void BundlePath(struct BundlePathResult *result) {
     }
     
     result->bundlePath = VNECopyNSString([main bundlePath]);
+}
+
+NSString * DaemonLabel(void) {
+    NSBundle *main = [NSBundle mainBundle];
+    if (!main) {
+        return @"";
+    }
+    
+    NSString *bundleIdentifier = [main bundleIdentifier];
+    if ([bundleIdentifier length] == 0) {
+        return bundleIdentifier;
+    }
+    
+    return [NSString stringWithFormat:@"%@.vnetd", bundleIdentifier];
+}
+
+NSString * DaemonPlist(void) {
+    NSString *label = DaemonLabel();
+    if ([label length] == 0) {
+        return label;
+    }
+    
+    return [NSString stringWithFormat:@"%@.plist", label];
+}
+
+void RegisterDaemon(struct RegisterDaemonResult *result) {
+    if (@available(macOS 13, *)) {
+        SMAppService *service;
+        NSError *error;
+        
+        service = [SMAppService daemonServiceWithPlistName:(DaemonPlist())];
+        
+        result->ok = [service registerAndReturnError:(&error)];
+        if (error) {
+            result->error_description = VNECopyNSString([error description]);
+        }
+        
+        // Grabbing the service status for debugging purposes, no matter if
+        // [service registerAndReturnError] succeeded or failed.
+        result->service_status = (int) service.status;
+    } else {
+        result->error_description = strdup("Service Management APIs are available on macOS 13.0+");
+    }
 }
 
 char *VNECopyNSString(NSString *val) {

--- a/lib/vnet/daemon/client_darwin.m
+++ b/lib/vnet/daemon/client_darwin.m
@@ -18,20 +18,6 @@
 
 #include "client_darwin.h"
 
-void BundlePath(struct BundlePathResult *result) {
-  // From the docs:
-  // > This method may return a valid bundle object even for unbundled apps.
-  // > It may also return nil if the bundle object could not be created,
-  // > so always check the return value.
-  NSBundle *main = [NSBundle mainBundle];
-  if (!main) {
-    result->bundlePath = strdup("");
-    return;
-  }
-
-  result->bundlePath = VNECopyNSString([main bundlePath]);
-}
-
 NSString *DaemonLabel(void) {
   NSBundle *main = [NSBundle mainBundle];
   if (!main) {

--- a/lib/vnet/daemon/client_darwin.m
+++ b/lib/vnet/daemon/client_darwin.m
@@ -1,0 +1,38 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "client_darwin.h"
+
+void BundlePath(struct BundlePathResult *result) {
+    // From the docs:
+    // > This method may return a valid bundle object even for unbundled apps.
+    // > It may also return nil if the bundle object could not be created,
+    // > so always check the return value. 
+    NSBundle *main = [NSBundle mainBundle];
+    if (!main) {
+        result->bundlePath = strdup("");
+        return;
+    }
+    
+    result->bundlePath = VNECopyNSString([main bundlePath]);
+}
+
+char *VNECopyNSString(NSString *val) {
+    if (val) {
+        return strdup([val UTF8String]);
+    }
+    return strdup("");
+}

--- a/lib/vnet/dns/osnameservers_darwin.go
+++ b/lib/vnet/dns/osnameservers_darwin.go
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build darwin
-// +build darwin
-
 package dns
 
 import (

--- a/lib/vnet/osconfig_darwin.go
+++ b/lib/vnet/osconfig_darwin.go
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build darwin
-// +build darwin
-
 package vnet
 
 import (

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -72,7 +72,7 @@ func SetupAndRun(ctx context.Context, config *SetupAndRunConfig) (*ProcessManage
 	})
 
 	pm.AddCriticalBackgroundTask("admin subcommand", func() error {
-		return trace.Wrap(execAdminSubcommand(processCtx, socketPath, ipv6Prefix.String(), dnsIPv6.String()))
+		return trace.Wrap(execAdminProcess(processCtx, socketPath, ipv6Prefix.String(), dnsIPv6.String()))
 	})
 
 	recvTUNErr := make(chan error, 1)

--- a/lib/vnet/setup_daemon_darwin.go
+++ b/lib/vnet/setup_daemon_darwin.go
@@ -1,0 +1,38 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build vnetdaemon
+// +build vnetdaemon
+
+package vnet
+
+import (
+	"context"
+	"os"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/vnet/daemon"
+)
+
+func execAdminProcess(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
+	// TODO(ravicious): Remove the feature env var after the daemon gets implemented.
+	if os.Getenv("VNETDAEMON") == "yes" {
+		return trace.Wrap(daemon.RegisterAndCall(ctx, socketPath, ipv6Prefix, dnsAddr))
+	}
+
+	return trace.Wrap(execAdminSubcommand(ctx, socketPath, ipv6Prefix, dnsAddr))
+}

--- a/lib/vnet/setup_darwin.go
+++ b/lib/vnet/setup_darwin.go
@@ -64,7 +64,7 @@ func execAdminProcess(ctx context.Context, socketPath, ipv6Prefix, dnsAddr strin
 		}
 
 		if isSigned {
-			return trace.NotImplemented("daemon is not implemented yet")
+			return trace.Wrap(daemon.RegisterAndCall(ctx, socketPath, ipv6Prefix, dnsAddr))
 		}
 	}
 

--- a/lib/vnet/setup_darwin.go
+++ b/lib/vnet/setup_darwin.go
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build darwin
-// +build darwin
-
 package vnet
 
 import (

--- a/lib/vnet/setup_nodaemon_darwin.go
+++ b/lib/vnet/setup_nodaemon_darwin.go
@@ -1,0 +1,30 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !vnetdaemon
+// +build !vnetdaemon
+
+package vnet
+
+import (
+	"github.com/gravitational/trace"
+
+	"context"
+)
+
+func execAdminProcess(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
+	return trace.Wrap(execAdminSubcommand(ctx, socketPath, ipv6Prefix, dnsAddr))
+}

--- a/lib/vnet/setup_other.go
+++ b/lib/vnet/setup_other.go
@@ -50,6 +50,6 @@ func configureOS(ctx context.Context, cfg *osConfig) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }
 
-func execAdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
+func execAdminProcess(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -183,8 +183,8 @@ export default class MainProcess {
         env: {
           ...process.env,
           TELEPORT_HOME: homeDir,
-          VNET_DAEMON: this.configService.get('feature.vnetDaemon').value
-            ? '1'
+          VNETDAEMON: this.configService.get('feature.vnetDaemon').value
+            ? 'yes'
             : undefined,
         },
       }

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -183,6 +183,9 @@ export default class MainProcess {
         env: {
           ...process.env,
           TELEPORT_HOME: homeDir,
+          VNET_DAEMON: this.configService.get('feature.vnetDaemon').value
+            ? '1'
+            : undefined,
         },
       }
     );

--- a/web/packages/teleterm/src/services/config/appConfigSchema.ts
+++ b/web/packages/teleterm/src/services/config/appConfigSchema.ts
@@ -122,6 +122,10 @@ export const createAppConfigSchema = (platform: Platform) => {
       .boolean()
       .default(false)
       .describe('Disables SSH connection resumption.'),
+    'feature.vnetDaemon': z
+      .boolean()
+      .default(false)
+      .describe('Use daemon instead of osascript for VNet'),
   });
 };
 


### PR DESCRIPTION
https://github.com/gravitational/teleport/assets/27113/43564260-1c1c-49fa-9f6a-553d9dace2e9

```
VNET_DAEMON=1 $skel/tsh.app/Contents/MacOS/tsh vnet -d
```

This PR makes it so running the above command using [a signed version of tsh](https://github.com/gravitational/teleport/blob/master/build.assets/macos/tshdev/README.md) adds a login item for VNet's daemon.

The login item functions as a launch daemon that is started on demand through XPC. The name of the XPC service is advertised in the plist file under `MachServices`. Since this PR doesn't include any code which calls this XPC service, the daemon won't be spawned. The code is safe to compile and run, after trashing and removing tsh.app it shouldn't leave any residue in the system.

The actual implementation of the daemon will be added in a subsequent PR, along with code which calls the XPC service.

## How the launch daemon works

The launch daemon is added through [`SMAppService`](https://developer.apple.com/documentation/servicemanagement/smappservice?language=objc) available in macOS 13.0+. [The RFD wasn't updated yet](https://github.com/gravitational/teleport/blob/master/rfd/0163-vnet.md#daemon) to reflect how the daemon is going to actually run, but it's not as important for this PR specifically. I'll update it in the upcoming PR.

So far we've been using `osascript` to spawn `tsh vnet-admin-setup` as root. This command then configures the OS for VNet and checks `TELEPORT_HOME` ever 10 seconds to update the DNS configuration. The daemon is going to execute the same code as that command, with the difference being that the daemon will be spawned by an unprivileged tsh sending a message through XPC.

When the user first launches VNet, a login item is added. Before calling the XPC service, we have to wait for the login item to be enabled by the user (since it requires root privileges). In theory, a system admin could add the plist of VNet daemon to launchd. This could work with MDMs, but I haven't actually checked if it works.

Since `SMAppService` works only with app bundles, we default to the old osascript method. This way Teleport developers can run VNet without having to go through the app signing flow, which is a bit complicated to set up.