### PR TITLE
Machine ID: `application-tunnel` service 

### DIFF
--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -528,6 +528,12 @@ func (o *ServiceConfigs) UnmarshalYAML(node *yaml.Node) error {
 				return trace.Wrap(err)
 			}
 			out = append(out, v)
+		case ApplicationTunnelServiceType:
+			v := &ApplicationTunnelService{}
+			if err := node.Decode(v); err != nil {
+				return trace.Wrap(err)
+			}
+			out = append(out, v)
 		default:
 			return trace.BadParameter("unrecognized service type (%s)", header.Type)
 		}

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -291,6 +291,11 @@ func TestBotConfig_YAML(t *testing.T) {
 							Path: "/bot/output",
 						},
 					},
+					&ApplicationTunnelService{
+						Listen:  "tcp://127.0.0.1:123",
+						Roles:   []string{"access"},
+						AppName: "my-app",
+					},
 				},
 			},
 		},

--- a/lib/tbot/config/service_application_tunnel.go
+++ b/lib/tbot/config/service_application_tunnel.go
@@ -1,0 +1,83 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package config
+
+import (
+	"net"
+	"net/url"
+
+	"github.com/gravitational/trace"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	_ ServiceConfig = &ApplicationTunnelService{}
+)
+
+const ApplicationTunnelServiceType = "application-tunnel"
+
+// ApplicationTunnelService opens an authenticated tunnel for Application
+// Access.
+type ApplicationTunnelService struct {
+	// Listen is the address on which database tunnel should listen. Example:
+	// - "tcp://127.0.0.1:3306"
+	// - "tcp://0.0.0.0:3306
+	Listen string `yaml:"listen"`
+	// Roles is the list of roles to request for the tunnel.
+	// If empty, it defaults to all the bot's roles.
+	Roles []string `yaml:"roles,omitempty"`
+	// AppName should be the name of the application as registered in Teleport
+	// that you wish to tunnel to.
+	AppName string `yaml:"app_name"`
+
+	// Listener overrides "listen" and directly provides an opened listener to
+	// use.
+	Listener net.Listener `yaml:"-"`
+}
+
+func (s *ApplicationTunnelService) Type() string {
+	return ApplicationTunnelServiceType
+}
+
+func (s *ApplicationTunnelService) MarshalYAML() (interface{}, error) {
+	type raw ApplicationTunnelService
+	return withTypeHeader((*raw)(s), ApplicationTunnelServiceType)
+}
+
+func (s *ApplicationTunnelService) UnmarshalYAML(node *yaml.Node) error {
+	// Alias type to remove UnmarshalYAML to avoid recursion
+	type raw ApplicationTunnelService
+	if err := node.Decode((*raw)(s)); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func (s *ApplicationTunnelService) CheckAndSetDefaults() error {
+	switch {
+	case s.Listen == "" && s.Listener == nil:
+		return trace.BadParameter("listen: should not be empty")
+	case s.AppName == "":
+		return trace.BadParameter("app_name: should not be empty")
+	}
+	if _, err := url.Parse(s.Listen); err != nil {
+		return trace.Wrap(err, "parsing listen")
+	}
+	return nil
+}

--- a/lib/tbot/config/service_application_tunnel_test.go
+++ b/lib/tbot/config/service_application_tunnel_test.go
@@ -1,0 +1,86 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package config
+
+import "testing"
+
+func TestApplicationTunnelService_YAML(t *testing.T) {
+	t.Parallel()
+
+	tests := []testYAMLCase[ApplicationTunnelService]{
+		{
+			name: "full",
+			in: ApplicationTunnelService{
+				Listen:  "tcp://0.0.0.0:3621",
+				AppName: "my-app",
+			},
+		},
+	}
+	testYAML(t, tests)
+}
+
+func TestApplicationTunnelService_CheckAndSetDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []testCheckAndSetDefaultsCase[*ApplicationTunnelService]{
+		{
+			name: "valid",
+			in: func() *ApplicationTunnelService {
+				return &ApplicationTunnelService{
+					Listen:  "tcp://0.0.0.0:3621",
+					Roles:   []string{"role1", "role2"},
+					AppName: "my-app",
+				}
+			},
+			wantErr: "",
+		},
+		{
+			name: "missing listen",
+			in: func() *ApplicationTunnelService {
+				return &ApplicationTunnelService{
+					Roles:   []string{"role1", "role2"},
+					AppName: "my-app",
+				}
+			},
+			wantErr: "listen: should not be empty",
+		},
+		{
+			name: "listen not url",
+			in: func() *ApplicationTunnelService {
+				return &ApplicationTunnelService{
+					Listen:  "\x00",
+					Roles:   []string{"role1", "role2"},
+					AppName: "my-app",
+				}
+			},
+			wantErr: "parsing listen",
+		},
+		{
+			name: "missing app name",
+			in: func() *ApplicationTunnelService {
+				return &ApplicationTunnelService{
+					Listen: "tcp://0.0.0.0:3621",
+					Roles:  []string{"role1", "role2"},
+				}
+			},
+			wantErr: "app_name: should not be empty",
+		},
+	}
+	testCheckAndSetDefaults(t, tests)
+}

--- a/lib/tbot/config/testdata/TestApplicationTunnelService_YAML/full.golden
+++ b/lib/tbot/config/testdata/TestApplicationTunnelService_YAML/full.golden
@@ -1,0 +1,3 @@
+type: application-tunnel
+listen: tcp://0.0.0.0:3621
+app_name: my-app

--- a/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
+++ b/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
@@ -45,6 +45,11 @@ services:
       path: /bot/output
     enable_resumption: null
     proxy_templates_path: ""
+  - type: application-tunnel
+    listen: tcp://127.0.0.1:123
+    roles:
+      - access
+    app_name: my-app
 debug: true
 auth_server: example.teleport.sh:443
 certificate_ttl: 1m0s

--- a/lib/tbot/service_application_output.go
+++ b/lib/tbot/service_application_output.go
@@ -119,7 +119,12 @@ func (s *ApplicationOutputService) generate(ctx context.Context) error {
 	}
 	defer impersonatedClient.Close()
 
-	routeToApp, err := getRouteToApp(ctx, s.getBotIdentity(), impersonatedClient, s.cfg)
+	routeToApp, _, err := getRouteToApp(
+		ctx,
+		s.getBotIdentity(),
+		impersonatedClient,
+		s.cfg.AppName,
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -197,13 +202,18 @@ func (s *ApplicationOutputService) render(
 	return trace.Wrap(writeTLSCAs(ctx, s.cfg.Destination, hostCAs, userCAs, databaseCAs))
 }
 
-func getRouteToApp(ctx context.Context, botIdentity *identity.Identity, client *authclient.Client, output *config.ApplicationOutput) (proto.RouteToApp, error) {
+func getRouteToApp(
+	ctx context.Context,
+	botIdentity *identity.Identity,
+	client *authclient.Client,
+	appName string,
+) (proto.RouteToApp, types.Application, error) {
 	ctx, span := tracer.Start(ctx, "getRouteToApp")
 	defer span.End()
 
-	app, err := getApp(ctx, client, output.AppName)
+	app, err := getApp(ctx, client, appName)
 	if err != nil {
-		return proto.RouteToApp{}, trace.Wrap(err)
+		return proto.RouteToApp{}, nil, trace.Wrap(err)
 	}
 
 	routeToApp := proto.RouteToApp{
@@ -213,12 +223,14 @@ func getRouteToApp(ctx context.Context, botIdentity *identity.Identity, client *
 	}
 
 	// TODO (Joerger): DELETE IN v17.0.0
+	// TODO(noah): When this is deleted, we can begin to cache the routeToApp
+	// rather than regenerating this on each renew in the ApplicationTunnelSvc
 	routeToApp.SessionID, err = authclient.TryCreateAppSessionForClientCertV15(ctx, client, botIdentity.X509Cert.Subject.CommonName, routeToApp)
 	if err != nil {
-		return proto.RouteToApp{}, trace.Wrap(err)
+		return proto.RouteToApp{}, nil, trace.Wrap(err)
 	}
 
-	return routeToApp, nil
+	return routeToApp, app, nil
 }
 
 func getApp(ctx context.Context, clt *authclient.Client, appName string) (types.Application, error) {

--- a/lib/tbot/service_application_tunnel.go
+++ b/lib/tbot/service_application_tunnel.go
@@ -1,0 +1,249 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/srv/alpnproxy"
+	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// ApplicationTunnelService is a service that listens on a socket and forwards
+// traffic to an application registered in Teleport Application Access. It is
+// an authenticating tunnel and will automatically issue and renew certificates
+// as needed.
+type ApplicationTunnelService struct {
+	botCfg         *config.BotConfig
+	cfg            *config.ApplicationTunnelService
+	proxyPingCache *proxyPingCache
+	log            *slog.Logger
+	resolver       reversetunnelclient.Resolver
+	botClient      *authclient.Client
+	getBotIdentity getBotIdentityFn
+}
+
+func (s *ApplicationTunnelService) Run(ctx context.Context) error {
+	ctx, span := tracer.Start(ctx, "ApplicationTunnelService/Run")
+	defer span.End()
+
+	l := s.cfg.Listener
+	if l == nil {
+		s.log.DebugContext(ctx, "Opening listener for application tunnel", "listen", s.cfg.Listen)
+		var err error
+		l, err = createListener(ctx, s.log, s.cfg.Listen)
+		if err != nil {
+			return trace.Wrap(err, "opening listener")
+		}
+		defer func() {
+			if err := l.Close(); err != nil && !utils.IsUseOfClosedNetworkError(err) {
+				s.log.ErrorContext(ctx, "Failed to close listener", "error", err)
+			}
+		}()
+	}
+
+	lpCfg, err := s.buildLocalProxyConfig(ctx)
+	if err != nil {
+		return trace.Wrap(err, "building local proxy config")
+	}
+	lpCfg.Listener = l
+
+	lp, err := alpnproxy.NewLocalProxy(lpCfg)
+	if err != nil {
+		return trace.Wrap(err, "creating local proxy")
+	}
+	defer func() {
+		if err := lp.Close(); err != nil {
+			s.log.ErrorContext(ctx, "Failed to close local proxy", "error", err)
+		}
+	}()
+	// Closed further down.
+
+	// lp.Start will block and continues to block until lp.Close() is called.
+	// Despite taking a context, it will not exit until the first connection is
+	// made after the context is canceled.
+	var errCh = make(chan error, 1)
+	go func() {
+		errCh <- lp.Start(ctx)
+	}()
+	s.log.InfoContext(ctx, "Listening for connections.", "address", l.Addr().String())
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-errCh:
+		return trace.Wrap(err, "local proxy failed")
+	}
+}
+
+func alpnProtocolForApp(app types.Application) common.Protocol {
+	if app.IsTCP() {
+		return common.ProtocolTCP
+	}
+	return common.ProtocolHTTP
+}
+
+// buildLocalProxyConfig initializes the service, fetching any initial information and setting
+// up the localproxy.
+func (s *ApplicationTunnelService) buildLocalProxyConfig(ctx context.Context) (lpCfg alpnproxy.LocalProxyConfig, err error) {
+	ctx, span := tracer.Start(ctx, "ApplicationTunnelService/buildLocalProxyConfig")
+	defer span.End()
+
+	// Determine the roles to use for the impersonated app access user. We fall
+	// back to all the roles the bot has if none are configured.
+	roles := s.cfg.Roles
+	if len(roles) == 0 {
+		roles, err = fetchDefaultRoles(ctx, s.botClient, s.getBotIdentity())
+		if err != nil {
+			return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "fetching default roles")
+		}
+		s.log.DebugContext(ctx, "No roles configured, using all roles available.", "roles", roles)
+	}
+
+	proxyPing, err := s.proxyPingCache.ping(ctx)
+	if err != nil {
+		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "pinging proxy")
+	}
+	proxyAddr := proxyPing.Proxy.SSH.PublicAddr
+
+	s.log.DebugContext(ctx, "Issuing initial certificate for local proxy.")
+	appCert, app, err := s.issueCert(ctx, roles)
+	if err != nil {
+		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err)
+	}
+	s.log.DebugContext(ctx, "Issued initial certificate for local proxy.")
+
+	middleware := alpnProxyMiddleware{
+		onNewConnection: func(ctx context.Context, lp *alpnproxy.LocalProxy) error {
+			ctx, span := tracer.Start(ctx, "ApplicationTunnelService/OnNewConnection")
+			defer span.End()
+
+			if err := lp.CheckCertExpiry(); err != nil {
+				s.log.InfoContext(ctx, "Certificate for tunnel needs reissuing.", "reason", err.Error())
+				cert, _, err := s.issueCert(ctx, roles)
+				if err != nil {
+					return trace.Wrap(err, "issuing cert")
+				}
+				lp.SetCert(*cert)
+			}
+			return nil
+		},
+	}
+
+	lpConfig := alpnproxy.LocalProxyConfig{
+		Middleware: middleware,
+
+		RemoteProxyAddr:    proxyAddr,
+		ParentContext:      ctx,
+		Protocols:          []common.Protocol{alpnProtocolForApp(app)},
+		Cert:               *appCert,
+		InsecureSkipVerify: s.botCfg.Insecure,
+	}
+	if client.IsALPNConnUpgradeRequired(
+		ctx,
+		proxyAddr,
+		s.botCfg.Insecure,
+	) {
+		lpConfig.ALPNConnUpgradeRequired = true
+		// If ALPN Conn Upgrade will be used, we need to set the cluster CAs
+		// to validate the Proxy's auth issued host cert.
+		lpConfig.RootCAs = s.getBotIdentity().TLSCAPool
+	}
+
+	return lpConfig, nil
+}
+
+func (s *ApplicationTunnelService) issueCert(
+	ctx context.Context,
+	roles []string,
+) (*tls.Certificate, types.Application, error) {
+	ctx, span := tracer.Start(ctx, "ApplicationTunnelService/issueCert")
+	defer span.End()
+
+	// Right now we have to redetermine the route to app each time as the
+	// session ID may need to change. Once v17 hits, this will be automagically
+	// calculated by the auth server on cert generation, and we can fetch the
+	// routeToApp once.
+	impersonatedIdentity, err := generateIdentity(
+		ctx,
+		s.botClient,
+		s.getBotIdentity(),
+		roles,
+		s.botCfg.CertificateTTL,
+		nil,
+	)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	impersonatedClient, err := clientForFacade(
+		ctx,
+		s.log,
+		s.botCfg,
+		identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, impersonatedIdentity),
+		s.resolver,
+	)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	defer func() {
+		if err := impersonatedClient.Close(); err != nil {
+			s.log.ErrorContext(ctx, "Failed to close impersonated client.", "error", err)
+		}
+	}()
+	route, app, err := getRouteToApp(ctx, s.getBotIdentity(), impersonatedClient, s.cfg.AppName)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	s.log.DebugContext(ctx, "Requesting issuance of certificate for tunnel proxy.")
+	routedIdent, err := generateIdentity(
+		ctx,
+		s.botClient,
+		s.getBotIdentity(),
+		roles,
+		s.botCfg.CertificateTTL,
+		func(req *proto.UserCertsRequest) {
+			req.RouteToApp = route
+		})
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	s.log.InfoContext(ctx, "Certificate issued for tunnel proxy.")
+
+	return routedIdent.TLSCert, app, nil
+}
+
+// String returns a human-readable string that can uniquely identify the
+// service.
+func (s *ApplicationTunnelService) String() string {
+	return fmt.Sprintf("%s:%s:%s", config.ApplicationTunnelServiceType, s.cfg.Listen, s.cfg.AppName)
+}

--- a/lib/tbot/service_application_tunnel_test.go
+++ b/lib/tbot/service_application_tunnel_test.go
@@ -1,0 +1,147 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/tool/teleport/testenv"
+)
+
+func TestE2E_ApplicationTunnelService(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := utils.NewSlogLoggerForTests()
+
+	// Spin up a test HTTP server
+	wantStatus := http.StatusTeapot
+	wantBody := []byte("hello this is a test")
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(wantStatus)
+		w.Write(wantBody)
+		return
+	}))
+	t.Cleanup(httpSrv.Close)
+
+	// Make a new auth server.
+	appName := "my-test-app"
+	process := testenv.MakeTestServer(
+		t,
+		defaultTestServerOpts(t, log),
+		testenv.WithConfig(func(cfg *servicecfg.Config) {
+			cfg.Apps.Enabled = true
+			cfg.Apps.Apps = []servicecfg.App{
+				{
+					Name: appName,
+					URI:  httpSrv.URL,
+				},
+			}
+		}),
+	)
+	rootClient := testenv.MakeDefaultAuthClient(t, process)
+
+	// Create role that allows the bot to access the app.
+	role, err := types.NewRole("app-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{
+				"*": apiutils.Strings{"*"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	role, err = rootClient.UpsertRole(ctx, role)
+	require.NoError(t, err)
+
+	botListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		botListener.Close()
+	})
+
+	// Prepare the bot config
+	onboarding, _ := makeBot(t, rootClient, "test", role.GetName())
+	botConfig := defaultBotConfig(
+		t, process, onboarding, config.ServiceConfigs{
+			&config.ApplicationTunnelService{
+				Listener: botListener,
+				AppName:  appName,
+			},
+		},
+		defaultBotConfigOpts{
+			useAuthServer: true,
+			// insecure required as the db tunnel will connect to proxies
+			// self-signed.
+			insecure: true,
+		},
+	)
+	botConfig.Oneshot = false
+	b := New(botConfig, log)
+
+	// Spin up goroutine for bot to run in
+	ctx, cancel := context.WithCancel(ctx)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := b.Run(ctx)
+		assert.NoError(t, err, "bot should not exit with error")
+		cancel()
+	}()
+	t.Cleanup(func() {
+		// Shut down bot and make sure it exits.
+		cancel()
+		wg.Wait()
+	})
+
+	// We can't predict exactly when the tunnel will be ready so we use
+	// EventuallyWithT to retry.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		proxyUrl := url.URL{
+			Scheme: "http",
+			Host:   botListener.Addr().String(),
+		}
+		resp, err := http.Get(proxyUrl.String())
+		if !assert.NoError(t, err) {
+			return
+		}
+		defer resp.Body.Close()
+		assert.Equal(t, wantStatus, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, wantBody, body)
+	}, 10*time.Second, 100*time.Millisecond)
+}

--- a/lib/tbot/service_application_tunnel_test.go
+++ b/lib/tbot/service_application_tunnel_test.go
@@ -51,7 +51,6 @@ func TestE2E_ApplicationTunnelService(t *testing.T) {
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(wantStatus)
 		w.Write(wantBody)
-		return
 	}))
 	t.Cleanup(httpSrv.Close)
 

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -431,6 +431,19 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 				teleport.ComponentKey, teleport.Component(componentTBot, "svc", svc.String()),
 			)
 			services = append(services, svc)
+		case *config.ApplicationTunnelService:
+			svc := &ApplicationTunnelService{
+				getBotIdentity: b.botIdentitySvc.GetIdentity,
+				proxyPingCache: proxyPingCache,
+				botClient:      b.botIdentitySvc.GetClient(),
+				resolver:       resolver,
+				botCfg:         b.cfg,
+				cfg:            svcCfg,
+			}
+			svc.log = b.log.With(
+				teleport.ComponentKey, teleport.Component(componentTBot, "svc", svc.String()),
+			)
+			services = append(services, svc)
 		default:
 			return trace.BadParameter("unknown service type: %T", svcCfg)
 		}

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -86,6 +86,9 @@ func defaultTestServerOpts(t *testing.T, log *slog.Logger) testenv.TestServerOpt
 			cfg.Proxy.PublicAddrs = []utils.NetAddr{
 				{AddrNetwork: "tcp", Addr: net.JoinHostPort("localhost", strconv.Itoa(cfg.Proxy.WebAddr.Port(0)))},
 			}
+			cfg.Proxy.TunnelPublicAddrs = []utils.NetAddr{
+				cfg.Proxy.ReverseTunnelListenAddr,
+			}
 		})(o)
 	}
 }

--- a/tool/teleport/testenv/test_server.go
+++ b/tool/teleport/testenv/test_server.go
@@ -174,7 +174,9 @@ func MakeTestServer(t *testing.T, opts ...TestServerOptFunc) (process *service.T
 
 	cfg.Proxy.WebAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: NewTCPListener(t, service.ListenerProxyWeb, &cfg.FileDescriptors)}
 	cfg.Proxy.SSHAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: NewTCPListener(t, service.ListenerProxySSH, &cfg.FileDescriptors)}
-	cfg.Proxy.ReverseTunnelListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: NewTCPListener(t, service.ListenerProxyTunnel, &cfg.FileDescriptors)}
+	reverseTunnelAddr := NewTCPListener(t, service.ListenerProxyTunnel, &cfg.FileDescriptors)
+	cfg.Proxy.ReverseTunnelListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: reverseTunnelAddr}
+	cfg.Proxy.TunnelPublicAddrs = []utils.NetAddr{{AddrNetwork: "tcp", Addr: reverseTunnelAddr}}
 	cfg.Proxy.DisableWebInterface = true
 
 	cfg.SSH.Addr = utils.NetAddr{AddrNetwork: "tcp", Addr: NewTCPListener(t, service.ListenerNodeSSH, &cfg.FileDescriptors)}

--- a/tool/teleport/testenv/test_server.go
+++ b/tool/teleport/testenv/test_server.go
@@ -174,9 +174,7 @@ func MakeTestServer(t *testing.T, opts ...TestServerOptFunc) (process *service.T
 
 	cfg.Proxy.WebAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: NewTCPListener(t, service.ListenerProxyWeb, &cfg.FileDescriptors)}
 	cfg.Proxy.SSHAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: NewTCPListener(t, service.ListenerProxySSH, &cfg.FileDescriptors)}
-	reverseTunnelAddr := NewTCPListener(t, service.ListenerProxyTunnel, &cfg.FileDescriptors)
-	cfg.Proxy.ReverseTunnelListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: reverseTunnelAddr}
-	cfg.Proxy.TunnelPublicAddrs = []utils.NetAddr{{AddrNetwork: "tcp", Addr: reverseTunnelAddr}}
+	cfg.Proxy.ReverseTunnelListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: NewTCPListener(t, service.ListenerProxyTunnel, &cfg.FileDescriptors)}
 	cfg.Proxy.DisableWebInterface = true
 
 	cfg.SSH.Addr = utils.NetAddr{AddrNetwork: "tcp", Addr: NewTCPListener(t, service.ListenerNodeSSH, &cfg.FileDescriptors)}


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/36291

Similar to the existing `database-tunnel` service, this adds the equivalent for Application Access. This removes the need to run a separate proxy process for each application and avoids writing any credentials to disk.

```yaml
services:
- type: application-tunnel
  listen: tcp://localhost:25432
  app_name: httpbin
- type: application-tunnel
  listen: tcp://localhost:35432
  app_name: httpbin-tcp
```

changelog: Added `application-tunnel` service to Machine ID for establishing a long-lived tunnel to a HTTP or TCP application for Machine to Machine access.