### PR TITLE
Fix typo in `gzdunek` username in dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -247,7 +247,7 @@ updates:
       - kimlisa
       - rudream
       - bl-nero
-      - gzdnunek
+      - gzdunek
       - ravicious
       - ryanclark
   - package-ecosystem: github-actions


### PR DESCRIPTION
I was wondering why I am not assigned in dependabot PRs... :)

@avatus this change shouldn't reopen the current PRs, no?