### PR TITLE
Always use "convertEol" option for terminal of kube exec document.

### DIFF
--- a/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.tsx
@@ -52,7 +52,7 @@ export default function DocumentKubeExec({ doc, visible }: Props) {
       tty={tty}
       fontFamily={theme.fonts.mono}
       theme={theme.colors.terminal}
-      convertEol={!doc.isInteractive}
+      convertEol
     />
   );
 


### PR DESCRIPTION
After changing flow of kube exec in web UI to have a modal window with details to pop up after establishing connection to the server, we no longer took into account `isInteractive` parameter when creating the terminal. This causes non-interactive sessions to have "staircase" text output because of wrongly processing newline characters. This PR switches to always use `convertEol` option for the xterm, it might be not necessary for the interactive mode, but it doesn't make any real difference.

![staircase_terminal](https://github.com/user-attachments/assets/e87b9bf4-57ca-4122-85dc-fb7eb7c2fe48)

Changelog: Fix "staircase" text output for non-interactive Kube exec sessions in Web UI.
