### PR TITLE
Revert "fix access request cache test race (#44653)"

### DIFF
--- a/lib/services/access_request_cache.go
+++ b/lib/services/access_request_cache.go
@@ -352,7 +352,6 @@ func (c *AccessRequestCache) getResourcesAndUpdateCurrent(ctx context.Context) e
 	c.rw.Lock()
 	defer c.rw.Unlock()
 	c.primaryCache = cache
-	close(c.initC)
 	return nil
 }
 
@@ -403,12 +402,6 @@ func (c *AccessRequestCache) initializationChan() <-chan struct{} {
 	c.rw.RLock()
 	defer c.rw.RUnlock()
 	return c.initC
-}
-
-// InitializationChan is part of the resourceCollector interface and gets the channel
-// used to signal that the accessRequestCache has been initialized.
-func (c *AccessRequestCache) InitializationChan() <-chan struct{} {
-	return c.initializationChan()
 }
 
 // Close terminates the background process that keeps the access request cache up to

--- a/lib/services/access_request_cache_test.go
+++ b/lib/services/access_request_cache_test.go
@@ -51,12 +51,6 @@ func newAccessRequestPack(t *testing.T) (accessRequestServices, *services.Access
 	})
 	require.NoError(t, err)
 
-	select {
-	case <-cache.InitializationChan():
-	case <-time.After(time.Second * 30):
-		require.FailNow(t, "timeout waiting for access request cache to initialize")
-	}
-
 	return svcs, cache
 }
 


### PR DESCRIPTION
Revert #44653  due to panic in auth servers that have backend connectivity interrupted.

changelog: Fixed an issue that could cause auth servers to panic when their backend connectivity was interrupted.