### PR TITLE
VNet: Make sure daemon client has adequate permissions for passed `TELEPORT_HOME`

### DIFF
--- a/lib/vnet/customdnszonevalidator.go
+++ b/lib/vnet/customdnszonevalidator.go
@@ -19,7 +19,6 @@ package vnet
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"net"
 	"slices"
 	"sync"
@@ -67,7 +66,7 @@ func (c *customDNSZoneValidator) validate(ctx context.Context, clusterName, cust
 	}
 
 	requiredTXTRecord := clusterTXTRecordPrefix + clusterName
-	slog.InfoContext(ctx, "Checking validity of custom DNS zone by querying for required TXT record.", "zone", customDNSZone, "record", requiredTXTRecord)
+	log.InfoContext(ctx, "Checking validity of custom DNS zone by querying for required TXT record.", "zone", customDNSZone, "record", requiredTXTRecord)
 
 	records, err := c.lookupTXT(ctx, customDNSZone)
 	if err != nil {
@@ -83,7 +82,7 @@ func (c *customDNSZoneValidator) validate(ctx context.Context, clusterName, cust
 		return trace.Wrap(errNoTXTRecord(customDNSZone, requiredTXTRecord))
 	}
 
-	slog.InfoContext(ctx, "Custom DNS zone has valid TXT record.", "zone", customDNSZone, "cluster", clusterName)
+	log.InfoContext(ctx, "Custom DNS zone has valid TXT record.", "zone", customDNSZone, "cluster", clusterName)
 
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/lib/vnet/daemon/common.go
+++ b/lib/vnet/daemon/common.go
@@ -17,6 +17,7 @@
 package daemon
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -46,6 +47,14 @@ type ClientCred struct {
 	Egid int
 	// Euid is the effective user ID of the unprivileged process.
 	Euid int
+}
+
+func (c ClientCred) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Bool("creds_valid", c.Valid),
+		slog.Int("egid", c.Egid),
+		slog.Int("euid", c.Euid),
+	)
 }
 
 func (c *Config) CheckAndSetDefaults() error {

--- a/lib/vnet/daemon/common.go
+++ b/lib/vnet/daemon/common.go
@@ -35,11 +35,13 @@ type Config struct {
 	// HomePath points to TELEPORT_HOME that will be used by the admin process.
 	HomePath string
 	// ClientCred are the credentials of the unprivileged process that wants to start VNet.
-	ClientCred *ClientCred
+	ClientCred ClientCred
 }
 
 // ClientCred are the credentials of the unprivileged process that wants to start VNet.
 type ClientCred struct {
+	// Valid is set if the Euid and Egid fields have been set.
+	Valid bool
 	// Egid is the effective group ID of the unprivileged process.
 	Egid int
 	// Euid is the effective user ID of the unprivileged process.
@@ -56,7 +58,7 @@ func (c *Config) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing DNS address")
 	case c.HomePath == "":
 		return trace.BadParameter("missing home path")
-	case c.ClientCred == nil:
+	case c.ClientCred.Valid == false:
 		return trace.BadParameter("missing client credentials")
 	}
 	return nil

--- a/lib/vnet/daemon/common.go
+++ b/lib/vnet/daemon/common.go
@@ -34,6 +34,16 @@ type Config struct {
 	DNSAddr string
 	// HomePath points to TELEPORT_HOME that will be used by the admin process.
 	HomePath string
+	// ClientCred are the credentials of the unprivileged process that wants to start VNet.
+	ClientCred *ClientCred
+}
+
+// ClientCred are the credentials of the unprivileged process that wants to start VNet.
+type ClientCred struct {
+	// Egid is the effective group ID of the unprivileged process.
+	Egid int
+	// Euid is the effective user ID of the unprivileged process.
+	Euid int
 }
 
 func (c *Config) CheckAndSetDefaults() error {
@@ -46,6 +56,8 @@ func (c *Config) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing DNS address")
 	case c.HomePath == "":
 		return trace.BadParameter("missing home path")
+	case c.ClientCred == nil:
+		return trace.BadParameter("missing client credentials")
 	}
 	return nil
 }

--- a/lib/vnet/daemon/service_darwin.go
+++ b/lib/vnet/daemon/service_darwin.go
@@ -26,7 +26,6 @@ import "C"
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 	"unsafe"
 
@@ -78,7 +77,7 @@ func Start(ctx context.Context, workFn func(context.Context, Config) error) erro
 		"ipv6_prefix", config.IPv6Prefix,
 		"dns_addr", config.DNSAddr,
 		"home_path", config.HomePath,
-		"cred", fmt.Sprintf("%#v", config.ClientCred),
+		"client_cred", config.ClientCred,
 	)
 
 	return trace.Wrap(workFn(ctx, config))

--- a/lib/vnet/daemon/service_darwin.go
+++ b/lib/vnet/daemon/service_darwin.go
@@ -103,8 +103,10 @@ func waitForVnetConfig(ctx context.Context) (Config, error) {
 			C.free(unsafe.Pointer(result.home_path))
 		}()
 
+		var clientCred C.ClientCred
+
 		// This call gets unblocked when the daemon gets stopped through C.DaemonStop.
-		C.WaitForVnetConfig(&result)
+		C.WaitForVnetConfig(&result, &clientCred)
 		if !result.ok {
 			errC <- trace.Wrap(errors.New(C.GoString(result.error_description)))
 			return
@@ -115,9 +117,10 @@ func waitForVnetConfig(ctx context.Context) (Config, error) {
 			IPv6Prefix: C.GoString(result.ipv6_prefix),
 			DNSAddr:    C.GoString(result.dns_addr),
 			HomePath:   C.GoString(result.home_path),
-			ClientCred: &ClientCred{
-				Egid: int(result.egid),
-				Euid: int(result.euid),
+			ClientCred: ClientCred{
+				Valid: bool(clientCred.valid),
+				Egid:  int(clientCred.egid),
+				Euid:  int(clientCred.euid),
 			},
 		}
 		errC <- nil

--- a/lib/vnet/daemon/service_darwin.go
+++ b/lib/vnet/daemon/service_darwin.go
@@ -26,6 +26,7 @@ import "C"
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 	"unsafe"
 
@@ -77,6 +78,7 @@ func Start(ctx context.Context, workFn func(context.Context, Config) error) erro
 		"ipv6_prefix", config.IPv6Prefix,
 		"dns_addr", config.DNSAddr,
 		"home_path", config.HomePath,
+		"cred", fmt.Sprintf("%#v", config.ClientCred),
 	)
 
 	return trace.Wrap(workFn(ctx, config))
@@ -113,6 +115,10 @@ func waitForVnetConfig(ctx context.Context) (Config, error) {
 			IPv6Prefix: C.GoString(result.ipv6_prefix),
 			DNSAddr:    C.GoString(result.dns_addr),
 			HomePath:   C.GoString(result.home_path),
+			ClientCred: &ClientCred{
+				Egid: int(result.egid),
+				Euid: int(result.euid),
+			},
 		}
 		errC <- nil
 	}()

--- a/lib/vnet/daemon/service_darwin.h
+++ b/lib/vnet/daemon/service_darwin.h
@@ -46,6 +46,10 @@ typedef struct VnetConfigResult {
   const char *ipv6_prefix;
   const char *dns_addr;
   const char *home_path;
+  // egid is the effective group ID of the process on the other side of the XPC connection.
+  gid_t egid;
+  // euid is the effective user ID of the process on the other side of the XPC connection.
+  uid_t euid;
 } VnetConfigResult;
 
 // WaitForVnetConfig blocks until a client calls the daemon with a config necessary to start VNet.

--- a/lib/vnet/daemon/service_darwin.h
+++ b/lib/vnet/daemon/service_darwin.h
@@ -46,17 +46,22 @@ typedef struct VnetConfigResult {
   const char *ipv6_prefix;
   const char *dns_addr;
   const char *home_path;
+} VnetConfigResult;
+
+typedef struct ClientCred {
+  // valid is set if the euid and egid fields have been set.
+  bool valid;
   // egid is the effective group ID of the process on the other side of the XPC connection.
   gid_t egid;
   // euid is the effective user ID of the process on the other side of the XPC connection.
   uid_t euid;
-} VnetConfigResult;
+} ClientCred;
 
 // WaitForVnetConfig blocks until a client calls the daemon with a config necessary to start VNet.
 // It can be interrupted by calling DaemonStop.
 //
 // The caller is expected to check outResult.ok to see if the call succeeded and to free strings
 // in VnetConfigResult.
-void WaitForVnetConfig(VnetConfigResult *outResult);
+void WaitForVnetConfig(VnetConfigResult *outResult, ClientCred *outClientCred);
 
 #endif /* TELEPORT_LIB_VNET_DAEMON_SERVICE_DARWIN_H_ */

--- a/lib/vnet/daemon/service_darwin.m
+++ b/lib/vnet/daemon/service_darwin.m
@@ -37,6 +37,8 @@
 @property(nonatomic, readwrite) NSString *ipv6Prefix;
 @property(nonatomic, readwrite) NSString *dnsAddr;
 @property(nonatomic, readwrite) NSString *homePath;
+@property(nonatomic, readwrite) gid_t egid;
+@property(nonatomic, readwrite) uid_t euid;
 @property(nonatomic, readwrite) dispatch_semaphore_t gotVnetConfigSema;
 
 @end
@@ -105,6 +107,10 @@
     _ipv6Prefix = @(vnetConfig->ipv6_prefix);
     _dnsAddr = @(vnetConfig->dns_addr);
     _homePath = @(vnetConfig->home_path);
+
+    NSXPCConnection *currentConn = [NSXPCConnection currentConnection];
+    _egid = [currentConn effectiveGroupIdentifier];
+    _euid = [currentConn effectiveUserIdentifier];
 
     dispatch_semaphore_signal(_gotVnetConfigSema);
     completion(nil);
@@ -180,6 +186,8 @@ void WaitForVnetConfig(VnetConfigResult *outResult) {
     outResult->ipv6_prefix = VNECopyNSString([daemonService ipv6Prefix]);
     outResult->dns_addr = VNECopyNSString([daemonService dnsAddr]);
     outResult->home_path = VNECopyNSString([daemonService homePath]);
+    outResult->egid = [daemonService egid];
+    outResult->euid = [daemonService euid];
     outResult->ok = true;
   }
 }

--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -18,7 +18,6 @@ package vnet
 
 import (
 	"context"
-	"log/slog"
 	"net"
 
 	"github.com/gravitational/trace"
@@ -137,14 +136,14 @@ func (c *osConfigurator) getDNSZonesAndCIDRRangesForProfile(ctx context.Context,
 	defer func() {
 		if shouldClearCacheForRoot {
 			if err := c.clientCache.ClearForRoot(profileName); err != nil {
-				slog.ErrorContext(ctx, "Error while clearing client cache", "profile", profileName, "error", err)
+				log.ErrorContext(ctx, "Error while clearing client cache", "profile", profileName, "error", err)
 			}
 		}
 	}()
 
 	rootClient, err := c.clientCache.Get(ctx, profileName, "" /*leafClusterName*/)
 	if err != nil {
-		slog.WarnContext(ctx,
+		log.WarnContext(ctx,
 			"Failed to get root cluster client from cache, profile may be expired, not configuring VNet for this cluster",
 			"profile", profileName, "error", err)
 
@@ -152,7 +151,7 @@ func (c *osConfigurator) getDNSZonesAndCIDRRangesForProfile(ctx context.Context,
 	}
 	clusterConfig, err := c.clusterConfigCache.GetClusterConfig(ctx, rootClient)
 	if err != nil {
-		slog.WarnContext(ctx,
+		log.WarnContext(ctx,
 			"Failed to load VNet configuration, profile may be expired, not configuring VNet for this cluster",
 			"profile", profileName, "error", err)
 
@@ -164,7 +163,7 @@ func (c *osConfigurator) getDNSZonesAndCIDRRangesForProfile(ctx context.Context,
 
 	leafClusters, err := getLeafClusters(ctx, rootClient)
 	if err != nil {
-		slog.WarnContext(ctx,
+		log.WarnContext(ctx,
 			"Failed to list leaf clusters, profile may be expired, not configuring VNet for leaf clusters of this cluster",
 			"profile", profileName, "error", err)
 
@@ -179,7 +178,7 @@ func (c *osConfigurator) getDNSZonesAndCIDRRangesForProfile(ctx context.Context,
 	for _, leafClusterName := range leafClusters {
 		clusterClient, err := c.clientCache.Get(ctx, profileName, leafClusterName)
 		if err != nil {
-			slog.WarnContext(ctx,
+			log.WarnContext(ctx,
 				"Failed to create leaf cluster client, not configuring VNet for this cluster",
 				"profile", profileName, "leaf_cluster", leafClusterName, "error", err)
 			continue
@@ -187,7 +186,7 @@ func (c *osConfigurator) getDNSZonesAndCIDRRangesForProfile(ctx context.Context,
 
 		clusterConfig, err := c.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
 		if err != nil {
-			slog.WarnContext(ctx,
+			log.WarnContext(ctx,
 				"Failed to load VNet configuration, not configuring VNet for this cluster",
 				"profile", profileName, "leaf_cluster", leafClusterName, "error", err)
 			continue

--- a/lib/vnet/osconfig_darwin.go
+++ b/lib/vnet/osconfig_darwin.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 
 	"github.com/gravitational/trace"
 )
@@ -138,4 +139,36 @@ func vnetManagedResolverFiles() (map[string]struct{}, error) {
 		}
 	}
 	return matchingFiles, nil
+}
+
+// doWithDroppedRootPrivileges drops the privileges of the current process to those of the client
+// process that called the VNet daemon.
+func (c *osConfigurator) doWithDroppedRootPrivileges(ctx context.Context, fn func() error) (err error) {
+	rootEgid := os.Getegid()
+	rootEuid := os.Geteuid()
+
+	if err := syscall.Setegid(c.daemonClientCred.Egid); err != nil {
+		return trace.Wrap(err, "setting egid")
+	}
+	defer func() {
+		syscallErr := trace.Wrap(syscall.Setegid(rootEgid), "reverting egid")
+		err = trace.NewAggregate(err, syscallErr)
+	}()
+
+	if err := syscall.Seteuid(c.daemonClientCred.Euid); err != nil {
+		return trace.Wrap(err, "setting euid")
+	}
+	defer func() {
+		syscallErr := trace.Wrap(syscall.Seteuid(rootEuid), "reverting euid")
+		err = trace.NewAggregate(err, syscallErr)
+	}()
+
+	log.InfoContext(ctx, "Temporarily dropping root privileges.", "egid", c.daemonClientCred.Egid, "euid", c.daemonClientCred.Euid)
+	defer func() {
+		if err == nil {
+			log.InfoContext(ctx, "Restored root privileges.", "egid", rootEgid, "euid", rootEuid)
+		}
+	}()
+
+	return trace.Wrap(fn())
 }

--- a/lib/vnet/osconfig_darwin.go
+++ b/lib/vnet/osconfig_darwin.go
@@ -19,7 +19,6 @@ package vnet
 import (
 	"bufio"
 	"context"
-	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -34,14 +33,14 @@ func configureOS(ctx context.Context, cfg *osConfig) error {
 	// process exits and the TUN is deleted.
 
 	if cfg.tunIPv4 != "" {
-		slog.InfoContext(ctx, "Setting IPv4 address for the TUN device.", "device", cfg.tunName, "address", cfg.tunIPv4)
+		log.InfoContext(ctx, "Setting IPv4 address for the TUN device.", "device", cfg.tunName, "address", cfg.tunIPv4)
 		cmd := exec.CommandContext(ctx, "ifconfig", cfg.tunName, cfg.tunIPv4, cfg.tunIPv4, "up")
 		if err := cmd.Run(); err != nil {
 			return trace.Wrap(err, "running %v", cmd.Args)
 		}
 	}
 	for _, cidrRange := range cfg.cidrRanges {
-		slog.InfoContext(ctx, "Setting an IP route for the VNet.", "netmask", cidrRange)
+		log.InfoContext(ctx, "Setting an IP route for the VNet.", "netmask", cidrRange)
 		cmd := exec.CommandContext(ctx, "route", "add", "-net", cidrRange, "-interface", cfg.tunName)
 		if err := cmd.Run(); err != nil {
 			return trace.Wrap(err, "running %v", cmd.Args)
@@ -49,13 +48,13 @@ func configureOS(ctx context.Context, cfg *osConfig) error {
 	}
 
 	if cfg.tunIPv6 != "" {
-		slog.InfoContext(ctx, "Setting IPv6 address for the TUN device.", "device", cfg.tunName, "address", cfg.tunIPv6)
+		log.InfoContext(ctx, "Setting IPv6 address for the TUN device.", "device", cfg.tunName, "address", cfg.tunIPv6)
 		cmd := exec.CommandContext(ctx, "ifconfig", cfg.tunName, "inet6", cfg.tunIPv6, "prefixlen", "64")
 		if err := cmd.Run(); err != nil {
 			return trace.Wrap(err, "running %v", cmd.Args)
 		}
 
-		slog.InfoContext(ctx, "Setting an IPv6 route for the VNet.")
+		log.InfoContext(ctx, "Setting an IPv6 route for the VNet.")
 		cmd = exec.CommandContext(ctx, "route", "add", "-inet6", cfg.tunIPv6, "-prefixlen", "64", "-interface", cfg.tunName)
 		if err := cmd.Run(); err != nil {
 			return trace.Wrap(err, "running %v", cmd.Args)
@@ -78,7 +77,7 @@ func configureDNS(ctx context.Context, nameserver string, zones []string) error 
 		return trace.BadParameter("empty nameserver with non-empty zones")
 	}
 
-	slog.DebugContext(ctx, "Configuring DNS.", "nameserver", nameserver, "zones", zones)
+	log.DebugContext(ctx, "Configuring DNS.", "nameserver", nameserver, "zones", zones)
 	if err := os.MkdirAll(resolverPath, os.FileMode(0755)); err != nil {
 		return trace.Wrap(err, "creating %s", resolverPath)
 	}

--- a/lib/vnet/osconfig_other.go
+++ b/lib/vnet/osconfig_other.go
@@ -21,37 +21,14 @@ package vnet
 
 import (
 	"context"
-	"net"
-	"os"
-	"runtime"
 
 	"github.com/gravitational/trace"
-	"golang.zx2c4.com/wireguard/tun"
-
-	"github.com/gravitational/teleport/lib/vnet/daemon"
 )
 
-var (
-	// ErrVnetNotImplemented is an error indicating that VNet is not implemented on the host OS.
-	ErrVnetNotImplemented = &trace.NotImplementedError{Message: "VNet is not implemented on " + runtime.GOOS}
-)
-
-func createUnixSocket() (*net.UnixListener, string, error) {
-	return nil, "", trace.Wrap(ErrVnetNotImplemented)
-}
-
-func sendTUNNameAndFd(socketPath, tunName string, tunFile *os.File) error {
+func configureOS(ctx context.Context, cfg *osConfig) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }
 
-func receiveTUNDevice(socket *net.UnixListener) (tun.Device, error) {
-	return nil, trace.Wrap(ErrVnetNotImplemented)
-}
-
-func execAdminProcess(ctx context.Context, config daemon.Config) error {
-	return trace.Wrap(ErrVnetNotImplemented)
-}
-
-func DaemonSubcommand(ctx context.Context) error {
+func (c *osConfigurator) doWithDroppedRootPrivileges(ctx context.Context, fn func() error) (err error) {
 	return trace.Wrap(ErrVnetNotImplemented)
 }

--- a/lib/vnet/setup.go
+++ b/lib/vnet/setup.go
@@ -240,7 +240,7 @@ func AdminSetup(ctx context.Context, config daemon.Config) error {
 
 	errCh := make(chan error)
 	go func() {
-		errCh <- trace.Wrap(osConfigurationLoop(ctx, tunName, config.IPv6Prefix, config.DNSAddr, config.HomePath, *config.ClientCred))
+		errCh <- trace.Wrap(osConfigurationLoop(ctx, tunName, config.IPv6Prefix, config.DNSAddr, config.HomePath, config.ClientCred))
 	}()
 
 	// Stay alive until we get an error on errCh, indicating that the osConfig loop exited.

--- a/lib/vnet/setup_darwin.go
+++ b/lib/vnet/setup_darwin.go
@@ -72,9 +72,11 @@ do shell script quoted form of executableName & `+
 		`" %s -d --socket " & quoted form of socketPath & `+
 		`" --ipv6-prefix " & quoted form of ipv6Prefix & `+
 		`" --dns-addr " & quoted form of dnsAddr & `+
+		`" --egid %d --euid %d" & `+
 		`" >/var/log/vnet.log 2>&1" `+
 		`with prompt "Teleport VNet wants to set up a virtual network device." with administrator privileges`,
-		executableName, config.SocketPath, config.IPv6Prefix, config.DNSAddr, teleport.VnetAdminSetupSubCommand)
+		executableName, config.SocketPath, config.IPv6Prefix, config.DNSAddr, teleport.VnetAdminSetupSubCommand,
+		os.Getegid(), os.Geteuid())
 
 	// The context we pass here has effect only on the password prompt being shown. Once osascript spawns the
 	// privileged process, canceling the context (and thus killing osascript) has no effect on the privileged

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -80,6 +80,12 @@ type vnetAdminSetupCommand struct {
 	ipv6Prefix string
 	// dnsAddr is the IP address for the VNet DNS server.
 	dnsAddr string
+	// egid of the user starting VNet. Unsafe for production use, as the egid comes from an unstrusted
+	// source.
+	egid int
+	// euid of the user starting VNet. Unsafe for production use, as the euid comes from an unstrusted
+	// source.
+	euid int
 }
 
 func newVnetAdminSetupCommand(app *kingpin.Application) *vnetAdminSetupCommand {
@@ -89,6 +95,8 @@ func newVnetAdminSetupCommand(app *kingpin.Application) *vnetAdminSetupCommand {
 	cmd.Flag("socket", "unix socket path").StringVar(&cmd.socketPath)
 	cmd.Flag("ipv6-prefix", "IPv6 prefix for the VNet").StringVar(&cmd.ipv6Prefix)
 	cmd.Flag("dns-addr", "VNet DNS address").StringVar(&cmd.dnsAddr)
+	cmd.Flag("egid", "effective group ID of the user starting VNet").IntVar(&cmd.egid)
+	cmd.Flag("euid", "effective user ID of the user starting VNet").IntVar(&cmd.euid)
 	return cmd
 }
 
@@ -104,6 +112,10 @@ func (c *vnetAdminSetupCommand) run(cf *CLIConf) error {
 		IPv6Prefix: c.ipv6Prefix,
 		DNSAddr:    c.dnsAddr,
 		HomePath:   homePath,
+		ClientCred: &daemon.ClientCred{
+			Egid: c.egid,
+			Euid: c.euid,
+		},
 	}
 
 	return trace.Wrap(vnet.AdminSetup(cf.Context, config))

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -112,9 +112,10 @@ func (c *vnetAdminSetupCommand) run(cf *CLIConf) error {
 		IPv6Prefix: c.ipv6Prefix,
 		DNSAddr:    c.dnsAddr,
 		HomePath:   homePath,
-		ClientCred: &daemon.ClientCred{
-			Egid: c.egid,
-			Euid: c.euid,
+		ClientCred: daemon.ClientCred{
+			Valid: true,
+			Egid:  c.egid,
+			Euid:  c.euid,
 		},
 	}
 


### PR DESCRIPTION
This is the last PR we need before we're able to ship the launch daemon version of VNet.

When starting VNet, the unprivileged process sends a couple of arguments to the privileged launch daemon, among them a path to `TELEPORT_HOME` of the user that wants to start VNet.

The daemon then lists profiles based on files from that dir, creates Teleport clients and for each profile it fetches the list of leaf clusters and a VNet config resource for each cluster.

This potentially allows a user to make the daemon read data belonging to any other user. To prevent this, this PR makes it so that before reading files from `TELEPORT_HOME`, the daemon sets its egid and euid to that of the daemon client. This way the daemon won't read data that the user doesn't have access to.

egid and euid of the daemon client is returned by the kernel based on an audit token included with each XPC message. I don't know if there's an official docs on this fact, but there's a couple of blog posts from security researchers on this topic ([example 1](https://knight.sc/reverse%20engineering/2020/03/20/audit-tokens-explained.html#xpc-and-audit-tokens), [example 2](https://www.synacktiv.com/publications/macos-xpc-exploitation-sandbox-share-case-study)). I used [Obj-C APIs](https://developer.apple.com/documentation/foundation/nsxpcconnection/1408346-effectiveuseridentifier?language=objc) for that which I assume use [C APIs](https://developer.apple.com/documentation/xpc/1448801-xpc_connection_get_euid?language=objc) underneath.


https://github.com/user-attachments/assets/137f9e4c-5064-4251-a1df-1c0e16dc8b82

In the demo video above, I first spawn a launch daemon as usual with my regular `TELEPORT_HOME`. Then I spawn it again but with `TELEPORT_HOME` set to a dir I don't have access to. Most of the time the execution won't even get to that point, because `tsh` will attempt to read its `config.yaml` from `TELEPORT_HOME`. The dir I used in the demo has permissions set to 777, unlike something like `/var/root` with 750.

---

I don't have much experience with syscalls that change (e)uids and guids, I know about them mostly from caveats in blogposts and manpages. I based my implementation on [Temporarily dropping root privileges in Go](https://medium.com/picus-security-engineering/temporarily-dropping-root-privileges-in-go-ac50d80be70c) and a couple of other articles I read about `setuid`.

Edoardo has already [brought up on Slack](https://gravitational.slack.com/archives/C0DF0TPMY/p1722244447797379?thread_ts=1721989003.047729&cid=C0DF0TPMY) the problem of not spawning a child process and setting the euid from there. For now, I think it should be safe, as the VNet admin process itself is quite simple and beyond the loop where it configures the DNS, it doesn't do any extra async work. As such, setting a process-wide euid and egid does not conflict with any other code that's executed at the same time.

If we wanted to reexec, we'd have to stop caching the VNet configs (`lib/vnet/clusterconfigcache.go`) or reimplement the cache so that it works across processes.