### PR TITLE
Revert "Update host user groups for existing users (#41919)"

### DIFF
--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -28,7 +28,6 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"slices"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -175,7 +174,7 @@ func TestRootHostUsersBackend(t *testing.T) {
 	})
 }
 
-func getUserGroups(t *testing.T, u *user.User) []string {
+func requireUserInGroups(t *testing.T, u *user.User, requiredGroups []string) {
 	var userGroups []string
 	userGids, err := u.GroupIds()
 	require.NoError(t, err)
@@ -184,11 +183,7 @@ func getUserGroups(t *testing.T, u *user.User) []string {
 		require.NoError(t, err)
 		userGroups = append(userGroups, group.Name)
 	}
-	return userGroups
-}
-
-func requireUserInGroups(t *testing.T, u *user.User, requiredGroups []string) {
-	require.Subset(t, getUserGroups(t, u), requiredGroups)
+	require.Subset(t, userGroups, requiredGroups)
 }
 
 func cleanupUsersAndGroups(users []string, groups []string) func() {
@@ -218,7 +213,7 @@ func TestRootHostUsers(t *testing.T) {
 		users := srv.NewHostUsers(context.Background(), presence, "host_uuid")
 
 		testGroups := []string{"group1", "group2"}
-		closer, err := users.UpsertUser(testuser, &services.HostUsersInfo{Groups: testGroups, Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP})
+		closer, err := users.CreateUser(testuser, &services.HostUsersInfo{Groups: testGroups, Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP})
 		require.NoError(t, err)
 
 		testGroups = append(testGroups, types.TeleportServiceGroup)
@@ -243,7 +238,7 @@ func TestRootHostUsers(t *testing.T) {
 		_, err := user.LookupGroupId(testGID)
 		require.ErrorIs(t, err, user.UnknownGroupIdError(testGID))
 
-		closer, err := users.UpsertUser(testuser, &services.HostUsersInfo{
+		closer, err := users.CreateUser(testuser, &services.HostUsersInfo{
 			Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
 			UID:  testUID,
 			GID:  testGID,
@@ -272,7 +267,7 @@ func TestRootHostUsers(t *testing.T) {
 		expectedHome := filepath.Join("/home", testuser)
 		require.NoDirExists(t, expectedHome)
 
-		closer, err := users.UpsertUser(testuser, &services.HostUsersInfo{Mode: types.CreateHostUserMode_HOST_USER_MODE_KEEP})
+		closer, err := users.CreateUser(testuser, &services.HostUsersInfo{Mode: types.CreateHostUserMode_HOST_USER_MODE_KEEP})
 		require.NoError(t, err)
 		require.Nil(t, closer)
 		t.Cleanup(cleanupUsersAndGroups([]string{testuser}, nil))
@@ -302,7 +297,7 @@ func TestRootHostUsers(t *testing.T) {
 			os.Remove(sudoersPath(testuser, uuid))
 			host.UserDel(testuser)
 		})
-		closer, err := users.UpsertUser(testuser,
+		closer, err := users.CreateUser(testuser,
 			&services.HostUsersInfo{
 				Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
 			})
@@ -333,12 +328,12 @@ func TestRootHostUsers(t *testing.T) {
 
 		deleteableUsers := []string{"teleport-user1", "teleport-user2", "teleport-user3"}
 		for _, user := range deleteableUsers {
-			_, err := users.UpsertUser(user, &services.HostUsersInfo{Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP})
+			_, err := users.CreateUser(user, &services.HostUsersInfo{Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP})
 			require.NoError(t, err)
 		}
 
 		// this user should not be in the service group as it was created with mode keep.
-		closer, err := users.UpsertUser("teleport-user4", &services.HostUsersInfo{
+		closer, err := users.CreateUser("teleport-user4", &services.HostUsersInfo{
 			Mode: types.CreateHostUserMode_HOST_USER_MODE_KEEP,
 		})
 		require.NoError(t, err)
@@ -357,68 +352,6 @@ func TestRootHostUsers(t *testing.T) {
 		for _, us := range deleteableUsers {
 			_, err := user.Lookup(us)
 			require.Equal(t, err, user.UnknownUserError(us))
-		}
-	})
-
-	t.Run("test update changed groups", func(t *testing.T) {
-		tests := []struct {
-			name         string
-			firstGroups  []string
-			secondGroups []string
-		}{
-			{
-				name:         "add groups",
-				secondGroups: []string{"group1", "group2"},
-			},
-			{
-				name:        "delete groups",
-				firstGroups: []string{"group1", "group2"},
-			},
-			{
-				name:         "change groups",
-				firstGroups:  []string{"group1", "group2"},
-				secondGroups: []string{"group2", "group3"},
-			},
-			{
-				name:         "no change",
-				firstGroups:  []string{"group1", "group2"},
-				secondGroups: []string{"group2", "group1"},
-			},
-		}
-
-		for _, tc := range tests {
-			t.Run(tc.name, func(t *testing.T) {
-				t.Cleanup(cleanupUsersAndGroups([]string{testuser}, slices.Concat(tc.firstGroups, tc.secondGroups)))
-
-				// Verify that the user is created with the first set of groups.
-				users := srv.NewHostUsers(context.Background(), presence, "host_uuid")
-				_, err := users.UpsertUser(testuser, &services.HostUsersInfo{
-					Groups: tc.firstGroups,
-					Mode:   types.CreateHostUserMode_HOST_USER_MODE_KEEP,
-				})
-				require.NoError(t, err)
-				u, err := user.Lookup(testuser)
-				require.NoError(t, err)
-				requireUserInGroups(t, u, tc.firstGroups)
-
-				// Verify that the user is updated with the second set of groups.
-				_, err = users.UpsertUser(testuser, &services.HostUsersInfo{
-					Groups: tc.secondGroups,
-					Mode:   types.CreateHostUserMode_HOST_USER_MODE_KEEP,
-				})
-				require.NoError(t, err)
-				u, err = user.Lookup(testuser)
-				require.NoError(t, err)
-				requireUserInGroups(t, u, tc.secondGroups)
-
-				// Verify that the appropriate groups form the first set were deleted.
-				userGroups := getUserGroups(t, u)
-				for _, group := range tc.firstGroups {
-					if !slices.Contains(tc.secondGroups, group) {
-						require.NotContains(t, userGroups, group)
-					}
-				}
-			})
 		}
 	})
 }

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -281,7 +281,7 @@ func (s *SessionRegistry) TryCreateHostUser(ctx *ServerContext) error {
 	if trace.IsAccessDenied(err) && existsErr != nil {
 		return trace.WrapWithMessage(err, "Insufficient permission for host user creation")
 	}
-	userCloser, err := s.users.UpsertUser(ctx.Identity.Login, ui)
+	userCloser, err := s.users.CreateUser(ctx.Identity.Login, ui)
 	if userCloser != nil {
 		ctx.AddCloser(userCloser)
 	}

--- a/lib/srv/usermgmt_linux.go
+++ b/lib/srv/usermgmt_linux.go
@@ -90,12 +90,6 @@ func (*HostUsersProvisioningBackend) LookupGroupByID(gid string) (*user.Group, e
 	return user.LookupGroupId(gid)
 }
 
-// SetUserGroups sets a user's groups, replacing their existing groups.
-func (*HostUsersProvisioningBackend) SetUserGroups(name string, groups []string) error {
-	_, err := host.SetUserGroups(name, groups)
-	return trace.Wrap(err)
-}
-
 // GetAllUsers returns a full list of users present on a system
 func (*HostUsersProvisioningBackend) GetAllUsers() ([]string, error) {
 	users, _, err := host.GetAllUsers()

--- a/lib/utils/host/hostusers.go
+++ b/lib/utils/host/hostusers.go
@@ -92,15 +92,17 @@ func UserAdd(username string, groups []string, home, uid, gid string) (exitCode 
 	return cmd.ProcessState.ExitCode(), trace.Wrap(err)
 }
 
-// SetUserGroups adds a user to a list of specified groups on a host using `usermod`,
-// overriding any existing supplementary groups.
-func SetUserGroups(username string, groups []string) (exitCode int, err error) {
+// AddUserToGroups adds a user to a list of specified groups on a host using `usermod`
+func AddUserToGroups(username string, groups []string) (exitCode int, err error) {
 	usermodBin, err := exec.LookPath("usermod")
 	if err != nil {
 		return -1, trace.Wrap(err, "cant find usermod binary")
 	}
-	// usermod -G (replace groups) (username)
-	cmd := exec.Command(usermodBin, "-G", strings.Join(groups, ","), username)
+	args := []string{"-aG"}
+	args = append(args, groups...)
+	args = append(args, username)
+	// usermod -aG (append groups) (username)
+	cmd := exec.Command(usermodBin, args...)
 	output, err := cmd.CombinedOutput()
 	log.Debugf("%s output: %s", cmd.Path, string(output))
 	return cmd.ProcessState.ExitCode(), trace.Wrap(err)


### PR DESCRIPTION
This change reverts host user group updates due to performance issues.