### PR TITLE
add verification funcs for tokens

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -209,6 +209,25 @@ const (
 	// MaxPasswordLength is maximum password length (for sanity)
 	MaxPasswordLength = 128
 
+	// MinTokenLength is the minimum token length.
+	MinTokenLength = 32
+
+	// MaxTokenLength is the maximum token length.
+	MaxTokenLength = 120
+
+	// MaxHashedTokenLength is the maximum length of a token that will
+	// be hashed by bcrypt. bcrypt does not accept inputs over 72
+	//characters in length.
+	MaxHashedTokenLength = 72
+
+	// MinTokenStrength is the minimum strength a token must have to be
+	// accepted. It was decided by generating millions of 16 character
+	// random strings, hex encoding them and then searching for the lowest
+	// token strength for all created strings. This is to ensure 32
+	// character long random tokens that are hex encoded will be
+	// accepted.
+	MinTokenStrength = 80.0
+
 	// MaxIterationLimit is max iteration limit
 	MaxIterationLimit = 1000
 

--- a/lib/utils/token/token.go
+++ b/lib/utils/token/token.go
@@ -1,0 +1,78 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package token
+
+import (
+	"math"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/defaults"
+)
+
+// Verify ensures the token fits into our length requirements and
+// its bits of entropy are sufficient.
+func Verify(token []byte) error {
+	return verify(token, defaults.MaxTokenLength)
+}
+
+// VerifyHashed ensures the token fits into our length requirements and
+// its bits of entropy are sufficient. If the token is not going to be
+// hashed by bcrypt before it will be used, use [Verify] instead.
+func VerifyHashed(token []byte) error {
+	return verify(token, defaults.MaxHashedTokenLength)
+}
+
+func verify(token []byte, maxLen int) error {
+	if len(token) < defaults.MinTokenLength {
+		return trace.BadParameter("token is too short, min length is %d", defaults.MinTokenLength)
+	}
+	if len(token) > maxLen {
+		return trace.BadParameter("token is too long, max length is %d", maxLen)
+	}
+
+	entropyBits := TokenStrength(token)
+	if entropyBits < defaults.MinTokenStrength {
+		return trace.BadParameter("token is not strong enough; try with a longer and/or more random token")
+	}
+
+	return nil
+}
+
+// TokenStrength returns an approximate value of the token's strength.
+// The strength is derived from the shannon entropy of the token
+// multiplied by the token's length.
+func TokenStrength(input []byte) float64 {
+	freq := make(map[byte]int)
+	for _, b := range input {
+		freq[b]++
+	}
+
+	// compute shannon entropy
+	// https://mathworld.wolfram.com/Entropy.html
+	var shannon float64
+	for _, count := range freq {
+		pval := float64(count) / float64(len(input))
+		pinv := float64(len(input)) / float64(count)
+		shannon += pval * math.Log2(pinv)
+	}
+
+	// multiply shannon entropy with length to reward longer tokens
+	return shannon * float64(len(input))
+}

--- a/lib/utils/token/token_test.go
+++ b/lib/utils/token/token_test.go
@@ -1,0 +1,85 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package token
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/defaults"
+)
+
+func TestVerify(t *testing.T) {
+	tests := []struct {
+		name      string
+		token     []byte
+		assertErr func(t require.TestingT, err error, msgAndArgs ...any)
+	}{
+		{
+			name:  "token too short",
+			token: []byte("abc123"),
+			assertErr: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.ErrorContains(t, err, "token is too short")
+			},
+		},
+		{
+			name:  "token too long",
+			token: make([]byte, defaults.MaxTokenLength+1),
+			assertErr: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.ErrorContains(t, err, "token is too long")
+			},
+		},
+		{
+			name:  "token doesn't have enough entropy",
+			token: bytes.Repeat([]byte("A"), defaults.MinTokenLength),
+			assertErr: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.ErrorContains(t, err, "token is not strong enough")
+			},
+		},
+		{
+			name:      "token is good",
+			token:     []byte("noonewilleverguessthistoken!!!!!"),
+			assertErr: require.NoError,
+		},
+		{
+			name:      "basic token is good",
+			token:     []byte("1234567890abcdefghijklmnopqrstuv"),
+			assertErr: require.NoError,
+		},
+		{
+			name:      "random token is good",
+			token:     []byte("b0fbcc4bee3b8a6523af6941869642e0"),
+			assertErr: require.NoError,
+		},
+		{
+			name:      "long random token is good",
+			token:     []byte("9a030be95f0dc7d70d8fb549e55074fa453de9c21690eb4a66f563c925c52766"),
+			assertErr: require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Verify(tt.token)
+			tt.assertErr(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Token verification functions were added as part of fixing https://github.com/gravitational/teleport-private/issues/1452. We still want to allow users to specify Okta SCIM tokens for diagnostic purposes but want to add checks in the backend to ensure user specified tokens are reasonably long and random. `Verify` was added in case we want to verify any other user specified tokens that won't be hashed by `bcrypt`.