### PR TITLE
[branch/v14] Add support for signing Windows binaries without a destination path (#42067)

### DIFF
--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -286,13 +286,18 @@ function Invoke-SignBinary {
     <#
     .SYNOPSIS
     Signs the provided binary with the base64-encoded certificate listed in "$WINDOWS_SIGNING_CERT"
+    .PARAMETER UnsignedBinaryPath
+    The path to the unsigned binary.
+    .PARAMETER SignedBinaryPath
+    The path where the signed binary should be written. If not provided, then the signed binary will
+    be written to a temporary path, and then moved to the unsigned binary path.
     #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [string] $UnsignedBinaryPath,
 
-        [Parameter(Mandatory)]
+        [Parameter()]
         [string] $SignedBinaryPath
     )
 
@@ -354,7 +359,7 @@ function Build-Tsh {
         $UnsignedBinaryPath = "$BuildDirectory\unsigned-$BinaryName"
         go build -tags piv -trimpath -ldflags "-s -w" -o "$UnsignedBinaryPath" "$TeleportSourceDirectory\tool\tsh"
         if ($LastExitCode -ne 0) {
-           exit $LastExitCode
+            exit $LastExitCode
         }
         Write-Host "::endgroup::"
 


### PR DESCRIPTION
Backport #41963

changelog: Fixed Teleport Connect binaries not being signed correctly.

Accidentally broke the last PR (https://github.com/gravitational/teleport/pull/44421)