### PR TITLE
docs: Don't provide commands to use Homebrew

### DIFF
--- a/docs/pages/access-controls/guides/passwordless.mdx
+++ b/docs/pages/access-controls/guides/passwordless.mdx
@@ -19,8 +19,8 @@ usernameless authentication for Teleport.
 - A web browser with WebAuthn support. To see if your browser supports
   WebAuthn, check the [WebAuthn
   Compatibility](https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/) page.
-- A signed and notarized version of `tsh` is required for Touch ID. This precludes
-  versions installed from Homebrew. [Download the macOS tsh installer](../../installation.mdx#macos).
+- A signed and notarized version of `tsh` is required for Touch ID. This means versions
+  installed from Homebrew will not work. [Download the macOS tsh installer](../../installation.mdx#macos).
 - (!docs/pages/includes/tctl.mdx!)
 
 A Teleport cluster capable of WebAuthn is automatically capable of passwordless.

--- a/docs/pages/access-controls/guides/passwordless.mdx
+++ b/docs/pages/access-controls/guides/passwordless.mdx
@@ -20,7 +20,7 @@ usernameless authentication for Teleport.
   WebAuthn, check the [WebAuthn
   Compatibility](https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/) page.
 - A signed and notarized version of `tsh` is required for Touch ID. This means versions
-  installed from Homebrew will not work. [Download the macOS tsh installer](../../installation.mdx#macos).
+  installed from Homebrew or compiled from source will not work. [Download the macOS tsh installer](../../installation.mdx#macos).
 - (!docs/pages/includes/tctl.mdx!)
 
 A Teleport cluster capable of WebAuthn is automatically capable of passwordless.

--- a/docs/pages/includes/install-tsh.mdx
+++ b/docs/pages/includes/install-tsh.mdx
@@ -9,18 +9,13 @@
   </TabItem>
 
   <TabItem label="Mac - Homebrew">
-    ```code
-    $ brew install teleport
-    ```
+    <Admonition type="danger">
+      Using Homebrew to install Teleport is not supported. The Teleport package in
+      Homebrew is not maintained by Teleport and we can't guarantee its reliability or
+      security.
 
-    <Admonition type="note">
-      The Teleport package in Homebrew is not maintained by Teleport and we can't
-      guarantee its reliability or security. We recommend the use of our [own Teleport packages](https://goteleport.com/download?os=mac).
-
-      If you choose to use Homebrew, you must verify that the versions of `tsh` and
-      `tctl` are compatible with the versions you run server-side. Homebrew usually
-      ships the latest release of Teleport, which may be incompatible with older
-      versions. See our [compatibility policy](../upgrading/overview.mdx) for details.
+      We recommend the use of our [own Teleport packages](https://goteleport.com/download?os=mac)
+      for any installations on MacOS.
     </Admonition>
   </TabItem>
 

--- a/docs/pages/includes/install-tsh.mdx
+++ b/docs/pages/includes/install-tsh.mdx
@@ -15,7 +15,7 @@
       security.
 
       We recommend the use of our [own Teleport packages](https://goteleport.com/download?os=mac)
-      for any installations on MacOS.
+      for any installations on macOS.
     </Admonition>
   </TabItem>
 


### PR DESCRIPTION
Homebrew appears to be stuck on Teleport v14.3.3 and hasn't been updated in a long time.

```console
gus@apollo:~ % brew info teleport
==> teleport: stable 14.3.3 (bottled), HEAD
Modern SSH server for teams managing distributed infrastructure
https://goteleport.com/
Conflicts with:
  etsh (because both install `tsh` binaries)
  tctl (because both install `tctl` binaries)
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/t/teleport.rb
License: AGPL-3.0-or-later
==> Dependencies
Build: go ✔, pkg-config ✔, yarn ✘
Required: libfido2 ✔, node ✘, openssl@3 ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 653 (30 days), 1,944 (90 days), 18,964 (365 days)
install-on-request: 651 (30 days), 1,929 (90 days), 18,923 (365 days)
build-error: 4 (30 days)
```

This is leading to confusion and support requests. Recommending artifacts installed via a system managed entirely by a third party is also an issue in terms of supply chain attacks. As such, we should not provide instructions for using Homebrew and explicitly direct people to use our provided binaries in all cases.

This PR also users plainer English to clarify expectations for Touch ID support in versions of `tsh` installed from Homebrew. The use of the verb "preclude" is not particularly friendly to non-native speakers.

To solve this problem properly, we should maintain our own Homebrew tap and advise folks to install and use it, as per https://github.com/gravitational/teleport/issues/22561