### PR TITLE
Fix flaky test for reissuing certificate for local kube proxy.

### DIFF
--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -544,7 +544,7 @@ func TestKubeMiddleware(t *testing.T) {
 			// request timed out.
 			return rw.Status() == http.StatusInternalServerError
 
-		}, time.Second, 100*time.Millisecond)
+		}, 5*time.Second, 100*time.Millisecond)
 		require.Contains(t, rw.Buffer().String(), "context canceled")
 
 		// just let the reissuing goroutine some time to replace certs.


### PR DESCRIPTION
In CPU-constrained environment reissuing goroutine managed to successfully finish before parent goroutine had a chance to check if context is expired, so we got unexpected successful result even though we provided already expired context. We use `require.Eventually` to account for this rare event.

Fixes https://github.com/gravitational/teleport/issues/43821