### PR TITLE
Add DiscoveryConfig name to Server Fetchers/Watchers

### DIFF
--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -2503,7 +2503,19 @@ func TestAzureVMDiscovery(t *testing.T) {
 				require.Eventually(t, func() bool {
 					server.muDynamicServerAzureFetchers.RLock()
 					defer server.muDynamicServerAzureFetchers.RUnlock()
-					return len(server.dynamicServerAzureFetchers) > 0
+
+					if len(server.dynamicServerAzureFetchers) == 0 {
+						return false
+					}
+					if len(server.dynamicServerAzureFetchers[tc.discoveryConfig.GetName()]) == 0 {
+						return false
+					}
+
+					fetcher := server.dynamicServerAzureFetchers[tc.discoveryConfig.GetName()][0]
+
+					require.Equal(t, fetcher.GetDiscoveryConfig(), tc.discoveryConfig.GetName())
+
+					return true
 				}, 1*time.Second, 100*time.Millisecond)
 			}
 
@@ -2768,7 +2780,19 @@ func TestGCPVMDiscovery(t *testing.T) {
 				require.Eventually(t, func() bool {
 					server.muDynamicServerGCPFetchers.RLock()
 					defer server.muDynamicServerGCPFetchers.RUnlock()
-					return len(server.dynamicServerGCPFetchers) > 0
+
+					if len(server.dynamicServerGCPFetchers) == 0 {
+						return false
+					}
+					if len(server.dynamicServerGCPFetchers[tc.discoveryConfig.GetName()]) == 0 {
+						return false
+					}
+
+					fetcher := server.dynamicServerGCPFetchers[tc.discoveryConfig.GetName()][0]
+
+					require.Equal(t, fetcher.GetDiscoveryConfig(), tc.discoveryConfig.GetName())
+
+					return true
 				}, 1*time.Second, 100*time.Millisecond)
 			}
 

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -97,7 +97,7 @@ func NewAzureWatcher(ctx context.Context, fetchersFn func() []Fetcher, opts ...O
 }
 
 // MatchersToAzureInstanceFetchers converts a list of Azure VM Matchers into a list of Azure VM Fetchers.
-func MatchersToAzureInstanceFetchers(matchers []types.AzureMatcher, clients azureClientGetter) []Fetcher {
+func MatchersToAzureInstanceFetchers(matchers []types.AzureMatcher, clients azureClientGetter, discoveryConfig string) []Fetcher {
 	ret := make([]Fetcher, 0)
 	for _, matcher := range matchers {
 		for _, subscription := range matcher.Subscriptions {
@@ -107,6 +107,7 @@ func MatchersToAzureInstanceFetchers(matchers []types.AzureMatcher, clients azur
 					Subscription:      subscription,
 					ResourceGroup:     resourceGroup,
 					AzureClientGetter: clients,
+					DiscoveryConfig:   discoveryConfig,
 				})
 				ret = append(ret, fetcher)
 			}
@@ -120,6 +121,7 @@ type azureFetcherConfig struct {
 	Subscription      string
 	ResourceGroup     string
 	AzureClientGetter azureClientGetter
+	DiscoveryConfig   string
 }
 
 type azureInstanceFetcher struct {
@@ -130,6 +132,7 @@ type azureInstanceFetcher struct {
 	Labels            types.Labels
 	Parameters        map[string]string
 	ClientID          string
+	DiscoveryConfig   string
 }
 
 func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
@@ -139,6 +142,7 @@ func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
 		Subscription:      cfg.Subscription,
 		ResourceGroup:     cfg.ResourceGroup,
 		Labels:            cfg.Matcher.ResourceTags,
+		DiscoveryConfig:   cfg.DiscoveryConfig,
 	}
 
 	if cfg.Matcher.Params != nil {
@@ -151,6 +155,12 @@ func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
 	}
 
 	return ret
+}
+
+// GetDiscoveryConfig returns the DiscoveryConfig name that originated this fetcher.
+// Empty if it was generated statically from the discovery_service.
+func (f *azureInstanceFetcher) GetDiscoveryConfig() string {
+	return f.DiscoveryConfig
 }
 
 func (*azureInstanceFetcher) GetMatchingInstances(_ []types.Server, _ bool) ([]Instances, error) {

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -38,6 +38,7 @@ func (c *mockClients) GetAzureVirtualMachinesClient(subscription string) (azure.
 func TestAzureWatcher(t *testing.T) {
 	t.Parallel()
 
+	discoveryConfigName := "my-dc"
 	clients := mockClients{
 		azureClient: azure.NewVirtualMachinesClientByAPI(&azure.ARMComputeMock{
 			VirtualMachines: map[string][]*armcompute.VirtualMachine{
@@ -139,7 +140,7 @@ func TestAzureWatcher(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			t.Cleanup(cancel)
 			watcher, err := NewAzureWatcher(ctx, func() []Fetcher {
-				return MatchersToAzureInstanceFetchers([]types.AzureMatcher{tc.matcher}, &clients)
+				return MatchersToAzureInstanceFetchers([]types.AzureMatcher{tc.matcher}, &clients, discoveryConfigName)
 			})
 			require.NoError(t, err)
 

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -69,6 +69,10 @@ type EC2Instances struct {
 
 	// EnrollMode is the mode used to enroll the instance into Teleport.
 	EnrollMode types.InstallParamEnrollMode
+
+	// DiscoveryConfigName is the name of the DiscoveryConfig that generated the Fetcher that discovered this set of instances.
+	// Empty when the matcher came from a static configuration of the discovery_service.
+	DiscoveryConfig string
 }
 
 // EC2Instance represents an AWS EC2 instance that has been
@@ -181,7 +185,7 @@ func NewEC2Watcher(ctx context.Context, fetchersFn func() []Fetcher, missedRotat
 }
 
 // MatchersToEC2InstanceFetchers converts a list of AWS EC2 Matchers into a list of AWS EC2 Fetchers.
-func MatchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatcher, clients cloud.Clients) ([]Fetcher, error) {
+func MatchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatcher, clients cloud.Clients, discoveryConfig string) ([]Fetcher, error) {
 	ret := []Fetcher{}
 	for _, matcher := range matchers {
 		for _, region := range matcher.Regions {
@@ -194,13 +198,14 @@ func MatchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatc
 			}
 
 			fetcher := newEC2InstanceFetcher(ec2FetcherConfig{
-				Matcher:     matcher,
-				Region:      region,
-				Document:    matcher.SSM.DocumentName,
-				EC2Client:   ec2Client,
-				Labels:      matcher.Tags,
-				Integration: matcher.Integration,
-				EnrollMode:  matcher.Params.EnrollMode,
+				Matcher:         matcher,
+				Region:          region,
+				Document:        matcher.SSM.DocumentName,
+				EC2Client:       ec2Client,
+				Labels:          matcher.Tags,
+				Integration:     matcher.Integration,
+				EnrollMode:      matcher.Params.EnrollMode,
+				DiscoveryConfig: discoveryConfig,
 			})
 			ret = append(ret, fetcher)
 		}
@@ -209,23 +214,25 @@ func MatchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatc
 }
 
 type ec2FetcherConfig struct {
-	Matcher     types.AWSMatcher
-	Region      string
-	Document    string
-	EC2Client   ec2iface.EC2API
-	Labels      types.Labels
-	Integration string
-	EnrollMode  types.InstallParamEnrollMode
+	Matcher         types.AWSMatcher
+	Region          string
+	Document        string
+	EC2Client       ec2iface.EC2API
+	Labels          types.Labels
+	Integration     string
+	EnrollMode      types.InstallParamEnrollMode
+	DiscoveryConfig string
 }
 
 type ec2InstanceFetcher struct {
-	Filters      []*ec2.Filter
-	EC2          ec2iface.EC2API
-	Region       string
-	DocumentName string
-	Parameters   map[string]string
-	Integration  string
-	EnrollMode   types.InstallParamEnrollMode
+	Filters         []*ec2.Filter
+	EC2             ec2iface.EC2API
+	Region          string
+	DocumentName    string
+	Parameters      map[string]string
+	Integration     string
+	EnrollMode      types.InstallParamEnrollMode
+	DiscoveryConfig string
 
 	// cachedInstances keeps all of the ec2 instances that were matched
 	// in the last run of GetInstances for use as a cache with
@@ -311,13 +318,14 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 	}
 
 	fetcherConfig := ec2InstanceFetcher{
-		EC2:          cfg.EC2Client,
-		Filters:      tagFilters,
-		Region:       cfg.Region,
-		DocumentName: cfg.Document,
-		Parameters:   parameters,
-		Integration:  cfg.Integration,
-		EnrollMode:   cfg.EnrollMode,
+		EC2:             cfg.EC2Client,
+		Filters:         tagFilters,
+		Region:          cfg.Region,
+		DocumentName:    cfg.Document,
+		Parameters:      parameters,
+		Integration:     cfg.Integration,
+		EnrollMode:      cfg.EnrollMode,
+		DiscoveryConfig: cfg.DiscoveryConfig,
 		cachedInstances: &instancesCache{
 			instances: map[cachedInstanceKey]struct{}{},
 		},
@@ -325,14 +333,21 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 	return &fetcherConfig
 }
 
+// GetDiscoveryConfig returns the DiscoveryConfig name that originated this fetcher.
+// Empty if it was generated statically from the discovery_service.
+func (f *ec2InstanceFetcher) GetDiscoveryConfig() string {
+	return f.DiscoveryConfig
+}
+
 // GetMatchingInstances returns a list of EC2 instances from a list of matching Teleport nodes
 func (f *ec2InstanceFetcher) GetMatchingInstances(nodes []types.Server, rotation bool) ([]Instances, error) {
 	insts := EC2Instances{
-		Region:       f.Region,
-		DocumentName: f.DocumentName,
-		Parameters:   f.Parameters,
-		Rotation:     rotation,
-		Integration:  f.Integration,
+		Region:          f.Region,
+		DocumentName:    f.DocumentName,
+		Parameters:      f.Parameters,
+		Rotation:        rotation,
+		Integration:     f.Integration,
+		DiscoveryConfig: f.DiscoveryConfig,
 	}
 	for _, node := range nodes {
 		// Heartbeating and expiration keeps Teleport Agents up to date, no need to consider those nodes.
@@ -409,14 +424,15 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 					}
 					ownerID := aws.StringValue(res.OwnerId)
 					inst := EC2Instances{
-						AccountID:    ownerID,
-						Region:       f.Region,
-						DocumentName: f.DocumentName,
-						Instances:    ToEC2Instances(res.Instances[i:end]),
-						Parameters:   f.Parameters,
-						Rotation:     rotation,
-						Integration:  f.Integration,
-						EnrollMode:   f.EnrollMode,
+						AccountID:       ownerID,
+						Region:          f.Region,
+						DocumentName:    f.DocumentName,
+						Instances:       ToEC2Instances(res.Instances[i:end]),
+						Parameters:      f.Parameters,
+						Rotation:        rotation,
+						Integration:     f.Integration,
+						EnrollMode:      f.EnrollMode,
+						DiscoveryConfig: f.DiscoveryConfig,
 					}
 					for _, ec2inst := range res.Instances[i:end] {
 						f.cachedInstances.add(ownerID, aws.StringValue(ec2inst.InstanceId))

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -141,6 +141,7 @@ func TestNewEC2InstanceFetcherTags(t *testing.T) {
 
 func TestEC2Watcher(t *testing.T) {
 	t.Parallel()
+	discoveryConfigName := "my-dc"
 	clients := mockClients{
 		ec2Client: &mockEC2Client{},
 	}
@@ -240,7 +241,7 @@ func TestEC2Watcher(t *testing.T) {
 	clients.ec2Client.output = &output
 
 	fetchersFn := func() []Fetcher {
-		fetchers, err := MatchersToEC2InstanceFetchers(ctx, matchers, &clients)
+		fetchers, err := MatchersToEC2InstanceFetchers(ctx, matchers, &clients, discoveryConfigName)
 		require.NoError(t, err)
 
 		return fetchers
@@ -252,22 +253,25 @@ func TestEC2Watcher(t *testing.T) {
 
 	result := <-watcher.InstancesC
 	require.Equal(t, EC2Instances{
-		Region:     "us-west-2",
-		Instances:  []EC2Instance{toEC2Instance(&present)},
-		Parameters: map[string]string{"token": "", "scriptName": ""},
+		Region:          "us-west-2",
+		Instances:       []EC2Instance{toEC2Instance(&present)},
+		Parameters:      map[string]string{"token": "", "scriptName": ""},
+		DiscoveryConfig: "my-dc",
 	}, *result.EC2)
 	result = <-watcher.InstancesC
 	require.Equal(t, EC2Instances{
-		Region:     "us-west-2",
-		Instances:  []EC2Instance{toEC2Instance(&presentOther)},
-		Parameters: map[string]string{"token": "", "scriptName": ""},
+		Region:          "us-west-2",
+		Instances:       []EC2Instance{toEC2Instance(&presentOther)},
+		Parameters:      map[string]string{"token": "", "scriptName": ""},
+		DiscoveryConfig: "my-dc",
 	}, *result.EC2)
 	result = <-watcher.InstancesC
 	require.Equal(t, EC2Instances{
-		Region:      "us-west-2",
-		Instances:   []EC2Instance{toEC2Instance(&presentForEICE)},
-		Parameters:  map[string]string{"token": "", "scriptName": "", "sshdConfigPath": ""},
-		Integration: "my-aws-integration",
+		Region:          "us-west-2",
+		Instances:       []EC2Instance{toEC2Instance(&presentForEICE)},
+		Parameters:      map[string]string{"token": "", "scriptName": "", "sshdConfigPath": ""},
+		Integration:     "my-aws-integration",
+		DiscoveryConfig: "my-dc",
 	}, *result.EC2)
 }
 

--- a/lib/srv/server/ssm_install.go
+++ b/lib/srv/server/ssm_install.go
@@ -71,6 +71,12 @@ type SSMRunRequest struct {
 	Region string
 	// AccountID is the AWS account being used to execute the SSM document.
 	AccountID string
+	// DiscoveryConfigName is the DiscoveryConfig that originated this SSMRunRequest.
+	// Empty if it was generated from a static configuration in discovery_service.
+	DiscoveryConfigName string
+	// IntegrationName is the integration name when using integration credentials.
+	// Empty if using ambient credentials.
+	IntegrationName string
 }
 
 // CheckAndSetDefaults ensures the emitter is present and creates a default logger if one is not provided.

--- a/lib/srv/server/watcher.go
+++ b/lib/srv/server/watcher.go
@@ -42,6 +42,9 @@ type Fetcher interface {
 	// GetMatchingInstances finds Instances from the list of nodes
 	// that the fetcher matches.
 	GetMatchingInstances(nodes []types.Server, rotation bool) ([]Instances, error)
+	// GetDiscoveryConfig returns the DiscoveryConfig name that originated this fetcher.
+	// Empty if it was generated statically from the discovery_service.
+	GetDiscoveryConfig() string
 }
 
 // WithTriggerFetchC sets a poll trigger to manual start a resource polling.


### PR DESCRIPTION
This change adds the DiscoveryConfig name to Server Fetchers.
A follow up PR will use this new field in order to expand report the total discovered resources per DiscoveryConfig in each Fetcher.