### PR TITLE
[sec_scan][14] create `AccessGraphSettings` on first auth init

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -869,33 +869,28 @@ func initializeSessionRecordingConfig(ctx context.Context, asrv *Server, newRecC
 }
 
 func initializeAccessGraphSettings(ctx context.Context, asrv *Server) error {
-	const iterationLimit = 3
-	for i := 0; i < iterationLimit; i++ {
-		stored, err := asrv.Services.GetAccessGraphSettings(ctx)
-		if err != nil && !trace.IsNotFound(err) {
-			return trace.Wrap(err)
-		}
-
-		if stored != nil {
-			return nil
-		}
-		stored, err = clusterconfig.NewAccessGraphSettings(&clusterconfigpb.AccessGraphSettingsSpec{
-			SecretsScanConfig: clusterconfigpb.AccessGraphSecretsScanConfig_ACCESS_GRAPH_SECRETS_SCAN_CONFIG_DISABLED,
-		})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		log.Infof("Creating access graph settings: %v.", stored)
-		_, err = asrv.CreateAccessGraphSettings(ctx, stored)
-		if trace.IsAlreadyExists(err) {
-			continue
-		}
-
+	stored, err := asrv.Services.GetAccessGraphSettings(ctx)
+	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
-
+	}
+	if stored != nil {
+		return nil
 	}
 
-	return trace.LimitExceeded("failed to initialize access graph settings in %v iterations", iterationLimit)
+	stored, err = clusterconfig.NewAccessGraphSettings(&clusterconfigpb.AccessGraphSettingsSpec{
+		SecretsScanConfig: clusterconfigpb.AccessGraphSecretsScanConfig_ACCESS_GRAPH_SECRETS_SCAN_CONFIG_DISABLED,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	log.Infof("Creating access graph settings: %v.", stored)
+	_, err = asrv.CreateAccessGraphSettings(ctx, stored)
+	if trace.IsAlreadyExists(err) {
+		return nil
+	}
+
+	return trace.Wrap(err)
 }
 
 // shouldInitReplaceResourceWithOrigin determines whether the candidate

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -43,9 +43,11 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	dbobjectimportrulev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/clusterconfig"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth/dbobjectimportrule/dbobjectimportrulev1"
@@ -435,6 +437,12 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 		ctx, span := cfg.Tracer.Start(gctx, "auth/InitializeSessionRecordingConfig")
 		defer span.End()
 		return trace.Wrap(initializeSessionRecordingConfig(ctx, asrv, cfg.SessionRecordingConfig))
+	})
+
+	g.Go(func() error {
+		ctx, span := cfg.Tracer.Start(gctx, "auth/InitializeAccessGraphSettings")
+		defer span.End()
+		return trace.Wrap(initializeAccessGraphSettings(ctx, asrv))
 	})
 
 	g.Go(func() error {
@@ -858,6 +866,36 @@ func initializeSessionRecordingConfig(ctx context.Context, asrv *Server, newRecC
 	}
 
 	return trace.LimitExceeded("failed to initialize session recording config in %v iterations", iterationLimit)
+}
+
+func initializeAccessGraphSettings(ctx context.Context, asrv *Server) error {
+	const iterationLimit = 3
+	for i := 0; i < iterationLimit; i++ {
+		stored, err := asrv.Services.GetAccessGraphSettings(ctx)
+		if err != nil && !trace.IsNotFound(err) {
+			return trace.Wrap(err)
+		}
+
+		if stored != nil {
+			return nil
+		}
+		stored, err = clusterconfig.NewAccessGraphSettings(&clusterconfigpb.AccessGraphSettingsSpec{
+			SecretsScanConfig: clusterconfigpb.AccessGraphSecretsScanConfig_ACCESS_GRAPH_SECRETS_SCAN_CONFIG_DISABLED,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		log.Infof("Creating access graph settings: %v.", stored)
+		_, err = asrv.CreateAccessGraphSettings(ctx, stored)
+		if trace.IsAlreadyExists(err) {
+			continue
+		}
+
+		return trace.Wrap(err)
+
+	}
+
+	return trace.LimitExceeded("failed to initialize access graph settings in %v iterations", iterationLimit)
 }
 
 // shouldInitReplaceResourceWithOrigin determines whether the candidate


### PR DESCRIPTION
This PR adds a init script that sets `AccessGraphSettings` into Teleport backend when auth first inits and there is no `AccessGraphSettings`.

This PR is part of https://github.com/gravitational/access-graph/issues/637.