### PR TITLE
[v14] reenable redshift serverless e2e test

### DIFF
--- a/e2e/aws/redshift_test.go
+++ b/e2e/aws/redshift_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func testRedshiftServerless(t *testing.T) {
-	t.Skip("skipped until we fix the spacelift stack")
 	t.Parallel()
 	accessRole := mustGetEnv(t, rssAccessRoleEnv)
 	discoveryRole := mustGetEnv(t, rssDiscoveryRoleEnv)


### PR DESCRIPTION
backport https://github.com/gravitational/teleport/pull/42602 to branch/v14.