### PR TITLE
[v15] send empty SAML service provider preset values as `unspecified` to Web UI

### DIFF
--- a/lib/web/ui/app.go
+++ b/lib/web/ui/app.go
@@ -150,8 +150,14 @@ func MakeApp(app types.Application, c MakeAppsConfig) App {
 
 // MakeSAMLApp creates a SAMLIdPServiceProvider object for the WebUI.
 // Keep in sync with lib/teleterm/apiserver/handler/handler_apps.go.
+// Note: The SAMLAppPreset field is used in SAML service provider update flow in the
+// Web UI. Thus, this field is currently not available in the Connect App type.
 func MakeSAMLApp(app types.SAMLIdPServiceProvider, c MakeAppsConfig) App {
 	labels := makeLabels(app.GetAllLabels())
+	samlAppPreset := "unspecified"
+	if app.GetPreset() != "" {
+		samlAppPreset = app.GetPreset()
+	}
 	resultApp := App{
 		Kind:          types.KindApp,
 		Name:          app.GetName(),
@@ -161,7 +167,7 @@ func MakeSAMLApp(app types.SAMLIdPServiceProvider, c MakeAppsConfig) App {
 		ClusterID:     c.AppClusterName,
 		FriendlyName:  types.FriendlyName(app),
 		SAMLApp:       true,
-		SAMLAppPreset: app.GetPreset(),
+		SAMLAppPreset: samlAppPreset,
 	}
 
 	return resultApp

--- a/lib/web/ui/app_test.go
+++ b/lib/web/ui/app_test.go
@@ -218,19 +218,29 @@ func TestMakeSAMLApp(t *testing.T) {
 		expected         App
 	}{
 		{
-			name: "empty",
+			name: "saml service provider with empty preset returns unspecified",
+			sp: types.SAMLIdPServiceProviderV1{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "test_app",
+					},
+				},
+				Spec: types.SAMLIdPServiceProviderSpecV1{
+					Preset: "",
+				},
+			},
 			expected: App{
 				Kind:          types.KindApp,
-				Name:          "",
+				Name:          "test_app",
 				Description:   "SAML Application",
 				PublicAddr:    "",
 				Labels:        []Label{},
 				SAMLApp:       true,
-				SAMLAppPreset: "",
+				SAMLAppPreset: "unspecified",
 			},
 		},
 		{
-			name: "saml idp service provider",
+			name: "saml service provider with preset",
 			sp: types.SAMLIdPServiceProviderV1{
 				ResourceHeader: types.ResourceHeader{
 					Metadata: types.Metadata{


### PR DESCRIPTION
Backport #43863 to branch/v15.

Manual backport. 