### PR TITLE
Manually fetch agent-pool-terraform modules

### DIFF
--- a/docs/pages/enroll-resources/agents/deploy-agents-terraform.mdx
+++ b/docs/pages/enroll-resources/agents/deploy-agents-terraform.mdx
@@ -77,6 +77,45 @@ a demo cluster using:
    
    </Notice>
 
+1. Fetch the Teleport code repository and copy the example Terraform
+   configuration for this project into your current working directory. Copy
+   the appropriate child module for your cloud provider into a subdirectory
+   called `cloud` and HCL configurations for Teleport resources into a
+   subdirectory called `teleport`:
+
+   <Tabs>
+   <TabItem label="AWS">
+
+   ```code
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone
+   $ cp -R teleport-clone/examples/agent-pool-terraform/teleport teleport
+   $ cp -R teleport-clone/examples/agent-pool-terraform/aws cloud
+   $ rm -rf teleport-clone
+   ```
+
+   </TabItem>
+   <TabItem label="Google Cloud">
+
+   ```code
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone
+   $ cp -R teleport-clone/examples/agent-pool-terraform/teleport teleport
+   $ cp -R teleport-clone/examples/agent-pool-terraform/gcp cloud
+   $ rm -rf teleport-clone
+   ```
+
+   </TabItem>
+   <TabItem label="Azure">
+
+   ```code
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone
+   $ cp -R teleport-clone/examples/agent-pool-terraform/teleport teleport
+   $ cp -R teleport-clone/examples/agent-pool-terraform/azure cloud
+   $ rm -rf teleport-clone
+   ```
+
+   </TabItem>
+   </Tabs>
+
 1. Create a file called `main.tf` with the following content, which imports the
    `agent-pool-terraform` module for your cloud provider:
 
@@ -85,7 +124,7 @@ a demo cluster using:
 
 ```hcl
 module "teleport" {
-  source                = "github.com/gravitational/teleport/examples/agent-pool-terraform/teleport"
+  source                = "./teleport"
   agent_count           = 2
   agent_roles           = ["Node"]
   proxy_service_address = "teleport.example.com:443"
@@ -95,7 +134,7 @@ module "teleport" {
 
 module "agents" {
   region           = ""
-  source           = "github.com/gravitational/teleport/examples/agent-pool-terraform/aws"
+  source           = "./cloud"
   subnet_id        = ""
   userdata_scripts = module.teleport.userdata_scripts
 }
@@ -106,7 +145,7 @@ module "agents" {
 
 ```hcl
 module "teleport" {
-  source                = "github.com/gravitational/teleport/examples/agent-pool-terraform/teleport"
+  source                = "./teleport"
   agent_count           = 2
   agent_roles           = ["Node"]
   proxy_service_address = "teleport.example.com:443"
@@ -117,7 +156,7 @@ module "teleport" {
 module "agents" {
   gcp_zone         = "us-east1-b"
   google_project   = ""
-  source           = "github.com/gravitational/teleport/examples/agent-pool-terraform/gcp"
+  source           = "./cloud"
   subnet_id        = ""
   userdata_scripts = module.teleport.userdata_scripts
 }
@@ -128,7 +167,7 @@ module "agents" {
 
 ```hcl
 module "teleport" {
-  source                = "github.com/gravitational/teleport/examples/agent-pool-terraform/teleport"
+  source                = "./teleport"
   agent_count           = 2
   agent_roles           = ["Node"]
   proxy_service_address = "teleport.example.com:443"
@@ -140,7 +179,7 @@ module "agents" {
   azure_resource_group = ""
   public_key_path      = ""
   region               = "East US"
-  source               = "github.com/gravitational/teleport/examples/agent-pool-terraform/azure"
+  source               = "./cloud"
   subnet_id            = ""
   userdata_scripts     = module.teleport.userdata_scripts
 }
@@ -555,5 +594,4 @@ instances:
 
 </TabItem>
 </Tabs>
-
 


### PR DESCRIPTION
Closes #43951

Rather than have the user declare `agent-pool-terraform` child modules using `github.com` addresses in the root `main.tf`, have the user pull a shallow clone of `gravitational/teleport` and copy the correct child modules into their project directory. This way, users who are not authorized to access private submodules of `gravitational/teleport` can still copy the `agent-pool-terraform` child modules.