### PR TITLE
fix error messages

### DIFF
--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -665,9 +665,9 @@ func buildIAMARN(partitionID, accountID, resourceType, resource string) string {
 // Rather than returning errors about why it failed, this message suggests a
 // simple fix for the user to specify a role or user to attach policies to.
 func failedToResolveAssumeRoleARN(roleIdentity string) string {
-	return fmt.Sprintf("Running with assumed-role credentials for %s. "+
-		"Policies cannot be attached to an assumed-role. "+
-		"Provide the name or ARN of the IAM user (--atttach-to-user) or role (--atttach-to-role) to attach policies to. ",
+	return fmt.Sprintf("running with assumed-role credentials for %s, but "+
+		"policies cannot be attached to an assumed-role; "+
+		"provide the name or ARN of an IAM role (--attach-to-role) or user (--attach-to-user) to attach policies to",
 		roleIdentity)
 }
 

--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -1877,7 +1877,7 @@ func TestAWSPoliciesTarget(t *testing.T) {
 			targetPartitionID: assumedRoleIdentity.GetPartition(),
 			targetString:      "arn:aws:iam::123456789012:role/example-role",
 			iamClient:         &iamMock{unauthorized: true},
-			wantErrContains:   "Policies cannot be attached to an assumed-role",
+			wantErrContains:   "policies cannot be attached to an assumed-role",
 		},
 		"AssumedRoleIdentityWithRoleFromFlags": {
 			flags:             configurators.BootstrapFlags{AttachToRole: "arn:aws:iam::123456789012:role/some/path/example-role"},

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -123,7 +123,7 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 		return trace.Wrap(err)
 	}
 	if err != nil {
-		return trace.Wrap(err, "could not get resource %v: %v", rc.ref.String(), err)
+		return trace.Wrap(err, "could not get resource %v", rc.ref.String())
 	}
 
 	originalSum, err := checksum(f.Name())


### PR DESCRIPTION
This PR fixes a couple of error messages I've run into this past week - a typo and an error message that we were printing twice.