### PR TITLE
docs: adding getting-started to route to linux demo

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2541,6 +2541,11 @@
     	"permanent": true
     },
     {
+    	"source": "/getting-started/",
+    	"destination": "/deploy-a-cluster/linux-demo/",
+    	"permanent": true
+    },
+    {
       "source": "/database-access/guides/snowflake/",
       "destination": "/enroll-resources/database-access/enroll-managed-databases/snowflake/",
       "permanent": true


### PR DESCRIPTION
The link https://goteleport.com/docs/getting-started/ is referenced in the README. Updating to have this route the same as `/get-started` to the Linux deployment demo.