### PR TITLE
Discovery Config Status: allow for other Fetchers to contribute to the global Status

### DIFF
--- a/lib/srv/discovery/access_graph.go
+++ b/lib/srv/discovery/access_graph.go
@@ -34,7 +34,6 @@ import (
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
 	"github.com/gravitational/teleport/lib/services"
@@ -67,7 +66,7 @@ func (s *Server) reconcileAccessGraph(ctx context.Context, currentTAGResources *
 		}
 		return trace.Wrap(errNoAccessGraphFetchers)
 	}
-	s.updateDiscoveryConfigStatus(allFetchers, nil, true /* preRun */)
+	s.updateAWSSyncDiscoveryConfigStatus(allFetchers, nil, true /* preRun */)
 	resultsC := make(chan fetcherResult, len(allFetchers))
 	// Use a channel to limit the number of concurrent fetchers.
 	tokens := make(chan struct{}, 3)
@@ -105,7 +104,7 @@ func (s *Server) reconcileAccessGraph(ctx context.Context, currentTAGResources *
 	// Merge all results into a single result
 	upsert, toDel := aws_sync.ReconcileResults(currentTAGResources, result)
 	err = push(stream, upsert, toDel)
-	s.updateDiscoveryConfigStatus(allFetchers, err, false /* preRun */)
+	s.updateAWSSyncDiscoveryConfigStatus(allFetchers, err, false /* preRun */)
 	if err != nil {
 		s.Log.WithError(err).Error("Error pushing TAGs")
 		return nil
@@ -458,32 +457,7 @@ func (s *Server) accessGraphFetchersFromMatchers(ctx context.Context, matchers M
 	return fetchers, trace.NewAggregate(errs...)
 }
 
-func (s *Server) updateDiscoveryConfigStatus(fetchers []aws_sync.AWSSync, pushErr error, preRun bool) {
-	lastUpdate := s.clock.Now()
-	for _, fetcher := range fetchers {
-		// Only update the status for fetchers that are from the discovery config.
-		if !fetcher.IsFromDiscoveryConfig() {
-			continue
-		}
-
-		status := buildFetcherStatus(fetcher, pushErr, lastUpdate)
-		if preRun {
-			// If this is a pre-run, the status is syncing.
-			status.State = discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_SYNCING.String()
-		}
-		ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
-		defer cancel()
-		_, err := s.AccessPoint.UpdateDiscoveryConfigStatus(ctx, fetcher.DiscoveryConfigName(), status)
-		switch {
-		case trace.IsNotImplemented(err):
-			s.Log.Warn("UpdateDiscoveryConfigStatus method is not implemented in Auth Server. Please upgrade it to a recent version.")
-		case err != nil:
-			s.Log.WithError(err).Infof("Error updating discovery config %q status", fetcher.DiscoveryConfigName())
-		}
-	}
-}
-
-func buildFetcherStatus(fetcher aws_sync.AWSSync, pushErr error, lastUpdate time.Time) discoveryconfig.Status {
+func buildAWSSyncFetcherStatus(fetcher aws_sync.AWSSync, pushErr error, lastUpdate time.Time) awsSyncResult {
 	count, err := fetcher.Status()
 	err = trace.NewAggregate(err, pushErr)
 	var errStr *string
@@ -493,10 +467,10 @@ func buildFetcherStatus(fetcher aws_sync.AWSSync, pushErr error, lastUpdate time
 		*errStr = err.Error()
 		state = discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_ERROR
 	}
-	return discoveryconfig.Status{
-		State:               state.String(),
-		ErrorMessage:        errStr,
-		LastSyncTime:        lastUpdate,
-		DiscoveredResources: count,
+	return awsSyncResult{
+		state:               state.String(),
+		errorMessage:        errStr,
+		lastSyncTime:        lastUpdate,
+		discoveredResources: count,
 	}
 }

--- a/lib/srv/discovery/access_graph.go
+++ b/lib/srv/discovery/access_graph.go
@@ -115,7 +115,7 @@ func (s *Server) reconcileAccessGraph(ctx context.Context, currentTAGResources *
 	}
 
 	if pushErr != nil {
-		s.Log.WithError(err).Error("Error pushing TAGs")
+		s.Log.WithError(pushErr).Error("Error pushing TAGs")
 		return nil
 	}
 	// Update the currentTAGResources with the result of the reconciliation.

--- a/lib/srv/discovery/access_graph_test.go
+++ b/lib/srv/discovery/access_graph_test.go
@@ -152,8 +152,9 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 					AccessPoint: accessPoint,
 					clock:       clock,
 				},
+				awsSyncStatus: newAWSSyncStatus(),
 			}
-			s.updateDiscoveryConfigStatus(tt.args.fetchers, tt.args.pushErr, tt.args.preRun)
+			s.updateAWSSyncDiscoveryConfigStatus(tt.args.fetchers, tt.args.pushErr, tt.args.preRun)
 			require.Equal(t, tt.want, accessPoint.reports)
 		})
 	}

--- a/lib/srv/discovery/access_graph_test.go
+++ b/lib/srv/discovery/access_graph_test.go
@@ -152,7 +152,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 					AccessPoint: accessPoint,
 					clock:       clock,
 				},
-				awsSyncStatus: newAWSSyncStatus(),
+				awsSyncStatus: awsSyncStatus{},
 			}
 			s.updateAWSSyncDiscoveryConfigStatus(tt.args.fetchers, tt.args.pushErr, tt.args.preRun)
 			require.Equal(t, tt.want, accessPoint.reports)

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -360,7 +360,7 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 		dynamicServerGCPFetchers:   make(map[string][]server.Fetcher),
 		dynamicTAGSyncFetchers:     make(map[string][]aws_sync.AWSSync),
 		dynamicDiscoveryConfig:     make(map[string]*discoveryconfig.DiscoveryConfig),
-		awsSyncStatus:              newAWSSyncStatus(),
+		awsSyncStatus:              awsSyncStatus{},
 	}
 	s.discardUnsupportedMatchers(&s.Matchers)
 

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -327,6 +327,8 @@ type Server struct {
 
 	dynamicDiscoveryConfig map[string]*discoveryconfig.DiscoveryConfig
 
+	awsSyncStatus awsSyncStatus
+
 	// caRotationCh receives nodes that need to have their CAs rotated.
 	caRotationCh chan []types.Server
 	// reconciler periodically reconciles the labels of discovered instances
@@ -358,6 +360,7 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 		dynamicServerGCPFetchers:   make(map[string][]server.Fetcher),
 		dynamicTAGSyncFetchers:     make(map[string][]aws_sync.AWSSync),
 		dynamicDiscoveryConfig:     make(map[string]*discoveryconfig.DiscoveryConfig),
+		awsSyncStatus:              newAWSSyncStatus(),
 	}
 	s.discardUnsupportedMatchers(&s.Matchers)
 

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -1,0 +1,120 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discovery
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
+)
+
+// updateDiscoveryConfigStatus updates the DiscoveryConfig Status field with the current in-memory status.
+// The status will be updated with the following matchers:
+// - AWS Sync (TAG) status
+func (s *Server) updateDiscoveryConfigStatus(discoveryConfigName string) {
+	discoveryConfigStatus := discoveryconfig.Status{
+		State:        discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_SYNCING.String(),
+		LastSyncTime: s.clock.Now(),
+	}
+
+	// Merge AWS Sync (TAG) status
+	discoveryConfigStatus = s.awsSyncStatus.mergeIntoGlobalStatus(discoveryConfigName, discoveryConfigStatus)
+
+	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := s.AccessPoint.UpdateDiscoveryConfigStatus(ctx, discoveryConfigName, discoveryConfigStatus)
+	switch {
+	case trace.IsNotImplemented(err):
+		s.Log.Warn("UpdateDiscoveryConfigStatus method is not implemented in Auth Server. Please upgrade it to a recent version.")
+	case err != nil:
+		s.Log.WithError(err).Infof("Error updating discovery config %q status", discoveryConfigName)
+	}
+}
+
+func newAWSSyncStatus() awsSyncStatus {
+	return awsSyncStatus{
+		awsSyncStatus: make(map[string]awsSyncResult),
+	}
+}
+
+type awsSyncStatus struct {
+	mu            sync.RWMutex
+	awsSyncStatus map[string]awsSyncResult
+}
+
+type awsSyncResult struct {
+	state               string
+	errorMessage        *string
+	lastSyncTime        time.Time
+	discoveredResources uint64
+}
+
+func (d *awsSyncStatus) upsertStatus(discoveryConfig string, result awsSyncResult) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.awsSyncStatus == nil {
+		d.awsSyncStatus = make(map[string]awsSyncResult)
+	}
+	d.awsSyncStatus[discoveryConfig] = result
+}
+
+func (d *awsSyncStatus) mergeIntoGlobalStatus(discoveryConfig string, existingStatus discoveryconfig.Status) discoveryconfig.Status {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	awsStatus, found := d.awsSyncStatus[discoveryConfig]
+	if !found {
+		return existingStatus
+	}
+
+	existingStatus.DiscoveredResources = existingStatus.DiscoveredResources + awsStatus.discoveredResources
+	existingStatus.ErrorMessage = awsStatus.errorMessage
+	existingStatus.State = awsStatus.state
+	existingStatus.LastSyncTime = awsStatus.lastSyncTime
+
+	return existingStatus
+}
+
+// updateAWSSyncDiscoveryConfigStatus updates the status for each DiscoveryConfig that originated the Fetchers.
+// It updates the internal state and updates the Status in the cluster.
+func (s *Server) updateAWSSyncDiscoveryConfigStatus(fetchers []aws_sync.AWSSync, pushErr error, preRun bool) error {
+	lastUpdate := s.clock.Now()
+	for _, fetcher := range fetchers {
+		// Only update the status for fetchers that are from the discovery config.
+		if !fetcher.IsFromDiscoveryConfig() {
+			continue
+		}
+
+		status := buildAWSSyncFetcherStatus(fetcher, pushErr, lastUpdate)
+		if preRun {
+			status.state = discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_SYNCING.String()
+		}
+		s.awsSyncStatus.upsertStatus(fetcher.DiscoveryConfigName(), status)
+		s.updateDiscoveryConfigStatus(fetcher.DiscoveryConfigName())
+	}
+	return nil
+}


### PR DESCRIPTION
This change should be a no-op, but it moves the AWS Sync Status logic to its own methods.
This paves the path for other Fetchers/Matchers to update the global state of the DiscoveryConfig Status.