### PR TITLE
Add discovery label account ID when deploying services

### DIFF
--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -197,7 +197,7 @@ func (h *Handler) awsOIDCDeployDatabaseServices(w http.ResponseWriter, r *http.R
 			types.Labels{
 				types.DiscoveryLabelVPCID:     []string{d.VPCID},
 				types.DiscoveryLabelRegion:    []string{req.Region},
-				types.DiscoveryLabelAccountID: []string{req.AccountId},
+				types.DiscoveryLabelAccountID: []string{req.AccountID},
 			},
 		)
 		if err != nil {

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -195,8 +195,9 @@ func (h *Handler) awsOIDCDeployDatabaseServices(w http.ResponseWriter, r *http.R
 			h.PublicProxyAddr(),
 			iamTokenName,
 			types.Labels{
-				types.DiscoveryLabelVPCID:  []string{d.VPCID},
-				types.DiscoveryLabelRegion: []string{req.Region},
+				types.DiscoveryLabelVPCID:     []string{d.VPCID},
+				types.DiscoveryLabelRegion:    []string{req.Region},
+				types.DiscoveryLabelAccountID: []string{req.AccountId},
 			},
 		)
 		if err != nil {

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -237,8 +237,8 @@ type AWSOIDCDeployDatabaseServiceRequest struct {
 	// Region is the AWS Region for the Service.
 	Region string `json:"region"`
 
-	// AccountId is the AWS account to deploy service to.
-	AccountId string `json:"accountId"`
+	// AccountID is the AWS account to deploy service to.
+	AccountID string `json:"accountId"`
 
 	// TaskRoleARN is the AWS Role's ARN used within the Task execution.
 	// Ensure the AWS Client's Role has `iam:PassRole` for this Role's ARN.

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -237,6 +237,9 @@ type AWSOIDCDeployDatabaseServiceRequest struct {
 	// Region is the AWS Region for the Service.
 	Region string `json:"region"`
 
+	// AccountId is the AWS account to deploy service to.
+	AccountId string `json:"accountId"`
+
 	// TaskRoleARN is the AWS Role's ARN used within the Task execution.
 	// Ensure the AWS Client's Role has `iam:PassRole` for this Role's ARN.
 	// This can be either the ARN or the short name of the AWS Role.

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
@@ -42,6 +42,7 @@ import {
   DiscoverServiceDeployType,
 } from 'teleport/services/userEvent';
 import cfg from 'teleport/config';
+import { splitAwsIamArn } from 'teleport/services/integrations/aws';
 
 import {
   ActionButtons,
@@ -102,9 +103,13 @@ export function AutoDeploy({ toggleDeployMethod }: DeployServiceProp) {
         dbMeta.autoDiscovery.requiredVpcsAndSubnets;
       const vpcIds = Object.keys(requiredVpcsAndSubnets);
 
+      const { awsAccountId } = splitAwsIamArn(
+        agentMeta.awsIntegration.spec.roleArn
+      );
       integrationService
         .deployDatabaseServices(integrationName, {
           region: dbMeta.awsRegion,
+          accountId: awsAccountId,
           taskRoleArn,
           deployments: vpcIds.map(vpcId => ({
             vpcId,

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -324,6 +324,8 @@ type DeployDatabaseServiceDeployment = {
 // -account-id: <AccountID>s
 // -vpc-id: <Deployments[].VPCID>
 export type AwsOidcDeployDatabaseServicesRequest = {
+  // The aws account to deploy the db service to.
+  accountId: string;
   // Region is the AWS Region for the Service.
   region: string;
   // TaskRoleARN is the AWS Role's ARN used within the Task execution.

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -324,7 +324,7 @@ type DeployDatabaseServiceDeployment = {
 // -account-id: <AccountID>s
 // -vpc-id: <Deployments[].VPCID>
 export type AwsOidcDeployDatabaseServicesRequest = {
-  // The aws account to deploy the db service to.
+  // The AWS account to deploy the db service to.
   accountId: string;
   // Region is the AWS Region for the Service.
   region: string;


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/41004

We overlooked in adding an account id label when deploying services, this PR adds it.

just FYI the single enrollment flow, doesn't add any discovery labels (we let users define their own, or default to asterisks)