### PR TITLE
docs: update vnet client guide

### DIFF
--- a/docs/pages/connect-your-client/vnet.mdx
+++ b/docs/pages/connect-your-client/vnet.mdx
@@ -5,6 +5,7 @@ description: Using VNet
 
 This guide explains how to use VNet to connect to TCP applications available through Teleport.
 
+
 ## How it works
 
 VNet automatically proxies connections from your computer to TCP apps available through Teleport. A
@@ -13,12 +14,13 @@ Teleport. Underneath, VNet authenticates the connection with your credentials, u
 routing technology](../architecture/tls-routing.mdx) as `tsh proxy app`. This is all done
 client-side – VNet sets up a local DNS name server and a virtual network device.
 
-VNet is available in Teleport Connect and tsh on macOS, with Windows and Linux version in the works.
+VNet is available in Teleport Connect and `tsh` on macOS, with Windows and Linux version in the works.
 
 ## Prerequisites
 
 - A client machine running macOS Ventura (13.0) or higher.
 - [Teleport Connect](teleport-connect.mdx), version 16.0.0 or higher.
+- TCP Application resources available to your user.
 
 ## Step 1/3. Start Teleport Connect
 


### PR DESCRIPTION
Include that tcp app resources are required to use vnet for users.