### PR TITLE
[v14] fix: Bypass OS compat workflow until GLIBC is fixed

### DIFF
--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -30,21 +30,24 @@ jobs:
         WEBASSETS_SKIP_BUILD: 1
 
     steps:
-      - name: Checkout Teleport
-        uses: actions/checkout@v3 # Cannot upgrade to v4 while this runs in centos:7 due to nodejs GLIBC incompatibility
+      - name: Bypass
+        run: echo 'Bypassed until the nodejs 20 GLIBC issue is fixed'
 
-      - name: Prepare workspace
-        uses: ./.github/actions/prepare-workspace
-
-      - name: Run make
-        run: |
-          make binaries FIDO2=static
-
-      - name: Upload binaries
-        uses: actions/upload-artifact@v3
-        with:
-          name: build
-          path: ${{ github.workspace }}/build/
+      # - name: Checkout Teleport
+      #   uses: actions/checkout@v3 # Cannot upgrade to v4 while this runs in centos:7 due to nodejs GLIBC incompatibility
+      #
+      # - name: Prepare workspace
+      #   uses: ./.github/actions/prepare-workspace
+      #
+      # - name: Run make
+      #   run: |
+      #     make binaries FIDO2=static
+      #
+      # - name: Upload binaries
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: build
+      #     path: ${{ github.workspace }}/build/
 
   test-compat:
     needs: build
@@ -55,19 +58,22 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Bypass
+        run: echo 'Bypassed until the nodejs 20 GLIBC issue is fixed'
 
-      - name: Download binaries
-        uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: ${{ github.workspace }}/build
-
-      - name: chmod +x
-        run: chmod +x ${GITHUB_WORKSPACE}/build/*
-
-      - name: Run compat matrix
-        timeout-minutes: 10
-        run: |
-          cd ${GITHUB_WORKSPACE} && ./build.assets/build-test-compat.sh
+      # - name: Checkout
+      #   uses: actions/checkout@v4
+      #
+      # - name: Download binaries
+      #   uses: actions/download-artifact@v3
+      #   with:
+      #     name: build
+      #     path: ${{ github.workspace }}/build
+      #
+      # - name: chmod +x
+      #   run: chmod +x ${GITHUB_WORKSPACE}/build/*
+      #
+      # - name: Run compat matrix
+      #   timeout-minutes: 10
+      #   run: |
+      #     cd ${GITHUB_WORKSPACE} && ./build.assets/build-test-compat.sh


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/43810 to branch/v14.