### PR TITLE
[v16] Clean up styles config

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "x-default-browser": "^0.5.2"
   },
   "devDependencies": {
+    "@emotion/core": "^10.0.9",
     "prettier": "^3.2.5",
     "typescript": "^5.4.2"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,10 +21,6 @@
     "target": "esnext",
     "types": ["node", "@emotion/core", "@types/wicg-file-system-access"],
     "paths": {
-      "//": [
-        "generator still uses 'grpc' package that has been deprecated in favor of '@grpc/grpc-js'"
-      ],
-      "grpc": ["node_modules/@grpc/grpc-js"],
       "shared/*": ["web/packages/shared/*"],
       "design/*": ["web/packages/design/src/*"],
       "design": ["web/packages/design/src/"],

--- a/web/packages/teleport/src/components/Layout/Layout.jsx
+++ b/web/packages/teleport/src/components/Layout/Layout.jsx
@@ -17,7 +17,6 @@
  */
 
 import styled from 'styled-components';
-import { border } from 'styled-system';
 import { Flex, Text } from 'design';
 
 /**
@@ -31,7 +30,6 @@ const FeatureHeader = styled(Flex)`
   margin-right: -40px;
   padding-left: 40px;
   padding-right: 40px;
-  ${border}
 `;
 
 FeatureHeader.defaultProps = {

--- a/web/packages/teleterm/src/types.ts
+++ b/web/packages/teleterm/src/types.ts
@@ -18,7 +18,7 @@
 
 import { ITshdEventsService } from 'gen-proto-ts/teleport/lib/teleterm/v1/tshd_events_service_pb.grpc-server';
 
-import { sendUnaryData, ServerUnaryCall } from 'grpc';
+import { sendUnaryData, ServerUnaryCall } from '@grpc/grpc-js';
 
 import { Logger, LoggerService } from 'teleterm/services/logger/types';
 import { FileStorage } from 'teleterm/services/fileStorage';


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/43850 to branch/v16

Because we don't have typed styled components in this branch, I didn't backport .d.ts files. Instead, I added `@emotion/core` as a dev dependency explicitly, so it can be used in tsconfig.json `types` after switching to pnpm.