### PR TITLE
Print accurate status in tsh login output

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1881,6 +1881,11 @@ func onLogin(cf *CLIConf) error {
 				return trace.Wrap(err)
 			}
 
+			profile, profiles, err = cf.FullProfileStatus()
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
 			// Print status to show information of the logged in user.
 			return trace.Wrap(printLoginInformation(cf, profile, profiles, cf.getAccessListsToReview(tc)))
 		// proxy is unspecified or the same as the currently provided proxy,


### PR DESCRIPTION
If tsh login was executed while the user had a valid session the resulting status shown to the user included data from the prior session. The root cause was the profile being passed to `printLoginInformation` was old. Any profiles retrieved prior to calling `(TeleportClient) SaveProfile` should be discarded and the profile should be retrieved again to reflect the new session. Other branches within the login logic were already correctly refreshing the profile.

Closes https://github.com/gravitational/teleport/issues/33732.


Changelog: Ensure that tsh login outputs accurate status information for the new session.