### PR TITLE
Bake pnpm into buildbox

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -238,6 +238,7 @@ USER root
 
 # Install Node.js.
 ARG NODE_VERSION
+ARG PNPM_VERSION
 ENV NODE_PATH="/usr/local/lib/nodejs-linux"
 ENV PATH="$PATH:${NODE_PATH}/bin"
 RUN export NODE_ARCH=$(if [ "$BUILDARCH" = "amd64" ]; then echo "x64"; else echo "arm64"; fi) && \
@@ -246,8 +247,7 @@ RUN export NODE_ARCH=$(if [ "$BUILDARCH" = "amd64" ]; then echo "x64"; else echo
     curl -o /tmp/nodejs.tar.xz -fsSL ${NODE_URL} && \
     tar -xJf /tmp/nodejs.tar.xz -C /usr/local/lib/nodejs-linux --strip-components=1
 RUN corepack enable yarn pnpm
-# Call pnpm to trigger corepack to download pnpm.
-RUN pnpm -v
+RUN corepack install -g pnpm@${PNPM_VERSION}
 
 # Install Go.
 ARG GOLANG_VERSION

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -246,6 +246,8 @@ RUN export NODE_ARCH=$(if [ "$BUILDARCH" = "amd64" ]; then echo "x64"; else echo
     curl -o /tmp/nodejs.tar.xz -fsSL ${NODE_URL} && \
     tar -xJf /tmp/nodejs.tar.xz -C /usr/local/lib/nodejs-linux --strip-components=1
 RUN corepack enable yarn pnpm
+# Call pnpm to trigger corepack to download pnpm.
+RUN pnpm -v
 
 # Install Go.
 ARG GOLANG_VERSION

--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -48,6 +48,7 @@ RUN apt-get -y update && \
 
 # Install Node.js.
 ARG NODE_VERSION
+ARG PNPM_VERSION
 ENV NODE_PATH="/usr/local/lib/nodejs-linux"
 ENV PATH="$PATH:${NODE_PATH}/bin"
 RUN NODE_ARCH="$(if [ "$BUILDARCH" = 'amd64' ]; then echo 'x64'; else echo 'arm64'; fi)" && \
@@ -58,6 +59,7 @@ RUN NODE_ARCH="$(if [ "$BUILDARCH" = 'amd64' ]; then echo 'x64'; else echo 'arm6
     tar -xJf "$NODE_FILE" -C /usr/local/lib/nodejs-linux --strip-components=1 && \
     rm -f "$NODE_FILE"
 RUN corepack enable pnpm
+RUN corepack install -g --cache-only pnpm@${PNPM_VERSION}
 
 # Install Go.
 ARG GOLANG_VERSION

--- a/build.assets/Dockerfile-node
+++ b/build.assets/Dockerfile-node
@@ -20,9 +20,9 @@ FROM node:${NODE_VERSION}-buster AS buildbox
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 ARG BUILDARCH
 
+ARG PNPM_VERSION
 RUN corepack enable pnpm
-# Call pnpm to trigger corepack to download pnpm.
-RUN pnpm -v
+RUN corepack install -g --cache-only pnpm@${PNPM_VERSION}
 
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile

--- a/build.assets/Dockerfile-node
+++ b/build.assets/Dockerfile-node
@@ -21,6 +21,8 @@ FROM node:${NODE_VERSION}-buster AS buildbox
 ARG BUILDARCH
 
 RUN corepack enable pnpm
+# Call pnpm to trigger corepack to download pnpm.
+RUN pnpm -v
 
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -182,6 +182,7 @@ buildbox:
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
+		--build-arg PNPM_VERSION=$(PNPM_VERSION) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--build-arg BUF_VERSION=$(BUF_VERSION) \
 		--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
@@ -270,6 +271,7 @@ buildbox-arm:
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
+		--build-arg PNPM_VERSION=$(PNPM_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--cache-to type=inline \
 		--cache-from $(BUILDBOX_ARM) \
@@ -292,6 +294,7 @@ buildbox-node:
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
+		--build-arg PNPM_VERSION=$(PNPM_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--cache-to type=inline \

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -7,6 +7,8 @@ GOLANG_VERSION ?= go1.22.5
 GOLANGCI_LINT_VERSION ?= v1.59.1
 
 NODE_VERSION ?= 20.14.0
+# Sync with packageManager field in package.json.
+PNPM_VERSION ?= 9.6.0
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.77.0


### PR DESCRIPTION
I noticed that each GitHub Action which uses our buildbox and pnpm would [download pnpm from scratch](https://github.com/gravitational/teleport/actions/runs/10263629169/job/28395883215?pr=45106#step:5:1). This is because when we do `corepack enable pnpm` in the Dockerfile, it merely installs a shim that causes pnpm to be downloaded the first time it's called.

This PR makes it so that we call `pnpm -v` which causes pnpm to be saved within the resulting image. corepack automatically detects that it's run in a CI environment and skips the prompt when downloading pnpm (as is shown in the run that I linked to above).