### PR TITLE
chore: Bump Buf to v1.35.0

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -17,7 +17,7 @@ LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 DEVTOOLSET ?= devtoolset-12
 
 # Protogen related versions.
-BUF_VERSION ?= v1.34.0
+BUF_VERSION ?= v1.35.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4


### PR DESCRIPTION
Update to the latest release. No codegen changes.

I had a quick look at the new `buf generate --clean`, but given how many different plugins we use (and how they all behave somewhat differently), it's simpler to keep the [rm -fr {,api/}gen/proto][1] that is already there.

* https://github.com/bufbuild/buf/releases/tag/v1.35.0

[1]: https://github.com/gravitational/teleport/blob/73793e747c41944491102c7a08482fec7bf6dd27/build.assets/genproto.sh#L37