### PR TITLE
Get PROXY protocol guide to match the style guide

### DIFF
--- a/docs/pages/admin-guides/management/security/proxy-protocol.mdx
+++ b/docs/pages/admin-guides/management/security/proxy-protocol.mdx
@@ -1,6 +1,6 @@
 ---
-title: Run Teleport Behind a Layer 4 Load Balancer
-description: Describes how to securely configure Teleport to use the PROXY protocol so you can run the Auth Service and Proxy Service behind a layer 4 load balancer.
+title: Run Teleport with the PROXY Protocol
+description: How to securely configure PROXY protocol usage with Teleport.
 ---
 
 This guide shows you how to configure the Teleport Auth Service and Proxy
@@ -43,14 +43,14 @@ PROXY TCP4 127.0.0.1 127.0.0.2 12345 42\r\n
 - A self-hosted Teleport Enterprise account. If you want to get started with
   self-hosted Teleport Enterprise, [contact
   Sales](https://goteleport.com/contact-us/). You can also [set up a demo
-  environment](../index.mdx) with Teleport Community Edition.
+  environment](../../deploy-a-cluster/linux-demo.mdx) with Teleport Community Edition.
 
   We recommend reading and understanding this guide completely before
   configuring your Teleport cluster to use the PROXY protocol.
 
 - The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
 
-  Visit [Installation](../installation.mdx) for instructions on downloading
+  Visit [Installation](../../../installation.mdx) for instructions on downloading
   `tctl` and `tsh`.
 
 ## Step 1/2. Plan your Teleport deployment

--- a/docs/pages/admin-guides/management/security/proxy-protocol.mdx
+++ b/docs/pages/admin-guides/management/security/proxy-protocol.mdx
@@ -1,88 +1,134 @@
 ---
-title: PROXY protocol
-description: How to securely configure PROXY protocol usage with Teleport
+title: Run Teleport Behind a Layer 4 Load Balancer
+description: Describes how to securely configure Teleport to use the PROXY protocol so you can run the Auth Service and Proxy Service behind a layer 4 load balancer.
 ---
-<Admonition type="note" scope={["cloud", "team"]}>
-Users of Teleport Cloud don't need to manage PROXY protocol setting manually. It's set to `on` automatically 
-and can't be changed, since cloud Proxy/Auth services managed by Teleport run behind a L4 load balancer with PROXY protocol configured. 
-</Admonition>
 
-## What is PROXY protocol
+This guide shows you how to configure the Teleport Auth Service and Proxy
+Service to run behind a layer 4 (l4) load balancer. 
 
-The PROXY protocol is a prefix added to the TCP connection containing information about the client IP. 
-It is most commonly used when networking setup includes a Layer 4 (L4) load balancer between the user and the endpoint service,
-like Teleport Proxy/Auth.
-L4 load balancers, by design, do not retain the original client's IP address and port when forwarding the connection and 
-PROXY protocol allows to overcome this problem by adding the client's original IP address and port before the actual TCP stream.
+In this setup, the Auth Service and Proxy Service rely on the PROXY protocol to
+retrieve the IP addresses of clients when behind an L4 load balancer. Having
+reliable client IP information is important from a security standpoint,
+because features like audit logging and IP pinning depend on it. If the PROXY
+protocol is not configured correctly, these features will be compromised.
 
-An example of the PROXYv1 protocol header:
+<Notice type="note">
+
+Users of Teleport Enterprise (Cloud) do not need to manage PROXY protocol
+setting. Teleport-managed Auth Service and Proxy Service deployments run behind
+an L4 load balancer with the PROXY protocol configured. 
+
+</Notice>
+
+## How it works
+
+The PROXY protocol adds a prefix to a TCP connection containing information
+about the client IP. It is most commonly used when a network includes an L4 load
+balancer between the user and the endpoint service, like the Teleport Auth
+Service and Proxy Service. 
+
+L4 load balancers, by design, do not retain the original client's IP address and
+port when forwarding the connection and the PROXY protocol allows systems to
+overcome this problem by adding the client's original IP address and port before
+the TCP stream.
+
+Here is an example of the PROXYv1 protocol header:
 
 ```text
 PROXY TCP4 127.0.0.1 127.0.0.2 12345 42\r\n
 ```
 
-## Security
+## Prerequisites
 
-Misconfiguration of the PROXY protocol behavior can lead to security problems. Since the PROXY protocol lacks built-in authentication, 
-a malicious attacker could send falsified custom PROXY protocol headers to spoof their IP address. To prevent this, you must 
-explicitly configure PROXY protocol settings according to your network setup - if you don't run Teleport behind a L4 load balancer, that
-send PROXY headers, you **must** disable PROXY protocol support on Teleport.
+- A self-hosted Teleport Enterprise account. If you want to get started with
+  self-hosted Teleport Enterprise, [contact
+  Sales](https://goteleport.com/contact-us/). You can also [set up a demo
+  environment](../index.mdx) with Teleport Community Edition.
 
-## Configuring PROXY protocol for Teleport
+  We recommend reading and understanding this guide completely before
+  configuring your Teleport cluster to use the PROXY protocol.
 
-Teleport Proxy/Auth relies on PROXY protocol to get the client's real IP address when behind a L4 load balancer. Having reliable
-client IP information is important from the security standpoint, because such features as audit logging and IP pinning depend on it and
-if PROXY protocol is not configured correctly, these features will be compromised.
+- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
 
-Usage of PROXY protocol in Teleport is controlled by `proxy_protocol` setting in the configuration for both 
-`proxy_service` and `auth_service` sections separately.
+  Visit [Installation](../installation.mdx) for instructions on downloading
+  `tctl` and `tsh`.
 
-By default in a new installation of Teleport `proxy_protocol` is unspecified, users can manually set `proxy_protocol` to
-`on` or `off`:
-- `on`: PROXY Protocol is enabled and mandatory. If a PROXY
-  protocol header is received, Teleport will parse the header and extract the client's IP
-  address and port. If the header isn't present, it will reject the connection with an error.
-- `off`: PROXY Protocol is disabled and forbidden. Any connection with a PROXY protocol header is automatically rejected.
+## Step 1/2. Plan your Teleport deployment
 
-Users are encouraged to explicitly set their `proxy_protocol` setting to `on` or `off` mode
-depending on the network setup. **Default unspecified value mode is not suitable for production**, it is only 
-suitable for test environments. If `proxy_protocol` is unspecified Teleport does not require PROXY header for the connection, but will 
-parse it if present, client's source IP address will be replaced with the one from PROXY header and this address will appear in
-the audit events. Incoming connections with PROXY header will also be marked by setting source port to `0` and this will be visible 
-in the audit events as well.
+Misconfiguration of the PROXY protocol behavior can lead to security problems.
+Since the PROXY protocol lacks built-in authentication, a malicious attacker
+could send falsified custom PROXY protocol headers to spoof their IP address. To
+prevent this, you must explicitly configure PROXY protocol settings according to
+your network setup:
 
-<Admonition type="warning">
+1. Determine which Auth Service and Proxy Service instances should enable the
+   PROXY protocol. PROXY protocol behavior is controlled separately for the Auth
+   Service and Proxy Service. 
 
-IP pinning will not work if `proxy_protocol` setting wasn't explicitly set in the config. Connections that are marked 
-with source port = 0 will be rejected during IP pinning checks.
+   If there's a PROXY-enabled L4 load balancer between your Proxy Service and
+   Auth Service instances, you should enable the PROXY protocol on the Auth
+   Service. Otherwise, you can disable it.
 
-</Admonition>
+   Teleport Proxy Service instances can also have different PROXY protocol
+   settings. If you run a subset of Proxy Service instances behind an L4 load
+   balancer, you can enable the PROXY protocol for only those instances.
 
-Main rule for configuring `proxy_protocol` setting - **If Teleport is running behind a L4 load balancer, that is set to 
-send PROXY protocol headers, you should set `proxy_protocol: on`**.
+1. Make sure that any Auth Service or Proxy Service instances that you run with
+   PROXY protocol support are only accessible through an L4 load balancer. This
+   prevents attackers from spoofing their IP addresses and bypassing IP pinning
+   restrictions by connecting directly and sending a custom PROXY header.
+   Teleport only allows one PROXY protocol header for an incoming connection -
+   it will reject requests that include multiple PROXY lines to prevent attacks.
+
+1. If you don't run Teleport behind an L4 load balancer that sends PROXY
+   headers, you **must** disable PROXY protocol support on the Auth Service and
+   Proxy Service. Running Teleport behind an L4 load balancer that doesn't send
+   PROXY protocol headers will lead to all incoming connections seemingly coming
+   from the same IP address from Teleport's point of view, compromising the
+   Teleport audit log and IP pinning feature.
+
+## Step 2/2. Edit your static Teleport configuration
+
+On a Teleport process, the Auth Service and Proxy Service can each support the
+PROXY protocol for its own communications with clients. To enable or disable the
+PROXY protocol, each service reads the `proxy_protocol` field in its section of
+the Teleport configuration file:
 
 ```yaml
 proxy_service:
-  proxy_protocol: on
+  proxy_protocol: on | off
+  # ...
+auth_service:
+  proxy_protocol: on | off
 ```
 
-Otherwise you should set `proxy_protocol: off`
+By default,  `proxy_protocol` is unspecified. Users can manually set
+`proxy_protocol` to `on` or `off`:
+- `on`: the PROXY protocol is enabled and mandatory. If a PROXY protocol header
+  is received, the Teleport service will parse the header and extract the
+  client's IP address and port. If the header isn't present, the Teleport
+  service will reject the connection with an error.
+- `off`: the PROXY protocol is disabled and forbidden. Any connection with a
+  PROXY protocol header is automatically rejected.
 
-```yaml
-proxy_service:
-  proxy_protocol: off
-```
+We encourage users to explicitly set their `proxy_protocol` setting to `on` or
+`off` mode depending on the network setup. 
 
-You should make sure that Teleport is only accessible through the load balancer if you run it with `proxy_protocol: on`, so malicious 
-attackers can't spoof their IP address or bypass IP Pinning restrictions by connecting directly and sending a custom PROXY header.
-Teleport only allows one PROXY protocol header for an incoming connection - it will reject requests that include multiple PROXY lines to prevent attacks when `proxy_protocol: on`.
+If `proxy_protocol` is unspecified, the associated Teleport service does not
+require the PROXY header for the connection, but will parse it if present, and
+replace the client's source IP address with the one from the PROXY header. This
+address will appear in audit events. Incoming connections with the PROXY header
+will also be marked by setting source port to `0`, and this will be visible in
+audit events as well.
 
-PROXY protocol behavior is controlled separately for Auth service and Proxy service. So you should ensure both have the correct 
-setting. If there's a PROXY-enabled L4 load balancer between your Proxy and Auth services, you should set `proxy_protocol: on` on the Auth,
-otherwise set it to `off`.
+IP pinning will not work if `proxy_protocol` setting wasn't explicitly set in
+the config. Connections that are marked with `0` as the source port will be
+rejected during IP pinning checks.
 
-You can also have Teleport Proxies have different PROXY protocol settings, if you run some of them behind a load balancer and some not, for
-example if you have dedicated Proxies for private and public networks.
+<Notice type="danger">
 
-Running Teleport behind a L4 load balancer that doesn't send PROXY protocol headers will lead to all incoming connections seemingly
-coming from the same IP address from Teleport's point of view, making the audit trail less useful and the IP pinning feature not helpful.
+The default unspecified value mode is not suitable for production. It is only
+suitable for test environments. 
+
+</Notice>
+


### PR DESCRIPTION
Closes #32168

Format the guide as a how-to guide (rather than a reference or architectural guide). This is appropriate, since the guide is a detailed look at a single configuration option that requires some architectural planning for users can enable it.

Also add an introductory section that describes the scope of the guide, and make various edits for readability and consistency with the rest of the docs site.