### PR TITLE
remove remaining refs of UserCertsRequest.PublicKey

### DIFF
--- a/integrations/terraform/testlib/main_test.go
+++ b/integrations/terraform/testlib/main_test.go
@@ -35,11 +35,13 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/testing/integration"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/identityfile"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 
 	"github.com/gravitational/teleport/integrations/terraform/provider"
 )
@@ -166,27 +168,33 @@ func (s *TerraformBaseSuite) SetupSuite() {
 func (s *TerraformBaseSuite) getTLSCreds(ctx context.Context, user types.User, outputPath string) {
 	s.T().Helper()
 
-	key, err := libclient.GenerateRSAKey()
+	signer, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
 	require.NoError(s.T(), err)
+	privateKeyPEM, err := keys.MarshalPrivateKey(signer)
+	require.NoError(s.T(), err)
+	publicKeyPEM, err := keys.MarshalPublicKey(signer.Public())
+	require.NoError(s.T(), err)
+	privateKey, err := keys.NewPrivateKey(signer, privateKeyPEM)
+	require.NoError(s.T(), err)
+	keyRing := libclient.NewKey(privateKey)
 
 	certs, err := s.client.GenerateUserCerts(ctx, proto.UserCertsRequest{
-		PublicKey: key.MarshalSSHPublicKey(),
-		Username:  user.GetName(),
-		Expires:   time.Now().Add(time.Hour),
-		Format:    constants.CertificateFormatStandard,
+		TLSPublicKey: publicKeyPEM,
+		Username:     user.GetName(),
+		Expires:      time.Now().Add(time.Hour),
+		Format:       constants.CertificateFormatStandard,
 	})
 	require.NoError(s.T(), err)
-	key.Cert = certs.SSH
-	key.TLSCert = certs.TLS
+	keyRing.TLSCert = certs.TLS
 
 	hostCAs, err := s.client.GetCertAuthorities(ctx, types.HostCA, false)
 	require.NoError(s.T(), err)
-	key.TrustedCerts = authclient.AuthoritiesToTrustedCerts(hostCAs)
+	keyRing.TrustedCerts = authclient.AuthoritiesToTrustedCerts(hostCAs)
 
 	// write the cert+private key to the output:
 	_, err = identityfile.Write(ctx, identityfile.WriteConfig{
 		OutputPath:           outputPath,
-		Key:                  key,
+		Key:                  keyRing,
 		Format:               identityfile.FormatTLS,
 		OverwriteDestination: false,
 		Writer:               &identityfile.StandardConfigWriter{},

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -70,6 +70,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/modules"
@@ -788,8 +789,10 @@ func TestGenerateUserCerts_deviceExtensions(t *testing.T) {
 	user, _, err := CreateUserAndRole(testServer.Auth(), "llama", []string{"llama"}, nil)
 	require.NoError(t, err, "CreateUserAndRole failed")
 
-	_, pub, err := testauthority.New().GenerateKeyPair()
-	require.NoError(t, err, "GenerateKeyPair failed")
+	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err, "GenerateKeyWithAlgorithm failed")
+	publicKeyPEM, err := keys.MarshalPublicKey(key.Public())
+	require.NoError(t, err, "MarshalPublicKey failed")
 
 	wantExtensions := &tlsca.DeviceExtensions{
 		DeviceID:     "device1",
@@ -835,9 +838,9 @@ func TestGenerateUserCerts_deviceExtensions(t *testing.T) {
 			require.NoError(t, err, "NewClient failed")
 
 			resp, err := userClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
-				PublicKey: pub,
-				Username:  user.GetName(),
-				Expires:   testServer.Clock().Now().Add(1 * time.Hour),
+				TLSPublicKey: publicKeyPEM,
+				Username:     user.GetName(),
+				Expires:      testServer.Clock().Now().Add(1 * time.Hour),
 			})
 			require.NoError(t, err, "GenerateUserCerts failed")
 
@@ -939,13 +942,12 @@ func TestGenerateUserCerts_deviceAuthz(t *testing.T) {
 	clientWithoutDevice.SetMFAPromptConstructor(promptConstructor)
 	clientWithDevice.SetMFAPromptConstructor(promptConstructor)
 
-	// Create a public key for UserCertsRequest.
-	_, pub, err := testauthority.New().GenerateKeyPair()
-	require.NoError(t, err, "GenerateKeyPair failed")
+	// Create public keys for UserCertsRequest.
+	_, sshPub, _, tlsPub := newSSHAndTLSKeyPairs(t)
 
 	expires := clock.Now().Add(1 * time.Hour)
 	sshReq := proto.UserCertsRequest{
-		PublicKey:      pub,
+		SSHPublicKey:   sshPub,
 		Username:       username,
 		Expires:        expires,
 		RouteToCluster: clusterName,
@@ -954,7 +956,7 @@ func TestGenerateUserCerts_deviceAuthz(t *testing.T) {
 		SSHLogin:       "llama",
 	}
 	appReq := proto.UserCertsRequest{
-		PublicKey:      pub,
+		TLSPublicKey:   tlsPub,
 		Username:       username,
 		Expires:        expires,
 		RouteToCluster: clusterName,
@@ -966,7 +968,7 @@ func TestGenerateUserCerts_deviceAuthz(t *testing.T) {
 		},
 	}
 	winReq := proto.UserCertsRequest{
-		PublicKey:      pub,
+		TLSPublicKey:   tlsPub,
 		Username:       username,
 		Expires:        expires,
 		RouteToCluster: clusterName,
@@ -1343,8 +1345,7 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 		}
 	}
 
-	_, pub, err := testauthority.New().GenerateKeyPair()
-	require.NoError(t, err)
+	_, sshPub, _, tlsPub := newSSHAndTLSKeyPairs(t)
 
 	// Used for device trust tests.
 	wantDeviceExtensions := tlsca.DeviceExtensions{
@@ -1362,8 +1363,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "ssh using webauthn",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
+					SSHPublicKey: sshPub,
+					Username:     user.GetName(),
 					// This expiry is longer than allowed, should be
 					// automatically adjusted.
 					Expires:  clock.Now().Add(2 * teleport.UserSingleUseCertTTL),
@@ -1394,8 +1395,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "ssh - adjusted expiry",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
+					SSHPublicKey: sshPub,
+					Username:     user.GetName(),
 					// This expiry is longer than allowed, should be
 					// automatically adjusted.
 					Expires:  clock.Now().Add(2 * teleport.UserSingleUseCertTTL),
@@ -1426,8 +1427,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "k8s",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
 					// This expiry is longer than allowed, should be
 					// automatically adjusted.
 					Expires:           clock.Now().Add(2 * teleport.UserSingleUseCertTTL),
@@ -1461,8 +1462,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "db",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
 					// This expiry is longer than allowed, should be
 					// automatically adjusted.
 					Expires: clock.Now().Add(2 * teleport.UserSingleUseCertTTL),
@@ -1499,8 +1500,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "app",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
 					// This expiry is longer than allowed, should be
 					// automatically adjusted.
 					Expires: clock.Now().Add(2 * teleport.UserSingleUseCertTTL),
@@ -1538,8 +1539,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "db with ttl limit disabled",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
 					// This expiry should *not* be adjusted to single user cert TTL,
 					// since ttl limiting is disabled when requester is a local proxy tunnel.
 					// It *should* be adjusted to the user cert ttl though.
@@ -1577,8 +1578,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "kube with ttl limit disabled",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
 					// This expiry should *not* be adjusted to single user cert TTL,
 					// since ttl limiting is disabled when requester is a local proxy.
 					// It *should* be adjusted to the user cert ttl though.
@@ -1614,8 +1615,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "app with ttl limit disabled",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
 					// This expiry should *not* be adjusted to single user cert TTL,
 					// since ttl limiting is disabled when requester is a local proxy.
 					// It *should* be adjusted to the user cert ttl though.
@@ -1655,8 +1656,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "desktops",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
 					// This expiry is longer than allowed, should be
 					// automatically adjusted.
 					Expires: clock.Now().Add(2 * teleport.UserSingleUseCertTTL),
@@ -1692,11 +1693,12 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "fail - wrong usage",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
-					Expires:   clock.Now().Add(teleport.UserSingleUseCertTTL),
-					Usage:     proto.UserCertsRequest_All,
-					NodeName:  "node-a",
+					SSHPublicKey: sshPub,
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
+					Expires:      clock.Now().Add(teleport.UserSingleUseCertTTL),
+					Usage:        proto.UserCertsRequest_All,
+					NodeName:     "node-a",
 				},
 				verifyErr: func(t require.TestingT, err error, i ...interface{}) {
 					require.ErrorContains(t, err, "all purposes")
@@ -1707,12 +1709,13 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "fail - mfa challenge fail",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
-					Expires:   clock.Now().Add(teleport.UserSingleUseCertTTL),
-					Usage:     proto.UserCertsRequest_SSH,
-					NodeName:  "node-a",
-					SSHLogin:  "role",
+					SSHPublicKey: sshPub,
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
+					Expires:      clock.Now().Add(teleport.UserSingleUseCertTTL),
+					Usage:        proto.UserCertsRequest_SSH,
+					NodeName:     "node-a",
+					SSHLogin:     "role",
 				},
 				mfaRequiredHandler: func(t *testing.T, required proto.MFARequired) {
 					require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, required)
@@ -1742,12 +1745,12 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			opts: generateUserSingleUseCertsTestOpts{
 				// Same as SSH options. Nothing special here.
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
-					Expires:   clock.Now().Add(teleport.UserSingleUseCertTTL),
-					Usage:     proto.UserCertsRequest_SSH,
-					NodeName:  "node-a",
-					SSHLogin:  "role",
+					SSHPublicKey: sshPub,
+					Username:     user.GetName(),
+					Expires:      clock.Now().Add(teleport.UserSingleUseCertTTL),
+					Usage:        proto.UserCertsRequest_SSH,
+					NodeName:     "node-a",
+					SSHLogin:     "role",
 				},
 				mfaRequiredHandler: func(t *testing.T, required proto.MFARequired) {
 					require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, required)
@@ -1789,10 +1792,10 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			opts: generateUserSingleUseCertsTestOpts{
 				// Same as Database options. Nothing special here.
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
-					Expires:   clock.Now().Add(teleport.UserSingleUseCertTTL),
-					Usage:     proto.UserCertsRequest_Database,
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
+					Expires:      clock.Now().Add(teleport.UserSingleUseCertTTL),
+					Usage:        proto.UserCertsRequest_Database,
 					RouteToDatabase: proto.RouteToDatabase{
 						ServiceName: "db-a",
 					},
@@ -1825,11 +1828,12 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "mfa unspecified when no SSHLogin provided",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
-					Expires:   clock.Now().Add(teleport.UserSingleUseCertTTL),
-					Usage:     proto.UserCertsRequest_SSH,
-					NodeName:  "node-a",
+					SSHPublicKey: sshPub,
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
+					Expires:      clock.Now().Add(teleport.UserSingleUseCertTTL),
+					Usage:        proto.UserCertsRequest_SSH,
+					NodeName:     "node-a",
 				},
 				mfaRequiredHandler: func(t *testing.T, required proto.MFARequired) {
 					require.Equal(t, proto.MFARequired_MFA_REQUIRED_UNSPECIFIED, required)
@@ -1847,8 +1851,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "k8s in leaf cluster",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
 					// This expiry is longer than allowed, should be
 					// automatically adjusted.
 					Expires:           clock.Now().Add(2 * teleport.UserSingleUseCertTTL),
@@ -1883,8 +1887,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "db in leaf cluster",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
 					// This expiry is longer than allowed, should be
 					// automatically adjusted.
 					Expires: clock.Now().Add(2 * teleport.UserSingleUseCertTTL),
@@ -1922,8 +1926,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "app in leaf cluster",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
+					TLSPublicKey: tlsPub,
+					Username:     user.GetName(),
 					// This expiry is longer than allowed, should be
 					// automatically adjusted.
 					Expires: clock.Now().Add(2 * teleport.UserSingleUseCertTTL),
@@ -1962,8 +1966,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 			desc: "ssh in leaf node",
 			opts: generateUserSingleUseCertsTestOpts{
 				initReq: &proto.UserCertsRequest{
-					PublicKey: pub,
-					Username:  user.GetName(),
+					SSHPublicKey: sshPub,
+					Username:     user.GetName(),
 					// This expiry is longer than allowed, should be
 					// automatically adjusted.
 					Expires:        clock.Now().Add(2 * teleport.UserSingleUseCertTTL),

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -2885,7 +2885,7 @@ func TestGenerateCerts(t *testing.T) {
 				t.Parallel()
 
 				certs, err := userClient2.GenerateUserCerts(ctx, proto.UserCertsRequest{
-					PublicKey:    tc.publicKey,
+					PublicKey:    tc.publicKey, //nolint:staticcheck // SA1019: testing the deprecated field.
 					SSHPublicKey: tc.sshPublicKey,
 					TLSPublicKey: tc.tlsPublicKey,
 					Username:     user2.GetName(),


### PR DESCRIPTION
In https://github.com/gravitational/teleport/pull/44418 I deprecated this field to replace it with SSHPublicKey and TLSPublicKey, but forgot to remove the references from a few tests.