### PR TITLE
docs: added 443 port to missing examples in db doc 

### DIFF
--- a/docs/pages/includes/database-access/self-hosted-config-start.mdx
+++ b/docs/pages/includes/database-access/self-hosted-config-start.mdx
@@ -10,14 +10,14 @@ your terminal, and manually adjust `/etc/teleport.yaml`.
 
 Run the following command to generate a configuration file at
 `/etc/teleport.yaml` for the Database Service. Update 
-<Var name="example.teleport.sh" /> to use the host and port of the Teleport Proxy
+<Var name="example.teleport.sh:443" /> to use the host and port of the Teleport Proxy
 Service:
 
 ```code
 $ sudo teleport db configure create \
    -o file \
    --token=/tmp/token \
-   --proxy=<Var name="example.teleport.sh" /> \
+   --proxy=<Var name="example.teleport.sh:443" /> \
    --name={{ dbName }} \
    --protocol={{ dbProtocol }} \
    --uri={{ databaseAddress }} \


### PR DESCRIPTION
Found a typo in the doc that is missing `:443` on the first two mentions of `example.teleport.sh`. Added those in to help with consistency of the doc. 