### PR TITLE
Fix automatic updater installation instructions

### DIFF
--- a/docs/pages/upgrading/automatic-agent-updates.mdx
+++ b/docs/pages/upgrading/automatic-agent-updates.mdx
@@ -189,9 +189,16 @@ Server ID                            Hostname      Services Version Upgrader
    </TabItem>
    <TabItem label="Self-Hosted Teleport Enterprise">
 
-   ```code
-   $ curl https://goteleport.com/static/install.sh | bash -s ${TELEPORT_VERSION?} enterprise
-   ```
+   1. Follow the instructions in the Teleport [installation
+      guide](../installation.mdx#package-repositories) to install the `teleport`
+      binary on your Linux server for your package manager.
+
+   1. Using your package manager, install `teleport-ent-updater` on the
+      server where you installed `teleport`. For example:
+
+      ```code
+      $ apt-get install -y teleport-ent-updater
+      ```
 
    </TabItem>
    </Tabs>


### PR DESCRIPTION
Closes #43865

For self-hosted Teleport Enterprise users, the current instructions show you how to use the one-line installation script to install Teleport on a Linux server. This script does not install the updater if the second argument is set to `enterprise`.

Instead, instruct the user to visit the Installation page section for package managers, install the `teleport` binary, and use the package manager to install the updater.

An alternative approach would be to use a nested `Tabs` component with instructions for different package managers, but nested `Tabs` look unsightly on our docs site.