### PR TITLE
Add implementation of VNet daemon

### DIFF
--- a/build.assets/macos/tshdev/README.md
+++ b/build.assets/macos/tshdev/README.md
@@ -81,6 +81,15 @@ through the steps here unless you are trying to recreate parts of the skeleton
     For example, click "build" and copy the app using "Product -> Show Build
     Folder in Finder".
 
+## FIDO2
+
+In order to have a signed binary with FIDO2 support, you need to statically link libfido2.
+
+```
+make build-fido2
+PKG_CONFIG_PATH=$(make print-fido2-pkg-path) FIDO2=static make build/tsh
+```
+
 ## Working with launch daemons
 
 tsh.app includes a launch daemon for VNet under `Contents/Library/LaunchDaemons`. tsh uses

--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -221,6 +221,11 @@ func bundlePath() (string, error) {
 }
 
 func startByCalling(ctx context.Context, bundlePath string, config Config) error {
+	// Before sending the config to another process, check that it's indeed valid.
+	if err := config.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err, "validating VNet config before sending it to daemon")
+	}
+
 	// C.StartVnet might hang if the daemon cannot be successfully spawned.
 	const daemonStartTimeout = 20 * time.Second
 	ctx, cancel := context.WithTimeoutCause(ctx, daemonStartTimeout,

--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+//go:build vnetdaemon
+// +build vnetdaemon
+
 package daemon
 
 // #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=10.15

--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -238,6 +238,7 @@ func startByCalling(ctx context.Context, bundlePath string, config Config) error
 				socket_path: C.CString(config.SocketPath),
 				ipv6_prefix: C.CString(config.IPv6Prefix),
 				dns_addr:    C.CString(config.DNSAddr),
+				home_path:   C.CString(config.HomePath),
 			},
 		}
 		defer func() {
@@ -245,6 +246,7 @@ func startByCalling(ctx context.Context, bundlePath string, config Config) error
 			C.free(unsafe.Pointer(req.vnet_config.socket_path))
 			C.free(unsafe.Pointer(req.vnet_config.ipv6_prefix))
 			C.free(unsafe.Pointer(req.vnet_config.dns_addr))
+			C.free(unsafe.Pointer(req.vnet_config.home_path))
 		}()
 		// Structs passed directly as arguments to cgo functions are automatically pinned.
 		// However, structs within structs have to be pinned by hand.

--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -229,7 +229,7 @@ func startByCalling(ctx context.Context, bundlePath string, config Config) error
 	// C.StartVnet might hang if the daemon cannot be successfully spawned.
 	const daemonStartTimeout = 20 * time.Second
 	ctx, cancel := context.WithTimeoutCause(ctx, daemonStartTimeout,
-		fmt.Errorf("could not connect to the VNet daemon within the timeout"))
+		errors.New("could not connect to the VNet daemon within the timeout"))
 	defer cancel()
 
 	defer C.InvalidateDaemonClient()

--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -221,11 +221,6 @@ func bundlePath() (string, error) {
 }
 
 func startByCalling(ctx context.Context, bundlePath string, config Config) error {
-	// Before sending the config to another process, check that it's indeed valid.
-	if err := config.CheckAndSetDefaults(); err != nil {
-		return trace.Wrap(err, "validating VNet config before sending it to daemon")
-	}
-
 	// C.StartVnet might hang if the daemon cannot be successfully spawned.
 	const daemonStartTimeout = 20 * time.Second
 	ctx, cancel := context.WithTimeoutCause(ctx, daemonStartTimeout,

--- a/lib/vnet/daemon/client_darwin.h
+++ b/lib/vnet/daemon/client_darwin.h
@@ -1,6 +1,7 @@
 #ifndef TELEPORT_LIB_VNET_DAEMON_CLIENT_DARWIN_H_
 #define TELEPORT_LIB_VNET_DAEMON_CLIENT_DARWIN_H_
 
+#include "common_darwin.h"
 #include "protocol_darwin.h"
 
 #import <Foundation/Foundation.h>

--- a/lib/vnet/daemon/client_darwin.h
+++ b/lib/vnet/daemon/client_darwin.h
@@ -38,7 +38,7 @@ void OpenSystemSettingsLoginItems(void);
 
 typedef struct StartVnetRequest {
   const char *bundle_path;
-  VnetParams *vnet_params;
+  VnetConfig *vnet_config;
 } StartVnetRequest;
 
 typedef struct StartVnetResult {
@@ -49,7 +49,7 @@ typedef struct StartVnetResult {
 
 // StartVnet spawns the daemon process. Only the first call does that,
 // subsequent calls are noops. The daemon process exits after the socket file
-// in request.vnet_params.socket_path is removed. After that it can be spawned
+// in request.vnet_config.socket_path is removed. After that it can be spawned
 // again by calling StartVnet.
 //
 // Blocks until the daemon receives the message or until the client gets
@@ -65,7 +65,7 @@ void StartVnet(StartVnetRequest *request, StartVnetResult *outResult);
 void InvalidateDaemonClient(void);
 
 @interface VNEDaemonClient : NSObject
-- (void)startVnet:(VnetParams *)vnetParams completion:(void (^)(NSError *error))completion;
+- (void)startVnet:(VnetConfig *)vnetConfig completion:(void (^)(NSError *error))completion;
 // invalidate executes all outstanding reply blocks, error handling blocks,
 // and invalidation blocks and forbids from sending or receiving new messages.
 - (void)invalidate;

--- a/lib/vnet/daemon/client_darwin.m
+++ b/lib/vnet/daemon/client_darwin.m
@@ -132,7 +132,7 @@ void OpenSystemSettingsLoginItems(void) {
   return _connection;
 }
 
-- (void)startVnet:(VnetParams *)vnetParams completion:(void (^)(NSError *))completion {
+- (void)startVnet:(VnetConfig *)vnetConfig completion:(void (^)(NSError *))completion {
   // This way of calling the XPC proxy ensures either the error handler or
   // the reply block gets called.
   // https://forums.developer.apple.com/forums/thread/713429
@@ -140,7 +140,7 @@ void OpenSystemSettingsLoginItems(void) {
     completion(error);
   }];
 
-  [(id<VNEDaemonProtocol>)proxy startVnet:vnetParams
+  [(id<VNEDaemonProtocol>)proxy startVnet:vnetConfig
                                completion:^(void) {
                                  completion(nil);
                                }];
@@ -163,7 +163,7 @@ void StartVnet(StartVnetRequest *request, StartVnetResult *outResult) {
 
   dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
-  [daemonClient startVnet:request->vnet_params
+  [daemonClient startVnet:request->vnet_config
                completion:^(NSError *error) {
                  if (error) {
                    outResult->error_domain = VNECopyNSString([error domain]);

--- a/lib/vnet/daemon/client_darwin.m
+++ b/lib/vnet/daemon/client_darwin.m
@@ -23,6 +23,7 @@
 
 #import <Foundation/Foundation.h>
 #import <ServiceManagement/ServiceManagement.h>
+#include <dispatch/dispatch.h>
 
 #include <string.h>
 

--- a/lib/vnet/daemon/client_darwin.m
+++ b/lib/vnet/daemon/client_darwin.m
@@ -1,3 +1,6 @@
+//go:build vnetdaemon
+// +build vnetdaemon
+
 // Teleport
 // Copyright (C) 2024 Gravitational, Inc.
 //
@@ -15,41 +18,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "client_darwin.h"
+#include "common_darwin.h"
+#include "protocol_darwin.h"
 
 #import <Foundation/Foundation.h>
 #import <ServiceManagement/ServiceManagement.h>
 
 #include <string.h>
-
-// VNECopyNSString duplicates an NSString into an UTF-8 encoded C string.
-// The caller is expected to free the returned pointer.
-const char *VNECopyNSString(NSString *val) {
-  if (val) {
-    return strdup([val UTF8String]);
-  }
-  return strdup("");
-}
-
-// Returns the label for the daemon by getting the identifier of the bundle
-// this executable is shipped in and appending ".vnetd" to it.
-//
-// The returned string might be empty if the executable is not in a bundle.
-//
-// The filename and the value of the Label key in the plist file and the Mach
-// service of of the daemon must match the string returned from this function.
-NSString *DaemonLabel(NSString *bundlePath) {
-  NSBundle *main = [NSBundle bundleWithPath:bundlePath];
-  if (!main) {
-    return @"";
-  }
-
-  NSString *bundleIdentifier = [main bundleIdentifier];
-  if (!bundleIdentifier || [bundleIdentifier length] == 0) {
-    return @"";
-  }
-
-  return [NSString stringWithFormat:@"%@.vnetd", bundleIdentifier];
-}
 
 // DaemonPlist takes the result of DaemonLabel and appends ".plist" to it
 // if not empty.

--- a/lib/vnet/daemon/common.go
+++ b/lib/vnet/daemon/common.go
@@ -35,21 +35,15 @@ type Config struct {
 }
 
 func (c *Config) CheckAndSetDefaults() error {
-	if c.SocketPath == "" {
+	switch {
+	case c.SocketPath == "":
 		return trace.BadParameter("missing socket path")
-	}
-
-	if c.IPv6Prefix == "" {
+	case c.IPv6Prefix == "":
 		return trace.BadParameter("missing IPv6 prefix")
-	}
-
-	if c.DNSAddr == "" {
+	case c.DNSAddr == "":
 		return trace.BadParameter("missing DNS address")
-	}
-
-	if c.HomePath == "" {
+	case c.HomePath == "":
 		return trace.BadParameter("missing home path")
 	}
-
 	return nil
 }

--- a/lib/vnet/daemon/common.go
+++ b/lib/vnet/daemon/common.go
@@ -29,7 +29,9 @@ type Config struct {
 	// IPv6Prefix is the IPv6 prefix for the VNet.
 	IPv6Prefix string
 	// DNSAddr is the IP address for the VNet DNS server.
-	DNSAddr    string
+	DNSAddr string
+	// HomePath points to TELEPORT_HOME that will be used by the admin process.
+	HomePath string
 }
 
 func (c *Config) CheckAndSetDefaults() error {
@@ -43,6 +45,10 @@ func (c *Config) CheckAndSetDefaults() error {
 
 	if c.DNSAddr == "" {
 		return trace.BadParameter("missing DNS address")
+	}
+
+	if c.HomePath == "" {
+		return trace.BadParameter("missing home path")
 	}
 
 	return nil

--- a/lib/vnet/daemon/common.go
+++ b/lib/vnet/daemon/common.go
@@ -1,0 +1,49 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package daemon
+
+import (
+	"github.com/gravitational/trace"
+)
+
+// Config contains fields necessary to start a daemon process for VNet running as root.
+// Changes to this string must be reflected in protocol.h and service.h.
+type Config struct {
+	// SocketPath is a path to a unix socket used for passing a TUN device from the admin process to
+	// the unprivileged process.
+	SocketPath string
+	// IPv6Prefix is the IPv6 prefix for the VNet.
+	IPv6Prefix string
+	// DNSAddr is the IP address for the VNet DNS server.
+	DNSAddr    string
+}
+
+func (c *Config) CheckAndSetDefaults() error {
+	if c.SocketPath == "" {
+		return trace.BadParameter("missing socket path")
+	}
+
+	if c.IPv6Prefix == "" {
+		return trace.BadParameter("missing IPv6 prefix")
+	}
+
+	if c.DNSAddr == "" {
+		return trace.BadParameter("missing DNS address")
+	}
+
+	return nil
+}

--- a/lib/vnet/daemon/common_darwin.h
+++ b/lib/vnet/daemon/common_darwin.h
@@ -1,0 +1,19 @@
+#ifndef TELEPORT_LIB_VNET_DAEMON_COMMON_DARWIN_H_
+#define TELEPORT_LIB_VNET_DAEMON_COMMON_DARWIN_H_
+
+#import <Foundation/Foundation.h>
+
+// Returns the label for the daemon by getting the identifier of the bundle
+// this executable is shipped in and appending ".vnetd" to it.
+//
+// The returned string might be empty if the executable is not in a bundle.
+//
+// The filename and the value of the Label key in the plist file and the Mach
+// service of of the daemon must match the string returned from this function.
+NSString *DaemonLabel(NSString *bundlePath);
+
+// VNECopyNSString duplicates an NSString into an UTF-8 encoded C string.
+// The caller is expected to free the returned pointer.
+const char *VNECopyNSString(NSString *val);
+
+#endif /* TELEPORT_LIB_VNET_DAEMON_COMMON_DARWIN_H_ */

--- a/lib/vnet/daemon/common_darwin.m
+++ b/lib/vnet/daemon/common_darwin.m
@@ -1,3 +1,6 @@
+//go:build vnetdaemon
+// +build vnetdaemon
+
 // Teleport
 // Copyright (C) 2024 Gravitational, Inc.
 //
@@ -14,29 +17,27 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build vnetdaemon
-// +build vnetdaemon
+#import <Foundation/Foundation.h>
 
-package vnet
+#include <string.h>
 
-import (
-	"context"
-	"os"
+NSString *DaemonLabel(NSString *bundlePath) {
+  NSBundle *main = [NSBundle bundleWithPath:bundlePath];
+  if (!main) {
+    return @"";
+  }
 
-	"github.com/gravitational/trace"
+  NSString *bundleIdentifier = [main bundleIdentifier];
+  if (!bundleIdentifier || [bundleIdentifier length] == 0) {
+    return @"";
+  }
 
-	"github.com/gravitational/teleport/lib/vnet/daemon"
-)
-
-func execAdminProcess(ctx context.Context, config daemon.Config) error {
-	// TODO(ravicious): Remove the feature env var after the daemon gets implemented.
-	if os.Getenv("VNETDAEMON") == "yes" {
-		return trace.Wrap(daemon.RegisterAndCall(ctx, config))
-	}
-
-	return trace.Wrap(execAdminSubcommand(ctx, config))
+  return [NSString stringWithFormat:@"%@.vnetd", bundleIdentifier];
 }
 
-func DaemonSubcommand(ctx context.Context) error {
-	return trace.Wrap(daemon.Start(ctx, AdminSetup))
+const char *VNECopyNSString(NSString *val) {
+  if (val) {
+    return strdup([val UTF8String]);
+  }
+  return strdup("");
 }

--- a/lib/vnet/daemon/protocol_darwin.h
+++ b/lib/vnet/daemon/protocol_darwin.h
@@ -1,8 +1,6 @@
 #ifndef TELEPORT_LIB_VNET_DAEMON_PROTOCOL_DARWIN_H_
 #define TELEPORT_LIB_VNET_DAEMON_PROTOCOL_DARWIN_H_
 
-#import <Foundation/Foundation.h>
-
 typedef struct VnetConfig {
   const char *socket_path;
   const char *ipv6_prefix;

--- a/lib/vnet/daemon/protocol_darwin.h
+++ b/lib/vnet/daemon/protocol_darwin.h
@@ -1,0 +1,20 @@
+#ifndef TELEPORT_LIB_VNET_DAEMON_PROTOCOL_DARWIN_H_
+#define TELEPORT_LIB_VNET_DAEMON_PROTOCOL_DARWIN_H_
+
+#import <Foundation/Foundation.h>
+
+typedef struct VnetParams {
+  const char *socket_path;
+  const char *ipv6_prefix;
+  const char *dns_addr;
+} VnetParams;
+
+@protocol VNEDaemonProtocol
+// startVnet starts VNet in a separate thread and returns immediately.
+// Only the first call to this method starts VNet. Subsequent calls are noops.
+// The daemon process exits after VNet is stopped, after which it can be
+// spawned again by calling this method.
+- (void)startVnet:(VnetParams *)vnetParams completion:(void (^)(void))completion;
+@end
+
+#endif /* TELEPORT_LIB_VNET_DAEMON_PROTOCOL_DARWIN_H_ */

--- a/lib/vnet/daemon/protocol_darwin.h
+++ b/lib/vnet/daemon/protocol_darwin.h
@@ -7,6 +7,7 @@ typedef struct VnetConfig {
   const char *socket_path;
   const char *ipv6_prefix;
   const char *dns_addr;
+  const char *home_path;
 } VnetConfig;
 
 @protocol VNEDaemonProtocol

--- a/lib/vnet/daemon/protocol_darwin.h
+++ b/lib/vnet/daemon/protocol_darwin.h
@@ -3,18 +3,18 @@
 
 #import <Foundation/Foundation.h>
 
-typedef struct VnetParams {
+typedef struct VnetConfig {
   const char *socket_path;
   const char *ipv6_prefix;
   const char *dns_addr;
-} VnetParams;
+} VnetConfig;
 
 @protocol VNEDaemonProtocol
 // startVnet starts VNet in a separate thread and returns immediately.
 // Only the first call to this method starts VNet. Subsequent calls are noops.
 // The daemon process exits after VNet is stopped, after which it can be
 // spawned again by calling this method.
-- (void)startVnet:(VnetParams *)vnetParams completion:(void (^)(void))completion;
+- (void)startVnet:(VnetConfig *)vnetConfig completion:(void (^)(void))completion;
 @end
 
 #endif /* TELEPORT_LIB_VNET_DAEMON_PROTOCOL_DARWIN_H_ */

--- a/lib/vnet/daemon/service_darwin.go
+++ b/lib/vnet/daemon/service_darwin.go
@@ -26,7 +26,7 @@ import "C"
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 	"unsafe"
 
@@ -68,7 +68,7 @@ func Start(ctx context.Context, workFn func(context.Context, Config) error) erro
 func waitForVnetConfig(ctx context.Context) (Config, error) {
 	const waitForVnetConfigTimeout = 20 * time.Second
 	ctx, cancel := context.WithTimeoutCause(ctx, waitForVnetConfigTimeout,
-		fmt.Errorf("did not receive the VNet config within the timeout"))
+		errors.New("did not receive the VNet config within the timeout"))
 	defer cancel()
 
 	var config Config
@@ -87,7 +87,7 @@ func waitForVnetConfig(ctx context.Context) (Config, error) {
 		// This call gets unblocked when the daemon gets stopped through C.DaemonStop.
 		C.WaitForVnetConfig(&result)
 		if !result.ok {
-			errC <- trace.Errorf(C.GoString(result.error_description))
+			errC <- trace.Wrap(errors.New(C.GoString(result.error_description)))
 			return
 		}
 

--- a/lib/vnet/daemon/service_darwin.go
+++ b/lib/vnet/daemon/service_darwin.go
@@ -21,6 +21,7 @@ package daemon
 
 // #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=10.15
 // #cgo LDFLAGS: -framework Foundation
+// #include <stdlib.h>
 // #include "service_darwin.h"
 import "C"
 
@@ -33,6 +34,8 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// Start starts an XPC listener and waits for it to receive a message with VNet config.
+// Once the message is received, it executes [workFn] with that config.
 func Start(ctx context.Context, workFn func(context.Context, Config) error) error {
 	bundlePath, err := bundlePath()
 	if err != nil {

--- a/lib/vnet/daemon/service_darwin.go
+++ b/lib/vnet/daemon/service_darwin.go
@@ -97,7 +97,7 @@ func waitForVnetConfig(ctx context.Context) (Config, error) {
 			DNSAddr:    C.GoString(result.dns_addr),
 			HomePath:   C.GoString(result.home_path),
 		}
-		errC <- trace.Wrap(config.CheckAndSetDefaults())
+		errC <- nil
 	}()
 
 	select {

--- a/lib/vnet/daemon/service_darwin.h
+++ b/lib/vnet/daemon/service_darwin.h
@@ -20,6 +20,7 @@
 @end
 
 // DaemonStart initializes the XPC service and starts listening for new connections.
+// It's expected to be called only once, noop if the daemon was already started.
 void DaemonStart(const char *bundle_path);
 // DaemonStop stops the XPC service. Noop if DaemonStart wasn't called.
 void DaemonStop(void);

--- a/lib/vnet/daemon/service_darwin.h
+++ b/lib/vnet/daemon/service_darwin.h
@@ -1,0 +1,43 @@
+#ifndef TELEPORT_LIB_VNET_DAEMON_SERVICE_DARWIN_H_
+#define TELEPORT_LIB_VNET_DAEMON_SERVICE_DARWIN_H_
+
+#import <Foundation/Foundation.h>
+
+@interface VNEDaemonService : NSObject
+
+- (id)initWithBundlePath:(NSString *)bundlePath;
+
+// start begins listening for incoming XPC connections.
+- (void)start;
+
+// stop stops listening for incoming XPC connections.
+- (void)stop;
+
+// waitForVnetConfig blocks until either startVnet signals that a VNet config was received
+// or until stop signals that the daemon has stopped listening for incoming connections.
+- (void)waitForVnetConfig;
+
+@end
+
+// DaemonStart initializes the XPC service and starts listening for new connections.
+void DaemonStart(const char *bundle_path);
+// DaemonStop stops the XPC service. Noop if DaemonStart wasn't called.
+void DaemonStop(void);
+
+typedef struct VnetConfigResult {
+  bool ok;
+  const char *error_description;
+  const char *socket_path;
+  const char *ipv6_prefix;
+  const char *dns_addr;
+  const char *home_path;
+} VnetConfigResult;
+
+// WaitForVnetConfig blocks until a client calls the daemon with a config necessary to start VNet.
+// It can be interrupted by calling DaemonStop.
+//
+// The caller is expected to check outResult.ok to see if the call succeeded and to free strings
+// in VnetConfigResult.
+void WaitForVnetConfig(VnetConfigResult *outResult);
+
+#endif /* TELEPORT_LIB_VNET_DAEMON_SERVICE_DARWIN_H_ */

--- a/lib/vnet/daemon/service_darwin.m
+++ b/lib/vnet/daemon/service_darwin.m
@@ -1,0 +1,143 @@
+//go:build vnetdaemon
+// +build vnetdaemon
+
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "common_darwin.h"
+#include "protocol_darwin.h"
+#include "service_darwin.h"
+
+#import <Foundation/Foundation.h>
+
+#include <string.h>
+
+@interface VNEDaemonService () <NSXPCListenerDelegate, VNEDaemonProtocol>
+
+@property(nonatomic, strong, readwrite) NSXPCListener *listener;
+@property(nonatomic, readwrite) BOOL started;
+
+@property(nonatomic, readwrite) NSString *socketPath;
+@property(nonatomic, readwrite) NSString *ipv6Prefix;
+@property(nonatomic, readwrite) NSString *dnsAddr;
+@property(nonatomic, readwrite) NSString *homePath;
+@property(nonatomic, readwrite) dispatch_semaphore_t gotVnetConfigSema;
+
+@end
+
+@implementation VNEDaemonService
+
+- (id)initWithBundlePath:(NSString *)bundlePath {
+  self = [super init];
+  if (self) {
+    // Launch daemons must configure their listener with the machServiceName
+    // initializer.
+    _listener = [[NSXPCListener alloc] initWithMachServiceName:DaemonLabel(bundlePath)];
+    _listener.delegate = self;
+
+    _started = NO;
+    _gotVnetConfigSema = dispatch_semaphore_create(0);
+  }
+  return self;
+}
+
+- (void)start {
+  assert(_started == NO);
+
+  // Begin listening for incoming XPC connections.
+  [_listener resume];
+
+  _started = YES;
+}
+
+- (void)stop {
+  assert(_started == YES);
+
+  // Stop listening for incoming XPC connections.
+  [_listener suspend];
+
+  _started = NO;
+  dispatch_semaphore_signal(_gotVnetConfigSema);
+}
+
+- (void)waitForVnetConfig {
+  assert(_started == YES);
+  dispatch_semaphore_wait(_gotVnetConfigSema, DISPATCH_TIME_FOREVER);
+}
+
+#pragma mark - VNEDaemonProtocol
+
+- (void)startVnet:(VnetConfig *)vnetConfig completion:(void (^)(void))completion {
+  _socketPath = @(vnetConfig->socket_path);
+  _ipv6Prefix = @(vnetConfig->ipv6_prefix);
+  _dnsAddr = @(vnetConfig->dns_addr);
+  _homePath = @(vnetConfig->home_path);
+  dispatch_semaphore_signal(_gotVnetConfigSema);
+  completion();
+}
+
+#pragma mark - NSXPCListenerDelegate
+
+- (BOOL)listener:(NSXPCListener *)listener
+    shouldAcceptNewConnection:(NSXPCConnection *)newConnection {
+  assert(listener == _listener);
+  assert(newConnection != nil);
+
+  // Configure the incoming connection.
+  newConnection.exportedInterface =
+      [NSXPCInterface interfaceWithProtocol:@protocol(VNEDaemonProtocol)];
+  newConnection.exportedObject = self;
+
+  // New connections always start in a suspended state.
+  [newConnection resume];
+
+  return YES;
+}
+
+@end
+
+static VNEDaemonService *daemonService = NULL;
+
+void DaemonStart(const char *bundle_path) {
+  daemonService = [[VNEDaemonService alloc] initWithBundlePath:@(bundle_path)];
+  [daemonService start];
+}
+
+void DaemonStop(void) {
+  if (daemonService && [daemonService started]) {
+    [daemonService stop];
+  }
+}
+
+void WaitForVnetConfig(VnetConfigResult *outResult) {
+  if (!daemonService) {
+    outResult->error_description = strdup("daemon was not initialized yet");
+    return;
+  }
+
+  [daemonService waitForVnetConfig];
+
+  if (![daemonService started]) {
+    outResult->error_description = strdup("daemon was stopped while waiting for VNet config");
+    return;
+  }
+
+  outResult->socket_path = VNECopyNSString([daemonService socketPath]);
+  outResult->ipv6_prefix = VNECopyNSString([daemonService ipv6Prefix]);
+  outResult->dns_addr = VNECopyNSString([daemonService dnsAddr]);
+  outResult->home_path = VNECopyNSString([daemonService homePath]);
+  outResult->ok = true;
+}

--- a/lib/vnet/daemon/service_darwin.m
+++ b/lib/vnet/daemon/service_darwin.m
@@ -22,7 +22,9 @@
 #include "service_darwin.h"
 
 #import <Foundation/Foundation.h>
+#include <dispatch/dispatch.h>
 
+#include <assert.h>
 #include <string.h>
 
 @interface VNEDaemonService () <NSXPCListenerDelegate, VNEDaemonProtocol>

--- a/lib/vnet/daemon/service_darwin.m
+++ b/lib/vnet/daemon/service_darwin.m
@@ -116,6 +116,9 @@
 static VNEDaemonService *daemonService = NULL;
 
 void DaemonStart(const char *bundle_path) {
+  if (daemonService) {
+    return;
+  }
   daemonService = [[VNEDaemonService alloc] initWithBundlePath:@(bundle_path)];
   [daemonService start];
 }

--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -20,13 +20,11 @@ import (
 	"context"
 	"log/slog"
 	"net"
-	"os"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/api/profile"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/client"
 )
@@ -50,11 +48,10 @@ type osConfigurator struct {
 	tunIPv4            string
 }
 
-func newOSConfigurator(tunName, ipv6Prefix, dnsAddr string) (*osConfigurator, error) {
-	homePath := os.Getenv(types.HomeEnvVar)
+func newOSConfigurator(tunName, ipv6Prefix, dnsAddr, homePath string) (*osConfigurator, error) {
 	if homePath == "" {
 		// This runs as root so we need to be configured with the user's home path.
-		return nil, trace.BadParameter("%s must be set", types.HomeEnvVar)
+		return nil, trace.BadParameter("homePath must be passed from unprivileged process")
 	}
 
 	// ipv6Prefix always looks like "fdxx:xxxx:xxxx::"

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -205,7 +205,7 @@ func (pm *ProcessManager) Close() {
 	pm.cancel()
 }
 
-// AdminSetup is supposed to be ran as root. It creates and setups a TUN device and passses the file
+// AdminSetup must run as root. It creates and setups a TUN device and passes the file
 // descriptor for that device over the unix socket found at config.socketPath.
 //
 // It also handles host OS configuration that must run as root, and stays alive to keep the host configuration

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -82,9 +82,6 @@ func SetupAndRun(ctx context.Context, config *SetupAndRunConfig) (*ProcessManage
 			DNSAddr:    dnsIPv6.String(),
 			HomePath:   config.HomePath,
 		}
-		if err := daemonConfig.CheckAndSetDefaults(); err != nil {
-			return trace.Wrap(err)
-		}
 		return trace.Wrap(execAdminProcess(processCtx, daemonConfig))
 	})
 
@@ -215,6 +212,10 @@ func (pm *ProcessManager) Close() {
 // up to date. It will stay running until the socket at config.socketPath is deleted or until encountering an
 // unrecoverable error.
 func AdminSetup(ctx context.Context, config daemon.Config) error {
+	if err := config.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/lib/vnet/setup_daemon_darwin.go
+++ b/lib/vnet/setup_daemon_darwin.go
@@ -28,11 +28,11 @@ import (
 	"github.com/gravitational/teleport/lib/vnet/daemon"
 )
 
-func execAdminProcess(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
+func execAdminProcess(ctx context.Context, config daemon.Config) error {
 	// TODO(ravicious): Remove the feature env var after the daemon gets implemented.
 	if os.Getenv("VNETDAEMON") == "yes" {
-		return trace.Wrap(daemon.RegisterAndCall(ctx, socketPath, ipv6Prefix, dnsAddr))
+		return trace.Wrap(daemon.RegisterAndCall(ctx, config))
 	}
 
-	return trace.Wrap(execAdminSubcommand(ctx, socketPath, ipv6Prefix, dnsAddr))
+	return trace.Wrap(execAdminSubcommand(ctx, config))
 }

--- a/lib/vnet/setup_darwin.go
+++ b/lib/vnet/setup_darwin.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/vnet/daemon"
 )
 
 // receiveTUNDevice is a blocking call which waits for the admin process to pass over the socket
@@ -52,7 +53,7 @@ func receiveTUNDevice(socket *net.UnixListener) (tun.Device, error) {
 
 // execAdminSubcommand starts an osascript wrapper that starts tsh vnet-daemon as root.
 // Used in execAdminProcess when vnetdaemon tag is not supplied.
-func execAdminSubcommand(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
+func execAdminSubcommand(ctx context.Context, config daemon.Config) error {
 	executableName, err := os.Executable()
 	if err != nil {
 		return trace.Wrap(err, "getting executable path")
@@ -74,7 +75,7 @@ do shell script quoted form of executableName & `+
 		`" --dns-addr " & quoted form of dnsAddr & `+
 		`" >/var/log/vnet.log 2>&1" `+
 		`with prompt "Teleport VNet wants to set up a virtual network device." with administrator privileges`,
-		executableName, socketPath, ipv6Prefix, dnsAddr, teleport.VnetAdminSetupSubCommand)
+		executableName, config.SocketPath, config.IPv6Prefix, config.DNSAddr, teleport.VnetAdminSetupSubCommand)
 
 	// The context we pass here has effect only on the password prompt being shown. Once osascript spawns the
 	// privileged process, canceling the context (and thus killing osascript) has no effect on the privileged

--- a/lib/vnet/setup_darwin.go
+++ b/lib/vnet/setup_darwin.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
-// receiveTUNDevice is a blocking call which waits for the admin subcommand to pass over the socket
+// receiveTUNDevice is a blocking call which waits for the admin process to pass over the socket
 // the name and fd of the TUN device.
 func receiveTUNDevice(socket *net.UnixListener) (tun.Device, error) {
 	tunName, tunFd, err := recvTUNNameAndFd(socket)

--- a/lib/vnet/setup_darwin.go
+++ b/lib/vnet/setup_darwin.go
@@ -34,7 +34,6 @@ import (
 	"golang.zx2c4.com/wireguard/tun"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/vnet/daemon"
 )
@@ -61,7 +60,7 @@ func execAdminSubcommand(ctx context.Context, config daemon.Config) error {
 
 	if homePath := os.Getenv(types.HomeEnvVar); homePath == "" {
 		// Explicitly set TELEPORT_HOME if not already set.
-		os.Setenv(types.HomeEnvVar, profile.FullProfilePath(""))
+		os.Setenv(types.HomeEnvVar, config.HomePath)
 	}
 
 	appleScript := fmt.Sprintf(`

--- a/lib/vnet/setup_nodaemon_darwin.go
+++ b/lib/vnet/setup_nodaemon_darwin.go
@@ -30,3 +30,7 @@ import (
 func execAdminProcess(ctx context.Context, config daemon.Config) error {
 	return trace.Wrap(execAdminSubcommand(ctx, config))
 }
+
+func DaemonSubcommand(ctx context.Context) error {
+	return trace.NotImplemented("tsh was built without support for VNet daemon")
+}

--- a/lib/vnet/setup_nodaemon_darwin.go
+++ b/lib/vnet/setup_nodaemon_darwin.go
@@ -23,8 +23,10 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/vnet/daemon"
 )
 
-func execAdminProcess(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
-	return trace.Wrap(execAdminSubcommand(ctx, socketPath, ipv6Prefix, dnsAddr))
+func execAdminProcess(ctx context.Context, config daemon.Config) error {
+	return trace.Wrap(execAdminSubcommand(ctx, config))
 }

--- a/lib/vnet/setup_other.go
+++ b/lib/vnet/setup_other.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"golang.zx2c4.com/wireguard/tun"
+
+	"github.com/gravitational/teleport/lib/vnet/daemon"
 )
 
 var (
@@ -50,6 +52,6 @@ func configureOS(ctx context.Context, cfg *osConfig) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }
 
-func execAdminProcess(ctx context.Context, socketPath, ipv6Prefix, dnsAddr string) error {
+func execAdminProcess(ctx context.Context, config daemon.Config) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }

--- a/lib/vnet/setup_other.go
+++ b/lib/vnet/setup_other.go
@@ -55,3 +55,7 @@ func configureOS(ctx context.Context, cfg *osConfig) error {
 func execAdminProcess(ctx context.Context, config daemon.Config) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }
+
+func DaemonSubcommand(ctx context.Context) error {
+	return trace.Wrap(ErrVnetNotImplemented)
+}

--- a/rfd/0163-vnet.md
+++ b/rfd/0163-vnet.md
@@ -1,6 +1,6 @@
 ---
 authors: Nic Klaassen (nic@goteleport.com), Rafał Cieślak (rafal.cieslak@goteleport.com)
-state: draft
+state: implemented
 ---
 
 # RFD 163 - Teleport VNet
@@ -469,46 +469,60 @@ in mind, but we can implement this in a similar way for Windows and Linux.
 
 #### Daemon
 
-All system configuration must run as a privileged user (root). To achieve that, VNet starts a daemon
-with `tsh vnet daemon` that runs as root, a Launch Daemon in macOS terms. The daemon handles
-creating a TUN device (and passing back its [file descriptor over a gRPC
-connection on Unix-like systems](https://pkg.go.dev/github.com/edwarnicke/grpcfd) or [GUID on
-Windows](https://github.com/WireGuard/wireguard-go/blob/12269c2761734b15625017d8565745096325392f/tun/tun_windows.go#L66-L68))
-as well as DNS configuration.
+All system configuration must run as a privileged user (root). The signed version of tsh ships with
+a plist describing [a Launch Daemon](https://developer.apple.com/documentation/xpc?language=objc).
+Running `tsh vnet` (or starting VNet in Connect) attempts to register the daemon through
+[`SMAppService`](https://developer.apple.com/documentation/servicemanagement/smappservice?language=objc).
+macOS then prompts the user to enable a new login item. This is the only time when the user is
+prompted for an admin password.
 
-The main reason behind adding a daemon is that otherwise we'd be forced to prompt for a password
-each time we need to carry out privileged operations.
+Despite what the names like "Launch Daemon" and "login item" might entice one to think, the daemon
+is spawned only when there's a demand for it. After the daemon is registered, tsh makes a call to an
+XPC service advertised in the daemon's plist. launchd receives the message and spawns `tsh
+vnet-daemon` as root to handle the message. The message includes arguments that are needed to start
+the daemon, including the path to a socket over which the daemon will send the TUN device fd and the
+`TELEPORT_HOME` of the user that wants to start VNet.
 
-On macOS, the daemon is added through [`SMAppService`](https://developer.apple.com/documentation/servicemanagement/smappservice?language=objc)
-and a plist that lives inside the app bundle. This has two nice properties. First, the daemon and
-the plist are signed by us, preventing 3rd parties from making any changes. Second, since the daemon
-plist lives in the app bundle, it is automatically removed when the user removes tsh.app or Teleport
-Connect.app.
+The daemon spawns and receives the message. It creates a TUN device and sends its fd over the
+socket. This allows the unprivileged process to listen to traffic on that device. The daemon also
+handles DNS configuration. Every 10 seconds it updates the DNS configuration of the OS to make sure
+that VNet works with any new clusters in `TELEPORT_HOME`. It also deconfigures any leftover clusters
+that the user logged out from.
 
-`SMAppService` requires macOS 13.0+. Since it only works with signed packages, in development we can
-substitute it with an osascript wrapper that runs the gRPC server as root and shuts down with the
-parent process.
+When the unprivileged process removes the socket file, the daemon detects that, it removes any DNS
+configuration needed by VNet and shuts down.
 
-The daemon allows other processes to talk to it through a gRPC service available over a Unix socket
-at `/var/run/teleport-vnet.socket`. Once the daemon establishes a listener on that socket, it chmods
-the socket to 666 to allow unprivileged processes to use the gRPC service. Since [launch daemons on
-macOS run in the system context](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/DesigningDaemons.html#//apple_ref/doc/uid/10000172i-SW4-SW5)
-and the daemon plist is going to be embedded within the app, we found no feasible way of restricting
-access to the daemon only to the current logged in user before communication happens. As such, we
-can restrict access to the daemon only after a user communicates with the daemon.
+##### `SMAppService`
 
-The daemon allows only one VNet TUN device to be active at a time. When a client connects to the
-gRPC service and requests the creation of a TUN device, the daemon saves [pid and uid of the
-client](https://pkg.go.dev/github.com/tailscale/peercred) (how to do this on Windows is outside of
-the scope of this RFD). Until the client explicitly tells the daemon to stop or the client process
-exits, no other client can create a TUN device.
+Adding a Launch Daemon through `SMAppService` has several advantages. The daemon and the plist are
+signed by us, preventing 3rd parties from making any changes. The daemon plist lives inside the app
+bundle – this means that the login item is automatically removed when the user removes tsh.app or
+Teleport Connect.app.
+
+In theory, if a user doesn't have admin privileges, an admin could enable the daemon plist in
+launchd. The user should then be able to call the daemon. This could allow VNet to be used in MDM
+scenarios, although we haven't verified that.
+
+`SMAppService` requires macOS 13.0+. Since it only works with bundled packages, in development we
+substitute it with an osascript wrapper that runs as root the same code as the daemon. The
+difference is that there's no XPC message being sent and the admin password needs to be entered on
+each VNet start.
+
+##### Daemon security
+
+The daemon calls [setCodeSigningRequirement](https://developer.apple.com/documentation/foundation/nsxpcconnection/3943309-setcodesigningrequirement?language=objc)
+with correct arguments, which makes it so that only software signed by the same team can call the
+daemon. This prevents 3rd-party software from interacting with the daemon.
+
+On top of that, it verifies that the user who spawned the daemon has access rights to the Teleport
+home directory that was passed in the XPC message.
+
+The daemon acts only upon the first message it receives, so sending multiple messages won't create
+multiple TUN devices. Since it's a Launch Daemon, there can be only one instance of it running at a
+time.
 
 The daemon allows changing the nameserver of an arbitrary DNS zone to that of VNet. This is needed
 so that we can update the DNS config as user logs in and out of clusters.
-
-The daemon will be registered on the first VNet launch, meaning it will get added to launch items
-and the user will have to accept it as an admin. After that, the daemon automatically starts on each
-system launch. It doesn't do anything by itself, other than setting up the gRPC server.
 
 ### VNet manager
 
@@ -836,7 +850,7 @@ Today, we allow users to download tsh in its unsigned form through the macOS .pk
 people also use Homebrew which does not provide a signed version of tsh. During development, signing
 tsh and Connect is somewhat cumbersome.
 
-As such, in those cases we can fall back to running `tsh vnet daemon` through osascript with
+As such, in those cases we can fall back to running `tsh vnet-daemon` through osascript with
 administrator privileges. The user gets prompted for their password and then the root process gets
 killed together with the unprivileged one which spawned it.
 
@@ -937,40 +951,6 @@ message UpsertVnetConfigRequest {
 
 // Request for DeleteVnetConfig.
 message DeleteVnetConfigRequest {}
-```
-
-#### Daemon service
-
-```proto
-service VnetRootDaemon {
-  // Start creates and configures a TUN device and configures DNS for all active profiles found in
-  // teleport_home. It also saves pid and uid of the client. Until the client calls Stop or exits,
-  // no other client can call Start or Stop.
-  //
-  // Start returns the fd of the TUN device so that the client can read and write from it. This is
-  // done through the underlying socket connection, see https://pkg.go.dev/github.com/edwarnicke/grpcfd.
-  rpc Start(StartRequest) returns (StartResponse);
-
-  // RefreshDNSConfig re-fetches cluster information and updates the existing DNS configuration to
-  // account for any changes. Typically called by the client after it detects that the user has
-  // logged in or out of a cluster.
-  rpc RefreshDNSConfig(RefreshDNSConfigRequest) returns (RefreshDNSConfigResponse);
-
-  // Stop closes any active connections, closes the TUN device and cleans up DNS configuration.
-  // This is also done automatically if the daemon detects that the client has exited without
-  // explicitly calling Stop.
-  rpc Stop(StopRequest) returns (StopResponse);
-}
-
-// Empty messages such as StopRequest have been omitted.
-
-message StartRequest {
-  // teleport_home is a path that points to the tsh home directory. VNet creates proxy clients for
-  // active profiles in this directory and configures DNS for each cluster found.
-  //
-  // teleport_home must belong to the client, as verified by uid of net.Conn.
-  string teleport_home = 1;
-}
 ```
 
 ### Binary size

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1193,6 +1193,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	vnetCmd := newVnetCommand(app)
 	vnetAdminSetupCmd := newVnetAdminSetupCommand(app)
+	vnetDaemonCmd := newVnetDaemonCommand(app)
 
 	if runtime.GOOS == constants.WindowsOS {
 		bench.Hidden()
@@ -1560,6 +1561,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = vnetCmd.run(&cf)
 	case vnetAdminSetupCmd.FullCommand():
 		err = vnetAdminSetupCmd.run(&cf)
+	case vnetDaemonCmd.FullCommand():
+		err = vnetDaemonCmd.run(&cf)
 	default:
 		// Handle commands that might not be available.
 		switch {

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -102,9 +102,6 @@ func (c *vnetAdminSetupCommand) run(cf *CLIConf) error {
 		DNSAddr:    c.dnsAddr,
 		HomePath:   homePath,
 	}
-	if err := config.CheckAndSetDefaults(); err != nil {
-		return trace.Wrap(err)
-	}
 
 	return trace.Wrap(vnet.AdminSetup(cf.Context, config))
 }

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -78,5 +78,5 @@ func newVnetAdminSetupCommand(app *kingpin.Application) *vnetAdminSetupCommand {
 }
 
 func (c *vnetAdminSetupCommand) run(cf *CLIConf) error {
-	return trace.Wrap(vnet.AdminSubcommand(cf.Context, c.socketPath, c.ipv6Prefix, c.dnsAddr))
+	return trace.Wrap(vnet.AdminSetup(cf.Context, c.socketPath, c.ipv6Prefix, c.dnsAddr))
 }

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -20,6 +20,7 @@
 package common
 
 import (
+	"log/slog"
 	"os"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/vnet"
 	"github.com/gravitational/teleport/lib/vnet/daemon"
 )
@@ -105,4 +107,28 @@ func (c *vnetAdminSetupCommand) run(cf *CLIConf) error {
 	}
 
 	return trace.Wrap(vnet.AdminSetup(cf.Context, config))
+}
+
+type vnetDaemonCommand struct {
+	*kingpin.CmdClause
+	// Launch daemons added through SMAppService are launched from a static .plist file, hence
+	// why this command does not accept any arguments.
+	// Instead, the daemon expects the arguments to be sent over XPC from an unprivileged process.
+}
+
+func newVnetDaemonCommand(app *kingpin.Application) *vnetDaemonCommand {
+	return &vnetDaemonCommand{
+		// The command must match the command provided in the .plist file.
+		CmdClause: app.Command("vnet-daemon", "Start the VNet daemon").Hidden(),
+	}
+}
+
+func (c *vnetDaemonCommand) run(cf *CLIConf) error {
+	if cf.Debug {
+		utils.InitLogger(utils.LoggingForDaemon, slog.LevelDebug)
+	} else {
+		utils.InitLogger(utils.LoggingForDaemon, slog.LevelInfo)
+	}
+
+	return trace.Wrap(vnet.DaemonSubcommand(cf.Context))
 }

--- a/tool/tsh/common/vnet_other.go
+++ b/tool/tsh/common/vnet_other.go
@@ -34,6 +34,10 @@ func newVnetAdminSetupCommand(app *kingpin.Application) vnetNotSupported {
 	return vnetNotSupported{}
 }
 
+func newVnetDaemonCommand(app *kingpin.Application) vnetNotSupported {
+	return vnetNotSupported{}
+}
+
 type vnetNotSupported struct{}
 
 func (vnetNotSupported) FullCommand() string {


### PR DESCRIPTION
https://github.com/gravitational/teleport/assets/27113/124c48dc-aa5e-4c7b-a7ba-a306014fe5c3

Building on top of #43746, this PR adds the implementation of the VNet daemon. This is accomplished by adding a new command, `tsh vnet-daemon`. It is the last big PR, the rest will be just smaller improvements over existing code. I need to iron out a couple of things before I remove the feature flag.

## Passing TELEPORT_HOME

The way VNet used to work was that it'd spawn an admin process through osascript. osascript seems to forward all env vars to the root process, so it was enough for the unprivileged process to set `TELEPORT_HOME` and everything would work without the need to pass the home path explicitly.

This is no longer possible with a launch daemon. It runs completely separate from the unprivileged process. As such, it needs to receive the path over XPC. I had to refactor the code that's shared between `tsh vnet-admin-setup` (run by osascript) and `tsh vnet-daemon` so that it's uses the home path given to it as an explicit argument, rather than reading it from an env var. 

## How XPC works

The implementation in this PR is based on an example implementation of a Launch Daemon with an XPC service that I found at https://github.com/jdspoone/SampleOSXLaunchDaemon.

### At a high level

`tsh vnet` sends an XPC message addressed to an XPC service advertised by daemon's plist. Since we first register a background item, launchd routes the message to a particular plist and executes a job by spawning the program listed in the plist with the given arguments. This results in launchd spawning `tsh vnet-daemon` as root.

That process then establishes an XPC service by creating an XPC listener. It receves the message (which carries arguments necessary to start VNet) and starts VNet. `tsh vnet` gets back a file descriptor for a TUN device (just as it would when using `osascript`) and that's how it knows to proceed.

When `tsh vnet` is done, it closes the socket over which the TUN device fd was exchanged. `tsh vnet-daemon` notices this and exits.

### At a low level

`protocol_darwin.h` defines `VNEDaemonProtocol` which defines how clients can communicate with the service. `client_darwin.h` uses that protocol to establish what's called [remote object proxy](https://developer.apple.com/documentation/foundation/nsxpcinterface?language=objc). `service_darwin.h` creates a listener which sets an instance of `VNEDaemonService` as the exported object, enabling a client to call methods on that object.

When spawned, `tsh vnet-daemon` creates a listener and then proceeds to wait for the first `startVnet` call on the exported object. When that is done, it starts VNet.