### PR TITLE
Add tags to SSM Doc when configuring the AWS OIDC EC2 flow

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -336,6 +336,12 @@ type IntegrationConfEC2SSMIAM struct {
 	// No trailing / is expected.
 	// Eg https://tenant.teleport.sh
 	ProxyPublicURL string
+	// ClusterName is the Teleport cluster name.
+	// Used for resource tagging.
+	ClusterName string
+	// IntegrationName is the Teleport AWS OIDC Integration name.
+	// Used for resource tagging.
+	IntegrationName string
 }
 
 // IntegrationConfEKSIAM contains the arguments of

--- a/lib/integrations/awsoidc/tags/tags.go
+++ b/lib/integrations/awsoidc/tags/tags.go
@@ -28,6 +28,7 @@ import (
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 
 	"github.com/gravitational/teleport/api/types"
 )
@@ -149,6 +150,18 @@ func (d AWSTags) ToAthenaTags() []athenatypes.Tag {
 		})
 	}
 	return athenaTags
+}
+
+// ToSSMTags returns the default tags using the expected type for SSM resources: [ssmtypes.Tag]
+func (d AWSTags) ToSSMTags() []ssmtypes.Tag {
+	ssmTags := make([]ssmtypes.Tag, 0, len(d))
+	for k, v := range d {
+		ssmTags = append(ssmTags, ssmtypes.Tag{
+			Key:   &k,
+			Value: &v,
+		})
+	}
+	return ssmTags
 }
 
 // ToMap returns the default tags using the expected type for other aws resources.

--- a/lib/integrations/awsoidc/tags/tags_test.go
+++ b/lib/integrations/awsoidc/tags/tags_test.go
@@ -25,6 +25,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,6 +66,15 @@ func TestDefaultTags(t *testing.T) {
 			{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
 		}
 		require.ElementsMatch(t, expectedEC2Tags, d.ToEC2Tags())
+	})
+
+	t.Run("ssm tags", func(t *testing.T) {
+		expectedTags := []ssmtypes.Tag{
+			{Key: aws.String("teleport.dev/cluster"), Value: aws.String("mycluster")},
+			{Key: aws.String("teleport.dev/integration"), Value: aws.String("myawsaccount")},
+			{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
+		}
+		require.ElementsMatch(t, expectedTags, d.ToSSMTags())
 	})
 
 	t.Run("resource is teleport managed", func(t *testing.T) {

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -284,30 +284,36 @@ func TestBuildEC2SSMIAMScript(t *testing.T) {
 		{
 			name: "valid",
 			reqQuery: url.Values{
-				"awsRegion":   []string{"us-east-1"},
-				"role":        []string{"myRole"},
-				"ssmDocument": []string{"TeleportDiscoveryInstallerTest"},
+				"awsRegion":       []string{"us-east-1"},
+				"role":            []string{"myRole"},
+				"ssmDocument":     []string{"TeleportDiscoveryInstallerTest"},
+				"integrationName": []string{"my-integration"},
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure ec2-ssm-iam " +
 				"--role=myRole " +
 				"--aws-region=us-east-1 " +
 				"--ssm-document-name=TeleportDiscoveryInstallerTest " +
-				"--proxy-public-url=" + proxyPublicURL,
+				"--proxy-public-url=" + proxyPublicURL + " " +
+				"--cluster=localhost " +
+				"--name=my-integration",
 		},
 		{
 			name: "valid with symbols in role",
 			reqQuery: url.Values{
-				"awsRegion":   []string{"us-east-1"},
-				"role":        []string{"Test+1=2,3.4@5-6_7"},
-				"ssmDocument": []string{"TeleportDiscoveryInstallerTest"},
+				"awsRegion":       []string{"us-east-1"},
+				"role":            []string{"Test+1=2,3.4@5-6_7"},
+				"ssmDocument":     []string{"TeleportDiscoveryInstallerTest"},
+				"integrationName": []string{"my-integration"},
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure ec2-ssm-iam " +
 				"--role=Test\\+1=2,3.4\\@5-6_7 " +
 				"--aws-region=us-east-1 " +
 				"--ssm-document-name=TeleportDiscoveryInstallerTest " +
-				"--proxy-public-url=" + proxyPublicURL,
+				"--proxy-public-url=" + proxyPublicURL + " " +
+				"--cluster=localhost " +
+				"--name=my-integration",
 		},
 		{
 			name: "missing aws-region",

--- a/tool/teleport/common/integration_configure.go
+++ b/tool/teleport/common/integration_configure.go
@@ -92,6 +92,8 @@ func onIntegrationConfEC2SSMIAM(ctx context.Context, params config.IntegrationCo
 		IntegrationRole: params.RoleName,
 		SSMDocumentName: params.SSMDocumentName,
 		ProxyPublicURL:  params.ProxyPublicURL,
+		ClusterName:     params.ClusterName,
+		IntegrationName: params.IntegrationName,
 	}
 	return trace.Wrap(awsoidc.ConfigureEC2SSM(ctx, awsClt, confReq))
 }

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -484,6 +484,8 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfEC2SSMCmd.Flag("ssm-document-name", "The AWS SSM Document name to create that will be used to install teleport.").Required().StringVar(&ccf.IntegrationConfEC2SSMIAMArguments.SSMDocumentName)
 	integrationConfEC2SSMCmd.Flag("proxy-public-url", "Proxy Public URL (eg https://mytenant.teleport.sh).").StringVar(&ccf.
 		IntegrationConfEC2SSMIAMArguments.ProxyPublicURL)
+	integrationConfEC2SSMCmd.Flag("cluster", "Teleport Cluster's name.").Required().StringVar(&ccf.IntegrationConfEC2SSMIAMArguments.ClusterName)
+	integrationConfEC2SSMCmd.Flag("name", "Integration name.").Required().StringVar(&ccf.IntegrationConfEC2SSMIAMArguments.IntegrationName)
 
 	integrationConfAWSAppAccessCmd := integrationConfigureCmd.Command("aws-app-access-iam", "Adds required IAM permissions to connect to AWS using App Access.")
 	integrationConfAWSAppAccessCmd.Flag("role", "The AWS Role name used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfAWSAppAccessIAMArguments.RoleName)

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
@@ -136,6 +136,7 @@ export function DiscoveryConfigSsm() {
       iamRoleName: arnResourceName,
       region: selectedRegion,
       ssmDocument: ssmDocumentName,
+      integrationName: agentMeta.awsIntegration.name,
     });
     setScriptUrl(scriptUrl);
   }

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -333,7 +333,7 @@ const cfg = {
       '/v1/webapi/scripts/integrations/configure/aws-app-access-iam.sh?role=:iamRoleName',
 
     awsConfigureIamEc2AutoDiscoverWithSsmPath:
-      '/v1/webapi/scripts/integrations/configure/ec2-ssm-iam.sh?role=:iamRoleName&awsRegion=:region&ssmDocument=:ssmDocument',
+      '/v1/webapi/scripts/integrations/configure/ec2-ssm-iam.sh?role=:iamRoleName&awsRegion=:region&ssmDocument=:ssmDocument&integrationName=:integrationName',
 
     eksClustersListPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/eksclusters',
@@ -1240,6 +1240,7 @@ export interface UrlAwsConfigureIamEc2AutoDiscoverWithSsmScriptParams {
   region: Regions;
   iamRoleName: string;
   ssmDocument: string;
+  integrationName: string;
 }
 
 export interface UrlGcpWorkforceConfigParam {


### PR DESCRIPTION
Demo:
<img width="1181" alt="image" src="https://github.com/user-attachments/assets/8f55535c-bbeb-4d6f-863b-fe8c6bf9fe87">

Context: https://github.com/gravitational/teleport/issues/43427