### PR TITLE
[v15] helm: Apply extraLabels to post-delete hooks in teleport-kube-agent chart

### DIFF
--- a/docs/pages/reference/helm-reference/includes/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/includes/zz_generated.teleport-kube-agent.mdx
@@ -1401,6 +1401,14 @@ for more information.
 
 `extraLabels.deployment` are labels to set on the Deployment or StatefulSet.
 
+### `extraLabels.job`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`extraLabels.job` are labels to set on the post-delete Job created by the chart.
+
 ### `extraLabels.pod`
 
 | Type | Default |

--- a/examples/chart/teleport-kube-agent/.lint/extra-labels.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/extra-labels.yaml
@@ -20,9 +20,9 @@ extraLabels:
   deployment:
     app.kubernetes.io/name: "teleport-kube-agent"
     resource: "deployment"
-  hooks:
-    app.kubernetes.io/extra-label: "hook-test"
-    test-resource: "hook"
+  job:
+    app.kubernetes.io/name: "teleport-kube-agent"
+    resource: "job"
   pod:
     app.kubernetes.io/name: "teleport-kube-agent"
     resource: "pod"

--- a/examples/chart/teleport-kube-agent/.lint/extra-labels.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/extra-labels.yaml
@@ -20,6 +20,9 @@ extraLabels:
   deployment:
     app.kubernetes.io/name: "teleport-kube-agent"
     resource: "deployment"
+  hooks:
+    app.kubernetes.io/extra-label: "hook-test"
+    test-resource: "hook"
   pod:
     app.kubernetes.io/name: "teleport-kube-agent"
     resource: "pod"

--- a/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
+++ b/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
@@ -8,14 +8,9 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-4"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-{{- if or .Values.extraLabels.hooks .Values.extraLabels.serviceAccount }}
+{{- if .Values.extraLabels.serviceAccount }}
   labels:
-  {{- if .Values.extraLabels.hooks }}
-  {{- toYaml .Values.extraLabels.hooks | nindent 4 }}
-  {{- end }}
-  {{- if .Values.extraLabels.serviceAccount }}
   {{- toYaml .Values.extraLabels.serviceAccount | nindent 4 }}
-  {{- end }}
 {{- end }}
 ---
 {{- end }}
@@ -29,14 +24,9 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-{{- if or .Values.extraLabels.hooks .Values.extraLabels.role }}
+{{- if .Values.extraLabels.role }}
   labels:
-  {{- if .Values.extraLabels.hooks }}
-  {{- toYaml .Values.extraLabels.hooks | nindent 4 }}
-  {{- end }}
-  {{- if .Values.extraLabels.role }}
   {{- toYaml .Values.extraLabels.role | nindent 4 }}
-  {{- end }}
 {{- end }}
 rules:
   - apiGroups: [""]
@@ -52,14 +42,9 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-2"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-{{- if or .Values.extraLabels.hooks .Values.extraLabels.roleBinding }}
+{{- if .Values.extraLabels.roleBinding }}
   labels:
-  {{- if .Values.extraLabels.hooks }}
-  {{- toYaml .Values.extraLabels.hooks | nindent 4 }}
-  {{- end }}
-  {{- if .Values.extraLabels.roleBinding }}
   {{- toYaml .Values.extraLabels.roleBinding | nindent 4 }}
-  {{- end }}
 {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -80,9 +65,9 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-{{- if .Values.extraLabels.hooks }}
+{{- if .Values.extraLabels.job }}
   labels:
-  {{- toYaml .Values.extraLabels.hooks | nindent 4 }}
+  {{- toYaml .Values.extraLabels.job | nindent 4 }}
 {{- end }}
 spec:
   template:

--- a/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
+++ b/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
@@ -8,6 +8,15 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-4"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- if or .Values.extraLabels.hooks .Values.extraLabels.serviceAccount }}
+  labels:
+  {{- if .Values.extraLabels.hooks }}
+  {{- toYaml .Values.extraLabels.hooks | nindent 4 }}
+  {{- end }}
+  {{- if .Values.extraLabels.serviceAccount }}
+  {{- toYaml .Values.extraLabels.serviceAccount | nindent 4 }}
+  {{- end }}
+{{- end }}
 ---
 {{- end }}
 {{- if .Values.rbac.create }}
@@ -20,6 +29,15 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- if or .Values.extraLabels.hooks .Values.extraLabels.role }}
+  labels:
+  {{- if .Values.extraLabels.hooks }}
+  {{- toYaml .Values.extraLabels.hooks | nindent 4 }}
+  {{- end }}
+  {{- if .Values.extraLabels.role }}
+  {{- toYaml .Values.extraLabels.role | nindent 4 }}
+  {{- end }}
+{{- end }}
 rules:
   - apiGroups: [""]
     resources: ["secrets",]
@@ -34,6 +52,15 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-2"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- if or .Values.extraLabels.hooks .Values.extraLabels.roleBinding }}
+  labels:
+  {{- if .Values.extraLabels.hooks }}
+  {{- toYaml .Values.extraLabels.hooks | nindent 4 }}
+  {{- end }}
+  {{- if .Values.extraLabels.roleBinding }}
+  {{- toYaml .Values.extraLabels.roleBinding | nindent 4 }}
+  {{- end }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -53,6 +80,10 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- if .Values.extraLabels.hooks }}
+  labels:
+  {{- toYaml .Values.extraLabels.hooks | nindent 4 }}
+{{- end }}
 spec:
   template:
     metadata:

--- a/examples/chart/teleport-kube-agent/tests/job_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/job_test.yaml
@@ -60,8 +60,8 @@ tests:
       - equal:
           path: metadata.labels
           value:
-            app.kubernetes.io/extra-label: "hook-test"
-            test-resource: "hook"
+            app.kubernetes.io/name: "teleport-kube-agent"
+            resource: "job"
 
   - it: should set nodeSelector in post-delete hook
     template: delete_hook.yaml
@@ -123,8 +123,6 @@ tests:
           value:
             app.kubernetes.io/name: "teleport-kube-agent"
             resource: "serviceaccount"
-            app.kubernetes.io/extra-label: "hook-test"
-            test-resource: "hook"
 
   - it: should create Role for post-delete hook by default
     template: delete_hook.yaml
@@ -147,8 +145,6 @@ tests:
           value:
             app.kubernetes.io/name: "teleport-kube-agent"
             resource: "role"
-            app.kubernetes.io/extra-label: "hook-test"
-            test-resource: "hook"
 
   - it: should create RoleBinding for post-delete hook by default
     template: delete_hook.yaml
@@ -171,8 +167,6 @@ tests:
           value:
             app.kubernetes.io/name: "teleport-kube-agent"
             resource: "rolebinding"
-            app.kubernetes.io/extra-label: "hook-test"
-            test-resource: "hook"
 
   - it: should not create ServiceAccount for post-delete hook if serviceAccount.create is false
     template: delete_hook.yaml

--- a/examples/chart/teleport-kube-agent/tests/job_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/job_test.yaml
@@ -50,6 +50,19 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
+  - it: should set extraLabels for Job in post-delete hook
+    template: delete_hook.yaml
+    # documentIndex: 0=ServiceAccount 1=Role 2=RoleBinding 3=Job
+    documentIndex: 3
+    values:
+      - ../.lint/extra-labels.yaml
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/extra-label: "hook-test"
+            test-resource: "hook"
+
   - it: should set nodeSelector in post-delete hook
     template: delete_hook.yaml
     # documentIndex: 0=ServiceAccount 1=Role 2=RoleBinding 3=Job
@@ -98,6 +111,21 @@ tests:
           path: metadata.name
           value: lint-serviceaccount-delete-hook
 
+  - it: should set extraLabels for ServiceAccount in post-delete hook
+    template: delete_hook.yaml
+    # documentIndex: 0=ServiceAccount 1=Role 2=RoleBinding 3=Job
+    documentIndex: 0
+    values:
+      - ../.lint/extra-labels.yaml
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/name: "teleport-kube-agent"
+            resource: "serviceaccount"
+            app.kubernetes.io/extra-label: "hook-test"
+            test-resource: "hook"
+
   - it: should create Role for post-delete hook by default
     template: delete_hook.yaml
     values:
@@ -107,6 +135,21 @@ tests:
           kind: Role
           apiVersion: rbac.authorization.k8s.io/v1
 
+  - it: should set extraLabels for Role in post-delete hook
+    template: delete_hook.yaml
+    # documentIndex: 0=ServiceAccount 1=Role 2=RoleBinding 3=Job
+    documentIndex: 1
+    values:
+      - ../.lint/extra-labels.yaml
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/name: "teleport-kube-agent"
+            resource: "role"
+            app.kubernetes.io/extra-label: "hook-test"
+            test-resource: "hook"
+
   - it: should create RoleBinding for post-delete hook by default
     template: delete_hook.yaml
     values:
@@ -115,6 +158,21 @@ tests:
       - containsDocument:
           kind: RoleBinding
           apiVersion: rbac.authorization.k8s.io/v1
+
+  - it: should set extraLabels for RoleBinding in post-delete hook
+    template: delete_hook.yaml
+    # documentIndex: 0=ServiceAccount 1=Role 2=RoleBinding 3=Job
+    documentIndex: 2
+    values:
+      - ../.lint/extra-labels.yaml
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/name: "teleport-kube-agent"
+            resource: "rolebinding"
+            app.kubernetes.io/extra-label: "hook-test"
+            test-resource: "hook"
 
   - it: should not create ServiceAccount for post-delete hook if serviceAccount.create is false
     template: delete_hook.yaml

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -558,6 +558,11 @@
                     "type": "object",
                     "default": {}
                 },
+                "hooks": {
+                    "$id": "#/properties/extraLabels/properties/hooks",
+                    "type": "object",
+                    "default": {}
+                },
                 "pod": {
                     "$id": "#/properties/extraLabels/properties/pod",
                     "type": "object",

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -558,8 +558,8 @@
                     "type": "object",
                     "default": {}
                 },
-                "hooks": {
-                    "$id": "#/properties/extraLabels/properties/hooks",
+                "job": {
+                    "$id": "#/properties/extraLabels/properties/job",
                     "type": "object",
                     "default": {}
                 },

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -1060,6 +1060,8 @@ extraLabels:
   config: {}
   # extraLabels.deployment(object) -- are labels to set on the Deployment or StatefulSet.
   deployment: {}
+  # extraLabels.job(object) -- are labels to set on the post-delete Job created by the chart.
+  job: {}
   # extraLabels.pod(object) -- are labels to set on the Pods created by the
   # Deployment or StatefulSet.
   pod: {}
@@ -1071,8 +1073,6 @@ extraLabels:
   secret: {}
   # extraLabels.serviceAccount(object) -- are labels to set on the ServiceAccount.
   serviceAccount: {}
-  # extraLabels.hooks(object) -- are labels to set on the post-delete Job and other hooks managed by the chart.
-  hooks: {}
 
 # annotations -- contains annotations to apply to the different Kubernetes
 # objects created by the chart. See [the Kubernetes annotation

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -1071,6 +1071,8 @@ extraLabels:
   secret: {}
   # extraLabels.serviceAccount(object) -- are labels to set on the ServiceAccount.
   serviceAccount: {}
+  # extraLabels.hooks(object) -- are labels to set on the post-delete Job and other hooks managed by the chart.
+  hooks: {}
 
 # annotations -- contains annotations to apply to the different Kubernetes
 # objects created by the chart. See [the Kubernetes annotation


### PR DESCRIPTION
Backport #43866 to branch/v15

changelog: Correctly propagate `extraLabels` configured in teleport-kube-agent chart values to post-delete hooks. A new `extraLabels.job` object has been added for labels which should only apply to the post-delete job.
