### PR TITLE
Fix AWS Console apps logins not being provided in all places

### DIFF
--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -774,7 +774,7 @@ func MakePaginatedResource(ctx context.Context, requestType string, r types.Reso
 			return nil, trace.BadParameter("%s has invalid type %T", resourceKind, resource)
 		}
 
-		protoResource = &proto.PaginatedResource{Resource: &proto.PaginatedResource_AppServer{AppServer: app}, RequiresRequest: requiresRequest}
+		protoResource = &proto.PaginatedResource{Resource: &proto.PaginatedResource_AppServer{AppServer: app}, Logins: logins, RequiresRequest: requiresRequest}
 	case types.KindNode:
 		srv, ok := resource.(*types.ServerV2)
 		if !ok {


### PR DESCRIPTION
Closes #45086

#44611 Changed the app resources to return the `Logins` field (from enriched resources) for AWS Console apps. However, the change needed to be completed, and the field needed to be added in some places.

TLDR: Tests weren't covering this scenario, so this PR also updates them.

Two tests cover those scenarios. However, none of them caught this issue:
- `TestListResources_WithLogins`: `AppServer` wasn't added to the list of resources fetched by the test.
- `TestListUnifiedResources_WithLogins`: This listing process was hard coded to fetch only a limited number of resources, meaning the resulting list would usually never return the apps. (The flakiness on this test was a case where the apps were included on the final list and returned). To improve it, we now consume all resources and assert the final number of resources, so if we add more resources, the test will fail. Hard coding the number of resources could be better. Still, a more scalable solution would require refactoring other tests, so I kept the changes scoped only for the affected tests.
