### PR TITLE
add discovery tip partial in database guides

### DIFF
--- a/docs/pages/database-access/enroll-aws-databases.mdx
+++ b/docs/pages/database-access/enroll-aws-databases.mdx
@@ -7,8 +7,8 @@ The guides in this section show you how to protect AWS-managed databases with
 Teleport.
 
 You can configure Teleport to discover databases in your AWS account and enroll
-them with your cluster automatically. Read more about [Teleport auto-discovery
-for AWS databases](../auto-discovery/databases.mdx).
+them with your cluster automatically. Read more about setting up
+[Database Auto-Discovery](../auto-discovery/databases.mdx).
 
 It is also possible to protect databases across your AWS accounts. Read the
 instructions in [AWS Cross-Account Database

--- a/docs/pages/database-access/enroll-aws-databases/aws-opensearch.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/aws-opensearch.mdx
@@ -25,10 +25,7 @@ requests with AWS credentials, and forwards them to the OpenSearch API.
 
 </Tabs>
 
-This guide shows how to enroll databases through the Teleport Database Service.
-For a more scalable approach, learn how to [configure the Teleport Discovery
-Service](../../auto-discovery/databases.mdx) to automatically enroll all AWS
-databases in your infrastructure.
+(!docs/pages/includes/database-access/auto-discovery-tip.mdx dbType="OpenSearch database" providerType="AWS"!)
 
 ## Prerequisites
 

--- a/docs/pages/database-access/enroll-aws-databases/postgres-redshift.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/postgres-redshift.mdx
@@ -20,10 +20,7 @@ videoBanner: UFhT52d5bYg
 
 </Tabs>
 
-This guide shows how to enroll a single Amazon Redshift cluster through the
-Teleport Database Service. For a more scalable approach, learn how to [configure
-the Teleport Discovery Service](../../auto-discovery/databases.mdx) to
-automatically enroll all AWS databases in your infrastructure.
+(!docs/pages/includes/database-access/auto-discovery-tip.mdx dbType="Amazon Redshift cluster" providerType="AWS"!)
 
 ## Prerequisites
 

--- a/docs/pages/database-access/enroll-aws-databases/rds.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/rds.mdx
@@ -34,10 +34,7 @@ which supports IAM authentication.
 
 </Admonition>
 
-This guide shows how to enroll a single database through the Teleport Database
-Service. For a more scalable approach, learn how to [configure the Teleport
-Discovery Service](../../auto-discovery/databases.mdx) to automatically enroll
-all AWS databases in your infrastructure.
+(!docs/pages/includes/database-access/auto-discovery-tip.mdx dbType="RDS" providerType="AWS" !)
 
 ## Prerequisites
 

--- a/docs/pages/database-access/enroll-aws-databases/redis-aws.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/redis-aws.mdx
@@ -31,11 +31,7 @@ AWS-hosted Redis database can take one of two forms:
 
 </Tabs>
 
-This guide shows how to enroll a single AWS Elasticache or MemoryDB cluster
-through the Teleport Database Service. For a more scalable approach, learn how
-to [configure the Teleport Discovery
-Service](../../auto-discovery/databases.mdx) to automatically enroll all AWS
-databases in your infrastructure.
+(!docs/pages/includes/database-access/auto-discovery-tip.mdx dbType="Amazon Elasticache or MemoryDB cluster" providerType="AWS"!)
 
 ## Prerequisites
 

--- a/docs/pages/database-access/enroll-aws-databases/redshift-serverless.mdx
+++ b/docs/pages/database-access/enroll-aws-databases/redshift-serverless.mdx
@@ -24,11 +24,7 @@ This guide will help you to:
 
 </Tabs>
 
-This guide shows how to enroll a single Amazon Redshift Serverless database
-through the Teleport Database Service. For a more scalable approach, learn how
-to [configure the Teleport Discovery
-Service](../../auto-discovery/databases.mdx) to automatically enroll all AWS
-databases in your infrastructure.
+(!docs/pages/includes/database-access/auto-discovery-tip.mdx dbType="Amazon Redshift Serverless database" providerType="AWS"!)
 
 ## Prerequisites
 

--- a/docs/pages/database-access/guides/dynamic-registration.mdx
+++ b/docs/pages/database-access/guides/dynamic-registration.mdx
@@ -106,7 +106,7 @@ $ tctl rm db/example
 ```
 
 Aside from `tctl`, dynamic resources can also be added by:
-- [AWS Discovery](../../auto-discovery/databases.mdx)
+- [Database Auto-Discovery](../../auto-discovery/databases.mdx)
 - [Terraform Provider](../../management/dynamic-resources/terraform-provider.mdx)
 - [Kubernetes Operator](../../management/dynamic-resources/teleport-operator.mdx)
 - [Teleport API](../../api/introduction.mdx)

--- a/docs/pages/includes/database-access/auto-discovery-tip.mdx
+++ b/docs/pages/includes/database-access/auto-discovery-tip.mdx
@@ -1,4 +1,4 @@
 This guide shows how to register a single {{ dbType }} with your
-Teleport cluster. For a more scalable approach, learn how to setup
+Teleport cluster. For a more scalable approach, learn how to set up
 [Database Auto-Discovery](../../auto-discovery/databases.mdx) to
 automatically enroll all {{ provideType }} databases in your infrastructure.

--- a/docs/pages/includes/database-access/auto-discovery-tip.mdx
+++ b/docs/pages/includes/database-access/auto-discovery-tip.mdx
@@ -1,0 +1,4 @@
+This guide shows how to register a single {{ dbType }} with your
+Teleport cluster. For a more scalable approach, learn how to setup
+[Database Auto-Discovery](../../auto-discovery/databases.mdx) to
+automatically enroll all {{ provideType }} databases in your infrastructure.

--- a/docs/pages/includes/database-access/aws-auto-discovery-prerequisite.mdx
+++ b/docs/pages/includes/database-access/aws-auto-discovery-prerequisite.mdx
@@ -1,2 +1,2 @@
-A running Teleport Discovery Service if you plan to use [Database
-Auto-Discovery](./../../auto-discovery/databases.mdx).
+A running Teleport Discovery Service if you plan to use
+[Database Auto-Discovery](./../../auto-discovery/databases.mdx).

--- a/docs/pages/includes/database-access/rds-proxy.mdx
+++ b/docs/pages/includes/database-access/rds-proxy.mdx
@@ -19,10 +19,7 @@ Teleport currently supports RDS Proxy instances with engine family
 [Microsoft SQL Server](../../database-access/enroll-aws-databases/rds-proxy-sqlserver.mdx).
 </Admonition>
 
-This guide shows how to enroll a single RDS Proxy instance cluster through the
-Teleport Database Service. For a more scalable approach, learn how to [configure
-the Teleport Discovery Service](../../auto-discovery/databases.mdx) to
-automatically enroll all AWS databases in your infrastructure.
+(!docs/pages/includes/database-access/auto-discovery-tip.mdx dbType="RDS Proxy" providerType="AWS"!)
 
 ## Prerequisites
 

--- a/docs/pages/includes/discovery/discovery-config.yaml
+++ b/docs/pages/includes/discovery/discovery-config.yaml
@@ -12,6 +12,7 @@ discovery_service:
     # poll_interval is the cadence at which the discovery server will run each of its
     # discovery cycles. The default is 5m.
     poll_interval: 5m
+    # Matchers for discovering AWS-hosted resources.
     aws:
       # AWS resource types to discover and register with your Teleport cluster.
       # Valid options are:
@@ -27,8 +28,8 @@ discovery_service:
     - types: ["ec2"]
       # AWS regions to search for resources from
       regions: ["us-east-1","us-west-1"]
-      # AWS resource tags to match when registering resources
-      # Optional section: Defaults to "*":"*"
+      # Optional AWS resource tags to match when registering resources
+      # Defaults to a wildcard selector that matches any resource: "*":"*"
       tags:
         "*": "*"
       # Optional AWS role that the Discovery Service will assume to discover


### PR DESCRIPTION
This PR adds a partial to include in database guides that links to auto-discovery setup, aligns phrasing around this link in a few places, and includes a small comment update in the reference discovery config yaml.