### PR TITLE
Web UI: saml service provider resource type and type refactoring

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
@@ -17,10 +17,11 @@
  */
 
 import { DiscoverEventResource } from 'teleport/services/userEvent';
+import { SamlServiceProviderPreset } from 'teleport/services/samlidp/types';
 
 import { ResourceKind } from '../Shared';
 
-import { ResourceSpec, SamlServiceProviderPreset } from './types';
+import { ResourceSpec } from './types';
 
 export const SAML_APPLICATIONS: ResourceSpec[] = [
   {

--- a/web/packages/teleport/src/Discover/SelectResource/types.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/types.ts
@@ -24,6 +24,8 @@ import { AuthType } from 'teleport/services/user';
 
 import { ResourceKind } from '../Shared/ResourceKind';
 
+import type { SamlServiceProviderPreset } from 'teleport/services/samlidp/types';
+
 import type {
   DiscoverDiscoveryConfigMethod,
   DiscoverEventResource,
@@ -67,16 +69,6 @@ export enum ServerLocation {
 export enum KubeLocation {
   SelfHosted,
   Aws,
-}
-
-/**
- * SamlServiceProviderPreset defines SAML service provider preset types.
- * Used to define custom or pre-defined configuration flow.
- */
-export enum SamlServiceProviderPreset {
-  Unspecified = 'unspecified',
-  Grafana = 'grafana',
-  GcpWorkforce = 'gcp-workforce',
 }
 
 export interface ResourceSpec {

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -55,6 +55,8 @@ import type {
   Regions,
 } from 'teleport/services/integrations';
 
+import type { SamlGcpWorkforce } from 'teleport/services/samlidp/types';
+
 export interface DiscoverContextState<T = any> {
   agentMeta: AgentMeta;
   currentStep: number;
@@ -554,17 +556,7 @@ export type AppMeta = BaseMeta & {
 // SamlMeta describes the fields for SAML IdP
 // service provider resource that needs to be
 // preserved throughout the flow.
-export type SamlMeta = BaseMeta & SamlGcpWorkforceMeta;
-
-// GcpWorkforceMeta describes the fields for SAML
-// GCP workforce pool resource that needs to be
-// preserved throughout the flow.
-export type SamlGcpWorkforceMeta = {
-  isAutoConfig: boolean;
-  orgId: string;
-  poolName: string;
-  poolProviderName: string;
-};
+export type SamlMeta = BaseMeta & SamlGcpWorkforce;
 
 export type AgentMeta =
   | DbMeta

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -553,9 +553,11 @@ export type AppMeta = BaseMeta & {
   app: App;
 };
 
-// SamlMeta describes the fields for SAML IdP
-// service provider resource that needs to be
-// preserved throughout the flow.
+/**
+ * SamlMeta describes the fields for SAML IdP
+ * service provider resource that needs to be
+ * preserved throughout the flow.
+ */
 export type SamlMeta = BaseMeta & SamlGcpWorkforce;
 
 export type AgentMeta =

--- a/web/packages/teleport/src/services/apps/types.ts
+++ b/web/packages/teleport/src/services/apps/types.ts
@@ -20,7 +20,7 @@ import { AwsRole } from 'shared/services/apps';
 
 import { ResourceLabel } from 'teleport/services/agents';
 
-import type { SamlServiceProviderPreset } from 'teleport/Discover/SelectResource/types';
+import type { SamlServiceProviderPreset } from 'teleport/services/samlidp/types';
 
 export interface App {
   kind: 'app';

--- a/web/packages/teleport/src/services/samlidp/types.ts
+++ b/web/packages/teleport/src/services/samlidp/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * SamlIdpServiceProvider defines fields that are available
+ * in the SAMLIdPServiceProviderV1 proto in the backend.
+ */
+export type SamlIdpServiceProvider = {
+  kind: string;
+  metadata: {
+    name: string;
+    labels: Record<string, string>;
+  };
+  spec: SamlIdpServiceProviderSpec;
+  version: string;
+};
+
+/**
+ * SamlIdpServiceProviderSpec defines fields that are available
+ * in the SAMLIdPServiceProviderSpecV1 proto in the backend.
+ */
+export type SamlIdpServiceProviderSpec = {
+  acs_url: string;
+  attribute_mapping: AttributeMapping[];
+  entity_descriptor: string;
+  entity_id: string;
+  preset: string;
+  relay_state: string;
+};
+
+/**
+ * AttributeMapping defines SAML service provider
+ * attribute mapping fields.
+ */
+export type AttributeMapping = {
+  name: string;
+  value: string;
+  nameFormat?: string;
+};
+
+/**
+ * SamlServiceProviderPreset defines SAML service provider preset types.
+ * Used to define custom or pre-defined configuration flow.
+ */
+export enum SamlServiceProviderPreset {
+  Unspecified = 'unspecified',
+  Grafana = 'grafana',
+  GcpWorkforce = 'gcp-workforce',
+}

--- a/web/packages/teleport/src/services/samlidp/types.ts
+++ b/web/packages/teleport/src/services/samlidp/types.ts
@@ -62,3 +62,15 @@ export enum SamlServiceProviderPreset {
   Grafana = 'grafana',
   GcpWorkforce = 'gcp-workforce',
 }
+
+/**
+ * GcpWorkforceMeta describes the fields for SAML
+ * GCP workforce pool resource that needs to be
+ * preserved throughout the flow.
+ */
+export type SamlGcpWorkforce = {
+  isAutoConfig: boolean;
+  orgId: string;
+  poolName: string;
+  poolProviderName: string;
+};

--- a/web/packages/teleport/src/services/samlidp/types.ts
+++ b/web/packages/teleport/src/services/samlidp/types.ts
@@ -64,7 +64,7 @@ export enum SamlServiceProviderPreset {
 }
 
 /**
- * GcpWorkforceMeta describes the fields for SAML
+ * SamlGcpWorkforce describes the fields for SAML
  * GCP workforce pool resource that needs to be
  * preserved throughout the flow.
  */


### PR DESCRIPTION
- Defines new `SamlIdpServiceProvider` `SamlIdpServiceProviderSpec` types to a new `samlidp/types.ts` file. 
- `SamlServiceProviderPreset` and `AttributeMapping` (moved from `e`) types are also added to new `samlidp/types.ts` file. Moving `SamlServiceProviderPreset` to this new type file removes circular dependency issue we had before in `Discover -> app -> saml -> Discover`.
- Moves `SamlGcpWorkforceMeta` type from Discover to new `samlidp/types.ts` file. 

This is done as a preliminary work to add `SamlIdpServiceProvider` to Discover `AgentMeta`, which is to be defined in OSS package. 

Part of https://github.com/gravitational/teleport.e/issues/4458