### PR TITLE
Increase the amount of time session trackers linger

### DIFF
--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -685,6 +685,7 @@ func (w *sliceWriter) completeStream() {
 		sort.Slice(w.completedParts, func(i, j int) bool {
 			return w.completedParts[i].Number < w.completedParts[j].Number
 		})
+
 		err := w.proto.cfg.Uploader.CompleteUpload(w.proto.cancelCtx, w.proto.cfg.Upload, w.completedParts)
 		w.proto.setCompleteResult(err)
 		if err != nil {

--- a/lib/services/local/sessiontracker.go
+++ b/lib/services/local/sessiontracker.go
@@ -34,9 +34,17 @@ import (
 const (
 	sessionPrefix   = "session_tracker"
 	retryDelay      = time.Second
-	terminatedTTL   = 3 * time.Minute
 	casRetryLimit   = 7
 	casErrorMessage = "CompareAndSwap reached retry limit"
+
+	// terminatedTTL is the TTL we set when a session tracker
+	// is put in a terminated state.
+	//
+	// Teleport's upload completer will attempt ot operate on any
+	// session that does not contain an active session tracker, so
+	// we choose a value here that will give sessions enough time
+	// to be uploaded.
+	terminatedTTL = 90 * time.Minute
 )
 
 type sessionTracker struct {

--- a/lib/srv/sessiontracker.go
+++ b/lib/srv/sessiontracker.go
@@ -67,7 +67,8 @@ func NewSessionTracker(ctx context.Context, trackerSpec types.SessionTrackerSpec
 	}, nil
 }
 
-// Close closes the session tracker and sets the tracker state to terminated
+// Close closes the session tracker and sets the tracker state to terminated.
+// The tracker will remain in a terminated state until it expires from the backend.
 func (s *SessionTracker) Close(ctx context.Context) error {
 	close(s.closeC)
 	err := s.UpdateState(ctx, types.SessionState_SessionStateTerminated)


### PR DESCRIPTION
When a session completes, the corresponding session tracker is put into a terminated state and its expiry is updated so that it will naturally expire shortly in the future.

Teleport's upload completer runs periodically and looks for uploads for which there is not a session tracker. If it finds any, it assumes there was an error and that no more data will be uploaded so it completes or aborts the upload.

There is a race condition here - if the TTL of the terminated session tracker is shorter than the time it takes for the session to be uploaded, then the upload completer may mistakenly determine that a session tracker which just recently expired (and is still being uploaded) needs to be completed, causing the upload to be cut short.

Increase the TTL of terminated sessions to drastically reduce the chances of this race occurring. Note that the web UI's active sessions page already filters out trackers with a state of terminated, so there should not be any user-visible change here.