### PR TITLE
Add redirects based on Teleport Enterprise

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2414,134 +2414,164 @@
       "permanent": true
     },
     {
-    	"source": "/database-access/guides/rds-proxy-postgres/",
-    	"destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
-    	"permanent": true
+      "source": "/database-access/guides/rds-proxy-postgres/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/rds-proxy-sqlserver/",
-    	"destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver/",
-    	"permanent": true
+      "source": "/database-access/guides/rds-proxy-sqlserver/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/rds-proxy-mysql/",
-    	"destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-mysql/",
-    	"permanent": true
+      "source": "/database-access/guides/rds-proxy-mysql/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-mysql/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/ha/",
-    	"destination": "/enroll-resources/database-access/guides/ha/",
-    	"permanent": true
+      "source": "/database-access/guides/ha/",
+      "destination": "/enroll-resources/database-access/guides/ha/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/dynamic-registration/",
-    	"destination": "/enroll-resources/database-access/guides/dynamic-registration/",
-    	"permanent": true
+      "source": "/database-access/guides/dynamic-registration/",
+      "destination": "/enroll-resources/database-access/guides/dynamic-registration/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/aws-dynamodb/",
-    	"destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
-    	"permanent": true
+      "source": "/database-access/guides/aws-dynamodb/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/redis-aws/",
-    	"destination": "/enroll-resources/database-access/enroll-aws-databases/redis-aws/",
-    	"permanent": true
+      "source": "/database-access/guides/redis-aws/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/redis-aws/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/aws-cassandra-keyspaces/",
-    	"destination": "/enroll-resources/database-access/enroll-aws-databases/aws-cassandra-keyspaces/",
-    	"permanent": true
+      "source": "/database-access/guides/aws-cassandra-keyspaces/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/aws-cassandra-keyspaces/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/postgres-redshift/",
-    	"destination": "/enroll-resources/database-access/enroll-aws-databases/postgres-redshift/",
-    	"permanent": true
+      "source": "/database-access/guides/postgres-redshift/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/postgres-redshift/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/redshift-serverless/",
-    	"destination": "/enroll-resources/database-access/enroll-aws-databases/redshift-serverless/",
-    	"permanent": true
+      "source": "/database-access/guides/redshift-serverless/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/redshift-serverless/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/azure-redis/",
-    	"destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
-    	"permanent": true
+      "source": "/database-access/guides/azure-redis/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/azure-postgres-mysql/",
-    	"destination": "/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql/",
-    	"permanent": true
+      "source": "/database-access/guides/azure-postgres-mysql/",
+      "destination": "/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/azure-postgres-mysql/",
-    	"destination": "/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql/",
-    	"permanent": true
+      "source": "/database-access/guides/azure-postgres-mysql/",
+      "destination": "/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/azure-sql-server-ad/",
-    	"destination": "/enroll-resources/database-access/enroll-azure-databases/azure-sql-server-ad/",
-    	"permanent": true
+      "source": "/database-access/guides/azure-sql-server-ad/",
+      "destination": "/enroll-resources/database-access/enroll-azure-databases/azure-sql-server-ad/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/sql-server-ad/",
-    	"destination": "/enroll-resources/database-access/enroll-aws-databases/sql-server-ad/",
-    	"permanent": true
+      "source": "/database-access/guides/sql-server-ad/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/sql-server-ad/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/mysql-cloudsql/",
-    	"destination": "/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql/",
-    	"permanent": true
+      "source": "/database-access/guides/mysql-cloudsql/",
+      "destination": "/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/postgres-cloudsql/",
-    	"destination": "/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql/",
-    	"permanent": true
+      "source": "/database-access/guides/postgres-cloudsql/",
+      "destination": "/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/mongodb-atlas/",
-    	"destination": "/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas/",
-    	"permanent": true
+      "source": "/database-access/guides/mongodb-atlas/",
+      "destination": "/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/cassandra-self-hosted/",
-    	"destination": "/enroll-resources/database-access/enroll-self-hosted-databases/cassandra-self-hosted/",
-    	"permanent": true
+      "source": "/database-access/guides/cassandra-self-hosted/",
+      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/cassandra-self-hosted/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/cockroachdb-self-hosted/",
-    	"destination": "/enroll-resources/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted/",
-    	"permanent": true
+      "source": "/database-access/guides/cockroachdb-self-hosted/",
+      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/elastic/",
-    	"destination": "/enroll-resources/database-access/enroll-self-hosted-databases/elastic/",
-    	"permanent": true
+      "source": "/database-access/guides/elastic/",
+      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/elastic/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/mongodb-self-hosted/",
-    	"destination": "/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted/",
-    	"permanent": true
+      "source": "/database-access/guides/mongodb-self-hosted/",
+      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/redis/",
-    	"destination": "/enroll-resources/database-access/enroll-self-hosted-databases/redis/",
-    	"permanent": true
+      "source": "/database-access/guides/redis/",
+      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/redis/",
+      "permanent": true
     },
     {
-    	"source": "/database-access/guides/redis-cluster/",
-    	"destination": "/enroll-resources/database-access/enroll-self-hosted-databases/redis-cluster/",
-    	"permanent": true
-    },
-    {
-    	"source": "/database-access/guides/snowflake/",
-    	"destination": "/enroll-resources/database-access/enroll-managed-databases/snowflake/",
-    	"permanent": true
+      "source": "/database-access/guides/redis-cluster/",
+      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/redis-cluster/",
+      "permanent": true
     },
     {
     	"source": "/get-started/",
     	"destination": "/deploy-a-cluster/linux-demo/",
     	"permanent": true
+    },
+    {
+      "source": "/database-access/guides/snowflake/",
+      "destination": "/enroll-resources/database-access/enroll-managed-databases/snowflake/",
+      "permanent": true
+    },
+    {
+      "source": "/enterprise/sso/google-workspace/",
+      "destination": "/access-controls/sso/google-workspace/",
+      "permanent": true
+    },
+    {
+      "source": "/enterprise/sso/",
+      "destination": "/access-controls/sso/",
+      "permanent": true
+    },
+    {
+      "source": "/access-controls/guides/device-trust/",
+      "destination": "/access-controls/device-trust/",
+      "permanent": true
+    },
+    {
+      "source": "/deploy-a-cluster/teleport-enterprise/getting-started/",
+      "destination": "/choose-an-edition/teleport-enterprise/introduction/",
+      "permanent": true
+    },
+    {
+      "source": "/deploy-a-cluster/teleport-enterprise/license/",
+      "destination": "/choose-an-edition/teleport-enterprise/license/",
+      "permanent": true
+    },
+    {
+      "source": "/application-access/okta/guide/",
+      "destination": "/enroll-resources/application-access/okta/",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
Redirects of outdated Teleport Enterprise Web UI links were removed during a reorganization of the docs.