### PR TITLE
Web: Move styled Mark into design package and update imports 

### DIFF
--- a/web/packages/design/src/Mark/Mark.story.tsx
+++ b/web/packages/design/src/Mark/Mark.story.tsx
@@ -1,0 +1,45 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+
+import Box from 'design/Box';
+
+import { Mark as M } from './Mark';
+
+export default {
+  title: 'Design/Mark',
+};
+
+export const SampleText = () => {
+  return (
+    <Box width="500px">
+      Some texts to demonstrate word <M>markings</M>. Lorem ipsum dolor sit amet{' '}
+      <M>consectetur</M> adipisicing <M>elit</M>. Quidem <M>corrupti</M>,{' '}
+      reprehenderit{' '}
+      <M>
+        <i>maxime</i>
+      </M>{' '}
+      rerum quam{' '}
+      <M>
+        <b>necessitatibus</b>
+      </M>{' '}
+      obcaecati asperiores neque.
+    </Box>
+  );
+};

--- a/web/packages/design/src/Mark/Mark.tsx
+++ b/web/packages/design/src/Mark/Mark.tsx
@@ -1,6 +1,6 @@
-/**
+/*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -18,12 +18,11 @@
 
 import styled from 'styled-components';
 
-export const Mark = styled.mark<{ light?: boolean }>`
+export const Mark = styled.mark`
   padding: 2px 5px;
   border-radius: 6px;
-  font-family: ${props => props.theme.fonts.mono};
-  font-size: 12px;
-  background-color: ${props =>
-    props.light ? '#d3d3d3' : props.theme.colors.spotBackground[2]};
+  font-family: ${p => p.theme.fonts.mono};
+  font-size: ${p => p.theme.fontSizes[1]}px;
+  background-color: ${p => p.theme.colors.interactive.tonal.neutral[2]};
   color: inherit;
 `;

--- a/web/packages/design/src/Mark/index.ts
+++ b/web/packages/design/src/Mark/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { Mark } from './Mark';

--- a/web/packages/design/src/index.ts
+++ b/web/packages/design/src/index.ts
@@ -38,6 +38,7 @@ import Label from './Label';
 import LabelInput from './LabelInput';
 import LabelState from './LabelState';
 import Link from './Link';
+import { Mark } from './Mark';
 import Image from './Image';
 import Text from './Text';
 import SideNav, { SideNavItem } from './SideNav';
@@ -74,6 +75,7 @@ export {
   Label,
   LabelInput,
   LabelState,
+  Mark,
   Link,
   Pill,
   Popover,

--- a/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { Box, Text, Flex, Link } from 'design';
+import { Box, Text, Flex, Link, Mark } from 'design';
 import TextEditor from 'shared/components/TextEditor';
 import { Danger } from 'design/Alert';
 import { ToolTipInfo } from 'shared/components/ToolTip';
@@ -31,7 +31,7 @@ import cfg from 'teleport/config';
 import { Container } from 'teleport/Discover/Shared/CommandBox';
 import { splitAwsIamArn } from 'teleport/services/integrations/aws';
 
-import { ActionButtons, Header, Mark } from '../../Shared';
+import { ActionButtons, Header } from '../../Shared';
 
 import { AppCreatedDialog } from './AppCreatedDialog';
 

--- a/web/packages/teleport/src/Discover/AwsMangementConsole/SetupAccess/SetupAccess.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/SetupAccess/SetupAccess.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { LabelInput, Text, Link } from 'design';
+import { LabelInput, Text, Link, Mark } from 'design';
 import { useTheme } from 'styled-components';
 import { Cross } from 'design/Icon';
 
@@ -31,7 +31,6 @@ import {
   useUserTraits,
   SetupAccessWrapper,
 } from 'teleport/Discover/Shared/SetupAccess';
-import { Mark } from 'teleport/Discover/Shared';
 import { styles } from 'teleport/Discover/Shared/SelectCreatable/SelectCreatable';
 import { AWS_TAG_INFO_LINK } from 'teleport/Discover/Shared/const';
 

--- a/web/packages/teleport/src/Discover/AwsMangementConsole/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/TestConnection/TestConnection.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useState } from 'react';
-import { Text, Box, Link } from 'design';
+import { Text, Box, Link, Mark } from 'design';
 import Select from 'shared/components/Select';
 import { OutlineInfo } from 'design/Alert/Alert';
 import { TextSelectCopy } from 'shared/components/TextSelectCopy';
@@ -29,7 +29,6 @@ import {
   ActionButtons,
   HeaderSubtitle,
   StyledBox,
-  Mark,
 } from 'teleport/Discover/Shared';
 import useTeleport from 'teleport/useTeleport';
 import { splitAwsIamArn } from 'teleport/services/integrations/aws';

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.tsx
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { Text, Box, Flex } from 'design';
+import { Text, Box, Flex, Mark } from 'design';
 
 import Validation, { Validator } from 'shared/components/Validation';
 import FieldInput from 'shared/components/FieldInput';
@@ -28,7 +28,6 @@ import {
   ActionButtons,
   HeaderSubtitle,
   LabelsCreater,
-  Mark,
   Header,
 } from '../../Shared';
 import { dbCU } from '../../yamlTemplates';

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
@@ -18,7 +18,7 @@
 
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { Box, ButtonSecondary, Link, Text } from 'design';
+import { Box, ButtonSecondary, Link, Text, Mark } from 'design';
 import * as Icons from 'design/Icon';
 import FieldInput from 'shared/components/FieldInput';
 import Validation, { Validator } from 'shared/components/Validation';
@@ -49,7 +49,6 @@ import {
   Header,
   DiscoverLabel,
   AlternateInstructionButton,
-  Mark,
 } from '../../../Shared';
 
 import { DeployServiceProp } from '../DeployService';

--- a/web/packages/teleport/src/Discover/Database/DeployService/ManualDeploy/ManualDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/ManualDeploy/ManualDeploy.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { Suspense, useState, useEffect } from 'react';
-import { Box, ButtonSecondary, Text } from 'design';
+import { Box, ButtonSecondary, Text, Mark } from 'design';
 import * as Icons from 'design/Icon';
 import Validation, { Validator } from 'shared/components/Validation';
 
@@ -54,7 +54,6 @@ import {
   DiscoverLabel,
   Header,
   HeaderSubtitle,
-  Mark,
   ResourceKind,
   TextIcon,
   useShowHint,

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useState } from 'react';
-import { Box, Text, Toggle } from 'design';
+import { Box, Text, Toggle, Mark } from 'design';
 import { FetchStatus } from 'design/DataTable/types';
 import { Danger } from 'design/Alert';
 import useAttempt, { Attempt } from 'shared/hooks/useAttemptNext';
@@ -50,7 +50,6 @@ import {
   AutoEnrollDialog,
   ActionButtons,
   Header,
-  Mark,
   SelfHostedAutoDiscoverDirections,
 } from '../../Shared';
 

--- a/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useState } from 'react';
-import { Text, Box, Flex, Link } from 'design';
+import { Text, Box, Flex, Link, Mark } from 'design';
 import { Danger } from 'design/Alert';
 import { Info } from 'design/Icon';
 import TextEditor from 'shared/components/TextEditor';
@@ -28,13 +28,7 @@ import useTeleport from 'teleport/useTeleport';
 import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
 import { Tabs } from 'teleport/components/Tabs';
 
-import {
-  HeaderSubtitle,
-  ActionButtons,
-  Mark,
-  Header,
-  StyledBox,
-} from '../../Shared';
+import { HeaderSubtitle, ActionButtons, Header, StyledBox } from '../../Shared';
 import { dbCU } from '../../yamlTemplates';
 import { DatabaseEngine } from '../../SelectResource';
 

--- a/web/packages/teleport/src/Discover/Database/SetupAccess/SetupAccess.tsx
+++ b/web/packages/teleport/src/Discover/Database/SetupAccess/SetupAccess.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { Box, Text, Flex, Link } from 'design';
+import { Box, Text, Flex, Link, Mark } from 'design';
 import { Info as InfoIcon } from 'design/Icon';
 
 import {
@@ -28,7 +28,7 @@ import {
   useUserTraits,
   SetupAccessWrapper,
 } from 'teleport/Discover/Shared/SetupAccess';
-import { Mark, StyledBox } from 'teleport/Discover/Shared';
+import { StyledBox } from 'teleport/Discover/Shared';
 import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
 import { DbMeta } from 'teleport/Discover/useDiscover';
 import { Tabs } from 'teleport/components/Tabs';

--- a/web/packages/teleport/src/Discover/Database/common.tsx
+++ b/web/packages/teleport/src/Discover/Database/common.tsx
@@ -17,11 +17,11 @@
  */
 
 import React from 'react';
-import { Box, Label as Pill, Text } from 'design';
+import { Box, Label as Pill, Text, Mark } from 'design';
 import * as Icons from 'design/Icon';
 
 import { ResourceLabel } from 'teleport/services/agents';
-import { LabelsCreater, Mark, TextIcon } from 'teleport/Discover/Shared';
+import { LabelsCreater, TextIcon } from 'teleport/Discover/Shared';
 import { Regions } from 'teleport/services/integrations';
 
 // serviceDeployedMethod is a flag to determine if user opted to

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -16,14 +16,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import Dialog, { DialogContent } from 'design/DialogConfirmation';
-import { AnimatedProgressBar, Box, ButtonPrimary, Text, Flex } from 'design';
+import {
+  AnimatedProgressBar,
+  Box,
+  ButtonPrimary,
+  Text,
+  Flex,
+  Mark,
+} from 'design';
 import React, { useEffect } from 'react';
 
 import * as Icons from 'design/Icon';
 
 import { Kube } from 'teleport/services/kube';
 import { usePingTeleport } from 'teleport/Discover/Shared/PingTeleportContext';
-import { Mark, TextIcon, useShowHint } from 'teleport/Discover/Shared';
+import { TextIcon, useShowHint } from 'teleport/Discover/Shared';
 import { HintBox } from 'teleport/Discover/Shared/HintBox';
 
 type AgentWaitingDialogProps = {

--- a/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
@@ -18,7 +18,7 @@
 
 import React, { Suspense, useState } from 'react';
 import styled from 'styled-components';
-import { Box, ButtonSecondary, Link, Text } from 'design';
+import { Box, ButtonSecondary, Link, Text, Mark } from 'design';
 import * as Icons from 'design/Icon';
 import FieldInput from 'shared/components/FieldInput';
 import Validation, { Validator } from 'shared/components/Validation';
@@ -46,7 +46,6 @@ import {
   ActionButtons,
   Header,
   HeaderSubtitle,
-  Mark,
   ResourceKind,
   TextIcon,
   useShowHint,

--- a/web/packages/teleport/src/Discover/Server/CreateEc2Ice/CreateEc2IceDialog.tsx
+++ b/web/packages/teleport/src/Discover/Server/CreateEc2Ice/CreateEc2IceDialog.tsx
@@ -24,6 +24,7 @@ import {
   ButtonPrimary,
   Link,
   Box,
+  Mark,
 } from 'design';
 import * as Icons from 'design/Icon';
 import Dialog, { DialogContent } from 'design/DialogConfirmation';
@@ -39,7 +40,7 @@ import {
   Ec2InstanceConnectEndpoint,
   integrationService,
 } from 'teleport/services/integrations';
-import { Mark, TextIcon } from 'teleport/Discover/Shared';
+import { TextIcon } from 'teleport/Discover/Shared';
 import { NodeMeta, useDiscover } from 'teleport/Discover/useDiscover';
 import { usePoll } from 'teleport/Discover/Shared/usePoll';
 import {

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
@@ -17,7 +17,14 @@
  */
 
 import React, { useState, useRef } from 'react';
-import { Box, Link as ExternalLink, Text, Flex, ButtonSecondary } from 'design';
+import {
+  Box,
+  Link as ExternalLink,
+  Text,
+  Flex,
+  ButtonSecondary,
+  Mark,
+} from 'design';
 import styled from 'styled-components';
 import { Danger, Info } from 'design/Alert';
 import TextEditor from 'shared/components/TextEditor';
@@ -42,7 +49,7 @@ import {
 import { splitAwsIamArn } from 'teleport/services/integrations/aws';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 
-import { ActionButtons, Header, Mark, StyledBox } from '../../Shared';
+import { ActionButtons, Header, StyledBox } from '../../Shared';
 
 import { SingleEc2InstanceInstallation } from '../Shared';
 

--- a/web/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.tsx
+++ b/web/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.tsx
@@ -18,7 +18,7 @@
 
 import React, { Suspense, useEffect, useState } from 'react';
 
-import { Box, Indicator, Text } from 'design';
+import { Box, Indicator, Text, Mark } from 'design';
 import * as Icons from 'design/Icon';
 
 import cfg from 'teleport/config';
@@ -46,7 +46,6 @@ import {
   ActionButtons,
   HeaderSubtitle,
   Header,
-  Mark,
   ResourceKind,
   TextIcon,
 } from '../../Shared';

--- a/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/NoEc2IceRequiredDialog.tsx
+++ b/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/NoEc2IceRequiredDialog.tsx
@@ -17,11 +17,10 @@
  */
 
 import React from 'react';
-import { Text, Flex, ButtonPrimary } from 'design';
+import { Text, Flex, ButtonPrimary, Mark } from 'design';
 import * as Icons from 'design/Icon';
 import Dialog, { DialogContent } from 'design/DialogConfirmation';
 
-import { Mark } from 'teleport/Discover/Shared';
 import { NodeMeta, useDiscover } from 'teleport/Discover/useDiscover';
 
 export function NoEc2IceRequiredDialog({ nextStep }: { nextStep: () => void }) {

--- a/web/packages/teleport/src/Discover/Server/Shared.tsx
+++ b/web/packages/teleport/src/Discover/Server/Shared.tsx
@@ -19,12 +19,11 @@
 import React from 'react';
 import { Link as InternalLink } from 'react-router-dom';
 import { OutlineInfo } from 'design/Alert/Alert';
-import { Box } from 'design';
+import { Box, Mark } from 'design';
 
 import cfg from 'teleport/config';
 
 import { InfoIcon } from '../Shared/InfoIcon';
-import { Mark } from '../Shared';
 
 export const SingleEc2InstanceInstallation = () => (
   <OutlineInfo mt={3} linkColor="buttons.link.default">

--- a/web/packages/teleport/src/Discover/Shared/AutoDiscovery/AutoEnrollDialog.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AutoDiscovery/AutoEnrollDialog.tsx
@@ -23,11 +23,10 @@ import {
   AnimatedProgressBar,
   ButtonPrimary,
   ButtonSecondary,
+  Mark,
 } from 'design';
 import * as Icons from 'design/Icon';
 import Dialog, { DialogContent } from 'design/DialogConfirmation';
-
-import { Mark } from 'teleport/Discover/Shared';
 
 import type { Attempt } from 'shared/hooks/useAttemptNext';
 

--- a/web/packages/teleport/src/Discover/Shared/AutoDiscovery/SelfHostedAutoDiscoverDirections.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AutoDiscovery/SelfHostedAutoDiscoverDirections.tsx
@@ -15,14 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Box, Flex, Input, Text } from 'design';
+import { Box, Flex, Input, Text, Mark } from 'design';
 import styled from 'styled-components';
 
 import { ToolTipInfo } from 'shared/components/ToolTip';
 
 import React from 'react';
 
-import { Mark } from 'teleport/Discover/Shared';
 import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
 import { Tabs } from 'teleport/components/Tabs';
 

--- a/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.tsx
@@ -18,12 +18,12 @@
 
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { ButtonSecondary, Text, Box, Flex, ButtonText } from 'design';
+import { ButtonSecondary, Text, Box, Flex, ButtonText, Mark } from 'design';
 import * as Icons from 'design/Icon';
 
 import { YamlReader } from 'teleport/Discover/Shared/SetupAccess/AccessInfo';
 
-import { StyledBox, TextIcon, Mark } from '..';
+import { StyledBox, TextIcon } from '..';
 
 import type { Attempt } from 'shared/hooks/useAttemptNext';
 import type { ConnectionDiagnostic } from 'teleport/services/agents';

--- a/web/packages/teleport/src/Discover/Shared/index.ts
+++ b/web/packages/teleport/src/Discover/Shared/index.ts
@@ -20,7 +20,6 @@ export { ActionButtons, AlternateInstructionButton } from './ActionButtons';
 export { ButtonBlueText } from './ButtonBlueText';
 export { Header, HeaderSubtitle, HeaderWithBackBtn } from './Header';
 export { Finished } from './Finished';
-export { Mark } from './Mark';
 export { PermissionsErrorMessage } from '../SelectResource/PermissionsErrorMessage';
 export { ResourceKind } from './ResourceKind';
 export { Step, StepContainer } from './Step';

--- a/web/packages/teleport/src/Integrations/UpdateAwsOidcThumbprint.tsx
+++ b/web/packages/teleport/src/Integrations/UpdateAwsOidcThumbprint.tsx
@@ -18,13 +18,19 @@
 
 import { useState } from 'react';
 import styled from 'styled-components';
-import { Text, Link as ExternalLink, Flex, Box, ButtonPrimary } from 'design';
+import {
+  Text,
+  Link as ExternalLink,
+  Flex,
+  Box,
+  ButtonPrimary,
+  Mark,
+} from 'design';
 import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
 import { ToolTipInfo } from 'shared/components/ToolTip';
 import useAttempt from 'shared/hooks/useAttemptNext';
 import * as Icons from 'design/Icon';
 
-import { Mark } from 'teleport/Discover/Shared';
 import {
   Integration,
   integrationService,


### PR DESCRIPTION
so we aren't importing it into other places from discover feature

<img width="535" alt="image" src="https://github.com/user-attachments/assets/9998289c-36a5-4b5d-9e3a-c75587a48e6d">

<img width="543" alt="image" src="https://github.com/user-attachments/assets/e49e9138-4d1a-4b61-b9e4-a70335d2c0d9">

<img width="516" alt="image" src="https://github.com/user-attachments/assets/fc93e55e-d98f-48a1-86ff-622542d2fe1a">
