### PR TITLE
Auto Discover Server must not overwrite manual changes

### DIFF
--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -350,7 +350,7 @@ func (ani *AutoDiscoverNodeInstaller) configureTeleportNode(ctx context.Context,
 		// However, for the last scenario (teleport was manually installed), this flow must not replace the currently running teleport service configuration.
 		// To prevent this, this flow checks for the existence of the discover notice file, and only allows replacement if it does exist.
 		if _, err := os.Stat(discoverNoticeFile); err != nil {
-			ani.Logger.InfoContext(ctx, "Refusing to replace the existing teleport configuration. For the script to replace the existing configuration remove the Teleport configuration.).",
+			ani.Logger.InfoContext(ctx, "Refusing to replace the existing teleport configuration. For the script to replace the existing configuration remove the Teleport configuration.",
 				"teleport_configuration", teleportYamlConfigurationPath,
 				"discover_notice_file", discoverNoticeFile)
 			return trace.BadParameter("missing discover notice file")

--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -350,7 +350,7 @@ func (ani *AutoDiscoverNodeInstaller) configureTeleportNode(ctx context.Context,
 		// However, for the last scenario (teleport was manually installed), this flow must not replace the currently running teleport service configuration.
 		// To prevent this, this flow checks for the existence of the discover notice file, and only allows replacement if it does exist.
 		if _, err := os.Stat(discoverNoticeFile); err != nil {
-			ani.Logger.InfoContext(ctx, "Refusing to replace the existing teleport configuration. For the script to replace the existing configuration, either remove the Teleport configuration or create the discover notice file ($ touch /etc/teleport.yaml.discover).",
+			ani.Logger.InfoContext(ctx, "Refusing to replace the existing teleport configuration. For the script to replace the existing configuration remove the Teleport configuration.).",
 				"teleport_configuration", teleportYamlConfigurationPath,
 				"discover_notice_file", discoverNoticeFile)
 			return trace.BadParameter("missing discover notice file")

--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -52,6 +52,13 @@ import (
 	"github.com/gravitational/teleport/lib/utils/packagemanager"
 )
 
+const (
+	discoverNotice = "" +
+		"Teleport Discover has successfully configured /etc/teleport.yaml for this server to join the cluster.\n" +
+		"Discover might replace the configuration if the server fails to join the cluster.\n" +
+		"Please remove this file if you are managing this instance using another tool or doing so manually.\n"
+)
+
 // AutoDiscoverNodeInstallerConfig installs and configures a Teleport Server into the current system.
 type AutoDiscoverNodeInstallerConfig struct {
 	Logger *slog.Logger
@@ -312,6 +319,7 @@ func (ani *AutoDiscoverNodeInstaller) configureTeleportNode(ctx context.Context,
 		_ = os.Remove(teleportYamlConfigurationPathNew)
 	}()
 
+	discoverNoticeFile := teleportYamlConfigurationPath + ".discover"
 	// Check if file already exists and has the same content that we are about to write
 	if _, err := os.Stat(teleportYamlConfigurationPath); err == nil {
 		hashExistingFile, err := checksum(teleportYamlConfigurationPath)
@@ -325,11 +333,35 @@ func (ani *AutoDiscoverNodeInstaller) configureTeleportNode(ctx context.Context,
 		}
 
 		if hashExistingFile == hashNewFile {
+			if err := os.WriteFile(discoverNoticeFile, []byte(discoverNotice), 0o644); err != nil {
+				return trace.Wrap(err)
+			}
+
 			return trace.AlreadyExists("teleport.yaml is up to date")
+		}
+
+		// If a previous /etc/teleport.yaml configuration file exists and is different from the target one, it might be because one of the following reasons:
+		// - discover installation params (eg token name) were changed
+		// - `$ teleport node configure` command produces a different output
+		// - teleport was manually installed / configured
+		//
+		// For the first two scenarios, it's fine, and even desired in most cases, to restart teleport with the new configuration.
+		//
+		// However, for the last scenario (teleport was manually installed), this flow must not replace the currently running teleport service configuration.
+		// To prevent this, this flow checks for the existence of the discover notice file, and only allows replacement if it does exist.
+		if _, err := os.Stat(discoverNoticeFile); err != nil {
+			ani.Logger.InfoContext(ctx, "Refusing to replace the existing teleport configuration. For the script to replace the existing configuration, either remove the teleport configuration or create the discover notice file ($ touch /etc/teleport.yaml.discover).",
+				"teleport_configuration", teleportYamlConfigurationPath,
+				"discover_notice_file", discoverNoticeFile)
+			return trace.BadParameter("missing discover notice file")
 		}
 	}
 
 	if err := os.Rename(teleportYamlConfigurationPathNew, teleportYamlConfigurationPath); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := os.WriteFile(discoverNoticeFile, []byte(discoverNotice), 0o644); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -350,7 +350,7 @@ func (ani *AutoDiscoverNodeInstaller) configureTeleportNode(ctx context.Context,
 		// However, for the last scenario (teleport was manually installed), this flow must not replace the currently running teleport service configuration.
 		// To prevent this, this flow checks for the existence of the discover notice file, and only allows replacement if it does exist.
 		if _, err := os.Stat(discoverNoticeFile); err != nil {
-			ani.Logger.InfoContext(ctx, "Refusing to replace the existing teleport configuration. For the script to replace the existing configuration, either remove the teleport configuration or create the discover notice file ($ touch /etc/teleport.yaml.discover).",
+			ani.Logger.InfoContext(ctx, "Refusing to replace the existing teleport configuration. For the script to replace the existing configuration, either remove the Teleport configuration or create the discover notice file ($ touch /etc/teleport.yaml.discover).",
 				"teleport_configuration", teleportYamlConfigurationPath,
 				"discover_notice_file", discoverNoticeFile)
 			return trace.BadParameter("missing discover notice file")


### PR DESCRIPTION
This PR changes the flow so that only discover managed installations might have their teleport.yaml configuration replaced.

Demo
Started by using a DiscoveryConfig which had a typo in the installer params.
As expected, the command was executed but the node couldn't join
Discover notice file was created:
<img width="914" alt="image" src="https://github.com/user-attachments/assets/c125ce5c-a3d9-4166-a50d-2edf216b19e2">

The discover notice file was removed and the typo was fixed.
The script refused to re-configure teleport because the discover file was not present.
<img width="1193" alt="image" src="https://github.com/user-attachments/assets/f89feb90-e707-431c-81b3-2fc6e8030954">

After fixing the typo and running the suggested command, and after a new iteration of SSM Run (discover flow), teleport was able to recover and join the cluster.

<img width="868" alt="image" src="https://github.com/user-attachments/assets/2f089321-6e4c-4730-abb7-42cf156f0b10">
