### PR TITLE
[aws_matchers] validate aws regions

### DIFF
--- a/api/types/discoveryconfig/discoveryconfig_test.go
+++ b/api/types/discoveryconfig/discoveryconfig_test.go
@@ -246,6 +246,69 @@ func TestNewDiscoveryConfig(t *testing.T) {
 			errCheck: require.NoError,
 		},
 		{
+			name: "tag aws sync with invalid region",
+			inMetadata: header.Metadata{
+				Name: "my-first-dc",
+			},
+			inSpec: Spec{
+				DiscoveryGroup: "dg1",
+				AccessGraph: &types.AccessGraphSync{
+					AWS: []*types.AccessGraphAWSSync{
+						{
+							Integration: "1234",
+							AssumeRole: &types.AssumeRole{
+								RoleARN: "arn:aws:iam::123456789012:role/teleport",
+							},
+							Regions: []string{"us<random>&-west-2"},
+						},
+					},
+				},
+			},
+			errCheck: require.Error,
+		},
+		{
+			name: "tag aws sync with empty region",
+			inMetadata: header.Metadata{
+				Name: "my-first-dc",
+			},
+			inSpec: Spec{
+				DiscoveryGroup: "dg1",
+				AccessGraph: &types.AccessGraphSync{
+					AWS: []*types.AccessGraphAWSSync{
+						{
+							Integration: "1234",
+							AssumeRole: &types.AssumeRole{
+								RoleARN: "arn:aws:iam::123456789012:role/teleport",
+							},
+							Regions: []string{""},
+						},
+					},
+				},
+			},
+			errCheck: require.Error,
+		},
+		{
+			name: "tag aws sync with region not set",
+			inMetadata: header.Metadata{
+				Name: "my-first-dc",
+			},
+			inSpec: Spec{
+				DiscoveryGroup: "dg1",
+				AccessGraph: &types.AccessGraphSync{
+					AWS: []*types.AccessGraphAWSSync{
+						{
+							Integration: "1234",
+							AssumeRole: &types.AssumeRole{
+								RoleARN: "arn:aws:iam::123456789012:role/teleport",
+							},
+							Regions: nil,
+						},
+					},
+				},
+			},
+			errCheck: require.Error,
+		},
+		{
 			name: "fills in kube matcher default values",
 			inMetadata: header.Metadata{
 				Name: "my-first-dc",

--- a/api/types/matchers_accessgraph.go
+++ b/api/types/matchers_accessgraph.go
@@ -18,6 +18,8 @@ package types
 
 import (
 	"github.com/gravitational/trace"
+
+	awsapiutils "github.com/gravitational/teleport/api/utils/aws"
 )
 
 // CheckAndSetDefaults that the matcher is correct and adds default values.
@@ -33,6 +35,12 @@ func (a *AccessGraphSync) CheckAndSetDefaults() error {
 func (a *AccessGraphAWSSync) CheckAndSetDefaults() error {
 	if len(a.Regions) == 0 {
 		return trace.BadParameter("discovery service requires at least one region")
+	}
+
+	for _, region := range a.Regions {
+		if err := awsapiutils.IsValidRegion(region); err != nil {
+			return trace.BadParameter("discovery service does not support region %q", region)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR introduces validation to AWS regions in Access Graph Matchers. It will prevent creating or updating discovery_configs with incorrect regions.