### PR TITLE
[dynamoevents] fix pagination when limit is reached at the boundary of a day

### DIFF
--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1173,7 +1173,6 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput, hasLeft
 		l.totalSize += len(data)
 		out = append(out, e)
 		l.left--
-
 		if l.left == 0 {
 			hf := false
 			if hasLeftFun != nil {
@@ -1244,6 +1243,11 @@ dateLoop:
 			}
 			values = append(values, result...)
 			if limitReached {
+				// If we achieved the limit, we need to check if we have more events to fetch from the current date
+				// or if we need to move the cursor to the next date.
+				if hasLeft() && len(l.checkpoint.Iterator) == 0 {
+					l.checkpoint.Date = l.dates[i+1]
+				}
 				return values, nil
 			}
 			if len(l.checkpoint.Iterator) == 0 {

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1243,9 +1243,16 @@ dateLoop:
 			}
 			values = append(values, result...)
 			if limitReached {
-				// If we achieved the limit, we need to check if we have more events to fetch from the current date
+				// If we've reached the limit, we need to determine whether there are more events to fetch from the current date
 				// or if we need to move the cursor to the next date.
-				if hasLeft() && len(l.checkpoint.Iterator) == 0 {
+				// To do this, we check if the iterator is empty and if the EventKey is empty.
+				// DynamoDB returns an empty iterator if all events from the current date have been consumed.
+				// We need to check if the EventKey is empty because it indicates that we left the page midway
+				// due to reaching the maximum response size. In this case, we need to resume the query
+				// from the same date and the request's iterator to fetch the remainder of the page.
+				// If the input iterator is empty but the EventKey is not, we need to resume the query from the same date
+				// and we shouldn't move to the next date.
+				if i < len(l.dates)-1 && len(l.checkpoint.Iterator) == 0 && l.checkpoint.EventKey == "" {
 					l.checkpoint.Date = l.dates[i+1]
 				}
 				return values, nil

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1154,12 +1154,6 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput, hasLeft
 		// Because this may break on non page boundaries an additional
 		// checkpoint is needed for sub-page breaks.
 		if l.totalSize+len(data) >= events.MaxEventBytesInResponse {
-			hf := false
-			if hasLeftFun != nil {
-				hf = hasLeftFun()
-			}
-			l.hasLeft = hf || len(l.checkpoint.Iterator) != 0
-
 			key, err := getSubPageCheckpoint(&e)
 			if err != nil {
 				return nil, false, trace.Wrap(err)
@@ -1168,6 +1162,12 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput, hasLeft
 
 			// We need to reset the iterator so we get the previous page again.
 			l.checkpoint.Iterator = oldIterator
+
+			// If we stopped because of the size limit, we know that at least one event has to be fetched from the
+			// current date and old iterator, so we must set it to true independently of the hasLeftFun or
+			// the new iterator being empty.
+			l.hasLeft = true
+
 			return out, true, nil
 		}
 		l.totalSize += len(data)


### PR DESCRIPTION
DynamoDB stores events using the day as one of the search indexes. When querying, it splits the [from, to] window into the containing days, i.e., [date(from), date(from)+1 day, ..., date(to)], and iterates through them sequentially until there are no more events to consume or the limit is reached. Each day is requested individually and after the previous day (assuming ascending order).

DynamoDB indicates that a client has consumed all events for a day by returning an empty iterator. According to the DynamoDB documentation:

```
// The primary key of the item where the operation stopped, inclusive of the
// previous result set. Use this value to start a new operation, excluding this
// value in the new request.
//
// If LastEvaluatedKey is empty, then the "last page" of results has been processed
// and there is no more data to be retrieved.
//
// If LastEvaluatedKey is not empty, it does not necessarily mean that there
// is more data in the result set. The only way to know when you have reached
// the end of the result set is when LastEvaluatedKey is empty.
```

Given the current indexing, we need to take special consideration when the limit is reached exactly at the end of a day. In this case, the iterator must be moved to the next day. Otherwise, the client receives a reset cursor with only the date set, causing a dead loop since the cursor resets to the beginning of the day, which is a specific issue for the event-handler.

This PR fixes the issue by advancing the cursor to the next day if the limit is reached at the end of a day, and the iterator is empty. It also fixes other bug where the iterator could discard events if the maximum message size was reached and it was the last page to iterate.

I wrote a test but couldn't reproduce the issue using DynamoDB local, as it never returns an empty cursor. Instead, it returns a cursor that, when called, returns an empty cursor and no events.


Changelog: Prevented an inifinite loop in DynamoDB event querying by advancing the cursor to the next day when the limit is reached at the end of a day with an empty iterator. This ensures the cursor does not reset to the beginning of the day.