### PR TITLE
Isolate electron updates to their own update group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -237,10 +237,15 @@ updates:
       - "ui"
       - "no-changelog"
     groups:
+      electron:
+        patterns:
+        - "electron*"
       ui:
         update-types:
           - "minor"
           - "patch"
+        exclude-patterns:
+          - "electron*"
     open-pull-requests-limit: 20
     reviewers:
       - avatus


### PR DESCRIPTION
This PR will remove electron related packages from the general "ui" group and adds their own grouping, to allow us to inspect for breaking changes due to electron without blocking the rest of the minor/patch updates