### PR TITLE
chore: rename key to keyRing

### DIFF
--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -138,15 +138,14 @@ func ExternalSSHCommand(o CommandOptions) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
-// CreateAgent creates a SSH agent with the passed in private key and
-// certificate that can be used in tests. This is useful so tests don't
-// clobber your system agent.
-func CreateAgent(me *user.User, key *client.KeyRing) (*teleagent.AgentServer, string, string, error) {
+// CreateAgent creates a SSH agent with the passed in key ring that can be used
+// in tests. This is useful so tests don't clobber your system agent.
+func CreateAgent(me *user.User, keyRing *client.KeyRing) (*teleagent.AgentServer, string, string, error) {
 	// create a path to the unix socket
 	sockDirName := "int-test"
 	sockName := "agent.sock"
 
-	agentKey, err := key.AsAgentKey()
+	agentKey, err := keyRing.AsAgentKey()
 	if err != nil {
 		return nil, "", "", trace.Wrap(err)
 	}
@@ -189,13 +188,13 @@ func CloseAgent(teleAgent *teleagent.AgentServer, socketDirPath string) error {
 	return nil
 }
 
-func MustCreateUserKey(t *testing.T, tc *TeleInstance, username string, ttl time.Duration) *client.KeyRing {
-	key, err := client.GenerateRSAKey()
+func MustCreateUserKeyRing(t *testing.T, tc *TeleInstance, username string, ttl time.Duration) *client.KeyRing {
+	keyRing, err := client.GenerateRSAKeyRing()
 	require.NoError(t, err)
-	key.ClusterName = tc.Secrets.SiteName
+	keyRing.ClusterName = tc.Secrets.SiteName
 
 	sshCert, tlsCert, err := tc.Process.GetAuthServer().GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
-		Key:            key.PrivateKey.MarshalSSHPublicKey(),
+		Key:            keyRing.PrivateKey.MarshalSSHPublicKey(),
 		Username:       username,
 		TTL:            ttl,
 		Compatibility:  constants.CertificateFormatStandard,
@@ -203,22 +202,22 @@ func MustCreateUserKey(t *testing.T, tc *TeleInstance, username string, ttl time
 	})
 	require.NoError(t, err)
 
-	key.Cert = sshCert
-	key.TLSCert = tlsCert
+	keyRing.Cert = sshCert
+	keyRing.TLSCert = tlsCert
 
 	hostCAs, err := tc.Process.GetAuthServer().GetCertAuthorities(context.Background(), types.HostCA, false)
 	require.NoError(t, err)
-	key.TrustedCerts = authclient.AuthoritiesToTrustedCerts(hostCAs)
-	return key
+	keyRing.TrustedCerts = authclient.AuthoritiesToTrustedCerts(hostCAs)
+	return keyRing
 }
 
 func MustCreateUserIdentityFile(t *testing.T, tc *TeleInstance, username string, ttl time.Duration) string {
-	key := MustCreateUserKey(t, tc, username, ttl)
+	keyRing := MustCreateUserKeyRing(t, tc, username, ttl)
 
 	idPath := filepath.Join(t.TempDir(), "user_identity")
 	_, err := identityfile.Write(context.Background(), identityfile.WriteConfig{
 		OutputPath: idPath,
-		Key:        key,
+		KeyRing:    keyRing,
 		Format:     identityfile.FormatFile,
 	})
 	require.NoError(t, err)

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -86,7 +86,7 @@ func fatalIf(err error) {
 type User struct {
 	Username      string          `json:"username"`
 	AllowedLogins []string        `json:"logins"`
-	Key           *client.KeyRing `json:"key"`
+	KeyRing       *client.KeyRing `json:"key"`
 	Roles         []types.Role    `json:"-"`
 }
 
@@ -1640,7 +1640,7 @@ func (i *TeleInstance) AddClientCredentials(tc *client.TeleportClient, cfg Clien
 
 	// Add key to client and update CAs that will be trusted (equivalent to
 	// updating "known hosts" with OpenSSH.
-	err = tc.AddKey(&creds.Key)
+	err = tc.AddKeyRing(&creds.KeyRing)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/integration/helpers/usercreds.go
+++ b/integration/helpers/usercreds.go
@@ -36,15 +36,15 @@ import (
 
 // UserCreds holds user client credentials
 type UserCreds struct {
-	// Key is user client key and certificate
-	Key client.KeyRing
-	// HostCA is a trusted host certificate authority
+	// KeyRing is user client key ring.
+	KeyRing client.KeyRing
+	// HostCA is a trusted host certificate authority.
 	HostCA types.CertAuthority
 }
 
 // SetupUserCreds sets up user credentials for client
 func SetupUserCreds(tc *client.TeleportClient, proxyHost string, creds UserCreds) error {
-	err := tc.AddKey(&creds.Key)
+	err := tc.AddKeyRing(&creds.KeyRing)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -145,7 +145,7 @@ func GenerateUserCreds(req UserCredsRequest) (*UserCreds, error) {
 
 	return &UserCreds{
 		HostCA: ca,
-		Key: client.KeyRing{
+		KeyRing: client.KeyRing{
 			PrivateKey: priv,
 			Cert:       sshCert,
 			TLSCert:    x509Cert,

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4533,7 +4533,7 @@ func testExternalClient(t *testing.T, suite *integrationTestSuite) {
 			require.NoError(t, err)
 
 			// Start (and defer close) a agent that runs during this integration test.
-			teleAgent, socketDirPath, socketPath, err := helpers.CreateAgent(suite.Me, &creds.Key)
+			teleAgent, socketDirPath, socketPath, err := helpers.CreateAgent(suite.Me, &creds.KeyRing)
 			require.NoError(t, err)
 			defer helpers.CloseAgent(teleAgent, socketDirPath)
 
@@ -4629,7 +4629,7 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 			require.NoError(t, err)
 
 			// Start (and defer close) a agent that runs during this integration test.
-			teleAgent, socketDirPath, socketPath, err := helpers.CreateAgent(suite.Me, &creds.Key)
+			teleAgent, socketDirPath, socketPath, err := helpers.CreateAgent(suite.Me, &creds.KeyRing)
 			require.NoError(t, err)
 			defer helpers.CloseAgent(teleAgent, socketDirPath)
 
@@ -4726,7 +4726,7 @@ func testX11Forwarding(t *testing.T, suite *integrationTestSuite) {
 			require.NoError(t, err)
 
 			// Start an agent that runs during this integration test.
-			teleAgent, socketDirPath, socketPath, err := helpers.CreateAgent(suite.Me, &creds.Key)
+			teleAgent, socketDirPath, socketPath, err := helpers.CreateAgent(suite.Me, &creds.KeyRing)
 			require.NoError(t, err)
 			t.Cleanup(func() { helpers.CloseAgent(teleAgent, socketDirPath) })
 

--- a/integration/tctl_terraform_env_test.go
+++ b/integration/tctl_terraform_env_test.go
@@ -217,15 +217,15 @@ func createTCTLTerraformUserAndRole(t *testing.T, username string, instance *hel
 // For the tests, the client is configured to trust the proxy TLS certs on first connection.
 func getAuthClientForProxy(t *testing.T, tc *helpers.TeleInstance, username string, ttl time.Duration) *authclient.Client {
 	// Get TLS and SSH material
-	key := helpers.MustCreateUserKey(t, tc, username, ttl)
+	keyRing := helpers.MustCreateUserKeyRing(t, tc, username, ttl)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	tlsConfig, err := key.TeleportClientTLSConfig(nil, []string{tc.Config.Auth.ClusterName.GetClusterName()})
+	tlsConfig, err := keyRing.TeleportClientTLSConfig(nil, []string{tc.Config.Auth.ClusterName.GetClusterName()})
 	require.NoError(t, err)
 	tlsConfig.InsecureSkipVerify = true
 	proxyAddr, err := tc.Process.ProxyWebAddr()
 	require.NoError(t, err)
-	sshConfig, err := key.ProxyClientSSHConfig(proxyAddr.Host())
+	sshConfig, err := keyRing.ProxyClientSSHConfig(proxyAddr.Host())
 	require.NoError(t, err)
 
 	// Build auth client configuration
@@ -276,10 +276,10 @@ func getAuthClientForProxy(t *testing.T, tc *helpers.TeleInstance, username stri
 // This client only has TLSConfig set (as opposed to TLSConfig+SSHConfig).
 func getAuthClientForAuth(t *testing.T, tc *helpers.TeleInstance, username string, ttl time.Duration) *authclient.Client {
 	// Get TLS and SSH material
-	key := helpers.MustCreateUserKey(t, tc, username, ttl)
+	keyRing := helpers.MustCreateUserKeyRing(t, tc, username, ttl)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	tlsConfig, err := key.TeleportClientTLSConfig(nil, []string{tc.Config.Auth.ClusterName.GetClusterName()})
+	tlsConfig, err := keyRing.TeleportClientTLSConfig(nil, []string{tc.Config.Auth.ClusterName.GetClusterName()})
 	require.NoError(t, err)
 
 	// Build auth client configuration

--- a/integrations/terraform/testlib/main_test.go
+++ b/integrations/terraform/testlib/main_test.go
@@ -194,7 +194,7 @@ func (s *TerraformBaseSuite) getTLSCreds(ctx context.Context, user types.User, o
 	// write the cert+private key to the output:
 	_, err = identityfile.Write(ctx, identityfile.WriteConfig{
 		OutputPath:           outputPath,
-		Key:                  keyRing,
+		KeyRing:              keyRing,
 		Format:               identityfile.FormatTLS,
 		OverwriteDestination: false,
 		Writer:               &identityfile.StandardConfigWriter{},

--- a/lib/benchmark/kube.go
+++ b/lib/benchmark/kube.go
@@ -106,7 +106,7 @@ func getKubeTLSClientConfig(ctx context.Context, tc *client.TeleportClient) (res
 		return rest.TLSClientConfig{}, trace.Wrap(err)
 	}
 
-	credentials, err := tc.LocalAgent().GetCoreKey()
+	credentials, err := tc.LocalAgent().GetCoreKeyRing()
 	if err != nil {
 		return rest.TLSClientConfig{}, trace.Wrap(err)
 	}

--- a/lib/client/alpn.go
+++ b/lib/client/alpn.go
@@ -115,12 +115,12 @@ func RunALPNAuthTunnel(ctx context.Context, cfg ALPNAuthTunnelConfig) error {
 
 func getUserCerts(ctx context.Context, client ALPNAuthClient, mfaResponse *proto.MFAAuthenticateResponse, expires time.Time, routeToDatabase proto.RouteToDatabase, connectionDiagnosticID string) (tls.Certificate, error) {
 	// TODO(nklaassen): support configurable signature algorithms.
-	key, err := GenerateRSAKey()
+	keyRing, err := GenerateRSAKeyRing()
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
 	}
 
-	publicKeyPEM, err := keys.MarshalPublicKey(key.PrivateKey.Public())
+	publicKeyPEM, err := keys.MarshalPublicKey(keyRing.PrivateKey.Public())
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
 	}
@@ -142,7 +142,7 @@ func getUserCerts(ctx context.Context, client ALPNAuthClient, mfaResponse *proto
 		return tls.Certificate{}, trace.Wrap(err)
 	}
 
-	tlsCert, err := keys.X509KeyPair(certs.TLS, key.PrivateKey.PrivateKeyPEM())
+	tlsCert, err := keys.X509KeyPair(certs.TLS, keyRing.PrivateKey.PrivateKeyPEM())
 	if err != nil {
 		return tls.Certificate{}, trace.BadParameter("failed to parse private key: %v", err)
 	}

--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -70,13 +70,13 @@ func NewMemClientStore() *Store {
 	}
 }
 
-// AddKey adds the given key to the key store. The key's trusted certificates are
+// AddKeyRing adds the given key ring to the key store. The key's trusted certificates are
 // added to the trusted certs store.
-func (s *Store) AddKey(key *KeyRing) error {
-	if err := s.KeyStore.AddKey(key); err != nil {
+func (s *Store) AddKeyRing(keyRing *KeyRing) error {
+	if err := s.KeyStore.AddKeyRing(keyRing); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := s.TrustedCertsStore.SaveTrustedCerts(key.ProxyHost, key.TrustedCerts); err != nil {
+	if err := s.TrustedCertsStore.SaveTrustedCerts(keyRing.ProxyHost, keyRing.TrustedCerts); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -99,27 +99,27 @@ func IsNoCredentialsError(err error) bool {
 	return errors.Is(err, ErrNoCredentials) || errors.Is(err, ErrNoProfile)
 }
 
-// GetKey gets the requested key with trusted the requested certificates. The key's
-// trusted certs will be retrieved from the trusted certs store. If the key is not
-// found or is missing data (certificates, etc.), then an ErrNoCredentials error
-// is returned.
-func (s *Store) GetKey(idx KeyIndex, opts ...CertOption) (*KeyRing, error) {
-	key, err := s.KeyStore.GetKey(idx, opts...)
+// GetKeyRing gets the requested key ring with trusted the requested
+// certificates. The key ring's trusted certs will be retrieved from the trusted
+// certs store. If the key ring is not found or is missing data (certificates, etc.),
+// then an ErrNoCredentials error is returned.
+func (s *Store) GetKeyRing(idx KeyRingIndex, opts ...CertOption) (*KeyRing, error) {
+	keyRing, err := s.KeyStore.GetKeyRing(idx, opts...)
 	if trace.IsNotFound(err) {
 		return nil, trace.Wrap(ErrNoCredentials, err.Error())
 	} else if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	tlsCertExpiration, err := key.TeleportTLSCertValidBefore()
+	tlsCertExpiration, err := keyRing.TeleportTLSCertValidBefore()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	s.log.Debugf("Teleport TLS certificate valid until %q.", tlsCertExpiration)
 
 	// Validate the SSH certificate.
-	if key.Cert != nil {
-		if err := key.CheckCert(); err != nil {
+	if keyRing.Cert != nil {
+		if err := keyRing.CheckCert(); err != nil {
 			if !utils.IsCertExpiredError(err) {
 				return nil, trace.Wrap(err)
 			}
@@ -130,8 +130,8 @@ func (s *Store) GetKey(idx KeyIndex, opts ...CertOption) (*KeyRing, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	key.TrustedCerts = trustedCerts
-	return key, nil
+	keyRing.TrustedCerts = trustedCerts
+	return keyRing, nil
 }
 
 // AddTrustedHostKeys is a helper function to add ssh host keys directly, rather than through SaveTrustedCerts.
@@ -173,16 +173,16 @@ func (s *Store) ReadProfileStatus(profileName string) (*ProfileStatus, error) {
 		}
 		return nil, trace.Wrap(err)
 	}
-	idx := KeyIndex{
+	idx := KeyRingIndex{
 		ProxyHost:   profileName,
 		ClusterName: profile.SiteName,
 		Username:    profile.Username,
 	}
-	key, err := s.GetKey(idx, WithAllCerts...)
+	keyRing, err := s.GetKeyRing(idx, WithAllCerts...)
 	if err != nil {
 		if trace.IsNotFound(err) || trace.IsConnectionProblem(err) {
-			// If we can't find a key to match the profile, or can't connect to
-			// the key (hardware key), return a partial status. This is used for
+			// If we can't find a keyRing to match the profile, or can't connect to
+			// the keyRing (hardware key), return a partial status. This is used for
 			// some superficial functions `tsh logout` and `tsh status`.
 			return &ProfileStatus{
 				Name: profileName,
@@ -204,7 +204,7 @@ func (s *Store) ReadProfileStatus(profileName string) (*ProfileStatus, error) {
 
 	_, onDisk := s.KeyStore.(*FSKeyStore)
 
-	return profileStatusFromKey(key, profileOptions{
+	return profileStatusFromKeyRing(keyRing, profileOptions{
 		ProfileName:             profileName,
 		ProfileDir:              profile.Dir,
 		WebProxyAddr:            profile.WebProxyAddr,
@@ -265,13 +265,13 @@ func (s *Store) FullProfileStatus() (*ProfileStatus, []*ProfileStatus, error) {
 func LoadKeysToKubeFromStore(profile *profile.Profile, dirPath, teleportCluster, kubeCluster string) ([]byte, []byte, error) {
 	fsKeyStore := NewFSKeyStore(dirPath)
 
-	certPath := fsKeyStore.kubeCertPath(KeyIndex{ProxyHost: profile.SiteName, ClusterName: teleportCluster, Username: profile.Username}, kubeCluster)
+	certPath := fsKeyStore.kubeCertPath(KeyRingIndex{ProxyHost: profile.SiteName, ClusterName: teleportCluster, Username: profile.Username}, kubeCluster)
 	kubeCert, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	privKeyPath := fsKeyStore.userKeyPath(KeyIndex{ProxyHost: profile.SiteName, Username: profile.Username})
+	privKeyPath := fsKeyStore.userKeyPath(KeyRingIndex{ProxyHost: profile.SiteName, Username: profile.Username})
 	privKey, err := os.ReadFile(privKeyPath)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/client/db/oracle/oracle.go
+++ b/lib/client/db/oracle/oracle.go
@@ -42,8 +42,8 @@ import (
 // wallet.jks   - Java Wallet format used by JDBC Drivers.
 // sqlnet.ora   - Generic Oracle Client Configuration File allowing to specify Wallet Location.
 // tnsnames.ora - Oracle Net Service mapped to connections descriptors.
-func GenerateClientConfiguration(key *client.KeyRing, db tlsca.RouteToDatabase, profile *client.ProfileStatus) error {
-	walletPath := profile.OracleWalletDir(key.ClusterName, db.ServiceName)
+func GenerateClientConfiguration(keyRing *client.KeyRing, db tlsca.RouteToDatabase, profile *client.ProfileStatus) error {
+	walletPath := profile.OracleWalletDir(keyRing.ClusterName, db.ServiceName)
 	if err := os.MkdirAll(walletPath, teleport.PrivateDirMode); err != nil {
 		return trace.Wrap(err)
 	}
@@ -57,7 +57,7 @@ func GenerateClientConfiguration(key *client.KeyRing, db tlsca.RouteToDatabase, 
 		return trace.ConvertSystemError(err)
 	}
 
-	jksWalletPath, err := createClientWallet(key, localProxyCAPem, password, walletPath)
+	jksWalletPath, err := createClientWallet(keyRing, localProxyCAPem, password, walletPath)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -73,8 +73,8 @@ func GenerateClientConfiguration(key *client.KeyRing, db tlsca.RouteToDatabase, 
 	return nil
 }
 
-func createClientWallet(key *client.KeyRing, certPem []byte, password string, walletPath string) (string, error) {
-	buff, err := createJKSWallet(key.PrivateKey.PrivateKeyPEM(), certPem, certPem, password)
+func createClientWallet(keyRing *client.KeyRing, certPem []byte, password string, walletPath string) (string, error) {
+	buff, err := createJKSWallet(keyRing.PrivateKey.PrivateKeyPEM(), certPem, certPem, password)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -180,8 +180,8 @@ type WriteConfig struct {
 	// formats (like FormatOpenSSH and FormatTLS) write multiple output files
 	// and use OutputPath as a prefix.
 	OutputPath string
-	// Key contains the credentials to write to the identity file.
-	Key *client.KeyRing
+	// KeyRing contains the credentials to write to the identity file.
+	KeyRing *client.KeyRing
 	// Format is the output format for the identity file.
 	Format Format
 	// KubeProxyAddr is the public address of the proxy with its kubernetes
@@ -230,19 +230,19 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 		}
 
 		idFile := &identityfile.IdentityFile{
-			PrivateKey: cfg.Key.PrivateKey.PrivateKeyPEM(),
+			PrivateKey: cfg.KeyRing.PrivateKey.PrivateKeyPEM(),
 			Certs: identityfile.Certs{
-				SSH: cfg.Key.Cert,
-				TLS: cfg.Key.TLSCert,
+				SSH: cfg.KeyRing.Cert,
+				TLS: cfg.KeyRing.TLSCert,
 			},
 		}
 		// append trusted host certificate authorities
-		for _, ca := range cfg.Key.TrustedCerts {
+		for _, ca := range cfg.KeyRing.TrustedCerts {
 			// append ssh ca certificates
 			for _, publicKey := range ca.AuthorizedKeys {
 				knownHost, err := sshutils.MarshalKnownHost(sshutils.KnownHost{
 					Hostname:      ca.ClusterName,
-					ProxyHost:     cfg.Key.ProxyHost,
+					ProxyHost:     cfg.KeyRing.ProxyHost,
 					AuthorizedKey: publicKey,
 				})
 				if err != nil {
@@ -272,18 +272,18 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 			return nil, trace.Wrap(err)
 		}
 
-		err = writer.WriteFile(certPath, cfg.Key.Cert, identityfile.FilePermissions)
+		err = writer.WriteFile(certPath, cfg.KeyRing.Cert, identityfile.FilePermissions)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		err = writer.WriteFile(keyPath, cfg.Key.PrivateKey.PrivateKeyPEM(), identityfile.FilePermissions)
+		err = writer.WriteFile(keyPath, cfg.KeyRing.PrivateKey.PrivateKeyPEM(), identityfile.FilePermissions)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
 	case FormatWindows:
-		for k, cert := range cfg.Key.WindowsDesktopCerts {
+		for k, cert := range cfg.KeyRing.WindowsDesktopCerts {
 			certPath := cfg.OutputPath + "." + k + ".der"
 			filesWritten = append(filesWritten, certPath)
 			if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, certPath); err != nil {
@@ -309,12 +309,12 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 			return nil, trace.Wrap(err)
 		}
 
-		err = writer.WriteFile(certPath, cfg.Key.TLSCert, identityfile.FilePermissions)
+		err = writer.WriteFile(certPath, cfg.KeyRing.TLSCert, identityfile.FilePermissions)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		err = writer.WriteFile(keyPath, cfg.Key.PrivateKey.PrivateKeyPEM(), identityfile.FilePermissions)
+		err = writer.WriteFile(keyPath, cfg.KeyRing.PrivateKey.PrivateKeyPEM(), identityfile.FilePermissions)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -329,7 +329,7 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 		}
 
 		var clientCACerts []byte
-		for _, ca := range cfg.Key.TrustedCerts {
+		for _, ca := range cfg.KeyRing.TrustedCerts {
 			for _, cert := range ca.TLSCertificates {
 				clientCACerts = append(clientCACerts, cert...)
 			}
@@ -349,17 +349,17 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 			return nil, trace.Wrap(err)
 		}
 
-		err = writer.WriteFile(certPath, cfg.Key.TLSCert, identityfile.FilePermissions)
+		err = writer.WriteFile(certPath, cfg.KeyRing.TLSCert, identityfile.FilePermissions)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		err = writer.WriteFile(keyPath, cfg.Key.PrivateKey.PrivateKeyPEM(), identityfile.FilePermissions)
+		err = writer.WriteFile(keyPath, cfg.KeyRing.PrivateKey.PrivateKeyPEM(), identityfile.FilePermissions)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		var caCerts []byte
-		for _, ca := range cfg.Key.TrustedCerts {
+		for _, ca := range cfg.KeyRing.TrustedCerts {
 			for _, cert := range ca.TLSCertificates {
 				caCerts = append(caCerts, cert...)
 			}
@@ -377,12 +377,12 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 		if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil {
 			return nil, trace.Wrap(err)
 		}
-		err = writer.WriteFile(certPath, append(cfg.Key.TLSCert, cfg.Key.PrivateKey.PrivateKeyPEM()...), identityfile.FilePermissions)
+		err = writer.WriteFile(certPath, append(cfg.KeyRing.TLSCert, cfg.KeyRing.PrivateKey.PrivateKeyPEM()...), identityfile.FilePermissions)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		var caCerts []byte
-		for _, ca := range cfg.Key.TrustedCerts {
+		for _, ca := range cfg.KeyRing.TrustedCerts {
 			for _, cert := range ca.TLSCertificates {
 				caCerts = append(caCerts, cert...)
 			}
@@ -400,7 +400,7 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 		}
 
 		var caCerts []byte
-		for _, ca := range cfg.Key.TrustedCerts {
+		for _, ca := range cfg.KeyRing.TrustedCerts {
 			for _, cert := range ca.TLSCertificates {
 				block, _ := pem.Decode(cert)
 				cert, err := x509.ParseCertificate(block.Bytes)
@@ -458,9 +458,9 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 		}
 
 		if err := kubeconfig.UpdateConfig(cfg.OutputPath, kubeconfig.Values{
-			TeleportClusterName: cfg.Key.ClusterName,
+			TeleportClusterName: cfg.KeyRing.ClusterName,
 			ClusterAddr:         cfg.KubeProxyAddr,
-			Credentials:         cfg.Key,
+			Credentials:         cfg.KeyRing,
 			TLSServerName:       cfg.KubeTLSServerName,
 			KubeClusters:        kubeCluster,
 		}, cfg.KubeStoreAllCAs, writer); err != nil {
@@ -513,11 +513,11 @@ func writeCassandraFormat(cfg WriteConfig, writer ConfigWriter) ([]string, error
 // is user env otherwise creates a p12 key-pair file allowing to run orapki on the Oracle server
 // and create the Oracle wallet manually.
 func writeOracleFormat(cfg WriteConfig, writer ConfigWriter) ([]string, error) {
-	certBlock, err := tlsca.ParseCertificatePEM(cfg.Key.TLSCert)
+	certBlock, err := tlsca.ParseCertificatePEM(cfg.KeyRing.TLSCert)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	keyK, err := keys.ParsePrivateKey(cfg.Key.PrivateKey.PrivateKeyPEM())
+	keyK, err := keys.ParsePrivateKey(cfg.KeyRing.PrivateKey.PrivateKeyPEM())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -537,7 +537,7 @@ func writeOracleFormat(cfg WriteConfig, writer ConfigWriter) ([]string, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	clientCAs := cfg.Key.TLSCAs()
+	clientCAs := cfg.KeyRing.TLSCAs()
 	var caPaths []string
 	for i, caPEM := range clientCAs {
 		var caPath string
@@ -633,7 +633,7 @@ func createOracleWallet(caCertPaths []string, walletPath, p12Path, password stri
 
 func prepareCassandraTruststore(cfg WriteConfig) (*bytes.Buffer, error) {
 	var caCerts []byte
-	for _, ca := range cfg.Key.TrustedCerts {
+	for _, ca := range cfg.KeyRing.TrustedCerts {
 		for _, cert := range ca.TLSCertificates {
 			block, _ := pem.Decode(cert)
 			caCerts = append(caCerts, block.Bytes...)
@@ -659,8 +659,8 @@ func prepareCassandraTruststore(cfg WriteConfig) (*bytes.Buffer, error) {
 }
 
 func prepareCassandraKeystore(cfg WriteConfig) (*bytes.Buffer, error) {
-	certBlock, _ := pem.Decode(cfg.Key.TLSCert)
-	privBlock, _ := pem.Decode(cfg.Key.PrivateKey.PrivateKeyPEM())
+	certBlock, _ := pem.Decode(cfg.KeyRing.TLSCert)
+	privBlock, _ := pem.Decode(cfg.KeyRing.PrivateKey.PrivateKeyPEM())
 
 	privKey, err := x509.ParsePKCS1PrivateKey(privBlock.Bytes)
 	if err != nil {
@@ -742,7 +742,7 @@ func KeyRingFromIdentityFile(identityPath, proxyHost, clusterName string) (*clie
 	keyRing := client.NewKeyRing(priv)
 	keyRing.Cert = ident.Certs.SSH
 	keyRing.TLSCert = ident.Certs.TLS
-	keyRing.KeyIndex = client.KeyIndex{
+	keyRing.KeyRingIndex = client.KeyRingIndex{
 		ProxyHost:   proxyHost,
 		ClusterName: clusterName,
 	}
@@ -835,18 +835,18 @@ func LoadIdentityFileIntoClientStore(store *client.Store, identityFile, proxyAdd
 		return trace.Wrap(err)
 	}
 
-	key, err := KeyRingFromIdentityFile(identityFile, proxyHost, clusterName)
+	keyRing, err := KeyRingFromIdentityFile(identityFile, proxyHost, clusterName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	// This key may already exist in a tsh profile, delete it before overwriting
 	// it with the identity key to avoid leaving app/db/kube certs from the old key.
-	if err := store.DeleteKey(key.KeyIndex); err != nil && !trace.IsNotFound(err) {
+	if err := store.DeleteKeyRing(keyRing.KeyRingIndex); err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
 
-	if err := store.AddKey(key); err != nil {
+	if err := store.AddKeyRing(keyRing); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -858,9 +858,9 @@ func LoadIdentityFileIntoClientStore(store *client.Store, identityFile, proxyAdd
 		profile := &profile.Profile{
 			MissingClusterDetails: true,
 			WebProxyAddr:          proxyAddr,
-			SiteName:              key.ClusterName,
-			Username:              key.Username,
-			PrivateKeyPolicy:      key.PrivateKey.GetPrivateKeyPolicy(),
+			SiteName:              keyRing.ClusterName,
+			Username:              keyRing.Username,
+			PrivateKeyPolicy:      keyRing.PrivateKey.GetPrivateKeyPolicy(),
 		}
 		if err := store.SaveProfile(profile, true); err != nil {
 			return trace.Wrap(err)

--- a/lib/client/identityfile/identity_test.go
+++ b/lib/client/identityfile/identity_test.go
@@ -73,7 +73,7 @@ func newSelfSignedCA(priv crypto.Signer) (*tlsca.CertAuthority, authclient.Trust
 	}, nil
 }
 
-func newClientKey(t *testing.T, modifiers ...func(*tlsca.Identity)) *client.KeyRing {
+func newClientKeyRing(t *testing.T, modifiers ...func(*tlsca.Identity)) *client.KeyRing {
 	privateKey, err := testauthority.New().GeneratePrivateKey()
 	require.NoError(t, err)
 
@@ -115,24 +115,24 @@ func newClientKey(t *testing.T, modifiers ...func(*tlsca.Identity)) *client.KeyR
 	})
 	require.NoError(t, err)
 
-	key := client.NewKeyRing(privateKey)
-	key.KeyIndex = client.KeyIndex{
+	keyRing := client.NewKeyRing(privateKey)
+	keyRing.KeyRingIndex = client.KeyRingIndex{
 		ProxyHost:   "localhost",
 		Username:    "testuser",
 		ClusterName: "root",
 	}
-	key.Cert = certificate
-	key.TLSCert = tlsCert
-	key.TrustedCerts = []authclient.TrustedCerts{tc}
+	keyRing.Cert = certificate
+	keyRing.TLSCert = tlsCert
+	keyRing.TrustedCerts = []authclient.TrustedCerts{tc}
 
-	return key
+	return keyRing
 }
 
 func TestWrite(t *testing.T) {
-	key := newClientKey(t)
+	keyRing := newClientKeyRing(t)
 
 	outputDir := t.TempDir()
-	cfg := WriteConfig{Key: key}
+	cfg := WriteConfig{KeyRing: keyRing}
 
 	// test OpenSSH-compatible identity file creation:
 	cfg.OutputPath = filepath.Join(outputDir, "openssh")
@@ -143,12 +143,12 @@ func TestWrite(t *testing.T) {
 	// key is OK:
 	out, err := os.ReadFile(cfg.OutputPath)
 	require.NoError(t, err)
-	require.Equal(t, string(out), string(key.PrivateKey.PrivateKeyPEM()))
+	require.Equal(t, string(out), string(keyRing.PrivateKey.PrivateKeyPEM()))
 
 	// cert is OK:
 	out, err = os.ReadFile(keypaths.IdentitySSHCertPath(cfg.OutputPath))
 	require.NoError(t, err)
-	require.Equal(t, string(out), string(key.Cert))
+	require.Equal(t, string(out), string(keyRing.Cert))
 
 	// test standard Teleport identity file creation:
 	cfg.OutputPath = filepath.Join(outputDir, "file")
@@ -161,18 +161,18 @@ func TestWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	knownHosts, err := sshutils.MarshalKnownHost(sshutils.KnownHost{
-		Hostname:      key.ClusterName,
-		ProxyHost:     key.ProxyHost,
-		AuthorizedKey: key.TrustedCerts[0].AuthorizedKeys[0],
+		Hostname:      keyRing.ClusterName,
+		ProxyHost:     keyRing.ProxyHost,
+		AuthorizedKey: keyRing.TrustedCerts[0].AuthorizedKeys[0],
 	})
 	require.NoError(t, err)
 
 	wantArr := [][]byte{
-		key.PrivateKey.PrivateKeyPEM(),
-		key.Cert,
-		key.TLSCert,
+		keyRing.PrivateKey.PrivateKeyPEM(),
+		keyRing.Cert,
+		keyRing.TLSCert,
 		[]byte(knownHosts),
-		bytes.Join(key.TrustedCerts[0].TLSCertificates, []byte{}),
+		bytes.Join(keyRing.TrustedCerts[0].TLSCertificates, []byte{}),
 	}
 	want := string(bytes.Join(wantArr, nil))
 	require.Equal(t, want, string(out))
@@ -184,19 +184,19 @@ func TestWrite(t *testing.T) {
 	cfg.KubeTLSServerName = constants.KubeTeleportProxyALPNPrefix + "far.away.cluster"
 	_, err = Write(context.Background(), cfg)
 	require.NoError(t, err)
-	assertKubeconfigContents(t, cfg.OutputPath, key.ClusterName, "far.away.cluster", cfg.KubeTLSServerName)
+	assertKubeconfigContents(t, cfg.OutputPath, keyRing.ClusterName, "far.away.cluster", cfg.KubeTLSServerName)
 }
 
 // Assert that the kubeconfig writer only writes to the supplied filesystem
 // abstraction, and not to the system
 func TestWriteKubeOnlyWritesToWriter(t *testing.T) {
-	key := newClientKey(t)
+	keyRing := newClientKeyRing(t)
 	outputDir := t.TempDir()
 
 	fs := NewInMemoryConfigWriter()
 	cfg := WriteConfig{
-		Key:    key,
-		Writer: fs,
+		KeyRing: keyRing,
+		Writer:  fs,
 	}
 
 	cfg.OutputPath = filepath.Join(outputDir, "kubeconfig")
@@ -226,15 +226,15 @@ func TestWriteKubeOnlyWritesToWriter(t *testing.T) {
 func TestWriteAllFormats(t *testing.T) {
 	for _, format := range KnownFileFormats {
 		t.Run(string(format), func(t *testing.T) {
-			key := newClientKey(t)
+			keyRing := newClientKeyRing(t)
 
-			key.WindowsDesktopCerts = map[string][]byte{
+			keyRing.WindowsDesktopCerts = map[string][]byte{
 				"windows-user": []byte("cert data"),
 			}
 
 			cfg := WriteConfig{
 				OutputPath: path.Join(t.TempDir(), "identity"),
-				Key:        key,
+				KeyRing:    keyRing,
 				Format:     format,
 			}
 
@@ -260,13 +260,13 @@ func TestWriteAllFormats(t *testing.T) {
 }
 
 func TestKubeconfigOverwrite(t *testing.T) {
-	key := newClientKey(t)
+	keyRing := newClientKeyRing(t)
 
 	// First write an ssh key to the file.
 	cfg := WriteConfig{
 		OutputPath:           filepath.Join(t.TempDir(), "out"),
 		Format:               FormatFile,
-		Key:                  key,
+		KeyRing:              keyRing,
 		OverwriteDestination: true,
 	}
 	_, err := Write(context.Background(), cfg)
@@ -277,7 +277,7 @@ func TestKubeconfigOverwrite(t *testing.T) {
 	cfg.KubeProxyAddr = "far.away.cluster"
 	_, err = Write(context.Background(), cfg)
 	require.NoError(t, err)
-	assertKubeconfigContents(t, cfg.OutputPath, key.ClusterName, "far.away.cluster", "")
+	assertKubeconfigContents(t, cfg.OutputPath, keyRing.ClusterName, "far.away.cluster", "")
 
 	// Write a kubeconfig for a different cluster to the same file path. It
 	// should be overwritten.
@@ -285,7 +285,7 @@ func TestKubeconfigOverwrite(t *testing.T) {
 	cfg.KubeTLSServerName = constants.KubeTeleportProxyALPNPrefix + "other.cluster"
 	_, err = Write(context.Background(), cfg)
 	require.NoError(t, err)
-	assertKubeconfigContents(t, cfg.OutputPath, key.ClusterName, "other.cluster", cfg.KubeTLSServerName)
+	assertKubeconfigContents(t, cfg.OutputPath, keyRing.ClusterName, "other.cluster", cfg.KubeTLSServerName)
 }
 
 func assertKubeconfigContents(t *testing.T, path, clusterName, serverAddr, kubeTLSName string) {
@@ -361,7 +361,7 @@ func fixturePath(path string) string {
 
 func TestKeyFromIdentityFile(t *testing.T) {
 	t.Parallel()
-	key := newClientKey(t)
+	keyRing := newClientKeyRing(t)
 
 	identityFilePath := filepath.Join(t.TempDir(), "out")
 
@@ -369,7 +369,7 @@ func TestKeyFromIdentityFile(t *testing.T) {
 	_, err := Write(context.Background(), WriteConfig{
 		OutputPath:           identityFilePath,
 		Format:               FormatFile,
-		Key:                  key,
+		KeyRing:              keyRing,
 		OverwriteDestination: true,
 	})
 	require.NoError(t, err)
@@ -379,19 +379,19 @@ func TestKeyFromIdentityFile(t *testing.T) {
 
 	t.Run("parsed key unchanged when both proxy and cluster provided", func(t *testing.T) {
 		// parsed key is unchanged from original with proxy and cluster provided.
-		parsedKey, err := KeyRingFromIdentityFile(identityFilePath, proxyHost, cluster)
-		key.ClusterName = cluster
-		key.ProxyHost = proxyHost
+		parsedKeyRing, err := KeyRingFromIdentityFile(identityFilePath, proxyHost, cluster)
+		keyRing.ClusterName = cluster
+		keyRing.ProxyHost = proxyHost
 		require.NoError(t, err)
-		require.Equal(t, key, parsedKey)
+		require.Equal(t, keyRing, parsedKeyRing)
 	})
 
 	t.Run("cluster name defaults if not provided", func(t *testing.T) {
 		// Identity file's cluster name defaults to root cluster name.
-		parsedKey, err := KeyRingFromIdentityFile(identityFilePath, proxyHost, "")
-		key.ClusterName = "root"
+		parsedKeyRing, err := KeyRingFromIdentityFile(identityFilePath, proxyHost, "")
+		keyRing.ClusterName = "root"
 		require.NoError(t, err)
-		require.Equal(t, key, parsedKey)
+		require.Equal(t, keyRing, parsedKeyRing)
 	})
 
 	t.Run("proxy host not provided", func(t *testing.T) {
@@ -404,28 +404,28 @@ func TestKeyFromIdentityFile(t *testing.T) {
 	t.Run("kubernetes certificate loaded", func(t *testing.T) {
 		k8sCluster := "my-cluster"
 		identityFilePath := filepath.Join(t.TempDir(), "out")
-		key := newClientKey(t, func(params *tlsca.Identity) {
+		keyRing := newClientKeyRing(t, func(params *tlsca.Identity) {
 			params.KubernetesCluster = k8sCluster
 		})
 		_, err := Write(context.Background(), WriteConfig{
 			OutputPath:           identityFilePath,
 			Format:               FormatFile,
-			Key:                  key,
+			KeyRing:              keyRing,
 			OverwriteDestination: true,
 		})
 		require.NoError(t, err)
-		parsedKey, err := KeyRingFromIdentityFile(identityFilePath, proxyHost, cluster)
+		parsedKeyRing, err := KeyRingFromIdentityFile(identityFilePath, proxyHost, cluster)
 		require.NoError(t, err)
-		require.NotNil(t, parsedKey.KubeTLSCerts[k8sCluster])
-		require.Equal(t, key.TLSCert, parsedKey.KubeTLSCerts[k8sCluster])
+		require.NotNil(t, parsedKeyRing.KubeTLSCerts[k8sCluster])
+		require.Equal(t, keyRing.TLSCert, parsedKeyRing.KubeTLSCerts[k8sCluster])
 	})
 }
 
 func TestNewClientStoreFromIdentityFile(t *testing.T) {
 	t.Parallel()
-	key := newClientKey(t)
-	key.ProxyHost = "proxy.example.com"
-	key.ClusterName = "cluster"
+	keyRing := newClientKeyRing(t)
+	keyRing.ProxyHost = "proxy.example.com"
+	keyRing.ClusterName = "cluster"
 
 	identityFilePath := filepath.Join(t.TempDir(), "out")
 
@@ -433,29 +433,29 @@ func TestNewClientStoreFromIdentityFile(t *testing.T) {
 	_, err := Write(context.Background(), WriteConfig{
 		OutputPath:           identityFilePath,
 		Format:               FormatFile,
-		Key:                  key,
+		KeyRing:              keyRing,
 		OverwriteDestination: true,
 	})
 	require.NoError(t, err)
 
-	clientStore, err := NewClientStoreFromIdentityFile(identityFilePath, key.ProxyHost+":3080", key.ClusterName)
+	clientStore, err := NewClientStoreFromIdentityFile(identityFilePath, keyRing.ProxyHost+":3080", keyRing.ClusterName)
 	require.NoError(t, err)
 
 	currentProfile, err := clientStore.CurrentProfile()
 	require.NoError(t, err)
-	require.Equal(t, key.ProxyHost, currentProfile)
+	require.Equal(t, keyRing.ProxyHost, currentProfile)
 
 	retrievedProfile, err := clientStore.GetProfile(currentProfile)
 	require.NoError(t, err)
 	require.Equal(t, &profile.Profile{
-		WebProxyAddr:          key.ProxyHost + ":3080",
-		SiteName:              key.ClusterName,
-		Username:              key.Username,
+		WebProxyAddr:          keyRing.ProxyHost + ":3080",
+		SiteName:              keyRing.ClusterName,
+		Username:              keyRing.Username,
 		PrivateKeyPolicy:      keys.PrivateKeyPolicyNone,
 		MissingClusterDetails: true,
 	}, retrievedProfile)
 
-	retrievedKey, err := clientStore.GetKey(key.KeyIndex, client.WithAllCerts...)
+	retrievedKeyRing, err := clientStore.GetKeyRing(keyRing.KeyRingIndex, client.WithAllCerts...)
 	require.NoError(t, err)
-	require.Equal(t, key, retrievedKey)
+	require.Equal(t, keyRing, retrievedKeyRing)
 }

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -168,34 +168,34 @@ func (a *LocalKeyAgent) UpdateLoadAllCAs(loadAllCAs bool) {
 	a.loadAllCAs = loadAllCAs
 }
 
-// LoadKeyForCluster fetches a cluster-specific SSH key and loads it into the
+// LoadKeyRingForCluster fetches a cluster-specific SSH key and loads it into the
 // SSH agent.
-func (a *LocalKeyAgent) LoadKeyForCluster(clusterName string) error {
-	key, err := a.GetKey(clusterName, WithSSHCerts{})
+func (a *LocalKeyAgent) LoadKeyRingForCluster(clusterName string) error {
+	keyRing, err := a.GetKeyRing(clusterName, WithSSHCerts{})
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	return a.LoadKey(*key)
+	return a.LoadKeyRing(*keyRing)
 }
 
-// LoadKey adds a key into the local agent as well as the system agent.
+// LoadKeyRing adds a key ring into the local agent as well as the system agent.
 // Some agent keys are only supported by the local agent, such as those
 // for a YubiKeyPrivateKey. Any failures to add the key will be aggregated
 // into the returned error to be handled by the caller if necessary.
-func (a *LocalKeyAgent) LoadKey(key KeyRing) error {
+func (a *LocalKeyAgent) LoadKeyRing(keyRing KeyRing) error {
 	// convert key into a format understood by x/crypto/ssh/agent
-	agentKey, err := key.AsAgentKey()
+	agentKey, err := keyRing.AsAgentKey()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	// remove any keys that the user may already have loaded
-	if err = a.UnloadKey(key.KeyIndex); err != nil {
+	if err = a.UnloadKeyRing(keyRing.KeyRingIndex); err != nil {
 		return trace.Wrap(err)
 	}
 
-	a.log.Infof("Loading SSH key for user %q and cluster %q.", a.username, key.ClusterName)
+	a.log.Infof("Loading SSH key for user %q and cluster %q.", a.username, keyRing.ClusterName)
 	agents := []agent.ExtendedAgent{a.ExtendedAgent}
 	if a.systemAgent != nil {
 		if canAddToSystemAgent(agentKey) {
@@ -236,9 +236,9 @@ func (a *LocalKeyAgent) LoadKey(key KeyRing) error {
 	return trace.Wrap(trace.NewAggregate(errs...), "failed to add one or more keys to the agent.")
 }
 
-// UnloadKey will unload keys matching the given KeyIndex from
-// the teleport ssh agent and the system agent.
-func (a *LocalKeyAgent) UnloadKey(key KeyIndex) error {
+// UnloadKeyRing will unload key rings matching the given KeyRingIndex from the
+// teleport ssh agent and the system agent.
+func (a *LocalKeyAgent) UnloadKeyRing(keyRing KeyRingIndex) error {
 	agents := []agent.Agent{a.ExtendedAgent}
 	if a.systemAgent != nil {
 		agents = append(agents, a.systemAgent)
@@ -254,7 +254,7 @@ func (a *LocalKeyAgent) UnloadKey(key KeyIndex) error {
 
 		// remove any teleport keys we currently have loaded in the agent for this user and proxy
 		for _, agentKey := range keyList {
-			if agentKeyIdx, ok := parseTeleportAgentKeyComment(agentKey.Comment); ok && agentKeyIdx.Match(key) {
+			if agentKeyIdx, ok := parseTeleportAgentKeyComment(agentKey.Comment); ok && agentKeyIdx.Match(keyRing) {
 				if err = agent.Remove(agentKey); err != nil {
 					a.log.Warnf("Unable to communicate with agent and remove key: %v", err)
 				}
@@ -294,11 +294,11 @@ func (a *LocalKeyAgent) UnloadKeys() error {
 	return nil
 }
 
-// GetKey returns the key for the given cluster of the proxy from
-// the backing keystore.
-func (a *LocalKeyAgent) GetKey(clusterName string, opts ...CertOption) (*KeyRing, error) {
-	idx := KeyIndex{a.proxyHost, a.username, clusterName}
-	key, err := a.clientStore.GetKey(idx, opts...)
+// GetKeyRing returns the key ring for the given cluster of the proxy from the
+// backing keystore.
+func (a *LocalKeyAgent) GetKeyRing(clusterName string, opts ...CertOption) (*KeyRing, error) {
+	idx := KeyRingIndex{a.proxyHost, a.username, clusterName}
+	keyRing, err := a.clientStore.GetKeyRing(idx, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -306,14 +306,14 @@ func (a *LocalKeyAgent) GetKey(clusterName string, opts ...CertOption) (*KeyRing
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	key.TrustedCerts = trustedCerts
-	return key, nil
+	keyRing.TrustedCerts = trustedCerts
+	return keyRing, nil
 }
 
-// GetCoreKey returns the key without any cluster-dependent certificates,
+// GetCoreKeyRing returns the key ring without any cluster-dependent certificates,
 // i.e. including only the private key and the Teleport TLS certificate.
-func (a *LocalKeyAgent) GetCoreKey() (*KeyRing, error) {
-	return a.GetKey("")
+func (a *LocalKeyAgent) GetCoreKeyRing() (*KeyRing, error) {
+	return a.GetKeyRing("")
 }
 
 // SaveTrustedCerts saves trusted TLS certificates and host keys of certificate authorities.
@@ -339,11 +339,11 @@ func (a *LocalKeyAgent) UserRefusedHosts() bool {
 // HostKeyCallback checks if the given host key was signed by a Teleport
 // certificate authority (CA) or a host certificate the user has seen before.
 func (a *LocalKeyAgent) HostKeyCallback(addr string, remote net.Addr, hostKey ssh.PublicKey) error {
-	key, err := a.GetCoreKey()
+	keyRing, err := a.GetCoreKeyRing()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	rootCluster, err := key.RootClusterName()
+	rootCluster, err := keyRing.RootClusterName()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -490,77 +490,77 @@ func (a *LocalKeyAgent) defaultHostPromptFunc(host string, key ssh.PublicKey, wr
 	return nil
 }
 
-// AddKey activates a new signed session key by adding it into the keystore and also
+// AddKeyRing activates a new signed session key by adding it into the keystore and also
 // by loading it into the SSH agent.
-func (a *LocalKeyAgent) AddKey(key *KeyRing) error {
-	if err := a.addKey(key); err != nil {
+func (a *LocalKeyAgent) AddKeyRing(keyRing *KeyRing) error {
+	if err := a.addKeyRing(keyRing); err != nil {
 		return trace.Wrap(err)
 	}
 	// Load key into the teleport agent and system agent.
-	if err := a.LoadKey(*key); err != nil {
+	if err := a.LoadKeyRing(*keyRing); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
 }
 
-// AddDatabaseKey activates a new signed database key by adding it into the keystore.
+// AddDatabaseKeyRing activates a new signed database key by adding it into the keystore.
 // key must contain at least one db cert. ssh cert is not required.
-func (a *LocalKeyAgent) AddDatabaseKey(key *KeyRing) error {
-	if len(key.DBTLSCerts) == 0 {
+func (a *LocalKeyAgent) AddDatabaseKeyRing(keyRing *KeyRing) error {
+	if len(keyRing.DBTLSCerts) == 0 {
 		return trace.BadParameter("key must contains at least one database access certificate")
 	}
-	return a.addKey(key)
+	return a.addKeyRing(keyRing)
 }
 
-// AddKubeKey activates a new signed Kubernetes key by adding it into the keystore.
+// AddKubeKeyRing activates a new signed Kubernetes key by adding it into the keystore.
 // key must contain at least one Kubernetes cert. ssh cert is not required.
-func (a *LocalKeyAgent) AddKubeKey(key *KeyRing) error {
-	if len(key.KubeTLSCerts) == 0 {
+func (a *LocalKeyAgent) AddKubeKeyRing(keyRing *KeyRing) error {
+	if len(keyRing.KubeTLSCerts) == 0 {
 		return trace.BadParameter("key must contains at least one Kubernetes access certificate")
 	}
-	return a.addKey(key)
+	return a.addKeyRing(keyRing)
 }
 
-// AddAppKey activates a new signed app key by adding it into the keystore.
+// AddAppKeyRing activates a new signed app key by adding it into the keystore.
 // key must contain at least one app credential. ssh cert is not required.
-func (a *LocalKeyAgent) AddAppKey(key *KeyRing) error {
-	if len(key.AppTLSCredentials) == 0 {
+func (a *LocalKeyAgent) AddAppKeyRing(keyRing *KeyRing) error {
+	if len(keyRing.AppTLSCredentials) == 0 {
 		return trace.BadParameter("key must contains at least one App access certificate")
 	}
-	return a.addKey(key)
+	return a.addKeyRing(keyRing)
 }
 
-// addKey activates a new signed session key by adding it into the keystore.
-func (a *LocalKeyAgent) addKey(key *KeyRing) error {
-	if key == nil {
+// addKeyRing activates a new signed session key ring by adding it into the keystore.
+func (a *LocalKeyAgent) addKeyRing(keyRing *KeyRing) error {
+	if keyRing == nil {
 		return trace.BadParameter("key is nil")
 	}
-	if key.ProxyHost == "" {
-		key.ProxyHost = a.proxyHost
+	if keyRing.ProxyHost == "" {
+		keyRing.ProxyHost = a.proxyHost
 	}
-	if key.Username == "" {
-		key.Username = a.username
+	if keyRing.Username == "" {
+		keyRing.Username = a.username
 	}
 
 	// In order to prevent unrelated key data to be left over after the new
 	// key is added, delete any already stored key with the same index if their
 	// RSA private keys do not match.
-	storedKey, err := a.clientStore.GetKey(key.KeyIndex)
+	storedKeyRing, err := a.clientStore.GetKeyRing(keyRing.KeyRingIndex)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
 	} else {
-		if !key.EqualPrivateKey(storedKey) {
-			a.log.Debugf("Deleting obsolete stored key with index %+v.", storedKey.KeyIndex)
-			if err := a.clientStore.DeleteKey(storedKey.KeyIndex); err != nil {
+		if !keyRing.EqualPrivateKey(storedKeyRing) {
+			a.log.Debugf("Deleting obsolete stored keyring with index %+v.", storedKeyRing.KeyRingIndex)
+			if err := a.clientStore.DeleteKeyRing(storedKeyRing.KeyRingIndex); err != nil {
 				return trace.Wrap(err)
 			}
 		}
 	}
 
 	// Save the new key to the keystore (usually into ~/.tsh).
-	if err := a.clientStore.AddKey(key); err != nil {
+	if err := a.clientStore.AddKeyRing(keyRing); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -571,14 +571,14 @@ func (a *LocalKeyAgent) addKey(key *KeyRing) error {
 // and unloads the key from the agent.
 func (a *LocalKeyAgent) DeleteKey() error {
 	// remove key from key store
-	err := a.clientStore.DeleteKey(KeyIndex{ProxyHost: a.proxyHost, Username: a.username})
+	err := a.clientStore.DeleteKeyRing(KeyRingIndex{ProxyHost: a.proxyHost, Username: a.username})
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	// remove any keys that are loaded for this user from the teleport and
 	// system agents
-	err = a.UnloadKey(KeyIndex{ProxyHost: a.proxyHost, Username: a.username})
+	err = a.UnloadKeyRing(KeyRingIndex{ProxyHost: a.proxyHost, Username: a.username})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -589,7 +589,7 @@ func (a *LocalKeyAgent) DeleteKey() error {
 // DeleteUserCerts deletes only the specified certs of the user's key,
 // keeping the private key intact.
 func (a *LocalKeyAgent) DeleteUserCerts(clusterName string, opts ...CertOption) error {
-	err := a.clientStore.DeleteUserCerts(KeyIndex{a.proxyHost, a.username, clusterName}, opts...)
+	err := a.clientStore.DeleteUserCerts(KeyRingIndex{a.proxyHost, a.username, clusterName}, opts...)
 	return trace.Wrap(err)
 }
 
@@ -616,8 +616,8 @@ func (a *LocalKeyAgent) DeleteKeys() error {
 func (a *LocalKeyAgent) Signers() ([]ssh.Signer, error) {
 	var signers []ssh.Signer
 
-	// If we find a valid key store, load all valid ssh certificates as signers.
-	if k, err := a.GetCoreKey(); err == nil {
+	// If we find a valid key ring, load all valid ssh certificates as signers.
+	if k, err := a.GetCoreKeyRing(); err == nil {
 		certs, err := a.clientStore.GetSSHCertificates(a.proxyHost, a.username)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -662,7 +662,7 @@ func (a *LocalKeyAgent) Signers() ([]ssh.Signer, error) {
 
 // signersForCluster returns a set of ssh.Signers using certificates for a specific cluster.
 func (a *LocalKeyAgent) signersForCluster(clusterName string) ([]ssh.Signer, error) {
-	k, err := a.GetKey(clusterName, WithSSHCerts{})
+	k, err := a.GetKeyRing(clusterName, WithSSHCerts{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -676,11 +676,11 @@ func (a *LocalKeyAgent) signersForCluster(clusterName string) ([]ssh.Signer, err
 // ClientCertPool returns x509.CertPool containing trusted CA.
 func (a *LocalKeyAgent) ClientCertPool(cluster string) (*x509.CertPool, error) {
 	pool := x509.NewCertPool()
-	key, err := a.GetKey(cluster)
+	keyRing, err := a.GetKeyRing(cluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	for _, caPEM := range key.TLSCAs() {
+	for _, caPEM := range keyRing.TLSCAs() {
 		if !pool.AppendCertsFromPEM(caPEM) {
 			return nil, trace.BadParameter("failed to parse TLS CA certificate")
 		}

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -54,7 +54,7 @@ import (
 
 type KeyAgentTestSuite struct {
 	keyDir      string
-	key         *KeyRing
+	keyRing     *KeyRing
 	username    string
 	hostname    string
 	clusterName string
@@ -113,7 +113,7 @@ func makeSuite(t *testing.T, opts ...keyAgentTestSuiteFunc) *KeyAgentTestSuite {
 	priv, err := keygen.GeneratePrivateKey()
 	require.NoError(t, err)
 
-	s.key = s.makeKey(t, s.username, s.hostname, priv)
+	s.keyRing = s.makeKeyRing(t, s.username, s.hostname, priv)
 
 	return s
 }
@@ -132,19 +132,19 @@ func TestAddKey(t *testing.T) {
 
 	// add the key to the local agent, this should write the key
 	// to disk as well as load it in the agent
-	err := lka.AddKey(s.key)
+	err := lka.AddKeyRing(s.keyRing)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		err = lka.UnloadKey(s.key.KeyIndex)
+		err = lka.UnloadKeyRing(s.keyRing.KeyRingIndex)
 		require.NoError(t, err)
 	})
 
 	// check that the key has been written to disk
 	expectedFiles := []string{
-		keypaths.UserKeyPath(s.keyDir, s.hostname, s.username),                    // private key
-		keypaths.TLSCertPath(s.keyDir, s.hostname, s.username),                    // Teleport TLS certificate
-		keypaths.SSHCertPath(s.keyDir, s.hostname, s.username, s.key.ClusterName), // SSH certificate
+		keypaths.UserKeyPath(s.keyDir, s.hostname, s.username),                        // private key
+		keypaths.TLSCertPath(s.keyDir, s.hostname, s.username),                        // Teleport TLS certificate
+		keypaths.SSHCertPath(s.keyDir, s.hostname, s.username, s.keyRing.ClusterName), // SSH certificate
 	}
 	for _, file := range expectedFiles {
 		require.FileExists(t, file)
@@ -158,7 +158,7 @@ func TestAddKey(t *testing.T) {
 
 	// check that we've loaded a cert as well as a private key into the teleport agent
 	// and it's for the user we expected to add a certificate for
-	expectComment := teleportAgentKeyComment(s.key.KeyIndex)
+	expectComment := teleportAgentKeyComment(s.keyRing.KeyRingIndex)
 	require.Len(t, teleportAgentKeys, 2)
 	require.Equal(t, ssh.CertAlgoRSAv01, teleportAgentKeys[0].Type())
 	require.Equal(t, expectComment, teleportAgentKeys[0].Comment)
@@ -202,11 +202,11 @@ func TestLoadKey(t *testing.T) {
 	systemAgentKeys, err := keyAgent.systemAgent.List()
 	require.NoError(t, err)
 
-	// Create 3 separate keys, with overlapping user and cluster names
-	keys := []*KeyRing{
-		s.key,
-		s.genKey(t, s.key.Username, "other-proxy-host"),
-		s.genKey(t, "other-user", s.key.ProxyHost),
+	// Create 3 separate keyRings, with overlapping user and cluster names
+	keyRings := []*KeyRing{
+		s.keyRing,
+		s.genKeyRing(t, s.keyRing.Username, "other-proxy-host"),
+		s.genKeyRing(t, "other-user", s.keyRing.ProxyHost),
 	}
 
 	// We should see two agent keys for each key added
@@ -216,20 +216,20 @@ func TestLoadKey(t *testing.T) {
 		agentsPerKey = 1
 	}
 
-	for i, key := range keys {
+	for i, keyRing := range keyRings {
 		t.Cleanup(func() {
-			err = keyAgent.UnloadKey(key.KeyIndex)
+			err = keyAgent.UnloadKeyRing(keyRing.KeyRingIndex)
 			require.NoError(t, err)
 		})
 
 		t.Run(fmt.Sprintf("key %v", i+1), func(t *testing.T) {
 			// load each key to the agent twice, this should not
 			// lead to duplicate keys in the agent.
-			keyAgent.username = key.Username
-			keyAgent.proxyHost = key.ProxyHost
-			err = keyAgent.LoadKey(*key)
+			keyAgent.username = keyRing.Username
+			keyAgent.proxyHost = keyRing.ProxyHost
+			err = keyAgent.LoadKeyRing(*keyRing)
 			require.NoError(t, err)
-			err = keyAgent.LoadKey(*key)
+			err = keyAgent.LoadKeyRing(*keyRing)
 			require.NoError(t, err)
 
 			// get an updated list of all keys in the teleport and system agent,
@@ -245,7 +245,7 @@ func TestLoadKey(t *testing.T) {
 
 			// gather all agent keys for the added key, making sure
 			// we added the correct amount to each agent.
-			keyAgentName := teleportAgentKeyComment(key.KeyIndex)
+			keyAgentName := teleportAgentKeyComment(keyRing.KeyRingIndex)
 			var agentKeysForKey []*agent.Key
 			for _, agentKey := range teleportAgentKeys {
 				if agentKey.Comment == keyAgentName {
@@ -270,9 +270,9 @@ func TestLoadKey(t *testing.T) {
 				require.NoError(t, err)
 
 				// verify data signed by both the teleport agent and system agent was signed correctly
-				err = key.PrivateKey.SSHPublicKey().Verify(userdata, teleportAgentSignature)
+				err = keyRing.PrivateKey.SSHPublicKey().Verify(userdata, teleportAgentSignature)
 				require.NoError(t, err)
-				err = key.PrivateKey.SSHPublicKey().Verify(userdata, systemAgentSignature)
+				err = keyRing.PrivateKey.SSHPublicKey().Verify(userdata, systemAgentSignature)
 				require.NoError(t, err)
 			}
 		})
@@ -343,11 +343,11 @@ func TestHostCertVerification(t *testing.T) {
 	// By default user has not refused any hosts.
 	require.False(t, lka.UserRefusedHosts())
 
-	err = lka.AddKey(s.key)
+	err = lka.AddKeyRing(s.keyRing)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		err = lka.UnloadKey(s.key.KeyIndex)
+		err = lka.UnloadKeyRing(s.keyRing.KeyRingIndex)
 		require.NoError(t, err)
 	})
 
@@ -478,11 +478,11 @@ func TestHostKeyVerification(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = lka.AddKey(s.key)
+	err = lka.AddKeyRing(s.keyRing)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		err = lka.UnloadKey(s.key.KeyIndex)
+		err = lka.UnloadKeyRing(s.keyRing.KeyRingIndex)
 		require.NoError(t, err)
 	})
 
@@ -569,10 +569,10 @@ func TestHostCertVerificationLoadAllCasProxyAddrEqClusterName(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = lka.AddKey(s.key)
+	err = lka.AddKeyRing(s.keyRing)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		err = lka.UnloadKey(s.key.KeyIndex)
+		err = lka.UnloadKeyRing(s.keyRing.KeyRingIndex)
 		require.NoError(t, err)
 	})
 
@@ -700,23 +700,23 @@ func TestLocalKeyAgent_AddDatabaseKey(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("no database cert", func(t *testing.T) {
-		require.Error(t, lka.AddDatabaseKey(s.key))
+		require.Error(t, lka.AddDatabaseKeyRing(s.keyRing))
 	})
 
 	t.Run("success", func(t *testing.T) {
 		// modify key to have db cert
-		addKey := *s.key
+		addKey := *s.keyRing
 		addKey.DBTLSCerts = map[string][]byte{"some-db": addKey.TLSCert}
 		require.NoError(t, lka.SaveTrustedCerts([]authclient.TrustedCerts{s.tlscaCert}))
-		require.NoError(t, lka.AddDatabaseKey(&addKey))
+		require.NoError(t, lka.AddDatabaseKeyRing(&addKey))
 
-		getKey, err := lka.GetKey(addKey.ClusterName, WithDBCerts{})
+		getKeyRing, err := lka.GetKeyRing(addKey.ClusterName, WithDBCerts{})
 		require.NoError(t, err)
-		require.Contains(t, getKey.DBTLSCerts, "some-db")
+		require.Contains(t, getKeyRing.DBTLSCerts, "some-db")
 	})
 }
 
-func (s *KeyAgentTestSuite) makeKey(t *testing.T, username, proxyHost string, priv *keys.PrivateKey) *KeyRing {
+func (s *KeyAgentTestSuite) makeKeyRing(t *testing.T, username, proxyHost string, priv *keys.PrivateKey) *KeyRing {
 	keygen := testauthority.New()
 	ttl := time.Minute
 
@@ -758,7 +758,7 @@ func (s *KeyAgentTestSuite) makeKey(t *testing.T, username, proxyHost string, pr
 		PrivateKey: priv,
 		Cert:       certificate,
 		TLSCert:    tlsCert,
-		KeyIndex: KeyIndex{
+		KeyRingIndex: KeyRingIndex{
 			ProxyHost:   proxyHost,
 			Username:    username,
 			ClusterName: s.clusterName,
@@ -766,10 +766,10 @@ func (s *KeyAgentTestSuite) makeKey(t *testing.T, username, proxyHost string, pr
 	}
 }
 
-func (s *KeyAgentTestSuite) genKey(t *testing.T, username, proxyHost string) *KeyRing {
+func (s *KeyAgentTestSuite) genKeyRing(t *testing.T, username, proxyHost string) *KeyRing {
 	priv, err := native.GeneratePrivateKey()
 	require.NoError(t, err)
-	return s.makeKey(t, username, proxyHost, priv)
+	return s.makeKeyRing(t, username, proxyHost, priv)
 }
 
 func startDebugAgent(t *testing.T) error {

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -54,49 +54,49 @@ func TestKeyStore(t *testing.T) {
 		t.Parallel()
 
 		// create a test key
-		idx := KeyIndex{"test.proxy.com", "test-user", "root"}
-		key := s.makeSignedKey(t, idx, false)
+		idx := KeyRingIndex{"test.proxy.com", "test-user", "root"}
+		keyRing := s.makeSignedKeyRing(t, idx, false)
 
 		// add the test key to the memory store
-		err := keyStore.AddKey(key)
+		err := keyStore.AddKeyRing(keyRing)
 		require.NoError(t, err)
 
 		// check that the key exists in the store and is the same,
 		// except the key's trusted certs should be empty, to be
 		// filled in by a trusted certs store.
-		retrievedKey, err := keyStore.GetKey(idx, WithAllCerts...)
+		retrievedKeyRing, err := keyStore.GetKeyRing(idx, WithAllCerts...)
 		require.NoError(t, err)
-		key.TrustedCerts = nil
-		require.Equal(t, key, retrievedKey)
+		keyRing.TrustedCerts = nil
+		require.Equal(t, keyRing, retrievedKeyRing)
 
 		// Delete just the db cert, reload & verify it's gone
 		err = keyStore.DeleteUserCerts(idx, WithDBCerts{})
 		require.NoError(t, err)
-		retrievedKey, err = keyStore.GetKey(idx, WithSSHCerts{}, WithDBCerts{})
+		retrievedKeyRing, err = keyStore.GetKeyRing(idx, WithSSHCerts{}, WithDBCerts{})
 		require.NoError(t, err)
-		expectKey := key.Copy()
-		expectKey.DBTLSCerts = make(map[string][]byte)
-		require.Equal(t, expectKey, retrievedKey)
+		expectKeyRing := keyRing.Copy()
+		expectKeyRing.DBTLSCerts = make(map[string][]byte)
+		require.Equal(t, expectKeyRing, retrievedKeyRing)
 
 		// check for the key, now without cluster name
-		retrievedKey, err = keyStore.GetKey(KeyIndex{idx.ProxyHost, idx.Username, ""})
+		retrievedKeyRing, err = keyStore.GetKeyRing(KeyRingIndex{idx.ProxyHost, idx.Username, ""})
 		require.NoError(t, err)
-		expectKey.ClusterName = ""
-		expectKey.Cert = nil
-		require.Equal(t, expectKey, retrievedKey)
+		expectKeyRing.ClusterName = ""
+		expectKeyRing.Cert = nil
+		require.Equal(t, expectKeyRing, retrievedKeyRing)
 
 		// delete the key
-		err = keyStore.DeleteKey(idx)
+		err = keyStore.DeleteKeyRing(idx)
 		require.NoError(t, err)
 
 		// check that the key doesn't exist in the store
-		retrievedKey, err = keyStore.GetKey(idx)
+		retrievedKeyRing, err = keyStore.GetKeyRing(idx)
 		require.Error(t, err)
 		require.True(t, trace.IsNotFound(err))
-		require.Nil(t, retrievedKey)
+		require.Nil(t, retrievedKeyRing)
 
 		// Delete non-existing
-		err = keyStore.DeleteKey(idx)
+		err = keyStore.DeleteKeyRing(idx)
 		require.Error(t, err)
 		require.True(t, trace.IsNotFound(err))
 	})
@@ -113,29 +113,29 @@ func TestListKeys(t *testing.T) {
 		// add 5 keys for "bob"
 		keys := make([]KeyRing, keyNum)
 		for i := 0; i < keyNum; i++ {
-			idx := KeyIndex{fmt.Sprintf("host-%v", i), "bob", "root"}
-			key := auth.makeSignedKey(t, idx, false)
-			require.NoError(t, keyStore.AddKey(key))
-			keys[i] = *key
+			idx := KeyRingIndex{fmt.Sprintf("host-%v", i), "bob", "root"}
+			keyRing := auth.makeSignedKeyRing(t, idx, false)
+			require.NoError(t, keyStore.AddKeyRing(keyRing))
+			keys[i] = *keyRing
 		}
 		// add 1 key for "sam"
-		samIdx := KeyIndex{"sam.host", "sam", "root"}
-		samKey := auth.makeSignedKey(t, samIdx, false)
-		require.NoError(t, keyStore.AddKey(samKey))
+		samIdx := KeyRingIndex{"sam.host", "sam", "root"}
+		samKeyRing := auth.makeSignedKeyRing(t, samIdx, false)
+		require.NoError(t, keyStore.AddKeyRing(samKeyRing))
 
 		// read all bob keys:
 		for i := 0; i < keyNum; i++ {
-			key, err := keyStore.GetKey(keys[i].KeyIndex, WithSSHCerts{}, WithDBCerts{})
+			keyRing, err := keyStore.GetKeyRing(keys[i].KeyRingIndex, WithSSHCerts{}, WithDBCerts{})
 			require.NoError(t, err)
-			key.TrustedCerts = keys[i].TrustedCerts
-			require.Equal(t, &keys[i], key)
+			keyRing.TrustedCerts = keys[i].TrustedCerts
+			require.Equal(t, &keys[i], keyRing)
 		}
 
 		// read sam's key and make sure it's the same:
-		skey, err := keyStore.GetKey(samIdx, WithSSHCerts{})
+		skeyRing, err := keyStore.GetKeyRing(samIdx, WithSSHCerts{})
 		require.NoError(t, err)
-		require.Equal(t, samKey.Cert, skey.Cert)
-		require.Equal(t, samKey.PrivateKey.MarshalSSHPublicKey(), skey.PrivateKey.MarshalSSHPublicKey())
+		require.Equal(t, samKeyRing.Cert, skeyRing.Cert)
+		require.Equal(t, samKeyRing.PrivateKey.MarshalSSHPublicKey(), skeyRing.PrivateKey.MarshalSSHPublicKey())
 	})
 }
 
@@ -152,12 +152,12 @@ func TestGetCertificates(t *testing.T) {
 		var proxy = "proxy.example.com"
 		var user = "bob"
 		for i := 0; i < keyNum; i++ {
-			idx := KeyIndex{proxy, user, fmt.Sprintf("cluster-%v", i)}
-			key := auth.makeSignedKey(t, idx, false)
-			err := keyStore.AddKey(key)
+			idx := KeyRingIndex{proxy, user, fmt.Sprintf("cluster-%v", i)}
+			keyRing := auth.makeSignedKeyRing(t, idx, false)
+			err := keyStore.AddKeyRing(keyRing)
 			require.NoError(t, err)
-			keys[i] = *key
-			certs[i], err = key.SSHCert()
+			keys[i] = *keyRing
+			certs[i], err = keyRing.SSHCert()
 			require.NoError(t, err)
 		}
 
@@ -173,21 +173,21 @@ func TestDeleteAll(t *testing.T) {
 
 	testEachKeyStore(t, func(t *testing.T, keyStore KeyStore) {
 		// generate keys
-		idxFoo := KeyIndex{"proxy.example.com", "foo", "root"}
-		keyFoo := auth.makeSignedKey(t, idxFoo, false)
-		idxBar := KeyIndex{"proxy.example.com", "bar", "root"}
-		keyBar := auth.makeSignedKey(t, idxBar, false)
+		idxFoo := KeyRingIndex{"proxy.example.com", "foo", "root"}
+		keyFoo := auth.makeSignedKeyRing(t, idxFoo, false)
+		idxBar := KeyRingIndex{"proxy.example.com", "bar", "root"}
+		keyBar := auth.makeSignedKeyRing(t, idxBar, false)
 
 		// add keys
-		err := keyStore.AddKey(keyFoo)
+		err := keyStore.AddKeyRing(keyFoo)
 		require.NoError(t, err)
-		err = keyStore.AddKey(keyBar)
+		err = keyStore.AddKeyRing(keyBar)
 		require.NoError(t, err)
 
 		// check keys exist
-		_, err = keyStore.GetKey(idxFoo)
+		_, err = keyStore.GetKeyRing(idxFoo)
 		require.NoError(t, err)
-		_, err = keyStore.GetKey(idxBar)
+		_, err = keyStore.GetKeyRing(idxBar)
 		require.NoError(t, err)
 
 		// delete all keys
@@ -195,9 +195,9 @@ func TestDeleteAll(t *testing.T) {
 		require.NoError(t, err)
 
 		// verify keys are gone
-		_, err = keyStore.GetKey(idxFoo)
+		_, err = keyStore.GetKeyRing(idxFoo)
 		require.True(t, trace.IsNotFound(err))
-		_, err = keyStore.GetKey(idxBar)
+		_, err = keyStore.GetKeyRing(idxBar)
 		require.Error(t, err)
 	})
 }
@@ -209,18 +209,18 @@ func TestCheckKey(t *testing.T) {
 	auth := newTestAuthority(t)
 
 	testEachKeyStore(t, func(t *testing.T, keyStore KeyStore) {
-		idx := KeyIndex{"host.a", "bob", "root"}
-		key := auth.makeSignedKey(t, idx, false)
+		idx := KeyRingIndex{"host.a", "bob", "root"}
+		keyRing := auth.makeSignedKeyRing(t, idx, false)
 
 		// Swap out the key with a ECDSA SSH key.
 		ellipticCertificate, _, err := cert.CreateEllipticCertificate("foo", ssh.UserCert)
 		require.NoError(t, err)
-		key.Cert = ssh.MarshalAuthorizedKey(ellipticCertificate)
+		keyRing.Cert = ssh.MarshalAuthorizedKey(ellipticCertificate)
 
-		err = keyStore.AddKey(key)
+		err = keyStore.AddKeyRing(keyRing)
 		require.NoError(t, err)
 
-		_, err = keyStore.GetKey(idx)
+		_, err = keyStore.GetKeyRing(idx)
 		require.NoError(t, err)
 	})
 }
@@ -237,19 +237,19 @@ func TestCheckKeyFIPS(t *testing.T) {
 	}
 
 	testEachKeyStore(t, func(t *testing.T, keyStore KeyStore) {
-		idx := KeyIndex{"host.a", "bob", "root"}
-		key := auth.makeSignedKey(t, idx, false)
+		idx := KeyRingIndex{"host.a", "bob", "root"}
+		keyRing := auth.makeSignedKeyRing(t, idx, false)
 
 		// Swap out the key with a ECDSA SSH key.
 		ellipticCertificate, _, err := cert.CreateEllipticCertificate("foo", ssh.UserCert)
 		require.NoError(t, err)
-		key.Cert = ssh.MarshalAuthorizedKey(ellipticCertificate)
+		keyRing.Cert = ssh.MarshalAuthorizedKey(ellipticCertificate)
 
-		err = keyStore.AddKey(key)
+		err = keyStore.AddKeyRing(keyRing)
 		require.NoError(t, err)
 
 		// Should return trace.BadParameter error because only RSA keys are supported.
-		_, err = keyStore.GetKey(idx)
+		_, err = keyStore.GetKeyRing(idx)
 		require.True(t, trace.IsBadParameter(err))
 	})
 }
@@ -260,18 +260,18 @@ func TestAddKey_withoutSSHCert(t *testing.T) {
 	keyStore := newTestFSKeyStore(t)
 
 	// without ssh cert, db certs only
-	idx := KeyIndex{"host.a", "bob", "root"}
-	key := auth.makeSignedKey(t, idx, false)
-	key.Cert = nil
-	require.NoError(t, keyStore.AddKey(key))
+	idx := KeyRingIndex{"host.a", "bob", "root"}
+	keyRing := auth.makeSignedKeyRing(t, idx, false)
+	keyRing.Cert = nil
+	require.NoError(t, keyStore.AddKeyRing(keyRing))
 
 	// ssh cert path should NOT exist
-	sshCertPath := keyStore.sshCertPath(key.KeyIndex)
+	sshCertPath := keyStore.sshCertPath(keyRing.KeyRingIndex)
 	_, err := os.Stat(sshCertPath)
 	require.ErrorIs(t, err, os.ErrNotExist)
 
 	// check db certs
-	keyCopy, err := keyStore.GetKey(idx, WithDBCerts{})
+	keyCopy, err := keyStore.GetKeyRing(idx, WithDBCerts{})
 	require.NoError(t, err)
 	require.Len(t, keyCopy.DBTLSCerts, 1)
 }
@@ -281,8 +281,8 @@ func TestConfigDirNotDeleted(t *testing.T) {
 	auth := newTestAuthority(t)
 	keyStore := newTestFSKeyStore(t)
 
-	idx := KeyIndex{"host.a", "bob", "root"}
-	keyStore.AddKey(auth.makeSignedKey(t, idx, false))
+	idx := KeyRingIndex{"host.a", "bob", "root"}
+	keyStore.AddKeyRing(auth.makeSignedKeyRing(t, idx, false))
 	configPath := filepath.Join(keyStore.KeyDir, "config")
 	require.NoError(t, os.Mkdir(configPath, 0700))
 	require.NoError(t, keyStore.DeleteKeys())

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -257,9 +257,9 @@ type profileOptions struct {
 	SAMLSingleLogoutEnabled bool
 }
 
-// profileFromkey returns a ProfileStatus for the given key and options.
-func profileStatusFromKey(key *KeyRing, opts profileOptions) (*ProfileStatus, error) {
-	sshCert, err := key.SSHCert()
+// profileStatueFromKeyRing returns a ProfileStatus for the given key ring and options.
+func profileStatusFromKeyRing(keyRing *KeyRing, opts profileOptions) (*ProfileStatus, error) {
+	sshCert, err := keyRing.SSHCert()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -319,7 +319,7 @@ func profileStatusFromKey(key *KeyRing, opts profileOptions) (*ProfileStatus, er
 	}
 	sort.Strings(extensions)
 
-	tlsCert, err := key.TeleportTLSCertificate()
+	tlsCert, err := keyRing.TeleportTLSCertificate()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -328,12 +328,12 @@ func profileStatusFromKey(key *KeyRing, opts profileOptions) (*ProfileStatus, er
 		return nil, trace.Wrap(err)
 	}
 
-	databases, err := findActiveDatabases(key)
+	databases, err := findActiveDatabases(keyRing)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	appCerts, err := key.AppTLSCertificates()
+	appCerts, err := keyRing.AppTLSCertificates()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -571,18 +571,18 @@ func (p *ProfileStatus) DatabasesForCluster(clusterName string) ([]tlsca.RouteTo
 		return p.Databases, nil
 	}
 
-	idx := KeyIndex{
+	idx := KeyRingIndex{
 		ProxyHost:   p.Name,
 		Username:    p.Username,
 		ClusterName: clusterName,
 	}
 
 	store := NewFSKeyStore(p.Dir)
-	key, err := store.GetKey(idx, WithDBCerts{})
+	keyRing, err := store.GetKeyRing(idx, WithDBCerts{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return findActiveDatabases(key)
+	return findActiveDatabases(keyRing)
 }
 
 // AppsForCluster returns a list of apps for this profile, for the
@@ -592,18 +592,18 @@ func (p *ProfileStatus) AppsForCluster(clusterName string) ([]tlsca.RouteToApp, 
 		return p.Apps, nil
 	}
 
-	idx := KeyIndex{
+	idx := KeyRingIndex{
 		ProxyHost:   p.Name,
 		Username:    p.Username,
 		ClusterName: clusterName,
 	}
 
 	store := NewFSKeyStore(p.Dir)
-	key, err := store.GetKey(idx, WithAppCerts{})
+	keyRing, err := store.GetKeyRing(idx, WithAppCerts{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return findActiveApps(key)
+	return findActiveApps(keyRing)
 }
 
 // AppNames returns a list of app names this profile is logged into.

--- a/lib/client/trusted_certs_store.go
+++ b/lib/client/trusted_certs_store.go
@@ -196,7 +196,7 @@ func (fs *FSTrustedCertsStore) clusterCAPath(proxy, clusterName string) string {
 	return keypaths.TLSCAsPathCluster(fs.Dir, proxy, clusterName)
 }
 
-// tlsCAsPath returns the TLS CA certificates legacy path for the given KeyIndex.
+// tlsCAsPath returns the TLS CA certificates legacy path for the given KeyRingIndex.
 func (fs *FSTrustedCertsStore) tlsCAsPath(proxy string) string {
 	return keypaths.TLSCAsPath(fs.Dir, proxy)
 }

--- a/lib/client/weblogin_test.go
+++ b/lib/client/weblogin_test.go
@@ -153,7 +153,7 @@ func TestSSHAgentPasswordlessLogin(t *testing.T) {
 
 	tc, err := client.NewClient(cfg)
 	require.NoError(t, err)
-	key, err := client.GenerateRSAKey()
+	keyRing, err := client.GenerateRSAKeyRing()
 	require.NoError(t, err)
 
 	// customPromptCalled is a flag to ensure the custom prompt was indeed called
@@ -213,7 +213,7 @@ func TestSSHAgentPasswordlessLogin(t *testing.T) {
 		req := client.SSHLoginPasswordless{
 			SSHLogin: client.SSHLogin{
 				ProxyAddr:         tc.WebProxyAddr,
-				PubKey:            key.PrivateKey.MarshalSSHPublicKey(),
+				PubKey:            keyRing.PrivateKey.MarshalSSHPublicKey(),
 				TTL:               tc.KeyTTL,
 				Insecure:          tc.InsecureSkipVerify,
 				Compatibility:     tc.CertificateFormat,

--- a/lib/kube/kubeconfig/kubeconfig_test.go
+++ b/lib/kube/kubeconfig/kubeconfig_test.go
@@ -176,7 +176,7 @@ func TestUpdate(t *testing.T) {
 		clusterAddr = "https://1.2.3.6:3080"
 	)
 	kubeconfigPath, initialConfig := setup(t)
-	creds, caCertPEM, err := genUserKey("localhost")
+	creds, caCertPEM, err := genUserKeyRing("localhost")
 	require.NoError(t, err)
 	err = Update(kubeconfigPath, Values{
 		TeleportClusterName: clusterName,
@@ -225,7 +225,7 @@ func TestUpdateWithExec(t *testing.T) {
 		namespace   = "kubeNamespace"
 	)
 
-	creds, caCertPEM, err := genUserKey("localhost")
+	creds, caCertPEM, err := genUserKeyRing("localhost")
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -350,7 +350,7 @@ func TestUpdateWithExecAndProxy(t *testing.T) {
 		home        = "/alt/home"
 	)
 	kubeconfigPath, initialConfig := setup(t)
-	creds, caCertPEM, err := genUserKey("localhost")
+	creds, caCertPEM, err := genUserKeyRing("localhost")
 	require.NoError(t, err)
 	err = Update(kubeconfigPath, Values{
 		TeleportClusterName: clusterName,
@@ -415,9 +415,9 @@ func TestUpdateLoadAllCAs(t *testing.T) {
 		clusterAddr     = "https://1.2.3.6:3080"
 	)
 	kubeconfigPath, _ := setup(t)
-	creds, _, err := genUserKey("localhost")
+	creds, _, err := genUserKeyRing("localhost")
 	require.NoError(t, err)
-	_, leafCACertPEM, err := genUserKey("example.com")
+	_, leafCACertPEM, err := genUserKeyRing("example.com")
 	require.NoError(t, err)
 	creds.TrustedCerts[0].ClusterName = clusterName
 	creds.TrustedCerts = append(creds.TrustedCerts, authclient.TrustedCerts{
@@ -455,7 +455,7 @@ func TestRemoveByClusterName(t *testing.T) {
 	)
 	kubeconfigPath, initialConfig := setup(t)
 
-	creds, _, err := genUserKey("localhost")
+	creds, _, err := genUserKeyRing("localhost")
 	require.NoError(t, err)
 
 	// Add teleport-generated entries to kubeconfig.
@@ -518,7 +518,7 @@ func TestRemoveByServerAddr(t *testing.T) {
 	)
 
 	kubeconfigPath, initialConfig := setup(t)
-	creds, _, err := genUserKey("localhost")
+	creds, _, err := genUserKeyRing("localhost")
 	require.NoError(t, err)
 
 	// Add teleport-generated entries to kubeconfig.
@@ -551,7 +551,7 @@ func TestRemoveByServerAddr(t *testing.T) {
 	require.Equal(t, wantConfig, config)
 }
 
-func genUserKey(hostname string) (*client.KeyRing, []byte, error) {
+func genUserKeyRing(hostname string) (*client.KeyRing, []byte, error) {
 	caKey, caCert, err := tlsca.GenerateSelfSignedCA(pkix.Name{
 		CommonName:   hostname,
 		Organization: []string{hostname},

--- a/lib/kube/kubeconfig/localproxy_test.go
+++ b/lib/kube/kubeconfig/localproxy_test.go
@@ -34,7 +34,7 @@ func TestLocalProxy(t *testing.T) {
 	)
 
 	kubeconfigPath, initialConfig := setup(t)
-	creds, _, err := genUserKey("localhost")
+	creds, _, err := genUserKeyRing("localhost")
 	require.NoError(t, err)
 	exec := &ExecValues{
 		TshBinaryPath: "/path/to/tsh",

--- a/lib/tbot/output_utils.go
+++ b/lib/tbot/output_utils.go
@@ -103,15 +103,15 @@ func (b *BotConfigWriter) ReadFile(name string) ([]byte, error) {
 // identityfile.ConfigWriter interface
 var _ identityfile.ConfigWriter = (*BotConfigWriter)(nil)
 
-// NewClientKey returns a sane client.Key for the given bot identity.
-func NewClientKey(ident *identity.Identity, hostCAs []types.CertAuthority) (*client.KeyRing, error) {
+// NewClientKeyRing returns a sane client.KeyRing for the given bot identity.
+func NewClientKeyRing(ident *identity.Identity, hostCAs []types.CertAuthority) (*client.KeyRing, error) {
 	pk, err := keys.ParsePrivateKey(ident.PrivateKeyBytes)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return &client.KeyRing{
-		KeyIndex: client.KeyIndex{
+		KeyRingIndex: client.KeyRingIndex{
 			ClusterName: ident.ClusterName,
 		},
 		PrivateKey:   pk,
@@ -128,7 +128,7 @@ func NewClientKey(ident *identity.Identity, hostCAs []types.CertAuthority) (*cli
 }
 
 func writeIdentityFile(
-	ctx context.Context, log *slog.Logger, key *client.KeyRing, dest bot.Destination,
+	ctx context.Context, log *slog.Logger, keyRing *client.KeyRing, dest bot.Destination,
 ) error {
 	ctx, span := tracer.Start(
 		ctx,
@@ -139,7 +139,7 @@ func writeIdentityFile(
 	cfg := identityfile.WriteConfig{
 		OutputPath: config.IdentityFilePath,
 		Writer:     newBotConfigWriter(ctx, dest, ""),
-		Key:        key,
+		KeyRing:    keyRing,
 		Format:     identityfile.FormatFile,
 
 		// Always overwrite to avoid hitting our no-op Stat() and Remove() functions.
@@ -160,7 +160,7 @@ func writeIdentityFile(
 // useful when writing out TLS certificates with alternative prefix and file
 // extensions for application compatibility reasons.
 func writeIdentityFileTLS(
-	ctx context.Context, log *slog.Logger, key *client.KeyRing, dest bot.Destination,
+	ctx context.Context, log *slog.Logger, keyRing *client.KeyRing, dest bot.Destination,
 ) error {
 	ctx, span := tracer.Start(
 		ctx,
@@ -171,7 +171,7 @@ func writeIdentityFileTLS(
 	cfg := identityfile.WriteConfig{
 		OutputPath: config.DefaultTLSPrefix,
 		Writer:     newBotConfigWriter(ctx, dest, ""),
-		Key:        key,
+		KeyRing:    keyRing,
 		Format:     identityfile.FormatTLS,
 
 		// Always overwrite to avoid hitting our no-op Stat() and Remove() functions.

--- a/lib/tbot/service_application_output.go
+++ b/lib/tbot/service_application_output.go
@@ -179,12 +179,12 @@ func (s *ApplicationOutputService) render(
 	)
 	defer span.End()
 
-	key, err := NewClientKey(routedIdentity, hostCAs)
+	keyRing, err := NewClientKeyRing(routedIdentity, hostCAs)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	if err := writeIdentityFile(ctx, s.log, key, s.cfg.Destination); err != nil {
+	if err := writeIdentityFile(ctx, s.log, keyRing, s.cfg.Destination); err != nil {
 		return trace.Wrap(err, "writing identity file")
 	}
 	if err := identity.SaveIdentity(
@@ -194,7 +194,7 @@ func (s *ApplicationOutputService) render(
 	}
 
 	if s.cfg.SpecificTLSExtensions {
-		if err := writeIdentityFileTLS(ctx, s.log, key, s.cfg.Destination); err != nil {
+		if err := writeIdentityFileTLS(ctx, s.log, keyRing, s.cfg.Destination); err != nil {
 			return trace.Wrap(err, "writing specific tls extension files")
 		}
 	}

--- a/lib/tbot/service_database_output.go
+++ b/lib/tbot/service_database_output.go
@@ -181,7 +181,7 @@ func (s *DatabaseOutputService) render(
 	)
 	defer span.End()
 
-	key, err := NewClientKey(routedIdentity, hostCAs)
+	keyRing, err := NewClientKeyRing(routedIdentity, hostCAs)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -190,7 +190,7 @@ func (s *DatabaseOutputService) render(
 		return trace.Wrap(err)
 	}
 
-	if err := writeIdentityFile(ctx, s.log, key, s.cfg.Destination); err != nil {
+	if err := writeIdentityFile(ctx, s.log, keyRing, s.cfg.Destination); err != nil {
 		return trace.Wrap(err, "writing identity file")
 	}
 	if err := identity.SaveIdentity(
@@ -214,7 +214,7 @@ func (s *DatabaseOutputService) render(
 		}
 	case config.TLSDatabaseFormat:
 		if err := writeIdentityFileTLS(
-			ctx, s.log, key, s.cfg.Destination,
+			ctx, s.log, keyRing, s.cfg.Destination,
 		); err != nil {
 			return trace.Wrap(err, "writing tls database format files")
 		}
@@ -237,7 +237,7 @@ func writeCockroachDatabaseFiles(
 	defer span.End()
 
 	// Cockroach format specifically uses database CAs rather than hostCAs
-	key, err := NewClientKey(routedIdentity, databaseCAs)
+	keyRing, err := NewClientKeyRing(routedIdentity, databaseCAs)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -245,7 +245,7 @@ func writeCockroachDatabaseFiles(
 	cfg := identityfile.WriteConfig{
 		OutputPath: config.DefaultCockroachDirName,
 		Writer:     newBotConfigWriter(ctx, dest, config.DefaultCockroachDirName),
-		Key:        key,
+		KeyRing:    keyRing,
 		Format:     identityfile.FormatCockroach,
 
 		// Always overwrite to avoid hitting our no-op Stat() and Remove() functions.
@@ -275,7 +275,7 @@ func writeMongoDatabaseFiles(
 	defer span.End()
 
 	// Mongo format specifically uses database CAs rather than hostCAs
-	key, err := NewClientKey(routedIdentity, databaseCAs)
+	keyRing, err := NewClientKeyRing(routedIdentity, databaseCAs)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -283,7 +283,7 @@ func writeMongoDatabaseFiles(
 	cfg := identityfile.WriteConfig{
 		OutputPath: config.DefaultMongoPrefix,
 		Writer:     newBotConfigWriter(ctx, dest, ""),
-		Key:        key,
+		KeyRing:    keyRing,
 		Format:     identityfile.FormatMongo,
 		// Always overwrite to avoid hitting our no-op Stat() and Remove() functions.
 		OverwriteDestination: true,

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -214,7 +214,7 @@ func (s *IdentityOutputService) render(
 	)
 	defer span.End()
 
-	key, err := NewClientKey(id, hostCAs)
+	keyRing, err := NewClientKeyRing(id, hostCAs)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -223,7 +223,7 @@ func (s *IdentityOutputService) render(
 		return trace.Wrap(err)
 	}
 
-	if err := writeIdentityFile(ctx, s.log, key, s.cfg.Destination); err != nil {
+	if err := writeIdentityFile(ctx, s.log, keyRing, s.cfg.Destination); err != nil {
 		return trace.Wrap(err, "writing identity file")
 	}
 	if err := identity.SaveIdentity(

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -196,7 +196,7 @@ func (s *KubernetesOutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	key, err := NewClientKey(routedIdentity, hostCAs)
+	keyRing, err := NewClientKeyRing(routedIdentity, hostCAs)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -204,7 +204,7 @@ func (s *KubernetesOutputService) generate(ctx context.Context) error {
 	status := &kubernetesStatus{
 		clusterAddr:           clusterAddr,
 		tlsServerName:         tlsServerName,
-		credentials:           key,
+		credentials:           keyRing,
 		teleportClusterName:   proxyPong.ClusterName,
 		kubernetesClusterName: kubeClusterName,
 	}

--- a/lib/tbot/service_kubernetes_output_test.go
+++ b/lib/tbot/service_kubernetes_output_test.go
@@ -162,7 +162,7 @@ func TestKubernetesOutputService_render(t *testing.T) {
 				log:            utils.NewSlogLoggerForTests(),
 			}
 
-			key, err := NewClientKey(
+			keyRing, err := NewClientKeyRing(
 				id,
 				[]types.CertAuthority{fakeCA(t, types.HostCA, mockClusterName)},
 			)
@@ -171,7 +171,7 @@ func TestKubernetesOutputService_render(t *testing.T) {
 				kubernetesClusterName: k8sCluster,
 				teleportClusterName:   mockClusterName,
 				tlsServerName:         client.GetKubeTLSServerName(mockClusterName),
-				credentials:           key,
+				credentials:           keyRing,
 				clusterAddr:           fmt.Sprintf("https://%s:443", mockClusterName),
 			}
 

--- a/lib/tbot/ssh_proxy.go
+++ b/lib/tbot/ssh_proxy.go
@@ -256,24 +256,24 @@ func resolveTargetHostWithClient(
 
 func parseIdentity(destPath, proxy, cluster string, insecure, fips bool) (*identity.Facade, agent.ExtendedAgent, error) {
 	identityPath := filepath.Join(destPath, config.IdentityFilePath)
-	key, err := identityfile.KeyRingFromIdentityFile(identityPath, proxy, cluster)
+	keyRing, err := identityfile.KeyRingFromIdentityFile(identityPath, proxy, cluster)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
 	i, err := identity.ReadIdentityFromStore(&identity.LoadIdentityParams{
-		PrivateKeyBytes: key.PrivateKey.PrivateKeyPEM(),
-		PublicKeyBytes:  key.PrivateKey.MarshalSSHPublicKey(),
+		PrivateKeyBytes: keyRing.PrivateKey.PrivateKeyPEM(),
+		PublicKeyBytes:  keyRing.PrivateKey.MarshalSSHPublicKey(),
 	}, &proto.Certs{
-		SSH:        key.Cert,
-		TLS:        key.TLSCert,
-		TLSCACerts: key.TLSCAs(),
+		SSH:        keyRing.Cert,
+		TLS:        keyRing.TLSCert,
+		TLSCACerts: keyRing.TLSCAs(),
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	agentKey, err := key.AsAgentKey()
+	agentKey, err := keyRing.AsAgentKey()
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -252,7 +252,7 @@ func (s *Storage) loadProfileStatusAndClusterKey(clusterClient *client.TeleportC
 	status := &client.ProfileStatus{}
 
 	// load profile status if key exists
-	_, err := clusterClient.LocalAgent().GetKey(clusterNameForKey)
+	_, err := clusterClient.LocalAgent().GetKeyRing(clusterNameForKey)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			s.Log.Infof("No keys found for cluster %v.", clusterNameForKey)

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -364,7 +364,7 @@ func (a *AuthCommand) generateWindowsCert(ctx context.Context, clusterAPI certif
 
 	_, err = identityfile.Write(ctx, identityfile.WriteConfig{
 		OutputPath: a.output,
-		Key: &client.KeyRing{
+		KeyRing: &client.KeyRing{
 			// the godocs say the map key is the desktop server name,
 			// but in this case we're just generating a cert that's not
 			// specific to a particular desktop
@@ -384,7 +384,7 @@ func (a *AuthCommand) generateWindowsCert(ctx context.Context, clusterAPI certif
 // generateSnowflakeKey exports DatabaseCA public key in the format required by Snowflake
 // Ref: https://docs.snowflake.com/en/user-guide/key-pair-auth.html#step-2-generate-a-public-key
 func (a *AuthCommand) generateSnowflakeKey(ctx context.Context, clusterAPI certificateSigner) error {
-	key, err := client.GenerateRSAKey()
+	keyRing, err := client.GenerateRSAKeyRing()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -401,11 +401,11 @@ func (a *AuthCommand) generateSnowflakeKey(ctx context.Context, clusterAPI certi
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	key.TrustedCerts = []authclient.TrustedCerts{{TLSCertificates: services.GetTLSCerts(dbClientCA)}}
+	keyRing.TrustedCerts = []authclient.TrustedCerts{{TLSCertificates: services.GetTLSCerts(dbClientCA)}}
 
 	filesWritten, err := identityfile.Write(ctx, identityfile.WriteConfig{
 		OutputPath:           a.output,
-		Key:                  key,
+		KeyRing:              keyRing,
 		Format:               a.outputFormat,
 		OverwriteDestination: a.signOverwrite,
 		Writer:               a.identityWriter,
@@ -496,7 +496,7 @@ func (a *AuthCommand) generateHostKeys(ctx context.Context, clusterAPI certifica
 	principals := strings.Split(a.genHost, ",")
 
 	// generate a keypair
-	key, err := client.GenerateRSAKey()
+	keyRing, err := client.GenerateRSAKeyRing()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -508,7 +508,7 @@ func (a *AuthCommand) generateHostKeys(ctx context.Context, clusterAPI certifica
 	clusterName := cn.GetClusterName()
 
 	res, err := clusterAPI.TrustClient().GenerateHostCert(ctx, &trustpb.GenerateHostCertRequest{
-		Key:         key.PrivateKey.MarshalSSHPublicKey(),
+		Key:         keyRing.PrivateKey.MarshalSSHPublicKey(),
 		HostId:      "",
 		NodeName:    "",
 		Principals:  principals,
@@ -519,13 +519,13 @@ func (a *AuthCommand) generateHostKeys(ctx context.Context, clusterAPI certifica
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	key.Cert = res.SshCertificate
+	keyRing.Cert = res.SshCertificate
 
 	hostCAs, err := clusterAPI.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	key.TrustedCerts = authclient.AuthoritiesToTrustedCerts(hostCAs)
+	keyRing.TrustedCerts = authclient.AuthoritiesToTrustedCerts(hostCAs)
 
 	// if no name was given, take the first name on the list of principals
 	filePath := a.output
@@ -535,7 +535,7 @@ func (a *AuthCommand) generateHostKeys(ctx context.Context, clusterAPI certifica
 
 	filesWritten, err := identityfile.Write(ctx, identityfile.WriteConfig{
 		OutputPath:           filePath,
-		Key:                  key,
+		KeyRing:              keyRing,
 		Format:               a.outputFormat,
 		OverwriteDestination: a.signOverwrite,
 		Writer:               a.identityWriter,
@@ -552,16 +552,16 @@ func (a *AuthCommand) generateHostKeys(ctx context.Context, clusterAPI certifica
 // generateDatabaseKeys generates a new unsigned key and signs it with Teleport
 // CA for database access.
 func (a *AuthCommand) generateDatabaseKeys(ctx context.Context, clusterAPI certificateSigner) error {
-	key, err := client.GenerateRSAKey()
+	keyRing, err := client.GenerateRSAKeyRing()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return a.generateDatabaseKeysForKey(ctx, clusterAPI, key)
+	return a.generateDatabaseKeysForKeyRing(ctx, clusterAPI, keyRing)
 }
 
-// generateDatabaseKeysForKey signs the provided unsigned key with Teleport CA
+// generateDatabaseKeysForKeyRing signs the provided unsigned key with Teleport CA
 // for database access.
-func (a *AuthCommand) generateDatabaseKeysForKey(ctx context.Context, clusterAPI certificateSigner, key *client.KeyRing) error {
+func (a *AuthCommand) generateDatabaseKeysForKeyRing(ctx context.Context, clusterAPI certificateSigner, keyRing *client.KeyRing) error {
 	principals := strings.Split(a.genHost, ",")
 
 	dbCertReq := db.GenerateDatabaseCertificatesRequest{
@@ -571,7 +571,7 @@ func (a *AuthCommand) generateDatabaseKeysForKey(ctx context.Context, clusterAPI
 		OutputCanOverwrite: a.signOverwrite,
 		OutputLocation:     a.output,
 		TTL:                a.genTTL,
-		Key:                key,
+		KeyRing:            keyRing,
 		Password:           a.password,
 		IdentityFileWriter: a.identityWriter,
 	}
@@ -853,7 +853,7 @@ func (a *AuthCommand) generateUserKeys(ctx context.Context, clusterAPI certifica
 
 	// Generate a keypair.
 	// TODO(nklaassen): support configurable key algorithms, split SSH and TLS keys.
-	key, err := client.GenerateRSAKey()
+	keyRing, err := client.GenerateRSAKeyRing()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -869,7 +869,7 @@ func (a *AuthCommand) generateUserKeys(ctx context.Context, clusterAPI certifica
 		}
 		a.leafCluster = cn.GetClusterName()
 	}
-	key.ClusterName = a.leafCluster
+	keyRing.ClusterName = a.leafCluster
 
 	if err := a.checkKubeCluster(ctx, clusterAPI); err != nil {
 		return trace.Wrap(err)
@@ -922,8 +922,8 @@ func (a *AuthCommand) generateUserKeys(ctx context.Context, clusterAPI certifica
 		certUsage = proto.UserCertsRequest_Database
 	}
 
-	sshPublicKey := key.PrivateKey.MarshalSSHPublicKey()
-	tlsPublicKey, err := keys.MarshalPublicKey(key.PrivateKey.Public())
+	sshPublicKey := keyRing.PrivateKey.MarshalSSHPublicKey()
+	tlsPublicKey, err := keys.MarshalPublicKey(keyRing.PrivateKey.Public())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -945,14 +945,14 @@ func (a *AuthCommand) generateUserKeys(ctx context.Context, clusterAPI certifica
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	key.Cert = certs.SSH
-	key.TLSCert = certs.TLS
+	keyRing.Cert = certs.SSH
+	keyRing.TLSCert = certs.TLS
 
 	hostCAs, err := clusterAPI.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	key.TrustedCerts = authclient.AuthoritiesToTrustedCerts(hostCAs)
+	keyRing.TrustedCerts = authclient.AuthoritiesToTrustedCerts(hostCAs)
 
 	// Is TLS routing enabled?
 	proxyListenerMode := types.ProxyListenerMode_Separate
@@ -976,7 +976,7 @@ func (a *AuthCommand) generateUserKeys(ctx context.Context, clusterAPI certifica
 		kubeTLSServerName = client.GetKubeTLSServerName(split[0])
 	}
 
-	expires, err := key.TeleportTLSCertValidBefore()
+	expires, err := keyRing.TeleportTLSCertValidBefore()
 	if err != nil {
 		log.WithError(err).Warn("Failed to check TTL validity")
 		// err swallowed on purpose
@@ -990,7 +990,7 @@ func (a *AuthCommand) generateUserKeys(ctx context.Context, clusterAPI certifica
 	// write the cert+private key to the output:
 	filesWritten, err := identityfile.Write(ctx, identityfile.WriteConfig{
 		OutputPath:           a.output,
-		Key:                  key,
+		KeyRing:              keyRing,
 		Format:               a.outputFormat,
 		KubeProxyAddr:        a.proxyAddr,
 		KubeClusterName:      a.kubeCluster,
@@ -1168,11 +1168,11 @@ func (a *AuthCommand) checkProxyAddr(ctx context.Context, clusterAPI certificate
 }
 
 func (a *AuthCommand) generateDBOracleCert(ctx context.Context, api certificateSigner) error {
-	key, err := client.GenerateRSAKey()
+	keyRing, err := client.GenerateRSAKeyRing()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return a.generateDatabaseKeysForKey(ctx, api, key)
+	return a.generateDatabaseKeysForKeyRing(ctx, api, keyRing)
 }
 
 func parseURL(rawurl string) (*url.URL, error) {

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -603,7 +603,7 @@ func TestGenerateDatabaseKeys(t *testing.T) {
 		cas: []types.CertAuthority{dbCA},
 	}
 
-	key, err := client.GenerateRSAKey()
+	keyRing, err := client.GenerateRSAKeyRing()
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -627,7 +627,7 @@ func TestGenerateDatabaseKeys(t *testing.T) {
 			outSubject:     pkix.Name{CommonName: "postgres.example.com"},
 			outServerNames: []string{"postgres.example.com"},
 			wantFiles: map[string][]byte{
-				"db.key": key.PrivateKey.PrivateKeyPEM(),
+				"db.key": keyRing.PrivateKey.PrivateKeyPEM(),
 				"db.crt": certBytes,
 				"db.cas": dbClientCABytes,
 			},
@@ -641,7 +641,7 @@ func TestGenerateDatabaseKeys(t *testing.T) {
 			outSubject:     pkix.Name{CommonName: "mysql.external.net"},
 			outServerNames: []string{"mysql.external.net", "mysql.internal.net", "192.168.1.1"},
 			wantFiles: map[string][]byte{
-				"db.key": key.PrivateKey.PrivateKeyPEM(),
+				"db.key": keyRing.PrivateKey.PrivateKeyPEM(),
 				"db.crt": certBytes,
 				"db.cas": dbClientCABytes,
 			},
@@ -655,7 +655,7 @@ func TestGenerateDatabaseKeys(t *testing.T) {
 			outSubject:     pkix.Name{CommonName: "mongo.example.com", Organization: []string{"example.com"}},
 			outServerNames: []string{"mongo.example.com"},
 			wantFiles: map[string][]byte{
-				"mongo.crt": append(certBytes, key.PrivateKey.PrivateKeyPEM()...),
+				"mongo.crt": append(certBytes, keyRing.PrivateKey.PrivateKeyPEM()...),
 				"mongo.cas": dbClientCABytes,
 			},
 		},
@@ -667,7 +667,7 @@ func TestGenerateDatabaseKeys(t *testing.T) {
 			outSubject:     pkix.Name{CommonName: "node"},
 			outServerNames: []string{"node", "localhost", "roach1"}, // "node" principal should always be added
 			wantFiles: map[string][]byte{
-				"node.key":      key.PrivateKey.PrivateKeyPEM(),
+				"node.key":      keyRing.PrivateKey.PrivateKeyPEM(),
 				"node.crt":      certBytes,
 				"ca.crt":        dbServerCABytes,
 				"ca-client.crt": dbClientCABytes,
@@ -682,7 +682,7 @@ func TestGenerateDatabaseKeys(t *testing.T) {
 			outSubject:     pkix.Name{CommonName: "localhost"},
 			outServerNames: []string{"localhost", "redis1", "172.0.0.1"},
 			wantFiles: map[string][]byte{
-				"db.key": key.PrivateKey.PrivateKeyPEM(),
+				"db.key": keyRing.PrivateKey.PrivateKeyPEM(),
 				"db.crt": certBytes,
 				"db.cas": dbClientCABytes,
 			},
@@ -707,7 +707,7 @@ func TestGenerateDatabaseKeys(t *testing.T) {
 				genTTL:        time.Hour,
 			}
 
-			err = ac.generateDatabaseKeysForKey(context.Background(), authClient, key)
+			err = ac.generateDatabaseKeysForKeyRing(context.Background(), authClient, keyRing)
 			if test.genKeyErrMsg == "" {
 				require.NoError(t, err)
 			} else {

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -444,14 +444,14 @@ func LoadConfigFromProfile(ccf *GlobalCLIFlags, cfg *servicecfg.Config) (*authcl
 	}
 
 	webProxyHost, _ := c.WebProxyHostPort()
-	idx := client.KeyIndex{ProxyHost: webProxyHost, Username: c.Username, ClusterName: profile.Cluster}
-	key, err := clientStore.GetKey(idx, client.WithSSHCerts{})
+	idx := client.KeyRingIndex{ProxyHost: webProxyHost, Username: c.Username, ClusterName: profile.Cluster}
+	keyRing, err := clientStore.GetKeyRing(idx, client.WithSSHCerts{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Auth config can be created only using a key associated with the root cluster.
-	rootCluster, err := key.RootClusterName()
+	rootCluster, err := keyRing.RootClusterName()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -460,13 +460,13 @@ func LoadConfigFromProfile(ccf *GlobalCLIFlags, cfg *servicecfg.Config) (*authcl
 	}
 
 	authConfig := &authclient.Config{}
-	authConfig.TLS, err = key.TeleportClientTLSConfig(cfg.CipherSuites, []string{rootCluster})
+	authConfig.TLS, err = keyRing.TeleportClientTLSConfig(cfg.CipherSuites, []string{rootCluster})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	authConfig.TLS.InsecureSkipVerify = ccf.Insecure
 	authConfig.Insecure = ccf.Insecure
-	authConfig.SSH, err = key.ProxyClientSSHConfig(rootCluster)
+	authConfig.SSH, err = keyRing.ProxyClientSSHConfig(rootCluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -79,7 +79,7 @@ func onAppLogin(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	if err := tc.LocalAgent().AddAppKey(key); err != nil {
+	if err := tc.LocalAgent().AddAppKeyRing(key); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/tool/tsh/common/app_azure.go
+++ b/tool/tsh/common/app_azure.go
@@ -78,7 +78,7 @@ type azureApp struct {
 
 // newAzureApp creates a new Azure app.
 func newAzureApp(tc *client.TeleportClient, cf *CLIConf, appInfo *appInfo) (*azureApp, error) {
-	key, err := tc.LocalAgent().GetCoreKey()
+	keyRing, err := tc.LocalAgent().GetCoreKeyRing()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -91,7 +91,7 @@ func newAzureApp(tc *client.TeleportClient, cf *CLIConf, appInfo *appInfo) (*azu
 	return &azureApp{
 		localProxyApp: newLocalProxyApp(tc, appInfo, cf.LocalProxyPort, cf.InsecureSkipVerify),
 		cf:            cf,
-		signer:        key.PrivateKey,
+		signer:        keyRing.PrivateKey,
 		msiSecret:     msiSecret,
 	}, nil
 }

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -302,14 +302,14 @@ func databaseLogin(cf *CLIConf, tc *client.TeleportClient, dbInfo *databaseInfo)
 		return trace.Wrap(err)
 	}
 
-	var key *client.KeyRing
+	var keyRing *client.KeyRing
 	// Identity files themselves act as the database credentials (if any), so
 	// don't bother fetching new certs.
 	if profile.IsVirtual {
 		log.Info("Note: already logged in due to an identity file (`-i ...`); will only update database config files.")
 	} else {
 		if err = client.RetryWithRelogin(cf.Context, tc, func() error {
-			key, err = tc.IssueUserCertsWithMFA(cf.Context, client.ReissueParams{
+			keyRing, err = tc.IssueUserCertsWithMFA(cf.Context, client.ReissueParams{
 				RouteToCluster: tc.SiteName,
 				RouteToDatabase: proto.RouteToDatabase{
 					ServiceName: dbInfo.ServiceName,
@@ -325,16 +325,16 @@ func databaseLogin(cf *CLIConf, tc *client.TeleportClient, dbInfo *databaseInfo)
 			return trace.Wrap(err)
 		}
 
-		if err = tc.LocalAgent().AddDatabaseKey(key); err != nil {
+		if err = tc.LocalAgent().AddDatabaseKeyRing(keyRing); err != nil {
 			return trace.Wrap(err)
 		}
 	}
 
 	if dbInfo.Protocol == defaults.ProtocolOracle {
-		if err := generateDBLocalProxyCert(key, profile); err != nil {
+		if err := generateDBLocalProxyCert(keyRing, profile); err != nil {
 			return trace.Wrap(err)
 		}
-		err = oracle.GenerateClientConfiguration(key, dbInfo.RouteToDatabase, profile)
+		err = oracle.GenerateClientConfiguration(keyRing, dbInfo.RouteToDatabase, profile)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -150,7 +150,7 @@ func (c *kubeJoinCommand) run(cf *CLIConf) error {
 	var k *client.KeyRing
 
 	// Try loading existing keys.
-	k, err = tc.LocalAgent().GetKey(cluster, client.WithKubeCerts{})
+	k, err = tc.LocalAgent().GetKeyRing(cluster, client.WithKubeCerts{})
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
@@ -180,7 +180,7 @@ func (c *kubeJoinCommand) run(cf *CLIConf) error {
 			}
 
 			// Cache the new cert on disk for reuse.
-			if err := tc.LocalAgent().AddKubeKey(k); err != nil {
+			if err := tc.LocalAgent().AddKubeKeyRing(k); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -664,7 +664,7 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 
 	_, span := tc.Tracer.Start(cf.Context, "tsh.kubeCredentials/GetKey")
 	// Try loading existing keys.
-	k, err := tc.LocalAgent().GetKey(c.teleportCluster, client.WithKubeCerts{})
+	k, err := tc.LocalAgent().GetKeyRing(c.teleportCluster, client.WithKubeCerts{})
 	span.End()
 
 	if err != nil && !trace.IsNotFound(err) {
@@ -769,7 +769,7 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 	// Cache the new cert on disk for reuse.
-	if err := tc.LocalAgent().AddKubeKey(k); err != nil {
+	if err := tc.LocalAgent().AddKubeKeyRing(k); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -791,8 +791,8 @@ func (c *kubeCredentialsCommand) checkLocalProxyRequirement(profile *profile.Pro
 	return nil
 }
 
-func (c *kubeCredentialsCommand) writeKeyResponse(output io.Writer, key *client.KeyRing, kubeClusterName string) error {
-	crt, err := key.KubeX509Cert(kubeClusterName)
+func (c *kubeCredentialsCommand) writeKeyResponse(output io.Writer, keyRing *client.KeyRing, kubeClusterName string) error {
+	crt, err := keyRing.KubeX509Cert(kubeClusterName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -805,12 +805,12 @@ func (c *kubeCredentialsCommand) writeKeyResponse(output io.Writer, key *client.
 
 	// TODO (Joerger): Create a custom k8s Auth Provider or Exec Provider to use
 	// hardware private keys for kube credentials (if possible)
-	keyPEM, err := key.PrivateKey.SoftwarePrivateKeyPEM()
+	keyPEM, err := keyRing.PrivateKey.SoftwarePrivateKeyPEM()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(c.writeResponse(output, key.KubeTLSCerts[kubeClusterName], keyPEM, expiry))
+	return trace.Wrap(c.writeResponse(output, keyRing.KubeTLSCerts[kubeClusterName], keyPEM, expiry))
 }
 
 // writeByteResponse writes the exec credential response to the output stream.
@@ -1449,7 +1449,7 @@ func fetchKubeStatus(ctx context.Context, tc *client.TeleportClient) (*kubernete
 	kubeStatus := &kubernetesStatus{
 		clusterAddr: tc.KubeClusterAddr(),
 	}
-	kubeStatus.credentials, err = tc.LocalAgent().GetCoreKey()
+	kubeStatus.credentials, err = tc.LocalAgent().GetCoreKeyRing()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -1511,16 +1511,16 @@ func TestProxyAppWithIdentity(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	key, err := client.GenerateRSAKey()
+	keyRing, err := client.GenerateRSAKeyRing()
 	require.NoError(t, err)
-	key.ClusterName = clusterName
+	keyRing.ClusterName = clusterName
 
 	// generate user certs with a RouteToApp. note that unlike certs generated
 	// with `tsh app login`, this is intended to match Machine ID-type certs
 	// which are not usage restricted to apps only; this is required for tsh to
 	// make other auth API calls beyond just accessing the app.
 	sshCert, tlsCert, err := authServer.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
-		Key:            key.PrivateKey.MarshalSSHPublicKey(),
+		Key:            keyRing.PrivateKey.MarshalSSHPublicKey(),
 		Username:       userName,
 		TTL:            time.Hour,
 		Compatibility:  constants.CertificateFormatStandard,
@@ -1530,17 +1530,17 @@ func TestProxyAppWithIdentity(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	key.Cert = sshCert
-	key.TLSCert = tlsCert
+	keyRing.Cert = sshCert
+	keyRing.TLSCert = tlsCert
 
 	hostCAs, err := authServer.GetCertAuthorities(context.Background(), types.HostCA, false)
 	require.NoError(t, err)
-	key.TrustedCerts = authclient.AuthoritiesToTrustedCerts(hostCAs)
+	keyRing.TrustedCerts = authclient.AuthoritiesToTrustedCerts(hostCAs)
 
 	idPath := filepath.Join(t.TempDir(), "identity")
 	_, err = identityfile.Write(context.Background(), identityfile.WriteConfig{
 		OutputPath: idPath,
-		Key:        key,
+		KeyRing:    keyRing,
 		Format:     identityfile.FormatFile,
 	})
 	require.NoError(t, err)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1985,7 +1985,7 @@ func onLogin(cf *CLIConf) error {
 		}
 		filesWritten, err := identityfile.Write(cf.Context, identityfile.WriteConfig{
 			OutputPath:           cf.IdentityFileOut,
-			Key:                  key,
+			KeyRing:              key,
 			Format:               cf.IdentityFormat,
 			KubeProxyAddr:        tc.KubeClusterAddr(),
 			OverwriteDestination: cf.IdentityOverwrite,
@@ -4402,19 +4402,19 @@ func flattenIdentity(cf *CLIConf) error {
 
 // onShow reads an identity file (a public SSH key or a cert) and dumps it to stdout
 func onShow(cf *CLIConf) error {
-	key, err := identityfile.KeyRingFromIdentityFile(cf.IdentityFileIn, cf.Proxy, cf.SiteName)
+	keyRing, err := identityfile.KeyRingFromIdentityFile(cf.IdentityFileIn, cf.Proxy, cf.SiteName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	// unmarshal certificate bytes into a ssh.PublicKey
-	cert, _, _, _, err := ssh.ParseAuthorizedKey(key.Cert)
+	cert, _, _, _, err := ssh.ParseAuthorizedKey(keyRing.Cert)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	fmt.Printf("Cert: %#v\nPriv: %#v\nPub: %#v\n", cert, key.PrivateKey.Signer, key.PrivateKey.MarshalSSHPublicKey())
-	fmt.Printf("Fingerprint: %s\n", ssh.FingerprintSHA256(key.PrivateKey.SSHPublicKey()))
+	fmt.Printf("Cert: %#v\nPriv: %#v\nPub: %#v\n", cert, keyRing.PrivateKey.Signer, keyRing.PrivateKey.MarshalSSHPublicKey())
+	fmt.Printf("Fingerprint: %s\n", ssh.FingerprintSHA256(keyRing.PrivateKey.SSHPublicKey()))
 	return nil
 }
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -2976,7 +2976,7 @@ func TestEnvFlags(t *testing.T) {
 func TestKubeConfigUpdate(t *testing.T) {
 	t.Parallel()
 	// don't need real creds for this test, just something to compare against
-	creds := &client.KeyRing{KeyIndex: client.KeyIndex{ProxyHost: "a.example.com"}}
+	creds := &client.KeyRing{KeyRingIndex: client.KeyRingIndex{ProxyHost: "a.example.com"}}
 	tests := []struct {
 		desc           string
 		cf             *CLIConf
@@ -5369,8 +5369,8 @@ func TestLogout(t *testing.T) {
 	require.NoError(t, err)
 	privateKey, err := keys.NewPrivateKey(key, privPEM)
 	require.NoError(t, err)
-	clientKey := &client.KeyRing{
-		KeyIndex: client.KeyIndex{
+	clientKeyRing := &client.KeyRing{
+		KeyRingIndex: client.KeyRingIndex{
 			ProxyHost:   "proxy",
 			Username:    "user",
 			ClusterName: "cluster",
@@ -5378,9 +5378,9 @@ func TestLogout(t *testing.T) {
 		PrivateKey: privateKey,
 	}
 	profile := &profile.Profile{
-		WebProxyAddr: clientKey.ProxyHost,
-		Username:     clientKey.Username,
-		SiteName:     clientKey.ClusterName,
+		WebProxyAddr: clientKeyRing.ProxyHost,
+		Username:     clientKeyRing.Username,
+		SiteName:     clientKeyRing.ClusterName,
 	}
 
 	for _, tt := range []struct {
@@ -5393,13 +5393,13 @@ func TestLogout(t *testing.T) {
 		}, {
 			name: "public key missing",
 			modifyKeyDir: func(t *testing.T, homePath string) {
-				pubKeyPath := keypaths.PublicKeyPath(homePath, clientKey.ProxyHost, clientKey.Username)
+				pubKeyPath := keypaths.PublicKeyPath(homePath, clientKeyRing.ProxyHost, clientKeyRing.Username)
 				require.NoError(t, os.Remove(pubKeyPath))
 			},
 		}, {
 			name: "private key missing",
 			modifyKeyDir: func(t *testing.T, homePath string) {
-				privKeyPath := keypaths.UserKeyPath(homePath, clientKey.ProxyHost, clientKey.Username)
+				privKeyPath := keypaths.UserKeyPath(homePath, clientKeyRing.ProxyHost, clientKeyRing.Username)
 				require.NoError(t, os.Remove(privKeyPath))
 			},
 		}, {
@@ -5410,7 +5410,7 @@ func TestLogout(t *testing.T) {
 				sshPub, err := ssh.NewPublicKey(newKey.Public())
 				require.NoError(t, err)
 
-				pubKeyPath := keypaths.PublicKeyPath(homePath, clientKey.ProxyHost, clientKey.Username)
+				pubKeyPath := keypaths.PublicKeyPath(homePath, clientKeyRing.ProxyHost, clientKeyRing.Username)
 				err = os.WriteFile(pubKeyPath, ssh.MarshalAuthorizedKey(sshPub), 0o600)
 				require.NoError(t, err)
 			},
@@ -5420,7 +5420,7 @@ func TestLogout(t *testing.T) {
 			tmpHomePath := t.TempDir()
 
 			store := client.NewFSClientStore(tmpHomePath)
-			err = store.AddKey(clientKey)
+			err = store.AddKeyRing(clientKeyRing)
 			require.NoError(t, err)
 			store.SaveProfile(profile, true)
 


### PR DESCRIPTION
Recently I renamed the type `lib/client.Key` to `lib/client.KeyRing` to reflect the fact that it's going to hold multiple keys for the user going forward. I mostly left a bunch of related types, functions, and variable names unchanged at the time. This PR is full of mostly automated changes to rename as many of those as I could easily find.

I'm not making any functional changes here, just renaming a bunch of functions, types, struct fields, and variables.