### PR TITLE
[v16] docs: search_as_roles only supports literals

### DIFF
--- a/docs/pages/access-controls/access-requests/access-request-configuration.mdx
+++ b/docs/pages/access-controls/access-requests/access-request-configuration.mdx
@@ -114,29 +114,25 @@ they search for a Teleport resource:
 - `allow.request.search_as_roles`
 - `deny.request.search_as_roles`
 
-For example, the following role enables a user to search for resources by
-assuming all roles *except* for the `k8s-viewer` role:
+For example, the following role enables a user to search for resources that the
+`k8s-viewer` role allows access to.
 
 ```yaml
 # requester.yaml
 kind: role
 version: v6
 metadata:
-  name: k8s-denier
+  name: k8s-requester
 spec:
   allow:
     request:
       search_as_roles:
-        - '*'
- deny:
-   request:
-      search_as_roles:
         - k8s-viewer
 ```
 
-As with [configuring role requests](#restrict-role-requests), the
-`request.search_as_roles` field is a list of role matchers that can include
-literal role names, wildcards, and regular expressions.
+In contrast to [configuring role requests](#restrict-role-requests), the
+`request.search_as_roles` field is a list of literal role names only, and does
+not support wildcards or regular expressions.
 
 The Teleport Auth Service combines the values of these fields for all of a
 user's Teleport roles in order to validate the user's Access Requests.
@@ -154,9 +150,9 @@ following:
    these to exclude roles specified in `deny.request.search_as_roles` or
    `deny.request.roles`.
 1. Determines which of the remaining roles can access the requested resource.
-   For a Resource Access Request to be valid, one of the role matchers listed in
-   a user's `search_as_roles` configuration must match a role that permits
-   access to the requested resources.
+   For a Resource Access Request to be valid, one of the roles listed in
+   a user's `search_as_roles` configuration must permit access to the requested
+   resources.
 
 ## How long access lasts
 

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -25,11 +25,12 @@ available in Teleport Enterprise.
 ## Step 1/8. Create the requester role
 
 <Admonition type="note">
-As of version 13.1.2, Teleport comes with built-in `reviewer` and `requester` roles that
-are defined similarly to the ones presented here. If you are looking to quickly try out
-Access Requests, you can skip to step 3 and use these built-in roles. However, if you are
-using an earlier version of Teleport or you are looking to get general guidance for creating
-roles for Access Requests, steps 1 and 2 are still useful.
+Teleport comes with built-in `reviewer` and `requester` roles that are defined
+similarly to the ones presented here. If you are looking to quickly try out
+Access Requests, you can skip to step 3 and use these built-in roles. However,
+if you are using an earlier version of Teleport or you are looking to get
+general guidance for creating roles for Access Requests, steps 1 and 2 are still
+useful.
 </Admonition>
 
 This role allows the requester to search for resources accessible by the

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -25,12 +25,11 @@ available in Teleport Enterprise.
 ## Step 1/8. Create the requester role
 
 <Admonition type="note">
-Teleport comes with built-in `reviewer` and `requester` roles that are defined
-similarly to the ones presented here. If you are looking to quickly try out
-Access Requests, you can skip to step 3 and use these built-in roles. However,
-if you are using an earlier version of Teleport or you are looking to get
-general guidance for creating roles for Access Requests, steps 1 and 2 are still
-useful.
+As of version 13.1.2, Teleport comes with built-in `reviewer` and `requester` roles that
+are defined similarly to the ones presented here. If you are looking to quickly try out
+Access Requests, you can skip to step 3 and use these built-in roles. However, if you are
+using an earlier version of Teleport or you are looking to get general guidance for creating
+roles for Access Requests, steps 1 and 2 are still useful.
 </Admonition>
 
 This role allows the requester to search for resources accessible by the


### PR DESCRIPTION
Backport #43825 to branch/v16