### PR TITLE
Add a "generated" note to Helm ref partials

### DIFF
--- a/build.assets/tooling/cmd/render-helm-ref/template.go
+++ b/build.assets/tooling/cmd/render-helm-ref/template.go
@@ -27,6 +27,9 @@ import (
 )
 
 const referenceTemplate = `
+{/* Generated file. Do not edit.*/}
+{/* Generate this file by navigating to examples/chart and running  make render-chart-ref*/}
+
 {{- range .Values }}
 #{{- range splitList "." .Name -}}#{{- end }} ` + "`" + `{{ .Name }}` + "`" + `
 

--- a/build.assets/tooling/cmd/render-helm-ref/testdata/expected-output.mdx
+++ b/build.assets/tooling/cmd/render-helm-ref/testdata/expected-output.mdx
@@ -1,4 +1,6 @@
 
+{/* Generated file. Do not edit.*/}
+{/* Generate this file by navigating to examples/chart and running  make render-chart-ref*/}
 ## `authServer`
 
 | Type | Default |

--- a/docs/pages/includes/helm-reference/zz_generated.access-discord.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-discord.mdx
@@ -1,4 +1,6 @@
 
+{/* Generated file. Do not edit.*/}
+{/* Generate this file by navigating to examples/chart and running  make render-chart-ref*/}
 ## `teleport`
 
 `teleport` contains the configuration describing how the plugin connects to

--- a/docs/pages/includes/helm-reference/zz_generated.access-email.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-email.mdx
@@ -1,4 +1,6 @@
 
+{/* Generated file. Do not edit.*/}
+{/* Generate this file by navigating to examples/chart and running  make render-chart-ref*/}
 ## `teleport`
 
 `teleport` contains the configuration describing how the plugin connects to

--- a/docs/pages/includes/helm-reference/zz_generated.access-jira.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-jira.mdx
@@ -1,4 +1,6 @@
 
+{/* Generated file. Do not edit.*/}
+{/* Generate this file by navigating to examples/chart and running  make render-chart-ref*/}
 ## `teleport`
 
 `teleport` contains the configuration describing how the plugin connects to

--- a/docs/pages/includes/helm-reference/zz_generated.access-mattermost.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-mattermost.mdx
@@ -1,4 +1,6 @@
 
+{/* Generated file. Do not edit.*/}
+{/* Generate this file by navigating to examples/chart and running  make render-chart-ref*/}
 ## `teleport`
 
 `teleport` contains the configuration describing how the plugin connects to

--- a/docs/pages/includes/helm-reference/zz_generated.access-msteams.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-msteams.mdx
@@ -1,4 +1,6 @@
 
+{/* Generated file. Do not edit.*/}
+{/* Generate this file by navigating to examples/chart and running  make render-chart-ref*/}
 ## `teleport`
 
 `teleport` contains the configuration describing how the plugin connects to

--- a/docs/pages/includes/helm-reference/zz_generated.access-pagerduty.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-pagerduty.mdx
@@ -1,4 +1,6 @@
 
+{/* Generated file. Do not edit.*/}
+{/* Generate this file by navigating to examples/chart and running  make render-chart-ref*/}
 ## `teleport`
 
 `teleport` contains the configuration describing how the plugin connects to

--- a/docs/pages/includes/helm-reference/zz_generated.access-slack.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-slack.mdx
@@ -1,4 +1,6 @@
 
+{/* Generated file. Do not edit.*/}
+{/* Generate this file by navigating to examples/chart and running  make render-chart-ref*/}
 ## `teleport`
 
 `teleport` contains the configuration describing how the plugin connects to

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -1,4 +1,6 @@
 
+{/* Generated file. Do not edit.*/}
+{/* Generate this file by navigating to examples/chart and running  make render-chart-ref*/}
 ## `roles`
 
 | Type | Default |

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
@@ -1,4 +1,6 @@
 
+{/* Generated file. Do not edit.*/}
+{/* Generate this file by navigating to examples/chart and running  make render-chart-ref*/}
 ## `enabled`
 
 | Type | Default |


### PR DESCRIPTION
Closes #44951

Indicate that Helm reference partials were generated and provide the command to regenerate them.