### PR TITLE
instance event plumbing

### DIFF
--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
 )
 
 // EventsService implements service to watch for events
@@ -211,6 +212,8 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newAccessMonitoringRuleParser()
 		case types.KindBotInstance:
 			parser = newBotInstanceParser()
+		case types.KindInstance:
+			parser = newInstanceParser()
 		default:
 			if watch.AllowPartialSuccess {
 				continue
@@ -2156,6 +2159,31 @@ func (p *botInstanceParser) parse(event backend.Event) (types.Resource, error) {
 			return nil, trace.Wrap(err)
 		}
 		return types.Resource153ToLegacy(botInstance), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+
+func newInstanceParser() *instanceParser {
+	return &instanceParser{
+		baseParser: newBaseParser(backend.Key(instancePrefix)),
+	}
+}
+
+type instanceParser struct {
+	baseParser
+}
+
+func (p *instanceParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		return resourceHeader(event, types.KindInstance, types.V1, 0)
+	case types.OpPut:
+		instance, err := generic.FastUnmarshal[*types.InstanceV1](event.Item)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return instance, nil
 	default:
 		return nil, trace.BadParameter("event %v is not supported", event.Type)
 	}

--- a/lib/services/local/generic/helpers.go
+++ b/lib/services/local/generic/helpers.go
@@ -1,0 +1,73 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package generic
+
+import (
+	"time"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// UnmarshalableResource represents a resource that can have all the necessary fields from backend.Item
+// set in a generic context.
+type UnmarshalableResource interface {
+	SetExpiry(time.Time)
+	SetRevision(string)
+}
+
+// FastUnmarshal is a generic helper used to unmarshal a resoruce from a backend.Item and
+// set the Expiry and Revision fields.  It isn't compatible with the standard Unmarshal function
+// signature used elsewhere and therefore may not be the best choice for all use cases, but it
+// has the benefit of being simpler to use and not requiring the caller to undergo the revision/expiry
+// ceremony at each call site.
+func FastUnmarshal[T UnmarshalableResource](item backend.Item) (T, error) {
+	var r T
+	if err := utils.FastUnmarshal(item.Value, &r); err != nil {
+		return r, err
+	}
+
+	r.SetExpiry(item.Expires)
+	r.SetRevision(item.Revision)
+	return r, nil
+}
+
+type MarshalableResource interface {
+	Expiry() time.Time
+	GetRevision() string
+}
+
+// FastMarshal is a generic helper used to marshal a resource to a backend.Item and
+// set the Expiry and Revision fields.  It isn't compatible with the standard Marshal function
+// signature used elsewhere and therefore may not be the best choice for all use cases, but it
+// has the benefit of being simpler to use and not requiring the caller to undergo the revision/expiry
+// ceremony at each call site.
+func FastMarshal[T MarshalableResource](key []byte, r T) (backend.Item, error) {
+	value, err := utils.FastMarshal(r)
+	if err != nil {
+		return backend.Item{}, err
+	}
+
+	return backend.Item{
+		Key:      key,
+		Value:    value,
+		Expires:  r.Expiry(),
+		Revision: r.GetRevision(),
+	}, nil
+}

--- a/lib/services/local/inventory.go
+++ b/lib/services/local/inventory.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/services/local/generic"
 )
 
 // GetInstances iterates all teleport instances.
@@ -52,8 +52,8 @@ func (s *PresenceService) GetInstances(ctx context.Context, req types.InstanceFi
 	endKey := backend.RangeEnd(startKey)
 	items := backend.StreamRange(ctx, s, startKey, endKey, pageSize)
 	return stream.FilterMap(items, func(item backend.Item) (types.Instance, bool) {
-		var instance types.InstanceV1
-		if err := utils.FastUnmarshal(item.Value, &instance); err != nil {
+		instance, err := generic.FastUnmarshal[*types.InstanceV1](item)
+		if err != nil {
 			s.log.Warnf("Skipping instance at %s, failed to unmarshal: %v", item.Key, err)
 			return nil, false
 		}
@@ -61,10 +61,10 @@ func (s *PresenceService) GetInstances(ctx context.Context, req types.InstanceFi
 			s.log.Warnf("Skipping instance at %s: %v", item.Key, err)
 			return nil, false
 		}
-		if !req.Match(&instance) {
+		if !req.Match(instance) {
 			return nil, false
 		}
-		return &instance, true
+		return instance, true
 	})
 }
 
@@ -75,8 +75,8 @@ func (s *PresenceService) getInstance(ctx context.Context, serverID string) (typ
 		return nil, trace.Wrap(err)
 	}
 
-	var instance types.InstanceV1
-	if err := utils.FastUnmarshal(item.Value, &instance); err != nil {
+	instance, err := generic.FastUnmarshal[*types.InstanceV1](*item)
+	if err != nil {
 		return nil, trace.BadParameter("failed to unmarshal instance %q: %v", serverID, err)
 	}
 
@@ -84,7 +84,7 @@ func (s *PresenceService) getInstance(ctx context.Context, serverID string) (typ
 		return nil, trace.BadParameter("instance %q appears malformed: %v", serverID, err)
 	}
 
-	return &instance, nil
+	return instance, nil
 }
 
 // UpsertInstance creates or updates an instance resource.
@@ -105,17 +105,9 @@ func (s *PresenceService) UpsertInstance(ctx context.Context, instance types.Ins
 		return trace.BadParameter("unexpected type %T, expected %T", instance, v1)
 	}
 
-	rev := instance.GetRevision()
-	value, err := utils.FastMarshal(v1)
+	item, err := generic.FastMarshal(backend.Key(instancePrefix, instance.GetName()), v1)
 	if err != nil {
 		return trace.Errorf("failed to marshal Instance: %v", err)
-	}
-
-	item := backend.Item{
-		Key:      backend.Key(instancePrefix, instance.GetName()),
-		Value:    value,
-		Expires:  instance.Expiry(),
-		Revision: rev,
 	}
 
 	_, err = s.Backend.Put(ctx, item)


### PR DESCRIPTION
Adds plumbing for `types.InstanceV1` events.  This PR only adds the local event plumbing as instance resources aren't cached and therefore can't be propagated to non-auth agents.  This is preparation for some proposed future work that might want to tap into instance events in order to monitor for misconfigurations.