### PR TITLE
docs: update teleport event handler service instructions

### DIFF
--- a/docs/pages/includes/start-event-handler.mdx
+++ b/docs/pages/includes/start-event-handler.mdx
@@ -4,7 +4,7 @@ Start the Teleport Teleport Event Handler by following the instructions below.
 <TabItem label="Linux server">
 Copy the `teleport-event-handler.toml` file to `/etc` on your Linux server.
 Update the settings within the `toml` file to match your environment. Make sure to
-use fully qualified paths on setting such as `identity` and `storage`. Files
+use absolute paths on settings such as `identity` and `storage`. Files
 and directories in use should only be accessible to the system user executing
 the `teleport-event-handler` service such as `/var/lib/teleport-event-handler`.
 

--- a/docs/pages/includes/start-event-handler.mdx
+++ b/docs/pages/includes/start-event-handler.mdx
@@ -3,6 +3,10 @@ Start the Teleport Teleport Event Handler by following the instructions below.
 <Tabs>
 <TabItem label="Linux server">
 Copy the `teleport-event-handler.toml` file to `/etc` on your Linux server.
+Update the settings within the `toml` file to match your environment. Make sure to
+use fully qualified paths on setting such as `identity` and `storage`. Files
+and directories in use should only be accessible to the system user executing
+the `teleport-event-handler` service such as `/var/lib/teleport-event-handler`.
 
 Next, create a systemd service definition at the path
 `/usr/lib/systemd/system/teleport-event-handler.service` with the following


### PR DESCRIPTION
Expand instructions on event-handler TOML file. Folks have been not updating to use fully qualified paths and should not be using home directories.