### PR TITLE
switch resumption pkg to slog

### DIFF
--- a/lib/resumption/client.go
+++ b/lib/resumption/client.go
@@ -23,6 +23,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"io"
+	"log/slog"
 	"net"
 	"regexp"
 	"strconv"
@@ -31,7 +32,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/lib/multiplexer"
 )
@@ -101,7 +101,7 @@ func WrapSSHClientConn(ctx context.Context, nc net.Conn, redial redialFunc) (net
 func wrapSSHClientConn(ctx context.Context, nc net.Conn, redial redialFunc, clock clockwork.Clock) (net.Conn, error) {
 	dhKey, err := ecdh.P256().GenerateKey(rand.Reader)
 	if err != nil {
-		logrus.WithError(err).Error("Failed to generate ECDH key, proceeding without resumption (this is a bug).")
+		slog.ErrorContext(ctx, "failed to generate ECDH key, proceeding without resumption (this is a bug)", "error", err)
 		return nc, nil
 	}
 
@@ -133,7 +133,7 @@ func wrapSSHClientConn(ctx context.Context, nc net.Conn, redial redialFunc, cloc
 		// regular SSH connection, conn is about to read the SSH- line from the
 		// server but we've sent sshPrefix already, so we have to skip it from
 		// the application side writes
-		logrus.Debug("Server does not support resumption, proceeding without.")
+		slog.DebugContext(ctx, "server does not support resumption, proceeding without")
 		return &sshVersionSkipConn{
 			Conn:           conn,
 			alreadyWritten: sshPrefix,
@@ -142,7 +142,7 @@ func wrapSSHClientConn(ctx context.Context, nc net.Conn, redial redialFunc, cloc
 
 	dhSecret, err := dhKey.ECDH(dhPub)
 	if err != nil {
-		logrus.WithError(err).Warn("Failed to complete ECDH key exchange, proceeding without resumption.")
+		slog.ErrorContext(ctx, "failed to complete ECDH key exchange, proceeding without resumption", "error", err)
 		return &sshVersionSkipConn{
 			Conn:           conn,
 			alreadyWritten: sshPrefix,
@@ -181,7 +181,7 @@ func runClientResumableUnlocking(ctx context.Context, resumableConn *Conn, first
 
 	// detached is held open by the current underlying connection
 	const isFirstConn = true
-	detached := goAttachResumableUnlocking(resumableConn, firstConn, isFirstConn)
+	detached := goAttachResumableUnlocking(ctx, resumableConn, firstConn, isFirstConn)
 
 	reconnectTicker := clock.NewTicker(replacementInterval)
 	defer reconnectTicker.Stop()
@@ -192,16 +192,16 @@ func runClientResumableUnlocking(ctx context.Context, resumableConn *Conn, first
 			return
 
 		case <-reconnectTicker.Chan():
-			logrus.Debug("Attempting periodic reconnection.")
+			slog.DebugContext(ctx, "attempting periodic reconnection", "host_id", hostID)
 
 			newConn, err := dialResumable(ctx, token, hostID, redial)
 			if err != nil {
-				logrus.Warnf("Periodic reconnection: %v.", err.Error())
+				slog.WarnContext(ctx, "periodic reconnection failed", "host_id", hostID, "error", err)
 				continue
 			}
 
 			if newConn == nil {
-				logrus.Warn("Impossible to resume connection, giving up on periodic reconnection.")
+				slog.WarnContext(ctx, "impossible to resume connection, giving up on periodic reconnection", "host_id", hostID)
 				reconnectTicker.Stop()
 				select {
 				case <-ctx.Done():
@@ -212,14 +212,14 @@ func runClientResumableUnlocking(ctx context.Context, resumableConn *Conn, first
 
 			resumableConn.mu.Lock()
 			const isNotFirstConn = false
-			detached = goAttachResumableUnlocking(resumableConn, newConn, isNotFirstConn)
+			detached = goAttachResumableUnlocking(ctx, resumableConn, newConn, isNotFirstConn)
 
 			continue
 
 		case <-detached:
 		}
 
-		logrus.Debug("Connection lost, starting reconnection loop.")
+		slog.DebugContext(ctx, "connection lost, starting reconnection loop", "host_id", hostID)
 		reconnectDeadline := time.Now().Add(reconnectTimeout)
 		backoff := minBackoff
 		for {
@@ -231,7 +231,7 @@ func runClientResumableUnlocking(ctx context.Context, resumableConn *Conn, first
 			resumableConn.mu.Unlock()
 
 			if time.Now().After(reconnectDeadline) {
-				logrus.Error("Failed to reconnect to server after timeout.")
+				slog.ErrorContext(ctx, "failed to reconnect to server after timeout", "host_id", hostID)
 				return
 			}
 
@@ -245,18 +245,18 @@ func runClientResumableUnlocking(ctx context.Context, resumableConn *Conn, first
 
 			newConn, err := dialResumable(ctx, token, hostID, redial)
 			if err != nil {
-				logrus.Warnf("Reconnection attempt: %v.", err.Error())
+				slog.WarnContext(ctx, "reconnection attempt failed", "host_id", hostID, "error", err)
 				continue
 			}
 
 			if newConn == nil {
-				logrus.Error("Impossible to resume connection.")
+				slog.WarnContext(ctx, "impossible to resume connection", "host_id", hostID)
 				return
 			}
 
 			resumableConn.mu.Lock()
 			const isNotFirstConn = false
-			detached = goAttachResumableUnlocking(resumableConn, newConn, isNotFirstConn)
+			detached = goAttachResumableUnlocking(ctx, resumableConn, newConn, isNotFirstConn)
 
 			break
 		}
@@ -273,23 +273,23 @@ func runClientResumableUnlocking(ctx context.Context, resumableConn *Conn, first
 // background goroutine, with some client-friendly logging, returning a channel
 // that gets closed at the end of the goroutine. resumableConn is expected to be
 // locked, like runResumeV1Unlocking.
-func goAttachResumableUnlocking(resumableConn *Conn, nc net.Conn, firstConn bool) <-chan struct{} {
+func goAttachResumableUnlocking(ctx context.Context, resumableConn *Conn, nc net.Conn, firstConn bool) <-chan struct{} {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 
 		if firstConn {
-			logrus.Debug("Attaching new resumable connection.")
+			slog.DebugContext(ctx, "attaching new resumable connection")
 		} else {
-			logrus.Debug("Attaching existing resumable connection.")
+			slog.DebugContext(ctx, "attaching existing resumable connection")
 		}
 
 		err := runResumeV1Unlocking(resumableConn, nc, firstConn)
 
 		if firstConn {
-			logrus.Debugf("Handling new resumable connection: %v", err.Error())
+			slog.DebugContext(ctx, "handling new resumable connection", "error", err)
 		} else {
-			logrus.Debugf("Handling existing resumable connection: %v", err.Error())
+			slog.DebugContext(ctx, "handling existing resumable connection", "error", err)
 		}
 	}()
 	return done
@@ -305,7 +305,7 @@ func dialResumable(ctx context.Context, token resumptionToken, hostID string, re
 		return nil, trace.Wrap(err)
 	}
 
-	logrus.Debug("Dialing server for connection resumption.")
+	slog.DebugContext(ctx, "dialing server for connection resumption", "host_id", hostID)
 	nc, err := redial(ctx, hostID)
 	if err != nil {
 		// If connections are failing because client certificates are expired
@@ -341,7 +341,7 @@ func dialResumable(ctx context.Context, token resumptionToken, hostID string, re
 
 	if dhPub == nil {
 		conn.Close()
-		logrus.Error("Reached a server without resumption support, giving up.")
+		slog.ErrorContext(ctx, "reached a server without resumption support, giving up", "host_id", hostID)
 		return nil, nil
 	}
 
@@ -377,11 +377,11 @@ func dialResumable(ctx context.Context, token resumptionToken, hostID string, re
 	_ = conn.Close()
 	switch responseTag {
 	case notFoundServerExchangeTag:
-		logrus.Error("Server responded with 'resumable connection not found', giving up.")
+		slog.ErrorContext(ctx, "server responded with 'resumable connection not found', giving up", "host_id", hostID)
 	case badAddressServerExchangeTag:
-		logrus.Error("Server responded with 'bad client IP address', giving up.")
+		slog.ErrorContext(ctx, "server responded with 'bad client IP address', giving up", "host_id", hostID)
 	default:
-		logrus.Errorf("Server responded with an unknown error tag (%v), giving up.", responseTag)
+		slog.ErrorContext(ctx, "server responded with an unknown error tag, giving up", "host_id", hostID, "tag", responseTag)
 	}
 
 	return nil, nil

--- a/lib/resumption/resumable.go
+++ b/lib/resumption/resumable.go
@@ -18,15 +18,18 @@ package resumption
 
 import (
 	"bufio"
+	"context"
 	"encoding/binary"
 	"io"
+	"log/slog"
 	"math"
 	"net"
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
+
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 func newResumableConn(localAddr, remoteAddr net.Addr) *Conn {
@@ -83,7 +86,7 @@ func runResumeV1Unlocking(r *Conn, nc net.Conn, firstConn bool) error {
 			r.cond.Wait()
 		}
 		if dt := time.Since(t0); dt > time.Second {
-			logrus.WithField("elapsed", dt.String()).Warn("Slow resumable connection detach took over one second.")
+			slog.WarnContext(context.TODO(), "slow resumable connection detach took over one second", "elapsed", logutils.StringerAttr(dt))
 		}
 
 		if r.remoteClosed {

--- a/lib/resumption/server_detect.go
+++ b/lib/resumption/server_detect.go
@@ -17,19 +17,19 @@
 package resumption
 
 import (
+	"context"
 	"crypto/ecdh"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/netip"
 	"sync"
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
@@ -60,8 +60,6 @@ func serverVersionCRLFV1(pubKey *ecdh.PublicKey, hostID string) string {
 }
 
 type SSHServerWrapperConfig struct {
-	Log logrus.FieldLogger
-
 	// SSHServer is a function that takes ownership of a [net.Conn] and uses it
 	// as a SSH server. If the Conn is a [sshutils.SSHServerVersionOverrider],
 	// the server should use the overridden server version.
@@ -79,16 +77,10 @@ type SSHServerWrapperConfig struct {
 
 // NewSSHServerWrapper creates a [SSHServerWrapper].
 func NewSSHServerWrapper(cfg SSHServerWrapperConfig) *SSHServerWrapper {
-	if cfg.Log == nil {
-		cfg.Log = logrus.WithField(teleport.ComponentKey, Component)
-	}
-
 	return &SSHServerWrapper{
 		sshServer: cfg.SSHServer,
-		log:       cfg.Log,
-
-		hostID:  cfg.HostID,
-		dataDir: cfg.DataDir,
+		hostID:    cfg.HostID,
+		dataDir:   cfg.DataDir,
 
 		conns: make(map[resumptionToken]*connEntry),
 	}
@@ -102,7 +94,6 @@ type resumptionToken = [16]byte
 // forcibly closed.
 type SSHServerWrapper struct {
 	sshServer func(net.Conn)
-	log       logrus.FieldLogger
 
 	hostID  string
 	dataDir string
@@ -143,7 +134,7 @@ func (e *connEntry) decreaseRunning() {
 func (r *SSHServerWrapper) PreDetect(nc net.Conn) (multiplexer.PostDetectFunc, error) {
 	dhKey, err := ecdh.P256().GenerateKey(rand.Reader)
 	if err != nil {
-		r.log.WithError(err).Error("Failed to generate ECDH key, proceeding without resumption (this is a bug).")
+		slog.ErrorContext(context.TODO(), "failed to generate ECDH key, proceeding without resumption (this is a bug)", "error", err)
 		// we are still responsible for sending a RFC 4253-compliant
 		// identification string as the PreDetect hook
 		return PreDetectFixedSSHVersion(sshutils.SSHVersionPrefix)(nc)
@@ -158,14 +149,14 @@ func (r *SSHServerWrapper) PreDetect(nc net.Conn) (multiplexer.PostDetectFunc, e
 		isResumeV1, err := peekPrelude(conn, clientPreludeV1)
 		if err != nil {
 			if !utils.IsOKNetworkError(err) {
-				r.log.WithError(err).Error("Error while peeking resumption prelude.")
+				slog.ErrorContext(context.TODO(), "error while peeking resumption prelude", "error", err)
 			}
 			_ = conn.Close()
 			return nil
 		}
 
 		if !isResumeV1 {
-			r.log.Debug("Returning non-resumable connection to multiplexer.")
+			slog.DebugContext(context.TODO(), "returning non-resumable connection to multiplexer")
 			return &sshVersionSkipConn{
 				Conn: conn,
 
@@ -177,7 +168,7 @@ func (r *SSHServerWrapper) PreDetect(nc net.Conn) (multiplexer.PostDetectFunc, e
 		// we successfully peeked clientPrelude, so Discard will succeed
 		_, _ = conn.Discard(len(clientPreludeV1))
 
-		r.log.Debug("Proceeding with connection resumption exchange.")
+		slog.DebugContext(context.TODO(), "proceeding with connection resumption exchange")
 		// this is the post detect hook in the multiplexer, we return nil here
 		// to signify that the connection has been hijacked
 		r.handleResumptionExchangeV1(conn, dhKey)
@@ -194,7 +185,7 @@ var _ multiplexer.PreDetectFunc = (*SSHServerWrapper)(nil).PreDetect
 func (r *SSHServerWrapper) HandleConnection(nc net.Conn) {
 	dhKey, err := ecdh.P256().GenerateKey(rand.Reader)
 	if err != nil {
-		r.log.WithError(err).Error("Failed to generate ECDH key, proceeding without resumption (this is a bug).")
+		slog.ErrorContext(context.TODO(), "failed to generate ECDH key, proceeding without resumption (this is a bug)", "error", err)
 		r.sshServer(nc)
 		return
 	}
@@ -202,7 +193,7 @@ func (r *SSHServerWrapper) HandleConnection(nc net.Conn) {
 	serverVersionCRLF := serverVersionCRLFV1(dhKey.PublicKey(), r.hostID)
 	if _, err := nc.Write([]byte(serverVersionCRLF)); err != nil {
 		if !utils.IsOKNetworkError(err) {
-			r.log.WithError(err).Warn("Error while sending SSH identification string.")
+			slog.ErrorContext(context.TODO(), "error while sending SSH identification string", "error", err)
 		}
 		_ = nc.Close()
 		return
@@ -213,14 +204,14 @@ func (r *SSHServerWrapper) HandleConnection(nc net.Conn) {
 	isResumeV1, err := peekPrelude(conn, clientPreludeV1)
 	if err != nil {
 		if !utils.IsOKNetworkError(err) {
-			r.log.WithError(err).Error("Error while peeking resumption prelude.")
+			slog.ErrorContext(context.TODO(), "error while peeking resumption prelude", "error", err)
 		}
 		_ = conn.Close()
 		return
 	}
 
 	if !isResumeV1 {
-		r.log.Debug("Returning non-resumable connection to multiplexer.")
+		slog.ErrorContext(context.TODO(), "returning non-resumable connection to multiplexer")
 		r.sshServer(&sshVersionSkipConn{
 			Conn: conn,
 
@@ -233,6 +224,6 @@ func (r *SSHServerWrapper) HandleConnection(nc net.Conn) {
 	// we successfully peeked clientPrelude, so Discard will succeed
 	_, _ = conn.Discard(len(clientPreludeV1))
 
-	r.log.Debug("Proceeding with connection resumption exchange.")
+	slog.DebugContext(context.TODO(), "proceeding with connection resumption exchange")
 	r.handleResumptionExchangeV1(conn, dhKey)
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2851,11 +2851,9 @@ func (process *TeleportProcess) initSSH() error {
 		var resumableServer *resumption.SSHServerWrapper
 		if os.Getenv("TELEPORT_UNSTABLE_DISABLE_SSH_RESUMPTION") == "" {
 			resumableServer = resumption.NewSSHServerWrapper(resumption.SSHServerWrapperConfig{
-				Log:       process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentNode, resumption.Component)),
 				SSHServer: s.HandleConnection,
-
-				HostID:  serverID,
-				DataDir: cfg.DataDir,
+				HostID:    serverID,
+				DataDir:   cfg.DataDir,
 			})
 
 			go func() {


### PR DESCRIPTION
This PR witches `lib/resumption` over to using `slog`.   It also adds a new `host_id` attribute to some client-side logs to make it easier to debug resumption issues in cases where multiple connections to multiple hosts are being proxied by a single tbot instance.