### PR TITLE
Packaging tsh.app in all mac distributions to unify our mac artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -552,7 +552,7 @@ release-arm64:
 # make build-archive - Packages the results of a build into a release tarball
 #
 .PHONY: build-archive
-ifeq ($(OS),"darwin")
+ifeq ("$(OS)","darwin")
 build-archive: INSTALL_SCRIPT=build.assets/macos/install
 else
 build-archive: INSTALL_SCRIPT=build.assets/install

--- a/Makefile
+++ b/Makefile
@@ -407,14 +407,12 @@ $(BUILDDIR)/fdpass-teleport:
 	install tool/fdpass-teleport/target/$(RUST_TARGET_ARCH)/release/fdpass-teleport $(BUILDDIR)/
 
 .PHONY: tsh-app
-tsh-app: TSH_APP_SKELETON = build.assets/macos/tsh/tsh.app
 tsh-app: TSH_APP_BUNDLE = $(BUILDDIR)/tsh.app
 tsh-app: TSH_APP_ENTITLEMENTS = build.assets/macos/tsh/tsh.entitlements
-tsh-app: TSH_BINARY = $(BUILDDIR)/tsh
 tsh-app:
-	cp -rf "$(TSH_APP_SKELETON)/" "$(TSH_APP_BUNDLE)"/
+	cp -rf "build.assets/macos/$(TSH_SKELETON)/tsh.app/" "$(TSH_APP_BUNDLE)/"
 	mkdir -p "$(TSH_APP_BUNDLE)/Contents/MacOS/"
-	cp "$(TSH_BINARY)" "$(TSH_APP_BUNDLE)/Contents/MacOS/."
+	cp "$(BUILDDIR)/tsh" "$(TSH_APP_BUNDLE)/Contents/MacOS/."
 	$(NOTARIZE_TSH_APP)
 
 #

--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ endif
 # and tsh.
 BINS_default = teleport tctl tsh tbot fdpass-teleport
 BINS_windows = tsh tctl
+BINS_darwin = $(subst tsh,tsh.app,$(BINS_default))
 BINS = $(or $(BINS_$(OS)),$(BINS_default))
 BINARIES = $(addprefix $(BUILDDIR)/,$(BINS))
 
@@ -405,6 +406,13 @@ teleport-hot-reload:
 $(BUILDDIR)/fdpass-teleport:
 	cd tool/fdpass-teleport && cargo build --release --locked $(CARGO_TARGET)
 	install tool/fdpass-teleport/target/$(RUST_TARGET_ARCH)/release/fdpass-teleport $(BUILDDIR)/
+
+.PHONY: $(BUILDDIR)/tsh.app
+$(BUILDDIR)/tsh.app: TSH_APP_SKELETON = build.assets/macos/tsh/tsh.app
+$(BUILDDIR)/tsh.app: $(BUILDDIR)/tsh
+	cp -r $(TSH_APP_SKELETON)/ $(BUILDDIR)/tsh.app/
+	mkdir -p "$(BUILDDIR)/tsh.app/Contents/MacOS/"
+	mv "$(BUILDDIR)/tsh" "$(BUILDDIR)/tsh.app/Contents/MacOS/."
 
 #
 # BPF support (IF ENABLED)
@@ -586,7 +594,7 @@ ifneq ($(ARCH),universal)
 release-darwin: release-darwin-unsigned
 	$(NOTARIZE_BINARIES)
 	$(MAKE) build-archive
-	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
+	@if [ -f e/Makefile ]; then $(MAKE) -C e release BINARIES=$(BINARIES_default); fi
 else
 
 # release-darwin for ARCH == universal does not build binaries, but instead

--- a/Makefile
+++ b/Makefile
@@ -408,7 +408,7 @@ $(BUILDDIR)/fdpass-teleport:
 
 .PHONY: tsh-app
 tsh-app: TSH_APP_BUNDLE = $(BUILDDIR)/tsh.app
-tsh-app: TSH_APP_ENTITLEMENTS = build.assets/macos/tsh/tsh.entitlements
+tsh-app: TSH_APP_ENTITLEMENTS = build.assets/macos/$(TSH_SKELETON)/tsh.entitlements
 tsh-app:
 	cp -rf "build.assets/macos/$(TSH_SKELETON)/tsh.app/" "$(TSH_APP_BUNDLE)/"
 	mkdir -p "$(TSH_APP_BUNDLE)/Contents/MacOS/"

--- a/Makefile
+++ b/Makefile
@@ -552,12 +552,17 @@ release-arm64:
 # make build-archive - Packages the results of a build into a release tarball
 #
 .PHONY: build-archive
+ifeq ($(OS),"darwin")
+build-archive: INSTALL_SCRIPT=build.assets/macos/install
+else
+build-archive: INSTALL_SCRIPT=build.assets/install
+endif
 build-archive: | $(RELEASE_DIR)
 	@echo "---> Creating OSS release archive."
 	mkdir teleport
 	cp -rf $(BINARIES) \
 		examples \
-		build.assets/install\
+		"$(INSTALL_SCRIPT)" \
 		README.md \
 		CHANGELOG.md \
 		teleport/

--- a/Makefile
+++ b/Makefile
@@ -406,12 +406,12 @@ $(BUILDDIR)/fdpass-teleport:
 	cd tool/fdpass-teleport && cargo build --release --locked $(CARGO_TARGET)
 	install tool/fdpass-teleport/target/$(RUST_TARGET_ARCH)/release/fdpass-teleport $(BUILDDIR)/
 
-.PHONY: $(BUILDDIR)/tsh.app
-$(BUILDDIR)/tsh.app: TSH_APP_SKELETON = build.assets/macos/tsh/tsh.app
-$(BUILDDIR)/tsh.app: TSH_APP_BUNDLE = $(BUILDDIR)/tsh.app
-$(BUILDDIR)/tsh.app: TSH_APP_ENTITLEMENTS = build.assets/macos/tsh/tsh.entitlements
-$(BUILDDIR)/tsh.app: TSH_BINARY = $(BUILDDIR)/tsh
-$(BUILDDIR)/tsh.app:
+.PHONY: tsh-app
+tsh-app: TSH_APP_SKELETON = build.assets/macos/tsh/tsh.app
+tsh-app: TSH_APP_BUNDLE = $(BUILDDIR)/tsh.app
+tsh-app: TSH_APP_ENTITLEMENTS = build.assets/macos/tsh/tsh.entitlements
+tsh-app: TSH_BINARY = $(BUILDDIR)/tsh
+tsh-app:
 	cp -rf "$(TSH_APP_SKELETON)/" "$(TSH_APP_BUNDLE)"/
 	mkdir -p "$(TSH_APP_BUNDLE)/Contents/MacOS/"
 	cp "$(TSH_BINARY)" "$(TSH_APP_BUNDLE)/Contents/MacOS/."
@@ -596,7 +596,7 @@ release-darwin-unsigned: full build-archive
 ifneq ($(ARCH),universal)
 release-darwin: release-darwin-unsigned
 	$(NOTARIZE_BINARIES)
-	$(MAKE) $(BUILDDIR)/tsh.app
+	$(MAKE) tsh-app
 	$(MAKE) build-archive BINARIES="$(subst tsh,tsh.app,$(BINARIES))"
 	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
 else
@@ -629,7 +629,7 @@ release-darwin: $(RELEASE_darwin_arm64) $(RELEASE_darwin_amd64)
 		$(BUILDDIR_amd64)/tsh.app/Contents/MacOS/tsh
 
 	$(NOTARIZE_BINARIES)
-	$(MAKE) $(BUILDDIR)/tsh.app
+	$(MAKE) tsh-app
 	$(MAKE) ARCH=universal build-archive BINARIES="$(subst tsh,tsh.app,$(BINARIES))"
 	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
 endif
@@ -1345,7 +1345,7 @@ tag-build:
 	@which gh >/dev/null 2>&1 || { echo 'gh command needed. https://github.com/cli/cli'; exit 1; }
 	gh workflow run tag-build.yaml \
 		--repo gravitational/teleport.e \
-		--ref "gus/unify-mac" \
+		--ref "v$(VERSION)" \
 		-f "oss-teleport-repo=$(shell gh repo view --json nameWithOwner --jq .nameWithOwner)" \
 		-f "oss-teleport-ref=v$(VERSION)" \
 		-f "cloud-only=$(CLOUD_ONLY)" \

--- a/Makefile
+++ b/Makefile
@@ -614,11 +614,13 @@ release-darwin: $(RELEASE_darwin_arm64) $(RELEASE_darwin_amd64)
 	mkdir -p $(BUILDDIR_arm64) $(BUILDDIR_amd64)
 	tar -C $(BUILDDIR_arm64) -xzf $(RELEASE_darwin_arm64) --strip-components=1 $(TARBINS)
 	tar -C $(BUILDDIR_amd64) -xzf $(RELEASE_darwin_amd64) --strip-components=1 $(TARBINS)
+	tsh_relpath=tsh.app/Contents/MacOS/tsh
+
 	lipo -create -output $(BUILDDIR)/teleport $(BUILDDIR_arm64)/teleport $(BUILDDIR_amd64)/teleport
 	lipo -create -output $(BUILDDIR)/tctl $(BUILDDIR_arm64)/tctl $(BUILDDIR_amd64)/tctl
-	lipo -create -output $(BUILDDIR)/tsh $(BUILDDIR_arm64)/tsh $(BUILDDIR_amd64)/tsh
 	lipo -create -output $(BUILDDIR)/tbot $(BUILDDIR_arm64)/tbot $(BUILDDIR_amd64)/tbot
 	lipo -create -output $(BUILDDIR)/fdpass-teleport $(BUILDDIR_arm64)/fdpass-teleport $(BUILDDIR_amd64)/fdpass-teleport
+	lipo -create -output $(BUILDDIR)/$$tsh_relpath $(BUILDDIR_arm64)/$$tsh_relpath $(BUILDDIR_amd64)/$$tsh_relpath
 	$(MAKE) ARCH=universal build-archive
 	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
 endif
@@ -1595,24 +1597,28 @@ ifneq ("$(OSS_TARBALL_PATH)", "")
 endif
 
 # build .pkg
+# builds two package files: tsh-$VERSION.pkg and teleport-bin-$VERSION.pkg
+# combines the two package files into one teleport-$VERSION.pkg
 .PHONY: pkg
 pkg: | $(RELEASE_DIR)
 	mkdir -p $(BUILDDIR)/
+	
+	@echo Building tsh-$(VERSION).pkg
+	./build.assets/build-pkg-tsh.sh -t oss -v $(VERSION) -b $(TSH_BUNDLEID) -a $(ARCH) $(TARBALL_PATH_SECTION)
+	mv tsh*.pkg* $(BUILDDIR)/
+
+	@echo Building teleport-bin-$(VERSION).pkg
 	cp ./build.assets/build-package.sh ./build.assets/build-common.sh $(BUILDDIR)/
 	chmod +x $(BUILDDIR)/build-package.sh
 	# runtime is currently ignored on OS X
 	# we pass it through for consistency - it will be dropped by the build script
 	cd $(BUILDDIR) && ./build-package.sh -t oss -v $(VERSION) -p pkg -b $(TELEPORT_BUNDLEID) -a $(ARCH) $(RUNTIME_SECTION) $(TARBALL_PATH_SECTION)
-	cp $(BUILDDIR)/teleport-*.pkg $(RELEASE_DIR)
-	if [ -f e/Makefile ]; then $(MAKE) -C e pkg; fi
 
-# build tsh client-only .pkg
-.PHONY: pkg-tsh
-pkg-tsh: | $(RELEASE_DIR)
-	./build.assets/build-pkg-tsh.sh -t oss -v $(VERSION) -b $(TSH_BUNDLEID) -a $(ARCH) $(TARBALL_PATH_SECTION)
-	mkdir -p $(BUILDDIR)/
-	mv tsh*.pkg* $(BUILDDIR)/
-	cp $(BUILDDIR)/tsh-*.pkg $(RELEASE_DIR)
+	@echo Combining teleport-bin-$(VERSION).pkg and tsh-$(VERSION).pkg into teleport-$(VERSION).pkg
+	productbuild --package $(BUILDDIR)/tsh*.pkg --package $(BUILDDIR)/teleport-bin*.pkg $(BUILDDIR)/teleport-$(VERSION).unsigned.pkg
+	$(call $(NOTARIZE_PKG),$(BUILDDIR)/teleport-$(VERSION).unsigned.pkg,$(RELEASE_DIR)/teleport-$(VERSION.pkg))
+
+	if [ -f e/Makefile ]; then $(MAKE) -C e pkg; fi
 
 # build .rpm
 .PHONY: rpm

--- a/Makefile
+++ b/Makefile
@@ -408,7 +408,7 @@ $(BUILDDIR)/fdpass-teleport:
 
 .PHONY: tsh-app
 tsh-app: TSH_APP_BUNDLE = $(BUILDDIR)/tsh.app
-tsh-app: TSH_APP_ENTITLEMENTS = build.assets/macos/$(TSH_SKELETON)/tsh.entitlements
+tsh-app: TSH_APP_ENTITLEMENTS = build.assets/macos/$(TSH_SKELETON)/$(TSH_SKELETON).entitlements
 tsh-app:
 	cp -rf "build.assets/macos/$(TSH_SKELETON)/tsh.app/" "$(TSH_APP_BUNDLE)/"
 	mkdir -p "$(TSH_APP_BUNDLE)/Contents/MacOS/"

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -223,7 +223,7 @@ if [[ "${PACKAGE_TYPE}" == "pkg" ]]; then
     if [[ "${TELEPORT_TYPE}" == "ent" ]]; then
         PKG_FILENAME="teleport-ent-${TELEPORT_VERSION}${ARCH_TAG}.${PACKAGE_TYPE}"
     else
-        PKG_FILENAME="teleport-${TELEPORT_VERSION}${ARCH_TAG}.${PACKAGE_TYPE}"
+        PKG_FILENAME="teleport-bin-${TELEPORT_VERSION}${ARCH_TAG}.${PACKAGE_TYPE}"
     fi
 else
     FILE_LIST="${TAR_PATH}/tsh ${TAR_PATH}/tctl ${TAR_PATH}/teleport ${TAR_PATH}/tbot ${TAR_PATH}/fdpass-teleport ${TAR_PATH}/examples/systemd/teleport.service ${TAR_PATH}/examples/systemd/post-upgrade"

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -218,7 +218,7 @@ if [[ "${PACKAGE_TYPE}" == "pkg" ]]; then
         ARCH_TAG="-${PACKAGE_ARCH}"
     fi
     SIGN_PKG="true"
-    FILE_LIST="${TAR_PATH}/tsh ${TAR_PATH}/tctl ${TAR_PATH}/teleport ${TAR_PATH}/tbot ${TAR_PATH}/fdpass-teleport"
+    FILE_LIST="${TAR_PATH}/tctl ${TAR_PATH}/teleport ${TAR_PATH}/tbot ${TAR_PATH}/fdpass-teleport"
     BUNDLE_ID="${b:-com.gravitational.teleport}"
     if [[ "${TELEPORT_TYPE}" == "ent" ]]; then
         PKG_FILENAME="teleport-ent-${TELEPORT_VERSION}${ARCH_TAG}.${PACKAGE_TYPE}"

--- a/build.assets/build-pkg-tsh.sh
+++ b/build.assets/build-pkg-tsh.sh
@@ -152,18 +152,15 @@ or name of the key to sign packages"
   tar xzf "$tarname" -C "$tmp"
 
   # Prepare app shell.
-  local skel="$buildassets/macos/$TSH_SKELETON"
   local target="$tmp/root/tsh.app"
-  cp -r "$skel/tsh.app" "$target"
-  mkdir -p "$target/Contents/MacOS/"
-  cp "$tmp"/teleport*/tsh "$target/Contents/MacOS/"
+  cp -r "$tmp/teleport/tsh.app" "$target"
 
   # Sign app.
   $DRY_RUN_PREFIX codesign -f \
     -o kill,hard,runtime \
     -s "$DEVELOPER_ID_APPLICATION" \
     -i "$BUNDLEID" \
-    --entitlements "$skel"/tsh*.entitlements \
+    --entitlements "$buildassets"/macos/$TSH_SKELETON/tsh*.entitlements \
     --timestamp \
     "$target"
 

--- a/build.assets/install
+++ b/build.assets/install
@@ -10,11 +10,12 @@ BINDIR=/usr/local/bin
 #
 VARDIR=/var/lib/teleport
 
+#
+# (mac only) the directory where Teleport .app bundles will be installed
+#
+APPS_DIR=/Applications
+
 [ ! $(id -u) != "0" ] || { echo "ERROR: You must be root"; exit 1; }
-echo "Starting Teleport installation..."
-cd $(dirname $0)
-mkdir -p $VARDIR $BINDIR
-cp -f teleport tctl tsh tbot $BINDIR/ || exit 1
 
 #
 # What operating system is the user running?
@@ -27,6 +28,15 @@ case "${unameOut}" in
     MINGW*)     machine=minGw;;
     *)          machine="UNKNOWN:${unameOut}"
 esac
+
+echo "Starting Teleport installation..."
+cd $(dirname $0)
+mkdir -p $VARDIR $BINDIR
+cp -f teleport tctl tsh tbot $BINDIR/ || exit 1
+
+if [[ machine == "Darwin" ]];then
+    cp -rf tsh.app/ "$APPS_DIR"/tsh.app/
+fi
 
 echo "Teleport binaries have been copied to $BINDIR"
 echo ""

--- a/build.assets/macos/install
+++ b/build.assets/macos/install
@@ -35,10 +35,7 @@ echo "Starting Teleport installation..."
 cd $(dirname $0)
 mkdir -p $VARDIR $BINDIR
 cp -f teleport tctl tbot fdpass-teleport $BINDIR/ || exit 1
-
-if [[ machine == "Darwin" ]];then
-    cp -rf tsh.app/ "$APPS_DIR"/tsh.app/
-fi
+cp -rf tsh.app/ "$APPS_DIR"/tsh.app/ || exit 1
 
 echo "Teleport binaries have been copied to $BINDIR"
 echo ""

--- a/build.assets/macos/install
+++ b/build.assets/macos/install
@@ -10,11 +10,12 @@ BINDIR=/usr/local/bin
 #
 VARDIR=/var/lib/teleport
 
+#
+# the directory where Teleport .app bundles will be installed
+#
+APPS_DIR=/Applications
+
 [ ! $(id -u) != "0" ] || { echo "ERROR: You must be root"; exit 1; }
-echo "Starting Teleport installation..."
-cd $(dirname $0)
-mkdir -p $VARDIR $BINDIR
-cp -f teleport tctl tsh tbot $BINDIR/ || exit 1
 
 #
 # What operating system is the user running?
@@ -27,6 +28,17 @@ case "${unameOut}" in
     MINGW*)     machine=minGw;;
     *)          machine="UNKNOWN:${unameOut}"
 esac
+
+[ "$machine" == "darwin" ] || { echo "ERROR: This script is intended for darwin this machine is $machine"; exit 1; }
+
+echo "Starting Teleport installation..."
+cd $(dirname $0)
+mkdir -p $VARDIR $BINDIR
+cp -f teleport tctl tbot fdpass-teleport $BINDIR/ || exit 1
+
+if [[ machine == "Darwin" ]];then
+    cp -rf tsh.app/ "$APPS_DIR"/tsh.app/
+fi
 
 echo "Teleport binaries have been copied to $BINDIR"
 echo ""

--- a/darwin-signing.mk
+++ b/darwin-signing.mk
@@ -142,7 +142,6 @@ define notarize_app_bundle
 		--apple-id="$(APPLE_USERNAME)" \
 		--password="$(APPLE_PASSWORD)" \
 		--wait
-	xcrun stapler staple $($@_BUNDLE)
 	rm $(notary_file)
 endef
 

--- a/darwin-signing.mk
+++ b/darwin-signing.mk
@@ -116,7 +116,7 @@ endef
 
 NOTARIZE_TSH_APP = $(if $(SHOULD_NOTARIZE),$(notarize_tsh_app),$(not_notarizing_cmd))
 define notarize_tsh_app
-	$(call notarize_app_bundle,$(TSH_APP_BUNDLE),$(TSH_APP_ENTITLEMENTS))
+	$(call notarize_app_bundle,$(TSH_APP_BUNDLE),$(TSH_BUNDLEID),$(TSH_APP_ENTITLEMENTS))
 endef
 
 NOTARIZE_TELEPORT_PKG = $(if $(SHOULD_NOTARIZE),$(notarize_teleport_pkg),$(not_notarizing_cmd))
@@ -126,15 +126,17 @@ endef
 
 define notarize_app_bundle
 	$(eval $@_BUNDLE = $(1))
-	$(eval $@_ENTITLEMENTS = $(2))
+	$(eval $@_BUNDLE_ID = $(2))
+	$(eval $@_ENTITLEMENTS = $(3))
 	codesign \
 		--sign '$(DEVELOPER_ID_APPLICATION)' \
+		--identifier "$($@_BUNDLE_ID)" \
 		--force \
 		--verbose \
 		--timestamp \
 		--options kill,hard,runtime \
-		--entitlements $($@_ENTITLEMENTS) \
-		$($@_BUNDLE)
+		--entitlements "$($@_ENTITLEMENTS)" \
+		"$($@_BUNDLE)"
 
 	ditto -c -k --keepParent $($@_BUNDLE) $(notary_file)
 	xcrun notarytool submit $(notary_file) \

--- a/darwin-signing.mk
+++ b/darwin-signing.mk
@@ -114,6 +114,24 @@ define notarize_binaries_cmd
 	rm -rf $(notary_dir) $(notary_file)
 endef
 
+
+NOTARIZE_PKG = $(if $(SHOULD_NOTARIZE),$(notarize_pkg),$(not_notarizing_cmd))
+
+define notarize_pkg
+	$(eval $@_IN_PKG = $(1))
+	$(eval $@_OUT_PKG = $(2))
+	productsign \
+		--sign '$(DEVELOPER_ID_APPLICATION)' \
+		--timestamp \
+		$($@_IN_PKG) \
+		$($@_OUT_PKG)
+	xcrun notarytool submit $(@_OUT_PKG) \
+		--team-id="$(TEAMID)" \
+		--apple-id="$(APPLE_USERNAME)" \
+		--password="$(APPLE_PASSWORD)" \
+		--wait
+endef
+
 echo_var = @echo $(1)=\''$($(1))'\'
 
 .PHONY: print-darwin-signing-vars


### PR DESCRIPTION
## Purpose

Currently for our Mac customers to get the full features that our product offers they need to install the `teleport` distribution package of their choice (.pkg, .tar.gz) and also download and install the `tsh.pkg` that contains the `tsh.app`. This has led to some unnecessary confusion for the community.

To address this the `tsh.app` (signed and notarized) will now be available in all distribution types.

## Implementation

* Added a new target `tsh-app` to our Makefile
* `release-darwin` will now call the `tsh-app` target and the signed and notarized app bundle will now be included in the tarball created by `build-archive`
* A new install script for `darwin` OS is now located under `build.assets/macos/install` and is bundled in the appropriate tarballs
* `pkg` combines the previous implementation of our `tsh.pkg` and `teleport.pkg` into one .pkg
  *  `productbuild --package $(BUILDDIR)/tsh*.pkg --package $(BUILDDIR)/teleport-bin*.pkg teleport.pkg`

changelog: Unifying Mac artifacts so that signed and notarized `tsh.app` capable of utilizing TouchID is now included in all package types.