### PR TITLE
Allow passing arguments to Storybook from CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build-term": "pnpm --filter=@gravitational/teleterm build",
     "start-term": "pnpm --filter=@gravitational/teleterm start",
     "package-term": "pnpm --filter=@gravitational/teleterm package",
-    "storybook": "if test -f web/certs/server.crt; then storybook dev -p 9002 -c web/.storybook --https --ssl-cert=web/certs/server.crt --ssl-key=web/certs/server.key; else echo \"Could not find SSL certificates. Please follow web/README.md to generate certificates.\" && false; fi",
+    "storybook": "./web/scripts/run-storybook.sh",
     "storybook-smoke-test": "storybook dev -p 9002 -c web/.storybook --ci --smoke-test",
     "test": "jest",
     "test-coverage": "jest --coverage && web/scripts/print-coverage-link.sh",

--- a/web/scripts/run-storybook.sh
+++ b/web/scripts/run-storybook.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if test -f web/certs/server.crt; then
+  storybook dev -p 9002 -c web/.storybook --https --ssl-cert=web/certs/server.crt --ssl-key=web/certs/server.key "$@"
+else
+  echo \"Could not find SSL certificates. Please follow web/README.md to generate certificates.\" && false
+fi


### PR DESCRIPTION
Extracts the script to a standalone file, enabling us to use the `$@` variable and inject additional CLI parameters where they belong (the `storybook` command). This allows e.g. overriding the port number.