### PR TITLE
allow EC ssh keys in FIPS mode

### DIFF
--- a/api/utils/sshutils/checker_test.go
+++ b/api/utils/sshutils/checker_test.go
@@ -17,55 +17,26 @@ limitations under the License.
 package sshutils
 
 import (
+	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/constants"
 )
 
-// TestCheckerValidate checks what algorithm are supported in regular (non-FIPS) mode.
-func TestCheckerValidate(t *testing.T) {
-	checker := CertChecker{}
-
-	rsaKey, err := rsa.GenerateKey(rand.Reader, constants.RSAKeySize)
-	require.NoError(t, err)
-	smallRSAKey, err := rsa.GenerateKey(rand.Reader, 1024)
-	require.NoError(t, err)
-	ellipticKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-
-	// 2048-bit RSA keys are valid.
-	cryptoKey := rsaKey.Public()
-	sshKey, err := ssh.NewPublicKey(cryptoKey)
-	require.NoError(t, err)
-	err = checker.validateFIPS(sshKey)
-	require.NoError(t, err)
-
-	// 1024-bit RSA keys are valid.
-	cryptoKey = smallRSAKey.Public()
-	sshKey, err = ssh.NewPublicKey(cryptoKey)
-	require.NoError(t, err)
-	err = checker.validateFIPS(sshKey)
-	require.NoError(t, err)
-
-	// ECDSA keys are valid.
-	cryptoKey = ellipticKey.Public()
-	sshKey, err = ssh.NewPublicKey(cryptoKey)
-	require.NoError(t, err)
-	err = checker.validateFIPS(sshKey)
-	require.NoError(t, err)
-}
-
 // TestCheckerValidateFIPS makes sure the public key is a valid algorithm
 // that Teleport supports while in FIPS mode.
 func TestCheckerValidateFIPS(t *testing.T) {
-	checker := CertChecker{
+	regularChecker := CertChecker{}
+	fipsChecker := CertChecker{
 		FIPS: true,
 	}
 
@@ -73,27 +44,68 @@ func TestCheckerValidateFIPS(t *testing.T) {
 	require.NoError(t, err)
 	smallRSAKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
-	ellipticKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	ellipticKeyP224, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	require.NoError(t, err)
+	ellipticKeyP256, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ellipticKeyP384, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	_, ed25519Key, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
 
-	// 2048-bit RSA keys are valid.
-	cryptoKey := rsaKey.Public()
-	sshKey, err := ssh.NewPublicKey(cryptoKey)
-	require.NoError(t, err)
-	err = checker.validateFIPS(sshKey)
-	require.NoError(t, err)
+	for _, tc := range []struct {
+		desc            string
+		key             crypto.Signer
+		expectSSHError  bool
+		expectFIPSError bool
+	}{
+		{
+			desc: "RSA2048",
+			key:  rsaKey,
+		},
+		{
+			desc:            "RSA1024",
+			key:             smallRSAKey,
+			expectFIPSError: true,
+		},
+		{
+			desc:            "ECDSAP224",
+			key:             ellipticKeyP224,
+			expectSSHError:  true,
+			expectFIPSError: true,
+		},
+		{
+			desc: "ECDSAP256",
+			key:  ellipticKeyP256,
+		},
+		{
+			desc: "ECDSAP384",
+			key:  ellipticKeyP384,
+		},
+		{
+			desc:            "Ed25519",
+			key:             ed25519Key,
+			expectFIPSError: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			cryptoKey := tc.key.Public()
+			sshKey, err := ssh.NewPublicKey(cryptoKey)
+			if tc.expectSSHError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 
-	// 1024-bit RSA keys are not valid.
-	cryptoKey = smallRSAKey.Public()
-	sshKey, err = ssh.NewPublicKey(cryptoKey)
-	require.NoError(t, err)
-	err = checker.validateFIPS(sshKey)
-	require.Error(t, err)
+			err = regularChecker.validateFIPS(sshKey)
+			assert.NoError(t, err)
 
-	// ECDSA keys are not valid.
-	cryptoKey = ellipticKey.Public()
-	sshKey, err = ssh.NewPublicKey(cryptoKey)
-	require.NoError(t, err)
-	err = checker.validateFIPS(sshKey)
-	require.Error(t, err)
+			err = fipsChecker.validateFIPS(sshKey)
+			if tc.expectFIPSError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -206,6 +206,9 @@ func TestHostSignerFIPS(t *testing.T) {
 	_, ellipticSigner, err := cert.CreateEllipticCertificate("foo", ssh.HostCert)
 	require.NoError(t, err)
 
+	_, ed25519Signer, err := cert.CreateEd25519Certificate("foo", ssh.HostCert)
+	require.NoError(t, err)
+
 	fn := NewChanHandlerFunc(func(_ context.Context, _ *ConnectionContext, nch ssh.NewChannel) {
 		err := nch.Reject(ssh.Prohibited, "nothing to see here")
 		assert.NoError(t, err)
@@ -216,16 +219,28 @@ func TestHostSignerFIPS(t *testing.T) {
 		inFIPS   bool
 		assert   require.ErrorAssertionFunc
 	}{
-		// ECDSA when in FIPS mode should fail.
+		// Ed25519 when in FIPS mode should fail.
+		{
+			inSigner: ed25519Signer,
+			inFIPS:   true,
+			assert:   require.Error,
+		},
+		// ECDSA when in FIPS mode is okay.
 		{
 			inSigner: ellipticSigner,
 			inFIPS:   true,
-			assert:   require.Error,
+			assert:   require.NoError,
 		},
 		// RSA when in FIPS mode is okay.
 		{
 			inSigner: signer,
 			inFIPS:   true,
+			assert:   require.NoError,
+		},
+		// Ed25519 when in not FIPS mode should succeed.
+		{
+			inSigner: ed25519Signer,
+			inFIPS:   false,
 			assert:   require.NoError,
 		},
 		// ECDSA when in not FIPS mode should succeed.

--- a/lib/utils/cert/certs.go
+++ b/lib/utils/cert/certs.go
@@ -21,6 +21,7 @@ package cert
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"time"
@@ -51,9 +52,7 @@ func CreateCertificate(principal string, certType uint32) (*ssh.Certificate, ssh
 	return cert, certSigner, nil
 }
 
-// CreateEllipticCertificate creates a valid, but not supported, ECDSA
-// SSH certificate. This certificate is used to make sure Teleport rejects
-// such certificates.
+// CreateEllipticCertificate creates a valid ECDSA P-256 certificate.
 func CreateEllipticCertificate(principal string, certType uint32) (*ssh.Certificate, ssh.Signer, error) {
 	// Create ECDSA key for CA and certificate to be signed by CA.
 	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -61,6 +60,27 @@ func CreateEllipticCertificate(principal string, certType uint32) (*ssh.Certific
 		return nil, nil, trace.Wrap(err)
 	}
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	cert, certSigner, err := createCertificate(principal, certType, caKey, key)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return cert, certSigner, nil
+}
+
+// CreateEd25519Certificate creates an Ed25519 certificate which should be
+// rejected in FIPS mode.
+func CreateEd25519Certificate(principal string, certType uint32) (*ssh.Certificate, ssh.Signer, error) {
+	// Create Ed25519 key for CA and certificate to be signed by CA.
+	_, caKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	_, key, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
This change allows ECDSA keys with curve P-256 or P-384 when the cluster is in FIPS mode. This is in service of [RFD 136](https://github.com/gravitational/teleport/blob/master/rfd/0136-modern-signature-algorithms.md) which will introduce the use of P-256. BoringCrypto supports these algorithms, and we already claim to support them on our FedRAMP docs page https://goteleport.com/docs/access-controls/compliance-frameworks/fedramp/#default-cryptographic-algorithms