### PR TITLE
Add Terraform Provider native MachineID support

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -500,4 +500,8 @@ const (
 	EnvVarTerraformRetryMaxTries = "TF_TELEPORT_RETRY_MAX_TRIES"
 	// EnvVarTerraformDialTimeoutDuration is the environment variable configuring the Terraform provider dial timeout.
 	EnvVarTerraformDialTimeoutDuration = "TF_TELEPORT_DIAL_TIMEOUT_DURATION"
+	// EnvVarTerraformJoinMethod is the environment variable configuring the Terraform provider native MachineID join method.
+	EnvVarTerraformJoinMethod = "TF_TELEPORT_JOIN_METHOD"
+	// EnvVarTerraformJoinToken is the environment variable configuring the Terraform provider native MachineID join token.
+	EnvVarTerraformJoinToken = "TF_TELEPORT_JOIN_TOKEN"
 )

--- a/docs/pages/reference/terraform-provider.mdx
+++ b/docs/pages/reference/terraform-provider.mdx
@@ -134,6 +134,8 @@ This auth method has the following limitations:
 - `identity_file` (String, Sensitive) Teleport identity file content. This can also be set with the environment variable `TF_TELEPORT_IDENTITY_FILE`.
 - `identity_file_base64` (String, Sensitive) Teleport identity file content base64 encoded. This can also be set with the environment variable `TF_TELEPORT_IDENTITY_FILE_BASE64`.
 - `identity_file_path` (String) Teleport identity file path. This can also be set with the environment variable `TF_TELEPORT_IDENTITY_FILE_PATH`.
+- `join_method` (String) Enables the native Terraform MachineID support. When set, Terraform uses MachineID to securely join the Teleport cluster and obtain credentials. See [the join method reference](./join-methods.mdx) for possible values, you must use [a delegated join method](./join-methods.mdx#secret-vs-delegated). This can also be set with the environment variable `TF_TELEPORT_JOIN_METHOD`.
+- `join_token` (String) Name of the token used for the native MachineID joining. This value is not sensitive for [delegated join methods](./join-methods.mdx#secret-vs-delegated). This can also be set with the environment variable `TF_TELEPORT_JOIN_TOKEN`.
 - `key_base64` (String, Sensitive) Base64 encoded TLS auth key. This can also be set with the environment variable `TF_TELEPORT_KEY_BASE64`.
 - `key_path` (String) Path to Teleport auth key file. This can also be set with the environment variable `TF_TELEPORT_KEY`.
 - `profile_dir` (String) Teleport profile path. This can also be set with the environment variable `TF_TELEPORT_PROFILE_PATH`.

--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -134,7 +134,7 @@ func TestBotJoinAuth(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, clusterName, pong.ClusterName)
 
-	botClient, err := bot.waitForClient(ctx, 10*time.Second)
+	botClient, err := bot.StartAndWaitForClient(ctx, 10*time.Second)
 	require.NoError(t, err)
 	botPong, err := botClient.Ping(ctx)
 	require.NoError(t, err)

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -221,6 +221,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
@@ -291,6 +292,7 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.3.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/thales-e-security/pool v0.0.2 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -1075,6 +1075,8 @@ github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs
 github.com/go-gorp/gorp/v3 v3.1.0/go.mod h1:dLEjIyyRNiXvNZ8PSmzpt1GsWAUK8kjVhEpjH8TixEw=
 github.com/go-jose/go-jose/v3 v3.0.3 h1:fFKWeig/irsp7XD2zBxvnmA/XaRWp5V3CBsZXJF7G7k=
 github.com/go-jose/go-jose/v3 v3.0.3/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v4 v4.0.2 h1:R3l3kkBds16bO7ZFAEEcofK0MkrAJt3jlJznWZG0nvk=
+github.com/go-jose/go-jose/v4 v4.0.2/go.mod h1:WVf9LFMHh/QVrmqrOfqun0C45tMe3RoiKJMPvgWwLfY=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-latex/latex v0.0.0-20210118124228-b3d85cf34e07/go.mod h1:CO1AlKB2CSIqUrmQPqA0gdRIlnLEY0gK5JGjh37zN5U=
 github.com/go-latex/latex v0.0.0-20210823091927-c0d11ff05a81/go.mod h1:SX0U8uGpxhq9o2S/CELCSUxEWWAuoCUcVCQWv7G2OCk=
@@ -1514,6 +1516,10 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
 github.com/josharian/native v1.1.0/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
+github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531 h1:hgVxRoDDPtQE68PT4LFvNlPz2nBKd3OMlGKIQ69OmR4=
+github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531/go.mod h1:fqTUQpVYBvhCNIsMXGl2GE9q6z94DIP6NtFKXCSTVbg=
+github.com/joshlf/testutil v0.0.0-20170608050642-b5d8aa79d93d h1:J8tJzRyiddAFF65YVgxli+TyWBi0f79Sld6rJP6CBcY=
+github.com/joshlf/testutil v0.0.0-20170608050642-b5d8aa79d93d/go.mod h1:b+Q3v8Yrg5o15d71PSUraUzYb+jWl6wQMSBXSGS/hv0=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -1839,6 +1845,8 @@ github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3k
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spiffe/go-spiffe/v2 v2.3.0 h1:g2jYNb/PDMB8I7mBGL2Zuq/Ur6hUhoroxGQFyD6tTj8=
+github.com/spiffe/go-spiffe/v2 v2.3.0/go.mod h1:Oxsaio7DBgSNqhAO9i/9tLClaVlfRok7zvJnTV8ZyIY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -1928,6 +1936,8 @@ github.com/zclconf/go-cty v1.14.4 h1:uXXczd9QDGsgu0i/QFR/hzI5NYCHLf6NQw/atrbnhq8
 github.com/zclconf/go-cty v1.14.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/errs v1.3.0 h1:hmiaKqgYZzcVgRL1Vkc1Mn2914BbzB0IBxs+ebeutGs=
+github.com/zeebo/errs v1.3.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=
 github.com/zmap/rc2 v0.0.0-20190804163417-abaa70531248/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=
@@ -2443,6 +2453,8 @@ golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNq
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 h1:+cNy6SZtPcJQH3LJVLOSmiC7MMxXNOb3PU/VUEz+EhU=
 golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
+gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
+gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/gonum v0.9.3/go.mod h1:TZumC3NeyVQskjXqmyWt4S3bINhy7B4eYwW69EbyX+0=

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -25,6 +25,9 @@ import (
 	"text/template"
 	"time"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/lib/embeddedtbot"
+	tbotconfig "github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -34,6 +37,7 @@ import (
 )
 
 var supportedCredentialSources = CredentialSources{
+	CredentialsFromNativeMachineID{},
 	CredentialsFromKeyAndCertPath{},
 	CredentialsFromKeyAndCertBase64{},
 	CredentialsFromIdentityFilePath{},
@@ -451,6 +455,76 @@ func (CredentialsFromProfile) Credentials(ctx context.Context, config providerDa
 	profileDir := stringFromConfigOrEnv(config.ProfileDir, constants.EnvVarTerraformProfilePath, "")
 
 	return client.LoadProfile(profileDir, profileName), nil
+}
+
+// CredentialsFromNativeMachineID builds credentials by performing a MachineID join and
+type CredentialsFromNativeMachineID struct{}
+
+// Name implements CredentialSource and returns the source name.
+func (CredentialsFromNativeMachineID) Name() string {
+	return "by performing native MachineID joining"
+}
+
+// IsActive implements CredentialSource and returns if the source is active and why.
+func (CredentialsFromNativeMachineID) IsActive(config providerData) (bool, string) {
+	joinMethod := stringFromConfigOrEnv(config.JoinMethod, constants.EnvVarTerraformJoinMethod, "")
+	joinToken := stringFromConfigOrEnv(config.JoinToken, constants.EnvVarTerraformJoinToken, "")
+
+	// This method is active as soon as a token or a join method are set.
+	active := joinMethod != "" || joinToken != ""
+	return activeReason(
+		active,
+		attributeTerraformJoinMethod, attributeTerraformJoinToken,
+		constants.EnvVarTerraformJoinMethod, constants.EnvVarTerraformJoinToken,
+	)
+}
+
+// Credentials implements CredentialSource and returns a client.Credentials for the provider.
+func (CredentialsFromNativeMachineID) Credentials(ctx context.Context, config providerData) (client.Credentials, error) {
+	joinMethod := stringFromConfigOrEnv(config.JoinMethod, constants.EnvVarTerraformJoinMethod, "")
+	joinToken := stringFromConfigOrEnv(config.JoinToken, constants.EnvVarTerraformJoinToken, "")
+	addr := stringFromConfigOrEnv(config.Addr, constants.EnvVarTerraformAddress, "")
+	caPath := stringFromConfigOrEnv(config.RootCaPath, constants.EnvVarTerraformRootCertificates, "")
+
+	if joinMethod == "" {
+		return nil, trace.BadParameter("missing parameter %q or environment variable %q", attributeTerraformJoinMethod, constants.EnvVarTerraformJoinMethod)
+	}
+	if joinToken == "" {
+		return nil, trace.BadParameter("missing parameter %q or environment variable %q", attributeTerraformJoinMethod, constants.EnvVarTerraformJoinMethod)
+	}
+	if addr == "" {
+		return nil, trace.BadParameter("missing parameter %q or environment variable %q", attributeTerraformAddress, constants.EnvVarTerraformAddress)
+	}
+
+	// TODO: reject token JoinMethod (or gate behind an env var)
+
+	if err := apitypes.ValidateJoinMethod(apitypes.JoinMethod(joinMethod)); err != nil {
+		return nil, trace.Wrap(err, "Invalid Join Method")
+	}
+	botConfig := &embeddedtbot.BotConfig{
+		AuthServer: addr,
+		Onboarding: tbotconfig.OnboardingConfig{
+			TokenValue: joinToken,
+			CAPath:     caPath,
+			JoinMethod: apitypes.JoinMethod(joinMethod),
+		},
+		CertificateTTL:  time.Hour,
+		RenewalInterval: 20 * time.Minute,
+	}
+	bot, err := embeddedtbot.New(botConfig)
+	if err != nil {
+		return nil, trace.Wrap(err, "Failed to create bot configuration, this is a provider bug, please open a GitHub issue.")
+	}
+
+	preflightCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	_, err = bot.Preflight(preflightCtx)
+	if err != nil {
+		return nil, trace.Wrap(err, "Failed to preflight bot configuration")
+	}
+
+	creds, err := bot.StartAndWaitForCredentials(ctx, 20*time.Second /* deadline */)
+	return creds, trace.Wrap(err, "Waiting for bot to obtain credentials")
 }
 
 // activeReason renders a user-friendly active reason message describing if the credentials source is active

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -25,15 +25,15 @@ import (
 	"text/template"
 	"time"
 
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/lib/embeddedtbot"
-	tbotconfig "github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/constants"
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/lib/embeddedtbot"
+	tbotconfig "github.com/gravitational/teleport/lib/tbot/config"
 )
 
 var supportedCredentialSources = CredentialSources{

--- a/integrations/terraform/testlib/machineid_join_test.go
+++ b/integrations/terraform/testlib/machineid_join_test.go
@@ -1,0 +1,144 @@
+package testlib
+
+import (
+	"context"
+	"fmt"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/lib/testing/fakejoin"
+	"github.com/gravitational/teleport/integrations/lib/testing/integration"
+	"github.com/gravitational/teleport/integrations/terraform/provider"
+	"github.com/gravitational/teleport/lib/kubernetestoken"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestTerraformJoin(t *testing.T) {
+	require.NoError(t, os.Setenv("TF_ACC", "true"))
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Test setup: start a Telpeort auth server
+	authHelper := &integration.MinimalAuthHelper{}
+	clt := authHelper.StartServer(t)
+
+	var err error
+	// Test setup: create the terraform role
+	tfRole := services.NewPresetTerraformProviderRole()
+	tfRole, err = clt.CreateRole(ctx, tfRole)
+	require.NoError(t, err)
+
+	// Test setup: create a fake Kubernetes signer that will allow us to use the kubernetes/jwks join method
+	clock := clockwork.NewRealClock()
+	signer, err := fakejoin.NewKubernetesSigner(clock)
+	require.NoError(t, err)
+
+	jwks, err := signer.GetMarshaledJWKS()
+	require.NoError(t, err)
+
+	// Test setup: create a token and a bot that can join the cluster with JWT signed by our fake Kubernetes signer
+	testBotName := "testBot"
+	testTokenName := "testToken"
+	fakeNamespace := "test-namespace"
+	fakeServiceAccount := "test-service-account"
+	token, err := types.NewProvisionTokenFromSpec(
+		testTokenName,
+		clock.Now().Add(time.Hour),
+		types.ProvisionTokenSpecV2{
+			Roles:      types.SystemRoles{types.RoleBot},
+			JoinMethod: types.JoinMethodKubernetes,
+			BotName:    testBotName,
+			Kubernetes: &types.ProvisionTokenSpecV2Kubernetes{
+				Allow: []*types.ProvisionTokenSpecV2Kubernetes_Rule{
+					{
+						ServiceAccount: fmt.Sprintf("%s:%s", fakeNamespace, fakeServiceAccount),
+					},
+				},
+				Type: types.KubernetesJoinTypeStaticJWKS,
+				StaticJWKS: &types.ProvisionTokenSpecV2Kubernetes_StaticJWKSConfig{
+					JWKS: jwks,
+				},
+			},
+		})
+	require.NoError(t, err)
+	err = clt.CreateToken(ctx, token)
+	require.NoError(t, err)
+
+	bot := &machineidv1.Bot{
+		Metadata: &headerv1.Metadata{
+			Name: testBotName,
+		},
+		Spec: &machineidv1.BotSpec{
+			Roles: []string{tfRole.GetName()},
+		},
+	}
+	bot, err = clt.BotServiceClient().CreateBot(ctx, &machineidv1.CreateBotRequest{Bot: bot})
+	require.NoError(t, err)
+
+	// Test setup sign a Kube JWT for our bot to join the cluster
+	// We sign the token, write it to a temporary file, and point the embedded tbot to it
+	// with an environment variable.
+	pong, err := clt.Ping(ctx)
+	require.NoError(t, err)
+	clusterName := pong.ClusterName
+	jwt, err := signer.SignServiceAccountJWT("pod-name-doesnt-matter", fakeNamespace, fakeServiceAccount, clusterName)
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+	jwtPath := filepath.Join(tempDir, "token")
+	require.NoError(t, os.WriteFile(jwtPath, []byte(jwt), 0600))
+	require.NoError(t, os.Setenv(kubernetestoken.EnvVarCustomKubernetesTokenPath, jwtPath))
+
+	// Test setup: craft a Terraform provider configuration
+	terraformConfig := fmt.Sprintf(`
+		provider "teleport" {
+			addr = %q
+			join_token = %q
+			join_method = %q
+			retry_base_duration = "900ms"
+			retry_cap_duration = "4s"
+			retry_max_tries = "12"
+		}
+	`, authHelper.ServerAddr(), testTokenName, types.JoinMethodKubernetes)
+
+	terraformProvider := provider.New()
+	terraformProviders := make(map[string]func() (tfprotov6.ProviderServer, error))
+	terraformProviders["teleport"] = func() (tfprotov6.ProviderServer, error) {
+		// Terraform configures provider on every test step, but does not clean up previous one, which produces
+		// to "too many open files" at some point.
+		//
+		// With this statement we try to forcefully close previously opened client, which stays cached in
+		// the provider variable.
+		p, ok := terraformProvider.(*provider.Provider)
+		require.True(t, ok)
+		require.NoError(t, p.Close())
+		return providerserver.NewProtocol6(terraformProvider)(), nil
+	}
+
+	// Do the test
+	dummyResource, err := fixtures.ReadFile(filepath.Join("fixtures", "app_0_create.tf"))
+	testConfig := terraformConfig + "\n" + string(dummyResource)
+	name := "teleport_app.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: terraformProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "app"),
+					resource.TestCheckResourceAttr(name, "spec.uri", "localhost:3000"),
+				),
+			},
+		},
+	})
+}

--- a/integrations/terraform/testlib/machineid_join_test.go
+++ b/integrations/terraform/testlib/machineid_join_test.go
@@ -100,7 +100,7 @@ func TestTerraformJoin(t *testing.T) {
 			Roles: []string{tfRole.GetName()},
 		},
 	}
-	bot, err = clt.BotServiceClient().CreateBot(ctx, &machineidv1.CreateBotRequest{Bot: bot})
+	_, err = clt.BotServiceClient().CreateBot(ctx, &machineidv1.CreateBotRequest{Bot: bot})
 	require.NoError(t, err)
 
 	// Test setup: sign a Kube JWT for our bot to join the cluster
@@ -145,6 +145,7 @@ func TestTerraformJoin(t *testing.T) {
 
 	// Test execution: apply a TF resource with the provider joining via MachineID
 	dummyResource, err := fixtures.ReadFile(filepath.Join("fixtures", "app_0_create.tf"))
+	require.NoError(t, err)
 	testConfig := terraformConfig + "\n" + string(dummyResource)
 	name := "teleport_app.test"
 

--- a/integrations/terraform/testlib/machineid_join_test.go
+++ b/integrations/terraform/testlib/machineid_join_test.go
@@ -3,23 +3,26 @@ package testlib
 import (
 	"context"
 	"fmt"
-	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
-	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/lib/testing/fakejoin"
-	"github.com/gravitational/teleport/integrations/lib/testing/integration"
-	"github.com/gravitational/teleport/integrations/terraform/provider"
-	"github.com/gravitational/teleport/lib/kubernetestoken"
-	"github.com/gravitational/teleport/lib/services"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"testing"
-	"time"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/lib/testing/fakejoin"
+	"github.com/gravitational/teleport/integrations/lib/testing/integration"
+	"github.com/gravitational/teleport/lib/kubernetestoken"
+	"github.com/gravitational/teleport/lib/services"
+
+	"github.com/gravitational/teleport/integrations/terraform/provider"
 )
 
 func TestTerraformJoin(t *testing.T) {

--- a/integrations/terraform/testlib/machineid_join_test.go
+++ b/integrations/terraform/testlib/machineid_join_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package testlib
 
 import (
@@ -87,7 +103,7 @@ func TestTerraformJoin(t *testing.T) {
 	bot, err = clt.BotServiceClient().CreateBot(ctx, &machineidv1.CreateBotRequest{Bot: bot})
 	require.NoError(t, err)
 
-	// Test setup sign a Kube JWT for our bot to join the cluster
+	// Test setup: sign a Kube JWT for our bot to join the cluster
 	// We sign the token, write it to a temporary file, and point the embedded tbot to it
 	// with an environment variable.
 	pong, err := clt.Ping(ctx)
@@ -127,7 +143,7 @@ func TestTerraformJoin(t *testing.T) {
 		return providerserver.NewProtocol6(terraformProvider)(), nil
 	}
 
-	// Do the test
+	// Test execution: apply a TF resource with the provider joining via MachineID
 	dummyResource, err := fixtures.ReadFile(filepath.Join("fixtures", "app_0_create.tf"))
 	testConfig := terraformConfig + "\n" + string(dummyResource)
 	name := "teleport_app.test"

--- a/integrations/terraform/testlib/main_test.go
+++ b/integrations/terraform/testlib/main_test.go
@@ -213,9 +213,7 @@ func (s *TerraformBaseSuite) closeClient() {
 	s.T().Helper()
 	p, ok := s.terraformProvider.(*provider.Provider)
 	require.True(s.T(), ok)
-	if p != nil && p.Client != nil {
-		require.NoError(s.T(), p.Client.Close())
-	}
+	require.NoError(s.T(), p.Close())
 }
 
 // getFixture loads fixture and returns it as string or <error> if failed

--- a/lib/kubernetestoken/token_source.go
+++ b/lib/kubernetestoken/token_source.go
@@ -24,7 +24,10 @@ import (
 	"github.com/gravitational/trace"
 )
 
-const kubernetesDefaultTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+const (
+	kubernetesDefaultTokenPath      = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	EnvVarCustomKubernetesTokenPath = "KUBERNETES_TOKEN_PATH"
+)
 
 type getEnvFunc func(key string) string
 type readFileFunc func(name string) ([]byte, error)
@@ -33,7 +36,7 @@ func GetIDToken(getEnv getEnvFunc, readFile readFileFunc) (string, error) {
 	// We check if we should use a custom location instead of the default one. This env var is not standard.
 	// This is useful when the operator wants to use a custom projected token, or another service account.
 	path := kubernetesDefaultTokenPath
-	if customPath := getEnv("KUBERNETES_TOKEN_PATH"); customPath != "" {
+	if customPath := getEnv(EnvVarCustomKubernetesTokenPath); customPath != "" {
 		path = customPath
 	}
 


### PR DESCRIPTION
Implements the second half of RFD 173:  adds support for native MachineID terraform joining.

Changelog: Add native MachineID support in the TF provider. The TF provide can now use bot join tokens to connect to Teleport.