### PR TITLE
[sec_scan][6] add device events

### DIFF
--- a/lib/devicetrust/keys_prefix.go
+++ b/lib/devicetrust/keys_prefix.go
@@ -1,0 +1,24 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package devicetrust
+
+var (
+	// DevicesIDPrefix is the backend prefix used to store device resources.
+	DevicesIDPrefix = []string{"devices", "id"}
+)

--- a/lib/services/device.go
+++ b/lib/services/device.go
@@ -19,11 +19,19 @@
 package services
 
 import (
+	"context"
+
 	"github.com/gravitational/trace"
 
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/utils"
 )
+
+type DevicesGetter interface {
+	ListDevices(ctx context.Context, pageSize int, pageToken string, view devicepb.DeviceView) (devices []*devicepb.Device, nextPageToken string, err error)
+}
 
 // UnmarshalDevice unmarshals a DeviceV1 resource and runs CheckAndSetDefaults.
 func UnmarshalDevice(raw []byte) (*types.DeviceV1, error) {
@@ -41,4 +49,31 @@ func MarshalDevice(dev *types.DeviceV1) ([]byte, error) {
 		return nil, trace.Wrap(err)
 	}
 	return devBytes, nil
+}
+
+var (
+	// unmarshalDeviceFromBackendItemConv is a convenience function that converts
+	// a backend.Item to a *devicepb.Device.
+	// It's populated when e/lib/devicetrust/storage/ is initialized.
+	unmarshalDeviceFromBackendItemConv func(item backend.Item) (*devicepb.Device, error)
+)
+
+// SetUnmarshalDeviceFromBackendItemConv allows to set a custom conversion function for
+// unmarshaling a [devicepb.Device] from a [backend.Item].
+// This function must be called in the init() function of the package that owns the conversion logic.
+// It's not safe to call this function concurrently.
+func SetUnmarshalDeviceFromBackendItemConv(conv func(item backend.Item) (*devicepb.Device, error)) {
+	unmarshalDeviceFromBackendItemConv = conv
+}
+
+// UnmarshalDeviceFromBackendItem unmarshals a devicepb.Device from a backend.Item.
+// It's a convenience function that uses UnmarshalDeviceFromBackendItemConv because
+// the storage package uses an internal representation of devicepb.Device when storing
+// it in the backend.
+func UnmarshalDeviceFromBackendItem(item backend.Item) (*devicepb.Device, error) {
+	if unmarshalDeviceFromBackendItemConv == nil {
+		return nil, trace.BadParameter("UnmarshalDeviceFromBackendItemConv is not set")
+	}
+	res, err := unmarshalDeviceFromBackendItemConv(item)
+	return res, trace.Wrap(err)
 }

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/types/kubewaitingcontainer"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/devicetrust"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 )
@@ -214,6 +215,8 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newBotInstanceParser()
 		case types.KindInstance:
 			parser = newInstanceParser()
+		case types.KindDevice:
+			parser = newDeviceParser()
 		default:
 			if watch.AllowPartialSuccess {
 				continue
@@ -2253,6 +2256,50 @@ func WaitForEvent(ctx context.Context, watcher types.Watcher, m EventMatcher, cl
 		case <-tick.Chan():
 			return nil, trace.LimitExceeded("timed out waiting for event")
 		}
+	}
+}
+
+func newDeviceParser() *deviceParser {
+	return &deviceParser{
+		baseParser: newBaseParser(backend.Key(devicetrust.DevicesIDPrefix...)),
+	}
+}
+
+type deviceParser struct {
+	baseParser
+}
+
+func (p *deviceParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		name, err := base(event.Item.Key, 0 /* offset */)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		device := &types.DeviceV1{
+			ResourceHeader: types.ResourceHeader{
+				Kind:    types.KindDevice,
+				Version: types.V1,
+				Metadata: types.Metadata{
+					Name: string(name),
+				},
+			},
+		}
+		return device, nil
+	case types.OpPut:
+		device, err := services.UnmarshalDeviceFromBackendItem(event.Item)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		// [devicepb.Device] doesn't satisfy types.Resource interface or Resource153 interface,
+		// so we need to convert it to types.DeviceV1 so it satisfy types.Resource interface.
+		dev := types.DeviceToResource(device)
+		// Set the expires and revision fields.
+		dev.SetExpiry(event.Item.Expires)
+		dev.SetRevision(event.Item.Revision)
+		return dev, nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
 	}
 }
 


### PR DESCRIPTION
This PR introduces the ability to watch for events related to `*devicepb.Device` objects.

The backend storage representation of `devicepb.Device` is managed using an internal format located in `e/lib/devicetrust/storage`, with its logic contained within the package.

To facilitate the necessary unmarshal logic for events to function, this PR adds a registration hook. The `e/lib/devicetrust/storage` package must call this hook during initialization to register the unmarshal function.

This PR is part of https://github.com/gravitational/access-graph/issues/637.