### PR TITLE
Stop using centos image for bloat check

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -25,7 +25,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport17-amd64
+      image: ghcr.io/gravitational/teleport-buildbox:teleport17
 
     steps:
       - name: Checkout base


### PR DESCRIPTION
The bloat check started failing after the checkout action started to require nodejs 20 (See https://github.com/actions/checkout/issues/1590#issuecomment-2192647851). By changing the image the bloat check should still provide enough insight into binary size at the expense of the binaries being slightly different from a production build.