### PR TITLE
add iam:CreateServiceLinkedRole to DeployService

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -65,6 +65,9 @@ func StatementForECSManageService() *Statement {
 
 			// EC2 DescribeSecurityGroups is required so that the user can list the SG and then pick which ones they want to apply to the ECS Service.
 			"ec2:DescribeSecurityGroups",
+
+			// IAM CreateServiceLinkedRole is required to ensure the ECS Service linked role exists.
+			"iam:CreateServiceLinkedRole",
 		},
 		Resources: allResources,
 	}


### PR DESCRIPTION
Part of:
- https://github.com/gravitational/teleport/issues/41004

Closes https://github.com/gravitational/teleport.e/issues/3603:
- https://github.com/gravitational/teleport.e/issues/3603

If the ECS service-linked role managed by AWS does not exist yet, then when the OIDC integration calls ecs:CreateCluster it will fail.

Adding `iam:CreateServiceLinkedRole` to the integration's permissions will allow the API call to automatically create the service-linked role on first use of ECS, but it may require retrying, so I added some automatic retrying as well and verified that this fix works within ~10-20 seconds when the service-linked role has to be created.