### PR TITLE
Add `packageManager` field on branch/v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,6 @@
       "web/packages/*",
       "e/web/*"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
pnpm won't be backport to v15, so we need to specify the correct manger here.