### PR TITLE
Use new `tbot install systemd` command in docs

### DIFF
--- a/docs/pages/enroll-resources/machine-id/deployment/jenkins.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/jenkins.mdx
@@ -154,36 +154,9 @@ outputs:
       path: /opt/machine-id
 ```
 
-Next, create a systemd.unit file at `/etc/systemd/system/machine-id.service`.
+### Create a `tbot` systemd unit file
 
-```systemd
-[Unit]
-Description=Teleport Machine ID Service
-After=network.target
-
-[Service]
-Type=simple
-User=teleport
-Group=teleport
-Restart=always
-RestartSec=5
-Environment="TELEPORT_ANONYMOUS_TELEMETRY=1"
-ExecStart=/usr/local/bin/tbot start -c /etc/tbot.yaml
-ExecReload=/bin/kill -HUP $MAINPID
-PIDFile=/run/machine-id.pid
-LimitNOFILE=524288
-
-[Install]
-WantedBy=multi-user.target
-```
-
-`TELEPORT_ANONYMOUS_TELEMETRY` enables the submission of anonymous usage
-telemetry. This helps us shape the future development of `tbot`. You can disable
-this by omitting this.
-
-Finally, run the following commands to start Machine ID.
-
-(!docs/pages/includes/machine-id/machine-id-service.mdx!)
+(!docs/pages/includes/machine-id/daemon.mdx!)
 
 ## Step 2/2. Update and run Jenkins pipelines
 

--- a/docs/pages/includes/machine-id/daemon.mdx
+++ b/docs/pages/includes/machine-id/daemon.mdx
@@ -4,37 +4,28 @@ service manager will start `tbot` on boot and ensure it is restarted if it
 fails. For this guide, systemd will be demonstrated but `tbot` should be
 compatible with all common alternatives.
 
-Create a systemd unit file `/etc/systemd/system/tbot.service`:
+Use `tbot install systemd` to generate a systemd service file:
 
-```systemd
-[Unit]
-Description=Teleport Machine ID Service
-After=network.target
-
-[Service]
-Type=simple
-User=teleport
-Group=teleport
-Restart=always
-RestartSec=5
-Environment="TELEPORT_ANONYMOUS_TELEMETRY=1"
-ExecStart=/usr/local/bin/tbot start -c /etc/tbot.yaml
-ExecReload=/bin/kill -HUP $MAINPID
-PIDFile=/run/tbot.pid
-LimitNOFILE=524288
-
-[Install]
-WantedBy=multi-user.target
+```code
+$ tbot install systemd \
+   --write \
+   --config /etc/tbot.yaml \
+   --user teleport \
+   --group teleport \
+   --anonymous-telemetry
 ```
 
 Ensure that you replace:
 
 - `teleport` with the name of Linux user you wish to run `tbot` as.
-- `/etc/tbot.yaml` with the path to the configuration file you have created
+- `/etc/tbot.yaml` with the path to the configuration file you have created.
 
-`TELEPORT_ANONYMOUS_TELEMETRY` enables the submission of anonymous usage
-telemetry. This helps us shape the future development of `tbot`. You can disable
-this by omitting this.
+You can omit `--write` to print the systemd service file to the console instead
+of writing it to disk.
+
+`--anonymous-telemetry` enables the submission of anonymous usage telemetry.
+This helps us shape the future development of `tbot`. You can disable this by
+omitting this.
 
 Next, enable the service so that it will start on boot and then start the
 service:

--- a/docs/pages/includes/machine-id/machine-id-service.mdx
+++ b/docs/pages/includes/machine-id/machine-id-service.mdx
@@ -1,5 +1,0 @@
-```code
-$ sudo systemctl enable machine-id
-$ sudo systemctl start machine-id
-$ sudo systemctl status machine-id
-```

--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -244,13 +244,27 @@ $ tbot start \
   </TabItem>
 </Tabs>
 
-## tbot tpm identify
+## tbot install systemd
 
-Output identifying information related to the TPM (Trusted Platform Module)
-detected on the system.
+Generates and installs a systemd unit file for a specific tbot configuration.
 
 ### Flags
 
-| Flag                 | Description                        |
-|----------------------|------------------------------------|
-| `-d/--debug`         | Enable verbose logging to stderr.  |
+| Flag                  | Description                                                                                                                      |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| `-d/--debug`          | Enable verbose logging to stderr.                                                                                                |
+| `-c/--config`         | Path to a configuration file.                                                                                                    |
+| `--write `            | Write the systemd unit file. If not specified, this command runs in a dry-run mode that outputs the generated content to stdout. |
+| `--systemd-directory` | Path to the directory that the systemd unit file should be written. Defaults to '/etc/systemd/system'.                           |
+| `--force`             | Overwrite existing systemd unit file if present.                                                                                 |
+| `--name`              | Name for the systemd unit. Defaults to 'tbot'.                                                                                   |
+| `--user`              | The user that the service should run as. Defaults to 'teleport'.                                                                 |
+| `--group`             | The group that the service should run as. Defaults to 'teleport'.                                                                |
+
+### Examples
+
+```code
+$ tbot install systemd \
+   --config=/etc/tbot.yaml \
+   ---write
+```


### PR DESCRIPTION
Updates the documentation to use the new `tbot install systemd` command.