### PR TITLE
Truncate AssumeRole session name to API limits

### DIFF
--- a/lib/srv/app/cloud.go
+++ b/lib/srv/app/cloud.go
@@ -191,7 +191,7 @@ func (c *cloud) getAWSSigninToken(ctx context.Context, req *AWSSigninRequest, en
 	options = append(options, func(creds *stscreds.AssumeRoleProvider) {
 		// Setting role session name to Teleport username will allow to
 		// associate CloudTrail events with the Teleport user.
-		creds.RoleSessionName = req.Identity.Username
+		creds.RoleSessionName = awsutils.TruncateRoleSessionName(req.Identity.Username)
 
 		// Setting web console session duration through AssumeRole call for AWS
 		// sessions with temporary credentials.

--- a/lib/utils/aws/aws.go
+++ b/lib/utils/aws/aws.go
@@ -68,6 +68,9 @@ const (
 	AmzJSON1_0 = "application/x-amz-json-1.0"
 	// AmzJSON1_1 is an AWS Content-Type header that indicates the media type is JSON.
 	AmzJSON1_1 = "application/x-amz-json-1.1"
+
+	// MaxRoleSessionName is the maximum length of the role session name used by the AssumeRole call.
+	MaxRoleSessionName = 64
 )
 
 // SigV4 contains parsed content of the AWS Authorization header.
@@ -483,4 +486,12 @@ func iamResourceARN(partition, accountID, resourceType, resourceName string) str
 		AccountID: accountID,
 		Resource:  fmt.Sprintf("%s/%s", resourceType, resourceName),
 	}.String()
+}
+
+// TruncateRoleSessionName truncates the role session name to AWS character limit (64).
+func TruncateRoleSessionName(roleSessionName string) string {
+	if len(roleSessionName) > MaxRoleSessionName {
+		return roleSessionName[:MaxRoleSessionName]
+	}
+	return roleSessionName
 }

--- a/lib/utils/aws/aws.go
+++ b/lib/utils/aws/aws.go
@@ -70,6 +70,7 @@ const (
 	AmzJSON1_1 = "application/x-amz-json-1.1"
 
 	// MaxRoleSessionName is the maximum length of the role session name used by the AssumeRole call.
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
 	MaxRoleSessionName = 64
 )
 

--- a/lib/utils/aws/aws_test.go
+++ b/lib/utils/aws/aws_test.go
@@ -493,3 +493,26 @@ func TestResourceARN(t *testing.T) {
 		})
 	}
 }
+
+func TestTruncateRoleSessionName(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		role     string
+		expected string
+	}{
+		{
+			name:     "role session name not truncated, less than 64 characters",
+			role:     "MyRole",
+			expected: "MyRole",
+		},
+		{
+			name:     "role session name truncated, longer than 64 characters",
+			role:     "remote-raimundo.oliveira@abigcompany.com-teleport.abigcompany.com",
+			expected: "remote-raimundo.oliveira@abigcompany.com-teleport.abigcompany.co",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, TruncateRoleSessionName(tt.role))
+		})
+	}
+}

--- a/lib/utils/aws/credentials.go
+++ b/lib/utils/aws/credentials.go
@@ -74,7 +74,7 @@ func (g *credentialsGetter) Get(_ context.Context, request GetCredentialsRequest
 	logrus.Debugf("Creating STS session %q for %q.", request.SessionName, request.RoleARN)
 	return stscreds.NewCredentials(request.Provider, request.RoleARN,
 		func(cred *stscreds.AssumeRoleProvider) {
-			cred.RoleSessionName = request.SessionName
+			cred.RoleSessionName = TruncateRoleSessionName(request.SessionName)
 			cred.Expiry.SetExpiration(request.Expiry, 0)
 
 			if request.ExternalID != "" {


### PR DESCRIPTION
The [issue](https://github.com/gravitational/teleport/issues/44833) describes the problem in more detail but essentially Teleport does not have any role session name restriction when calling AWS AssumeRole API. This is causing an AWS API error to propagate to the client and prevents calling the AWS API through Teleport in some conditions (the issue is likely more frequent in trusted clusters configurations due to the way the role session name is computed).  

This PR proposes a potential fix regarding the limitation above by truncating the role session name to match AWS AssumeRole API limits.  

The error that is being propagated to the client is:
```
... roleSessionName - failed to satisfy constraint: Member must have length less than or equal to 64...
```

Issue https://github.com/gravitational/teleport/issues/44833