### PR TITLE
Remove v2-config-warning header from Machine ID docs

### DIFF
--- a/docs/pages/enroll-resources/machine-id/access-guides/applications.mdx
+++ b/docs/pages/enroll-resources/machine-id/access-guides/applications.mdx
@@ -3,8 +3,6 @@ title: Machine ID with Application Access
 description: How to use Machine ID to access applications
 ---
 
-(!docs/pages/includes/machine-id/v2-config-warning.mdx!)
-
 Teleport protects and controls access to HTTP and TCP applications. Machine ID
 can be used to grant machines secure, short-lived access to these applications.
 

--- a/docs/pages/enroll-resources/machine-id/access-guides/databases.mdx
+++ b/docs/pages/enroll-resources/machine-id/access-guides/databases.mdx
@@ -3,8 +3,6 @@ title: Machine ID with Database Access
 description: How to use Machine ID to access database servers
 ---
 
-(!docs/pages/includes/machine-id/v2-config-warning.mdx!)
-
 Teleport protects and controls access to databases. Machine ID
 can be used to grant machines secure, short-lived access to these databases.
 

--- a/docs/pages/enroll-resources/machine-id/access-guides/kubernetes.mdx
+++ b/docs/pages/enroll-resources/machine-id/access-guides/kubernetes.mdx
@@ -3,8 +3,6 @@ title: Machine ID with Kubernetes Access
 description: How to use Machine ID to access Kubernetes clusters
 ---
 
-(!docs/pages/includes/machine-id/v2-config-warning.mdx!)
-
 Teleport protects and controls access to Kubernetes
 clusters. Machine ID can be used to grant machines secure, short-lived
 access to these clusters.

--- a/docs/pages/enroll-resources/machine-id/access-guides/ssh.mdx
+++ b/docs/pages/enroll-resources/machine-id/access-guides/ssh.mdx
@@ -3,8 +3,6 @@ title: Machine ID with Server Access
 description: How to use Machine ID to access servers via SSH
 ---
 
-(!docs/pages/includes/machine-id/v2-config-warning.mdx!)
-
 Teleport protects and controls SSH access to servers. Machine ID
 can be used to grant machines secure, short-lived access to these servers.
 

--- a/docs/pages/enroll-resources/machine-id/deployment/jenkins.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/jenkins.mdx
@@ -3,8 +3,6 @@ title: Deploying Machine ID on Jenkins
 description: How to install and configure Machine ID on Jenkins
 ---
 
-(!docs/pages/includes/machine-id/v2-config-warning.mdx!)
-
 Jenkins is an open source automation server that is frequently used to build
 Continuous Integration and Continuous Delivery (CI/CD) pipelines.
 

--- a/docs/pages/includes/machine-id/v2-config-warning.mdx
+++ b/docs/pages/includes/machine-id/v2-config-warning.mdx
@@ -1,3 +1,0 @@
-This version of the guide uses the v2 `tbot` configuration. This version is only
-supported by Teleport 14 and beyond. Change the selected version of the
-documentation to view the guide for previous Teleport versions.


### PR DESCRIPTION
Removes the warning intended for those migrating on v13 from the Machine ID docs. I'll backport this to v15/v16, but leave it in v14.