### PR TITLE
operator: fix operator dockerfile COPY statements

### DIFF
--- a/integrations/operator/Dockerfile.gha
+++ b/integrations/operator/Dockerfile.gha
@@ -75,9 +75,9 @@ RUN go mod download
 COPY *.go ./
 COPY lib/ lib/
 COPY gen/ gen/
+COPY integrations/lib/embeddedtbot/ integrations/lib/embeddedtbot/
 COPY integrations/operator/apis/ integrations/operator/apis/
 COPY integrations/operator/controllers/ integrations/operator/controllers/
-COPY integrations/operator/embeddedtbot/ integrations/operator/embeddedtbot/
 COPY integrations/operator/main.go integrations/operator/main.go
 COPY integrations/operator/namespace.go integrations/operator/namespace.go
 COPY integrations/operator/config.go integrations/operator/config.go


### PR DESCRIPTION
Update `Dockerfile.gha` to copy embeddedtbot from its new location in
`integrations/lib`. This change was made to `Dockerfile` but missed
`Dockerfile.gha`.

A follow-up commit will remove the "old" Dockerfile which should have
been done shortly after Drone was decommissioned. This will prevent this
being missed again.
