### PR TITLE
Update Bot Terraform docs

### DIFF
--- a/docs/pages/machine-id/reference.mdx
+++ b/docs/pages/machine-id/reference.mdx
@@ -11,3 +11,4 @@ description: Configuration and CLI reference for Teleport Machine ID.
 - [Telemetry](./reference/telemetry.mdx)
 - [V14 Upgrade Guide](./reference/v14-upgrade-guide.mdx)
 - [V16 Upgrade Guide](./reference/v16-upgrade-guide.mdx)
+- [Bot Terraform Resource](../reference/terraform-provider/resources/bot.mdx)

--- a/docs/pages/reference/terraform-provider/resources/bot.mdx
+++ b/docs/pages/reference/terraform-provider/resources/bot.mdx
@@ -40,7 +40,6 @@ resource "teleport_provision_token" "bot_example" {
 
 resource "teleport_bot" "example" {
   name     = local.bot_name
-  token_id = teleport_provision_token.bot_example.metadata.name
   roles    = ["access"]
 }
 ```

--- a/docs/pages/reference/terraform-provider/resources/bot.mdx
+++ b/docs/pages/reference/terraform-provider/resources/bot.mdx
@@ -39,8 +39,8 @@ resource "teleport_provision_token" "bot_example" {
 }
 
 resource "teleport_bot" "example" {
-  name     = local.bot_name
-  roles    = ["access"]
+  name  = local.bot_name
+  roles = ["access"]
 }
 ```
 

--- a/integrations/terraform/examples/resources/teleport_bot/resource.tf
+++ b/integrations/terraform/examples/resources/teleport_bot/resource.tf
@@ -29,6 +29,6 @@ resource "teleport_provision_token" "bot_example" {
 }
 
 resource "teleport_bot" "example" {
-  name     = local.bot_name
-  roles    = ["access"]
+  name  = local.bot_name
+  roles = ["access"]
 }

--- a/integrations/terraform/examples/resources/teleport_bot/resource.tf
+++ b/integrations/terraform/examples/resources/teleport_bot/resource.tf
@@ -30,6 +30,5 @@ resource "teleport_provision_token" "bot_example" {
 
 resource "teleport_bot" "example" {
   name     = local.bot_name
-  token_id = teleport_provision_token.bot_example.metadata.name
   roles    = ["access"]
 }


### PR DESCRIPTION
Changes:
- Updates the Machine ID reference page to link to the Bot TF resource reference
- Removes usage of deprecated fields from the example bot spec.