### PR TITLE
[v15] Fixed access plugins tarballs containing the `build` directory

### DIFF
--- a/integrations/access/common.mk
+++ b/integrations/access/common.mk
@@ -51,7 +51,7 @@ release: clean $(BINARY)
 		cmd/teleport-$(ACCESS_PLUGIN)/install \
 		build/$(RELEASE_NAME)/
 	echo $(VERSION) > build/$(RELEASE_NAME)/VERSION
-	tar -czf build/$(RELEASE).tar.gz build/$(RELEASE_NAME)
+	tar -C build/ -czf build/$(RELEASE).tar.gz $(RELEASE_NAME)
 	rm -rf build/$(RELEASE_NAME)/
 	@echo "---> Created build/$(RELEASE).tar.gz."
 


### PR DESCRIPTION
Backport #44296 to branch/v15

changelog: Fixed Teleport access plugin tarballs containing a `build` directory, which was accidentally added upon v15.4.5 release.
