### PR TITLE
[v15] fix errors.As() panic in msteams plugin

### DIFF
--- a/integrations/access/msteams/msapi/graph_client.go
+++ b/integrations/access/msteams/msapi/graph_client.go
@@ -101,8 +101,8 @@ func (e graphError) Error() string {
 
 // GetErrorCode returns the
 func GetErrorCode(err error) string {
-	var graphErr *graphError
-	ok := errors.As(err, graphErr)
+	var graphErr graphError
+	ok := errors.As(err, &graphErr)
 	if !ok {
 		return ""
 	}


### PR DESCRIPTION
Backport #44984 to branch/v15

changelog: Fix a panic in the Microsoft teams plugin when it receives an error.
