### PR TITLE
Remove strict constraint on kernel version for backported BPF

### DIFF
--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -130,11 +130,6 @@ func New(config *servicecfg.BPFConfig) (BPF, error) {
 		return &NOP{}, nil
 	}
 
-	// Check if the host can run BPF programs.
-	if err := IsHostCompatible(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	// Create a cgroup controller to add/remote cgroups.
 	cgroup, err := controlgroup.New(&controlgroup.Config{
 		MountPath: config.CgroupPath,

--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -118,7 +118,7 @@ type Service struct {
 }
 
 // New creates a BPF service.
-func New(config *servicecfg.BPFConfig) (BPF, error) {
+func New(config *servicecfg.BPFConfig) (bpf BPF, err error) {
 	if err := config.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -130,15 +130,6 @@ func New(config *servicecfg.BPFConfig) (BPF, error) {
 		return &NOP{}, nil
 	}
 
-	// Create a cgroup controller to add/remote cgroups.
-	cgroup, err := controlgroup.New(&controlgroup.Config{
-		MountPath: config.CgroupPath,
-		RootPath:  config.RootPath,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	closeContext, closeFunc := context.WithCancel(context.Background())
 
 	s := &Service{
@@ -148,9 +139,23 @@ func New(config *servicecfg.BPFConfig) (BPF, error) {
 
 		closeContext: closeContext,
 		closeFunc:    closeFunc,
-
-		cgroup: cgroup,
 	}
+
+	// Create a cgroup controller to add/remote cgroups.
+	s.cgroup, err = controlgroup.New(&controlgroup.Config{
+		MountPath: config.CgroupPath,
+		RootPath:  config.RootPath,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer func() {
+		if err != nil {
+			if err := s.cgroup.Close(true); err != nil {
+				log.WithError(err).Warn("Failed to close cgroup")
+			}
+		}
+	}()
 
 	// Create args cache used by the exec BPF program.
 	s.argsCache, err = ttlmap.New(ArgsCacheSize)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2877,7 +2877,11 @@ func (process *TeleportProcess) initSSH() error {
 		// return a NOP struct that can be used to discard BPF data.
 		ebpf, err := bpf.New(cfg.SSH.BPF)
 		if err != nil {
-			return trace.Wrap(err)
+			// Check kernel version if the host can run BPF programs.
+			return trace.NewAggregate(
+				trace.Wrap(bpf.IsHostCompatible()),
+				trace.Wrap(err),
+			)
 		}
 		defer func() { warnOnErr(process.ExitContext(), ebpf.Close(restartingOnGracefulShutdown), logger) }()
 


### PR DESCRIPTION
In this PR removed strict kernel version check for PBF library initialization as proposed in https://github.com/gravitational/teleport/issues/40847#issuecomment-2073437305. Verified with the RHEL version 8.1 and 8.10, both with kernel version 4.18, but in case of the 8.10 BPF is backported.

<details>
  <summary>Default configuration:</summary>

```yaml
version: v3
teleport:
  nodename: rhel8.myguest.virtualbox.org
  data_dir: /var/lib/teleport
  log:
    output: stderr
    severity: INFO
    format:
      output: text
  ca_pin: ""
  diag_addr: ""
auth_service:
  enabled: "yes"
  listen_addr: 0.0.0.0:3025
  proxy_listener_mode: multiplex
ssh_service:
  enabled: "yes"
  enhanced_recording:
    # Enable or disable enhanced auditing for this node. Default value: false.
    enabled: true

    # Optional: command_buffer_size is optional with a default value of 8 pages.
    command_buffer_size: 8

    # Optional: disk_buffer_size is optional with default value of 128 pages.
    disk_buffer_size: 128

    # Optional: network_buffer_size is optional with default value of 8 pages.
    network_buffer_size: 8

    # Optional: Controls where cgroupv2 hierarchy is mounted. Default value:
    # /cgroup2.
    cgroup_path: /cgroup2

    # Optional: Controls the path inside cgroupv2 hierarchy where Teleport
    # cgroups will be placed. Default value: /teleport
    root_path: /teleport
proxy_service:
  enabled: "yes"
  https_keypairs: []
  https_keypairs_reload_interval: 0s
  acme: {}
```
</details>

<details>
  <summary>RHEL8.10 teleport init log</summary>

```
2024-08-01T19:46:59-04:00 INFO  Starting Teleport with a config file version:17.0.0-dev config_file:/etc/teleport.conf common/teleport.go:746
2024-08-01T19:47:00-04:00 INFO [PROC:1]    Service is creating new listener. pid:93132.1 type:debug address:/var/lib/teleport/debug.sock service/signals.go:249
2024-08-01T19:47:01-04:00 INFO [AUTH]      Updating cluster configuration: StaticTokens([]). auth/init.go:457
2024-08-01T19:47:01-04:00 INFO [AUTH]      Updating cluster networking configuration: Kind:"cluster_networking_config" Version:"v2" Metadata:<Name:"cluster-networking-config" Namespace:"default" Labels:<key:"teleport.dev/origin" value:"config-file" > > Spec:<KeepAliveInterval:300000000000 KeepAliveCountMax:3 ProxyListenerMode:Multiplex TunnelStrategy:<AgentMesh:<> > > . auth/init.go:818
2024-08-01T19:47:01-04:00 INFO [AUTH]      Creating namespace: "default". auth/init.go:464
2024-08-01T19:47:01-04:00 INFO [AUTH]      Updating session recording config: Kind:"session_recording_config" Version:"v2" Metadata:<Name:"session-recording-config" Namespace:"default" Labels:<key:"teleport.dev/origin" value:"defaults" > > Spec:<Mode:"node" ProxyChecksHostKeys:"\010\001" > . auth/init.go:858
2024-08-01T19:47:01-04:00 INFO [AUTH]      Auth server is running periodic operations. auth/init.go:564
2024-08-01T19:47:01-04:00 INFO [AUTH:COMP] upload completer will run every 5m0s events/complete.go:161
2024-08-01T19:47:01-04:00 INFO [AUTH:1:CA] Cache "auth" first init succeeded. cache/cache.go:1011
2024-08-01T19:47:01-04:00 INFO [PROC:1]    Service is creating new listener. pid:93132.1 type:auth address:0.0.0.0:3025 service/signals.go:249
2024-08-01T19:47:01-04:00 WARN [AUTH:1]    'proxy_protocol' unspecified. Starting Auth service with external PROXY protocol support, but IP pinned connection affected by PROXY headers will not be allowed. Set 'proxy_protocol: on' in 'auth_service' config if Auth service runs behind L4 load balancer with enabled PROXY protocol, or set 'proxy_protocol: off' otherwise pid:93132.1 service/service.go:2376
2024-08-01T19:47:01-04:00 WARN [AUTH:1]    Configuration setting auth_service/advertise_ip is not set, using inferred address pid:93132.1 address:10.0.2.15:3025 service/service.go:2465
2024-08-01T19:47:01-04:00 WARN [PROC:1]    No TLS Keys provided, using self-signed certificate. pid:93132.1 service/service.go:6144
2024-08-01T19:47:01-04:00 INFO [UPLOAD:1]  starting upload completer service pid:93132.1 service/service.go:3236
2024-08-01T19:47:01-04:00 INFO [UPLOAD:1]  Creating directory. pid:93132.1 directory:/var/lib/teleport/log service/service.go:3252
2024-08-01T19:47:01-04:00 INFO [UPLOAD:1]  Creating directory. pid:93132.1 directory:/var/lib/teleport/log/upload service/service.go:3252
2024-08-01T19:47:01-04:00 INFO [UPLOAD:1]  Creating directory. pid:93132.1 directory:/var/lib/teleport/log/upload/streaming service/service.go:3252
2024-08-01T19:47:01-04:00 INFO [UPLOAD:1]  Creating directory. pid:93132.1 directory:/var/lib/teleport/log/upload/streaming/default service/service.go:3252
2024-08-01T19:47:01-04:00 INFO [UPLOAD:1]  Creating directory. pid:93132.1 directory:/var/lib/teleport/log service/service.go:3252
2024-08-01T19:47:01-04:00 INFO [UPLOAD:1]  Creating directory. pid:93132.1 directory:/var/lib/teleport/log/upload service/service.go:3252
2024-08-01T19:47:01-04:00 INFO [UPLOAD:1]  Creating directory. pid:93132.1 directory:/var/lib/teleport/log/upload/corrupted service/service.go:3252
2024-08-01T19:47:01-04:00 INFO [UPLOAD:1]  Creating directory. pid:93132.1 directory:/var/lib/teleport/log/upload/corrupted/default service/service.go:3252
2024-08-01T19:47:01-04:00 INFO [AUTH:1]    Auth service is starting. pid:93132.1 version:17.0.0-dev git_ref:api/v17.0.0-dev.gusr.1-202-g6922aa0b50 listen_address:10.0.2.15:3025 service/service.go:2413
2024-08-01T19:47:01-04:00 INFO [UPLOAD]    uploader will scan /var/lib/teleport/log/upload/streaming/default every 5s filesessions/fileasync.go:196
2024-08-01T19:47:01-04:00 INFO [UPLOAD:1:] upload completer will run every 5m0s events/complete.go:161
2024-08-01T19:47:01-04:00 INFO [PROC:1]    Connecting to the cluster with TLS client certificate. pid:93132.1 cluster:rhel8.myguest.virtualbox.org service/connect.go:235
2024-08-01T19:47:01-04:00 INFO [PROC:1]    Connecting to the cluster with TLS client certificate. pid:93132.1 cluster:rhel8.myguest.virtualbox.org service/connect.go:235
2024-08-01T19:47:01-04:00 INFO [PROC:1]    Connecting to the cluster with TLS client certificate. pid:93132.1 cluster:rhel8.myguest.virtualbox.org service/connect.go:235
2024-08-01T19:47:01-04:00 INFO [PROC:1]    features loaded from auth server pid:93132.1 identity:Instance features:Kubernetes:true App:true DB:true Desktop:true DeviceTrust:<> AccessRequests:<> AccessList:<> AccessMonitoring:<> Policy:<> SupportType:SUPPORT_TYPE_FREE JoinActiveSessions:true entitlements:<key:"AccessLists" value:<> > entitlements:<key:"AccessMonitoring" value:<> > entitlements:<key:"AccessRequests" value:<> > entitlements:<key:"App" value:<enabled:true > > entitlements:<key:"CloudAuditLogRetention" value:<> > entitlements:<key:"DB" value:<enabled:true > > entitlements:<key:"Desktop" value:<enabled:true > > entitlements:<key:"DeviceTrust" value:<> > entitlements:<key:"ExternalAuditStorage" value:<> > entitlements:<key:"FeatureHiding" value:<> > entitlements:<key:"HSM" value:<> > entitlements:<key:"Identity" value:<> > entitlements:<key:"JoinActiveSessions" value:<enabled:true > > entitlements:<key:"K8s" value:<enabled:true > > entitlements:<key:"MobileDeviceManagement" value:<> > entitlements:<key:"OIDC" value:<> > entitlements:<key:"OktaSCIM" value:<> > entitlements:<key:"OktaUserSync" value:<> > entitlements:<key:"Policy" value:<> > entitlements:<key:"SAML" value:<> > entitlements:<key:"SessionLocks" value:<> > entitlements:<key:"UpsellAlert" value:<> > entitlements:<key:"UsageReporting" value:<> >  service/connect.go:1131
2024-08-01T19:47:01-04:00 INFO [INSTANCE:] Successfully registered instance client. pid:93132.1 service/service.go:2813
2024-08-01T19:47:01-04:00 INFO [PROC:1]    Reusing Instance client. pid:93132.1 identity:Proxy additional_system_roles:[Auth Node Proxy] service/connect.go:1105
2024-08-01T19:47:01-04:00 INFO [PROC:1]    Reusing Instance client. pid:93132.1 identity:Node additional_system_roles:[Auth Node Proxy] service/connect.go:1105
2024-08-01T19:47:02-04:00 INFO [NODE:1:CA] Cache "node" first init succeeded. cache/cache.go:1011
libbpf: loading object 'command' from buffer
libbpf: elf: section(2) .text, size 2704, link 0, flags 6, type=1
libbpf: sec '.text': found program 'enter_execve' at insn offset 0 (0 bytes), code size 267 insns (2136 bytes)
libbpf: sec '.text': found program 'exit_execve' at insn offset 267 (2136 bytes), code size 71 insns (568 bytes)
libbpf: elf: section(3) .rel.text, size 192, link 19, flags 40, type=9
libbpf: elf: section(4) tp/syscalls/sys_execve, size 40, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_execve': found program 'tracepoint__syscalls__sys_enter_execve' at insn offset 0 (0 bytes), code size 5 insns (40 bytes)
libbpf: elf: section(5) .reltp/syscalls/sys_execve, size 16, link 19, flags 40, type=9
libbpf: elf: section(6) tp/syscalls/sys_exit_execve, size 32, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_exit_execve': found program 'tracepoint__syscalls__sys_exit_execve' at insn offset 0 (0 bytes), code size 4 insns (32 bytes)
libbpf: elf: section(7) .reltp/syscalls/sys_exit_execve, size 16, link 19, flags 40, type=9
libbpf: elf: section(8) tp/syscalls/sys_execveat, size 40, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_execveat': found program 'tracepoint__syscalls__sys_enter_execveat' at insn offset 0 (0 bytes), code size 5 insns (40 bytes)
libbpf: elf: section(9) .reltp/syscalls/sys_execveat, size 16, link 19, flags 40, type=9
libbpf: elf: section(10) tp/syscalls/sys_exit_execveat, size 32, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_exit_execveat': found program 'tracepoint__syscalls__sys_exit_execveat' at insn offset 0 (0 bytes), code size 4 insns (32 bytes)
libbpf: elf: section(11) .reltp/syscalls/sys_exit_execveat, size 16, link 19, flags 40, type=9
libbpf: elf: section(12) license, size 13, link 0, flags 3, type=1
libbpf: license of command is Dual BSD/GPL
libbpf: elf: section(13) .maps, size 96, link 0, flags 3, type=1
libbpf: elf: section(14) .BTF, size 29339, link 0, flags 0, type=1
libbpf: elf: section(16) .BTF.ext, size 3988, link 0, flags 0, type=1
libbpf: elf: section(19) .symtab, size 696, link 1, flags 0, type=2
libbpf: looking for externs among 29 symbols...
libbpf: collected 0 externs total
libbpf: map 'monitored_cgroups': at sec_idx 13, offset 0.
libbpf: map 'monitored_cgroups': found type = 1.
libbpf: map 'monitored_cgroups': found key [8], sz = 8.
libbpf: map 'monitored_cgroups': found value [12], sz = 8.
libbpf: map 'monitored_cgroups': found max_entries = 1024.
libbpf: map 'execve_events': at sec_idx 13, offset 32.
libbpf: map 'execve_events': found type = 27.
libbpf: map 'execve_events': found max_entries = 32768.
libbpf: map 'lost_counter': at sec_idx 13, offset 48.
libbpf: map 'lost_counter': found type = 2.
libbpf: map 'lost_counter': found key [27], sz = 4.
libbpf: map 'lost_counter': found value [8], sz = 8.
libbpf: map 'lost_counter': found max_entries = 1.
libbpf: map 'lost_doorbell': at sec_idx 13, offset 80.
libbpf: map 'lost_doorbell': found type = 27.
libbpf: map 'lost_doorbell': found max_entries = 4096.
libbpf: sec '.rel.text': collecting relocation for section(2) '.text'
libbpf: sec '.rel.text': relo #0: insn #9 against 'monitored_cgroups'
libbpf: prog 'enter_execve': found map 0 (monitored_cgroups, sec 13, off 0) for insn #9
libbpf: sec '.rel.text': relo #1: insn #42 against 'execve_events'
libbpf: prog 'enter_execve': found map 1 (execve_events, sec 13, off 32) for insn #42
libbpf: sec '.rel.text': relo #2: insn #61 against 'lost_counter'
libbpf: prog 'enter_execve': found map 2 (lost_counter, sec 13, off 48) for insn #61
libbpf: sec '.rel.text': relo #3: insn #117 against 'execve_events'
libbpf: prog 'enter_execve': found map 1 (execve_events, sec 13, off 32) for insn #117
libbpf: sec '.rel.text': relo #4: insn #179 against 'execve_events'
libbpf: prog 'enter_execve': found map 1 (execve_events, sec 13, off 32) for insn #179
libbpf: sec '.rel.text': relo #5: insn #199 against 'lost_counter'
libbpf: prog 'enter_execve': found map 2 (lost_counter, sec 13, off 48) for insn #199
libbpf: sec '.rel.text': relo #6: insn #210 against 'lost_counter'
libbpf: prog 'enter_execve': found map 2 (lost_counter, sec 13, off 48) for insn #210
libbpf: sec '.rel.text': relo #7: insn #219 against 'lost_doorbell'
libbpf: prog 'enter_execve': found map 3 (lost_doorbell, sec 13, off 80) for insn #219
libbpf: sec '.rel.text': relo #8: insn #272 against 'monitored_cgroups'
libbpf: prog 'exit_execve': found map 0 (monitored_cgroups, sec 13, off 0) for insn #5
libbpf: sec '.rel.text': relo #9: insn #277 against 'execve_events'
libbpf: prog 'exit_execve': found map 1 (execve_events, sec 13, off 32) for insn #10
libbpf: sec '.rel.text': relo #10: insn #287 against 'lost_counter'
libbpf: prog 'exit_execve': found map 2 (lost_counter, sec 13, off 48) for insn #20
libbpf: sec '.rel.text': relo #11: insn #297 against 'lost_doorbell'
libbpf: prog 'exit_execve': found map 3 (lost_doorbell, sec 13, off 80) for insn #30
libbpf: sec '.reltp/syscalls/sys_execve': collecting relocation for section(4) 'tp/syscalls/sys_execve'
libbpf: sec '.reltp/syscalls/sys_execve': relo #0: insn #2 against '.text'
libbpf: sec '.reltp/syscalls/sys_exit_execve': collecting relocation for section(6) 'tp/syscalls/sys_exit_execve'
libbpf: sec '.reltp/syscalls/sys_exit_execve': relo #0: insn #1 against '.text'
libbpf: sec '.reltp/syscalls/sys_execveat': collecting relocation for section(8) 'tp/syscalls/sys_execveat'
libbpf: sec '.reltp/syscalls/sys_execveat': relo #0: insn #2 against '.text'
libbpf: sec '.reltp/syscalls/sys_exit_execveat': collecting relocation for section(10) 'tp/syscalls/sys_exit_execveat'
libbpf: sec '.reltp/syscalls/sys_exit_execveat': relo #0: insn #1 against '.text'
libbpf: map 'monitored_cgroups': created successfully, fd=21
libbpf: map 'execve_events': created successfully, fd=23
libbpf: map 'lost_counter': created successfully, fd=24
libbpf: map 'lost_doorbell': created successfully, fd=25
libbpf: sec 'tp/syscalls/sys_execve': found 2 CO-RE relocations
libbpf: CO-RE relocating [37] struct syscall_trace_enter: found target candidate [27692] struct syscall_trace_enter in [vmlinux]
libbpf: prog 'tracepoint__syscalls__sys_enter_execve': relo #0: <byte_off> [37] struct syscall_trace_enter.args[1] (0:2:1 @ offset 24)
libbpf: prog 'tracepoint__syscalls__sys_enter_execve': relo #0: matching candidate #0 <byte_off> [27692] struct syscall_trace_enter.args[1] (0:2:1 @ offset 24)
libbpf: prog 'tracepoint__syscalls__sys_enter_execve': relo #0: patched insn #0 (LDX/ST/STX) off 24 -> 24
libbpf: prog 'tracepoint__syscalls__sys_enter_execve': relo #1: <byte_off> [37] struct syscall_trace_enter.args[0] (0:2:0 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_enter_execve': relo #1: matching candidate #0 <byte_off> [27692] struct syscall_trace_enter.args[0] (0:2:0 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_enter_execve': relo #1: patched insn #1 (LDX/ST/STX) off 16 -> 16
libbpf: sec '.text': found 4 CO-RE relocations
libbpf: CO-RE relocating [52] struct task_struct: found target candidate [172] struct task_struct in [vmlinux]
libbpf: prog 'enter_execve': relo #0: <byte_off> [52] struct task_struct.real_parent (0:74 @ offset 2288)
libbpf: prog 'enter_execve': relo #0: matching candidate #0 <byte_off> [172] struct task_struct.real_parent (0:68 @ offset 2320)
libbpf: prog 'enter_execve': relo #0: patched insn #19 (ALU/ALU64) imm 2288 -> 2320
libbpf: prog 'enter_execve': relo #1: <byte_off> [52] struct task_struct.tgid (0:72 @ offset 2276)
libbpf: prog 'enter_execve': relo #1: matching candidate #0 <byte_off> [172] struct task_struct.tgid (0:66 @ offset 2308)
libbpf: prog 'enter_execve': relo #1: patched insn #26 (ALU/ALU64) imm 2276 -> 2308
libbpf: prog 'exit_execve': relo #2: <byte_off> [52] struct task_struct.real_parent (0:74 @ offset 2288)
libbpf: prog 'exit_execve': relo #2: matching candidate #0 <byte_off> [172] struct task_struct.real_parent (0:68 @ offset 2320)
libbpf: prog 'exit_execve': relo #2: patched insn #42 (ALU/ALU64) imm 2288 -> 2320
libbpf: prog 'exit_execve': relo #3: <byte_off> [52] struct task_struct.tgid (0:72 @ offset 2276)
libbpf: prog 'exit_execve': relo #3: matching candidate #0 <byte_off> [172] struct task_struct.tgid (0:66 @ offset 2308)
libbpf: prog 'exit_execve': relo #3: patched insn #49 (ALU/ALU64) imm 2276 -> 2308
libbpf: sec 'tp/syscalls/sys_exit_execve': found 1 CO-RE relocations
libbpf: CO-RE relocating [354] struct syscall_trace_exit: found target candidate [27693] struct syscall_trace_exit in [vmlinux]
libbpf: prog 'tracepoint__syscalls__sys_exit_execve': relo #0: <byte_off> [354] struct syscall_trace_exit.ret (0:2 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_exit_execve': relo #0: matching candidate #0 <byte_off> [27693] struct syscall_trace_exit.ret (0:2 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_exit_execve': relo #0: patched insn #0 (LDX/ST/STX) off 16 -> 16
libbpf: sec 'tp/syscalls/sys_execveat': found 2 CO-RE relocations
libbpf: prog 'tracepoint__syscalls__sys_enter_execveat': relo #0: <byte_off> [37] struct syscall_trace_enter.args[2] (0:2:2 @ offset 32)
libbpf: prog 'tracepoint__syscalls__sys_enter_execveat': relo #0: matching candidate #0 <byte_off> [27692] struct syscall_trace_enter.args[2] (0:2:2 @ offset 32)
libbpf: prog 'tracepoint__syscalls__sys_enter_execveat': relo #0: patched insn #0 (LDX/ST/STX) off 32 -> 32
libbpf: prog 'tracepoint__syscalls__sys_enter_execveat': relo #1: <byte_off> [37] struct syscall_trace_enter.args[1] (0:2:1 @ offset 24)
libbpf: prog 'tracepoint__syscalls__sys_enter_execveat': relo #1: matching candidate #0 <byte_off> [27692] struct syscall_trace_enter.args[1] (0:2:1 @ offset 24)
libbpf: prog 'tracepoint__syscalls__sys_enter_execveat': relo #1: patched insn #1 (LDX/ST/STX) off 24 -> 24
libbpf: sec 'tp/syscalls/sys_exit_execveat': found 1 CO-RE relocations
libbpf: prog 'tracepoint__syscalls__sys_exit_execveat': relo #0: <byte_off> [354] struct syscall_trace_exit.ret (0:2 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_exit_execveat': relo #0: matching candidate #0 <byte_off> [27693] struct syscall_trace_exit.ret (0:2 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_exit_execveat': relo #0: patched insn #0 (LDX/ST/STX) off 16 -> 16
libbpf: prog 'tracepoint__syscalls__sys_enter_execve': added 267 insns from sub-prog 'enter_execve'
libbpf: prog 'tracepoint__syscalls__sys_enter_execve': insn #2 relocated, imm 2 points to subprog 'enter_execve' (now at 5 offset)
libbpf: prog 'tracepoint__syscalls__sys_exit_execve': added 71 insns from sub-prog 'exit_execve'
libbpf: prog 'tracepoint__syscalls__sys_exit_execve': insn #1 relocated, imm 2 points to subprog 'exit_execve' (now at 4 offset)
libbpf: prog 'tracepoint__syscalls__sys_enter_execveat': added 267 insns from sub-prog 'enter_execve'
libbpf: prog 'tracepoint__syscalls__sys_enter_execveat': insn #2 relocated, imm 2 points to subprog 'enter_execve' (now at 5 offset)
libbpf: prog 'tracepoint__syscalls__sys_exit_execveat': added 71 insns from sub-prog 'exit_execve'
libbpf: prog 'tracepoint__syscalls__sys_exit_execveat': insn #1 relocated, imm 2 points to subprog 'exit_execve' (now at 4 offset)
libbpf: loading object 'disk' from buffer
libbpf: elf: section(2) .text, size 864, link 0, flags 6, type=1
libbpf: sec '.text': found program 'exit_open' at insn offset 0 (0 bytes), code size 108 insns (864 bytes)
libbpf: elf: section(3) .rel.text, size 96, link 27, flags 40, type=9
libbpf: elf: section(4) tp/syscalls/sys_enter_creat, size 144, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_enter_creat': found program 'tracepoint__syscalls__sys_enter_creat' at insn offset 0 (0 bytes), code size 18 insns (144 bytes)
libbpf: elf: section(5) .reltp/syscalls/sys_enter_creat, size 16, link 27, flags 40, type=9
libbpf: elf: section(6) tp/syscalls/sys_exit_creat, size 32, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_exit_creat': found program 'tracepoint__syscalls__sys_exit_creat' at insn offset 0 (0 bytes), code size 4 insns (32 bytes)
libbpf: elf: section(7) .reltp/syscalls/sys_exit_creat, size 16, link 27, flags 40, type=9
libbpf: elf: section(8) tp/syscalls/sys_enter_open, size 160, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_enter_open': found program 'tracepoint__syscalls__sys_enter_open' at insn offset 0 (0 bytes), code size 20 insns (160 bytes)
libbpf: elf: section(9) .reltp/syscalls/sys_enter_open, size 16, link 27, flags 40, type=9
libbpf: elf: section(10) tp/syscalls/sys_exit_open, size 32, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_exit_open': found program 'tracepoint__syscalls__sys_exit_open' at insn offset 0 (0 bytes), code size 4 insns (32 bytes)
libbpf: elf: section(11) .reltp/syscalls/sys_exit_open, size 16, link 27, flags 40, type=9
libbpf: elf: section(12) tp/syscalls/sys_enter_openat, size 160, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_enter_openat': found program 'tracepoint__syscalls__sys_enter_openat' at insn offset 0 (0 bytes), code size 20 insns (160 bytes)
libbpf: elf: section(13) .reltp/syscalls/sys_enter_openat, size 16, link 27, flags 40, type=9
libbpf: elf: section(14) tp/syscalls/sys_exit_openat, size 32, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_exit_openat': found program 'tracepoint__syscalls__sys_exit_openat' at insn offset 0 (0 bytes), code size 4 insns (32 bytes)
libbpf: elf: section(15) .reltp/syscalls/sys_exit_openat, size 16, link 27, flags 40, type=9
libbpf: elf: section(16) tp/syscalls/sys_enter_openat2, size 216, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_enter_openat2': found program 'tracepoint__syscalls__sys_enter_openat2' at insn offset 0 (0 bytes), code size 27 insns (216 bytes)
libbpf: elf: section(17) .reltp/syscalls/sys_enter_openat2, size 16, link 27, flags 40, type=9
libbpf: elf: section(18) tp/syscalls/sys_exit_openat2, size 32, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_exit_openat2': found program 'tracepoint__syscalls__sys_exit_openat2' at insn offset 0 (0 bytes), code size 4 insns (32 bytes)
libbpf: elf: section(19) .reltp/syscalls/sys_exit_openat2, size 16, link 27, flags 40, type=9
libbpf: elf: section(20) license, size 13, link 0, flags 3, type=1
libbpf: license of disk is Dual BSD/GPL
libbpf: elf: section(21) .maps, size 128, link 0, flags 3, type=1
libbpf: elf: section(22) .BTF, size 4221, link 0, flags 0, type=1
libbpf: elf: section(24) .BTF.ext, size 2132, link 0, flags 0, type=1
libbpf: elf: section(27) .symtab, size 672, link 1, flags 0, type=2
libbpf: looking for externs among 28 symbols...
libbpf: collected 0 externs total
libbpf: map 'infotmp': at sec_idx 21, offset 0.
libbpf: map 'infotmp': found type = 1.
libbpf: map 'infotmp': found key [8], sz = 8.
libbpf: map 'infotmp': found value [12], sz = 24.
libbpf: map 'infotmp': found max_entries = 8192.
libbpf: map 'monitored_cgroups': at sec_idx 21, offset 32.
libbpf: map 'monitored_cgroups': found type = 1.
libbpf: map 'monitored_cgroups': found key [8], sz = 8.
libbpf: map 'monitored_cgroups': found value [21], sz = 8.
libbpf: map 'monitored_cgroups': found max_entries = 1024.
libbpf: map 'open_events': at sec_idx 21, offset 64.
libbpf: map 'open_events': found type = 27.
libbpf: map 'open_events': found max_entries = 524288.
libbpf: map 'lost_counter': at sec_idx 21, offset 80.
libbpf: map 'lost_counter': found type = 2.
libbpf: map 'lost_counter': found key [36], sz = 4.
libbpf: map 'lost_counter': found value [8], sz = 8.
libbpf: map 'lost_counter': found max_entries = 1.
libbpf: map 'lost_doorbell': at sec_idx 21, offset 112.
libbpf: map 'lost_doorbell': found type = 27.
libbpf: map 'lost_doorbell': found max_entries = 4096.
libbpf: sec '.rel.text': collecting relocation for section(2) '.text'
libbpf: sec '.rel.text': relo #0: insn #45 against 'infotmp'
libbpf: prog 'exit_open': found map 0 (infotmp, sec 21, off 0) for insn #45
libbpf: sec '.rel.text': relo #1: insn #52 against 'monitored_cgroups'
libbpf: prog 'exit_open': found map 1 (monitored_cgroups, sec 21, off 32) for insn #52
libbpf: sec '.rel.text': relo #2: insn #78 against 'open_events'
libbpf: prog 'exit_open': found map 2 (open_events, sec 21, off 64) for insn #78
libbpf: sec '.rel.text': relo #3: insn #87 against 'lost_counter'
libbpf: prog 'exit_open': found map 3 (lost_counter, sec 21, off 80) for insn #87
libbpf: sec '.rel.text': relo #4: insn #97 against 'lost_doorbell'
libbpf: prog 'exit_open': found map 4 (lost_doorbell, sec 21, off 112) for insn #97
libbpf: sec '.rel.text': relo #5: insn #104 against 'infotmp'
libbpf: prog 'exit_open': found map 0 (infotmp, sec 21, off 0) for insn #104
libbpf: sec '.reltp/syscalls/sys_enter_creat': collecting relocation for section(4) 'tp/syscalls/sys_enter_creat'
libbpf: sec '.reltp/syscalls/sys_enter_creat': relo #0: insn #12 against 'infotmp'
libbpf: prog 'tracepoint__syscalls__sys_enter_creat': found map 0 (infotmp, sec 21, off 0) for insn #12
libbpf: sec '.reltp/syscalls/sys_exit_creat': collecting relocation for section(6) 'tp/syscalls/sys_exit_creat'
libbpf: sec '.reltp/syscalls/sys_exit_creat': relo #0: insn #1 against '.text'
libbpf: sec '.reltp/syscalls/sys_enter_open': collecting relocation for section(8) 'tp/syscalls/sys_enter_open'
libbpf: sec '.reltp/syscalls/sys_enter_open': relo #0: insn #14 against 'infotmp'
libbpf: prog 'tracepoint__syscalls__sys_enter_open': found map 0 (infotmp, sec 21, off 0) for insn #14
libbpf: sec '.reltp/syscalls/sys_exit_open': collecting relocation for section(10) 'tp/syscalls/sys_exit_open'
libbpf: sec '.reltp/syscalls/sys_exit_open': relo #0: insn #1 against '.text'
libbpf: sec '.reltp/syscalls/sys_enter_openat': collecting relocation for section(12) 'tp/syscalls/sys_enter_openat'
libbpf: sec '.reltp/syscalls/sys_enter_openat': relo #0: insn #14 against 'infotmp'
libbpf: prog 'tracepoint__syscalls__sys_enter_openat': found map 0 (infotmp, sec 21, off 0) for insn #14
libbpf: sec '.reltp/syscalls/sys_exit_openat': collecting relocation for section(14) 'tp/syscalls/sys_exit_openat'
libbpf: sec '.reltp/syscalls/sys_exit_openat': relo #0: insn #1 against '.text'
libbpf: sec '.reltp/syscalls/sys_enter_openat2': collecting relocation for section(16) 'tp/syscalls/sys_enter_openat2'
libbpf: sec '.reltp/syscalls/sys_enter_openat2': relo #0: insn #21 against 'infotmp'
libbpf: prog 'tracepoint__syscalls__sys_enter_openat2': found map 0 (infotmp, sec 21, off 0) for insn #21
libbpf: sec '.reltp/syscalls/sys_exit_openat2': collecting relocation for section(18) 'tp/syscalls/sys_exit_openat2'
libbpf: sec '.reltp/syscalls/sys_exit_openat2': relo #0: insn #1 against '.text'
libbpf: map 'infotmp': created successfully, fd=37
libbpf: map 'monitored_cgroups': created successfully, fd=38
libbpf: map 'open_events': created successfully, fd=39
libbpf: map 'lost_counter': created successfully, fd=40
libbpf: map 'lost_doorbell': created successfully, fd=41
libbpf: sec 'tp/syscalls/sys_enter_creat': found 1 CO-RE relocations
libbpf: CO-RE relocating [46] struct syscall_trace_enter: found target candidate [27692] struct syscall_trace_enter in [vmlinux]
libbpf: prog 'tracepoint__syscalls__sys_enter_creat': relo #0: <byte_off> [46] struct syscall_trace_enter.args[0] (0:2:0 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_enter_creat': relo #0: matching candidate #0 <byte_off> [27692] struct syscall_trace_enter.args[0] (0:2:0 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_enter_creat': relo #0: patched insn #0 (LDX/ST/STX) off 16 -> 16
libbpf: sec 'tp/syscalls/sys_exit_creat': found 1 CO-RE relocations
libbpf: CO-RE relocating [55] struct syscall_trace_exit: found target candidate [27693] struct syscall_trace_exit in [vmlinux]
libbpf: prog 'tracepoint__syscalls__sys_exit_creat': relo #0: <byte_off> [55] struct syscall_trace_exit.ret (0:2 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_exit_creat': relo #0: matching candidate #0 <byte_off> [27693] struct syscall_trace_exit.ret (0:2 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_exit_creat': relo #0: patched insn #0 (LDX/ST/STX) off 16 -> 16
libbpf: sec 'tp/syscalls/sys_enter_open': found 2 CO-RE relocations
libbpf: prog 'tracepoint__syscalls__sys_enter_open': relo #0: <byte_off> [46] struct syscall_trace_enter.args[0] (0:2:0 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_enter_open': relo #0: matching candidate #0 <byte_off> [27692] struct syscall_trace_enter.args[0] (0:2:0 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_enter_open': relo #0: patched insn #0 (LDX/ST/STX) off 16 -> 16
libbpf: prog 'tracepoint__syscalls__sys_enter_open': relo #1: <byte_off> [46] struct syscall_trace_enter.args[1] (0:2:1 @ offset 24)
libbpf: prog 'tracepoint__syscalls__sys_enter_open': relo #1: matching candidate #0 <byte_off> [27692] struct syscall_trace_enter.args[1] (0:2:1 @ offset 24)
libbpf: prog 'tracepoint__syscalls__sys_enter_open': relo #1: patched insn #1 (LDX/ST/STX) off 24 -> 24
libbpf: sec 'tp/syscalls/sys_exit_open': found 1 CO-RE relocations
libbpf: prog 'tracepoint__syscalls__sys_exit_open': relo #0: <byte_off> [55] struct syscall_trace_exit.ret (0:2 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_exit_open': relo #0: matching candidate #0 <byte_off> [27693] struct syscall_trace_exit.ret (0:2 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_exit_open': relo #0: patched insn #0 (LDX/ST/STX) off 16 -> 16
libbpf: sec 'tp/syscalls/sys_enter_openat': found 2 CO-RE relocations
libbpf: prog 'tracepoint__syscalls__sys_enter_openat': relo #0: <byte_off> [46] struct syscall_trace_enter.args[1] (0:2:1 @ offset 24)
libbpf: prog 'tracepoint__syscalls__sys_enter_openat': relo #0: matching candidate #0 <byte_off> [27692] struct syscall_trace_enter.args[1] (0:2:1 @ offset 24)
libbpf: prog 'tracepoint__syscalls__sys_enter_openat': relo #0: patched insn #0 (LDX/ST/STX) off 24 -> 24
libbpf: prog 'tracepoint__syscalls__sys_enter_openat': relo #1: <byte_off> [46] struct syscall_trace_enter.args[2] (0:2:2 @ offset 32)
libbpf: prog 'tracepoint__syscalls__sys_enter_openat': relo #1: matching candidate #0 <byte_off> [27692] struct syscall_trace_enter.args[2] (0:2:2 @ offset 32)
libbpf: prog 'tracepoint__syscalls__sys_enter_openat': relo #1: patched insn #1 (LDX/ST/STX) off 32 -> 32
libbpf: sec 'tp/syscalls/sys_exit_openat': found 1 CO-RE relocations
libbpf: prog 'tracepoint__syscalls__sys_exit_openat': relo #0: <byte_off> [55] struct syscall_trace_exit.ret (0:2 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_exit_openat': relo #0: matching candidate #0 <byte_off> [27693] struct syscall_trace_exit.ret (0:2 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_exit_openat': relo #0: patched insn #0 (LDX/ST/STX) off 16 -> 16
libbpf: sec 'tp/syscalls/sys_enter_openat2': found 3 CO-RE relocations
libbpf: prog 'tracepoint__syscalls__sys_enter_openat2': relo #0: <byte_off> [46] struct syscall_trace_enter.args[2] (0:2:2 @ offset 32)
libbpf: prog 'tracepoint__syscalls__sys_enter_openat2': relo #0: matching candidate #0 <byte_off> [27692] struct syscall_trace_enter.args[2] (0:2:2 @ offset 32)
libbpf: prog 'tracepoint__syscalls__sys_enter_openat2': relo #0: patched insn #0 (LDX/ST/STX) off 32 -> 32
libbpf: CO-RE relocating [71] struct open_how: found target candidate [16660] struct open_how in [vmlinux]
libbpf: prog 'tracepoint__syscalls__sys_enter_openat2': relo #1: <byte_off> [71] struct open_how.flags (0:0 @ offset 0)
libbpf: prog 'tracepoint__syscalls__sys_enter_openat2': relo #1: matching candidate #0 <byte_off> [16660] struct open_how.flags (0:0 @ offset 0)
libbpf: prog 'tracepoint__syscalls__sys_enter_openat2': relo #1: patched insn #1 (ALU/ALU64) imm 0 -> 0
libbpf: prog 'tracepoint__syscalls__sys_enter_openat2': relo #2: <byte_off> [46] struct syscall_trace_enter.args[1] (0:2:1 @ offset 24)
libbpf: prog 'tracepoint__syscalls__sys_enter_openat2': relo #2: matching candidate #0 <byte_off> [27692] struct syscall_trace_enter.args[1] (0:2:1 @ offset 24)
libbpf: prog 'tracepoint__syscalls__sys_enter_openat2': relo #2: patched insn #3 (LDX/ST/STX) off 24 -> 24
libbpf: sec 'tp/syscalls/sys_exit_openat2': found 1 CO-RE relocations
libbpf: prog 'tracepoint__syscalls__sys_exit_openat2': relo #0: <byte_off> [55] struct syscall_trace_exit.ret (0:2 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_exit_openat2': relo #0: matching candidate #0 <byte_off> [27693] struct syscall_trace_exit.ret (0:2 @ offset 16)
libbpf: prog 'tracepoint__syscalls__sys_exit_openat2': relo #0: patched insn #0 (LDX/ST/STX) off 16 -> 16
libbpf: prog 'tracepoint__syscalls__sys_exit_creat': added 108 insns from sub-prog 'exit_open'
libbpf: prog 'tracepoint__syscalls__sys_exit_creat': insn #1 relocated, imm 2 points to subprog 'exit_open' (now at 4 offset)
libbpf: prog 'tracepoint__syscalls__sys_exit_open': added 108 insns from sub-prog 'exit_open'
libbpf: prog 'tracepoint__syscalls__sys_exit_open': insn #1 relocated, imm 2 points to subprog 'exit_open' (now at 4 offset)
libbpf: prog 'tracepoint__syscalls__sys_exit_openat': added 108 insns from sub-prog 'exit_open'
libbpf: prog 'tracepoint__syscalls__sys_exit_openat': insn #1 relocated, imm 2 points to subprog 'exit_open' (now at 4 offset)
libbpf: prog 'tracepoint__syscalls__sys_exit_openat2': added 108 insns from sub-prog 'exit_open'
libbpf: prog 'tracepoint__syscalls__sys_exit_openat2': insn #1 relocated, imm 2 points to subprog 'exit_open' (now at 4 offset)
libbpf: loading object 'network' from buffer
libbpf: elf: section(2) .text, size 1184, link 0, flags 6, type=1
libbpf: sec '.text': found program 'trace_connect_return' at insn offset 0 (0 bytes), code size 148 insns (1184 bytes)
libbpf: elf: section(3) .rel.text, size 128, link 19, flags 40, type=9
libbpf: elf: section(4) kprobe/tcp_v4_connect, size 112, link 0, flags 6, type=1
libbpf: sec 'kprobe/tcp_v4_connect': found program 'kprobe__tcp_v4_connect' at insn offset 0 (0 bytes), code size 14 insns (112 bytes)
libbpf: elf: section(5) .relkprobe/tcp_v4_connect, size 16, link 19, flags 40, type=9
libbpf: elf: section(6) kretprobe/tcp_v4_connect, size 40, link 0, flags 6, type=1
libbpf: sec 'kretprobe/tcp_v4_connect': found program 'kretprobe__tcp_v4_connect' at insn offset 0 (0 bytes), code size 5 insns (40 bytes)
libbpf: elf: section(7) .relkretprobe/tcp_v4_connect, size 16, link 19, flags 40, type=9
libbpf: elf: section(8) kprobe/tcp_v6_connect, size 112, link 0, flags 6, type=1
libbpf: sec 'kprobe/tcp_v6_connect': found program 'kprobe__tcp_v6_connect' at insn offset 0 (0 bytes), code size 14 insns (112 bytes)
libbpf: elf: section(9) .relkprobe/tcp_v6_connect, size 16, link 19, flags 40, type=9
libbpf: elf: section(10) kretprobe/tcp_v6_connect, size 40, link 0, flags 6, type=1
libbpf: sec 'kretprobe/tcp_v6_connect': found program 'kretprobe__tcp_v6_connect' at insn offset 0 (0 bytes), code size 5 insns (40 bytes)
libbpf: elf: section(11) .relkretprobe/tcp_v6_connect, size 16, link 19, flags 40, type=9
libbpf: elf: section(12) license, size 13, link 0, flags 3, type=1
libbpf: license of network is Dual BSD/GPL
libbpf: elf: section(13) .maps, size 144, link 0, flags 3, type=1
libbpf: elf: section(14) .BTF, size 30598, link 0, flags 0, type=1
libbpf: elf: section(16) .BTF.ext, size 1660, link 0, flags 0, type=1
libbpf: elf: section(19) .symtab, size 528, link 1, flags 0, type=2
libbpf: looking for externs among 22 symbols...
libbpf: collected 0 externs total
libbpf: map 'currsock': at sec_idx 13, offset 0.
libbpf: map 'currsock': found type = 1.
libbpf: map 'currsock': found key [8], sz = 4.
libbpf: map 'currsock': found value [12], sz = 8.
libbpf: map 'currsock': found max_entries = 8192.
libbpf: map 'monitored_cgroups': at sec_idx 13, offset 32.
libbpf: map 'monitored_cgroups': found type = 1.
libbpf: map 'monitored_cgroups': found key [129], sz = 8.
libbpf: map 'monitored_cgroups': found value [405], sz = 8.
libbpf: map 'monitored_cgroups': found max_entries = 1024.
libbpf: map 'ipv4_events': at sec_idx 13, offset 64.
libbpf: map 'ipv4_events': found type = 27.
libbpf: map 'ipv4_events': found max_entries = 32768.
libbpf: map 'ipv6_events': at sec_idx 13, offset 80.
libbpf: map 'ipv6_events': found type = 27.
libbpf: map 'ipv6_events': found max_entries = 32768.
libbpf: map 'lost_counter': at sec_idx 13, offset 96.
libbpf: map 'lost_counter': found type = 2.
libbpf: map 'lost_counter': found key [8], sz = 4.
libbpf: map 'lost_counter': found value [129], sz = 8.
libbpf: map 'lost_counter': found max_entries = 1.
libbpf: map 'lost_doorbell': at sec_idx 13, offset 128.
libbpf: map 'lost_doorbell': found type = 27.
libbpf: map 'lost_doorbell': found max_entries = 4096.
libbpf: sec '.rel.text': collecting relocation for section(2) '.text'
libbpf: sec '.rel.text': relo #0: insn #9 against 'monitored_cgroups'
libbpf: prog 'trace_connect_return': found map 1 (monitored_cgroups, sec 13, off 32) for insn #9
libbpf: sec '.rel.text': relo #1: insn #15 against 'currsock'
libbpf: prog 'trace_connect_return': found map 0 (currsock, sec 13, off 0) for insn #15
libbpf: sec '.rel.text': relo #2: insn #69 against 'ipv4_events'
libbpf: prog 'trace_connect_return': found map 2 (ipv4_events, sec 13, off 64) for insn #69
libbpf: sec '.rel.text': relo #3: insn #78 against 'lost_counter'
libbpf: prog 'trace_connect_return': found map 4 (lost_counter, sec 13, off 96) for insn #78
libbpf: sec '.rel.text': relo #4: insn #118 against 'ipv6_events'
libbpf: prog 'trace_connect_return': found map 3 (ipv6_events, sec 13, off 80) for insn #118
libbpf: sec '.rel.text': relo #5: insn #127 against 'lost_counter'
libbpf: prog 'trace_connect_return': found map 4 (lost_counter, sec 13, off 96) for insn #127
libbpf: sec '.rel.text': relo #6: insn #137 against 'lost_doorbell'
libbpf: prog 'trace_connect_return': found map 5 (lost_doorbell, sec 13, off 128) for insn #137
libbpf: sec '.rel.text': relo #7: insn #144 against 'currsock'
libbpf: prog 'trace_connect_return': found map 0 (currsock, sec 13, off 0) for insn #144
libbpf: sec '.relkprobe/tcp_v4_connect': collecting relocation for section(4) 'kprobe/tcp_v4_connect'
libbpf: sec '.relkprobe/tcp_v4_connect': relo #0: insn #8 against 'currsock'
libbpf: prog 'kprobe__tcp_v4_connect': found map 0 (currsock, sec 13, off 0) for insn #8
libbpf: sec '.relkretprobe/tcp_v4_connect': collecting relocation for section(6) 'kretprobe/tcp_v4_connect'
libbpf: sec '.relkretprobe/tcp_v4_connect': relo #0: insn #2 against '.text'
libbpf: sec '.relkprobe/tcp_v6_connect': collecting relocation for section(8) 'kprobe/tcp_v6_connect'
libbpf: sec '.relkprobe/tcp_v6_connect': relo #0: insn #8 against 'currsock'
libbpf: prog 'kprobe__tcp_v6_connect': found map 0 (currsock, sec 13, off 0) for insn #8
libbpf: sec '.relkretprobe/tcp_v6_connect': collecting relocation for section(10) 'kretprobe/tcp_v6_connect'
libbpf: sec '.relkretprobe/tcp_v6_connect': relo #0: insn #2 against '.text'
libbpf: map 'currsock': created successfully, fd=59
libbpf: map 'monitored_cgroups': created successfully, fd=60
libbpf: map 'ipv4_events': created successfully, fd=61
libbpf: map 'ipv6_events': created successfully, fd=62
libbpf: map 'lost_counter': created successfully, fd=63
libbpf: map 'lost_doorbell': created successfully, fd=64
libbpf: sec 'kprobe/tcp_v4_connect': found 1 CO-RE relocations
libbpf: CO-RE relocating [425] struct pt_regs: found target candidate [222] struct pt_regs in [vmlinux]
libbpf: prog 'kprobe__tcp_v4_connect': relo #0: <byte_off> [425] struct pt_regs.di (0:14 @ offset 112)
libbpf: prog 'kprobe__tcp_v4_connect': relo #0: matching candidate #0 <byte_off> [222] struct pt_regs.di (0:14 @ offset 112)
libbpf: prog 'kprobe__tcp_v4_connect': relo #0: patched insn #0 (LDX/ST/STX) off 112 -> 112
libbpf: sec 'kretprobe/tcp_v4_connect': found 1 CO-RE relocations
libbpf: prog 'kretprobe__tcp_v4_connect': relo #0: <byte_off> [425] struct pt_regs.ax (0:10 @ offset 80)
libbpf: prog 'kretprobe__tcp_v4_connect': relo #0: matching candidate #0 <byte_off> [222] struct pt_regs.ax (0:10 @ offset 80)
libbpf: prog 'kretprobe__tcp_v4_connect': relo #0: patched insn #0 (LDX/ST/STX) off 80 -> 80
libbpf: sec '.text': found 5 CO-RE relocations
libbpf: CO-RE relocating [13] struct sock: found target candidate [3581] struct sock in [vmlinux]
libbpf: prog 'trace_connect_return': relo #0: <byte_off> [13] struct sock.__sk_common.skc_dport (0:0:2:1:0 @ offset 12)
libbpf: prog 'trace_connect_return': relo #0: matching candidate #0 <byte_off> [3581] struct sock.__sk_common.skc_dport (0:0:2:1:0 @ offset 12)
libbpf: prog 'trace_connect_return': relo #0: patched insn #22 (ALU/ALU64) imm 12 -> 12
libbpf: prog 'trace_connect_return': relo #1: <byte_off> [13] struct sock.__sk_common.skc_rcv_saddr (0:0:0:1:1 @ offset 4)
libbpf: prog 'trace_connect_return': relo #1: matching candidate #0 <byte_off> [3581] struct sock.__sk_common.skc_rcv_saddr (0:0:0:1:1 @ offset 4)
libbpf: prog 'trace_connect_return': relo #1: patched insn #43 (ALU/ALU64) imm 4 -> 4
libbpf: prog 'trace_connect_return': relo #2: <byte_off> [13] struct sock.__sk_common.skc_daddr (0:0:0:1:0 @ offset 0)
libbpf: prog 'trace_connect_return': relo #2: matching candidate #0 <byte_off> [3581] struct sock.__sk_common.skc_daddr (0:0:0:1:0 @ offset 0)
libbpf: prog 'trace_connect_return': relo #2: patched insn #50 (ALU/ALU64) imm 0 -> 0
libbpf: prog 'trace_connect_return': relo #3: <byte_off> [13] struct sock.__sk_common.skc_v6_rcv_saddr (0:0:14 @ offset 72)
libbpf: prog 'trace_connect_return': relo #3: matching candidate #0 <byte_off> [3581] struct sock.__sk_common.skc_v6_rcv_saddr (0:0:14 @ offset 72)
libbpf: prog 'trace_connect_return': relo #3: patched insn #94 (ALU/ALU64) imm 72 -> 72
libbpf: prog 'trace_connect_return': relo #4: <byte_off> [13] struct sock.__sk_common.skc_v6_daddr (0:0:13 @ offset 56)
libbpf: prog 'trace_connect_return': relo #4: matching candidate #0 <byte_off> [3581] struct sock.__sk_common.skc_v6_daddr (0:0:13 @ offset 56)
libbpf: prog 'trace_connect_return': relo #4: patched insn #101 (ALU/ALU64) imm 56 -> 56
libbpf: sec 'kprobe/tcp_v6_connect': found 1 CO-RE relocations
libbpf: prog 'kprobe__tcp_v6_connect': relo #0: <byte_off> [425] struct pt_regs.di (0:14 @ offset 112)
libbpf: prog 'kprobe__tcp_v6_connect': relo #0: matching candidate #0 <byte_off> [222] struct pt_regs.di (0:14 @ offset 112)
libbpf: prog 'kprobe__tcp_v6_connect': relo #0: patched insn #0 (LDX/ST/STX) off 112 -> 112
libbpf: sec 'kretprobe/tcp_v6_connect': found 1 CO-RE relocations
libbpf: prog 'kretprobe__tcp_v6_connect': relo #0: <byte_off> [425] struct pt_regs.ax (0:10 @ offset 80)
libbpf: prog 'kretprobe__tcp_v6_connect': relo #0: matching candidate #0 <byte_off> [222] struct pt_regs.ax (0:10 @ offset 80)
libbpf: prog 'kretprobe__tcp_v6_connect': relo #0: patched insn #0 (LDX/ST/STX) off 80 -> 80
libbpf: prog 'kretprobe__tcp_v4_connect': added 148 insns from sub-prog 'trace_connect_return'
libbpf: prog 'kretprobe__tcp_v4_connect': insn #2 relocated, imm 2 points to subprog 'trace_connect_return' (now at 5 offset)
libbpf: prog 'kretprobe__tcp_v6_connect': added 148 insns from sub-prog 'trace_connect_return'
libbpf: prog 'kretprobe__tcp_v6_connect': insn #2 relocated, imm 2 points to subprog 'trace_connect_return' (now at 5 offset)
2024-08-01T19:47:02-04:00 INFO [PROXY:1:C] Cache "proxy" first init succeeded. cache/cache.go:1011
2024-08-01T19:47:02-04:00 INFO [PROC:1]    Service is creating new listener. pid:93132.1 type:proxy:web address:0.0.0.0:3080 service/signals.go:249
2024-08-01T19:47:02-04:00 INFO [PROXY:SER] Starting reverse tunnel server pid:93132.1 version:17.0.0-dev git_ref:api/v17.0.0-dev.gusr.1-202-g6922aa0b50 listen_address: cache_policy:in-memory cache service/service.go:4371
2024-08-01T19:47:02-04:00 INFO [PROXY:SER] Starting web proxy service. pid:93132.1 version:17.0.0-dev git_ref:api/v17.0.0-dev.gusr.1-202-g6922aa0b50 listen_address:0.0.0.0:3080 service/service.go:4644
2024-08-01T19:47:02-04:00 INFO [PROXY:SER]  Stating SSH proxy service pid:93132.1 version:17.0.0-dev git_ref:api/v17.0.0-dev.gusr.1-202-g6922aa0b50 listen_address:[::]:3080 service/service.go:4865
2024-08-01T19:47:02-04:00 INFO [PROXY:AGE] Starting reverse tunnel agent pool. service/service.go:4919
2024-08-01T19:47:02-04:00 INFO [PROXY:PRO] Starting Kube proxy. pid:93132.1 listen_address:[::]:3080 service/service.go:5013
2024-08-01T19:47:02-04:00 INFO [DB:SERVIC] Starting Database Postgres proxy server. pid:93132.1 listen_address:[::]:3080 service/service.go:5109
2024-08-01T19:47:02-04:00 INFO [DB:SERVIC] Starting Database TLS proxy server. pid:93132.1 listen_address:0.0.0.0:3080 service/service.go:5127
2024-08-01T19:47:02-04:00 INFO [PROC:1]    Starting proxy gRPC server. pid:93132.1 listen_address:[::]:3080 service/service.go:6521
2024-08-01T19:47:02-04:00 INFO [PROC:1]    Starting proxy gRPC server. pid:93132.1 listen_address:[::]:3080 service/service.go:6598
2024-08-01T19:47:02-04:00 INFO [PROXY:SER] Starting TLS ALPN SNI proxy server on. pid:93132.1 listen_address:[::]:3080 service/service.go:5205
2024-08-01T19:47:02-04:00 WARN [NODE:1]    Login UID is set, but it shouldn't be. Incorrect login UID breaks session ID when using auditd. Please make sure that Teleport runs as a daemon and any parent process doesn't set the login UID. pid:93132.1 service/service.go:2904
2024-08-01T19:47:02-04:00 INFO [PROC:1]    Service is creating new listener. pid:93132.1 type:node address:0.0.0.0:3022 service/signals.go:249
2024-08-01T19:47:02-04:00 INFO [NODE:1]    SSH Service is starting. pid:93132.1 version:17.0.0-dev git_ref:api/v17.0.0-dev.gusr.1-202-g6922aa0b50 listen_address:0.0.0.0:3022 cache_policy:in-memory cache service/service.go:3031
2024-08-01T19:47:02-04:00 INFO [PROC:1]    The new service has started successfully. Starting syncing rotation status. pid:93132.1 max_retry_period:1m30s service/connect.go:680
```
</details>

<details>
  <summary>RHEL8.1 teleport init log</summary>

```
2024-08-02T11:49:14-04:00 INFO  Starting Teleport with a config file version:17.0.0-dev config_file:/etc/teleport.conf common/teleport.go:746
2024-08-02T11:49:15-04:00 INFO [PROC:1]    Service is creating new listener. pid:7585.1 type:debug address:/var/lib/teleport/debug.sock service/signals.go:249
2024-08-02T11:49:16-04:00 INFO [AUTH]      Updating cluster configuration: StaticTokens([]). auth/init.go:457
2024-08-02T11:49:16-04:00 INFO [AUTH]      Creating namespace: "default". auth/init.go:464
2024-08-02T11:49:16-04:00 INFO [AUTH]      Updating session recording config: Kind:"session_recording_config" Version:"v2" Metadata:<Name:"session-recording-config" Namespace:"default" Labels:<key:"teleport.dev/origin" value:"defaults" > > Spec:<Mode:"node" ProxyChecksHostKeys:"\010\001" > . auth/init.go:858
2024-08-02T11:49:16-04:00 INFO [AUTH]      Updating cluster networking configuration: Kind:"cluster_networking_config" Version:"v2" Metadata:<Name:"cluster-networking-config" Namespace:"default" Labels:<key:"teleport.dev/origin" value:"config-file" > > Spec:<KeepAliveInterval:300000000000 KeepAliveCountMax:3 ProxyListenerMode:Multiplex TunnelStrategy:<AgentMesh:<> > > . auth/init.go:818
2024-08-02T11:49:17-04:00 INFO [AUTH]      Auth server is running periodic operations. auth/init.go:564
2024-08-02T11:49:17-04:00 INFO [AUTH:COMP] upload completer will run every 5m0s events/complete.go:161
2024-08-02T11:49:17-04:00 INFO [AUTH:1:CA] Cache "auth" first init succeeded. cache/cache.go:1011
2024-08-02T11:49:17-04:00 INFO [PROC:1]    Service is creating new listener. pid:7585.1 type:auth address:0.0.0.0:3025 service/signals.go:249
2024-08-02T11:49:17-04:00 WARN [AUTH:1]    'proxy_protocol' unspecified. Starting Auth service with external PROXY protocol support, but IP pinned connection affected by PROXY headers will not be allowed. Set 'proxy_protocol: on' in 'auth_service' config if Auth service runs behind L4 load balancer with enabled PROXY protocol, or set 'proxy_protocol: off' otherwise pid:7585.1 service/service.go:2376
2024-08-02T11:49:17-04:00 WARN [AUTH:1]    Configuration setting auth_service/advertise_ip is not set, using inferred address pid:7585.1 address:10.0.2.15:3025 service/service.go:2465
2024-08-02T11:49:17-04:00 WARN [PROC:1]    No TLS Keys provided, using self-signed certificate. pid:7585.1 service/service.go:6146
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1]  starting upload completer service pid:7585.1 service/service.go:3238
2024-08-02T11:49:17-04:00 INFO [AUTH:1]    Auth service is starting. pid:7585.1 version:17.0.0-dev git_ref:api/v17.0.0-dev.gusr.1-202-g6922aa0b50 listen_address:10.0.2.15:3025 service/service.go:2413
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1]  Creating directory. pid:7585.1 directory:/var/lib/teleport/log service/service.go:3254
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1]  Creating directory. pid:7585.1 directory:/var/lib/teleport/log/upload service/service.go:3254
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1]  Creating directory. pid:7585.1 directory:/var/lib/teleport/log/upload/streaming service/service.go:3254
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1]  Creating directory. pid:7585.1 directory:/var/lib/teleport/log/upload/streaming/default service/service.go:3254
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1]  Creating directory. pid:7585.1 directory:/var/lib/teleport/log service/service.go:3254
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1]  Creating directory. pid:7585.1 directory:/var/lib/teleport/log/upload service/service.go:3254
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1]  Creating directory. pid:7585.1 directory:/var/lib/teleport/log/upload/corrupted service/service.go:3254
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1]  Creating directory. pid:7585.1 directory:/var/lib/teleport/log/upload/corrupted/default service/service.go:3254
2024-08-02T11:49:17-04:00 INFO [UPLOAD]    uploader will scan /var/lib/teleport/log/upload/streaming/default every 5s filesessions/fileasync.go:196
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1:] upload completer will run every 5m0s events/complete.go:161
2024-08-02T11:49:17-04:00 INFO [PROC:1]    Connecting to the cluster with TLS client certificate. pid:7585.1 cluster:rhel8.myguest.virtualbox.org service/connect.go:235
2024-08-02T11:49:17-04:00 INFO [PROC:1]    Connecting to the cluster with TLS client certificate. pid:7585.1 cluster:rhel8.myguest.virtualbox.org service/connect.go:235
2024-08-02T11:49:17-04:00 INFO [PROC:1]    Connecting to the cluster with TLS client certificate. pid:7585.1 cluster:rhel8.myguest.virtualbox.org service/connect.go:235
2024-08-02T11:49:17-04:00 INFO [PROC:1]    features loaded from auth server pid:7585.1 identity:Instance features:Kubernetes:true App:true DB:true Desktop:true DeviceTrust:<> AccessRequests:<> AccessList:<> AccessMonitoring:<> Policy:<> SupportType:SUPPORT_TYPE_FREE JoinActiveSessions:true entitlements:<key:"AccessLists" value:<> > entitlements:<key:"AccessMonitoring" value:<> > entitlements:<key:"AccessRequests" value:<> > entitlements:<key:"App" value:<enabled:true > > entitlements:<key:"CloudAuditLogRetention" value:<> > entitlements:<key:"DB" value:<enabled:true > > entitlements:<key:"Desktop" value:<enabled:true > > entitlements:<key:"DeviceTrust" value:<> > entitlements:<key:"ExternalAuditStorage" value:<> > entitlements:<key:"FeatureHiding" value:<> > entitlements:<key:"HSM" value:<> > entitlements:<key:"Identity" value:<> > entitlements:<key:"JoinActiveSessions" value:<enabled:true > > entitlements:<key:"K8s" value:<enabled:true > > entitlements:<key:"MobileDeviceManagement" value:<> > entitlements:<key:"OIDC" value:<> > entitlements:<key:"OktaSCIM" value:<> > entitlements:<key:"OktaUserSync" value:<> > entitlements:<key:"Policy" value:<> > entitlements:<key:"SAML" value:<> > entitlements:<key:"SessionLocks" value:<> > entitlements:<key:"UpsellAlert" value:<> > entitlements:<key:"UsageReporting" value:<> >  service/connect.go:1131
2024-08-02T11:49:17-04:00 INFO [INSTANCE:] Successfully registered instance client. pid:7585.1 service/service.go:2813
2024-08-02T11:49:17-04:00 INFO [PROC:1]    Reusing Instance client. pid:7585.1 identity:Proxy additional_system_roles:[Auth Node Proxy] service/connect.go:1105
2024-08-02T11:49:17-04:00 INFO [PROC:1]    Reusing Instance client. pid:7585.1 identity:Node additional_system_roles:[Auth Node Proxy] service/connect.go:1105
2024-08-02T11:49:17-04:00 INFO [NODE:1:CA] Cache "node" first init succeeded. cache/cache.go:1011
libbpf: loading object 'command' from buffer
libbpf: elf: section(2) .text, size 2704, link 0, flags 6, type=1
libbpf: sec '.text': found program 'enter_execve' at insn offset 0 (0 bytes), code size 267 insns (2136 bytes)
libbpf: sec '.text': found program 'exit_execve' at insn offset 267 (2136 bytes), code size 71 insns (568 bytes)
libbpf: elf: section(3) .rel.text, size 192, link 19, flags 40, type=9
libbpf: elf: section(4) tp/syscalls/sys_execve, size 40, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_execve': found program 'tracepoint__syscalls__sys_enter_execve' at insn offset 0 (0 bytes), code size 5 insns (40 bytes)
libbpf: elf: section(5) .reltp/syscalls/sys_execve, size 16, link 19, flags 40, type=9
libbpf: elf: section(6) tp/syscalls/sys_exit_execve, size 32, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_exit_execve': found program 'tracepoint__syscalls__sys_exit_execve' at insn offset 0 (0 bytes), code size 4 insns (32 bytes)
libbpf: elf: section(7) .reltp/syscalls/sys_exit_execve, size 16, link 19, flags 40, type=9
libbpf: elf: section(8) tp/syscalls/sys_execveat, size 40, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_execveat': found program 'tracepoint__syscalls__sys_enter_execveat' at insn offset 0 (0 bytes), code size 5 insns (40 bytes)
libbpf: elf: section(9) .reltp/syscalls/sys_execveat, size 16, link 19, flags 40, type=9
libbpf: elf: section(10) tp/syscalls/sys_exit_execveat, size 32, link 0, flags 6, type=1
libbpf: sec 'tp/syscalls/sys_exit_execveat': found program 'tracepoint__syscalls__sys_exit_execveat' at insn offset 0 (0 bytes), code size 4 insns (32 bytes)
libbpf: elf: section(11) .reltp/syscalls/sys_exit_execveat, size 16, link 19, flags 40, type=9
libbpf: elf: section(12) license, size 13, link 0, flags 3, type=1
libbpf: license of command is Dual BSD/GPL
libbpf: elf: section(13) .maps, size 96, link 0, flags 3, type=1
libbpf: elf: section(14) .BTF, size 29339, link 0, flags 0, type=1
libbpf: elf: section(16) .BTF.ext, size 3988, link 0, flags 0, type=1
libbpf: elf: section(19) .symtab, size 696, link 1, flags 0, type=2
libbpf: looking for externs among 29 symbols...
libbpf: collected 0 externs total
libbpf: map 'monitored_cgroups': at sec_idx 13, offset 0.
libbpf: map 'monitored_cgroups': found type = 1.
libbpf: map 'monitored_cgroups': found key [8], sz = 8.
libbpf: map 'monitored_cgroups': found value [12], sz = 8.
libbpf: map 'monitored_cgroups': found max_entries = 1024.
libbpf: map 'execve_events': at sec_idx 13, offset 32.
libbpf: map 'execve_events': found type = 27.
libbpf: map 'execve_events': found max_entries = 32768.
libbpf: map 'lost_counter': at sec_idx 13, offset 48.
libbpf: map 'lost_counter': found type = 2.
libbpf: map 'lost_counter': found key [27], sz = 4.
libbpf: map 'lost_counter': found value [8], sz = 8.
libbpf: map 'lost_counter': found max_entries = 1.
libbpf: map 'lost_doorbell': at sec_idx 13, offset 80.
libbpf: map 'lost_doorbell': found type = 27.
libbpf: map 'lost_doorbell': found max_entries = 4096.
libbpf: sec '.rel.text': collecting relocation for section(2) '.text'
libbpf: sec '.rel.text': relo #0: insn #9 against 'monitored_cgroups'
libbpf: prog 'enter_execve': found map 0 (monitored_cgroups, sec 13, off 0) for insn #9
libbpf: sec '.rel.text': relo #1: insn #42 against 'execve_events'
libbpf: prog 'enter_execve': found map 1 (execve_events, sec 13, off 32) for insn #42
libbpf: sec '.rel.text': relo #2: insn #61 against 'lost_counter'
libbpf: prog 'enter_execve': found map 2 (lost_counter, sec 13, off 48) for insn #61
libbpf: sec '.rel.text': relo #3: insn #117 against 'execve_events'
libbpf: prog 'enter_execve': found map 1 (execve_events, sec 13, off 32) for insn #117
libbpf: sec '.rel.text': relo #4: insn #179 against 'execve_events'
libbpf: prog 'enter_execve': found map 1 (execve_events, sec 13, off 32) for insn #179
libbpf: sec '.rel.text': relo #5: insn #199 against 'lost_counter'
libbpf: prog 'enter_execve': found map 2 (lost_counter, sec 13, off 48) for insn #199
libbpf: sec '.rel.text': relo #6: insn #210 against 'lost_counter'
libbpf: prog 'enter_execve': found map 2 (lost_counter, sec 13, off 48) for insn #210
libbpf: sec '.rel.text': relo #7: insn #219 against 'lost_doorbell'
libbpf: prog 'enter_execve': found map 3 (lost_doorbell, sec 13, off 80) for insn #219
libbpf: sec '.rel.text': relo #8: insn #272 against 'monitored_cgroups'
libbpf: prog 'exit_execve': found map 0 (monitored_cgroups, sec 13, off 0) for insn #5
libbpf: sec '.rel.text': relo #9: insn #277 against 'execve_events'
libbpf: prog 'exit_execve': found map 1 (execve_events, sec 13, off 32) for insn #10
libbpf: sec '.rel.text': relo #10: insn #287 against 'lost_counter'
libbpf: prog 'exit_execve': found map 2 (lost_counter, sec 13, off 48) for insn #20
libbpf: sec '.rel.text': relo #11: insn #297 against 'lost_doorbell'
libbpf: prog 'exit_execve': found map 3 (lost_doorbell, sec 13, off 80) for insn #30
libbpf: sec '.reltp/syscalls/sys_execve': collecting relocation for section(4) 'tp/syscalls/sys_execve'
libbpf: sec '.reltp/syscalls/sys_execve': relo #0: insn #2 against '.text'
libbpf: sec '.reltp/syscalls/sys_exit_execve': collecting relocation for section(6) 'tp/syscalls/sys_exit_execve'
libbpf: sec '.reltp/syscalls/sys_exit_execve': relo #0: insn #1 against '.text'
libbpf: sec '.reltp/syscalls/sys_execveat': collecting relocation for section(8) 'tp/syscalls/sys_execveat'
libbpf: sec '.reltp/syscalls/sys_execveat': relo #0: insn #2 against '.text'
libbpf: sec '.reltp/syscalls/sys_exit_execveat': collecting relocation for section(10) 'tp/syscalls/sys_exit_execveat'
libbpf: sec '.reltp/syscalls/sys_exit_execveat': relo #0: insn #1 against '.text'
libbpf: map 'monitored_cgroups': created successfully, fd=26
libbpf: map 'execve_events': failed to create: Invalid argument(-22)
libbpf: failed to load object 'command'
2024-08-02T11:49:17-04:00 WARN [PROC:1]    Teleport process has exited with error. error:[
ERROR REPORT:
Original Error: trace.aggregate incompatible kernel found, minimum supported kernel is 5.8.0, failed to load BPF object: invalid argument
Stack Trace:
	github.com/gravitational/teleport/lib/service/service.go:2881 github.com/gravitational/teleport/lib/service.(*TeleportProcess).initSSH.func1
	github.com/gravitational/teleport/lib/service/supervisor.go:588 github.com/gravitational/teleport/lib/service.(*LocalService).Serve
	github.com/gravitational/teleport/lib/service/supervisor.go:313 github.com/gravitational/teleport/lib/service.(*LocalSupervisor).serve.func1
	runtime/asm_amd64.s:1695 runtime.goexit
User Message: incompatible kernel found, minimum supported kernel is 5.8.0, failed to load BPF object: invalid argument] pid:7585.1 service:ssh.node service/supervisor.go:319
2024-08-02T11:49:17-04:00 ERRO [PROC:1]    Critical service has exited with error, aborting. pid:7585.1 service:ssh.node error:[
ERROR REPORT:
Original Error: trace.aggregate incompatible kernel found, minimum supported kernel is 5.8.0, failed to load BPF object: invalid argument
Stack Trace:
	github.com/gravitational/teleport/lib/service/service.go:2881 github.com/gravitational/teleport/lib/service.(*TeleportProcess).initSSH.func1
	github.com/gravitational/teleport/lib/service/supervisor.go:588 github.com/gravitational/teleport/lib/service.(*LocalService).Serve
	github.com/gravitational/teleport/lib/service/supervisor.go:313 github.com/gravitational/teleport/lib/service.(*LocalSupervisor).serve.func1
	runtime/asm_amd64.s:1695 runtime.goexit
User Message: incompatible kernel found, minimum supported kernel is 5.8.0, failed to load BPF object: invalid argument] service/signals.go:177
2024-08-02T11:49:17-04:00 WARN  cert authority watch loop for client TLS config generator failed error:[
ERROR REPORT:
Original Error: *errors.errorString ca watcher exited with: event fanout system reset
Stack Trace:
	github.com/gravitational/teleport/lib/auth/client_tls_config_generator.go:241 github.com/gravitational/teleport/lib/auth.(*ClientTLSConfigGenerator).watchForCAChanges
	github.com/gravitational/teleport/lib/auth/client_tls_config_generator.go:189 github.com/gravitational/teleport/lib/auth.(*ClientTLSConfigGenerator).refreshClientTLSConfigs
	runtime/asm_amd64.s:1695 runtime.goexit
User Message: ca watcher exited with: event fanout system reset] auth/client_tls_config_generator.go:195
2024-08-02T11:49:17-04:00 INFO [DEBUG:1]   Shutting down immediately. pid:7585.1 service/service.go:3604
2024-08-02T11:49:17-04:00 INFO [DEBUG:1]   Exited. pid:7585.1 service/service.go:3611
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1]  File upload completer is shutting down. pid:7585.1 error:<nil> service/service.go:3326
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1]  File upload completer has shut down. pid:7585.1 service/service.go:3328
2024-08-02T11:49:17-04:00 INFO [AUTH:1]    Shutting down immediately. pid:7585.1 service/service.go:2526
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1]  File uploader is shutting down. pid:7585.1 service/service.go:3294
2024-08-02T11:49:17-04:00 INFO [UPLOAD:1]  File uploader has shut down. pid:7585.1 service/service.go:3296
2024-08-02T11:49:17-04:00 INFO [AUTH:1]    Exited. pid:7585.1 service/service.go:2545
2024-08-02T11:49:17-04:00 WARN [AUTH:1]    Mux serve failed. error:[<nil>] auth/middleware.go:310
ERROR: incompatible kernel found, minimum supported kernel is 5.8.0, failed to load BPF object: invalid argument
```
</details>

Related: https://github.com/gravitational/teleport/issues/40847
Related: https://github.com/gravitational/customer-sensitive-requests/issues/297
changelog: Fixed kernel version check of Enhanced Session Recording for distributions with backported BPF