### PR TITLE
Fix singing -> signing typos where necessary

### DIFF
--- a/integrations/kube-agent-updater/hack/cosign-fixtures.go
+++ b/integrations/kube-agent-updater/hack/cosign-fixtures.go
@@ -495,7 +495,7 @@ func generateSignedManifest(scenario string, signer digestedRefSigner, keys ...*
 		return
 	}
 
-	// Singing the manifest
+	// Signing the manifest
 	sigLayers, sigManifest, err := makeSignature(manifestRef, signer, keys...)
 	if err != nil {
 		return nil, nil, v1.Hash{}, trace.Wrap(err)

--- a/integrations/kube-agent-updater/pkg/img/doc.go
+++ b/integrations/kube-agent-updater/pkg/img/doc.go
@@ -32,7 +32,7 @@
 // signed multiple times and this does not affect its digest.
 // At the time of writing, cosign supports both static key signing and
 // "keyless" (short-lived certificates) signing through the Fulcio CA.
-// Keyless singing is still experimental and we don't use it yet, support might
+// Keyless Signing is still experimental and we don't use it yet, support might
 // be added in the future.
 //
 // The Cosign validator delegates all validation logic to the upstream cosign

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -105,7 +105,7 @@ func (a *Server) UpdateSAMLConnector(ctx context.Context, connector types.SAMLCo
 
 	// If someone is applying a SAML Connector obtained with `tctl get` without secrets, the signing key pair is
 	// not empty (cert is set) but the private key is missing. In this case we want to look up the existing SAML
-	// connector and populate the singing key from it if it's the same certificate. This avoids accidentally clearing
+	// connector and populate the signing key from it if it's the same certificate. This avoids accidentally clearing
 	// the private key and creating an unusable connector.
 	if connector.GetSigningKeyPair().PrivateKey == "" {
 		err := services.FillSAMLSigningKeyFromExisting(ctx, connector, a.Services)

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -45,7 +45,7 @@ type SAMLConnectorGetter interface {
 	GetSAMLConnector(ctx context.Context, id string, withSecrets bool) (types.SAMLConnector, error)
 }
 
-const ErrMsgHowToFixMissingPrivateKey = "You must either specify the singing key pair (obtain the existing one with `tctl get saml --with-secrets`) or let Teleport generate a new one (remove singing_key_pair in the resource you're trying to create)."
+const ErrMsgHowToFixMissingPrivateKey = "You must either specify the signing key pair (obtain the existing one with `tctl get saml --with-secrets`) or let Teleport generate a new one (remove signing_key_pair in the resource you're trying to create)."
 
 // ValidateSAMLConnector validates the SAMLConnector and sets default values.
 // If a remote to fetch roles is specified, roles will be validated to exist.

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -179,7 +179,7 @@ func TestFillSAMLSigningKeyFromExisting(t *testing.T) {
 		assertResult  require.ValueAssertionFunc
 	}{
 		{
-			name:          "should read singing key from existing connector with matching cert",
+			name:          "should read signing key from existing connector with matching cert",
 			connectorName: existingConnectorName,
 			connectorSpec: types.SAMLConnectorSpecV2{
 				SigningKeyPair: &types.AsymmetricKeyPair{


### PR DESCRIPTION
I was only going to fix the original typo in the SAML implementation, but it turns out this affects a number of files.