### PR TITLE
discover: generate config with --silent flag

### DIFF
--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -518,6 +518,7 @@ EOF
 install_teleport_node_config() {
     log "Writing Teleport node service config to ${TELEPORT_CONFIG_PATH}"
     ${TELEPORT_BINARY_DIR}/teleport node configure \
+      --silent \
       --token ${JOIN_TOKEN} \
       ${JOIN_METHOD_FLAG} \
       --ca-pin ${CA_PINS} \

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -919,7 +919,7 @@ func onConfigDump(flags dumpFlags) error {
 				fmt.Fprintf(flags.stdout, "- The Teleport configuration is located at %q.\n", configPath)
 			}
 			if !canWriteToDataDir {
-				fmt.Fprintf(flags.stdout, "- Teleport will be storing data at %q. To change that, run \"teleport configure\" with the \"--data-dir\" flag.\n", flags.DataDir)
+				fmt.Fprintf(flags.stdout, "- Teleport will be storing data at %q. To change that, edit the \"data_dir\" field in %q.", flags.DataDir, configPath)
 			}
 			fmt.Fprintf(flags.stdout, "\n")
 		} else {


### PR DESCRIPTION
When you add a node through the discover flow, we use the teleport node configure command to generate a configuration file, and then we actually start Teleport.

By default, the configure command prints some hint messages telling the user to run teleport start, but this is not necessary in the discover flow since we start it up for you.

The --silent command was added to solve this, but we never went back and updated the install script to use it.

Closes #29518