### PR TITLE
Fix title for the web kube exec sessions.

### DIFF
--- a/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.story.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.story.tsx
@@ -131,6 +131,5 @@ const session: Session = {
   addr: '',
   participantModes: [],
   moderated: false,
-  isInteractive: true,
   command: '/bin/bash',
 };

--- a/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.test.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.test.tsx
@@ -159,6 +159,5 @@ const baseSession: Session = {
   addr: '',
   participantModes: [],
   moderated: false,
-  isInteractive: true,
   command: '/bin/bash',
 };

--- a/web/packages/teleport/src/services/session/types.ts
+++ b/web/packages/teleport/src/services/session/types.ts
@@ -31,7 +31,6 @@ export interface Session {
   clusterId: string;
   parties: Participant[];
   addr: string;
-  kubeExec?: boolean;
   // resourceName depending on the "kind" field, is the name
   // of resource that the session is running in:
   //  - ssh: is referring to the hostname
@@ -46,7 +45,6 @@ export interface Session {
   moderated: boolean;
   // command is the command that was run to start this session.
   command: string;
-  isInteractive?: boolean;
 }
 
 export type SessionMetadata = {


### PR DESCRIPTION
After changing flow of kube exec in web UI to have a modal window with details to pop up after establishing connection to the server, title setting was broken. We now don't use login field of session to store data about cluster/pod/container. This PR changes to use the data from the modal directly to create the title of the session. Also we make sure that if modal waiting timed out we don't display it anymore (new status="disconnected"). And we also remove some leftover unneeded fields from the session.