### PR TITLE
Fix the login page divider

### DIFF
--- a/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
@@ -451,7 +451,6 @@ const StyledOr = styled.div`
   width: 32px;
   justify-content: center;
   position: absolute;
-  z-index: 1;
   text-transform: uppercase;
 `;
 

--- a/web/packages/teleport/src/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
+++ b/web/packages/teleport/src/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
@@ -3830,7 +3830,6 @@ exports[`sso providers rendering 1`] = `
   width: 32px;
   justify-content: center;
   position: absolute;
-  z-index: 1;
   text-transform: uppercase;
 }
 


### PR DESCRIPTION
The z-index caused it to overlap with the MFA method dropdown. See the linked issue for screenshot of the problem.

Fixes https://github.com/gravitational/teleport/issues/43843

Manual test: signed in using password+WebAuthn.