### PR TITLE
build: Find feature headers outside system include dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,14 +258,14 @@ TEST_LOG_DIR = ${abspath ./test-logs}
 ifeq ("$(OS)","linux")
 # True if $ARCH == amd64 || $ARCH == arm64
 ifeq ("$(ARCH)","arm64")
-	ifeq ($(IS_NATIVE_BUILD),"no")
+	ifeq (,$(IS_NATIVE_BUILD))
 		CGOFLAG += CC=aarch64-linux-gnu-gcc
 	endif
 else ifeq ("$(ARCH)","arm")
 CGOFLAG = CGO_ENABLED=1
 
 # ARM builds need to specify the correct C compiler
-ifeq ($(IS_NATIVE_BUILD),"no")
+ifeq (,$(IS_NATIVE_BUILD))
 CC=arm-linux-gnueabihf-gcc
 endif
 
@@ -406,7 +406,7 @@ $(ER_BPF_BUILDDIR):
 
 # Build BPF code
 $(ER_BPF_BUILDDIR)/%.bpf.o: bpf/enhancedrecording/%.bpf.c $(wildcard bpf/*.h) | $(ER_BPF_BUILDDIR)
-	$(CLANG) -g -O2 -target bpf -D__TARGET_ARCH_$(KERNEL_ARCH) -I/usr/libbpf-${LIBBPF_VER}/include $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES) -c $(filter %.c,$^) -o $@
+	$(CLANG) -g -O2 -target bpf -D__TARGET_ARCH_$(KERNEL_ARCH) $(BPF_INCLUDES) $(CLANG_BPF_SYS_INCLUDES) -c $(filter %.c,$^) -o $@
 	$(LLVM_STRIP) -g $@ # strip useless DWARF info
 
 .PHONY: bpf-er-bytecode

--- a/Makefile
+++ b/Makefile
@@ -71,18 +71,16 @@ FIPS_MESSAGE := with-FIPS-support
 RELEASE = teleport-$(GITTAG)-$(OS)-$(ARCH)-fips-bin
 endif
 
-# PAM support will only be built into Teleport if headers exist at build time.
+# Look for the PAM header "security/pam_appl.h" to determine if we should
+# enable PAM support in teleport. A native build will have it in /usr/include.
+# Darwin has it in /usr/local/include (SIP prevents us from modifying/creating
+# it in /usr/include), and the ng buildbox has it in one of the
+# $(C_INCLUDE_PATH) paths.
+PAM_HEADER_CANDIDATES := $(subst :, ,$(C_INCLUDE_PATH)) /usr/local/include /usr/include
 PAM_MESSAGE := without-PAM-support
-ifneq ("$(wildcard /usr/include/security/pam_appl.h)","")
+ifneq (,$(wildcard $(addsuffix /security/pam_appl.h,$(PAM_HEADER_CANDIDATES))))
 PAM_TAG := pam
 PAM_MESSAGE := with-PAM-support
-else
-# PAM headers for Darwin live under /usr/local/include/security instead, as SIP
-# prevents us from modifying/creating /usr/include/security on newer versions of MacOS
-ifneq ("$(wildcard /usr/local/include/security/pam_appl.h)","")
-PAM_TAG := pam
-PAM_MESSAGE := with-PAM-support
-endif
 endif
 
 # darwin universal (Intel + Apple Silicon combined) binary support

--- a/common.mk
+++ b/common.mk
@@ -1,33 +1,81 @@
 # Common makefile shared between Teleport OSS and Ent.
 
+# -----------------------------------------------------------------------------
+# pkg-config / pkgconf
+# Set $(PKGCONF) to either pkgconf or pkg-config if either are installed
+# or /usr/bin/false if not. When it is set to "false", running $(PKGCONF)
+# will exit non-zero with no output.
+
+PKGCONF := $(firstword $(shell which pkgconf pkg-config false 2>/dev/null))
+
+# -----------------------------------------------------------------------------
+# libbpf detection
+#
+# Requirements for building with BPF support:
+# * clang and llvm-strip programs
+# * linux on amd64 or amd64
+# * libbpf 1.2.2 (either in /usr/libbpf-1.2.2 or pkg-config)
+#   * The centos7 buildbox puts this in /usr/libbpf-1.2.2
+#   * The ng buildbox has a pkg-config file for it
+#   * Native/local builds have a pkg-config file for it
+# * Either using a cross-compiling buildbox or is a native build
+#
+# The default is without BPF support unless all the critera are met.
+#
+# TODO(camh): Remove /usr/libbpf-1.2.2 when old buildboxes are replaced by ng
+
+with_bpf := no
+BPF_MESSAGE := without-BPF-support
+
+CLANG ?= $(shell which clang || which clang-12)
+LLVM_STRIP ?= $(shell which llvm-strip || which llvm-strip-12)
+
 # libbpf version required by the build.
 LIBBPF_VER := 1.2.2
+
+FOUND_LIBBPF :=
+
+ifneq (,$(wildcard /usr/libbpf-$(LIBBPF_VER)))
+FOUND_LIBBPF := true
+LIBBPF_INCLUDES := -I/usr/libbpf-$(LIBBPF_VER)/include
+LIBBPF_LIBS := -L/usr/libbpf-$(LIBBPF_VER)/lib64 -lbpf
+# libbpf needs libelf. Try to find it with pkg-config/pkgconf and fallback to
+# hard-coded defaults if pkg-config says nothing.
+LIBBPF_LIBS += $(or $(shell $(PKGCONF) --silence-errors --static --libs libelf),-lelf -lz)
+else
+ifneq (,$(shell $(PKGCONF) --exists 'libbpf = $(LIBBPF_VER)' && echo true))
+FOUND_LIBBPF := true
+LIBBPF_INCLUDES := $(shell $(PKGCONF) --cflags libbpf)
+LIBBPF_LIBS := $(shell $(PKGCONF) --libs --static libbpf)
+endif
+endif
 
 # Is this build targeting the same OS & architecture it is being compiled on, or
 # will it require cross-compilation? We need to know this (especially for ARM) so we
 # can set the cross-compiler path (and possibly feature flags) correctly.
-IS_NATIVE_BUILD ?= $(if $(filter $(ARCH), $(shell go env GOARCH)),"yes","no")
+IS_NATIVE_BUILD ?= $(filter $(ARCH),$(shell go env GOARCH))
+IS_CROSS_COMPILE_BB = $(filter $(BUILDBOX_MODE),cross)
 
-# BPF support will only be built into Teleport if headers exist at build time.
-BPF_MESSAGE := without-BPF-support
+# Only build with BPF if clang and llvm-strip are installed.
+ifneq (,$(and $(CLANG),$(LLVM_STRIP)))
 
-# We don't compile BPF for anything except linux/amd64 and linux/arm64 for now,
-# as other builds have compilation issues that require fixing.
-with_bpf := no
-ifeq ("$(OS)","linux")
-# True if $ARCH == amd64 || $ARCH == arm64
-ifneq (,$(filter "$(ARCH)","amd64" "arm64"))
-# We only support BPF in native builds
-ifeq ($(IS_NATIVE_BUILD),"yes")
-ifneq ("$(wildcard /usr/libbpf-${LIBBPF_VER}/include/bpf/bpf.h)","")
+# Only build with BPF for linux/amd64 and linux/arm64.
+# Other builds have compilation issues that require fixing.
+ifneq (,$(filter $(OS)/$(ARCH),linux/amd64 linux/arm64))
+
+# Only build with BPF if we found the right version installed
+ifneq (,$(FOUND_LIBBPF))
+
+# Only build with BPF if its a native build or in a cross-compiling buildbox.
+ifneq (,$(or $(IS_NATIVE_BUILD),$(IS_CROSS_COMPILE_BB)))
+
 with_bpf := yes
 BPF_TAG := bpf
 BPF_MESSAGE := with-BPF-support
-CLANG ?= $(shell which clang || which clang-12)
-LLVM_STRIP ?= $(shell which llvm-strip || which llvm-strip-12)
 KERNEL_ARCH := $(shell uname -m | sed 's/x86_64/x86/g; s/aarch64/arm64/g')
-INCLUDES :=
 ER_BPF_BUILDDIR := lib/bpf/bytecode
+BPF_INCLUDES := $(LIBBPF_INCLUDES)
+STATIC_LIBS += $(LIBBPF_LIBS)
 
 # Get Clang's default includes on this system. We'll explicitly add these dirs
 # to the includes list when compiling with `-target bpf` because otherwise some
@@ -40,33 +88,23 @@ ER_BPF_BUILDDIR := lib/bpf/bytecode
 CLANG_BPF_SYS_INCLUDES = $(shell $(CLANG) -v -E - </dev/null 2>&1 \
 	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
 
-# Include libbpf dependency. We don't use pkg-config here because we use specific version of libbpf
-# and we don't want to include the system libbpf.
-STATIC_LIBS += -L/usr/libbpf-${LIBBPF_VER}/lib64/ -lbpf
-
-# Check if pkgconf is installed
-PKGCONF := $(shell which pkgconf 2>/dev/null)
-ifeq ($(PKGCONF),)
-    PKGCONF := $(shell which pkg-config 2>/dev/null)
-endif
-
-# Check if libelf is available
-HAVE_LIBELF := $(shell $(PKGCONF) --exists libelf && echo 1 || echo 0)
-
-# If pkgconf and libelf are available, use them to get the static libraries
-# and all required dependencies for the Teleport build.
-# If not, use the default libraries (libelf, libz) and hope for the best.
-# This fallback used to work until Ubuntu 24.04 which compiles with libzstd by default.
-ifeq ($(HAVE_LIBELF),1)
-    STATIC_LIBS += $(shell $(PKGCONF) --static --libs libelf)
-else
-    STATIC_LIBS += -lelf -lz
-endif
-
-# Link static version of libraries required by Teleport (bpf, pcsc) to reduce system dependencies. Avoid dependencies on dynamic libraries if we already link the static version using --as-needed.
-CGOFLAG = CGO_ENABLED=1 CGO_CFLAGS="-I/usr/libbpf-${LIBBPF_VER}/include" CGO_LDFLAGS="-Wl,-Bstatic $(STATIC_LIBS) -Wl,-Bdynamic -Wl,--as-needed"
+# Link static version of libraries required by Teleport (bpf, pcsc) to reduce
+# system dependencies. Avoid dependencies on dynamic libraries if we already
+# link the static version using --as-needed.
+CGOFLAG = CGO_ENABLED=1 CGO_CFLAGS="$(BPF_INCLUDES)" CGO_LDFLAGS="-Wl,-Bstatic $(STATIC_LIBS) -Wl,-Bdynamic -Wl,--as-needed"
 CGOFLAG_TSH = CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-Bstatic $(STATIC_LIBS_TSH) -Wl,-Bdynamic -Wl,--as-needed"
-endif # bpf/bpf.h found
-endif # IS_NATIVE_BUILD == yes
-endif # ARCH == amd64 OR arm64
-endif # OS == linux
+
+endif # IS_NATIVE_BUILD || IS_CROSS_COMPILE_BB
+endif # libbpf found
+endif # OS/ARCH == linux/amd64 OR linux/arm64
+endif # clang and llvm-strip found
+
+.PHONY: diag-bpf-vars
+diag-bpf-vars:
+	@echo clang: $(CLANG)
+	@echo llvm-strip: $(LLVM_STRIP)
+	@echo os/arch: $(OS)-$(ARCH)
+	@echo found bpf: $(FOUND_LIBBPF)
+	@echo is-native: $(IS_NATIVE_BUILD)
+	@echo is-cross: $(IS_CROSS_COMPILE_BB)
+	@echo buildbox-mode: $(BUILDBOX_MODE)


### PR DESCRIPTION
Look for PAM and BPF header files that control including features in
teleport binaries more generally instead of assuming they are in the
system include headers or the one location in the buildbox (for libbpf
in `/usr/libbpf-1.2.2`).

This allows a cross-compiler to be used that sets the standard
environment variables `C_INCLUDE_PATH` and `LIBRARY_PATH` to point to
where additional headers and libraries live.

This cleans up the BPF detection in `common.mk` as it had some
head-scratching failure modes when clang or llvm-strip were not found.
The logic for enabling BPF is clearer now and safer.

Make `IS_NATIVE_BUILD` into a proper make variable - empty means false,
non-empty means true, and adjust the Makefile where it is used.
