### PR TITLE
Remove outdated RoleOptions.device_trust_mode comment

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -2864,7 +2864,6 @@ message RoleOptions {
   // DeviceTrustMode is the device authorization mode used for the resources
   // associated with the role.
   // See DeviceTrust.Mode.
-  // Reserved for future use, not yet used by Teleport.
   string DeviceTrustMode = 24 [(gogoproto.jsontag) = "device_trust_mode,omitempty"];
 
   // IDP is a set of options related to accessing IdPs within Teleport.

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -7476,7 +7476,6 @@ type RoleOptions struct {
 	// DeviceTrustMode is the device authorization mode used for the resources
 	// associated with the role.
 	// See DeviceTrust.Mode.
-	// Reserved for future use, not yet used by Teleport.
 	DeviceTrustMode string `protobuf:"bytes,24,opt,name=DeviceTrustMode,proto3" json:"device_trust_mode,omitempty"`
 	// IDP is a set of options related to accessing IdPs within Teleport.
 	// Requires Teleport Enterprise.


### PR DESCRIPTION
The Role's device_trust_mode has an effect in all active releases.