### PR TITLE
[v14] docs: update to use branch for git clone examples

### DIFF
--- a/docs/pages/api/automatically-register-agents.mdx
+++ b/docs/pages/api/automatically-register-agents.mdx
@@ -59,7 +59,7 @@ services with your Teleport cluster.
 Download the source code for our minimal API client:
 
 ```code
-$ git clone https://github.com/gravitational/teleport
+$ git clone https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
 $ cd examples/service-discovery-api-client
 ```
 

--- a/docs/pages/api/rbac.mdx
+++ b/docs/pages/api/rbac.mdx
@@ -389,7 +389,7 @@ client application.
 Download the source code for the API client application:
 
 ```code
-$ git clone --depth=1 https://github.com/gravitational/teleport
+$ git clone --depth=1 https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
 $ cd teleport/examples/api-sync-roles
 ```
 


### PR DESCRIPTION
Backport #44217 to branch/v14