### PR TITLE
[v14] buildbox: Update centos7 buildbox for EOL, using vault

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -2,7 +2,7 @@
 
 ARG RUST_VERSION
 
-# Set up a base container from centos:7 adjusted for using valut.centos.org
+# Set up a base container from centos:7 adjusted for using vault.centos.org
 FROM centos:7 AS base
 
 ARG BUILDARCH

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -1,9 +1,50 @@
+# syntax=docker/dockerfile:1
+
 ARG RUST_VERSION
+
+# Set up a base container from centos:7 adjusted for using valut.centos.org
+FROM centos:7 AS base
+
+ARG BUILDARCH
+ARG TARGETARCH
+ARG DEVTOOLSET
+
+# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
+# published to the official CentOS SCL repos.
+ENV DEVTOOLSET=${DEVTOOLSET} \
+    TARGETARCH=${TARGETARCH}
+
+RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
+    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
+
+# mirrorlist is no longer available since CentOS 7 EOL. The software collection
+# stuff for arm64 (aarch64) is in /altarch not /centos on vault.centos.org.
+# Make the fixup a script as it needs to be run multiple times as installing
+# and updating centos-release-scl-rh leaves the old unavailable URLs.
+# https://serverfault.com/a/1161847
+RUN cat <<EOF > /tmp/fix-yum-repo-list.sh
+#!/bin/sh
+sed -e 's/mirror.centos.org/vault.centos.org/g' \
+    -e 's/^#.*baseurl=http/baseurl=http/g' \
+    -e 's/^mirrorlist=http/#mirrorlist=http/g' \
+    -i /etc/yum.repos.d/*.repo
+if [ "$(uname -m)" = 'aarch64' ]; then
+    sed 's|centos/7/sclo|altarch/7/sclo|' -i /etc/yum.repos.d/*.repo
+fi
+EOF
+RUN chmod 755 /tmp/fix-yum-repo-list.sh && \
+    /tmp/fix-yum-repo-list.sh
+
+RUN yum groupinstall -y 'Development Tools' && \
+    yum install -y \
+        centos-release-scl-rh \
+        centos-release-scl && \
+    /tmp/fix-yum-repo-list.sh
 
 ## GIT2 ###################################################################
 
 # git2 packages are not available on ARM64, so we need to build it from source.
-FROM centos:7 AS git2
+FROM base AS git2
 
 ARG BUILDARCH
 ARG TARGETARCH
@@ -55,7 +96,7 @@ FROM ghcr.io/gravitational/teleport-buildbox-centos7-assets:teleport14-${BUILDAR
 ## LIBFIDO2 ###################################################################
 
 # Build libfido2 separately for isolation, speed and flexibility.
-FROM centos:7 AS libfido2
+FROM base AS libfido2
 
 ARG DEVTOOLSET
 ARG TARGETARCH
@@ -133,7 +174,7 @@ RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.13.0 && \
 
 ## LIBBPF #####################################################################
 
-FROM centos:7 AS libbpf
+FROM base AS libbpf
 
 ARG DEVTOOLSET
 ARG TARGETARCH
@@ -173,7 +214,7 @@ RUN mkdir -p /opt && cd /opt && \
 
 ## LIBPCSCLITE #####################################################################
 
-FROM centos:7 AS libpcsclite
+FROM base AS libpcsclite
 
 ARG DEVTOOLSET
 ARG TARGETARCH
@@ -213,7 +254,7 @@ RUN git clone --depth=1 https://github.com/gravitational/PCSC.git -b ${LIBPCSCLI
 
 ## BUILDBOX ###################################################################
 
-FROM centos:7 AS buildbox
+FROM base AS buildbox
 
 ENV LANGUAGE=en_US.UTF-8 \
     LANG=en_US.UTF-8 \

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -47,20 +47,9 @@ RUN yum groupinstall -y 'Development Tools' && \
 FROM base AS git2
 
 ARG BUILDARCH
-ARG TARGETARCH
-ARG DEVTOOLSET
-
-# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
-# published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
-
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
 
 # Install required dependencies.
-RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y \
+RUN yum install -y \
     ca-certificates  \
     curl-devel  \
     expat-devel  \
@@ -70,9 +59,6 @@ RUN yum groupinstall -y 'Development Tools' && \
     perl-CPAN  \
     perl-devel wget && \
     yum update -y && \
-    yum -y install centos-release-scl-rh && \
-    yum install -y \
-    centos-release-scl && \
     yum clean all
 
 # As mentioned above, these packages are unsigned.
@@ -98,20 +84,7 @@ FROM ghcr.io/gravitational/teleport-buildbox-centos7-assets:teleport14-${BUILDAR
 # Build libfido2 separately for isolation, speed and flexibility.
 FROM base AS libfido2
 
-ARG DEVTOOLSET
-ARG TARGETARCH
-
-# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
-# published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
-
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
-
-RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y epel-release && \
-    yum install -y centos-release-scl-rh && \
+RUN yum install -y epel-release && \
     yum update -y && \
     yum install -y \
         cmake3 \
@@ -176,24 +149,10 @@ RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.13.0 && \
 
 FROM base AS libbpf
 
-ARG DEVTOOLSET
-ARG TARGETARCH
-
-# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
-# published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
-
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
-
 # Install required dependencies.
-RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y epel-release && \
+RUN yum install -y epel-release && \
     yum update -y && \
-    yum -y install centos-release-scl-rh && \
     yum install -y \
-        centos-release-scl \
         elfutils-libelf-devel-static \
         scl-utils && \
     yum clean all
@@ -216,26 +175,12 @@ RUN mkdir -p /opt && cd /opt && \
 
 FROM base AS libpcsclite
 
-ARG DEVTOOLSET
-ARG TARGETARCH
-
-# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
-# published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
-
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
-
 # Install required dependencies.
-RUN yum groupinstall -y 'Development Tools' && \
-    yum update -y && \
-    yum -y install centos-release-scl-rh && \
+RUN yum update -y && \
     yum install -y \
         autoconf-archive \
         libudev-devel \
-        scl-utils \
-        centos-release-scl \
+        scl-utils && \
     yum clean all
 
 # As mentioned above, these packages are unsigned.
@@ -271,21 +216,9 @@ ARG GID
 RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
-# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
-# published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
-
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
-
-RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y epel-release && \
+RUN yum install -y epel-release && \
     yum update -y && \
-    yum -y install centos-release-scl-rh && \
     yum install -y \
-    # required by libbpf
-    centos-release-scl \
     # required by libbpf
     elfutils-libelf-devel-static \
     net-tools \

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -4,7 +4,7 @@
 ARG BUILDARCH
 FROM ghcr.io/gravitational/teleport-buildbox-centos7-assets:teleport14-${BUILDARCH} AS teleport-buildbox-centos7-assets
 
-# Set up a base container from centos:7 adjusted for using valut.centos.org
+# Set up a base container from centos:7 adjusted for using vault.centos.org
 FROM centos:7 AS base
 
 ARG BUILDARCH

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -45,25 +45,10 @@ RUN yum groupinstall -y 'Development Tools' && \
 
 FROM base AS libbpf
 
-ARG BUILDARCH
-ARG TARGETARCH
-ARG DEVTOOLSET
-
-# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
-# published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
-
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
-
 # Install required dependencies.
-RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y epel-release && \
+RUN yum install -y epel-release && \
     yum update -y && \
-    yum -y install centos-release-scl-rh && \
     yum install -y \
-        centos-release-scl \
         elfutils-libelf-devel-static \
         scl-utils && \
     yum clean all
@@ -98,22 +83,10 @@ ARG GID
 RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
-# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
-# published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
-
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
-
 # Install required dependencies.
-RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y epel-release && \
+RUN yum install -y epel-release && \
     yum update -y && \
-    yum -y install centos-release-scl-rh && \
     yum install -y \
-    # required by libbpf
-    centos-release-scl \
     # required by Clang/LLVM
     cmake3 \
     # required by libbpf

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -1,8 +1,49 @@
+# syntax=docker/dockerfile:1
+
 # Create an alias to the assets image. Ref: https://github.com/docker/for-mac/issues/2155
 ARG BUILDARCH
 FROM ghcr.io/gravitational/teleport-buildbox-centos7-assets:teleport14-${BUILDARCH} AS teleport-buildbox-centos7-assets
 
-FROM centos:7 AS libbpf
+# Set up a base container from centos:7 adjusted for using valut.centos.org
+FROM centos:7 AS base
+
+ARG BUILDARCH
+ARG TARGETARCH
+ARG DEVTOOLSET
+
+# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
+# published to the official CentOS SCL repos.
+ENV DEVTOOLSET=${DEVTOOLSET} \
+    TARGETARCH=${TARGETARCH}
+
+RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
+    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
+
+# mirrorlist is no longer available since CentOS 7 EOL. The software collection
+# stuff for arm64 (aarch64) is in /altarch not /centos on vault.centos.org.
+# Make the fixup a script as it needs to be run multiple times as installing
+# and updating centos-release-scl-rh leaves the old unavailable URLs.
+# https://serverfault.com/a/1161847
+RUN cat <<EOF > /tmp/fix-yum-repo-list.sh
+#!/bin/sh
+sed -e 's/mirror.centos.org/vault.centos.org/g' \
+    -e 's/^#.*baseurl=http/baseurl=http/g' \
+    -e 's/^mirrorlist=http/#mirrorlist=http/g' \
+    -i /etc/yum.repos.d/*.repo
+if [ "$(uname -m)" = 'aarch64' ]; then
+    sed 's|centos/7/sclo|altarch/7/sclo|' -i /etc/yum.repos.d/*.repo
+fi
+EOF
+RUN chmod 755 /tmp/fix-yum-repo-list.sh && \
+    /tmp/fix-yum-repo-list.sh
+
+RUN yum groupinstall -y 'Development Tools' && \
+    yum install -y \
+        centos-release-scl-rh \
+        centos-release-scl && \
+    /tmp/fix-yum-repo-list.sh
+
+FROM base AS libbpf
 
 ARG BUILDARCH
 ARG TARGETARCH
@@ -41,7 +82,7 @@ RUN mkdir -p /opt && cd /opt && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
     scl enable ${DEVTOOLSET} "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install install_uapi_headers"
 
-FROM centos:7
+FROM base
 
 ARG BUILDARCH
 ARG TARGETARCH


### PR DESCRIPTION
CentOS 7 became EOL on 2024/06/30. `mirrorlist` and `mirror.centos.org`
became unavailable, so use `baseurl` and `vault.centos.org` instead,
updating all references in `/etc/yum.repos.d/*`.

The software collection stuff (`centos-release-scl-rh`) is on a
different path on `vault.centos.org` for `aarch64` so also update those
paths.

Apply these changes multiple times as installing `centos-release-scl-rh`
installs a yum repo file with the old paths, as does installing
`centos-release-scl`.

Also added is a `syntax` line to the two touched dockerfiles. This is
needed for here-documents to work (`<<EOF`) as the version of docker on
our GitHub runners is too old to understand that. The `syntax` line says
to use a different dockerfile parser to the built-in one.

This backport is more involved than the v16/v15 ones as the Dockerfiles on
`branch/v14` have not had a number of changes backported for arm64 builds.

Backport: https://github.com/gravitational/teleport/pull/43785