### PR TITLE
Explicit that TF reference is generated

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -58,6 +58,8 @@ jobs:
               - 'integrations/terraform/Makefile'
               - 'integrations/terraform/examples/**'
               - 'integrations/terraform/templates/**'
+              # rendered doc changes
+              - 'docs/pages/reference/terraform-provider/**'
 
   lint-go:
     name: Lint (Go)

--- a/docs/pages/reference/terraform-provider.mdx
+++ b/docs/pages/reference/terraform-provider.mdx
@@ -3,6 +3,9 @@ title: "Teleport Terraform Provider"
 description: Reference documentation of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 The Teleport Terraform provider allows Terraform users to configure Teleport
 from Terraform.
 

--- a/docs/pages/reference/terraform-provider/data-sources.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources.mdx
@@ -3,6 +3,9 @@ title: "Terraform data-sources index"
 description: "Index of all the data-sources supported by the Teleport Terraform Provider"
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 {/*
     This file will be renamed data-sources.mdx during build time.
     The template name is reserved by tfplugindocs so we suffix with -index.

--- a/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_access_list Terraform data-source
 description: This page describes the supported values of the teleport_access_list data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/app.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/app.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_app Terraform data-source
 description: This page describes the supported values of the teleport_app data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/auth_preference.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/auth_preference.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_auth_preference Terraform data-source
 description: This page describes the supported values of the teleport_auth_preference data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/cluster_maintenance_config.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_cluster_maintenance_config Terraform data-sour
 description: This page describes the supported values of the teleport_cluster_maintenance_config data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/cluster_networking_config.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/cluster_networking_config.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_cluster_networking_config Terraform data-sourc
 description: This page describes the supported values of the teleport_cluster_networking_config data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/database.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/database.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_database Terraform data-source
 description: This page describes the supported values of the teleport_database data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/github_connector.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/github_connector.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_github_connector Terraform data-source
 description: This page describes the supported values of the teleport_github_connector data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/login_rule.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/login_rule.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_login_rule Terraform data-source
 description: This page describes the supported values of the teleport_login_rule data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/oidc_connector.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/oidc_connector.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_oidc_connector Terraform data-source
 description: This page describes the supported values of the teleport_oidc_connector data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/okta_import_rule.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/okta_import_rule.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_okta_import_rule Terraform data-source
 description: This page describes the supported values of the teleport_okta_import_rule data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/provision_token.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/provision_token.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_provision_token Terraform data-source
 description: This page describes the supported values of the teleport_provision_token data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/role.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/role.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_role Terraform data-source
 description: This page describes the supported values of the teleport_role data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/saml_connector.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/saml_connector.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_saml_connector Terraform data-source
 description: This page describes the supported values of the teleport_saml_connector data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/session_recording_config.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/session_recording_config.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_session_recording_config Terraform data-source
 description: This page describes the supported values of the teleport_session_recording_config data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/trusted_cluster.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/trusted_cluster.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_trusted_cluster Terraform data-source
 description: This page describes the supported values of the teleport_trusted_cluster data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/trusted_device.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/trusted_device.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_trusted_device Terraform data-source
 description: This page describes the supported values of the teleport_trusted_device data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/user.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/user.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_user Terraform data-source
 description: This page describes the supported values of the teleport_user data-source of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 

--- a/docs/pages/reference/terraform-provider/resources.mdx
+++ b/docs/pages/reference/terraform-provider/resources.mdx
@@ -3,6 +3,9 @@ title: "Terraform resources index"
 description: "Index of all the datasources supported by the Teleport Terraform Provider"
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 {/*
     This file will be renamed data-sources.mdx during build time.
     The template name is reserved by tfplugindocs so we suffix with -index.

--- a/docs/pages/reference/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/resources/access_list.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_access_list Terraform resource
 description: This page describes the supported values of the teleport_access_list resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/app.mdx
+++ b/docs/pages/reference/terraform-provider/resources/app.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_app Terraform resource
 description: This page describes the supported values of the teleport_app resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/auth_preference.mdx
+++ b/docs/pages/reference/terraform-provider/resources/auth_preference.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_auth_preference Terraform resource
 description: This page describes the supported values of the teleport_auth_preference resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/bot.mdx
+++ b/docs/pages/reference/terraform-provider/resources/bot.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_bot Terraform resource
 description: This page describes the supported values of the teleport_bot resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/cluster_maintenance_config.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_cluster_maintenance_config Terraform resource
 description: This page describes the supported values of the teleport_cluster_maintenance_config resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/cluster_networking_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/cluster_networking_config.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_cluster_networking_config Terraform resource
 description: This page describes the supported values of the teleport_cluster_networking_config resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/database.mdx
+++ b/docs/pages/reference/terraform-provider/resources/database.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_database Terraform resource
 description: This page describes the supported values of the teleport_database resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/github_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/github_connector.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_github_connector Terraform resource
 description: This page describes the supported values of the teleport_github_connector resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/login_rule.mdx
+++ b/docs/pages/reference/terraform-provider/resources/login_rule.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_login_rule Terraform resource
 description: This page describes the supported values of the teleport_login_rule resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_oidc_connector Terraform resource
 description: This page describes the supported values of the teleport_oidc_connector resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/okta_import_rule.mdx
+++ b/docs/pages/reference/terraform-provider/resources/okta_import_rule.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_okta_import_rule Terraform resource
 description: This page describes the supported values of the teleport_okta_import_rule resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/terraform-provider/resources/provision_token.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_provision_token Terraform resource
 description: This page describes the supported values of the teleport_provision_token resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/role.mdx
+++ b/docs/pages/reference/terraform-provider/resources/role.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_role Terraform resource
 description: This page describes the supported values of the teleport_role resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_saml_connector Terraform resource
 description: This page describes the supported values of the teleport_saml_connector resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/server.mdx
+++ b/docs/pages/reference/terraform-provider/resources/server.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_server Terraform resource
 description: This page describes the supported values of the teleport_server resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/session_recording_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/session_recording_config.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_session_recording_config Terraform resource
 description: This page describes the supported values of the teleport_session_recording_config resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/trusted_cluster.mdx
+++ b/docs/pages/reference/terraform-provider/resources/trusted_cluster.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_trusted_cluster Terraform resource
 description: This page describes the supported values of the teleport_trusted_cluster resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/trusted_device.mdx
+++ b/docs/pages/reference/terraform-provider/resources/trusted_device.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_trusted_device Terraform resource
 description: This page describes the supported values of the teleport_trusted_device resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/docs/pages/reference/terraform-provider/resources/user.mdx
+++ b/docs/pages/reference/terraform-provider/resources/user.mdx
@@ -3,6 +3,9 @@ title: Reference for the teleport_user Terraform resource
 description: This page describes the supported values of the teleport_user resource of the Teleport Terraform provider.
 ---
 
+{/*Auto-generated file. Do not edit.*/}
+{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
+
 
 
 ## Example Usage

--- a/integrations/terraform/templates/data-sources-index.mdx.tmpl
+++ b/integrations/terraform/templates/data-sources-index.mdx.tmpl
@@ -3,6 +3,9 @@ title: "Terraform data-sources index"
 description: "Index of all the data-sources supported by the Teleport Terraform Provider"
 ---
 
+{{ "{/*Auto-generated file. Do not edit.*/}" }}
+{{ "{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}" }}
+
 {/*
     This file will be renamed data-sources.mdx during build time.
     The template name is reserved by tfplugindocs so we suffix with -index.

--- a/integrations/terraform/templates/data-sources.md.tmpl
+++ b/integrations/terraform/templates/data-sources.md.tmpl
@@ -3,6 +3,9 @@ title: Reference for the {{.Name}} Terraform data-source
 description: This page describes the supported values of the {{.Name}} data-source of the Teleport Terraform provider.
 ---
 
+{{ "{/*Auto-generated file. Do not edit.*/}" }}
+{{ "{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}" }}
+
 {{ .Description | trimspace }}
 
 {{ if .HasExample -}}

--- a/integrations/terraform/templates/index.md.tmpl
+++ b/integrations/terraform/templates/index.md.tmpl
@@ -3,6 +3,9 @@ title: "Teleport Terraform Provider"
 description: Reference documentation of the Teleport Terraform provider.
 ---
 
+{{ "{/*Auto-generated file. Do not edit.*/}" }}
+{{ "{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}" }}
+
 The Teleport Terraform provider allows Terraform users to configure Teleport
 from Terraform.
 

--- a/integrations/terraform/templates/resources-index.mdx.tmpl
+++ b/integrations/terraform/templates/resources-index.mdx.tmpl
@@ -3,6 +3,9 @@ title: "Terraform resources index"
 description: "Index of all the datasources supported by the Teleport Terraform Provider"
 ---
 
+{{ "{/*Auto-generated file. Do not edit.*/}" }}
+{{ "{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}" }}
+
 {/*
     This file will be renamed data-sources.mdx during build time.
     The template name is reserved by tfplugindocs so we suffix with -index.

--- a/integrations/terraform/templates/resources.md.tmpl
+++ b/integrations/terraform/templates/resources.md.tmpl
@@ -3,6 +3,9 @@ title: Reference for the {{.Name}} Terraform resource
 description: This page describes the supported values of the {{.Name}} resource of the Teleport Terraform provider.
 ---
 
+{{ "{/*Auto-generated file. Do not edit.*/}" }}
+{{ "{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}" }}
+
 {{ .Description | trimspace }}
 
 {{ if .HasExample -}}


### PR DESCRIPTION
This PR warns users that TF ref should not be manually edited and triggers the CI on manual changes so we don't mistakenly try to edit the TF ref.