### PR TITLE
[v16] Stop using centos image for bloat check

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -25,7 +25,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport16-amd64
+      image: ghcr.io/gravitational/teleport-buildbox:teleport16
 
     steps:
       - name: Checkout base


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/44365 to branch/v16