### PR TITLE
Omit prerelease information from rejected connection alert

### DIFF
--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -461,9 +461,14 @@ func (a *Middleware) displayRejectedClientAlert(ctx context.Context, userAgent s
 		return
 	}
 
+	alertVersion := semver.Version{
+		Major: a.OldestSupportedVersion.Major,
+		Minor: a.OldestSupportedVersion.Minor,
+		Patch: a.OldestSupportedVersion.Patch,
+	}
 	alert, err := types.NewClusterAlert(
 		"rejected-unsupported-connection",
-		fmt.Sprintf("Connections were rejected from %s running unsupported Teleport versions(<%s), they will be inaccessible until upgraded.", connectionType, a.OldestSupportedVersion),
+		fmt.Sprintf("Connections were rejected from %s running unsupported Teleport versions(<%s), they will be inaccessible until upgraded.", connectionType, alertVersion),
 		types.WithAlertSeverity(types.AlertSeverity_MEDIUM),
 		types.WithAlertLabel(types.AlertOnLogin, "yes"),
 		types.WithAlertLabel(types.AlertVerbPermit, fmt.Sprintf("%s:%s", types.KindToken, types.VerbCreate)),

--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -789,6 +789,8 @@ func TestRejectedClientClusterAlert(t *testing.T) {
 	require.Len(t, alerts, 1)
 	require.Equal(t, "rejected-unsupported-connection", alerts[0].GetName())
 	require.Contains(t, alerts[0].Spec.Message, "agents")
+	// Assert that the version in the message does not contain any prereleases
+	require.NotContains(t, alerts[0].Spec.Message, "-aa")
 
 	for _, tool := range []string{"tsh", "tctl", "tbot"} {
 		t.Run(tool, func(t *testing.T) {
@@ -825,6 +827,8 @@ func TestRejectedClientClusterAlert(t *testing.T) {
 			require.Len(t, alerts, 1)
 			assert.Equal(t, "rejected-unsupported-connection", alerts[0].GetName())
 			require.Contains(t, alerts[0].Spec.Message, tool)
+			// Assert that the version in the message does not contain any prereleases
+			require.NotContains(t, alerts[0].Spec.Message, "-aa")
 		})
 	}
 


### PR DESCRIPTION
The oldest supported version used in the version check has a prerelease of `-aa` to account for any alpha,beta,rc releases. Since the alert blindly included said version it resulted in alerts including `<15.0.0-aa` in the message causing confusion. This change ensures that only the major, minor, and patch release are included in any user facing messaging when connections are rejected.