### PR TITLE
Strictly check attributes in button wrappers

### DIFF
--- a/web/packages/design/src/Button/Button.tsx
+++ b/web/packages/design/src/Button/Button.tsx
@@ -31,6 +31,7 @@ import {
   WidthProps,
   HeightProps,
   AlignSelfProps,
+  GapProps,
 } from 'design/system';
 import { TextAndBackgroundColors, Theme } from 'design/theme/themes/types';
 
@@ -39,7 +40,8 @@ export type ButtonProps<E extends React.ElementType> =
     SpaceProps &
     WidthProps &
     HeightProps &
-    AlignSelfProps & {
+    AlignSelfProps &
+    GapProps & {
       /**
        * Specifies if an element's display is set to block or not. Set to true
        * to set display to block.
@@ -368,21 +370,21 @@ const StyledButton = styled.button`
   ${themedStyles}
 `;
 
-export const ButtonPrimary = <E extends React.ElementType>(
+export const ButtonPrimary = <E extends React.ElementType = 'button'>(
   props: ButtonProps<E>
 ) => <Button fill="filled" intent="primary" {...props} />;
-export const ButtonSecondary = <E extends React.ElementType>(
+export const ButtonSecondary = <E extends React.ElementType = 'button'>(
   props: ButtonProps<E>
 ) => <Button fill="filled" intent="neutral" {...props} />;
-export const ButtonBorder = <E extends React.ElementType>(
+export const ButtonBorder = <E extends React.ElementType = 'button'>(
   props: ButtonProps<E>
 ) => <Button fill="border" intent="neutral" {...props} />;
-export const ButtonWarning = <E extends React.ElementType>(
+export const ButtonWarning = <E extends React.ElementType = 'button'>(
   props: ButtonProps<E>
 ) => <Button fill="filled" intent="danger" {...props} />;
-export const ButtonWarningBorder = <E extends React.ElementType>(
+export const ButtonWarningBorder = <E extends React.ElementType = 'button'>(
   props: ButtonProps<E>
 ) => <Button fill="border" intent="danger" {...props} />;
-export const ButtonText = <E extends React.ElementType>(
+export const ButtonText = <E extends React.ElementType = 'button'>(
   props: ButtonProps<E>
 ) => <Button fill="minimal" intent="neutral" {...props} />;

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -378,7 +378,7 @@ type SortMenuProps = {
   sortType: string;
   sortDir: SortDir;
   onChange: (value: string) => void;
-  onDirChange: (dir: SortDir) => void;
+  onDirChange: () => void;
 };
 
 const SortMenu: React.FC<SortMenuProps> = props => {

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -368,7 +368,7 @@ function TokenDelete({
   attempt,
 }: {
   token: JoinToken;
-  onDelete: (token: string) => Promise<any>;
+  onDelete: () => void;
   onClose: () => void;
   attempt: Attempt<void>;
 }) {

--- a/web/packages/teleport/src/Login/Motd/Motd.tsx
+++ b/web/packages/teleport/src/Login/Motd/Motd.tsx
@@ -28,13 +28,7 @@ export function Motd({ message, onClick }: Props) {
         <StyledText typography="body1" mb={3} textAlign="left">
           {message}
         </StyledText>
-        <ButtonPrimary
-          width="100%"
-          mt={3}
-          size="large"
-          onClick={onClick}
-          align="center"
-        >
+        <ButtonPrimary width="100%" mt={3} size="large" onClick={onClick}>
           Acknowledge
         </ButtonPrimary>
       </Box>

--- a/web/packages/teleport/src/Users/UserAddEdit/TraitsEditor.tsx
+++ b/web/packages/teleport/src/Users/UserAddEdit/TraitsEditor.tsx
@@ -190,7 +190,6 @@ export function TraitsEditor({
       <Box mt={5}>
         <ButtonBorder
           onClick={addNewTraitPair}
-          label={addLabelText}
           css={`
             padding-left: 12px;
             &:disabled {


### PR DESCRIPTION
Previously, though the `Button` component had strict attribute checking, the wrappers accidentally turned it off.

Requires https://github.com/gravitational/teleport.e/pull/4799