### PR TITLE
Example Update: Teleport has to be able to write to /events/

### DIFF
--- a/examples/athena/accessmonitoring.tf
+++ b/examples/athena/accessmonitoring.tf
@@ -78,6 +78,7 @@ data "aws_iam_policy_document" "access_monitoring_policy" {
       "s3:PutObject"
     ]
     resources = [
+      "${aws_s3_bucket.long_term_storage.arn}/events/*",
       "${aws_s3_bucket.long_term_storage.arn}/report_results/*",
       "${aws_s3_bucket.transient_storage.arn}/results/*"
     ]


### PR DESCRIPTION
While setting up Access Monitoring, I found that Teleport was processing the SQS queue as it wasn't able to write messages to S3.  Added /events/ to it's PUT permissions.