### PR TITLE
docs: claims_to_roles is not optional for OIDC

### DIFF
--- a/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
@@ -44,6 +44,7 @@ resource "teleport_oidc_connector" "example" {
 
 - `spec` (Attributes) Spec is an OIDC connector specification. (see [below for nested schema](#nested-schema-for-spec))
 - `version` (String) Version is the resource version. It must be specified. Supported values are: `v3`.
+- `claims_to_roles` (Attributes List) ClaimsToRoles specifies a dynamic mapping from claims to roles. (see [below for nested schema](#nested-schema-for-specclaims_to_roles))
 
 ### Optional
 
@@ -56,7 +57,6 @@ Optional:
 
 - `acr_values` (String) ACR is an Authentication Context Class Reference value. The meaning of the ACR value is context-specific and varies for identity providers.
 - `allow_unverified_email` (Boolean) AllowUnverifiedEmail tells the connector to accept OIDC users with unverified emails.
-- `claims_to_roles` (Attributes List) ClaimsToRoles specifies a dynamic mapping from claims to roles. (see [below for nested schema](#nested-schema-for-specclaims_to_roles))
 - `client_id` (String) ClientID is the id of the authentication client (Teleport Auth server).
 - `client_redirect_settings` (Attributes) ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones. (see [below for nested schema](#nested-schema-for-specclient_redirect_settings))
 - `client_secret` (String, Sensitive) ClientSecret is used to authenticate the client.
@@ -74,7 +74,7 @@ Optional:
 
 ### Nested Schema for `spec.claims_to_roles`
 
-Optional:
+Required:
 
 - `claim` (String) Claim is a claim name.
 - `roles` (List of String) Roles is a list of static teleport roles to match.


### PR DESCRIPTION
`claims_to_roles` is required for the Terraform Provider resource `oidc_connector`

Closes #44577