### PR TITLE
[v14] helm: Apply extraLabels to post-delete hooks in teleport-kube-agent chart

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -1633,6 +1633,24 @@ Kubernetes labels that should be applied to the `Deployment` or `StatefulSet` cr
       app.kubernetes.io/name: teleport-kube-agent
   ```
 
+## `extraLabels.job`
+
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+
+Kubernetes labels that should be applied to the post-delete hook `Job` created by the chart.
+
+`values.yaml` example:
+
+  ```yaml
+  extraLabels:
+    job:
+      app.kubernetes.io/name: teleport-kube-agent
+  ```
+
 ## `extraLabels.pod`
 
 | Type     | Default value |

--- a/examples/chart/teleport-kube-agent/.lint/extra-labels.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/extra-labels.yaml
@@ -20,6 +20,9 @@ extraLabels:
   deployment:
     app.kubernetes.io/name: "teleport-kube-agent"
     resource: "deployment"
+  job:
+    app.kubernetes.io/name: "teleport-kube-agent"
+    resource: "job"
   pod:
     app.kubernetes.io/name: "teleport-kube-agent"
     resource: "pod"

--- a/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
+++ b/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
@@ -8,6 +8,10 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-4"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- if .Values.extraLabels.serviceAccount }}
+  labels:
+  {{- toYaml .Values.extraLabels.serviceAccount | nindent 4 }}
+{{- end }}
 ---
 {{- end }}
 {{- if .Values.rbac.create }}
@@ -20,6 +24,10 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- if .Values.extraLabels.role }}
+  labels:
+  {{- toYaml .Values.extraLabels.role | nindent 4 }}
+{{- end }}
 rules:
   - apiGroups: [""]
     resources: ["secrets",]
@@ -34,6 +42,10 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-2"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- if .Values.extraLabels.roleBinding }}
+  labels:
+  {{- toYaml .Values.extraLabels.roleBinding | nindent 4 }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -53,6 +65,10 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- if .Values.extraLabels.job }}
+  labels:
+  {{- toYaml .Values.extraLabels.job | nindent 4 }}
+{{- end }}
 spec:
   template:
     metadata:

--- a/examples/chart/teleport-kube-agent/tests/job_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/job_test.yaml
@@ -50,6 +50,19 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
+  - it: should set extraLabels for Job in post-delete hook
+    template: delete_hook.yaml
+    # documentIndex: 0=ServiceAccount 1=Role 2=RoleBinding 3=Job
+    documentIndex: 3
+    values:
+      - ../.lint/extra-labels.yaml
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/name: "teleport-kube-agent"
+            resource: "job"
+
   - it: should set nodeSelector in post-delete hook
     template: delete_hook.yaml
     # documentIndex: 0=ServiceAccount 1=Role 2=RoleBinding 3=Job
@@ -98,6 +111,19 @@ tests:
           path: metadata.name
           value: lint-serviceaccount-delete-hook
 
+  - it: should set extraLabels for ServiceAccount in post-delete hook
+    template: delete_hook.yaml
+    # documentIndex: 0=ServiceAccount 1=Role 2=RoleBinding 3=Job
+    documentIndex: 0
+    values:
+      - ../.lint/extra-labels.yaml
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/name: "teleport-kube-agent"
+            resource: "serviceaccount"
+
   - it: should create Role for post-delete hook by default
     template: delete_hook.yaml
     values:
@@ -107,6 +133,19 @@ tests:
           kind: Role
           apiVersion: rbac.authorization.k8s.io/v1
 
+  - it: should set extraLabels for Role in post-delete hook
+    template: delete_hook.yaml
+    # documentIndex: 0=ServiceAccount 1=Role 2=RoleBinding 3=Job
+    documentIndex: 1
+    values:
+      - ../.lint/extra-labels.yaml
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/name: "teleport-kube-agent"
+            resource: "role"
+
   - it: should create RoleBinding for post-delete hook by default
     template: delete_hook.yaml
     values:
@@ -115,6 +154,19 @@ tests:
       - containsDocument:
           kind: RoleBinding
           apiVersion: rbac.authorization.k8s.io/v1
+
+  - it: should set extraLabels for RoleBinding in post-delete hook
+    template: delete_hook.yaml
+    # documentIndex: 0=ServiceAccount 1=Role 2=RoleBinding 3=Job
+    documentIndex: 2
+    values:
+      - ../.lint/extra-labels.yaml
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/name: "teleport-kube-agent"
+            resource: "rolebinding"
 
   - it: should not create ServiceAccount for post-delete hook if serviceAccount.create is false
     template: delete_hook.yaml

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -507,6 +507,11 @@
                     "type": "object",
                     "default": {}
                 },
+                "job": {
+                    "$id": "#/properties/extraLabels/properties/job",
+                    "type": "object",
+                    "default": {}
+                },
                 "pod": {
                     "$id": "#/properties/extraLabels/properties/pod",
                     "type": "object",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -403,6 +403,8 @@ extraLabels:
   config: {}
   # Labels for the Deployment/StatefulSet
   deployment: {}
+  # Labels to set on the post-delete Job created by the chart.
+  job: {}
   # Labels for each Pod in the Deployment/StatefulSet
   pod: {}
   # Labels for the Pod Disruption Budget (ignored when disabled)


### PR DESCRIPTION
Backport #43866 to branch/v14

changelog: Fixed `teleport-kube-agent` helm chart to correctly propagate `extraLabels` to post-delete hooks. A new `extraLabels.job` object has been added for labels which should only apply to the post-delete job.
