### PR TITLE
Docs: Multi auth `tsh login` using hardware key

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -251,7 +251,7 @@ a browser of your choice to continue the login flow.
 Multi-factor Authentication can be configured, however, a Hardware Key cannot be your primary 
 authentication method. For user accounts configured to use hardware key as the primary 
 authentication method, this will become your secondary factor when using `tsh login`. 
-If you do not have a password configured on your web account you will need to set one 
+If you do not have a password configured on your user account you will need to set one 
 to use `tsh login`. 
 
 ### Inspecting an SSH certificate

--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -248,6 +248,12 @@ a browser of your choice to continue the login flow.
 
 [CLI Docs - tsh login](../reference/cli/tsh.mdx#tsh-login)
 
+Multi-factor Authentication can be configured, however, a Hardware Key cannot be your primary 
+authentication method. For web accounts configured to use hardware key as the primary 
+authentication method, this will become your secondary factor when using `tsh login`. 
+If you do not have a password configured on your web account you will need to set one 
+to use `tsh login`. 
+
 ### Inspecting an SSH certificate
 
 To inspect the SSH certificates in `~/.tsh`, a user may execute the following

--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -249,7 +249,7 @@ a browser of your choice to continue the login flow.
 [CLI Docs - tsh login](../reference/cli/tsh.mdx#tsh-login)
 
 Multi-factor Authentication can be configured, however, a Hardware Key cannot be your primary 
-authentication method. For web accounts configured to use hardware key as the primary 
+authentication method. For user accounts configured to use hardware key as the primary 
 authentication method, this will become your secondary factor when using `tsh login`. 
 If you do not have a password configured on your web account you will need to set one 
 to use `tsh login`. 


### PR DESCRIPTION
Adding a small comment about multi-auth for tsh login. My account was created with hardware key authentication only and I hit this error where I could not authenticate on the CLI.

The fix was to add a password in the web portal then reattempt the tsh login. Having this comment would have helped me progress past the problem a bit faster.