### PR TITLE
Remove client side port guessing from tsh puttyconfig

### DIFF
--- a/tool/tsh/common/putty_config_windows.go
+++ b/tool/tsh/common/putty_config_windows.go
@@ -42,7 +42,6 @@ const puttyRegistrySSHHostCAsKey = puttyRegistryKey + `\SshHostCAs`
 const puttyProtocol = `ssh`
 
 // ints
-const puttyDefaultSSHPort = 3022
 const puttyDefaultProxyPort = 0 // no need to set the proxy port as it's abstracted by `tsh proxy ssh`
 
 // dwords
@@ -86,11 +85,6 @@ func addPuTTYSession(proxyHostname string, hostname string, port int, login stri
 		puttySessionName = fmt.Sprintf(`%v%%20(leaf:%v,proxy:%v)`, hostname, leafClusterName, proxyHostname)
 	}
 	registryKey := fmt.Sprintf(`%v\%v`, puttyRegistrySessionsKey, puttySessionName)
-
-	// if the port passed is 0, this means "use server default" so we override it to 3022
-	if port == 0 {
-		port = puttyDefaultSSHPort
-	}
 
 	sessionDwords := puttyRegistrySessionDwords{
 		Present:        puttyDwordPresent,


### PR DESCRIPTION
If no port was provided puttyconfig would default to 3022. That is not guaranteed to be the correct port and causes UX issues. To allow the port to be optional and guarantee the correct port is used puttyconfig is updated to use 0 instead of 3022. This is a special port that indicates to Teleport to use whatever port is defined in the node when making dial request. Since the value from puttyconfig is fed into tsh proxy ssh this value is honored by Teleport during connections.


Changelog: Use the registered port of the target host when tsh puttyconfig is invoked without --port. 