### PR TITLE
[v16] Fixed access plugins tarballs containing the `build` directory

### DIFF
--- a/integrations/access/common.mk
+++ b/integrations/access/common.mk
@@ -52,7 +52,7 @@ release: $(BINARY)
 		cmd/teleport-$(ACCESS_PLUGIN)/install \
 		build/$(RELEASE_NAME)/
 	echo $(VERSION) > build/$(RELEASE_NAME)/VERSION
-	tar -czf build/$(RELEASE).tar.gz build/$(RELEASE_NAME)
+	tar -C build/ -czf build/$(RELEASE).tar.gz $(RELEASE_NAME)
 	rm -rf build/$(RELEASE_NAME)/
 	@echo "---> Created build/$(RELEASE).tar.gz."
 


### PR DESCRIPTION
Backport #44296 to branch/v16

changelog: Fixed Teleport access plugin tarballs containing a `build` directory, which was accidentally added upon v16.0.0 release.
