### PR TITLE
[docs] remove iam user instructions

### DIFF
--- a/docs/pages/database-access/enroll-aws-databases/aws-cross-account.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-cross-account.mdx
@@ -167,7 +167,7 @@ AWS IAM identity and the external AWS IAM role:
   [AWS cross-account policy evaluation](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic-cross-account.html#policy-eval-cross-account).
 </Details>
 
-(!docs/pages/includes/database-access/aws-bootstrap.mdx attachToRole="teleport-db-service" attachToUser="teleport-db-service"!)
+(!docs/pages/includes/database-access/aws-bootstrap.mdx attachToRole="teleport-db-service" !)
 
 Specifically, the Teleport Database Service's AWS IAM identity must be granted
 `sts:AssumeRole` permission for the external AWS IAM role. For example:

--- a/docs/pages/database-access/enroll-aws-databases/redshift-serverless.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/redshift-serverless.mdx
@@ -160,7 +160,7 @@ Redshift Serverless database.
 
 (!docs/pages/includes/aws-credentials.mdx service="the Database Service"!)
 
-(!docs/pages/includes/database-access/aws-bootstrap.mdx attachToRole="teleport-redshift-serverless-node" attachToUser="teleport-redshift-serverless-access" !)
+(!docs/pages/includes/database-access/aws-bootstrap.mdx attachToRole="teleport-redshift-serverless-node" !)
 
 ### Start the Database service
 

--- a/docs/pages/database-access/reference/aws.mdx
+++ b/docs/pages/database-access/reference/aws.mdx
@@ -55,8 +55,8 @@ performs auto-discovery:
 
 The Teleport Database Service can automatically manage IAM policies of the
 attached IAM identity for RDS access. To use this feature, Teleport requires
-`iam:PutRolePolicy` or `iam:PutUserPolicy` permissions to grant itself
-necessary IAM permissions for each registered database.
+`iam:PutRolePolicy` permissions to grant itself necessary IAM permissions for
+each registered database.
 
 If you prefer to manage IAM identities manually, refer to the [manage IAM
 identities yourself](#manage-iam-identities-yourself-for-rds-access) section
@@ -64,154 +64,74 @@ which outlines the required IAM permissions.
 
 #### Teleport-managed IAM identities for RDS access
 
-Teleport requires the following IAM permissions depending on the IAM identity
-Teleport is managing:
+Teleport requires the following IAM permissions attached to a role:
 
-<Tabs>
-  <TabItem label="IAM role">
-  Use this policy if your Teleport Database Service runs as an IAM role (for
-  example, on an EC2 instance with an attached IAM role):
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "rds:DescribeDBInstances",
-                  "rds:DescribeDBClusters",
-                  "rds:ModifyDBInstance",
-                  "rds:ModifyDBCluster",
-                  "rds:DescribeDBProxies",
-                  "rds:DescribeDBProxyEndpoints",
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "iam:GetRolePolicy",
-                  "iam:PutRolePolicy",
-                  "iam:DeleteRolePolicy"
-              ],
-              "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:role/<Var name="sample-role"/>"
-          }
-      ]
-  }
-  ```
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:DescribeDBInstances",
+                "rds:DescribeDBClusters",
+                "rds:ModifyDBInstance",
+                "rds:ModifyDBCluster",
+                "rds:DescribeDBProxies",
+                "rds:DescribeDBProxyEndpoints",
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy"
+            ],
+            "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:role/<Var name="sample-role"/>"
+        }
+    ]
+}
+```
 
-  (!docs/pages/includes/database-access/reference/rds-action-notes.mdx!)
+(!docs/pages/includes/database-access/reference/rds-action-notes.mdx!)
 
-  (!docs/pages/includes/database-access/reference/rds-action-notes-on-modify.mdx!)
+(!docs/pages/includes/database-access/reference/rds-action-notes-on-modify.mdx!)
 
-  For best security, use the following boundary policy that limits Teleport's
-  self-granting capability on the IAM user:
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "rds:DescribeDBInstances",
-                  "rds:DescribeDBClusters",
-                  "rds:ModifyDBInstance",
-                  "rds:ModifyDBCluster",
-                  "rds:DescribeDBProxies",
-                  "rds:DescribeDBProxyEndpoints",
-                  "rds-db:connect"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "iam:GetRolePolicy",
-                  "iam:PutRolePolicy",
-                  "iam:DeleteRolePolicy"
-              ],
-              "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:role/<Var name="sample-role"/>"
-          }
-      ]
-  }
-  ```
-  (!docs/pages/includes/database-access/reference/permissions-boundaries-link.mdx!)
+For best security, use the following boundary policy that limits Teleport's
+self-granting capability on the IAM role:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:DescribeDBInstances",
+                "rds:DescribeDBClusters",
+                "rds:ModifyDBInstance",
+                "rds:ModifyDBCluster",
+                "rds:DescribeDBProxies",
+                "rds:DescribeDBProxyEndpoints",
+                "rds-db:connect"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy"
+            ],
+            "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:role/<Var name="sample-role"/>"
+        }
+    ]
+}
+```
 
-  </TabItem>
-
-  <TabItem label="IAM user">
-  Use this policy if you're connecting to RDS instances and Aurora clusters,
-  and your Teleport Database Service instance runs as an IAM user:
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "rds:DescribeDBInstances",
-                  "rds:DescribeDBClusters",
-                  "rds:ModifyDBInstance",
-                  "rds:ModifyDBCluster",
-                  "rds:DescribeDBProxies",
-                  "rds:DescribeDBProxyEndpoints",
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "iam:GetUserPolicy",
-                  "iam:PutUserPolicy",
-                  "iam:DeleteUserPolicy"
-              ],
-              "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:user/<Var name="sample-user"/>"
-          }
-      ]
-  }
-  ```
-
-  (!docs/pages/includes/database-access/reference/rds-action-notes.mdx!)
-
-  (!docs/pages/includes/database-access/reference/rds-action-notes-on-modify.mdx!)
-
-  For best security, use the following boundary policy that limits Teleport's
-  self-granting capability on the IAM user:
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "rds:DescribeDBInstances",
-                  "rds:DescribeDBClusters",
-                  "rds:ModifyDBInstance",
-                  "rds:ModifyDBCluster",
-                  "rds:DescribeDBProxies",
-                  "rds:DescribeDBProxyEndpoints",
-                  "rds-db:connect"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "iam:GetUserPolicy",
-                  "iam:PutUserPolicy",
-                  "iam:DeleteUserPolicy"
-              ],
-              "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:user/<Var name="sample-user"/>"
-          }
-      ]
-  }
-  ```
-
-  (!docs/pages/includes/database-access/reference/permissions-boundaries-link.mdx!)
-
-  </TabItem>
-
-</Tabs>
+(!docs/pages/includes/database-access/reference/permissions-boundaries-link.mdx!)
 
 #### Manage IAM identities yourself for RDS access
 
@@ -287,8 +207,8 @@ role for Redshift.
 
 When authenticating as an existing database user, the Teleport Database Service
 can automatically manage IAM policies of the attached IAM identity for Redshift
-access. To use this feature, Teleport requires `iam:PutRolePolicy` or
-`iam:PutUserPolicy` permissions to grant itself necessary IAM permissions for
+access. To use this feature, Teleport requires `iam:PutRolePolicy`
+permissions to grant itself necessary IAM permissions for
 each registered database. If you prefer to manage IAM identities manually,
 refer to the [manage IAM identities
 yourself](#manage-iam-identities-yourself-for-redshift-access) section which
@@ -300,124 +220,60 @@ role](#iam-authentication-as-iam-role-for-redshift-access) section.
 
 #### Teleport-managed IAM identities for Redshift access
 
-Teleport requires the following IAM permissions depending on the IAM identity
-Teleport is managing:
+Teleport requires the following IAM permissions:
 
-<Tabs>
-  <TabItem label="IAM role">
-  Use this policy if your Teleport Database Service instance runs as an IAM
-  role (for example, on an EC2 instance with an attached IAM role):
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "redshift:DescribeClusters",
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "iam:GetRolePolicy",
-                  "iam:PutRolePolicy",
-                  "iam:DeleteRolePolicy"
-              ],
-              "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:role/<Var name="sample-role"/>"
-          }
-      ]
-  }
-  ```
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "redshift:DescribeClusters",
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy"
+            ],
+            "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:role/<Var name="sample-role"/>"
+        }
+    ]
+}
+```
 
-  For best security, use the following boundary policy that limits Teleport's
-  self-granting capability on the IAM role:
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "redshift:DescribeClusters",
-                  "redshift:GetClusterCredentials",
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "iam:GetRolePolicy",
-                  "iam:PutRolePolicy",
-                  "iam:DeleteRolePolicy"
-              ],
-              "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:role/<Var name="sample-role"/>"
-          }
-      ]
-  }
-  ```
+For best security, use the following boundary policy that limits Teleport's
+self-granting capability on the IAM role:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "redshift:DescribeClusters",
+                "redshift:GetClusterCredentials",
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy"
+            ],
+            "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:role/<Var name="sample-role"/>"
+        }
+    ]
+}
+```
 
-  (!docs/pages/includes/database-access/reference/permissions-boundaries-link.mdx!)
-
-  </TabItem>
-  <TabItem label="IAM user">
-  Use this policy if your Teleport Database Service runs as an IAM user:
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "redshift:DescribeClusters",
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "iam:GetUserPolicy",
-                  "iam:PutUserPolicy",
-                  "iam:DeleteUserPolicy"
-              ],
-              "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:user/<Var name="sample-user"/>"
-          }
-      ]
-  }
-  ```
-
-  For best security, use the following boundary policy that limits Teleport's
-  self-granting capability on the IAM user:
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "redshift:DescribeClusters",
-                  "redshift:GetClusterCredentials"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "iam:GetUserPolicy",
-                  "iam:PutUserPolicy",
-                  "iam:DeleteUserPolicy"
-              ],
-              "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:user/<Var name="sample-user"/>"
-          }
-      ]
-  }
-  ```
-
-  (!docs/pages/includes/database-access/reference/permissions-boundaries-link.mdx!)
-
-  </TabItem>
-</Tabs>
+(!docs/pages/includes/database-access/reference/permissions-boundaries-link.mdx!)
 
 #### Manage IAM identities yourself for Redshift access
 
@@ -625,8 +481,8 @@ performs auto-discovery:
 ElastiCache and MemoryDB supports IAM authentication for Redis engine version
 7.0 or above. The Teleport Database Service can automatically manage IAM
 policies of the attached IAM identity for ElastiCache and MemoryDB that use IAM
-authentication. To use this feature, Teleport requires `iam:PutRolePolicy` or
-`iam:PutUserPolicy` permissions to grant itself necessary IAM permissions for
+authentication. To use this feature, Teleport requires `iam:PutRolePolicy`
+permissions to grant itself necessary IAM permissions for
 each registered database. If you prefer to manage IAM identities on your own,
 refer to the [manage IAM identities
 yourself](#manage-iam-identities-yourself-for-elasticachememorydb-access)
@@ -642,160 +498,79 @@ rotation](#auto-password-rotation-for-elasticachememorydb) section.
 The required IAM permissions are slightly different depending on the IAM
 identity Teleport is managing:
 
-<Tabs>
-  <TabItem label="IAM role">
-  Use this policy if your Teleport Database Service instance runs as an IAM
-  role (for example, on an EC2 instance with an attached IAM role):
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "elasticache:DescribeReplicationGroups",
-                  "elasticache:DescribeUsers"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "memorydb:DescribeSubnetGroups",
-                  "memorydb:DescribeUsers"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "iam:GetRolePolicy",
-                  "iam:PutRolePolicy",
-                  "iam:DeleteRolePolicy"
-              ],
-              "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:role/<Var name="sample-role"/>"
-          }
-      ]
-  }
-  ```
+Use this policy if your Teleport Database Service instance runs as an IAM
+role (for example, on an EC2 instance with an attached IAM role):
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticache:DescribeReplicationGroups",
+                "elasticache:DescribeUsers"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "memorydb:DescribeSubnetGroups",
+                "memorydb:DescribeUsers"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy"
+            ],
+            "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:role/<Var name="sample-role"/>"
+        }
+    ]
+}
+```
 
-  For best security, use the following boundary policy that limits Teleport's
-  self-granting capability on the IAM role:
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "elasticache:DescribeReplicationGroups",
-                  "elasticache:DescribeUsers",
-                  "elasticache:Connect",
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "memorydb:DescribeSubnetGroups",
-                  "memorydb:DescribeUsers",
-                  "memorydb:Connect"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "iam:GetRolePolicy",
-                  "iam:PutRolePolicy",
-                  "iam:DeleteRolePolicy"
-              ],
-              "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:role/<Var name="sample-role"/>"
-          }
-      ]
-  }
-  ```
+For best security, use the following boundary policy that limits Teleport's
+self-granting capability on the IAM role:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticache:DescribeReplicationGroups",
+                "elasticache:DescribeUsers",
+                "elasticache:Connect",
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "memorydb:DescribeSubnetGroups",
+                "memorydb:DescribeUsers",
+                "memorydb:Connect"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy"
+            ],
+            "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:role/<Var name="sample-role"/>"
+        }
+    ]
+}
+```
 
-  (!docs/pages/includes/database-access/reference/permissions-boundaries-link.mdx!)
-
-  </TabItem>
-  <TabItem label="IAM user">
-  Use this policy if your Teleport Database Service runs as an IAM user (for
-  example, it uses an AWS credentials file):
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "elasticache:DescribeReplicationGroups",
-                  "elasticache:DescribeUsers"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "memorydb:DescribeSubnetGroups",
-                  "memorydb:DescribeUsers"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "iam:GetUserPolicy",
-                  "iam:PutUserPolicy",
-                  "iam:DeleteUserPolicy"
-              ],
-              "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:user/<Var name="sample-user"/>"
-          }
-      ]
-  }
-  ```
-
-  For best security, use the following boundary policy that limits Teleport's
-  self-granting capability on the IAM user:
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "elasticache:DescribeReplicationGroups",
-                  "elasticache:DescribeUsers",
-                  "elasticache:Connect",
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "memorydb:DescribeClusters",
-                  "memorydb:DescribeUsers",
-                  "memorydb:Connect"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "iam:GetUserPolicy",
-                  "iam:PutUserPolicy",
-                  "iam:DeleteUserPolicy"
-              ],
-              "Resource": "arn:aws:iam::<Var name="aws-account-id"/>:user/<Var name="sample-user"/>"
-          }
-      ]
-  }
-  ```
-
-  (!docs/pages/includes/database-access/reference/permissions-boundaries-link.mdx!)
-
-  </TabItem>
-</Tabs>
+(!docs/pages/includes/database-access/reference/permissions-boundaries-link.mdx!)
 
 ### Manage IAM identities yourself for ElastiCache/MemoryDB access
 

--- a/docs/pages/includes/database-access/aws-bootstrap.mdx
+++ b/docs/pages/includes/database-access/aws-bootstrap.mdx
@@ -1,27 +1,17 @@
-{{ attachToRole="TeleportRole" attachToUser="TeleportUser" account="123456789012" output="/etc/teleport.yaml" }}
+{{ attachToRole="TeleportRole" account="123456789012" output="/etc/teleport.yaml" }}
 
 Teleport can bootstrap IAM permissions for the Database Service based on its
 configuration using the `teleport db configure bootstrap` command. You can use
 this command in automatic or manual mode:
 
 - In automatic mode, Teleport will attempt to create appropriate IAM policies
-  and attach them to the specified IAM identity (user or role). This requires
+  and attach them to the specified IAM identity role. This requires
   IAM permissions to create and attach IAM policies.
 - In manual mode, Teleport will print required IAM policies. You can then create
   and attach them manually using the AWS management console.
 
 <Tabs>
-  <TabItem label="Automatic / IAM User">
-  Use this command to bootstrap the permissions automatically when
-  your Teleport Database Service runs as an IAM user (for example, uses an AWS
-  credentials file).
-
-  ```code
-  $ teleport db configure bootstrap -c {{ output }} --attach-to-user {{ attachToUser }}
-  ```
-  </TabItem>
-
-  <TabItem label="Automatic / IAM Role">
+  <TabItem label="Automatic IAM setup">
   Use this command to bootstrap the permissions automatically when
   your Teleport Database Service runs as an IAM role (for example, on an EC2
   instance with an attached IAM role).
@@ -31,15 +21,7 @@ this command in automatic or manual mode:
   ```
   </TabItem>
 
-  <TabItem label="Manual / IAM User">
-  Use this command to display required IAM policies which you will then create in your AWS console:
-
-  ```code
-  $ teleport db configure bootstrap -c {{ output }} --manual --attach-to-user arn:aws:iam::{{ account }}:user/{{ attachToUser }}
-  ```
-  </TabItem>
-
-  <TabItem label="Manual / IAM Role">
+  <TabItem label="Manual IAM setup">
   Use this command to display required IAM policies which you will then create in your AWS console:
 
   ```code


### PR DESCRIPTION
This is a docs PR that removes the instructions for configuring permissions for Teleport running as an IAM user.
Part of https://github.com/gravitational/teleport/issues/43829

The PR looks bigger than it really is, a lot of changes are just fixing indentation after removing tabs.

## Why

1. To simplify the IAM configuration instructions relevant to the vast majority of customers by eliminating these branches in our IAM permissions docs.
2. To discourage bad security practice: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#bp-workloads-use-roles

Realistically, most Teleport DB agents are going to be running in EC2 with an attached role, EKS with IRSA setup, or some other kube workload with an OIDC provider setup.
Running Teleport as an IAM user requires using a long-lived access key - I doubt any of our customers even do this, but we should not encourage it.