### PR TITLE
Use entitlements over legacy feature fields

### DIFF
--- a/web/packages/teleport/src/Sessions/Sessions.story.test.tsx
+++ b/web/packages/teleport/src/Sessions/Sessions.story.test.tsx
@@ -35,7 +35,6 @@ test('loaded', async () => {
 });
 
 test('active sessions CTA', async () => {
-  cfg.isTeam = true;
   cfg.isEnterprise = true;
   const { container } = render(<ActiveSessionsCTA />);
   await screen.findByText(/cluster: teleport/i);

--- a/web/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/web/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -590,7 +590,7 @@ exports[`active sessions CTA 1`] = `
         class="c8"
         fill="filled"
         height="36px"
-        href="https://goteleport.com/r/upgrade-team?e_4.4.0-dev&utm_campaign=CTA_ACTIVE_SESSIONS"
+        href="https://goteleport.com/r/upgrade-igs?e_4.4.0-dev&utm_campaign=CTA_ACTIVE_SESSIONS"
         rel="noreferrer"
         style="text-transform: none;"
         target="blank"

--- a/web/packages/teleport/src/Sessions/useSessions.ts
+++ b/web/packages/teleport/src/Sessions/useSessions.ts
@@ -58,6 +58,6 @@ export default function useSessions(ctx: Ctx, clusterId: string) {
     sessions,
     // moderated is available with any enterprise editions
     showModeratedSessionsCTA: !ctx.isEnterprise,
-    showActiveSessionsCTA: !cfg.joinActiveSessions,
+    showActiveSessionsCTA: !cfg.entitlements.JoinActiveSessions.enabled,
   };
 }

--- a/web/packages/teleport/src/Support/Support.story.test.tsx
+++ b/web/packages/teleport/src/Support/Support.story.test.tsx
@@ -69,7 +69,6 @@ test('support Enterprise', () => {
 
 test('support Enterprise with CTA', () => {
   cfg.isEnterprise = true;
-  cfg.isTeam = true;
   const { container } = render(
     <MemoryRouter>
       <SupportEnterpriseWithCTA />

--- a/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
+++ b/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
@@ -1168,7 +1168,7 @@ exports[`support Enterprise with CTA 1`] = `
         <a
           class="c13"
           fill="filled"
-          href="https://goteleport.com/r/upgrade-team?e_4.4.0-dev&utm_campaign=CTA_PREMIUM_SUPPORT"
+          href="https://goteleport.com/r/upgrade-igs?e_4.4.0-dev&utm_campaign=CTA_PREMIUM_SUPPORT"
           rel="noreferrer"
           style="text-transform: none;"
           target="blank"

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -40,9 +40,7 @@ import type { ParticipantMode } from 'teleport/services/session';
 import type { YamlSupportedResourceKind } from './services/yaml/types';
 
 const cfg = {
-  /**
-   * @deprecated use cfg.edition instead
-   */
+  /** @deprecated Use cfg.edition instead. */
   isEnterprise: false,
   edition: 'oss',
   isCloud: false,
@@ -62,26 +60,22 @@ const cfg = {
   isUsageBasedBilling: false,
   hideInaccessibleFeatures: false,
   customTheme: '',
-  /**
-   * isTeam is true if [Features.ProductType] == Team
-   * @deprecated use other flags do determine cluster features istead of relying on isTeam
-   * TODO(mcbattirola): remove isTeam when it is no longer used
-   */
+  /** @deprecated */
   isTeam: false,
   isStripeManaged: false,
   hasQuestionnaire: false,
   externalAuditStorage: false,
   premiumSupport: false,
   accessRequests: false,
+  /** @deprecated Use entitlements instead. */
   trustedDevices: false,
   oidc: false,
   saml: false,
+  /** @deprecated Use entitlements instead. */
   joinActiveSessions: false,
+  /** @deprecated Use entitlements instead. */
   mobileDeviceManagement: false,
-
-  // isIgsEnabled refers to Identity Governance & Security product.
-  // It refers to a group of features: access request, device trust,
-  // access list, and access monitoring.
+  /** @deprecated Use entitlements instead. */
   isIgsEnabled: false,
 
   // isPolicyEnabled refers to the Teleport Policy product
@@ -92,11 +86,13 @@ const cfg = {
   baseUrl: window.location.origin,
 
   // featureLimits define limits for features.
-  // Typically used with feature teasers if feature is not enabled for the
-  // product type eg: Team product contains teasers to upgrade to Enterprise.
+  /** @deprecated Use entitlements instead. */
   featureLimits: {
+    /** @deprecated Use entitlements instead. */
     accessListCreateLimit: 0,
+    /** @deprecated Use entitlements instead. */
     accessMonitoringMaxReportRangeLimit: 0,
+    /** @deprecated Use entitlements instead. */
     AccessRequestMonthlyRequestLimit: 0,
   },
 
@@ -456,18 +452,6 @@ const cfg = {
     if (cfg.auth.authType === 'local') return 'local';
 
     return 'sso';
-  },
-
-  // isLegacyEnterprise describes product that should have legacy support
-  // where certain features access remain unlimited. This was before
-  // product EUB (enterprise usage based) was introduced.
-  // eg: access request and device trust.
-  isLegacyEnterprise() {
-    return cfg.isEnterprise && !cfg.isUsageBasedBilling;
-  },
-
-  getAuthType() {
-    return cfg.auth.authType;
   },
 
   getDeviceTrustAuthorizeRoute(id: string, token: string) {

--- a/web/packages/teleport/src/services/sales/index.ts
+++ b/web/packages/teleport/src/services/sales/index.ts
@@ -17,12 +17,10 @@
  */
 
 import { CtaEvent } from 'teleport/services/userEvent';
-import cfg from 'teleport/config';
 
 // These URLs are the shorten URL version. These marketing URL's
 // are defined in the "next" repo.
 // eg: https://github.com/gravitational/next/pull/2298
-const UPGRADE_TEAM_URL = 'https://goteleport.com/r/upgrade-team';
 const UPGRADE_COMMUNITY_URL = 'https://goteleport.com/r/upgrade-community';
 // UPGRADE_IGS_URL is enterprise upgrading to enterprise with Identity Governance & Security
 const UPGRADE_IGS_URL = 'https://goteleport.com/r/upgrade-igs';
@@ -46,11 +44,7 @@ export function getSalesURL(
   url?: string
 ) {
   if (!url) {
-    url = UPGRADE_COMMUNITY_URL;
-    if (isEnterprise) {
-      // TODO(mcbattirola): remove isTeam when it is no longer used
-      url = cfg.isTeam ? UPGRADE_TEAM_URL : UPGRADE_IGS_URL;
-    }
+    url = isEnterprise ? UPGRADE_IGS_URL : UPGRADE_COMMUNITY_URL;
   }
   const params = getParams(version, isEnterprise, event);
   return `${url}?${params}`;

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -76,16 +76,12 @@ class TeleportContext implements types.Context {
 
   // lockedFeatures are the features disabled in the user's cluster.
   // Mainly used to hide features and/or show CTAs when the user cluster doesn't support it.
-  // todo michellescripts use entitlements
   lockedFeatures: types.LockedFeatures = {
-    authConnectors: !(cfg.oidc && cfg.saml),
-    // Below should be locked for the following cases:
-    //  1) feature disabled in the cluster features
-    //  2) is not a legacy and igs is not enabled. legacies should have unlimited access.
-    accessRequests:
-      !cfg.accessRequests || (!cfg.isLegacyEnterprise() && !cfg.isIgsEnabled),
-    trustedDevices:
-      !cfg.trustedDevices || (!cfg.isLegacyEnterprise() && !cfg.isIgsEnabled),
+    authConnectors: !(
+      cfg.entitlements.OIDC.enabled && cfg.entitlements.SAML.enabled
+    ),
+    accessRequests: !cfg.entitlements.AccessRequests.enabled,
+    trustedDevices: !cfg.entitlements.DeviceTrust.enabled,
   };
   // entitlements define a customer’s access to a specific features
   entitlements = cfg.entitlements;


### PR DESCRIPTION
This PR leverages the non-limited entitlements to enable, disable, and limit the features rather than the legacy feature fields

Removes isTeam references

Supports https://github.com/gravitational/cloud/issues/9022