### PR TITLE
[v15] Set `TERM_PROGRAM` and `TERM_PROGRAM_VERSION` env vars in Teleport Connect

### DIFF
--- a/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -66,6 +66,8 @@ export async function buildPtyOptions(
       const combinedEnv = {
         ...process.env,
         ...shellEnv,
+        TERM_PROGRAM: 'Teleport_Connect',
+        TERM_PROGRAM_VERSION: settings.appVersion,
         TELEPORT_HOME: settings.tshd.homeDir,
         TELEPORT_CLUSTER: cmd.clusterName,
         TELEPORT_PROXY: cmd.proxyHost,


### PR DESCRIPTION
Backport #45014 to branch/v15

changelog: Teleport Connect now sets `TERM_PROGRAM: Teleport_Connect` and `TERM_PROGRAM_VERSION: <app_version>` environment variables in the integrated terminal
