### PR TITLE
[v15] build: Ensure we target the min version supported on Mac builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,11 +278,18 @@ BUILDFLAGS_TBOT = $(ADDFLAGS) -ldflags '-w -s $(KUBECTL_SETVERSION)' -trimpath
 endif
 
 ifeq ("$(OS)","darwin")
+# Set the minimum version for macOS builds for Go, Rust and Xcode builds.
 # Note the minimum version for Apple silicon (ARM64) is 11.0 and will be automatically
 # clamped to the value for builds of that architecture
 MINIMUM_SUPPORTED_MACOS_VERSION = 10.15
 MACOSX_VERSION_MIN_FLAG = -mmacosx-version-min=$(MINIMUM_SUPPORTED_MACOS_VERSION)
-CGOFLAG = CGO_ENABLED=1 CGO_CFLAGS=$(MACOSX_VERSION_MIN_FLAG) CGO_LDFLAGS=$(MACOSX_VERSION_MIN_FLAG)
+
+# Go
+CGOFLAG = CGO_ENABLED=1 CGO_CFLAGS=$(MACOSX_VERSION_MIN_FLAG)
+
+# Xcode and rust and Go linking
+MACOSX_DEPLOYMENT_TARGET = $(MINIMUM_SUPPORTED_MACOS_VERSION)
+export MACOSX_DEPLOYMENT_TARGET
 endif
 
 CGOFLAG_TSH ?= $(CGOFLAG)
@@ -382,14 +389,6 @@ update-vmlinux-h:
 else
 .PHONY: bpf-bytecode
 bpf-bytecode:
-endif
-
-ifeq ("$(OS)-$(with_rdpclient)", "darwin-yes")
-# Set the minimum version linker flag for the rust build of rdpclient (and only rdpclient,
-# as the flag is invalid for building ironrdp to wasm in the web UI). Also set an env
-# var so any C libraries built by this build also target the correct min version.
-rdpclient: export RUSTFLAGS = -C link-arg=$(MACOSX_VERSION_MIN_FLAG)
-rdpclient: export MACOSX_DEPLOYMENT_TARGET = $(MINIMUM_SUPPORTED_MACOS_VERSION)
 endif
 
 .PHONY: rdpclient


### PR DESCRIPTION
Ensure relevant flags are passed to the Go, rust and C compilers (xcode)
when building the Teleport binaries to target the minimum version of
macOS we support. Currently that is 10.15 (Catalina) on x86_64 and 11
(Big Sur) on arm64 (the first supported Apple silicon macOS release).

Note that we set the minimum to 10.15 in the build, but it will be
updated to 11 by the compilers/tools when building for ARM64.

Care is taken with rust builds not to set this min os globally as we
also use rust to target web assembly in the web UI and the flags are
invalid there.

Backport: https://github.com/gravitational/teleport/pull/43231
Backport: https://github.com/gravitational/teleport/pull/43996
Link: https://goteleport.com/docs/installation/#operating-system-support
Issue: https://github.com/gravitational/teleport/issues/32601
Companion: https://github.com/gravitational/teleport.e/pull/4611

---

I'dd add an `e` ref update to include the companion PR once that gets merged.
