### PR TITLE
Batch access list review reminders and provide link (slack)

### DIFF
--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -170,16 +170,13 @@ func (a *App) remindIfNecessary(ctx context.Context) error {
 		for _, accessList := range accessLists {
 			recipients, err := a.getRecipientsRequiringReminders(ctx, accessList)
 			if err != nil {
-				log.WithError(err).Warn("Error getting recipients to notify for access list reviews")
+				log.WithError(err).Warn("Error getting recipients to notify for review due for access list %q", accessList.Spec.Title)
 				continue
 			}
 
 			// Store all recipients and the accesslist needing review
 			// for later processing.
 			for _, recipient := range recipients {
-				if _, ok := remindersLookup[recipient]; !ok {
-					remindersLookup[recipient] = []*accesslist.AccessList{}
-				}
 				remindersLookup[recipient] = append(remindersLookup[recipient], accessList)
 			}
 		}
@@ -197,7 +194,7 @@ func (a *App) remindIfNecessary(ctx context.Context) error {
 		}
 	}
 
-	if err != nil {
+	if len(errs) > 0 {
 		log.WithError(trace.NewAggregate(errs...)).Warn("Error notifying for access list reviews")
 	}
 

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -170,7 +170,7 @@ func (a *App) remindIfNecessary(ctx context.Context) error {
 		for _, accessList := range accessLists {
 			recipients, err := a.getRecipientsRequiringReminders(ctx, accessList)
 			if err != nil {
-				log.WithError(err).Warn("Error getting recipients to notify for review due for access list %q", accessList.Spec.Title)
+				log.WithError(err).Warnf("Error getting recipients to notify for review due for access list %q", accessList.Spec.Title)
 				continue
 			}
 

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -43,9 +43,6 @@ import (
 
 type mockMessagingBot struct {
 	lastReminderRecipients []common.Recipient
-	isBatchTest            bool
-	numSentSingleReminders int
-	numSentBatchReminders  int
 	recipients             map[string]*common.Recipient
 	mutex                  sync.Mutex
 }
@@ -54,19 +51,10 @@ func (m *mockMessagingBot) CheckHealth(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockMessagingBot) SendReviewReminders(ctx context.Context, recipient common.Recipient, accessList *accesslist.AccessList) error {
+func (m *mockMessagingBot) SendReviewReminders(ctx context.Context, recipient common.Recipient, accessLists []*accesslist.AccessList) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.lastReminderRecipients = append(m.lastReminderRecipients, recipient)
-	m.numSentSingleReminders += 1
-	return nil
-}
-
-func (m *mockMessagingBot) SendBatchedReviewReminder(ctx context.Context, recipient common.Recipient, accessLists []*accesslist.AccessList) error {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	m.lastReminderRecipients = append(m.lastReminderRecipients, recipient)
-	m.numSentBatchReminders += 1
 	return nil
 }
 
@@ -80,8 +68,6 @@ func (m *mockMessagingBot) resetLastRecipients() {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.lastReminderRecipients = make([]common.Recipient, 0)
-	m.numSentBatchReminders = 0
-	m.numSentSingleReminders = 0
 }
 
 func (m *mockMessagingBot) FetchRecipient(ctx context.Context, recipient string) (*common.Recipient, error) {
@@ -235,7 +221,6 @@ func TestAccessListReminders_Batched(t *testing.T) {
 	})
 
 	bot := &mockMessagingBot{
-		isBatchTest: true,
 		recipients: map[string]*common.Recipient{
 			"owner1": {Name: "owner1", ID: "owner1"},
 			"owner2": {Name: "owner2", ID: "owner2"},
@@ -393,12 +378,6 @@ func advanceAndLookForRecipients(t *testing.T,
 	clock.BlockUntil(1)
 
 	require.ElementsMatch(t, expectedRecipients, bot.getLastRecipients())
-
-	if bot.isBatchTest {
-		require.Equal(t, len(expectedRecipients), bot.numSentBatchReminders, "batched reminders")
-	} else {
-		require.Equal(t, len(expectedRecipients), bot.numSentSingleReminders, "single reminders")
-	}
 }
 
 func newTestAuth(t *testing.T) *auth.TestServer {

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -33,14 +33,19 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 )
 
 type mockMessagingBot struct {
 	lastReminderRecipients []common.Recipient
+	isBatchTest            bool
+	numSentSingleReminders int
+	numSentBatchReminders  int
 	recipients             map[string]*common.Recipient
 	mutex                  sync.Mutex
 }
@@ -53,6 +58,15 @@ func (m *mockMessagingBot) SendReviewReminders(ctx context.Context, recipient co
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.lastReminderRecipients = append(m.lastReminderRecipients, recipient)
+	m.numSentSingleReminders += 1
+	return nil
+}
+
+func (m *mockMessagingBot) SendBatchedReviewReminder(ctx context.Context, recipient common.Recipient, accessLists []*accesslist.AccessList) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.lastReminderRecipients = append(m.lastReminderRecipients, recipient)
+	m.numSentBatchReminders += 1
 	return nil
 }
 
@@ -66,6 +80,8 @@ func (m *mockMessagingBot) resetLastRecipients() {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.lastReminderRecipients = make([]common.Recipient, 0)
+	m.numSentBatchReminders = 0
+	m.numSentSingleReminders = 0
 }
 
 func (m *mockMessagingBot) FetchRecipient(ctx context.Context, recipient string) (*common.Recipient, error) {
@@ -106,7 +122,7 @@ func (m *mockPluginConfig) GetPluginType() types.PluginType {
 	return types.PluginTypeSlack
 }
 
-func TestAccessListReminders(t *testing.T) {
+func TestAccessListReminders_Single(t *testing.T) {
 	t.Parallel()
 
 	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -120,8 +136,8 @@ func TestAccessListReminders(t *testing.T) {
 
 	bot := &mockMessagingBot{
 		recipients: map[string]*common.Recipient{
-			"owner1": {Name: "owner1"},
-			"owner2": {Name: "owner2"},
+			"owner1": {Name: "owner1", ID: "owner1"},
+			"owner2": {Name: "owner2", ID: "owner2"},
 		},
 	}
 	app := common.NewApp(&mockPluginConfig{client: as, bot: bot}, "test-plugin")
@@ -158,44 +174,137 @@ func TestAccessListReminders(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	accessLists := []*accesslist.AccessList{accessList}
+
 	// No notifications for today
-	advanceAndLookForRecipients(t, bot, as, clock, 0, accessList)
+	advanceAndLookForRecipients(t, bot, as, clock, 0, accessLists)
 
 	// Advance by one week, expect no notifications.
-	advanceAndLookForRecipients(t, bot, as, clock, oneDay*7, accessList)
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay*7, accessLists)
 
 	// Advance by one week, expect a notification. "not-found" will be missing as a recipient.
-	advanceAndLookForRecipients(t, bot, as, clock, oneDay*7, accessList, "owner1")
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay*7, accessLists, "owner1")
 
 	// Add a new owner.
 	accessList.Spec.Owners = append(accessList.Spec.Owners, accesslist.Owner{Name: "owner2"})
 
 	// Advance by one day, expect a notification only to the new owner.
-	advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessList, "owner2")
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessLists, "owner2")
 
 	// Advance by one day, expect no notifications.
-	advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessList)
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessLists)
 
 	// Advance by five more days, to the next week, expect two notifications
-	advanceAndLookForRecipients(t, bot, as, clock, oneDay*5, accessList, "owner1", "owner2")
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay*5, accessLists, "owner1", "owner2")
 
 	// Advance by one day, expect no notifications
-	advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessList)
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessLists)
 
 	// Advance by one day, expect no notifications
-	advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessList)
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessLists)
 
 	// Advance by five more days, to the next week, expect two notifications
-	advanceAndLookForRecipients(t, bot, as, clock, oneDay*5, accessList, "owner1", "owner2")
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay*5, accessLists, "owner1", "owner2")
 
 	// Advance 60 days a day at a time, expect two notifications each time.
 	for i := 0; i < 60; i++ {
 		// Make sure we only get a notification once per day by iterating through each 6 hours at a time.
 		for j := 0; j < 3; j++ {
-			advanceAndLookForRecipients(t, bot, as, clock, 6*time.Hour, accessList)
+			advanceAndLookForRecipients(t, bot, as, clock, 6*time.Hour, accessLists)
 		}
-		advanceAndLookForRecipients(t, bot, as, clock, 6*time.Hour, accessList, "owner1", "owner2")
+		advanceAndLookForRecipients(t, bot, as, clock, 6*time.Hour, accessLists, "owner1", "owner2")
 	}
+}
+
+func TestAccessListReminders_Batched(t *testing.T) {
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.Identity: {Enabled: true},
+			},
+		},
+	})
+
+	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	server := newTestAuth(t)
+
+	as := server.Auth()
+	t.Cleanup(func() {
+		require.NoError(t, as.Close())
+	})
+
+	bot := &mockMessagingBot{
+		isBatchTest: true,
+		recipients: map[string]*common.Recipient{
+			"owner1": {Name: "owner1", ID: "owner1"},
+			"owner2": {Name: "owner2", ID: "owner2"},
+		},
+	}
+	app := common.NewApp(&mockPluginConfig{client: as, bot: bot}, "test-plugin")
+	app.Clock = clock
+	ctx := context.Background()
+	go func() {
+		app.Run(ctx)
+	}()
+
+	ready, err := app.WaitReady(ctx)
+	require.NoError(t, err)
+	require.True(t, ready)
+
+	t.Cleanup(func() {
+		app.Terminate()
+		<-app.Done()
+		require.NoError(t, app.Err())
+	})
+
+	accessList1, err := accesslist.NewAccessList(header.Metadata{
+		Name: "test-access-list",
+	}, accesslist.Spec{
+		Title:  "test access list",
+		Owners: []accesslist.Owner{{Name: "owner1"}, {Name: "owner2"}, {Name: "not-found"}},
+		Grants: accesslist.Grants{
+			Roles: []string{"role"},
+		},
+		Audit: accesslist.Audit{
+			NextAuditDate: clock.Now().Add(28 * 24 * time.Hour), // Four weeks out from today
+			Notifications: accesslist.Notifications{
+				Start: oneDay * 14, // Start alerting at two weeks before audit date
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	accessList2, err := accesslist.NewAccessList(header.Metadata{
+		Name: "test-access-list-2",
+	}, accesslist.Spec{
+		Title:  "test access list 2",
+		Owners: []accesslist.Owner{{Name: "owner1"}, {Name: "owner2"}, {Name: "not-found"}},
+		Grants: accesslist.Grants{
+			Roles: []string{"role"},
+		},
+		Audit: accesslist.Audit{
+			NextAuditDate: clock.Now().Add(28 * 24 * time.Hour), // Four weeks out from today
+			Notifications: accesslist.Notifications{
+				Start: oneDay * 14, // Start alerting at two weeks before audit date
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	accessLists := []*accesslist.AccessList{accessList1, accessList2}
+
+	// No notifications for today
+	advanceAndLookForRecipients(t, bot, as, clock, 0, accessLists)
+
+	// Advance by one week, expect no notifications.
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay*7, accessLists)
+
+	// Advance by one week, expect a notification. "not-found" will be missing as a recipient.
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay*7, accessLists, "owner1", "owner2")
+
+	// Advance another week, expect notifications.
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay*7, accessLists, "owner1", "owner2")
 }
 
 type mockClient struct {
@@ -261,13 +370,15 @@ func advanceAndLookForRecipients(t *testing.T,
 	alSvc services.AccessLists,
 	clock clockwork.FakeClock,
 	advance time.Duration,
-	accessList *accesslist.AccessList,
+	accessLists []*accesslist.AccessList,
 	recipients ...string) {
 
 	ctx := context.Background()
 
-	_, err := alSvc.UpsertAccessList(ctx, accessList)
-	require.NoError(t, err)
+	for _, accessList := range accessLists {
+		_, err := alSvc.UpsertAccessList(ctx, accessList)
+		require.NoError(t, err)
+	}
 
 	bot.resetLastRecipients()
 
@@ -275,13 +386,19 @@ func advanceAndLookForRecipients(t *testing.T,
 	if len(recipients) > 0 {
 		expectedRecipients = make([]common.Recipient, len(recipients))
 		for i, r := range recipients {
-			expectedRecipients[i] = common.Recipient{Name: r}
+			expectedRecipients[i] = common.Recipient{Name: r, ID: r}
 		}
 	}
 	clock.Advance(advance)
 	clock.BlockUntil(1)
 
 	require.ElementsMatch(t, expectedRecipients, bot.getLastRecipients())
+
+	if bot.isBatchTest {
+		require.Equal(t, len(expectedRecipients), bot.numSentBatchReminders, "batched reminders")
+	} else {
+		require.Equal(t, len(expectedRecipients), bot.numSentSingleReminders, "single reminders")
+	}
 }
 
 func newTestAuth(t *testing.T) *auth.TestServer {

--- a/integrations/access/accesslist/bot.go
+++ b/integrations/access/accesslist/bot.go
@@ -29,7 +29,5 @@ type MessagingBot interface {
 	common.MessagingBot
 
 	// SendReviewReminders will send a review reminder that an access list needs to be reviewed.
-	SendReviewReminders(ctx context.Context, recipient common.Recipient, accessList *accesslist.AccessList) error
-	// SendBatchedReviewReminder will send a batched review reminder.
-	SendBatchedReviewReminder(ctx context.Context, recipient common.Recipient, accessLists []*accesslist.AccessList) error
+	SendReviewReminders(ctx context.Context, recipient common.Recipient, accessLists []*accesslist.AccessList) error
 }

--- a/integrations/access/accesslist/bot.go
+++ b/integrations/access/accesslist/bot.go
@@ -30,4 +30,6 @@ type MessagingBot interface {
 
 	// SendReviewReminders will send a review reminder that an access list needs to be reviewed.
 	SendReviewReminders(ctx context.Context, recipient common.Recipient, accessList *accesslist.AccessList) error
+	// SendBatchedReviewReminder will send a batched review reminder.
+	SendBatchedReviewReminder(ctx context.Context, recipient common.Recipient, accessLists []*accesslist.AccessList) error
 }

--- a/integrations/access/discord/bot.go
+++ b/integrations/access/discord/bot.go
@@ -122,6 +122,11 @@ func (b DiscordBot) SendReviewReminders(ctx context.Context, recipients []common
 	return trace.NotImplemented("access list review reminder is not yet implemented")
 }
 
+// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
+func (b DiscordBot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+	return trace.NotImplemented("access list batched review reminder is not yet implemented")
+}
+
 // BroadcastAccessRequestMessage posts request info to Discord.
 func (b DiscordBot) BroadcastAccessRequestMessage(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (accessrequest.SentMessages, error) {
 	var data accessrequest.SentMessages

--- a/integrations/access/discord/bot.go
+++ b/integrations/access/discord/bot.go
@@ -118,13 +118,8 @@ func (b DiscordBot) SupportedApps() []common.App {
 }
 
 // SendReviewReminders will send a review reminder that an access list needs to be reviewed.
-func (b DiscordBot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+func (b DiscordBot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessLists []*accesslist.AccessList) error {
 	return trace.NotImplemented("access list review reminder is not yet implemented")
-}
-
-// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
-func (b DiscordBot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
-	return trace.NotImplemented("access list batched review reminder is not yet implemented")
 }
 
 // BroadcastAccessRequestMessage posts request info to Discord.

--- a/integrations/access/mattermost/bot.go
+++ b/integrations/access/mattermost/bot.go
@@ -245,6 +245,11 @@ func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipi
 	return trace.NotImplemented("access list review reminder is not yet implemented")
 }
 
+// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
+func (b Bot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+	return trace.NotImplemented("access list batched review reminder is not yet implemented")
+}
+
 // BroadcastAccessRequestMessage posts request info to Mattermost.
 func (b Bot) BroadcastAccessRequestMessage(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (accessrequest.SentMessages, error) {
 	text, err := b.buildPostText(reqID, reqData)

--- a/integrations/access/mattermost/bot.go
+++ b/integrations/access/mattermost/bot.go
@@ -241,13 +241,8 @@ func (b Bot) GetMe(ctx context.Context) (User, error) {
 }
 
 // SendReviewReminders will send a review reminder that an access list needs to be reviewed.
-func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessLists []*accesslist.AccessList) error {
 	return trace.NotImplemented("access list review reminder is not yet implemented")
-}
-
-// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
-func (b Bot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
-	return trace.NotImplemented("access list batched review reminder is not yet implemented")
 }
 
 // BroadcastAccessRequestMessage posts request info to Mattermost.

--- a/integrations/access/opsgenie/bot.go
+++ b/integrations/access/opsgenie/bot.go
@@ -55,13 +55,8 @@ func (b *Bot) CheckHealth(ctx context.Context) error {
 }
 
 // SendReviewReminders will send a review reminder that an access list needs to be reviewed.
-func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessLists []*accesslist.AccessList) error {
 	return trace.NotImplemented("access list review reminder is not yet implemented")
-}
-
-// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
-func (b Bot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
-	return trace.NotImplemented("access list batched review reminder is not yet implemented")
 }
 
 // BroadcastAccessRequestMessage creates an alert for the provided recipients (schedules)

--- a/integrations/access/opsgenie/bot.go
+++ b/integrations/access/opsgenie/bot.go
@@ -59,6 +59,11 @@ func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipi
 	return trace.NotImplemented("access list review reminder is not yet implemented")
 }
 
+// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
+func (b Bot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+	return trace.NotImplemented("access list batched review reminder is not yet implemented")
+}
+
 // BroadcastAccessRequestMessage creates an alert for the provided recipients (schedules)
 func (b *Bot) BroadcastAccessRequestMessage(ctx context.Context, recipientSchedules []common.Recipient, reqID string, reqData pd.AccessRequestData) (data accessrequest.SentMessages, err error) {
 	notificationSchedules := make([]string, 0, len(recipientSchedules))

--- a/integrations/access/servicenow/bot.go
+++ b/integrations/access/servicenow/bot.go
@@ -54,13 +54,8 @@ func (b *Bot) CheckHealth(ctx context.Context) error {
 }
 
 // SendReviewReminders will send a review reminder that an access list needs to be reviewed.
-func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessLists []*accesslist.AccessList) error {
 	return trace.NotImplemented("access list review reminder is not yet implemented")
-}
-
-// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
-func (b Bot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
-	return trace.NotImplemented("access list batched review reminder is not yet implemented")
 }
 
 // BroadcastAccessRequestMessage creates a ServiceNow incident.

--- a/integrations/access/servicenow/bot.go
+++ b/integrations/access/servicenow/bot.go
@@ -58,6 +58,11 @@ func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipi
 	return trace.NotImplemented("access list review reminder is not yet implemented")
 }
 
+// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
+func (b Bot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+	return trace.NotImplemented("access list batched review reminder is not yet implemented")
+}
+
 // BroadcastAccessRequestMessage creates a ServiceNow incident.
 func (b *Bot) BroadcastAccessRequestMessage(ctx context.Context, _ []common.Recipient, reqID string, reqData pd.AccessRequestData) (data accessrequest.SentMessages, err error) {
 	serviceNowReqData := RequestData{

--- a/integrations/access/slack/testlib/suite.go
+++ b/integrations/access/slack/testlib/suite.go
@@ -831,7 +831,7 @@ func (s *SlackSuiteEnterprise) TestRace() {
 
 // TestAccessListReminder validates that Access List reminders are sent before
 // the Access List expires.
-func (s *SlackSuiteEnterprise) TestAccessListReminder() {
+func (s *SlackSuiteEnterprise) TestAccessListReminder_Singular() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -885,6 +885,66 @@ func (s *SlackSuiteEnterprise) TestAccessListReminder() {
 	s.requireReminderMsgEqual(ctx, s.reviewer1SlackUser.ID, "Access List *simple title* is 7 day(s) past due for a review! Please review it.")
 }
 
+// TestAccessListReminder_Batched validates that Access List reminders are sent in batches
+// if multiple access lists are given.
+func (s *SlackSuiteEnterprise) TestAccessListReminder_Batched() {
+	t := s.T()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
+	s.appConfig.Clock = clock
+	s.startApp()
+
+	// Test setup: create a couple accesslists
+
+	accessList1, err := accesslist.NewAccessList(header.Metadata{
+		Name: "access-list1",
+	}, accesslist.Spec{
+		Title: "simple title one",
+		Grants: accesslist.Grants{
+			Roles: []string{"grant"},
+		},
+		Owners: []accesslist.Owner{
+			{Name: integration.Reviewer1UserName},
+		},
+		Audit: accesslist.Audit{
+			NextAuditDate: time.Date(2023, 3, 2, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.Ruler().AccessListClient().UpsertAccessList(ctx, accessList1)
+	require.NoError(t, err)
+
+	accessList2, err := accesslist.NewAccessList(header.Metadata{
+		Name: "access-list2",
+	}, accesslist.Spec{
+		Title: "simple title two",
+		Grants: accesslist.Grants{
+			Roles: []string{"grant"},
+		},
+		Owners: []accesslist.Owner{
+			{Name: integration.Reviewer1UserName},
+		},
+		Audit: accesslist.Audit{
+			NextAuditDate: time.Date(2023, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.Ruler().AccessListClient().UpsertAccessList(ctx, accessList2)
+	require.NoError(t, err)
+
+	// Trigger a reminder.
+	clock.BlockUntil(1)
+	clock.Advance(46 * 25 * time.Hour)
+	s.requireReminderMsgEqual(ctx, s.reviewer1SlackUser.ID, "2 Access Lists are due for reviews, earliest of which is due by 2023-03-01")
+
+	// Make it overdue.
+	clock.BlockUntil(1)
+	clock.Advance(20 * 24 * time.Hour)
+	s.requireReminderMsgEqual(ctx, s.reviewer1SlackUser.ID, "2 Access Lists are due for reviews, earliest of which is 8 day(s) past due")
+}
+
 func (s *SlackBaseSuite) requireReminderMsgEqual(ctx context.Context, id, text string) {
 	s.T().Helper()
 	t := s.T()
@@ -893,5 +953,5 @@ func (s *SlackBaseSuite) requireReminderMsgEqual(ctx context.Context, id, text s
 	require.NoError(t, err)
 	require.Equal(t, id, msg.Channel)
 	require.IsType(t, slack.SectionBlock{}, msg.BlockItems[0].Block)
-	require.Equal(t, text, (msg.BlockItems[0].Block).(slack.SectionBlock).Text.GetText())
+	require.Contains(t, (msg.BlockItems[0].Block).(slack.SectionBlock).Text.GetText(), text)
 }


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/3571

Instead of sending a reminder PER access list review due, it now only sends one (batched or singular) and includes link to the access list page. This required to gather all access list upfront (instead of processing reminders per page), putting it into a lookup map by recipients. 

If a recipient has >1 access list reviews due, the messaging is batched, with the earliest due date mentioned, and links out to the access list listing page:

<img width="672" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/63229a6b-1e54-4bd4-b0db-390c079e4859">


If a recipient has only one review due, it keeps the previous messaging, including a link out to the specific access list:

<img width="724" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/61b05102-8560-4c4a-a256-9d77dd8155b6">

changelog: For slack integration, Access List reminders are batched into 1 message and provides link out to the web UI.

