### PR TITLE
nicer errors for GenerateUserCerts version compat

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -1053,8 +1053,9 @@ func (c *Client) GenerateUserCerts(ctx context.Context, req proto.UserCertsReque
 		// This could be a v17+ client connecting to a v16- auth (which we
 		// officially don't support), or a difference between commits on master
 		// during the v17 dev cycle.
-		if req.PublicKey == nil && (req.TLSPublicKey != nil || req.SSHPublicKey != nil) &&
-			strings.Contains(err.Error(), "ssh: no key found") {
+		usingLegacyPubKey := req.PublicKey != nil //nolint:staticcheck // SA1019: intentional reference to deprecated field.
+		usingNewPubKey := req.TLSPublicKey != nil || req.SSHPublicKey != nil
+		if !usingLegacyPubKey && usingNewPubKey && strings.Contains(err.Error(), "ssh: no key found") {
 			authVersion := "unknown"
 			if pingResp, err := c.Ping(ctx); err == nil && pingResp.ServerVersion != "" {
 				authVersion = pingResp.ServerVersion

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"net"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -46,6 +47,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/client/accesslist"
 	"github.com/gravitational/teleport/api/client/accessmonitoringrules"
@@ -1046,6 +1048,22 @@ func (c *Client) DeleteUser(ctx context.Context, user string) error {
 func (c *Client) GenerateUserCerts(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
 	certs, err := c.grpc.GenerateUserCerts(ctx, &req)
 	if err != nil {
+		// Try to print a nicer error message when newer clients connect to
+		// older auth servers that don't recognize the new public key fields.
+		// This could be a v17+ client connecting to a v16- auth (which we
+		// officially don't support), or a difference between commits on master
+		// during the v17 dev cycle.
+		if req.PublicKey == nil && (req.TLSPublicKey != nil || req.SSHPublicKey != nil) &&
+			strings.Contains(err.Error(), "ssh: no key found") {
+			authVersion := "unknown"
+			if pingResp, err := c.Ping(ctx); err == nil && pingResp.ServerVersion != "" {
+				authVersion = pingResp.ServerVersion
+			}
+			return nil, trace.Wrap(err, "auth server did not recognize new public key fields, "+
+				"client version (%s) is likely newer than your auth server version (%s), "+
+				"consider downgrading your client or upgrading your auth server",
+				api.Version, authVersion)
+		}
 		return nil, trace.Wrap(err)
 	}
 	return certs, nil


### PR DESCRIPTION
This improves the error message when a client on a newer version connects to an older auth and tries to GenerateUserCerts without sending PublicKey (using SSHPublicKey and/or TLSPublicKey instead)

This would apply to v17+ clients logging in to v16- clusters, or certain version differences on master during the v17 dev cycle. We officially don't support clients on a newer major version than the auth server https://goteleport.com/docs/upgrading/overview/

```sh
$ go run ./tool/tsh login one.private
ERROR: auth server did not recognize new public key fields, client version (17.0.0-dev) is likely newer than your auth server version (16.0.0-alpha.2), consider downgrading your client or upgrading your auth server
        rpc error: code = Unknown desc = ssh: no key found

exit status 1
```