### PR TITLE
Set `TERM_PROGRAM` and `TERM_PROGRAM_VERSION` env vars in Teleport Connect

### DIFF
--- a/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -66,6 +66,8 @@ export async function buildPtyOptions(
       const combinedEnv = {
         ...process.env,
         ...shellEnv,
+        TERM_PROGRAM: 'Teleport_Connect',
+        TERM_PROGRAM_VERSION: settings.appVersion,
         TELEPORT_HOME: settings.tshd.homeDir,
         TELEPORT_CLUSTER: cmd.clusterName,
         TELEPORT_PROXY: cmd.proxyHost,


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/22536

According to the table in https://github.com/Maximus5/ConEmu/issues/1837#issuecomment-469199525, the value of `TERM_PROGRAM` is usually the app name, so I set it to `Teleport_Connect`.
`TERM_PROGRAM_VERSION` is the version of the app.

changelog: Teleport Connect now sets `TERM_PROGRAM: Teleport_Connect` and `TERM_PROGRAM_VERSION: <app_version>` environment variables in the integrated terminal