### PR TITLE
web: add `SamlIdPServiceProviderAccess` getter

### DIFF
--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -153,6 +153,10 @@ export default class StoreUserContext extends Store<UserContext> {
     return this.state.acl.accessGraph;
   }
 
+  getSamlIdPServiceProviderAccess() {
+    return this.state.acl.samlIdpServiceProvider;
+  }
+
   // hasPrereqAccessToAddAgents checks if user meets the prerequisite
   // access to add an agent:
   //  - user should be able to create provisioning tokens


### PR DESCRIPTION
Adds `getSamlIdPServiceProviderAccess` to StoreUserContext that returns user's SAML IdP resource permission.

https://github.com/gravitational/teleport.e/issues/4458 