### PR TITLE
[v14] re-add grace period to Upload completer (again)

### DIFF
--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -792,6 +792,9 @@ type StreamPart struct {
 	Number int64
 	// ETag is a part e-tag
 	ETag string
+	// LastModified is the time of last modification of this part (if
+	// available).
+	LastModified time.Time
 }
 
 // StreamUpload represents stream multipart upload

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -110,6 +110,10 @@ const (
 	// AbandonedUploadPollingRate defines how often to check for
 	// abandoned uploads which need to be completed.
 	AbandonedUploadPollingRate = apidefaults.SessionTrackerTTL / 6
+
+	// UploadCompleterGracePeriod is the default period after which an upload's
+	// session tracker will be checked to see if it's an abandoned upload.
+	UploadCompleterGracePeriod = 24 * time.Hour
 )
 
 var (

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -446,7 +447,8 @@ func (h *Handler) UploadPart(ctx context.Context, upload events.StreamUpload, pa
 
 	// our parts are just over 5 MiB (events.MinUploadPartSizeBytes) so we can
 	// upload them in one shot
-	if _, err := cErr(partBlob.Upload(ctx, streaming.NopCloser(partBody), nil)); err != nil {
+	response, err := cErr(partBlob.Upload(ctx, streaming.NopCloser(partBody), nil))
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	h.log.WithFields(logrus.Fields{
@@ -455,7 +457,11 @@ func (h *Handler) UploadPart(ctx context.Context, upload events.StreamUpload, pa
 		fieldPartNumber: partNumber,
 	}).Debug("Uploaded part.")
 
-	return &events.StreamPart{Number: partNumber}, nil
+	var lastModified time.Time
+	if response.LastModified != nil {
+		lastModified = *response.LastModified
+	}
+	return &events.StreamPart{Number: partNumber, LastModified: lastModified}, nil
 }
 
 // ListParts implements [events.MultipartUploader].
@@ -488,8 +494,15 @@ func (h *Handler) ListParts(ctx context.Context, upload events.StreamUpload) ([]
 			if err != nil {
 				continue
 			}
-
-			parts = append(parts, events.StreamPart{Number: partNumber})
+			var lastModified time.Time
+			if b.Properties != nil &&
+				b.Properties.LastModified != nil {
+				lastModified = *b.Properties.LastModified
+			}
+			parts = append(parts, events.StreamPart{
+				Number:       partNumber,
+				LastModified: lastModified,
+			})
 		}
 	}
 

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -17,6 +17,7 @@ limitations under the License.
 package events
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"os"
@@ -57,6 +58,11 @@ type UploadCompleterConfig struct {
 	Component string
 	// CheckPeriod is a period for checking the upload
 	CheckPeriod time.Duration
+	// GracePeriod is the period after which an upload's session tracker will be
+	// checked to see if it's an abandoned upload. A duration of zero will
+	// result in a sensible default, any negative value will result in no grace
+	// period.
+	GracePeriod time.Duration
 	// Clock is used to override clock in tests
 	Clock clockwork.Clock
 	// ClusterName identifies the originating teleport cluster
@@ -219,10 +225,20 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 		}
 	}()
 
+	gracePeriod := cmp.Or(u.cfg.GracePeriod, UploadCompleterGracePeriod)
 	incompleteSessionUploads.Set(float64(len(uploads)))
 	// Complete upload for any uploads without an active session tracker
 	for _, upload := range uploads {
 		log := u.log.WithField("upload", upload.ID).WithField("session", upload.SessionID)
+
+		if gracePeriod > 0 && u.cfg.Clock.Since(upload.Initiated) <= gracePeriod {
+			log.Debug("Found incomplete upload within grace period, terminating check early.")
+			// not only we can skip this upload, but since uploads are sorted by
+			// Initiated oldest-to-newest, we can actually just stop checking as
+			// all further uploads will be closer in time to now and thus they
+			// will all be within the grace period
+			break
+		}
 
 		switch _, err := u.cfg.SessionTracker.GetSessionTracker(ctx, upload.SessionID.String()); {
 		case err == nil: // session is still in progress, continue to other uploads

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -261,6 +261,16 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 			}
 			return trace.Wrap(err, "listing parts")
 		}
+		var lastModified time.Time
+		for _, part := range parts {
+			if part.LastModified.After(lastModified) {
+				lastModified = part.LastModified
+			}
+		}
+		if u.cfg.Clock.Since(lastModified) <= gracePeriod {
+			log.Debug("Found incomplete upload with recently uploaded part, skipping.")
+			continue
+		}
 
 		log.Debugf("upload has %d parts", len(parts))
 

--- a/lib/events/eventstest/uploader.go
+++ b/lib/events/eventstest/uploader.go
@@ -303,8 +303,8 @@ type MockUploader struct {
 
 	CreateUploadError      error
 	ReserveUploadPartError error
-	ListPartsError         error
 
+	MockListParts      func(ctx context.Context, upload events.StreamUpload) ([]events.StreamPart, error)
 	MockListUploads    func(ctx context.Context) ([]events.StreamUpload, error)
 	MockCompleteUpload func(ctx context.Context, upload events.StreamUpload, parts []events.StreamPart) error
 }
@@ -324,9 +324,9 @@ func (m *MockUploader) ReserveUploadPart(_ context.Context, _ events.StreamUploa
 	return m.ReserveUploadPartError
 }
 
-func (m *MockUploader) ListParts(_ context.Context, _ events.StreamUpload) ([]events.StreamPart, error) {
-	if m.ListPartsError != nil {
-		return nil, m.ListPartsError
+func (m *MockUploader) ListParts(ctx context.Context, upload events.StreamUpload) ([]events.StreamPart, error) {
+	if m.MockListParts != nil {
+		return m.MockListParts(ctx, upload)
 	}
 
 	return []events.StreamPart{}, nil

--- a/lib/events/gcssessions/gcsstream.go
+++ b/lib/events/gcssessions/gcsstream.go
@@ -96,7 +96,7 @@ func (h *Handler) UploadPart(ctx context.Context, upload events.StreamUpload, pa
 	if err != nil {
 		return nil, convertGCSError(err)
 	}
-	return &events.StreamPart{Number: partNumber}, nil
+	return &events.StreamPart{Number: partNumber, LastModified: writer.Attrs().Created}, nil
 }
 
 // CompleteUpload completes the upload
@@ -246,6 +246,7 @@ func (h *Handler) ListParts(ctx context.Context, upload events.StreamUpload) ([]
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+		part.LastModified = attrs.Updated
 		parts = append(parts, *part)
 	}
 	return parts, nil

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -130,8 +130,12 @@ func TestNewStreamErrors(t *testing.T) {
 			expectedErr error
 		}{
 			{
-				desc:     "ListPartsError",
-				uploader: &eventstest.MockUploader{ListPartsError: expectedErr},
+				desc: "ListPartsError",
+				uploader: &eventstest.MockUploader{
+					MockListParts: func(ctx context.Context, upload events.StreamUpload) ([]events.StreamPart, error) {
+						return nil, expectedErr
+					},
+				},
 			},
 			{
 				desc:     "ReserveUploadPartError",


### PR DESCRIPTION
Backport #44941 to branch/v14

changelog: fixed race condition between session recording uploads and session recording upload cleanup
