### PR TITLE
[v16] Add device trust web redirect to githubCallback

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1857,6 +1857,11 @@ func (h *Handler) githubCallback(w http.ResponseWriter, r *http.Request, p httpr
 
 		if dwt := response.Session.GetDeviceWebToken(); dwt != nil {
 			logger.Debug("GitHub WebSession created with device web token")
+			// if a device web token is present, we must send the user to the device authorize page
+			// to upgrade the session.
+			// TODO (avatus) the web client currently doesn't handle any redirects after authorizing a web
+			// session with device trust. Once it does, append a redirect_url here as a query parameter
+			return fmt.Sprintf("/web/device/authorize/%s/%s", dwt.Id, dwt.Token)
 		}
 		return res.ClientRedirectURL
 	}


### PR DESCRIPTION
Backport #44888 to branch/v16

changelog: SSO login flows can now authorize web sessions with Device Trust
