### PR TITLE
[v16] web: rename SAML application button from `Login` to `Log In`

### DIFF
--- a/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
@@ -226,8 +226,9 @@ const AppLaunch = ({ app, setResourceSpec }: AppLaunchProps) => {
           href={samlAppSsoUrl}
           rel="noreferrer"
           textTransform="none"
+          title="Log in to SAML application"
         >
-          Login
+          Log In
         </ButtonBorder>
       );
     }

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -249,14 +249,14 @@ function AppButton(props: {
         onClick={props.onLaunchUrl}
         as="a"
         textTransform="none"
-        title="Log in to the app in the browser"
+        title="Log in to the SAML application in the browser"
         href={getSamlAppSsoUrl({
           app: props.app,
           rootCluster: props.rootCluster,
         })}
         target="_blank"
       >
-        Login
+        Log In
       </ButtonBorder>
     );
   }


### PR DESCRIPTION
Backport #44251 to branch/v16

https://github.com/gravitational/teleport.e/issues/4458