### PR TITLE
[v15] [dynamoevents] fix pagination when limit is reached at the boundary of a day

### DIFF
--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1172,7 +1172,6 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput, hasLeft
 		l.totalSize += len(data)
 		out = append(out, e)
 		l.left--
-
 		if l.left == 0 {
 			hf := false
 			if hasLeftFun != nil {
@@ -1243,6 +1242,11 @@ dateLoop:
 			}
 			values = append(values, result...)
 			if limitReached {
+				// If we achieved the limit, we need to check if we have more events to fetch from the current date
+				// or if we need to move the cursor to the next date.
+				if hasLeft() && len(l.checkpoint.Iterator) == 0 {
+					l.checkpoint.Date = l.dates[i+1]
+				}
 				return values, nil
 			}
 			if len(l.checkpoint.Iterator) == 0 {


### PR DESCRIPTION
Backport #44246 to branch/v15

changelog: Prevented an infinite loop in DynamoDB event querying by advancing the cursor to the next day when the limit is reached at the end of a day with an empty iterator. This ensures the cursor does not reset to the beginning of the day.
