### PR TITLE
VNet: Use NSObject instead of C struct in XPC message

### DIFF
--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -30,7 +30,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -261,28 +260,20 @@ func startByCalling(ctx context.Context, bundlePath string, config Config) error
 	errC := make(chan error, 1)
 
 	go func() {
-		var pinner runtime.Pinner
-		defer pinner.Unpin()
-
 		req := C.StartVnetRequest{
 			bundle_path: C.CString(bundlePath),
-			vnet_config: &C.VnetConfig{
-				socket_path: C.CString(config.SocketPath),
-				ipv6_prefix: C.CString(config.IPv6Prefix),
-				dns_addr:    C.CString(config.DNSAddr),
-				home_path:   C.CString(config.HomePath),
-			},
+			socket_path: C.CString(config.SocketPath),
+			ipv6_prefix: C.CString(config.IPv6Prefix),
+			dns_addr:    C.CString(config.DNSAddr),
+			home_path:   C.CString(config.HomePath),
 		}
 		defer func() {
 			C.free(unsafe.Pointer(req.bundle_path))
-			C.free(unsafe.Pointer(req.vnet_config.socket_path))
-			C.free(unsafe.Pointer(req.vnet_config.ipv6_prefix))
-			C.free(unsafe.Pointer(req.vnet_config.dns_addr))
-			C.free(unsafe.Pointer(req.vnet_config.home_path))
+			C.free(unsafe.Pointer(req.socket_path))
+			C.free(unsafe.Pointer(req.ipv6_prefix))
+			C.free(unsafe.Pointer(req.dns_addr))
+			C.free(unsafe.Pointer(req.home_path))
 		}()
-		// Structs passed directly as arguments to cgo functions are automatically pinned.
-		// However, structs within structs have to be pinned by hand.
-		pinner.Pin(req.vnet_config)
 
 		var res C.StartVnetResult
 		defer func() {

--- a/lib/vnet/daemon/client_darwin.h
+++ b/lib/vnet/daemon/client_darwin.h
@@ -38,7 +38,11 @@ void OpenSystemSettingsLoginItems(void);
 
 typedef struct StartVnetRequest {
   const char *bundle_path;
-  VnetConfig *vnet_config;
+
+  const char *socket_path;
+  const char *ipv6_prefix;
+  const char *dns_addr;
+  const char *home_path;
 } StartVnetRequest;
 
 typedef struct StartVnetResult {
@@ -73,7 +77,7 @@ void StartVnet(StartVnetRequest *request, StartVnetResult *outResult);
 void InvalidateDaemonClient(void);
 
 @interface VNEDaemonClient : NSObject
-- (void)startVnet:(VnetConfig *)vnetConfig completion:(void (^)(NSError *error))completion;
+- (void)startVnet:(VNEConfig *)config completion:(void (^)(NSError *error))completion;
 // invalidate executes all outstanding reply blocks, error handling blocks,
 // and invalidation blocks and forbids from sending or receiving new messages.
 - (void)invalidate;

--- a/lib/vnet/daemon/client_darwin.m
+++ b/lib/vnet/daemon/client_darwin.m
@@ -73,15 +73,11 @@ void OpenSystemSettingsLoginItems(void) {
   }
 }
 
-@interface VNEDaemonClient ()
-
-@property(nonatomic, strong, readwrite) NSXPCConnection *connection;
-@property(nonatomic, strong, readonly) NSString *bundlePath;
-@property(nonatomic, strong, readonly) NSString *codeSigningRequirement;
-
-@end
-
-@implementation VNEDaemonClient
+@implementation VNEDaemonClient {
+  NSXPCConnection *_connection;
+  NSString *_bundlePath;
+  NSString *_codeSigningRequirement;
+}
 
 - (id)initWithBundlePath:(NSString *)bundlePath codeSigningRequirement:(NSString *)codeSigningRequirement {
   self = [super init];

--- a/lib/vnet/daemon/client_darwin.m
+++ b/lib/vnet/daemon/client_darwin.m
@@ -111,7 +111,7 @@ void OpenSystemSettingsLoginItems(void) {
   return _connection;
 }
 
-- (void)startVnet:(VnetConfig *)vnetConfig completion:(void (^)(NSError *))completion {
+- (void)startVnet:(VNEConfig *)config completion:(void (^)(NSError *))completion {
   // This way of calling the XPC proxy ensures either the error handler or
   // the reply block gets called.
   // https://forums.developer.apple.com/forums/thread/713429
@@ -119,10 +119,9 @@ void OpenSystemSettingsLoginItems(void) {
     completion(error);
   }];
 
-  [(id<VNEDaemonProtocol>)proxy startVnet:vnetConfig
-                               completion:^(NSError *error) {
-                                 completion(error);
-                               }];
+  [(id<VNEDaemonProtocol>)proxy startVnet:config completion:^(NSError *error) {
+    completion(error);
+  }];
 }
 
 - (void)invalidate {
@@ -151,9 +150,15 @@ void StartVnet(StartVnetRequest *request, StartVnetResult *outResult) {
     daemonClient = [[VNEDaemonClient alloc] initWithBundlePath:@(request->bundle_path) codeSigningRequirement:requirement];
   }
 
+  VNEConfig *config = [[VNEConfig alloc] init];
+  [config setSocketPath:@(request->socket_path)];
+  [config setIpv6Prefix:@(request->ipv6_prefix)];
+  [config setDnsAddr:@(request->dns_addr)];
+  [config setHomePath:@(request->home_path)];
+
   dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
-  [daemonClient startVnet:request->vnet_config
+  [daemonClient startVnet:config
                completion:^(NSError *error) {
                  if (error) {
                    outResult->ok = false;

--- a/lib/vnet/daemon/common_darwin.m
+++ b/lib/vnet/daemon/common_darwin.m
@@ -16,6 +16,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#include "common_darwin.h"
 
 #import <CoreFoundation/CoreFoundation.h>
 #import <Foundation/Foundation.h>
@@ -118,3 +119,27 @@ bool getCodeSigningRequirement(NSString **outRequirement, NSError **outError) {
 
   return true;
 }
+
+@implementation VNEConfig
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(nonnull NSCoder *)coder {
+  [coder encodeObject:self.socketPath forKey:@"socketPath"];
+  [coder encodeObject:self.ipv6Prefix forKey:@"ipv6Prefix"];
+  [coder encodeObject:self.dnsAddr forKey:@"dnsAddr"];
+  [coder encodeObject:self.homePath forKey:@"homePath"];
+}
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)coder {
+  if (self = [super init]) {
+    [self setSocketPath:[coder decodeObjectOfClass:[NSString class] forKey:@"socketPath"]];
+    [self setIpv6Prefix:[coder decodeObjectOfClass:[NSString class] forKey:@"ipv6Prefix"]];
+    [self setDnsAddr:[coder decodeObjectOfClass:[NSString class] forKey:@"dnsAddr"]];
+    [self setHomePath:[coder decodeObjectOfClass:[NSString class] forKey:@"homePath"]];
+  }
+  return self;
+}
+
+@end


### PR DESCRIPTION
Edoardo asked if we need to worry about the size of the C struct that's passed in the XPC message between the client and the daemon service (https://github.com/gravitational/teleport/pull/44751#discussion_r1696692223). This might be the case if the client uses a different version of tsh where the struct happens to have, say, new fields. It didn't occur to me to check this. But after a quick test it turned out that XPC is smart enough to reject messages where the size of the struct doesn't match (check the linked comment for more details).

However, this also means that instead of getting a clear error on the daemon side when incompatible tsh versions talk to each other, we'll see the error only when running Console.app. To make sure this doesn't happen in the future, I replaced the C struct with an `NSObject`, which [by necessity must implement `NSSecureCoding`](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html#//apple_ref/doc/uid/10000172i-SW6-SW7) ([docs for `NSSecureCoding`](https://developer.apple.com/documentation/foundation/nssecurecoding?language=objc)).

To that end, now that I know a little more about properties in Obj-C, I also cleaned up how they're defined and accessed.

## A quick primer on properties in Obj-C

Each property is backed by an instance variable, automatically created by the compiler when you declare a property through `@property …` inside `@interface`. This is similar to any other object-oriented language where if you want to expose an instance variable you define some kind of a getter (and perhaps a setter). `@property foo` defines an ivar `_foo`.

By default, properties have the following attributes:

* [`atomic`](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/EncapsulatingData/EncapsulatingData.html#//apple_ref/doc/uid/TP40011210-CH5-SW37): "Property atomicity is not synonymous with an object’s thread safety". As far as I understand it, a setter for example can perform multiple operations on the underlying ivar and this attribute makes sure that the ivar doesn't change for the duration of the setter. 
* [`readwrite`](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/EncapsulatingData/EncapsulatingData.html#//apple_ref/doc/uid/TP40011210-CH5-SW5): both accessors are generated for the property, unlike `readonly` which creates only the getter.
* [`strong`](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/EncapsulatingData/EncapsulatingData.html#//apple_ref/doc/uid/TP40011210-CH5-SW30): uses a strong reference for the ivar. It has to do with reference counting, the linked docs includes an explanation, I also found [a pretty entertaining one using balloons to demonstrate the concept](https://stackoverflow.com/a/18344946/742872).

As far as I understand, this has changed over time, e.g. before Arc `strong` wasn't the default attribute. The code I based the implementation of the launch daemon on is also pretty old, as well as half of the SO answers you can find about Obj-C. As such, I ended up including a bunch of cruft that can be removed. A couple of examples:

* People often add `nonatomic` if they know they don't have to worry about thread safety because it makes accessing properties "faster". But we only ever send a single message, so we don't have to worry about it at all.
* A good practice is to use [`copy` for `NSString` properties](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/EncapsulatingData/EncapsulatingData.html#//apple_ref/doc/uid/TP40011210-CH5-SW35) in case `NSMutableString` is provided to the setter. But this doesn't matter if the property is `readonly` since there's no setter.
* Properties can be accessed using the dot shorthand instead of having to use square brackets. `[[foo bar] baz]` can be just `foo.bar.baz` or `[foo.bar baz]` if `baz` is a method call.
* Declaring ivars inside `@implementation` blocks [was added circa 2012](https://stackoverflow.com/a/8840959/742872), so people used to add properties because there was no other choice. But a property is needed only if we need to make the ivar public. Here's an example of defining private ivars inside `@implementation`:

https://github.com/gravitational/teleport/blob/b03f33cca169cbd457c5c20f62f4321202d5fea8/lib/vnet/daemon/service_darwin.m#L46-L49