### PR TITLE
Simplify the edition name linter

### DIFF
--- a/.github/vale-styles/messaging/edition-names.yml
+++ b/.github/vale-styles/messaging/edition-names.yml
@@ -2,7 +2,7 @@ extends: existence
 scope:
   # Using the raw scope so we can catch instances in TabItem labels.
   - raw
-message: '"%s" is no longer a recognized Teleport edition. Use "Teleport Enterprise" instead, and clarify the hosting type rather than including it in the name of the product. For example, you could say, "For managed Teleport Enterprise...", "Teleport Enterprise (managed)", "self-hosted Teleport Enterprise," etc., as long as the implication is that Teleport Enterprise is a single product that users can host in two ways. If the hosting type is not important in a given sentence, there is no need to specify it.'
+message: '"%s" is no longer a recognized Teleport edition. Use "Teleport Enterprise (Self-Hosted)" or "Teleport Enterprise (Cloud)" instead. If the hosting type is not important in a given sentence, there is no need to specify it, and you can use "Teleport Enterprise".'
 level: error
 ignorecase: false
 tokens:


### PR DESCRIPTION
Instead of "Teleport Enterprise Cloud", recommend a consistent value. Previously, the linter's recommendation was more subject to interpretation.