### PR TITLE
Update access_graph version in docs

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1281,7 +1281,7 @@
       "nodeIP": "ip-172-31-35-170"
     },
     "access_graph": {
-      "version": "1.20.4"
+      "version": "1.22.0"
     },
     "ansible": {
       "min_version": "2.9.6"


### PR DESCRIPTION
Upgraded the access_graph version from 1.20.4 to 1.22.0 in the docs/config.json file.