### PR TITLE
[v15] Update electron to 31.1.0

### DIFF
--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -42,7 +42,7 @@
     "@types/node-forge": "^1.0.4",
     "@types/tar-fs": "^2.0.1",
     "@types/whatwg-url": "^11.0.1",
-    "electron": "31.0.1",
+    "electron": "31.1.0",
     "electron-notarize": "^1.2.1",
     "electron-vite": "^2.0.0",
     "google-protobuf": "^3.21.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7449,10 +7449,10 @@ electron-vite@^2.0.0:
     magic-string "^0.30.5"
     picocolors "^1.0.0"
 
-electron@31.0.1:
-  version "31.0.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-31.0.1.tgz#0039524f8f38c24da802c3b18a42c3951acb5897"
-  integrity sha512-2eBcp4iqLkTsml6mMq+iqrS5u3kJ/2mpOLP7Mj7lo0uNK3OyfNqRS9z1ArsHjBF2/HV250Te/O9nKrwQRTX/+g==
+electron@31.1.0:
+  version "31.1.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-31.1.0.tgz#2836dbeb8f80c9b278aa4563c8fc3a6e6afbe723"
+  integrity sha512-TBOwqLxSxnx6+pH6GMri7R3JPH2AkuGJHfWZS0p1HsmN+Qr1T9b0IRJnnehSd/3NZAmAre4ft9Ljec7zjyKFJA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"


### PR DESCRIPTION
Backport #43712. Well, partially, because we want all releases to use the same version of Electron.