### PR TITLE
[v16] reenable redshift serverless e2e test

### DIFF
--- a/e2e/aws/redshift_test.go
+++ b/e2e/aws/redshift_test.go
@@ -37,7 +37,6 @@ import (
 )
 
 func testRedshiftServerless(t *testing.T) {
-	t.Skip("skipped until we fix the spacelift stack")
 	t.Parallel()
 	accessRole := mustGetEnv(t, rssAccessRoleARNEnv)
 	discoveryRole := mustGetEnv(t, rssDiscoveryRoleARNEnv)


### PR DESCRIPTION
backport https://github.com/gravitational/teleport/pull/42602 to branch/v16.