### PR TITLE
Fix TestFileSharedWriterFinalizer test race fail

### DIFF
--- a/lib/utils/log/file_writer.go
+++ b/lib/utils/log/file_writer.go
@@ -61,6 +61,7 @@ func NewFileSharedWriter(logFileName string, flag int, mode fs.FileMode) (*FileS
 	}
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
+		_ = logFile.Close()
 		return nil, trace.Wrap(err)
 	}
 
@@ -78,7 +79,7 @@ func (s *FileSharedWriter) Write(b []byte) (int, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if s.closed {
-		return 0, ErrFileSharedWriterClosed
+		return 0, trace.Wrap(ErrFileSharedWriterClosed)
 	}
 
 	return s.file.Write(b)


### PR DESCRIPTION
Related to this report: https://github.com/gravitational/teleport.e/actions/runs/10006229789/job/27658537508#step:7:492

this fix was tested with
```bash
go test -race -count 50000 -failfast -v -run "^TestFileSharedWriterFinalizer$" ./lib/utils/log/

PASS
ok  	github.com/gravitational/teleport/lib/utils/log	369.254s
```