### PR TITLE
[v16] [buddy] fix(helm-chart): adjust to entrypoint within dockerfile

### DIFF
--- a/examples/chart/event-handler/templates/deployment.yaml
+++ b/examples/chart/event-handler/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - /usr/local/bin/teleport-event-handler
+            - /usr/local/bin/teleport-plugin
             - start
             - "--config"
             - "/etc/teleport-event-handler.toml"

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -24,7 +24,7 @@ should match the snapshot:
         spec:
           containers:
           - command:
-            - /usr/local/bin/teleport-event-handler
+            - /usr/local/bin/teleport-plugin
             - start
             - --config
             - /etc/teleport-event-handler.toml
@@ -73,7 +73,7 @@ should mount tls.existingCASecretName and set environment when set in values:
   1: |
     containers:
     - command:
-      - /usr/local/bin/teleport-event-handler
+      - /usr/local/bin/teleport-plugin
       - start
       - --config
       - /etc/teleport-event-handler.toml


### PR DESCRIPTION
Backport #44607 to branch/v16

changelog: Fixed event-handler Helm charts using the wrong command when starting the event-handler container
