### PR TITLE
Update Event Handler guides to correctly configure Machine ID

### DIFF
--- a/docs/pages/includes/plugins/rbac-impersonate-event-handler-machine-id.mdx
+++ b/docs/pages/includes/plugins/rbac-impersonate-event-handler-machine-id.mdx
@@ -1,0 +1,8 @@
+With the role created, you now need to allow the Machine ID bot to produce
+credentials for this role.
+
+This can be done with `tctl`, replacing `my-bot` with the name of your bot:
+
+```code
+$ tctl bots update my-bot --add-roles teleport-event-handler
+```

--- a/docs/pages/includes/plugins/rbac-impersonate-event-handler.mdx
+++ b/docs/pages/includes/plugins/rbac-impersonate-event-handler.mdx
@@ -32,9 +32,8 @@ Next, create the role:
 $ tctl create teleport-event-handler-impersonator.yaml
 ```
 
-If you are using Machine ID to provide short-lived credentials to the Event
-Handler, add this role to the Machine ID bot user. Otherwise, add this role to
-the user that generates signed credentials for the Event Handler:
+Add this role to the user that generates signed credentials for the Event
+Handler:
 
 (!docs/pages/includes/add-role-to-user.mdx role="teleport-event-handler-impersonator"!)
 

--- a/docs/pages/management/export-audit-events/datadog.mdx
+++ b/docs/pages/management/export-audit-events/datadog.mdx
@@ -47,9 +47,16 @@ from Teleport's events API, and forwards them to Fluentd.
 
 ## Step 4/6. Create teleport-event-handler credentials
 
-### Enable impersonation of the Event Handler user
+### Enable issuing of credentials for the Event Handler role
 
+<Tabs>
+<TabItem label="Machine ID">
+(!docs/pages/includes/plugins/rbac-impersonate-event-handler-machine-id.mdx!)
+</TabItem>
+<TabItem label="Long-lived identity files">
 (!docs/pages/includes/plugins/rbac-impersonate-event-handler.mdx!)
+</TabItem>
+</Tabs>
 
 ### Export an identity file for the Event Handler plugin user
 

--- a/docs/pages/management/export-audit-events/elastic-stack.mdx
+++ b/docs/pages/management/export-audit-events/elastic-stack.mdx
@@ -73,9 +73,16 @@ locally.
 
 </Details>
 
-### Enable impersonation of the Event Handler plugin user
+### Allow issuing of credentials for the role
 
+<Tabs>
+<TabItem label="Machine ID">
+(!docs/pages/includes/plugins/rbac-impersonate-event-handler-machine-id.mdx!)
+</TabItem>
+<TabItem label="Long-lived identity files">
 (!docs/pages/includes/plugins/rbac-impersonate-event-handler.mdx!)
+</TabItem>
+</Tabs>
 
 ### Export the access plugin identity
 

--- a/docs/pages/management/export-audit-events/elastic-stack.mdx
+++ b/docs/pages/management/export-audit-events/elastic-stack.mdx
@@ -73,7 +73,7 @@ locally.
 
 </Details>
 
-### Allow issuing of credentials for the role
+### Enable issuing of credentials for the Event Handler role
 
 <Tabs>
 <TabItem label="Machine ID">

--- a/docs/pages/management/export-audit-events/fluentd.mdx
+++ b/docs/pages/management/export-audit-events/fluentd.mdx
@@ -61,9 +61,16 @@ key from the same certificate authority for the Teleport Event Handler to use.
 
 ## Step 4/6. Create teleport-event-handler credentials
 
-### Enable impersonation of the Fluentd plugin user
+### Enable issuing of credentials for the event handler role
 
+<Tabs>
+<TabItem label="Machine ID">
+(!docs/pages/includes/plugins/rbac-impersonate-event-handler-machine-id.mdx!)
+</TabItem>
+<TabItem label="Long-lived identity files">
 (!docs/pages/includes/plugins/rbac-impersonate-event-handler.mdx!)
+</TabItem>
+</Tabs>
 
 ### Export an identity file for the Fluentd plugin user
 

--- a/docs/pages/management/export-audit-events/panther.mdx
+++ b/docs/pages/management/export-audit-events/panther.mdx
@@ -49,12 +49,16 @@ from Teleport's events API, and forwards them to Fluentd.
 
 ## Step 4/7. Create teleport-event-handler credentials
 
-In order for the Event Handler plugin to forward events from your Teleport cluster, 
-it needs signed credentials from the cluster's certificate authority. The teleport-event-handler 
-user cannot request this itself, and should use Teleport Machine ID to obtain the credentials.
+### Enable issuing of credentials for the Event Handler role
 
-Teleport Machine ID bot should leverage the `teleport-event-handler` role to request the credentials.
-Machine ID already impersonates roles when requesting credentials from the Teleport cluster.  
+<Tabs>
+<TabItem label="Machine ID">
+(!docs/pages/includes/plugins/rbac-impersonate-event-handler-machine-id.mdx!)
+</TabItem>
+<TabItem label="Long-lived identity files">
+(!docs/pages/includes/plugins/rbac-impersonate-event-handler.mdx!)
+</TabItem>
+</Tabs>
 
 ### Export an identity file for the Event Handler plugin user
 

--- a/docs/pages/management/export-audit-events/splunk.mdx
+++ b/docs/pages/management/export-audit-events/splunk.mdx
@@ -69,9 +69,16 @@ We'll re-purpose the files generated for Fluentd in our Universal Forwarder conf
 
 (!docs/pages/includes/plugins/event-handler-role-user.mdx!)
 
-### Enable impersonation of the Teleport Event Handler plugin user
+### Enable issuing of credentials for the Event Handler role
 
+<Tabs>
+<TabItem label="Machine ID">
+(!docs/pages/includes/plugins/rbac-impersonate-event-handler-machine-id.mdx!)
+</TabItem>
+<TabItem label="Long-lived identity files">
 (!docs/pages/includes/plugins/rbac-impersonate-event-handler.mdx!)
+</TabItem>
+</Tabs>
 
 ### Export the plugin identity
 


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/41690

The guides had a few issues when using Machine ID:

- The impersonator role does not need to be created or assigned to a user, instead the event handler role should be directly granted to the bot. If you follow the guide today, you encounter a permissions issue.
- There was no example of how to assign the role to a bot.

This has led to quite a few support tickets so I figured I'd have a bash at fixing this. This is still a little suboptimal because it still recommends the creation of the unnecessary event-handler user - but - since that's based on the output created by the event handler plugins example, it seems difficult to change the flow in the docs without addressing that first. The changes in this PR at least mean the guides work for Machine ID.