### PR TITLE
docs: update error message for standard RDP security

### DIFF
--- a/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
@@ -311,10 +311,10 @@ why the certificate cannot be verified.
 
 ### RDP server only uses Standard RDP Security
 
-Attempts to connect to a desktop fail, and the logs show an error similar to:
+Attempts to connect to a desktop fail with an error similar to
 
 ```
-Rdp(RdpError(RdpError { kind: ProtocolNegFailure, message: "Error during negotiation step: the server is configured to only use standard RDP security mechanisms and does not support external security protocols" }))
+client advertised SSL, but server selected STANDARD_RDP_SECURITY
 ```
 
 **Solution:** Enable Enhanced RDP security


### PR DESCRIPTION
The error message that users see when the RDP server insists upon using standard RDP security changed after the IronRDP migration. Update the troubleshooting page to mention the new error (the solution remains the same - enable enhanced RDP security).