### PR TITLE
Make sure ConfigService works in the browser

### DIFF
--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -243,6 +243,7 @@ export enum FileStorageEventType {
   Write = 'Write',
   Replace = 'Replace',
   GetFilePath = 'GetFilePath',
+  GetFileName = 'GetFileName',
   GetFileLoadingError = 'GetFileLoadingError',
 }
 

--- a/web/packages/teleterm/src/services/config/configService.ts
+++ b/web/packages/teleterm/src/services/config/configService.ts
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import path from 'path';
-
 import { z, ZodIssue } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
 
@@ -64,6 +62,9 @@ export interface ConfigService {
   getConfigError(): ConfigError | undefined;
 }
 
+// createConfigService must return a client that works both in the browser and in Node.js, as the
+// returned service is used both in the main process and in Storybook to provide a fake
+// implementation of config service.
 export function createConfigService({
   configFile,
   jsonSchemaFile,
@@ -124,7 +125,7 @@ function updateJsonSchema({
     schema.extend({ $schema: z.string() }),
     { $refStrategy: 'none' }
   );
-  const jsonSchemaFileName = path.basename(jsonSchemaFile.getFilePath());
+  const jsonSchemaFileName = jsonSchemaFile.getFileName();
   const jsonSchemaFileNameInConfig = configFile.get('$schema');
 
   jsonSchemaFile.replace(jsonSchema);

--- a/web/packages/teleterm/src/services/fileStorage/fileStorage.ts
+++ b/web/packages/teleterm/src/services/fileStorage/fileStorage.ts
@@ -19,6 +19,7 @@
 // Both versions are imported because some operations need to be sync.
 import fsAsync from 'node:fs/promises';
 import fs from 'node:fs';
+import path from 'node:path';
 
 import { debounce } from 'shared/utils/highbar';
 
@@ -43,6 +44,12 @@ export interface FileStorage {
 
   /** Returns the file path used to create the storage. */
   getFilePath(): string;
+
+  /** Returns the file name used to create the storage.
+   *
+   * Added so that ConfigService itself doesn't need to import node:path and can remain universal.
+   */
+  getFileName(): string;
 
   /** Returns the error that could occur while reading and parsing the file. */
   getFileLoadingError(): Error | undefined;
@@ -116,6 +123,10 @@ export function createFileStorage(opts: {
     return opts.filePath;
   }
 
+  function getFileName(): string {
+    return path.basename(opts.filePath);
+  }
+
   function getFileLoadingError(): Error | undefined {
     return error;
   }
@@ -134,6 +145,7 @@ export function createFileStorage(opts: {
     get,
     replace,
     getFilePath,
+    getFileName,
     getFileLoadingError,
   };
 }

--- a/web/packages/teleterm/src/services/fileStorage/fileStorageClient.ts
+++ b/web/packages/teleterm/src/services/fileStorage/fileStorageClient.ts
@@ -25,6 +25,10 @@ import {
 
 import { FileStorage } from './fileStorage';
 
+// TODO(ravicious): The main process should not expose the whole interface of FileStorage to the
+// renderer, only what's absolutely needed by the renderer. FileStorage at the moment includes a
+// bunch of functions that are used only in the main process (and should be used only there).
+// https://github.com/gravitational/teleport/issues/24380
 export function subscribeToFileStorageEvents(configService: FileStorage): void {
   ipcMain.on(
     FileStorageEventChannel,
@@ -40,8 +44,12 @@ export function subscribeToFileStorageEvents(configService: FileStorage): void {
           return configService.replace(item.json);
         case FileStorageEventType.GetFilePath:
           return configService.getFilePath();
+        case FileStorageEventType.GetFileName:
+          return configService.getFileName();
         case FileStorageEventType.GetFileLoadingError:
           return configService.getFileLoadingError();
+        default:
+          eventType satisfies never;
       }
     }
   );
@@ -72,6 +80,12 @@ export function createFileStorageClient(): FileStorage {
       ipcRenderer.sendSync(
         FileStorageEventChannel,
         FileStorageEventType.GetFilePath,
+        {}
+      ),
+    getFileName: () =>
+      ipcRenderer.sendSync(
+        FileStorageEventChannel,
+        FileStorageEventType.GetFileName,
         {}
       ),
     getFileLoadingError: () =>

--- a/web/packages/teleterm/src/services/fileStorage/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/fileStorage/fixtures/mocks.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { FileStorage } from 'teleterm/services/fileStorage';
+import type { FileStorage } from 'teleterm/services/fileStorage';
 
 export function createMockFileStorage(opts?: {
   filePath: string;
@@ -39,6 +39,10 @@ export function createMockFileStorage(opts?: {
 
     getFilePath() {
       return opts?.filePath || '';
+    },
+
+    getFileName() {
+      return opts?.filePath.split('/').at(-1) || '';
     },
 
     getFileLoadingError() {


### PR DESCRIPTION
`ConfigService` used to import `node:path` just to call `path.basename` on a file path it got from `FileStorage`. This PR adds a method to `FileStorage` that returns the basename itself. This way `ConfigService` itself doesn't need to import Node's stdlib and can work both in the browser and in Node.js.

This fixes broken teleterm stories that depend on a `ConfigService` mock. This used to work, because AFAIK Webpack used to autopolyfill `path` or we had an explicit config to do this.

I treat it as a band-aid because:

* `ConfigService` is supposed to be used in the main process in a Node.js environment. The mock of config service client shouldn't need to use the actual implementation.
* I couldn't find a way in Jest to ensure that `ConfigService` is universal (works both in the browser and in Node.js). Even though by default we use the JSDOM environment, Jest is happy with Node-specific imports.