### PR TITLE
Add static host user service

### DIFF
--- a/api/types/userprovisioning/statichostuser.go
+++ b/api/types/userprovisioning/statichostuser.go
@@ -1,0 +1,37 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package userprovisioning
+
+import (
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// NewStaticHostUser creates a new host user to be applied to matching SSH nodes.
+func NewStaticHostUser(name string, spec *userprovisioningpb.StaticHostUserSpec) *userprovisioningpb.StaticHostUser {
+	return &userprovisioningpb.StaticHostUser{
+		Kind:    types.KindStaticHostUser,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: name,
+		},
+		Spec: spec,
+	}
+}

--- a/lib/services/local/statichostuser.go
+++ b/lib/services/local/statichostuser.go
@@ -1,0 +1,111 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package local
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
+)
+
+const (
+	staticHostUserPrefix = "static_host_user"
+)
+
+// StaticHostUserService manages host users that should be created on SSH nodes.
+type StaticHostUserService struct {
+	svc *generic.ServiceWrapper[*userprovisioningpb.StaticHostUser]
+}
+
+// NewStaticHostUserService creates a new static host user service.
+func NewStaticHostUserService(bk backend.Backend) (*StaticHostUserService, error) {
+	svc, err := generic.NewServiceWrapper(
+		bk,
+		types.KindStaticHostUser,
+		staticHostUserPrefix,
+		services.MarshalProtoResource[*userprovisioningpb.StaticHostUser],
+		services.UnmarshalProtoResource[*userprovisioningpb.StaticHostUser],
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &StaticHostUserService{
+		svc: svc,
+	}, nil
+}
+
+// ListStaticHostUsers lists static host users.
+func (s *StaticHostUserService) ListStaticHostUsers(ctx context.Context, pageSize int, pageToken string) ([]*userprovisioningpb.StaticHostUser, string, error) {
+	out, nextToken, err := s.svc.ListResources(ctx, pageSize, pageToken)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return out, nextToken, nil
+}
+
+// GetStaticHostUser returns a static host user by name.
+func (s *StaticHostUserService) GetStaticHostUser(ctx context.Context, name string) (*userprovisioningpb.StaticHostUser, error) {
+	out, err := s.svc.GetResource(ctx, name)
+	return out, trace.Wrap(err)
+}
+
+// CreateStaticHostUser creates a static host user.
+func (s *StaticHostUserService) CreateStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error) {
+	if err := services.ValidateStaticHostUser(in); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	out, err := s.svc.CreateResource(ctx, in)
+	return out, trace.Wrap(err)
+}
+
+// UpdateStaticHostUser updates a static host user.
+func (s *StaticHostUserService) UpdateStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error) {
+	if err := services.ValidateStaticHostUser(in); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	out, err := s.svc.ConditionalUpdateResource(ctx, in)
+	return out, trace.Wrap(err)
+}
+
+// UpsertStaticHostUser upserts a static host user.
+func (s *StaticHostUserService) UpsertStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error) {
+	if err := services.ValidateStaticHostUser(in); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	out, err := s.svc.UpsertResource(ctx, in)
+	return out, trace.Wrap(err)
+}
+
+// DeleteStaticHostUser deletes a static host user. Note that this does not
+// remove any host users created on nodes from the resource.
+func (s *StaticHostUserService) DeleteStaticHostUser(ctx context.Context, name string) error {
+	return trace.Wrap(s.svc.DeleteResource(ctx, name))
+}
+
+// DeleteStaticHostUser deletes a static host user. Note that this does not
+// remove any host users created on nodes from the resources.
+func (s *StaticHostUserService) DeleteAllStaticHostUsers(ctx context.Context) error {
+	return trace.Wrap(s.svc.DeleteAllResources(ctx))
+}

--- a/lib/services/local/statichostuser_test.go
+++ b/lib/services/local/statichostuser_test.go
@@ -1,0 +1,280 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/mailgun/holster/v3/clock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
+	"github.com/gravitational/teleport/api/types/userprovisioning"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+func TestCreateStaticHostUser(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service := getStaticHostUserService(t)
+
+	obj := getStaticHostUser(0)
+
+	// first attempt should succeed
+	objOut, err := service.CreateStaticHostUser(ctx, obj)
+	require.NoError(t, err)
+	require.Equal(t, obj, objOut)
+
+	// second attempt should fail, object already exists
+	_, err = service.CreateStaticHostUser(ctx, obj)
+	require.True(t, trace.IsAlreadyExists(err))
+}
+
+func TestUpsertStaticHostUser(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service := getStaticHostUserService(t)
+
+	obj := getStaticHostUser(0)
+
+	// first attempt should succeed
+	objOut, err := service.UpsertStaticHostUser(ctx, obj)
+	require.NoError(t, err)
+	require.Equal(t, obj, objOut)
+
+	// second attempt should also succeed
+	objOut, err = service.UpsertStaticHostUser(ctx, obj)
+	require.NoError(t, err)
+	require.Equal(t, obj, objOut)
+}
+
+func TestGetStaticHostUser(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service := getStaticHostUserService(t)
+	prepopulateStaticHostUsers(t, service, 1)
+
+	tests := []struct {
+		name      string
+		key       string
+		assertErr assert.ErrorAssertionFunc
+		wantObj   *userprovisioningpb.StaticHostUser
+	}{
+		{
+			name: "object does not exist",
+			key:  "dummy",
+			assertErr: func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
+				return assert.True(t, trace.IsNotFound(err), msgAndArgs...)
+			},
+		},
+		{
+			name:      "success",
+			key:       getStaticHostUser(0).GetMetadata().GetName(),
+			assertErr: assert.NoError,
+			wantObj:   getStaticHostUser(0),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj, err := service.GetStaticHostUser(ctx, tc.key)
+			tc.assertErr(t, err)
+			if tc.wantObj == nil {
+				assert.Nil(t, obj)
+			} else {
+				cmpOpts := []cmp.Option{
+					protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+					protocmp.Transform(),
+				}
+				require.Equal(t, "", cmp.Diff(tc.wantObj, obj, cmpOpts...))
+			}
+		})
+	}
+}
+
+func TestUpdateStaticHostUser(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service := getStaticHostUserService(t)
+	prepopulateStaticHostUsers(t, service, 1)
+
+	expiry := timestamppb.New(clock.Now().Add(30 * time.Minute))
+
+	// Fetch the object from the backend so the revision is populated.
+	key := getStaticHostUser(0).GetMetadata().GetName()
+	obj, err := service.GetStaticHostUser(ctx, key)
+	require.NoError(t, err)
+	obj.Metadata.Expires = expiry
+
+	objUpdated, err := service.UpdateStaticHostUser(ctx, obj)
+	require.NoError(t, err)
+	require.Equal(t, expiry, objUpdated.Metadata.Expires)
+
+	objFresh, err := service.GetStaticHostUser(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, expiry, objFresh.Metadata.Expires)
+}
+
+func TestUpdateStaticHostUserMissingRevision(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service := getStaticHostUserService(t)
+	prepopulateStaticHostUsers(t, service, 1)
+
+	expiry := timestamppb.New(clock.Now().Add(30 * time.Minute))
+
+	obj := getStaticHostUser(0)
+	obj.Metadata.Expires = expiry
+
+	// Update should be rejected as the revision is missing.
+	_, err := service.UpdateStaticHostUser(ctx, obj)
+	require.True(t, trace.IsCompareFailed(err))
+}
+
+func TestDeleteStaticHostUser(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service := getStaticHostUserService(t)
+	prepopulateStaticHostUsers(t, service, 1)
+
+	tests := []struct {
+		name      string
+		key       string
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "object does not exist",
+			key:  "dummy",
+			assertErr: func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+				require.True(t, trace.IsNotFound(err), msgAndArgs...)
+			},
+		},
+		{
+			name:      "success",
+			key:       getStaticHostUser(0).GetMetadata().GetName(),
+			assertErr: require.NoError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := service.DeleteStaticHostUser(ctx, tc.key)
+			tc.assertErr(t, err)
+		})
+	}
+}
+
+func TestListStaticHostUsers(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	counts := []int{0, 1, 5, 10}
+
+	for _, count := range counts {
+		t.Run(fmt.Sprintf("count=%v", count), func(t *testing.T) {
+			service := getStaticHostUserService(t)
+			prepopulateStaticHostUsers(t, service, count)
+
+			t.Run("one page", func(t *testing.T) {
+				// Fetch all objects.
+				elements, nextToken, err := service.ListStaticHostUsers(ctx, 200, "")
+				require.NoError(t, err)
+				require.Empty(t, nextToken)
+				require.Len(t, elements, count)
+
+				for i := 0; i < count; i++ {
+					cmpOpts := []cmp.Option{
+						protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+						protocmp.Transform(),
+					}
+					require.Equal(t, "", cmp.Diff(getStaticHostUser(i), elements[i], cmpOpts...))
+				}
+			})
+
+			t.Run("paginated", func(t *testing.T) {
+				// Fetch a paginated list of objects
+				elements := make([]*userprovisioningpb.StaticHostUser, 0)
+				nextToken := ""
+				for {
+					out, token, err := service.ListStaticHostUsers(ctx, 2, nextToken)
+					require.NoError(t, err)
+					nextToken = token
+
+					elements = append(elements, out...)
+					if nextToken == "" {
+						break
+					}
+				}
+
+				for i := 0; i < count; i++ {
+					cmpOpts := []cmp.Option{
+						protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+						protocmp.Transform(),
+					}
+					require.Equal(t, "", cmp.Diff(getStaticHostUser(i), elements[i], cmpOpts...))
+				}
+			})
+		})
+	}
+}
+
+func getStaticHostUserService(t *testing.T) services.StaticHostUser {
+	backend, err := memory.New(memory.Config{
+		Context: context.Background(),
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	service, err := NewStaticHostUserService(backend)
+	require.NoError(t, err)
+	return service
+}
+
+func getStaticHostUser(index int) *userprovisioningpb.StaticHostUser {
+	name := fmt.Sprintf("obj%v", index)
+	return userprovisioning.NewStaticHostUser(name, &userprovisioningpb.StaticHostUserSpec{
+		Login:  "alice",
+		Groups: []string{"foo", "bar"},
+		Uid:    "1234",
+		Gid:    "1234",
+	})
+}
+
+func prepopulateStaticHostUsers(t *testing.T, service services.StaticHostUser, count int) {
+	for i := 0; i < count; i++ {
+		_, err := service.CreateStaticHostUser(context.Background(), getStaticHostUser(i))
+		require.NoError(t, err)
+	}
+}

--- a/lib/services/statichostuser.go
+++ b/lib/services/statichostuser.go
@@ -1,0 +1,96 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package services
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/gravitational/trace"
+
+	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// StaticHostUserService manages host users that should be created on SSH nodes.
+type StaticHostUser interface {
+	// ListStaticHostUsers lists static host users.
+	ListStaticHostUsers(ctx context.Context, pageSize int, pageToken string) ([]*userprovisioningpb.StaticHostUser, string, error)
+	// GetStaticHostUser returns a static host user by name.
+	GetStaticHostUser(ctx context.Context, name string) (*userprovisioningpb.StaticHostUser, error)
+	// CreateStaticHostUser creates a static host user.
+	CreateStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error)
+	// UpdateStaticHostUser updates a static host user.
+	UpdateStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error)
+	// UpsertStaticHostUser upserts a static host user.
+	UpsertStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error)
+	// DeleteStaticHostUser deletes a static host user. Note that this does not
+	// remove any host users created on nodes from the resource.
+	DeleteStaticHostUser(ctx context.Context, name string) error
+}
+
+func isValidUidOrGid(s string) bool {
+	// No uid/gid is OK.
+	if s == "" {
+		return true
+	}
+	// If uid/gid is present, it must be an integer (uid/gid are strings instead
+	// of ints to match user traits).
+	_, err := strconv.Atoi(s)
+	return err == nil
+}
+
+// ValidateStaticHostUser checks that required parameters are set for the
+// specified StaticHostUser.
+func ValidateStaticHostUser(u *userprovisioningpb.StaticHostUser) error {
+	if u == nil {
+		return trace.BadParameter("StaticHostUser is nil")
+	}
+	if u.Metadata == nil {
+		return trace.BadParameter("Metadata is nil")
+	}
+	if u.Metadata.Name == "" {
+		return trace.BadParameter("missing name")
+	}
+	if u.Spec == nil {
+		return trace.BadParameter("Spec is nil")
+	}
+	if u.Spec.Login == "" {
+		return trace.BadParameter("missing login")
+	}
+	if u.Spec.NodeLabels != nil {
+		for key, value := range u.Spec.NodeLabels.Values {
+			if key == types.Wildcard && !(len(value.Values) == 1 && value.Values[0] == types.Wildcard) {
+				return trace.BadParameter("selector *:<val> is not supported")
+			}
+		}
+	}
+	if len(u.Spec.NodeLabelsExpression) > 0 {
+		if _, err := parseLabelExpression(u.Spec.NodeLabelsExpression); err != nil {
+			return trace.BadParameter("parsing node labels expression: %v", err)
+		}
+	}
+	if !isValidUidOrGid(u.Spec.Uid) {
+		return trace.BadParameter("invalid uid: %q", u.Spec.Uid)
+	}
+	if !isValidUidOrGid(u.Spec.Gid) {
+		return trace.BadParameter("invalid gid: %q", u.Spec.Gid)
+	}
+	return nil
+}

--- a/lib/services/statichostuser_test.go
+++ b/lib/services/statichostuser_test.go
@@ -1,0 +1,143 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/userprovisioning"
+	"github.com/gravitational/teleport/api/types/wrappers"
+)
+
+func TestValidateStaticHostUser(t *testing.T) {
+	t.Parallel()
+
+	nodeLabels := func(labels map[string]string) *wrappers.LabelValues {
+		if len(labels) == 0 {
+			return nil
+		}
+		values := &wrappers.LabelValues{
+			Values: make(map[string]wrappers.StringValues, len(labels)),
+		}
+		for k, v := range labels {
+			values.Values[k] = wrappers.StringValues{
+				Values: []string{v},
+			}
+		}
+		return values
+	}
+
+	tests := []struct {
+		name     string
+		hostUser *userprovisioningpb.StaticHostUser
+		assert   require.ErrorAssertionFunc
+	}{
+		{
+			name:   "nil user",
+			assert: require.Error,
+		},
+		{
+			name: "no name",
+			hostUser: userprovisioning.NewStaticHostUser("", &userprovisioningpb.StaticHostUserSpec{
+				Login: "alice",
+			}),
+			assert: require.Error,
+		},
+		{
+			name:     "no spec",
+			hostUser: userprovisioning.NewStaticHostUser("alice_user", nil),
+			assert:   require.Error,
+		},
+		{
+			name:     "missing login",
+			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{}),
+			assert:   require.Error,
+		},
+		{
+			name: "invalid node labels",
+			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{
+				Login:      "alice",
+				NodeLabels: nodeLabels(map[string]string{types.Wildcard: "bar"}),
+			}),
+			assert: require.Error,
+		},
+		{
+			name: "invalid node labels expression",
+			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{
+				Login:                "alice",
+				NodeLabelsExpression: "foo bar xyz",
+			}),
+			assert: require.Error,
+		},
+		{
+			name: "valid wildcard labels",
+			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{
+				Login: "alice",
+				NodeLabels: nodeLabels(map[string]string{
+					"foo":          types.Wildcard,
+					types.Wildcard: types.Wildcard,
+				}),
+			}),
+			assert: require.NoError,
+		},
+		{
+			name: "non-numeric uid",
+			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{
+				Login:      "alice",
+				Groups:     []string{"foo", "bar"},
+				Uid:        "abcd",
+				Gid:        "1234",
+				NodeLabels: nodeLabels(map[string]string{"foo": "bar"}),
+			}),
+			assert: require.Error,
+		},
+		{
+			name: "non-numeric gid",
+			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{
+				Login:      "alice",
+				Groups:     []string{"foo", "bar"},
+				Uid:        "1234",
+				Gid:        "abcd",
+				NodeLabels: nodeLabels(map[string]string{"foo": "bar"}),
+			}),
+			assert: require.Error,
+		},
+		{
+			name: "ok",
+			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{
+				Login:                "alice",
+				Groups:               []string{"foo", "bar"},
+				Uid:                  "1234",
+				Gid:                  "5678",
+				NodeLabels:           nodeLabels(map[string]string{"foo": "bar"}),
+				NodeLabelsExpression: `labels["env"] == "staging" || labels["env"] == "test"`,
+			}),
+			assert: require.NoError,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.assert(t, ValidateStaticHostUser(tc.hostUser))
+		})
+	}
+}


### PR DESCRIPTION
This change adds a local service for the static host user resource ([RFD 175](https://github.com/gravitational/teleport/blob/master/rfd/0175-static-host-users.md)).

Part of #42712.