### PR TITLE
add matcher type to discovered resource labels

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -750,6 +750,8 @@ const (
 	KubernetesClusterLabel = TeleportNamespace + "/kubernetes-cluster"
 
 	// DiscoveryTypeLabel specifies type of discovered service that should be created from Kubernetes service.
+	// Also added by discovery service to indicate the type of discovered
+	// resource, e.g. "rds" for RDS databases, "eks" for EKS kube clusters, etc.
 	DiscoveryTypeLabel = TeleportNamespace + "/discovery-type"
 	// DiscoveryPortLabel specifies preferred port for a discovered app created from Kubernetes service.
 	DiscoveryPortLabel = TeleportNamespace + "/port"

--- a/docs/pages/enroll-resources/auto-discovery/databases.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/databases.mdx
@@ -42,6 +42,8 @@ information such as:
   - Imported database tags
   - Database location/region
   - Cloud account information, e.g. AWS Account ID / Azure Subscription ID
+  - The type of database discovered corresponding to the matcher type, e.g.
+    "rds", "redshift", etc.
 - *Endpoint Info*: Connection endpoint the database can be reached at
 
 <Notice type="tip">

--- a/docs/pages/reference/agent-services/database-access-reference/labels.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/labels.mdx
@@ -45,6 +45,7 @@ resource attributes:
 | `source-server`    | The source server of an Azure DB Flexible server replica. |
 | `vpc-id`           | ID of the Amazon VPC the resource resides in, if available. |
 | `workgroup`        | Amazon Redshift Serverless workgroup name. |
+| `teleport.dev/discovery-type` | Specifies the type of resource matched by the Teleport Discovery Service, e.g. "rds", "redshift", etc. |
 
 ### `endpoint-type`
 

--- a/lib/srv/db/watcher_test.go
+++ b/lib/srv/db/watcher_test.go
@@ -283,6 +283,15 @@ func setDiscoveryGroupLabel(r types.ResourceWithLabels, discoveryGroup string) {
 	r.SetStaticLabels(staticLabels)
 }
 
+func setDiscoveryTypeLabel(r types.ResourceWithLabels, matcherType string) {
+	staticLabels := r.GetStaticLabels()
+	if staticLabels == nil {
+		staticLabels = make(map[string]string)
+	}
+	staticLabels[types.DiscoveryTypeLabel] = matcherType
+	r.SetStaticLabels(staticLabels)
+}
+
 // TestWatcherCloudFetchers tests usage of discovery database fetchers by the
 // database service.
 func TestWatcherCloudFetchers(t *testing.T) {
@@ -293,11 +302,13 @@ func TestWatcherCloudFetchers(t *testing.T) {
 	require.NoError(t, err)
 	redshiftServerlessDatabase.SetStatusAWS(redshiftServerlessDatabase.GetAWS())
 	setDiscoveryGroupLabel(redshiftServerlessDatabase, "")
+	setDiscoveryTypeLabel(redshiftServerlessDatabase, types.AWSMatcherRedshiftServerless)
 	redshiftServerlessDatabase.SetOrigin(types.OriginCloud)
 	discovery.ApplyAWSDatabaseNameSuffix(redshiftServerlessDatabase, types.AWSMatcherRedshiftServerless)
 	// Test an Azure fetcher.
 	azSQLServer, azSQLServerDatabase := makeAzureSQLServer(t, "discovery-azure", "group")
 	setDiscoveryGroupLabel(azSQLServerDatabase, "")
+	setDiscoveryTypeLabel(azSQLServerDatabase, types.AzureMatcherSQLServer)
 	azSQLServerDatabase.SetOrigin(types.OriginCloud)
 	ctx := context.Background()
 	testCtx := setupTestContext(ctx, t)

--- a/lib/srv/discovery/common/watcher.go
+++ b/lib/srv/discovery/common/watcher.go
@@ -180,6 +180,12 @@ func (w *Watcher) fetchAndSend() {
 					staticLabels[types.CloudLabel] = c
 				}
 
+				// Set the discovery type label to provide information about the
+				// matcher type that matched the resource.
+				if t := lFetcher.FetcherType(); t != "" {
+					staticLabels[types.DiscoveryTypeLabel] = t
+				}
+
 				r.SetStaticLabels(staticLabels)
 			}
 


### PR DESCRIPTION
Changelog: Added a label teleport.dev/discovery-type to all auto-discovered databases, Kubernetes clusters, and Kubernetes apps, which corresponds to the matcher type that matched the resource, for example "rds", "elasticache", "eks", "app", etc.

Related issue: https://github.com/gravitational/teleport/issues/38922