### PR TITLE
Gracefully handle quick relaunches of VNet daemon

### DIFF
--- a/build.assets/macos/tsh/tsh.app/Contents/Library/LaunchDaemons/com.gravitational.teleport.tsh.vnetd.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Library/LaunchDaemons/com.gravitational.teleport.tsh.vnetd.plist
@@ -20,5 +20,7 @@
 	<string>/var/log/vnet.log</string>
 	<key>StandardOutPath</key>
 	<string>/var/log/vnet.log</string>
+	<key>ThrottleInterval</key>
+	<integer>5</integer>
 </dict>
 </plist>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Library/LaunchDaemons/com.goteleport.tshdev.vnetd.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Library/LaunchDaemons/com.goteleport.tshdev.vnetd.plist
@@ -20,5 +20,7 @@
 	<string>/var/log/vnet.log</string>
 	<key>StandardOutPath</key>
 	<string>/var/log/vnet.log</string>
+	<key>ThrottleInterval</key>
+	<integer>5</integer>
 </dict>
 </plist>

--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -324,7 +324,7 @@ var (
 	vnetErrorDomain = C.GoString(C.VNEErrorDomain)
 	// errorCodeAlreadyRunning is returned within [vnetErrorDomain] errors to indicate that the daemon
 	// received a message to start after it was already running.
-	errorCodeAlreadyRunning = C.VNEAlreadyRunningError
+	errorCodeAlreadyRunning = int(C.VNEAlreadyRunningError)
 	errAlreadyRunning       = errors.New("VNet is already running")
 )
 

--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -125,17 +125,17 @@ func register(ctx context.Context, bundlePath string) (ServiceStatus, error) {
 	return ServiceStatus(result.service_status), nil
 }
 
-const waitingForEnablementTimeout = time.Minute
-
-var waitingForEnablementTimeoutExceeded = errors.New("the login item was not enabled within the timeout")
-
 // waitForEnablement periodically checks if the status of the daemon has changed to
 // [serviceStatusEnabled]. This happens when the user approves the login item in system settings.
 func waitForEnablement(ctx context.Context, bundlePath string) error {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
-	ctx, cancel := context.WithTimeoutCause(ctx, waitingForEnablementTimeout, waitingForEnablementTimeoutExceeded)
+	// It should be less than receiveTunTimeout in the vnet package
+	// so that the user sees the error about the background item first.
+	const waitingForEnablementTimeout = 50 * time.Second
+	ctx, cancel := context.WithTimeoutCause(ctx, waitingForEnablementTimeout,
+		errors.New("the background item was not enabled within the timeout"))
 	defer cancel()
 
 	for {

--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -23,6 +23,7 @@ package daemon
 // #cgo LDFLAGS: -framework Foundation -framework ServiceManagement
 // #include <stdlib.h>
 // #include "client_darwin.h"
+// #include "protocol_darwin.h"
 import "C"
 
 import (
@@ -318,8 +319,8 @@ func startByCalling(ctx context.Context, bundlePath string, config Config) error
 	}
 }
 
-// vnetErrorDomain maps to VNEErrorDomain from Objective-C.
-const vnetErrorDomain = "com.Gravitational.Vnet.ErrorDomain"
+// vnetErrorDomain is a custom error domain used for Objective-C errors that pertain to VNet.
+var vnetErrorDomain = C.GoString(C.VNEErrorDomain)
 
 // errorCode maps to VNEErrorCode from Objective-C.
 type errorCode int

--- a/lib/vnet/daemon/client_darwin.h
+++ b/lib/vnet/daemon/client_darwin.h
@@ -45,6 +45,8 @@ typedef struct StartVnetRequest {
 typedef struct StartVnetResult {
   bool ok;
   const char *error_domain;
+  // error_code is code taken from an NSError instance encountered during the call to StartVnet.
+  // If ok is false, error_code is greater than zero and identifies the reason behind the error.
   int error_code;
   const char *error_description;
 } StartVnetResult;

--- a/lib/vnet/daemon/client_darwin.h
+++ b/lib/vnet/daemon/client_darwin.h
@@ -45,6 +45,7 @@ typedef struct StartVnetRequest {
 typedef struct StartVnetResult {
   bool ok;
   const char *error_domain;
+  int error_code;
   const char *error_description;
 } StartVnetResult;
 

--- a/lib/vnet/daemon/client_darwin.m
+++ b/lib/vnet/daemon/client_darwin.m
@@ -117,8 +117,8 @@ void OpenSystemSettingsLoginItems(void) {
   }];
 
   [(id<VNEDaemonProtocol>)proxy startVnet:vnetConfig
-                               completion:^(void) {
-                                 completion(nil);
+                               completion:^(NSError *error) {
+                                 completion(error);
                                }];
 }
 
@@ -143,6 +143,7 @@ void StartVnet(StartVnetRequest *request, StartVnetResult *outResult) {
                completion:^(NSError *error) {
                  if (error) {
                    outResult->error_domain = VNECopyNSString([error domain]);
+                   outResult->error_code = (int)[error code];
                    outResult->error_description = VNECopyNSString([error description]);
                    dispatch_semaphore_signal(sema);
                    return;

--- a/lib/vnet/daemon/common.go
+++ b/lib/vnet/daemon/common.go
@@ -17,6 +17,8 @@
 package daemon
 
 import (
+	"time"
+
 	"github.com/gravitational/trace"
 )
 
@@ -47,3 +49,7 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 	return nil
 }
+
+// CheckUnprivilegedProcessInterval denotes how often the admin process should check if the
+// unprivileged process has quit.
+const CheckUnprivilegedProcessInterval = time.Second

--- a/lib/vnet/daemon/protocol_darwin.h
+++ b/lib/vnet/daemon/protocol_darwin.h
@@ -3,7 +3,7 @@
 
 #import <Foundation/Foundation.h>
 
-static NSString *const VNEErrorDomain = @"com.Gravitational.Vnet.ErrorDomain";
+extern const char* const VNEErrorDomain;
 
 typedef enum VNEErrorCode {
   // VNEAlreadyRunningError indicates that the daemon already received a VNet config.

--- a/lib/vnet/daemon/protocol_darwin.h
+++ b/lib/vnet/daemon/protocol_darwin.h
@@ -3,12 +3,13 @@
 
 #import <Foundation/Foundation.h>
 
+// VNEErrorDomain is a custom error domain used for Objective-C errors that pertain to VNet.
 extern const char* const VNEErrorDomain;
 
 // VNEAlreadyRunningError indicates that the daemon already received a VNet config.
 // It won't accept a new one during its lifetime, instead it's expected to stop, after
 // which the client might spawn a new instance of the daemon.
-static const int VNEAlreadyRunningError = 1;
+extern const int VNEAlreadyRunningError;
 
 typedef struct VnetConfig {
   const char *socket_path;

--- a/lib/vnet/daemon/protocol_darwin.h
+++ b/lib/vnet/daemon/protocol_darwin.h
@@ -1,6 +1,17 @@
 #ifndef TELEPORT_LIB_VNET_DAEMON_PROTOCOL_DARWIN_H_
 #define TELEPORT_LIB_VNET_DAEMON_PROTOCOL_DARWIN_H_
 
+#import <Foundation/Foundation.h>
+
+static NSString *const VNEErrorDomain = @"com.Gravitational.Vnet.ErrorDomain";
+
+typedef enum VNEErrorCode {
+  // VNEAlreadyRunningError indicates that the daemon already received a VNet config.
+  // It won't accept a new one during its lifetime, instead it's expected to stop, after
+  // which the client might spawn a new instance of the daemon.
+  VNEAlreadyRunningError,
+} VNEErrorCode;
+
 typedef struct VnetConfig {
   const char *socket_path;
   const char *ipv6_prefix;
@@ -9,11 +20,13 @@ typedef struct VnetConfig {
 } VnetConfig;
 
 @protocol VNEDaemonProtocol
-// startVnet starts VNet in a separate thread and returns immediately.
-// Only the first call to this method starts VNet. Subsequent calls are noops.
-// The daemon process exits after VNet is stopped, after which it can be
-// spawned again by calling this method.
-- (void)startVnet:(VnetConfig *)vnetConfig completion:(void (^)(void))completion;
+// startVnet passes the config back to Go code (which then starts VNet in a separate thread)
+// and returns immediately.
+//
+// Only the first call to this method starts VNet. Subsequent calls return VNEAlreadyRunningError.
+// The daemon process exits after VNet is stopped, after which it can be spawned again by calling
+// this method.
+- (void)startVnet:(VnetConfig *)vnetConfig completion:(void (^)(NSError *error))completion;
 @end
 
 #endif /* TELEPORT_LIB_VNET_DAEMON_PROTOCOL_DARWIN_H_ */

--- a/lib/vnet/daemon/protocol_darwin.h
+++ b/lib/vnet/daemon/protocol_darwin.h
@@ -5,12 +5,10 @@
 
 extern const char* const VNEErrorDomain;
 
-typedef enum VNEErrorCode {
-  // VNEAlreadyRunningError indicates that the daemon already received a VNet config.
-  // It won't accept a new one during its lifetime, instead it's expected to stop, after
-  // which the client might spawn a new instance of the daemon.
-  VNEAlreadyRunningError,
-} VNEErrorCode;
+// VNEAlreadyRunningError indicates that the daemon already received a VNet config.
+// It won't accept a new one during its lifetime, instead it's expected to stop, after
+// which the client might spawn a new instance of the daemon.
+static const int VNEAlreadyRunningError = 1;
 
 typedef struct VnetConfig {
   const char *socket_path;

--- a/lib/vnet/daemon/protocol_darwin.m
+++ b/lib/vnet/daemon/protocol_darwin.m
@@ -18,3 +18,5 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 const char* const VNEErrorDomain = "com.Gravitational.Vnet.ErrorDomain";
+
+const int VNEAlreadyRunningError = 1;

--- a/lib/vnet/daemon/protocol_darwin.m
+++ b/lib/vnet/daemon/protocol_darwin.m
@@ -1,0 +1,20 @@
+//go:build vnetdaemon
+// +build vnetdaemon
+
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+const char* const VNEErrorDomain = "com.Gravitational.Vnet.ErrorDomain";

--- a/lib/vnet/daemon/service_darwin.m
+++ b/lib/vnet/daemon/service_darwin.m
@@ -89,7 +89,7 @@
     // In such scenarios, we want to return an error so that the client can wait for the daemon
     // to exit and retry the call.
     if (_gotConfig) {
-      NSError *error = [[NSError alloc] initWithDomain:VNEErrorDomain
+      NSError *error = [[NSError alloc] initWithDomain:@(VNEErrorDomain)
                                                   code:VNEAlreadyRunningError
                                               userInfo:nil];
       completion(error);

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -238,9 +238,9 @@ func AdminSetup(ctx context.Context, config daemon.Config) error {
 	}()
 
 	// Stay alive until we get an error on errCh, indicating that the osConfig loop exited.
-	// If the socket is deleted, indicating that the parent process exited, cancel the context and then wait
-	// for the osConfig loop to exit and send an err on errCh.
-	ticker := time.NewTicker(time.Second)
+	// If the socket is deleted, indicating that the unprivileged process exited, cancel the context
+	// and then wait for the osConfig loop to exit and send an err on errCh.
+	ticker := time.NewTicker(daemon.CheckUnprivilegedProcessInterval)
 	defer ticker.Stop()
 	for {
 		select {


### PR DESCRIPTION
This is hopefully the last less-than-trivial Obj-C PR.

## The problem

At the moment, the VNet admin process stats every second the socket path used to send over the TUN device. If the socket is gone, the admin process shuts down. There are ideas to improve this behavior (#44270), but they are outside of the scope of this PR.

launchd guarantees that there's always only one launch daemon of a kind running. If the user shuts down VNet and then starts it again very quickly, the unprivileged process might end up sending a message to the "old" admin process from the previous invocation, before the admin process had a chance to notice that the previous socket is gone and shut down.

At the moment, this causes the unprivileged process to think that it successfully connected to the daemon. It then proceeds to wait for the admin process to send a TUN device over the socket. The admin process gets the message sent to the daemon, but it doesn't do anything with it and then it shuts down because it finally notices that the socket is gone. As we don't have any timeouts on waiting for the socket, the unprivileged process just hangs until sigterm.

## The solution

<details>
<summary>Demo recording</summary>

In this recording you can see `tsh vnet` noticing that it got an error while contacting the daemon, waiting for a few seconds and contacting it successfully again.

https://github.com/user-attachments/assets/75ff0257-aee7-47ed-9c5c-abde268c869b

</details>

This PR addresses a couple of issues. First, it adds a timeout to waiting for the TUN device to be sent over the socket. We used to have deadlines set on the socket itself, which we erroneously removed in a refactor, I belive it was #41413. I realized though that handling this through a context timeout is much better. 

When the context gets canceled, `vnet.SetupAndRun` exits, which closes the process manager. This in turn closes the socket, unblocking the gorouting that was stuck on reading from it.

<details>
<summary>Related code</summary>

https://github.com/gravitational/teleport/blob/372d5db0b317506025a06de837030c0d6bc54f1f/lib/vnet/setup.go#L58-L63

https://github.com/gravitational/teleport/blob/372d5db0b317506025a06de837030c0d6bc54f1f/lib/vnet/setup.go#L71-L76

https://github.com/gravitational/teleport/blob/372d5db0b317506025a06de837030c0d6bc54f1f/lib/vnet/setup_darwin.go#L166-L180

</details>

Second, it makes it so that when the daemon receives the `startVnet` message after VNet has been already started, it returns an error expressing that fact rather than just silently dropping the message.

Third, when the unprivileged process receives that error, it waits for double the "heartbeat" time and attempts to start the daemon again, it case the daemon was just about to shut down.

Fourth, `ThrottleInterval` has been changed from the default of 10 seconds to 5 seconds. From `man launchd.plist`:

> ThrottleInterval <integer>
> This key lets one override the default throttling policy imposed on jobs by launchd.  The value is in seconds, and by default, jobs will not be spawned more than once every 10 seconds. The principle behind this is that jobs should linger around just in case they are needed again in the near future. This not only reduces the latency of responses, but it encourages developers to amortize the cost of program invocation.

This makes it so that when someone happens to be repeatedly starting VNet (in Connect it's as easy as clicking a button), they don't have to wait 10 seconds before the next call to the daemon. I did consider implementing logic that would make the daemon linger for a few seconds before quitting. Ultimately though, `tsh vnet-daemon` is very lightweight and the benefits didn't outweigh the cost for me (which would be more lines of complex code).