### PR TITLE
[Docs] Add SAML Single Logout instructions to docs

### DIFF
--- a/docs/pages/access-controls/sso.mdx
+++ b/docs/pages/access-controls/sso.mdx
@@ -256,7 +256,6 @@ create a `cluster_auth_preference` resource.
       type: saml|oidc|github
   ```
 
-  (!docs/pages/includes/sso/idp-initiated.mdx!)
   </TabItem>
   <TabItem scope={["cloud","team"]} label="Dynamic Resources (All Editions)">
   Create a file called `cap.yaml`:
@@ -278,7 +277,6 @@ create a `cluster_auth_preference` resource.
   $ tctl create -f cap.yaml
   ```
 
-  (!docs/pages/includes/sso/idp-initiated.mdx!)
   </TabItem>
 </Tabs>
 
@@ -293,6 +291,8 @@ based on one of the following examples.
 ```
 
 (!docs/pages/includes/sso/idp-initiated.mdx!)
+
+(!docs/pages/includes/sso/saml-slo.mdx!)
 
 </TabItem>
 <TabItem label="OneLogin">
@@ -330,6 +330,8 @@ based on one of the following examples.
 ```
 
 (!docs/pages/includes/sso/idp-initiated.mdx!)
+
+(!docs/pages/includes/sso/saml-slo.mdx!)
 
 </TabItem>
 <TabItem label="GitHub">

--- a/docs/pages/includes/sso/saml-slo.mdx
+++ b/docs/pages/includes/sso/saml-slo.mdx
@@ -1,0 +1,9 @@
+<Details title="SAML Single Logout">
+    Setting the `spec.single_logout_url` endpoint in SAML connectors enables SAML SLO (Single Logout).
+    If enabled, upon logging out of Teleport, users will also be logged out of the SAML provider session, which 
+    may also log them out of any other non-Teleport applications which they are currently logged into using the same SAML provider.
+
+    For optimal user experience, we recommend keeping this disabled unless necessary.
+
+    Refer to your SAML provider's documentation for instructions on where to obtain this URL.
+</Details>

--- a/examples/resources/saml-connector.yaml
+++ b/examples/resources/saml-connector.yaml
@@ -28,6 +28,7 @@ spec:
     - access
   # Provides a path to the IdP metadata.
   entity_descriptor_url: https://example.okta.com/app/your-app-id/sso/saml/metadata
-  # Optional SAML Single Logout endpoint. If set, upon logging out of Teleport, users will also be signed out of the SAML provider session.
+  # Optional SAML Single Logout endpoint. If set, logging out of Teleport
+  # will also log the user out of the SAML provider session.
   single_logout_url: https://example.okta.com/app/your-app-id/slo/saml
   

--- a/examples/resources/saml-connector.yaml
+++ b/examples/resources/saml-connector.yaml
@@ -28,4 +28,6 @@ spec:
     - access
   # Provides a path to the IdP metadata.
   entity_descriptor_url: https://example.okta.com/app/your-app-id/sso/saml/metadata
+  # Optional SAML Single Logout endpoint. If set, upon logging out of Teleport, users will also be signed out of the SAML provider session.
+  single_logout_url: https://example.okta.com/app/your-app-id/slo/saml
   


### PR DESCRIPTION
## Purpose

Part of https://github.com/gravitational/teleport/issues/41076

Adds SAML Single Logout instructions to the SAML connector reference in the docs.

I also noticed an existing issue where there were a couple additional duplicate IdP Initiated SSO instructions sections in the wrong place, and removed them.

## Preview

<img width="952" alt="image" src="https://github.com/user-attachments/assets/ecf1863f-d480-4f00-833f-6db708be9b91">

