### PR TITLE
[v15] reduce flake during backend interruptions & slow auth cache init

### DIFF
--- a/lib/backend/buffer_test.go
+++ b/lib/backend/buffer_test.go
@@ -82,6 +82,7 @@ func TestWatcherCapacity(t *testing.T) {
 		BufferCapacity(1),
 		BufferClock(clock),
 		BacklogGracePeriod(gracePeriod),
+		CreationGracePeriod(time.Nanosecond),
 	)
 	defer b.Close()
 	b.SetInit()
@@ -141,6 +142,71 @@ func TestWatcherCapacity(t *testing.T) {
 	case <-w.Done():
 	default:
 		t.Fatalf("buffer did not close watcher that was past grace period")
+	}
+}
+
+func TestWatcherCreationGracePeriod(t *testing.T) {
+	const backlogGracePeriod = time.Second
+	const creationGracePeriod = backlogGracePeriod * 3
+	const queueSize = 1
+	clock := clockwork.NewFakeClock()
+
+	ctx := context.Background()
+	b := NewCircularBuffer(
+		BufferCapacity(1),
+		BufferClock(clock),
+		BacklogGracePeriod(backlogGracePeriod),
+		CreationGracePeriod(creationGracePeriod),
+	)
+	defer b.Close()
+	b.SetInit()
+
+	w, err := b.NewWatcher(ctx, Watch{
+		QueueSize: queueSize,
+	})
+	require.NoError(t, err)
+	defer w.Close()
+
+	select {
+	case e := <-w.Events():
+		require.Equal(t, types.OpInit, e.Type)
+	default:
+		t.Fatalf("Expected immediate OpInit.")
+	}
+
+	// emit enough events to create a backlog
+	for i := 0; i < queueSize*2; i++ {
+		b.Emit(Event{Item: Item{Key: []byte{Separator}}})
+	}
+
+	select {
+	case <-w.Done():
+		t.Fatal("watcher closed unexpectedly")
+	default:
+	}
+
+	// sanity-check
+	require.Greater(t, creationGracePeriod, backlogGracePeriod*2)
+
+	// advance well past the backlog grace period, but not past the creation grace period
+	clock.Advance(backlogGracePeriod * 2)
+
+	b.Emit(Event{Item: Item{Key: []byte{Separator}}})
+
+	select {
+	case <-w.Done():
+		t.Fatal("watcher closed unexpectedly")
+	default:
+	}
+
+	// advance well past creation grace period
+	clock.Advance(creationGracePeriod)
+
+	b.Emit(Event{Item: Item{Key: []byte{Separator}}})
+	select {
+	case <-w.Done():
+	default:
+		t.Fatal("watcher did not close after creation grace period exceeded")
 	}
 }
 

--- a/lib/backend/defaults.go
+++ b/lib/backend/defaults.go
@@ -32,6 +32,12 @@ const (
 	// (e.g. heartbeats) are be created. If a watcher can't catch up in under a minute,
 	// it probably won't catch up.
 	DefaultBacklogGracePeriod = time.Second * 59
+	// DefaultCreationGracePeriod is the default amount of time time that the circular buffer
+	// will wait before enforcing the backlog grace period. This is intended to give downstream
+	// caches time to initialize before they start receiving events. Without this, large caches
+	// may be unable to successfully initialize even if they would otherwise be able to keep up
+	// with the event stream once established.
+	DefaultCreationGracePeriod = DefaultBacklogGracePeriod * 3
 	// DefaultPollStreamPeriod is a default event poll stream period
 	DefaultPollStreamPeriod = time.Second
 	// DefaultEventsTTL is a default events TTL period

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -2773,7 +2773,7 @@ func TestRelativeExpiryLimit(t *testing.T) {
 	require.Len(t, nodes, nodeCount)
 
 	clock.Advance(time.Hour * 24)
-	for expired := nodeCount - expiryLimit; expired > 0; expired -= expiryLimit {
+	for expired := nodeCount - expiryLimit; expired > expiryLimit; expired -= expiryLimit {
 		// get rid of events that were emitted before clock advanced
 		drainEvents(p.eventsC)
 		// wait for next relative expiry check to run


### PR DESCRIPTION
Backport #44601 to branch/v15

changelog: Improved stability of very large teleport clusters during temporary backend disruption/degradation.
