### PR TITLE
docs: update to use branch for git clone examples

### DIFF
--- a/docs/pages/api/automatically-register-agents.mdx
+++ b/docs/pages/api/automatically-register-agents.mdx
@@ -60,7 +60,7 @@ services with your Teleport cluster.
 Download the source code for our minimal API client:
 
 ```code
-$ git clone https://github.com/gravitational/teleport
+$ git clone https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
 $ cd examples/service-discovery-api-client
 ```
 

--- a/docs/pages/api/rbac.mdx
+++ b/docs/pages/api/rbac.mdx
@@ -389,7 +389,7 @@ client application.
 Download the source code for the API client application:
 
 ```code
-$ git clone --depth=1 https://github.com/gravitational/teleport
+$ git clone --depth=1 https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
 $ cd teleport/examples/api-sync-roles
 ```
 


### PR DESCRIPTION
git clones should include the branch so as to not pull `master`. Note that access plugin git clones are updated in https://github.com/gravitational/teleport/pull/44215