### PR TITLE
[v15] Ensure tbot compiles on windows

### DIFF
--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -42,4 +42,4 @@ jobs:
         shell: bash
         run: |
           export OS="windows"
-          make build/tsh build/tctl
+          make build/tsh build/tctl build/tbot

--- a/Makefile
+++ b/Makefile
@@ -348,14 +348,12 @@ $(BUILDDIR)/tsh:
 	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG_TSH) go build -tags "$(FIPS_TAG) $(LIBFIDO2_BUILD_TAG) $(TOUCHID_TAG) $(PIV_BUILD_TAG)" -o $(BUILDDIR)/tsh $(BUILDFLAGS) ./tool/tsh
 
 .PHONY: $(BUILDDIR)/tbot
-$(BUILDDIR)/tbot: CGO_ENABLED ?= 0
+# tbot is CGO-less by default except on Windows because lib/client/terminal/ wants CGO on this OS
+$(BUILDDIR)/tbot: TBOT_CGO_FLAGS ?= $(if $(filter windows,$(OS)),$(CGOFLAG))
+# Build mode pie requires CGO
+$(BUILDDIR)/tbot: BUILDFLAGS_TBOT += $(if $(TBOT_CGO_FLAGS), -buildmode=pie)
 $(BUILDDIR)/tbot:
-# The -buildmode=pie flag requires external cgo linking.
-ifeq ("$(CGO_ENABLED)", "1")
-	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=1 go build -tags "$(FIPS_TAG)" -o $(BUILDDIR)/tbot $(BUILDFLAGS_TBOT) -buildmode=pie ./tool/tbot
-else
-	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build -tags "$(FIPS_TAG)" -o $(BUILDDIR)/tbot $(BUILDFLAGS_TBOT) ./tool/tbot
-endif
+	GOOS=$(OS) GOARCH=$(ARCH) $(TBOT_CGO_FLAGS) go build -tags "$(FIPS_TAG)" -o $(BUILDDIR)/tbot $(BUILDFLAGS_TBOT) ./tool/tbot
 
 .PHONY: $(BUILDDIR)/fdpass-teleport
 $(BUILDDIR)/fdpass-teleport:

--- a/lib/tbot/botfs/botfs.go
+++ b/lib/tbot/botfs/botfs.go
@@ -23,14 +23,10 @@ import (
 	"io/fs"
 	"os"
 	"os/user"
-	"runtime"
-	"strconv"
-	"syscall"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/constants"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
@@ -138,38 +134,4 @@ func createStandard(path string, isDir bool) error {
 	}
 
 	return nil
-}
-
-// GetOwner attempts to retrieve the owner of the given file. This is not
-// supported on all platforms and will return a trace.NotImplemented in that
-// case.
-func GetOwner(fileInfo fs.FileInfo) (*user.User, error) {
-	info, ok := fileInfo.Sys().(*syscall.Stat_t)
-	if !ok {
-		return nil, trace.NotImplemented("Cannot verify file ownership on this platform.")
-	}
-
-	user, err := user.LookupId(strconv.Itoa(int(info.Uid)))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return user, nil
-}
-
-// IsOwnedBy checks that the file at the given path is owned by the given user.
-// Returns a trace.NotImplemented() on unsupported platforms.
-func IsOwnedBy(fileInfo fs.FileInfo, user *user.User) (bool, error) {
-	if runtime.GOOS == constants.WindowsOS {
-		// no-op on windows
-		return false, trace.NotImplemented("Cannot verify file ownership on this platform.")
-	}
-
-	info, ok := fileInfo.Sys().(*syscall.Stat_t)
-	if !ok {
-		return false, trace.NotImplemented("Cannot verify file ownership on this platform.")
-	}
-
-	// Our files are 0600, so don't bother checking gid.
-	return strconv.Itoa(int(info.Uid)) == user.Uid, nil
 }

--- a/lib/tbot/botfs/fs_windows.go
+++ b/lib/tbot/botfs/fs_windows.go
@@ -1,0 +1,142 @@
+//go:build windows
+// +build windows
+
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package botfs
+
+import (
+	"context"
+	"io"
+	"io/fs"
+	"os/user"
+	"sync"
+
+	"github.com/gravitational/trace"
+)
+
+// unsupportedPlatformWarning is used to reduce log spam when on an unsupported
+// platform.
+var unsupportedPlatformWarning sync.Once
+
+// Create attempts to create the given file or directory without
+// evaluating symlinks. This is only supported on recent Linux kernel versions
+// (5.6+). The resulting file permissions are unspecified; Chmod should be
+// called afterward.
+func Create(path string, isDir bool, symlinksMode SymlinksMode) error {
+	if symlinksMode == SymlinksSecure {
+		return trace.BadParameter("cannot write with `symlinks: secure` on unsupported platform")
+	}
+
+	return trace.Wrap(createStandard(path, isDir))
+}
+
+// Read reads the contents of the given file into memory.
+func Read(path string, symlinksMode SymlinksMode) ([]byte, error) {
+	switch symlinksMode {
+	case SymlinksSecure:
+		return nil, trace.BadParameter("cannot read with `symlinks: secure` on unsupported platform")
+	case SymlinksTrySecure:
+		unsupportedPlatformWarning.Do(func() {
+			log.WarnContext(
+				context.TODO(),
+				"Secure symlinks not supported on this platform, set `symlinks: insecure` to disable this message",
+				"path", path,
+			)
+		})
+	}
+
+	file, err := openStandard(path, ReadMode)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return data, nil
+}
+
+// Write stores the given data to the file at the given path.
+func Write(path string, data []byte, symlinksMode SymlinksMode) error {
+	switch symlinksMode {
+	case SymlinksSecure:
+		return trace.BadParameter("cannot write with `symlinks: secure` on unsupported platform")
+	case SymlinksTrySecure:
+		unsupportedPlatformWarning.Do(func() {
+			log.WarnContext(
+				context.TODO(),
+				"Secure symlinks not supported on this platform, set `symlinks: insecure` to disable this message",
+				"path", path,
+			)
+		})
+	}
+
+	file, err := openStandard(path, WriteMode)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	defer file.Close()
+
+	if _, err := file.Write(data); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// VerifyACL verifies whether the ACL of the given file allows writes from the
+// bot user.
+//
+//nolint:staticcheck // staticcheck does not like our nop implementations.
+func VerifyACL(path string, opts *ACLOptions) error {
+	return trace.NotImplemented("ACLs not supported on this platform")
+}
+
+// ConfigureACL configures ACLs of the given file to allow writes from the bot
+// user.
+//
+//nolint:staticcheck // staticcheck does not like our nop implementations.
+func ConfigureACL(path string, owner *user.User, opts *ACLOptions) error {
+	return trace.NotImplemented("ACLs not supported on this platform")
+}
+
+// HasACLSupport determines if this binary / system supports ACLs. This
+// catch-all implementation just returns false.
+func HasACLSupport() bool {
+	return false
+}
+
+// HasSecureWriteSupport determines if `CreateSecure()` should be supported
+// on this OS / kernel version. This is only supported on Linux, so this
+// catch-all implementation just returns false.
+func HasSecureWriteSupport() bool {
+	return false
+}
+
+// IsOwnedBy checks that the file at the given path is owned by the given user.
+// Returns a trace.NotImplemented() on unsupported platforms.
+func IsOwnedBy(_ fs.FileInfo, _ *user.User) (bool, error) {
+	return false, trace.NotImplemented("Cannot verify file ownership on this platform.")
+}

--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -34,7 +34,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -849,52 +848,4 @@ func (s *cyclingHostDialClient) DialHost(ctx context.Context, target string, clu
 	}
 	wrappedConn.parent.Store(currentClt)
 	return wrappedConn, details, nil
-}
-
-// ConnectToSSHMultiplex connects to the SSH multiplexer and sends the target
-// to the multiplexer. It then returns the connection to the SSH multiplexer
-// over stdout.
-func ConnectToSSHMultiplex(ctx context.Context, socketPath string, target string, stdout *os.File) error {
-	outConn, err := net.FileConn(stdout)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer outConn.Close()
-	outUnix, ok := outConn.(*net.UnixConn)
-	if !ok {
-		return trace.BadParameter("expected stdout to be %T, got %T", outUnix, outConn)
-	}
-
-	c, err := new(net.Dialer).DialContext(ctx, "unix", socketPath)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer c.Close()
-
-	if _, err := fmt.Fprint(c, target, "\x00"); err != nil {
-		return trace.Wrap(err)
-	}
-
-	rawC, err := c.(*net.UnixConn).SyscallConn()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	var innerErr error
-	if controlErr := rawC.Control(func(fd uintptr) {
-		// We have to write something in order to send a control message so
-		// we just write NUL.
-		_, _, innerErr = outUnix.WriteMsgUnix(
-			[]byte{0},
-			syscall.UnixRights(int(fd)),
-			nil,
-		)
-	}); controlErr != nil {
-		return trace.Wrap(controlErr)
-	}
-	if innerErr != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
 }

--- a/lib/tbot/service_ssh_multiplexer_unix.go
+++ b/lib/tbot/service_ssh_multiplexer_unix.go
@@ -1,0 +1,79 @@
+//go:build unix
+
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+
+	"github.com/gravitational/trace"
+)
+
+// ConnectToSSHMultiplex connects to the SSH multiplexer and sends the target
+// to the multiplexer. It then returns the connection to the SSH multiplexer
+// over stdout.
+func ConnectToSSHMultiplex(ctx context.Context, socketPath string, target string, stdout *os.File) error {
+	outConn, err := net.FileConn(stdout)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer outConn.Close()
+	outUnix, ok := outConn.(*net.UnixConn)
+	if !ok {
+		return trace.BadParameter("expected stdout to be %T, got %T", outUnix, outConn)
+	}
+
+	c, err := new(net.Dialer).DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer c.Close()
+
+	if _, err := fmt.Fprint(c, target, "\x00"); err != nil {
+		return trace.Wrap(err)
+	}
+
+	rawC, err := c.(*net.UnixConn).SyscallConn()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var innerErr error
+	if controlErr := rawC.Control(func(fd uintptr) {
+		// We have to write something in order to send a control message so
+		// we just write NUL.
+		_, _, innerErr = outUnix.WriteMsgUnix(
+			[]byte{0},
+			syscall.UnixRights(int(fd)),
+			nil,
+		)
+	}); controlErr != nil {
+		return trace.Wrap(controlErr)
+	}
+	if innerErr != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}

--- a/lib/tbot/service_ssh_multiplexer_windows.go
+++ b/lib/tbot/service_ssh_multiplexer_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"context"
+	"os"
+
+	"github.com/gravitational/trace"
+)
+
+// ConnectToSSHMultiplex connects to the SSH multiplexer and sends the target
+// to the multiplexer. It then returns the connection to the SSH multiplexer
+// over stdout.
+func ConnectToSSHMultiplex(ctx context.Context, socketPath string, target string, stdout *os.File) error {
+	return trace.NotImplemented("SSH Multiplexing not supported on Windows.")
+}

--- a/tool/tbot/signals_unix.go
+++ b/tool/tbot/signals_unix.go
@@ -1,0 +1,56 @@
+//go:build unix
+
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// handleSignals handles incoming Unix signals.
+func handleSignals(
+	ctx context.Context,
+	log *slog.Logger,
+	cancel context.CancelFunc,
+	reloadCh chan<- struct{},
+) {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGHUP, syscall.SIGUSR1)
+
+	for sig := range signals {
+		switch sig {
+		case syscall.SIGINT:
+			log.InfoContext(ctx, "Received interrupt, triggering shutdown")
+			cancel()
+			return
+		case syscall.SIGHUP, syscall.SIGUSR1:
+			log.InfoContext(ctx, "Received reload signal, queueing reload")
+			select {
+			case reloadCh <- struct{}{}:
+			default:
+				log.WarnContext(ctx, "Unable to queue reload, reload already queued")
+			}
+		}
+	}
+}

--- a/tool/tbot/signals_windows.go
+++ b/tool/tbot/signals_windows.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// handleSignals handles incoming signals.
+func handleSignals(
+	ctx context.Context,
+	log *slog.Logger,
+	cancel context.CancelFunc,
+	reloadCh chan<- struct{},
+) {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGHUP)
+
+	for sig := range signals {
+		switch sig {
+		case syscall.SIGINT:
+			log.InfoContext(ctx, "Received interrupt, triggering shutdown")
+			cancel()
+			return
+		case syscall.SIGHUP:
+			log.InfoContext(ctx, "Received reload signal, queueing reload")
+			select {
+			case reloadCh <- struct{}{}:
+			default:
+				log.WarnContext(ctx, "Unable to queue reload, reload already queued")
+			}
+		}
+	}
+}


### PR DESCRIPTION
Manual backport of https://github.com/gravitational/teleport/pull/43877 to `branch/v15` because of a Makefile conflict.

changelog: Made `tbot` compilable on Windows.