### PR TITLE
[v16] Machine ID: Allow Kubernetes Secret to be specified as output destination or data dir from the commandline.

### DIFF
--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -631,6 +631,27 @@ func destinationFromURI(uriString string) (bot.Destination, error) {
 			)
 		}
 		return &DestinationMemory{}, nil
+	case "kubernetes-secret":
+		if uri.Host != "" {
+			return nil, trace.BadParameter(
+				"kubernetes-secret scheme should not be specified with host",
+			)
+		}
+		if uri.Path == "" {
+			return nil, trace.BadParameter(
+				"kubernetes-secret scheme should have a path specified",
+			)
+		}
+		// kubernetes-secret:///my-secret
+		// TODO(noah): Eventually we'll support namespace in the host part of
+		// the URI. For now, we'll default to the namespace tbot is running in.
+
+		// Path will be prefixed with '/' so we'll strip it off.
+		secretName := strings.TrimPrefix(uri.Path, "/")
+
+		return &DestinationKubernetesSecret{
+			Name: secretName,
+		}, nil
 	default:
 		return nil, trace.BadParameter(
 			"unrecognized data storage scheme",

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -198,6 +198,19 @@ func TestDestinationFromURI(t *testing.T) {
 			in:      "foobar://",
 			wantErr: true,
 		},
+		{
+			in: "kubernetes-secret:///my-secret",
+			want: &DestinationKubernetesSecret{
+				Name: "my-secret",
+			},
+		},
+		{
+			in: "kubernetes-secret://my-secret",
+			want: &DestinationKubernetesSecret{
+				Name: "my-secret",
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {


### PR DESCRIPTION
Backport #44737 to branch/v16

changelog: Machine ID can now be configured to use Kubernetes Secret destinations from the command line using the `kubernetes-secret` schema.
