### PR TITLE
[v14] Add ingress.useExisting value

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -1851,6 +1851,25 @@ Boolean value that specifies whether to generate a Kubernetes `Ingress` for the 
     enabled: true
   ```
 
+## `ingress.useExisting`
+
+| Type      | Default value | Required? |
+|-----------|---------------|-----------|
+| `boolean` | `false`       | No        |
+
+
+`ingress.useExisting` indicates to the chart that you are providing your own ingress.
+The chart will configure Teleport like it's running behind an ingress,but will not
+create the ingress resource. You are responsible for creating and managing the ingress.
+
+`values.yaml` example:
+
+```yaml
+ingress:
+  enabled: true
+  useExisting: true
+```
+
 ## `ingress.suppressAutomaticWildcards`
 
 | Type      | Default value | Required? |

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -1858,7 +1858,8 @@ Boolean value that specifies whether to generate a Kubernetes `Ingress` for the 
 | `boolean` | `false`       | No        |
 
 
-`ingress.useExisting` indicates to the chart that you are providing your own ingress.
+`ingress.useExisting` indicates to the chart that you are managing your own ingress
+(or HTTPRoute, or any other LoadBalancing method that terminates TLS).
 The chart will configure Teleport like it's running behind an ingress, but will not
 create the ingress resource. You are responsible for creating and managing the ingress.
 

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -1859,7 +1859,7 @@ Boolean value that specifies whether to generate a Kubernetes `Ingress` for the 
 
 
 `ingress.useExisting` indicates to the chart that you are providing your own ingress.
-The chart will configure Teleport like it's running behind an ingress,but will not
+The chart will configure Teleport like it's running behind an ingress, but will not
 create the ingress resource. You are responsible for creating and managing the ingress.
 
 `values.yaml` example:

--- a/examples/chart/teleport-cluster/templates/proxy/ingress.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/ingress.yaml
@@ -3,21 +3,22 @@
   {{- if (not (eq .Values.proxyListenerMode "multiplex")) -}}
     {{- fail "Use of an ingress requires TLS multiplexing to be enabled, so you must also set proxyListenerMode=multiplex - see https://goteleport.com/docs/architecture/tls-routing/" -}}
   {{- end -}}
-  {{- $publicAddr := coalesce .Values.publicAddr (list .Values.clusterName) -}}
-  {{- /* Trim ports from all public addresses if present */ -}}
-  {{- range $publicAddr -}}
-    {{- $address := . -}}
-    {{- if (contains ":" $address) -}}
-      {{- $split := split ":" $address -}}
-      {{- $address = $split._0 -}}
-      {{- $publicAddr = append (mustWithout $publicAddr .) $address -}}
+  {{- if not .Values.ingress.useExisting }}
+    {{- $publicAddr := coalesce .Values.publicAddr (list .Values.clusterName) -}}
+    {{- /* Trim ports from all public addresses if present */ -}}
+    {{- range $publicAddr -}}
+      {{- $address := . -}}
+      {{- if (contains ":" $address) -}}
+        {{- $split := split ":" $address -}}
+        {{- $address = $split._0 -}}
+        {{- $publicAddr = append (mustWithout $publicAddr .) $address -}}
+      {{- end -}}
+      {{- $wildcard := printf "*.%s" $address -}}
+      {{- /* Add wildcard versions of all public addresses to ingress, unless 1) suppressed or 2) wildcard version already exists */ -}}
+      {{- if and (not $.Values.ingress.suppressAutomaticWildcards) (not (hasPrefix "*." $address)) (not (has $wildcard $publicAddr)) -}}
+        {{- $publicAddr = append $publicAddr (printf "*.%s" $address) -}}
+      {{- end -}}
     {{- end -}}
-    {{- $wildcard := printf "*.%s" $address -}}
-    {{- /* Add wildcard versions of all public addresses to ingress, unless 1) suppressed or 2) wildcard version already exists */ -}}
-    {{- if and (not $.Values.ingress.suppressAutomaticWildcards) (not (hasPrefix "*." $address)) (not (has $wildcard $publicAddr)) -}}
-      {{- $publicAddr = append $publicAddr (printf "*.%s" $address) -}}
-    {{- end -}}
-  {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -58,4 +59,5 @@ spec:
             port:
               number: 443
     {{- end }}
+  {{- end }}
 {{- end }}

--- a/examples/chart/teleport-cluster/tests/ingress_test.yaml
+++ b/examples/chart/teleport-cluster/tests/ingress_test.yaml
@@ -18,6 +18,16 @@ tests:
       - isKind:
           of: Ingress
 
+  - it: does not create an Ingress when ingress.enabled=true, proxyListenerMode=multiplex but ingress.useExisting is true
+    values:
+      - ../.lint/ingress.yaml
+    set:
+      ingress:
+        useExisting: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: fails to deploy an Ingress when ingress.enabled=true and proxyListenerMode is not set
     values:
       - ../.lint/ingress.yaml

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -682,6 +682,10 @@ service:
 # See https://goteleport.com/docs/architecture/tls-routing/#working-with-layer-7-load-balancers-or-reverse-proxies-preview for details.
 ingress:
   enabled: false
+  # Use existing indicates to the chart that you are providing your own ingress.
+  # The chart will configure Teleport like it's running behind an ingress, but will not create the ingress resource.
+  # You are responsible for creating and managing the ingress.
+  useExisting: false
   # Setting suppressAutomaticWildcards to true will not automatically add *.<clusterName> as a hostname served
   # by the Ingress. This may be desirable if you don't use Teleport Application Access.
   suppressAutomaticWildcards: false

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -682,7 +682,7 @@ service:
 # See https://goteleport.com/docs/architecture/tls-routing/#working-with-layer-7-load-balancers-or-reverse-proxies-preview for details.
 ingress:
   enabled: false
-  # Use existing indicates to the chart that you are providing your own ingress.
+  # useExisting indicates to the chart that you are providing your own ingress.
   # The chart will configure Teleport like it's running behind an ingress, but will not create the ingress resource.
   # You are responsible for creating and managing the ingress.
   useExisting: false

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -682,7 +682,7 @@ service:
 # See https://goteleport.com/docs/architecture/tls-routing/#working-with-layer-7-load-balancers-or-reverse-proxies-preview for details.
 ingress:
   enabled: false
-  # useExisting indicates to the chart that you are providing your own ingress.
+  # useExisting indicates to the chart that you are managing your own ingress.
   # The chart will configure Teleport like it's running behind an ingress, but will not create the ingress resource.
   # You are responsible for creating and managing the ingress.
   useExisting: false

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -683,6 +683,7 @@ service:
 ingress:
   enabled: false
   # useExisting indicates to the chart that you are managing your own ingress.
+  # (or HTTPRoute, or any other LoadBalancing method that terminates TLS).
   # The chart will configure Teleport like it's running behind an ingress, but will not create the ingress resource.
   # You are responsible for creating and managing the ingress.
   useExisting: false


### PR DESCRIPTION
Backport #44009 to branch/v14

changelog: The `teleport-cluster` chart can now use existing ingresses instead of creating its own.
