### PR TITLE
hide the flag that allows users to pass their own Okta SCIM auth token to tctl

### DIFF
--- a/tool/tctl/common/plugin/okta.go
+++ b/tool/tctl/common/plugin/okta.go
@@ -58,6 +58,7 @@ func (p *PluginsCommand) initInstallOkta(parent *kingpin.CmdClause) {
 		BoolVar(&p.install.okta.scimEnabled)
 	p.install.okta.cmd.
 		Flag("scim-token", "Okta SCIM auth token for the plugin to use").
+		Hidden().
 		StringVar(&p.install.okta.scimToken)
 	p.install.okta.cmd.
 		Flag("users-sync", "Enable user synchronization").


### PR DESCRIPTION
Part of fixing https://github.com/gravitational/teleport-private/issues/1452. Another PR will be opened that will ensure SCIM tokens pass a length requirement.