### PR TITLE
[v16] Document changes to auto-enroll since v16.1.1

### DIFF
--- a/docs/pages/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/access-controls/device-trust/device-management.mdx
@@ -142,6 +142,12 @@ For auto-enrollment to work, the following conditions must be met:
 [manual](#register-a-trusted-device) or performed using an
 integration, like the [Jamf Pro integration](./jamf-integration.mdx).
 - Auto-enrollment must be enabled in the cluster setting.
+- User must have either preset `editor` or `device-enroll` (available v13.3.6+) role assigned to them.
+
+<Admonition type="tip">
+  Since Teleport v16.1.1 users don't need the device/enroll permission to
+  benefit from auto-enrollment.
+</Admonition>
 
 Enable auto-enrollment in your cluster settings:
 

--- a/docs/pages/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/access-controls/device-trust/device-management.mdx
@@ -142,7 +142,6 @@ For auto-enrollment to work, the following conditions must be met:
 [manual](#register-a-trusted-device) or performed using an
 integration, like the [Jamf Pro integration](./jamf-integration.mdx).
 - Auto-enrollment must be enabled in the cluster setting.
-- User must have either preset `editor` or `device-enroll` (available v13.3.6+) role assigned to them.
 
 Enable auto-enrollment in your cluster settings:
 
@@ -179,9 +178,8 @@ After saving the changes, restart the Teleport service.
 </TabItem>
 </Tabs>
 
-Once enabled, user's with their device registered in Teleport and with the required permission
-(preset `editor` or `device-enroll` role) will have their device enrolled to Teleport in
-their next login.
+Once enabled, users with their device registered in Teleport will have their
+device enrolled to Teleport in their next login.
 
 ```code
 $ tsh logout

--- a/docs/pages/access-controls/guides/webauthn.mdx
+++ b/docs/pages/access-controls/guides/webauthn.mdx
@@ -385,6 +385,12 @@ For auto-enrollment to work, the following conditions must be met:
 - A device must be registered. Registration may be [manual](#implement-cluster-wide-device-trust) or performed using an
 integration, like the [Jamf Pro integration](../device-trust/jamf-integration.mdx).
 - Auto-enrollment must be enabled in the cluster setting.
+- User must have either preset `editor` or `device-enroll` (available v13.3.6+) role assigned to them.
+
+<Admonition type="tip">
+  Since Teleport v16.1.1 users don't need the device/enroll permission to
+  benefit from auto-enrollment.
+</Admonition>
 
 ### Step 1/2. Enable auto-enrollment in your cluster settings
 

--- a/docs/pages/access-controls/guides/webauthn.mdx
+++ b/docs/pages/access-controls/guides/webauthn.mdx
@@ -385,7 +385,6 @@ For auto-enrollment to work, the following conditions must be met:
 - A device must be registered. Registration may be [manual](#implement-cluster-wide-device-trust) or performed using an
 integration, like the [Jamf Pro integration](../device-trust/jamf-integration.mdx).
 - Auto-enrollment must be enabled in the cluster setting.
-- User must have either preset `editor` or `device-enroll` (available v13.3.6+) role assigned to them.
 
 ### Step 1/2. Enable auto-enrollment in your cluster settings
 
@@ -405,9 +404,8 @@ spec:
 
 ### Step 2/2. Log out and back in
 
-Once enabled, user's with their device registered in Teleport and with the required permission
-(preset `editor` or `device-enroll` role) will have their device enrolled to Teleport in
-their next login.
+Once enabled, users with their device registered in Teleport will have their
+device enrolled to Teleport in their next login.
 
 ```code
 $ tsh logout


### PR DESCRIPTION
Backport #45019 to branch/v16.

Edit changed to an admonition in branch/v16, so docs are still valid for versions < v16.1.1.