### PR TITLE
[v16] Omit control plane instances from inventory list

### DIFF
--- a/docs/pages/upgrading/automatic-agent-updates.mdx
+++ b/docs/pages/upgrading/automatic-agent-updates.mdx
@@ -150,10 +150,6 @@ Server ID                            Hostname      Services Version Upgrader
 ...
 ```
 
-Note that the `inventory ls` command will also list `teleport-auth` and
-`teleport-proxy` services. If you use managed Teleport Enterprise, the Teleport
-team updates these services automatically.
-
 ## Step 3/4. Enroll agents on Linux servers in automatic updates
 
 1. For each agent ID returned by the `tctl inventory ls` command, copy the ID

--- a/docs/pages/upgrading/reference.mdx
+++ b/docs/pages/upgrading/reference.mdx
@@ -278,10 +278,6 @@ self-hosted clusters, as well as all Teleport agents.
    ...
    ```
 
-   Note that the `inventory ls` command will also list `teleport-auth` and
-   `teleport-proxy` services. These services are managed by the Teleport team, and
-   updates will be performed automatically.
-
 1. For each agent ID returned by the `tctl inventory ls` command, copy the ID
    and run the following `tctl` command to access the host via `tsh`:
 


### PR DESCRIPTION
Backport #43521 to branch/v16

changelog: Omit control plane services from the inventory list output for Cloud-Hosted instances
