### PR TITLE
[v14] Fix flaky test for reissuing certificate for local kube proxy.

### DIFF
--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -531,12 +531,18 @@ func TestKubeMiddleware(t *testing.T) {
 		err := km.CheckAndSetDefaults()
 		require.NoError(t, err)
 
-		rw := responsewriters.NewMemoryResponseWriter()
-		// HandleRequest will reissue certificate if needed.
-		km.HandleRequest(rw, req)
+		var rw *responsewriters.MemoryResponseWriter
+		// We use `require.Eventually` to avoid a very rare test flakiness case when reissue goroutine manages to
+		// successfully finish before the parent goroutine has a chance to check the context (and see that it's expired).
+		require.Eventually(t, func() bool {
+			rw = responsewriters.NewMemoryResponseWriter()
+			// HandleRequest will reissue certificate if needed.
+			km.HandleRequest(rw, req)
 
-		// request timed out.
-		require.Equal(t, http.StatusInternalServerError, rw.Status())
+			// request timed out.
+			return rw.Status() == http.StatusInternalServerError
+
+		}, time.Second, 100*time.Millisecond)
 		require.Contains(t, rw.Buffer().String(), "context canceled")
 
 		// just let the reissuing goroutine some time to replace certs.

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -542,7 +542,7 @@ func TestKubeMiddleware(t *testing.T) {
 			// request timed out.
 			return rw.Status() == http.StatusInternalServerError
 
-		}, time.Second, 100*time.Millisecond)
+		}, 5*time.Second, 100*time.Millisecond)
 		require.Contains(t, rw.Buffer().String(), "context canceled")
 
 		// just let the reissuing goroutine some time to replace certs.


### PR DESCRIPTION
Backport #44723 to branch/v14