### PR TITLE
pluralize: Return plural noun when num is 0

### DIFF
--- a/web/packages/shared/utils/text.test.ts
+++ b/web/packages/shared/utils/text.test.ts
@@ -18,8 +18,9 @@
 
 import { pluralize, capitalizeFirstLetter } from './text';
 
-test('pluralize: sending in zero number', () => {
-  expect(pluralize(0, 'apple')).toBe('apple');
+test('pluralize', () => {
+  expect(pluralize(0, 'apple')).toBe('apples');
+  expect(pluralize(1, 'apple')).toBe('apple');
   expect(pluralize(2, 'apple')).toBe('apples');
 });
 

--- a/web/packages/shared/utils/text.ts
+++ b/web/packages/shared/utils/text.ts
@@ -17,17 +17,17 @@
  */
 
 /**
- * pluralize adds an 's' to the given word if num is bigger than 1.
+ * pluralize adds an 's' to the given word if num is other than 1.
  */
 // If you ever need to pluralize a word which cannot be pluralized by appending 's', just add a
 // third optional argument which is the pluralized noun.
 // https://api.rubyonrails.org/v7.0.4.2/classes/ActionView/Helpers/TextHelper.html#method-i-pluralize
 export function pluralize(num: number, word: string) {
-  if (num > 1) {
-    return `${word}s`;
+  if (num === 1) {
+    return word;
   }
 
-  return word;
+  return `${word}s`;
 }
 
 /**


### PR DESCRIPTION
AFAIK it should be "0 apples", not "0 apple" for countable nouns.