### PR TITLE
Clean up electron-builder peer deps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,7 +447,7 @@ importers:
         version: 31.3.1
       electron-builder:
         specifier: ^25.0.3
-        version: 25.0.3(electron-builder-squirrel-windows@25.0.1(dmg-builder@25.0.3))
+        version: 25.0.3(electron-builder-squirrel-windows@25.0.3(dmg-builder@25.0.3))
       electron-notarize:
         specifier: ^1.2.2
         version: 1.2.2
@@ -2758,18 +2758,8 @@ packages:
     resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
     engines: {node: '>= 8'}
 
-  app-builder-bin@5.0.0-alpha.6:
-    resolution: {integrity: sha512-KVrQQpaYHTlzuj1TE8k+qwwu/o/R8bsFyglUl/3guc2MUbSYvVqeAlxucotAxfp4SnNNBdNE6GGMbhqAKagakQ==}
-
   app-builder-bin@5.0.0-alpha.7:
     resolution: {integrity: sha512-ww2mK4ITUvqisnqOuUWAeHzokpPidyZ7a0ZkwW+V7sF5/Pdi2OldkRjAWqEzn6Xtmj3SLVT84as4wB59A6jJ4g==}
-
-  app-builder-lib@25.0.1:
-    resolution: {integrity: sha512-zpSaCgGnv1D+dv9IC/ry/x4JAuqHsW/VFDp7lg+IzvTOIgLJkfqyavyP5gEOtUFI5rOO3bwB2TENV5i6lLIpIQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      dmg-builder: 25.0.1
-      electron-builder-squirrel-windows: 25.0.1
 
   app-builder-lib@25.0.3:
     resolution: {integrity: sha512-c0LJCJMGgDDGmZUSKeyDYKI5rYc6sQ4PS0Ak62HWArotHDwgAk9qIIewNnvIn/9KskEGwHQr8Y/TumWRqUKRwQ==}
@@ -3027,9 +3017,6 @@ packages:
   builder-util-runtime@9.2.5:
     resolution: {integrity: sha512-HjIDfhvqx/8B3TDN4GbABQcgpewTU4LMRTQPkVpKYV3lsuxEJoIfvg09GyWTNmfVNSUAYf+fbTN//JX4TH20pg==}
     engines: {node: '>=12.0.0'}
-
-  builder-util@25.0.1:
-    resolution: {integrity: sha512-bxT7+1rnxEGIZGrzBdMAL0brasBmQV4bon3sZC0XC4V2Za4FZ7CXAO9tuetuVpFXYFau+6BL63UbN9HFGMmV5g==}
 
   builder-util@25.0.3:
     resolution: {integrity: sha512-eH5c1ukdY2xjtFQWQ6jlzEuXuqcuAVc3UQ6V6fdYu9Kg3CkDbCR82Mox42uaJDmee9WXSbP/88cOworFdOHPhw==}
@@ -3572,8 +3559,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-builder-squirrel-windows@25.0.1:
-    resolution: {integrity: sha512-MsfO7wHky5aYf72i9wFd1hZINyQHvnB4o2CHcXnEzsM21WHZJpXol62NBJhp+1pk6fuARA0jF1DtAcBco+y9YA==}
+  electron-builder-squirrel-windows@25.0.3:
+    resolution: {integrity: sha512-VeKeCKn8VgMG3loPnCtxPcximwpyb9a1YVubsyYMN/0CDGlsjfwdQEjrU5FD2/DkbZT7ghjei4QGjCQkRlZ1Cg==}
 
   electron-builder@25.0.3:
     resolution: {integrity: sha512-CToK0oEH/vxTbnEhXgInQWAuPEgkj11nQ3Jlse/Pc/aPNULxRSimH2UodZHrVlmVLozI4XVJqqh+pTVFXXZBaw==}
@@ -3584,9 +3571,6 @@ packages:
     resolution: {integrity: sha512-ZStVWYcWI7g87/PgjPJSIIhwQXOaw4/XeXU+pWqMMktSLHaGMLHdyPPN7Cmao7+Cr7fYufA16npdtMndYciHNw==}
     engines: {node: '>= 10.0.0'}
     deprecated: Please use @electron/notarize moving forward.  There is no API change, just a package name change
-
-  electron-publish@25.0.1:
-    resolution: {integrity: sha512-9ADYaKARy9rfCgiaFt/q2YJxZdx26WAZbnq06LBaZEg48YnlyPBo2ZwcIVbt6+RszTOgKvaZY/KqT6GkDRiikw==}
 
   electron-publish@25.0.3:
     resolution: {integrity: sha512-wSGm+TFK2lArswIFBPLuIRHbo945s3MCvG5y1xVC57zL/PsrElUkaGH2ERtRrcKNpaDNq77rDA9JnMJhAFJjUg==}
@@ -9405,48 +9389,9 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  app-builder-bin@5.0.0-alpha.6: {}
-
   app-builder-bin@5.0.0-alpha.7: {}
 
-  app-builder-lib@25.0.1(dmg-builder@25.0.3(electron-builder-squirrel-windows@25.0.1))(electron-builder-squirrel-windows@25.0.1(dmg-builder@25.0.3)):
-    dependencies:
-      '@develar/schema-utils': 2.6.5
-      '@electron/notarize': 2.3.2
-      '@electron/osx-sign': 1.3.1
-      '@electron/rebuild': 3.6.0
-      '@electron/universal': 2.0.1
-      '@malept/flatpak-bundler': 0.4.0
-      '@types/fs-extra': 9.0.13
-      async-exit-hook: 2.0.1
-      bluebird-lst: 1.0.9
-      builder-util: 25.0.1
-      builder-util-runtime: 9.2.5
-      chromium-pickle-js: 0.2.0
-      debug: 4.3.6
-      dmg-builder: 25.0.3(electron-builder-squirrel-windows@25.0.1)
-      ejs: 3.1.10
-      electron-builder-squirrel-windows: 25.0.1(dmg-builder@25.0.3)
-      electron-publish: 25.0.1
-      form-data: 4.0.0
-      fs-extra: 10.1.0
-      hosted-git-info: 4.1.0
-      is-ci: 3.0.1
-      isbinaryfile: 5.0.2
-      js-yaml: 4.1.0
-      lazy-val: 1.0.5
-      minimatch: 10.0.1
-      read-config-file: 6.4.0
-      resedit: 1.7.0
-      sanitize-filename: 1.6.3
-      semver: 7.6.3
-      tar: 6.2.1
-      temp-file: 3.4.0
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-
-  app-builder-lib@25.0.3(dmg-builder@25.0.3(electron-builder-squirrel-windows@25.0.1))(electron-builder-squirrel-windows@25.0.1(dmg-builder@25.0.3)):
+  app-builder-lib@25.0.3(dmg-builder@25.0.3(electron-builder-squirrel-windows@25.0.3))(electron-builder-squirrel-windows@25.0.3(dmg-builder@25.0.3)):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.3.2
@@ -9461,9 +9406,9 @@ snapshots:
       builder-util-runtime: 9.2.5
       chromium-pickle-js: 0.2.0
       debug: 4.3.6
-      dmg-builder: 25.0.3(electron-builder-squirrel-windows@25.0.1)
+      dmg-builder: 25.0.3(electron-builder-squirrel-windows@25.0.3)
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 25.0.1(dmg-builder@25.0.3)
+      electron-builder-squirrel-windows: 25.0.3(dmg-builder@25.0.3)
       electron-publish: 25.0.3
       form-data: 4.0.0
       fs-extra: 10.1.0
@@ -9864,27 +9809,6 @@ snapshots:
     dependencies:
       debug: 4.3.6
       sax: 1.2.4
-    transitivePeerDependencies:
-      - supports-color
-
-  builder-util@25.0.1:
-    dependencies:
-      7zip-bin: 5.2.0
-      '@types/debug': 4.1.12
-      app-builder-bin: 5.0.0-alpha.6
-      bluebird-lst: 1.0.9
-      builder-util-runtime: 9.2.5
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.6
-      fs-extra: 10.1.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      is-ci: 3.0.1
-      js-yaml: 4.1.0
-      source-map-support: 0.5.21
-      stat-mode: 1.0.0
-      temp-file: 3.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10409,9 +10333,9 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  dmg-builder@25.0.3(electron-builder-squirrel-windows@25.0.1):
+  dmg-builder@25.0.3(electron-builder-squirrel-windows@25.0.3):
     dependencies:
-      app-builder-lib: 25.0.3(dmg-builder@25.0.3(electron-builder-squirrel-windows@25.0.1))(electron-builder-squirrel-windows@25.0.1(dmg-builder@25.0.3))
+      app-builder-lib: 25.0.3(dmg-builder@25.0.3(electron-builder-squirrel-windows@25.0.3))(electron-builder-squirrel-windows@25.0.3(dmg-builder@25.0.3))
       builder-util: 25.0.3
       builder-util-runtime: 9.2.5
       fs-extra: 10.1.0
@@ -10477,24 +10401,24 @@ snapshots:
     dependencies:
       jake: 10.8.5
 
-  electron-builder-squirrel-windows@25.0.1(dmg-builder@25.0.3):
+  electron-builder-squirrel-windows@25.0.3(dmg-builder@25.0.3):
     dependencies:
-      app-builder-lib: 25.0.1(dmg-builder@25.0.3(electron-builder-squirrel-windows@25.0.1))(electron-builder-squirrel-windows@25.0.1(dmg-builder@25.0.3))
+      app-builder-lib: 25.0.3(dmg-builder@25.0.3(electron-builder-squirrel-windows@25.0.3))(electron-builder-squirrel-windows@25.0.3(dmg-builder@25.0.3))
       archiver: 5.3.2
-      builder-util: 25.0.1
+      builder-util: 25.0.3
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - bluebird
       - dmg-builder
       - supports-color
 
-  electron-builder@25.0.3(electron-builder-squirrel-windows@25.0.1(dmg-builder@25.0.3)):
+  electron-builder@25.0.3(electron-builder-squirrel-windows@25.0.3(dmg-builder@25.0.3)):
     dependencies:
-      app-builder-lib: 25.0.3(dmg-builder@25.0.3(electron-builder-squirrel-windows@25.0.1))(electron-builder-squirrel-windows@25.0.1(dmg-builder@25.0.3))
+      app-builder-lib: 25.0.3(dmg-builder@25.0.3(electron-builder-squirrel-windows@25.0.3))(electron-builder-squirrel-windows@25.0.3(dmg-builder@25.0.3))
       builder-util: 25.0.3
       builder-util-runtime: 9.2.5
       chalk: 4.1.2
-      dmg-builder: 25.0.3(electron-builder-squirrel-windows@25.0.1)
+      dmg-builder: 25.0.3(electron-builder-squirrel-windows@25.0.3)
       fs-extra: 10.1.0
       is-ci: 3.0.1
       lazy-val: 1.0.5
@@ -10510,18 +10434,6 @@ snapshots:
     dependencies:
       debug: 4.3.6
       fs-extra: 9.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  electron-publish@25.0.1:
-    dependencies:
-      '@types/fs-extra': 9.0.13
-      builder-util: 25.0.1
-      builder-util-runtime: 9.2.5
-      chalk: 4.1.2
-      fs-extra: 10.1.0
-      lazy-val: 1.0.5
-      mime: 2.6.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
electron-builder has this weird situation with peer deps where one of the deps of electron-builder is app-builder-lib. In its peer deps, it has `electron-builder-squirrel-windows` and `dmg-builder` and both packages have `app-builder-lib` in its deps. I'm not sure how valid is that, but in #44925, pnpm got all woozy and kept a wrong resolution of `electron-builder-squirrel-windows`. It was pinned to 25.0.1 despite `app-builder-lib` specifically saying 25.0.3.

Another thing is that app-builder-lib doesn't mark electron-builder-squirrel-windows as an optional peer dep, which AFAIK it should.

Anyway, I solved this by manually adding electron-builder-squirrel-windows to deps (`pnpm add --filter @gravitational/teleterm -D electron-builder-squirrel-windows@25.0.3`), then removing the `package.json` changes and running `pnpm i` again.