### PR TITLE
Define server-side device assertion interfaces

### DIFF
--- a/api/gen/proto/go/teleport/devicetrust/v1/assert.pb.go
+++ b/api/gen/proto/go/teleport/devicetrust/v1/assert.pb.go
@@ -41,8 +41,8 @@ const (
 // either streams or multi-stage RPCs. The ceremony is resolved by a co-located
 // DeviceTrustService.
 //
-// See the lib/devicetrust/assert (client) and
-// e/lib/devicetrust/devicetrustv1/assert (server) packages.
+// See the lib/devicetrust/assert (client) and lib/devicetrust/assertserver
+// (server) packages.
 //
 // Assertion ceremony flow:
 // -> AssertDeviceInit (client)

--- a/api/proto/teleport/devicetrust/v1/assert.proto
+++ b/api/proto/teleport/devicetrust/v1/assert.proto
@@ -28,8 +28,8 @@ option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport
 // either streams or multi-stage RPCs. The ceremony is resolved by a co-located
 // DeviceTrustService.
 //
-// See the lib/devicetrust/assert (client) and
-// e/lib/devicetrust/devicetrustv1/assert (server) packages.
+// See the lib/devicetrust/assert (client) and lib/devicetrust/assertserver
+// (server) packages.
 //
 // Assertion ceremony flow:
 // -> AssertDeviceInit (client)

--- a/gen/proto/ts/teleport/devicetrust/v1/assert_pb.ts
+++ b/gen/proto/ts/teleport/devicetrust/v1/assert_pb.ts
@@ -40,8 +40,8 @@ import { AuthenticateDeviceChallengeResponse } from "./authenticate_challenge_pb
  * either streams or multi-stage RPCs. The ceremony is resolved by a co-located
  * DeviceTrustService.
  *
- * See the lib/devicetrust/assert (client) and
- * e/lib/devicetrust/devicetrustv1/assert (server) packages.
+ * See the lib/devicetrust/assert (client) and lib/devicetrust/assertserver
+ * (server) packages.
  *
  * Assertion ceremony flow:
  * -> AssertDeviceInit (client)

--- a/lib/devicetrust/assertserver/assert.go
+++ b/lib/devicetrust/assertserver/assert.go
@@ -1,0 +1,50 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package assertserver
+
+import (
+	"context"
+
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+)
+
+// AssertDeviceServerStream represents a server-side device assertion stream.
+type AssertDeviceServerStream interface {
+	Send(*devicepb.AssertDeviceResponse) error
+	Recv() (*devicepb.AssertDeviceRequest, error)
+}
+
+// Ceremony is the server-side device assertion ceremony.
+//
+// Device assertion is a light form of device authentication where the user
+// isn't considered and no side-effects (like certificate issuance) happen.
+//
+// Assertion is meant to be embedded in RPCs or streams external to the
+// DeviceTrustService itself.
+//
+// Implementations are provided by e/.
+// See e/lib/devicetrustv1.Service.CreateAssertCeremony.
+type Ceremony interface {
+	// AssertDevice runs the device assertion ceremonies.
+	//
+	// Requests and responses are consumed from the stream until the device is
+	// asserted or authentication fails.
+	//
+	// As long as any device information is acquired from the stream, a non-nil
+	// device is returned, even if the ceremony itself failed.
+	AssertDevice(ctx context.Context, stream AssertDeviceServerStream) (*devicepb.Device, error)
+}

--- a/lib/devicetrust/assertserver/doc.go
+++ b/lib/devicetrust/assertserver/doc.go
@@ -1,0 +1,21 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package assertserver provides server-side assert interfaces for device trust.
+//
+// It explicitly does not depend on devicetrust/native or other client-side
+// packages. All implementations are provided by e/.
+package assertserver


### PR DESCRIPTION
Define assert interfaces required to be in OSS.

Follow up from https://github.com/gravitational/teleport.e/pull/4592.

https://github.com/gravitational/access-graph/issues/637