### PR TITLE
update `NewTestCAWithConfig` to use RSA key for SAML IdP CA

### DIFF
--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -87,6 +87,12 @@ func NewTestCAWithConfig(config TestCAConfig) *types.CertAuthorityV2 {
 		// Always use pre-generated RSA key for the db_client CA.
 		keyPEM = fixtures.PEMBytes["rsa-db-client"]
 	}
+	if config.Type == types.SAMLIDPCA {
+		// The SAML IdP uses xmldsig RSA SHA256 signature method
+		// http://www.w3.org/2001/04/xmldsig-more#rsa-sha256
+		// to sign the SAML assertion, so the key must be an RSA key.
+		keyPEM = fixtures.PEMBytes["rsa"]
+	}
 	if len(config.PrivateKeys) > 0 {
 		// Allow test to override the private key.
 		keyPEM = config.PrivateKeys[0]


### PR DESCRIPTION
The `NewTestCAWithConfig` function was recently updated to use `ECDSAP256` (https://github.com/gravitational/teleport/pull/44418) as a default algorithm to generate private key. 

Unfortunately, the SAML IdP still uses xmldsig RSA SHA256 signature method (http://www.w3.org/2001/04/xmldsig-more#rsa-sha256) to sign the SAML assertion, so the signing key must be an RSA key.


Fixes test in this PR https://github.com/gravitational/teleport.e/pull/4732 that uses `e` web test suite to test SAML auth middleware. 
