### PR TITLE
remove RSA-specific methods on keys.PrivateKey

### DIFF
--- a/api/utils/sshutils/ppk/ppk.go
+++ b/api/utils/sshutils/ppk/ppk.go
@@ -37,6 +37,9 @@ import (
 
 // ConvertToPPK takes a regular RSA-formatted keypair and converts it into the PPK file format used by the PuTTY SSH client.
 // The file format is described here: https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixC.html#ppk
+//
+// TODO(nklaassen): support Ed25519 and ECDSA keys. The file format supports it,
+// we just don't support writing them here.
 func ConvertToPPK(privateKey *rsa.PrivateKey, pub []byte) ([]byte, error) {
 	// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixC.html#ppk
 	// RSA keys are stored using an algorithm-name of 'ssh-rsa'. (Keys stored like this are also used by the updated RSA signature schemes that use

--- a/lib/benchmark/kube.go
+++ b/lib/benchmark/kube.go
@@ -101,7 +101,7 @@ func getKubeTLSClientConfig(ctx context.Context, tc *client.TeleportClient) (res
 
 	certPem := k.KubeTLSCerts[tc.KubernetesCluster]
 
-	rsaKeyPEM, err := k.PrivateKey.RSAPrivateKeyPEM()
+	keyPEM, err := k.PrivateKey.SoftwarePrivateKeyPEM()
 	if err != nil {
 		return rest.TLSClientConfig{}, trace.Wrap(err)
 	}
@@ -133,7 +133,7 @@ func getKubeTLSClientConfig(ctx context.Context, tc *client.TeleportClient) (res
 	return rest.TLSClientConfig{
 		CAData:     bytes.Join(clusterCAs, []byte("\n")),
 		CertData:   certPem,
-		KeyData:    rsaKeyPEM,
+		KeyData:    keyPEM,
 		ServerName: tlsServerName,
 	}, nil
 }

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -208,13 +208,13 @@ const (
 func makeDatabaseClientPEM(proto string, cert []byte, pk *Key) ([]byte, error) {
 	// MongoDB expects certificate and key pair in the same pem file.
 	if proto == defaults.ProtocolMongoDB {
-		rsaKeyPEM, err := pk.PrivateKey.RSAPrivateKeyPEM()
+		keyPEM, err := pk.PrivateKey.SoftwarePrivateKeyPEM()
 		if err == nil {
-			return append(cert, rsaKeyPEM...), nil
+			return append(cert, keyPEM...), nil
 		} else if !trace.IsBadParameter(err) {
 			return nil, trace.Wrap(err)
 		}
-		log.WithError(err).Warn("MongoDB integration is not supported when logging in with a non-rsa private key.")
+		log.WithError(err).Warn("MongoDB integration is not supported when logging in with a hardware private key.")
 	}
 	return cert, nil
 }

--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -275,8 +275,8 @@ func LoadKeysToKubeFromStore(profile *profile.Profile, dirPath, teleportCluster,
 		return nil, nil, trace.Wrap(err)
 	}
 
-	if ok := keys.IsRSAPrivateKey(privKey); !ok {
-		return nil, nil, trace.BadParameter("unsupported private key type")
+	if err := keys.AssertSoftwarePrivateKey(privKey); err != nil {
+		return nil, nil, trace.Wrap(err, "unsupported private key type")
 	}
 	return kubeCert, privKey, nil
 }

--- a/lib/kube/kubeconfig/kubeconfig.go
+++ b/lib/kube/kubeconfig/kubeconfig.go
@@ -250,9 +250,9 @@ func UpdateConfig(path string, v Values, storeAllCAs bool, fs ConfigFS) error {
 		// Validate the provided credentials, to avoid partially-populated
 		// kubeconfig.
 
-		// TODO (Joerger): Create a custom k8s Auth Provider or Exec Provider to use non-rsa
-		// private keys for kube credentials (if possible)
-		rsaKeyPEM, err := v.Credentials.PrivateKey.RSAPrivateKeyPEM()
+		// TODO (Joerger): Create a custom k8s Auth Provider or Exec Provider to
+		// use hardware private keys for kube credentials (if possible)
+		keyPEM, err := v.Credentials.PrivateKey.SoftwarePrivateKeyPEM()
 		if err == nil {
 			if len(v.Credentials.TLSCert) == 0 {
 				return trace.BadParameter("TLS certificate missing in provided credentials")
@@ -260,7 +260,7 @@ func UpdateConfig(path string, v Values, storeAllCAs bool, fs ConfigFS) error {
 
 			config.AuthInfos[contextName] = &clientcmdapi.AuthInfo{
 				ClientCertificateData: v.Credentials.TLSCert,
-				ClientKeyData:         rsaKeyPEM,
+				ClientKeyData:         keyPEM,
 			}
 			setContext(config.Contexts, contextName, clusterName, contextName, kubeClusterName, v.Namespace)
 			setSelectedExtension(config.Contexts, config.CurrentContext, clusterName)
@@ -268,7 +268,7 @@ func UpdateConfig(path string, v Values, storeAllCAs bool, fs ConfigFS) error {
 		} else if !trace.IsBadParameter(err) {
 			return trace.Wrap(err)
 		}
-		log.WithError(err).Warn("Kubernetes integration is not supported when logging in with a non-rsa private key.")
+		log.WithError(err).Warn("Kubernetes integration is not supported when logging in with a hardware private key.")
 	}
 
 	return SaveConfig(path, *config, fs)


### PR DESCRIPTION
`RSAPrivateKeyPEM` and `IsRSAPrivateKey` were really used to make sure the key was a regular software key and not a yubikey, we don't actually rely on it being an RSA key. Kube and Mongo should both support ECDSA software keys. I replaced these with `SoftwarePrivateKeyPEM` and `AssertSoftwarePrivateKey` (which now has nicer error messages in error cases).

We will need to add support for Ed25519 and ECDSA in putty PPK files in the future, I didn't actually make any changes to that here