### PR TITLE
[v16] Always use "convertEol" option for terminal of kube exec document.

### DIFF
--- a/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.tsx
@@ -52,7 +52,7 @@ export default function DocumentKubeExec({ doc, visible }: Props) {
       tty={tty}
       fontFamily={theme.fonts.mono}
       theme={theme.colors.terminal}
-      convertEol={!doc.isInteractive}
+      convertEol
     />
   );
 


### PR DESCRIPTION
Backport #44228 to branch/v16

changelog: Fix "staircase" text output for non-interactive Kube exec sessions in Web UI.
