### PR TITLE
web: rename SAML application button from `Login` to `Log In`

### DIFF
--- a/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
@@ -227,8 +227,9 @@ const AppLaunch = ({ app, setResourceSpec }: AppLaunchProps) => {
           href={samlAppSsoUrl}
           rel="noreferrer"
           textTransform="none"
+          title="Log in to SAML application"
         >
-          Login
+          Log In
         </ButtonBorder>
       );
     }

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -249,14 +249,14 @@ function AppButton(props: {
         onClick={props.onLaunchUrl}
         as="a"
         textTransform="none"
-        title="Log in to the app in the browser"
+        title="Log in to the SAML application in the browser"
         href={getSamlAppSsoUrl({
           app: props.app,
           rootCluster: props.rootCluster,
         })}
         target="_blank"
       >
-        Login
+        Log In
       </ButtonBorder>
     );
   }


### PR DESCRIPTION
Recommended by design to update button copy. See suggestion on this slack discussion https://gravitational.slack.com/archives/C07KG2RFA/p1718906178986299?thread_ts=1718889881.939519&cid=C07KG2RFA

To summarize, we should use "Log In" because:
- Log In: a verb + adverb
- Login: a noun or an adjective, but never an action

