### PR TITLE
Address staticcheck false positives

### DIFF
--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -319,7 +319,9 @@ func (u *HostUserManagement) UpsertUser(name string, ui *services.HostUsersInfo)
 
 	var home string
 	if ui.Mode != types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP {
+		//nolint:staticcheck // SA4023. False positive on macOS.
 		home, err = readDefaultHome(name)
+		//nolint:staticcheck // SA4023. False positive on macOS.
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/usermgmt_other.go
+++ b/lib/srv/usermgmt_other.go
@@ -35,6 +35,7 @@ func newHostSudoersBackend(_ string) (HostSudoersBackend, error) {
 	return nil, trace.NotImplemented("Host user creation management is only supported on linux")
 }
 
+//nolint:staticcheck // intended to always return an error for non-linux builds
 func readDefaultHome(user string) (string, error) {
 	return "", trace.NotImplemented("readDefaultHome is only supported on linux")
 }


### PR DESCRIPTION
Addresses false positives on macOS.

Sadly we need all three lines, otherwise it still gets flagged.