### PR TITLE
[v15] rdp: Change rdpclient type casts from ulong to uintptr_t

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -429,7 +429,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 
 		c.cfg.Log.Debugf("Client changed screen size: %dx%d", m.Width, m.Height)
 		if errCode := C.client_write_screen_resize(
-			C.ulong(c.handle),
+			C.uintptr_t(c.handle),
 			C.uint32_t(m.Width),
 			C.uint32_t(m.Height),
 		); errCode != C.ErrCodeSuccess {
@@ -438,7 +438,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 	case tdp.MouseMove:
 		c.mouseX, c.mouseY = m.X, m.Y
 		if errCode := C.client_write_rdp_pointer(
-			C.ulong(c.handle),
+			C.uintptr_t(c.handle),
 			C.CGOMousePointerEvent{
 				x:      C.uint16_t(m.X),
 				y:      C.uint16_t(m.Y),
@@ -462,7 +462,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 			button = C.PointerButtonNone
 		}
 		if errCode := C.client_write_rdp_pointer(
-			C.ulong(c.handle),
+			C.uintptr_t(c.handle),
 			C.CGOMousePointerEvent{
 				x:      C.uint16_t(c.mouseX),
 				y:      C.uint16_t(c.mouseY),
@@ -490,7 +490,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 			wheel = C.PointerWheelNone
 		}
 		if errCode := C.client_write_rdp_pointer(
-			C.ulong(c.handle),
+			C.uintptr_t(c.handle),
 			C.CGOMousePointerEvent{
 				x:           C.uint16_t(c.mouseX),
 				y:           C.uint16_t(c.mouseY),
@@ -503,7 +503,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 		}
 	case tdp.KeyboardButton:
 		if errCode := C.client_write_rdp_keyboard(
-			C.ulong(c.handle),
+			C.uintptr_t(c.handle),
 			C.CGOKeyboardEvent{
 				code: C.uint16_t(m.KeyCode),
 				down: m.State == tdp.ButtonPressed,
@@ -512,7 +512,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 			return trace.Errorf("KeyboardButton: client_write_rdp_keyboard: %v", errCode)
 		}
 	case tdp.SyncKeys:
-		if errCode := C.client_write_rdp_sync_keys(C.ulong(c.handle),
+		if errCode := C.client_write_rdp_sync_keys(C.uintptr_t(c.handle),
 			C.CGOSyncKeys{
 				scroll_lock_down: m.ScrollLockState == tdp.ButtonPressed,
 				num_lock_down:    m.NumLockState == tdp.ButtonPressed,
@@ -528,7 +528,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 		}
 		if len(m) > 0 {
 			if errCode := C.client_update_clipboard(
-				C.ulong(c.handle),
+				C.uintptr_t(c.handle),
 				(*C.uint8_t)(unsafe.Pointer(&m[0])),
 				C.uint32_t(len(m)),
 			); errCode != C.ErrCodeSuccess {
@@ -541,7 +541,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 		if c.cfg.AllowDirectorySharing {
 			driveName := C.CString(m.Name)
 			defer C.free(unsafe.Pointer(driveName))
-			if errCode := C.client_handle_tdp_sd_announce(C.ulong(c.handle), C.CGOSharedDirectoryAnnounce{
+			if errCode := C.client_handle_tdp_sd_announce(C.uintptr_t(c.handle), C.CGOSharedDirectoryAnnounce{
 				directory_id: C.uint32_t(m.DirectoryID),
 				name:         driveName,
 			}); errCode != C.ErrCodeSuccess {
@@ -552,7 +552,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 		if c.cfg.AllowDirectorySharing {
 			path := C.CString(m.Fso.Path)
 			defer C.free(unsafe.Pointer(path))
-			if errCode := C.client_handle_tdp_sd_info_response(C.ulong(c.handle), C.CGOSharedDirectoryInfoResponse{
+			if errCode := C.client_handle_tdp_sd_info_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryInfoResponse{
 				completion_id: C.uint32_t(m.CompletionID),
 				err_code:      m.ErrCode,
 				fso: C.CGOFileSystemObject{
@@ -570,7 +570,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 		if c.cfg.AllowDirectorySharing {
 			path := C.CString(m.Fso.Path)
 			defer C.free(unsafe.Pointer(path))
-			if errCode := C.client_handle_tdp_sd_create_response(C.ulong(c.handle), C.CGOSharedDirectoryCreateResponse{
+			if errCode := C.client_handle_tdp_sd_create_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryCreateResponse{
 				completion_id: C.uint32_t(m.CompletionID),
 				err_code:      m.ErrCode,
 				fso: C.CGOFileSystemObject{
@@ -586,7 +586,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 		}
 	case tdp.SharedDirectoryDeleteResponse:
 		if c.cfg.AllowDirectorySharing {
-			if errCode := C.client_handle_tdp_sd_delete_response(C.ulong(c.handle), C.CGOSharedDirectoryDeleteResponse{
+			if errCode := C.client_handle_tdp_sd_delete_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryDeleteResponse{
 				completion_id: C.uint32_t(m.CompletionID),
 				err_code:      m.ErrCode,
 			}); errCode != C.ErrCodeSuccess {
@@ -619,7 +619,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 				cgoFsoList = (*C.CGOFileSystemObject)(unsafe.Pointer(&fsoList))
 			}
 
-			if errCode := C.client_handle_tdp_sd_list_response(C.ulong(c.handle), C.CGOSharedDirectoryListResponse{
+			if errCode := C.client_handle_tdp_sd_list_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryListResponse{
 				completion_id:   C.uint32_t(m.CompletionID),
 				err_code:        m.ErrCode,
 				fso_list_length: C.uint32_t(fsoListLen),
@@ -637,7 +637,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 				readData = (*C.uint8_t)(unsafe.Pointer(&m.ReadData))
 			}
 
-			if errCode := C.client_handle_tdp_sd_read_response(C.ulong(c.handle), C.CGOSharedDirectoryReadResponse{
+			if errCode := C.client_handle_tdp_sd_read_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryReadResponse{
 				completion_id:    C.uint32_t(m.CompletionID),
 				err_code:         m.ErrCode,
 				read_data_length: C.uint32_t(m.ReadDataLength),
@@ -648,7 +648,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 		}
 	case tdp.SharedDirectoryWriteResponse:
 		if c.cfg.AllowDirectorySharing {
-			if errCode := C.client_handle_tdp_sd_write_response(C.ulong(c.handle), C.CGOSharedDirectoryWriteResponse{
+			if errCode := C.client_handle_tdp_sd_write_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryWriteResponse{
 				completion_id: C.uint32_t(m.CompletionID),
 				err_code:      m.ErrCode,
 				bytes_written: C.uint32_t(m.BytesWritten),
@@ -658,7 +658,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 		}
 	case tdp.SharedDirectoryMoveResponse:
 		if c.cfg.AllowDirectorySharing {
-			if errCode := C.client_handle_tdp_sd_move_response(C.ulong(c.handle), C.CGOSharedDirectoryMoveResponse{
+			if errCode := C.client_handle_tdp_sd_move_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryMoveResponse{
 				completion_id: C.uint32_t(m.CompletionID),
 				err_code:      m.ErrCode,
 			}); errCode != C.ErrCodeSuccess {
@@ -667,7 +667,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 		}
 	case tdp.SharedDirectoryTruncateResponse:
 		if c.cfg.AllowDirectorySharing {
-			if errCode := C.client_handle_tdp_sd_truncate_response(C.ulong(c.handle), C.CGOSharedDirectoryTruncateResponse{
+			if errCode := C.client_handle_tdp_sd_truncate_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryTruncateResponse{
 				completion_id: C.uint32_t(m.CompletionID),
 				err_code:      m.ErrCode,
 			}); errCode != C.ErrCodeSuccess {
@@ -682,7 +682,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 		rdpResponsePDU := (*C.uint8_t)(unsafe.SliceData(m))
 
 		if errCode := C.client_handle_tdp_rdp_response_pdu(
-			C.ulong(c.handle), rdpResponsePDU, C.uint32_t(pduLen),
+			C.uintptr_t(c.handle), rdpResponsePDU, C.uint32_t(pduLen),
 		); errCode != C.ErrCodeSuccess {
 			return trace.Errorf("RDPResponsePDU failed: %v", errCode)
 		}


### PR DESCRIPTION
Change the C type casts of `c.handle` from `C.ulong` to `C.uintptr_t`.
This is needed to compile on 32-bit architectures.

We do not currently build in the RDP client for 32-bit architectures but
it will be possible with a crosstool-NG based buildbox and is otherwise
of no detriment.

Co-authored-by: Jakub Nyckowski <jakub.nyckowski@goteleport.com>
Backport: https://github.com/gravitational/teleport/pull/43944
