### PR TITLE
Fix Help And Support links

### DIFF
--- a/web/packages/teleport/src/Support/Support.tsx
+++ b/web/packages/teleport/src/Support/Support.tsx
@@ -174,9 +174,9 @@ const getDocUrls = (version = '', isEnterprise: boolean) => {
   }
 
   return {
-    getStarted: withUTM(`https://goteleport.com/docs${docVer}/getting-started`),
+    getStarted: withUTM(`https://goteleport.com/docs${docVer}`),
     tshGuide: withUTM(
-      `https://goteleport.com/docs${docVer}/server-access/guides/tsh`
+      `https://goteleport.com/docs${docVer}/connect-your-client/tsh/`
     ),
     adminGuide: withUTM(
       `https://goteleport.com/docs${docVer}/management/admin/`

--- a/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
+++ b/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
@@ -249,7 +249,7 @@ exports[`support Cloud 1`] = `
         </div>
         <a
           class="c12"
-          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -257,7 +257,7 @@ exports[`support Cloud 1`] = `
         </a>
         <a
           class="c12"
-          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/connect-your-client/tsh/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -695,7 +695,7 @@ exports[`support Enterprise 1`] = `
         </div>
         <a
           class="c12"
-          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -703,7 +703,7 @@ exports[`support Enterprise 1`] = `
         </a>
         <a
           class="c12"
-          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/connect-your-client/tsh/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1238,7 +1238,7 @@ exports[`support Enterprise with CTA 1`] = `
         </div>
         <a
           class="c12"
-          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1246,7 +1246,7 @@ exports[`support Enterprise with CTA 1`] = `
         </a>
         <a
           class="c12"
-          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/connect-your-client/tsh/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1677,7 +1677,7 @@ exports[`support OSS 1`] = `
         </div>
         <a
           class="c12"
-          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1685,7 +1685,7 @@ exports[`support OSS 1`] = `
         </a>
         <a
           class="c12"
-          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/connect-your-client/tsh/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2220,7 +2220,7 @@ exports[`support OSSWithCTA 1`] = `
         </div>
         <a
           class="c12"
-          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2228,7 +2228,7 @@ exports[`support OSSWithCTA 1`] = `
         </a>
         <a
           class="c12"
-          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/connect-your-client/tsh/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >


### PR DESCRIPTION
We moved some docs around and the links no longer work.
This PR fixes the links