### PR TITLE
Derive dynamic cryptographic configurations from `*service.Connector`

### DIFF
--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -112,16 +112,6 @@ func (c *TLSServerConfig) CheckAndSetDefaults() error {
 	if c.TLS == nil {
 		return trace.BadParameter("missing parameter TLS")
 	}
-	c.TLS.ClientAuth = tls.RequireAndVerifyClientCert
-	if c.TLS.ClientCAs == nil {
-		return trace.BadParameter("missing parameter TLS.ClientCAs")
-	}
-	if c.TLS.RootCAs == nil {
-		return trace.BadParameter("missing parameter TLS.RootCAs")
-	}
-	if len(c.TLS.Certificates) == 0 {
-		return trace.BadParameter("missing parameter TLS.Certificates")
-	}
 	if c.AccessPoint == nil {
 		return trace.BadParameter("missing parameter AccessPoint")
 	}

--- a/lib/proxy/peer/server.go
+++ b/lib/proxy/peer/server.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -46,16 +45,11 @@ const (
 
 // ServerConfig configures a Server instance.
 type ServerConfig struct {
-	AccessCache   authclient.CAGetter
 	Listener      net.Listener
 	TLSConfig     *tls.Config
 	ClusterDialer ClusterDialer
 	Log           logrus.FieldLogger
 	ClusterName   string
-
-	// getConfigForClient gets the client tls config.
-	// configurable for testing purposes.
-	getConfigForClient func(*tls.ClientHelloInfo) (*tls.Config, error)
 
 	// service is a custom ProxyServiceServer
 	// configurable for testing purposes.
@@ -72,10 +66,6 @@ func (c *ServerConfig) checkAndSetDefaults() error {
 		teleport.Component(teleport.ComponentProxy, "peer"),
 	)
 
-	if c.AccessCache == nil {
-		return trace.BadParameter("missing access cache")
-	}
-
 	if c.Listener == nil {
 		return trace.BadParameter("missing listener")
 	}
@@ -91,18 +81,7 @@ func (c *ServerConfig) checkAndSetDefaults() error {
 	if c.TLSConfig == nil {
 		return trace.BadParameter("missing tls config")
 	}
-
-	if len(c.TLSConfig.Certificates) == 0 {
-		return trace.BadParameter("missing tls certificate")
-	}
-
-	c.TLSConfig = c.TLSConfig.Clone()
 	c.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
-
-	if c.getConfigForClient == nil {
-		c.getConfigForClient = getConfigForClient(c.TLSConfig, c.AccessCache, c.Log, c.ClusterName)
-	}
-	c.TLSConfig.GetConfigForClient = c.getConfigForClient
 
 	if c.service == nil {
 		c.service = &proxyService{

--- a/lib/proxy/peer/server_test.go
+++ b/lib/proxy/peer/server_test.go
@@ -34,7 +34,7 @@ func TestServerTLS(t *testing.T) {
 	ca2 := newSelfSignedCA(t)
 
 	// trusted certificates with proxy roles.
-	client1 := setupClient(t, ca1, ca1, types.RoleProxy)
+	client1 := setupClient(t, ca1, newAtomicCA(ca1), types.RoleProxy)
 	_, serverDef1 := setupServer(t, "s1", ca1, ca1, types.RoleProxy)
 	err := client1.updateConnections([]types.Server{serverDef1})
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestServerTLS(t *testing.T) {
 	stream.Close()
 
 	// trusted certificates with incorrect server role.
-	client2 := setupClient(t, ca1, ca1, types.RoleNode)
+	client2 := setupClient(t, ca1, newAtomicCA(ca1), types.RoleNode)
 	_, serverDef2 := setupServer(t, "s2", ca1, ca1, types.RoleProxy)
 	err = client2.updateConnections([]types.Server{serverDef2})
 	require.NoError(t, err) // connection succeeds but is in transient failure state
@@ -52,7 +52,7 @@ func TestServerTLS(t *testing.T) {
 	require.Error(t, err)
 
 	// certificates with correct role from different CAs
-	client3 := setupClient(t, ca1, ca2, types.RoleProxy)
+	client3 := setupClient(t, ca1, newAtomicCA(ca2), types.RoleProxy)
 	_, serverDef3 := setupServer(t, "s3", ca2, ca1, types.RoleProxy)
 	err = client3.updateConnections([]types.Server{serverDef3})
 	require.NoError(t, err)

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -20,7 +20,6 @@ package reversetunnel
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
@@ -131,9 +130,12 @@ type Config struct {
 	ID string
 	// ClusterName is a name of this cluster
 	ClusterName string
-	// ClientTLS is a TLS config associated with this proxy
-	// used to connect to remote auth servers on remote clusters
-	ClientTLS *tls.Config
+	// ClientTLSCipherSuites optionally contains a list of TLS ciphersuites to
+	// use when connecting to other clusters.
+	ClientTLSCipherSuites []uint16
+	// GetClientTLSCertificate returns a TLS certificate to use when connecting
+	// to other clusters.
+	GetClientTLSCertificate utils.GetCertificateFunc
 	// Listener is a listener address for reverse tunnel server
 	Listener net.Listener
 	// HostSigners is a list of host signers
@@ -226,8 +228,8 @@ func (cfg *Config) CheckAndSetDefaults() error {
 	if cfg.ClusterName == "" {
 		return trace.BadParameter("missing parameter ClusterName")
 	}
-	if cfg.ClientTLS == nil {
-		return trace.BadParameter("missing parameter ClientTLS")
+	if cfg.GetClientTLSCertificate == nil {
+		return trace.BadParameter("missing parameter GetClientTLSCertificate")
 	}
 	if cfg.Listener == nil {
 		return trace.BadParameter("missing parameter Listener")

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -189,7 +189,7 @@ func (process *TeleportProcess) connectToAuthService(role types.SystemRole, opts
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	process.logger.DebugContext(process.ExitContext(), "Client successfully connected to cluster", "client_identity", connector.ClientIdentityString())
+	process.logger.DebugContext(process.ExitContext(), "Client successfully connected to cluster", "client_identity", connector.clientIdentityString())
 	process.addConnector(connector)
 
 	return connector, nil

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -63,17 +63,6 @@ func (process *TeleportProcess) initDiscoveryService() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	// tlsConfig is the DiscoveryService's TLS certificate signed by the cluster's
-	// Host certificate authority.
-	// It is used to authenticate the DiscoveryService to the Access Graph service.
-	tlsConfig, err := conn.ServerTLSConfig(process.Config.CipherSuites)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	if tlsConfig != nil {
-		tlsConfig.ServerName = "" /* empty the server name to avoid SNI collisions with access graph addr */
-	}
 
 	accessGraphCfg, err := buildAccessGraphFromTAGOrFallbackToAuth(
 		process.ExitContext(),
@@ -102,7 +91,7 @@ func (process *TeleportProcess) initDiscoveryService() error {
 		ClusterName:       conn.ClusterName(),
 		ClusterFeatures:   process.GetClusterFeatures,
 		PollInterval:      process.Config.Discovery.PollInterval,
-		ServerCredentials: tlsConfig,
+		GetClientCert:     conn.ClientGetCertificate,
 		AccessGraphConfig: accessGraphCfg,
 	})
 	if err != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -84,6 +84,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 	"github.com/gravitational/teleport/api/utils/keys"
+	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/agentless"
 	"github.com/gravitational/teleport/lib/auditd"
@@ -158,6 +159,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/transport/transportv1"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/system"
+	"github.com/gravitational/teleport/lib/tlsca"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
@@ -296,18 +298,97 @@ const (
 	TeleportOKEvent = "TeleportOKEvent"
 )
 
+func newConnector(clientIdentity, serverIdentity *state.Identity) (*Connector, error) {
+	clientState, err := newConnectorState(clientIdentity)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	serverState, err := newConnectorState(serverIdentity)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	c := &Connector{
+		clusterName: clientIdentity.ClusterName,
+		hostID:      clientIdentity.ID.HostUUID,
+		role:        clientIdentity.ID.Role,
+	}
+	c.clientState.Store(clientState)
+	c.serverState.Store(serverState)
+	return c, nil
+}
+
+func newConnectorState(identity *state.Identity) (*connectorState, error) {
+	state := &connectorState{
+		identity: identity,
+	}
+	if identity.Cert != nil {
+		hostCheckers, err := apisshutils.ParseAuthorizedKeys(identity.SSHCACertBytes)
+		if err != nil {
+			return nil, trace.Wrap(err, "parsing SSH host CAs")
+		}
+		state.hostCheckers = hostCheckers
+
+		state.sshCert = identity.Cert
+		state.sshCertSigner = identity.KeySigner
+	}
+	if identity.HasTLSConfig() {
+		tlsCert, err := keys.X509KeyPair(identity.TLSCertBytes, identity.KeyBytes)
+		if err != nil {
+			return nil, trace.Wrap(err, "parsing X.509 certificate")
+		}
+		tlsCert.Leaf = identity.XCert
+		certPool := x509.NewCertPool()
+		for j := range identity.TLSCACertsBytes {
+			parsedCert, err := tlsca.ParseCertificatePEM(identity.TLSCACertsBytes[j])
+			if err != nil {
+				return nil, trace.Wrap(err, "parsing X.509 host CA")
+			}
+			certPool.AddCert(parsedCert)
+		}
+		state.tlsCert = &tlsCert
+		state.pool = certPool
+	}
+	return state, nil
+}
+
+// connectorState contains immutable state (generally derived from a
+// [*state.Identity]) suitable for sharing behind an atomic pointer.
+type connectorState struct {
+	identity *state.Identity
+
+	// tlsCert is the TLS client certificate for the identity, with Signer and
+	// Leaf filled.
+	tlsCert *tls.Certificate
+	// pool contains the host CA certificates trusted by the identity.
+	pool *x509.CertPool
+
+	// sshCert is the SSH certificate associated with the identity.
+	sshCert *ssh.Certificate
+	// sshCertSigner is a [ssh.Signer] presenting the sshCert certificate as its
+	// public key.
+	sshCertSigner ssh.Signer
+	// hostCheckers contains the (non-certificate) public keys that make up the
+	// host CA trusted by the identity.
+	hostCheckers []ssh.PublicKey
+}
+
 // Connector has all resources process needs to connect to other parts of the
 // cluster: client and identity.
 type Connector struct {
-	// clientIdentity is the identity to be used in internal cluster
-	// clients to the auth service.
-	clientIdentity *state.Identity
+	clusterName string
+	hostID      string
+	role        types.SystemRole
 
-	// serverIdentity is the identity to be used in servers - serving SSH
-	// and x509 certificates to clients.
-	serverIdentity *state.Identity
+	// clientState contains the current connector state for outbound connections
+	// to the cluster.
+	clientState atomic.Pointer[connectorState]
+	// serverState contains the current connector state for inbound connections
+	// from the cluster.
+	serverState atomic.Pointer[connectorState]
 
-	// Client is authenticated client with credentials from ClientIdentity.
+	// Client is an authenticated client intended to use the credentials in
+	// clientState (unless it's a client shared from some other connector as
+	// signified by ReusedClient).
 	Client *authclient.Client
 
 	// ReusedClient, if true, indicates that the client reference is owned by
@@ -316,65 +397,113 @@ type Connector struct {
 }
 
 func (c *Connector) ClusterName() string {
-	return c.clientIdentity.ClusterName
+	return c.clusterName
 }
 
 func (c *Connector) HostID() string {
-	return c.clientIdentity.ID.HostUUID
+	return c.hostID
 }
 
 func (c *Connector) Role() types.SystemRole {
-	return c.clientIdentity.ID.Role
-}
-
-func (c *Connector) ClientTLSConfig(cipherSuites []uint16) (*tls.Config, error) {
-	return c.clientIdentity.TLSConfig(cipherSuites)
+	return c.role
 }
 
 func (c *Connector) ClientGetCertificate() (*tls.Certificate, error) {
-	cert, err := keys.X509KeyPair(c.clientIdentity.TLSCertBytes, c.clientIdentity.KeyBytes)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	tlsCert := c.clientState.Load().tlsCert
+	if tlsCert == nil {
+		return nil, trace.NotFound("no TLS credentials setup for this identity")
 	}
-	return &cert, nil
+	return tlsCert, nil
+}
+
+func (c *Connector) ClientGetPool() (*x509.CertPool, error) {
+	roots := c.clientState.Load().pool
+	if roots == nil {
+		return nil, trace.NotFound("no TLS credentials setup for this identity")
+	}
+	return roots, nil
 }
 
 func (c *Connector) ClientAuthMethods() []ssh.AuthMethod {
-	return []ssh.AuthMethod{ssh.PublicKeys(c.clientIdentity.KeySigner)}
+	return []ssh.AuthMethod{
+		ssh.PublicKeysCallback(func() (signers []ssh.Signer, err error) {
+			sshCertSigner := c.clientState.Load().sshCertSigner
+			if sshCertSigner == nil {
+				return nil, nil
+			}
+			return []ssh.Signer{sshCertSigner}, nil
+		}),
+	}
 }
 
 func (c *Connector) ClientIdentityString() string {
-	return c.clientIdentity.String()
+	return c.clientState.Load().identity.String()
 }
 
-func (c *Connector) ClientInstanceSystemRoles() []string {
-	return slices.Clone(c.clientIdentity.SystemRoles)
-}
+// Deprecated: use ServerTLSConfigTemplate instead.
+// func (c *Connector) ServerTLSConfig(cipherSuites []uint16) (*tls.Config, error) {
+// 	return c.ServerTLSConfigTemplate(cipherSuites)
+// }
 
 func (c *Connector) ServerTLSConfig(cipherSuites []uint16) (*tls.Config, error) {
-	return c.serverIdentity.TLSConfig(cipherSuites)
+	conf := utils.TLSConfig(cipherSuites)
+	conf.GetCertificate = func(cri *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		tlsCert := c.clientState.Load().tlsCert
+		if tlsCert == nil {
+			return nil, trace.NotFound("no TLS credentials setup for this identity")
+		}
+		return tlsCert, nil
+	}
+	return conf, nil
+}
+
+func (c *Connector) ServerGetCertificate() (*tls.Certificate, error) {
+	tlsCert := c.serverState.Load().tlsCert
+	if tlsCert == nil {
+		return nil, trace.NotFound("no TLS credentials setup for this identity")
+	}
+	return tlsCert, nil
+}
+
+func (c *Connector) ServerGetPool() (*x509.CertPool, error) {
+	roots := c.serverState.Load().pool
+	if roots == nil {
+		return nil, trace.NotFound("no TLS credentials setup for this identity")
+	}
+	return roots, nil
 }
 
 func (c *Connector) ServerGetHostSigners() []ssh.Signer {
-	return []ssh.Signer{c.serverIdentity.KeySigner}
+	sshCertSigner := c.serverState.Load().sshCertSigner
+	if sshCertSigner == nil {
+		return nil
+	}
+	return []ssh.Signer{sshCertSigner}
 }
 
 func (c *Connector) ServerGetValidPrincipals() []string {
-	return slices.Clone(c.serverIdentity.Cert.ValidPrincipals)
+	// TODO(espadolini): get rid of this function after refactoring the two
+	// integration tests that use it
+	sshCert := c.serverState.Load().sshCert
+	if sshCert == nil {
+		return nil
+	}
+	return slices.Clone(sshCert.ValidPrincipals)
 }
 
 func (c *Connector) getPROXYSigner(clock clockwork.Clock) (multiplexer.PROXYHeaderSigner, error) {
-	signer, err := keys.ParsePrivateKey(c.serverIdentity.KeyBytes)
+	serverIdentity := c.serverState.Load().identity
+	signer, err := keys.ParsePrivateKey(serverIdentity.KeyBytes)
 	if err != nil {
 		return nil, trace.Wrap(err, "could not parse identity's private key")
 	}
 
-	jwtSigner, err := services.GetJWTSigner(signer, c.serverIdentity.ClusterName, clock)
+	jwtSigner, err := services.GetJWTSigner(signer, serverIdentity.ClusterName, clock)
 	if err != nil {
 		return nil, trace.Wrap(err, "could not create JWT signer")
 	}
 
-	proxySigner, err := multiplexer.NewPROXYSigner(c.serverIdentity.XCert, jwtSigner)
+	proxySigner, err := multiplexer.NewPROXYSigner(serverIdentity.XCert, jwtSigner)
 	if err != nil {
 		return nil, trace.Wrap(err, "could not create PROXY signer")
 	}
@@ -2226,7 +2355,7 @@ func (process *TeleportProcess) initAuthService() error {
 	}
 
 	// Register TLS endpoint of the auth service
-	tlsConfig, err := connector.ServerTLSConfig(cfg.CipherSuites)
+	tlsConfigTemplate, err := connector.ServerTLSConfig(cfg.CipherSuites)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -2274,7 +2403,7 @@ func (process *TeleportProcess) initAuthService() error {
 	authMetrics := &auth.Metrics{GRPCServerLatency: cfg.Metrics.GRPCServerLatency}
 
 	tlsServer, err := auth.NewTLSServer(process.ExitContext(), auth.TLSServerConfig{
-		TLS:                  tlsConfig,
+		TLS:                  tlsConfigTemplate,
 		GetClientCertificate: connector.ClientGetCertificate,
 
 		APIConfig:     *apiConf,
@@ -2956,7 +3085,7 @@ func (process *TeleportProcess) initSSH() error {
 				process.ExitContext(),
 				reversetunnel.AgentPoolConfig{
 					Component:            teleport.ComponentNode,
-					HostUUID:             conn.serverIdentity.ID.HostUUID,
+					HostUUID:             conn.HostID(),
 					Resolver:             conn.TunnelProxyResolver(),
 					Client:               conn.Client,
 					AccessPoint:          authClient,
@@ -4089,11 +4218,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		return trace.Wrap(err)
 	}
 
-	clientTLSConfig, err := conn.ClientTLSConfig(cfg.CipherSuites)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	clusterNetworkConfig, err := accessPoint.GetClusterNetworkingConfig(process.ExitContext())
 	if err != nil {
 		return trace.Wrap(err)
@@ -4192,14 +4316,16 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	if !process.Config.Proxy.DisableReverseTunnel {
 		if listeners.proxyPeer != nil {
 			peerClient, err = peer.NewClient(peer.ClientConfig{
-				Context:     process.ExitContext(),
-				ID:          process.Config.HostUUID,
-				AuthClient:  conn.Client,
-				AccessPoint: accessPoint,
-				TLSConfig:   clientTLSConfig,
-				Log:         process.log,
-				Clock:       process.Clock,
-				ClusterName: clusterName,
+				Context:           process.ExitContext(),
+				ID:                process.Config.HostUUID,
+				AuthClient:        conn.Client,
+				AccessPoint:       accessPoint,
+				TLSCipherSuites:   cfg.CipherSuites,
+				GetTLSCertificate: conn.ClientGetCertificate,
+				GetTLSRoots:       conn.ClientGetPool,
+				Log:               process.log,
+				Clock:             process.Clock,
+				ClusterName:       clusterName,
 			})
 			if err != nil {
 				return trace.Wrap(err)
@@ -4213,11 +4339,13 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 		tsrv, err = reversetunnel.NewServer(
 			reversetunnel.Config{
+				ClientTLSCipherSuites:   process.Config.CipherSuites,
+				GetClientTLSCertificate: conn.ClientGetCertificate,
+
 				Context:               process.ExitContext(),
 				Component:             teleport.Component(teleport.ComponentProxy, process.id),
 				ID:                    process.Config.HostUUID,
 				ClusterName:           clusterName,
-				ClientTLS:             clientTLSConfig,
 				Listener:              rtListener,
 				GetHostSigners:        conn.ServerGetHostSigners,
 				LocalAuthClient:       conn.Client,
@@ -4433,30 +4561,30 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		})
 
 		webConfig := web.Config{
-			Proxy:                   tsrv,
-			AuthServers:             cfg.AuthServerAddresses()[0],
-			DomainName:              cfg.Hostname,
-			ProxyClient:             conn.Client,
-			ProxySSHAddr:            proxySSHAddr,
-			ProxyWebAddr:            cfg.Proxy.WebAddr,
-			ProxyPublicAddrs:        cfg.Proxy.PublicAddrs,
-			CipherSuites:            cfg.CipherSuites,
-			FIPS:                    cfg.FIPS,
-			AccessPoint:             accessPoint,
-			Emitter:                 asyncEmitter,
-			PluginRegistry:          process.PluginRegistry,
-			HostUUID:                process.Config.HostUUID,
-			Context:                 process.GracefulExitContext(),
-			StaticFS:                fs,
-			ClusterFeatures:         process.GetClusterFeatures(),
-			GetProxyClientTLSConfig: conn.ClientTLSConfig,
-			UI:                      cfg.Proxy.UI,
-			ProxySettings:           proxySettings,
-			PublicProxyAddr:         process.proxyPublicAddr().Addr,
-			ALPNHandler:             alpnHandlerForWeb.HandleConnection,
-			ProxyKubeAddr:           proxyKubeAddr,
-			TraceClient:             traceClt,
-			Router:                  proxyRouter,
+			Proxy:                     tsrv,
+			AuthServers:               cfg.AuthServerAddresses()[0],
+			DomainName:                cfg.Hostname,
+			ProxyClient:               conn.Client,
+			ProxySSHAddr:              proxySSHAddr,
+			ProxyWebAddr:              cfg.Proxy.WebAddr,
+			ProxyPublicAddrs:          cfg.Proxy.PublicAddrs,
+			CipherSuites:              cfg.CipherSuites,
+			FIPS:                      cfg.FIPS,
+			AccessPoint:               accessPoint,
+			Emitter:                   asyncEmitter,
+			PluginRegistry:            process.PluginRegistry,
+			HostUUID:                  process.Config.HostUUID,
+			Context:                   process.GracefulExitContext(),
+			StaticFS:                  fs,
+			ClusterFeatures:           process.GetClusterFeatures(),
+			GetProxyClientCertificate: conn.ClientGetCertificate,
+			UI:                        cfg.Proxy.UI,
+			ProxySettings:             proxySettings,
+			PublicProxyAddr:           process.proxyPublicAddr().Addr,
+			ALPNHandler:               alpnHandlerForWeb.HandleConnection,
+			ProxyKubeAddr:             proxyKubeAddr,
+			TraceClient:               traceClt,
+			Router:                    proxyRouter,
 			SessionControl: web.SessionControllerFunc(func(ctx context.Context, sctx *web.SessionContext, login, localAddr, remoteAddr string) (context.Context, error) {
 				controller := srv.WebSessionController(sessionController)
 				ctx, err := controller(ctx, sctx, login, localAddr, remoteAddr)
@@ -4555,10 +4683,23 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			return trace.Wrap(err)
 		}
 		peerAddrString = peerAddr.String()
+
+		// TODO(espadolini): once connectors are live updated we can get rid of
+		// this and just refer to the host CA pool in the connector instead
+		peerServerTLSConfig := serverTLSConfig.Clone()
+		peerServerTLSConfig.GetConfigForClient = func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+			pool, _, err := authclient.ClientCertPool(chi.Context(), accessPoint, clusterName, types.HostCA)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			tlsConfig := peerServerTLSConfig.Clone()
+			tlsConfig.ClientCAs = pool
+			return tlsConfig, nil
+		}
+
 		proxyServer, err = peer.NewServer(peer.ServerConfig{
-			AccessCache:   accessPoint,
 			Listener:      listeners.proxyPeer,
-			TLSConfig:     serverTLSConfig,
+			TLSConfig:     peerServerTLSConfig,
 			ClusterDialer: clusterdial.NewClusterDialer(tsrv),
 			Log:           process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
 			ClusterName:   clusterName,
@@ -4648,16 +4789,16 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		ClusterName: clusterName,
 	}
 
-	tlscfg := serverTLSConfig.Clone()
-	tlscfg.ClientAuth = tls.RequireAndVerifyClientCert
+	sshGRPCTLSConfig := serverTLSConfig.Clone()
+	sshGRPCTLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
 	if lib.IsInsecureDevMode() {
-		tlscfg.InsecureSkipVerify = true
-		tlscfg.ClientAuth = tls.RequireAnyClientCert
+		sshGRPCTLSConfig.InsecureSkipVerify = true
+		sshGRPCTLSConfig.ClientAuth = tls.RequireAnyClientCert
 	}
 
 	// clientTLSConfigGenerator pre-generates specialized per-cluster client TLS config values
 	clientTLSConfigGenerator, err := auth.NewClientTLSConfigGenerator(auth.ClientTLSConfigGeneratorConfig{
-		TLS:                  tlscfg.Clone(),
+		TLS:                  sshGRPCTLSConfig,
 		ClusterName:          clusterName,
 		PermitRemoteClusters: true,
 		AccessPoint:          accessPoint,
@@ -4665,11 +4806,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	sshGRPCTLSConfig.GetConfigForClient = clientTLSConfigGenerator.GetConfigForClient
 
-	tlscfg.GetConfigForClient = clientTLSConfigGenerator.GetConfigForClient
-
-	creds, err := auth.NewTransportCredentials(auth.TransportCredentialsConfig{
-		TransportCredentials: credentials.NewTLS(tlscfg),
+	sshGRPCCreds, err := auth.NewTransportCredentials(auth.TransportCredentialsConfig{
+		TransportCredentials: credentials.NewTLS(sshGRPCTLSConfig),
 		UserGetter:           authMiddleware,
 		Authorizer:           authorizer,
 		GetAuthPreference:    accessPoint.GetAuthPreference,
@@ -4691,7 +4831,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			// the interceptor. See https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4576.
 			otelgrpc.StreamServerInterceptor(),
 		),
-		grpc.Creds(creds),
+		grpc.Creds(sshGRPCCreds),
 		grpc.MaxConcurrentStreams(defaults.GRPCMaxConcurrentStreams),
 	)
 
@@ -4805,11 +4945,8 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+
 		// Register TLS endpoint of the Kube proxy service
-		tlsConfig, err := conn.ServerTLSConfig(cfg.CipherSuites)
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		component := teleport.Component(teleport.ComponentProxy, teleport.ComponentProxyKube)
 		kubeServiceType := kubeproxy.ProxyService
 		if cfg.Proxy.Kube.LegacyKubeProxy {
@@ -4854,10 +4991,12 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				// using Impersonation headers. The upstream service will validate if
 				// the provided connection certificate is from a proxy server and
 				// will impersonate the identity of the user that is making the request.
-				ConnTLSConfig:   tlsConfig.Clone(),
-				ClusterFeatures: process.GetClusterFeatures,
+				GetConnTLSCertificate: conn.ClientGetCertificate,
+				GetConnTLSRoots:       conn.ClientGetPool,
+				ConnTLSCipherSuites:   cfg.CipherSuites,
+				ClusterFeatures:       process.GetClusterFeatures,
 			},
-			TLS:                      tlsConfig.Clone(),
+			TLS:                      serverTLSConfig.Clone(),
 			LimiterConfig:            cfg.Proxy.Limiter,
 			AccessPoint:              accessPoint,
 			GetRotation:              process.GetRotation,
@@ -4907,10 +5046,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		tlsConfig, err := conn.ServerTLSConfig(cfg.CipherSuites)
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		connLimiter, err := limiter.NewLimiter(process.Config.Databases.Limiter)
 		if err != nil {
 			return trace.Wrap(err)
@@ -4935,7 +5070,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				AccessPoint:        accessPoint,
 				Authorizer:         authorizer,
 				Tunnel:             tsrv,
-				TLSConfig:          tlsConfig,
+				TLSConfig:          serverTLSConfig.Clone(),
 				Limiter:            connLimiter,
 				IngressReporter:    ingressReporter,
 				ConnectionMonitor:  connMonitor,
@@ -5006,7 +5141,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		if listeners.db.mongo != nil {
 			process.RegisterCriticalFunc("proxy.db.mongo", func() error {
 				logger.InfoContext(process.ExitContext(), "Starting Database Mongo proxy server.", "listen_address", cfg.Proxy.MongoAddr.Addr)
-				if err := dbProxyServer.ServeMongo(listeners.db.mongo, tlsConfigWeb.Clone()); err != nil {
+				if err := dbProxyServer.ServeMongo(listeners.db.mongo, tlsConfigWeb); err != nil {
 					logger.WarnContext(process.ExitContext(), "Database Mongo proxy server exited with error.", "error", err)
 				}
 				return nil
@@ -5054,13 +5189,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			HandlerWithConnInfo: authDialerService.HandleConnection,
 			ForwardTLS:          true,
 		})
-		identityTLSConf, err := conn.ServerTLSConfig(cfg.CipherSuites)
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		alpnServer, err = alpnproxy.New(alpnproxy.ProxyConfig{
 			WebTLSConfig:      tlsConfigWeb.Clone(),
-			IdentityTLSConfig: identityTLSConf,
+			IdentityTLSConfig: serverTLSConfig,
 			Router:            alpnRouter,
 			Listener:          listeners.alpn,
 			ClusterName:       clusterName,
@@ -5087,7 +5218,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		if reverseTunnelALPNRouter != nil {
 			reverseTunnelALPNServer, err = alpnproxy.New(alpnproxy.ProxyConfig{
 				WebTLSConfig:      tlsConfigWeb.Clone(),
-				IdentityTLSConfig: identityTLSConf,
+				IdentityTLSConfig: serverTLSConfig,
 				Router:            reverseTunnelALPNRouter,
 				Listener:          listeners.reverseTunnelALPN,
 				ClusterName:       clusterName,
@@ -5399,10 +5530,8 @@ func (process *TeleportProcess) setupTLSConfigClientCAGeneratorForCluster(tlsCon
 	return nil
 }
 
-func (process *TeleportProcess) setupALPNTLSConfigForWeb(serverTLSConfig *tls.Config, accessPoint authclient.ReadProxyAccessPoint, clusterName string) (*tls.Config, error) {
-	tlsConfig := utils.TLSConfig(process.Config.CipherSuites)
-	tlsConfig.Certificates = serverTLSConfig.Certificates
-
+func (process *TeleportProcess) setupALPNTLSConfigForWeb(tlsConfig *tls.Config, accessPoint authclient.ReadProxyAccessPoint, clusterName string) (*tls.Config, error) {
+	tlsConfig = tlsConfig.Clone()
 	setupTLSConfigALPNProtocols(tlsConfig)
 	if err := process.setupTLSConfigClientCAGeneratorForCluster(tlsConfig, accessPoint, clusterName); err != nil {
 		return nil, trace.Wrap(err)
@@ -5745,7 +5874,7 @@ func (process *TeleportProcess) initApps() {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		tlsConfig, err := conn.ServerTLSConfig(nil)
+		tlsConfig, err := conn.ServerTLSConfig(process.Config.CipherSuites)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -6390,7 +6519,6 @@ func (process *TeleportProcess) initPublicGRPCServer(
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)
-
 	}
 
 	accessgraphsecretsv1pb.RegisterSecretsScannerServiceServer(server, accessGraphProxySvc)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -369,9 +368,8 @@ func TestServiceCheckPrincipals(t *testing.T) {
 	require.NoError(t, err)
 	defer tlsServer.Close()
 
-	testConnector := &Connector{
-		serverIdentity: tlsServer.Identity,
-	}
+	testConnector, err := newConnector(tlsServer.Identity, tlsServer.Identity)
+	require.NoError(t, err)
 
 	tests := []struct {
 		inPrincipals  []string
@@ -889,18 +887,8 @@ func TestSetupProxyTLSConfig(t *testing.T) {
 				// Setting Supervisor so that `ExitContext` can be called.
 				Supervisor: NewSupervisor("process-id", cfg.Log),
 			}
-			conn := &Connector{
-				clientIdentity: &state.Identity{},
-				serverIdentity: &state.Identity{
-					Cert: &ssh.Certificate{
-						Permissions: ssh.Permissions{
-							Extensions: map[string]string{},
-						},
-					},
-				},
-			}
 			tls, err := process.setupProxyTLSConfig(
-				conn,
+				&Connector{},
 				&mockReverseTunnelServer{},
 				&mockAccessPoint{},
 				"cluster",
@@ -1239,11 +1227,9 @@ func TestProxyGRPCServers(t *testing.T) {
 	serverIdentity, err := auth.NewServerIdentity(testAuthServer.AuthServer, hostID, types.RoleProxy)
 	require.NoError(t, err)
 
-	testConnector := &Connector{
-		clientIdentity: serverIdentity,
-		serverIdentity: serverIdentity,
-		Client:         client,
-	}
+	testConnector, err := newConnector(serverIdentity, serverIdentity)
+	require.NoError(t, err)
+	testConnector.Client = client
 
 	// Create a listener for the insecure gRPC server.
 	insecureListener, err := net.Listen("tcp", "localhost:0")
@@ -1360,10 +1346,10 @@ func TestProxyGRPCServers(t *testing.T) {
 		{
 			name: "secure client to secure server",
 			credentials: func() credentials.TransportCredentials {
-				// Create a new client using the server identity.
-				creds, err := testConnector.ServerTLSConfig(nil)
-				require.NoError(t, err)
-				return credentials.NewTLS(creds)
+				// // Create a new client using the client identity.
+				// creds, err := testConnector.ClientTLSConfig(nil)
+				// require.NoError(t, err)
+				return credentials.NewTLS(testConnector.Client.TLSConfig())
 			}(),
 			listenerAddr: secureListener.Addr().String(),
 			assertErr:    require.NoError,

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -138,9 +138,9 @@ type Config struct {
 	// Default: [github.com/gravitational/teleport/lib/srv/discovery/common.DefaultDiscoveryPollInterval]
 	PollInterval time.Duration
 
-	// ServerCredentials are the credentials used to identify the discovery service
+	// GetClientCert returns credentials used to identify the discovery service
 	// to the Access Graph service.
-	ServerCredentials *tls.Config
+	GetClientCert func() (*tls.Certificate, error)
 	// AccessGraphConfig is the configuration for the Access Graph client
 	AccessGraphConfig AccessGraphConfig
 

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -21,6 +21,7 @@ package regular
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1488,8 +1489,10 @@ func TestProxyRoundRobin(t *testing.T) {
 	caWatcher := newCertAuthorityWatcher(ctx, t, proxyClient)
 
 	reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
+		GetClientTLSCertificate: func() (*tls.Certificate, error) {
+			return &proxyClient.TLSConfig().Certificates[0], nil
+		},
 		ClusterName:           f.testSrv.ClusterName(),
-		ClientTLS:             proxyClient.TLSConfig(),
 		ID:                    hostID,
 		Listener:              listener,
 		GetHostSigners:        sshutils.StaticHostSigners(f.signer),
@@ -1625,7 +1628,9 @@ func TestProxyDirectAccess(t *testing.T) {
 	caWatcher := newCertAuthorityWatcher(ctx, t, proxyClient)
 
 	reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
-		ClientTLS:             proxyClient.TLSConfig(),
+		GetClientTLSCertificate: func() (*tls.Certificate, error) {
+			return &proxyClient.TLSConfig().Certificates[0], nil
+		},
 		ID:                    hostID,
 		ClusterName:           f.testSrv.ClusterName(),
 		Listener:              listener,
@@ -2338,7 +2343,9 @@ func TestParseSubsystemRequest(t *testing.T) {
 		caWatcher := newCertAuthorityWatcher(ctx, t, proxyClient)
 
 		reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
-			ClientTLS:             proxyClient.TLSConfig(),
+			GetClientTLSCertificate: func() (*tls.Certificate, error) {
+				return &proxyClient.TLSConfig().Certificates[0], nil
+			},
 			ID:                    hostID,
 			ClusterName:           f.testSrv.ClusterName(),
 			Listener:              listener,
@@ -2600,7 +2607,9 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 	caWatcher := newCertAuthorityWatcher(ctx, t, proxyClient)
 
 	reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
-		ClientTLS:             proxyClient.TLSConfig(),
+		GetClientTLSCertificate: func() (*tls.Certificate, error) {
+			return &proxyClient.TLSConfig().Certificates[0], nil
+		},
 		ID:                    hostID,
 		ClusterName:           f.testSrv.ClusterName(),
 		Listener:              listener,

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -21,6 +21,7 @@ package utils
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"net"
 	"time"
 
@@ -63,6 +64,63 @@ func CipherSuiteMapping(cipherSuites []string) ([]uint16, error) {
 
 	return out, nil
 }
+
+// VerifyConnectionWithRoots returns a [tls.Config.VerifyConnection] function
+// that uses the provided function to generate a [*x509.CertPool] that's used as
+// the source of root CAs for verification. Use of this function requires a
+// modicum of care: the [*tls.Config] using the returned callback should be
+// generated as close to its point of use as possible. An example use for this
+// would be something like:
+//
+//	c := utils.TLSConfig(cfg.cipherSuites)
+//	c.GetClientCertificate = func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+//		return cfg.getCert()
+//	}
+//	c.ServerName = apiutils.EncodeClusterName(cfg.clusterName)
+//	c.InsecureSkipVerify = true
+//	c.VerifyConnection = VerifyConnectionWithRoots(cfg.getRoots)
+//	httpTransport.TLSClientConfig = c
+//	clientConn := grpc.NewClient(target, grpc.WithTransportCredentials(credentials.NewTLS(c)))
+//
+// The necessity of using InsecureSkipVerify is the reason why this construction
+// is deliberately not packaged into a utility function, as the stakes must be
+// clear to whoever is interacting with the constructed [*tls.Config]. The
+// recommended approach is to push the getter functions as close to the point of
+// use as possible.
+func VerifyConnectionWithRoots(getRoots func() (*x509.CertPool, error)) func(cs tls.ConnectionState) error {
+	return func(cs tls.ConnectionState) error {
+		if cs.ServerName == "" {
+			return trace.BadParameter("TLS verification requires a server name")
+		}
+		roots, err := getRoots()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		opts := x509.VerifyOptions{
+			Roots:         roots,
+			Intermediates: nil,
+
+			DNSName: cs.ServerName,
+		}
+		if len(cs.PeerCertificates) > 1 {
+			opts.Intermediates = x509.NewCertPool()
+			for _, cert := range cs.PeerCertificates[1:] {
+				opts.Intermediates.AddCert(cert)
+			}
+		}
+		if _, err := cs.PeerCertificates[0].Verify(opts); err != nil {
+			return trace.Wrap(err)
+		}
+
+		return nil
+	}
+}
+
+type (
+	GetCertificateFunc = func() (*tls.Certificate, error)
+	GetRootsFunc       = func() (*x509.CertPool, error)
+)
 
 // TLSConn is a `net.Conn` that implements some of the functions defined by the
 // `tls.Conn` struct. This interface can be used where it could receive a

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -227,8 +227,8 @@ type Config struct {
 	ProxyWebAddr utils.NetAddr
 	// ProxyPublicAddr contains web proxy public addresses.
 	ProxyPublicAddrs []utils.NetAddr
-	// GetProxyClientTLSConfig returns the client TLS config of the proxy
-	GetProxyClientTLSConfig func(ciphersuites []uint16) (*tls.Config, error)
+	// GetProxyClientCertificate returns the proxy client certificate.
+	GetProxyClientCertificate func() (*tls.Certificate, error)
 	// CipherSuites is the list of cipher suites Teleport suppports.
 	CipherSuites []uint16
 
@@ -986,13 +986,16 @@ func (h *Handler) GetProxyClient() authclient.ClientI {
 	return h.cfg.ProxyClient
 }
 
-// GetProxyClientTLSConfig returns the client TLS config of the proxy
-func (h *Handler) GetProxyClientTLSConfig(ciphersuites []uint16) (*tls.Config, error) {
-	if h.cfg.GetProxyClientTLSConfig == nil {
-		return nil, trace.BadParameter("GetProxyClientTLSConfig function is not set")
+// GetProxyClientCertificate returns the proxy client certificate.
+func (h *Handler) GetProxyClientCertificate() (*tls.Certificate, error) {
+	if h.cfg.GetProxyClientCertificate == nil {
+		return nil, trace.BadParameter("GetProxyClientCertificate is not set")
 	}
-	tlsConfig, err := h.cfg.GetProxyClientTLSConfig(ciphersuites)
-	return tlsConfig, trace.Wrap(err)
+	tlsCert, err := h.cfg.GetProxyClientCertificate()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return tlsCert, nil
 }
 
 // GetAccessPoint returns the caching access point.


### PR DESCRIPTION
This PR converts `*service.Connector` to be a holder of process credentials that can be changed as Teleport is running. Doing so has required anything that makes use of process credentials (mostly servers and a handful of clients) to be checked and tweaked to support the use of dynamic credentials. This PR does not update the actual api clients that are used by the process, nor does it update the registration and credential reissue machinery to actually update the connector in memory - such a change should be restricted to the innards of `lib/service.TeleportProcess` and will be part of a later PR.

No significant updates were necessary for TLS servers, as they already make use of dynamic verification (due to the necessity of keeping up with leaf clusters that change at runtime), and there's a standard way to carry a dynamic getter for host credentials in `*tls.Config`. This PR didn't happen to touch any SSH clients, the SSH servers were already enabled for dynamic host key use in #41227 and, like TLS servers, already authenticated clients against CAs that can change at runtime.

TLS clients required a bit more finesse, as there's no builtin way for a `*tls.Config` to specify a dynamic root CA pool (see golang/go#64796). There's two bad options to use a dynamic root CA pool: one is to provide dialing functions that read or generate a TLS config object dynamically and manually create the TLS connection object on top of the plaintext one - which, unfortunately, is not possible with `http.Transport` when using a proxied (in the HTTP_PROXY sense) connection - and the other, which is what this PR does, is to disable the standard host certificate verification and reimplement it in a custom `VerifyConnection` function. As this requires quite a bit of care, this PR gets rid of any "client side" TLS config object passed around, replacing them with getters for the client certificate and trusted CA pool, and uses them to generate the `tls.Config` object as close as practical to the point where it's used.