### PR TITLE
Release 15.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 15.4.10 (07/28/24)
+
+* Improved stability of very large teleport clusters during temporary backend disruption/degradation. [#44695](https://github.com/gravitational/teleport/pull/44695)
+* Resolved compatibility issue with Paramiko and Machine ID's SSH multiplexer SSH agent. [#44672](https://github.com/gravitational/teleport/pull/44672)
+* Fixed a fatal error in `tbot` when unable to lookup the user from a given UID in containerized environments for checking ACL configuration. [#44646](https://github.com/gravitational/teleport/pull/44646)
+* Fixed Application Access regression where an HTTP header wasn't set in forwarded requests. [#44629](https://github.com/gravitational/teleport/pull/44629)
+* Use the registered port of the target host when `tsh puttyconfig` is invoked without `--port`. [#44573](https://github.com/gravitational/teleport/pull/44573)
+* Added more icons for guessing application icon by name or by label `teleport.icon` in the web UI. [#44568](https://github.com/gravitational/teleport/pull/44568)
+* Removed deprecated S3 bucket option when creating or editing AWS OIDC integration in the web UI. [#44487](https://github.com/gravitational/teleport/pull/44487)
+* Fixed terminal sessions with a database CLI client in Teleport Connect hanging indefinitely if the client cannot be found. [#44466](https://github.com/gravitational/teleport/pull/44466)
+* Added application-tunnel service to Machine ID for establishing a long-lived tunnel to a HTTP or TCP application for Machine to Machine access. [#44446](https://github.com/gravitational/teleport/pull/44446)
+* Fixed a low-probability panic in audit event upload logic. [#44424](https://github.com/gravitational/teleport/pull/44424)
+* Fixed Teleport Connect binaries not being signed correctly. [#44420](https://github.com/gravitational/teleport/pull/44420)
+* Prevented DoSing the cluster during a mass failed join event by agents. [#44415](https://github.com/gravitational/teleport/pull/44415)
+* Added audit events for AWS and Azure integration resource actions. [#44404](https://github.com/gravitational/teleport/pull/44404)
+* Fixed automatic updates with previous versions of the `teleport.yaml` config. [#44378](https://github.com/gravitational/teleport/pull/44378)
+* Added support for Rocky and AlmaLinux when enrolling a new server from the UI. [#44331](https://github.com/gravitational/teleport/pull/44331)
+* Fixed Teleport access plugin tarballs containing a `build` directory, which was accidentally added upon v15.4.5 release. [#44301](https://github.com/gravitational/teleport/pull/44301)
+* Prevented an infinite loop in DynamoDB event querying by advancing the cursor to the next day when the limit is reached at the end of a day with an empty iterator. This ensures the cursor does not reset to the beginning of the day. [#44274](https://github.com/gravitational/teleport/pull/44274)
+* The clipboard sharing tooltip for desktop sessions now indicates why clipboard sharing is disabled. [#44238](https://github.com/gravitational/teleport/pull/44238)
+* Fixed a `kube-agent-updater` bug affecting resolutions of private images. [#44192](https://github.com/gravitational/teleport/pull/44192)
+* Prevented redirects to arbitrary URLs when launching an app. [#44189](https://github.com/gravitational/teleport/pull/44189)
+* Added audit event field describing if the "MFA for admin actions" requirement changed. [#44185](https://github.com/gravitational/teleport/pull/44185)
+* The `teleport-cluster` chart can now use existing ingresses instead of creating its own. [#44147](https://github.com/gravitational/teleport/pull/44147)
+* Ensured that `tsh login` outputs accurate status information for the new session. [#44144](https://github.com/gravitational/teleport/pull/44144)
+* Fixed "device trust mode _x_ requires Teleport Enterprise" errors on `tctl`. [#44134](https://github.com/gravitational/teleport/pull/44134)
+* Added a `--skip-idle-time` flag to `tsh play`. [#44095](https://github.com/gravitational/teleport/pull/44095)
+* Added the `tbot install systemd` command for installing tbot as a service on Linux systems. [#44082](https://github.com/gravitational/teleport/pull/44082)
+* Added ability to list access list members in json format in `tctl` cli tool. [#44072](https://github.com/gravitational/teleport/pull/44072)
+* Made `tbot` compilable on Windows. [#44070](https://github.com/gravitational/teleport/pull/44070)
+* For slack integration, Access List reminders are batched into 1 message and provides link out to the web UI. [#44035](https://github.com/gravitational/teleport/pull/44035)
+* Fixed denying access despite access being configured for Notification Routing Rules in the web UI. [#44028](https://github.com/gravitational/teleport/pull/44028)
+* Fixed eBPF error occurring during startup on Linux RHEL 9. [#44024](https://github.com/gravitational/teleport/pull/44024)
+* Lowered latency of detecting Kubernetes cluster becoming online. [#43971](https://github.com/gravitational/teleport/pull/43971)
+* Enabled Access Monitoring Rules routing with Mattermost plugin. [#43600](https://github.com/gravitational/teleport/pull/43600)
+
+Enterprise:
+* Fixed an Access List permission bug where an access list owner, who is also a member, was not able to add/rm access list member.
+* Fixed an issue with incorrect yum/zypper updater packages being installed.
+* Fixed empty condition from unquoted string with yaml editor for Notification Routing Rules in the Web UI.
+
 ## 15.4.9 (07/11/24)
 
 * Honor proxy templates in tsh ssh. [#44027](https://github.com/gravitational/teleport/pull/44027)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=15.4.9
+VERSION=15.4.10
 
 DOCKER_IMAGE ?= teleport
 

--- a/api/version.go
+++ b/api/version.go
@@ -3,6 +3,6 @@ package api
 
 import "github.com/coreos/go-semver/semver"
 
-const Version = "15.4.9"
+const Version = "15.4.10"
 
 var SemVersion = semver.New(Version)

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -19,13 +19,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>15.4.9</string>
+		<string>15.4.10</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>15.4.9</string>
+		<string>15.4.10</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -17,13 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>15.4.9</string>
+		<string>15.4.10</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>15.4.9</string>
+		<string>15.4.10</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -167,6 +167,7 @@
     "PSUBSCRIBE",
     "PSYNC",
     "PUNSUBSCRIBE",
+    "Paramiko",
     "Passcode",
     "Passwordless",
     "Pbbd",

--- a/examples/chart/access/discord/Chart.yaml
+++ b/examples/chart/access/discord/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.9"
+.version: &version "15.4.10"
 
 apiVersion: v2
 name: teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-discord-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-discord-15.4.10
       name: RELEASE-NAME-teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-discord-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-discord-15.4.10
       name: RELEASE-NAME-teleport-plugin-discord
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-discord
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-discord-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-discord-15.4.10
         spec:
           containers:
           - command:

--- a/examples/chart/access/email/Chart.yaml
+++ b/examples/chart/access/email/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.9"
+.version: &version "15.4.10"
 
 apiVersion: v2
 name: teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,8 +26,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-email-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-email-15.4.10
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
@@ -59,8 +59,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-email-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-email-15.4.10
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, no starttls):
   1: |
@@ -92,8 +92,8 @@ should match the snapshot (smtp on, no starttls):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-email-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-email-15.4.10
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
@@ -125,8 +125,8 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-email-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-email-15.4.10
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, roleToRecipients set):
   1: |
@@ -161,8 +161,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-email-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-email-15.4.10
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -194,6 +194,6 @@ should match the snapshot (smtp on, starttls disabled):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-email-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-email-15.4.10
       name: RELEASE-NAME-teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-email-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-email-15.4.10
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should be possible to override volume name (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-email-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-email-15.4.10
         spec:
           containers:
           - command:
@@ -34,7 +34,7 @@ should be possible to override volume name (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.9
+            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.10
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -75,8 +75,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-email-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-email-15.4.10
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-email-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-email-15.4.10
         spec:
           containers:
           - command:
@@ -136,8 +136,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-email-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-email-15.4.10
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -151,8 +151,8 @@ should match the snapshot (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-email-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-email-15.4.10
         spec:
           containers:
           - command:
@@ -163,7 +163,7 @@ should match the snapshot (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.9
+            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.10
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -204,8 +204,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-email-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-email-15.4.10
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -219,8 +219,8 @@ should match the snapshot (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-email-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-email-15.4.10
         spec:
           containers:
           - command:
@@ -231,7 +231,7 @@ should match the snapshot (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.9
+            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.10
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -272,8 +272,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-email-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-email-15.4.10
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -287,8 +287,8 @@ should mount external secret (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-email-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-email-15.4.10
         spec:
           containers:
           - command:
@@ -299,7 +299,7 @@ should mount external secret (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.9
+            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.10
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -340,8 +340,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-email-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-email-15.4.10
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -355,8 +355,8 @@ should mount external secret (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-email-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-email-15.4.10
         spec:
           containers:
           - command:
@@ -367,7 +367,7 @@ should mount external secret (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.9
+            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.10
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/examples/chart/access/jira/Chart.yaml
+++ b/examples/chart/access/jira/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.9"
+.version: &version "15.4.10"
 
 apiVersion: v2
 name: teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -32,6 +32,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-jira-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-jira-15.4.10
       name: RELEASE-NAME-teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-jira-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-jira-15.4.10
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-jira
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-jira-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-jira-15.4.10
         spec:
           containers:
           - command:

--- a/examples/chart/access/mattermost/Chart.yaml
+++ b/examples/chart/access/mattermost/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.9"
+.version: &version "15.4.10"
 
 apiVersion: v2
 name: teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -22,6 +22,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-mattermost-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-mattermost-15.4.10
       name: RELEASE-NAME-teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-mattermost-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-mattermost-15.4.10
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-mattermost-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-mattermost-15.4.10
         spec:
           containers:
           - command:
@@ -75,8 +75,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-mattermost-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-mattermost-15.4.10
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should mount external secret:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-mattermost-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-mattermost-15.4.10
         spec:
           containers:
           - command:
@@ -102,7 +102,7 @@ should mount external secret:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:15.4.9
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:15.4.10
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -143,8 +143,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-mattermost-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-mattermost-15.4.10
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -158,8 +158,8 @@ should override volume name:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-mattermost-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-mattermost-15.4.10
         spec:
           containers:
           - command:
@@ -170,7 +170,7 @@ should override volume name:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:15.4.9
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:15.4.10
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/examples/chart/access/msteams/Chart.yaml
+++ b/examples/chart/access/msteams/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.9"
+.version: &version "15.4.10"
 
 apiVersion: v2
 name: teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
@@ -29,6 +29,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-msteams-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-msteams-15.4.10
       name: RELEASE-NAME-teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-msteams-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-msteams-15.4.10
       name: RELEASE-NAME-teleport-plugin-msteams
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-msteams
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-msteams-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-msteams-15.4.10
         spec:
           containers:
           - command:

--- a/examples/chart/access/pagerduty/Chart.yaml
+++ b/examples/chart/access/pagerduty/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.9"
+.version: &version "15.4.10"
 
 apiVersion: v2
 name: teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -21,6 +21,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-pagerduty-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-pagerduty-15.4.10
       name: RELEASE-NAME-teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-pagerduty-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-pagerduty-15.4.10
       name: RELEASE-NAME-teleport-plugin-pagerduty
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-pagerduty
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-pagerduty-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-pagerduty-15.4.10
         spec:
           containers:
           - command:

--- a/examples/chart/access/slack/Chart.yaml
+++ b/examples/chart/access/slack/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.9"
+.version: &version "15.4.10"
 
 apiVersion: v2
 name: teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-slack-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-slack-15.4.10
       name: RELEASE-NAME-teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-slack-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-slack-15.4.10
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-plugin-slack-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-plugin-slack-15.4.10
         spec:
           containers:
           - command:

--- a/examples/chart/event-handler/Chart.yaml
+++ b/examples/chart/event-handler/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.9"
+.version: &version "15.4.10"
 
 apiVersion: v2
 name: teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-event-handler-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-event-handler-15.4.10
       name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-plugin-event-handler-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-plugin-event-handler-15.4.10
       name: RELEASE-NAME-teleport-plugin-event-handler
     spec:
       replicas: 1
@@ -82,7 +82,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:15.4.9
+      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:15.4.10
       imagePullPolicy: IfNotPresent
       name: teleport-plugin-event-handler
       ports:

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.9"
+.version: &version "15.4.10"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.9"
+.version: &version "15.4.10"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
@@ -8,8 +8,8 @@ adds operator permissions to ClusterRole:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-cluster-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-cluster-15.4.10
         teleport.dev/majorVersion: "15"
       name: RELEASE-NAME
     rules:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -1848,8 +1848,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-cluster-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-cluster-15.4.10
         teleport.dev/majorVersion: "15"
       name: RELEASE-NAME-auth
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -8,7 +8,7 @@
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -141,7 +141,7 @@ should set nodeSelector when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -238,7 +238,7 @@ should set resources when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -324,7 +324,7 @@ should set securityContext when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -567,8 +567,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-cluster-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-cluster-15.4.10
         teleport.dev/majorVersion: "15"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -11,8 +11,8 @@ sets clusterDomain on Deployment Pods:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 15.4.9
-        helm.sh/chart: teleport-cluster-15.4.9
+        app.kubernetes.io/version: 15.4.10
+        helm.sh/chart: teleport-cluster-15.4.10
         teleport.dev/majorVersion: "15"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE
@@ -26,7 +26,7 @@ sets clusterDomain on Deployment Pods:
       template:
         metadata:
           annotations:
-            checksum/config: 07a444fafcfdc473fd73e732291177b65af2c746df9de6334062432079bbdcb6
+            checksum/config: f2b93ff558c89e2eb225ce55ca0a702e8b1fd8788fd431ac0f58c7f920faa15b
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -34,8 +34,8 @@ sets clusterDomain on Deployment Pods:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-cluster
-            app.kubernetes.io/version: 15.4.9
-            helm.sh/chart: teleport-cluster-15.4.9
+            app.kubernetes.io/version: 15.4.10
+            helm.sh/chart: teleport-cluster-15.4.10
             teleport.dev/majorVersion: "15"
         spec:
           affinity:
@@ -44,7 +44,7 @@ sets clusterDomain on Deployment Pods:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
-            image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+            image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -105,7 +105,7 @@ sets clusterDomain on Deployment Pods:
             - wait
             - no-resolve
             - RELEASE-NAME-auth-v14.NAMESPACE.svc.test.com
-            image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+            image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
             name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
@@ -137,7 +137,7 @@ should provision initContainer correctly when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       name: wait-auth-update
       resources:
         limits:
@@ -201,7 +201,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -262,7 +262,7 @@ should set nodeSelector when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       name: wait-auth-update
     nodeSelector:
       environment: security
@@ -313,7 +313,7 @@ should set resources for wait-auth-update initContainer when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -381,7 +381,7 @@ should set resources for wait-auth-update initContainer when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       name: wait-auth-update
       resources:
         limits:
@@ -421,7 +421,7 @@ should set resources when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -489,7 +489,7 @@ should set resources when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       name: wait-auth-update
       resources:
         limits:
@@ -529,7 +529,7 @@ should set securityContext for initContainers when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -597,7 +597,7 @@ should set securityContext for initContainers when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false
@@ -637,7 +637,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -705,7 +705,7 @@ should set securityContext when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.9"
+.version: &version "15.4.10"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -32,7 +32,7 @@ sets Deployment annotations when specified if action is Upgrade:
               value: "true"
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+            image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -107,7 +107,7 @@ sets Deployment labels when specified if action is Upgrade:
             value: "true"
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-          image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+          image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -169,7 +169,7 @@ sets Pod annotations when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -231,7 +231,7 @@ sets Pod labels when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -310,7 +310,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -373,7 +373,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -435,7 +435,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -495,7 +495,7 @@ should expose diag port if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -569,7 +569,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -643,7 +643,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -705,7 +705,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -767,7 +767,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -836,7 +836,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -908,7 +908,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -976,7 +976,7 @@ should provision initContainer correctly when set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1074,7 +1074,7 @@ should set SecurityContext if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1156,7 +1156,7 @@ should set affinity when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1218,7 +1218,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1293,7 +1293,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1417,7 +1417,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1479,7 +1479,7 @@ should set nodeSelector if set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1543,7 +1543,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1617,7 +1617,7 @@ should set preferred affinity when more than one replica is used if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1679,7 +1679,7 @@ should set priorityClassName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1742,7 +1742,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1814,7 +1814,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1876,7 +1876,7 @@ should set resources when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1945,7 +1945,7 @@ should set serviceAccountName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2007,7 +2007,7 @@ should set tolerations when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -104,7 +104,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+            image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
             imagePullPolicy: IfNotPresent
             name: post-delete-job
             securityContext:
@@ -132,7 +132,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -160,7 +160,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -190,7 +190,7 @@ should set securityContext in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -16,7 +16,7 @@ sets Pod annotations when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -84,7 +84,7 @@ sets Pod labels when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -176,7 +176,7 @@ sets StatefulSet labels when specified:
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+            image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -272,7 +272,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -340,7 +340,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -428,7 +428,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+            image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -506,7 +506,7 @@ should add volumeMount for data volume when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -574,7 +574,7 @@ should expose diag port:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -642,7 +642,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -724,7 +724,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -804,7 +804,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -872,7 +872,7 @@ should have one replica when replicaCount is not set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -940,7 +940,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1010,7 +1010,7 @@ should mount extraVolumes and extraVolumeMounts:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1085,7 +1085,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: RELEASE-NAME
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1165,7 +1165,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1241,7 +1241,7 @@ should not add emptyDir for data when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1309,7 +1309,7 @@ should provision initContainer correctly when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1413,7 +1413,7 @@ should set SecurityContext:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1501,7 +1501,7 @@ should set affinity when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1569,7 +1569,7 @@ should set default serviceAccountName when not set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1650,7 +1650,7 @@ should set environment when extraEnv set in values:
         value: RELEASE-NAME
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1786,7 +1786,7 @@ should set imagePullPolicy when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1854,7 +1854,7 @@ should set nodeSelector if set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1936,7 +1936,7 @@ should set preferred affinity when more than one replica is used:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2004,7 +2004,7 @@ should set probeTimeoutSeconds when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2082,7 +2082,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2150,7 +2150,7 @@ should set resources when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2225,7 +2225,7 @@ should set serviceAccountName when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2293,7 +2293,7 @@ should set storage.requests when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2361,7 +2361,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2429,7 +2429,7 @@ should set tolerations when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.9
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:15.4.9
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -71,7 +71,7 @@ sets the tolerations:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:15.4.9
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:15.4.10
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6


### PR DESCRIPTION
* Improved stability of very large teleport clusters during temporary backend disruption/degradation. [#44695](https://github.com/gravitational/teleport/pull/44695)
* Resolved compatibility issue with Paramiko and Machine ID's SSH multiplexer SSH agent. [#44672](https://github.com/gravitational/teleport/pull/44672)
* Fixed a fatal error in `tbot` when unable to lookup the user from a given UID in containerized environments for checking ACL configuration. [#44646](https://github.com/gravitational/teleport/pull/44646)
* Fixed Application Access regression where an HTTP header wasn't set in forwarded requests. [#44629](https://github.com/gravitational/teleport/pull/44629)
* Use the registered port of the target host when `tsh puttyconfig` is invoked without `--port`. [#44573](https://github.com/gravitational/teleport/pull/44573)
* Added more icons for guessing application icon by name or by label `teleport.icon` in the web UI. [#44568](https://github.com/gravitational/teleport/pull/44568)
* Removed deprecated S3 bucket option when creating or editing AWS OIDC integration in the web UI. [#44487](https://github.com/gravitational/teleport/pull/44487)
* Fixed terminal sessions with a database CLI client in Teleport Connect hanging indefinitely if the client cannot be found. [#44466](https://github.com/gravitational/teleport/pull/44466)
* Added application-tunnel service to Machine ID for establishing a long-lived tunnel to a HTTP or TCP application for Machine to Machine access. [#44446](https://github.com/gravitational/teleport/pull/44446)
* Fixed a low-probability panic in audit event upload logic. [#44424](https://github.com/gravitational/teleport/pull/44424)
* Fixed Teleport Connect binaries not being signed correctly. [#44420](https://github.com/gravitational/teleport/pull/44420)
* Prevented DoSing the cluster during a mass failed join event by agents. [#44415](https://github.com/gravitational/teleport/pull/44415)
* Added audit events for AWS and Azure integration resource actions. [#44404](https://github.com/gravitational/teleport/pull/44404)
* Fixed automatic updates with previous versions of the `teleport.yaml` config. [#44378](https://github.com/gravitational/teleport/pull/44378)
* Added support for Rocky and AlmaLinux when enrolling a new server from the UI. [#44331](https://github.com/gravitational/teleport/pull/44331)
* Fixed Teleport access plugin tarballs containing a `build` directory, which was accidentally added upon v15.4.5 release. [#44301](https://github.com/gravitational/teleport/pull/44301)
* Prevented an infinite loop in DynamoDB event querying by advancing the cursor to the next day when the limit is reached at the end of a day with an empty iterator. This ensures the cursor does not reset to the beginning of the day. [#44274](https://github.com/gravitational/teleport/pull/44274)
* The clipboard sharing tooltip for desktop sessions now indicates why clipboard sharing is disabled. [#44238](https://github.com/gravitational/teleport/pull/44238)
* Fixed a `kube-agent-updater` bug affecting resolutions of private images. [#44192](https://github.com/gravitational/teleport/pull/44192)
* Prevented redirects to arbitrary URLs when launching an app. [#44189](https://github.com/gravitational/teleport/pull/44189)
* Added audit event field describing if the "MFA for admin actions" requirement changed. [#44185](https://github.com/gravitational/teleport/pull/44185)
* The `teleport-cluster` chart can now use existing ingresses instead of creating its own. [#44147](https://github.com/gravitational/teleport/pull/44147)
* Ensured that `tsh login` outputs accurate status information for the new session. [#44144](https://github.com/gravitational/teleport/pull/44144)
* Fixed "device trust mode _x_ requires Teleport Enterprise" errors on `tctl`. [#44134](https://github.com/gravitational/teleport/pull/44134)
* Added a `--skip-idle-time` flag to `tsh play`. [#44095](https://github.com/gravitational/teleport/pull/44095)
* Added the `tbot install systemd` command for installing tbot as a service on Linux systems. [#44082](https://github.com/gravitational/teleport/pull/44082)
* Added ability to list access list members in json format in `tctl` cli tool. [#44072](https://github.com/gravitational/teleport/pull/44072)
* Made `tbot` compilable on Windows. [#44070](https://github.com/gravitational/teleport/pull/44070)
* For slack integration, Access List reminders are batched into 1 message and provides link out to the web UI. [#44035](https://github.com/gravitational/teleport/pull/44035)
* Fixed denying access despite access being configured for Notification Routing Rules in the web UI. [#44028](https://github.com/gravitational/teleport/pull/44028)
* Fixed eBPF error occurring during startup on Linux RHEL 9. [#44024](https://github.com/gravitational/teleport/pull/44024)
* Lowered latency of detecting Kubernetes cluster becoming online. [#43971](https://github.com/gravitational/teleport/pull/43971)
* Enabled Access Monitoring Rules routing with Mattermost plugin. [#43600](https://github.com/gravitational/teleport/pull/43600)

Enterprise:
* Fixed an Access List permission bug where an access list owner, who is also a member, was not able to add/rm access list member.
* Fixed an issue with incorrect yum/zypper updater packages being installed.
* Fixed empty condition from unquoted string with yaml editor for Notification Routing Rules in the Web UI.
