### PR TITLE
docs: remove prerequisites notice that tctl only linux and macos

### DIFF
--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,6 +1,5 @@
 To check that you can connect to your Teleport cluster, sign in with `tsh login`, then 
 verify that you can run `tctl` commands using your current credentials. 
-`tctl` is supported on macOS and Linux machines.
 
 For example:
 


### PR DESCRIPTION
`tctl` now available from v16 on linux, macos and windows.