### PR TITLE
[v16] Add PostgreSQL session recording player translator

### DIFF
--- a/lib/player/db/postgres.go
+++ b/lib/player/db/postgres.go
@@ -1,0 +1,158 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package db
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/utils"
+)
+
+// PostgresTranslator is responsible for converting PostgreSQL session recording
+// events into their text representation.
+type PostgresTranslator struct {
+	sessionStartAt time.Time
+	// preparedStatements is a map of parsed prepared statements.
+	preparedStatements map[string]string
+	// preparedStatementPortalBindings is a map of binded prepared statements
+	// portals and their arguments.
+	preparedStatementPortalBidings map[string]preparedStatementBind
+	// expectingResult determines if the translator is expecting a command
+	// result. This is used to skip commands and their results.
+	expectingResult bool
+}
+
+type preparedStatementBind struct {
+	stmtName string
+	params   []string
+}
+
+func newPreparedStatementBind(stmt string, params []string) preparedStatementBind {
+	return preparedStatementBind{stmt, params}
+}
+
+// NewPostgresTranslator constructs a new instance of PostgreSQL translator.
+func NewPostgresTranslator() *PostgresTranslator {
+	return &PostgresTranslator{
+		preparedStatements:             make(map[string]string),
+		preparedStatementPortalBidings: make(map[string]preparedStatementBind),
+		expectingResult:                false,
+	}
+}
+
+// TranslateEvent converts PostgreSQL audit events into session print events.
+func (p *PostgresTranslator) TranslateEvent(evt events.AuditEvent) *events.SessionPrint {
+	switch e := evt.(type) {
+	case *events.DatabaseSessionQuery:
+		p.expectingResult = true
+		return p.generatePrintEvent(e.Metadata, p.generateCommandPrint(e.DatabaseMetadata, e.DatabaseQuery))
+	case *events.DatabaseSessionCommandResult:
+		if p.expectingResult {
+			p.expectingResult = false
+			return p.generatePrintEvent(e.Metadata, p.generateResultPrint(e))
+		}
+	case *events.PostgresParse:
+		p.expectingResult = false
+		p.preparedStatements[e.StatementName] = e.Query
+	case *events.PostgresBind:
+		p.expectingResult = false
+		p.preparedStatementPortalBidings[e.PortalName] = newPreparedStatementBind(e.StatementName, e.Parameters)
+	case *events.PostgresExecute:
+		printEvent := p.generatePreparedStatementPrint(e.Metadata, e.DatabaseMetadata, e.PortalName)
+		p.expectingResult = printEvent != nil
+		return printEvent
+	case *events.PostgresFunctionCall:
+		// Function calls are skipped on the playback since the lack of
+		// information to present informative/understandable messages. For
+		// example, we only have the function OID (not the string representation,
+		// or definition),  In addition, they are considered legacy/deprecated,
+		// function call is now done through queries (e.g., SELECT func()).
+		p.expectingResult = false
+	case *events.DatabaseSessionStart:
+		p.sessionStartAt = e.Time
+		return p.generatePrintEvent(e.Metadata, fmt.Sprintf("Session started to database %q at %s%s", e.DatabaseService, utils.HumanTimeFormat(e.Time), lineBreak))
+	case *events.DatabaseSessionEnd:
+		return p.generatePrintEvent(e.Metadata, lineBreak+"Session ended at "+utils.HumanTimeFormat(e.Time)+lineBreak)
+	}
+
+	return nil
+}
+
+const lineBreak = "\r\n"
+
+func (p *PostgresTranslator) generateCommandPrint(metadata events.DatabaseMetadata, command string) string {
+	return lineBreak + fmt.Sprintf("%s=> %s", metadata.DatabaseName, command) + lineBreak
+}
+
+func (p *PostgresTranslator) generatePreparedStatementPrint(metadata events.Metadata, databaseMetadata events.DatabaseMetadata, portalName string) *events.SessionPrint {
+	bind, hasBind := p.preparedStatementPortalBidings[portalName]
+
+	// In case of an unbinded portal, we cannot present the execution properly,
+	// so we skip those executions.
+	if !hasBind {
+		return nil
+	}
+
+	var sb strings.Builder
+	if stmt, ok := p.preparedStatements[bind.stmtName]; ok {
+		sb.WriteString(stmt)
+	} else {
+		fmt.Fprintf(&sb, "EXECUTE %s", bind.stmtName)
+	}
+
+	if len(bind.params) > 0 {
+		sb.WriteString(" (")
+
+		for i, param := range bind.params {
+			fmt.Fprintf(&sb, "$%d = %q", i+1, param)
+			if i != len(bind.params)-1 {
+				sb.WriteString(", ")
+			}
+		}
+
+		sb.WriteString(")")
+	}
+
+	return p.generatePrintEvent(metadata, p.generateCommandPrint(databaseMetadata, sb.String()))
+}
+
+func (p *PostgresTranslator) generateResultPrint(evt *events.DatabaseSessionCommandResult) string {
+	if !evt.Status.Success {
+		return evt.Status.Error + lineBreak
+	}
+
+	return fmt.Sprintf("SUCCESS%s(%d row%s affected)", lineBreak, evt.AffectedRecords, pluralizeRows(int(evt.AffectedRecords))) + lineBreak
+}
+
+func (p *PostgresTranslator) generatePrintEvent(metadata events.Metadata, data string) *events.SessionPrint {
+	return &events.SessionPrint{
+		Metadata:          metadata,
+		Data:              []byte(data),
+		DelayMilliseconds: metadata.Time.Sub(p.sessionStartAt).Milliseconds(),
+	}
+}
+
+func pluralizeRows(count int) string {
+	if count == 1 {
+		return ""
+	}
+
+	return "s"
+}

--- a/lib/player/db/postgres_test.go
+++ b/lib/player/db/postgres_test.go
@@ -1,0 +1,365 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package db
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/utils"
+)
+
+func TestPostgresRecording(t *testing.T) {
+	fixedTime := time.Now()
+
+	for name, test := range map[string]struct {
+		events         []events.AuditEvent
+		expectedPrints [][]byte
+	}{
+		"session start": {
+			events: []events.AuditEvent{
+				&events.DatabaseSessionStart{
+					Metadata:         events.Metadata{Time: fixedTime},
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseService: "my-pg-instance"},
+				},
+			},
+			expectedPrints: [][]byte{
+				[]byte("Session started to database \"my-pg-instance\" at " + utils.HumanTimeFormat(fixedTime) + "\r\n"),
+			},
+		},
+		"session end": {
+			events: []events.AuditEvent{
+				&events.DatabaseSessionEnd{
+					Metadata: events.Metadata{Time: fixedTime},
+				},
+			},
+			expectedPrints: [][]byte{
+				[]byte("\r\nSession ended at " + utils.HumanTimeFormat(fixedTime) + "\r\n"),
+			},
+		},
+		"queries": {
+			events: []events.AuditEvent{
+				&events.DatabaseSessionQuery{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					DatabaseQuery:    "SELECT 1;",
+				},
+				&events.DatabaseSessionCommandResult{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					Status:           events.Status{Success: true},
+					AffectedRecords:  1,
+				},
+				&events.DatabaseSessionQuery{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					DatabaseQuery:    "SELECT * from events;",
+				},
+				&events.DatabaseSessionCommandResult{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					Status:           events.Status{Success: true},
+					AffectedRecords:  15,
+				},
+			},
+			expectedPrints: [][]byte{
+				[]byte("\r\ntest=> SELECT 1;\r\n"),
+				[]byte("SUCCESS\r\n(1 row affected)\r\n"),
+				[]byte("\r\ntest=> SELECT * from events;\r\n"),
+				[]byte("SUCCESS\r\n(15 rows affected)\r\n"),
+			},
+		},
+		"queries with errors": {
+			events: []events.AuditEvent{
+				&events.DatabaseSessionQuery{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					DatabaseQuery:    "SELECT err;",
+				},
+				&events.DatabaseSessionCommandResult{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					Status:           events.Status{Success: false, Error: "ERROR: column error"},
+				},
+			},
+			expectedPrints: [][]byte{
+				[]byte("\r\ntest=> SELECT err;\r\n"),
+				[]byte("ERROR: column error\r\n"),
+			},
+		},
+		"prepared statements": {
+			events: []events.AuditEvent{
+				&events.PostgresParse{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "test",
+					Query:            "SELECT $1::varchar",
+				},
+				&events.PostgresBind{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "test",
+					Parameters:       []string{"hello world"},
+				},
+				&events.PostgresExecute{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+				},
+				&events.DatabaseSessionCommandResult{
+					Status:          events.Status{Success: true},
+					AffectedRecords: 1,
+				},
+				&events.PostgresBind{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "test",
+					Parameters:       []string{"hello new execution"},
+				},
+				&events.PostgresExecute{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+				},
+				&events.DatabaseSessionCommandResult{
+					Status:          events.Status{Success: true},
+					AffectedRecords: 1,
+				},
+			},
+			expectedPrints: [][]byte{
+				nil,
+				nil,
+				[]byte("\r\ntest=> SELECT $1::varchar ($1 = \"hello world\")\r\n"),
+				[]byte("SUCCESS\r\n(1 row affected)\r\n"),
+				nil,
+				[]byte("\r\ntest=> SELECT $1::varchar ($1 = \"hello new execution\")\r\n"),
+				[]byte("SUCCESS\r\n(1 row affected)\r\n"),
+				nil,
+				[]byte("\r\ntest=> EXECUTE random ($1 = \"hello new execution\")\r\n"),
+				[]byte("SUCCESS\r\n(1 row affected)\r\n"),
+			},
+		},
+		"multiple parameters prepared statements": {
+			events: []events.AuditEvent{
+				&events.PostgresParse{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "test",
+					Query:            "SELECT $1::varchar",
+				},
+				&events.PostgresBind{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "test",
+					Parameters:       []string{"hello", "world"},
+				},
+				&events.PostgresExecute{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+				},
+				&events.DatabaseSessionCommandResult{
+					Status:          events.Status{Success: true},
+					AffectedRecords: 1,
+				},
+			},
+			expectedPrints: [][]byte{
+				nil,
+				nil,
+				[]byte("\r\ntest=> SELECT $1::varchar ($1 = \"hello\", $2 = \"world\")\r\n"),
+				[]byte("SUCCESS\r\n(1 row affected)\r\n"),
+			},
+		},
+		"unknown prepared statements": {
+			events: []events.AuditEvent{
+				&events.PostgresBind{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "random",
+					Parameters:       []string{"hello world"},
+				},
+				&events.PostgresExecute{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+				},
+				&events.DatabaseSessionCommandResult{
+					Status:          events.Status{Success: true},
+					AffectedRecords: 1,
+				},
+			},
+			expectedPrints: [][]byte{
+				nil,
+				[]byte("\r\ntest=> EXECUTE random ($1 = \"hello world\")\r\n"),
+				[]byte("SUCCESS\r\n(1 row affected)\r\n"),
+			},
+		},
+		"prepared statements without binding": {
+			events: []events.AuditEvent{
+				&events.PostgresExecute{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+				},
+				&events.DatabaseSessionCommandResult{
+					Status:          events.Status{Success: true},
+					AffectedRecords: 1,
+				},
+			},
+			expectedPrints: [][]byte{
+				nil,
+				nil,
+			},
+		},
+		"prepared statements with multiple portal bindings": {
+			events: []events.AuditEvent{
+				&events.PostgresParse{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "test",
+					Query:            "SELECT $1::varchar || ' ' || $2::varchar",
+				},
+				&events.PostgresBind{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "test",
+					PortalName:       "hello1",
+					Parameters:       []string{"hello", "first"},
+				},
+				&events.PostgresBind{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "test",
+					PortalName:       "hello2",
+					Parameters:       []string{"hello", "second"},
+				},
+				&events.PostgresExecute{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					PortalName:       "hello1",
+				},
+				&events.DatabaseSessionCommandResult{
+					Status:          events.Status{Success: true},
+					AffectedRecords: 1,
+				},
+				&events.PostgresExecute{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					PortalName:       "hello2",
+				},
+				&events.DatabaseSessionCommandResult{
+					Status:          events.Status{Success: true},
+					AffectedRecords: 1,
+				},
+			},
+			expectedPrints: [][]byte{
+				nil,
+				nil,
+				nil,
+				[]byte("\r\ntest=> SELECT $1::varchar || ' ' || $2::varchar ($1 = \"hello\", $2 = \"first\")\r\n"),
+				[]byte("SUCCESS\r\n(1 row affected)\r\n"),
+				[]byte("\r\ntest=> SELECT $1::varchar || ' ' || $2::varchar ($1 = \"hello\", $2 = \"second\")\r\n"),
+				[]byte("SUCCESS\r\n(1 row affected)\r\n"),
+			},
+		},
+		"prepared statements mixed name and unnamed portals": {
+			events: []events.AuditEvent{
+				&events.PostgresParse{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "test",
+					Query:            "SELECT $1::varchar || ' ' || $2::varchar",
+				},
+				&events.PostgresBind{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "test",
+					PortalName:       "hello1",
+					Parameters:       []string{"hello", "first"},
+				},
+				&events.PostgresBind{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "test",
+					PortalName:       "hello2",
+					Parameters:       []string{"hello", "second"},
+				},
+				// unnamed bind
+				&events.PostgresBind{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "test",
+					Parameters:       []string{"hello", "unamed1"},
+				},
+				&events.PostgresExecute{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+				},
+				&events.DatabaseSessionCommandResult{
+					Status:          events.Status{Success: true},
+					AffectedRecords: 1,
+				},
+				// named hello1
+				&events.PostgresExecute{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					PortalName:       "hello1",
+				},
+				&events.DatabaseSessionCommandResult{
+					Status:          events.Status{Success: true},
+					AffectedRecords: 1,
+				},
+				// unnamed 2 bind
+				&events.PostgresBind{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					StatementName:    "test",
+					Parameters:       []string{"hello", "unamed2"},
+				},
+				&events.PostgresExecute{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+				},
+				&events.DatabaseSessionCommandResult{
+					Status:          events.Status{Success: true},
+					AffectedRecords: 1,
+				},
+				// named hello2
+				&events.PostgresExecute{
+					DatabaseMetadata: events.DatabaseMetadata{DatabaseName: "test"},
+					PortalName:       "hello2",
+				},
+				&events.DatabaseSessionCommandResult{
+					Status:          events.Status{Success: true},
+					AffectedRecords: 1,
+				},
+			},
+			expectedPrints: [][]byte{
+				nil,
+				nil,
+				nil,
+				nil, // unnamed bind
+				[]byte("\r\ntest=> SELECT $1::varchar || ' ' || $2::varchar ($1 = \"hello\", $2 = \"unamed1\")\r\n"),
+				[]byte("SUCCESS\r\n(1 row affected)\r\n"),
+				[]byte("\r\ntest=> SELECT $1::varchar || ' ' || $2::varchar ($1 = \"hello\", $2 = \"first\")\r\n"),
+				[]byte("SUCCESS\r\n(1 row affected)\r\n"),
+				nil, // unnamed 2 bind
+				[]byte("\r\ntest=> SELECT $1::varchar || ' ' || $2::varchar ($1 = \"hello\", $2 = \"unamed2\")\r\n"),
+				[]byte("SUCCESS\r\n(1 row affected)\r\n"),
+				[]byte("\r\ntest=> SELECT $1::varchar || ' ' || $2::varchar ($1 = \"hello\", $2 = \"second\")\r\n"),
+				[]byte("SUCCESS\r\n(1 row affected)\r\n"),
+			},
+		},
+		"skip unexpected command results": {
+			events: []events.AuditEvent{
+				&events.DatabaseSessionCommandResult{
+					Status:          events.Status{Success: true},
+					AffectedRecords: 1,
+				},
+			},
+			expectedPrints: [][]byte{
+				nil,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			translator := NewPostgresTranslator()
+
+			for i, evt := range test.events {
+				expectedResult := test.expectedPrints[i]
+				result := translator.TranslateEvent(evt)
+
+				if expectedResult == nil {
+					require.Nil(t, result, "expected event to be skipped")
+					continue
+				}
+
+				require.NotNil(t, result, "expected event to not be skipped")
+				require.True(t, bytes.Equal(expectedResult, result.Data), "expected data %q but got %q", expectedResult, result.Data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backport #43781 to branch/v16

changelog: Added support for playing PostgreSQL database access session recordings through `tsh play`.