### PR TITLE
fix errors.As() panic in msteams plugin

### DIFF
--- a/integrations/access/msteams/msapi/graph_client.go
+++ b/integrations/access/msteams/msapi/graph_client.go
@@ -101,8 +101,8 @@ func (e graphError) Error() string {
 
 // GetErrorCode returns the
 func GetErrorCode(err error) string {
-	var graphErr *graphError
-	ok := errors.As(err, graphErr)
+	var graphErr graphError
+	ok := errors.As(err, &graphErr)
 	if !ok {
 		return ""
 	}


### PR DESCRIPTION
Fix a panic that was introduced somehwere between 15.1 and 15.2 due to invalid error casting, likely by me when importing code into the main Teleport.

I'm not sure why the static linters did not catch this.

Changelog: Fix a panic in the Microsoft teams plugin when it receives an error.