### PR TITLE
Update list of supported join methods in ProvisionTokenV2

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -1254,18 +1254,7 @@ message ProvisionTokenSpecV2 {
     (gogoproto.casttype) = "Duration"
   ];
   // JoinMethod is the joining method required in order to use this token.
-  // Supported joining methods include:
-  // - azure
-  // - circleci
-  // - ec2
-  // - gcp
-  // - github
-  // - gitlab
-  // - iam
-  // - kubernetes
-  // - spacelift
-  // - token
-  // - tpm
+  // Supported joining methods include: azure, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm
   string JoinMethod = 4 [
     (gogoproto.jsontag) = "join_method",
     (gogoproto.casttype) = "JoinMethod"

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -1254,7 +1254,18 @@ message ProvisionTokenSpecV2 {
     (gogoproto.casttype) = "Duration"
   ];
   // JoinMethod is the joining method required in order to use this token.
-  // Supported joining methods include "token", "ec2", and "iam".
+  // Supported joining methods include:
+  // - azure
+  // - circleci
+  // - ec2
+  // - gcp
+  // - github
+  // - gitlab
+  // - iam
+  // - kubernetes
+  // - spacelift
+  // - token
+  // - tpm
   string JoinMethod = 4 [
     (gogoproto.jsontag) = "join_method",
     (gogoproto.casttype) = "JoinMethod"

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -4122,7 +4122,18 @@ type ProvisionTokenSpecV2 struct {
 	// to join the cluster with this token.
 	AWSIIDTTL Duration `protobuf:"varint,3,opt,name=AWSIIDTTL,proto3,casttype=Duration" json:"aws_iid_ttl,omitempty"`
 	// JoinMethod is the joining method required in order to use this token.
-	// Supported joining methods include "token", "ec2", and "iam".
+	// Supported joining methods include:
+	// - azure
+	// - circleci
+	// - ec2
+	// - gcp
+	// - github
+	// - gitlab
+	// - iam
+	// - kubernetes
+	// - spacelift
+	// - token
+	// - tpm
 	JoinMethod JoinMethod `protobuf:"bytes,4,opt,name=JoinMethod,proto3,casttype=JoinMethod" json:"join_method"`
 	// BotName is the name of the bot this token grants access to, if any
 	BotName string `protobuf:"bytes,5,opt,name=BotName,proto3" json:"bot_name,omitempty"`

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -4122,18 +4122,7 @@ type ProvisionTokenSpecV2 struct {
 	// to join the cluster with this token.
 	AWSIIDTTL Duration `protobuf:"varint,3,opt,name=AWSIIDTTL,proto3,casttype=Duration" json:"aws_iid_ttl,omitempty"`
 	// JoinMethod is the joining method required in order to use this token.
-	// Supported joining methods include:
-	// - azure
-	// - circleci
-	// - ec2
-	// - gcp
-	// - github
-	// - gitlab
-	// - iam
-	// - kubernetes
-	// - spacelift
-	// - token
-	// - tpm
+	// Supported joining methods include: azure, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm
 	JoinMethod JoinMethod `protobuf:"bytes,4,opt,name=JoinMethod,proto3,casttype=JoinMethod" json:"join_method"`
 	// BotName is the name of the bot this token grants access to, if any
 	BotName string `protobuf:"bytes,5,opt,name=BotName,proto3" json:"bot_name,omitempty"`

--- a/docs/pages/reference/terraform-provider/data-sources/provision_token.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/provision_token.mdx
@@ -36,7 +36,7 @@ Optional:
 - `gcp` (Attributes) GCP allows the configuration of options specific to the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `github` (Attributes) GitHub allows the configuration of options specific to the "github" join method. (see [below for nested schema](#nested-schema-for-specgithub))
 - `gitlab` (Attributes) GitLab allows the configuration of options specific to the "gitlab" join method. (see [below for nested schema](#nested-schema-for-specgitlab))
-- `join_method` (String) JoinMethod is the joining method required in order to use this token. Supported joining methods include "token", "ec2", and "iam".
+- `join_method` (String) JoinMethod is the joining method required in order to use this token. Supported joining methods include: - azure - circleci - ec2 - gcp - github - gitlab - iam - kubernetes - spacelift - token - tpm
 - `kubernetes` (Attributes) Kubernetes allows the configuration of options specific to the "kubernetes" join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
 - `spacelift` (Attributes) Spacelift allows the configuration of options specific to the "spacelift" join method. (see [below for nested schema](#nested-schema-for-specspacelift))
 - `suggested_agent_matcher_labels` (Map of List of String)

--- a/docs/pages/reference/terraform-provider/data-sources/provision_token.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/provision_token.mdx
@@ -36,7 +36,7 @@ Optional:
 - `gcp` (Attributes) GCP allows the configuration of options specific to the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `github` (Attributes) GitHub allows the configuration of options specific to the "github" join method. (see [below for nested schema](#nested-schema-for-specgithub))
 - `gitlab` (Attributes) GitLab allows the configuration of options specific to the "gitlab" join method. (see [below for nested schema](#nested-schema-for-specgitlab))
-- `join_method` (String) JoinMethod is the joining method required in order to use this token. Supported joining methods include: - azure - circleci - ec2 - gcp - github - gitlab - iam - kubernetes - spacelift - token - tpm
+- `join_method` (String) JoinMethod is the joining method required in order to use this token. Supported joining methods include: azure, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm
 - `kubernetes` (Attributes) Kubernetes allows the configuration of options specific to the "kubernetes" join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
 - `spacelift` (Attributes) Spacelift allows the configuration of options specific to the "spacelift" join method. (see [below for nested schema](#nested-schema-for-specspacelift))
 - `suggested_agent_matcher_labels` (Map of List of String)

--- a/docs/pages/reference/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/terraform-provider/resources/provision_token.mdx
@@ -70,7 +70,7 @@ Optional:
 - `gcp` (Attributes) GCP allows the configuration of options specific to the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `github` (Attributes) GitHub allows the configuration of options specific to the "github" join method. (see [below for nested schema](#nested-schema-for-specgithub))
 - `gitlab` (Attributes) GitLab allows the configuration of options specific to the "gitlab" join method. (see [below for nested schema](#nested-schema-for-specgitlab))
-- `join_method` (String) JoinMethod is the joining method required in order to use this token. Supported joining methods include: - azure - circleci - ec2 - gcp - github - gitlab - iam - kubernetes - spacelift - token - tpm
+- `join_method` (String) JoinMethod is the joining method required in order to use this token. Supported joining methods include: azure, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm
 - `kubernetes` (Attributes) Kubernetes allows the configuration of options specific to the "kubernetes" join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
 - `spacelift` (Attributes) Spacelift allows the configuration of options specific to the "spacelift" join method. (see [below for nested schema](#nested-schema-for-specspacelift))
 - `suggested_agent_matcher_labels` (Map of List of String)

--- a/docs/pages/reference/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/terraform-provider/resources/provision_token.mdx
@@ -70,7 +70,7 @@ Optional:
 - `gcp` (Attributes) GCP allows the configuration of options specific to the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `github` (Attributes) GitHub allows the configuration of options specific to the "github" join method. (see [below for nested schema](#nested-schema-for-specgithub))
 - `gitlab` (Attributes) GitLab allows the configuration of options specific to the "gitlab" join method. (see [below for nested schema](#nested-schema-for-specgitlab))
-- `join_method` (String) JoinMethod is the joining method required in order to use this token. Supported joining methods include "token", "ec2", and "iam".
+- `join_method` (String) JoinMethod is the joining method required in order to use this token. Supported joining methods include: - azure - circleci - ec2 - gcp - github - gitlab - iam - kubernetes - spacelift - token - tpm
 - `kubernetes` (Attributes) Kubernetes allows the configuration of options specific to the "kubernetes" join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
 - `spacelift` (Attributes) Spacelift allows the configuration of options specific to the "spacelift" join method. (see [below for nested schema](#nested-schema-for-specspacelift))
 - `suggested_agent_matcher_labels` (Map of List of String)

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_provisiontokens.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_provisiontokens.yaml
@@ -257,9 +257,9 @@ spec:
                     type: string
                 type: object
               join_method:
-                description: JoinMethod is the joining method required in order to
-                  use this token. Supported joining methods include "token", "ec2",
-                  and "iam".
+                description: 'JoinMethod is the joining method required in order to
+                  use this token. Supported joining methods include: azure, circleci,
+                  ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm'
                 type: string
               kubernetes:
                 description: Kubernetes allows the configuration of options specific

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_provisiontokens.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_provisiontokens.yaml
@@ -257,9 +257,9 @@ spec:
                     type: string
                 type: object
               join_method:
-                description: JoinMethod is the joining method required in order to
-                  use this token. Supported joining methods include "token", "ec2",
-                  and "iam".
+                description: 'JoinMethod is the joining method required in order to
+                  use this token. Supported joining methods include: azure, circleci,
+                  ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm'
                 type: string
               kubernetes:
                 description: Kubernetes allows the configuration of options specific

--- a/integrations/terraform/tfschema/token/types_terraform.go
+++ b/integrations/terraform/tfschema/token/types_terraform.go
@@ -366,7 +366,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 					Optional:    true,
 				},
 				"join_method": {
-					Description: "JoinMethod is the joining method required in order to use this token. Supported joining methods include: - azure - circleci - ec2 - gcp - github - gitlab - iam - kubernetes - spacelift - token - tpm",
+					Description: "JoinMethod is the joining method required in order to use this token. Supported joining methods include: azure, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},

--- a/integrations/terraform/tfschema/token/types_terraform.go
+++ b/integrations/terraform/tfschema/token/types_terraform.go
@@ -366,7 +366,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 					Optional:    true,
 				},
 				"join_method": {
-					Description: "JoinMethod is the joining method required in order to use this token. Supported joining methods include \"token\", \"ec2\", and \"iam\".",
+					Description: "JoinMethod is the joining method required in order to use this token. Supported joining methods include: - azure - circleci - ec2 - gcp - github - gitlab - iam - kubernetes - spacelift - token - tpm",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},


### PR DESCRIPTION
A customer pointed out that the automatically generated Terraform docs did not mention all of the possible join methods and this initially led them to believe that not all were supported by the provider. I've updated the protobuf comment and regenerated the docs/generated code.