### PR TITLE
[v14] Fixes a bug in the kube-agent-updater breaking private image resolution

### DIFF
--- a/integrations/kube-agent-updater/pkg/controller/deployment.go
+++ b/integrations/kube-agent-updater/pkg/controller/deployment.go
@@ -78,6 +78,7 @@ func (r *DeploymentVersionUpdater) Reconcile(ctx context.Context, req ctrl.Reque
 	var (
 		noNewVersionErr *version.NoNewVersionError
 		maintenanceErr  *MaintenanceNotTriggeredError
+		trustErr        *trace.TrustError
 	)
 	switch {
 	case errors.As(err, &noNewVersionErr):
@@ -88,9 +89,9 @@ func (r *DeploymentVersionUpdater) Reconcile(ctx context.Context, req ctrl.Reque
 		// Not logging the error because it provides no other information than its type.
 		log.Info("No maintenance triggered, not updating.", "currentVersion", currentVersion)
 		return requeueLater, nil
-	case trace.IsTrustError(err):
+	case errors.As(err, &trustErr):
 		// Logging as error as image verification should not fail under normal use
-		log.Error(err, "Image verification failed, not updating.")
+		log.Error(trustErr.OrigError(), "Image verification failed, not updating.")
 		return requeueLater, nil
 	case err != nil:
 		log.Error(err, "Unexpected error, not updating.")

--- a/integrations/kube-agent-updater/pkg/controller/statefulset.go
+++ b/integrations/kube-agent-updater/pkg/controller/statefulset.go
@@ -102,6 +102,7 @@ func (r *StatefulSetVersionUpdater) Reconcile(ctx context.Context, req ctrl.Requ
 	var (
 		noNewVersionErr *version.NoNewVersionError
 		maintenanceErr  *MaintenanceNotTriggeredError
+		trustErr        *trace.TrustError
 	)
 	switch {
 	case errors.As(err, &noNewVersionErr):
@@ -117,9 +118,9 @@ func (r *StatefulSetVersionUpdater) Reconcile(ctx context.Context, req ctrl.Requ
 		// No need to check for blocked rollout because the unhealthy workload
 		// trigger has not approved the maintenance
 		return requeueLater, nil
-	case trace.IsTrustError(err):
+	case errors.As(err, &trustErr):
 		// Logging as error as image verification should not fail under normal use
-		log.Error(err, "Image verification failed, not updating.")
+		log.Error(trustErr.OrigError(), "Image verification failed, not updating.")
 		if err := r.unblockStatefulSetRolloutIfStuck(ctx, &obj); err != nil {
 			log.Error(err, "statefulset unblocking failed, the rollout might get stuck")
 		}

--- a/integrations/kube-agent-updater/pkg/img/cosign.go
+++ b/integrations/kube-agent-updater/pkg/img/cosign.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto"
 	"encoding/hex"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/distribution/reference"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -30,6 +29,7 @@ import (
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // hashAlgo is the Digest algorithm for OCI artfiacts:

--- a/integrations/kube-agent-updater/pkg/img/cosign.go
+++ b/integrations/kube-agent-updater/pkg/img/cosign.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto"
 	"encoding/hex"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/distribution/reference"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -62,8 +63,6 @@ func (v *cosignKeyValidator) Name() string {
 // ValidateAndResolveDigest resolves the image digest and validates it was
 // signed with cosign using a trusted static key.
 func (v *cosignKeyValidator) ValidateAndResolveDigest(ctx context.Context, image reference.NamedTagged) (NamedTaggedDigested, error) {
-	// No RegistryClientOpts for now, this means no private repo support
-	// This might also be useful for local testing (running a test registry)
 	checkOpts := &cosign.CheckOpts{
 		RegistryClientOpts: v.registryOptions,
 		Annotations:        nil,
@@ -71,19 +70,24 @@ func (v *cosignKeyValidator) ValidateAndResolveDigest(ctx context.Context, image
 		SigVerifier:        v.verifier,
 		IgnoreTlog:         true, // TODO: should we keep this?
 	}
+	// Those are debug logs only
+	log := ctrllog.FromContext(ctx).V(1)
+	log.Info("Resolving digest", "image", image.String())
 
-	ref, err := NamedTaggedToDigest(image)
+	ref, err := NamedTaggedToDigest(image, v.registryOptions...)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "failed to resolve image digest")
 	}
+	log.Info("Resolved digest", "image", image.String(), "digest", ref.Digest, "reference", ref.String())
 
 	verified, _, err := cosign.VerifyImageSignatures(ctx, ref, checkOpts)
 	if err != nil {
-		return nil, trace.Trust(err, "failed to verify image signature")
+		return nil, trace.Wrap(err, "failed to verify image signature")
 	}
 	if len(verified) == 0 {
 		return nil, trace.Wrap(&trace.TrustError{Message: "cannot validate image: no valid signature found"})
 	}
+	log.Info("Signature validated", "image", image.String(), "digest", ref.Digest, "reference", ref.String())
 
 	// There are legitimate use-cases where the signing reference is not the same
 	// as the img we're pulling from: img promoted to an internal registry,
@@ -119,11 +123,11 @@ func NewCosignSingleKeyValidator(pem []byte, name string) (Validator, error) {
 
 // NamedTaggedToDigest resolves the digest of a reference.NamedTagged image and
 // returns a name.Digest image corresponding to the resolved image.
-func NamedTaggedToDigest(image reference.NamedTagged) (name.Digest, error) {
+func NamedTaggedToDigest(image reference.NamedTagged, opts ...ociremote.Option) (name.Digest, error) {
 	ref, err := name.ParseReference(image.String())
 	if err != nil {
 		return name.Digest{}, trace.Wrap(err)
 	}
-	digested, err := ociremote.ResolveDigest(ref)
+	digested, err := ociremote.ResolveDigest(ref, opts...)
 	return digested, trace.Wrap(err)
 }

--- a/integrations/kube-agent-updater/pkg/img/cosign_test.go
+++ b/integrations/kube-agent-updater/pkg/img/cosign_test.go
@@ -18,6 +18,13 @@ package img
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/distribution/reference"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -41,9 +48,8 @@ func Test_NewCosignSingleKeyValidator(t *testing.T) {
 	require.Equal(t, "distroless-799a5c21a7f8c39707274cbd065ba2e1969d8d29", a.Name())
 }
 
-// We don't test the digest resolution here (we call the validation function with
-// a digested reference, the resolution step will return the digest instead of
-// contacting the upstream to get it.
+// Test_cosignKeyValidator_ValidateAndResolveDigest tests both the resolution and the validation
+// of images in a public registry.
 func Test_cosignKeyValidator_ValidateAndResolveDigest(t *testing.T) {
 	// Setup and start a test OCI registry
 
@@ -54,31 +60,20 @@ func Test_cosignKeyValidator_ValidateAndResolveDigest(t *testing.T) {
 
 	// Put test layers and manifests into the registry
 	for digest, contents := range blobs {
-		u, err := url.Parse(testRegistry.URL + "/v2/testrepo/blobs/uploads/1?digest=" + digest)
-		require.NoError(t, err)
-		req := &http.Request{
-			Method: "PUT",
-			URL:    u,
-			Body:   io.NopCloser(strings.NewReader(contents)),
-		}
-		resp, err := testRegistry.Client().Do(req)
-		require.NoError(t, err)
-		require.Equal(t, http.StatusCreated, resp.StatusCode)
-		require.NoError(t, resp.Body.Close())
+		uploadBlob(t, testRegistry, digest, contents, "")
 	}
 	for manifest, contents := range manifests {
-		u, err := url.Parse(testRegistry.URL + "/v2/testrepo/manifests/" + manifest)
-		require.NoError(t, err)
-		req := &http.Request{
-			Method: "PUT",
-			URL:    u,
-			Body:   io.NopCloser(strings.NewReader(contents)),
-		}
-		resp, err := testRegistry.Client().Do(req)
-		require.NoError(t, err)
-		require.Equal(t, http.StatusCreated, resp.StatusCode)
-		require.NoError(t, resp.Body.Close())
+		uploadManifest(t, testRegistry, manifest, contents, "")
 	}
+	regURL, err := url.Parse(testRegistry.URL)
+	require.NoError(t, err)
+
+	// Build a special test case: an image with a tag that must be resolved
+	namedImage, err := reference.ParseNamed(regURL.Host + "/testrepo")
+	require.NoError(t, err)
+	signedManifestTaggedImage, err := reference.WithTag(namedImage, "signed-manifest")
+	require.NoError(t, err)
+	uploadManifest(t, testRegistry, "signed-manifest", manifests[signedManifest], "")
 
 	// Build a validator
 	pubKey, err := cryptoutils.UnmarshalPEMToPublicKey(publicKey)
@@ -94,18 +89,273 @@ func Test_cosignKeyValidator_ValidateAndResolveDigest(t *testing.T) {
 		registryOptions: []ociremote.Option{ociremote.WithRemoteOptions(remote.WithTransport(testRegistry.Client().Transport))},
 	}
 
-	regURL, err := url.Parse(testRegistry.URL)
-	require.NoError(t, err)
-
 	// Doing the real test: submitting several images to the validator and checking its output
 	tests := []struct {
 		name      string
-		image     NamedTaggedDigested
+		image     reference.NamedTagged
 		assertErr require.ErrorAssertionFunc
 	}{
 		{
 			name:      "signed manifest",
 			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", signedManifest),
+			assertErr: require.NoError,
+		},
+		{
+			name:      "signed manifest needs resolution",
+			image:     signedManifestTaggedImage,
+			assertErr: require.NoError,
+		},
+		{
+			name:      "unsigned manifest",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", unsignedManifest),
+			assertErr: require.Error,
+		},
+		{
+			name:      "untrusted signed manifest",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", untrustedSignedManifest),
+			assertErr: require.Error,
+		},
+		{
+			name:      "double signed manifest",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", doubleSignedManifest),
+			assertErr: require.NoError,
+		},
+		{
+			name:      "untrusted double signed manifest",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", untrustedDoubleSignedManifest),
+			assertErr: require.Error,
+		},
+		{
+			name:      "wrongly signed manifest",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", wronglySignedManifest),
+			assertErr: require.Error,
+		},
+		{
+			name:      "untrusted wrongly signed manifest",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", untrustedWronglySignedManifest),
+			assertErr: require.Error,
+		},
+		{
+			name:      "signed index",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", signedIndex),
+			assertErr: require.NoError,
+		},
+		{
+			name:      "unsigned index",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", unsignedIndex),
+			assertErr: require.Error,
+		},
+		{
+			name:      "untrusted signed index",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", untrustedSignedIndex),
+			assertErr: require.Error,
+		},
+		{
+			name:      "double signed index",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", doubleSignedIndex),
+			assertErr: require.NoError,
+		},
+		{
+			name:      "untrusted double signed index",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", untrustedDoubleSignedIndex),
+			assertErr: require.Error,
+		},
+		{
+			name:      "wrongly signed index",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", wronglySignedIndex),
+			assertErr: require.Error,
+		},
+		{
+			name:      "untrusted wrongly signed index",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", untrustdedWronglySignedIndex),
+			assertErr: require.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validator.ValidateAndResolveDigest(context.Background(), tt.image)
+			tt.assertErr(t, err)
+		})
+	}
+}
+
+func uploadBlob(t *testing.T, testRegistry *httptest.Server, digest, content, authHeader string) {
+	u, err := url.Parse(testRegistry.URL + "/v2/testrepo/blobs/uploads/1?digest=" + digest)
+	require.NoError(t, err)
+	uploadToRegistry(t, testRegistry, u, content, authHeader)
+}
+
+func uploadManifest(t *testing.T, testRegistry *httptest.Server, ref, content, authHeader string) {
+	u, err := url.Parse(testRegistry.URL + "/v2/testrepo/manifests/" + ref)
+	require.NoError(t, err)
+	uploadToRegistry(t, testRegistry, u, content, authHeader)
+}
+
+func uploadToRegistry(t *testing.T, testRegistry *httptest.Server, u *url.URL, content, authHeader string) {
+	header := http.Header{}
+	if authHeader != "" {
+		header.Set("Authorization", authHeader)
+	}
+	req := &http.Request{
+		Method: "PUT",
+		URL:    u,
+		Header: header,
+		Body:   io.NopCloser(strings.NewReader(content)),
+	}
+	resp, err := testRegistry.Client().Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
+// registryAuthMiddleware mocks the docker registry authentication and allows us to run cosign tests against an
+// authenticated in-memory registry.
+// The auth dance is described in https://github.com/google/go-containerregistry/blob/main/pkg/authn/README.md
+// This dummy registry authentication accepts a single user/password pair, and a single static Bearer token.
+type registryAuthMiddleware struct {
+	t *testing.T
+
+	registryHandler http.Handler
+	user            string
+	password        string
+
+	// fields below are randomly generated
+	service     string
+	bearerToken string
+}
+
+// ServeHTTP implements http.Handler. The handler intercepts every request and checks if they are authenticated.
+// Unauthenticated requests receive a 401 and are redirected to "/token".
+// "/token" checks the baic auth credentials and returns the registry token.
+func (auth registryAuthMiddleware) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	// Catch login requests
+	if req.URL.Path == "/token" {
+		// We don't check service and scope, we just see if user and pass are sent
+		user, password, ok := req.BasicAuth()
+		if !ok || user != auth.user || password != auth.password {
+			resp.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		resp.Header().Add("Content-Type", "application/json")
+		resp.WriteHeader(http.StatusOK)
+		token := struct {
+			Token string `json:"token"`
+		}{
+			Token: auth.bearerToken,
+		}
+		jsonToken, err := json.Marshal(token)
+		assert.NoError(auth.t, err)
+		_, err = resp.Write(jsonToken)
+		assert.NoError(auth.t, err)
+		return
+	}
+
+	// Allow authenticated requests to pass
+	if bearer := req.Header.Get("Authorization"); bearer != "" {
+		assert.Equal(auth.t, auth.authorizationHeader(), bearer)
+		auth.registryHandler.ServeHTTP(resp, req)
+		return
+	}
+
+	// Request is not authenticated, we return 401 and redirect to the login endpoint
+	realm := "http://" + req.Host + "/token"
+	resp.Header().Set("Content-Type", "application/json")
+	resp.Header().Set("Www-Authenticate", fmt.Sprintf("Bearer realm=%q,service=%q", realm, auth.service))
+	resp.WriteHeader(http.StatusUnauthorized)
+	return
+}
+
+// authorizationHeader returns the content of the Authorization header to authenticate a request.
+func (auth registryAuthMiddleware) authorizationHeader() string {
+	return fmt.Sprintf("Bearer %s", auth.bearerToken)
+}
+
+// newRegistryAuthMiddleware takes the http.Handler of a docker registry and wraps it to provide
+// basic auth for the registry.
+func newRegistryAuthMiddleware(t *testing.T, user, password string, registryHandler http.Handler) registryAuthMiddleware {
+	service := uuid.New().String()
+	bearerToken := base64.StdEncoding.EncodeToString([]byte(uuid.New().String()))
+	return registryAuthMiddleware{
+		t:               t,
+		registryHandler: registryHandler,
+		user:            user,
+		password:        password,
+		service:         service,
+		bearerToken:     bearerToken,
+	}
+}
+
+// Test_cosignKeyValidator_ValidateAndResolveDigest tests both the resolution and the validation
+// of images in a private registry (basic auth).
+func Test_cosignKeyValidator_ValidateAndResolveDigestAuthenticated(t *testing.T) {
+	// Setup and start a test OCI registry
+	testUser := "user"
+	testPassword := "password"
+
+	// Referrer API is enabled even though the signature manifests don't have the `Subject` field set.
+	// This is the worst case scenario and also reduces the amount of noise and failed calls in the logs.
+	registryHandler := registry.New(registry.WithReferrersSupport(true))
+	authRegistryHandler := newRegistryAuthMiddleware(t, testUser, testPassword, registryHandler)
+	testRegistry := httptest.NewServer(authRegistryHandler)
+	t.Cleanup(testRegistry.Close)
+	authHeader := authRegistryHandler.authorizationHeader()
+
+	// Put test layers and manifests into the registry
+	for digest, contents := range blobs {
+		uploadBlob(t, testRegistry, digest, contents, authHeader)
+	}
+	for manifest, contents := range manifests {
+		uploadManifest(t, testRegistry, manifest, contents, authHeader)
+	}
+
+	regURL, err := url.Parse(testRegistry.URL)
+	require.NoError(t, err)
+
+	// Build a special test case: an image with a tag that must be resolved
+	namedImage, err := reference.ParseNamed(regURL.Host + "/testrepo")
+	require.NoError(t, err)
+	signedManifestTaggedImage, err := reference.WithTag(namedImage, "signed-manifest")
+	require.NoError(t, err)
+	uploadManifest(t, testRegistry, "signed-manifest", manifests[signedManifest], authHeader)
+
+	// Build a validator
+	pubKey, err := cryptoutils.UnmarshalPEMToPublicKey(publicKey)
+	require.NoError(t, err)
+	skid, err := cryptoutils.SKID(pubKey)
+	require.NoError(t, err)
+	verifier, err := signature.LoadVerifier(pubKey, hashAlgo)
+	require.NoError(t, err)
+	basicAuth := &authn.Basic{
+		Username: testUser,
+		Password: testPassword,
+	}
+
+	validator := &cosignKeyValidator{
+		verifier: verifier,
+		skid:     skid,
+		name:     "test",
+		registryOptions: []ociremote.Option{
+			ociremote.WithRemoteOptions(
+				remote.WithTransport(testRegistry.Client().Transport),
+				remote.WithAuth(basicAuth),
+			),
+		},
+	}
+	// Doing the real test: submitting several images to the validator and checking its output
+	tests := []struct {
+		name      string
+		image     reference.NamedTagged
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "signed manifest",
+			image:     NewImageRef(regURL.Host, "testrepo", "not-resolved", signedManifest),
+			assertErr: require.NoError,
+		},
+		{
+			name:      "signed manifest needs resolution",
+			image:     signedManifestTaggedImage,
 			assertErr: require.NoError,
 		},
 		{

--- a/integrations/kube-agent-updater/pkg/img/cosign_test.go
+++ b/integrations/kube-agent-updater/pkg/img/cosign_test.go
@@ -263,7 +263,6 @@ func (auth registryAuthMiddleware) ServeHTTP(resp http.ResponseWriter, req *http
 	resp.Header().Set("Content-Type", "application/json")
 	resp.Header().Set("Www-Authenticate", fmt.Sprintf("Bearer realm=%q,service=%q", realm, auth.service))
 	resp.WriteHeader(http.StatusUnauthorized)
-	return
 }
 
 // authorizationHeader returns the content of the Authorization header to authenticate a request.

--- a/integrations/kube-agent-updater/pkg/img/cosign_test.go
+++ b/integrations/kube-agent-updater/pkg/img/cosign_test.go
@@ -21,10 +21,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/distribution/reference"
-	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -32,11 +28,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/distribution/reference"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/uuid"
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Backport #44112 to branch/v14

changelog: Fixed a `kube-agent-updater` bug affecting resolutions of private images.
