### PR TITLE
[v16] fix: Bypass OS compat workflow until GLIBC is fixed

### DIFF
--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -42,21 +42,24 @@ jobs:
         WEBASSETS_SKIP_BUILD: 1
 
     steps:
-      - name: Checkout Teleport
-        uses: actions/checkout@v3 # Cannot upgrade to v4 while this runs in centos:7 due to nodejs GLIBC incompatibility
+      - name: Bypass
+        run: echo 'Bypassed until the nodejs 20 GLIBC issue is fixed'
 
-      - name: Prepare workspace
-        uses: ./.github/actions/prepare-workspace
-
-      - name: Run make
-        run: |
-          make -j"$(nproc)" binaries FIDO2=static
-
-      - name: Upload binaries
-        uses: actions/upload-artifact@v3
-        with:
-          name: build
-          path: ${{ github.workspace }}/build/
+      # - name: Checkout Teleport
+      #   uses: actions/checkout@v3 # Cannot upgrade to v4 while this runs in centos:7 due to nodejs GLIBC incompatibility
+      #
+      # - name: Prepare workspace
+      #   uses: ./.github/actions/prepare-workspace
+      #
+      # - name: Run make
+      #   run: |
+      #     make -j"$(nproc)" binaries FIDO2=static
+      #
+      # - name: Upload binaries
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: build
+      #     path: ${{ github.workspace }}/build/
 
   test-compat:
     needs: build
@@ -67,19 +70,22 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Bypass
+        run: echo 'Bypassed until the nodejs 20 GLIBC issue is fixed'
 
-      - name: Download binaries
-        uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: ${{ github.workspace }}/build
-
-      - name: chmod +x
-        run: chmod +x ${GITHUB_WORKSPACE}/build/*
-
-      - name: Run compat matrix
-        timeout-minutes: 10
-        run: |
-          cd ${GITHUB_WORKSPACE} && ./build.assets/build-test-compat.sh
+      # - name: Checkout
+      #   uses: actions/checkout@v4
+      #
+      # - name: Download binaries
+      #   uses: actions/download-artifact@v3
+      #   with:
+      #     name: build
+      #     path: ${{ github.workspace }}/build
+      #
+      # - name: chmod +x
+      #   run: chmod +x ${GITHUB_WORKSPACE}/build/*
+      #
+      # - name: Run compat matrix
+      #   timeout-minutes: 10
+      #   run: |
+      #     cd ${GITHUB_WORKSPACE} && ./build.assets/build-test-compat.sh


### PR DESCRIPTION
Unblocks CI until a permanent fix is found for the Nodejs 20 / GLIBC issue.

Example failure:

- https://github.com/gravitational/teleport/actions/runs/9781127985/job/27005303054?pr=43798

```
Run actions/checkout@v3
/usr/bin/docker exec  a3c8b5a03f1363737a9063ac100747a43b92b175fbf8fc8b0c0b20cf3c03d8f0 sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node[20](https://github.com/gravitational/teleport/actions/runs/9781127985/job/27005303054?pr=43798#step:3:21)/bin/node: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)

Post job cleanup.
/usr/bin/docker exec  a3c8b5a03f1363737a9063ac100747a43b9[2](https://github.com/gravitational/teleport/actions/runs/9781127985/job/27005303054?pr=43798#step:11:2)b175fbf8fc8b0c0b20cf3c03d8f0 sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_[3](https://github.com/gravitational/teleport/actions/runs/9781127985/job/27005303054?pr=43798#step:11:3).4.20' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib6[4](https://github.com/gravitational/teleport/actions/runs/9781127985/job/27005303054?pr=43798#step:11:4)/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.2[5](https://github.com/gravitational/teleport/actions/runs/9781127985/job/27005303054?pr=43798#step:11:5)' not found (required by /__e/node20/bin/node)
```

Context:

- https://github.com/actions/checkout/issues/1590#issuecomment-2192647851

Backports #43810