### PR TITLE
Add a client-side API to assert devices

### DIFF
--- a/lib/devicetrust/assert/assert.go
+++ b/lib/devicetrust/assert/assert.go
@@ -99,6 +99,9 @@ func (d *devicesClientAdapter) AuthenticateDevice(ctx context.Context, opts ...g
 	}, nil
 }
 
+// authnStreamAdapter adapts an [AssertDeviceClientStream] to a
+// [devicepb.DeviceTrustService_AuthenticateDeviceClient] stream. This allows
+// the assertion ceremony to borrow the [authn.Ceremony] logic for itself.
 type authnStreamAdapter struct {
 	devicepb.DeviceTrustService_AuthenticateDeviceClient
 

--- a/lib/devicetrust/assert/assert.go
+++ b/lib/devicetrust/assert/assert.go
@@ -1,0 +1,180 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package assert
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/grpc"
+
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	"github.com/gravitational/teleport/lib/devicetrust/authn"
+)
+
+// AssertDeviceClientStream is the client-side device assertion stream.
+type AssertDeviceClientStream interface {
+	Send(*devicepb.AssertDeviceRequest) error
+	Recv() (*devicepb.AssertDeviceResponse, error)
+}
+
+// Ceremony implements the client-side assertion ceremony.
+//
+// See [devicepb.AssertDeviceRequest] for details.
+type Ceremony struct {
+	// newAuthnCeremony defaults to authn.NewCeremony.
+	newAuthnCeremony func() *authn.Ceremony
+}
+
+// CeremonyOpt is a creation option for [Ceremony].
+type CeremonyOpt func(*Ceremony)
+
+// WithNewAuthnCeremonyFunc overrides the default authn.Ceremony constructor,
+// allowing callers to change the underlying assert implementation.
+//
+// Useful for testing. Avoid for production code.
+func WithNewAuthnCeremonyFunc(f func() *authn.Ceremony) CeremonyOpt {
+	return func(c *Ceremony) {
+		c.newAuthnCeremony = f
+	}
+}
+
+// NewCeremony creates a new [Ceremony], binding all native device trust
+// methods.
+func NewCeremony(opts ...CeremonyOpt) (*Ceremony, error) {
+	c := &Ceremony{
+		newAuthnCeremony: authn.NewCeremony,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, nil
+}
+
+// Run runs the client-side device assertion ceremony.
+// Requests and responses are consumed from the stream until the device is
+// asserted or authentication fails.
+func (c *Ceremony) Run(ctx context.Context, stream AssertDeviceClientStream) error {
+	newAuthn := c.newAuthnCeremony
+	if newAuthn == nil {
+		newAuthn = authn.NewCeremony
+	}
+
+	devices := &devicesClientAdapter{
+		stream: stream,
+	}
+	certs := &devicepb.UserCertificates{} // required but unused
+
+	// Implement Assertion in terms of Authentication, so we borrow both the
+	// Secure Enclave and TPM branches from it.
+	// TODO(codingllama): Refactor so we don't need so many adapters?
+	_, err := newAuthn().Run(ctx, devices, certs)
+	return trace.Wrap(err)
+}
+
+type devicesClientAdapter struct {
+	devicepb.DeviceTrustServiceClient
+
+	stream AssertDeviceClientStream
+}
+
+func (d *devicesClientAdapter) AuthenticateDevice(ctx context.Context, opts ...grpc.CallOption) (devicepb.DeviceTrustService_AuthenticateDeviceClient, error) {
+	return &authnStreamAdapter{
+		ctx:    ctx,
+		stream: d.stream,
+	}, nil
+}
+
+type authnStreamAdapter struct {
+	devicepb.DeviceTrustService_AuthenticateDeviceClient
+
+	ctx    context.Context
+	stream AssertDeviceClientStream
+}
+
+func (s *authnStreamAdapter) CloseSend() error {
+	return nil
+}
+
+func (s *authnStreamAdapter) Context() context.Context {
+	return s.ctx
+}
+
+func (s *authnStreamAdapter) Recv() (*devicepb.AuthenticateDeviceResponse, error) {
+	resp, err := s.stream.Recv()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if resp == nil || resp.Payload == nil {
+		return nil, trace.BadParameter("assertion response payload required")
+	}
+
+	switch resp.Payload.(type) {
+	case *devicepb.AssertDeviceResponse_Challenge:
+		return &devicepb.AuthenticateDeviceResponse{
+			Payload: &devicepb.AuthenticateDeviceResponse_Challenge{
+				Challenge: resp.GetChallenge(),
+			},
+		}, nil
+	case *devicepb.AssertDeviceResponse_TpmChallenge:
+		return &devicepb.AuthenticateDeviceResponse{
+			Payload: &devicepb.AuthenticateDeviceResponse_TpmChallenge{
+				TpmChallenge: resp.GetTpmChallenge(),
+			},
+		}, nil
+	case *devicepb.AssertDeviceResponse_DeviceAsserted:
+		// Pass an empty UserCertificates to signify success.
+		return &devicepb.AuthenticateDeviceResponse{
+			Payload: &devicepb.AuthenticateDeviceResponse_UserCertificates{
+				UserCertificates: &devicepb.UserCertificates{},
+			},
+		}, nil
+	default:
+		return nil, trace.BadParameter("unexpected assertion response payload: %T", resp.Payload)
+	}
+}
+
+func (s *authnStreamAdapter) Send(authnReq *devicepb.AuthenticateDeviceRequest) error {
+	if authnReq == nil || authnReq.Payload == nil {
+		return trace.BadParameter("authenticate request payload required")
+	}
+
+	req := &devicepb.AssertDeviceRequest{}
+	switch authnReq.Payload.(type) {
+	case *devicepb.AuthenticateDeviceRequest_Init:
+		init := authnReq.GetInit()
+		req.Payload = &devicepb.AssertDeviceRequest_Init{
+			Init: &devicepb.AssertDeviceInit{
+				CredentialId: init.GetCredentialId(),
+				DeviceData:   init.GetDeviceData(),
+			},
+		}
+	case *devicepb.AuthenticateDeviceRequest_ChallengeResponse:
+		req.Payload = &devicepb.AssertDeviceRequest_ChallengeResponse{
+			ChallengeResponse: authnReq.GetChallengeResponse(),
+		}
+	case *devicepb.AuthenticateDeviceRequest_TpmChallengeResponse:
+		req.Payload = &devicepb.AssertDeviceRequest_TpmChallengeResponse{
+			TpmChallengeResponse: authnReq.GetTpmChallengeResponse(),
+		}
+	default:
+		return trace.BadParameter("unexpected authenticate request payload: %T", authnReq.Payload)
+	}
+
+	return trace.Wrap(s.stream.Send(req))
+}

--- a/lib/devicetrust/assert/assert_test.go
+++ b/lib/devicetrust/assert/assert_test.go
@@ -1,0 +1,164 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package assert_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	"github.com/gravitational/teleport/lib/devicetrust/assert"
+	"github.com/gravitational/teleport/lib/devicetrust/authn"
+	"github.com/gravitational/teleport/lib/devicetrust/enroll"
+	"github.com/gravitational/teleport/lib/devicetrust/testenv"
+)
+
+func TestCeremony(t *testing.T) {
+	t.Parallel()
+
+	env := testenv.MustNew(
+		testenv.WithAutoCreateDevice(true),
+	)
+
+	devicesClient := env.DevicesClient
+	ctx := context.Background()
+
+	macDev, err := testenv.NewFakeMacOSDevice()
+	require.NoError(t, err, "NewFakeMacOSDevice errored")
+
+	linuxDev := testenv.NewFakeLinuxDevice()
+
+	tests := []struct {
+		name string
+		dev  testenv.FakeDevice
+	}{
+		{
+			name: "ok (macOs)",
+			dev:  macDev,
+		},
+		{
+			name: "ok (TPM)",
+			dev:  linuxDev,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Enroll the device before we attempt authentication (auto creates device
+			// as part of ceremony)
+			dev := test.dev
+			enrollC := enroll.Ceremony{
+				GetDeviceOSType:         dev.GetDeviceOSType,
+				EnrollDeviceInit:        dev.EnrollDeviceInit,
+				SignChallenge:           dev.SignChallenge,
+				SolveTPMEnrollChallenge: dev.SolveTPMEnrollChallenge,
+			}
+			_, err := enrollC.Run(ctx, devicesClient, false, testenv.FakeEnrollmentToken)
+			require.NoError(t, err, "EnrollDevice errored")
+
+			assertC, err := assert.NewCeremony(assert.WithNewAuthnCeremonyFunc(func() *authn.Ceremony {
+				return &authn.Ceremony{
+					GetDeviceCredential: func() (*devicepb.DeviceCredential, error) {
+						return dev.GetDeviceCredential(), nil
+					},
+					CollectDeviceData:            dev.CollectDeviceData,
+					SignChallenge:                dev.SignChallenge,
+					SolveTPMAuthnDeviceChallenge: dev.SolveTPMAuthnDeviceChallenge,
+					GetDeviceOSType:              dev.GetDeviceOSType,
+				}
+			}))
+			require.NoError(t, err, "NewCeremony errored")
+
+			authnStream, err := devicesClient.AuthenticateDevice(ctx)
+			require.NoError(t, err, "AuthenticateDevice errored")
+
+			// Typically this would be some other, non-DeviceTrustService stream, but
+			// here this is a good way to test it (as it runs actual fake device
+			// authn)
+			if err := assertC.Run(ctx, &assertStreamAdapter{
+				stream: authnStream,
+			}); err != nil {
+				t.Errorf("Run returned err=%q, want nil", err)
+			}
+		})
+	}
+}
+
+type assertStreamAdapter struct {
+	stream devicepb.DeviceTrustService_AuthenticateDeviceClient
+}
+
+func (s *assertStreamAdapter) Recv() (*devicepb.AssertDeviceResponse, error) {
+	resp, err := s.stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.Payload.(type) {
+	case *devicepb.AuthenticateDeviceResponse_Challenge:
+		return &devicepb.AssertDeviceResponse{
+			Payload: &devicepb.AssertDeviceResponse_Challenge{
+				Challenge: resp.GetChallenge(),
+			},
+		}, nil
+	case *devicepb.AuthenticateDeviceResponse_TpmChallenge:
+		return &devicepb.AssertDeviceResponse{
+			Payload: &devicepb.AssertDeviceResponse_TpmChallenge{
+				TpmChallenge: resp.GetTpmChallenge(),
+			},
+		}, nil
+	case *devicepb.AuthenticateDeviceResponse_UserCertificates:
+		// UserCertificates means success.
+		return &devicepb.AssertDeviceResponse{
+			Payload: &devicepb.AssertDeviceResponse_DeviceAsserted{
+				DeviceAsserted: &devicepb.DeviceAsserted{},
+			},
+		}, nil
+	default:
+		return nil, trace.BadParameter("unexpected authenticate response payload: %T", resp.Payload)
+	}
+}
+
+func (s *assertStreamAdapter) Send(req *devicepb.AssertDeviceRequest) error {
+	authnReq := &devicepb.AuthenticateDeviceRequest{}
+	switch req.Payload.(type) {
+	case *devicepb.AssertDeviceRequest_Init:
+		init := req.GetInit()
+		authnReq.Payload = &devicepb.AuthenticateDeviceRequest_Init{
+			Init: &devicepb.AuthenticateDeviceInit{
+				CredentialId: init.CredentialId,
+				DeviceData:   init.DeviceData,
+			},
+		}
+	case *devicepb.AssertDeviceRequest_ChallengeResponse:
+		authnReq.Payload = &devicepb.AuthenticateDeviceRequest_ChallengeResponse{
+			ChallengeResponse: req.GetChallengeResponse(),
+		}
+	case *devicepb.AssertDeviceRequest_TpmChallengeResponse:
+		authnReq.Payload = &devicepb.AuthenticateDeviceRequest_TpmChallengeResponse{
+			TpmChallengeResponse: req.GetTpmChallengeResponse(),
+		}
+	default:
+		return trace.BadParameter("unexpected assert request payload: %T", req.Payload)
+	}
+
+	return s.stream.Send(authnReq)
+}


### PR DESCRIPTION
Implements the client-side device assertion ceremony.

Callers must only adapt their streams (or RPCs) to the AssertDeviceClientStream interface.

See #43804 for protobuf definitions and a more in-depth explanation.

Related to gravitational/access-graph#637 and #43462 (aka tsh scan).