### PR TITLE
iam-join: Add additional test cases to cover assumed-role arns

### DIFF
--- a/lib/auth/join_iam_test.go
+++ b/lib/auth/join_iam_test.go
@@ -211,6 +211,121 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			assertError: require.NoError,
 		},
 		{
+			desc:             "arn assumed role",
+			tokenName:        "test-token",
+			requestTokenName: "test-token",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Allow: []*types.TokenRule{
+					{
+						AWSAccount: "123456789012",
+						AWSARN:     "arn:aws:sts::123456789012:assumed-role/my-super-001-test-role/my-session-name",
+					},
+				},
+				JoinMethod: types.JoinMethodIAM,
+			},
+			stsClient: &mockClient{
+				respStatusCode: http.StatusOK,
+				respBody: responseFromAWSIdentity(awsIdentity{
+					Account: "123456789012",
+					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-001-test-role/my-session-name",
+				}),
+			},
+			assertError: require.NoError,
+		},
+		{
+			desc:             "wildcard arn assumed role",
+			tokenName:        "test-token",
+			requestTokenName: "test-token",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Allow: []*types.TokenRule{
+					{
+						AWSAccount: "123456789012",
+						AWSARN:     "arn:aws:sts::123456789012:assumed-role/my-*-test-role/my-session-name",
+					},
+				},
+				JoinMethod: types.JoinMethodIAM,
+			},
+			stsClient: &mockClient{
+				respStatusCode: http.StatusOK,
+				respBody: responseFromAWSIdentity(awsIdentity{
+					Account: "123456789012",
+					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-001-test-role/my-session-name",
+				}),
+			},
+			assertError: require.NoError,
+		},
+		{
+			desc:             "wildcard 2 arn assumed role",
+			tokenName:        "test-token",
+			requestTokenName: "test-token",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Allow: []*types.TokenRule{
+					{
+						AWSAccount: "123456789012",
+						AWSARN:     "arn:aws:sts::123456789012:assumed-role/my-*-test-role/*",
+					},
+				},
+				JoinMethod: types.JoinMethodIAM,
+			},
+			stsClient: &mockClient{
+				respStatusCode: http.StatusOK,
+				respBody: responseFromAWSIdentity(awsIdentity{
+					Account: "123456789012",
+					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-001-test-role/my-session-name",
+				}),
+			},
+			assertError: require.NoError,
+		},
+		{
+			desc:             "wrong wildcard arn assumed role",
+			tokenName:        "test-token",
+			requestTokenName: "test-token",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Allow: []*types.TokenRule{
+					{
+						AWSAccount: "123456789012",
+						AWSARN:     "arn:aws:sts::123456789012:assumed-role/my-*-test-role",
+					},
+				},
+				JoinMethod: types.JoinMethodIAM,
+			},
+			stsClient: &mockClient{
+				respStatusCode: http.StatusOK,
+				respBody: responseFromAWSIdentity(awsIdentity{
+					Account: "123456789012",
+					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-002-test-role/my-session-name",
+				}),
+			},
+			assertError: isAccessDenied,
+		},
+		{
+			desc:             "wrong wildcard 2 arn assumed role",
+			tokenName:        "test-token",
+			requestTokenName: "test-token",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Allow: []*types.TokenRule{
+					{
+						AWSAccount: "123456789012",
+						AWSARN:     "arn:aws:sts::123456789012:assumed-role/my-*-test-role",
+					},
+				},
+				JoinMethod: types.JoinMethodIAM,
+			},
+			stsClient: &mockClient{
+				respStatusCode: http.StatusOK,
+				respBody: responseFromAWSIdentity(awsIdentity{
+					Account: "123456789012",
+					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-002-test-role/my-session-name2",
+				}),
+			},
+			assertError: isAccessDenied,
+		},
+		{
 			desc:             "wrong token",
 			tokenName:        "test-token",
 			requestTokenName: "wrong-token",


### PR DESCRIPTION
### Summary

Add testcases to cover Assumed Roles with Role Session Names[^1] for IAM Join Token[^2] functionality.

[^1]: https://aws.amazon.com/blogs/security/easily-control-naming-individual-iam-role-sessions/
[^2]: https://goteleport.com/docs/enroll-resources/agents/join-services-to-your-cluster/aws-iam/

### Context

I'm planning to use IAM Join Tokens[^2] and wanted to make sure that Role Session Names[^1] are supported, so I've added couple of test-cases to cover this use-case.


