### PR TITLE
[v16] buildbox: Update centos7 buildbox for EOL, using vault

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -24,10 +24,29 @@ gpgcheck=0
 enabled=1
 EOF
 
+# mirrorlist is no longer available since CentOS 7 EOL. The software collection
+# stuff for arm64 (aarch64) is in /altarch not /centos on vault.centos.org.
+# Make the fixup a script as it needs to be run multiple times as installing
+# and updating centos-release-scl-rh leaves the old unavailable URLs.
+# https://serverfault.com/a/1161847
+RUN cat <<EOF > /tmp/fix-yum-repo-list.sh
+#!/bin/sh
+sed -e 's/mirror.centos.org/vault.centos.org/g' \
+    -e 's/^#.*baseurl=http/baseurl=http/g' \
+    -e 's/^mirrorlist=http/#mirrorlist=http/g' \
+    -i /etc/yum.repos.d/*.repo
+if [ "$(uname -m)" = 'aarch64' ]; then
+    sed 's|centos/7/sclo|altarch/7/sclo|' -i /etc/yum.repos.d/*.repo
+fi
+EOF
+RUN chmod 755 /tmp/fix-yum-repo-list.sh && \
+    /tmp/fix-yum-repo-list.sh
+
 # Install required dependencies.
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
     yum install -y centos-release-scl-rh && \
+    /tmp/fix-yum-repo-list.sh \
     yum update -y && \
     yum install -y \
       ca-certificates \
@@ -43,7 +62,8 @@ RUN yum groupinstall -y 'Development Tools' && \
       perl-devel \
       scl-utils \
       wget && \
-    yum clean all
+    yum clean all && \
+    /tmp/fix-yum-repo-list.sh
 
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \


### PR DESCRIPTION
CentOS 7 became EOL on 2024/06/30. `mirrorlist` and `mirror.centos.org`
became unavailable, so use `baseurl` and `vault.centos.org` instead,
updating all references in `/etc/yum.repos.d/*`.

The software collection stuff (`centos-release-scl-rh`) is on a
different path on `vault.centos.org` for `aarch64` so also update those
paths.

Apply these changes multiple times as installing `centos-release-scl-rh`
installs a yum repo file with the old paths, as does installing
`centos-release-scl`.

Backport: https://github.com/gravitational/teleport/pull/43785
