### PR TITLE
Allow word splitting $SHA_COMMAND to support sha commmand with args

### DIFF
--- a/assets/install-scripts/install.sh
+++ b/assets/install-scripts/install.sh
@@ -220,7 +220,8 @@ install_via_curl() {
 
   set -x
   cd "$TEMP_DIR"
-  $SUDO "$SHA_COMMAND" -c "$TMP_CHECKSUM"
+  # shellcheck disable=SC2086
+  $SUDO $SHA_COMMAND -c "$TMP_CHECKSUM"
   cd -
 
   $SUDO tar -xzf "${TEMP_DIR}/${TELEPORT_FILENAME}" -C "$TEMP_DIR"


### PR DESCRIPTION
If `SHA_COMMAND` is set to `shasum -a 256` on line 284 the invocation of `$SHA_COMMAND` will fail with
```
+ sudo 'shasum -a 256' -c /tmp/teleport-sqRW3a0Xl2/teleport-v16.1.0-linux-amd64-bin.tar.gz.sha256
sudo: shasum -a 256: command not found
```
if the expansion of `$SHA_COMMAND` quoted.