### PR TITLE
Fix device trust passthrough styles

### DIFF
--- a/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.tsx
+++ b/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.tsx
@@ -139,8 +139,10 @@ export const DeviceTrustConnectPassthrough = ({
 const SkipAuthNotice = styled(Box)`
   text-align: center;
   width: 100%;
-  position: absolute;
-  bottom: 24px;
+  @media (min-height: 500px) {
+    position: absolute;
+    bottom: 24px;
+  }
 `;
 
 const DownloadButton = styled(ButtonLink)`
@@ -156,5 +158,5 @@ const BoldText = styled.span`
 const Wrapper = styled(Box)`
   text-align: center;
   line-height: 32px;
-  padding-top: 200px;
+  padding-top: 5vh;
 `;


### PR DESCRIPTION
This will set the top padding of the passthrough page to a screen height ratio instead of a fixed pixel size. Also, this will remove the absolute positioning of the bottom text for very short screen sizes to prevent it from overlapping with the text above

old 
![Screenshot 2024-07-25 at 11 43 14 AM](https://github.com/user-attachments/assets/c0236058-f7fc-4f64-a436-90a3fef0a72a)

New short page
![Screenshot 2024-07-25 at 11 42 50 AM](https://github.com/user-attachments/assets/9ac16396-4748-44d1-8e08-535afd8fadfd)


New full page
![Screenshot 2024-07-25 at 11 42 42 AM](https://github.com/user-attachments/assets/1e83b2bc-18dd-4161-8009-401cbd0d82f5)
