### PR TITLE
fix access request cache test race

### DIFF
--- a/lib/services/access_request_cache.go
+++ b/lib/services/access_request_cache.go
@@ -352,6 +352,7 @@ func (c *AccessRequestCache) getResourcesAndUpdateCurrent(ctx context.Context) e
 	c.rw.Lock()
 	defer c.rw.Unlock()
 	c.primaryCache = cache
+	close(c.initC)
 	return nil
 }
 
@@ -402,6 +403,12 @@ func (c *AccessRequestCache) initializationChan() <-chan struct{} {
 	c.rw.RLock()
 	defer c.rw.RUnlock()
 	return c.initC
+}
+
+// InitializationChan is part of the resourceCollector interface and gets the channel
+// used to signal that the accessRequestCache has been initialized.
+func (c *AccessRequestCache) InitializationChan() <-chan struct{} {
+	return c.initializationChan()
 }
 
 // Close terminates the background process that keeps the access request cache up to

--- a/lib/services/access_request_cache_test.go
+++ b/lib/services/access_request_cache_test.go
@@ -51,6 +51,12 @@ func newAccessRequestPack(t *testing.T) (accessRequestServices, *services.Access
 	})
 	require.NoError(t, err)
 
+	select {
+	case <-cache.InitializationChan():
+	case <-time.After(time.Second * 30):
+		require.FailNow(t, "timeout waiting for access request cache to initialize")
+	}
+
 	return svcs, cache
 }
 


### PR DESCRIPTION
Access request cache tests were not properly waiting for cache init before running.  Since all tests were starting with an empty in-memory backend as the upstream data source init was generally too fast for this to matter.  If init was slightly slower than usual though, tests would become flaky due to inconsistent values being returned from reads.