### PR TITLE
Opsgenie Plugin support schedules/teams ID and Name

### DIFF
--- a/integrations/access/opsgenie/client.go
+++ b/integrations/access/opsgenie/client.go
@@ -23,13 +23,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"text/template"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/go-resty/resty/v2"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
@@ -50,11 +50,7 @@ const (
 
 	ResolveAlertRequestRetryInterval = time.Second * 10
 	ResolveAlertRequestRetryTimeout  = time.Minute * 2
-
-	UUIDRegexPattern = `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`
 )
-
-var uuidRegex = regexp.MustCompile(UUIDRegexPattern)
 
 var alertBodyTemplate = template.Must(template.New("alert body").Parse(
 	`{{.User}} requested permissions for roles {{range $index, $element := .Roles}}{{if $index}}, {{end}}{{ . }}{{end}} on Teleport at {{.Created.Format .TimeFormat}}.
@@ -234,7 +230,7 @@ func (og Client) getResponders(reqData RequestData) []Responder {
 
 // Check if the responder is a UUID. If it is, then it is an ID; otherwise, it is a name.
 func createResponder(responderType string, value string) Responder {
-	if uuidRegex.MatchString(value) {
+	if _, err := uuid.Parse(value); err == nil {
 		return Responder{
 			Type: responderType,
 			ID:   value,

--- a/integrations/access/opsgenie/client_test.go
+++ b/integrations/access/opsgenie/client_test.go
@@ -59,8 +59,8 @@ func TestCreateAlert(t *testing.T) {
 		Roles:         []string{"role1", "role2"},
 		RequestReason: "someReason",
 		SystemAnnotations: types.Labels{
-			types.TeleportNamespace + types.ReqAnnotationNotifySchedulesLabel: {"responder@example.com"},
-			types.TeleportNamespace + types.ReqAnnotationTeamsLabel:           {"MyOpsGenieTeam"},
+			types.TeleportNamespace + types.ReqAnnotationNotifySchedulesLabel: {"responder@example.com", "bb4d9938-c3c2-455d-aaab-727aa701c0d8"},
+			types.TeleportNamespace + types.ReqAnnotationTeamsLabel:           {"MyOpsGenieTeam", "aee8a0de-c80f-4515-a232-501c0bc9d715"},
 		},
 	})
 	assert.NoError(t, err)
@@ -70,8 +70,10 @@ func TestCreateAlert(t *testing.T) {
 		Alias:       "teleport-access-request/someRequestID",
 		Description: "someUser requested permissions for roles role1, role2 on Teleport at 01 Jan 01 00:00 UTC.\nReason: someReason\n\n",
 		Responders: []Responder{
-			{Type: "schedule", Name: "responder@example.com", ID: "responder@example.com"},
-			{Type: "team", Name: "MyOpsGenieTeam", ID: "MyOpsGenieTeam"},
+			{Type: "schedule", Name: "responder@example.com"},
+			{Type: "schedule", ID: "bb4d9938-c3c2-455d-aaab-727aa701c0d8"},
+			{Type: "team", Name: "MyOpsGenieTeam"},
+			{Type: "team", ID: "aee8a0de-c80f-4515-a232-501c0bc9d715"},
 		},
 		Priority: "somePriority",
 	}


### PR DESCRIPTION
In a previous PR (https://github.com/gravitational/teleport/pull/43535), we identified that the Opsgenie alert payload was using the schedule ID, while the documentation refers to the schedule name in the annotations.

To support backwards compatibility, both `ID` and `Name` were added to the payload. However, the Opsgenie API requires only one of these fields, not both.

All Opsgenie IDs (schedules, teams, requests, etc.) are UUIDs. Therefore, in this PR, I propose checking if the schedule/team in the annotation is a UUID. If it is, we will include the `ID` in the payload; otherwise, we will include the `Name`.

Example:
```yaml
kind: role
metadata:
  name: prod-write-access-request
spec:
  allow:
    request:
      annotations:
        teleport.dev/notify-services:
        - MySchedule
        - bb4d9938-c3c2-455d-aaab-727aa701c0d8
        teleport.dev/teams:
        - MyTeam
        - aee8a0de-c80f-4515-a232-501c0bc9d715
      roles:
      - prod-write-role
```

Results in following payload
```json
{
  "message": "Access request from ...",
  "alias": "....",
  "description":"....",
  "responders": [
        {
           "type": "schedule",
           "name": "MySchedule"
        },
        {
           "type": "schedule",
           "id": "bb4d9938-c3c2-455d-aaab-727aa701c0d8"
        },
        {
           "type": "team",
           "name": "MyTeam"
        },
        {
           "type": "team",
           "id": "aee8a0de-c80f-4515-a232-501c0bc9d715"
        }
     ],
  "priority":"P2"
```
