### PR TITLE
[v15] [kube] add `namespace/podName` as `SessionTracker` hostname

### DIFF
--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"reflect"
 	"slices"
 	"strings"
@@ -1325,7 +1326,7 @@ func (s *session) trackSession(p *party, policySet []*types.SessionTrackerPolicy
 		SessionID:         s.id.String(),
 		Kind:              string(types.KubernetesSessionKind),
 		State:             types.SessionState_SessionStatePending,
-		Hostname:          s.podName,
+		Hostname:          path.Join(s.podNamespace, s.podName),
 		ClusterName:       s.ctx.teleportCluster.name,
 		KubernetesCluster: s.ctx.kubeClusterName,
 		HostUser:          p.Ctx.User.GetName(),
@@ -1362,7 +1363,7 @@ func (s *session) trackSession(p *party, policySet []*types.SessionTrackerPolicy
 	case err != nil:
 		return trace.Wrap(err)
 	// the tracker was created successfully
-	case err == nil:
+	default:
 		s.tracker = tracker
 	}
 

--- a/lib/kube/proxy/sess_test.go
+++ b/lib/kube/proxy/sess_test.go
@@ -281,16 +281,18 @@ func Test_session_trackSession(t *testing.T) {
 			assertErr: require.NoError,
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sess := &session{
 				log: logrus.New().WithField(teleport.ComponentKey, "test"),
 				id:  uuid.New(),
 				req: &http.Request{
-					URL: &url.URL{},
+					URL: &url.URL{
+						RawQuery: "command=command&command=arg1&command=arg2",
+					},
 				},
 				podName:         "podName",
+				podNamespace:    "podNamespace",
 				accessEvaluator: auth.NewSessionAccessEvaluator(tt.args.policies, types.KubernetesSessionKind, "username"),
 				ctx: authContext{
 					Context: authz.Context{
@@ -319,6 +321,18 @@ func Test_session_trackSession(t *testing.T) {
 			}
 			err := sess.trackSession(p, tt.args.policies)
 			tt.assertErr(t, err)
+			if err != nil {
+				return
+			}
+			tracker := tt.args.authClient.(*mockSessionTrackerService).tracker
+			require.Equal(t, "username", tracker.GetHostUser())
+			require.Equal(t, "name", tracker.GetClusterName())
+			require.Equal(t, "kubeClusterName", tracker.GetKubeCluster())
+			require.Equal(t, sess.id.String(), tracker.GetSessionID())
+			require.Equal(t, []string{"command", "arg1", "arg2"}, tracker.GetCommand())
+			require.Equal(t, "podNamespace/podName", tracker.GetHostname())
+			require.Equal(t, types.KubernetesSessionKind, tracker.GetSessionKind())
+
 		})
 	}
 }
@@ -326,9 +340,11 @@ func Test_session_trackSession(t *testing.T) {
 type mockSessionTrackerService struct {
 	authclient.ClientI
 	returnErr bool
+	tracker   types.SessionTracker
 }
 
-func (m *mockSessionTrackerService) CreateSessionTracker(ctx context.Context, tracker types.SessionTracker) (types.SessionTracker, error) {
+func (m *mockSessionTrackerService) CreateSessionTracker(_ context.Context, tracker types.SessionTracker) (types.SessionTracker, error) {
+	m.tracker = tracker
 	if m.returnErr {
 		return nil, trace.ConnectionProblem(nil, "mock error")
 	}


### PR DESCRIPTION
Backport #44614 to branch/v15