### PR TITLE
docs: add redirect for get-started

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2537,6 +2537,11 @@
     	"source": "/database-access/guides/snowflake/",
     	"destination": "/enroll-resources/database-access/enroll-managed-databases/snowflake/",
     	"permanent": true
+    },
+    {
+    	"source": "/get-started/",
+    	"destination": "/deploy-a-cluster/linux-demo/",
+    	"permanent": true
     }
   ]
 }


### PR DESCRIPTION
Referred in https://github.com/gravitational/teleport?tab=readme-ov-file#installing-and-running and https://goteleport.com/docs/get-started currently results in a 404 page.