### PR TITLE
[v15] Workload Identity: Federation bundle endpoint

### DIFF
--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -448,6 +448,8 @@ github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs
 github.com/go-gorp/gorp/v3 v3.1.0/go.mod h1:dLEjIyyRNiXvNZ8PSmzpt1GsWAUK8kjVhEpjH8TixEw=
 github.com/go-jose/go-jose/v3 v3.0.3 h1:fFKWeig/irsp7XD2zBxvnmA/XaRWp5V3CBsZXJF7G7k=
 github.com/go-jose/go-jose/v3 v3.0.3/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v4 v4.0.1 h1:QVEPDE3OluqXBQZDcnNvQrInro2h0e4eqNbnZSWqS6U=
+github.com/go-jose/go-jose/v4 v4.0.1/go.mod h1:WVf9LFMHh/QVrmqrOfqun0C45tMe3RoiKJMPvgWwLfY=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-ldap/ldap/v3 v3.4.6 h1:ert95MdbiG7aWo/oPYp9btL3KJlMPKnP58r09rI8T+A=
@@ -1178,6 +1180,8 @@ github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyh
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spiffe/go-spiffe/v2 v2.2.0 h1:9Vf06UsvsDbLYK/zJ4sYsIsHmMFknUD+feA7IYoWMQY=
+github.com/spiffe/go-spiffe/v2 v2.2.0/go.mod h1:Urzb779b3+IwDJD2ZbN8fVl3Aa8G4N/PiUe6iXC0XxU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
@@ -1259,6 +1263,8 @@ github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q
 github.com/zclconf/go-cty v1.9.1 h1:viqrgQwFl5UpSxc046qblj78wZXVDFnSOufaOTER+cc=
 github.com/zclconf/go-cty v1.9.1/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
+github.com/zeebo/errs v1.3.0 h1:hmiaKqgYZzcVgRL1Vkc1Mn2914BbzB0IBxs+ebeutGs=
+github.com/zeebo/errs v1.3.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=
 github.com/zmap/rc2 v0.0.0-20190804163417-abaa70531248/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -969,6 +969,9 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET(OIDCJWKWURI, h.WithLimiter(h.jwksOIDC))
 	h.GET("/webapi/thumbprint", h.WithLimiter(h.thumbprint))
 
+	// SPIFFE Federation Trust Bundle
+	h.GET("/webapi/spiffe/bundle.json", h.WithLimiter(h.getSPIFFEBundle))
+
 	// DiscoveryConfig CRUD
 	h.GET("/webapi/sites/:site/discoveryconfig", h.WithClusterAuth(h.discoveryconfigList))
 	h.POST("/webapi/sites/:site/discoveryconfig", h.WithClusterAuth(h.discoveryconfigCreate))

--- a/lib/web/spiffe.go
+++ b/lib/web/spiffe.go
@@ -85,8 +85,7 @@ func (h *Handler) getSPIFFEBundle(w http.ResponseWriter, r *http.Request, _ http
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write(bundleBytes)
-	if err != nil {
+	if _, err = w.Write(bundleBytes); err != nil {
 		h.logger.DebugContext(h.cfg.Context, "Failed to write SPIFFE bundle response", "error", err)
 	}
 	return nil, nil

--- a/lib/web/spiffe.go
+++ b/lib/web/spiffe.go
@@ -32,6 +32,8 @@ import (
 // getSPIFFEBundle returns the SPIFFE-compatible trust bundle which allows other
 // trust domains to federate with this Teleport cluster.
 //
+// Mounted at /webapi/spiffe/bundle.json
+//
 // Must abide by the standard for a "https_web" profile as described in
 // https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#5-serving-and-consuming-a-spiffe-bundle-endpoint
 func (h *Handler) getSPIFFEBundle(w http.ResponseWriter, r *http.Request, _ httprouter.Params) (interface{}, error) {

--- a/lib/web/spiffe.go
+++ b/lib/web/spiffe.go
@@ -1,0 +1,77 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package web
+
+import (
+	"net/http"
+
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+// getSPIFFEBundle returns the SPIFFE-compatible trust bundle which allows other
+// trust domains to federate with this Teleport cluster.
+//
+// Must abide by the standard for a "https_web" profile as described in
+// https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#5-serving-and-consuming-a-spiffe-bundle-endpoint
+func (h *Handler) getSPIFFEBundle(w http.ResponseWriter, r *http.Request, _ httprouter.Params) (interface{}, error) {
+	cn, err := h.GetAccessPoint().GetClusterName()
+	if err != nil {
+		return nil, trace.Wrap(err, "fetching cluster name")
+	}
+
+	td, err := spiffeid.TrustDomainFromString(cn.GetClusterName())
+	if err != nil {
+		return nil, trace.Wrap(err, "creating trust domain")
+	}
+	bundle := spiffebundle.New(td)
+
+	spiffeCA, err := h.GetAccessPoint().GetCertAuthority(r.Context(), types.CertAuthID{
+		Type:       types.SPIFFECA,
+		DomainName: cn.GetClusterName(),
+	}, false)
+	if err != nil {
+		return nil, trace.Wrap(err, "fetching SPIFFE CA")
+	}
+
+	for _, certPEM := range services.GetTLSCerts(spiffeCA) {
+		cert, err := tlsca.ParseCertificatePEM(certPEM)
+		if err != nil {
+			return nil, trace.Wrap(err, "parsing certificate")
+		}
+		bundle.AddX509Authority(cert)
+	}
+
+	bundleBytes, err := bundle.Marshal()
+	if err != nil {
+		return nil, trace.Wrap(err, "marshalling bundle")
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(bundleBytes)
+	if err != nil {
+		h.logger.DebugContext(h.cfg.Context, "Failed to write SPIFFE bundle response", "error", err)
+	}
+	return nil, nil
+}

--- a/lib/web/spiffe.go
+++ b/lib/web/spiffe.go
@@ -37,7 +37,7 @@ import (
 //
 // Must abide by the standard for a "https_web" profile as described in
 // https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#5-serving-and-consuming-a-spiffe-bundle-endpoint
-func (h *Handler) getSPIFFEBundle(w http.ResponseWriter, r *http.Request, _ httprouter.Params) (interface{}, error) {
+func (h *Handler) getSPIFFEBundle(w http.ResponseWriter, r *http.Request, _ httprouter.Params) (any, error) {
 	cn, err := h.GetAccessPoint().GetClusterName()
 	if err != nil {
 		return nil, trace.Wrap(err, "fetching cluster name")

--- a/lib/web/spiffe.go
+++ b/lib/web/spiffe.go
@@ -55,7 +55,7 @@ func (h *Handler) getSPIFFEBundle(w http.ResponseWriter, r *http.Request, _ http
 	// https_web, it's not critical for a federated trust domain to catch
 	// all phases of the rotation - however, if we support https_spiffe in
 	// future, we may need to consider a lower value or enforcing a wait
-	// period during rotations equivelant to the refresh hint.
+	// period during rotations equivalent to the refresh hint.
 	bundle.SetRefreshHint(5 * time.Minute)
 	// TODO(noah):
 	// For now, we omit the SequenceNumber field. This is only a SHOULD not a

--- a/lib/web/spiffe.go
+++ b/lib/web/spiffe.go
@@ -62,10 +62,11 @@ func (h *Handler) getSPIFFEBundle(w http.ResponseWriter, r *http.Request, _ http
 	// MUST per the spec. To add this, we will add a sequence number to the
 	// cert authority and increment it on every update.
 
+	const loadKeysFalse = false
 	spiffeCA, err := h.GetAccessPoint().GetCertAuthority(r.Context(), types.CertAuthID{
 		Type:       types.SPIFFECA,
 		DomainName: cn.GetClusterName(),
-	}, false)
+	}, loadKeysFalse)
 	if err != nil {
 		return nil, trace.Wrap(err, "fetching SPIFFE CA")
 	}

--- a/lib/web/spiffe_test.go
+++ b/lib/web/spiffe_test.go
@@ -66,13 +66,8 @@ func TestGetSPIFFEBundle(t *testing.T) {
 	gotBundle, err := spiffebundle.Read(td, res.Reader())
 	require.NoError(t, err)
 
-	gotCACerts := gotBundle.X509Bundle().X509Authorities()
-	require.Len(t, gotCACerts, len(wantCACerts))
-	for i := range gotCACerts {
-		match := slices.ContainsFunc(wantCACerts, func(want *x509.Certificate) bool {
-			got := gotCACerts[i]
-			return got.Equal(want)
-		})
-		require.True(t, match, "certificate not found in wantCACerts")
+	require.Len(t, gotBundle.X509Authorities(), len(wantCACerts))
+	for _, caCert := range wantCACerts {
+		require.True(t, gotBundle.HasX509Certificate(caCert), "certificate not found in bundle")
 	}
 }

--- a/lib/web/spiffe_test.go
+++ b/lib/web/spiffe_test.go
@@ -21,7 +21,6 @@ package web
 import (
 	"context"
 	"crypto/x509"
-	"slices"
 	"testing"
 
 	"github.com/gravitational/roundtrip"
@@ -68,6 +67,6 @@ func TestGetSPIFFEBundle(t *testing.T) {
 
 	require.Len(t, gotBundle.X509Authorities(), len(wantCACerts))
 	for _, caCert := range wantCACerts {
-		require.True(t, gotBundle.HasX509Certificate(caCert), "certificate not found in bundle")
+		require.True(t, gotBundle.HasX509Authority(caCert), "certificate not found in bundle")
 	}
 }

--- a/lib/web/spiffe_test.go
+++ b/lib/web/spiffe_test.go
@@ -1,0 +1,78 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import (
+	"context"
+	"crypto/x509"
+	"slices"
+	"testing"
+
+	"github.com/gravitational/roundtrip"
+	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+func TestGetSPIFFEBundle(t *testing.T) {
+	ctx := context.Background()
+	env := newWebPack(t, 1)
+	authServer := env.server.Auth()
+	cn, err := authServer.GetClusterName()
+	require.NoError(t, err)
+	ca, err := authServer.GetCertAuthority(ctx, types.CertAuthID{
+		Type:       types.SPIFFECA,
+		DomainName: cn.GetClusterName(),
+	}, false)
+	require.NoError(t, err)
+
+	var wantCACerts []*x509.Certificate
+	for _, certPem := range services.GetTLSCerts(ca) {
+		cert, err := tlsca.ParseCertificatePEM(certPem)
+		require.NoError(t, err)
+		wantCACerts = append(wantCACerts, cert)
+	}
+
+	clt, err := client.NewWebClient(env.proxies[0].webURL.String(), roundtrip.HTTPClient(client.NewInsecureWebClient()))
+	require.NoError(t, err)
+
+	res, err := clt.Get(ctx, clt.Endpoint("webapi", "spiffe", "bundle.json"), nil)
+	require.NoError(t, err)
+
+	td, err := spiffeid.TrustDomainFromString(cn.GetClusterName())
+	require.NoError(t, err)
+	gotBundle, err := spiffebundle.Read(td, res.Reader())
+	require.NoError(t, err)
+
+	gotCACerts := gotBundle.X509Bundle().X509Authorities()
+	require.Len(t, gotCACerts, len(wantCACerts))
+	for i := range gotCACerts {
+		match := slices.ContainsFunc(wantCACerts, func(want *x509.Certificate) bool {
+			got := gotCACerts[i]
+			return got.Equal(want)
+		})
+		require.True(t, match, "certificate not found in wantCACerts")
+	}
+}

--- a/lib/web/spiffe_test.go
+++ b/lib/web/spiffe_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gravitational/roundtrip"
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"


### PR DESCRIPTION
Backport #44870 to branch/v15

changelog: Adds SPIFFE compatible federation bundle endpoint to the Proxy API, allowing other workload identity platforms to federate with the Teleport cluster.
