### PR TITLE
fix panic during audit upload

### DIFF
--- a/api/client/auditstreamer.go
+++ b/api/client/auditstreamer.go
@@ -153,8 +153,8 @@ func (s *auditStreamer) recv() {
 }
 
 func (s *auditStreamer) closeWithError(err error) {
-	s.cancel()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.err = err
+	s.cancel()
 }

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -534,7 +534,9 @@ func (u *Uploader) upload(ctx context.Context, up *upload) error {
 		return trace.Errorf("operation has been canceled, uploader is closed")
 	case <-stream.Done():
 		if errStream, ok := stream.(interface{ Error() error }); ok {
-			return trace.ConnectionProblem(errStream.Error(), errStream.Error().Error())
+			if err := errStream.Error(); err != nil {
+				return trace.ConnectionProblem(err, err.Error())
+			}
 		}
 
 		return trace.ConnectionProblem(nil, "upload stream terminated unexpectedly")


### PR DESCRIPTION
Fixes a pair of related issues that could lead to a panic during audit event uploads:
- Improper error handling in `filesessions/fileasync.go` would cause a nil pointer deref if a stream's `Error()` method returned a `nil` error.
- A race condition in `client/auditstreamer.go` would sometimes cause users of a stream to spuriously observe a `nil` error because their calls to the `Error()` method would race with the error itself being set.  This race condition seems to only emerge in contexts where agents are severely CPU-constrained, which is likely how it's managed to persist this long.

changelog: fix a low-probability panic in audit event upload logic.