### PR TITLE
Remove warnings about passwordless support in Firefox

### DIFF
--- a/web/packages/teleport/src/Welcome/NewCredentials/NewPasswordlessDevice.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewPasswordlessDevice.tsx
@@ -18,7 +18,7 @@
 
 import React, { useState } from 'react';
 import { Box, ButtonPrimary, ButtonText, H2 } from 'design';
-import { Danger, Info } from 'design/Alert';
+import { Danger } from 'design/Alert';
 import FieldInput from 'shared/components/FieldInput';
 import Validation, { Validator } from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
@@ -73,15 +73,6 @@ export function NewPasswordlessDevice(props: UseTokenState & SliderProps) {
     changeFlow({ flow: 'local', applyNextAnimation });
   }
 
-  // Firefox currently does not support passwordless and when
-  // registering, users will 'soft lock' where firefox prompts
-  // but when touching the device, it does not do anything.
-  // We display a soft warning because firefox may provide
-  // support in the near future: https://github.com/gravitational/webapps/pull/876
-  const isFirefox = window.navigator?.userAgent
-    ?.toLowerCase()
-    .includes('firefox');
-
   return (
     <Validation>
       {({ validator }) => (
@@ -89,12 +80,6 @@ export function NewPasswordlessDevice(props: UseTokenState & SliderProps) {
           <H2 mb={3}>Set up Passwordless Authentication</H2>
           {submitAttempt.status === 'failed' && (
             <Danger children={submitAttempt.statusText} />
-          )}
-          {isFirefox && (
-            <Info mt={3}>
-              Firefox may not support passwordless register. Please try Chrome
-              or Safari.
-            </Info>
           )}
           Setting up account for: {resetToken.user}
           <Box mb={3}>

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
@@ -143,21 +143,8 @@ const Passwordless = ({
   const ref = useRefAutoFocus<HTMLButtonElement>({
     shouldFocus: hasTransitionEnded && autoFocus,
   });
-  // Firefox currently does not support passwordless and when
-  // logging in, it will return an ambiguous error.
-  // We display a soft warning because firefox may provide
-  // support in the near future: https://github.com/gravitational/webapps/pull/876
-  const isFirefox = window.navigator?.userAgent
-    ?.toLowerCase()
-    .includes('firefox');
   return (
     <Box data-testid="passwordless">
-      {isFirefox && (
-        <Alerts.Info mt={3}>
-          Firefox may not support passwordless login. Please try Chrome or
-          Safari.
-        </Alerts.Info>
-      )}
       <Flex
         flexDirection="column"
         border={1}


### PR DESCRIPTION
Firefox has supported passwordless on Windows since 2019. On macOS, [passkeys have been supported since January of this year](https://www.mozilla.org/en-US/firefox/122.0/releasenotes/). I don't know when support on Linux was added, but it works.

<details>
<summary>Demo videos</summary>

Demos taken on my 16.1.1 cluster. There are two entries for the same domain simply because I had to recreate my cluster and that hardware key already had a passkey for this domain registered. But this at least shows that the credential picker is uniformly supported on all three platforms.


https://github.com/user-attachments/assets/0a3e6893-336a-4a28-a54a-97909fa22af1


https://github.com/user-attachments/assets/7cbd82c5-a4a4-44b2-80a4-339c6f1f7e9a


https://github.com/user-attachments/assets/6de3db32-9425-4216-a49d-08dde38d6436

</details>