### PR TITLE
[sec_scan][7] add authorizedKeys and privateKeys events support

### DIFF
--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	accessgraphsecretsv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessgraph/v1"
 	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
@@ -217,6 +218,10 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newInstanceParser()
 		case types.KindDevice:
 			parser = newDeviceParser()
+		case types.KindAccessGraphSecretPrivateKey:
+			parser = newAccessGraphSecretPrivateKeyParser()
+		case types.KindAccessGraphSecretAuthorizedKey:
+			parser = newAccessGraphSecretAuthorizedKeyParser()
 		default:
 			if watch.AllowPartialSuccess {
 				continue
@@ -2298,6 +2303,94 @@ func (p *deviceParser) parse(event backend.Event) (types.Resource, error) {
 		dev.SetExpiry(event.Item.Expires)
 		dev.SetRevision(event.Item.Revision)
 		return dev, nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+
+func newAccessGraphSecretPrivateKeyParser() *accessGraphSecretPrivateKeyParser {
+	return &accessGraphSecretPrivateKeyParser{
+		baseParser: newBaseParser(backend.Key(privateKeysPrefix)),
+	}
+}
+
+type accessGraphSecretPrivateKeyParser struct {
+	baseParser
+}
+
+func (p *accessGraphSecretPrivateKeyParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		deviceID, name, err := baseTwoKeys(event.Item.Key)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		privateKey := &accessgraphsecretsv1pb.PrivateKey{
+			Kind:    types.KindAccessGraphSecretPrivateKey,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: name,
+			},
+			Spec: &accessgraphsecretsv1pb.PrivateKeySpec{
+				DeviceId: deviceID,
+			},
+		}
+
+		return types.Resource153ToLegacy(privateKey), nil
+	case types.OpPut:
+		pk, err := services.UnmarshalAccessGraphPrivateKey(
+			event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return types.Resource153ToLegacy(pk), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+
+func newAccessGraphSecretAuthorizedKeyParser() *accessGraphSecretAuthorizedKeyParser {
+	return &accessGraphSecretAuthorizedKeyParser{
+		baseParser: newBaseParser(backend.Key(authorizedKeysPrefix)),
+	}
+}
+
+type accessGraphSecretAuthorizedKeyParser struct {
+	baseParser
+}
+
+func (p *accessGraphSecretAuthorizedKeyParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		hostID, name, err := baseTwoKeys(event.Item.Key)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		authorizedKey := &accessgraphsecretsv1pb.AuthorizedKey{
+			Kind:    types.KindAccessGraphSecretAuthorizedKey,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: name,
+			},
+			Spec: &accessgraphsecretsv1pb.AuthorizedKeySpec{
+				HostId: hostID,
+			},
+		}
+
+		return types.Resource153ToLegacy(authorizedKey), nil
+	case types.OpPut:
+		ak, err := services.UnmarshalAccessGraphAuthorizedKey(
+			event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return types.Resource153ToLegacy(ak), nil
 	default:
 		return nil, trace.BadParameter("event %v is not supported", event.Type)
 	}


### PR DESCRIPTION
This PR introduces the ability to watch for events related to `accessgraphsecretsv1pb.AuthorizedKey` and `accessgraphsecretsv1pb.PrivateKey` objects.

This PR is part of https://github.com/gravitational/access-graph/issues/637.