### PR TITLE
Add Ownership tags when creating AWS Resources for External Audit Storage

### DIFF
--- a/lib/integrations/awsoidc/create_ec2ice.go
+++ b/lib/integrations/awsoidc/create_ec2ice.go
@@ -26,6 +26,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 )
 
 // CreateEC2ICERequest contains the required fields to create an AWS EC2 Instance Connect Endpoint.
@@ -46,7 +48,7 @@ type CreateEC2ICERequest struct {
 	// - teleport.dev/cluster: <cluster>
 	// - teleport.dev/origin: aws-oidc-integration
 	// - teleport.dev/integration: <integrationName>
-	ResourceCreationTags AWSTags
+	ResourceCreationTags tags.AWSTags
 }
 
 // EC2ICEEndpoint contains the information for a single Endpoint to be created.
@@ -83,7 +85,7 @@ func (req *CreateEC2ICERequest) CheckAndSetDefaults() error {
 	}
 
 	if len(req.ResourceCreationTags) == 0 {
-		req.ResourceCreationTags = defaultResourceCreationTags(req.Cluster, req.IntegrationName)
+		req.ResourceCreationTags = tags.DefaultResourceCreationTags(req.Cluster, req.IntegrationName)
 	}
 
 	return nil

--- a/lib/integrations/awsoidc/create_ec2ice_test.go
+++ b/lib/integrations/awsoidc/create_ec2ice_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 )
 
 type mockCreateEC2ICEClient struct {
@@ -185,7 +187,7 @@ func TestCreateEC2ICERequest(t *testing.T) {
 					SubnetID:         "subnet-123",
 					SecurityGroupIDs: []string{"sg-1", "sg-2"},
 				}},
-				ResourceCreationTags: AWSTags{
+				ResourceCreationTags: tags.AWSTags{
 					"teleport.dev/origin":      "integration_awsoidc",
 					"teleport.dev/cluster":     "teleport-cluster",
 					"teleport.dev/integration": "teleportdev",

--- a/lib/integrations/awsoidc/deploydatabaseservice.go
+++ b/lib/integrations/awsoidc/deploydatabaseservice.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 )
 
 // DeployDatabaseServiceRequest contains the required fields to deploy multiple Teleport Databases Services.
@@ -58,7 +59,7 @@ type DeployDatabaseServiceRequest struct {
 	TeleportVersionTag string
 
 	// ResourceCreationTags is used to add tags when creating resources in AWS.
-	ResourceCreationTags AWSTags
+	ResourceCreationTags tags.AWSTags
 
 	// DeploymentJoinTokenName is the Teleport IAM Join Token name that the deployed service must use to join the cluster.
 	DeploymentJoinTokenName string
@@ -115,7 +116,7 @@ func (r *DeployDatabaseServiceRequest) CheckAndSetDefaults() error {
 	}
 
 	if r.ResourceCreationTags == nil {
-		r.ResourceCreationTags = defaultResourceCreationTags(r.TeleportClusterName, r.IntegrationName)
+		r.ResourceCreationTags = tags.DefaultResourceCreationTags(r.TeleportClusterName, r.IntegrationName)
 	}
 
 	r.ecsClusterName = normalizeECSClusterName(r.TeleportClusterName)

--- a/lib/integrations/awsoidc/deploydatabaseservice_test.go
+++ b/lib/integrations/awsoidc/deploydatabaseservice_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 )
 
 func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
@@ -157,7 +158,7 @@ func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
 				Region:              "r",
 				TaskRoleARN:         "arn",
 				IntegrationName:     "teleportdev",
-				ResourceCreationTags: AWSTags{
+				ResourceCreationTags: tags.AWSTags{
 					"teleport.dev/origin":      "integration_awsoidc",
 					"teleport.dev/cluster":     "mycluster",
 					"teleport.dev/integration": "teleportdev",
@@ -202,7 +203,7 @@ type mockDeployServiceClient struct {
 	iamTokenMissing bool
 
 	iamAccessDeniedListServices bool
-	defaultTags                 AWSTags
+	defaultTags                 tags.AWSTags
 }
 
 // DescribeClusters lists ECS Clusters.

--- a/lib/integrations/awsoidc/deployservice.go
+++ b/lib/integrations/awsoidc/deployservice.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 	"github.com/gravitational/teleport/lib/modules"
 )
 
@@ -141,7 +142,7 @@ type DeployServiceRequest struct {
 	IntegrationName string
 
 	// ResourceCreationTags is used to add tags when creating resources in AWS.
-	ResourceCreationTags AWSTags
+	ResourceCreationTags tags.AWSTags
 
 	// DeploymentMode is the identifier of a deployment mode - which Teleport Services to enable and their configuration.
 	DeploymentMode string
@@ -250,7 +251,7 @@ func (r *DeployServiceRequest) CheckAndSetDefaults() error {
 	}
 
 	if r.ResourceCreationTags == nil {
-		r.ResourceCreationTags = defaultResourceCreationTags(r.TeleportClusterName, r.IntegrationName)
+		r.ResourceCreationTags = tags.DefaultResourceCreationTags(r.TeleportClusterName, r.IntegrationName)
 	}
 
 	if r.TeleportConfigString == "" {
@@ -471,7 +472,7 @@ type upsertTaskRequest struct {
 	ClusterName          string
 	ServiceName          string
 	TeleportVersionTag   string
-	ResourceCreationTags AWSTags
+	ResourceCreationTags tags.AWSTags
 	Region               string
 	TeleportConfigB64    string
 }
@@ -542,7 +543,7 @@ func upsertTask(ctx context.Context, clt DeployServiceClient, req upsertTaskRequ
 // It will re-create if its status is INACTIVE.
 // If the cluster status is not ACTIVE, an error is returned.
 // The cluster is returned.
-func upsertCluster(ctx context.Context, clt DeployServiceClient, clusterName string, resourceCreationTags AWSTags) (*ecsTypes.Cluster, error) {
+func upsertCluster(ctx context.Context, clt DeployServiceClient, clusterName string, resourceCreationTags tags.AWSTags) (*ecsTypes.Cluster, error) {
 	describeClustersResponse, err := clt.DescribeClusters(ctx, &ecs.DescribeClustersInput{
 		Clusters: []string{clusterName},
 		Include: []ecsTypes.ClusterField{
@@ -687,7 +688,7 @@ func deployServiceNetworkConfiguration(subnetIDs, securityGroups []string) *ecsT
 type upsertServiceRequest struct {
 	ServiceName          string
 	ClusterName          string
-	ResourceCreationTags AWSTags
+	ResourceCreationTags tags.AWSTags
 	SubnetIDs            []string
 	SecurityGroups       []string
 }

--- a/lib/integrations/awsoidc/deployservice_iam_config.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config.go
@@ -30,6 +30,7 @@ import (
 
 	awsapiutils "github.com/gravitational/teleport/api/utils/aws"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 	awslibutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
@@ -68,7 +69,7 @@ type DeployServiceIAMConfigureRequest struct {
 	// - teleport.dev/cluster: <cluster>
 	// - teleport.dev/origin: aws-oidc-integration
 	// - teleport.dev/integration: <integrationName>
-	ResourceCreationTags AWSTags
+	ResourceCreationTags tags.AWSTags
 
 	// partitionID is the AWS Partition ID.
 	// Eg, aws, aws-cn, aws-us-gov
@@ -103,7 +104,7 @@ func (r *DeployServiceIAMConfigureRequest) CheckAndSetDefaults() error {
 	}
 
 	if len(r.ResourceCreationTags) == 0 {
-		r.ResourceCreationTags = defaultResourceCreationTags(r.Cluster, r.IntegrationName)
+		r.ResourceCreationTags = tags.DefaultResourceCreationTags(r.Cluster, r.IntegrationName)
 	}
 
 	r.partitionID = awsapiutils.GetPartitionFromRegion(r.Region)

--- a/lib/integrations/awsoidc/deployservice_iam_config_test.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 )
 
 var badParameterCheck = func(t require.TestingT, err error, msgAndArgs ...interface{}) {
@@ -72,7 +74,7 @@ func TestDeployServiceIAMConfigReqDefaults(t *testing.T) {
 				TaskRole:                           "taskrole",
 				partitionID:                        "aws",
 				IntegrationRoleDeployServicePolicy: "DeployService",
-				ResourceCreationTags: AWSTags{
+				ResourceCreationTags: tags.AWSTags{
 					"teleport.dev/cluster":     "mycluster",
 					"teleport.dev/integration": "myintegration",
 					"teleport.dev/origin":      "integration_awsoidc",

--- a/lib/integrations/awsoidc/deployservice_test.go
+++ b/lib/integrations/awsoidc/deployservice_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 )
 
 func TestDeployServiceRequest(t *testing.T) {
@@ -152,7 +153,7 @@ func TestDeployServiceRequest(t *testing.T) {
 				TaskName:                stringPointer("mycluster-teleport-database-service"),
 				DeploymentJoinTokenName: "discover-aws-oidc-iam-token",
 				IntegrationName:         "teleportdev",
-				ResourceCreationTags: AWSTags{
+				ResourceCreationTags: tags.AWSTags{
 					"teleport.dev/origin":      "integration_awsoidc",
 					"teleport.dev/cluster":     "mycluster",
 					"teleport.dev/integration": "teleportdev",

--- a/lib/integrations/awsoidc/deployservice_update.go
+++ b/lib/integrations/awsoidc/deployservice_update.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 )
 
 // waitDuration specifies the amount of time to wait for a service to become healthy after an update.
@@ -44,7 +45,7 @@ type UpdateServiceRequest struct {
 	// TeleportVersionTag specifies the desired teleport version in the format "13.4.0"
 	TeleportVersionTag string
 	// OwnershipTags specifies ownership tags
-	OwnershipTags AWSTags
+	OwnershipTags tags.AWSTags
 }
 
 // CheckAndSetDefaults checks and sets default config values.
@@ -90,7 +91,7 @@ func UpdateDeployService(ctx context.Context, clt DeployServiceClient, log *slog
 	return nil
 }
 
-func updateServiceContainerImage(ctx context.Context, clt DeployServiceClient, log *slog.Logger, service *ecsTypes.Service, teleportImage string, ownershipTags AWSTags) error {
+func updateServiceContainerImage(ctx context.Context, clt DeployServiceClient, log *slog.Logger, service *ecsTypes.Service, teleportImage string, ownershipTags tags.AWSTags) error {
 	taskDefinition, err := getManagedTaskDefinition(ctx, clt, aws.ToString(service.TaskDefinition), ownershipTags)
 	if err != nil {
 		return trace.Wrap(err)
@@ -166,7 +167,7 @@ func getAllServiceNamesForCluster(ctx context.Context, clt DeployServiceClient, 
 	return ret, nil
 }
 
-func getManagedServices(ctx context.Context, clt DeployServiceClient, log *slog.Logger, teleportClusterName string, ownershipTags AWSTags) ([]ecsTypes.Service, error) {
+func getManagedServices(ctx context.Context, clt DeployServiceClient, log *slog.Logger, teleportClusterName string, ownershipTags tags.AWSTags) ([]ecsTypes.Service, error) {
 	// The Cluster name is created using the Teleport Cluster Name.
 	// Check the DeployDatabaseServiceRequest.CheckAndSetDefaults
 	// and DeployServiceRequest.CheckAndSetDefaults.
@@ -224,7 +225,7 @@ func getManagedServices(ctx context.Context, clt DeployServiceClient, log *slog.
 	return ecsServices, nil
 }
 
-func getManagedTaskDefinition(ctx context.Context, clt DeployServiceClient, taskDefinitionName string, ownershipTags AWSTags) (*ecsTypes.TaskDefinition, error) {
+func getManagedTaskDefinition(ctx context.Context, clt DeployServiceClient, taskDefinitionName string, ownershipTags tags.AWSTags) (*ecsTypes.TaskDefinition, error) {
 	describeTaskDefinitionOut, err := clt.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(taskDefinitionName),
 		Include:        []ecsTypes.TaskDefinitionField{ecsTypes.TaskDefinitionFieldTags},

--- a/lib/integrations/awsoidc/deployservice_update_test.go
+++ b/lib/integrations/awsoidc/deployservice_update_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -160,7 +161,7 @@ func TestUpdateDeployServices(t *testing.T) {
 
 	clusterName := "my-cluster"
 	integrationName := "my-integration"
-	ownershipTags := defaultResourceCreationTags(clusterName, integrationName)
+	ownershipTags := tags.DefaultResourceCreationTags(clusterName, integrationName)
 	teleportVersion := teleport.Version
 	log := utils.NewSlogLoggerForTests().With("test", t.Name())
 

--- a/lib/integrations/awsoidc/idp_iam_config.go
+++ b/lib/integrations/awsoidc/idp_iam_config.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 	awsutil "github.com/gravitational/teleport/lib/utils/aws"
 	"github.com/gravitational/teleport/lib/utils/oidc"
 )
@@ -98,7 +99,7 @@ type IdPIAMConfigureRequest struct {
 	// IntegrationRole is the Integration's AWS Role used to set up Teleport as an OIDC IdP.
 	IntegrationRole string
 
-	ownershipTags AWSTags
+	ownershipTags tags.AWSTags
 }
 
 // CheckAndSetDefaults ensures the required fields are present.
@@ -151,7 +152,7 @@ func (r *IdPIAMConfigureRequest) CheckAndSetDefaults() error {
 		}
 	}
 
-	r.ownershipTags = defaultResourceCreationTags(r.Cluster, r.IntegrationName)
+	r.ownershipTags = tags.DefaultResourceCreationTags(r.Cluster, r.IntegrationName)
 
 	return nil
 }

--- a/lib/integrations/awsoidc/idp_iam_config_test.go
+++ b/lib/integrations/awsoidc/idp_iam_config_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 )
 
 func TestIdPIAMConfigReqDefaults(t *testing.T) {
@@ -79,7 +80,7 @@ func TestIdPIAMConfigReqDefaults(t *testing.T) {
 				ProxyPublicAddress: "https://proxy.example.com",
 				issuer:             "proxy.example.com",
 				issuerURL:          "https://proxy.example.com",
-				ownershipTags: AWSTags{
+				ownershipTags: tags.AWSTags{
 					"teleport.dev/cluster":     "mycluster",
 					"teleport.dev/integration": "myintegration",
 					"teleport.dev/origin":      "integration_awsoidc",
@@ -110,7 +111,7 @@ func TestIdPIAMConfigReqDefaults(t *testing.T) {
 				S3JWKSContentsB64: base64EncodedString,
 				issuer:            "bucket-1.s3.amazonaws.com/prefix-2",
 				issuerURL:         "https://bucket-1.s3.amazonaws.com/prefix-2",
-				ownershipTags: AWSTags{
+				ownershipTags: tags.AWSTags{
 					"teleport.dev/cluster":     "mycluster",
 					"teleport.dev/integration": "myintegration",
 					"teleport.dev/origin":      "integration_awsoidc",

--- a/lib/integrations/awsoidc/tags/tags.go
+++ b/lib/integrations/awsoidc/tags/tags.go
@@ -20,6 +20,7 @@ package tags
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	athenatypes "github.com/aws/aws-sdk-go-v2/service/athena/types"
@@ -60,7 +61,6 @@ func DefaultResourceCreationTags(clusterName, integrationName string) AWSTags {
 func (d AWSTags) ToECSTags() []ecsTypes.Tag {
 	ecsTags := make([]ecsTypes.Tag, 0, len(d))
 	for k, v := range d {
-		k, v := k, v
 		ecsTags = append(ecsTags, ecsTypes.Tag{
 			Key:   &k,
 			Value: &v,
@@ -73,7 +73,6 @@ func (d AWSTags) ToECSTags() []ecsTypes.Tag {
 func (d AWSTags) ToEC2Tags() []ec2Types.Tag {
 	ec2Tags := make([]ec2Types.Tag, 0, len(d))
 	for k, v := range d {
-		k, v := k, v
 		ec2Tags = append(ec2Tags, ec2Types.Tag{
 			Key:   &k,
 			Value: &v,
@@ -120,7 +119,6 @@ func (d AWSTags) MatchesIAMTags(resourceTags []iamTypes.Tag) bool {
 func (d AWSTags) ToIAMTags() []iamTypes.Tag {
 	iamTags := make([]iamTypes.Tag, 0, len(d))
 	for k, v := range d {
-		k, v := k, v
 		iamTags = append(iamTags, iamTypes.Tag{
 			Key:   &k,
 			Value: &v,
@@ -133,7 +131,6 @@ func (d AWSTags) ToIAMTags() []iamTypes.Tag {
 func (d AWSTags) ToS3Tags() []s3types.Tag {
 	s3Tags := make([]s3types.Tag, 0, len(d))
 	for k, v := range d {
-		k, v := k, v
 		s3Tags = append(s3Tags, s3types.Tag{
 			Key:   &k,
 			Value: &v,
@@ -146,7 +143,6 @@ func (d AWSTags) ToS3Tags() []s3types.Tag {
 func (d AWSTags) ToAthenaTags() []athenatypes.Tag {
 	athenaTags := make([]athenatypes.Tag, 0, len(d))
 	for k, v := range d {
-		k, v := k, v
 		athenaTags = append(athenaTags, athenatypes.Tag{
 			Key:   &k,
 			Value: &v,
@@ -158,10 +154,5 @@ func (d AWSTags) ToAthenaTags() []athenatypes.Tag {
 // ToMap returns the default tags using the expected type for other aws resources.
 // Eg Glue resources
 func (d AWSTags) ToMap() map[string]string {
-	mapTags := make(map[string]string, len(d))
-	for k, v := range d {
-		k, v := k, v
-		mapTags[k] = v
-	}
-	return mapTags
+	return maps.Clone((map[string]string)(d))
 }

--- a/lib/integrations/awsoidc/tags/tags.go
+++ b/lib/integrations/awsoidc/tags/tags.go
@@ -16,15 +16,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package awsoidc
+package tags
 
 import (
 	"fmt"
 	"strings"
 
+	athenatypes "github.com/aws/aws-sdk-go-v2/service/athena/types"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 
 	"github.com/gravitational/teleport/api/types"
 )
@@ -41,12 +43,12 @@ func (d AWSTags) String() string {
 	return strings.Join(tagsString, ", ")
 }
 
-// defaultResourceCreationTags returns the default tags that should be applied when creating new AWS resources.
+// DefaultResourceCreationTags returns the default tags that should be applied when creating new AWS resources.
 // The following tags are returned:
 // - teleport.dev/cluster: <clusterName>
 // - teleport.dev/origin: aws-oidc-integration
 // - teleport.dev/integration: <integrationName>
-func defaultResourceCreationTags(clusterName, integrationName string) AWSTags {
+func DefaultResourceCreationTags(clusterName, integrationName string) AWSTags {
 	return AWSTags{
 		types.ClusterLabel:     clusterName,
 		types.OriginLabel:      types.OriginIntegrationAWSOIDC,
@@ -125,4 +127,41 @@ func (d AWSTags) ToIAMTags() []iamTypes.Tag {
 		})
 	}
 	return iamTags
+}
+
+// ToS3Tags returns the default tags using the expected type for S3 resources: [s3types.Tag]
+func (d AWSTags) ToS3Tags() []s3types.Tag {
+	s3Tags := make([]s3types.Tag, 0, len(d))
+	for k, v := range d {
+		k, v := k, v
+		s3Tags = append(s3Tags, s3types.Tag{
+			Key:   &k,
+			Value: &v,
+		})
+	}
+	return s3Tags
+}
+
+// ToAthenaTags returns the default tags using the expected type for Athena resources: [athenatypes.Tag]
+func (d AWSTags) ToAthenaTags() []athenatypes.Tag {
+	athenaTags := make([]athenatypes.Tag, 0, len(d))
+	for k, v := range d {
+		k, v := k, v
+		athenaTags = append(athenaTags, athenatypes.Tag{
+			Key:   &k,
+			Value: &v,
+		})
+	}
+	return athenaTags
+}
+
+// ToMap returns the default tags using the expected type for other aws resources.
+// Eg Glue resources
+func (d AWSTags) ToMap() map[string]string {
+	mapTags := make(map[string]string, len(d))
+	for k, v := range d {
+		k, v := k, v
+		mapTags[k] = v
+	}
+	return mapTags
 }

--- a/lib/integrations/awsoidc/tags/tags_test.go
+++ b/lib/integrations/awsoidc/tags/tags_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package awsoidc
+package tags
 
 import (
 	"testing"
@@ -31,7 +31,7 @@ import (
 func TestDefaultTags(t *testing.T) {
 	clusterName := "mycluster"
 	integrationName := "myawsaccount"
-	d := defaultResourceCreationTags(clusterName, integrationName)
+	d := DefaultResourceCreationTags(clusterName, integrationName)
 
 	expectedTags := AWSTags{
 		"teleport.dev/cluster":     "mycluster",

--- a/lib/integrations/externalauditstorage/bootstrap.go
+++ b/lib/integrations/externalauditstorage/bootstrap.go
@@ -228,6 +228,8 @@ func createBucket(ctx context.Context, clt BootstrapS3Client, bucketName string,
 		return trace.Wrap(awsutil.ConvertS3Error(err))
 	}
 
+	// s3:CreateBucket doesn't support tags, so the best we can do is
+	// to tag the bucket shortly after creating it
 	if _, err := clt.PutBucketTagging(ctx, &s3.PutBucketTaggingInput{
 		Bucket:  &bucketName,
 		Tagging: &s3types.Tagging{TagSet: ownershipTags},

--- a/lib/integrations/externalauditstorage/easconfig/externalauditstroageconfig.go
+++ b/lib/integrations/externalauditstorage/easconfig/externalauditstroageconfig.go
@@ -25,6 +25,12 @@ type ExternalAuditStorageConfiguration struct {
 	Bootstrap bool
 	// Region is the AWS Region used.
 	Region string
+	// ClusterName is the Teleport cluster name.
+	// Used for reasource tagging.
+	ClusterName string
+	// IntegrationName is the Teleport AWS OIDC Integration name.
+	// Used for reasource tagging.
+	IntegrationName string
 	// Role is the AWS IAM Role associated with the OIDC integration.
 	Role string
 	// Policy is the name to use for the IAM policy.

--- a/lib/integrations/externalauditstorage/easconfig/externalauditstroageconfig.go
+++ b/lib/integrations/externalauditstorage/easconfig/externalauditstroageconfig.go
@@ -26,10 +26,10 @@ type ExternalAuditStorageConfiguration struct {
 	// Region is the AWS Region used.
 	Region string
 	// ClusterName is the Teleport cluster name.
-	// Used for reasource tagging.
+	// Used for resource tagging.
 	ClusterName string
 	// IntegrationName is the Teleport AWS OIDC Integration name.
-	// Used for reasource tagging.
+	// Used for resource tagging.
 	IntegrationName string
 	// Role is the AWS IAM Role associated with the OIDC integration.
 	Role string

--- a/tool/teleport/common/integration_configure.go
+++ b/tool/teleport/common/integration_configure.go
@@ -183,7 +183,6 @@ func onIntegrationConfExternalAuditCmd(ctx context.Context, params easconfig.Ext
 			Athena: athena.NewFromConfig(cfg),
 			Glue:   glue.NewFromConfig(cfg),
 			S3:     s3.NewFromConfig(cfg),
-			STS:    sts.NewFromConfig(cfg),
 			Spec: &ecatypes.ExternalAuditStorageSpec{
 				SessionRecordingsURI:   params.SessionRecordingsURI,
 				AuditEventsLongTermURI: params.AuditEventsURI,

--- a/tool/teleport/common/integration_configure.go
+++ b/tool/teleport/common/integration_configure.go
@@ -183,6 +183,7 @@ func onIntegrationConfExternalAuditCmd(ctx context.Context, params easconfig.Ext
 			Athena: athena.NewFromConfig(cfg),
 			Glue:   glue.NewFromConfig(cfg),
 			S3:     s3.NewFromConfig(cfg),
+			STS:    sts.NewFromConfig(cfg),
 			Spec: &ecatypes.ExternalAuditStorageSpec{
 				SessionRecordingsURI:   params.SessionRecordingsURI,
 				AuditEventsLongTermURI: params.AuditEventsURI,
@@ -191,7 +192,9 @@ func onIntegrationConfExternalAuditCmd(ctx context.Context, params easconfig.Ext
 				GlueDatabase:           params.GlueDatabase,
 				GlueTable:              params.GlueTable,
 			},
-			Region: params.Region,
+			Region:          params.Region,
+			ClusterName:     params.ClusterName,
+			IntegrationName: params.IntegrationName,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -518,6 +518,8 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfExternalAuditCmd := integrationConfigureCmd.Command("externalauditstorage", "Bootstraps required infrastructure and adds required IAM permissions for External Audit Storage logs.")
 	integrationConfExternalAuditCmd.Flag("bootstrap", "Bootstrap required infrastructure.").Default("false").BoolVar(&ccf.IntegrationConfExternalAuditStorageArguments.Bootstrap)
 	integrationConfExternalAuditCmd.Flag("aws-region", "AWS region.").Required().StringVar(&ccf.IntegrationConfExternalAuditStorageArguments.Region)
+	integrationConfExternalAuditCmd.Flag("cluster-name", "Teleport Cluster name.").Required().StringVar(&ccf.IntegrationConfExternalAuditStorageArguments.ClusterName)
+	integrationConfExternalAuditCmd.Flag("integration", "AWS OIDC Integration name.").Required().StringVar(&ccf.IntegrationConfExternalAuditStorageArguments.IntegrationName)
 	integrationConfExternalAuditCmd.Flag("role", "The IAM Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfExternalAuditStorageArguments.Role)
 	integrationConfExternalAuditCmd.Flag("policy", "The name for the Policy to attach to the IAM role.").Required().StringVar(&ccf.IntegrationConfExternalAuditStorageArguments.Policy)
 	integrationConfExternalAuditCmd.Flag("session-recordings", "The S3 URI where session recordings are stored.").Required().StringVar(&ccf.IntegrationConfExternalAuditStorageArguments.SessionRecordingsURI)


### PR DESCRIPTION
This PR adds the ownership tags to all aws resources created. This will help users track everything that was created by the integration/cluster.

A PR against `e` will be created as well.

Demo:
<img width="1002" alt="image" src="https://github.com/user-attachments/assets/c5799cc6-0410-4302-ab0e-e11a44e261b5">
<img width="956" alt="image" src="https://github.com/user-attachments/assets/b43adde7-9837-4ecc-ba42-2e9f5cb8df30">

(I couldn't find a way to show the glue database tags)
Related: https://github.com/gravitational/teleport/issues/43427