### PR TITLE
Improve the output of tsh sessions ls

### DIFF
--- a/api/types/session_tracker.go
+++ b/api/types/session_tracker.go
@@ -25,22 +25,25 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 )
 
-const (
-	SSHSessionKind            SessionKind            = "ssh"
-	KubernetesSessionKind     SessionKind            = "k8s"
-	DatabaseSessionKind       SessionKind            = "db"
-	AppSessionKind            SessionKind            = "app"
-	WindowsDesktopSessionKind SessionKind            = "desktop"
-	SessionObserverMode       SessionParticipantMode = "observer"
-	SessionModeratorMode      SessionParticipantMode = "moderator"
-	SessionPeerMode           SessionParticipantMode = "peer"
-)
-
 // SessionKind is a type of session.
 type SessionKind string
 
+const (
+	SSHSessionKind            SessionKind = "ssh"
+	KubernetesSessionKind     SessionKind = "k8s"
+	DatabaseSessionKind       SessionKind = "db"
+	AppSessionKind            SessionKind = "app"
+	WindowsDesktopSessionKind SessionKind = "desktop"
+)
+
 // SessionParticipantMode is the mode that determines what you can do when you join a session.
 type SessionParticipantMode string
+
+const (
+	SessionObserverMode  SessionParticipantMode = "observer"
+	SessionModeratorMode SessionParticipantMode = "moderator"
+	SessionPeerMode      SessionParticipantMode = "peer"
+)
 
 // SessionTracker is a resource which tracks an active session.
 type SessionTracker interface {


### PR DESCRIPTION
- Rename "hostname" to target, which now includes the OS-user for SSH sessions and a more accurate description of the target for other kinds of sessions.
- Remove the "login" column, as this info is now included in the "target" column.
- Humanize the created time rather than showing a UTC timestamp. The tsh sessions ls command is most commonly used to get the ID of a session you want to join, so people are looking for clues as to which session is the right one, they don't need precise UTC timestamps.
- Remove the "command" column, as it's typically only set for non-interactive commands. Note: the command will be placed in the "address" column for kube sessions.

After:

```
➜ tsh sessions ls
ID                                   Kind    Created        User Target                          Address
------------------------------------ ------- -------------- ---- ------------------------------- ------------------------------------
9deb1351-508c-40f1-852a-4e3f3df6765e ssh     15 minutes ago zac  zmb@mbp16                       307e091b-7f6b-42e0-b78d-3362ad10b55d
aa5caa03-561d-476f-be81-29d9a23d8a24 desktop 15 minutes ago zac  Administrator@child-dc          100.112.9.10:3389
f1028013-c198-42c3-a1cf-044fc1895c7e app     3 seconds ago  zac  dumper
096e2b12-53d6-415e-9b79-964f23f4fb5d k8s     2 seconds ago  zac  default/my-shell@docker-desktop /bin/bash
```

Closes #42253

Changelog: Improve the output of `tsh sessions ls`.