### PR TITLE
Host user creation - create user once per connection

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -396,9 +396,6 @@ type ServerContext struct {
 	// ServerSubKind if the sub kind of the node this context is for.
 	ServerSubKind string
 
-	// UserCreatedByTeleport is true when the system user was created by Teleport user auto-provision.
-	UserCreatedByTeleport bool
-
 	// approvedFileReq is an approved file transfer request that will only be
 	// set when the session's pending file transfer request is approved.
 	approvedFileReq *FileTransferRequest

--- a/lib/sshutils/ctx.go
+++ b/lib/sshutils/ctx.go
@@ -75,6 +75,9 @@ type ConnectionContext struct {
 	// clientLastActive records the last time there was activity from the client.
 	clientLastActive time.Time
 
+	// UserCreatedByTeleport is true when the system user was created by Teleport user auto-provision.
+	UserCreatedByTeleport bool
+
 	clock clockwork.Clock
 }
 


### PR DESCRIPTION
This change updates host user creation to create host users at the start of a new SSH connection, rather than at the start of certain new channels opening. This ensures that host creation is only run once per connection and that the host user is available no matter what channels are opened.

Fixes #22710.


This builds on https://github.com/gravitational/teleport/pull/44991 to prevent any further performance regressions caused by https://github.com/gravitational/teleport/pull/41919.

Changelog: Fixed host user creation for `tsh scp`