### PR TITLE
[v15] Fix Paramiko and SSH multiplexer agent support

### DIFF
--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -358,6 +358,19 @@ func (s *SSHMultiplexerService) generateIdentity(ctx context.Context) (*identity
 	if err != nil {
 		return nil, trace.Wrap(err, "adding identity to agent")
 	}
+	// There's a bug with Paramiko and older versions of OpenSSH that requires
+	// that the bare key also be included in the agent or the key with the
+	// certificate will not be used.
+	// See the following: https://bugzilla.mindrot.org/show_bug.cgi?id=2550
+	err = newAgent.Add(agent.AddedKey{
+		PrivateKey:   id.PrivateKey,
+		Certificate:  nil,
+		LifetimeSecs: 0,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "adding bare key to agent")
+	}
+
 	s.agentMu.Lock()
 	s.agent = newAgent.(agent.ExtendedAgent)
 	s.agentMu.Unlock()

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1085,6 +1085,12 @@ func TestBotSSHMultiplexer(t *testing.T) {
 			out, err := sshSess.CombinedOutput("echo hello")
 			require.NoError(t, err)
 			require.Equal(t, "hello\n", string(out))
+
+			// Check that the agent presents a key with cert and a bare key
+			// for compat with Paramiko and older versions of OpenSSH.
+			keys, err := agentClient.List()
+			require.NoError(t, err)
+			require.Len(t, keys, 2)
 		})
 	}
 }


### PR DESCRIPTION
Backport #44638 to branch/v15

changelog: Resolved compatibility issue with Paramiko and Machine ID's SSH multiplexer SSH agent.
