### PR TITLE
Web: fix undefined limit sending undefined as a value to backend

### DIFF
--- a/web/packages/teleport/src/generateResourcePath.test.ts
+++ b/web/packages/teleport/src/generateResourcePath.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cfg, { UrlResourcesParams } from './config';
+import generateResourcePath from './generateResourcePath';
+
+test('undefined params are set to empty string', () => {
+  expect(
+    generateResourcePath(cfg.api.unifiedResourcesPath, { clusterId: 'cluster' })
+  ).toStrictEqual(
+    '/v1/webapi/sites/cluster/resources?searchAsRoles=&limit=&startKey=&kinds=&query=&search=&sort=&pinnedOnly=&includedResourceMode='
+  );
+});
+
+test('defined params are set', () => {
+  const unifiedParams: UrlResourcesParams = {
+    query: 'query',
+    search: 'search',
+    sort: { fieldName: 'field', dir: 'DESC' },
+    limit: 100,
+    startKey: 'startkey',
+    searchAsRoles: 'yes',
+    pinnedOnly: true,
+    includedResourceMode: 'all',
+    kinds: ['app'],
+  };
+  expect(
+    generateResourcePath(cfg.api.unifiedResourcesPath, {
+      clusterId: 'cluster',
+      ...unifiedParams,
+    })
+  ).toStrictEqual(
+    '/v1/webapi/sites/cluster/resources?searchAsRoles=yes&limit=100&startKey=startkey&kinds=app&query=query&search=search&sort=field:desc&pinnedOnly=true&includedResourceMode=all'
+  );
+});
+
+test('defined params but set to empty values are set to empty string', () => {
+  const unifiedParams: UrlResourcesParams = {
+    query: '',
+    search: null,
+    limit: 0,
+    pinnedOnly: false,
+    kinds: [],
+  };
+  expect(
+    generateResourcePath(cfg.api.unifiedResourcesPath, {
+      clusterId: 'cluster',
+      ...unifiedParams,
+    })
+  ).toStrictEqual(
+    '/v1/webapi/sites/cluster/resources?searchAsRoles=&limit=&startKey=&kinds=&query=&search=&sort=&pinnedOnly=&includedResourceMode='
+  );
+});

--- a/web/packages/teleport/src/generateResourcePath.ts
+++ b/web/packages/teleport/src/generateResourcePath.ts
@@ -50,7 +50,7 @@ export default function generateResourcePath(
 
   const output = path
     .replace(':clusterId', params.clusterId)
-    .replace(':limit?', params.limit)
+    .replace(':limit?', params.limit || '')
     .replace(':startKey?', params.startKey || '')
     .replace(':query?', processedParams.query || '')
     .replace(':search?', processedParams.search || '')


### PR DESCRIPTION
sending `undefined` value gets interpreted as a string `undefined` and is an invalid value for a limit