### PR TITLE
Check if binary exists before passing it to node-pty

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,9 @@ importers:
       '@grpc/grpc-js':
         specifier: 1.10.10
         version: 1.10.10
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
       node-forge:
         specifier: ^1.3.1
         version: 1.3.1
@@ -2760,6 +2763,9 @@ packages:
 
   '@types/whatwg-url@11.0.5':
     resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
+
+  '@types/which@3.0.4':
+    resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
 
   '@types/wicg-file-system-access@2023.10.5':
     resolution: {integrity: sha512-e9kZO9kCdLqT2h9Tw38oGv9UNzBBWaR1MzuAavxPcsV/7FJ3tWbU6RI3uB+yKIDPGLkGVbplS52ub0AcRLvrhA==}
@@ -11662,6 +11668,8 @@ snapshots:
   '@types/whatwg-url@11.0.5':
     dependencies:
       '@types/webidl-conversions': 7.0.1
+
+  '@types/which@3.0.4': {}
 
   '@types/wicg-file-system-access@2023.10.5': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,9 @@ importers:
       tar-fs:
         specifier: ^3.0.6
         version: 3.0.6
+      which:
+        specifier: ^4.0.0
+        version: 4.0.0
       winston:
         specifier: ^3.13.0
         version: 3.13.0
@@ -5468,6 +5471,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isexe@3.1.1:
+    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
+    engines: {node: '>=16'}
+
   isobject@2.1.0:
     resolution: {integrity: sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==}
     engines: {node: '>=0.10.0'}
@@ -8201,6 +8208,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
     hasBin: true
 
   wide-align@1.1.5:
@@ -15061,6 +15073,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isexe@3.1.1: {}
+
   isobject@2.1.0:
     dependencies:
       isarray: 1.0.0
@@ -18344,6 +18358,10 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  which@4.0.0:
+    dependencies:
+      isexe: 3.1.1
 
   wide-align@1.1.5:
     dependencies:

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://goteleport.com",
   "dependencies": {
     "@grpc/grpc-js": "1.10.10",
+    "@types/which": "^3.0.4",
     "node-forge": "^1.3.1",
     "node-pty": "1.1.0-beta14",
     "ring-buffer-ts": "^1.2.0",

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -30,6 +30,7 @@
     "split2": "4.2.0",
     "strip-ansi": "^7.1.0",
     "tar-fs": "^3.0.6",
+    "which": "^4.0.0",
     "winston": "^3.13.0"
   },
   "devDependencies": {

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyEventsStreamHandler.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyEventsStreamHandler.ts
@@ -112,8 +112,13 @@ export class PtyEventsStreamHandler {
         })
       );
     });
-    this.ptyProcess.start(event.columns, event.rows);
-    this.logger.info(`stream has started`);
+    // PtyProcess.prototype.start always returns a fulfilled promise. If an error is caught during
+    // start, it's reported through PtyProcess.prototype.onStartError. Similarly, the information
+    // about a successful start is also conveyed through an emitted event rather than the method
+    // returning with no error. Hence why we can ignore what this promise returns.
+    void this.ptyProcess.start(event.columns, event.rows).then(() => {
+      this.logger.info(`stream has started`);
+    });
   }
 
   private handleDataEvent(event: PtyEventData): void {

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.test.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import crypto from 'node:crypto';
+
+import Logger, { NullService } from 'teleterm/logger';
+
+import { PtyProcess } from './ptyProcess';
+
+beforeAll(() => {
+  Logger.init(new NullService());
+});
+
+describe('PtyProcess', () => {
+  describe('start', () => {
+    it('emits a start error when attempting to execute a nonexistent command', async () => {
+      const path = `nonexistent-executable-${crypto.randomUUID()}`;
+      const pty = new PtyProcess({
+        path,
+        args: [],
+        env: { PATH: '/foo/bar' },
+        ptyId: '1234',
+      });
+
+      const startErrorCb = jest.fn();
+
+      pty.onStartError(startErrorCb);
+
+      await pty.start(80, 20);
+
+      expect(startErrorCb).toHaveBeenCalledWith(
+        expect.stringContaining(`not found: ${path}`)
+      );
+    });
+  });
+});

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.ts
@@ -16,15 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { readlink } from 'fs';
-
-import { exec } from 'child_process';
-
-import { promisify } from 'util';
-
-import { EventEmitter } from 'events';
+import { readlink } from 'node:fs';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { EventEmitter } from 'node:events';
 
 import * as nodePTY from 'node-pty';
+import which from 'which';
 
 import Logger from 'teleterm/logger';
 
@@ -54,8 +52,18 @@ export class PtyProcess extends EventEmitter implements IPtyProcess {
     return this.options.ptyId;
   }
 
-  start(cols: number, rows: number) {
+  /**
+   * start spawns a new PTY with the arguments given through the constructor.
+   * It emits TermEventEnum.StartError on error. start itself always returns a fulfilled promise.
+   */
+  async start(cols: number, rows: number) {
     try {
+      // which throws an error if the argument is not found in path.
+      // TODO(ravicious): Remove the manual check for the existence of the executable after node-pty
+      // makes its behavior consistent across platforms.
+      // https://github.com/microsoft/node-pty/issues/689
+      await which(this.options.path);
+
       // TODO(ravicious): Set argv0 when node-pty adds support for it.
       // https://github.com/microsoft/node-pty/issues/472
       this._process = nodePTY.spawn(this.options.path, this.options.args, {

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.ts
@@ -30,6 +30,8 @@ import { PtyProcessOptions, IPtyProcess } from './types';
 
 type Status = 'open' | 'not_initialized' | 'terminated';
 
+const pathEnvVar = process.platform === 'win32' ? 'Path' : 'PATH';
+
 export class PtyProcess extends EventEmitter implements IPtyProcess {
   private _buffered = true;
   private _attachedBufferTimer;
@@ -62,7 +64,7 @@ export class PtyProcess extends EventEmitter implements IPtyProcess {
       // TODO(ravicious): Remove the manual check for the existence of the executable after node-pty
       // makes its behavior consistent across platforms.
       // https://github.com/microsoft/node-pty/issues/689
-      await which(this.options.path);
+      await which(this.options.path, { path: this.options.env[pathEnvVar] });
 
       // TODO(ravicious): Set argv0 when node-pty adds support for it.
       // https://github.com/microsoft/node-pty/issues/472


### PR DESCRIPTION
Fixes #44385.

At some point between 0.11.0-beta29 to 1.1.0-beta5, node-pty stopped throwing errors on Linux and macOS if the command to execute doesn't exist (https://github.com/microsoft/node-pty/issues/689). Instead, the PTY simply exits with error code 1.

This PR makes it so that we manually run the equivalent of Go's `os/exec.LookPath` before starting a terminal session. This way we can bubble up the error about a nonexistent command to the UI.

<img width="1280" alt="nonexistent-command" src="https://github.com/user-attachments/assets/88b2c789-06d5-4bfd-9955-564bd848807b">

changelog: Fixed terminal sessions with a database CLI client in Teleport Connect hanging indefinitely if the client cannot be found