### PR TITLE
Remove `aws-sdk-go/aws/awsutil` package

### DIFF
--- a/lib/integrations/awsoidc/deployservice_update.go
+++ b/lib/integrations/awsoidc/deployservice_update.go
@@ -20,13 +20,13 @@ package awsoidc
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
@@ -126,7 +126,11 @@ func updateServiceContainerImage(ctx context.Context, clt DeployServiceClient, l
 	oldTaskDefinitionARN := aws.ToString(service.TaskDefinition)
 
 	// Update service with new task definition
-	serviceNewVersion, err := clt.UpdateService(ctx, generateServiceWithTaskDefinition(service, aws.ToString(newTaskDefinitionARN)))
+	targetNewServiceVersion, err := generateServiceWithTaskDefinition(service, aws.ToString(newTaskDefinitionARN))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	serviceNewVersion, err := clt.UpdateService(ctx, targetNewServiceVersion)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -262,7 +266,14 @@ func waitServiceStableOrRollback(ctx context.Context, clt DeployServiceClient, l
 	}
 
 	log.WarnContext(ctx, "ECS Service is not stable, restarting the service with its previous TaskDefinition", "error", waitErr)
-	_, rollbackErr := clt.UpdateService(ctx, generateServiceWithTaskDefinition(service, oldTaskDefinitionARN))
+
+	rollbackServiceInput, err := generateServiceWithTaskDefinition(service, oldTaskDefinitionARN)
+	if err != nil {
+		log.WarnContext(ctx, "Failed to generate UpdateServiceInput targeting its previous version", "error", err)
+		return
+	}
+
+	_, rollbackErr := clt.UpdateService(ctx, rollbackServiceInput)
 	if rollbackErr != nil {
 		log.WarnContext(ctx, "Failed to update ECS Service with its previous version", "error", rollbackErr)
 	}
@@ -275,13 +286,23 @@ func generateTaskDefinitionWithImage(taskDefinition *ecsTypes.TaskDefinition, te
 	}
 
 	// Copy container definition and replace the teleport image with desired version
-	newContainerDefinition := new(ecsTypes.ContainerDefinition)
-	awsutil.Copy(newContainerDefinition, &taskDefinition.ContainerDefinitions[0])
+	newContainerDefinition := &taskDefinition.ContainerDefinitions[0]
 	newContainerDefinition.Image = aws.String(teleportImage)
 
 	// Copy task definition and replace container definitions
-	registerTaskDefinitionIn := new(ecs.RegisterTaskDefinitionInput)
-	awsutil.Copy(registerTaskDefinitionIn, taskDefinition)
+	//
+	// AWS SDK Go v1 had a `awsutil.Copy` which we could use to copy all the values from one struct into another one.
+	// AWS SDK Go v2 does not expose such method: https://github.com/aws/aws-sdk-go-v2/blob/9005edfbb1194c8f340b9bb7288698b58fc7274a/internal/awsutil/copy.go#L15
+	// To solve this, the TaskDefinition is json marshaled and unmarshalled into a RegisterTaskDefinitionInput.
+	registerTaskDefinitionIn := &ecs.RegisterTaskDefinitionInput{}
+	taskDefinitionJSON, err := json.Marshal(taskDefinition)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := json.Unmarshal(taskDefinitionJSON, registerTaskDefinitionIn); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	registerTaskDefinitionIn.ContainerDefinitions = []ecsTypes.ContainerDefinition{*newContainerDefinition}
 	registerTaskDefinitionIn.Tags = tags
 
@@ -319,11 +340,21 @@ func ensureUpgraderEnvironmentVariables(taskDefinition *ecs.RegisterTaskDefiniti
 }
 
 // generateServiceWithTaskDefinition returns new update service input with the desired task definition
-func generateServiceWithTaskDefinition(service *ecsTypes.Service, taskDefinitionName string) *ecs.UpdateServiceInput {
-	updateServiceIn := new(ecs.UpdateServiceInput)
-	awsutil.Copy(updateServiceIn, service)
+func generateServiceWithTaskDefinition(service *ecsTypes.Service, taskDefinitionName string) (*ecs.UpdateServiceInput, error) {
+	// AWS SDK Go v1 had a `awsutil.Copy` which we could use to copy all the values from one struct into another one.
+	// AWS SDK Go v2 does not expose such method: https://github.com/aws/aws-sdk-go-v2/blob/9005edfbb1194c8f340b9bb7288698b58fc7274a/internal/awsutil/copy.go#L15
+	// To solve this, the Service is json marshaled and unmarshalled into a UpdateServiceInput.
+	updateServiceIn := &ecs.UpdateServiceInput{}
+	serviceJSON, err := json.Marshal(service)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := json.Unmarshal(serviceJSON, updateServiceIn); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	updateServiceIn.Service = service.ServiceName
 	updateServiceIn.Cluster = service.ClusterArn
 	updateServiceIn.TaskDefinition = aws.String(taskDefinitionName)
-	return updateServiceIn
+	return updateServiceIn, nil
 }

--- a/lib/integrations/awsoidc/deployservice_update_test.go
+++ b/lib/integrations/awsoidc/deployservice_update_test.go
@@ -45,6 +45,8 @@ func TestGenerateServiceWithTaskDefinition(t *testing.T) {
 			},
 		},
 		PropagateTags: ecsTypes.PropagateTagsService,
+		CreatedBy:     aws.String("an extra field that is not present in the UpdateServiceInput"),
+		DesiredCount:  2,
 	}
 
 	expected := &ecs.UpdateServiceInput{
@@ -58,9 +60,15 @@ func TestGenerateServiceWithTaskDefinition(t *testing.T) {
 			},
 		},
 		PropagateTags: ecsTypes.PropagateTagsService,
-	}
+		DesiredCount:  aws.Int32(2),
 
-	require.Equal(t, expected, generateServiceWithTaskDefinition(service, "task-definition-v2"))
+		// Fields that are have a literal value in ecsTypes.Service but a pointer type in ecs.UpdateServiceInput will have their value defaulted to the 0-value
+		EnableECSManagedTags: aws.Bool(false),
+		EnableExecuteCommand: aws.Bool(false),
+	}
+	gotService, err := generateServiceWithTaskDefinition(service, "task-definition-v2")
+	require.NoError(t, err)
+	require.Equal(t, expected, gotService)
 }
 
 func TestGenerateTaskDefinitionWithImage(t *testing.T) {
@@ -71,6 +79,8 @@ func TestGenerateTaskDefinitionWithImage(t *testing.T) {
 		},
 		Cpu:    aws.String(taskCPU),
 		Memory: aws.String(taskMem),
+
+		RegisteredBy: aws.String("a field that doesn't exist in ecs.RegisterTaskDefinitionInput"),
 
 		NetworkMode:      ecsTypes.NetworkModeAwsvpc,
 		TaskRoleArn:      aws.String("task-role-arn"),


### PR DESCRIPTION
We are migrating away from aws sdk v1.
This PR removes the usage of the awsutil package.

Changes include removing a helper method that was not ported to V2. This method would copy from one struct into another one, using their field names.
That's useful when we want to mutate a single field (eg update the ECS image version).
However, that helper method was not ported.
Instead, we are now using json marshal/unmarshal to the same effect.