### PR TITLE
Fix HostCAs not being returned during bot renewal

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3385,8 +3385,13 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	// If the cert is renewable, process any certificate generation counter.
 	if certReq.renewable {
 		currentIdentityGeneration := a.context.Identity.GetIdentity().Generation
-
 		if experiment.Enabled() {
+			// If we're handling a renewal for a bot, we want to return the
+			// Host CAs as well as the User CAs.
+			if certReq.botName != "" {
+				certReq.includeHostCA = true
+			}
+
 			// Update the bot instance based on this authentication. This may create
 			// a new bot instance record if the identity is missing an instance ID.
 			if err := a.authServer.updateBotInstance(

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -194,6 +194,9 @@ func TestRegisterBotCertificateGenerationCheck(t *testing.T) {
 		renewedIdent, err := tlsca.FromSubject(renewedCert.Subject, renewedCert.NotAfter)
 		require.NoError(t, err)
 
+		// Validate that we receive 2 TLS CAs (Host and User)
+		require.Len(t, certs.TLSCACerts, 2)
+
 		// Cert must be renewable.
 		require.True(t, renewedIdent.Renewable)
 		require.False(t, renewedIdent.DisallowReissue)


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/41456

We used to set `includeHostCA` as a side effect in `validateGenerationLabel`, if you had the experiment enabled, then this is not called and the host CA was not included. This would cause failures after the first renewal.

Rather than continue to have this be a side effect of a helper, I've chosen to take a more explicit approach here.