### PR TITLE
docs: update links for linux demo and others

### DIFF
--- a/docs/pages/access-controls/sso/okta.mdx
+++ b/docs/pages/access-controls/sso/okta.mdx
@@ -18,7 +18,7 @@ Teleport administrators to define policies like:
 
 In Teleport Enterprise Cloud and Self-Hosted Teleport Enterprise, Teleport can
 automatically configure an SSO connector for you when as part of [enrolling the
-hosted Okta integration](../../index.mdx).
+hosted Okta integration](../../enroll-resources/application-access/okta.mdx).
 
 You can enroll the Okta integration from the Teleport Web UI.
 

--- a/docs/pages/choose-an-edition/introduction.mdx
+++ b/docs/pages/choose-an-edition/introduction.mdx
@@ -38,7 +38,7 @@ For hobby and personal use, we provide a free, open source distribution of
 Teleport that enables you to get secure access to databases, Windows desktops,
 Kubernetes clusters, and more.
 
-[Try out Teleport on a Linux server](../index.mdx). If you would like to take a
+[Try out Teleport on a Linux server](../deploy-a-cluster/linux-demo.mdx). If you would like to take a
 look at the source, visit the [Teleport GitHub
 repository](https://github.com/gravitational/teleport).
 

--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -17,7 +17,7 @@ within your infrastructure, such as Kubernetes clusters and Windows desktops.
 A minimal Teleport cluster consists of the **Teleport Auth Service** and
 **Teleport Proxy Service**. In a demo environment, you can run these two
 services from a single `teleport` process on a [Linux
-host](./index.mdx).
+host](./deploy-a-cluster/linux-demo.mdx).
 
 ### Teleport Auth Service
 

--- a/docs/pages/documentation-overview.mdx
+++ b/docs/pages/documentation-overview.mdx
@@ -13,7 +13,7 @@ documentation, adjust the dropdown menu at the top of the page.
 ## Get started
 
 If you are curious to see how Teleport works, you can get started by [spinning
-up a demo cluster](./index.mdx) on a Linux server. After seeing how your demo
+up a demo cluster](./deploy-a-cluster/linux-demo.mdx) on a Linux server. After seeing how your demo
 Teleport cluster lets you securely access a server and play back your SSH
 sessions, you can configure RBAC, add resources, and protect your infrastructure
 with Teleport.
@@ -30,7 +30,7 @@ probably need to consult at some point:
 
 - [Installation](./installation.mdx): How to install Teleport binaries on your
   environment. If you are just getting started with Teleport, we recommend
-  spinning up a [demo cluster](./index.mdx) or signing up for a [Teleport
+  spinning up a [demo cluster](./deploy-a-cluster/linux-demo.mdx) or signing up for a [Teleport
   Enterprise Cloud trial](https://goteleport.com/signup).
 - [Frequently Asked Questions](./faq.mdx): If this page does not answer your
   question, try our AI-assisted search box on the left sidebar.

--- a/docs/pages/enroll-resources/agents/deploy-agents-terraform.mdx
+++ b/docs/pages/enroll-resources/agents/deploy-agents-terraform.mdx
@@ -35,7 +35,7 @@ We recommend following this guide on a fresh Teleport demo cluster so you can
 see how an agent pool works. After you are familiar with the setup, apply the
 lessons from this guide to protect your infrastructure. You can get started with
 a demo cluster using:
-- A demo deployment on a [Linux server](../../index.mdx)
+- A demo deployment on a [Linux server](../../deploy-a-cluster/linux-demo.mdx)
 - A [Teleport Enterprise Cloud trial](https://goteleport.com/signup)
 
 </Admonition>

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -2,7 +2,7 @@
 
 - A running Teleport cluster version {{ version }} or above. If you want to get started with Teleport, [sign
   up](https://goteleport.com/signup) for a free trial or [set up a demo
-  environment](../index.mdx).
+  environment](../deploy-a-cluster/linux-demo.mdx).
 
 - The `tctl` admin tool and `tsh` client tool.
 

--- a/docs/pages/includes/self-hosted-prereqs-tabs.mdx
+++ b/docs/pages/includes/self-hosted-prereqs-tabs.mdx
@@ -1,7 +1,7 @@
 - A running self-hosted Teleport cluster. If you want to get started with
   self-hosted Teleport Enterprise, [contact
   Sales](https://goteleport.com/contact-us/). You can also [set up a demo
-  environment](../index.mdx) with Teleport Community Edition.
+  environment](../deploy-a-cluster/linux-demo.mdx) with Teleport Community Edition.
 
 - The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
 

--- a/docs/pages/management/admin/self-signed-certs.mdx
+++ b/docs/pages/management/admin/self-signed-certs.mdx
@@ -34,7 +34,7 @@ to the Proxy Service.
 <TabItem scope={["oss"]} label="Open Source">
 
 - A running Teleport cluster. For details on how to set this up, see our
-  [Getting Started](../../index.mdx) guide (skip TLS certificate setup).
+  [Getting Started](../../deploy-a-cluster/linux-demo.mdx) guide (skip TLS certificate setup).
 
 - A Teleport Proxy Service which does not have certificates or ACME automatic certificates configured.
 For example, this Teleport Proxy Service configuration would use self-signed certs:


### PR DESCRIPTION
Links for creating a linux demo env went to the original index page, not the new one.
Corrected link for Okta Integration.