### PR TITLE
Add initial AMR servicenow integration

### DIFF
--- a/integrations/access/servicenow/app.go
+++ b/integrations/access/servicenow/app.go
@@ -357,7 +357,7 @@ func (a *App) onDeletedRequest(ctx context.Context, reqID string) error {
 	return a.resolveIncident(ctx, reqID, Resolution{State: ResolutionStateResolved})
 }
 
-func (a *App) getOnCallServiceNames(ctx context.Context, req types.AccessRequest) ([]string, error) {
+func (a *App) getOnCallServiceNames(req types.AccessRequest) ([]string, error) {
 	annotationKey := types.TeleportNamespace + types.ReqAnnotationApproveSchedulesLabel
 	return common.GetServiceNamesFromAnnotations(req, annotationKey)
 }
@@ -436,7 +436,7 @@ func (a *App) postReviewNotes(ctx context.Context, reqID string, reqReviews []ty
 func (a *App) tryApproveRequest(ctx context.Context, req types.AccessRequest) error {
 	log := logger.Get(ctx)
 
-	serviceNames, err := a.getOnCallServiceNames(ctx, req)
+	serviceNames, err := a.getOnCallServiceNames(req)
 	if err != nil {
 		logger.Get(ctx).Debugf("Skipping the approval: %s", err)
 		return nil

--- a/integrations/access/servicenow/app.go
+++ b/integrations/access/servicenow/app.go
@@ -50,8 +50,6 @@ const (
 	minServerVersion = "13.0.0"
 	// initTimeout is used to bound execution time of health check and teleport version check.
 	initTimeout = time.Second * 10
-	// handlerTimeout is used to bound the execution time of watcher event handler.
-	handlerTimeout = time.Second * 30
 	// modifyPluginDataBackoffBase is an initial (minimum) backoff value.
 	modifyPluginDataBackoffBase = time.Millisecond
 	// modifyPluginDataBackoffMax is a backoff threshold

--- a/integrations/access/servicenow/testlib/suite.go
+++ b/integrations/access/servicenow/testlib/suite.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
+	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/access/servicenow"
 	"github.com/gravitational/teleport/integrations/lib/logger"
@@ -75,6 +77,7 @@ func (s *ServiceNowBaseSuite) SetupTest() {
 
 	var conf servicenow.Config
 	conf.Teleport = s.TeleportConfig()
+	conf.PluginType = "servicenow"
 	conf.ClientConfig.APIEndpoint = s.fakeServiceNow.URL()
 	conf.ClientConfig.CloseCode = "resolved"
 
@@ -134,6 +137,55 @@ func (s *ServiceNowSuiteOSS) TestIncidentCreation() {
 	require.NoError(t, err, "no new incidents stored")
 
 	assert.Equal(t, incident.IncidentID, pluginData.IncidentID)
+}
+
+// TestMessagePostingWithAMR validates that a message is sent to each recipient
+// specified in the monitoring rule and the plugin config is ignored. It also checks that the message
+// content is correct.
+func (s *ServiceNowSuiteOSS) TestMessagePostingWithAMR() {
+	t := s.T()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	s.startApp()
+
+	_, err := s.ClientByName(integration.RulerUserName).
+		AccessMonitoringRulesClient().
+		CreateAccessMonitoringRule(ctx, &accessmonitoringrulesv1.AccessMonitoringRule{
+			Kind:    types.KindAccessMonitoringRule,
+			Version: types.V1,
+			Metadata: &v1.Metadata{
+				Name: "test-servicenow-amr",
+			},
+			Spec: &accessmonitoringrulesv1.AccessMonitoringRuleSpec{
+				Subjects:  []string{types.KindAccessRequest},
+				Condition: "!is_empty(access_request.spec.roles)",
+				Notification: &accessmonitoringrulesv1.Notification{
+					Name: "servicenow",
+					Recipients: []string{
+						"someReviewer", // recipient 1
+					},
+				},
+			},
+		})
+	assert.NoError(t, err)
+
+	// Test execution: we create a new access request.
+	req := s.CreateAccessRequest(ctx, integration.RequesterOSSUserName, nil)
+	pluginData := s.checkPluginData(ctx, req.GetName(), func(data servicenow.PluginData) bool {
+		return data.IncidentID != ""
+	})
+
+	// Validating a new incident was created.
+	incident, err := s.fakeServiceNow.CheckNewIncident(ctx)
+	require.NoError(t, err, "no new incidents stored")
+
+	require.Equal(t, "someReviewer", incident.AssignedTo)
+
+	assert.Equal(t, incident.IncidentID, pluginData.IncidentID)
+	
+	assert.NoError(t, s.ClientByName(integration.RulerUserName).
+		AccessMonitoringRulesClient().DeleteAccessMonitoringRule(ctx, "test-servicenow-amr"))
 }
 
 // TestApproval tests that when a request is approved, its corresponding incident

--- a/integrations/access/servicenow/testlib/suite.go
+++ b/integrations/access/servicenow/testlib/suite.go
@@ -183,7 +183,7 @@ func (s *ServiceNowSuiteOSS) TestMessagePostingWithAMR() {
 	require.Equal(t, "someReviewer", incident.AssignedTo)
 
 	assert.Equal(t, incident.IncidentID, pluginData.IncidentID)
-	
+
 	assert.NoError(t, s.ClientByName(integration.RulerUserName).
 		AccessMonitoringRulesClient().DeleteAccessMonitoringRule(ctx, "test-servicenow-amr"))
 }


### PR DESCRIPTION
Initial integration of ServiceNow plugin and Access Monitoring Rules routing

Depends on https://github.com/gravitational/teleport/pull/43298 being merged first and will take this out of draft and update the description when it is.

changelog: Allow ServiceNow service used by plugin to be dynamically configured by creating Access Monitoring Rules resources with the desired ServiceNow assignee as the recipient.