### PR TITLE
docs: include Panther link in export audit logs intro

### DIFF
--- a/docs/pages/admin-guides/management/export-audit-events.mdx
+++ b/docs/pages/admin-guides/management/export-audit-events.mdx
@@ -22,6 +22,9 @@ events to your solution of choice:
   Stack](./export-audit-events/elastic-stack.mdx): How to configure the Event
   Handler plugin to forward Teleport audit logs to Logstash for ingestion in
   Elasticsearch so you can explore them in Kibana.
+- [Monitor Teleport Audit Events with Panther](./export-audit-events/panther.mdx):
+  How to configure the Event Handler plugin to send logs to Panther via Fluentd
+  so you can explore your audit events in Panther.
 - [Monitor Teleport Audit Events with Splunk](./export-audit-events/splunk.mdx):
   How to configure the Event Handler plugin to send logs to Splunk's Universal
   Forwarder so you can explore your audit events in Splunk.


### PR DESCRIPTION
Panther not included in exporting audit events intro page.