### PR TITLE
Refactor Terraform credential loading

### DIFF
--- a/api/client/credentials_test.go
+++ b/api/client/credentials_test.go
@@ -203,6 +203,32 @@ func TestLoadKeyPair(t *testing.T) {
 	require.False(t, ok, "expiry should be unknown on a broken credential")
 }
 
+func TestKeyPair(t *testing.T) {
+	t.Parallel()
+
+	// Load expected tls.Config.
+	expectedTLSConfig := getExpectedTLSConfig(t)
+
+	// Load key pair from disk.
+	creds, err := KeyPair(tlsCert, keyPEM, tlsCACert)
+	require.NoError(t, err)
+
+	// Build tls.Config and compare to expected tls.Config.
+	tlsConfig, err := creds.TLSConfig()
+	require.NoError(t, err)
+	requireEqualTLSConfig(t, expectedTLSConfig, tlsConfig)
+
+	// Load invalid keypairs.
+	invalidIdentityCreds, err := KeyPair([]byte("invalid_cert"), []byte("invalid_key"), []byte("invalid_ca_cert"))
+	require.NoError(t, err)
+	_, err = invalidIdentityCreds.TLSConfig()
+	require.Error(t, err)
+
+	// Load missing keypairs
+	_, err = KeyPair(nil, nil, nil)
+	require.Error(t, err)
+}
+
 func TestLoadProfile(t *testing.T) {
 	t.Parallel()
 	profileName := "proxy.example.com"

--- a/docs/pages/reference/terraform-provider.mdx
+++ b/docs/pages/reference/terraform-provider.mdx
@@ -127,7 +127,7 @@ This auth method has the following limitations:
 
 ### Optional
 
-- `addr` (String) host:port where Teleport Auth Service is running. This can also be set with the environment variable `TF_TELEPORT_ADDR`.
+- `addr` (String) host:port of the Teleport address. This can be the Teleport Proxy Service address (port 443 or 4080) or the Teleport Auth Service address (port 3025). This can also be set with the environment variable `TF_TELEPORT_ADDR`.
 - `cert_base64` (String) Base64 encoded TLS auth certificate. This can also be set with the environment variable `TF_TELEPORT_CERT_BASE64`.
 - `cert_path` (String) Path to Teleport auth certificate file. This can also be set with the environment variable `TF_TELEPORT_CERT`.
 - `dial_timeout_duration` (String) DialTimeout sets timeout when trying to connect to the server. This can also be set with the environment variable `TF_TELEPORT_DIAL_TIMEOUT_DURATION`.

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -28,6 +28,8 @@ require (
 	google.golang.org/protobuf v1.34.2
 )
 
+require github.com/hashicorp/terraform-plugin-log v0.9.0
+
 require (
 	cloud.google.com/go v0.115.0 // indirect
 	cloud.google.com/go/auth v0.6.1 // indirect
@@ -207,7 +209,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.1 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -1,0 +1,340 @@
+package provider
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"strings"
+)
+
+var supportedCredentialSources = CredentialSources{
+	CredentialsFromKeyAndCertPath{},
+	CredentialsFromKeyAndCertBase64{},
+	CredentialsFromIdentityFilePath{},
+	CredentialsFromIdentityFileString{},
+	CredentialsFromIdentityFileBase64{},
+	CredentialsFromProfile{},
+}
+
+// CredentialSources is a list of CredentialSource
+type CredentialSources []CredentialSource
+
+// ActiveSources returns the list of active sources, and an error diagnostic if no source is active.
+// The error diagnostic explains why every source is inactive.
+func (s CredentialSources) ActiveSources(ctx context.Context, config providerData) (CredentialSources, diag.Diagnostics) {
+	var activeSources CredentialSources
+	inactiveReason := strings.Builder{}
+	for _, source := range s {
+		active, reason := source.IsActive(config)
+		logFields := map[string]interface{}{
+			"source": source.Name(),
+			"active": active,
+			"reason": reason,
+		}
+		if !active {
+			tflog.Info(ctx, "credentials source is not active, skipping", logFields)
+			inactiveReason.WriteString(fmt.Sprintf(" - cannot read credentials %s because %s\n", source.Name(), reason))
+			continue
+		}
+		tflog.Info(ctx, "credentials source is active", logFields)
+		activeSources = append(activeSources, source)
+	}
+	if len(activeSources) == 0 {
+		return nil, diag.Diagnostics{diag.NewErrorDiagnostic(
+			"No active credentials source found",
+			inactiveReason.String(),
+		)}
+	}
+	return activeSources, nil
+}
+
+// BuildClient sequentially builds credentials for every source and tries to use them to connect to Teleport.
+// Any CredentialSource failing to return a Credential and a tls.Config causes a hard failure.
+// If we have a valid credential but cannot connect, we send a warning and continue with the next credential
+// (this is for backward compatibility).
+func (s CredentialSources) BuildClient(ctx context.Context, clientCfg client.Config, providerCfg providerData) (*client.Client, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+	for _, source := range s {
+		logFields := map[string]interface{}{
+			"source": source.Name(),
+		}
+		tflog.Info(ctx, fmt.Sprintf("trying to build a client %s", source.Name()), logFields)
+		creds, err := source.Credentials(ctx, providerCfg)
+		if err != nil {
+			logFields["error"] = err.Error()
+			tflog.Error(ctx, "failed to obtain credential", logFields)
+			_, reason := source.IsActive(providerCfg)
+			diags.AddError(
+				fmt.Sprintf("Failed to build credentials %s", source.Name()),
+				brokenCredentialErrorSummary(source.Name(), reason, err),
+			)
+			return nil, diags
+		}
+
+		// Smoke test to see if the credential is valid
+		// This catches all the "file not found" issues and other broken credentials
+		// so we can turn them into a hard failure.
+		_, err = creds.TLSConfig()
+		if err != nil {
+			logFields["error"] = err.Error()
+			tflog.Error(ctx, "failed to get a TLSConfig from the credential", logFields)
+			_, reason := source.IsActive(providerCfg)
+			diags.AddError(
+				fmt.Sprintf("Failed to build credentials %s", source.Name()),
+				brokenCredentialErrorSummary(source.Name(), reason, err),
+			)
+
+			return nil, diags
+		}
+
+		// TODO: add credential expiry warning here when we will merge the credential expiry PR
+
+		clientCfg.Credentials = []client.Credentials{creds}
+		clt, err := client.New(ctx, clientCfg)
+		if err != nil {
+			logFields["error"] = err.Error()
+			tflog.Error(ctx, "failed to connect with the credential", logFields)
+			diags.AddWarning(
+				fmt.Sprintf("Failed to connect with credentials %s", source.Name()),
+				fmt.Sprintf("The client built from the credentials %s failed to connect to %q with the error: %s.",
+					source.Name(), clientCfg.Addrs[0], err,
+				))
+			continue
+		}
+		// A client was successfully built
+		return clt, diags
+	}
+	// No client was built
+	diags.AddError("Impossible to build client", s.failedToBuildClientErrorSummary(clientCfg.Addrs[0]))
+	return nil, diags
+}
+
+func (s CredentialSources) failedToBuildClientErrorSummary(addr string) string {
+	sb := strings.Builder{}
+	sb.WriteString("Every credential source provided has failed. The Terraform cannot connect to the Teleport cluster '")
+	sb.WriteString(addr)
+	sb.WriteString("'.\n")
+	sb.WriteRune('\n')
+	sb.WriteString("We tried building a client:\n")
+	for _, source := range s {
+		sb.WriteString(" - ")
+		sb.WriteString(source.Name())
+		sb.WriteRune('\n')
+	}
+	sb.WriteRune('\n')
+	sb.WriteString("You can find more information about each credential source specific errors in the Terraform warnings above this error.")
+	return sb.String()
+}
+
+func brokenCredentialErrorSummary(name, activeReason string, err error) string {
+	sb := strings.Builder{}
+	sb.WriteString("The Terraform provider tried to build credentials ")
+	sb.WriteString(name)
+	sb.WriteString(" but received the following error:\n\n")
+	sb.WriteString(err.Error())
+	sb.WriteString("\n\nThe provider tried to use the credential source because ")
+	sb.WriteString(activeReason)
+	sb.WriteString(". You must either address the error or disable the credential source by removing its values.")
+	return sb.String()
+}
+
+type CredentialSource interface {
+	Name() string
+	IsActive(providerData) (bool, string)
+	Credentials(context.Context, providerData) (client.Credentials, error)
+}
+
+type CredentialsFromKeyAndCertPath struct{}
+
+func (CredentialsFromKeyAndCertPath) Name() string {
+	return "from Key, Cert, and CA path"
+}
+
+func (CredentialsFromKeyAndCertPath) IsActive(config providerData) (bool, string) {
+	certPath := stringFromConfigOrEnv(config.CertPath, constants.EnvVarTerraformCertificates, "")
+	keyPath := stringFromConfigOrEnv(config.KeyPath, constants.EnvVarTerraformKey, "")
+
+	// This method is active as soon as a cert or a key path are set.
+	if certPath == "" && keyPath == "" {
+		return false, "neither cert_path, key_path, TF_TELEPORT_CERT nor TF_TELEPORT_KEY are set"
+	}
+
+	return true, "at least one of cert_path, key_path, TF_TELEPORT_CERT nor TF_TELEPORT_KEY is set"
+}
+
+func (CredentialsFromKeyAndCertPath) Credentials(ctx context.Context, config providerData) (client.Credentials, error) {
+	certPath := stringFromConfigOrEnv(config.CertPath, constants.EnvVarTerraformCertificates, "")
+	keyPath := stringFromConfigOrEnv(config.KeyPath, constants.EnvVarTerraformKey, "")
+	caPath := stringFromConfigOrEnv(config.RootCaPath, constants.EnvVarTerraformRootCertificates, "")
+
+	// Validate that we have all paths.
+	if certPath == "" {
+		return nil, trace.BadParameter("missing parameter 'cert_path' or environment variable 'TF_TELEPORT_CERT'")
+	}
+	if keyPath == "" {
+		return nil, trace.BadParameter("missing parameter 'key_path' or environment variable 'TF_TELEPORT_KEY'")
+	}
+	if caPath == "" {
+		return nil, trace.BadParameter("missing parameter 'root_ca_path' or environment variable 'TF_TELEPORT_ROOT_CA'")
+	}
+
+	// Validate the files exist for a better UX?
+
+	creds := client.LoadKeyPair(certPath, keyPath, caPath)
+	return creds, nil
+}
+
+type CredentialsFromKeyAndCertBase64 struct{}
+
+func (CredentialsFromKeyAndCertBase64) Name() string {
+	return "from Key, Cert, and CA base64"
+}
+
+func (CredentialsFromKeyAndCertBase64) IsActive(config providerData) (bool, string) {
+	certBase64 := stringFromConfigOrEnv(config.CertBase64, constants.EnvVarTerraformCertificatesBase64, "")
+	keyBase64 := stringFromConfigOrEnv(config.KeyBase64, constants.EnvVarTerraformKeyBase64, "")
+
+	// This method is active as soon as a cert or a key path are set.
+	if certBase64 == "" && keyBase64 == "" {
+		return false, "neither cert_base64, key_base64, TF_TELEPORT_CERT_BASE64 nor TF_TELEPORT_KEY_BASE64 are set"
+	}
+
+	return true, "at least one of cert_base64, key_base64, TF_TELEPORT_CERT_BASE64 nor TF_TELEPORT_KEY_BASE64 is set"
+}
+
+func (CredentialsFromKeyAndCertBase64) Credentials(ctx context.Context, config providerData) (client.Credentials, error) {
+	certBase64 := stringFromConfigOrEnv(config.CertBase64, constants.EnvVarTerraformCertificatesBase64, "")
+	keyBase64 := stringFromConfigOrEnv(config.KeyBase64, constants.EnvVarTerraformKeyBase64, "")
+	caBase64 := stringFromConfigOrEnv(config.RootCaBase64, constants.EnvVarTerraformRootCertificatesBase64, "")
+
+	// Validate that we have all paths.
+	if certBase64 == "" {
+		return nil, trace.BadParameter("missing parameter 'cert_base64' or environment variable 'TF_TELEPORT_CERT_BASE64'")
+	}
+	if keyBase64 == "" {
+		return nil, trace.BadParameter("missing parameter 'key_base64' or environment variable 'TF_TELEPORT_KEY_BASE64'")
+	}
+	if caBase64 == "" {
+		return nil, trace.BadParameter("missing parameter 'root_ca_base64' or environment variable 'TF_TELEPORT_ROOT_CA_BASE64'")
+	}
+
+	certPEM, err := base64.StdEncoding.DecodeString(certBase64)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to decode the certificate's base64 (standard b64 encoding)")
+	}
+	keyPEM, err := base64.StdEncoding.DecodeString(keyBase64)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to decode the key's base64 (standard b64 encoding)")
+	}
+	caPEM, err := base64.StdEncoding.DecodeString(caBase64)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to decode the CA's base64 (standard b64 encoding)")
+	}
+
+	creds, err := client.KeyPair(certPEM, keyPEM, caPEM)
+	return creds, trace.Wrap(err, "failed to load credentials from the PEM-encoded key and certificate")
+}
+
+type CredentialsFromIdentityFilePath struct{}
+
+func (CredentialsFromIdentityFilePath) Name() string {
+	return "from the identity file path"
+}
+
+func (CredentialsFromIdentityFilePath) IsActive(config providerData) (bool, string) {
+	identityFilePath := stringFromConfigOrEnv(config.IdentityFilePath, constants.EnvVarTerraformIdentityFilePath, "")
+
+	// This method is active as soon as a cert or a key path are set.
+	if identityFilePath == "" {
+		return false, "neither identity_file_path nor TF_TELEPORT_IDENTITY_FILE_PATH are set"
+	}
+
+	return true, "either identity_file_path or TF_TELEPORT_IDENTITY_FILE_PATH is set"
+}
+
+func (CredentialsFromIdentityFilePath) Credentials(ctx context.Context, config providerData) (client.Credentials, error) {
+	identityFilePath := stringFromConfigOrEnv(config.IdentityFilePath, constants.EnvVarTerraformIdentityFilePath, "")
+
+	return client.LoadIdentityFile(identityFilePath), nil
+}
+
+type CredentialsFromIdentityFileString struct{}
+
+func (CredentialsFromIdentityFileString) Name() string {
+	return "from the identity file (passed as a string)"
+}
+
+func (CredentialsFromIdentityFileString) IsActive(config providerData) (bool, string) {
+	identityFileString := stringFromConfigOrEnv(config.IdentityFile, constants.EnvVarTerraformIdentityFile, "")
+
+	// This method is active as soon as a cert or a key path are set.
+	if identityFileString == "" {
+		return false, "neither identity_file nor TF_TELEPORT_IDENTITY_FILE are set"
+	}
+
+	return true, "either identity_file or TF_TELEPORT_IDENTITY_FILE is set"
+}
+
+func (CredentialsFromIdentityFileString) Credentials(ctx context.Context, config providerData) (client.Credentials, error) {
+	identityFileString := stringFromConfigOrEnv(config.IdentityFile, constants.EnvVarTerraformIdentityFile, "")
+
+	return client.LoadIdentityFileFromString(identityFileString), nil
+}
+
+type CredentialsFromIdentityFileBase64 struct{}
+
+func (CredentialsFromIdentityFileBase64) Name() string {
+	return "from the identity file (passed as a base64-encoded string)"
+}
+
+func (CredentialsFromIdentityFileBase64) IsActive(config providerData) (bool, string) {
+	identityFileBase64 := stringFromConfigOrEnv(config.IdentityFileBase64, constants.EnvVarTerraformIdentityFileBase64, "")
+
+	// This method is active as soon as a cert or a key path are set.
+	if identityFileBase64 == "" {
+		return false, "neither identity_file_base64 nor TF_TELEPORT_IDENTITY_FILE_BASE64 are set"
+	}
+
+	return true, "either identity_file_base64 or TF_TELEPORT_IDENTITY_FILE_BASE64 is set"
+}
+
+func (CredentialsFromIdentityFileBase64) Credentials(ctx context.Context, config providerData) (client.Credentials, error) {
+	identityFileBase64 := stringFromConfigOrEnv(config.IdentityFileBase64, constants.EnvVarTerraformIdentityFileBase64, "")
+
+	identityFile, err := base64.StdEncoding.DecodeString(identityFileBase64)
+	if err != nil {
+		return nil, trace.Wrap(err, "decoding base64 identity file")
+	}
+
+	return client.LoadIdentityFileFromString(string(identityFile)), nil
+}
+
+type CredentialsFromProfile struct{}
+
+func (CredentialsFromProfile) Name() string {
+	return "from the local profile"
+}
+
+func (CredentialsFromProfile) IsActive(config providerData) (bool, string) {
+	profileName := stringFromConfigOrEnv(config.ProfileName, constants.EnvVarTerraformProfileName, "")
+	profileDir := stringFromConfigOrEnv(config.ProfileDir, constants.EnvVarTerraformProfilePath, "")
+
+	// This method is active as soon as a cert or a key path are set.
+	if profileDir == "" && profileName == "" {
+		return false, "neither profile_name, profile_dir, TF_TELEPORT_PROFILE_NAME or TF_TELEPORT_PROFILE_PATH are set"
+	}
+
+	return true, "either profile_name, profile_dir, TF_TELEPORT_PROFILE_NAME or TF_TELEPORT_PROFILE_PATH are set"
+}
+
+func (CredentialsFromProfile) Credentials(ctx context.Context, config providerData) (client.Credentials, error) {
+	profileName := stringFromConfigOrEnv(config.ProfileName, constants.EnvVarTerraformProfileName, "")
+	profileDir := stringFromConfigOrEnv(config.ProfileDir, constants.EnvVarTerraformProfilePath, "")
+
+	return client.LoadProfile(profileDir, profileName), nil
+}

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -47,7 +47,7 @@ func (s CredentialSources) ActiveSources(ctx context.Context, config providerDat
 	}
 	if len(activeSources) == 0 {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic(
-			"No active credentials source found",
+			"No active Teleport credentials source found",
 			inactiveReason.String(),
 		)}
 	}
@@ -73,7 +73,7 @@ func (s CredentialSources) BuildClient(ctx context.Context, clientCfg client.Con
 			tflog.Error(ctx, "failed to obtain credential", logFields)
 			_, reason := source.IsActive(providerCfg)
 			diags.AddError(
-				fmt.Sprintf("Failed to build credentials %s", source.Name()),
+				fmt.Sprintf("Failed to obtain Teleport credentials %s", source.Name()),
 				brokenCredentialErrorSummary(source.Name(), reason, err),
 			)
 			return nil, diags
@@ -88,7 +88,7 @@ func (s CredentialSources) BuildClient(ctx context.Context, clientCfg client.Con
 			tflog.Error(ctx, "failed to get a TLSConfig from the credential", logFields)
 			_, reason := source.IsActive(providerCfg)
 			diags.AddError(
-				fmt.Sprintf("Failed to build credentials %s", source.Name()),
+				fmt.Sprintf("Invalid Teleport credentials %s", source.Name()),
 				brokenCredentialErrorSummary(source.Name(), reason, err),
 			)
 
@@ -98,7 +98,7 @@ func (s CredentialSources) BuildClient(ctx context.Context, clientCfg client.Con
 		now := time.Now()
 		if expiry, ok := creds.Expiry(); ok && !expiry.IsZero() && expiry.Before(now) {
 			diags.AddWarning(
-				fmt.Sprintf("Credentials %s are expired", source.Name()),
+				fmt.Sprintf("Teleport credentials %s are expired", source.Name()),
 				fmt.Sprintf(`The credentials %s are expired. Expiration is %q while current time is %q). You might need to refresh them. The provider will not attempt to use those credentials.`,
 					source.Name(), expiry.Local(), now.Local()),
 			)
@@ -130,10 +130,9 @@ func (s CredentialSources) BuildClient(ctx context.Context, clientCfg client.Con
 // client and listing every connection method we tried.
 func (s CredentialSources) failedToBuildClientErrorSummary(addr string) string {
 	sb := strings.Builder{}
-	sb.WriteString("Every credential source provided has failed. The Terraform cannot connect to the Teleport cluster '")
+	sb.WriteString("Every credential source provided has failed. The Terraform provider cannot connect to the Teleport cluster '")
 	sb.WriteString(addr)
-	sb.WriteString("'.\n")
-	sb.WriteRune('\n')
+	sb.WriteString("'.\n\n")
 	sb.WriteString("We tried building a client:\n")
 	for _, source := range s {
 		sb.WriteString(" - ")

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -96,11 +96,12 @@ func (s CredentialSources) BuildClient(ctx context.Context, clientCfg client.Con
 		now := time.Now()
 		if expiry, ok := creds.Expiry(); ok && !expiry.IsZero() && expiry.Before(now) {
 			diags.AddWarning(
-				fmt.Sprintf("Credential %s is expired", source.Name()),
-				fmt.Sprintf(`The credentials %s is expired. Expiration is %q while current time is %q).
-You might need to refresh them. The provider will still attempt to connect with them, but it will likely fail.`,
+				fmt.Sprintf("Credential %s are expired", source.Name()),
+				fmt.Sprintf(`The credentials %s are expired. Expiration is %q while current time is %q).
+You might need to refresh them. The provider will not attempt to use those credentials.`,
 					source.Name(), expiry.Local(), now.Local()),
 			)
+			continue
 		}
 
 		clientCfg.Credentials = []client.Credentials{creds}

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -120,7 +120,7 @@ You might need to refresh them. The provider will not attempt to use those crede
 		return clt, diags
 	}
 	// No client was built
-	diags.AddError("Impossible to build client", s.failedToBuildClientErrorSummary(clientCfg.Addrs[0]))
+	diags.AddError("Impossible to build Teleport client", s.failedToBuildClientErrorSummary(clientCfg.Addrs[0]))
 	return nil, diags
 }
 

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -71,7 +71,7 @@ func (s CredentialSources) ActiveSources(ctx context.Context, config providerDat
 		// As trying broken credentials takes 30 seconds this is a very bad UX and we should get rid of this.
 		// Credentials from profile are not passing MFA4Admin anyway.
 		summary := inactiveReason.String() +
-			"\nThe provider will fallback to your current local profile (this behaviour is deprecated and will be removed in v17, you should specify the profile name or directory)."
+			"\nThe provider will fallback to your current local profile (this behavior is deprecated and will be removed in v17, you should specify the profile name or directory)."
 		return CredentialSources{CredentialsFromProfile{isDefault: true}}, diag.Diagnostics{diag.NewWarningDiagnostic(
 			"No active Teleport credentials source found",
 			summary,
@@ -191,7 +191,7 @@ const brokenCredentialErrorTemplate = `The Terraform provider tried to build cre
 
 The provider tried to use the credential source because {{ .Reason }}. You must either address the error or disable the credential source by removing its values.`
 
-// brokenCredentialErrorSummary returns a user-friendly message expalining why we failed to
+// brokenCredentialErrorSummary returns a user-friendly message explaining why we failed to
 func brokenCredentialErrorSummary(name, activeReason string, err error) string {
 	tpl := template.Must(template.New("broken-credential-error-summary").Parse(brokenCredentialErrorTemplate))
 	values := struct {

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -71,7 +71,7 @@ func (s CredentialSources) ActiveSources(ctx context.Context, config providerDat
 		// As trying broken credentials takes 30 seconds this is a very bad UX and we should get rid of this.
 		// Credentials from profile are not passing MFA4Admin anyway.
 		summary := inactiveReason.String() +
-			"\n\n The provider will attempt to use your current local profile (this behaviour is deprecated and will be removed in v17, you should specify the profile name or directory)."
+			"\nThe provider will fallback to your current local profile (this behaviour is deprecated and will be removed in v17, you should specify the profile name or directory)."
 		return CredentialSources{CredentialsFromProfile{isDefault: true}}, diag.Diagnostics{diag.NewWarningDiagnostic(
 			"No active Teleport credentials source found",
 			summary,
@@ -419,8 +419,12 @@ type CredentialsFromProfile struct {
 }
 
 // Name implements CredentialSource and returns the source name.
-func (CredentialsFromProfile) Name() string {
-	return "from the local profile"
+func (c CredentialsFromProfile) Name() string {
+	name := "from the local profile"
+	if c.isDefault {
+		name += " (default)"
+	}
+	return name
 }
 
 // IsActive implements CredentialSource and returns if the source is active and why.

--- a/integrations/terraform/provider/credentials_test.go
+++ b/integrations/terraform/provider/credentials_test.go
@@ -1,11 +1,29 @@
+/*
+Copyright 2024 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package provider
 
 import (
 	"context"
-	"github.com/gravitational/teleport/api/client"
+	"testing"
+
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/gravitational/teleport/api/client"
 )
 
 func TestActiveSources(t *testing.T) {

--- a/integrations/terraform/provider/credentials_test.go
+++ b/integrations/terraform/provider/credentials_test.go
@@ -1,0 +1,100 @@
+package provider
+
+import (
+	"context"
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestActiveSources(t *testing.T) {
+	ctx := context.Background()
+
+	activeSource1 := fakeActiveCredentialsSource{"active1"}
+	activeSource2 := fakeActiveCredentialsSource{"active2"}
+	inactiveSource1 := fakeInactiveCredentialsSource{"inactive1"}
+	inactiveSource2 := fakeInactiveCredentialsSource{"inactive2"}
+
+	tests := []struct {
+		name            string
+		sources         CredentialSources
+		expectedSources CredentialSources
+		wantErr         bool
+	}{
+		{
+			name:            "no source",
+			sources:         CredentialSources{},
+			expectedSources: nil,
+			wantErr:         true,
+		},
+		{
+			name: "no active source",
+			sources: CredentialSources{
+				inactiveSource1,
+				inactiveSource2,
+			},
+			expectedSources: nil,
+			wantErr:         true,
+		},
+		{
+			name: "single active source",
+			sources: CredentialSources{
+				activeSource1,
+			},
+			expectedSources: CredentialSources{activeSource1},
+			wantErr:         false,
+		},
+		{
+			name: "multiple active and inactive sources",
+			sources: CredentialSources{
+				inactiveSource1,
+				activeSource1,
+				inactiveSource2,
+				activeSource2,
+			},
+			expectedSources: CredentialSources{activeSource1, activeSource2},
+			wantErr:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, diags := tt.sources.ActiveSources(ctx, providerData{})
+			require.Equal(t, tt.wantErr, diags.HasError())
+			require.Equal(t, tt.expectedSources, result)
+		})
+	}
+}
+
+type fakeActiveCredentialsSource struct {
+	name string
+}
+
+func (f fakeActiveCredentialsSource) Name() string {
+	return f.name
+}
+
+func (f fakeActiveCredentialsSource) IsActive(data providerData) (bool, string) {
+	return true, ""
+}
+
+func (f fakeActiveCredentialsSource) Credentials(ctx context.Context, data providerData) (client.Credentials, error) {
+	return nil, trace.NotImplemented("not implemented")
+}
+
+type fakeInactiveCredentialsSource struct {
+	name string
+}
+
+func (f fakeInactiveCredentialsSource) Name() string {
+	return f.name
+}
+
+func (f fakeInactiveCredentialsSource) IsActive(data providerData) (bool, string) {
+	return false, ""
+}
+
+func (f fakeInactiveCredentialsSource) Credentials(ctx context.Context, data providerData) (client.Credentials, error) {
+	return nil, trace.NotImplemented("not implemented")
+}

--- a/integrations/terraform/provider/provider.go
+++ b/integrations/terraform/provider/provider.go
@@ -408,10 +408,10 @@ func (p *Provider) validateAddr(addr string, resp *tfsdk.ConfigureProviderRespon
 
 	_, _, err := net.SplitHostPort(addr)
 	if err != nil {
-		log.WithField("addr", addr).WithError(err).Debug("Teleport addr format error!")
+		log.WithField("addr", addr).WithError(err).Debug("Teleport address format error!")
 		resp.Diagnostics.AddError(
 			"Invalid Teleport address format",
-			fmt.Sprintf("Teleport addr must be specified as host:port. Got %q", addr),
+			fmt.Sprintf("Teleport address must be specified as host:port. Got %q", addr),
 		)
 		return false
 	}

--- a/integrations/terraform/provider/provider.go
+++ b/integrations/terraform/provider/provider.go
@@ -18,13 +18,9 @@ package provider
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/base64"
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -45,6 +41,47 @@ import (
 const (
 	// minServerVersion is the minimal teleport version the plugin supports.
 	minServerVersion = "15.0.0-0"
+)
+
+const (
+	// attributeTerraformAddress is the attribute configuring the Teleport address the Terraform provider connects to.
+	attributeTerraformAddress = "addr"
+	// attributeTerraformCertificates is the attribute configuring the path the Terraform provider loads its
+	// client certificates from. This only works for direct auth joining.
+	attributeTerraformCertificates = "cert_path"
+	// attributeTerraformCertificatesBase64 is the attribute configuring the client certificates used by the
+	// Terraform provider. This only works for direct auth joining.
+	attributeTerraformCertificatesBase64 = "cert_base64"
+	// attributeTerraformKey is the attribute configuring the path the Terraform provider loads its
+	// client key from. This only works for direct auth joining.
+	attributeTerraformKey = "key_path"
+	// attributeTerraformKeyBase64 is the attribute configuring the client key used by the
+	// Terraform provider. This only works for direct auth joining.
+	attributeTerraformKeyBase64 = "key_base64"
+	// attributeTerraformRootCertificates is the attribute configuring the path the Terraform provider loads its
+	// trusted CA certificates from. This only works for direct auth joining.
+	attributeTerraformRootCertificates = "root_ca_path"
+	// attributeTerraformRootCertificatesBase64 is the attribute configuring the CA certificates trusted by the
+	// Terraform provider. This only works for direct auth joining.
+	attributeTerraformRootCertificatesBase64 = "root_ca_base64"
+	// attributeTerraformProfileName is the attribute containing name of the profile used by the Terraform provider.
+	attributeTerraformProfileName = "profile_name"
+	// attributeTerraformProfilePath is the attribute containing the profile directory used by the Terraform provider.
+	attributeTerraformProfilePath = "profile_dir"
+	// attributeTerraformIdentityFilePath is the attribute containing the path to the identity file used by the provider.
+	attributeTerraformIdentityFilePath = "identity_file_path"
+	// attributeTerraformIdentityFile is the attribute containing the identity file used by the Terraform provider.
+	attributeTerraformIdentityFile = "identity_file"
+	// attributeTerraformIdentityFileBase64 is the attribute containing the base64-encoded identity file used by the Terraform provider.
+	attributeTerraformIdentityFileBase64 = "identity_file_base64"
+	// attributeTerraformRetryBaseDuration is the attribute configuring the base duration between two Terraform provider retries.
+	attributeTerraformRetryBaseDuration = "retry_base_duration"
+	// attributeTerraformRetryCapDuration is the attribute configuring the maximum duration between two Terraform provider retries.
+	attributeTerraformRetryCapDuration = "retry_cap_duration"
+	// attributeTerraformRetryMaxTries is the attribute configuring the maximum number of Terraform provider retries.
+	attributeTerraformRetryMaxTries = "retry_max_tries"
+	// attributeTerraformDialTimeoutDuration is the attribute configuring the Terraform provider dial timeout.
+	attributeTerraformDialTimeoutDuration = "dial_timeout_duration"
 )
 
 type RetryConfig struct {
@@ -105,92 +142,92 @@ func New() tfsdk.Provider {
 func (p *Provider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		Attributes: map[string]tfsdk.Attribute{
-			"addr": {
+			attributeTerraformAddress: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "host:port where Teleport Auth Service is running. This can also be set with the environment variable `TF_TELEPORT_ADDR`.",
+				Description: fmt.Sprintf("host:port of the Teleport address. This can be the Teleport Proxy Service address (port 443 or 4080) or the Teleport Auth Service address (port 3025). This can also be set with the environment variable `%s`.", constants.EnvVarTerraformAddress),
 			},
-			"cert_path": {
+			attributeTerraformCertificates: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Path to Teleport auth certificate file. This can also be set with the environment variable `TF_TELEPORT_CERT`.",
+				Description: fmt.Sprintf("Path to Teleport auth certificate file. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformCertificates),
 			},
-			"cert_base64": {
+			attributeTerraformCertificatesBase64: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Base64 encoded TLS auth certificate. This can also be set with the environment variable `TF_TELEPORT_CERT_BASE64`.",
+				Description: fmt.Sprintf("Base64 encoded TLS auth certificate. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformCertificatesBase64),
 			},
-			"key_path": {
+			attributeTerraformKey: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Path to Teleport auth key file. This can also be set with the environment variable `TF_TELEPORT_KEY`.",
+				Description: fmt.Sprintf("Path to Teleport auth key file. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformKey),
 			},
-			"key_base64": {
+			attributeTerraformKeyBase64: {
 				Type:        types.StringType,
 				Sensitive:   true,
 				Optional:    true,
-				Description: "Base64 encoded TLS auth key. This can also be set with the environment variable `TF_TELEPORT_KEY_BASE64`.",
+				Description: fmt.Sprintf("Base64 encoded TLS auth key. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformKeyBase64),
 			},
-			"root_ca_path": {
+			attributeTerraformRootCertificates: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Path to Teleport Root CA. This can also be set with the environment variable `TF_TELEPORT_ROOT_CA`.",
+				Description: fmt.Sprintf("Path to Teleport Root CA. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformRootCertificates),
 			},
-			"root_ca_base64": {
+			attributeTerraformRootCertificatesBase64: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Base64 encoded Root CA. This can also be set with the environment variable `TF_TELEPORT_CA_BASE64`.",
+				Description: fmt.Sprintf("Base64 encoded Root CA. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformRootCertificatesBase64),
 			},
-			"profile_name": {
+			attributeTerraformProfileName: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Teleport profile name. This can also be set with the environment variable `TF_TELEPORT_PROFILE_NAME`.",
+				Description: fmt.Sprintf("Teleport profile name. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformProfileName),
 			},
-			"profile_dir": {
+			attributeTerraformProfilePath: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Teleport profile path. This can also be set with the environment variable `TF_TELEPORT_PROFILE_PATH`.",
+				Description: fmt.Sprintf("Teleport profile path. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformProfilePath),
 			},
-			"identity_file_path": {
+			attributeTerraformIdentityFilePath: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Teleport identity file path. This can also be set with the environment variable `TF_TELEPORT_IDENTITY_FILE_PATH`.",
+				Description: fmt.Sprintf("Teleport identity file path. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformIdentityFilePath),
 			},
-			"identity_file": {
-				Type:        types.StringType,
-				Sensitive:   true,
-				Optional:    true,
-				Description: "Teleport identity file content. This can also be set with the environment variable `TF_TELEPORT_IDENTITY_FILE`.",
-			},
-			"identity_file_base64": {
+			attributeTerraformIdentityFile: {
 				Type:        types.StringType,
 				Sensitive:   true,
 				Optional:    true,
-				Description: "Teleport identity file content base64 encoded. This can also be set with the environment variable `TF_TELEPORT_IDENTITY_FILE_BASE64`.",
+				Description: fmt.Sprintf("Teleport identity file content. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformIdentityFile),
 			},
-			"retry_base_duration": {
+			attributeTerraformIdentityFileBase64: {
+				Type:        types.StringType,
+				Sensitive:   true,
+				Optional:    true,
+				Description: fmt.Sprintf("Teleport identity file content base64 encoded. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformIdentityFileBase64),
+			},
+			attributeTerraformRetryBaseDuration: {
 				Type:        types.StringType,
 				Sensitive:   false,
 				Optional:    true,
-				Description: "Retry algorithm when the API returns 'not found': base duration between retries (https://pkg.go.dev/time#ParseDuration). This can also be set with the environment variable `TF_TELEPORT_RETRY_BASE_DURATION`.",
+				Description: fmt.Sprintf("Retry algorithm when the API returns 'not found': base duration between retries (https://pkg.go.dev/time#ParseDuration). This can also be set with the environment variable `%s`.", constants.EnvVarTerraformRetryBaseDuration),
 			},
-			"retry_cap_duration": {
+			attributeTerraformRetryCapDuration: {
 				Type:        types.StringType,
 				Sensitive:   false,
 				Optional:    true,
-				Description: "Retry algorithm when the API returns 'not found': max duration between retries (https://pkg.go.dev/time#ParseDuration). This can also be set with the environment variable `TF_TELEPORT_RETRY_CAP_DURATION`.",
+				Description: fmt.Sprintf("Retry algorithm when the API returns 'not found': max duration between retries (https://pkg.go.dev/time#ParseDuration). This can also be set with the environment variable `%s`.", constants.EnvVarTerraformRetryCapDuration),
 			},
-			"retry_max_tries": {
+			attributeTerraformRetryMaxTries: {
 				Type:        types.StringType,
 				Sensitive:   false,
 				Optional:    true,
-				Description: "Retry algorithm when the API returns 'not found': max tries. This can also be set with the environment variable `TF_TELEPORT_RETRY_MAX_TRIES`.",
+				Description: fmt.Sprintf("Retry algorithm when the API returns 'not found': max tries. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformRetryMaxTries),
 			},
-			"dial_timeout_duration": {
+			attributeTerraformDialTimeoutDuration: {
 				Type:        types.StringType,
 				Sensitive:   false,
 				Optional:    true,
-				Description: "DialTimeout sets timeout when trying to connect to the server. This can also be set with the environment variable `TF_TELEPORT_DIAL_TIMEOUT_DURATION`.",
+				Description: fmt.Sprintf("DialTimeout sets timeout when trying to connect to the server. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformDialTimeoutDuration),
 			},
 		},
 	}, nil
@@ -235,7 +272,10 @@ func (p *Provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to parse Dial Timeout Duration Cap Duration",
-			fmt.Sprintf("Please check if dial_timeout_duration (or TF_TELEPORT_DIAL_TIMEOUT_DURATION) is set correctly. Error: %s", err),
+			fmt.Sprintf(
+				"Please check if %s (or %s) is set correctly. Error: %s",
+				attributeTerraformDialTimeoutDuration, constants.EnvVarTerraformDialTimeoutDuration, err,
+			),
 		)
 		return
 	}
@@ -271,7 +311,10 @@ func (p *Provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to parse Retry Base Duration",
-			fmt.Sprintf("Please check if retry_cap_duration (or TF_TELEPORT_RETRY_BASE_DURATION) is set correctly. Error: %s", err),
+			fmt.Sprintf(
+				"Please check if %s (or %s) is set correctly. Error: %s",
+				attributeTerraformRetryBaseDuration, constants.EnvVarTerraformRetryBaseDuration, err,
+			),
 		)
 		return
 	}
@@ -280,7 +323,10 @@ func (p *Provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to parse Retry Cap Duration",
-			fmt.Sprintf("Please check if retry_cap_duration (or TF_TELEPORT_RETRY_CAP_DURATION) is set correctly. Error: %s", err),
+			fmt.Sprintf(
+				"Please check if %s (or %s) is set correctly. Error: %s",
+				attributeTerraformRetryCapDuration, constants.EnvVarTerraformRetryCapDuration, err,
+			),
 		)
 		return
 	}
@@ -289,7 +335,10 @@ func (p *Provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to parse Retry Max Tries",
-			fmt.Sprintf("Please check if retry_max_tries (or TF_TELEPORT_RETRY_MAX_TRIES) is set correctly. Error: %s", err),
+			fmt.Sprintf(
+				"Please check if %s (or %s) is set correctly. Error: %s",
+				attributeTerraformRetryMaxTries, constants.EnvVarTerraformRetryMaxTries, err,
+			),
 		)
 		return
 	}
@@ -351,7 +400,8 @@ func (p *Provider) validateAddr(addr string, resp *tfsdk.ConfigureProviderRespon
 	if addr == "" {
 		resp.Diagnostics.AddError(
 			"Teleport address is empty",
-			"Please, specify either TF_TELEPORT_ADDR or addr in provider configuration",
+			fmt.Sprintf("Please, specify either %s in provider configuration, or the %s environment variable",
+				attributeTerraformAddress, constants.EnvVarTerraformAddress),
 		)
 		return false
 	}
@@ -360,100 +410,15 @@ func (p *Provider) validateAddr(addr string, resp *tfsdk.ConfigureProviderRespon
 	if err != nil {
 		log.WithField("addr", addr).WithError(err).Debug("Teleport addr format error!")
 		resp.Diagnostics.AddError(
-			"Invalid Teleport addr format",
-			"Teleport addr must be specified as host:port",
+			"Invalid Teleport address format",
+			fmt.Sprintf("Teleport addr must be specified as host:port. Got %q", addr),
 		)
 		return false
 	}
 	return true
 }
 
-// getCredentialsFromBase64 returns client.Credentials built from base64 encoded keys
-func (p *Provider) getCredentialsFromBase64(certBase64, keyBase64, caBase64 string, resp *tfsdk.ConfigureProviderResponse) (client.Credentials, bool) {
-	cert, err := base64.StdEncoding.DecodeString(certBase64)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Failed to base64 decode cert",
-			fmt.Sprintf("Please check if cert_base64 (or TF_TELEPORT_CERT_BASE64) is set correctly. Error: %s", err),
-		)
-		return nil, false
-	}
-	key, err := base64.StdEncoding.DecodeString(keyBase64)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Failed to base64 decode key",
-			fmt.Sprintf("Please check if key_base64 (or TF_TELEPORT_KEY_BASE64) is set correctly. Error: %s", err),
-		)
-		return nil, false
-	}
-	rootCa, err := base64.StdEncoding.DecodeString(caBase64)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Failed to base64 decode root ca",
-			fmt.Sprintf("Please check if root_ca_base64 (or TF_TELEPORT_CA_BASE64) is set correctly. Error: %s", err),
-		)
-		return nil, false
-	}
-	tlsConfig, err := createTLSConfig(cert, key, rootCa)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Failed to create TLS config",
-			fmt.Sprintf("Error: %s", err),
-		)
-		return nil, false
-	}
-	return client.LoadTLS(tlsConfig), true
-}
-
-// getCredentialsFromKeyPair returns client.Credentials built from path to key files
-func (p *Provider) getCredentialsFromKeyPair(certPath string, keyPath string, caPath string, resp *tfsdk.ConfigureProviderResponse) (client.Credentials, bool) {
-	if !p.fileExists(certPath) {
-		resp.Diagnostics.AddError(
-			"Certificate file not found",
-			fmt.Sprintf("File %v not found! Use 'tctl auth sign --user=example@example.com --format=tls --out=%v' to generate keys",
-				certPath,
-				filepath.Dir(certPath),
-			),
-		)
-		return nil, false
-	}
-
-	if !p.fileExists(keyPath) {
-		resp.Diagnostics.AddError(
-			"Private key file not found",
-			fmt.Sprintf("File %v not found! Use 'tctl auth sign --user=example@example.com --format=tls --out=%v' to generate keys",
-				keyPath,
-				filepath.Dir(keyPath),
-			),
-		)
-		return nil, false
-	}
-
-	if !p.fileExists(caPath) {
-		resp.Diagnostics.AddError(
-			"Root CA certificate file not found",
-			fmt.Sprintf("File %v not found! Use 'tctl auth sign --user=example@example.com --format=tls --out=%v' to generate keys",
-				caPath,
-				filepath.Dir(caPath),
-			),
-		)
-		return nil, false
-	}
-
-	return client.LoadKeyPair(certPath, keyPath, caPath), true
-}
-
-// fileExists returns true if file exists
-func (p *Provider) fileExists(path string) bool {
-	_, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		return false
-	}
-	if err != nil {
-		return false
-	}
-	return true
-}
+// TODO(hugoShaka): fix logging in a future release by converting to tflog.
 
 // configureLog configures logging
 func (p *Provider) configureLog() {
@@ -472,21 +437,6 @@ func (p *Provider) configureLog() {
 		l := grpclog.NewLoggerV2(log.StandardLogger().Out, log.StandardLogger().Out, log.StandardLogger().Out)
 		grpclog.SetLoggerV2(l)
 	}
-}
-
-// createTLSConfig returns tls.Config build from keys
-func createTLSConfig(cert, key, rootCa []byte) (*tls.Config, error) {
-	keyPair, err := tls.X509KeyPair(cert, key)
-	if err != nil {
-		return nil, err
-	}
-	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(rootCa)
-
-	return &tls.Config{
-		Certificates: []tls.Certificate{keyPair},
-		RootCAs:      caCertPool,
-	}, nil
 }
 
 // GetResources returns the map of provider resources


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/42437

This PR refactors Terraform's credential loading to stop YOLO-ing all the credentials into the client and praying that one of them works.

Now each credential is individually tested. Terraform also lists the supported credentials and can explain why a credential is active or not.

This change will open the way for 2 other changes:
- have Terraform check if credentials are expired and warn the user
- have Terraform support MachineID joining

Other notable changes are:
- introduce a new KeyPair() function that builds a credential from DER material. This is neeed as creds built from tls.Config don't allow to report the expiry.
- use `terraform-plugin-log` to provide structured logging. We'll be able to tell the users to diagnose with `export TF_LOG=INFO`

Changelog: clearer terraform-provider error and warning messages about its credentials.

## Example output
### No credential source
```
╷
│ Error: No active credentials source found
│ 
│   with provider["terraform.releases.teleport.dev/gravitational/teleport"],
│   on main.tf line 11, in provider "teleport":
│   11: provider "teleport" {
│ 
│  - cannot read credentials from Key, Cert, and CA path because neither cert_path, key_path, TF_TELEPORT_CERT, nor TF_TELEPORT_KEY are set
│  - cannot read credentials from Key, Cert, and CA base64 because neither cert_base64, key_base64, TF_TELEPORT_CERT_BASE64, nor TF_TELEPORT_KEY_BASE64 are set
│  - cannot read credentials from the identity file path because neither identity_file_path, nor TF_TELEPORT_IDENTITY_FILE_PATH are set
│  - cannot read credentials from the identity file (passed as a string) because neither identity_file, nor TF_TELEPORT_IDENTITY_FILE are set
│  - cannot read credentials from the identity file (passed as a base64-encoded string) because neither identity_file_base64, nor TF_TELEPORT_IDENTITY_FILE_BASE64 are set
│  - cannot read credentials from the local profile because neither profile_name, profile_dir, TF_TELEPORT_PROFILE_NAME, nor TF_TELEPORT_PROFILE_PATH are set
│ 
```

### Expired credentials

```
│ Warning: Credentials from the identity file (passed as a base64-encoded string) are expired
│ 
│   with provider["terraform.releases.teleport.dev/gravitational/teleport"],
│   on main.tf line 11, in provider "teleport":
│   11: provider "teleport" {
│ 
│ The credentials from the identity file (passed as a base64-encoded string) are expired. Expiration is "2024-07-16 12:57:13 -0400 EDT" while current time is "2024-07-16
│ 12:57:37.066592 -0400 EDT"). You might need to refresh them. The provider will not attempt to use those credentials.
╵
╷
│ Error: Impossible to build Teleport client
│ 
│   with provider["terraform.releases.teleport.dev/gravitational/teleport"],
│   on main.tf line 11, in provider "teleport":
│   11: provider "teleport" {
│ 
│ Every credential source provided has failed. The Terraform cannot connect to the Teleport cluster '0.0.0.0:3025'.
│ 
│ We tried building a client:
│  - from the identity file (passed as a base64-encoded string)
│ 
│ You can find more information about each credential source specific errors in the Terraform warnings above this error.
╵
```

### Failed to build credentials

```
╷
│ Error: Failed to build credentials from the identity file (passed as a base64-encoded string)
│ 
│   with provider["terraform.releases.teleport.dev/gravitational/teleport"],
│   on main.tf line 11, in provider "teleport":
│   11: provider "teleport" {
│ 
│ The Terraform provider tried to build credentials from the identity file (passed as a base64-encoded string) but received the following error:
│ 
│ decoding base64 identity file
│       illegal base64 data at input byte 4
│ 
│ The provider tried to use the credential source because either identity_file_base64, or TF_TELEPORT_IDENTITY_FILE_BASE64 are set. You must either address the error or
│ disable the credential source by removing its values.
╵
```

### Failed to connect (teleport not running)
```
╷
│ Warning: Failed to connect with credentials from the identity file (passed as a base64-encoded string)
│ 
│   with provider["terraform.releases.teleport.dev/gravitational/teleport"],
│   on main.tf line 11, in provider "teleport":
│   11: provider "teleport" {
│ 
│ The client built from the credentials from the identity file (passed as a base64-encoded string) failed to connect to "0.0.0.0:3025" with the error: all connection methods
│ failed
│       
│       failed to connect to addr 0.0.0.0:3025 as a web proxy
│               context deadline exceeded: connection error: desc = "transport: Error while dialing: failed to dial: Get \"https://0.0.0.0:3025/webapi/find\": dial tcp 0.0.0.0:3025:
│ connect: connection refused", 
│       failed to connect to addr 0.0.0.0:3025 as a reverse tunnel proxy
│               context deadline exceeded: connection error: desc = "transport: Error while dialing: failed to dial: dial tcp 0.0.0.0:3025: connect: connection refused", 
│       failed to connect to addr 0.0.0.0:3025 as an auth server
│               context deadline exceeded: connection error: desc = "transport: Error while dialing: failed to dial: dial tcp 0.0.0.0:3025: connect: connection refused", 
│       failed to connect to addr 0.0.0.0:3025 with TLS Routing with ALPN connection upgrade dialer
│               context deadline exceeded: connection error: desc = "transport: Error while dialing: failed to dial: Get \"https://0.0.0.0:3025/webapi/find\": dial tcp 0.0.0.0:3025:
│ connect: connection refused", 
│       failed to connect to addr 0.0.0.0:3025 with TLS Routing dialer
│               context deadline exceeded: connection error: desc = "transport: Error while dialing: failed to dial: Get \"https://0.0.0.0:3025/webapi/find\": dial tcp 0.0.0.0:3025:
│ connect: connection refused".
╵
╷
│ Error: Impossible to build Teleport client
│ 
│   with provider["terraform.releases.teleport.dev/gravitational/teleport"],
│   on main.tf line 11, in provider "teleport":
│   11: provider "teleport" {
│ 
│ Every credential source provided has failed. The Terraform cannot connect to the Teleport cluster '0.0.0.0:3025'.
│ 
│ We tried building a client:
│  - from the identity file (passed as a base64-encoded string)
│ 
│ You can find more information about each credential source specific errors in the Terraform warnings above this error.
╵

```
