### PR TITLE
send empty SAML service provider preset values as `unspecified` to Web UI.

### DIFF
--- a/lib/web/ui/app.go
+++ b/lib/web/ui/app.go
@@ -19,6 +19,7 @@
 package ui
 
 import (
+	"cmp"
 	"sort"
 
 	"github.com/sirupsen/logrus"
@@ -159,10 +160,6 @@ func MakeApp(app types.Application, c MakeAppsConfig) App {
 // Web UI. Thus, this field is currently not available in the Connect App type.
 func MakeAppTypeFromSAMLApp(app types.SAMLIdPServiceProvider, c MakeAppsConfig) App {
 	labels := makeLabels(app.GetAllLabels())
-	samlAppPreset := "unspecified"
-	if app.GetPreset() != "" {
-		samlAppPreset = app.GetPreset()
-	}
 	resultApp := App{
 		Kind:            types.KindApp,
 		Name:            app.GetName(),
@@ -172,7 +169,7 @@ func MakeAppTypeFromSAMLApp(app types.SAMLIdPServiceProvider, c MakeAppsConfig) 
 		ClusterID:       c.AppClusterName,
 		FriendlyName:    types.FriendlyName(app),
 		SAMLApp:         true,
-		SAMLAppPreset:   samlAppPreset,
+		SAMLAppPreset:   cmp.Or(app.GetPreset(), "unspecified"),
 		RequiresRequest: c.RequiresRequest,
 	}
 

--- a/lib/web/ui/app.go
+++ b/lib/web/ui/app.go
@@ -155,8 +155,14 @@ func MakeApp(app types.Application, c MakeAppsConfig) App {
 
 // MakeAppTypeFromSAMLApp creates App type from SAMLIdPServiceProvider type for the WebUI.
 // Keep in sync with lib/teleterm/apiserver/handler/handler_apps.go.
+// Note: The SAMLAppPreset field is used in SAML service provider update flow in the
+// Web UI. Thus, this field is currently not available in the Connect App type.
 func MakeAppTypeFromSAMLApp(app types.SAMLIdPServiceProvider, c MakeAppsConfig) App {
 	labels := makeLabels(app.GetAllLabels())
+	samlAppPreset := "unspecified"
+	if app.GetPreset() != "" {
+		samlAppPreset = app.GetPreset()
+	}
 	resultApp := App{
 		Kind:            types.KindApp,
 		Name:            app.GetName(),
@@ -166,7 +172,7 @@ func MakeAppTypeFromSAMLApp(app types.SAMLIdPServiceProvider, c MakeAppsConfig) 
 		ClusterID:       c.AppClusterName,
 		FriendlyName:    types.FriendlyName(app),
 		SAMLApp:         true,
-		SAMLAppPreset:   app.GetPreset(),
+		SAMLAppPreset:   samlAppPreset,
 		RequiresRequest: c.RequiresRequest,
 	}
 

--- a/lib/web/ui/app_test.go
+++ b/lib/web/ui/app_test.go
@@ -231,19 +231,29 @@ func TestMakeAppTypeFromSAMLApp(t *testing.T) {
 		expected         App
 	}{
 		{
-			name: "empty",
+			name: "saml service provider with empty preset returns unspecified",
+			sp: types.SAMLIdPServiceProviderV1{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "test_app",
+					},
+				},
+				Spec: types.SAMLIdPServiceProviderSpecV1{
+					Preset: "",
+				},
+			},
 			expected: App{
 				Kind:          types.KindApp,
-				Name:          "",
+				Name:          "test_app",
 				Description:   "SAML Application",
 				PublicAddr:    "",
 				Labels:        []Label{},
 				SAMLApp:       true,
-				SAMLAppPreset: "",
+				SAMLAppPreset: "unspecified",
 			},
 		},
 		{
-			name: "saml idp service provider",
+			name: "saml service provider with preset",
 			sp: types.SAMLIdPServiceProviderV1{
 				ResourceHeader: types.ResourceHeader{
 					Metadata: types.Metadata{


### PR DESCRIPTION
This is added to unified resource response so that web UI does not need to think about empty string to `unspecified` conversion. 