### PR TITLE
Enable `pnpm` in buildbox

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -245,7 +245,7 @@ RUN export NODE_ARCH=$(if [ "$BUILDARCH" = "amd64" ]; then echo "x64"; else echo
     mkdir -p ${NODE_PATH} && \
     curl -o /tmp/nodejs.tar.xz -fsSL ${NODE_URL} && \
     tar -xJf /tmp/nodejs.tar.xz -C /usr/local/lib/nodejs-linux --strip-components=1
-RUN corepack enable yarn
+RUN corepack enable yarn pnpm
 
 # Install Go.
 ARG GOLANG_VERSION


### PR DESCRIPTION
 Enables `pnpm` in the buildbox, so JS lint and tests can pass in https://github.com/gravitational/teleport/pull/44167.

@camscale this needs to be backported to v16 to take effect in a PR to master, correct? From what I see, GHA workflows on master use `teleport-buildbox:teleport16`.