### PR TITLE
Align FetchRoleList to continue on missing role

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -8400,6 +8400,7 @@ func TestIsMFARequired_AdminAction(t *testing.T) {
 }
 
 func TestLocalUserAuthIfRoleDoesntExist(t *testing.T) {
+	t.Parallel()
 	testAuth, err := NewTestAuthServer(TestAuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
 	ctx := context.Background()

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -8411,8 +8411,8 @@ func TestLocalUserAuthIfRoleDoesntExist(t *testing.T) {
 	userCtx, err := authz.ContextForLocalUser(ctx, localUser, testAuth.AuthServer.Services, testAuth.ClusterName, true)
 	require.NoError(t, err)
 
-	got := convertRolesToSlice(userCtx.Checker.Roles())
-	want := []string{role.GetName(), constants.DefaultImplicitRole}
+	got := userCtx.Checker.RoleNames()
+	want := []string{role.GetName()}
 	require.Equal(t, want, got)
 
 	unknownRole := "unknown-role"
@@ -8420,15 +8420,7 @@ func TestLocalUserAuthIfRoleDoesntExist(t *testing.T) {
 	userCtx, err = authz.ContextForLocalUser(ctx, localUser, testAuth.AuthServer.Services, testAuth.ClusterName, true)
 	require.NoError(t, err)
 
-	got = convertRolesToSlice(userCtx.Checker.Roles())
-	want = []string{role.GetName(), constants.DefaultImplicitRole}
+	got = userCtx.Checker.RoleNames()
+	want = []string{role.GetName()}
 	require.Equal(t, want, got)
-}
-
-func convertRolesToSlice(roles []types.Role) []string {
-	var roleNames []string
-	for _, role := range roles {
-		roleNames = append(roleNames, role.GetName())
-	}
-	return roleNames
 }

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1330,7 +1330,7 @@ func ContextForLocalUser(ctx context.Context, u LocalUser, accessPoint Authorize
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	accessChecker, err := services.NewAccessChecker(accessInfo, clusterName, accessPoint, services.WithContinueIfRoleDoesntExists())
+	accessChecker, err := services.NewAccessChecker(accessInfo, clusterName, accessPoint)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1330,7 +1330,7 @@ func ContextForLocalUser(ctx context.Context, u LocalUser, accessPoint Authorize
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	accessChecker, err := services.NewAccessChecker(accessInfo, clusterName, accessPoint)
+	accessChecker, err := services.NewAccessChecker(accessInfo, clusterName, accessPoint, services.WithContinueIfRoleDoesntExists())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -309,8 +309,8 @@ type accessChecker struct {
 //     clusters.
 //   - `access RoleGetter` should be a RoleGetter which will be used to fetch the
 //     full RoleSet
-func NewAccessChecker(info *AccessInfo, localCluster string, access RoleGetter) (AccessChecker, error) {
-	roleSet, err := FetchRoles(info.Roles, access, info.Traits, WithContinueIfRoleDoesntExists())
+func NewAccessChecker(info *AccessInfo, localCluster string, access RoleGetter, opts ...FetchRolesOption) (AccessChecker, error) {
+	roleSet, err := FetchRoles(info.Roles, access, info.Traits, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -310,7 +310,7 @@ type accessChecker struct {
 //   - `access RoleGetter` should be a RoleGetter which will be used to fetch the
 //     full RoleSet
 func NewAccessChecker(info *AccessInfo, localCluster string, access RoleGetter) (AccessChecker, error) {
-	roleSet, err := FetchRoles(info.Roles, access, info.Traits)
+	roleSet, err := FetchRoles(info.Roles, access, info.Traits, WithContinueIfRoleDoesntExists())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -309,8 +309,8 @@ type accessChecker struct {
 //     clusters.
 //   - `access RoleGetter` should be a RoleGetter which will be used to fetch the
 //     full RoleSet
-func NewAccessChecker(info *AccessInfo, localCluster string, access RoleGetter, opts ...FetchRolesOption) (AccessChecker, error) {
-	roleSet, err := FetchRoles(info.Roles, access, info.Traits, opts...)
+func NewAccessChecker(info *AccessInfo, localCluster string, access RoleGetter) (AccessChecker, error) {
+	roleSet, err := FetchRoles(info.Roles, access, info.Traits, WithContinueIfRoleDoesntExists())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
### What


Fixed an issue where the `FetchRoleList` returned NotFound during the `authCtx, err := a.authorizer.Authorize(ctx)` flow, caused by an attempt to fetch a non-existing role:

Broken Behavior: 

https://github.com/user-attachments/assets/fd415129-b57a-4b40-877a-6891e3318e92


The `WithContinueIfRoleDoesntExist` option should be applied only to NewAccessChecker, where user permissions are evaluated. When a user has a role that doesn't exist, it seems reasonable to continue and skip that role. However, during certificate generation in the CSR process, roles need to prevent users to issue a CSR with in blank role that can be created in the future. 


changelog: Fixed an issue where deleting a role was causing access errors.