### PR TITLE
Fix rare TestResumption deadlock

### DIFF
--- a/lib/resumption/client.go
+++ b/lib/resumption/client.go
@@ -219,6 +219,12 @@ func runClientResumableUnlocking(ctx context.Context, resumableConn *Conn, first
 		case <-detached:
 		}
 
+		reconnectTicker.Stop()
+		select {
+		case <-reconnectTicker.Chan():
+		default:
+		}
+
 		slog.DebugContext(ctx, "connection lost, starting reconnection loop", "host_id", hostID)
 		reconnectDeadline := time.Now().Add(reconnectTimeout)
 		backoff := minBackoff
@@ -262,10 +268,6 @@ func runClientResumableUnlocking(ctx context.Context, resumableConn *Conn, first
 		}
 
 		reconnectTicker.Reset(replacementInterval)
-		select {
-		case <-reconnectTicker.Chan():
-		default:
-		}
 	}
 }
 

--- a/lib/resumption/resumption_test.go
+++ b/lib/resumption/resumption_test.go
@@ -212,6 +212,9 @@ func testResumption(t *testing.T, network, address string, expectedHostID string
 		default:
 		}
 
+		// wait until the reconnection loop has passed the reconnection phase
+		// and is waiting on the reconnection timer again
+		clock.BlockUntil(1)
 		clock.Advance(replacementInterval)
 		redialingSyncPoint <- struct{}{}
 


### PR DESCRIPTION
This PR disables the periodic reconnection ticker before running the reconnection-on-drop loop instead of resetting the ticker at the end of the loop. This enables TestResumption to correctly wait for the ticker to be running before advancing the fake clock that triggers the periodic reconnection in the test, [which can very rarely deadlock in tests](https://github.com/gravitational/teleport/actions/runs/10149459158/job/28064458163?pr=44610). The observable behavior of the resumable connection client is unaltered.