### PR TITLE
[v15] Batch access list review reminders and provide link (slack)

### DIFF
--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -170,16 +170,13 @@ func (a *App) remindIfNecessary(ctx context.Context) error {
 		for _, accessList := range accessLists {
 			recipients, err := a.getRecipientsRequiringReminders(ctx, accessList)
 			if err != nil {
-				log.WithError(err).Warn("Error getting recipients to notify for access list reviews")
+				log.WithError(err).Warn("Error getting recipients to notify for review due for access list %q", accessList.Spec.Title)
 				continue
 			}
 
 			// Store all recipients and the accesslist needing review
 			// for later processing.
 			for _, recipient := range recipients {
-				if _, ok := remindersLookup[recipient]; !ok {
-					remindersLookup[recipient] = []*accesslist.AccessList{}
-				}
 				remindersLookup[recipient] = append(remindersLookup[recipient], accessList)
 			}
 		}
@@ -197,7 +194,7 @@ func (a *App) remindIfNecessary(ctx context.Context) error {
 		}
 	}
 
-	if err != nil {
+	if len(errs) > 0 {
 		log.WithError(trace.NewAggregate(errs...)).Warn("Error notifying for access list reviews")
 	}
 

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -170,7 +170,7 @@ func (a *App) remindIfNecessary(ctx context.Context) error {
 		for _, accessList := range accessLists {
 			recipients, err := a.getRecipientsRequiringReminders(ctx, accessList)
 			if err != nil {
-				log.WithError(err).Warn("Error getting recipients to notify for review due for access list %q", accessList.Spec.Title)
+				log.WithError(err).Warnf("Error getting recipients to notify for review due for access list %q", accessList.Spec.Title)
 				continue
 			}
 

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
-	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/lib/auth"
@@ -209,16 +208,19 @@ func TestAccessListReminders_Single(t *testing.T) {
 func TestAccessListReminders_Batched(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-				entitlements.Identity: {Enabled: true},
-			},
+			IdentityGovernanceSecurity: true,
 		},
 	})
 
 	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
 
-	server := newTestAuth(t)
-
+	server, err := auth.NewTestServer(auth.TestServerConfig{
+		Auth: auth.TestAuthServerConfig{
+			Dir:   t.TempDir(),
+			Clock: clockwork.NewFakeClock(),
+		},
+	})
+	require.NoError(t, err)
 	as := server.Auth()
 	t.Cleanup(func() {
 		require.NoError(t, as.Close())

--- a/integrations/access/accesslist/bot.go
+++ b/integrations/access/accesslist/bot.go
@@ -29,7 +29,5 @@ type MessagingBot interface {
 	common.MessagingBot
 
 	// SendReviewReminders will send a review reminder that an access list needs to be reviewed.
-	SendReviewReminders(ctx context.Context, recipient common.Recipient, accessList *accesslist.AccessList) error
-	// SendBatchedReviewReminder will send a batched review reminder.
-	SendBatchedReviewReminder(ctx context.Context, recipient common.Recipient, accessLists []*accesslist.AccessList) error
+	SendReviewReminders(ctx context.Context, recipient common.Recipient, accessLists []*accesslist.AccessList) error
 }

--- a/integrations/access/accesslist/bot.go
+++ b/integrations/access/accesslist/bot.go
@@ -30,4 +30,6 @@ type MessagingBot interface {
 
 	// SendReviewReminders will send a review reminder that an access list needs to be reviewed.
 	SendReviewReminders(ctx context.Context, recipient common.Recipient, accessList *accesslist.AccessList) error
+	// SendBatchedReviewReminder will send a batched review reminder.
+	SendBatchedReviewReminder(ctx context.Context, recipient common.Recipient, accessLists []*accesslist.AccessList) error
 }

--- a/integrations/access/discord/bot.go
+++ b/integrations/access/discord/bot.go
@@ -122,6 +122,11 @@ func (b DiscordBot) SendReviewReminders(ctx context.Context, recipients []common
 	return trace.NotImplemented("access list review reminder is not yet implemented")
 }
 
+// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
+func (b DiscordBot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+	return trace.NotImplemented("access list batched review reminder is not yet implemented")
+}
+
 // BroadcastAccessRequestMessage posts request info to Discord.
 func (b DiscordBot) BroadcastAccessRequestMessage(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (accessrequest.SentMessages, error) {
 	var data accessrequest.SentMessages

--- a/integrations/access/discord/bot.go
+++ b/integrations/access/discord/bot.go
@@ -118,13 +118,8 @@ func (b DiscordBot) SupportedApps() []common.App {
 }
 
 // SendReviewReminders will send a review reminder that an access list needs to be reviewed.
-func (b DiscordBot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+func (b DiscordBot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessLists []*accesslist.AccessList) error {
 	return trace.NotImplemented("access list review reminder is not yet implemented")
-}
-
-// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
-func (b DiscordBot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
-	return trace.NotImplemented("access list batched review reminder is not yet implemented")
 }
 
 // BroadcastAccessRequestMessage posts request info to Discord.

--- a/integrations/access/mattermost/bot.go
+++ b/integrations/access/mattermost/bot.go
@@ -244,6 +244,11 @@ func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipi
 	return trace.NotImplemented("access list review reminder is not yet implemented")
 }
 
+// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
+func (b Bot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+	return trace.NotImplemented("access list batched review reminder is not yet implemented")
+}
+
 // BroadcastAccessRequestMessage posts request info to Mattermost.
 func (b Bot) BroadcastAccessRequestMessage(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (accessrequest.SentMessages, error) {
 	text, err := b.buildPostText(reqID, reqData)

--- a/integrations/access/mattermost/bot.go
+++ b/integrations/access/mattermost/bot.go
@@ -240,13 +240,8 @@ func (b Bot) GetMe(ctx context.Context) (User, error) {
 }
 
 // SendReviewReminders will send a review reminder that an access list needs to be reviewed.
-func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessLists []*accesslist.AccessList) error {
 	return trace.NotImplemented("access list review reminder is not yet implemented")
-}
-
-// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
-func (b Bot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
-	return trace.NotImplemented("access list batched review reminder is not yet implemented")
 }
 
 // BroadcastAccessRequestMessage posts request info to Mattermost.

--- a/integrations/access/opsgenie/bot.go
+++ b/integrations/access/opsgenie/bot.go
@@ -55,13 +55,8 @@ func (b *Bot) CheckHealth(ctx context.Context) error {
 }
 
 // SendReviewReminders will send a review reminder that an access list needs to be reviewed.
-func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessLists []*accesslist.AccessList) error {
 	return trace.NotImplemented("access list review reminder is not yet implemented")
-}
-
-// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
-func (b Bot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
-	return trace.NotImplemented("access list batched review reminder is not yet implemented")
 }
 
 // BroadcastAccessRequestMessage creates an alert for the provided recipients (schedules)

--- a/integrations/access/opsgenie/bot.go
+++ b/integrations/access/opsgenie/bot.go
@@ -59,6 +59,11 @@ func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipi
 	return trace.NotImplemented("access list review reminder is not yet implemented")
 }
 
+// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
+func (b Bot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+	return trace.NotImplemented("access list batched review reminder is not yet implemented")
+}
+
 // BroadcastAccessRequestMessage creates an alert for the provided recipients (schedules)
 func (b *Bot) BroadcastAccessRequestMessage(ctx context.Context, recipientSchedules []common.Recipient, reqID string, reqData pd.AccessRequestData) (data accessrequest.SentMessages, err error) {
 	notificationSchedules := make([]string, 0, len(recipientSchedules))

--- a/integrations/access/servicenow/bot.go
+++ b/integrations/access/servicenow/bot.go
@@ -54,13 +54,8 @@ func (b *Bot) CheckHealth(ctx context.Context) error {
 }
 
 // SendReviewReminders will send a review reminder that an access list needs to be reviewed.
-func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessLists []*accesslist.AccessList) error {
 	return trace.NotImplemented("access list review reminder is not yet implemented")
-}
-
-// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
-func (b Bot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
-	return trace.NotImplemented("access list batched review reminder is not yet implemented")
 }
 
 // BroadcastAccessRequestMessage creates a ServiceNow incident.

--- a/integrations/access/servicenow/bot.go
+++ b/integrations/access/servicenow/bot.go
@@ -58,6 +58,11 @@ func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipi
 	return trace.NotImplemented("access list review reminder is not yet implemented")
 }
 
+// SendBatchedReviewReminder will send a review reminder that an access list needs to be reviewed.
+func (b Bot) SendBatchedReviewReminder(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+	return trace.NotImplemented("access list batched review reminder is not yet implemented")
+}
+
 // BroadcastAccessRequestMessage creates a ServiceNow incident.
 func (b *Bot) BroadcastAccessRequestMessage(ctx context.Context, _ []common.Recipient, reqID string, reqData pd.AccessRequestData) (data accessrequest.SentMessages, err error) {
 	serviceNowReqData := RequestData{

--- a/integrations/access/slack/testlib/suite.go
+++ b/integrations/access/slack/testlib/suite.go
@@ -832,7 +832,7 @@ func (s *SlackSuiteEnterprise) TestRace() {
 
 // TestAccessListReminder validates that Access List reminders are sent before
 // the Access List expires.
-func (s *SlackSuiteEnterprise) TestAccessListReminder() {
+func (s *SlackSuiteEnterprise) TestAccessListReminder_Singular() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -886,6 +886,66 @@ func (s *SlackSuiteEnterprise) TestAccessListReminder() {
 	s.requireReminderMsgEqual(ctx, s.reviewer1SlackUser.ID, "Access List *simple title* is 7 day(s) past due for a review! Please review it.")
 }
 
+// TestAccessListReminder_Batched validates that Access List reminders are sent in batches
+// if multiple access lists are given.
+func (s *SlackSuiteEnterprise) TestAccessListReminder_Batched() {
+	t := s.T()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
+	s.appConfig.Clock = clock
+	s.startApp()
+
+	// Test setup: create a couple accesslists
+
+	accessList1, err := accesslist.NewAccessList(header.Metadata{
+		Name: "access-list1",
+	}, accesslist.Spec{
+		Title: "simple title one",
+		Grants: accesslist.Grants{
+			Roles: []string{"grant"},
+		},
+		Owners: []accesslist.Owner{
+			{Name: integration.Reviewer1UserName},
+		},
+		Audit: accesslist.Audit{
+			NextAuditDate: time.Date(2023, 3, 2, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.Ruler().AccessListClient().UpsertAccessList(ctx, accessList1)
+	require.NoError(t, err)
+
+	accessList2, err := accesslist.NewAccessList(header.Metadata{
+		Name: "access-list2",
+	}, accesslist.Spec{
+		Title: "simple title two",
+		Grants: accesslist.Grants{
+			Roles: []string{"grant"},
+		},
+		Owners: []accesslist.Owner{
+			{Name: integration.Reviewer1UserName},
+		},
+		Audit: accesslist.Audit{
+			NextAuditDate: time.Date(2023, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.Ruler().AccessListClient().UpsertAccessList(ctx, accessList2)
+	require.NoError(t, err)
+
+	// Trigger a reminder.
+	clock.BlockUntil(1)
+	clock.Advance(46 * 25 * time.Hour)
+	s.requireReminderMsgEqual(ctx, s.reviewer1SlackUser.ID, "2 Access Lists are due for reviews, earliest of which is due by 2023-03-01")
+
+	// Make it overdue.
+	clock.BlockUntil(1)
+	clock.Advance(20 * 24 * time.Hour)
+	s.requireReminderMsgEqual(ctx, s.reviewer1SlackUser.ID, "2 Access Lists are due for reviews, earliest of which is 8 day(s) past due")
+}
+
 func (s *SlackBaseSuite) requireReminderMsgEqual(ctx context.Context, id, text string) {
 	t := s.T()
 
@@ -893,5 +953,5 @@ func (s *SlackBaseSuite) requireReminderMsgEqual(ctx context.Context, id, text s
 	require.NoError(t, err)
 	require.Equal(t, id, msg.Channel)
 	require.IsType(t, slack.SectionBlock{}, msg.BlockItems[0].Block)
-	require.Equal(t, text, (msg.BlockItems[0].Block).(slack.SectionBlock).Text.GetText())
+	require.Contains(t, (msg.BlockItems[0].Block).(slack.SectionBlock).Text.GetText(), text)
 }


### PR DESCRIPTION
Backport #43782 to branch/v15

changelog: For slack integration, Access List reminders are batched into 1 message and provides link out to the web UI.
