### PR TITLE
Fix redirect checker

### DIFF
--- a/docs/check-redirects/check-redirects.test.js
+++ b/docs/check-redirects/check-redirects.test.js
@@ -24,6 +24,8 @@ This is a link to a [documentation page](https://goteleport.com/docs/subdirector
 
 Here is a link to a [missing page](https://goteleport.com/docs/page3).
 
+Here is a link to a [missing page](https://goteleport.com/docs/page3).
+
 `,
     '/docs/content/1.x/docs/pages/page1.mdx': `---
 title: "Sample Page 1"
@@ -71,8 +73,80 @@ title: "Desktop Access Getting Started"
     const fs = createFsFromVolume(vol);
     const checker = new RedirectChecker(fs, '/blog', '/docs/content/1.x', [
       {
-        source: '/docs/page3/',
-        destination: '/docs/page1',
+        source: '/page3/',
+        destination: '/page1/',
+        permanent: true,
+      },
+    ]);
+    const results = checker.check();
+    expect(results).toEqual([]);
+  });
+
+  test(`allows missing docs pages for links with fragments if there is a redirect`, () => {
+    const vol = Volume.fromJSON({
+      '/blog/content2.mdx': `---
+title: "Sample Page 2"
+---
+
+Here is a link to a [missing page](https://goteleport.com/docs/page3/#my-fragment).
+
+`,
+      '/docs/content/1.x/docs/pages/page1.mdx': `---
+title: "Sample Page 1"
+---
+`,
+    });
+    const fs = createFsFromVolume(vol);
+    const checker = new RedirectChecker(fs, '/blog', '/docs/content/1.x', [
+      {
+        source: '/page3/',
+        destination: '/page1/',
+        permanent: true,
+      },
+    ]);
+    const results = checker.check();
+    expect(results).toEqual([]);
+  });
+
+  test(`catches missing redirects for URLs with query strings`, () => {
+    const vol = Volume.fromJSON({
+      '/blog/content2.mdx': `---
+title: "Sample Page 2"
+---
+
+Here is a link to a [missing page](https://goteleport.com/docs/access-controls/device-trust/guide/?scope=enterprise#step-12-register-a-trusted-device").
+
+`,
+      '/docs/content/1.x/docs/pages/page1.mdx': `---
+title: "Sample Page 1"
+---
+`,
+    });
+    const fs = createFsFromVolume(vol);
+    const checker = new RedirectChecker(fs, '/blog', '/docs/content/1.x', []);
+    const results = checker.check();
+    expect(results).toEqual(['https://goteleport.com/docs/access-controls/device-trust/guide/']);
+  });
+
+  test(`allows a docs URL with a query string if there is a redirect`, () => {
+    const vol = Volume.fromJSON({
+      '/blog/content2.mdx': `---
+title: "Sample Page 2"
+---
+
+Here is a link to a [missing page](https://goteleport.com/docs/access-controls/device-trust/guide/?scope=enterprise#step-12-register-a-trusted-device").
+
+`,
+      '/docs/content/1.x/docs/pages/page1.mdx': `---
+title: "Sample Page 1"
+---
+`,
+    });
+    const fs = createFsFromVolume(vol);
+    const checker = new RedirectChecker(fs, '/blog', '/docs/content/1.x', [
+      {
+        source: '/access-controls/device-trust/guide/',
+        destination: '/access-controls/device-trust/',
         permanent: true,
       },
     ]);


### PR DESCRIPTION
The checker assumed that values of the `source` field in each redirect configuration begin with `/docs/`, but they do not. Remove `/docs/` from docs site URLs in the target directory before checking them against configured redirects.

Fix an issue with the first item in the output of the program always being `undefined` by correctly concatenating the result arrays.

Finally, fix a bug in which the checker would not accept redirects for docs URLs with fragments.