### PR TITLE
Fixed access plugins tarballs containing the `build` directory

### DIFF
--- a/integrations/access/common.mk
+++ b/integrations/access/common.mk
@@ -52,7 +52,7 @@ release: $(BINARY)
 		cmd/teleport-$(ACCESS_PLUGIN)/install \
 		build/$(RELEASE_NAME)/
 	echo $(VERSION) > build/$(RELEASE_NAME)/VERSION
-	tar -czf build/$(RELEASE).tar.gz build/$(RELEASE_NAME)
+	tar -C build/ -czf build/$(RELEASE).tar.gz $(RELEASE_NAME)
 	rm -rf build/$(RELEASE_NAME)/
 	@echo "---> Created build/$(RELEASE).tar.gz."
 


### PR DESCRIPTION
The past few access plugins releases have the following tarball file structure:
```
.
├── build
│   └── teleport-access-slack
│       ├── README.md
│       ├── VERSION
│       ├── install
│       └── teleport-slack
└── teleport-access-slack-v16.0.4-linux-amd64-bin.tar.gz
```

This doesn't match our docs and is a breaking change. This reverts the structure to what it was previously:
```
.
├── teleport-access-slack
│   ├── README.md
│   ├── VERSION
│   ├── install
│   └── teleport-slack
└── teleport-access-slack-v16.0.4-linux-amd64-bin.tar.gz
```

This has been tested locally and should fix the problem both in builds and in local development.

changelog: Fixed Teleport access plugin tarballs containing a `build` directory, which was accidentally added upon v16.0.0 release.