### PR TITLE
docs: update plugins download and build instrs

### DIFF
--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -76,9 +76,12 @@ We'll reference the exported file(s) later when configuring the plugin.
 
 <Tabs>
 <TabItem label="Download">
+  Access Request Plugins are available as `amd64` or `arm64` Linux binaries for downloading.
+  Replace `ARCH` with your required version.
+
   ```code
-  $ curl -L https://get.gravitational.com/teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-  $ tar -xzf teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ curl -L https://cdn.teleport.dev/teleport-access-mattermost-v(=teleport.plugin.version=)-linux-<Var name="ARCH" />-bin.tar.gz
+  $ tar -xzf teleport-access-mattermost-v(=teleport.plugin.version=)-linux-<Var name="ARCH" />-bin.tar.gz
   $ cd teleport-access-mattermost
   $ ./install
   ```
@@ -88,7 +91,7 @@ We'll reference the exported file(s) later when configuring the plugin.
 
   ```code
   # Checkout the Teleport repo and go in the mattermost access plugin directory
-  $ git clone https://github.com/gravitational/teleport.git
+  $ git clone https://github.com/gravitational/teleport.git -b branch/v(=teleport.major_version=)
   $ cd teleport/integrations/access/mattermost
   $ git checkout (=teleport.plugin.version=)
   $ make

--- a/docs/pages/api/access-plugin.mdx
+++ b/docs/pages/api/access-plugin.mdx
@@ -62,7 +62,7 @@ repository on GitHub.
 Download the source code for our minimal Access Request plugin:
 
 ```code
-$ git clone https://github.com/gravitational/teleport
+$ git clone https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
 $ cd teleport/examples/access-plugin-minimal
 ```
 

--- a/docs/pages/includes/install-event-handler.mdx
+++ b/docs/pages/includes/install-event-handler.mdx
@@ -1,29 +1,27 @@
 <Tabs>
 <TabItem label="Linux">
 
+The Event Handler plugin is provided in `amd64` and `arm64` binaries for downloading.
+Replace `ARCH` with your required version.
+
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ curl -L -O https://cdn.teleport.dev/teleport-event-handler-v(=teleport.plugin.version=)-linux-<Var name="ARCH" />-bin.tar.gz
+$ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-linux-<Var name="ARCH" />-bin.tar.gz
 $ sudo ./teleport-event-handler/install
 ```
-
-We currently only build the Event Handler plugin for amd64 machines. For ARM
-architecture, you can build from source.
 
 </TabItem>
 
 <TabItem label="macOS">
 
+The Event Handler plugin is provided in `amd64` and `arm64` binaries for downloading.
+Replace `ARCH` with your required version.
+
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
-$ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
+$ curl -L -O https://cdn.teleport.dev/teleport-event-handler-v(=teleport.plugin.version=)-darwin-<Var name="ARCH" />-bin.tar.gz
+$ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-darwin-<Var name="ARCH" />-bin.tar.gz
 $ sudo ./teleport-event-handler/install
 ```
-
-We currently only build the event handler plugin for amd64 machines. If your
-macOS machine uses Apple silicon, you will need to [install
-Rosetta](https://support.apple.com/en-us/HT211861) before you can run the
-event handler plugin. You can also build from source.
 
 </TabItem>
 
@@ -58,7 +56,7 @@ You will need Go >= (=teleport.golang=) installed.
 Run the following commands on your Universal Forwarder host:
 
 ```code
-$ git clone https://github.com/gravitational/teleport.git --depth 1
+$ git clone https://github.com/gravitational/teleport.git --depth 1 -b branch/v(=teleport.major_version=)
 $ cd teleport/integrations/event-handler
 $ git checkout (=teleport.plugin.version=)
 $ make build

--- a/docs/pages/includes/plugins/install-access-request.mdx
+++ b/docs/pages/includes/plugins/install-access-request.mdx
@@ -1,13 +1,12 @@
 <Tabs>
 <TabItem label="Download">
 
-We currently only provide `linux-amd64` binaries. You can also compile these
-plugins from source. You can run the plugin from a remote host or your local
-development machine.
+Access Request Plugins are available as `amd64` and `arm64` Linux binaries for downloading.
+Replace `ARCH` with your required version.
 
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ curl -L -O https://cdn.teleport.dev/teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-<Var name="ARCH" />-bin.tar.gz
+$ tar -xzf teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-<Var name="ARCH" />-bin.tar.gz
 $ cd teleport-access-{{ name }}
 $ sudo ./install
 ```
@@ -21,9 +20,6 @@ teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=tele
 
 </TabItem>
 <TabItem label="Docker Image">
-
-We currently only provide Docker images for `linux-amd64`. 
-Pull the Docker image for the latest access request plugin by running the following command:
 
 ```code
 $ docker pull public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.plugin.version=)
@@ -44,7 +40,7 @@ To install from source you need `git` and `go` installed. If you do not have Go
 installed, visit the Go [downloads page](https://go.dev/dl/).
 
 ```code
-$ git clone https://github.com/gravitational/teleport
+$ git clone https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
 $ cd teleport/integrations/access/{{ name }}
 $ git checkout (=teleport.plugin.version=)
 $ make


### PR DESCRIPTION
Updates:
 - V16 has amd64 and arm64 downloads for plugins. Updates instructions include
 - git clones were not pulling the same major version but current `master`