### PR TITLE
[v15] Enable ConPTY by default in terminals on Windows

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -945,6 +945,7 @@
     "winadj",
     "windowsaccountname",
     "windowsdesktop",
+    "winpty",
     "winscp",
     "winserver",
     "workgroups",

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -419,6 +419,7 @@ Below is the list of the supported config properties.
 | `theme`                       | `system`                                                                                                             | Color theme for the app. Available modes: `light`, `dark`, `system`.   |
 | `terminal.fontFamily`         | `Menlo, Monaco, monospace` on macOS<br/>`Consolas, monospace` on Windows<br/>`'Droid Sans Mono', monospace` on Linux | Font family for the terminal.                                          |
 | `terminal.fontSize`           | 15                                                                                                                   | Font size for the terminal.                                            |
+| `terminal.windowsBackend` | `auto` | `auto` uses modern [ConPTY](https://devblogs.microsoft.com/commandline/windows-command-line-introducing-the-windows-pseudo-console-conpty/) system if available, which requires Windows 10 (19H1) or above. Set to `winpty` to use winpty even if ConPTY is available. |
 | `usageReporting.enabled`      | `false`                                                                                                              | Enables collecting anonymous usage data (see [Telemetry](#telemetry)). |
 | `keymap.tab1` - `keymap.tab9` | `Command+1` - `Command+9` on macOS <br/> `Ctrl+1` - `Ctrl+9` on Windows<br/>`Alt+1` - `Alt+9` on Linux               | Shortcut to open tab 1–9.                                              |
 | `keymap.closeTab`             | `Command+W` on macOS<br/>`Ctrl+W` on Windows/Linux                                                                   | Shortcut to close a tab.                                               |
@@ -431,6 +432,7 @@ Below is the list of the supported config properties.
 | `keymap.openProfiles`         | `Command+I` on macOS<br/>`Ctrl+I` on Windows/Linux                                                                   | Shortcut to open the profile selector.                                 |
 | `keymap.openSearchBar`        | `Command+K` on macOS<br/>`Ctrl+K` on Windows/Linux                                                                   | Shortcut to open the search bar.                                       |
 | `headless.skipConfirm` | false | Skips the confirmation prompt for Headless WebAuthn approval and instead prompts for WebAuthn immediately. |
+| `ssh.noResume`                | false                                                                                                                | Disables SSH connection resumption.                                                                        |
 
 <Admonition
   type="note"

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -44,6 +44,7 @@ import {
   ChildProcessAddresses,
   MainProcessIpc,
   RendererIpc,
+  TERMINATE_MESSAGE,
 } from 'teleterm/mainProcess/types';
 import { getAssetPath } from 'teleterm/mainProcess/runtimeSettings';
 import { RootClusterUri } from 'teleterm/ui/uri';
@@ -141,7 +142,11 @@ export default class MainProcess {
       terminateWithTimeout(this.tshdProcess, 10_000, () => {
         this.gracefullyKillTshdProcess();
       }),
-      terminateWithTimeout(this.sharedProcess),
+      terminateWithTimeout(this.sharedProcess, 5_000, process =>
+        // process.kill doesn't allow running a cleanup code in the child process
+        // on Windows
+        process.send(TERMINATE_MESSAGE)
+      ),
       this.agentRunner.killAll(),
     ]);
   }

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -277,3 +277,12 @@ export enum MainProcessIpc {
 export enum WindowsManagerIpc {
   SignalUserInterfaceReadiness = 'windows-manager-signal-user-interface-readiness',
 }
+
+/**
+ * A custom message to gracefully quit a process.
+ * It is sent to the child process with `process.send`.
+ *
+ * We need this because `process.kill('SIGTERM')` doesn't work on Windows,
+ * so we couldn't run any cleanup logic.
+ */
+export const TERMINATE_MESSAGE = 'TERMINATE_MESSAGE';

--- a/web/packages/teleterm/src/preload.ts
+++ b/web/packages/teleterm/src/preload.ts
@@ -73,7 +73,14 @@ async function getElectronGlobals(): Promise<ElectronGlobals> {
     credentials.shared,
     runtimeSettings,
     {
-      noResume: mainProcessClient.configService.get('ssh.noResume').value,
+      ssh: {
+        noResume: mainProcessClient.configService.get('ssh.noResume').value,
+      },
+      terminal: {
+        windowsBackend: mainProcessClient.configService.get(
+          'terminal.windowsBackend'
+        ).value,
+      },
     }
   );
   const {

--- a/web/packages/teleterm/src/services/config/appConfigSchema.ts
+++ b/web/packages/teleterm/src/services/config/appConfigSchema.ts
@@ -22,6 +22,9 @@ import { Platform } from 'teleterm/mainProcess/types';
 
 import { createKeyboardShortcutSchema } from './keyboardShortcutSchema';
 
+// When adding a new config property, add it to the docs too
+// (teleport-connect.mdx#configuration).
+
 export type AppConfigSchema = ReturnType<typeof createAppConfigSchema>;
 export type AppConfig = z.infer<AppConfigSchema>;
 
@@ -54,6 +57,12 @@ export const createAppConfigSchema = (platform: Platform) => {
       .max(256)
       .default(15)
       .describe('Font size for the terminal.'),
+    'terminal.windowsBackend': z
+      .enum(['auto', 'winpty'])
+      .default('auto')
+      .describe(
+        '`auto` uses modern ConPTY system if available, which requires Windows 10 (19H1) or above. Set to `winpty` to use winpty even if ConPTY is available.'
+      ),
     'usageReporting.enabled': z
       .boolean()
       .default(false)

--- a/web/packages/teleterm/src/services/pty/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/pty/fixtures/mocks.ts
@@ -20,6 +20,7 @@ import { IPtyProcess } from 'teleterm/sharedProcess/ptyHost';
 import {
   PtyProcessCreationStatus,
   PtyServiceClient,
+  WindowsPty,
 } from 'teleterm/services/pty';
 
 export class MockPtyProcess implements IPtyProcess {
@@ -29,7 +30,7 @@ export class MockPtyProcess implements IPtyProcess {
 
   resize() {}
 
-  dispose() {}
+  async dispose() {}
 
   onData() {
     return () => {};
@@ -64,10 +65,12 @@ export class MockPtyServiceClient implements PtyServiceClient {
   createPtyProcess(): Promise<{
     process: IPtyProcess;
     creationStatus: PtyProcessCreationStatus;
+    windowsPty: WindowsPty;
   }> {
     return Promise.resolve({
       process: new MockPtyProcess(),
       creationStatus: PtyProcessCreationStatus.Ok,
+      windowsPty: undefined,
     });
   }
 }

--- a/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.test.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.test.ts
@@ -47,7 +47,7 @@ describe('getPtyProcessOptions', () => {
 
       const { env } = getPtyProcessOptions(
         makeRuntimeSettings(),
-        { noResume: false },
+        { ssh: { noResume: false }, windowsPty: { useConpty: true } },
         cmd,
         processEnv
       );
@@ -76,7 +76,7 @@ describe('getPtyProcessOptions', () => {
 
       const { env } = getPtyProcessOptions(
         makeRuntimeSettings(),
-        { noResume: false },
+        { ssh: { noResume: false }, windowsPty: { useConpty: true } },
         cmd,
         processEnv
       );
@@ -103,7 +103,7 @@ describe('getPtyProcessOptions', () => {
 
       const { args } = getPtyProcessOptions(
         makeRuntimeSettings(),
-        { noResume: true },
+        { ssh: { noResume: true }, windowsPty: { useConpty: true } },
         cmd,
         processEnv
       );

--- a/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -25,8 +25,9 @@ import { assertUnreachable } from 'teleterm/ui/utils';
 import {
   PtyCommand,
   PtyProcessCreationStatus,
-  SshOptions,
   TshKubeLoginCommand,
+  SshOptions,
+  WindowsPty,
 } from '../types';
 
 import {
@@ -34,9 +35,14 @@ import {
   ResolveShellEnvTimeoutError,
 } from './resolveShellEnv';
 
+type PtyOptions = {
+  ssh: SshOptions;
+  windowsPty: Pick<WindowsPty, 'useConpty'>;
+};
+
 export async function buildPtyOptions(
   settings: RuntimeSettings,
-  sshOptions: SshOptions,
+  options: PtyOptions,
   cmd: PtyCommand
 ): Promise<{
   processOptions: PtyProcessOptions;
@@ -68,7 +74,7 @@ export async function buildPtyOptions(
       return {
         processOptions: getPtyProcessOptions(
           settings,
-          sshOptions,
+          options,
           cmd,
           combinedEnv
         ),
@@ -79,10 +85,12 @@ export async function buildPtyOptions(
 
 export function getPtyProcessOptions(
   settings: RuntimeSettings,
-  sshOptions: SshOptions,
+  options: PtyOptions,
   cmd: PtyCommand,
   env: typeof process.env
 ): PtyProcessOptions {
+  const useConpty = options.windowsPty?.useConpty;
+
   switch (cmd.kind) {
     case 'pty.shell': {
       // Teleport Connect bundles a tsh binary, but the user might have one already on their system.
@@ -104,6 +112,7 @@ export function getPtyProcessOptions(
         cwd: cmd.cwd,
         env: { ...env, ...cmd.env },
         initMessage: cmd.initMessage,
+        useConpty,
       };
     }
 
@@ -129,6 +138,7 @@ export function getPtyProcessOptions(
         path: settings.defaultShell,
         args: isWindows ? powershellCommandArgs : bashCommandArgs,
         env: { ...env, KUBECONFIG: getKubeConfigFilePath(cmd, settings) },
+        useConpty,
       };
     }
 
@@ -140,7 +150,7 @@ export function getPtyProcessOptions(
       const args = [
         `--proxy=${cmd.rootClusterId}`,
         'ssh',
-        ...(sshOptions.noResume ? ['--no-resume'] : []),
+        ...(options.ssh.noResume ? ['--no-resume'] : []),
         '--forward-agent',
         loginHost,
       ];
@@ -149,6 +159,7 @@ export function getPtyProcessOptions(
         path: settings.tshd.binaryPath,
         args,
         env,
+        useConpty,
       };
     }
 
@@ -159,6 +170,7 @@ export function getPtyProcessOptions(
         path: cmd.path,
         args: cmd.args,
         env: { ...env, ...cmd.env },
+        useConpty,
       };
     }
 

--- a/web/packages/teleterm/src/services/pty/ptyHost/ptyHostClient.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/ptyHostClient.ts
@@ -41,6 +41,7 @@ export function createPtyHostClient(
         args: ptyOptions.args,
         path: ptyOptions.path,
         env: Struct.fromJson(ptyOptions.env),
+        useConpty: ptyOptions.useConpty,
       });
 
       if (ptyOptions.cwd) {

--- a/web/packages/teleterm/src/services/pty/ptyHost/ptyProcess.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/ptyProcess.ts
@@ -47,7 +47,7 @@ export function createPtyProcess(
       exchangeEventsStream.resize(columns, rows);
     },
 
-    dispose(): void {
+    async dispose(): Promise<void> {
       exchangeEventsStream.dispose();
     },
 

--- a/web/packages/teleterm/src/services/pty/ptyHost/windowsPty.test.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/windowsPty.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { makeRuntimeSettings } from 'teleterm/mainProcess/fixtures/mocks';
+
+import { getWindowsPty } from './windowsPty';
+
+test.each([
+  {
+    name: 'uses conpty on supported Windows version',
+    platform: 'win32' as const,
+    osVersion: '10.0.22621',
+    terminalOptions: { windowsBackend: 'auto' as const },
+    expected: { useConpty: true, buildNumber: 22621 },
+  },
+  {
+    name: 'uses winpty on unsupported Windows version',
+    platform: 'win32' as const,
+    osVersion: '10.0.18308',
+    terminalOptions: { windowsBackend: 'auto' as const },
+    expected: { useConpty: false, buildNumber: 18308 },
+  },
+  {
+    name: 'uses winpty when Windows version is supported, but conpty is disabled in options',
+    platform: 'win32' as const,
+    osVersion: '10.0.22621',
+    terminalOptions: { windowsBackend: 'winpty' as const },
+    expected: { useConpty: false, buildNumber: 22621 },
+  },
+  {
+    name: 'undefined on non-Windows OS',
+    platform: 'darwin' as const,
+    osVersion: '23.5.0',
+    terminalOptions: { windowsBackend: 'auto' as const },
+    expected: undefined,
+  },
+])('$name', ({ platform, osVersion, terminalOptions, expected }) => {
+  const pty = getWindowsPty(
+    makeRuntimeSettings({
+      platform,
+      osVersion,
+    }),
+    terminalOptions
+  );
+  expect(pty).toEqual(expected);
+});

--- a/web/packages/teleterm/src/services/pty/ptyHost/windowsPty.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/windowsPty.ts
@@ -1,0 +1,49 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { RuntimeSettings } from 'teleterm/mainProcess/types';
+
+import { TerminalOptions, WindowsPty } from '../types';
+
+export const WIN_BUILD_STABLE_CONPTY = 18309;
+
+export function getWindowsPty(
+  runtimeSettings: RuntimeSettings,
+  terminalOptions: TerminalOptions
+): WindowsPty {
+  if (runtimeSettings.platform !== 'win32') {
+    return undefined;
+  }
+
+  const buildNumber = getWindowsBuildNumber(runtimeSettings.osVersion);
+  const useConpty =
+    terminalOptions.windowsBackend === 'auto' &&
+    buildNumber >= WIN_BUILD_STABLE_CONPTY;
+  return {
+    useConpty,
+    buildNumber,
+  };
+}
+
+function getWindowsBuildNumber(osVersion: string): number {
+  const parsedOsVersion = /(\d+)\.(\d+)\.(\d+)/g.exec(osVersion);
+  if (parsedOsVersion?.length === 4) {
+    return parseInt(parsedOsVersion[3]);
+  }
+  return 0;
+}

--- a/web/packages/teleterm/src/services/pty/ptyService.ts
+++ b/web/packages/teleterm/src/services/pty/ptyService.ts
@@ -23,21 +23,26 @@ import { RuntimeSettings } from 'teleterm/mainProcess/types';
 import { buildPtyOptions } from './ptyHost/buildPtyOptions';
 import { createPtyHostClient } from './ptyHost/ptyHostClient';
 import { createPtyProcess } from './ptyHost/ptyProcess';
-import { PtyServiceClient, SshOptions } from './types';
+import { PtyServiceClient, PtyOptions } from './types';
+import { getWindowsPty } from './ptyHost/windowsPty';
 
 export function createPtyService(
   address: string,
   credentials: ChannelCredentials,
   runtimeSettings: RuntimeSettings,
-  sshOptions: SshOptions
+  options: PtyOptions
 ): PtyServiceClient {
   const ptyHostClient = createPtyHostClient(address, credentials);
 
   return {
     createPtyProcess: async command => {
+      const windowsPty = getWindowsPty(runtimeSettings, options.terminal);
       const { processOptions, creationStatus } = await buildPtyOptions(
         runtimeSettings,
-        sshOptions,
+        {
+          ssh: options.ssh,
+          windowsPty,
+        },
         command
       );
       const ptyId = await ptyHostClient.createPtyProcess(processOptions);
@@ -46,6 +51,7 @@ export function createPtyService(
       return {
         process: createPtyProcess(ptyHostClient, ptyId),
         creationStatus,
+        windowsPty,
       };
     },
   };

--- a/web/packages/teleterm/src/services/pty/types.ts
+++ b/web/packages/teleterm/src/services/pty/types.ts
@@ -37,8 +37,20 @@ export type PtyServiceClient = {
   createPtyProcess: (cmd: PtyCommand) => Promise<{
     process: IPtyProcess;
     creationStatus: PtyProcessCreationStatus;
+    windowsPty: WindowsPty;
   }>;
 };
+
+/**
+ * Pty information for Windows.
+ * undefined for non-Windows OS.
+ */
+export type WindowsPty =
+  | {
+      useConpty: boolean;
+      buildNumber: number;
+    }
+  | undefined;
 
 export type ShellCommand = PtyCommandBase & {
   kind: 'pty.shell';
@@ -106,4 +118,13 @@ export type SshOptions = {
    * (by adding the `--no-resume` option).
    */
   noResume: boolean;
+};
+
+export type TerminalOptions = {
+  windowsBackend: 'auto' | 'winpty';
+};
+
+export type PtyOptions = {
+  ssh: SshOptions;
+  terminal: TerminalOptions;
 };

--- a/web/packages/teleterm/src/sharedProcess/api/proto/ptyHostService.proto
+++ b/web/packages/teleterm/src/sharedProcess/api/proto/ptyHostService.proto
@@ -41,6 +41,7 @@ message PtyCreate {
   reserved "init_command";
   google.protobuf.Struct env = 7;
   string init_message = 8;
+  bool use_conpty = 9;
 }
 
 message PtyClientEvent {

--- a/web/packages/teleterm/src/sharedProcess/api/protogen/ptyHostService_pb.ts
+++ b/web/packages/teleterm/src/sharedProcess/api/protogen/ptyHostService_pb.ts
@@ -69,6 +69,10 @@ export interface PtyCreate {
      * @generated from protobuf field: string init_message = 8;
      */
     initMessage: string;
+    /**
+     * @generated from protobuf field: bool use_conpty = 9;
+     */
+    useConpty: boolean;
 }
 /**
  * @generated from protobuf message PtyClientEvent
@@ -266,7 +270,8 @@ class PtyCreate$Type extends MessageType<PtyCreate> {
             { no: 4, name: "args", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 5, name: "cwd", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 7, name: "env", kind: "message", T: () => Struct },
-            { no: 8, name: "init_message", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 8, name: "init_message", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 9, name: "use_conpty", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<PtyCreate>): PtyCreate {
@@ -275,6 +280,7 @@ class PtyCreate$Type extends MessageType<PtyCreate> {
         message.args = [];
         message.cwd = "";
         message.initMessage = "";
+        message.useConpty = false;
         if (value !== undefined)
             reflectionMergePartial<PtyCreate>(this, message, value);
         return message;
@@ -298,6 +304,9 @@ class PtyCreate$Type extends MessageType<PtyCreate> {
                     break;
                 case /* string init_message */ 8:
                     message.initMessage = reader.string();
+                    break;
+                case /* bool use_conpty */ 9:
+                    message.useConpty = reader.bool();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -326,6 +335,9 @@ class PtyCreate$Type extends MessageType<PtyCreate> {
         /* string init_message = 8; */
         if (message.initMessage !== "")
             writer.tag(8, WireType.LengthDelimited).string(message.initMessage);
+        /* bool use_conpty = 9; */
+        if (message.useConpty !== false)
+            writer.tag(9, WireType.Varint).bool(message.useConpty);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyEventsStreamHandler.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyEventsStreamHandler.ts
@@ -131,16 +131,16 @@ export class PtyEventsStreamHandler {
 
   private handleStreamError(error: Error): void {
     this.logger.error(`stream has ended with error`, error);
-    this.cleanResources();
+    void this.cleanResources();
   }
 
   private handleStreamEnd(): void {
     this.logger.info(`stream has ended`);
-    this.cleanResources();
+    void this.cleanResources();
   }
 
-  private cleanResources(): void {
-    this.ptyProcess.dispose();
+  private async cleanResources(): Promise<void> {
+    await this.ptyProcess.dispose();
     if (this.ptyId) {
       this.ptyProcesses.delete(this.ptyId);
     }

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyHostService.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyHostService.ts
@@ -27,7 +27,9 @@ import { IPtyHost } from './../api/protogen/ptyHostService_pb.grpc-server';
 import { PtyCwd, PtyId } from './../api/protogen/ptyHostService_pb';
 import { PtyEventsStreamHandler } from './ptyEventsStreamHandler';
 
-export function createPtyHostService(): IPtyHost {
+export function createPtyHostService(): IPtyHost & {
+  dispose(): Promise<void>;
+} {
   const logger = new Logger('PtyHostService');
   const ptyProcesses = new Map<string, PtyProcess>();
 
@@ -43,6 +45,7 @@ export function createPtyHostService(): IPtyHost {
           ptyId,
           env: Struct.toJson(call.request.env!) as Record<string, string>,
           initMessage: ptyOptions.initMessage,
+          useConpty: ptyOptions.useConpty,
         });
         ptyProcesses.set(ptyId, ptyProcess);
       } catch (error) {
@@ -73,5 +76,12 @@ export function createPtyHostService(): IPtyHost {
         });
     },
     exchangeEvents: stream => new PtyEventsStreamHandler(stream, ptyProcesses),
+    dispose: async () => {
+      await Promise.all(
+        Array.from(ptyProcesses.values()).map(ptyProcess =>
+          ptyProcess.dispose()
+        )
+      );
+    },
   };
 }

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.test.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.test.ts
@@ -38,6 +38,7 @@ describe('PtyProcess', () => {
         args: [],
         env: { PATH: '/foo/bar' },
         ptyId: '1234',
+        useConpty: true,
       });
 
       const startErrorCb = jest.fn();

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/types.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/types.ts
@@ -22,13 +22,15 @@ export type PtyProcessOptions = {
   args: string[];
   cwd?: string;
   initMessage?: string;
+  /** Whether to use the ConPTY system on Windows. */
+  useConpty: boolean;
 };
 
 export type IPtyProcess = {
   start(cols: number, rows: number): void;
   write(data: string): void;
   resize(cols: number, rows: number): void;
-  dispose(): void;
+  dispose(): Promise<void>;
   getCwd(): Promise<string>;
   getPtyId(): string;
   // The listener removal functions are used only on the frontend app side from the renderer process.

--- a/web/packages/teleterm/src/ui/DocumentTerminal/DocumentTerminal.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/DocumentTerminal.tsx
@@ -132,6 +132,7 @@ export function DocumentTerminal(props: {
           unsanitizedFontFamily={unsanitizedTerminalFontFamily}
           fontSize={terminalFontSize}
           onEnterKey={attempt.data.refreshTitle}
+          windowsPty={attempt.data.windowsPty}
         />
       )}
     </Document>

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.tsx
@@ -27,6 +27,7 @@ import {
   makeSuccessAttempt,
 } from 'shared/hooks/useAsync';
 
+import { WindowsPty } from 'teleterm/services/pty';
 import { IPtyProcess } from 'teleterm/sharedProcess/ptyHost';
 import { DocumentTerminal } from 'teleterm/ui/services/workspacesService';
 
@@ -48,6 +49,7 @@ type TerminalProps = {
   unsanitizedFontFamily: string;
   fontSize: number;
   onEnterKey?(): void;
+  windowsPty: WindowsPty;
 };
 
 export function Terminal(props: TerminalProps) {
@@ -72,6 +74,7 @@ export function Terminal(props: TerminalProps) {
       el: refElement.current,
       fontSize: props.fontSize,
       theme: theme.colors.terminal,
+      windowsPty: props.windowsPty,
     });
 
     // Start the PTY process.

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.ts
@@ -21,6 +21,7 @@ import { IDisposable, ITheme, Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import { debounce } from 'shared/utils/highbar';
 
+import { WindowsPty } from 'teleterm/services/pty';
 import { IPtyProcess } from 'teleterm/sharedProcess/ptyHost';
 import Logger from 'teleterm/logger';
 
@@ -30,6 +31,7 @@ type Options = {
   el: HTMLElement;
   fontSize: number;
   theme: ITheme;
+  windowsPty: WindowsPty;
 };
 
 export default class TtyTerminal {
@@ -68,6 +70,10 @@ export default class TtyTerminal {
       scrollback: 5000,
       minimumContrastRatio: 4.5, // minimum for WCAG AA compliance
       theme: this.options.theme,
+      windowsPty: this.options.windowsPty && {
+        backend: this.options.windowsPty.useConpty ? 'conpty' : 'winpty',
+        buildNumber: this.options.windowsPty.buildNumber,
+      },
       windowOptions: {
         setWinSizeChars: true,
       },

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
@@ -237,6 +237,7 @@ test('useDocumentTerminal shows a warning notification if the call to TerminalsS
   jest.spyOn(terminalsService, 'createPtyProcess').mockResolvedValue({
     process: getPtyProcessMock(),
     creationStatus: PtyProcessCreationStatus.ResolveShellEnvTimeout,
+    windowsPty: undefined,
   });
   jest.spyOn(notificationsService, 'notifyWarning');
 
@@ -574,6 +575,7 @@ const testSetup = (
       return {
         process: getPtyProcessMock(),
         creationStatus: PtyProcessCreationStatus.Ok,
+        windowsPty: undefined,
       };
     });
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/44468 to branch/v15

Changelog: Teleport Connect now uses ConPTY for better terminal resizing and accurate color rendering on Windows, with an option to disable it in the app config