### PR TITLE
update AWS OIDC database service task IAM permissions

### DIFF
--- a/lib/integrations/awsoidc/clientsv1_test.go
+++ b/lib/integrations/awsoidc/clientsv1_test.go
@@ -99,7 +99,7 @@ func TestNewSessionV1(t *testing.T) {
 			integration: "myawsintegration",
 			expectedErr: require.NoError,
 			sessionValidator: func(t *testing.T, s *session.Session) {
-				require.Equal(t, aws.String(""), s.Config.Region)
+				require.Equal(t, "", aws.StringValue(s.Config.Region))
 			},
 		},
 		{

--- a/lib/integrations/awsoidc/deployservice_iam_config.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config.go
@@ -33,10 +33,6 @@ import (
 	awslibutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
-const (
-	boundarySuffix = "Boundary"
-)
-
 var taskRoleDescription = "Used by Teleport Database Service deployed in Amazon ECS."
 
 // DeployServiceIAMConfigureRequest is a request to configure the DeployService action required Roles.
@@ -62,10 +58,6 @@ type DeployServiceIAMConfigureRequest struct {
 
 	// TaskRole is the AWS Role used by the deployed service.
 	TaskRole string
-
-	// TaskRoleBoundaryPolicyName is the name to be used to create a Policy to be used as boundary for the TaskRole.
-	// Defaults to <TaskRole>Boundary
-	TaskRoleBoundaryPolicyName string
 
 	// AccountID is the AWS Account ID.
 	// Optional. sts.GetCallerIdentity is used if not provided.
@@ -110,10 +102,6 @@ func (r *DeployServiceIAMConfigureRequest) CheckAndSetDefaults() error {
 		return trace.BadParameter("task role is required")
 	}
 
-	if r.TaskRoleBoundaryPolicyName == "" {
-		r.TaskRoleBoundaryPolicyName = r.TaskRole + boundarySuffix
-	}
-
 	if len(r.ResourceCreationTags) == 0 {
 		r.ResourceCreationTags = defaultResourceCreationTags(r.Cluster, r.IntegrationName)
 	}
@@ -127,9 +115,6 @@ func (r *DeployServiceIAMConfigureRequest) CheckAndSetDefaults() error {
 type DeployServiceIAMConfigureClient interface {
 	// GetCallerIdentity returns information about the caller identity.
 	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
-
-	// CreatePolicy creates a new IAM Policy.
-	CreatePolicy(ctx context.Context, params *iam.CreatePolicyInput, optFns ...func(*iam.Options)) (*iam.CreatePolicyOutput, error)
 
 	// CreateRole creates a new IAM Role.
 	CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error)
@@ -170,18 +155,14 @@ func (d defaultDeployServiceIAMConfigureClient) GetCallerIdentity(ctx context.Co
 //
 // A) Role to be used by the deployed service, also known as _TaskRole_.
 // The Role is able to manage policies and create logs.
-// To ensure there's no priv escalation, we also set up a boundary policy.
-// The boundary policy only allows the above permissions and the `rds-db:connect`.
 //
 // B) Create a Policy in the Integration Role - the role used when setting up the integration.
 // This policy allows for the required API Calls to set up the Amazon ECS TaskDefinition, Cluster and Service.
 // It also allows to 'iam:PassRole' only for the _TaskRole_.
 //
 // The following actions must be allowed by the IAM Role assigned in the Client.
-// - iam:CreatePolicy
 // - iam:CreateRole
 // - iam:PutRolePolicy
-// - iam:TagPolicy
 // - iam:TagRole
 func ConfigureDeployServiceIAM(ctx context.Context, clt DeployServiceIAMConfigureClient, req DeployServiceIAMConfigureRequest) error {
 	if err := req.CheckAndSetDefaults(); err != nil {
@@ -194,10 +175,6 @@ func ConfigureDeployServiceIAM(ctx context.Context, clt DeployServiceIAMConfigur
 			return trace.Wrap(err)
 		}
 		req.AccountID = aws.ToString(callerIdentity.Account)
-	}
-
-	if err := createBoundaryPolicyForTaskRole(ctx, clt, req); err != nil {
-		return trace.Wrap(err)
 	}
 
 	if err := createTaskRole(ctx, clt, req); err != nil {
@@ -215,44 +192,7 @@ func ConfigureDeployServiceIAM(ctx context.Context, clt DeployServiceIAMConfigur
 	return nil
 }
 
-// createBoundaryPolicyForTaskRole creates a Policy to be used as TaskRole's Role Boundary.
-// It allows for the TaskRole to:
-// - connect to any RDS DB
-// - Get, Put and Delete Role Policies to manage the Policy Statements when adding other rds-db:connect entries
-// - write application logs to CloudWatch
-func createBoundaryPolicyForTaskRole(ctx context.Context, clt DeployServiceIAMConfigureClient, req DeployServiceIAMConfigureRequest) error {
-	taskRoleARN := awslibutils.RoleARN(req.partitionID, req.AccountID, req.TaskRole)
-
-	taskRoleBoundaryPolicyDocument, err := awslib.NewPolicyDocument(
-		awslib.StatementForRDSDBConnect(),
-		awslib.StatementForIAMEditRolePolicy(taskRoleARN),
-		awslib.StatementForWritingLogs(),
-	).Marshal()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	_, err = clt.CreatePolicy(ctx, &iam.CreatePolicyInput{
-		PolicyName:     &req.TaskRoleBoundaryPolicyName,
-		PolicyDocument: &taskRoleBoundaryPolicyDocument,
-		Tags:           req.ResourceCreationTags.ToIAMTags(),
-	})
-	if err != nil {
-		convertedErr := awslib.ConvertIAMv2Error(err)
-		if trace.IsAlreadyExists(convertedErr) {
-			return trace.AlreadyExists("Policy %q already exists, please remove it and try again.", req.TaskRoleBoundaryPolicyName)
-		}
-		return trace.Wrap(convertedErr)
-	}
-
-	slog.InfoContext(ctx, "Boundary policy set for Task Role",
-		"boundary", req.TaskRoleBoundaryPolicyName,
-		"task_role", req.TaskRole,
-	)
-	return nil
-}
-
-// createTaskRole creates the TaskRole and sets up the Role Boundary and its Trust Relationship.
+// createTaskRole creates the TaskRole and sets up its permissions and trust relationship.
 func createTaskRole(ctx context.Context, clt DeployServiceIAMConfigureClient, req DeployServiceIAMConfigureRequest) error {
 	taskRoleAssumeRoleDocument, err := awslib.NewPolicyDocument(
 		awslib.StatementForECSTaskRoleTrustRelationships(),
@@ -261,13 +201,10 @@ func createTaskRole(ctx context.Context, clt DeployServiceIAMConfigureClient, re
 		return trace.Wrap(err)
 	}
 
-	policyARNForRoleBoundary := awslibutils.PolicyARN(req.partitionID, req.AccountID, req.TaskRoleBoundaryPolicyName)
-
 	_, err = clt.CreateRole(ctx, &iam.CreateRoleInput{
 		RoleName:                 &req.TaskRole,
 		Description:              &taskRoleDescription,
 		AssumeRolePolicyDocument: &taskRoleAssumeRoleDocument,
-		PermissionsBoundary:      &policyARNForRoleBoundary,
 		Tags:                     req.ResourceCreationTags.ToIAMTags(),
 	})
 	if err != nil {
@@ -278,9 +215,8 @@ func createTaskRole(ctx context.Context, clt DeployServiceIAMConfigureClient, re
 		return trace.Wrap(convertedErr)
 	}
 
-	slog.InfoContext(ctx, "Task role created with boundary",
+	slog.InfoContext(ctx, "Task role created",
 		"task_role", req.TaskRole,
-		"boundary", policyARNForRoleBoundary,
 	)
 	return nil
 }
@@ -289,10 +225,8 @@ func createTaskRole(ctx context.Context, clt DeployServiceIAMConfigureClient, re
 // - manage Policies of the TaskRole
 // - write logs to CloudWatch
 func addPolicyToTaskRole(ctx context.Context, clt DeployServiceIAMConfigureClient, req DeployServiceIAMConfigureRequest) error {
-	taskRoleARN := awslibutils.RoleARN(req.partitionID, req.AccountID, req.TaskRole)
-
 	taskRolePolicyDocument, err := awslib.NewPolicyDocument(
-		awslib.StatementForIAMEditRolePolicy(taskRoleARN),
+		awslib.StatementForRDSDBConnect(),
 		awslib.StatementForWritingLogs(),
 	).Marshal()
 	if err != nil {

--- a/lib/integrations/awsoidc/deployservice_iam_config_test.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config_test.go
@@ -72,7 +72,6 @@ func TestDeployServiceIAMConfigReqDefaults(t *testing.T) {
 				TaskRole:                           "taskrole",
 				partitionID:                        "aws",
 				IntegrationRoleDeployServicePolicy: "DeployService",
-				TaskRoleBoundaryPolicyName:         "taskroleBoundary",
 				ResourceCreationTags: AWSTags{
 					"teleport.dev/cluster":     "mycluster",
 					"teleport.dev/integration": "myintegration",
@@ -143,51 +142,38 @@ func TestDeployServiceIAMConfig(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range []struct {
-		name                 string
-		mockAccountID        string
-		mockExistingPolicies []string
-		mockExistingRoles    []string
-		req                  func() DeployServiceIAMConfigureRequest
-		errCheck             require.ErrorAssertionFunc
+		name              string
+		mockAccountID     string
+		mockExistingRoles []string
+		req               func() DeployServiceIAMConfigureRequest
+		errCheck          require.ErrorAssertionFunc
 	}{
 		{
-			name:                 "valid",
-			mockAccountID:        "123456789012",
-			mockExistingPolicies: []string{},
-			mockExistingRoles:    []string{"integrationrole"},
-			req:                  baseReq,
-			errCheck:             require.NoError,
+			name:              "valid",
+			mockAccountID:     "123456789012",
+			mockExistingRoles: []string{"integrationrole"},
+			req:               baseReq,
+			errCheck:          require.NoError,
 		},
 		{
-			name:                 "boundary policy already exists",
-			mockAccountID:        "123456789012",
-			mockExistingPolicies: []string{"taskroleBoundary"},
-			mockExistingRoles:    []string{"integrationrole"},
-			req:                  baseReq,
-			errCheck:             alreadyExistsCheck,
+			name:              "task role already exists",
+			mockAccountID:     "123456789012",
+			mockExistingRoles: []string{"integrationrole", "taskrole"},
+			req:               baseReq,
+			errCheck:          alreadyExistsCheck,
 		},
 		{
-			name:                 "task role already exists",
-			mockAccountID:        "123456789012",
-			mockExistingPolicies: []string{},
-			mockExistingRoles:    []string{"integrationrole", "taskrole"},
-			req:                  baseReq,
-			errCheck:             alreadyExistsCheck,
-		},
-		{
-			name:                 "integration role does not exist",
-			mockAccountID:        "123456789012",
-			mockExistingPolicies: []string{},
-			mockExistingRoles:    []string{},
-			req:                  baseReq,
-			errCheck:             notFoundCheck,
+			name:              "integration role does not exist",
+			mockAccountID:     "123456789012",
+			mockExistingRoles: []string{},
+			req:               baseReq,
+			errCheck:          notFoundCheck,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			clt := mockDeployServiceIAMConfigClient{
-				accountID:        tt.mockAccountID,
-				existingPolicies: tt.mockExistingPolicies,
-				existingRoles:    tt.mockExistingRoles,
+				accountID:     tt.mockAccountID,
+				existingRoles: tt.mockExistingRoles,
 			}
 
 			err := ConfigureDeployServiceIAM(ctx, &clt, tt.req())
@@ -197,9 +183,8 @@ func TestDeployServiceIAMConfig(t *testing.T) {
 }
 
 type mockDeployServiceIAMConfigClient struct {
-	accountID        string
-	existingPolicies []string
-	existingRoles    []string
+	accountID     string
+	existingRoles []string
 }
 
 // GetCallerIdentity returns information about the caller identity.
@@ -207,19 +192,6 @@ func (m *mockDeployServiceIAMConfigClient) GetCallerIdentity(ctx context.Context
 	return &sts.GetCallerIdentityOutput{
 		Account: &m.accountID,
 	}, nil
-}
-
-// CreatePolicy creates a new IAM Policy.
-func (m *mockDeployServiceIAMConfigClient) CreatePolicy(ctx context.Context, params *iam.CreatePolicyInput, optFns ...func(*iam.Options)) (*iam.CreatePolicyOutput, error) {
-	alreadyExistsMessage := fmt.Sprintf("Policy %q already exists.", *params.PolicyName)
-	if slices.Contains(m.existingPolicies, *params.PolicyName) {
-		return nil, &iamTypes.EntityAlreadyExistsException{
-			Message: &alreadyExistsMessage,
-		}
-	}
-
-	m.existingPolicies = append(m.existingPolicies, *params.PolicyName)
-	return nil, nil
 }
 
 // CreateRole creates a new IAM Role.


### PR DESCRIPTION
This PR changes the AWS OIDC integration permissions setup to use static IAM permissions for `rds-db:connect` rather than the dynamic permissions managed by `iam:[Get|Put]RolePolicy`.

Context: https://github.com/gravitational/teleport/issues/43829

tl;dr this is part of simplifying the deployment. Fewer things can go wrong, the permissions granted are effectively the same, and the security of this is better because we don't rely on a permission boundary to prevent full AWS account privileges escalation. We are less likely to get customer questions/complaints about this as well.

This is actually not a breaking change either, because the integration has always required that they specify a new role to setup:
```
	_, err = clt.CreateRole(ctx, &iam.CreateRoleInput{
		RoleName:                 &req.TaskRole,
		Description:              &taskRoleDescription,
		AssumeRolePolicyDocument: &taskRoleAssumeRoleDocument,
		Tags:                     req.ResourceCreationTags.ToIAMTags(),
	})
	if err != nil {
		convertedErr := awslib.ConvertIAMv2Error(err)
		if trace.IsAlreadyExists(convertedErr) {
			return trace.AlreadyExists("Role %q already exists, please remove it and try again.", req.TaskRole)
		}
```

so there is no need to worry about old setups - besides those setups would already have `rds-db:connect: *` in their permissions boundary. I'm backporting this since it's not breaking.