### PR TITLE
Add initial JoinTokens UI

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -770,6 +770,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/auth/export", h.authExportPublic)
 
 	// join token handlers
+	h.PUT("/webapi/token/yaml", h.WithAuth(h.upsertTokenContent))
 	h.POST("/webapi/token", h.WithAuth(h.createTokenHandle))
 	h.GET("/webapi/tokens", h.WithAuth(h.getTokens))
 	h.DELETE("/webapi/tokens", h.WithAuth(h.deleteToken))

--- a/lib/web/ui/join_token.go
+++ b/lib/web/ui/join_token.go
@@ -19,6 +19,9 @@ package ui
 import (
 	"time"
 
+	yaml "github.com/ghodss/yaml"
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -40,22 +43,33 @@ type JoinToken struct {
 	Method types.JoinMethod `json:"method"`
 	// AllowRules is a list of allow rules
 	AllowRules []string `json:"allowRules,omitempty"`
+	// Content is resource yaml content.
+	Content string `json:"content"`
 }
 
-func MakeJoinToken(token types.ProvisionToken) JoinToken {
-	return JoinToken{
+func MakeJoinToken(token types.ProvisionToken) (*JoinToken, error) {
+	content, err := yaml.Marshal(token)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &JoinToken{
 		ID:       token.GetName(),
 		SafeName: token.GetSafeName(),
 		Expiry:   token.Expiry(),
 		Roles:    token.GetRoles(),
 		IsStatic: token.IsStatic(),
 		Method:   token.GetJoinMethod(),
-	}
+		Content:  string(content[:]),
+	}, nil
 }
 
-func MakeJoinTokens(tokens []types.ProvisionToken) (joinTokens []JoinToken) {
+func MakeJoinTokens(tokens []types.ProvisionToken) (joinTokens []JoinToken, err error) {
 	for _, t := range tokens {
-		joinTokens = append(joinTokens, MakeJoinToken(t))
+		uiToken, err := MakeJoinToken(t)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		joinTokens = append(joinTokens, *uiToken)
 	}
-	return joinTokens
+	return joinTokens, nil
 }

--- a/web/packages/shared/components/ToolTip/HoverTooltip.tsx
+++ b/web/packages/shared/components/ToolTip/HoverTooltip.tsx
@@ -19,6 +19,7 @@
 import React, { PropsWithChildren, useState } from 'react';
 import styled from 'styled-components';
 import { Popover, Flex, Text } from 'design';
+import { JustifyContentProps } from 'design/system';
 
 type OriginProps = {
   vertical: string;
@@ -32,6 +33,7 @@ export const HoverTooltip: React.FC<
     className?: string;
     anchorOrigin?: OriginProps;
     transformOrigin?: OriginProps;
+    justifyContentProps?: JustifyContentProps;
   }>
 > = ({
   tipContent,
@@ -40,6 +42,7 @@ export const HoverTooltip: React.FC<
   className,
   anchorOrigin = { vertical: 'top', horizontal: 'center' },
   transformOrigin = { vertical: 'bottom', horizontal: 'center' },
+  justifyContentProps = {},
 }) => {
   const [anchorEl, setAnchorEl] = useState<Element | undefined>();
   const open = Boolean(anchorEl);
@@ -77,6 +80,7 @@ export const HoverTooltip: React.FC<
       onMouseEnter={handlePopoverOpen}
       onMouseLeave={handlePopoverClose}
       className={className}
+      {...justifyContentProps}
     >
       {children}
       <Popover

--- a/web/packages/teleport/src/Apps/AddApp/AddApp.story.tsx
+++ b/web/packages/teleport/src/Apps/AddApp/AddApp.story.tsx
@@ -78,5 +78,14 @@ const props = {
     status: '',
     statusText: '',
   } as any,
-  token: { id: 'join-token', expiryText: '1 hour', expiry: null },
+  token: {
+    id: 'join-token',
+    expiryText: '1 hour',
+    expiry: null,
+    safeName: '',
+    isStatic: false,
+    method: 'kubernetes',
+    roles: [],
+    content: '',
+  },
 };

--- a/web/packages/teleport/src/Apps/AddApp/Automatically.test.tsx
+++ b/web/packages/teleport/src/Apps/AddApp/Automatically.test.tsx
@@ -24,7 +24,16 @@ import { act } from '@testing-library/react';
 import { Automatically, createAppBashCommand } from './Automatically';
 
 test('render command only after form submit', async () => {
-  const token = { id: 'token', expiryText: '', expiry: null };
+  const token = {
+    id: 'token',
+    expiryText: '',
+    expiry: null,
+    safeName: '',
+    isStatic: false,
+    method: 'kubernetes',
+    roles: [],
+    content: '',
+  };
   render(
     <Automatically
       token={token}

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/GitHubActions.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/GitHubActions.test.tsx
@@ -69,6 +69,11 @@ describe('gitHub component', () => {
     jest.spyOn(ctx.joinTokenService, 'fetchJoinToken').mockResolvedValue({
       id: tokenName,
       expiry: new Date('2020-01-01'),
+      safeName: '',
+      isStatic: false,
+      method: 'kubernetes',
+      roles: [],
+      content: '',
     });
     jest.spyOn(botService, 'createBot').mockResolvedValue();
     jest.spyOn(botService, 'createBotToken').mockResolvedValue({

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -49,6 +49,11 @@ export function AgentWaitingDialog({
     // These are not used by usePingTeleport
     // todo(anton): Refactor usePingTeleport to not require full join token.
     expiry: undefined,
+    safeName: '',
+    isStatic: false,
+    method: 'kubernetes',
+    roles: [],
+    content: '',
     expiryText: '',
     id: '',
     suggestedLabels: [],

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.story.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.story.tsx
@@ -1,0 +1,122 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { rest } from 'msw';
+import { initialize, mswLoader } from 'msw-storybook-addon';
+
+import { ContextProvider } from 'teleport';
+import cfg from 'teleport/config';
+import { JoinToken } from 'teleport/services/joinToken';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+
+import { JoinTokens } from './JoinTokens';
+
+export default {
+  title: 'Teleport/JoinTokens',
+  loaders: [mswLoader],
+};
+
+initialize();
+
+export const Loaded = () => (
+  <Provider>
+    <JoinTokens />
+  </Provider>
+);
+
+Loaded.parameters = {
+  msw: {
+    handlers: [
+      rest.get(cfg.api.joinTokensPath, (req, res, ctx) => {
+        return res.once(ctx.json({ items: tokens }));
+      }),
+      rest.put(cfg.api.joinTokenYamlPath, (req, res, ctx) => {
+        return res.once(ctx.json(editedToken));
+      }),
+    ],
+  },
+};
+
+const Provider = ({ children }) => {
+  const ctx = createTeleportContext();
+
+  return (
+    <MemoryRouter>
+      <ContextProvider ctx={ctx}>{children}</ContextProvider>
+    </MemoryRouter>
+  );
+};
+
+const tokens: JoinToken[] = [
+  {
+    id: 'token1',
+    roles: ['Node'],
+    isStatic: true,
+    expiry: new Date('0001-01-01'),
+    method: 'token',
+    safeName: '******',
+    content: '',
+  },
+  {
+    id: 'iam-EDIT-ME-BUT-DONT-SAVE',
+    roles: ['Node', 'App', 'Trusted_cluster'],
+    isStatic: false,
+    expiry: new Date('2023-06-01'),
+    method: 'iam',
+    safeName: 'iam-EDIT-ME-BUT-DONT-SAVE',
+    content: `kind: token
+        metadata:
+        name: iam-EDIT-ME-BUT-DONT-SAVE
+        revision: d018f5e3-774f-43b5-a349-4529147eab2c
+        spec:
+        gcp:
+            allow:
+            - project_ids:
+            - "123123"
+        join_method: iam
+        roles:
+        - Node
+        version: v2
+    `,
+  },
+];
+
+const editedToken: JoinToken = {
+  id: 'iam-I-SAID-DONT-SAVE',
+  roles: ['Node', 'App', 'Trusted_cluster'],
+  isStatic: false,
+  expiry: new Date(),
+  method: 'iam',
+  safeName: 'iam-I-SAID-DONT-SAVE',
+  content: `kind: token
+            metadata:
+            name: iam-I-SAID-DONT-SAVE
+            revision: d018f5e3-774f-43b5-a349-4529147eab2c
+            spec:
+            gcp:
+                allow:
+                - project_ids:
+                - "123123"
+            join_method: iam
+            roles:
+            - Node
+            version: v2
+        `,
+};

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -1,0 +1,402 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+import { useEffect, useState } from 'react';
+import { isAfter, addHours } from 'date-fns';
+import {
+  Box,
+  Text,
+  Flex,
+  Indicator,
+  Label,
+  Alert,
+  Link,
+  MenuItem,
+  ButtonWarning,
+  ButtonSecondary,
+} from 'design';
+import Table, { Cell } from 'design/DataTable';
+import { Warning } from 'design/Icon';
+import Dialog, {
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from 'design/Dialog';
+import { MenuButton } from 'shared/components/MenuAction';
+import { Attempt, useAsync } from 'shared/hooks/useAsync';
+import { HoverTooltip } from 'shared/components/ToolTip';
+import { CopyButton } from 'shared/components/UnifiedResources/shared/CopyButton';
+
+import { useTeleport } from 'teleport';
+import useResources from 'teleport/components/useResources';
+
+import {
+  FeatureBox,
+  FeatureHeader,
+  FeatureHeaderTitle,
+} from 'teleport/components/Layout';
+import { JoinToken } from 'teleport/services/joinToken';
+import { Resource, KindJoinToken } from 'teleport/services/resources';
+import ResourceEditor from 'teleport/components/ResourceEditor';
+
+function makeTokenResource(token: JoinToken): Resource<KindJoinToken> {
+  return {
+    id: token.id,
+    name: token.safeName,
+    kind: 'join_token',
+    content: token.content,
+  };
+}
+
+export const JoinTokens = () => {
+  const ctx = useTeleport();
+  const [tokenToDelete, setTokenToDelete] = useState<JoinToken | null>(null);
+  const [joinTokensAttempt, runJoinTokensAttempt, setJoinTokensAttempt] =
+    useAsync(async () => await ctx.joinTokenService.fetchJoinTokens());
+
+  const resources = useResources(
+    joinTokensAttempt.data?.items.map(makeTokenResource) || [],
+    { join_token: '' } // we are only editing for now, so template can be empty
+  );
+
+  async function handleSave(content: string): Promise<void> {
+    const token = await ctx.joinTokenService.upsertJoinToken({ content });
+    let items = [...joinTokensAttempt.data.items];
+    if (resources.status === 'creating') {
+      items.push(token);
+    } else {
+      let tokenExistsInPreviousList = false;
+      const newItems = items.map(item => {
+        if (item.id === token.id) {
+          tokenExistsInPreviousList = true;
+          return token;
+        }
+        return item;
+      });
+      // in the edge case that someone only edits the name of the token, it will return
+      // a "new" token via the upsert, and therefore should be treated as a new token
+      if (!tokenExistsInPreviousList) {
+        newItems.push(token);
+      }
+      items = newItems;
+    }
+    setJoinTokensAttempt({
+      data: { ...joinTokensAttempt.data, items },
+      status: 'success',
+      statusText: '',
+    });
+  }
+
+  const [deleteTokenAttempt, runDeleteTokenAttempt] = useAsync(
+    async (token: string) => {
+      await ctx.joinTokenService.deleteJoinToken(token);
+      setJoinTokensAttempt({
+        status: 'success',
+        statusText: '',
+        data: {
+          items: joinTokensAttempt.data.items.filter(t => t.id !== token),
+        },
+      });
+      setTokenToDelete(null);
+    }
+  );
+
+  useEffect(() => {
+    runJoinTokensAttempt();
+  }, []);
+
+  return (
+    <FeatureBox>
+      <FeatureHeader
+        css={`
+          // TODO (avatus) remove all border-bottom from FeatureHeader, requested by design
+          border-bottom: none;
+        `}
+        alignItems="center"
+      >
+        <FeatureHeaderTitle>Join Tokens</FeatureHeaderTitle>
+      </FeatureHeader>
+      <Box>
+        {joinTokensAttempt.status === 'error' && (
+          <Alert kind="danger">{joinTokensAttempt.statusText}</Alert>
+        )}
+        {deleteTokenAttempt.status === 'error' && (
+          <Alert kind="danger">{deleteTokenAttempt.statusText}</Alert>
+        )}
+        {joinTokensAttempt.status === 'success' && (
+          <Table
+            isSearchable
+            data={joinTokensAttempt.data.items}
+            columns={[
+              {
+                key: 'id',
+                headerText: 'Name',
+                isSortable: false,
+                render: token => <NameCell token={token} />,
+              },
+              {
+                key: 'method',
+                headerText: 'Join Method',
+                isSortable: true,
+              },
+              {
+                key: 'roles',
+                headerText: 'Roles',
+                isSortable: false,
+                render: renderRolesCell,
+              },
+              // expiryText is non render and used for searching
+              {
+                key: 'expiryText',
+                isNonRender: true,
+              },
+              // expiry is used for sorting, but we display the expiryText value
+              {
+                key: 'expiry',
+                headerText: 'Expires in',
+                isSortable: true,
+                render: ({ expiry, expiryText, isStatic, method }) => {
+                  const now = new Date();
+                  const isLongLived =
+                    isAfter(expiry, addHours(now, 24)) && method === 'token';
+                  return (
+                    <Cell>
+                      <Flex alignItems="center" gap={2}>
+                        <Text>{expiryText}</Text>
+                        {(isLongLived || isStatic) && (
+                          <HoverTooltip tipContent="Long-lived and static tokens are insecure and will be deprecated. Use short-lived tokens or alternative join methods (gcp, iam) for long-lived access.">
+                            <Warning size="small" color="error.main" />
+                          </HoverTooltip>
+                        )}
+                      </Flex>
+                    </Cell>
+                  );
+                },
+              },
+              {
+                altKey: 'options-btn',
+                render: (token: JoinToken) => (
+                  <ActionCell
+                    token={token}
+                    onEdit={() => resources.edit(token.id)}
+                    onDelete={() => setTokenToDelete(token)}
+                  />
+                ),
+              },
+            ]}
+            emptyText="No active join tokens found"
+            pagination={{ pageSize: 30, pagerPosition: 'top' }}
+            customSearchMatchers={[searchMatcher]}
+            initialSort={{
+              key: 'expiry',
+              dir: 'ASC',
+            }}
+          />
+        )}
+        {joinTokensAttempt.status === 'processing' && (
+          <Flex justifyContent="center">
+            <Indicator />
+          </Flex>
+        )}
+      </Box>
+      {tokenToDelete && (
+        <TokenDelete
+          token={tokenToDelete}
+          onClose={() => setTokenToDelete(null)}
+          onDelete={() => runDeleteTokenAttempt(tokenToDelete.id)}
+          attempt={deleteTokenAttempt}
+        />
+      )}
+      {resources.status === 'editing' && (
+        <ResourceEditor
+          docsURL="https://goteleport.com/docs/reference/join-methods"
+          title={'Edit token'}
+          text={resources.item.content}
+          name={resources.item.name}
+          isNew={false} // only editting is allowed
+          onSave={handleSave}
+          onClose={resources.disregard}
+          directions={<Directions />}
+          kind={'join_token'}
+        />
+      )}
+    </FeatureBox>
+  );
+};
+
+export function searchMatcher(
+  targetValue: any,
+  searchValue: string,
+  propName: keyof JoinToken & string
+) {
+  if (propName === 'roles') {
+    return targetValue.some((role: string) =>
+      role.toUpperCase().includes(searchValue)
+    );
+  }
+}
+
+const renderRolesCell = ({ roles }: JoinToken) => {
+  return (
+    <Cell>
+      {roles.map(role => (
+        <StyledLabel key={role}>{role}</StyledLabel>
+      ))}
+    </Cell>
+  );
+};
+
+const NameCell = ({ token }: { token: JoinToken }) => {
+  const { id, safeName, method } = token;
+  const [hovered, setHovered] = useState(false);
+  return (
+    <Cell
+      align="left"
+      style={{
+        minWidth: '320px',
+        fontFamily: 'monospace',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <Flex alignItems="center" gap={2}>
+        <Text
+          css={`
+            text-overflow: clip;
+            overflow-x: auto;
+          `}
+        >
+          {method !== 'token' ? id : safeName}
+        </Text>
+        {hovered && <CopyButton name={id} />}
+      </Flex>
+    </Cell>
+  );
+};
+
+const StyledLabel = styled(Label)`
+  height: 20px;
+  margin: 1px 0;
+  margin-right: ${props => props.theme.space[2]}px;
+  background-color: ${props => props.theme.colors.interactive.tonal.neutral[0]};
+  color: ${props => props.theme.colors.text.main};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 20px;
+`;
+
+function TokenDelete({
+  token,
+  onDelete,
+  onClose,
+  attempt,
+}: {
+  token: JoinToken;
+  onDelete: (token: string) => Promise<any>;
+  onClose: () => void;
+  attempt: Attempt<void>;
+}) {
+  return (
+    <Dialog
+      dialogCss={() => ({ maxWidth: '500px', width: '100%' })}
+      disableEscapeKeyDown={false}
+      onClose={close}
+      open={true}
+    >
+      <DialogHeader>
+        <DialogTitle>Delete Join Token?</DialogTitle>
+      </DialogHeader>
+      <DialogContent>
+        {attempt.status === 'error' && <Alert children={attempt.statusText} />}
+        <Text mb={4}>
+          You are about to delete join token
+          <Text bold as="span">
+            {` ${token.safeName}`}
+          </Text>
+          . This will not remove any resources that used this token to join the
+          cluster. This will remove the ability for any new resources to join
+          with this token and any non-renewable resource from renewing.
+        </Text>
+      </DialogContent>
+      <DialogFooter>
+        <ButtonWarning
+          mr="3"
+          disabled={attempt.status === 'processing'}
+          onClick={onDelete}
+        >
+          I understand, delete token
+        </ButtonWarning>
+        <ButtonSecondary onClick={onClose}>Cancel</ButtonSecondary>
+      </DialogFooter>
+    </Dialog>
+  );
+}
+
+const ActionCell = ({
+  onEdit,
+  onDelete,
+  token,
+}: {
+  onEdit(): void;
+  onDelete(): void;
+  token: JoinToken;
+}) => {
+  const buttonProps = { width: '100px' };
+  if (token.isStatic) {
+    return (
+      <Cell align="right">
+        <HoverTooltip
+          justifyContentProps={{ justifyContent: 'end' }}
+          tipContent="You cannot configure or delete static tokens via the web UI. Static tokens should be removed from your Teleport configuration file."
+        >
+          <MenuButton buttonProps={{ disabled: true, ...buttonProps }} />
+        </HoverTooltip>
+      </Cell>
+    );
+  }
+  return (
+    <Cell align="right">
+      <MenuButton buttonProps={buttonProps}>
+        <MenuItem onClick={onEdit}>View/Edit...</MenuItem>
+        <MenuItem onClick={onDelete}>Delete...</MenuItem>
+      </MenuButton>
+    </Cell>
+  );
+};
+
+function Directions() {
+  return (
+    <>
+      WARNING Roles are defined using{' '}
+      <Link
+        color="text.main"
+        target="_blank"
+        href="https://en.wikipedia.org/wiki/YAML"
+      >
+        YAML format
+      </Link>
+      . YAML is sensitive to white space, so please be careful.
+    </>
+  );
+}

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -258,6 +258,7 @@ const cfg = {
     connectMyComputerLoginsPath: '/v1/webapi/connectmycomputer/logins',
 
     joinTokenPath: '/v1/webapi/token',
+    joinTokenYamlPath: '/v1/webapi/token/yaml',
     joinTokensPath: '/v1/webapi/tokens',
     dbScriptPath: '/scripts/:token/install-database.sh',
     nodeScriptPath: '/scripts/:token/install-node.sh',
@@ -500,6 +501,10 @@ const cfg = {
 
   getJoinTokenUrl() {
     return cfg.api.joinTokenPath;
+  },
+
+  getJoinTokenYamlUrl() {
+    return cfg.api.joinTokenYamlPath;
   },
 
   getNodeScriptUrl(token: string) {

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -68,6 +68,7 @@ import { LockedAccessRequests } from './AccessRequests';
 import { Integrations } from './Integrations';
 import { Bots } from './Bots';
 import { AddBots } from './Bots/Add';
+import { JoinTokens } from './JoinTokens/JoinTokens';
 
 import type { FeatureFlags, TeleportFeature } from './types';
 
@@ -118,6 +119,21 @@ export class FeatureNodes implements TeleportFeature {
 
   hasAccess(flags: FeatureFlags) {
     return flags.nodes;
+  }
+}
+
+// TODO (avatus) add navigationItem when ready to release
+export class FeatureJoinTokens implements TeleportFeature {
+  category = NavigationCategory.Management;
+  route = {
+    title: NavTitle.JoinTokens,
+    path: cfg.routes.joinTokens,
+    exact: true,
+    component: JoinTokens,
+  };
+
+  hasAccess(flags: FeatureFlags): boolean {
+    return flags.tokens;
   }
 }
 
@@ -626,6 +642,7 @@ export function getOSSFeatures(): TeleportFeature[] {
     new FeatureAddBots(),
     new FeatureAuthConnectors(),
     new FeatureIntegrations(),
+    new FeatureJoinTokens(),
     new FeatureDiscover(),
     new FeatureIntegrationEnroll(),
 

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -77,6 +77,15 @@ const api = {
     );
   },
 
+  deleteWithHeaders(url, headers?: Record<string, string>, signal?) {
+    return api.fetch(url, {
+      method: 'DELETE',
+      headers,
+      signal,
+    });
+  },
+
+  // TODO (avatus) add abort signal to this
   put(url, data, webauthnResponse?: WebauthnAssertionResponse) {
     return api.fetchJsonWithMfaAuthnRetry(
       url,

--- a/web/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.ts
@@ -25,6 +25,7 @@ import makeJoinToken from './makeJoinToken';
 import { JoinToken, JoinRule, JoinTokenRequest } from './types';
 
 class JoinTokenService {
+  // TODO (avatus) refactor this code to eventually use `createJoinToken`
   fetchJoinToken(
     req: JoinTokenRequest,
     signal: AbortSignal = null
@@ -43,6 +44,32 @@ class JoinTokenService {
         signal
       )
       .then(makeJoinToken);
+  }
+
+  // TODO (avatus) for the first iteration, we will create tokens using only yaml and
+  // slowly create a form for each token type.
+  upsertJoinToken(req: JoinTokenRequest): Promise<JoinToken> {
+    return api
+      .put(cfg.getJoinTokenYamlUrl(), {
+        content: req.content,
+      })
+      .then(makeJoinToken);
+  }
+
+  fetchJoinTokens(signal: AbortSignal = null): Promise<{ items: JoinToken[] }> {
+    return api.get(cfg.getJoinTokensUrl(), signal).then(resp => {
+      return {
+        items: resp.items.map(makeJoinToken),
+      };
+    });
+  }
+
+  deleteJoinToken(id: string, signal: AbortSignal = null) {
+    return api.deleteWithHeaders(
+      cfg.getJoinTokensUrl(),
+      { 'X-Teleport-TokenName': id },
+      signal
+    );
   }
 }
 

--- a/web/packages/teleport/src/services/joinToken/makeJoinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/makeJoinToken.ts
@@ -24,19 +24,42 @@ export const INTERNAL_RESOURCE_ID_LABEL_KEY = 'teleport.internal/resource-id';
 
 export default function makeToken(json): JoinToken {
   json = json || {};
-  const { id, expiry, suggestedLabels } = json;
+  const {
+    id,
+    roles,
+    isStatic,
+    expiry,
+    method,
+    suggestedLabels,
+    safeName,
+    content,
+  } = json;
 
   const labels = suggestedLabels || [];
 
   return {
     id,
+    isStatic,
+    safeName,
+    method,
+    roles: roles?.sort((a, b) => a.localeCompare(b)) || [],
     suggestedLabels: labels,
     internalResourceId: extractInternalResourceId(labels),
     expiry: expiry ? new Date(expiry) : null,
-    expiryText: expiry
-      ? formatDistanceStrict(new Date(), new Date(expiry))
-      : '',
+    expiryText: getExpiryText(expiry, isStatic),
+    content,
   };
+}
+
+function getExpiryText(expiry: string, isStatic: boolean): string {
+  // a manually configured token with no TTL will be set to zero date
+  if (expiry == '0001-01-01T00:00:00Z' || isStatic) {
+    return 'never';
+  }
+  if (!expiry) {
+    return '';
+  }
+  return formatDistanceStrict(new Date(), new Date(expiry));
 }
 
 function extractInternalResourceId(labels: any[]) {

--- a/web/packages/teleport/src/services/joinToken/types.ts
+++ b/web/packages/teleport/src/services/joinToken/types.ts
@@ -20,6 +20,15 @@ import { ResourceLabel } from '../agents';
 
 export type JoinToken = {
   id: string;
+  // safeName is the name represented by "*". If the name is longer than 16 chars,
+  // the first 16 chars will be * and the rest of the token's chars will be visible
+  // ex. ****************asdf1234
+  safeName: string;
+  isStatic: boolean;
+  // the join method of the token
+  method: string;
+  // Roles are the roles granted to the token
+  roles: string[];
   expiry: Date;
   expiryText?: string;
   // suggestedLabels are labels that the resource should add when adding
@@ -30,6 +39,8 @@ export type JoinToken = {
   //
   // Extracted from suggestedLabels.
   internalResourceId?: string;
+  // yaml content of the resource
+  content: string;
 };
 
 // JoinRole defines built-in system roles and are roles associated with
@@ -53,7 +64,17 @@ export type JoinRole =
 // Same hard-corded value as the backend.
 // - 'token' is the default method, where nodes join the cluster by
 //   presenting a secret token.
-export type JoinMethod = 'token' | 'ec2' | 'iam' | 'github';
+export type JoinMethod =
+  | 'token'
+  | 'ec2'
+  | 'iam'
+  | 'github'
+  | 'azure'
+  | 'gcp'
+  | 'circleci'
+  | 'gitlab'
+  | 'kubernetes'
+  | 'tpm';
 
 // JoinRule is a rule that a joining node must match in order to use the
 // associated token.
@@ -66,7 +87,7 @@ export type JoinRule = {
 export type JoinTokenRequest = {
   // roles is a list of join roles, since there can be more than
   // one role associated with a token.
-  roles: JoinRole[];
+  roles?: JoinRole[];
   // rules is a list of allow rules associated with the join token
   // and the node using this token must match one of the rules.
   rules?: JoinRule[];
@@ -76,4 +97,6 @@ export type JoinTokenRequest = {
   // means adding the labels to `db_service.resources.labels`.
   suggestedAgentMatcherLabels?: ResourceLabel[];
   method?: JoinMethod;
+  // content is the yaml content of the joinToken to be created
+  content?: string;
 };

--- a/web/packages/teleport/src/services/resources/types.ts
+++ b/web/packages/teleport/src/services/resources/types.ts
@@ -28,7 +28,12 @@ export type Resource<T extends Kind> = {
 export type KindRole = 'role';
 export type KindTrustedCluster = 'trusted_cluster';
 export type KindAuthConnectors = 'github' | 'saml' | 'oidc';
-export type Kind = KindRole | KindTrustedCluster | KindAuthConnectors;
+export type KindJoinToken = 'join_token';
+export type Kind =
+  | KindRole
+  | KindTrustedCluster
+  | KindAuthConnectors
+  | KindJoinToken;
 
 /** Describes a Teleport role. */
 export type RoleResource = Resource<KindRole>;

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -60,6 +60,7 @@ export enum NavTitle {
   Users = 'Users',
   Bots = 'Bots',
   Roles = 'User Roles',
+  JoinTokens = 'Join Tokens',
   AuthConnectors = 'Auth Connectors',
   Integrations = 'Integrations',
   EnrollNewResource = 'Enroll New Resource',


### PR DESCRIPTION
This PR is part of the new join tokens feature. This will make the join tokens UI available on /web/tokens but not enable it in the navigation. You will have to manually view it. We will add it to the navigation just before the backport to the release branch. I did it this way so we can start PRing the larger chunks while we work on the "create token" forms. So obviously, the "create token" button doesn't exist on here. this PR is for viewing/editting tokens
![Screenshot 2024-07-02 at 3 30 16 PM](https://github.com/gravitational/teleport/assets/5201977/2d177a75-ce06-451f-948c-01de230a25c5)
