### PR TITLE
Generate docs from proto definitions

### DIFF
--- a/api/gen/proto/go/teleport/clusterconfig/v1/clusterconfig_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/clusterconfig/v1/clusterconfig_service_grpc.pb.go
@@ -87,7 +87,7 @@ type ClusterConfigServiceClient interface {
 	ResetAuthPreference(ctx context.Context, in *ResetAuthPreferenceRequest, opts ...grpc.CallOption) (*types.AuthPreferenceV2, error)
 	// GetClusterAuditConfig retrieves the active cluster audit configuration.
 	GetClusterAuditConfig(ctx context.Context, in *GetClusterAuditConfigRequest, opts ...grpc.CallOption) (*types.ClusterAuditConfigV2, error)
-	// GetClusterAccessGraphConfig retrieves the cluster Access Graph configuration from Auth server.
+	// GetClusterAccessGraphConfig retrieves the cluster Access Graph configuration from Auth service.
 	GetClusterAccessGraphConfig(ctx context.Context, in *GetClusterAccessGraphConfigRequest, opts ...grpc.CallOption) (*GetClusterAccessGraphConfigResponse, error)
 	// GetAccessGraphSettings updates the cluster Access Graph configuration.
 	GetAccessGraphSettings(ctx context.Context, in *GetAccessGraphSettingsRequest, opts ...grpc.CallOption) (*AccessGraphSettings, error)
@@ -331,7 +331,7 @@ type ClusterConfigServiceServer interface {
 	ResetAuthPreference(context.Context, *ResetAuthPreferenceRequest) (*types.AuthPreferenceV2, error)
 	// GetClusterAuditConfig retrieves the active cluster audit configuration.
 	GetClusterAuditConfig(context.Context, *GetClusterAuditConfigRequest) (*types.ClusterAuditConfigV2, error)
-	// GetClusterAccessGraphConfig retrieves the cluster Access Graph configuration from Auth server.
+	// GetClusterAccessGraphConfig retrieves the cluster Access Graph configuration from Auth service.
 	GetClusterAccessGraphConfig(context.Context, *GetClusterAccessGraphConfigRequest) (*GetClusterAccessGraphConfigResponse, error)
 	// GetAccessGraphSettings updates the cluster Access Graph configuration.
 	GetAccessGraphSettings(context.Context, *GetAccessGraphSettingsRequest) (*AccessGraphSettings, error)

--- a/api/proto/teleport/clusterconfig/v1/clusterconfig_service.proto
+++ b/api/proto/teleport/clusterconfig/v1/clusterconfig_service.proto
@@ -54,7 +54,7 @@ service ClusterConfigService {
   // GetClusterAuditConfig retrieves the active cluster audit configuration.
   rpc GetClusterAuditConfig(GetClusterAuditConfigRequest) returns (types.ClusterAuditConfigV2);
 
-  // GetClusterAccessGraphConfig retrieves the cluster Access Graph configuration from Auth server.
+  // GetClusterAccessGraphConfig retrieves the cluster Access Graph configuration from Auth service.
   rpc GetClusterAccessGraphConfig(GetClusterAccessGraphConfigRequest) returns (GetClusterAccessGraphConfigResponse);
 
   // GetAccessGraphSettings updates the cluster Access Graph configuration.

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -2802,7 +2802,7 @@ message RoleOptions {
   // concurrent sessions per connection.
   int64 MaxSessions = 10 [(gogoproto.jsontag) = "max_sessions,omitempty"];
 
-  // RequestAccess defines the access request strategy (optional|note|always)
+  // RequestAccess defines the request strategy (optional|note|always)
   // where optional is the default.
   string RequestAccess = 11 [
     (gogoproto.jsontag) = "request_access,omitempty",

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -7521,7 +7521,7 @@ type RoleOptions struct {
 	// MaxSessions defines the maximum number of
 	// concurrent sessions per connection.
 	MaxSessions int64 `protobuf:"varint,10,opt,name=MaxSessions,proto3" json:"max_sessions,omitempty"`
-	// RequestAccess defines the access request strategy (optional|note|always)
+	// RequestAccess defines the request strategy (optional|note|always)
 	// where optional is the default.
 	RequestAccess RequestStrategy `protobuf:"bytes,11,opt,name=RequestAccess,proto3,casttype=RequestStrategy" json:"request_access,omitempty"`
 	// RequestPrompt is an optional message which tells users what they aught to request.

--- a/docs/pages/enroll-resources/agents/deploy-agents-terraform.mdx
+++ b/docs/pages/enroll-resources/agents/deploy-agents-terraform.mdx
@@ -1,17 +1,19 @@
 ---
-title: "Deploy Teleport Agents with Terraform"
-description: "In this guide, we will show you how to deploy a pool of Teleport agents so you can apply dynamic resources to enroll your infrastructure with Teleport."
+title: "Deploy Agents with Terraform"
+description: "In this guide, we will show you how to deploy a pool of Agents so you can apply dynamic resources to enroll your infrastructure with Teleport."
 ---
+
+## How it works
 
 An agent is a Teleport instance configured to run one or more Teleport services
 in order to proxy infrastructure resources. For a brief architectural overview
 of how agents run in a Teleport cluster, read the [Introduction to Teleport
 Agents](introduction.mdx).
 
-This guide shows you how to deploy a pool of Teleport agents running on virtual
+This guide shows you how to deploy a pool of Agents running on virtual
 machines by declaring it as code using Terraform.
 
-There are several methods you can use to join a Teleport agent to your cluster,
+There are several methods you can use to join a Agents to your cluster,
 which we discuss in the [Joining Services to your
 Cluster](join-services-to-your-cluster.mdx) guide. In this guide, we will use
 the **join token** method, where the operator stores a secure token on the Auth
@@ -23,7 +25,7 @@ resources:
 - Compute instances to run Teleport services
 - A join token for each compute instance in the agent pool
 
-![A Teleport agent pool](../../../img/tf-agent-diagram.png)
+![An Agent pool](../../../img/tf-agent-diagram.png)
 
 ## Prerequisites
 
@@ -36,7 +38,7 @@ see how an agent pool works. After you are familiar with the setup, apply the
 lessons from this guide to protect your infrastructure. You can get started with
 a demo cluster using:
 - A demo deployment on a [Linux server](../../deploy-a-cluster/linux-demo.mdx)
-- A [Teleport Enterprise Cloud trial](https://goteleport.com/signup)
+- A [Teleport Enterprise (managed) trial](https://goteleport.com/signup)
 
 </Admonition>
 
@@ -320,7 +322,7 @@ provider "aws" {
 }
 
 provider "teleport" {
-  # Update addr to point to your Teleport Cloud tenant URL's host:port
+  # Update addr to point to your Teleport Enterprise (managed) tenant URL's host:port
   addr               = PROXY_SERVICE_ADDRESS
   identity_file_path = "terraform-identity"
 }
@@ -356,7 +358,7 @@ provider "google" {
 }
 
 provider "teleport" {
-  # Update addr to point to your Teleport Cloud tenant URL's host:port
+  # Update addr to point to your Teleport Enterprise (managed) tenant URL's host:port
   addr               = PROXY_SERVICE_ADDRESS
   identity_file_path = "terraform-identity"
 }
@@ -390,7 +392,7 @@ terraform {
 
 provider "teleport" {
   identity_file_path = "terraform-identity"
-  # Update addr to point to your Teleport Cloud tenant URL's host:port
+  # Update addr to point to your Teleport Enterprise (managed) tenant URL's host:port
   addr               = PROXY_SERVICE_ADDRESS
 }
 
@@ -529,7 +531,7 @@ In this section, we explain the resources configured in the
 ### Join token
 
 The `agent-pool-terraform` module deploys one virtual machine instance for each
-Teleport agent. Each agent joins the cluster using a token. We create each token
+Agent. Each agent joins the cluster using a token. We create each token
 using the `teleport_provision_token` Terraform resource, specifying the token's
 value with a `random_string` resource:
 
@@ -542,7 +544,7 @@ provider creates them on the Teleport Auth Service backend.
 
 ### User data script
 
-Each Teleport agent deployed by the `agent-pool-terraform` module loads a user
+Each Agent deployed by the `agent-pool-terraform` module loads a user
 data script that creates a Teleport configuration file for the agent. The
 services enabled by the configuration file depend on the value of the
 `agent_roles` input variable:

--- a/docs/pages/reference/terraform-provider.mdx
+++ b/docs/pages/reference/terraform-provider.mdx
@@ -63,7 +63,7 @@ terraform {
 }
 
 provider "teleport" {
-  # Update addr to point to your Teleport Cloud tenant URL's host:port
+  # Update addr to point to your Teleport Enterprise (managed) tenant URL's host:port
   addr               = "mytenant.teleport.sh:443"
   identity_file_path = "terraform-identity/identity"
 }
@@ -127,7 +127,7 @@ This auth method has the following limitations:
 
 ### Optional
 
-- `addr` (String) host:port where Teleport Auth server is running. This can also be set with the environment variable `TF_TELEPORT_ADDR`.
+- `addr` (String) host:port where Teleport Auth Service is running. This can also be set with the environment variable `TF_TELEPORT_ADDR`.
 - `cert_base64` (String) Base64 encoded TLS auth certificate. This can also be set with the environment variable `TF_TELEPORT_CERT_BASE64`.
 - `cert_path` (String) Path to Teleport auth certificate file. This can also be set with the environment variable `TF_TELEPORT_CERT`.
 - `dial_timeout_duration` (String) DialTimeout sets timeout when trying to connect to the server. This can also be set with the environment variable `TF_TELEPORT_DIAL_TIMEOUT_DURATION`.

--- a/docs/pages/reference/terraform-provider/data-sources/database.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/database.mdx
@@ -80,6 +80,7 @@ Optional:
 
 - `account_id` (String) AccountID is the AWS account ID this database belongs to.
 - `assume_role_arn` (String) AssumeRoleARN is an optional AWS role ARN to assume when accessing a database. Set this field and ExternalID to enable access across AWS accounts.
+- `docdb` (Attributes) DocumentDB contains AWS DocumentDB specific metadata. (see [below for nested schema](#nested-schema-for-specawsdocdb))
 - `elasticache` (Attributes) ElastiCache contains AWS ElastiCache Redis specific metadata. (see [below for nested schema](#nested-schema-for-specawselasticache))
 - `external_id` (String) ExternalID is an optional AWS external ID used to enable assuming an AWS role across accounts.
 - `iam_policy_status` (Number) IAMPolicyStatus indicates whether the IAM Policy is configured properly for database access. If not, the user must update the AWS profile identity to allow access to the Database. Eg for an RDS Database: the underlying AWS profile allows for `rds-db:connect` for the Database.
@@ -92,6 +93,15 @@ Optional:
 - `region` (String) Region is a AWS cloud region.
 - `secret_store` (Attributes) SecretStore contains secret store configurations. (see [below for nested schema](#nested-schema-for-specawssecret_store))
 - `session_tags` (Map of String) SessionTags is a list of AWS STS session tags.
+
+### Nested Schema for `spec.aws.docdb`
+
+Optional:
+
+- `cluster_id` (String) ClusterID is the cluster identifier.
+- `endpoint_type` (String) EndpointType is the type of the endpoint.
+- `instance_id` (String) InstanceID is the instance identifier.
+
 
 ### Nested Schema for `spec.aws.elasticache`
 

--- a/docs/pages/reference/terraform-provider/data-sources/role.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/role.mdx
@@ -381,7 +381,7 @@ Optional:
 - `create_host_user_mode` (Number) CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop".
 - `desktop_clipboard` (Boolean)
 - `desktop_directory_sharing` (Boolean)
-- `device_trust_mode` (String) DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode. Reserved for future use, not yet used by Teleport.
+- `device_trust_mode` (String) DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode.
 - `disconnect_expired_cert` (Boolean) DisconnectExpiredCert sets disconnect clients on expired certificates.
 - `enhanced_recording` (List of String) BPF defines what events to record for the BPF-based session recorder.
 - `forward_agent` (Boolean) ForwardAgent is SSH agent forwarding.
@@ -395,7 +395,7 @@ Optional:
 - `pin_source_ip` (Boolean) PinSourceIP forces the same client IP for certificate generation and usage
 - `port_forwarding` (Boolean)
 - `record_session` (Attributes) RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false. (see [below for nested schema](#nested-schema-for-specoptionsrecord_session))
-- `request_access` (String) RequestAccess defines the access request strategy (optional|note|always) where optional is the default.
+- `request_access` (String) RequestAccess defines the request strategy (optional|note|always) where optional is the default.
 - `request_prompt` (String) RequestPrompt is an optional message which tells users what they aught to request.
 - `require_session_mfa` (Number) RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
 - `ssh_file_copy` (Boolean)

--- a/docs/pages/reference/terraform-provider/resources/database.mdx
+++ b/docs/pages/reference/terraform-provider/resources/database.mdx
@@ -99,6 +99,7 @@ Optional:
 
 - `account_id` (String) AccountID is the AWS account ID this database belongs to.
 - `assume_role_arn` (String) AssumeRoleARN is an optional AWS role ARN to assume when accessing a database. Set this field and ExternalID to enable access across AWS accounts.
+- `docdb` (Attributes) DocumentDB contains AWS DocumentDB specific metadata. (see [below for nested schema](#nested-schema-for-specawsdocdb))
 - `elasticache` (Attributes) ElastiCache contains AWS ElastiCache Redis specific metadata. (see [below for nested schema](#nested-schema-for-specawselasticache))
 - `external_id` (String) ExternalID is an optional AWS external ID used to enable assuming an AWS role across accounts.
 - `iam_policy_status` (Number) IAMPolicyStatus indicates whether the IAM Policy is configured properly for database access. If not, the user must update the AWS profile identity to allow access to the Database. Eg for an RDS Database: the underlying AWS profile allows for `rds-db:connect` for the Database.
@@ -111,6 +112,15 @@ Optional:
 - `region` (String) Region is a AWS cloud region.
 - `secret_store` (Attributes) SecretStore contains secret store configurations. (see [below for nested schema](#nested-schema-for-specawssecret_store))
 - `session_tags` (Map of String) SessionTags is a list of AWS STS session tags.
+
+### Nested Schema for `spec.aws.docdb`
+
+Optional:
+
+- `cluster_id` (String) ClusterID is the cluster identifier.
+- `endpoint_type` (String) EndpointType is the type of the endpoint.
+- `instance_id` (String) InstanceID is the instance identifier.
+
 
 ### Nested Schema for `spec.aws.elasticache`
 

--- a/docs/pages/reference/terraform-provider/resources/role.mdx
+++ b/docs/pages/reference/terraform-provider/resources/role.mdx
@@ -434,7 +434,7 @@ Optional:
 - `create_host_user_mode` (Number) CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop".
 - `desktop_clipboard` (Boolean)
 - `desktop_directory_sharing` (Boolean)
-- `device_trust_mode` (String) DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode. Reserved for future use, not yet used by Teleport.
+- `device_trust_mode` (String) DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode.
 - `disconnect_expired_cert` (Boolean) DisconnectExpiredCert sets disconnect clients on expired certificates.
 - `enhanced_recording` (List of String) BPF defines what events to record for the BPF-based session recorder.
 - `forward_agent` (Boolean) ForwardAgent is SSH agent forwarding.
@@ -448,7 +448,7 @@ Optional:
 - `pin_source_ip` (Boolean) PinSourceIP forces the same client IP for certificate generation and usage
 - `port_forwarding` (Boolean)
 - `record_session` (Attributes) RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false. (see [below for nested schema](#nested-schema-for-specoptionsrecord_session))
-- `request_access` (String) RequestAccess defines the access request strategy (optional|note|always) where optional is the default.
+- `request_access` (String) RequestAccess defines the request strategy (optional|note|always) where optional is the default.
 - `request_prompt` (String) RequestPrompt is an optional message which tells users what they aught to request.
 - `require_session_mfa` (Number) RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
 - `ssh_file_copy` (Boolean)

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_roles.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_roles.yaml
@@ -1241,8 +1241,8 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the access request strategy
-                      (optional|note|always) where optional is the default.
+                    description: RequestAccess defines the request strategy (optional|note|always)
+                      where optional is the default.
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells
@@ -2572,8 +2572,8 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the access request strategy
-                      (optional|note|always) where optional is the default.
+                    description: RequestAccess defines the request strategy (optional|note|always)
+                      where optional is the default.
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv6.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv6.yaml
@@ -1244,8 +1244,8 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the access request strategy
-                      (optional|note|always) where optional is the default.
+                    description: RequestAccess defines the request strategy (optional|note|always)
+                      where optional is the default.
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv7.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv7.yaml
@@ -1244,8 +1244,8 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the access request strategy
-                      (optional|note|always) where optional is the default.
+                    description: RequestAccess defines the request strategy (optional|note|always)
+                      where optional is the default.
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells

--- a/examples/resources/terraform/provider-cloud.tf
+++ b/examples/resources/terraform/provider-cloud.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "teleport" {
-  # Update addr to point to your Teleport Cloud tenant URL's host:port
+  # Update addr to point to your Teleport Enterprise (managed) tenant URL's host:port
   addr               = "mytenant.teleport.sh:443"
   identity_file_path = "terraform-identity/identity"
 }

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
@@ -1241,8 +1241,8 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the access request strategy
-                      (optional|note|always) where optional is the default.
+                    description: RequestAccess defines the request strategy (optional|note|always)
+                      where optional is the default.
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells
@@ -2572,8 +2572,8 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the access request strategy
-                      (optional|note|always) where optional is the default.
+                    description: RequestAccess defines the request strategy (optional|note|always)
+                      where optional is the default.
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv6.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv6.yaml
@@ -1244,8 +1244,8 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the access request strategy
-                      (optional|note|always) where optional is the default.
+                    description: RequestAccess defines the request strategy (optional|note|always)
+                      where optional is the default.
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv7.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv7.yaml
@@ -1244,8 +1244,8 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the access request strategy
-                      (optional|note|always) where optional is the default.
+                    description: RequestAccess defines the request strategy (optional|note|always)
+                      where optional is the default.
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells

--- a/integrations/terraform/examples/provider/provider-cloud.tf
+++ b/integrations/terraform/examples/provider/provider-cloud.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "teleport" {
-  # Update addr to point to your Teleport Cloud tenant URL's host:port
+  # Update addr to point to your Teleport Enterprise (managed) tenant URL's host:port
   addr               = "mytenant.teleport.sh:443"
   identity_file_path = "terraform-identity/identity"
 }

--- a/integrations/terraform/provider/provider.go
+++ b/integrations/terraform/provider/provider.go
@@ -108,7 +108,7 @@ func (p *Provider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 			"addr": {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "host:port where Teleport Auth server is running. This can also be set with the environment variable `TF_TELEPORT_ADDR`.",
+				Description: "host:port where Teleport Auth Service is running. This can also be set with the environment variable `TF_TELEPORT_ADDR`.",
 			},
 			"cert_path": {
 				Type:        types.StringType,

--- a/integrations/terraform/templates/index.md.tmpl
+++ b/integrations/terraform/templates/index.md.tmpl
@@ -55,7 +55,7 @@ The identity file can be obtained via several ways:
 
 #### Obtaining an identity file via `tbot`
 
-Tbot relies on [MachineID](../machine-id/introduction.mdx) to obtain and automatically renew short-lived credentials.
+Tbot relies on [MachineID](../enroll-resources/machine-id/introduction.mdx) to obtain and automatically renew short-lived credentials.
 Such credentials are harder to exfiltrate, and you can control more precisely who has access to which roles
 (e.g. you can allow only GitHub Actions pipelines targeting the `prod` environment to get certificates).
 

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -2416,7 +2416,7 @@ func GenSchemaRoleV6(ctx context.Context) (github_com_hashicorp_terraform_plugin
 							Optional:    true,
 						},
 						"request_access": {
-							Description: "RequestAccess defines the access request strategy (optional|note|always) where optional is the default.",
+							Description: "RequestAccess defines the request strategy (optional|note|always) where optional is the default.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},


### PR DESCRIPTION
We didn't run the linter for the last couple of weeks.
Some things were merged but were not correctly formatted.

This PR fixes some issues and generates all the terraform and operator schemas

See https://github.com/gravitational/teleport/pull/44541