### PR TITLE
Add missing license header to make linter happy

### DIFF
--- a/web/packages/design/src/Button/buttons.story.test.tsx
+++ b/web/packages/design/src/Button/buttons.story.test.tsx
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import React from 'react';
 
 import { render } from 'design/utils/testing';


### PR DESCRIPTION
Adds a missing license header blockingus from merging go code.
The license checks runs in `Lint(Go)`, which means TS-only PRs skip it and we end up with a broken master.
We'll have to fix this later.