### PR TITLE
Add checkExpiredCredentials function

### DIFF
--- a/api/utils/keys/privatekey.go
+++ b/api/utils/keys/privatekey.go
@@ -97,7 +97,7 @@ func (k *PrivateKey) TLSCertificate(certPEMBlock []byte) (tls.Certificate, error
 	return TLSCertificateForSigner(k.Signer, certPEMBlock)
 }
 
-// TLSCertificate parses the given TLS certificate(s) paired with the given
+// TLSCertificateForSigner parses the given TLS certificate(s) paired with the given
 // signer to return a tls.Certificate, ready to be used in a TLS handshake.
 func TLSCertificateForSigner(signer crypto.Signer, certPEMBlock []byte) (tls.Certificate, error) {
 	cert := tls.Certificate{
@@ -136,6 +136,10 @@ func TLSCertificateForSigner(signer crypto.Signer, certPEMBlock []byte) (tls.Cer
 	} else if !keyPub.Equal(x509Cert.PublicKey) {
 		return tls.Certificate{}, trace.BadParameter("private key does not match certificate's public key")
 	}
+
+	// Setting the leaf will allow the tls.Certificate object to not parse a second time the leaf certificate
+	// It also allows us to check quickly the leaf of the tls.Certificate is expired.
+	cert.Leaf = x509Cert
 
 	return cert, nil
 }


### PR DESCRIPTION
Fixes part of https://github.com/gravitational/teleport/issues/17139

This PR adds a function that checks a credential array and returns all credentials we know are expired, without having to actually connect to Teleport.

If one or more items are expired, we can decide to send an actionable warning to the user, or bail out entierly.

This will fix the user experience in case of expired credentials. I'm doing this mainly for the Terraform provider since `tctl terraform env` issues short-lived certificates and Terraform must send a clear warning when this happens. However, this can also be used to improve other teleport clients.

Note for reviewers: this is a draft to check if you think the approach is sane or if you want to do it differently. I'll write tests once you're happy with the plan.