### PR TITLE
vnet.osConfigurator: Use clientcache.Cache, fix leak

### DIFF
--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -255,6 +255,11 @@ func osConfigurationLoop(ctx context.Context, tunName, ipv6Prefix, dnsAddr strin
 	if err != nil {
 		return trace.Wrap(err, "creating OS configurator")
 	}
+	defer func() {
+		if err := osConfigurator.close(); err != nil {
+			slog.ErrorContext(ctx, "Error while closing OS configurator", "error", err)
+		}
+	}()
 
 	// Clean up any stale configuration left by a previous VNet instance that may have failed to clean up.
 	// This is necessary in case any stale /etc/resolver/<proxy address> entries are still present, we need to


### PR DESCRIPTION
The admin process spawned by VNet was not closing `lib/client.ClusterClient`s that it was creating, resulting in a memory leak and possibly exhausting cluster resources.

This could be fixed by closing the clients when `osConfigurator.updateOSConfiguration` exits. I went one step further and used a client cache (already used by the non-privileged VNet process and lib/teleterm).

## How it was discovered

When working on the launch daemon for VNet, I noticed that the memory usage of the admin process would just grow and grow. At some point it'd stop, which would also coincide with me not being able to access the cluster – not only through VNet, but also outside the VM that was running VNet.

I ssh'd into the cluster and I saw this in nginx logs:

```
2024/07/12 11:12:14 [alert] 15749#15749: 768 worker_connections are not enough
```

On top of that, stopping VNet would result in a ton of those items being logged in nginx access logs. Notice how the duration between those requests differs by 10 seconds?

```
192.166.202.48 - - [12/Jul/2024:12:04:40 +0200] "GET https://cluster.mirrors.link/webapi/connectionupgrade HTTP/1.1" 101 4633 "-" "Go-http-client/1.1" 95.505
192.166.202.48 - - [12/Jul/2024:12:04:40 +0200] "GET https://cluster.mirrors.link/webapi/connectionupgrade HTTP/1.1" 101 4948 "-" "Go-http-client/1.1" 105.722
```

At this point, I had a strong suspicion that it has to do with how we handle clients.

## How it works

The admin process is responsible for [host configuration](https://github.com/gravitational/teleport/blob/master/rfd/0163-vnet.md#host-configuration). It is given `TELEPORT_HOME` by the unprivileged process when spawned and every 10 seconds it configures DNS for clusters in that dir. This automatically picks up new clusters and removes stale configuration for removed clusters.

To configure DNS, it needs to make a couple of calls. Most of them are cached, but there's one that's not – the call to get leaf clusters.

I added the cache, which usually gets invalidated during logout or when logging in again. Those actions do not happen within the admin process. Instead, it assumes that the user runs other tsh commands that trigger relogin. As such, the cache in the admin process gets invalidated whenever the client runs into an error – this might mean that the cert has expired and a new client should be created.

--- 

changelog: Fixed a leak in the admin process spawned by starting VNet through `tsh vnet` or Teleport Connect