### PR TITLE
[v15] docs: update to use branch for git clone examples

### DIFF
--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -88,7 +88,7 @@ We'll reference the exported file(s) later when configuring the plugin.
 
   ```code
   # Checkout the Teleport repo and go in the mattermost access plugin directory
-  $ git clone https://github.com/gravitational/teleport.git
+  $ git clone https://github.com/gravitational/teleport.git -b branch/v(=teleport.major_version=)
   $ cd teleport/integrations/access/mattermost
   $ git checkout (=teleport.plugin.version=)
   $ make

--- a/docs/pages/api/access-plugin.mdx
+++ b/docs/pages/api/access-plugin.mdx
@@ -62,7 +62,7 @@ repository on GitHub.
 Download the source code for our minimal Access Request plugin:
 
 ```code
-$ git clone https://github.com/gravitational/teleport
+$ git clone https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
 $ cd teleport/examples/access-plugin-minimal
 ```
 

--- a/docs/pages/api/automatically-register-agents.mdx
+++ b/docs/pages/api/automatically-register-agents.mdx
@@ -59,7 +59,7 @@ services with your Teleport cluster.
 Download the source code for our minimal API client:
 
 ```code
-$ git clone https://github.com/gravitational/teleport
+$ git clone https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
 $ cd examples/service-discovery-api-client
 ```
 

--- a/docs/pages/api/rbac.mdx
+++ b/docs/pages/api/rbac.mdx
@@ -389,7 +389,7 @@ client application.
 Download the source code for the API client application:
 
 ```code
-$ git clone --depth=1 https://github.com/gravitational/teleport
+$ git clone --depth=1 https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
 $ cd teleport/examples/api-sync-roles
 ```
 

--- a/docs/pages/includes/install-event-handler.mdx
+++ b/docs/pages/includes/install-event-handler.mdx
@@ -58,7 +58,7 @@ You will need Go >= (=teleport.golang=) installed.
 Run the following commands on your Universal Forwarder host:
 
 ```code
-$ git clone https://github.com/gravitational/teleport.git --depth 1
+$ git clone https://github.com/gravitational/teleport.git --depth 1 -b branch/v(=teleport.major_version=)
 $ cd teleport/integrations/event-handler
 $ git checkout (=teleport.plugin.version=)
 $ make build

--- a/docs/pages/includes/plugins/install-access-request.mdx
+++ b/docs/pages/includes/plugins/install-access-request.mdx
@@ -44,7 +44,7 @@ To install from source you need `git` and `go` installed. If you do not have Go
 installed, visit the Go [downloads page](https://go.dev/dl/).
 
 ```code
-$ git clone https://github.com/gravitational/teleport
+$ git clone https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
 $ cd teleport/integrations/access/{{ name }}
 $ git checkout (=teleport.plugin.version=)
 $ make


### PR DESCRIPTION
Backport #44217 to branch/v15