### PR TITLE
Adding a clean check to update-tag target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1270,6 +1270,10 @@ $(VERSRC): Makefile
 update-tag: TAG_REMOTE ?= origin
 update-tag:
 	@test $(VERSION)
+	@if [[ -n "$$(git status --porcelain)" && -z "$${SKIP_CLEAN_CHECK}" ]]; then \
+		echo "Git state is not clean refusing to continue. If you are sure you want to continue regardless set SKIP_CLEAN_CHECK."; \
+		exit 1; \
+	fi
 	cd build.assets/tooling && CGO_ENABLED=0 go run ./cmd/check -check valid -tag $(GITTAG)
 	git tag $(GITTAG)
 	git tag api/$(GITTAG)

--- a/Makefile
+++ b/Makefile
@@ -1270,8 +1270,9 @@ $(VERSRC): Makefile
 update-tag: TAG_REMOTE ?= origin
 update-tag:
 	@test $(VERSION)
-	@if [[ -n "$$(git status --porcelain --branch)" && -z "$${SKIP_CLEAN_CHECK}" ]]; then \
-		echo "Git state is not clean refusing to continue. If you are sure you want to continue regardless set SKIP_CLEAN_CHECK."; \
+	@if [[ -n "$$(git status --porcelain)" && -z "$${SKIP_CLEAN_CHECK}" ]]; then \
+		echo "Git state is not clean refusing to continue. Commit changes to continue"; \
+		echo "If you are sure you want to continue regardless set SKIP_CLEAN_CHECK."; \
 		exit 1; \
 	fi
 	cd build.assets/tooling && CGO_ENABLED=0 go run ./cmd/check -check valid -tag $(GITTAG)

--- a/Makefile
+++ b/Makefile
@@ -1270,7 +1270,7 @@ $(VERSRC): Makefile
 update-tag: TAG_REMOTE ?= origin
 update-tag:
 	@test $(VERSION)
-	@if [[ -n "$$(git status --porcelain)" && -z "$${SKIP_CLEAN_CHECK}" ]]; then \
+	@if [[ -n "$$(git status --porcelain --branch)" && -z "$${SKIP_CLEAN_CHECK}" ]]; then \
 		echo "Git state is not clean refusing to continue. If you are sure you want to continue regardless set SKIP_CLEAN_CHECK."; \
 		exit 1; \
 	fi


### PR DESCRIPTION
Relates to #41018 

# Purpose

Add a check to the update-tag Makefile target to ensure that there are no uncommitted and unpushed changes in the local repository. As part of our release process changes to the branch are expected and those should be committed. Failing to commit those changes would break the workflow build later on. This will give a warning message and error out if it detects unpushed and uncommitted changes.

This can be skipped by setting the `SKIP_CLEAN_CHECK` variable to any value.