### PR TITLE
Update the SSO button design and fix autofocus

### DIFF
--- a/examples/resources/github.yaml
+++ b/examples/resources/github.yaml
@@ -10,9 +10,9 @@ spec:
   # GitHub will make a callback to this URL after successful authentication
   # cluster-url is the address the cluster UI is reachable at
   redirect_url: "https://<cluster-url>/v1/webapi/github/callback"
-  # connector display name that will be appended to the title of "Login with"
-  # button on the cluster login screen so it will say "Login with GitHub"
-  display: Github
+  # Connector display name that will become the title of an SSO login button on
+  # the cluster login screen.
+  display: GitHub
   # mapping of GitHub team memberships to Teleport cluster roles
   teams_to_logins:
   - logins:

--- a/examples/resources/saml-connector.yaml
+++ b/examples/resources/saml-connector.yaml
@@ -8,8 +8,8 @@ metadata:
   # the name of the connector
   name: okta
 spec:
-  # connector display name that will be appended to the title of "Login with"
-  # button on the cluster login screen so it will say "Login with Okta"
+  # Connector display name that will become the title of an SSO login button on
+  # the cluster login screen.
   display: Okta
   # SAML provider will make a callback to this URL after successful authentication
   # cluster-url is the address the cluster UI is reachable at.

--- a/web/packages/design/src/Button/Button.tsx
+++ b/web/packages/design/src/Button/Button.tsx
@@ -31,6 +31,7 @@ import {
   WidthProps,
   HeightProps,
   AlignSelfProps,
+  GapProps,
 } from 'design/system';
 import { TextAndBackgroundColors, Theme } from 'design/theme/themes/types';
 
@@ -39,7 +40,8 @@ export type ButtonProps<E extends React.ElementType> =
     SpaceProps &
     WidthProps &
     HeightProps &
-    AlignSelfProps & {
+    AlignSelfProps &
+    GapProps & {
       /**
        * Specifies if an element's display is set to block or not. Set to true
        * to set display to block.

--- a/web/packages/design/src/ResourceIcon/index.tsx
+++ b/web/packages/design/src/ResourceIcon/index.tsx
@@ -45,7 +45,9 @@ export const ResourceIcon = ({ name, ...props }: ResourceIconProps) => {
   if (!icon) {
     return null;
   }
-  return <Image src={icon} {...props} />;
+  // Note: we add the class name for consistency with `Icon`, where it's used
+  // for testing.
+  return <Image src={icon} className={`res-icon-${name}`} {...props} />;
 };
 
 export { type ResourceIconName, resourceIconSpecs, iconNames };

--- a/web/packages/design/src/ResourceIcon/index.tsx
+++ b/web/packages/design/src/ResourceIcon/index.tsx
@@ -45,9 +45,7 @@ export const ResourceIcon = ({ name, ...props }: ResourceIconProps) => {
   if (!icon) {
     return null;
   }
-  // Note: we add the class name for consistency with `Icon`, where it's used
-  // for testing.
-  return <Image src={icon} className={`res-icon-${name}`} {...props} />;
+  return <Image src={icon} data-testid={`res-icon-${name}`} {...props} />;
 };
 
 export { type ResourceIconName, resourceIconSpecs, iconNames };

--- a/web/packages/shared/components/ButtonSso/ButtonSso.test.tsx
+++ b/web/packages/shared/components/ButtonSso/ButtonSso.test.tsx
@@ -24,16 +24,21 @@ import { render } from 'design/utils/testing';
 import ButtonSso from '.';
 
 test.each`
-  ssoType           | expectedIcon
-  ${'default type'} | ${'icon-key'}
-  ${'Microsoft'}    | ${'res-icon-microsoft'}
-  ${'github'}       | ${'res-icon-github'}
-  ${'bitbucket'}    | ${'res-icon-atlassianbitbucket'}
-  ${'google'}       | ${'res-icon-google'}
+  ssoType        | expectedIcon
+  ${'Microsoft'} | ${'res-icon-microsoft'}
+  ${'github'}    | ${'res-icon-github'}
+  ${'bitbucket'} | ${'res-icon-atlassianbitbucket'}
+  ${'google'}    | ${'res-icon-google'}
 `('rendering of $ssoType', ({ ssoType, expectedIcon }) => {
   render(<ButtonSso ssoType={ssoType} title="hello" />);
-  screen.debug();
 
-  expect(screen.getByTestId('icon')).toHaveClass(expectedIcon);
+  expect(screen.getByRole('img')).toHaveAttribute('data-testid', expectedIcon);
+  expect(screen.getByText(/hello/i)).toBeInTheDocument();
+});
+
+test('rendering unknown SSO type', () => {
+  render(<ButtonSso ssoType="unknown" title="hello" />);
+
+  expect(screen.getByTestId('icon')).toHaveClass('icon-key');
   expect(screen.getByText(/hello/i)).toBeInTheDocument();
 });

--- a/web/packages/shared/components/ButtonSso/ButtonSso.test.tsx
+++ b/web/packages/shared/components/ButtonSso/ButtonSso.test.tsx
@@ -26,12 +26,13 @@ import ButtonSso from '.';
 test.each`
   ssoType           | expectedIcon
   ${'default type'} | ${'icon-key'}
-  ${'Microsoft'}    | ${'icon-windows'}
-  ${'github'}       | ${'icon-github'}
-  ${'bitbucket'}    | ${'icon-key'}
-  ${'google'}       | ${'icon-google'}
+  ${'Microsoft'}    | ${'res-icon-microsoft'}
+  ${'github'}       | ${'res-icon-github'}
+  ${'bitbucket'}    | ${'res-icon-atlassianbitbucket'}
+  ${'google'}       | ${'res-icon-google'}
 `('rendering of $ssoType', ({ ssoType, expectedIcon }) => {
   render(<ButtonSso ssoType={ssoType} title="hello" />);
+  screen.debug();
 
   expect(screen.getByTestId('icon')).toHaveClass(expectedIcon);
   expect(screen.getByText(/hello/i)).toBeInTheDocument();

--- a/web/packages/shared/components/ButtonSso/ButtonSso.tsx
+++ b/web/packages/shared/components/ButtonSso/ButtonSso.tsx
@@ -17,35 +17,28 @@
  */
 
 import React, { forwardRef } from 'react';
-import styled from 'styled-components';
-import { darken, lighten } from 'design/theme/utils/colorManipulator';
 import * as Icons from 'design/Icon';
 
-import { Button } from 'design/Button';
+import { ButtonProps, ButtonSecondary } from 'design/Button';
+
+import { ResourceIcon } from 'design/ResourceIcon';
 
 import { AuthProviderType } from 'shared/services';
 
-const ButtonSso = forwardRef<HTMLInputElement, Props>((props: Props, ref) => {
+const ButtonSso = forwardRef<HTMLButtonElement, Props>((props: Props, ref) => {
   const { ssoType = 'unknown', title, ...rest } = props;
-  const { color, Icon } = getSSOIcon(ssoType);
 
   return (
-    <StyledButton size="extra-large" color={color} block {...rest} ref={ref}>
-      {Boolean(Icon) && (
-        <IconBox>
-          <Icon data-testid="icon" color="white" />
-        </IconBox>
-      )}
+    <ButtonSecondary gap={3} size="extra-large" {...rest} setRef={ref}>
+      <SSOIcon type={ssoType} />
       {title}
-    </StyledButton>
+    </ButtonSecondary>
   );
 });
 
-type Props = {
+type Props = ButtonProps<'button'> & {
   ssoType: SSOType;
   title: string;
-  // TS: temporary handles ...styles
-  [key: string]: any;
 };
 
 type SSOType =
@@ -54,21 +47,31 @@ type SSOType =
   | 'bitbucket'
   | 'google'
   | 'openid'
+  | 'okta'
   | 'unknown';
 
-function getSSOIcon(type: SSOType) {
+function SSOIcon({ type }: { type: SSOType }) {
+  const commonResourceIconProps = {
+    width: '24px',
+    height: '24px',
+    'data-testid': 'icon',
+  };
   switch (type.toLowerCase()) {
     case 'microsoft':
-      return { color: '#2672ec', Icon: Icons.Windows, type };
+      return <ResourceIcon name="microsoft" {...commonResourceIconProps} />;
     case 'github':
-      return { color: '#444444', Icon: Icons.GitHub, type };
+      return <ResourceIcon name="github" {...commonResourceIconProps} />;
     case 'bitbucket':
-      return { color: '#205081', Icon: Icons.Key, /*temporary icon */ type };
+      return (
+        <ResourceIcon name="atlassianbitbucket" {...commonResourceIconProps} />
+      );
     case 'google':
-      return { color: '#dd4b39', Icon: Icons.Google, type };
+      return <ResourceIcon name="google" {...commonResourceIconProps} />;
+    case 'okta':
+      return <ResourceIcon name="okta" {...commonResourceIconProps} />;
     default:
       // provide default icon for unknown social providers
-      return { color: '#f7931e', Icon: Icons.Key /*temporary icon */ };
+      return <Icons.Key data-testid="icon" />;
   }
 }
 
@@ -94,46 +97,15 @@ export function guessProviderType(
     return 'github';
   }
 
+  if (name.indexOf('okta') !== -1) {
+    return 'okta';
+  }
+
   if (providerType === 'oidc') {
     return 'openid';
   }
 
   return 'unknown';
 }
-
-const StyledButton = styled(Button)`
-  background-color: ${props => props.color};
-  display: block;
-  width: 100%;
-  border: 1px solid transparent;
-  color: white;
-
-  &:hover,
-  &:focus {
-    background: ${props => darken(props.color, 0.1)};
-    border: 1px solid ${props => lighten(props.color, 0.4)};
-  }
-  height: 40px;
-  position: relative;
-  box-sizing: border-box;
-
-  svg {
-    opacity: 0.87;
-  }
-`;
-
-const IconBox = styled.div`
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 56px;
-  font-size: 24px;
-  text-align: center;
-  border-right: 1px solid rgba(0, 0, 0, 0.12);
-`;
 
 export default ButtonSso;

--- a/web/packages/shared/components/ButtonSso/ButtonSso.tsx
+++ b/web/packages/shared/components/ButtonSso/ButtonSso.tsx
@@ -29,7 +29,7 @@ const ButtonSso = forwardRef<HTMLButtonElement, Props>((props: Props, ref) => {
   const { ssoType = 'unknown', title, ...rest } = props;
 
   return (
-    <ButtonSecondary gap={3} size="extra-large" {...rest} setRef={ref}>
+    <ButtonSecondary gap={3} size="extra-large" block {...rest} setRef={ref}>
       <SSOIcon type={ssoType} />
       {title}
     </ButtonSecondary>

--- a/web/packages/shared/components/ButtonSso/ButtonSso.tsx
+++ b/web/packages/shared/components/ButtonSso/ButtonSso.tsx
@@ -54,7 +54,6 @@ function SSOIcon({ type }: { type: SSOType }) {
   const commonResourceIconProps = {
     width: '24px',
     height: '24px',
-    'data-testid': 'icon',
   };
   switch (type.toLowerCase()) {
     case 'microsoft':

--- a/web/packages/teleport/src/AuthConnectors/templates/github.yaml
+++ b/web/packages/teleport/src/AuthConnectors/templates/github.yaml
@@ -10,8 +10,8 @@ spec:
   # GitHub will make a callback to this URL after successful authentication
   # cluster-url is the address the cluster UI is reachable at
   redirect_url: 'https://<cluster-url>/v1/webapi/github/callback'
-  # connector display name that will be appended to the title of "Login with"
-  # button on the cluster login screen so it will say "Login with GitHub"
+  # Connector display name that will become the title of an SSO login button on
+  # the cluster login screen.
   display: GitHub
   # mapping of GitHub team memberships to Teleport roles
   teams_to_roles:

--- a/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
+++ b/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
@@ -333,7 +333,7 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22"
+            class="c22 res-icon-apple"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -373,7 +373,7 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22"
+            class="c22 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -413,7 +413,7 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22"
+            class="c22 res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -453,7 +453,7 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22"
+            class="c22 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -493,7 +493,7 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22"
+            class="c22 res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -533,7 +533,7 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22"
+            class="c22 res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -573,7 +573,7 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22"
+            class="c22 res-icon-laptop"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -606,7 +606,7 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22"
+            class="c22 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -646,7 +646,7 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22"
+            class="c22 res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -686,7 +686,7 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22"
+            class="c22 res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -726,7 +726,7 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22"
+            class="c22 res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1029,7 +1029,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-apple"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1069,7 +1069,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1109,7 +1109,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-application"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1143,7 +1143,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1183,7 +1183,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1223,7 +1223,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1257,7 +1257,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1297,7 +1297,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1337,7 +1337,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1377,7 +1377,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-kube"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1417,7 +1417,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1457,7 +1457,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-postgres"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1497,7 +1497,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1537,7 +1537,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1577,7 +1577,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1617,7 +1617,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1657,7 +1657,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-laptop"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1690,7 +1690,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1730,7 +1730,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1770,7 +1770,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1810,7 +1810,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-googlecloud"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1850,7 +1850,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-googlecloud"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1890,7 +1890,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-cockroach"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1930,7 +1930,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-database"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1970,7 +1970,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-dynamo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2010,7 +2010,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2050,7 +2050,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2090,7 +2090,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-database"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2130,7 +2130,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2170,7 +2170,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2210,7 +2210,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-mongo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2250,7 +2250,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-mongo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2284,7 +2284,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2324,7 +2324,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2364,7 +2364,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2404,7 +2404,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2444,7 +2444,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2484,7 +2484,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2524,7 +2524,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2564,7 +2564,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2604,7 +2604,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2644,7 +2644,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-snowflake"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2678,7 +2678,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2718,7 +2718,7 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3028,7 +3028,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3070,7 +3070,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3111,7 +3111,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-application"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3146,7 +3146,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3187,7 +3187,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3228,7 +3228,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3266,7 +3266,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3311,7 +3311,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3356,7 +3356,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-googlecloud"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3401,7 +3401,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-googlecloud"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3446,7 +3446,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-cockroach"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3488,7 +3488,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-laptop"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3523,7 +3523,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3567,7 +3567,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-database"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3612,7 +3612,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-dynamo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3654,7 +3654,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3695,7 +3695,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3739,7 +3739,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3784,7 +3784,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3829,7 +3829,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-database"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3874,7 +3874,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3916,7 +3916,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-kube"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3960,7 +3960,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4002,7 +4002,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-apple"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4046,7 +4046,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-mongo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4091,7 +4091,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-mongo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4130,7 +4130,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4172,7 +4172,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4213,7 +4213,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-postgres"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4257,7 +4257,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4299,7 +4299,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4340,7 +4340,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4384,7 +4384,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4429,7 +4429,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4474,7 +4474,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4519,7 +4519,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4564,7 +4564,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4609,7 +4609,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4654,7 +4654,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4696,7 +4696,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4740,7 +4740,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-snowflake"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4779,7 +4779,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4824,7 +4824,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4866,7 +4866,7 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18"
+            class="c18 res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5201,7 +5201,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-apple"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5241,7 +5241,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5281,7 +5281,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-application"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5315,7 +5315,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5349,7 +5349,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5389,7 +5389,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5429,7 +5429,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5469,7 +5469,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-kube"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5509,7 +5509,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5549,7 +5549,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5589,7 +5589,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-laptop"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5622,7 +5622,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5662,7 +5662,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5704,7 +5704,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5745,7 +5745,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5789,7 +5789,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5834,7 +5834,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5879,7 +5879,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-googlecloud"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5924,7 +5924,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-googlecloud"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5969,7 +5969,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-cockroach"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6014,7 +6014,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-database"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6059,7 +6059,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-dynamo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6104,7 +6104,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6149,7 +6149,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6194,7 +6194,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-database"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6239,7 +6239,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6284,7 +6284,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-mongo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6329,7 +6329,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-mongo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6368,7 +6368,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6410,7 +6410,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6451,7 +6451,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-postgres"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6495,7 +6495,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6537,7 +6537,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6578,7 +6578,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6622,7 +6622,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6667,7 +6667,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6712,7 +6712,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6757,7 +6757,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6802,7 +6802,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6847,7 +6847,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6892,7 +6892,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6937,7 +6937,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-snowflake"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6976,7 +6976,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -7021,7 +7021,7 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16"
+            class="c16 res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"

--- a/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
+++ b/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
@@ -333,7 +333,8 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22 res-icon-apple"
+            class="c22"
+            data-testid="res-icon-apple"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -373,7 +374,8 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22 res-icon-aws"
+            class="c22"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -413,7 +415,8 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22 res-icon-linux"
+            class="c22"
+            data-testid="res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -453,7 +456,8 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22 res-icon-aws"
+            class="c22"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -493,7 +497,8 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22 res-icon-linux"
+            class="c22"
+            data-testid="res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -533,7 +538,8 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22 res-icon-linux"
+            class="c22"
+            data-testid="res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -573,7 +579,8 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22 res-icon-laptop"
+            class="c22"
+            data-testid="res-icon-laptop"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -606,7 +613,8 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22 res-icon-aws"
+            class="c22"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -646,7 +654,8 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22 res-icon-redshift"
+            class="c22"
+            data-testid="res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -686,7 +695,8 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22 res-icon-azure"
+            class="c22"
+            data-testid="res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -726,7 +736,8 @@ p+.c28 {
           width="24px"
         >
           <img
-            class="c22 res-icon-windows"
+            class="c22"
+            data-testid="res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1029,7 +1040,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-apple"
+            class="c16"
+            data-testid="res-icon-apple"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1069,7 +1081,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1109,7 +1122,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-application"
+            class="c16"
+            data-testid="res-icon-application"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1143,7 +1157,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1183,7 +1198,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1223,7 +1239,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1257,7 +1274,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-linux"
+            class="c16"
+            data-testid="res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1297,7 +1315,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1337,7 +1356,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1377,7 +1397,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-kube"
+            class="c16"
+            data-testid="res-icon-kube"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1417,7 +1438,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-selfhosted"
+            class="c16"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1457,7 +1479,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-postgres"
+            class="c16"
+            data-testid="res-icon-postgres"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1497,7 +1520,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1537,7 +1561,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1577,7 +1602,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-linux"
+            class="c16"
+            data-testid="res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1617,7 +1643,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-linux"
+            class="c16"
+            data-testid="res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1657,7 +1684,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-laptop"
+            class="c16"
+            data-testid="res-icon-laptop"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1690,7 +1718,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-windows"
+            class="c16"
+            data-testid="res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1730,7 +1759,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-azure"
+            class="c16"
+            data-testid="res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1770,7 +1800,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-selfhosted"
+            class="c16"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1810,7 +1841,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-googlecloud"
+            class="c16"
+            data-testid="res-icon-googlecloud"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1850,7 +1882,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-googlecloud"
+            class="c16"
+            data-testid="res-icon-googlecloud"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1890,7 +1923,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-cockroach"
+            class="c16"
+            data-testid="res-icon-cockroach"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1930,7 +1964,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-database"
+            class="c16"
+            data-testid="res-icon-database"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -1970,7 +2005,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-dynamo"
+            class="c16"
+            data-testid="res-icon-dynamo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2010,7 +2046,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2050,7 +2087,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-selfhosted"
+            class="c16"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2090,7 +2128,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-database"
+            class="c16"
+            data-testid="res-icon-database"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2130,7 +2169,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2170,7 +2210,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-windows"
+            class="c16"
+            data-testid="res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2210,7 +2251,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-mongo"
+            class="c16"
+            data-testid="res-icon-mongo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2250,7 +2292,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-mongo"
+            class="c16"
+            data-testid="res-icon-mongo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2284,7 +2327,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-azure"
+            class="c16"
+            data-testid="res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2324,7 +2368,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-azure"
+            class="c16"
+            data-testid="res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2364,7 +2409,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2404,7 +2450,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2444,7 +2491,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2484,7 +2532,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-selfhosted"
+            class="c16"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2524,7 +2573,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-selfhosted"
+            class="c16"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2564,7 +2614,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-redshift"
+            class="c16"
+            data-testid="res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2604,7 +2655,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-redshift"
+            class="c16"
+            data-testid="res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2644,7 +2696,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-snowflake"
+            class="c16"
+            data-testid="res-icon-snowflake"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2678,7 +2731,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-azure"
+            class="c16"
+            data-testid="res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -2718,7 +2772,8 @@ p+.c22 {
           width="24px"
         >
           <img
-            class="c16 res-icon-windows"
+            class="c16"
+            data-testid="res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3028,7 +3083,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-windows"
+            class="c18"
+            data-testid="res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3070,7 +3126,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-aws"
+            class="c18"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3111,7 +3168,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-application"
+            class="c18"
+            data-testid="res-icon-application"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3146,7 +3204,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-aws"
+            class="c18"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3187,7 +3246,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-aws"
+            class="c18"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3228,7 +3288,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-aws"
+            class="c18"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3266,7 +3327,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-azure"
+            class="c18"
+            data-testid="res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3311,7 +3373,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-selfhosted"
+            class="c18"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3356,7 +3419,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-googlecloud"
+            class="c18"
+            data-testid="res-icon-googlecloud"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3401,7 +3465,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-googlecloud"
+            class="c18"
+            data-testid="res-icon-googlecloud"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3446,7 +3511,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-cockroach"
+            class="c18"
+            data-testid="res-icon-cockroach"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3488,7 +3554,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-laptop"
+            class="c18"
+            data-testid="res-icon-laptop"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3523,7 +3590,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-linux"
+            class="c18"
+            data-testid="res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3567,7 +3635,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-database"
+            class="c18"
+            data-testid="res-icon-database"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3612,7 +3681,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-dynamo"
+            class="c18"
+            data-testid="res-icon-dynamo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3654,7 +3724,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-aws"
+            class="c18"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3695,7 +3766,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-aws"
+            class="c18"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3739,7 +3811,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-aws"
+            class="c18"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3784,7 +3857,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-selfhosted"
+            class="c18"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3829,7 +3903,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-database"
+            class="c18"
+            data-testid="res-icon-database"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3874,7 +3949,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-aws"
+            class="c18"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3916,7 +3992,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-kube"
+            class="c18"
+            data-testid="res-icon-kube"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -3960,7 +4037,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-windows"
+            class="c18"
+            data-testid="res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4002,7 +4080,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-apple"
+            class="c18"
+            data-testid="res-icon-apple"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4046,7 +4125,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-mongo"
+            class="c18"
+            data-testid="res-icon-mongo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4091,7 +4171,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-mongo"
+            class="c18"
+            data-testid="res-icon-mongo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4130,7 +4211,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-azure"
+            class="c18"
+            data-testid="res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4172,7 +4254,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-selfhosted"
+            class="c18"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4213,7 +4296,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-postgres"
+            class="c18"
+            data-testid="res-icon-postgres"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4257,7 +4341,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-azure"
+            class="c18"
+            data-testid="res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4299,7 +4384,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-aws"
+            class="c18"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4340,7 +4426,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-aws"
+            class="c18"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4384,7 +4471,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-aws"
+            class="c18"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4429,7 +4517,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-aws"
+            class="c18"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4474,7 +4563,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-aws"
+            class="c18"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4519,7 +4609,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-selfhosted"
+            class="c18"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4564,7 +4655,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-selfhosted"
+            class="c18"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4609,7 +4701,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-redshift"
+            class="c18"
+            data-testid="res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4654,7 +4747,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-redshift"
+            class="c18"
+            data-testid="res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4696,7 +4790,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-linux"
+            class="c18"
+            data-testid="res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4740,7 +4835,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-snowflake"
+            class="c18"
+            data-testid="res-icon-snowflake"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4779,7 +4875,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-azure"
+            class="c18"
+            data-testid="res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4824,7 +4921,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-windows"
+            class="c18"
+            data-testid="res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -4866,7 +4964,8 @@ p+.c23 {
           width="24px"
         >
           <img
-            class="c18 res-icon-linux"
+            class="c18"
+            data-testid="res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5201,7 +5300,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-apple"
+            class="c16"
+            data-testid="res-icon-apple"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5241,7 +5341,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5281,7 +5382,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-application"
+            class="c16"
+            data-testid="res-icon-application"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5315,7 +5417,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5349,7 +5452,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-linux"
+            class="c16"
+            data-testid="res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5389,7 +5493,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5429,7 +5534,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5469,7 +5575,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-kube"
+            class="c16"
+            data-testid="res-icon-kube"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5509,7 +5616,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-linux"
+            class="c16"
+            data-testid="res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5549,7 +5657,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-linux"
+            class="c16"
+            data-testid="res-icon-linux"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5589,7 +5698,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-laptop"
+            class="c16"
+            data-testid="res-icon-laptop"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5622,7 +5732,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-windows"
+            class="c16"
+            data-testid="res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5662,7 +5773,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-windows"
+            class="c16"
+            data-testid="res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5704,7 +5816,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5745,7 +5858,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5789,7 +5903,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-azure"
+            class="c16"
+            data-testid="res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5834,7 +5949,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-selfhosted"
+            class="c16"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5879,7 +5995,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-googlecloud"
+            class="c16"
+            data-testid="res-icon-googlecloud"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5924,7 +6041,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-googlecloud"
+            class="c16"
+            data-testid="res-icon-googlecloud"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -5969,7 +6087,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-cockroach"
+            class="c16"
+            data-testid="res-icon-cockroach"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6014,7 +6133,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-database"
+            class="c16"
+            data-testid="res-icon-database"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6059,7 +6179,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-dynamo"
+            class="c16"
+            data-testid="res-icon-dynamo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6104,7 +6225,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6149,7 +6271,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-selfhosted"
+            class="c16"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6194,7 +6317,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-database"
+            class="c16"
+            data-testid="res-icon-database"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6239,7 +6363,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6284,7 +6409,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-mongo"
+            class="c16"
+            data-testid="res-icon-mongo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6329,7 +6455,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-mongo"
+            class="c16"
+            data-testid="res-icon-mongo"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6368,7 +6495,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-azure"
+            class="c16"
+            data-testid="res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6410,7 +6538,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-selfhosted"
+            class="c16"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6451,7 +6580,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-postgres"
+            class="c16"
+            data-testid="res-icon-postgres"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6495,7 +6625,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-azure"
+            class="c16"
+            data-testid="res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6537,7 +6668,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6578,7 +6710,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6622,7 +6755,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6667,7 +6801,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6712,7 +6847,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-aws"
+            class="c16"
+            data-testid="res-icon-aws"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6757,7 +6893,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-selfhosted"
+            class="c16"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6802,7 +6939,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-selfhosted"
+            class="c16"
+            data-testid="res-icon-selfhosted"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6847,7 +6985,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-redshift"
+            class="c16"
+            data-testid="res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6892,7 +7031,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-redshift"
+            class="c16"
+            data-testid="res-icon-redshift"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6937,7 +7077,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-snowflake"
+            class="c16"
+            data-testid="res-icon-snowflake"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -6976,7 +7117,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-azure"
+            class="c16"
+            data-testid="res-icon-azure"
             height="24px"
             src="file_stub"
             width="23.9px"
@@ -7021,7 +7163,8 @@ p+.c25 {
           width="24px"
         >
           <img
-            class="c16 res-icon-windows"
+            class="c16"
+            data-testid="res-icon-windows"
             height="24px"
             src="file_stub"
             width="23.9px"

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.story.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.story.tsx
@@ -153,6 +153,11 @@ export const PrimarySso = () => {
       url: '',
     } as const,
     {
+      name: 'Okta',
+      type: 'saml',
+      url: '',
+    } as const,
+    {
       displayName: 'Microsoft',
       name: 'microsoft',
       type: 'oidc',

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
@@ -183,6 +183,53 @@ test('primary passwordless', () => {
   expect(screen.queryByTestId('userpassword')).not.toBeInTheDocument();
 });
 
+test('focuses the username input', () => {
+  render(<FormLogin {...props} isPasswordlessEnabled />);
+
+  expect(screen.getByLabelText(/username/i)).toHaveFocus();
+  expect(
+    screen.getByRole('button', { name: /sign in with a passkey/i })
+  ).not.toHaveFocus();
+});
+
+test('focuses the passkey button', () => {
+  render(
+    <FormLogin
+      {...props}
+      isPasswordlessEnabled
+      primaryAuthType="passwordless"
+      authProviders={[
+        { name: 'github', type: 'github', url: '' },
+        { name: 'google', type: 'saml', url: '' },
+      ]}
+    />
+  );
+
+  expect(
+    screen.getByRole('button', { name: /sign in with a passkey/i })
+  ).toHaveFocus();
+  expect(screen.getByRole('button', { name: 'github' })).not.toHaveFocus();
+});
+
+test('focuses the first SSO button', () => {
+  render(
+    <FormLogin
+      {...props}
+      authProviders={[
+        { name: 'github', type: 'github', url: '' },
+        { name: 'google', type: 'saml', url: '' },
+      ]}
+      isPasswordlessEnabled
+      primaryAuthType="sso"
+    />
+  );
+
+  expect(screen.getByRole('button', { name: 'github' })).toHaveFocus();
+  expect(
+    screen.getByRole('button', { name: /sign in with a passkey/i })
+  ).not.toHaveFocus();
+});
+
 const props: Props = {
   auth2faType: 'off',
   authProviders: [],

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
@@ -119,7 +119,7 @@ const SsoList = ({
   autoFocus = false,
   hasTransitionEnded,
 }: Props & { hasTransitionEnded?: boolean }) => {
-  const ref = useRefAutoFocus<HTMLInputElement>({
+  const ref = useRefAutoFocus<HTMLButtonElement>({
     shouldFocus: hasTransitionEnded && autoFocus,
   });
   const { isProcessing } = attempt;
@@ -357,6 +357,7 @@ const LoginOptions = ({
         refCallback={refCallback}
         authType={otherProps.primaryAuthType}
         primary
+        autoFocus
       />
       {otherAuthTypes.length > 0 && <Divider />}
       {otherAuthTypes.map(authType => (

--- a/web/packages/teleport/src/components/FormLogin/SsoButtons.tsx
+++ b/web/packages/teleport/src/components/FormLogin/SsoButtons.tsx
@@ -28,20 +28,18 @@ const SSOBtnList = forwardRef<HTMLButtonElement, Props>(
       const title = displayName || name;
       const ssoType = guessProviderType(title, type);
       return (
-        <React.Fragment key={index}>
-          <ButtonSso
-            ref={index === 0 ? ref : null}
-            key={index}
-            title={title}
-            ssoType={ssoType}
-            disabled={isDisabled}
-            autoFocus={index === 0 && autoFocus}
-            onClick={e => {
-              e.preventDefault();
-              onClick(item);
-            }}
-          />
-        </React.Fragment>
+        <ButtonSso
+          ref={index === 0 ? ref : null}
+          key={index}
+          title={title}
+          ssoType={ssoType}
+          disabled={isDisabled}
+          autoFocus={index === 0 && autoFocus}
+          onClick={e => {
+            e.preventDefault();
+            onClick(item);
+          }}
+        />
       );
     });
 

--- a/web/packages/teleport/src/components/FormLogin/SsoButtons.tsx
+++ b/web/packages/teleport/src/components/FormLogin/SsoButtons.tsx
@@ -21,25 +21,27 @@ import { Flex, Text } from 'design';
 import ButtonSso, { guessProviderType } from 'shared/components/ButtonSso';
 import { AuthProvider } from 'shared/services';
 
-const SSOBtnList = forwardRef<HTMLInputElement, Props>(
+const SSOBtnList = forwardRef<HTMLButtonElement, Props>(
   ({ providers, isDisabled, onClick, autoFocus = false }, ref) => {
     const $btns = providers.map((item, index) => {
       let { name, type, displayName } = item;
       const title = displayName || name;
       const ssoType = guessProviderType(title, type);
       return (
-        <ButtonSso
-          setRef={index === 0 ? ref : null}
-          key={index}
-          title={title}
-          ssoType={ssoType}
-          disabled={isDisabled}
-          autoFocus={index === 0 && autoFocus}
-          onClick={e => {
-            e.preventDefault();
-            onClick(item);
-          }}
-        />
+        <React.Fragment key={index}>
+          <ButtonSso
+            ref={index === 0 ? ref : null}
+            key={index}
+            title={title}
+            ssoType={ssoType}
+            disabled={isDisabled}
+            autoFocus={index === 0 && autoFocus}
+            onClick={e => {
+              e.preventDefault();
+              onClick(item);
+            }}
+          />
+        </React.Fragment>
       );
     });
 

--- a/web/packages/teleport/src/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
+++ b/web/packages/teleport/src/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
@@ -3202,6 +3202,7 @@ exports[`sso list still renders when local auth is disabled 1`] = `
   font-size: 16px;
   line-height: 24px;
   letter-spacing: 0.2px;
+  width: 100%;
   gap: 16px;
 }
 
@@ -3342,8 +3343,8 @@ exports[`sso list still renders when local auth is disabled 1`] = `
               fill="filled"
             >
               <img
-                class="c8 res-icon-github"
-                data-testid="icon"
+                class="c8"
+                data-testid="res-icon-github"
                 height="24px"
                 src="file_stub"
                 width="24px"
@@ -3355,8 +3356,8 @@ exports[`sso list still renders when local auth is disabled 1`] = `
               fill="filled"
             >
               <img
-                class="c8 res-icon-google"
-                data-testid="icon"
+                class="c8"
+                data-testid="res-icon-google"
                 height="24px"
                 src="file_stub"
                 width="24px"
@@ -3435,6 +3436,7 @@ exports[`sso providers rendering 1`] = `
   font-size: 16px;
   line-height: 24px;
   letter-spacing: 0.2px;
+  width: 100%;
   gap: 16px;
 }
 
@@ -3664,8 +3666,8 @@ exports[`sso providers rendering 1`] = `
               fill="filled"
             >
               <img
-                class="c8 res-icon-github"
-                data-testid="icon"
+                class="c8"
+                data-testid="res-icon-github"
                 height="24px"
                 src="file_stub"
                 width="24px"
@@ -3677,8 +3679,8 @@ exports[`sso providers rendering 1`] = `
               fill="filled"
             >
               <img
-                class="c8 res-icon-google"
-                data-testid="icon"
+                class="c8"
+                data-testid="res-icon-google"
                 height="24px"
                 src="file_stub"
                 width="24px"
@@ -3690,8 +3692,8 @@ exports[`sso providers rendering 1`] = `
               fill="filled"
             >
               <img
-                class="c8 res-icon-atlassianbitbucket"
-                data-testid="icon"
+                class="c8"
+                data-testid="res-icon-atlassianbitbucket"
                 height="24px"
                 src="file_stub"
                 width="24px"
@@ -3729,8 +3731,8 @@ exports[`sso providers rendering 1`] = `
               fill="filled"
             >
               <img
-                class="c8 res-icon-okta"
-                data-testid="icon"
+                class="c8"
+                data-testid="res-icon-okta"
                 height="24px"
                 src="file_stub"
                 width="24px"
@@ -3742,8 +3744,8 @@ exports[`sso providers rendering 1`] = `
               fill="filled"
             >
               <img
-                class="c8 res-icon-microsoft"
-                data-testid="icon"
+                class="c8"
+                data-testid="res-icon-microsoft"
                 height="24px"
                 src="file_stub"
                 width="24px"

--- a/web/packages/teleport/src/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
+++ b/web/packages/teleport/src/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
@@ -3193,8 +3193,8 @@ exports[`sso list still renders when local auth is disabled 1`] = `
   text-decoration: none;
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
-  background-color: #9F85FF;
-  color: #000000;
+  background-color: rgba(255,255,255,0.07);
+  color: rgba(255, 255, 255, 0.72);
   border-color: transparent;
   border-width: 1.5px;
   padding: 0 30.5px;
@@ -3202,31 +3202,31 @@ exports[`sso list still renders when local auth is disabled 1`] = `
   font-size: 16px;
   line-height: 24px;
   letter-spacing: 0.2px;
-  width: 100%;
+  gap: 16px;
 }
 
 .c7:focus-visible,
 .teleport-button__force-focus-visible .c7 {
-  background-color: #9F85FF;
-  color: #000000;
-  border-color: #000000;
-  border-radius: 2px;
-  outline: 2px solid #9F85FF;
+  background-color: rgba(255,255,255,0.07);
+  color: rgba(255, 255, 255, 0.72);
+  border-color: rgba(255, 255, 255, 0.72);
+  border-radius: 4px;
+  outline: none;
 }
 
 .c7:hover,
 .teleport-button__force-hover .c7 {
-  background-color: #B29DFF;
+  background-color: rgba(255,255,255,0.13);
   border-color: transparent;
-  color: #000000;
-  box-shadow: 0px 3px 5px -1px rgba(0, 0, 0, 0.20),0px 5px 8px 0px rgba(0, 0, 0, 0.14),0px 1px 14px 0px rgba(0, 0, 0, 0.12);
+  color: #FFFFFF;
+  box-shadow: none;
 }
 
 .c7:active,
 .teleport-button__force-active .c7 {
-  background-color: #C5B6FF;
+  background-color: rgba(255,255,255,0.18);
   border-color: transparent;
-  color: #000000;
+  color: #FFFFFF;
 }
 
 .c7:disabled {
@@ -3237,17 +3237,17 @@ exports[`sso list still renders when local auth is disabled 1`] = `
   cursor: auto;
 }
 
-.c10 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: white;
-}
-
 .c1 {
   box-shadow: 0px 3px 5px -1px rgba(0, 0, 0, 0.2),0px 6px 10px rgba(0, 0, 0, 0.14),0px 1px 18px rgba(0, 0, 0, 0.12);
   border-radius: 8px;
   background-color: #222C59;
+}
+
+.c8 {
+  display: block;
+  outline: none;
+  width: 24px;
+  height: 24px;
 }
 
 .c2 {
@@ -3311,62 +3311,6 @@ exports[`sso list still renders when local auth is disabled 1`] = `
   transition: transform 500ms ease;
 }
 
-.c8 {
-  background-color: #444444;
-  display: block;
-  width: 100%;
-  border: 1px solid transparent;
-  color: white;
-  height: 40px;
-  position: relative;
-  box-sizing: border-box;
-}
-
-.c8:hover,
-.c8:focus {
-  background: rgb(61, 61, 61);
-  border: 1px solid rgb(142, 142, 142);
-}
-
-.c8 svg {
-  opacity: 0.87;
-}
-
-.c11 {
-  background-color: #dd4b39;
-  display: block;
-  width: 100%;
-  border: 1px solid transparent;
-  color: white;
-  height: 40px;
-  position: relative;
-  box-sizing: border-box;
-}
-
-.c11:hover,
-.c11:focus {
-  background: rgb(198, 67, 51);
-  border: 1px solid rgb(234, 147, 136);
-}
-
-.c11 svg {
-  opacity: 0.87;
-}
-
-.c9 {
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 56px;
-  font-size: 24px;
-  text-align: center;
-  border-right: 1px solid rgba(0,0,0,0.12);
-}
-
 <div
   class="c0 c1"
   width="500"
@@ -3394,61 +3338,29 @@ exports[`sso list still renders when local auth is disabled 1`] = `
             data-testid="sso-list"
           >
             <button
-              class="c7 c8"
-              color="#444444"
+              class="c7"
               fill="filled"
             >
-              <div
-                class="c9"
-              >
-                <span
-                  class="c10 icon icon-github"
-                  color="white"
-                  data-testid="icon"
-                >
-                  <svg
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                  >
-                    <path
-                      clip-rule="evenodd"
-                      d="M7.12482 2.25C8.06954 2.24978 8.9991 2.4875 9.82773 2.94123C10.5329 3.32738 11.1457 3.85939 11.6261 4.5H13.8739C14.3543 3.85939 14.9671 3.32738 15.6723 2.94123C16.5009 2.4875 17.4305 2.24978 18.3752 2.25C18.6429 2.25006 18.8902 2.39278 19.0242 2.62449C19.4445 3.35119 19.6966 4.16285 19.762 4.9998C19.8173 5.70844 19.7376 6.41996 19.5282 7.09681C19.9929 7.89994 20.2427 8.81191 20.25 9.74414L20.25 9.75L20.25 10.5C20.25 11.8924 19.6969 13.2277 18.7123 14.2123C17.8973 15.0273 16.842 15.5467 15.7129 15.7014C16.2204 16.3555 16.5 17.1633 16.5 18V21.75C16.5 22.1642 16.1642 22.5 15.75 22.5C15.3358 22.5 15 22.1642 15 21.75V18C15 17.4033 14.7629 16.831 14.341 16.409C13.919 15.9871 13.3467 15.75 12.75 15.75C12.1533 15.75 11.581 15.9871 11.159 16.409C10.7371 16.831 10.5 17.4033 10.5 18V21.75C10.5 22.1642 10.1642 22.5 9.75 22.5C9.33579 22.5 9 22.1642 9 21.75V20.25H6.75C5.75544 20.25 4.80161 19.8549 4.09835 19.1516C3.39509 18.4484 3 17.4946 3 16.5C3 15.9033 2.76295 15.331 2.34099 14.909C1.91903 14.4871 1.34674 14.25 0.75 14.25C0.335786 14.25 0 13.9142 0 13.5C0 13.0858 0.335786 12.75 0.75 12.75C1.74456 12.75 2.69839 13.1451 3.40165 13.8484C4.10491 14.5516 4.5 15.5054 4.5 16.5C4.5 17.0967 4.73705 17.669 5.15901 18.091C5.58097 18.5129 6.15326 18.75 6.75 18.75H9V18C9 17.1633 9.27961 16.3555 9.78707 15.7014C8.658 15.5467 7.60267 15.0273 6.78769 14.2123C5.80312 13.2277 5.25 11.8924 5.25 10.5V9.74414C5.25728 8.81191 5.50709 7.89994 5.97176 7.09681C5.76243 6.41996 5.68268 5.70844 5.73801 4.9998C5.80336 4.16285 6.05546 3.35119 6.47578 2.62449C6.6098 2.39278 6.85715 2.25006 7.12482 2.25ZM15 14.25H10.5C9.50544 14.25 8.55161 13.8549 7.84835 13.1517C7.14509 12.4484 6.75 11.4946 6.75 10.5V9.75306C6.75652 8.98906 6.98903 8.24406 7.41827 7.61196C7.55651 7.4084 7.5861 7.14997 7.49745 6.92043C7.27577 6.34642 7.18556 5.73002 7.23346 5.11655C7.26972 4.65213 7.38443 4.19833 7.57171 3.77413C8.10886 3.8325 8.63084 3.996 9.10731 4.2569C9.71496 4.58964 10.229 5.07006 10.6021 5.65385C10.7399 5.8695 10.9781 6 11.2341 6H14.2659C14.5219 6 14.7601 5.8695 14.8979 5.65385C15.271 5.07006 15.785 4.58964 16.3927 4.2569C16.8692 3.996 17.3911 3.8325 17.9283 3.77413C18.1156 4.19833 18.2303 4.65213 18.2665 5.11655C18.3144 5.73002 18.2242 6.34642 18.0025 6.92043C17.9139 7.14997 17.9435 7.4084 18.0817 7.61196C18.511 8.24406 18.7435 8.98906 18.75 9.75306V10.5C18.75 11.4946 18.3549 12.4484 17.6517 13.1517C16.9484 13.8549 15.9946 14.25 15 14.25Z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </div>
+              <img
+                class="c8 res-icon-github"
+                data-testid="icon"
+                height="24px"
+                src="file_stub"
+                width="24px"
+              />
               github
             </button>
             <button
-              class="c7 c11"
-              color="#dd4b39"
+              class="c7"
               fill="filled"
             >
-              <div
-                class="c9"
-              >
-                <span
-                  class="c10 icon icon-google"
-                  color="white"
-                  data-testid="icon"
-                >
-                  <svg
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                  >
-                    <path
-                      clip-rule="evenodd"
-                      d="M13.3573 4.62289C11.6205 4.30329 9.82663 4.60681 8.29163 5.47999C6.75664 6.35317 5.579 7.74001 4.96613 9.39622C4.35326 11.0524 4.34448 12.8718 4.94134 14.5339C5.53819 16.1959 6.7024 17.594 8.2289 18.482C9.75539 19.37 11.5463 19.6908 13.2861 19.3879C15.0259 19.0851 16.6031 18.1781 17.7398 16.8266C18.7146 15.6675 19.3119 14.2453 19.4623 12.7499H12C11.5858 12.7499 11.25 12.4141 11.25 11.9999C11.25 11.5857 11.5858 11.2499 12 11.2499H20.25C20.4489 11.2499 20.6397 11.3289 20.7804 11.4696C20.921 11.6103 21 11.8011 21 12C20.9998 14.1192 20.2518 16.1703 18.8877 17.7921C17.5237 19.4139 15.6311 20.5023 13.5433 20.8657C11.4555 21.2291 9.30647 20.8441 7.47467 19.7786C5.64288 18.713 4.24583 17.0353 3.52961 15.0408C2.81338 13.0464 2.82391 10.8631 3.55935 8.87566C4.29479 6.8882 5.70796 5.224 7.54996 4.17618C9.39195 3.12836 11.5446 2.76413 13.6288 3.14765C15.713 3.53117 17.595 4.63784 18.9433 6.27273C19.2068 6.59228 19.1614 7.06498 18.8419 7.32853C18.5223 7.59208 18.0496 7.54667 17.7861 7.22711C16.6625 5.86471 15.0941 4.94249 13.3573 4.62289Z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </div>
+              <img
+                class="c8 res-icon-google"
+                data-testid="icon"
+                height="24px"
+                src="file_stub"
+                width="24px"
+              />
               google
             </button>
           </div>
@@ -3481,7 +3393,7 @@ exports[`sso providers rendering 1`] = `
   padding-right: 24px;
 }
 
-.c15 {
+.c10 {
   box-sizing: border-box;
   margin-top: 16px;
   margin-bottom: 16px;
@@ -3489,7 +3401,7 @@ exports[`sso providers rendering 1`] = `
   border-color: rgba(255, 255, 255, 0.54);
 }
 
-.c18 {
+.c13 {
   box-sizing: border-box;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -3514,8 +3426,8 @@ exports[`sso providers rendering 1`] = `
   text-decoration: none;
   transition: background-color 0.1s,border-color 0.1s,outline-color 0.1s,box-shadow 0.1s;
   -webkit-font-smoothing: antialiased;
-  background-color: #9F85FF;
-  color: #000000;
+  background-color: rgba(255,255,255,0.07);
+  color: rgba(255, 255, 255, 0.72);
   border-color: transparent;
   border-width: 1.5px;
   padding: 0 30.5px;
@@ -3523,31 +3435,31 @@ exports[`sso providers rendering 1`] = `
   font-size: 16px;
   line-height: 24px;
   letter-spacing: 0.2px;
-  width: 100%;
+  gap: 16px;
 }
 
 .c7:focus-visible,
 .teleport-button__force-focus-visible .c7 {
-  background-color: #9F85FF;
-  color: #000000;
-  border-color: #000000;
-  border-radius: 2px;
-  outline: 2px solid #9F85FF;
+  background-color: rgba(255,255,255,0.07);
+  color: rgba(255, 255, 255, 0.72);
+  border-color: rgba(255, 255, 255, 0.72);
+  border-radius: 4px;
+  outline: none;
 }
 
 .c7:hover,
 .teleport-button__force-hover .c7 {
-  background-color: #B29DFF;
+  background-color: rgba(255,255,255,0.13);
   border-color: transparent;
-  color: #000000;
-  box-shadow: 0px 3px 5px -1px rgba(0, 0, 0, 0.20),0px 5px 8px 0px rgba(0, 0, 0, 0.14),0px 1px 14px 0px rgba(0, 0, 0, 0.12);
+  color: #FFFFFF;
+  box-shadow: none;
 }
 
 .c7:active,
 .teleport-button__force-active .c7 {
-  background-color: #C5B6FF;
+  background-color: rgba(255,255,255,0.18);
   border-color: transparent;
-  color: #000000;
+  color: #FFFFFF;
 }
 
 .c7:disabled {
@@ -3558,7 +3470,7 @@ exports[`sso providers rendering 1`] = `
   cursor: auto;
 }
 
-.c19 {
+.c14 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -3589,8 +3501,8 @@ exports[`sso providers rendering 1`] = `
   width: 100%;
 }
 
-.c19:focus-visible,
-.teleport-button__force-focus-visible .c19 {
+.c14:focus-visible,
+.teleport-button__force-focus-visible .c14 {
   background-color: rgba(255,255,255,0.07);
   color: rgba(255, 255, 255, 0.72);
   border-color: rgba(255, 255, 255, 0.72);
@@ -3598,22 +3510,22 @@ exports[`sso providers rendering 1`] = `
   outline: none;
 }
 
-.c19:hover,
-.teleport-button__force-hover .c19 {
+.c14:hover,
+.teleport-button__force-hover .c14 {
   background-color: rgba(255,255,255,0.13);
   border-color: transparent;
   color: #FFFFFF;
   box-shadow: none;
 }
 
-.c19:active,
-.teleport-button__force-active .c19 {
+.c14:active,
+.teleport-button__force-active .c14 {
   background-color: rgba(255,255,255,0.18);
   border-color: transparent;
   color: #FFFFFF;
 }
 
-.c19:disabled {
+.c14:disabled {
   background-color: rgba(255,255,255,0.07);
   color: rgba(255, 255, 255, 0.3);
   border-color: transparent;
@@ -3621,17 +3533,23 @@ exports[`sso providers rendering 1`] = `
   cursor: auto;
 }
 
-.c10 {
+.c9 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: white;
 }
 
 .c1 {
   box-shadow: 0px 3px 5px -1px rgba(0, 0, 0, 0.2),0px 6px 10px rgba(0, 0, 0, 0.14),0px 1px 18px rgba(0, 0, 0, 0.12);
   border-radius: 8px;
   background-color: #222C59;
+}
+
+.c8 {
+  display: block;
+  outline: none;
+  width: 24px;
+  height: 24px;
 }
 
 .c2 {
@@ -3651,7 +3569,7 @@ exports[`sso providers rendering 1`] = `
   gap: 16px;
 }
 
-.c16 {
+.c11 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -3702,126 +3620,7 @@ exports[`sso providers rendering 1`] = `
   transition: transform 500ms ease;
 }
 
-.c8 {
-  background-color: #444444;
-  display: block;
-  width: 100%;
-  border: 1px solid transparent;
-  color: white;
-  height: 40px;
-  position: relative;
-  box-sizing: border-box;
-}
-
-.c8:hover,
-.c8:focus {
-  background: rgb(61, 61, 61);
-  border: 1px solid rgb(142, 142, 142);
-}
-
-.c8 svg {
-  opacity: 0.87;
-}
-
-.c11 {
-  background-color: #dd4b39;
-  display: block;
-  width: 100%;
-  border: 1px solid transparent;
-  color: white;
-  height: 40px;
-  position: relative;
-  box-sizing: border-box;
-}
-
-.c11:hover,
-.c11:focus {
-  background: rgb(198, 67, 51);
-  border: 1px solid rgb(234, 147, 136);
-}
-
-.c11 svg {
-  opacity: 0.87;
-}
-
 .c12 {
-  background-color: #205081;
-  display: block;
-  width: 100%;
-  border: 1px solid transparent;
-  color: white;
-  height: 40px;
-  position: relative;
-  box-sizing: border-box;
-}
-
-.c12:hover,
-.c12:focus {
-  background: rgb(28, 72, 116);
-  border: 1px solid rgb(121, 150, 179);
-}
-
-.c12 svg {
-  opacity: 0.87;
-}
-
-.c13 {
-  background-color: #f7931e;
-  display: block;
-  width: 100%;
-  border: 1px solid transparent;
-  color: white;
-  height: 40px;
-  position: relative;
-  box-sizing: border-box;
-}
-
-.c13:hover,
-.c13:focus {
-  background: rgb(222, 132, 27);
-  border: 1px solid rgb(250, 190, 120);
-}
-
-.c13 svg {
-  opacity: 0.87;
-}
-
-.c14 {
-  background-color: #2672ec;
-  display: block;
-  width: 100%;
-  border: 1px solid transparent;
-  color: white;
-  height: 40px;
-  position: relative;
-  box-sizing: border-box;
-}
-
-.c14:hover,
-.c14:focus {
-  background: rgb(34, 102, 212);
-  border: 1px solid rgb(124, 170, 243);
-}
-
-.c14 svg {
-  opacity: 0.87;
-}
-
-.c9 {
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 56px;
-  font-size: 24px;
-  text-align: center;
-  border-right: 1px solid rgba(0,0,0,0.12);
-}
-
-.c17 {
   background: #222C59;
   display: flex;
   align-items: center;
@@ -3861,186 +3660,111 @@ exports[`sso providers rendering 1`] = `
             data-testid="sso-list"
           >
             <button
-              class="c7 c8"
-              color="#444444"
+              class="c7"
               fill="filled"
             >
-              <div
-                class="c9"
-              >
-                <span
-                  class="c10 icon icon-github"
-                  color="white"
-                  data-testid="icon"
-                >
-                  <svg
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                  >
-                    <path
-                      clip-rule="evenodd"
-                      d="M7.12482 2.25C8.06954 2.24978 8.9991 2.4875 9.82773 2.94123C10.5329 3.32738 11.1457 3.85939 11.6261 4.5H13.8739C14.3543 3.85939 14.9671 3.32738 15.6723 2.94123C16.5009 2.4875 17.4305 2.24978 18.3752 2.25C18.6429 2.25006 18.8902 2.39278 19.0242 2.62449C19.4445 3.35119 19.6966 4.16285 19.762 4.9998C19.8173 5.70844 19.7376 6.41996 19.5282 7.09681C19.9929 7.89994 20.2427 8.81191 20.25 9.74414L20.25 9.75L20.25 10.5C20.25 11.8924 19.6969 13.2277 18.7123 14.2123C17.8973 15.0273 16.842 15.5467 15.7129 15.7014C16.2204 16.3555 16.5 17.1633 16.5 18V21.75C16.5 22.1642 16.1642 22.5 15.75 22.5C15.3358 22.5 15 22.1642 15 21.75V18C15 17.4033 14.7629 16.831 14.341 16.409C13.919 15.9871 13.3467 15.75 12.75 15.75C12.1533 15.75 11.581 15.9871 11.159 16.409C10.7371 16.831 10.5 17.4033 10.5 18V21.75C10.5 22.1642 10.1642 22.5 9.75 22.5C9.33579 22.5 9 22.1642 9 21.75V20.25H6.75C5.75544 20.25 4.80161 19.8549 4.09835 19.1516C3.39509 18.4484 3 17.4946 3 16.5C3 15.9033 2.76295 15.331 2.34099 14.909C1.91903 14.4871 1.34674 14.25 0.75 14.25C0.335786 14.25 0 13.9142 0 13.5C0 13.0858 0.335786 12.75 0.75 12.75C1.74456 12.75 2.69839 13.1451 3.40165 13.8484C4.10491 14.5516 4.5 15.5054 4.5 16.5C4.5 17.0967 4.73705 17.669 5.15901 18.091C5.58097 18.5129 6.15326 18.75 6.75 18.75H9V18C9 17.1633 9.27961 16.3555 9.78707 15.7014C8.658 15.5467 7.60267 15.0273 6.78769 14.2123C5.80312 13.2277 5.25 11.8924 5.25 10.5V9.74414C5.25728 8.81191 5.50709 7.89994 5.97176 7.09681C5.76243 6.41996 5.68268 5.70844 5.73801 4.9998C5.80336 4.16285 6.05546 3.35119 6.47578 2.62449C6.6098 2.39278 6.85715 2.25006 7.12482 2.25ZM15 14.25H10.5C9.50544 14.25 8.55161 13.8549 7.84835 13.1517C7.14509 12.4484 6.75 11.4946 6.75 10.5V9.75306C6.75652 8.98906 6.98903 8.24406 7.41827 7.61196C7.55651 7.4084 7.5861 7.14997 7.49745 6.92043C7.27577 6.34642 7.18556 5.73002 7.23346 5.11655C7.26972 4.65213 7.38443 4.19833 7.57171 3.77413C8.10886 3.8325 8.63084 3.996 9.10731 4.2569C9.71496 4.58964 10.229 5.07006 10.6021 5.65385C10.7399 5.8695 10.9781 6 11.2341 6H14.2659C14.5219 6 14.7601 5.8695 14.8979 5.65385C15.271 5.07006 15.785 4.58964 16.3927 4.2569C16.8692 3.996 17.3911 3.8325 17.9283 3.77413C18.1156 4.19833 18.2303 4.65213 18.2665 5.11655C18.3144 5.73002 18.2242 6.34642 18.0025 6.92043C17.9139 7.14997 17.9435 7.4084 18.0817 7.61196C18.511 8.24406 18.7435 8.98906 18.75 9.75306V10.5C18.75 11.4946 18.3549 12.4484 17.6517 13.1517C16.9484 13.8549 15.9946 14.25 15 14.25Z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </div>
+              <img
+                class="c8 res-icon-github"
+                data-testid="icon"
+                height="24px"
+                src="file_stub"
+                width="24px"
+              />
               GitHub
             </button>
             <button
-              class="c7 c11"
-              color="#dd4b39"
+              class="c7"
               fill="filled"
             >
-              <div
-                class="c9"
-              >
-                <span
-                  class="c10 icon icon-google"
-                  color="white"
-                  data-testid="icon"
-                >
-                  <svg
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                  >
-                    <path
-                      clip-rule="evenodd"
-                      d="M13.3573 4.62289C11.6205 4.30329 9.82663 4.60681 8.29163 5.47999C6.75664 6.35317 5.579 7.74001 4.96613 9.39622C4.35326 11.0524 4.34448 12.8718 4.94134 14.5339C5.53819 16.1959 6.7024 17.594 8.2289 18.482C9.75539 19.37 11.5463 19.6908 13.2861 19.3879C15.0259 19.0851 16.6031 18.1781 17.7398 16.8266C18.7146 15.6675 19.3119 14.2453 19.4623 12.7499H12C11.5858 12.7499 11.25 12.4141 11.25 11.9999C11.25 11.5857 11.5858 11.2499 12 11.2499H20.25C20.4489 11.2499 20.6397 11.3289 20.7804 11.4696C20.921 11.6103 21 11.8011 21 12C20.9998 14.1192 20.2518 16.1703 18.8877 17.7921C17.5237 19.4139 15.6311 20.5023 13.5433 20.8657C11.4555 21.2291 9.30647 20.8441 7.47467 19.7786C5.64288 18.713 4.24583 17.0353 3.52961 15.0408C2.81338 13.0464 2.82391 10.8631 3.55935 8.87566C4.29479 6.8882 5.70796 5.224 7.54996 4.17618C9.39195 3.12836 11.5446 2.76413 13.6288 3.14765C15.713 3.53117 17.595 4.63784 18.9433 6.27273C19.2068 6.59228 19.1614 7.06498 18.8419 7.32853C18.5223 7.59208 18.0496 7.54667 17.7861 7.22711C16.6625 5.86471 15.0941 4.94249 13.3573 4.62289Z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </div>
+              <img
+                class="c8 res-icon-google"
+                data-testid="icon"
+                height="24px"
+                src="file_stub"
+                width="24px"
+              />
               Google
             </button>
             <button
-              class="c7 c12"
-              color="#205081"
+              class="c7"
               fill="filled"
             >
-              <div
-                class="c9"
-              >
-                <span
-                  class="c10 icon icon-key"
-                  color="white"
-                  data-testid="icon"
-                >
-                  <svg
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                  >
-                    <path
-                      d="M17.8125 7.125C17.8125 7.64277 17.3928 8.0625 16.875 8.0625C16.3572 8.0625 15.9375 7.64277 15.9375 7.125C15.9375 6.60723 16.3572 6.1875 16.875 6.1875C17.3928 6.1875 17.8125 6.60723 17.8125 7.125Z"
-                    />
-                    <path
-                      clip-rule="evenodd"
-                      d="M15.7546 1.53916C14.0354 1.36504 12.3087 1.78997 10.8666 2.74211C9.42448 3.69425 8.35541 5.11517 7.84013 6.76463C7.37496 8.2537 7.38688 9.84653 7.86716 11.3221L2.46967 16.7196C2.32902 16.8603 2.25 17.051 2.25 17.2499V20.9999C2.25 21.4142 2.58579 21.7499 3 21.7499H6.75C7.16421 21.7499 7.5 21.4142 7.5 20.9999V19.4999H9C9.41421 19.4999 9.75 19.1642 9.75 18.7499V17.2499H11.25C11.4489 17.2499 11.6397 17.1709 11.7803 17.0303L12.6778 16.1328C14.1534 16.6131 15.7462 16.625 17.2353 16.1598C18.8848 15.6445 20.3057 14.5755 21.2578 13.1334C22.21 11.6913 22.6349 9.96459 22.4608 8.24531C22.2867 6.52603 21.5242 4.91962 20.3023 3.69769C19.0803 2.47576 17.4739 1.71327 15.7546 1.53916ZM11.6931 3.99389C12.8467 3.23218 14.2281 2.89223 15.6035 3.03152C16.9789 3.17082 18.264 3.7808 19.2416 4.75835C20.2191 5.73589 20.8291 7.02102 20.9684 8.39645C21.1077 9.77187 20.7678 11.1532 20.0061 12.3069C19.2443 13.4606 18.1076 14.3158 16.788 14.728C15.4685 15.1403 14.047 15.0842 12.7641 14.5692C12.4853 14.4574 12.1667 14.5225 11.9544 14.7349L10.9393 15.7499H9C8.58579 15.7499 8.25 16.0857 8.25 16.4999V17.9999H6.75C6.33579 17.9999 6 18.3357 6 18.7499V20.2499H3.75V17.5606L9.26502 12.0456C9.47739 11.8332 9.54259 11.5146 9.43072 11.2359C8.91577 9.95291 8.85967 8.53148 9.27189 7.21191C9.68412 5.89234 10.5394 4.7556 11.6931 3.99389Z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </div>
+              <img
+                class="c8 res-icon-atlassianbitbucket"
+                data-testid="icon"
+                height="24px"
+                src="file_stub"
+                width="24px"
+              />
               Bitbucket
             </button>
             <button
-              class="c7 c13"
-              color="#f7931e"
+              class="c7"
               fill="filled"
             >
-              <div
-                class="c9"
+              <span
+                class="c9 icon icon-key"
+                data-testid="icon"
               >
-                <span
-                  class="c10 icon icon-key"
-                  color="white"
-                  data-testid="icon"
+                <svg
+                  fill="currentColor"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
                 >
-                  <svg
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                  >
-                    <path
-                      d="M17.8125 7.125C17.8125 7.64277 17.3928 8.0625 16.875 8.0625C16.3572 8.0625 15.9375 7.64277 15.9375 7.125C15.9375 6.60723 16.3572 6.1875 16.875 6.1875C17.3928 6.1875 17.8125 6.60723 17.8125 7.125Z"
-                    />
-                    <path
-                      clip-rule="evenodd"
-                      d="M15.7546 1.53916C14.0354 1.36504 12.3087 1.78997 10.8666 2.74211C9.42448 3.69425 8.35541 5.11517 7.84013 6.76463C7.37496 8.2537 7.38688 9.84653 7.86716 11.3221L2.46967 16.7196C2.32902 16.8603 2.25 17.051 2.25 17.2499V20.9999C2.25 21.4142 2.58579 21.7499 3 21.7499H6.75C7.16421 21.7499 7.5 21.4142 7.5 20.9999V19.4999H9C9.41421 19.4999 9.75 19.1642 9.75 18.7499V17.2499H11.25C11.4489 17.2499 11.6397 17.1709 11.7803 17.0303L12.6778 16.1328C14.1534 16.6131 15.7462 16.625 17.2353 16.1598C18.8848 15.6445 20.3057 14.5755 21.2578 13.1334C22.21 11.6913 22.6349 9.96459 22.4608 8.24531C22.2867 6.52603 21.5242 4.91962 20.3023 3.69769C19.0803 2.47576 17.4739 1.71327 15.7546 1.53916ZM11.6931 3.99389C12.8467 3.23218 14.2281 2.89223 15.6035 3.03152C16.9789 3.17082 18.264 3.7808 19.2416 4.75835C20.2191 5.73589 20.8291 7.02102 20.9684 8.39645C21.1077 9.77187 20.7678 11.1532 20.0061 12.3069C19.2443 13.4606 18.1076 14.3158 16.788 14.728C15.4685 15.1403 14.047 15.0842 12.7641 14.5692C12.4853 14.4574 12.1667 14.5225 11.9544 14.7349L10.9393 15.7499H9C8.58579 15.7499 8.25 16.0857 8.25 16.4999V17.9999H6.75C6.33579 17.9999 6 18.3357 6 18.7499V20.2499H3.75V17.5606L9.26502 12.0456C9.47739 11.8332 9.54259 11.5146 9.43072 11.2359C8.91577 9.95291 8.85967 8.53148 9.27189 7.21191C9.68412 5.89234 10.5394 4.7556 11.6931 3.99389Z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </div>
+                  <path
+                    d="M17.8125 7.125C17.8125 7.64277 17.3928 8.0625 16.875 8.0625C16.3572 8.0625 15.9375 7.64277 15.9375 7.125C15.9375 6.60723 16.3572 6.1875 16.875 6.1875C17.3928 6.1875 17.8125 6.60723 17.8125 7.125Z"
+                  />
+                  <path
+                    clip-rule="evenodd"
+                    d="M15.7546 1.53916C14.0354 1.36504 12.3087 1.78997 10.8666 2.74211C9.42448 3.69425 8.35541 5.11517 7.84013 6.76463C7.37496 8.2537 7.38688 9.84653 7.86716 11.3221L2.46967 16.7196C2.32902 16.8603 2.25 17.051 2.25 17.2499V20.9999C2.25 21.4142 2.58579 21.7499 3 21.7499H6.75C7.16421 21.7499 7.5 21.4142 7.5 20.9999V19.4999H9C9.41421 19.4999 9.75 19.1642 9.75 18.7499V17.2499H11.25C11.4489 17.2499 11.6397 17.1709 11.7803 17.0303L12.6778 16.1328C14.1534 16.6131 15.7462 16.625 17.2353 16.1598C18.8848 15.6445 20.3057 14.5755 21.2578 13.1334C22.21 11.6913 22.6349 9.96459 22.4608 8.24531C22.2867 6.52603 21.5242 4.91962 20.3023 3.69769C19.0803 2.47576 17.4739 1.71327 15.7546 1.53916ZM11.6931 3.99389C12.8467 3.23218 14.2281 2.89223 15.6035 3.03152C16.9789 3.17082 18.264 3.7808 19.2416 4.75835C20.2191 5.73589 20.8291 7.02102 20.9684 8.39645C21.1077 9.77187 20.7678 11.1532 20.0061 12.3069C19.2443 13.4606 18.1076 14.3158 16.788 14.728C15.4685 15.1403 14.047 15.0842 12.7641 14.5692C12.4853 14.4574 12.1667 14.5225 11.9544 14.7349L10.9393 15.7499H9C8.58579 15.7499 8.25 16.0857 8.25 16.4999V17.9999H6.75C6.33579 17.9999 6 18.3357 6 18.7499V20.2499H3.75V17.5606L9.26502 12.0456C9.47739 11.8332 9.54259 11.5146 9.43072 11.2359C8.91577 9.95291 8.85967 8.53148 9.27189 7.21191C9.68412 5.89234 10.5394 4.7556 11.6931 3.99389Z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
               Mission Control
             </button>
             <button
-              class="c7 c14"
-              color="#2672ec"
+              class="c7"
               fill="filled"
             >
-              <div
-                class="c9"
-              >
-                <span
-                  class="c10 icon icon-windows"
-                  color="white"
-                  data-testid="icon"
-                >
-                  <svg
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                  >
-                    <path
-                      clip-rule="evenodd"
-                      d="M20.7305 3.17418C20.9013 3.31668 21 3.52761 21 3.75001V10.5C21 10.9142 20.6642 11.25 20.25 11.25H12.75C12.3358 11.25 12 10.9142 12 10.5V5.11407C12 4.75162 12.2592 4.44103 12.6158 4.37617L20.1158 3.01211C20.3346 2.97231 20.5598 3.03168 20.7305 3.17418ZM13.5 5.73997V9.75001H19.5V4.64872L13.5 5.73997Z"
-                      fill-rule="evenodd"
-                    />
-                    <path
-                      clip-rule="evenodd"
-                      d="M3.75 12.75C3.33579 12.75 3 13.0858 3 13.5V17.25C3 17.6124 3.2592 17.923 3.6158 17.9879L9.6158 19.0791C9.83461 19.1189 10.0598 19.0596 10.2305 18.9171C10.4013 18.7746 10.5 18.5637 10.5 18.3412V13.5C10.5 13.0858 10.1642 12.75 9.75 12.75H3.75ZM4.5 16.6241V14.25H9V17.4425L4.5 16.6241Z"
-                      fill-rule="evenodd"
-                    />
-                    <path
-                      clip-rule="evenodd"
-                      d="M12.75 12.75C12.3358 12.75 12 13.0858 12 13.5V18.8869C12 19.2494 12.2592 19.56 12.6159 19.6248L20.1159 20.9879C20.3347 21.0277 20.5598 20.9683 20.7306 20.8258C20.9013 20.6833 21 20.4724 21 20.25V13.5C21 13.0858 20.6642 12.75 20.25 12.75H12.75ZM13.5 18.2609V14.25H19.5V19.3514L13.5 18.2609Z"
-                      fill-rule="evenodd"
-                    />
-                    <path
-                      clip-rule="evenodd"
-                      d="M10.5 5.65919C10.5 5.43679 10.4013 5.22586 10.2305 5.08336C10.0598 4.94086 9.83461 4.88149 9.6158 4.92129L3.6158 6.01254C3.2592 6.0774 3 6.38799 3 6.75044V10.5004C3 10.9146 3.33579 11.2504 3.75 11.2504H9.75C10.1642 11.2504 10.5 10.9146 10.5 10.5004V5.65919ZM4.5 9.75044V7.37633L9 6.5579V9.75044H4.5Z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </div>
+              <img
+                class="c8 res-icon-okta"
+                data-testid="icon"
+                height="24px"
+                src="file_stub"
+                width="24px"
+              />
+              Okta
+            </button>
+            <button
+              class="c7"
+              fill="filled"
+            >
+              <img
+                class="c8 res-icon-microsoft"
+                data-testid="icon"
+                height="24px"
+                src="file_stub"
+                width="24px"
+              />
               Microsoft
             </button>
           </div>
           <div
-            class="c15 c16"
+            class="c10 c11"
           >
             <div
-              class="c17"
+              class="c12"
             >
               Or
             </div>
           </div>
           <div
-            class="c18"
+            class="c13"
           >
             <button
-              class="c19"
+              class="c14"
               fill="filled"
             >
               Sign in with Username and Password


### PR DESCRIPTION
- Use correct IDP icons
- Add Okta to the list of guessed providers
- Fix broken autofocus for SSO and passwordless methods
- Update the docs that contained previously incorrect information about the display attribute of the connector resource definition

<img width="620" alt="Screenshot 2024-07-31 at 19 25 03" src="https://github.com/user-attachments/assets/ab9ed171-08b9-4b49-b58d-b76ee9fa5dd2">

Figma: https://www.figma.com/design/v6GunK50D2VC7w7I2FBDNf/Management?node-id=4044-8185&m=dev

Deviations from the design:
- We decided to abandon the "sign in with" prefix, as it may conflict with existing deployments.
- We decided to revert back to the centered text.

Fixes #44874
Fixes #36883