### PR TITLE
support separate SSH and TLS keys in `generateUserCert`

### DIFF
--- a/e2e/aws/databases_test.go
+++ b/e2e/aws/databases_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client"
@@ -274,9 +275,12 @@ func generateClientDBCert(t *testing.T, authSrv *auth.Server, user string, route
 	clusterName, err := authSrv.GetClusterName()
 	require.NoError(t, err)
 
+	publicKeyPEM, err := keys.MarshalPublicKey(key.Public())
+	require.NoError(t, err)
+
 	clientCert, err := authSrv.GenerateDatabaseTestCert(
 		auth.DatabaseTestCertRequest{
-			PublicKey:       key.MarshalSSHPublicKey(),
+			PublicKey:       publicKeyPEM,
 			Cluster:         clusterName.GetClusterName(),
 			Username:        user,
 			RouteToDatabase: route,

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -26,7 +26,9 @@ package auth
 
 import (
 	"bytes"
+	"cmp"
 	"context"
+	"crypto"
 	"crypto/rand"
 	"crypto/subtle"
 	"crypto/x509"
@@ -1929,6 +1931,18 @@ func (a *Server) GetKeyStore() *keystore.Manager {
 }
 
 type certRequest struct {
+	// sshPublicKey is a public key in SSH authorized_keys format. If set it
+	// will be used as the subject public key for the returned SSH certificate.
+	sshPublicKey []byte
+	// tlsPublicKey is a PEM-encoded public key in PKCS#1 or PKIX ASN.1 DER
+	// form. If set it will be used as the subject public key for the returned
+	// TLS certificate.
+	tlsPublicKey []byte
+	// sshPublicKeyAttestationStatement is an attestation statement associated with sshPublicKey.
+	sshPublicKeyAttestationStatement *keys.AttestationStatement
+	// tlsPublicKeyAttestationStatement is an attestation statement associated with tlsPublicKey.
+	tlsPublicKeyAttestationStatement *keys.AttestationStatement
+
 	// user is a user to generate certificate for
 	user services.UserState
 	// impersonator is a user who generates the certificate,
@@ -1938,8 +1952,6 @@ type certRequest struct {
 	checker services.AccessChecker
 	// ttl is Duration of the certificate
 	ttl time.Duration
-	// publicKey is RSA public key in authorized_keys format
-	publicKey []byte
 	// compatibility is compatibility mode
 	compatibility string
 	// overrideRoleTTL is used for requests when the requested TTL should not be
@@ -2019,8 +2031,6 @@ type certRequest struct {
 	// connectionDiagnosticID contains the ID of the ConnectionDiagnostic.
 	// The Node/Agent will append connection traces to this instance.
 	connectionDiagnosticID string
-	// attestationStatement is an attestation statement associated with the given public key.
-	attestationStatement *keys.AttestationStatement
 	// deviceExtensions holds device-aware user certificate extensions.
 	deviceExtensions DeviceExtensions
 	// botName is the name of the bot requesting this cert, if any
@@ -2047,6 +2057,11 @@ func (r *certRequest) check() error {
 			return trace.BadParameter("must provide database user name to generate certificate for database %q", r.dbService)
 		}
 	}
+
+	if r.sshPublicKey == nil && r.tlsPublicKey == nil {
+		return trace.BadParameter("must provide a public key")
+	}
+
 	return nil
 }
 
@@ -2133,7 +2148,7 @@ func (a *Server) GenerateOpenSSHCert(ctx context.Context, req *proto.OpenSSHCert
 
 	certs, err := a.generateOpenSSHCert(ctx, certRequest{
 		user:            req.User,
-		publicKey:       req.PublicKey,
+		sshPublicKey:    req.PublicKey,
 		compatibility:   constants.CertificateFormatStandard,
 		checker:         checker,
 		ttl:             sessionTTL,
@@ -2180,20 +2195,34 @@ func (a *Server) GenerateUserTestCerts(req GenerateUserTestCertsRequest) ([]byte
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
+
+	// TODO(nklaassen): separate SSH and TLS keys. For now they are the same.
+	sshPublicKey := req.Key
+	cryptoPubKey, err := sshutils.CryptoPublicKey(req.Key)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	tlsPublicKey, err := keys.MarshalPublicKey(cryptoPubKey)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
 	certs, err := a.generateUserCert(ctx, certRequest{
-		user:                 userState,
-		ttl:                  req.TTL,
-		compatibility:        req.Compatibility,
-		publicKey:            req.Key,
-		routeToCluster:       req.RouteToCluster,
-		checker:              checker,
-		traits:               userState.GetTraits(),
-		loginIP:              req.PinnedIP,
-		pinIP:                req.PinnedIP != "",
-		mfaVerified:          req.MFAVerified,
-		attestationStatement: req.AttestationStatement,
-		appName:              req.AppName,
-		appSessionID:         req.AppSessionID,
+		user:                             userState,
+		ttl:                              req.TTL,
+		compatibility:                    req.Compatibility,
+		sshPublicKey:                     sshPublicKey,
+		tlsPublicKey:                     tlsPublicKey,
+		routeToCluster:                   req.RouteToCluster,
+		checker:                          checker,
+		traits:                           userState.GetTraits(),
+		loginIP:                          req.PinnedIP,
+		pinIP:                            req.PinnedIP != "",
+		mfaVerified:                      req.MFAVerified,
+		sshPublicKeyAttestationStatement: req.AttestationStatement,
+		tlsPublicKeyAttestationStatement: req.AttestationStatement,
+		appName:                          req.AppName,
+		appSessionID:                     req.AppSessionID,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -2203,7 +2232,7 @@ func (a *Server) GenerateUserTestCerts(req GenerateUserTestCertsRequest) ([]byte
 
 // AppTestCertRequest combines parameters for generating a test app access cert.
 type AppTestCertRequest struct {
-	// PublicKey is the public key to sign.
+	// PublicKey is the public key to sign, in PEM-encoded PKCS#1 or PKIX DER format.
 	PublicKey []byte
 	// Username is the Teleport user name to sign certificate for.
 	Username string
@@ -2255,10 +2284,10 @@ func (a *Server) GenerateUserAppTestCert(req AppTestCertRequest) ([]byte, error)
 	}
 
 	certs, err := a.generateUserCert(ctx, certRequest{
-		user:      userState,
-		publicKey: req.PublicKey,
-		checker:   checker,
-		ttl:       req.TTL,
+		user:         userState,
+		tlsPublicKey: req.PublicKey,
+		checker:      checker,
+		ttl:          req.TTL,
 		// Set the login to be a random string. Application certificates are never
 		// used to log into servers but SSH certificate generation code requires a
 		// principal be in the certificate.
@@ -2316,12 +2345,12 @@ func (a *Server) GenerateDatabaseTestCert(req DatabaseTestCertRequest) ([]byte, 
 		return nil, trace.Wrap(err)
 	}
 	certs, err := a.generateUserCert(ctx, certRequest{
-		user:      userState,
-		publicKey: req.PublicKey,
-		loginIP:   req.PinnedIP,
-		pinIP:     req.PinnedIP != "",
-		checker:   checker,
-		ttl:       time.Hour,
+		user:         userState,
+		tlsPublicKey: req.PublicKey,
+		loginIP:      req.PinnedIP,
+		pinIP:        req.PinnedIP != "",
+		checker:      checker,
+		ttl:          time.Hour,
 		traits: map[string][]string{
 			constants.TraitLogins: {req.Username},
 		},
@@ -2702,7 +2731,7 @@ func (a *Server) augmentUserCertificates(
 
 // submitCertificateIssuedEvent submits a certificate issued usage event to the
 // usage reporting service.
-func (a *Server) submitCertificateIssuedEvent(req *certRequest, params services.UserCertParams) {
+func (a *Server) submitCertificateIssuedEvent(req *certRequest, attestedKeyPolicy keys.PrivateKeyPolicy) {
 	var database, app, kubernetes, desktop bool
 
 	if req.dbService != "" {
@@ -2745,7 +2774,7 @@ func (a *Server) submitCertificateIssuedEvent(req *certRequest, params services.
 		UsageApp:         app,
 		UsageKubernetes:  kubernetes,
 		UsageDesktop:     desktop,
-		PrivateKeyPolicy: string(params.PrivateKeyPolicy),
+		PrivateKeyPolicy: string(attestedKeyPolicy),
 	})
 }
 
@@ -2782,12 +2811,6 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		activeAccessRequests: req.activeRequests.AccessRequests,
 		deviceID:             req.deviceExtensions.DeviceID,
 	}); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// reuse the same RSA keys for SSH and TLS keys
-	cryptoPubKey, err := sshutils.CryptoPublicKey(req.publicKey)
-	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -2833,6 +2856,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 			return nil, trace.Wrap(err)
 		}
 	}
+	notAfter := a.clock.Now().UTC().Add(sessionTTL)
 
 	attestedKeyPolicy := keys.PrivateKeyPolicyNone
 	requiredKeyPolicy, err := req.checker.PrivateKeyPolicy(readOnlyAuthPref.GetPrivateKeyPolicy())
@@ -2841,60 +2865,51 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	}
 
 	if requiredKeyPolicy != keys.PrivateKeyPolicyNone {
-		// Try to attest the given hardware key using the given attestation statement.
-		attestationData, err := modules.GetModules().AttestHardwareKey(ctx, a, req.attestationStatement, cryptoPubKey, sessionTTL)
-		if trace.IsNotFound(err) {
-			return nil, keys.NewPrivateKeyPolicyError(requiredKeyPolicy)
-		} else if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		// verify that the required private key policy for the requested identity
-		// is met by the provided attestation statement.
-		attestedKeyPolicy = attestationData.PrivateKeyPolicy
-		if err := requiredKeyPolicy.VerifyPolicy(attestedKeyPolicy); err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		var validateSerialNumber bool
-		hksnv, err := readOnlyAuthPref.GetHardwareKeySerialNumberValidation()
-		if err == nil {
-			validateSerialNumber = hksnv.Enabled
-		}
-
-		// Validate the serial number if enabled, unless this is a web session.
-		if validateSerialNumber && attestedKeyPolicy != keys.PrivateKeyPolicyWebSession {
-			const defaultSerialNumberTraitName = "hardware_key_serial_numbers"
-			// Note: currently only yubikeys are supported as hardware keys. If we extend
-			// support to more hardware keys, we can add prefixes to serial numbers.
-			// Ex: solokey_12345678 or s_12345678.
-			// When prefixes are added, we can default to assuming that serial numbers
-			// without prefixes are for yubikeys, meaning there will be no backwards
-			// compatibility issues.
-			serialNumberTraitName := hksnv.SerialNumberTraitName
-			if serialNumberTraitName == "" {
-				serialNumberTraitName = defaultSerialNumberTraitName
+		var (
+			sshAttestedKeyPolicy keys.PrivateKeyPolicy
+			tlsAttestedKeyPolicy keys.PrivateKeyPolicy
+		)
+		if req.sshPublicKey != nil {
+			sshCryptoPubKey, err := sshutils.CryptoPublicKey(req.sshPublicKey)
+			if err != nil {
+				return nil, trace.Wrap(err)
 			}
-
-			// Check that the attested hardware key serial number matches
-			// a serial number in the user's traits, if any are set.
-			registeredSerialNumbers, ok := req.checker.Traits()[serialNumberTraitName]
-			if !ok || len(registeredSerialNumbers) == 0 {
-				log.Debugf("user %q tried to sign in with hardware key support, but has no known hardware keys. A user's known hardware key serial numbers should be set \"in user.traits.%v\"", req.user.GetName(), serialNumberTraitName)
-				return nil, trace.BadParameter("cannot generate certs for user with no known hardware keys")
-			}
-
-			attestatedSerialNumber := strconv.Itoa(int(attestationData.SerialNumber))
-			// serial number traits can be a comma separated list, or a list of comma separated lists.
-			// e.g. [["12345678,87654321"], ["13572468"]].
-			if !slices.ContainsFunc(registeredSerialNumbers, func(s string) bool {
-				return slices.Contains(strings.Split(s, ","), attestatedSerialNumber)
-			}) {
-				log.Debugf("user %q tried to sign in with hardware key support with an unknown hardware key and was denied: YubiKey serial number %q", req.user.GetName(), attestatedSerialNumber)
-				return nil, trace.BadParameter("cannot generate certs for user with unknown hardware key: YubiKey serial number %q", attestatedSerialNumber)
+			sshAttestedKeyPolicy, err = a.attestHardwareKey(ctx, &attestHardwareKeyParams{
+				requiredKeyPolicy:    requiredKeyPolicy,
+				pubKey:               sshCryptoPubKey,
+				attestationStatement: req.sshPublicKeyAttestationStatement,
+				sessionTTL:           sessionTTL,
+				readOnlyAuthPref:     readOnlyAuthPref,
+				userName:             req.user.GetName(),
+				userTraits:           req.checker.Traits(),
+			})
+			if err != nil {
+				return nil, trace.Wrap(err, "attesting SSH key")
 			}
 		}
-
+		if req.tlsPublicKey != nil {
+			tlsCryptoPubKey, err := keys.ParsePublicKey(req.tlsPublicKey)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			tlsAttestedKeyPolicy, err = a.attestHardwareKey(ctx, &attestHardwareKeyParams{
+				requiredKeyPolicy:    requiredKeyPolicy,
+				pubKey:               tlsCryptoPubKey,
+				attestationStatement: req.tlsPublicKeyAttestationStatement,
+				sessionTTL:           sessionTTL,
+				readOnlyAuthPref:     readOnlyAuthPref,
+				userName:             req.user.GetName(),
+				userTraits:           req.checker.Traits(),
+			})
+			if err != nil {
+				return nil, trace.Wrap(err, "attesting TLS key")
+			}
+		}
+		if req.sshPublicKey != nil && req.tlsPublicKey != nil && sshAttestedKeyPolicy != tlsAttestedKeyPolicy {
+			return nil, trace.BadParameter("SSH attested key policy %q does not match TLS attested key policy %q, this not supported",
+				sshAttestedKeyPolicy, tlsAttestedKeyPolicy)
+		}
+		attestedKeyPolicy = cmp.Or(sshAttestedKeyPolicy, tlsAttestedKeyPolicy)
 	}
 
 	clusterName, err := a.GetDomainName()
@@ -2943,46 +2958,50 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	sshSigner, err := a.keyStore.GetSSHSigner(ctx, ca)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 
-	params := services.UserCertParams{
-		CASigner:                sshSigner,
-		PublicUserKey:           req.publicKey,
-		Username:                req.user.GetName(),
-		Impersonator:            req.impersonator,
-		AllowedLogins:           allowedLogins,
-		TTL:                     sessionTTL,
-		Roles:                   req.checker.RoleNames(),
-		CertificateFormat:       certificateFormat,
-		PermitPortForwarding:    req.checker.CanPortForward(),
-		PermitAgentForwarding:   req.checker.CanForwardAgents(),
-		PermitX11Forwarding:     req.checker.PermitX11Forwarding(),
-		RouteToCluster:          req.routeToCluster,
-		Traits:                  req.traits,
-		ActiveRequests:          req.activeRequests,
-		MFAVerified:             req.mfaVerified,
-		PreviousIdentityExpires: req.previousIdentityExpires,
-		LoginIP:                 req.loginIP,
-		PinnedIP:                pinnedIP,
-		DisallowReissue:         req.disallowReissue,
-		Renewable:               req.renewable,
-		Generation:              req.generation,
-		BotName:                 req.botName,
-		BotInstanceID:           req.botInstanceID,
-		CertificateExtensions:   req.checker.CertificateExtensions(),
-		AllowedResourceIDs:      requestedResourcesStr,
-		ConnectionDiagnosticID:  req.connectionDiagnosticID,
-		PrivateKeyPolicy:        attestedKeyPolicy,
-		DeviceID:                req.deviceExtensions.DeviceID,
-		DeviceAssetTag:          req.deviceExtensions.AssetTag,
-		DeviceCredentialID:      req.deviceExtensions.CredentialID,
-	}
-	signedSSHCert, err := a.GenerateUserCert(params)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	var signedSSHCert []byte
+	if req.sshPublicKey != nil {
+		sshSigner, err := a.keyStore.GetSSHSigner(ctx, ca)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		params := services.UserCertParams{
+			CASigner:                sshSigner,
+			PublicUserKey:           req.sshPublicKey,
+			Username:                req.user.GetName(),
+			Impersonator:            req.impersonator,
+			AllowedLogins:           allowedLogins,
+			TTL:                     sessionTTL,
+			Roles:                   req.checker.RoleNames(),
+			CertificateFormat:       certificateFormat,
+			PermitPortForwarding:    req.checker.CanPortForward(),
+			PermitAgentForwarding:   req.checker.CanForwardAgents(),
+			PermitX11Forwarding:     req.checker.PermitX11Forwarding(),
+			RouteToCluster:          req.routeToCluster,
+			Traits:                  req.traits,
+			ActiveRequests:          req.activeRequests,
+			MFAVerified:             req.mfaVerified,
+			PreviousIdentityExpires: req.previousIdentityExpires,
+			LoginIP:                 req.loginIP,
+			PinnedIP:                pinnedIP,
+			DisallowReissue:         req.disallowReissue,
+			Renewable:               req.renewable,
+			Generation:              req.generation,
+			BotName:                 req.botName,
+			BotInstanceID:           req.botInstanceID,
+			CertificateExtensions:   req.checker.CertificateExtensions(),
+			AllowedResourceIDs:      requestedResourcesStr,
+			ConnectionDiagnosticID:  req.connectionDiagnosticID,
+			PrivateKeyPolicy:        attestedKeyPolicy,
+			DeviceID:                req.deviceExtensions.DeviceID,
+			DeviceAssetTag:          req.deviceExtensions.AssetTag,
+			DeviceCredentialID:      req.deviceExtensions.CredentialID,
+		}
+		signedSSHCert, err = a.GenerateUserCert(params)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	kubeGroups, kubeUsers, err := req.checker.CheckKubeGroupsAndUsers(sessionTTL, req.overrideRoleTTL)
@@ -3080,10 +3099,11 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	}
 
 	var signedTLSCert []byte
-	notAfter := a.clock.Now().UTC().Add(sessionTTL)
-	// generate TLS certificate if the signing CA isn't OpenSSH CA, as
-	// OpenSSH CA doesn't have any TLS keypairs
-	if caType != types.OpenSSHCA {
+	if req.tlsPublicKey != nil {
+		tlsCryptoPubKey, err := keys.ParsePublicKey(req.tlsPublicKey)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		tlsCert, tlsSigner, err := a.keyStore.GetTLSCertAndSigner(ctx, ca)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -3098,7 +3118,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		}
 		certRequest := tlsca.CertificateRequest{
 			Clock:     a.clock,
-			PublicKey: cryptoPubKey,
+			PublicKey: tlsCryptoPubKey,
 			Subject:   subject,
 			NotAfter:  notAfter,
 		}
@@ -3136,11 +3156,77 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		certs.SSHCACerts = append(certs.SSHCACerts, services.GetSSHCheckingKeys(ca)...)
 	}
 
-	a.submitCertificateIssuedEvent(&req, params)
-
+	a.submitCertificateIssuedEvent(&req, attestedKeyPolicy)
 	userCertificatesGeneratedMetric.WithLabelValues(string(attestedKeyPolicy)).Inc()
 
 	return certs, nil
+}
+
+type attestHardwareKeyParams struct {
+	requiredKeyPolicy    keys.PrivateKeyPolicy
+	pubKey               crypto.PublicKey
+	attestationStatement *keys.AttestationStatement
+	sessionTTL           time.Duration
+	readOnlyAuthPref     readonly.AuthPreference
+	userName             string
+	userTraits           map[string][]string
+}
+
+func (a *Server) attestHardwareKey(ctx context.Context, params *attestHardwareKeyParams) (attestedKeyPolicy keys.PrivateKeyPolicy, err error) {
+	// Try to attest the given hardware key using the given attestation statement.
+	attestationData, err := modules.GetModules().AttestHardwareKey(ctx, a, params.attestationStatement, params.pubKey, params.sessionTTL)
+	if trace.IsNotFound(err) {
+		return attestedKeyPolicy, keys.NewPrivateKeyPolicyError(params.requiredKeyPolicy)
+	} else if err != nil {
+		return attestedKeyPolicy, trace.Wrap(err)
+	}
+
+	// verify that the required private key policy for the requested identity
+	// is met by the provided attestation statement.
+	attestedKeyPolicy = attestationData.PrivateKeyPolicy
+	if err := params.requiredKeyPolicy.VerifyPolicy(attestedKeyPolicy); err != nil {
+		return attestedKeyPolicy, trace.Wrap(err)
+	}
+
+	var validateSerialNumber bool
+	hksnv, err := params.readOnlyAuthPref.GetHardwareKeySerialNumberValidation()
+	if err == nil {
+		validateSerialNumber = hksnv.Enabled
+	}
+
+	// Validate the serial number if enabled, unless this is a web session.
+	if validateSerialNumber && attestedKeyPolicy != keys.PrivateKeyPolicyWebSession {
+		const defaultSerialNumberTraitName = "hardware_key_serial_numbers"
+		// Note: currently only yubikeys are supported as hardware keys. If we extend
+		// support to more hardware keys, we can add prefixes to serial numbers.
+		// Ex: solokey_12345678 or s_12345678.
+		// When prefixes are added, we can default to assuming that serial numbers
+		// without prefixes are for yubikeys, meaning there will be no backwards
+		// compatibility issues.
+		serialNumberTraitName := hksnv.SerialNumberTraitName
+		if serialNumberTraitName == "" {
+			serialNumberTraitName = defaultSerialNumberTraitName
+		}
+
+		// Check that the attested hardware key serial number matches
+		// a serial number in the user's traits, if any are set.
+		registeredSerialNumbers, ok := params.userTraits[serialNumberTraitName]
+		if !ok || len(registeredSerialNumbers) == 0 {
+			log.Debugf("user %q tried to sign in with hardware key support, but has no known hardware keys. A user's known hardware key serial numbers should be set \"in user.traits.%v\"", params.userName, serialNumberTraitName)
+			return attestedKeyPolicy, trace.BadParameter("cannot generate certs for user with no known hardware keys")
+		}
+
+		attestedSerialNumber := strconv.Itoa(int(attestationData.SerialNumber))
+		// serial number traits can be a comma separated list, or a list of comma separated lists.
+		// e.g. [["12345678,87654321"], ["13572468"]].
+		if !slices.ContainsFunc(registeredSerialNumbers, func(s string) bool {
+			return slices.Contains(strings.Split(s, ","), attestedSerialNumber)
+		}) {
+			log.Debugf("user %q tried to sign in with hardware key support with an unknown hardware key and was denied: YubiKey serial number %q", params.userName, attestedSerialNumber)
+			return attestedKeyPolicy, trace.BadParameter("cannot generate certs for user with unknown hardware key: YubiKey serial number %q", attestedSerialNumber)
+		}
+	}
+	return attestedKeyPolicy, nil
 }
 
 type verifyLocksForUserCertsReq struct {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2315,7 +2315,7 @@ func (a *Server) GenerateUserAppTestCert(req AppTestCertRequest) ([]byte, error)
 // DatabaseTestCertRequest combines parameters for generating test database
 // access certificate.
 type DatabaseTestCertRequest struct {
-	// PublicKey is the public key to sign.
+	// PublicKey is the public key to sign, in PEM-encoded PKCS#1 or PKIX format.
 	PublicKey []byte
 	// Cluster is the Teleport cluster name.
 	Cluster string

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -205,12 +205,9 @@ func (a *ServerWithRoles) updateBotInstance(ctx context.Context, req *certReques
 	if req.tlsPublicKey != nil {
 		publicKeyPEM = req.tlsPublicKey
 	} else {
-		// At least one key will be set, this is validated by [req.check].
-		cryptoPubKey, err := sshutils.CryptoPublicKey(req.sshPublicKey)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		publicKeyPEM, err = keys.MarshalPublicKey(cryptoPubKey)
+		// At least one of tlsPublicKey or sshPublicKey will be set, this is validated by [req.check].
+		var err error
+		publicKeyPEM, err = sshPublicKeyToPKIXPEM(req.sshPublicKey)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -261,7 +258,7 @@ func (a *ServerWithRoles) updateBotInstance(ctx context.Context, req *certReques
 		return nil
 	}
 
-	_, err = a.authServer.BotInstance.PatchBotInstance(ctx, ident.BotName, ident.BotInstanceID, func(bi *machineidv1pb.BotInstance) (*machineidv1pb.BotInstance, error) {
+	_, err := a.authServer.BotInstance.PatchBotInstance(ctx, ident.BotName, ident.BotInstanceID, func(bi *machineidv1pb.BotInstance) (*machineidv1pb.BotInstance, error) {
 		if bi.Status == nil {
 			bi.Status = &machineidv1pb.BotInstanceStatus{}
 		}

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -34,12 +34,14 @@ import (
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -715,17 +717,32 @@ func (a *Server) AuthenticateSSHUser(ctx context.Context, req authclient.Authent
 		return nil, trace.BadParameter("source IP pinning is enabled but client IP is unknown")
 	}
 
+	// TODO(nklaassen): separate SSH and TLS keys. For now they are the same.
+	sshPublicKey := req.PublicKey
+	publicKey, err := sshutils.CryptoPublicKey(req.PublicKey)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsPublicKey, err := keys.MarshalPublicKey(publicKey)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	sshPublicKeyAttestationStatement := req.AttestationStatement
+	tlsPublicKeyAttestationStatement := req.AttestationStatement
+
 	certReq := certRequest{
-		user:                 user,
-		ttl:                  req.TTL,
-		publicKey:            req.PublicKey,
-		compatibility:        req.CompatibilityMode,
-		checker:              checker,
-		traits:               user.GetTraits(),
-		routeToCluster:       req.RouteToCluster,
-		kubernetesCluster:    req.KubernetesCluster,
-		loginIP:              clientIP,
-		attestationStatement: req.AttestationStatement,
+		user:                             user,
+		ttl:                              req.TTL,
+		sshPublicKey:                     sshPublicKey,
+		tlsPublicKey:                     tlsPublicKey,
+		compatibility:                    req.CompatibilityMode,
+		checker:                          checker,
+		traits:                           user.GetTraits(),
+		routeToCluster:                   req.RouteToCluster,
+		kubernetesCluster:                req.KubernetesCluster,
+		loginIP:                          clientIP,
+		sshPublicKeyAttestationStatement: sshPublicKeyAttestationStatement,
+		tlsPublicKeyAttestationStatement: tlsPublicKeyAttestationStatement,
 	}
 
 	// For headless authentication, a short-lived mfa-verified cert should be generated.

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -1948,9 +1949,14 @@ func (c *testContext) startLocalALPNProxy(ctx context.Context, proxyAddr, telepo
 		return nil, trace.Wrap(err)
 	}
 
+	publicKeyPEM, err := keys.MarshalPublicKey(key.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	clientCert, err := c.authServer.GenerateDatabaseTestCert(
 		auth.DatabaseTestCertRequest{
-			PublicKey:       key.MarshalSSHPublicKey(),
+			PublicKey:       publicKeyPEM,
 			Cluster:         c.clusterName,
 			Username:        teleportUser,
 			RouteToDatabase: route,

--- a/lib/srv/db/common/test.go
+++ b/lib/srv/db/common/test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -185,9 +186,13 @@ func MakeTestClientTLSCert(config TestClientConfig) (*tls.Certificate, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	publicKeyPEM, err := keys.MarshalPublicKey(key.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	// Generate client certificate for the Teleport user.
 	cert, err := config.AuthServer.GenerateDatabaseTestCert(auth.DatabaseTestCertRequest{
-		PublicKey:       key.MarshalSSHPublicKey(),
+		PublicKey:       publicKeyPEM,
 		Cluster:         config.Cluster,
 		Username:        config.Username,
 		RouteToDatabase: config.RouteToDatabase,

--- a/lib/sshutils/signer.go
+++ b/lib/sshutils/signer.go
@@ -63,9 +63,9 @@ func NewSigner(keyBytes, certBytes []byte) (ssh.Signer, error) {
 	return ssh.NewCertSigner(cert, keySigner)
 }
 
-// CryptoPublicKey extracts public key from RSA public key in authorized_keys format
+// CryptoPublicKey extracts a crypto.PublicKey from any public key in
+// authorized_keys format.
 func CryptoPublicKey(publicKey []byte) (crypto.PublicKey, error) {
-	// reuse the same RSA keys for SSH and TLS keys
 	pubKey, _, _, _, err := ssh.ParseAuthorizedKey(publicKey)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
This PR splits the SSH and TLS public keys passed to `auth.(*Server).generateUserCert`. The attestation statement associated with the public key is also split.

Now, `sshPublicKey` will be the subject public key of the returned SSH certificate, and `tlsPublicKey` will be the subject public key of the returned TLS certificate. If either is not provided, the corresponding certificate is not generated or returned.

This does not update any code paths to actually use different keys here, but prepares for that in the future.