### PR TITLE
[kube] fix greedy deny rule blocking namespace list when blocking other resources

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1134,14 +1134,14 @@ func matchKubernetesResource(resource types.KubernetesResource, allowed, denied 
 	// utils.KubeResourceMatchesRegex checks if the resource.Kind is strictly equal
 	// to each entry and validates if the Name and Namespace fields matches the
 	// regex allowed by each entry.
-	result, err := utils.KubeResourceMatchesRegex(resource, denied)
+	result, err := utils.KubeResourceMatchesRegex(resource, denied, types.Deny)
 	if err != nil {
 		return false, trace.Wrap(err)
 	} else if result {
 		return false, nil
 	}
 
-	result, err = utils.KubeResourceMatchesRegex(resource, allowed)
+	result, err = utils.KubeResourceMatchesRegex(resource, allowed, types.Allow)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2421,7 +2421,7 @@ func NewKubernetesResourceMatcher(resource types.KubernetesResource) *Kubernetes
 
 // Match matches a Kubernetes Resource against provided role and condition.
 func (m *KubernetesResourceMatcher) Match(role types.Role, condition types.RoleConditionType) (bool, error) {
-	result, err := utils.KubeResourceMatchesRegex(m.resource, role.GetKubeResources(condition))
+	result, err := utils.KubeResourceMatchesRegex(m.resource, role.GetKubeResources(condition), condition)
 
 	return result, trace.Wrap(err)
 }

--- a/lib/utils/replace_test.go
+++ b/lib/utils/replace_test.go
@@ -162,6 +162,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 		name      string
 		input     types.KubernetesResource
 		resources []types.KubernetesResource
+		action    types.RoleConditionType
 		matches   bool
 		assert    require.ErrorAssertionFunc
 	}{
@@ -180,7 +181,82 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.Error,
+			action:  types.Allow,
 			matches: false,
+		},
+		{
+			name: "list namespace matches resource",
+			input: types.KubernetesResource{
+				Kind:  types.KindNamespace,
+				Verbs: []string{types.KubeVerbList},
+			},
+			resources: []types.KubernetesResource{
+				{
+					Kind:      types.KindKubeSecret,
+					Namespace: "*",
+					Name:      "*",
+					Verbs:     []string{types.Wildcard},
+				},
+			},
+			assert:  require.NoError,
+			action:  types.Allow,
+			matches: true,
+		},
+		{
+			name: "list namespace doesn't match denying secrets",
+			input: types.KubernetesResource{
+				Kind:  types.KindNamespace,
+				Verbs: []string{types.KubeVerbList},
+			},
+			resources: []types.KubernetesResource{
+				{
+					Kind:      types.KindKubeSecret,
+					Namespace: "*",
+					Name:      "*",
+					Verbs:     []string{types.Wildcard},
+				},
+			},
+			assert:  require.NoError,
+			action:  types.Deny,
+			matches: false,
+		},
+		{
+			name: "get namespace doesn't match denying secrets",
+			input: types.KubernetesResource{
+				Kind:  types.KindNamespace,
+				Name:  "default",
+				Verbs: []string{types.KubeVerbGet},
+			},
+			resources: []types.KubernetesResource{
+				{
+					Kind:      types.KindKubeSecret,
+					Namespace: "*",
+					Name:      "*",
+					Verbs:     []string{types.Wildcard},
+				},
+			},
+			assert:  require.NoError,
+			action:  types.Deny,
+			matches: false,
+		},
+		{
+			name: "get secret matches denying secrets",
+			input: types.KubernetesResource{
+				Kind:  types.KindKubeSecret,
+				Name:  "default",
+				Verbs: []string{types.KubeVerbGet},
+			},
+			resources: []types.KubernetesResource{
+				{
+					Kind:      types.KindKubeSecret,
+					Namespace: "*",
+					Name:      "*",
+					Verbs:     []string{types.Wildcard},
+				},
+			},
+			assert:  require.NoError,
+			action:  types.Deny,
+			matches: true,
 		},
 		{
 			name: "input matches single resource with wildcard verb",
@@ -199,6 +275,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: true,
 		},
 		{
@@ -218,6 +295,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: true,
 		},
 		{
@@ -237,6 +315,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: false,
 		},
 		{
@@ -255,6 +334,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: false,
 		},
 		{
@@ -286,6 +366,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: true,
 		},
 		{
@@ -305,6 +386,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: true,
 		},
 		{
@@ -324,6 +406,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: false,
 		},
 		{
@@ -342,6 +425,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 					Verbs:     []string{types.Wildcard},
 				},
 			},
+			action: types.Allow,
 			assert: require.Error,
 		},
 		{
@@ -359,6 +443,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 					Name:      "podname",
 				},
 			},
+			action: types.Allow,
 			assert: require.NoError,
 		},
 		{
@@ -376,6 +461,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: true,
 		},
 		{
@@ -394,6 +480,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: true,
 		},
 		{
@@ -412,6 +499,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: false,
 		},
 		{
@@ -430,6 +518,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: true,
 		},
 
@@ -449,6 +538,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: false,
 		},
 
@@ -468,6 +558,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: true,
 		},
 		{
@@ -486,6 +577,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: false,
 		},
 
@@ -505,6 +597,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: true,
 		},
 		{
@@ -523,6 +616,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: false,
 		},
 		{
@@ -547,12 +641,13 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
+			action:  types.Allow,
 			matches: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := KubeResourceMatchesRegex(tt.input, tt.resources)
+			got, err := KubeResourceMatchesRegex(tt.input, tt.resources, tt.action)
 			tt.assert(t, err)
 			require.Equal(t, tt.matches, got)
 		})
@@ -612,6 +707,42 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 					Kind:      types.KindKubePod,
 					Namespace: "default",
 					Name:      "podname",
+					Verbs:     []string{types.Wildcard},
+				},
+			},
+			action:  types.Allow,
+			assert:  require.NoError,
+			matches: true,
+		},
+		{
+			name: "input doesn't match kind deny",
+			input: types.KubernetesResource{
+				Kind:  types.KindNamespace,
+				Verbs: []string{types.KubeVerbList},
+			},
+			resources: []types.KubernetesResource{
+				{
+					Kind:      types.KindKubeSecret,
+					Namespace: "*",
+					Name:      "*",
+					Verbs:     []string{types.Wildcard},
+				},
+			},
+			action:  types.Deny,
+			assert:  require.NoError,
+			matches: false,
+		},
+		{
+			name: "input doesn't match kind allow",
+			input: types.KubernetesResource{
+				Kind:  types.KindNamespace,
+				Verbs: []string{types.KubeVerbList},
+			},
+			resources: []types.KubernetesResource{
+				{
+					Kind:      types.KindKubeSecret,
+					Namespace: "*",
+					Name:      "*",
 					Verbs:     []string{types.Wildcard},
 				},
 			},
@@ -1030,9 +1161,10 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 				},
 			},
 			assert:  require.NoError,
-			matches: true,
+			matches: false,
 			action:  types.Deny,
 		},
+
 		{
 			name: "list namespace with resource denying update access to namespace",
 			input: types.KubernetesResource{

--- a/lib/utils/replace_test.go
+++ b/lib/utils/replace_test.go
@@ -221,6 +221,25 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 			matches: false,
 		},
 		{
+			name: "get namespace match denying everything",
+			input: types.KubernetesResource{
+				Kind:  types.KindNamespace,
+				Name:  "default",
+				Verbs: []string{types.KubeVerbGet},
+			},
+			resources: []types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Namespace: types.Wildcard,
+					Name:      types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+				},
+			},
+			assert:  require.NoError,
+			action:  types.Deny,
+			matches: true,
+		},
+		{
 			name: "get namespace doesn't match denying secrets",
 			input: types.KubernetesResource{
 				Kind:  types.KindNamespace,


### PR DESCRIPTION
This PR fixes an edge case where the deny rule for blocking access to a resource becomes greedy and blocks access to the whole namespace.

eg:

```
  allow:
    kubernetes_labels:
      '*': '*'
    kubernetes_resources:
    - kind: '*'
      name: '*'
      namespace: '*'
      verbs:
      - '*'
  deny:
    kubernetes_resources:
    - kind: secret
      name: '*'
      namespace: '*'
      verbs:
      - '*'

```

With the example above, access to secrets must be blocked but the user is allowed to access every other resource in any namespace. The previous model was greedy and blocked access to namespace list.


Changelog: Prevent Kubernetes per-Resource RBAC from blocking access to namespaces when denying access to a single resource kind in every namespace.