### PR TITLE
Update the list of preset roles

### DIFF
--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -20,18 +20,9 @@ wrap up with creating your own role.
 
 ## Step 1/3. Add local users with preset roles
 
-Teleport provides several preset roles: `editor`, `auditor`, and `access`.
+Teleport provides several preset roles:
 
-- The `editor` role authorizes users to modify cluster configuration.
-- The `auditor` role authorizes users to view audit logs.
-- The `access` role authorizes users to access cluster resources.
-
-<Details title='Enterprise built in roles'>
-Teleport Enterprise contains two additional preset roles: `reviewer` and `requester`.
-
-- The `reviewer` role authorizes users to review Access Requests.
-- The `requester` role authorizes users to request resources.
-</Details>
+(!docs/pages/includes/preset-roles-table.mdx!)
 
 <Tabs>
 <TabItem scope={["oss"]} label="Teleport Community Edition">

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -74,15 +74,9 @@ user:
 
 ## Preset roles
 
-Teleport provides several pre-defined roles out-of-the-box:
+Teleport provides several preset roles:
 
-| Role | Description |
-| --- | --- |
-| `editor` | Allows editing of cluster configuration settings. |
-| `auditor`| Allows reading cluster events, audit logs, and playing back session records. |
-| `access`| Allows access to cluster resources. |
-| `requester`| Enterprise-only role that allows a user to create Access Requests. |
-| `reviewer`| Enterprise-only role that allows review of Access Requests. |
+(!docs/pages/includes/preset-roles-table.mdx!)
 
 ### Role versions
 

--- a/docs/pages/includes/preset-roles-table.mdx
+++ b/docs/pages/includes/preset-roles-table.mdx
@@ -1,13 +1,13 @@
 | Role | Description |
 | --- | --- |
 | `access`| Allows access to cluster resources. |
-| `auditor`| Allows reading cluster events, audit logs, and playing back session records. |
-| `device-admin`| Used to manage trusted devices.| 
-| `device-enroll`| Used to grant device enrollment powers to users.|
 | `editor` | Allows editing of cluster configuration settings. |
-| `group-access`| Allows access to all user groups.| 
+| `auditor`| Allows reading cluster events, audit logs, and playing back session records. |
 | `requester`| Enterprise-only role that allows a user to create Access Requests. |
-| `require-trusted-device`| Requires trusted device access to resources.|
 | `reviewer`| Enterprise-only role that allows review of Access Requests. |
-| `terraform-provider`|Allows the Teleport Terraform provider to configure all of its supported Teleport resources.|
+| `group-access`| Allows access to all user groups. | 
+| `device-admin`| Used to manage trusted devices. | 
+| `device-enroll`| Used to grant device enrollment powers to users. |
+| `require-trusted-device`| Requires trusted device access to resources. |
+| `terraform-provider`| Allows the Teleport Terraform provider to configure all of its supported Teleport resources. |
 

--- a/docs/pages/includes/preset-roles-table.mdx
+++ b/docs/pages/includes/preset-roles-table.mdx
@@ -1,0 +1,13 @@
+| Role | Description |
+| --- | --- |
+| `access`| Allows access to cluster resources. |
+| `auditor`| Allows reading cluster events, audit logs, and playing back session records. |
+| `device-admin`| Used to manage trusted devices.| 
+| `device-enroll`| Used to grant device enrollment powers to users.|
+| `editor` | Allows editing of cluster configuration settings. |
+| `group-access`| Allows access to all user groups.| 
+| `requester`| Enterprise-only role that allows a user to create Access Requests. |
+| `require-trusted-device`| Requires trusted device access to resources.|
+| `reviewer`| Enterprise-only role that allows review of Access Requests. |
+| `terraform-provider`|Allows the Teleport Terraform provider to configure all of its supported Teleport resources.|
+


### PR DESCRIPTION
Closes #44086

In the Access Controls reference, mention preset roles based on `constants.go`.

Since we use a list of preset roles in two guides, extract the table of preset roles from the Access Controls reference into a partial.