### PR TITLE
Fix the button border color for the neutral+border combination

### DIFF
--- a/web/packages/design/src/Button/Button.tsx
+++ b/web/packages/design/src/Button/Button.tsx
@@ -253,7 +253,7 @@ const buttonPalette = <E extends React.ElementType>({
         return {
           default: {
             text: colors.text.slightlyMuted,
-            border: colors.interactive.tonal.neutral[0].background,
+            border: colors.interactive.tonal.neutral[2].background,
             background: 'transparent',
           },
           hover: colors.interactive.tonal.neutral[1],

--- a/web/packages/design/src/Button/Button.tsx
+++ b/web/packages/design/src/Button/Button.tsx
@@ -252,7 +252,7 @@ const buttonPalette = <E extends React.ElementType>({
       if (intent === 'neutral') {
         return {
           default: {
-            text: colors.text.muted,
+            text: colors.text.slightlyMuted,
             border: colors.interactive.tonal.neutral[0].background,
             background: 'transparent',
           },

--- a/web/packages/design/src/Button/Button.tsx
+++ b/web/packages/design/src/Button/Button.tsx
@@ -158,21 +158,21 @@ const buttonStyle = <E extends React.ElementType>(
   const { fill, intent } = props;
   const palette = buttonPalette(props);
   return {
-    backgroundColor: palette.default.background ?? 'transparent',
+    backgroundColor: palette.default.background,
     color: palette.default.text,
     borderColor: palette.default.border ?? 'transparent',
     ['&:focus-visible, .teleport-button__force-focus-visible &']: {
-      backgroundColor: palette.focus.background ?? 'transparent',
+      backgroundColor: palette.focus.background,
       color: palette.focus.text,
       borderColor: palette.focus.border ?? 'transparent',
       borderRadius: intent === 'neutral' || fill === 'minimal' ? '4px' : '2px',
       outline:
         intent !== 'neutral' && fill !== 'minimal'
-          ? `2px solid ${palette.focus.background ?? 'transparent'}`
+          ? `2px solid ${palette.focus.background}`
           : 'none',
     },
     '&:hover, .teleport-button__force-hover &': {
-      backgroundColor: palette.hover.background ?? 'transparent',
+      backgroundColor: palette.hover.background,
       borderColor: palette.hover.border ?? 'transparent',
       color: palette.hover.text,
       boxShadow:
@@ -183,7 +183,7 @@ const buttonStyle = <E extends React.ElementType>(
             0px 1px 14px 0px rgba(0, 0, 0, 0.12)`,
     },
     '&:active, .teleport-button__force-active &': {
-      backgroundColor: palette.active.background ?? 'transparent',
+      backgroundColor: palette.active.background,
       borderColor: palette.active.border ?? 'transparent',
       color: palette.active.text,
     },
@@ -192,7 +192,7 @@ const buttonStyle = <E extends React.ElementType>(
 
 type ButtonPaletteEntry = {
   text: string;
-  background?: string;
+  background: string;
   border?: string;
 };
 
@@ -238,12 +238,14 @@ const buttonPalette = <E extends React.ElementType>({
             intent === 'neutral'
               ? colors.text.slightlyMuted
               : colors.interactive.solid[intent].default.background,
+          background: 'transparent',
         },
         hover: colors.interactive.tonal[intent][0],
         active: colors.interactive.tonal[intent][1],
         focus: {
           text: colors.interactive.tonal[intent][0].text,
           border: colors.interactive.tonal[intent][0].text,
+          background: 'transparent',
         },
       };
     case 'border':
@@ -252,6 +254,7 @@ const buttonPalette = <E extends React.ElementType>({
           default: {
             text: colors.text.muted,
             border: colors.interactive.tonal.neutral[0].background,
+            background: 'transparent',
           },
           hover: colors.interactive.tonal.neutral[1],
           active: colors.interactive.tonal.neutral[2],
@@ -265,6 +268,7 @@ const buttonPalette = <E extends React.ElementType>({
           default: {
             text: colors.interactive.solid[intent].default.background,
             border: colors.interactive.solid[intent].default.background,
+            background: 'transparent',
           },
           hover: colors.interactive.solid[intent].hover,
           active: colors.interactive.solid[intent].active,

--- a/web/packages/design/src/Button/Button.tsx
+++ b/web/packages/design/src/Button/Button.tsx
@@ -32,7 +32,7 @@ import {
   HeightProps,
   AlignSelfProps,
 } from 'design/system';
-import { TextAndBackgroundColors, Theme } from 'design/theme/themes/types';
+import { Theme } from 'design/theme/themes/types';
 
 export type ButtonProps<E extends React.ElementType> =
   React.ComponentPropsWithoutRef<E> &
@@ -158,23 +158,22 @@ const buttonStyle = <E extends React.ElementType>(
   const { fill, intent } = props;
   const palette = buttonPalette(props);
   return {
-    backgroundColor: palette.default.background,
+    backgroundColor: palette.default.background ?? 'transparent',
     color: palette.default.text,
-    borderColor: props.fill === 'border' ? palette.default.text : 'transparent',
+    borderColor: palette.default.border ?? 'transparent',
     ['&:focus-visible, .teleport-button__force-focus-visible &']: {
-      backgroundColor:
-        props.fill !== 'minimal' ? palette.focus.background : 'transparent',
+      backgroundColor: palette.focus.background ?? 'transparent',
       color: palette.focus.text,
-      borderColor: palette.focus.text,
+      borderColor: palette.focus.border ?? 'transparent',
       borderRadius: intent === 'neutral' || fill === 'minimal' ? '4px' : '2px',
       outline:
         intent !== 'neutral' && fill !== 'minimal'
-          ? `2px solid ${palette.focus.background}`
+          ? `2px solid ${palette.focus.background ?? 'transparent'}`
           : 'none',
     },
     '&:hover, .teleport-button__force-hover &': {
-      backgroundColor: palette.hover.background,
-      borderColor: 'transparent',
+      backgroundColor: palette.hover.background ?? 'transparent',
+      borderColor: palette.hover.border ?? 'transparent',
       color: palette.hover.text,
       boxShadow:
         intent === 'neutral' || fill === 'minimal'
@@ -184,18 +183,24 @@ const buttonStyle = <E extends React.ElementType>(
             0px 1px 14px 0px rgba(0, 0, 0, 0.12)`,
     },
     '&:active, .teleport-button__force-active &': {
-      backgroundColor: palette.active.background,
-      borderColor: 'transparent',
+      backgroundColor: palette.active.background ?? 'transparent',
+      borderColor: palette.active.border ?? 'transparent',
       color: palette.active.text,
     },
   };
 };
 
+type ButtonPaletteEntry = {
+  text: string;
+  background?: string;
+  border?: string;
+};
+
 type ButtonPalette = {
-  default: TextAndBackgroundColors;
-  hover: TextAndBackgroundColors;
-  active: TextAndBackgroundColors;
-  focus: TextAndBackgroundColors;
+  default: ButtonPaletteEntry;
+  hover: ButtonPaletteEntry;
+  active: ButtonPaletteEntry;
+  focus: ButtonPaletteEntry;
 };
 
 const buttonPalette = <E extends React.ElementType>({
@@ -210,20 +215,25 @@ const buttonPalette = <E extends React.ElementType>({
           default: colors.interactive.tonal.neutral[0],
           hover: colors.interactive.tonal.neutral[1],
           active: colors.interactive.tonal.neutral[2],
-          focus: colors.interactive.tonal.neutral[0],
+          focus: {
+            ...colors.interactive.tonal.neutral[0],
+            border: colors.interactive.tonal.neutral[0].text,
+          },
         };
       } else {
         return {
           default: colors.interactive.solid[intent].default,
           hover: colors.interactive.solid[intent].hover,
           active: colors.interactive.solid[intent].active,
-          focus: colors.interactive.solid[intent].default,
+          focus: {
+            ...colors.interactive.solid[intent].default,
+            border: colors.text.primaryInverse,
+          },
         };
       }
     case 'minimal':
       return {
         default: {
-          background: 'transparent',
           text:
             intent === 'neutral'
               ? colors.text.slightlyMuted
@@ -231,28 +241,37 @@ const buttonPalette = <E extends React.ElementType>({
         },
         hover: colors.interactive.tonal[intent][0],
         active: colors.interactive.tonal[intent][1],
-        focus: colors.interactive.tonal[intent][0],
+        focus: {
+          text: colors.interactive.tonal[intent][0].text,
+          border: colors.interactive.tonal[intent][0].text,
+        },
       };
     case 'border':
       if (intent === 'neutral') {
         return {
           default: {
-            background: 'transparent',
             text: colors.text.muted,
+            border: colors.interactive.tonal.neutral[0].background,
           },
           hover: colors.interactive.tonal.neutral[1],
           active: colors.interactive.tonal.neutral[2],
-          focus: colors.interactive.tonal.neutral[0],
+          focus: {
+            ...colors.interactive.tonal.neutral[0],
+            border: colors.interactive.tonal.neutral[0].text,
+          },
         };
       } else {
         return {
           default: {
-            background: 'transparent',
             text: colors.interactive.solid[intent].default.background,
+            border: colors.interactive.solid[intent].default.background,
           },
           hover: colors.interactive.solid[intent].hover,
           active: colors.interactive.solid[intent].active,
-          focus: colors.interactive.solid[intent].default,
+          focus: {
+            ...colors.interactive.solid[intent].default,
+            border: colors.text.primaryInverse,
+          },
         };
       }
     default:

--- a/web/packages/design/src/Button/__snapshots__/buttons.story.test.tsx.snap
+++ b/web/packages/design/src/Button/__snapshots__/buttons.story.test.tsx.snap
@@ -522,7 +522,7 @@ exports[`buttons 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 30.5px;
   min-height: 32px;
@@ -1330,7 +1330,7 @@ exports[`buttons 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 30.5px;
   min-height: 32px;
@@ -1394,7 +1394,7 @@ exports[`buttons 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 30.5px;
   min-height: 40px;
@@ -1456,7 +1456,7 @@ exports[`buttons 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 30.5px;
   min-height: 40px;
@@ -1520,7 +1520,7 @@ exports[`buttons 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1582,7 +1582,7 @@ exports[`buttons 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/design/src/Button/__snapshots__/buttons.story.test.tsx.snap
+++ b/web/packages/design/src/Button/__snapshots__/buttons.story.test.tsx.snap
@@ -522,7 +522,7 @@ exports[`buttons 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 30.5px;
   min-height: 32px;
@@ -1330,7 +1330,7 @@ exports[`buttons 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 30.5px;
   min-height: 32px;
@@ -1394,7 +1394,7 @@ exports[`buttons 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 30.5px;
   min-height: 40px;
@@ -1456,7 +1456,7 @@ exports[`buttons 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 30.5px;
   min-height: 40px;
@@ -1520,7 +1520,7 @@ exports[`buttons 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1582,7 +1582,7 @@ exports[`buttons 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/design/src/Button/__snapshots__/buttons.story.test.tsx.snap
+++ b/web/packages/design/src/Button/__snapshots__/buttons.story.test.tsx.snap
@@ -521,7 +521,7 @@ exports[`buttons 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 30.5px;
@@ -1329,7 +1329,7 @@ exports[`buttons 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 30.5px;
@@ -1393,7 +1393,7 @@ exports[`buttons 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 30.5px;
@@ -1455,7 +1455,7 @@ exports[`buttons 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 30.5px;
@@ -1519,7 +1519,7 @@ exports[`buttons 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -1581,7 +1581,7 @@ exports[`buttons 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/__snapshots__/RequestCheckout.story.test.tsx.snap
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/__snapshots__/RequestCheckout.story.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`failed state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1591,7 +1591,7 @@ exports[`loaded state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/__snapshots__/RequestCheckout.story.test.tsx.snap
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/__snapshots__/RequestCheckout.story.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`failed state 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -1590,7 +1590,7 @@ exports[`loaded state 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/__snapshots__/RequestCheckout.story.test.tsx.snap
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/__snapshots__/RequestCheckout.story.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`failed state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1591,7 +1591,7 @@ exports[`loaded state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/shared/components/AccessRequests/NewRequest/ResourceList/__snapshots__/ResourceList.story.test.tsx.snap
+++ b/web/packages/shared/components/AccessRequests/NewRequest/ResourceList/__snapshots__/ResourceList.story.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`render Apps 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -344,7 +344,7 @@ exports[`render Databases 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -682,7 +682,7 @@ exports[`render Desktops 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -972,7 +972,7 @@ exports[`render Kubes 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1254,7 +1254,7 @@ exports[`render Nodes 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1555,7 +1555,7 @@ exports[`render Roles 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -2071,7 +2071,7 @@ exports[`render UserGroups 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/shared/components/AccessRequests/NewRequest/ResourceList/__snapshots__/ResourceList.story.test.tsx.snap
+++ b/web/packages/shared/components/AccessRequests/NewRequest/ResourceList/__snapshots__/ResourceList.story.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`render Apps 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -343,7 +343,7 @@ exports[`render Databases 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -681,7 +681,7 @@ exports[`render Desktops 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -971,7 +971,7 @@ exports[`render Kubes 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -1253,7 +1253,7 @@ exports[`render Nodes 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -1554,7 +1554,7 @@ exports[`render Roles 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -2070,7 +2070,7 @@ exports[`render UserGroups 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;

--- a/web/packages/shared/components/AccessRequests/NewRequest/ResourceList/__snapshots__/ResourceList.story.test.tsx.snap
+++ b/web/packages/shared/components/AccessRequests/NewRequest/ResourceList/__snapshots__/ResourceList.story.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`render Apps 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -344,7 +344,7 @@ exports[`render Databases 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -682,7 +682,7 @@ exports[`render Desktops 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -972,7 +972,7 @@ exports[`render Kubes 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1254,7 +1254,7 @@ exports[`render Nodes 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1555,7 +1555,7 @@ exports[`render Roles 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -2071,7 +2071,7 @@ exports[`render UserGroups 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/__snapshots__/RequestView.story.test.tsx.snap
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/__snapshots__/RequestView.story.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`loaded approved role based request state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -925,7 +925,7 @@ exports[`loaded denied role based request state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1625,7 +1625,7 @@ exports[`loaded pending role based request state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -2521,7 +2521,7 @@ exports[`loaded pending search based request state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/__snapshots__/RequestView.story.test.tsx.snap
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/__snapshots__/RequestView.story.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`loaded approved role based request state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -925,7 +925,7 @@ exports[`loaded denied role based request state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1625,7 +1625,7 @@ exports[`loaded pending role based request state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -2521,7 +2521,7 @@ exports[`loaded pending search based request state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/__snapshots__/RequestView.story.test.tsx.snap
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/__snapshots__/RequestView.story.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`loaded approved role based request state 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -924,7 +924,7 @@ exports[`loaded denied role based request state 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -1624,7 +1624,7 @@ exports[`loaded pending role based request state 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -2520,7 +2520,7 @@ exports[`loaded pending search based request state 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;

--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`list of all events 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -13486,7 +13486,7 @@ exports[`loaded audit log screen 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`list of all events 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -13486,7 +13486,7 @@ exports[`loaded audit log screen 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`list of all events 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -13485,7 +13485,7 @@ exports[`loaded audit log screen 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;

--- a/web/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
+++ b/web/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`render clusters 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
+++ b/web/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`render clusters 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;

--- a/web/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
+++ b/web/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`render clusters 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -133,7 +133,7 @@ exports[`render DocumentNodes 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`render DocumentNodes 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;

--- a/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -133,7 +133,7 @@ exports[`render DocumentNodes 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -114,7 +114,7 @@ exports[`empty state 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 30.5px;
@@ -383,7 +383,7 @@ exports[`failed 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -1653,7 +1653,7 @@ exports[`loaded 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;

--- a/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`empty state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 30.5px;
   min-height: 32px;
@@ -384,7 +384,7 @@ exports[`failed 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1654,7 +1654,7 @@ exports[`loaded 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`empty state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 30.5px;
   min-height: 32px;
@@ -384,7 +384,7 @@ exports[`failed 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1654,7 +1654,7 @@ exports[`loaded 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/web/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -114,7 +114,7 @@ exports[`active sessions CTA 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -1356,7 +1356,7 @@ exports[`loaded 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
@@ -2554,7 +2554,7 @@ exports[`moderated sessions CTA for non-enterprise 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;

--- a/web/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/web/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`active sessions CTA 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1357,7 +1357,7 @@ exports[`loaded 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -2555,7 +2555,7 @@ exports[`moderated sessions CTA for non-enterprise 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/web/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`active sessions CTA 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -1357,7 +1357,7 @@ exports[`loaded 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;
@@ -2555,7 +2555,7 @@ exports[`moderated sessions CTA for non-enterprise 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
+++ b/web/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`success state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.54);
-  border-color: rgba(255, 255, 255, 0.54);
+  border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
+++ b/web/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`success state 1`] = `
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.18);
   border-width: 1.5px;
   padding: 0 6.5px;
   min-height: 24px;

--- a/web/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
+++ b/web/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`success state 1`] = `
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.54);
+  color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255,255,255,0.07);
   border-width: 1.5px;
   padding: 0 6.5px;


### PR DESCRIPTION
According to [the design](https://www.figma.com/design/Gpjs9vjhzUKF1GDbeG9JGE/Application-Design-System?node-id=6912-35607&m=dev), this is a corner case where the button border is different from the button text color.

![Screenshot 2024-08-02 at 13 44 50](https://github.com/user-attachments/assets/ae2a0fcc-b115-409b-a5ce-6d682930615c)

![Screenshot 2024-08-02 at 13 44 27](https://github.com/user-attachments/assets/4adf658f-8614-4c0c-b7ec-da1e29eb3a40)

Needs to be merged together with https://github.com/gravitational/teleport.e/pull/4800

Deviation from the design: though the design calls for using 6% opacity, this turned out quite hard to see in practice, especially on a low-density display where the borders are displayed as 1px. I substituted it with 18% opacity, which still is distinctively different from the text (72%)