### PR TITLE
update generic SAML Application discover tile name

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
@@ -25,7 +25,7 @@ import { ResourceSpec } from './types';
 
 export const SAML_APPLICATIONS: ResourceSpec[] = [
   {
-    name: 'SAML Application',
+    name: 'SAML Application (Generic)',
     kind: ResourceKind.SamlApplication,
     samlMeta: { preset: SamlServiceProviderPreset.Unspecified },
     keywords: 'saml sso application idp',


### PR DESCRIPTION
Updates SAML discover tile name "SAML Application" to "SAML Application (Generic)". 

I had to update it now so the tile can be tested in the Discover flow. It is also visually meaningful.