### PR TITLE
Update Resource Guidelines RFD to mention adding parser for Resource

### DIFF
--- a/rfd/0153-resource-guidelines.md
+++ b/rfd/0153-resource-guidelines.md
@@ -478,55 +478,6 @@ func (s *FooService) ListFoos(ctx context.Context, pageSize int, pageToken strin
 }
 ```
 
-### Event stream mechanism
-
-The event stream mechanism allows events (e.g creation, updates, delete) regarding your resource to be subscribed to
-by consumers. Whilst this is not strictly a requirement for adding a resource, it will be necessary if you intend to
-add your resource to the cache.
-
-In order to add your resource to the event stream mechanism, you must write a "parser" which will allow your resource
-to be decoded from the event. This can be found in `lib/services/local/events.go`.
-
-For example, to add a parser for `foo`:
-
-```go
-func newFooParser() *fooParser {
-	return &fooParser{
-		baseParser: newBaseParser(backend.Key(fooPrefix)),
-	}
-}
-
-type fooParser struct {
-	baseParser
-}
-
-func (p *fooParser) parse(event backend.Event) (types.Resource, error) {
-	switch event.Type {
-	case types.OpDelete:
-		return resourceHeader(event, types.KindFoo, types.V1, 0)
-	case types.OpPut:
-		foo, err := services.UnmarshalFoo(
-			event.Item.Value,
-			services.WithExpires(event.Item.Expires),
-			services.WithRevision(event.Item.Revision))
-		if err != nil {
-			return nil, trace.Wrap(err, "unmarshalling resource from event")
-		}
-		return types.Resource153ToLegacy(foo), nil
-	default:
-		return nil, trace.BadParameter("event %v is not supported", event.Type)
-	}
-}
-```
-
-In addition, you will need to add support for instantiating this parser to the
-switch in the `NewWatcher` function in `lib/services/local/events.go`:
-
-```go
-		case types.KindFoo:
-			parser = newFooParser()
-```
-
 ### Cache
 
 One thing to consider when creating a resource is whether it will need to be cached. As mentioned above, any resource
@@ -585,6 +536,54 @@ func (fooExecutor) deleteAll(ctx context.Context, cache *Cache) error {
 func (fooExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
 	return cache.Foo.DeleteFoo(ctx, &foov1.DeleteFoo{Name: resource.GetName()})
 }
+```
+
+#### Event stream mechanism
+
+The event stream mechanism allows events (e.g creation, updates, delete) regarding your resource to be subscribed to
+by consumers.
+
+In order to add your resource to the event stream mechanism, you must write a "parser" which will allow your resource
+to be decoded from the event. This can be found in `lib/services/local/events.go`.
+
+For example, to add a parser for `foo`:
+
+```go
+func newFooParser() *fooParser {
+	return &fooParser{
+		baseParser: newBaseParser(backend.Key(fooPrefix)),
+	}
+}
+
+type fooParser struct {
+	baseParser
+}
+
+func (p *fooParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		return resourceHeader(event, types.KindFoo, types.V1, 0)
+	case types.OpPut:
+		foo, err := services.UnmarshalFoo(
+			event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision))
+		if err != nil {
+			return nil, trace.Wrap(err, "unmarshalling resource from event")
+		}
+		return types.Resource153ToLegacy(foo), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+```
+
+In addition, you will need to add support for instantiating this parser to the
+switch in the `NewWatcher` function in `lib/services/local/events.go`:
+
+```go
+		case types.KindFoo:
+			parser = newFooParser()
 ```
 
 ### api client

--- a/rfd/0153-resource-guidelines.md
+++ b/rfd/0153-resource-guidelines.md
@@ -72,6 +72,7 @@ detail about what is needed to complete a particular item.
 - [ ] Create backend service
 - [ ] Add resource client to `api` client
 - [ ] Implement gRPC service
+- [ ] Add resource parser to event stream mechanism
 - [ ] Add resource support to tctl (get, create, edit)
 - [ ] Optional: Add resource to cache
 - [ ] Add support for bootstrapping the resource
@@ -475,6 +476,55 @@ func (s *FooService) ListFoos(ctx context.Context, pageSize int, pageToken strin
 
 	return foos, nextToken, trace.NewAggregate(err, fooStream.Done())
 }
+```
+
+### Event stream mechanism
+
+The event stream mechanism allows events (e.g creation, updates, delete) regarding your resource to be subscribed to
+by consumers. Whilst this is not strictly a requirement for adding a resource, it will be necessary if you intend to
+add your resource to the cache.
+
+In order to add your resource to the event stream mechanism, you must write a "parser" which will allow your resource
+to be decoded from the event. This can be found in `lib/services/local/events.go`.
+
+For example, to add a parser for `foo`:
+
+```go
+func newFooParser() *fooParser {
+	return &fooParser{
+		baseParser: newBaseParser(backend.Key(fooPrefix)),
+	}
+}
+
+type fooParser struct {
+	baseParser
+}
+
+func (p *fooParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		return resourceHeader(event, types.KindFoo, types.V1, 0)
+	case types.OpPut:
+		foo, err := services.UnmarshalFoo(
+			event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision))
+		if err != nil {
+			return nil, trace.Wrap(err, "unmarshalling resource from event")
+		}
+		return types.Resource153ToLegacy(foo), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+```
+
+In addition, you will need to add support for instantiating this parser to the
+switch in the `NewWatcher` function in `lib/services/local/events.go`:
+
+```go
+		case types.KindFoo:
+			parser = newFooParser()
 ```
 
 ### Cache


### PR DESCRIPTION
Whilst recently adding a new resource, I noticed that this step was omitted from the guidelines but is a necessary step if you wish to support caching your resource.