### PR TITLE
[v14] fix panic during audit upload

### DIFF
--- a/api/client/auditstreamer.go
+++ b/api/client/auditstreamer.go
@@ -153,8 +153,8 @@ func (s *auditStreamer) recv() {
 }
 
 func (s *auditStreamer) closeWithError(err error) {
-	s.cancel()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.err = err
+	s.cancel()
 }

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -532,7 +532,9 @@ func (u *Uploader) upload(ctx context.Context, up *upload) error {
 		return trace.Errorf("operation has been canceled, uploader is closed")
 	case <-stream.Done():
 		if errStream, ok := stream.(interface{ Error() error }); ok {
-			return trace.ConnectionProblem(errStream.Error(), errStream.Error().Error())
+			if err := errStream.Error(); err != nil {
+				return trace.ConnectionProblem(err, err.Error())
+			}
 		}
 
 		return trace.ConnectionProblem(nil, "upload stream terminated unexpectedly")


### PR DESCRIPTION
Backport #44422 to branch/v14

changelog: Fixed a low-probability panic in audit event upload logic.
