### PR TITLE
update db enrollment task role instructions

### DIFF
--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
@@ -387,24 +387,21 @@ const CreateAccessRole = ({
     <StyledBox mb={5}>
       <H3 mb={2}>Step 1</H3>
       <P mb={2}>
-        Name a Task Role ARN for this Database Service and generate a configure
-        command. This command will configure the required permissions in your
-        AWS account.
+        Name an IAM role for the Teleport Database Service and generate a
+        configuration command. The generated command will create the role and
+        configure permissions for it in your AWS account.
       </P>
       <FieldInput
         mb={4}
         disabled={disabled}
         rule={requiredIamRoleName}
-        label="Name a Task Role ARN"
+        label="Name an IAM role"
         autoFocus
         value={taskRoleArn}
         placeholder="TeleportDatabaseAccess"
         width="440px"
         mr="3"
         onChange={e => setTaskRoleArn(e.target.value)}
-        toolTipContent={`Amazon Resource Names (ARNs) uniquely identify AWS \
-        resources. In this case you will naming an IAM role that this \
-        deployed service will be using`}
       />
       <ButtonSecondary mb={3} onClick={generateAutoConfigScript}>
         {scriptUrl ? 'Regenerate Command' : 'Generate Command'}


### PR DESCRIPTION
This is a small update to the wording around the task role name prompt.
We asked user for an ARN, but we actually don't accept ARN characters (colon chars) and the backend handles the input as a name.

Related to:
- https://github.com/gravitational/teleport/issues/41004

cc @kimlisa