### PR TITLE
Clarify role of the Auth Service in diagram

### DIFF
--- a/docs/pages/reference/architecture/proxy.mdx
+++ b/docs/pages/reference/architecture/proxy.mdx
@@ -11,11 +11,12 @@ provides the following key features:
   SSH and Windows desktops using the Teleport web UI.
 - Intercepts traffic for multiple protocols, including SSH, Kubernetes, HTTPS, 
   and databases, and ensures that only authenticated clients can connect to target resources.
-- Records commands, API calls, and queries and streams them to the audit log.
 - Provides networking and connectivity so that servers and proxies behind firewalls can connect
   using reverse tunnels.
 - Enables system administrators to use TLS routing feature to compress all ports for all protocols 
   to one TLS port using TLS routing feature.
+- Records commands and API calls, and queries and streams them to the audit log.
+  The audit log is stored on the Teleport Auth Service backend.
 
 ![Proxy service](../../../img/architecture/proxy.png)
 

--- a/docs/pages/reference/architecture/proxy.mdx
+++ b/docs/pages/reference/architecture/proxy.mdx
@@ -16,7 +16,8 @@ provides the following key features:
 - Enables system administrators to use TLS routing feature to compress all ports for all protocols 
   to one TLS port using TLS routing feature.
 - Records commands and API calls, and queries and streams them to the audit log.
-  The audit log is stored on the Teleport Auth Service backend.
+  The audit log is stored on one of the Teleport Auth Service
+  [backends](../backends.mdx).
 
 ![Proxy service](../../../img/architecture/proxy.png)
 


### PR DESCRIPTION
Closes #28341

Currently, the Proxy Service architecture guide begins with a diagram that contains the Auth Service and associates it with an audit log, but does not provide context as to why this association exists. This change introduces the association in the preceding text.