### PR TITLE
[v16] event-handler chart updates

### DIFF
--- a/examples/chart/event-handler/templates/configmap.yaml
+++ b/examples/chart/event-handler/templates/configmap.yaml
@@ -14,8 +14,12 @@ data:
     {{- if .Values.eventHandler.types }}
     types = "{{ .Values.eventHandler.types }}"
     {{- end }}
-    skip-event-types = "{{ default "" .Values.eventHandler.skipEventTypes }}"
-    skip-session-types = "{{ default "" .Values.eventHandler.skipSessionTypes }}"
+    {{- if .Values.eventHandler.skipEventTypes }}
+    skip-event-types = "{{ .Values.eventHandler.skipEventTypes }}"
+    {{- end }}
+    {{- if .Values.eventHandler.skipSessionTypes  }}
+    skip-session-types = "{{ .Values.eventHandler.skipSessionTypes }}"
+    {{- end }}
 
     [teleport]
     addr = "{{ .Values.teleport.address }}"

--- a/examples/chart/event-handler/templates/configmap.yaml
+++ b/examples/chart/event-handler/templates/configmap.yaml
@@ -11,6 +11,11 @@ data:
     batch = {{ .Values.eventHandler.batch }}
     window-size = {{ default "24h" .Values.eventHandler.windowSize | quote }}
     debug = {{ default "false" .Values.eventHandler.debug }}
+    {{- if .Values.eventHandler.types }}
+    types = "{{ .Values.eventHandler.types }}"
+    {{- end }}
+    skip-event-types = "{{ default "" .Values.eventHandler.skipEventTypes }}"
+    skip-session-types = "{{ default "" .Values.eventHandler.skipSessionTypes }}"
 
     [teleport]
     addr = "{{ .Values.teleport.address }}"

--- a/examples/chart/event-handler/templates/configmap.yaml
+++ b/examples/chart/event-handler/templates/configmap.yaml
@@ -12,13 +12,13 @@ data:
     window-size = {{ default "24h" .Values.eventHandler.windowSize | quote }}
     debug = {{ default "false" .Values.eventHandler.debug }}
     {{- if .Values.eventHandler.types }}
-    types = "{{ .Values.eventHandler.types }}"
+    types = "{{ join "," .Values.eventHandler.types }}"
     {{- end }}
     {{- if .Values.eventHandler.skipEventTypes }}
-    skip-event-types = "{{ .Values.eventHandler.skipEventTypes }}"
+    skip-event-types = "{{ join "," .Values.eventHandler.skipEventTypes  }}"
     {{- end }}
     {{- if .Values.eventHandler.skipSessionTypes  }}
-    skip-session-types = "{{ .Values.eventHandler.skipSessionTypes }}"
+    skip-session-types = "{{ join "," .Values.eventHandler.skipSessionTypes }}"
     {{- end }}
 
     [teleport]

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -8,8 +8,6 @@ should match the snapshot:
         batch = 20
         window-size = "24h"
         debug = false
-        skip-event-types = ""
-        skip-session-types = ""
 
         [teleport]
         addr = "teleport.example.com:1234"

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -8,6 +8,8 @@ should match the snapshot:
         batch = 20
         window-size = "24h"
         debug = false
+        skip-event-types = ""
+        skip-session-types = ""
 
         [teleport]
         addr = "teleport.example.com:1234"

--- a/examples/chart/event-handler/values.schema.json
+++ b/examples/chart/event-handler/values.schema.json
@@ -373,26 +373,26 @@
                 },
                 "types": {
                     "$id": "#/properties/eventHandler/properties/types",
-                    "type": "string",
+                    "type": "array",
                     "default": "",
                     "examples": [
-                        "TYPE1,TYPE2"
+                        ["TYPE1,TYPE2"]
                     ]
                 },
                 "skipEventTypes": {
                     "$id": "#/properties/eventHandler/properties/skipEventTypes",
-                    "type": "string",
+                    "type": "array",
                     "default": "",
                     "examples": [
-                        "TYPE1,TYPE2"
+                        ["TYPE1"]
                     ]
                 },
                 "skipSessionTypes": {
                     "$id": "#/properties/eventHandler/properties/skipSessionTypes",
-                    "type": "string",
+                    "type": "array",
                     "default": "",
                     "examples": [
-                        "print"
+                        ["print"]
                     ]
                 }
             },

--- a/examples/chart/event-handler/values.schema.json
+++ b/examples/chart/event-handler/values.schema.json
@@ -370,6 +370,30 @@
                     "examples": [
                         false
                     ]
+                },
+                "types": {
+                    "$id": "#/properties/eventHandler/properties/types",
+                    "type": "string",
+                    "default": "",
+                    "examples": [
+                        "TYPE1,TYPE2"
+                    ]
+                },
+                "skipEventTypes": {
+                    "$id": "#/properties/eventHandler/properties/skipEventTypes",
+                    "type": "string",
+                    "default": "",
+                    "examples": [
+                        "TYPE1,TYPE2"
+                    ]
+                },
+                "skipSessionTypes": {
+                    "$id": "#/properties/eventHandler/properties/skipSessionTypes",
+                    "type": "string",
+                    "default": "",
+                    "examples": [
+                        "print"
+                    ]
                 }
             },
             "additionalProperties": true

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -21,7 +21,15 @@ eventHandler:
   # The window size should be specified as a duration string, parsed by Go's time.ParseDuration.
   windowSize: "24h"
   # Optional setting to enable debug logging
-  # debugLogger: true
+  # debug: true
+  # Optional setting for event types to forward
+  # types: "TYPE1"
+  # Optional setting for event types to skip
+  # skipEventTypes: "TYPE1"
+  # Optional setting for session types to skip
+  # skipSessionTypes: "TYPE1"
+
+  
 
 fluentd:
   url: ""

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -23,11 +23,11 @@ eventHandler:
   # Optional setting to enable debug logging
   # debug: true
   # Optional setting for event types to forward
-  # types: "TYPE1"
+  # types: ["TYPE1", "TYPE2"]
   # Optional setting for event types to skip
-  # skipEventTypes: "TYPE1"
+  # skipEventTypes: ["TYPE1"]
   # Optional setting for session types to skip
-  # skipSessionTypes: "TYPE1"
+  # skipSessionTypes: ["TYPE1"]
 
   
 


### PR DESCRIPTION
Backport #43590 to branch/v16

changelog: enables setting event types to forward, skip events, skip session types in event-handler helm chart
