### PR TITLE
Show bot instance ID in tbot log output

### DIFF
--- a/lib/tbot/output_utils.go
+++ b/lib/tbot/output_utils.go
@@ -276,9 +276,16 @@ func describeTLSIdentity(ctx context.Context, log *slog.Logger, ident *identity.
 		}
 	}
 
+	botDesc := ""
+	if tlsIdent.BotInstanceID != "" {
+		botDesc = fmt.Sprintf(", id=%s", tlsIdent.BotInstanceID)
+	}
+
 	duration := cert.NotAfter.Sub(cert.NotBefore)
 	return fmt.Sprintf(
-		"valid: after=%v, before=%v, duration=%s | kind=tls, renewable=%v, disallow-reissue=%v, roles=%v, principals=%v, generation=%v",
+		"%s%s | valid: after=%v, before=%v, duration=%s | kind=tls, renewable=%v, disallow-reissue=%v, roles=%v, principals=%v, generation=%v",
+		tlsIdent.BotName,
+		botDesc,
 		cert.NotBefore.Format(time.RFC3339),
 		cert.NotAfter.Format(time.RFC3339),
 		duration,


### PR DESCRIPTION
This tweaks the "fetched new bot identity" message to show the bot name and instance ID as embedded in the bot's certificate.

Example:

```
2024-07-23T15:51:20-06:00 INFO [TBOT:IDEN] Fetched new bot identity identity:tpm-test, id=5a2865d3-d3dc-4eaa-853c-5377a1fe83f6 | valid: after=2024-07-23T21:50:20Z, before=2024-07-23T21:56:19Z, duration=5m59s | kind=tls, renewable=false, disallow-reissue=false, roles=[bot-tpm-test], principals=[-teleport-internal-join], generation=0 tbot/service_bot_identity.go:223
```

If the bot isn't issued an instance ID, the `, id=....` is not included, but the bot name is still shown. Bot names have been present in certs (I think) since the initial Machine ID release, so we can always expect it to exist.

I found I was getting annoyed by the lack of this info while testing some other PRs. We may want to further iterate on the formatting here, but I figured I'd put up this trivial fix now.

changelog: Include bot name and instance ID in tbot log output