### PR TITLE
feat: update Discover flow to support update resource mechanism

### DIFF
--- a/web/packages/teleport/src/Discover/Discover.test.tsx
+++ b/web/packages/teleport/src/Discover/Discover.test.tsx
@@ -48,7 +48,7 @@ import { makeTestUserContext } from 'teleport/User/testHelpers/makeTestUserConte
 import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
 
 import { ResourceKind } from './Shared';
-import { useDiscover } from './useDiscover';
+import { useDiscover, DiscoverUpdateProps } from './useDiscover';
 
 import type { ResourceSpec } from 'teleport/Discover/SelectResource/types';
 
@@ -209,12 +209,7 @@ describe('location state', () => {
   });
 });
 
-type updateProps = {
-  resourceName?: string;
-  resourceSpecForUpdate?: ResourceSpec;
-};
-
-const renderUpdate = (props: updateProps) => {
+const renderUpdate = (props: DiscoverUpdateProps) => {
   const defaultPref = makeDefaultUserPreferences();
   defaultPref.onboard.preferredResources = [Resource.WEB_APPLICATIONS];
 
@@ -255,19 +250,14 @@ const renderUpdate = (props: updateProps) => {
       ]}
     >
       <TeleportContextProvider ctx={ctx}>
-        <DiscoverComponent
-          eViewConfigs={testViews}
-          isUpdateFlow={true}
-          resourceSpecForUpdate={props.resourceSpecForUpdate}
-          agentMetaForUpdate={{ resourceName: props.resourceName }}
-        />
+        <DiscoverComponent eViewConfigs={testViews} updateFlow={props} />
       </TeleportContextProvider>
     </MemoryRouter>
   );
 };
 
-test('update flow: renders single component based on resourceSpecForUpdatvalue', () => {
-  const resourceSpecForUpdate: ResourceSpec = {
+test('update flow: renders single component based on resourceSpec', () => {
+  const resourceSpec: ResourceSpec = {
     name: 'Connect My Computer',
     kind: ResourceKind.ConnectMyComputer,
     event: null,
@@ -276,7 +266,7 @@ test('update flow: renders single component based on resourceSpecForUpdatvalue',
     hasAccess: true,
   };
 
-  renderUpdate({ resourceSpecForUpdate: resourceSpecForUpdate });
+  renderUpdate({ resourceSpec: resourceSpec, agentMeta: { resourceName: '' } });
 
   expect(screen.queryAllByTestId(ResourceKind.Server).length).toBeFalsy();
 
@@ -289,8 +279,8 @@ test('update flow: renders single component based on resourceSpecForUpdatvalue',
   expect(screen.getByText('Sign In & Connect My Computer')).toBeInTheDocument();
 });
 
-test('update flow: agentMeta is prepopulated based on agentMetaForUpdate', () => {
-  const resourceSpecForUpdate: ResourceSpec = {
+test('update flow: agentMeta is prepopulated based on agentMeta', () => {
+  const resourceSpec: ResourceSpec = {
     name: 'MockComponent1',
     kind: ResourceKind.SamlApplication,
     event: null,
@@ -300,8 +290,8 @@ test('update flow: agentMeta is prepopulated based on agentMetaForUpdate', () =>
   };
 
   renderUpdate({
-    resourceName: 'saml2',
-    resourceSpecForUpdate: resourceSpecForUpdate,
+    resourceSpec: resourceSpec,
+    agentMeta: { resourceName: 'saml2' },
   });
 
   expect(screen.getByText('saml2')).toBeInTheDocument();

--- a/web/packages/teleport/src/Discover/Discover.tsx
+++ b/web/packages/teleport/src/Discover/Discover.tsx
@@ -29,8 +29,10 @@ import { findViewAtIndex } from 'teleport/components/Wizard/flow';
 
 import { EViewConfigs } from './types';
 
-import { DiscoverProvider, useDiscover } from './useDiscover';
+import { DiscoverProvider, useDiscover, AgentMeta } from './useDiscover';
 import { DiscoverIcon } from './SelectResource/icons';
+
+import type { ResourceSpec } from './SelectResource';
 
 function DiscoverContent() {
   const {
@@ -94,10 +96,21 @@ function DiscoverContent() {
   );
 }
 
-export function DiscoverComponent({ eViewConfigs = [] }: Props) {
+export function DiscoverComponent({
+  eViewConfigs = [],
+  isUpdateFlow,
+  resourceSpecForUpdate,
+  agentMetaForUpdate,
+}: DiscoverComponentProps) {
   const location = useLocation();
   return (
-    <DiscoverProvider eViewConfigs={eViewConfigs} key={location.key}>
+    <DiscoverProvider
+      eViewConfigs={eViewConfigs}
+      key={location.key}
+      isUpdateFlow={isUpdateFlow}
+      resourceSpecForUpdate={resourceSpecForUpdate}
+      agentMetaForUpdate={agentMetaForUpdate}
+    >
       <DiscoverContent />
     </DiscoverProvider>
   );
@@ -107,6 +120,9 @@ export function Discover() {
   return <DiscoverComponent />;
 }
 
-type Props = {
+export type DiscoverComponentProps = {
   eViewConfigs?: EViewConfigs;
+  isUpdateFlow?: boolean;
+  resourceSpecForUpdate?: ResourceSpec;
+  agentMetaForUpdate?: AgentMeta;
 };

--- a/web/packages/teleport/src/Discover/Discover.tsx
+++ b/web/packages/teleport/src/Discover/Discover.tsx
@@ -29,10 +29,12 @@ import { findViewAtIndex } from 'teleport/components/Wizard/flow';
 
 import { EViewConfigs } from './types';
 
-import { DiscoverProvider, useDiscover, AgentMeta } from './useDiscover';
+import {
+  DiscoverProvider,
+  useDiscover,
+  DiscoverUpdateProps,
+} from './useDiscover';
 import { DiscoverIcon } from './SelectResource/icons';
-
-import type { ResourceSpec } from './SelectResource';
 
 function DiscoverContent() {
   const {
@@ -98,18 +100,14 @@ function DiscoverContent() {
 
 export function DiscoverComponent({
   eViewConfigs = [],
-  isUpdateFlow,
-  resourceSpecForUpdate,
-  agentMetaForUpdate,
+  updateFlow,
 }: DiscoverComponentProps) {
   const location = useLocation();
   return (
     <DiscoverProvider
       eViewConfigs={eViewConfigs}
       key={location.key}
-      isUpdateFlow={isUpdateFlow}
-      resourceSpecForUpdate={resourceSpecForUpdate}
-      agentMetaForUpdate={agentMetaForUpdate}
+      updateFlow={updateFlow}
     >
       <DiscoverContent />
     </DiscoverProvider>
@@ -122,7 +120,5 @@ export function Discover() {
 
 export type DiscoverComponentProps = {
   eViewConfigs?: EViewConfigs;
-  isUpdateFlow?: boolean;
-  resourceSpecForUpdate?: ResourceSpec;
-  agentMetaForUpdate?: AgentMeta;
+  updateFlow?: DiscoverUpdateProps;
 };

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -89,19 +89,22 @@ type CustomEventInput = {
   discoveryConfigMethod?: DiscoverDiscoveryConfigMethod;
 };
 
+export type DiscoverUpdateProps = {
+  // resourceSpecForUpdate specifies ResourceSpec which should be used to
+  // start a Discover flow.
+  resourceSpec: ResourceSpec;
+  // agentMetaForUpdate includes data that will be used to prepopulate input fields
+  // in the respective Discover compnents.
+  agentMeta: AgentMeta;
+};
+
 type DiscoverProviderProps = {
   // mockCtx used for testing purposes.
   mockCtx?: DiscoverContextState;
   // Extra view configs that are passed in. This is used to add view configs from Enterprise.
   eViewConfigs?: EViewConfigs;
-  // isUpdateFlow indicates if the Discover flow is an update resource flow.
-  isUpdateFlow?: boolean;
-  // resourceSpecForUpdate specifies ResourceSpec which should be used to
-  // start a Discover flow.
-  resourceSpecForUpdate?: ResourceSpec;
-  // agentMetaForUpdate includes data that will be used to prepopulate input fields
-  // in the respective Discover compnents.
-  agentMetaForUpdate?: AgentMeta;
+  // updateFlow holds properties used in Discover update flow.
+  updateFlow?: DiscoverUpdateProps;
 };
 
 // DiscoverUrlLocationState define fields to preserve state between
@@ -126,9 +129,7 @@ export function DiscoverProvider({
   mockCtx,
   children,
   eViewConfigs = [],
-  isUpdateFlow,
-  resourceSpecForUpdate,
-  agentMetaForUpdate,
+  updateFlow,
 }: React.PropsWithChildren<DiscoverProviderProps>) {
   const history = useHistory();
   const location = useLocation<DiscoverUrlLocationState>();
@@ -243,11 +244,11 @@ export function DiscoverProvider({
 
   // trigger update Discover flow.
   useEffect(() => {
-    if (isUpdateFlow) {
-      onSelectResource(resourceSpecForUpdate);
-      updateAgentMeta(agentMetaForUpdate);
+    if (updateFlow) {
+      onSelectResource(updateFlow.resourceSpec);
+      updateAgentMeta(updateFlow.agentMeta);
     }
-  }, [agentMetaForUpdate]);
+  }, [updateFlow]);
 
   // If a location.state.discover was provided, that means the user is
   // coming back from another location to resume the flow.
@@ -473,7 +474,7 @@ export function DiscoverProvider({
     emitErrorEvent,
     emitEvent,
     eventState,
-    isUpdateFlow,
+    isUpdateFlow: Boolean(updateFlow),
   };
 
   return (

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -70,6 +70,7 @@ export interface DiscoverContextState<T = any> {
   emitErrorEvent(errorStr: string): void;
   emitEvent(status: DiscoverEventStepStatus, custom?: CustomEventInput): void;
   eventState: EventState;
+  isUpdateFlow?: boolean;
 }
 
 type EventState = {
@@ -93,6 +94,14 @@ type DiscoverProviderProps = {
   mockCtx?: DiscoverContextState;
   // Extra view configs that are passed in. This is used to add view configs from Enterprise.
   eViewConfigs?: EViewConfigs;
+  // isUpdateFlow indicates if the Discover flow is an update resource flow.
+  isUpdateFlow?: boolean;
+  // resourceSpecForUpdate specifies ResourceSpec which should be used to
+  // start a Discover flow.
+  resourceSpecForUpdate?: ResourceSpec;
+  // agentMetaForUpdate includes data that will be used to prepopulate input fields
+  // in the respective Discover compnents.
+  agentMetaForUpdate?: AgentMeta;
 };
 
 // DiscoverUrlLocationState define fields to preserve state between
@@ -117,6 +126,9 @@ export function DiscoverProvider({
   mockCtx,
   children,
   eViewConfigs = [],
+  isUpdateFlow,
+  resourceSpecForUpdate,
+  agentMetaForUpdate,
 }: React.PropsWithChildren<DiscoverProviderProps>) {
   const history = useHistory();
   const location = useLocation<DiscoverUrlLocationState>();
@@ -228,6 +240,14 @@ export function DiscoverProvider({
       },
     });
   }
+
+  // trigger update Discover flow.
+  useEffect(() => {
+    if (isUpdateFlow) {
+      onSelectResource(resourceSpecForUpdate);
+      updateAgentMeta(agentMetaForUpdate);
+    }
+  }, [agentMetaForUpdate]);
 
   // If a location.state.discover was provided, that means the user is
   // coming back from another location to resume the flow.
@@ -453,6 +473,7 @@ export function DiscoverProvider({
     emitErrorEvent,
     emitEvent,
     eventState,
+    isUpdateFlow,
   };
 
   return (


### PR DESCRIPTION
Updates `DiscoverComponent` component and `useDiscover` to support update resource mechanism.

A new props `updateFlow` have been added of type `DiscoverUpdateProps`:

```
export type DiscoverUpdateProps = {
  // resourceSpecForUpdate specifies ResourceSpec which should be used to
  // start a Discover flow.
  resourceSpec: ResourceSpec;
  // agentMetaForUpdate includes data that will be used to prepopulate input fields
  // in the respective Discover compnents.
  agentMeta: AgentMeta;
};
```

Implemented to support SAML application update flow - https://github.com/gravitational/teleport.e/issues/4458