### PR TITLE
Send cluster name as SNI when connecting to TAG

### DIFF
--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -149,6 +149,10 @@ func (process *TeleportProcess) integrationOnlyCredentials() bool {
 	return process.Config.Auth.Enabled && modules.GetModules().Features().Cloud
 }
 
+// accessGraphClusterSNI is a constant representing the SNI (Server Name Indication) prefix value
+// used when connecting to Access Graph.
+const accessGraphClusterSNI = "access-graph.cluster."
+
 // buildAccessGraphFromTAGOrFallbackToAuth builds the AccessGraphConfig from the Teleport Agent configuration or falls back to the Auth server's configuration.
 // If the AccessGraph configuration is not enabled locally, it will fall back to the Auth server's configuration.
 func buildAccessGraphFromTAGOrFallbackToAuth(ctx context.Context, config *servicecfg.Config, client authclient.ClientI, logger *slog.Logger) (discovery.AccessGraphConfig, error) {
@@ -176,7 +180,7 @@ func buildAccessGraphFromTAGOrFallbackToAuth(ctx context.Context, config *servic
 		Addr:        config.AccessGraph.Addr,
 		Insecure:    config.AccessGraph.Insecure,
 		CA:          accessGraphCAData,
-		ClusterName: clusterName.GetClusterName(),
+		ClusterName: accessGraphClusterSNI + clusterName.GetClusterName(),
 	}
 	if !accessGraphCfg.Enabled {
 		logger.DebugContext(ctx, "Access graph is disabled or not configured. Falling back to the Auth server's access graph configuration.")

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -165,11 +165,18 @@ func buildAccessGraphFromTAGOrFallbackToAuth(ctx context.Context, config *servic
 			return discovery.AccessGraphConfig{}, trace.Wrap(err, "failed to read access graph CA file")
 		}
 	}
+
+	clusterName, err := client.GetClusterName()
+	if err != nil {
+		return discovery.AccessGraphConfig{}, trace.Wrap(err)
+	}
+
 	accessGraphCfg := discovery.AccessGraphConfig{
-		Enabled:  config.AccessGraph.Enabled,
-		Addr:     config.AccessGraph.Addr,
-		Insecure: config.AccessGraph.Insecure,
-		CA:       accessGraphCAData,
+		Enabled:     config.AccessGraph.Enabled,
+		Addr:        config.AccessGraph.Addr,
+		Insecure:    config.AccessGraph.Insecure,
+		CA:          accessGraphCAData,
+		ClusterName: clusterName.GetClusterName(),
 	}
 	if !accessGraphCfg.Enabled {
 		logger.DebugContext(ctx, "Access graph is disabled or not configured. Falling back to the Auth server's access graph configuration.")

--- a/lib/service/discovery_test.go
+++ b/lib/service/discovery_test.go
@@ -101,7 +101,7 @@ func TestTeleportProcess_initDiscoveryService(t *testing.T) {
 			want: discovery.AccessGraphConfig{
 				Enabled:     true,
 				Addr:        "localhost:5000",
-				ClusterName: "cluster-name",
+				ClusterName: "access-graph.cluster.cluster-name",
 				Insecure:    true,
 			},
 			assertErr: require.NoError,
@@ -120,7 +120,7 @@ func TestTeleportProcess_initDiscoveryService(t *testing.T) {
 			want: discovery.AccessGraphConfig{
 				Enabled:     true,
 				Addr:        "localhost:5000",
-				ClusterName: "cluster-name",
+				ClusterName: "access-graph.cluster.cluster-name",
 				Insecure:    true,
 			},
 			assertErr: require.NoError,
@@ -134,7 +134,7 @@ func TestTeleportProcess_initDiscoveryService(t *testing.T) {
 			err: trace.NotImplemented("err"),
 			want: discovery.AccessGraphConfig{
 				Enabled:     false,
-				ClusterName: "cluster-name",
+				ClusterName: "access-graph.cluster.cluster-name",
 			},
 			assertErr: require.NoError,
 		},

--- a/lib/service/discovery_test.go
+++ b/lib/service/discovery_test.go
@@ -27,9 +27,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery"
 )
 
@@ -97,9 +99,10 @@ func TestTeleportProcess_initDiscoveryService(t *testing.T) {
 			rsp: nil,
 			err: nil,
 			want: discovery.AccessGraphConfig{
-				Enabled:  true,
-				Addr:     "localhost:5000",
-				Insecure: true,
+				Enabled:     true,
+				Addr:        "localhost:5000",
+				ClusterName: "cluster-name",
+				Insecure:    true,
 			},
 			assertErr: require.NoError,
 		},
@@ -115,9 +118,10 @@ func TestTeleportProcess_initDiscoveryService(t *testing.T) {
 			},
 			err: nil,
 			want: discovery.AccessGraphConfig{
-				Enabled:  true,
-				Addr:     "localhost:5000",
-				Insecure: true,
+				Enabled:     true,
+				Addr:        "localhost:5000",
+				ClusterName: "cluster-name",
+				Insecure:    true,
 			},
 			assertErr: require.NoError,
 		},
@@ -129,7 +133,8 @@ func TestTeleportProcess_initDiscoveryService(t *testing.T) {
 			rsp: nil,
 			err: trace.NotImplemented("err"),
 			want: discovery.AccessGraphConfig{
-				Enabled: false,
+				Enabled:     false,
+				ClusterName: "cluster-name",
 			},
 			assertErr: require.NoError,
 		},
@@ -176,4 +181,12 @@ func (f *fakeClient) GetClusterAccessGraphConfig(ctx context.Context) (*clusterc
 		return nil, f.err
 	}
 	return f.rsp, nil
+}
+
+func (f *fakeClient) GetClusterName(_ ...services.MarshalOption) (types.ClusterName, error) {
+	return &types.ClusterNameV2{
+		Spec: types.ClusterNameSpecV2{
+			ClusterName: "cluster-name",
+		},
+	}, nil
 }

--- a/lib/srv/discovery/access_graph.go
+++ b/lib/srv/discovery/access_graph.go
@@ -385,6 +385,7 @@ func grpcCredentials(config AccessGraphConfig, certs []tls.Certificate) (grpc.Di
 		MinVersion:         tls.VersionTLS13,
 		InsecureSkipVerify: config.Insecure,
 		RootCAs:            pool,
+		ServerName:         config.ClusterName,
 	}
 	return grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)), nil
 }

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -173,6 +173,9 @@ type AccessGraphConfig struct {
 	// CA is the CA in PEM format used by the Access Graph service.
 	CA []byte
 
+	// ClusterName if the name of Teleport cluster.
+	ClusterName string
+
 	// Insecure is true if the connection to the Access Graph service should be insecure.
 	Insecure bool
 }


### PR DESCRIPTION
Include Teleport cluster name in the connection information when connecting to TAG event stream endpoint. TAG will use that information to manage open connections. Only EventStream endpoint need that information, so Proxy connection can still send empty server name as it does right now.

changelog: Access Graph clients includes SNI server name when connecting