### PR TITLE
[v16] Update install script references to use CDN (#44838)

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -104,7 +104,8 @@ jobs:
               .variables.teleport.latest_oss_docker_image |= sub(":.*";":")+$version |
               .variables.teleport.latest_oss_debug_docker_image |= sub(":.*";":")+$version |
               .variables.teleport.latest_ent_docker_image |= sub(":.*";":")+$version |
-              .variables.teleport.latest_ent_debug_docker_image |= sub(":.*";":")+$version' \
+              .variables.teleport.latest_ent_debug_docker_image |= sub(":.*";":")+$version |
+              .variables.teleport.teleport_install_script_url |=  sub("install-v.*.sh"; "install-v"+$version+".sh")' \
               docs/config.json > docs/confignew.json
           cat docs/confignew.json
           mv docs/confignew.json docs/config.json

--- a/docs/config.json
+++ b/docs/config.json
@@ -1624,7 +1624,8 @@
       "latest_oss_docker_image": "public.ecr.aws/gravitational/teleport-distroless:16.1.1",
       "latest_oss_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:16.1.1",
       "latest_ent_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless:16.1.1",
-      "latest_ent_debug_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless-debug:16.1.1"
+      "latest_ent_debug_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless-debug:16.1.1",
+      "teleport_install_script_url": "https://cdn.teleport.dev/install-v16.1.1.sh"
     },
     "terraform": {
       "version": "1.0.0"

--- a/docs/pages/deploy-a-cluster/linux-demo.mdx
+++ b/docs/pages/deploy-a-cluster/linux-demo.mdx
@@ -88,7 +88,7 @@ set up records for:
 On your Linux host, run the following command to install the Teleport binary:
 
 ```code
-$ curl https://goteleport.com/static/install.sh | bash -s (=teleport.version=)
+$ curl (=teleport.teleport_install_script_url=) | bash -s (=teleport.version=)
 ```
 
 ### Configure Teleport

--- a/docs/pages/includes/install-linux-oss.mdx
+++ b/docs/pages/includes/install-linux-oss.mdx
@@ -2,6 +2,6 @@ The following command updates the repository for the package manager on the
 local operating system and installs the provided Teleport version:
 
 ```code
-$ curl https://goteleport.com/static/install.sh | bash -s (=teleport.version=)
+$ curl (=teleport.teleport_install_script_url=) | bash -s (=teleport.version=)
 ```
 

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -28,7 +28,7 @@ Install Teleport on your Linux server:
 1. Install Teleport on your Linux server:
 
    ```code
-   $ curl https://goteleport.com/static/install.sh | bash -s ${TELEPORT_VERSION} <Var name="edition" />
+   $ curl (=teleport.teleport_install_script_url=) | bash -s ${TELEPORT_VERSION} <Var name="edition" />
    ```
 
    The installation script detects the package manager on your Linux server and

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -126,7 +126,7 @@ Download and run the installation script on the server where you want to install
 Teleport:
 
 ```code
-$ curl https://goteleport.com/static/install.sh | bash -s ${TELEPORT_VERSION?} ${TELEPORT_EDITION?}
+$ curl (=teleport.teleport_install_script_url=) | bash -s ${TELEPORT_VERSION?} ${TELEPORT_EDITION?}
 ```
 
 ### Package repositories

--- a/docs/pages/upgrading/automatic-agent-updates.mdx
+++ b/docs/pages/upgrading/automatic-agent-updates.mdx
@@ -183,7 +183,7 @@ Server ID                            Hostname      Services Version Upgrader
    <TabItem label="Managed Teleport Enterprise">
 
    ```code
-   $ curl https://goteleport.com/static/install.sh | bash -s ${TELEPORT_VERSION?} cloud
+   $ curl (=teleport.teleport_install_script_url=) | bash -s ${TELEPORT_VERSION?} cloud
    ```
 
    </TabItem>

--- a/docs/pages/upgrading/reference.mdx
+++ b/docs/pages/upgrading/reference.mdx
@@ -327,7 +327,7 @@ Service, then on each of your agents:
 1. Install the new Teleport version on your Linux server:
 
    ```code
-   $ curl https://goteleport.com/static/install.sh | bash -s <Var name="version" /> <Var name="edition" />
+   $ curl (=teleport.teleport_install_script_url=) | bash -s <Var name="version" /> <Var name="edition" />
    ```
 
    The installation script detects the package manager on your Linux server and

--- a/examples/agent-pool-terraform/teleport/userdata
+++ b/examples/agent-pool-terraform/teleport/userdata
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-curl https://goteleport.com/static/install.sh | bash -s ${teleport_version} ${teleport_edition}
+curl https://cdn.teleport.dev/install-v${teleport_version}.sh | bash -s ${teleport_version} ${teleport_edition}
 
 echo ${token} > /var/lib/teleport/token
 cat<<EOF >/etc/teleport.yaml


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/44838 to v16