### PR TITLE
Change availability filter to a toggle

### DIFF
--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -140,7 +140,7 @@ export function FilterPanel({
           kindsFromParams={kinds || []}
         />
         {ClusterDropdown}
-        {availabilityFilter && availabilityFilter.canRequestAll && (
+        {availabilityFilter && (
           <IncludedResourcesSelector
             availabilityFilter={availabilityFilter}
             onChange={changeAvailableResourceMode}
@@ -528,7 +528,7 @@ const IncludedResourcesSelector = ({
       onChange('accessible');
       return;
     }
-    onChange('all');
+    onChange(availabilityFilter.canRequestAll ? 'all' : 'requestable');
   }
 
   return (


### PR DESCRIPTION
This PR will remove the radio/checkbox options for the availability filter and instead use a toggle to "show requestable resources or not"

This takes into account if users have the `requestable` option toggled in their user prefs still so everything should work for them in the new version

The default option for new users is still to show requestable resources, aka "toggled on".
![Screenshot 2024-07-12 at 6 04 14 PM](https://github.com/user-attachments/assets/bea75779-08d8-4cc3-bd54-d93e86ec6615)

changelog: the availability filter is now a toggle to show (or hide) requestable resources