### PR TITLE
Fix eBPF on RHEL 9 family systems

### DIFF
--- a/bpf/enhancedrecording/command.bpf.c
+++ b/bpf/enhancedrecording/command.bpf.c
@@ -165,7 +165,7 @@ static int exit_execve(int ret)
 }
 
 SEC("tp/syscalls/sys_execve")
-int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter *tp)
+int tracepoint__syscalls__sys_enter_execve(struct syscall_trace_enter *tp)
 {
     const char *filename = (const char *)tp->args[0];
     const char *const *argv = (const char *const *)tp->args[1];
@@ -175,13 +175,13 @@ int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter *tp)
 }
 
 SEC("tp/syscalls/sys_exit_execve")
-int tracepoint__syscalls__sys_exit_execve(struct trace_event_raw_sys_exit *tp)
+int tracepoint__syscalls__sys_exit_execve(struct syscall_trace_exit *tp)
 {
     return exit_execve(tp->ret);
 }
 
 SEC("tp/syscalls/sys_execveat")
-int tracepoint__syscalls__sys_enter_execveat(struct trace_event_raw_sys_enter *tp)
+int tracepoint__syscalls__sys_enter_execveat(struct syscall_trace_enter *tp)
 {
     const char *filename = (const char *)tp->args[1];
     const char *const *argv = (const char *const *)tp->args[2];
@@ -191,7 +191,7 @@ int tracepoint__syscalls__sys_enter_execveat(struct trace_event_raw_sys_enter *t
 }
 
 SEC("tp/syscalls/sys_exit_execveat")
-int tracepoint__syscalls__sys_exit_execveat(struct trace_event_raw_sys_exit *tp)
+int tracepoint__syscalls__sys_exit_execveat(struct syscall_trace_exit *tp)
 {
     return exit_execve(tp->ret);
 }

--- a/bpf/enhancedrecording/counter_test.bpf.c
+++ b/bpf/enhancedrecording/counter_test.bpf.c
@@ -10,7 +10,7 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 BPF_COUNTER(test_counter);
 
 SEC("tp/syscalls/sys_close")
-int tracepoint__syscalls__sys_enter_close(struct trace_event_raw_sys_enter *tp)
+int tracepoint__syscalls__sys_enter_close(struct syscall_trace_enter *tp)
 {
     int fd = (int)tp->args[0];
 
@@ -23,7 +23,7 @@ int tracepoint__syscalls__sys_enter_close(struct trace_event_raw_sys_enter *tp)
 }
 
 SEC("tp/syscalls/sys_exit_close")
-int tracepoint__syscalls__sys_exit_close(struct trace_event_raw_sys_exit *tp)
+int tracepoint__syscalls__sys_exit_close(struct syscall_trace_exit *tp)
 {
 	return 0;
 }

--- a/bpf/enhancedrecording/disk.bpf.c
+++ b/bpf/enhancedrecording/disk.bpf.c
@@ -97,7 +97,7 @@ static int exit_open(int ret) {
 
 
 SEC("tp/syscalls/sys_enter_creat")
-int tracepoint__syscalls__sys_enter_creat(struct trace_event_raw_sys_enter *tp)
+int tracepoint__syscalls__sys_enter_creat(struct syscall_trace_enter *tp)
 {
     const char *filename = (const char*) tp->args[0];
 
@@ -105,7 +105,7 @@ int tracepoint__syscalls__sys_enter_creat(struct trace_event_raw_sys_enter *tp)
 }
 
 SEC("tp/syscalls/sys_exit_creat")
-int tracepoint__syscalls__sys_exit_creat(struct trace_event_raw_sys_exit *tp)
+int tracepoint__syscalls__sys_exit_creat(struct syscall_trace_exit *tp)
 {
     return exit_open(tp->ret);
 }
@@ -114,7 +114,7 @@ int tracepoint__syscalls__sys_exit_creat(struct trace_event_raw_sys_exit *tp)
 #ifndef __TARGET_ARCH_arm64
 
 SEC("tp/syscalls/sys_enter_open")
-int tracepoint__syscalls__sys_enter_open(struct trace_event_raw_sys_enter *tp)
+int tracepoint__syscalls__sys_enter_open(struct syscall_trace_enter *tp)
 {
     const char *filename = (const char*) tp->args[0];
     int flags = tp->args[1];
@@ -125,13 +125,13 @@ int tracepoint__syscalls__sys_enter_open(struct trace_event_raw_sys_enter *tp)
 #endif // __aarch64__
 
 SEC("tp/syscalls/sys_exit_open")
-int tracepoint__syscalls__sys_exit_open(struct trace_event_raw_sys_exit *tp)
+int tracepoint__syscalls__sys_exit_open(struct syscall_trace_exit *tp)
 {
     return exit_open(tp->ret);
 }
 
 SEC("tp/syscalls/sys_enter_openat")
-int tracepoint__syscalls__sys_enter_openat(struct trace_event_raw_sys_enter *tp)
+int tracepoint__syscalls__sys_enter_openat(struct syscall_trace_enter *tp)
 {
     const char *filename = (const char*) tp->args[1];
     int flags = tp->args[2];
@@ -140,13 +140,13 @@ int tracepoint__syscalls__sys_enter_openat(struct trace_event_raw_sys_enter *tp)
 };
 
 SEC("tp/syscalls/sys_exit_openat")
-int tracepoint__syscalls__sys_exit_openat(struct trace_event_raw_sys_exit *tp)
+int tracepoint__syscalls__sys_exit_openat(struct syscall_trace_exit *tp)
 {
     return exit_open(tp->ret);
 }
 
 SEC("tp/syscalls/sys_enter_openat2")
-int tracepoint__syscalls__sys_enter_openat2(struct trace_event_raw_sys_enter *tp)
+int tracepoint__syscalls__sys_enter_openat2(struct syscall_trace_enter *tp)
 {
     const char *filename = (const char*) tp->args[1];
     struct open_how *how = (struct open_how *) tp->args[2];
@@ -155,7 +155,7 @@ int tracepoint__syscalls__sys_enter_openat2(struct trace_event_raw_sys_enter *tp
 };
 
 SEC("tp/syscalls/sys_exit_openat2")
-int tracepoint__syscalls__sys_exit_openat2(struct trace_event_raw_sys_exit *tp)
+int tracepoint__syscalls__sys_exit_openat2(struct syscall_trace_exit *tp)
 {
     return exit_open(tp->ret);
 }


### PR DESCRIPTION
Fix `failed to attach to tracepoint 'syscalls/sys_exit_execve': Permission denied` error that happens on RHEL 9 systems.

Background:
Our code was incorrect in the first place. As described here https://github.com/torvalds/linux/commit/ba8ea72388a192c10f1ee5f5a4a32332e7cced76 we should be using `syscall_trace_*` from the very beginning. The only reason why this code used to work in the first place was the same size of `trace_event_raw_sys_*` and `syscall_trace_*` structs. When the `raw` version was modified or code failed to load as the provided struct had a wrong size. 

Closes https://github.com/gravitational/teleport/issues/35286

changelog: Fix eBPF error occuring during startup on Linux RHEL 9 