### PR TITLE
make ensure js package manager: Run only when pnpm is needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,11 +95,6 @@ TARBINS = $(addprefix teleport/,$(BINS))
 CHECK_CARGO := $(shell cargo --version 2>/dev/null)
 CHECK_RUST := $(shell rustc --version 2>/dev/null)
 
-# Check if pnpm is enabled before using it
-CHECK_PNPM := $(shell COREPACK_ENABLE_DOWNLOAD_PROMPT=0 pnpm --version 2>/dev/null)
-# Check if Corepack is installed before using it
-CHECK_COREPACK := $(shell corepack --version 2>/dev/null)
-
 RUST_TARGET_ARCH ?= $(CARGO_TARGET_$(OS)_$(ARCH))
 
 CARGO_TARGET_darwin_amd64 := x86_64-apple-darwin
@@ -1636,7 +1631,7 @@ ensure-webassets-e:
 	@if [[ "${WEBASSETS_SKIP_BUILD}" -eq 1 ]]; then mkdir -p webassets/teleport && mkdir -p webassets/e/teleport/app && cp web/packages/teleport/index.html webassets/e/teleport/index.html; \
 	else MAKE="$(MAKE)" "$(MAKE_DIR)/build.assets/build-webassets-if-changed.sh" Enterprise webassets/e/e-sha build-ui-e web e/web; fi
 
-# Enables the pnpm package manager if  pnpm is not already enabled and Corepack
+# Enables the pnpm package manager if it is not already enabled and Corepack
 # is available.
 # We check if pnpm is enabled, as the user may not have permission to
 # enable it, but it may already be available.
@@ -1645,8 +1640,8 @@ ensure-webassets-e:
 # by issuing a bogus pnpm call with an env var that skips the prompt.
 .PHONY: ensure-js-package-manager
 ensure-js-package-manager:
-	@if [ -z "$(CHECK_PNPM)" ]; then \
-		if [ -n "$(CHECK_COREPACK)" ]; then \
+	@if [ -z "$$(COREPACK_ENABLE_DOWNLOAD_PROMPT=0 pnpm -v 2>/dev/null)" ]; then \
+		if [ -n "$$(corepack --version 2>/dev/null)" ]; then \
 			echo 'Info: pnpm is not enabled via Corepack. Enabling pnpm…'; \
 			corepack enable pnpm; \
 			echo "pnpm $$(COREPACK_ENABLE_DOWNLOAD_PROMPT=0 pnpm -v)"; \

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ CHECK_CARGO := $(shell cargo --version 2>/dev/null)
 CHECK_RUST := $(shell rustc --version 2>/dev/null)
 
 # Check if pnpm is enabled before using it
-CHECK_PNPM := $(shell pnpm --version 2>/dev/null)
+CHECK_PNPM := $(shell COREPACK_ENABLE_DOWNLOAD_PROMPT=0 pnpm --version 2>/dev/null)
 # Check if Corepack is installed before using it
 CHECK_COREPACK := $(shell corepack --version 2>/dev/null)
 

--- a/Makefile
+++ b/Makefile
@@ -1649,7 +1649,7 @@ ensure-js-package-manager:
 		if [ -n "$(CHECK_COREPACK)" ]; then \
 			echo 'Info: pnpm is not enabled via Corepack. Enabling pnpm…'; \
 			corepack enable pnpm; \
-			COREPACK_ENABLE_DOWNLOAD_PROMPT=0 pnpm -v; \
+			echo "pnpm $$(COREPACK_ENABLE_DOWNLOAD_PROMPT=0 pnpm -v)"; \
 		else \
 			echo 'Error: Corepack is not installed, cannot enable pnpm. See the installation guide https://pnpm.io/installation#using-corepack'; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ ifeq ("$(GITHUB_REPOSITORY_OWNER)","gravitational")
 # This is done here to prevent any changes to the (BUI)LDFLAGS passed to the other binaries
 TELEPORT_LDFLAGS ?= -ldflags '$(GO_LDFLAGS) -X github.com/gravitational/teleport/lib/modules.teleportBuildType=community'
 endif
-$(BUILDDIR)/teleport: ensure-js-package-manager ensure-webassets bpf-bytecode rdpclient
+$(BUILDDIR)/teleport: ensure-webassets bpf-bytecode rdpclient
 	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -tags "webassets_embed $(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(WEBASSETS_TAG) $(RDPCLIENT_TAG) $(PIV_BUILD_TAG) $(KUSTOMIZE_NO_DYNAMIC_PLUGIN)" -o $(BUILDDIR)/teleport $(BUILDFLAGS) $(TELEPORT_LDFLAGS) ./tool/teleport
 
 # NOTE: Any changes to the `tsh` build here must be copied to `build.assets/windows/build.ps1`
@@ -1636,8 +1636,8 @@ ensure-webassets-e:
 	@if [[ "${WEBASSETS_SKIP_BUILD}" -eq 1 ]]; then mkdir -p webassets/teleport && mkdir -p webassets/e/teleport/app && cp web/packages/teleport/index.html webassets/e/teleport/index.html; \
 	else MAKE="$(MAKE)" "$(MAKE_DIR)/build.assets/build-webassets-if-changed.sh" Enterprise webassets/e/e-sha build-ui-e web e/web; fi
 
-# Enables the pnpm package manager if building webassets is not skipped,
-# pnpm is not already enabled and Corepack is available.
+# Enables the pnpm package manager if  pnpm is not already enabled and Corepack
+# is available.
 # We check if pnpm is enabled, as the user may not have permission to
 # enable it, but it may already be available.
 # Enabling it merely installs a shim which then needs to be downloaded before first use.
@@ -1645,7 +1645,6 @@ ensure-webassets-e:
 # by issuing a bogus pnpm call with an env var that skips the prompt.
 .PHONY: ensure-js-package-manager
 ensure-js-package-manager:
-ifneq ($(WEBASSETS_SKIP_BUILD),1)
 	@if [ -z "$(CHECK_PNPM)" ]; then \
 		if [ -n "$(CHECK_COREPACK)" ]; then \
 			echo 'Info: pnpm is not enabled via Corepack. Enabling pnpm…'; \
@@ -1654,9 +1653,8 @@ ifneq ($(WEBASSETS_SKIP_BUILD),1)
 		else \
 			echo 'Error: Corepack is not installed, cannot enable pnpm. See the installation guide https://pnpm.io/installation#using-corepack'; \
 			exit 1; \
-		fi \
+		fi; \
 	fi
-endif
 
 .PHONY: init-submodules-e
 init-submodules-e:
@@ -1672,7 +1670,7 @@ backport:
 .PHONY: ensure-js-deps
 ensure-js-deps:
 	@if [[ "${WEBASSETS_SKIP_BUILD}" -eq 1 ]]; then mkdir -p webassets/teleport && touch webassets/teleport/index.html; \
-	else pnpm install --frozen-lockfile; fi
+	else $(MAKE) ensure-js-package-manager && pnpm install --frozen-lockfile; fi
 
 .PHONY: build-ui
 build-ui: ensure-js-deps


### PR DESCRIPTION
We added auto-enabling pnpm in `make build/teleport` if Corepack is available to make devs life easier. 
Unfortunately, it also broke builds, because we don't always need pnpm when building a teleport. This is the case with centos 7, where we don't have Node.js (and Corepack), and instead webassets are pre-built on a different image.

I thought it's enough to check if `WEBASSETS_SKIP_BUILD` is set to decide whether pnpm should be installed, but it's not true; instead we should run the target just before building the web UI (which depends on the result of `build-webassets-if-changed.sh` and `WEBASSETS_SKIP_BUILD`).

A test build passed: [16.0.0-dev.gzdunek.12](https://github.com/gravitational/teleport.e/actions/runs/10036143479).