### PR TITLE
Type the UI entitlements to match the response

### DIFF
--- a/api/client/webclient/webconfig.go
+++ b/api/client/webclient/webconfig.go
@@ -134,9 +134,9 @@ type WebConfig struct {
 // { Enabled: false, Limit: >=0 } => no access to feature X
 type EntitlementInfo struct {
 	// Enabled indicates the feature is 'on' if true; feature is disabled if false
-	Enabled bool
+	Enabled bool `json:"enabled"`
 	// Limit indicates the allotted amount of use when limited; if 0 use is unlimited
-	Limit int32
+	Limit int32 `json:"limit"`
 }
 
 // featureLimits define limits for features.

--- a/entitlements/entitlements.go
+++ b/entitlements/entitlements.go
@@ -21,7 +21,9 @@ type EntitlementKind string
 // The EntitlementKind list should be 1:1 with the Features & FeatureStrings in salescenter/product/product.go,
 // except CustomTheme which is dropped. CustomTheme entitlement only toggles the ability to "set" a theme;
 // the value of that theme, if set, is stored and accessed outside of entitlements.
-// All EntitlementKinds added here should also be added to AllEntitlements.
+//
+// All EntitlementKinds added here should also be added to AllEntitlements below and defaultEntitlements in
+// web/packages/teleport/src/entitlement.ts.
 const (
 	AccessLists            EntitlementKind = "AccessLists"
 	AccessMonitoring       EntitlementKind = "AccessMonitoring"

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -22,6 +22,8 @@ import { IncludedResourceMode } from 'shared/components/UnifiedResources';
 
 import generateResourcePath from './generateResourcePath';
 
+import { defaultEntitlements } from './entitlement';
+
 import type {
   Auth2faType,
   AuthProvider,
@@ -99,33 +101,7 @@ const cfg = {
   },
 
   // default entitlements to false
-  entitlements: {
-    hsm: { enabled: false, limit: 0 },
-    oidc: { enabled: false, limit: 0 },
-    assist: { enabled: false, limit: 0 },
-    app: { enabled: false, limit: 0 },
-    db: { enabled: false, limit: 0 },
-    desktop: { enabled: false, limit: 0 },
-    accessMonitoring: { enabled: false, limit: 0 },
-    customTheme: { enabled: false, limit: 0 },
-    featureHiding: { enabled: false, limit: 0 },
-    policy: { enabled: false, limit: 0 },
-    identity: { enabled: false, limit: 0 },
-    deviceTrust: { enabled: false, limit: 0 },
-    k8s: { enabled: false, limit: 0 },
-    usageReporting: { enabled: false, limit: 0 },
-    upsellAlert: { enabled: false, limit: 0 },
-    saml: { enabled: false, limit: 0 },
-    cloudAuditLogRetention: { enabled: false, limit: 0 },
-    externalAuditStorage: { enabled: false, limit: 0 },
-    joinActiveSessions: { enabled: false, limit: 0 },
-    mobileDeviceManagement: { enabled: false, limit: 0 },
-    accessRequests: { enabled: false, limit: 0 },
-    accessLists: { enabled: false, limit: 0 },
-    sessionLocks: { enabled: false, limit: 0 },
-    oktaUserSync: { enabled: false, limit: 0 },
-    oktaSCIM: { enabled: false, limit: 0 },
-  },
+  entitlements: defaultEntitlements,
 
   ui: {
     scrollbackLines: 1000,

--- a/web/packages/teleport/src/entitlement.ts
+++ b/web/packages/teleport/src/entitlement.ts
@@ -1,0 +1,72 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// entitlement list should be 1:1 with EntitlementKinds in entitlements/entitlements.go
+type entitlement =
+  | 'AccessLists'
+  | 'AccessMonitoring'
+  | 'AccessRequests'
+  | 'App'
+  | 'CloudAuditLogRetention'
+  | 'DB'
+  | 'Desktop'
+  | 'DeviceTrust'
+  | 'ExternalAuditStorage'
+  | 'FeatureHiding'
+  | 'HSM'
+  | 'Identity'
+  | 'JoinActiveSessions'
+  | 'K8s'
+  | 'MobileDeviceManagement'
+  | 'OIDC'
+  | 'OktaSCIM'
+  | 'OktaUserSync'
+  | 'Policy'
+  | 'SAML'
+  | 'SessionLocks'
+  | 'UpsellAlert'
+  | 'UsageReporting';
+
+export const defaultEntitlements: Record<
+  entitlement,
+  { enabled: boolean; limit: number }
+> = {
+  AccessLists: { enabled: false, limit: 0 },
+  AccessMonitoring: { enabled: false, limit: 0 },
+  AccessRequests: { enabled: false, limit: 0 },
+  App: { enabled: false, limit: 0 },
+  CloudAuditLogRetention: { enabled: false, limit: 0 },
+  DB: { enabled: false, limit: 0 },
+  Desktop: { enabled: false, limit: 0 },
+  DeviceTrust: { enabled: false, limit: 0 },
+  ExternalAuditStorage: { enabled: false, limit: 0 },
+  FeatureHiding: { enabled: false, limit: 0 },
+  HSM: { enabled: false, limit: 0 },
+  Identity: { enabled: false, limit: 0 },
+  JoinActiveSessions: { enabled: false, limit: 0 },
+  K8s: { enabled: false, limit: 0 },
+  MobileDeviceManagement: { enabled: false, limit: 0 },
+  OIDC: { enabled: false, limit: 0 },
+  OktaSCIM: { enabled: false, limit: 0 },
+  OktaUserSync: { enabled: false, limit: 0 },
+  Policy: { enabled: false, limit: 0 },
+  SAML: { enabled: false, limit: 0 },
+  SessionLocks: { enabled: false, limit: 0 },
+  UpsellAlert: { enabled: false, limit: 0 },
+  UsageReporting: { enabled: false, limit: 0 },
+};


### PR DESCRIPTION
This PR updates the entitlements struct in webCfg to be typed according to the response

Supports https://github.com/gravitational/cloud/issues/9022
