### PR TITLE
Document SSO caveats on UserSpecV2.TrustedDeviceIDs

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -3490,6 +3490,13 @@ message UserSpecV2 {
   LocalAuthSecrets LocalAuth = 9 [(gogoproto.jsontag) = "local_auth,omitempty"];
 
   // TrustedDeviceIDs contains the IDs of trusted devices enrolled by the user.
+  //
+  // Note that SSO users are transient and thus may contain an empty
+  // TrustedDeviceIDs field, even though the user->device association exists
+  // under the Device Trust subsystem. Do not rely on this field to determine
+  // device associations or ownership, it exists for legacy/informative purposes
+  // only.
+  //
   // Managed by the Device Trust subsystem, avoid manual edits.
   repeated string TrustedDeviceIDs = 10 [(gogoproto.jsontag) = "trusted_device_ids,omitempty"];
 }

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -8757,6 +8757,13 @@ type UserSpecV2 struct {
 	// authentication
 	LocalAuth *LocalAuthSecrets `protobuf:"bytes,9,opt,name=LocalAuth,proto3" json:"local_auth,omitempty"`
 	// TrustedDeviceIDs contains the IDs of trusted devices enrolled by the user.
+	//
+	// Note that SSO users are transient and thus may contain an empty
+	// TrustedDeviceIDs field, even though the user->device association exists
+	// under the Device Trust subsystem. Do not rely on this field to determine
+	// device associations or ownership, it exists for legacy/informative purposes
+	// only.
+	//
 	// Managed by the Device Trust subsystem, avoid manual edits.
 	TrustedDeviceIDs     []string `protobuf:"bytes,10,rep,name=TrustedDeviceIDs,proto3" json:"trusted_device_ids,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/docs/pages/reference/terraform-provider/data-sources/user.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/user.mdx
@@ -46,7 +46,7 @@ Optional:
 - `roles` (List of String) Roles is a list of roles assigned to user
 - `saml_identities` (Attributes List) SAMLIdentities lists associated SAML identities that let user log in using externally verified identity (see [below for nested schema](#nested-schema-for-specsaml_identities))
 - `traits` (Map of List of String)
-- `trusted_device_ids` (List of String) TrustedDeviceIDs contains the IDs of trusted devices enrolled by the user. Managed by the Device Trust subsystem, avoid manual edits.
+- `trusted_device_ids` (List of String) TrustedDeviceIDs contains the IDs of trusted devices enrolled by the user.  Note that SSO users are transient and thus may contain an empty TrustedDeviceIDs field, even though the user->device association exists under the Device Trust subsystem. Do not rely on this field to determine device associations or ownership, it exists for legacy/informative purposes only.  Managed by the Device Trust subsystem, avoid manual edits.
 
 ### Nested Schema for `spec.github_identities`
 

--- a/docs/pages/reference/terraform-provider/resources/user.mdx
+++ b/docs/pages/reference/terraform-provider/resources/user.mdx
@@ -92,7 +92,7 @@ Optional:
 - `roles` (List of String) Roles is a list of roles assigned to user
 - `saml_identities` (Attributes List) SAMLIdentities lists associated SAML identities that let user log in using externally verified identity (see [below for nested schema](#nested-schema-for-specsaml_identities))
 - `traits` (Map of List of String)
-- `trusted_device_ids` (List of String) TrustedDeviceIDs contains the IDs of trusted devices enrolled by the user. Managed by the Device Trust subsystem, avoid manual edits.
+- `trusted_device_ids` (List of String) TrustedDeviceIDs contains the IDs of trusted devices enrolled by the user.  Note that SSO users are transient and thus may contain an empty TrustedDeviceIDs field, even though the user->device association exists under the Device Trust subsystem. Do not rely on this field to determine device associations or ownership, it exists for legacy/informative purposes only.  Managed by the Device Trust subsystem, avoid manual edits.
 
 ### Nested Schema for `spec.github_identities`
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_users.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_users.yaml
@@ -119,8 +119,12 @@ spec:
                 type: object
               trusted_device_ids:
                 description: TrustedDeviceIDs contains the IDs of trusted devices
-                  enrolled by the user. Managed by the Device Trust subsystem, avoid
-                  manual edits.
+                  enrolled by the user.  Note that SSO users are transient and thus
+                  may contain an empty TrustedDeviceIDs field, even though the user->device
+                  association exists under the Device Trust subsystem. Do not rely
+                  on this field to determine device associations or ownership, it
+                  exists for legacy/informative purposes only.  Managed by the Device
+                  Trust subsystem, avoid manual edits.
                 items:
                   type: string
                 nullable: true

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_users.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_users.yaml
@@ -119,8 +119,12 @@ spec:
                 type: object
               trusted_device_ids:
                 description: TrustedDeviceIDs contains the IDs of trusted devices
-                  enrolled by the user. Managed by the Device Trust subsystem, avoid
-                  manual edits.
+                  enrolled by the user.  Note that SSO users are transient and thus
+                  may contain an empty TrustedDeviceIDs field, even though the user->device
+                  association exists under the Device Trust subsystem. Do not rely
+                  on this field to determine device associations or ownership, it
+                  exists for legacy/informative purposes only.  Managed by the Device
+                  Trust subsystem, avoid manual edits.
                 items:
                   type: string
                 nullable: true

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -2582,7 +2582,7 @@ func GenSchemaUserV2(ctx context.Context) (github_com_hashicorp_terraform_plugin
 				},
 				"traits": GenSchemaTraits(ctx),
 				"trusted_device_ids": {
-					Description: "TrustedDeviceIDs contains the IDs of trusted devices enrolled by the user. Managed by the Device Trust subsystem, avoid manual edits.",
+					Description: "TrustedDeviceIDs contains the IDs of trusted devices enrolled by the user.  Note that SSO users are transient and thus may contain an empty TrustedDeviceIDs field, even though the user->device association exists under the Device Trust subsystem. Do not rely on this field to determine device associations or ownership, it exists for legacy/informative purposes only.  Managed by the Device Trust subsystem, avoid manual edits.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},


### PR DESCRIPTION
Document that UserSpecV2.TrustedDeviceIDs may (and will!) disappear for SSO users.

The "correct" query is now under [e/lib/devicetrust/storage.S.GetUserTrustedDeviceIDs][1].

#44598

[1]: https://github.com/gravitational/teleport.e/blob/bbcb3f9e94533d5f165a3ea345deb7aa9164246e/lib/devicetrust/storage/storage.go#L1082