### PR TITLE
Add "v1" prefix to oidc integration endpoints

### DIFF
--- a/web/packages/teleport/src/config.test.ts
+++ b/web/packages/teleport/src/config.test.ts
@@ -30,7 +30,7 @@ test('getDeployServiceIamConfigureScriptPath formatting', async () => {
     taskRoleArn: 'task-arn',
   };
   const base =
-    'http://localhost/webapi/scripts/integrations/configure/deployservice-iam.sh?';
+    'http://localhost/v1/webapi/scripts/integrations/configure/deployservice-iam.sh?';
   const expected = `integrationName=${'int-name'}&awsRegion=${'us-east-1'}&role=${'oidc-arn'}&taskRole=${'task-arn'}`;
   expect(cfg.getDeployServiceIamConfigureScriptUrl(params)).toBe(
     `${base}${expected}`
@@ -45,7 +45,7 @@ test('getAwsOidcConfigureIdpScriptUrl formatting with s3 fields', async () => {
     s3Prefix: 's3-prefix',
   };
   const base =
-    'http://localhost/webapi/scripts/integrations/configure/awsoidc-idp.sh?';
+    'http://localhost/v1/webapi/scripts/integrations/configure/awsoidc-idp.sh?';
   const expected = `integrationName=int-name&role=role-arn&s3Bucket=s3-bucket&s3Prefix=s3-prefix`;
   expect(cfg.getAwsOidcConfigureIdpScriptUrl(params)).toBe(
     `${base}${expected}`
@@ -58,7 +58,7 @@ test('getAwsOidcConfigureIdpScriptUrl formatting, without s3 fields', async () =
     roleName: 'role-arn',
   };
   const base =
-    'http://localhost/webapi/scripts/integrations/configure/awsoidc-idp.sh?';
+    'http://localhost/v1/webapi/scripts/integrations/configure/awsoidc-idp.sh?';
   const expected = `integrationName=int-name&role=role-arn`;
   expect(cfg.getAwsOidcConfigureIdpScriptUrl(params)).toBe(
     `${base}${expected}`

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -300,18 +300,18 @@ const cfg = {
     thumbprintPath: '/v1/webapi/thumbprint',
 
     awsConfigureIamScriptOidcIdpPath:
-      '/webapi/scripts/integrations/configure/awsoidc-idp.sh?integrationName=:integrationName&role=:roleName',
+      '/v1/webapi/scripts/integrations/configure/awsoidc-idp.sh?integrationName=:integrationName&role=:roleName',
     awsConfigureIamScriptDeployServicePath:
-      '/webapi/scripts/integrations/configure/deployservice-iam.sh?integrationName=:integrationName&awsRegion=:region&role=:awsOidcRoleArn&taskRole=:taskRoleArn',
+      '/v1/webapi/scripts/integrations/configure/deployservice-iam.sh?integrationName=:integrationName&awsRegion=:region&role=:awsOidcRoleArn&taskRole=:taskRoleArn',
     awsConfigureIamScriptListDatabasesPath:
-      '/webapi/scripts/integrations/configure/listdatabases-iam.sh?awsRegion=:region&role=:iamRoleName',
+      '/v1/webapi/scripts/integrations/configure/listdatabases-iam.sh?awsRegion=:region&role=:iamRoleName',
     awsConfigureIamScriptEc2InstanceConnectPath:
       '/v1/webapi/scripts/integrations/configure/eice-iam.sh?awsRegion=:region&role=:iamRoleName',
     awsConfigureIamEksScriptPath:
       '/v1/webapi/scripts/integrations/configure/eks-iam.sh?awsRegion=:region&role=:iamRoleName',
 
     awsRdsDbDeployServicesPath:
-      '/webapi/sites/:clusterId/integrations/aws-oidc/:name/deploydatabaseservices',
+      '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/deploydatabaseservices',
     awsRdsDbRequiredVpcsPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/requireddatabasesvpcs',
     awsRdsDbListPath:


### PR DESCRIPTION
All of the other endpoints have the "v1" prefix. Without that prefix, the endpoint sometimes didn't work for me when working with a dev web ui.