### PR TITLE
Add token create forms to Join Tokens UI

### DIFF
--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -121,6 +121,8 @@ type ProvisionToken interface {
 	GetAllowRules() []*TokenRule
 	// SetAllowRules sets the allow rules
 	SetAllowRules([]*TokenRule)
+	// GetGCPRules will return the GCP rules within this token.
+	GetGCPRules() *ProvisionTokenSpecV2GCP
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() Duration
 	// GetJoinMethod returns joining method that must be used with this token.
@@ -383,6 +385,11 @@ func (p *ProvisionTokenV2) GetAllowRules() []*TokenRule {
 // SetAllowRules sets the allow rules.
 func (p *ProvisionTokenV2) SetAllowRules(rules []*TokenRule) {
 	p.Spec.Allow = rules
+}
+
+// GetGCPRules will return the GCP rules within this token.
+func (p *ProvisionTokenV2) GetGCPRules() *ProvisionTokenSpecV2GCP {
+	return p.Spec.GCP
 }
 
 // GetAWSIIDTTL returns the TTL of EC2 IIDs

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -771,8 +771,13 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/auth/export", h.authExportPublic)
 
 	// join token handlers
-	h.PUT("/webapi/token/yaml", h.WithAuth(h.upsertTokenContent))
-	h.POST("/webapi/token", h.WithAuth(h.createTokenHandle))
+	h.PUT("/webapi/tokens/yaml", h.WithAuth(h.updateTokenYAML))
+	// used for creating a new token
+	h.POST("/webapi/tokens", h.WithAuth(h.upsertTokenHandle))
+	// used for updating a token
+	h.PUT("/webapi/tokens", h.WithAuth(h.upsertTokenHandle))
+	// used for creating tokens used during guided discover flows
+	h.POST("/webapi/token", h.WithAuth(h.createTokenForDiscoveryHandle))
 	h.GET("/webapi/tokens", h.WithAuth(h.getTokens))
 	h.DELETE("/webapi/tokens", h.WithAuth(h.deleteToken))
 

--- a/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
@@ -1,0 +1,230 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { Flex, Text, ButtonIcon, ButtonText } from 'design';
+import { Plus, Trash } from 'design/Icon';
+import { requiredField } from 'shared/components/Validation/rules';
+import FieldInput from 'shared/components/FieldInput';
+import { FieldSelectCreatable } from 'shared/components/FieldSelect';
+
+import { NewJoinTokenState, OptionGCP, RuleBox } from './UpsertJoinTokenDialog';
+
+export const JoinTokenIAMForm = ({
+  tokenState,
+  onUpdateState,
+}: {
+  tokenState: NewJoinTokenState;
+  onUpdateState: (newToken: NewJoinTokenState) => void;
+}) => {
+  const rules = tokenState.iam;
+
+  function removeRule(index: number) {
+    const newRules = rules.filter((_, i) => index !== i);
+    const newState = {
+      ...tokenState,
+      iam: newRules,
+    };
+    onUpdateState(newState);
+  }
+
+  function setTokenRulesField(
+    ruleIndex: number,
+    fieldName: string,
+    value: string
+  ) {
+    const newState = {
+      ...tokenState,
+      [tokenState.method.value]: tokenState[tokenState.method.value].map(
+        (rule, i) => {
+          if (ruleIndex !== i) {
+            return rule;
+          }
+          return {
+            ...rule,
+            [fieldName]: value,
+          };
+        }
+      ),
+    };
+    onUpdateState(newState);
+  }
+
+  function addNewRule() {
+    const newState = {
+      ...tokenState,
+      iam: [...tokenState.iam, { aws_account: '' }],
+    };
+    onUpdateState(newState);
+  }
+
+  return (
+    <>
+      {rules.map((rule, index) => (
+        <RuleBox
+          key={index} // order does not change without updating the reference array
+        >
+          <Flex alignItems="center" justifyContent="space-between">
+            <Text fontWeight={700} mb={2}>
+              AWS Rule
+            </Text>
+
+            {rules.length > 1 && ( // at least one rule is required, so lets not allow the user to remove it
+              <ButtonIcon
+                data-testid="delete_rule"
+                onClick={() => removeRule(index)}
+              >
+                <Trash size={16} color="text.muted" />
+              </ButtonIcon>
+            )}
+          </Flex>
+          <FieldInput
+            label="Account ID"
+            rule={requiredField('Account ID is required')}
+            placeholder="AWS Account ID"
+            value={rule.aws_account}
+            onChange={e =>
+              setTokenRulesField(index, 'aws_account', e.target.value)
+            }
+          />
+          <FieldInput
+            label="ARN"
+            toolTipContent={`The joining nodes must match this ARN. Supports wildcards "*" and "?"`}
+            placeholder="arn:aws:iam::account-id:role/*"
+            value={rule.aws_arn}
+            onChange={e => setTokenRulesField(index, 'aws_arn', e.target.value)}
+          />
+        </RuleBox>
+      ))}
+      <ButtonText onClick={addNewRule}>
+        <Plus size={16} mr={2} />
+        Add another AWS Rule
+      </ButtonText>
+    </>
+  );
+};
+
+export const JoinTokenGCPForm = ({
+  tokenState,
+  onUpdateState,
+}: {
+  tokenState: NewJoinTokenState;
+  onUpdateState: (newToken: NewJoinTokenState) => void;
+}) => {
+  const rules = tokenState.gcp;
+  function removeRule(index: number) {
+    const newRules = rules.filter((_, i) => index !== i);
+    const newState = {
+      ...tokenState,
+      gcp: newRules,
+    };
+    onUpdateState(newState);
+  }
+
+  function addNewRule() {
+    const newState = {
+      ...tokenState,
+      gcp: [
+        ...tokenState.gcp,
+        { project_ids: [], locations: [], service_accounts: [] },
+      ],
+    };
+    onUpdateState(newState);
+  }
+
+  function updateRuleField(
+    index: number,
+    fieldName: string,
+    opts: OptionGCP[]
+  ) {
+    const newState = {
+      ...tokenState,
+      gcp: tokenState.gcp.map((rule, i) => {
+        if (i === index) {
+          return { ...rule, [fieldName]: opts };
+        }
+        return rule;
+      }),
+    };
+    onUpdateState(newState);
+  }
+
+  return (
+    <>
+      {rules.map((rule, index) => (
+        <RuleBox
+          key={index} // order doesn't change without updating the referrenced array
+        >
+          <Flex alignItems="center" justifyContent="space-between">
+            <Text fontWeight={700} mb={2}>
+              GCP Rule
+            </Text>
+
+            {rules.length > 1 && ( // at least one rule is required, so lets not allow the user to remove it
+              <ButtonIcon
+                data-testid="delete_rule"
+                onClick={() => removeRule(index)}
+              >
+                <Trash size={16} color="text.muted" />
+              </ButtonIcon>
+            )}
+          </Flex>
+          <FieldSelectCreatable
+            placeholder="Type a Project ID"
+            isMulti
+            isClearable
+            isSearchable
+            onChange={opts =>
+              updateRuleField(index, 'project_ids', opts as OptionGCP[])
+            }
+            value={rule.project_ids}
+            label="Add Project ID(s)"
+            rule={requiredField('At least 1 Project ID required')}
+          />
+          <FieldSelectCreatable
+            placeholder="us-west1, us-east1-a"
+            isMulti
+            isClearable
+            isSearchable
+            onChange={opts =>
+              updateRuleField(index, 'locations', opts as OptionGCP[])
+            }
+            value={rule.locations}
+            label="Add Locations"
+            labelTip="Allows regions and/or zones."
+          />
+          <FieldSelectCreatable
+            placeholder="PROJECT_compute@developer.gserviceaccount.com"
+            isMulti
+            isClearable
+            isSearchable
+            onChange={opts =>
+              updateRuleField(index, 'service_accounts', opts as OptionGCP[])
+            }
+            value={rule.service_accounts}
+            label="Add Service Account Emails"
+          />
+        </RuleBox>
+      ))}
+      <ButtonText onClick={addNewRule}>
+        <Plus size={16} mr={2} />
+        Add another GCP Rule
+      </ButtonText>
+    </>
+  );
+};

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.story.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.story.tsx
@@ -68,6 +68,10 @@ const tokens: JoinToken[] = [
     expiry: new Date('0001-01-01'),
     method: 'token',
     safeName: '******',
+    allow: [],
+    gcp: {
+      allow: [],
+    },
     content: '',
   },
   {
@@ -77,6 +81,10 @@ const tokens: JoinToken[] = [
     expiry: new Date('2023-06-01'),
     method: 'iam',
     safeName: 'iam-EDIT-ME-BUT-DONT-SAVE',
+    allow: [],
+    gcp: {
+      allow: [],
+    },
     content: `kind: token
         metadata:
         name: iam-EDIT-ME-BUT-DONT-SAVE

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.test.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { render, screen, fireEvent } from 'design/utils/testing';
+import userEvent from '@testing-library/user-event';
+import { within } from '@testing-library/react';
+
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { ContextProvider } from 'teleport';
+import makeJoinToken from 'teleport/services/joinToken/makeJoinToken';
+
+import { JoinTokens } from './JoinTokens';
+
+describe('JoinTokens', () => {
+  test('create dialog opens', async () => {
+    render(<Component />);
+    await userEvent.click(
+      screen.getByRole('button', { name: /create new token/i })
+    );
+
+    expect(screen.getByText(/create a new join token/i)).toBeInTheDocument();
+  });
+
+  test('edit dialog opens with values', async () => {
+    const token = tokens[0];
+    render(<Component />);
+    const optionButtons = await screen.findAllByText(/options/i);
+    await userEvent.click(optionButtons[0]);
+    const editButtons = await screen.findAllByText(/view\/edit/i);
+    await userEvent.click(editButtons[0]);
+    expect(screen.getByText(/edit token/i)).toBeInTheDocument();
+
+    expect(screen.getByDisplayValue(token.id)).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue(token.allow[0].aws_account)
+    ).toBeInTheDocument();
+  });
+
+  test('create form fails if roles arent selected', async () => {
+    render(<Component />);
+    await userEvent.click(
+      screen.getByRole('button', { name: /create new token/i })
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('iam-token-name'), {
+      target: { value: 'the_token' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /create join token/i }));
+    expect(
+      screen.getByText('At least one role is required')
+    ).toBeInTheDocument();
+  });
+
+  test('successful create adds token to the table', async () => {
+    render(<Component />);
+    await userEvent.click(
+      screen.getByRole('button', { name: /create new token/i })
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('iam-token-name'), {
+      target: { value: 'the_token' },
+    });
+
+    const inputEl = within(screen.getByTestId('role_select')).getByRole(
+      'textbox'
+    );
+    fireEvent.change(inputEl, { target: { value: 'Node' } });
+    fireEvent.focus(inputEl);
+    fireEvent.keyDown(inputEl, { key: 'Enter', keyCode: 13 });
+
+    fireEvent.click(screen.getByRole('button', { name: /create join token/i }));
+    expect(
+      screen.queryByText('At least one role is required')
+    ).not.toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('AWS Account ID'), {
+      target: { value: '123123123' },
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /create join token/i })
+    );
+
+    expect(
+      screen.queryByText(/create a new join token/i)
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('the_token')).toBeInTheDocument();
+  });
+
+  test('a rule cannot be deleted if it is the only rule', async () => {
+    render(<Component />);
+    await userEvent.click(
+      screen.getByRole('button', { name: /create new token/i })
+    );
+
+    const buttons = screen.queryAllByTestId('delete_rule');
+    expect(buttons).toHaveLength(0);
+  });
+
+  test('a rule can be deleted more than one rule exists', async () => {
+    render(<Component />);
+    await userEvent.click(
+      screen.getByRole('button', { name: /create new token/i })
+    );
+
+    fireEvent.click(screen.getByText('Add another AWS Rule'));
+
+    const buttons = screen.queryAllByTestId('delete_rule');
+    expect(buttons).toHaveLength(2);
+  });
+});
+
+const Component = () => {
+  const ctx = createTeleportContext();
+  jest
+    .spyOn(ctx.joinTokenService, 'fetchJoinTokens')
+    .mockResolvedValue({ items: tokens.map(makeJoinToken) });
+
+  jest.spyOn(ctx.joinTokenService, 'createJoinToken').mockResolvedValue(
+    makeJoinToken({
+      id: 'the_token',
+      safeName: 'the_token',
+      bot_name: '',
+      expiry: '3024-07-26T11:52:48.320045Z',
+      roles: ['Node'],
+      isStatic: false,
+      method: 'iam',
+      allow: [
+        {
+          aws_account: '1234444',
+          aws_arn: 'asdf',
+        },
+      ],
+      content: 'fake content',
+    })
+  );
+
+  return (
+    <ContextProvider ctx={ctx}>
+      <JoinTokens />
+    </ContextProvider>
+  );
+};
+
+const tokens = [
+  {
+    id: '123123ffff',
+    safeName: '123123ffff',
+    bot_name: '',
+    expiry: '3024-07-26T11:52:48.320045Z',
+    roles: ['Node'],
+    isStatic: false,
+    method: 'iam',
+    allow: [
+      {
+        aws_account: '1234444',
+        aws_arn: 'asdf',
+      },
+    ],
+    content: 'fake content',
+  },
+  {
+    id: 'rrrrr',
+    safeName: 'rrrrr',
+    bot_name: '7777777',
+    expiry: '3024-07-26T12:05:48.08241Z',
+    roles: ['Bot', 'Node'],
+    isStatic: false,
+    method: 'iam',
+    allow: [
+      {
+        aws_account: '445555444',
+      },
+    ],
+    content: 'fake content',
+  },
+];

--- a/web/packages/teleport/src/JoinTokens/UpsertJoinTokenDialog.tsx
+++ b/web/packages/teleport/src/JoinTokens/UpsertJoinTokenDialog.tsx
@@ -1,0 +1,367 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState } from 'react';
+
+import {
+  Flex,
+  Text,
+  Box,
+  ButtonIcon,
+  ButtonText,
+  ButtonPrimary,
+  ButtonSecondary,
+  Alert,
+} from 'design';
+import styled from 'styled-components';
+import { HoverTooltip } from 'shared/components/ToolTip';
+import { Cross } from 'design/Icon';
+import Validation from 'shared/components/Validation';
+import FieldInput from 'shared/components/FieldInput';
+import { requiredField } from 'shared/components/Validation/rules';
+import { FieldSelect } from 'shared/components/FieldSelect';
+import { Option } from 'shared/components/Select';
+import { useAsync } from 'shared/hooks/useAsync';
+
+import { useTeleport } from 'teleport';
+import {
+  AWSRules,
+  CreateJoinTokenRequest,
+  JoinMethod,
+  JoinRole,
+  JoinToken,
+} from 'teleport/services/joinToken';
+
+import { JoinTokenGCPForm, JoinTokenIAMForm } from './JoinTokenForms';
+
+const maxWidth = '550px';
+
+const joinRoleOptions: OptionJoinRole[] = [
+  'App',
+  'Node',
+  'Db',
+  'Kube',
+  'Bot',
+  'WindowsDesktop',
+  'Discovery',
+].map(role => ({ value: role as JoinRole, label: role as JoinRole }));
+
+const availableJoinMethods: OptionJoinMethod[] = ['iam', 'gcp'].map(method => ({
+  value: method as JoinMethod,
+  label: method as JoinMethod,
+}));
+
+export type OptionGCP = Option<string, string>;
+type OptionJoinMethod = Option<JoinMethod, JoinMethod>;
+type OptionJoinRole = Option<JoinRole, JoinRole>;
+type NewJoinTokenGCPState = {
+  project_ids: OptionGCP[];
+  service_accounts: OptionGCP[];
+  locations: OptionGCP[];
+};
+
+export type NewJoinTokenState = {
+  name: string;
+  // bot_name is only required when Bot is selected in the roles
+  bot_name?: string;
+  method: OptionJoinMethod;
+  roles: OptionJoinRole[];
+  iam: AWSRules[];
+  gcp: NewJoinTokenGCPState[];
+};
+
+export const defaultNewTokenState: NewJoinTokenState = {
+  name: '',
+  bot_name: '',
+  method: { value: 'iam', label: 'iam' },
+  roles: [],
+  iam: [{ aws_account: '', aws_arn: '' }],
+  gcp: [{ project_ids: [], service_accounts: [], locations: [] }],
+};
+
+function makeDefaultEditState(token: JoinToken): NewJoinTokenState {
+  return {
+    name: token.id,
+    bot_name: token.bot_name,
+    method: {
+      value: token.method,
+      label: token.method,
+    } as OptionJoinMethod,
+    roles: token.roles.map(r => ({ value: r, label: r })) as OptionJoinRole[],
+    iam: token.allow,
+    gcp: token.gcp?.allow.map(r => ({
+      project_ids: r.project_ids?.map(i => ({ value: i, label: i })),
+      service_accounts: r.service_accounts?.map(i => ({ value: i, label: i })),
+      locations: r.locations?.map(i => ({ value: i, label: i })),
+    })),
+  };
+}
+
+export const UpsertJoinTokenDialog = ({
+  onClose,
+  updateTokenList,
+  editToken,
+  editTokenWithYAML,
+}: {
+  onClose(): void;
+  updateTokenList: (token: JoinToken) => void;
+  editToken?: JoinToken;
+  editTokenWithYAML: (tokenId: string) => void;
+}) => {
+  const ctx = useTeleport();
+  const [newTokenState, setNewTokenState] = useState<NewJoinTokenState>(
+    editToken ? makeDefaultEditState(editToken) : defaultNewTokenState
+  );
+
+  const [createTokenAttempt, runCreateTokenAttempt] = useAsync(
+    async (req: CreateJoinTokenRequest) => {
+      const token = await ctx.joinTokenService.createJoinToken(req);
+      updateTokenList(token);
+      onClose();
+    }
+  );
+
+  function reset(validator) {
+    validator.reset();
+    setNewTokenState(defaultNewTokenState);
+  }
+
+  async function save(validator) {
+    if (!validator.validate()) {
+      return;
+    }
+
+    const request: CreateJoinTokenRequest = {
+      name: newTokenState.name,
+      roles: newTokenState.roles.map(r => r.value),
+      join_method: newTokenState.method.value,
+    };
+
+    if (newTokenState.method.value === 'iam') {
+      request.allow = newTokenState.iam;
+    }
+
+    if (request.roles.includes('Bot')) {
+      request.bot_name = newTokenState.bot_name;
+    }
+
+    if (newTokenState.method.value === 'gcp') {
+      const gcp = {
+        allow: newTokenState.gcp.map(rule => ({
+          project_ids: rule.project_ids?.map(id => id.value),
+          locations: rule.locations?.map(loc => loc.value),
+          service_accounts: rule.service_accounts?.map(
+            account => account.value
+          ),
+        })),
+      };
+      request.gcp = gcp;
+    }
+
+    runCreateTokenAttempt(request);
+  }
+
+  function setTokenRoles(roles: OptionJoinRole[]) {
+    setNewTokenState(prevState => ({
+      ...prevState,
+      roles: roles || [],
+    }));
+  }
+
+  function setTokenMethod(method: OptionJoinMethod) {
+    // set the method and reset the token rules per type for a fresh form
+    setNewTokenState(prevState => ({
+      ...prevState,
+      method,
+      iam: [{ aws_account: '', aws_arn: '' }], // default
+    }));
+  }
+
+  function setTokenField(fieldName: string, value: string) {
+    setNewTokenState(prevState => ({
+      ...prevState,
+      [fieldName]: value,
+    }));
+  }
+
+  return (
+    <Flex width="500px">
+      <Box
+        pr={4}
+        pl={4}
+        css={`
+          overflow: auto;
+          width: 100%;
+          min-height: 50vh;
+          padding-bottom: 0;
+        `}
+      >
+        <Flex
+          alignItems="center"
+          mb={3}
+          justifyContent="space-between"
+          maxWidth={maxWidth}
+        >
+          <Flex alignItems="center" mr={3}>
+            <HoverTooltip tipContent="Back to Join Tokens">
+              <ButtonIcon onClick={onClose} mr={2} ml={'-8px'}>
+                <Cross size="medium" />
+              </ButtonIcon>
+            </HoverTooltip>
+            <Text typography="h3" fontWeight={400}>
+              {editToken ? `Edit Token` : 'Create a New Join Token'}
+            </Text>
+          </Flex>
+          {editToken && (
+            <ButtonText
+              p={2}
+              onClick={() => {
+                onClose();
+                editTokenWithYAML(editToken.id);
+              }}
+            >
+              <Text color="buttons.link.default">Use YAML editor</Text>
+            </ButtonText>
+          )}
+        </Flex>
+        <Validation>
+          {({ validator }) => (
+            <Box maxWidth={maxWidth}>
+              {createTokenAttempt.status === 'error' && (
+                <Alert kind="danger">{createTokenAttempt.statusText}</Alert>
+              )}
+              {!editToken && ( // We only want to change the method when creating a new token
+                <FieldSelect
+                  label="Method"
+                  rule={requiredField('Select a join method')}
+                  isSearchable
+                  isSimpleValue
+                  isClearable={false}
+                  value={newTokenState.method}
+                  onChange={setTokenMethod}
+                  options={availableJoinMethods}
+                />
+              )}
+              {newTokenState.method.value !== 'token' && ( // if the method is token, we generate the name for them on the backend
+                <FieldInput
+                  label="Token name"
+                  data-testid="name_field"
+                  toolTipContent={
+                    editToken ? 'Editing token names is not supported.' : ''
+                  }
+                  rule={requiredField('Token name is required')}
+                  placeholder={
+                    newTokenState.method.value === 'iam'
+                      ? 'iam-token-name'
+                      : 'gcp-token-name'
+                  }
+                  autoFocus
+                  value={newTokenState.name}
+                  onChange={e => setTokenField('name', e.target.value)}
+                  readonly={!!editToken}
+                />
+              )}
+              <FieldSelect
+                label="Join Roles"
+                data-testid="role_select"
+                rule={requiredField('At least one role is required')}
+                placeholder="Click to select roles"
+                isSearchable
+                isMulti
+                isSimpleValue
+                mb={5}
+                isClearable={false}
+                value={newTokenState.roles}
+                onChange={setTokenRoles}
+                options={joinRoleOptions}
+              />
+              {newTokenState.roles.some(i => i.value === 'Bot') && ( // if Bot is included, we must get a bot name as well
+                <FieldInput
+                  label="Bot name"
+                  toolTipContent="Bot names are required when the Bot role is selected"
+                  rule={requiredField('Bot name is required')}
+                  placeholder="Enter bot name"
+                  value={newTokenState.bot_name}
+                  onChange={e => setTokenField('bot_name', e.target.value)}
+                />
+              )}
+              {newTokenState.method.value === 'iam' && (
+                <JoinTokenIAMForm
+                  tokenState={newTokenState}
+                  onUpdateState={newState => setNewTokenState(newState)}
+                />
+              )}
+              {newTokenState.method.value === 'gcp' && (
+                <JoinTokenGCPForm
+                  tokenState={newTokenState}
+                  onUpdateState={newState => setNewTokenState(newState)}
+                />
+              )}
+              <Flex
+                mt={4}
+                py={4}
+                gap={2}
+                css={`
+                  position: sticky;
+                  bottom: 0;
+                  background: ${({ theme }) => theme.colors.levels.sunken};
+                  border-top: 1px solid
+                    ${props => props.theme.colors.spotBackground[1]};
+                `}
+              >
+                <ButtonPrimary
+                  width="100%"
+                  size="large"
+                  textTransform="none"
+                  onClick={() => save(validator)}
+                  disabled={createTokenAttempt.status === 'processing'}
+                >
+                  {editToken ? 'Edit' : 'Create'} Join Token
+                </ButtonPrimary>
+                <ButtonSecondary
+                  width="100%"
+                  textTransform="none"
+                  size="large"
+                  onClick={() => {
+                    reset(validator);
+                    onClose();
+                  }}
+                  disabled={false}
+                >
+                  Cancel
+                </ButtonSecondary>
+              </Flex>
+            </Box>
+          )}
+        </Validation>
+      </Box>
+    </Flex>
+  );
+};
+
+export const RuleBox = styled(Box)`
+  border-color: ${props =>
+    props.theme.colors.interactive.tonal.neutral[0].background};
+  border-width: 2px;
+  border-style: solid;
+  border-radius: ${props => props.theme.radii[2]}px;
+
+  margin-bottom: ${props => props.theme.space[3]}px;
+
+  padding: ${props => props.theme.space[3]}px;
+`;

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -263,7 +263,7 @@ const cfg = {
     connectMyComputerLoginsPath: '/v1/webapi/connectmycomputer/logins',
 
     joinTokenPath: '/v1/webapi/token',
-    joinTokenYamlPath: '/v1/webapi/token/yaml',
+    joinTokenYamlPath: '/v1/webapi/tokens/yaml',
     joinTokensPath: '/v1/webapi/tokens',
     dbScriptPath: '/scripts/:token/install-database.sh',
     nodeScriptPath: '/scripts/:token/install-node.sh',

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -25,6 +25,7 @@ import {
   ClipboardUser,
   Cluster,
   Integrations as IntegrationsIcon,
+  Key,
   Laptop,
   ListAddCheck,
   ListThin,
@@ -125,6 +126,16 @@ export class FeatureNodes implements TeleportFeature {
 // TODO (avatus) add navigationItem when ready to release
 export class FeatureJoinTokens implements TeleportFeature {
   category = NavigationCategory.Management;
+  section = ManagementSection.Access;
+  navigationItem = {
+    title: NavTitle.JoinTokens,
+    icon: Key,
+    exact: true,
+    getLink() {
+      return cfg.getJoinTokensRoute();
+    },
+  };
+
   route = {
     title: NavTitle.JoinTokens,
     path: cfg.routes.joinTokens,

--- a/web/packages/teleport/src/services/api/api.test.ts
+++ b/web/packages/teleport/src/services/api/api.test.ts
@@ -120,6 +120,31 @@ describe('api.fetch', () => {
       },
     });
   });
+
+  const customContentType = {
+    ...customOpts,
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'multipart/form-data',
+    },
+  };
+
+  test('with customOptions including custom content-type', async () => {
+    await api.fetch('/something', customContentType, null);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+
+    const firstCall = mockedFetch.mock.calls[0];
+    const [, actualRequestOptions] = firstCall;
+
+    expect(actualRequestOptions).toStrictEqual({
+      ...defaultRequestOptions,
+      ...customOpts,
+      headers: {
+        ...customContentType.headers,
+        ...getAuthHeaders(),
+      },
+    });
+  });
 });
 
 // The code below should guard us from changes to api.fetchJson which would cause it to lose type

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -77,12 +77,21 @@ const api = {
     );
   },
 
-  deleteWithHeaders(url, headers?: Record<string, string>, signal?) {
-    return api.fetch(url, {
-      method: 'DELETE',
-      headers,
-      signal,
-    });
+  deleteWithHeaders(
+    url,
+    headers?: Record<string, string>,
+    signal?,
+    webauthnResponse?: WebauthnAssertionResponse
+  ) {
+    return api.fetchJsonWithMfaAuthnRetry(
+      url,
+      {
+        method: 'DELETE',
+        headers,
+        signal,
+      },
+      webauthnResponse
+    );
   },
 
   // TODO (avatus) add abort signal to this
@@ -92,6 +101,23 @@ const api = {
       {
         body: JSON.stringify(data),
         method: 'PUT',
+      },
+      webauthnResponse
+    );
+  },
+
+  putWithHeaders(
+    url,
+    data,
+    headers?: Record<string, string>,
+    webauthnResponse?: WebauthnAssertionResponse
+  ) {
+    return api.fetchJsonWithMfaAuthnRetry(
+      url,
+      {
+        body: JSON.stringify(data),
+        method: 'PUT',
+        headers,
       },
       webauthnResponse
     );

--- a/web/packages/teleport/src/services/joinToken/types.ts
+++ b/web/packages/teleport/src/services/joinToken/types.ts
@@ -24,6 +24,8 @@ export type JoinToken = {
   // the first 16 chars will be * and the rest of the token's chars will be visible
   // ex. ****************asdf1234
   safeName: string;
+  // bot_name is present on tokens with Bot in their join roles
+  bot_name?: string;
   isStatic: boolean;
   // the join method of the token
   method: string;
@@ -41,6 +43,10 @@ export type JoinToken = {
   internalResourceId?: string;
   // yaml content of the resource
   content: string;
+  allow?: AWSRules[];
+  gcp?: {
+    allow: GCPRules[];
+  };
 };
 
 // JoinRole defines built-in system roles and are roles associated with
@@ -50,6 +56,7 @@ export type JoinToken = {
 // - 'Db' is a role for a database proxy in the cluster
 // - 'Kube' is a role for a kube service
 // - 'Node' is a role for a node in the cluster
+// - 'Bot' for MachineID (when set, "spec.bot_name" must be set in the token)
 // - 'WindowsDesktop' is a role for a windows desktop service.
 // - 'Discovery' is a role for a discovery service.
 export type JoinRole =
@@ -57,6 +64,7 @@ export type JoinRole =
   | 'Node'
   | 'Db'
   | 'Kube'
+  | 'Bot'
   | 'WindowsDesktop'
   | 'Discovery';
 
@@ -82,6 +90,37 @@ export type JoinRule = {
   awsAccountId: string;
   // awsArn is used for the IAM join method.
   awsArn?: string;
+  regions?: string[];
+};
+
+export type AWSRules = {
+  aws_account: string; // naming kept consistent with backend spec
+  aws_arn?: string;
+};
+
+export type GCPRules = {
+  project_ids: string[];
+  locations: string[];
+  service_accounts: string[];
+};
+
+export type JoinTokenRulesObject = AWSRules | GCPRules;
+
+export type CreateJoinTokenRequest = {
+  name: string;
+  // roles is a list of join roles, since there can be more than
+  // one role associated with a token.
+  roles: JoinRole[];
+  // bot_name only needs to be specified if "Bot" is in the selected roles.
+  // otherwise, it is ignored
+  bot_name?: string;
+  join_method: JoinMethod;
+  // rules is a list of allow rules associated with the join token
+  // and the node using this token must match one of the rules.
+  allow?: JoinTokenRulesObject[];
+  gcp?: {
+    allow: GCPRules[];
+  };
 };
 
 export type JoinTokenRequest = {


### PR DESCRIPTION
This adds the create tokens forms to our Join Tokens UI. The forms only support IAM, GCP and tokens for now (preferred) and allow a yaml editor for other types. You can also edit IAM and GCP and "token" in yaml if you wish but its purposefully kinda "hidden".

This adds the feature to the navigation under "Join Tokens". 

closes https://github.com/gravitational/teleport/issues/31671

