### PR TITLE
Add `packageManager` field on branch/v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,6 @@
       "web/packages/*",
       "e/web/*"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
pnpm won't be backport to v14, so we need to specify the correct manger here.