### PR TITLE
Updating make changelog to use new changelog tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -766,6 +766,14 @@ $(RERUN): $(wildcard $(TOOLINGDIR)/cmd/rerun/*.go)
 RELEASE_NOTES_GEN := $(TOOLINGDIR)/bin/release-notes
 $(RELEASE_NOTES_GEN): $(wildcard $(TOOLINGDIR)/cmd/release-notes/*.go)
 	cd $(TOOLINGDIR) && go build -o "$@" ./cmd/release-notes
+#
+# Downloads and builds changelog from source.
+# PHONY is set so that we rely on Go's mod cache and not Make's cache.
+#
+CHANGELOG := $(TOOLINGDIR)/bin/changelog
+.PHONY: $(CHANGELOG)
+$(CHANGELOG):
+	@GOBIN=$(TOOLINGDIR)/bin go install github.com/gravitational/shared-workflows/tools/changelog@latest
 
 .PHONY: tooling
 tooling: ensure-gotestsum $(DIFF_TEST)
@@ -1712,8 +1720,8 @@ rustup-install-target-toolchain: rustup-set-version
 # BASE_BRANCH and BASE_TAG will be automatically determined if not specified.
 # See ./build.assets/changelog.sh
 .PHONY: changelog
-changelog:
-	@BASE_BRANCH=$(BASE_BRANCH) BASE_TAG=$(BASE_TAG) ./build.assets/changelog.sh
+changelog: $(CHANGELOG)
+	@$(CHANGELOG) --base-branch=$(BASE_BRANCH) --base-tag=$(BASE_TAG) ./
 
 # create-github-release will generate release notes from the CHANGELOG.md and will
 # create release notes from them.

--- a/Makefile
+++ b/Makefile
@@ -1712,15 +1712,14 @@ rustup-install-target-toolchain: rustup-set-version
 # changelog generates PR changelog between the provided base tag and the tip of
 # the specified branch.
 #
-# usage: make changelog
-# usage: make changelog BASE_BRANCH=branch/v13 BASE_TAG=13.2.0
-# usage: BASE_BRANCH=branch/v13 BASE_TAG=13.2.0 make changelog
+# usage: make -s changelog
+# usage: make -s changelog BASE_BRANCH=branch/v13 BASE_TAG=13.2.0
+# usage: BASE_BRANCH=branch/v13 BASE_TAG=13.2.0 make -s changelog
 #
 # BASE_BRANCH and BASE_TAG will be automatically determined if not specified.
-# See ./build.assets/changelog.sh
 .PHONY: changelog
 changelog: $(CHANGELOG)
-	@$(CHANGELOG) --base-branch=$(BASE_BRANCH) --base-tag=$(BASE_TAG) ./
+	$(CHANGELOG) --base-branch="$(BASE_BRANCH)" --base-tag="$(BASE_TAG)" ./
 
 # create-github-release will generate release notes from the CHANGELOG.md and will
 # create release notes from them.

--- a/Makefile
+++ b/Makefile
@@ -771,9 +771,8 @@ $(RELEASE_NOTES_GEN): $(wildcard $(TOOLINGDIR)/cmd/release-notes/*.go)
 # PHONY is set so that we rely on Go's mod cache and not Make's cache.
 #
 CHANGELOG := $(TOOLINGDIR)/bin/changelog
-.PHONY: $(CHANGELOG)
 $(CHANGELOG):
-	@GOBIN=$(TOOLINGDIR)/bin go install github.com/gravitational/shared-workflows/tools/changelog@latest
+	GOBIN=$(TOOLINGDIR)/bin go install github.com/gravitational/shared-workflows/tools/changelog@v1.0.0
 
 .PHONY: tooling
 tooling: ensure-gotestsum $(DIFF_TEST)


### PR DESCRIPTION
Closes [#4470](https://github.com/gravitational/teleport.e/issues/4470)

`changelog` target updated to use the new Go rewrite of changelog.