### PR TITLE
Pass a client cert getter through auth.TLSServer and plugins

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -845,6 +845,7 @@ func NewTestTLSServer(cfg TestTLSServerConfig) (*TestTLSServer, error) {
 		return nil, trace.Wrap(err)
 	}
 	tlsConfig.Time = cfg.AuthServer.Clock().Now
+	tlsCert := tlsConfig.Certificates[0]
 
 	srv.Listener, err = net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -852,12 +853,13 @@ func NewTestTLSServer(cfg TestTLSServerConfig) (*TestTLSServer, error) {
 	}
 
 	srv.TLSServer, err = NewTLSServer(context.Background(), TLSServerConfig{
-		Listener:      srv.Listener,
-		AccessPoint:   srv.AuthServer.AuthServer.Cache,
-		TLS:           tlsConfig,
-		APIConfig:     *srv.APIConfig,
-		LimiterConfig: *srv.Limiter,
-		AcceptedUsage: cfg.AcceptedUsage,
+		Listener:             srv.Listener,
+		AccessPoint:          srv.AuthServer.AuthServer.Cache,
+		TLS:                  tlsConfig,
+		GetClientCertificate: func() (*tls.Certificate, error) { return &tlsCert, nil },
+		APIConfig:            *srv.APIConfig,
+		LimiterConfig:        *srv.Limiter,
+		AcceptedUsage:        cfg.AcceptedUsage,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2239,7 +2239,9 @@ func (process *TeleportProcess) initAuthService() error {
 	authMetrics := &auth.Metrics{GRPCServerLatency: cfg.Metrics.GRPCServerLatency}
 
 	tlsServer, err := auth.NewTLSServer(process.ExitContext(), auth.TLSServerConfig{
-		TLS:           tlsConfig,
+		TLS:                  tlsConfig,
+		GetClientCertificate: connector.ClientGetCertificate,
+
 		APIConfig:     *apiConf,
 		LimiterConfig: cfg.Auth.Limiter,
 		AccessPoint:   authServer.Cache,


### PR DESCRIPTION
This PR will let enterprise plugins that are created before the `TeleportProcess` have access to auth client credentials at initialization time.

Will break enteprise builds until gravitational/teleport.e#4588 is merged.