### PR TITLE
Add missing `entitlements` directory to container image builds

### DIFF
--- a/integrations/operator/Dockerfile
+++ b/integrations/operator/Dockerfile
@@ -58,6 +58,7 @@ RUN go mod download
 COPY *.go ./
 COPY lib/ lib/
 COPY gen/ gen/
+COPY entitlements/ entitlements/
 COPY integrations/lib/embeddedtbot/ integrations/lib/embeddedtbot/
 COPY integrations/operator/apis/ integrations/operator/apis/
 COPY integrations/operator/controllers/ integrations/operator/controllers/

--- a/integrations/operator/Dockerfile.gha
+++ b/integrations/operator/Dockerfile.gha
@@ -75,6 +75,7 @@ RUN go mod download
 COPY *.go ./
 COPY lib/ lib/
 COPY gen/ gen/
+COPY entitlements/ entitlements/
 COPY integrations/lib/embeddedtbot/ integrations/lib/embeddedtbot/
 COPY integrations/operator/apis/ integrations/operator/apis/
 COPY integrations/operator/controllers/ integrations/operator/controllers/

--- a/integrations/teleport-spacelift-runner/Dockerfile
+++ b/integrations/teleport-spacelift-runner/Dockerfile
@@ -20,6 +20,7 @@ COPY lib/ lib/
 COPY api/ api/
 COPY gen/ gen/
 COPY build.assets/ build.assets/
+COPY entitlements/ entitlements/
 COPY *.go ./
 COPY Makefile Makefile
 COPY darwin-signing.mk darwin-signing.mk


### PR DESCRIPTION
Master branch builds are broken because these Dockerfiles are not copying in the new `entitlements` directory. Change tested locally and this seems to fix the issue.