### PR TITLE
Add aarch64 linker to .cargo config for fdpass-teleport

### DIFF
--- a/tool/fdpass-teleport/.cargo/config.toml
+++ b/tool/fdpass-teleport/.cargo/config.toml
@@ -1,2 +1,4 @@
 [target.arm-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
I'm currently unable to cross compile `fdpass-teleport` for arm64 on a Ubuntu amd64 instance using the Makefile due to linker errors. I'm using the following command:

```
$ ARCH=arm64 make build/fdpass-teleport
cd tool/fdpass-teleport && cargo build --release --locked --target=aarch64-unknown-linux-gnu
   Compiling once_cell v1.19.0
   Compiling indenter v0.3.3
   Compiling memoffset v0.9.1
   Compiling libc v0.2.155
   Compiling cfg-if v1.0.0
   Compiling bitflags v2.5.0
   Compiling eyre v0.6.12
   Compiling simple-eyre v0.3.1
   Compiling nix v0.29.0
   Compiling fdpass-teleport v0.1.0 (/home/mikael/teleport/tool/fdpass-teleport)
error: linking with `cc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/home/mikael/.rustup/toolchains/1.77.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin:/home/mikael/.cargo/bin:/home/mikael/.nvm/versions/node/v20.14.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/usr/sbin:/sbin:/usr/sbin:/sbin:/usr/local/go/bin" VSLANG="1033" "cc" "/tmp/rustcXOtKgG/symbols.o" "/home/mikael/teleport/tool/fdpass-teleport/target/aarch64-unknown-linux-gnu/release/deps/fdpass_teleport-20e31d59d73ca7df.fdpass_teleport.a208bc0bc47ce0d7-cgu.0.rcgu.o" "-Wl,--as-needed" "-L" "/home/mikael/teleport/tool/fdpass-teleport/target/aarch64-unknown-linux-gnu/release/deps" "-L" "/home/mikael/teleport/tool/fdpass-teleport/target/release/deps" "-L" "/home/mikael/.rustup/toolchains/1.77.0-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "/home/mikael/.rustup/toolchains/1.77.0-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-gnu/lib/libcompiler_builtins-07bc1efee5f44168.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/home/mikael/.rustup/toolchains/1.77.0-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-gnu/lib" "-o" "/home/mikael/teleport/tool/fdpass-teleport/target/aarch64-unknown-linux-gnu/release/deps/fdpass_teleport-20e31d59d73ca7df" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-Wl,--strip-all" "-nodefaultlibs"
  = note: /usr/bin/ld: /home/mikael/teleport/tool/fdpass-teleport/target/aarch64-unknown-linux-gnu/release/deps/fdpass_teleport-20e31d59d73ca7df.fdpass_teleport.a208bc0bc47ce0d7-cgu.0.rcgu.o: Relocations in generic ELF (EM: 183)
          /usr/bin/ld: /home/mikael/teleport/tool/fdpass-teleport/target/aarch64-unknown-linux-gnu/release/deps/fdpass_teleport-20e31d59d73ca7df.fdpass_teleport.a208bc0bc47ce0d7-cgu.0.rcgu.o: Relocations in generic ELF (EM: 183)
          ...
          /usr/bin/ld: /home/mikael/teleport/tool/fdpass-teleport/target/aarch64-unknown-linux-gnu/release/deps/fdpass_teleport-20e31d59d73ca7df.fdpass_teleport.a208bc0bc47ce0d7-cgu.0.rcgu.o: error adding symbols: file in wrong format
          collect2: error: ld returned 1 exit status
```

By adding the linker for arm64 to `.cargo/config.toml` the build succeeds without error:

```
ARCH=arm64 make build/fdpass-teleport
cd tool/fdpass-teleport && cargo build --release --locked --target=aarch64-unknown-linux-gnu
   Compiling once_cell v1.19.0
   Compiling indenter v0.3.3
   Compiling libc v0.2.155
   Compiling bitflags v2.5.0
   Compiling eyre v0.6.12
   Compiling simple-eyre v0.3.1
   Compiling nix v0.29.0
   Compiling fdpass-teleport v0.1.0 (/home/mikael/teleport/tool/fdpass-teleport)
    Finished release [optimized] target(s) in 58.91s
install tool/fdpass-teleport/target/aarch64-unknown-linux-gnu/release/fdpass-teleport build/
```