### PR TITLE
fix: Clarify tbot proxy-server/auth-server validation message

### DIFF
--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -499,7 +499,7 @@ func (b *Bot) preRunChecks(ctx context.Context) (_ func() error, err error) {
 	switch _, addrKind := b.cfg.Address(); addrKind {
 	case config.AddressKindUnspecified:
 		return nil, trace.BadParameter(
-			"either a proxy set with --proxy-server (or configuration) or auth address set with --auth-server (or configuration) can be used but not both.",
+			"either a proxy set with --proxy-server (or configuration) or auth address set with --auth-server (or configuration) must be used but not both.",
 		)
 	case config.AddressKindAuth:
 		// TODO(noah): DELETE IN V17.0.0

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -499,7 +499,7 @@ func (b *Bot) preRunChecks(ctx context.Context) (_ func() error, err error) {
 	switch _, addrKind := b.cfg.Address(); addrKind {
 	case config.AddressKindUnspecified:
 		return nil, trace.BadParameter(
-			"either a proxy set with --proxy-server (or configuration) or auth address set with --auth-server (or configuration) must be used but not both.",
+			"exactly one of the proxy address server or the auth server address must be configured",
 		)
 	case config.AddressKindAuth:
 		// TODO(noah): DELETE IN V17.0.0

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -499,7 +499,7 @@ func (b *Bot) preRunChecks(ctx context.Context) (_ func() error, err error) {
 	switch _, addrKind := b.cfg.Address(); addrKind {
 	case config.AddressKindUnspecified:
 		return nil, trace.BadParameter(
-			"either a proxy or auth address must be set using --proxy, --auth-server or configuration",
+			"either a proxy set with --proxy-server (or configuration) or auth address set with --auth-server (or configuration) can be used but not both.",
 		)
 	case config.AddressKindAuth:
 		// TODO(noah): DELETE IN V17.0.0


### PR DESCRIPTION
According to the validation logic in [`b.cfg.Address()`][1], users should not set both the proxy-server **and** the auth-server.

English is not my first language, feel free to improve my message :).

I hope this change will help other users. It took me a while to understand that providing both the proxy-server and the auth-server was an error.

[1]: https://github.com/gravitational/teleport/blob/aae05c570c129f98cd1fe0588bf67dfd0804cc63/lib/tbot/config/config.go#L329-L337