### PR TITLE
build: Explicitly make `all` the default goal/target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@
 #  clean  : removes all build artifacts
 #  test   : runs tests
 
+.DEFAULT_GOAL := all
+
 # To update the Teleport version, update VERSION variable:
 # Naming convention:
 #   Stable releases:   "1.0.0"


### PR DESCRIPTION
Add a default goal of `all` to the Makefile so we do not need to rely on
a particular ordering of goals. A recent changed added an early include
that had a diagnosis target which then became the default goal, meaning
`make` on it's own no longer built teleport.
