### PR TITLE
[v16] docs: update tctl references to include windows

### DIFF
--- a/docs/pages/enroll-resources/server-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/server-access/getting-started.mdx
@@ -67,24 +67,10 @@ that a user intends to access.
 On your local workstation, create a join token so you can add the server to your
 Teleport cluster:
 
-<Tabs>
-<TabItem label="Linux">
-
 ```code
 Let's save the token to a file
 $ tctl tokens add --type=node --format=text > token.file
 ```
-
-</TabItem>
-<TabItem label="macOS">
-
-```code
-Let's save the token to a file
-$ tctl tokens add --type=node --format=text > token.file
-```
-
-</TabItem>
-</Tabs>
 
 `--type=node` specifies that the Teleport process will act and join as an SSH
 server.

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -34,7 +34,7 @@ running Teleport on UNIX variants other than Linux \[1].
 | - | - | - | - | - | - |
 | Linux v2.6.23+ (RHEL/CentOS 7+, Amazon Linux 2+, Amazon Linux 2023+, Ubuntu 16.04+, Debian 9+, SLES 12 SP 5+, and SLES 15 SP 5+) \[3] | yes | yes | yes | yes | yes |
 | macOS v10.15+  (Catalina)| yes | yes | yes | yes | yes |
-| Windows 10+ (rev. 1607) \[4] | no | no | yes | yes | no |
+| Windows 10+ (rev. 1607) \[4] | no | yes | yes | yes | no |
 
 \[1] *Teleport is written in Go and many of these system requirements are due to the requirements
 of the [Go toolchain](https://github.com/golang/go/wiki/MinimumRequirements)*.


### PR DESCRIPTION
Backport #45059 to branch/v16