### PR TITLE
Add host user creation benchmark test

### DIFF
--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -20,6 +20,7 @@ package services
 
 import (
 	"context"
+	"time"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/internalutils/stream"
@@ -203,4 +204,7 @@ type Presence interface {
 type PresenceInternal interface {
 	Presence
 	InventoryInternal
+
+	UpsertHostUserInteractionTime(ctx context.Context, name string, loginTime time.Time) error
+	GetHostUserInteractionTime(ctx context.Context, name string) (time.Time, error)
 }

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -66,7 +66,6 @@ import (
 	authorizedkeysreporter "github.com/gravitational/teleport/lib/secretsscanner/authorizedkeys"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/srv/ingress"
 	"github.com/gravitational/teleport/lib/sshutils"
@@ -211,7 +210,7 @@ type Server struct {
 	// creation
 	createHostUser bool
 
-	storage *local.PresenceService
+	storage services.PresenceInternal
 
 	// users is used to start the automatic user deletion loop
 	users srv.HostUsers
@@ -616,7 +615,7 @@ func SetCreateHostUser(createUser bool) ServerOption {
 }
 
 // SetStoragePresenceService configures host user creation on a server
-func SetStoragePresenceService(service *local.PresenceService) ServerOption {
+func SetStoragePresenceService(service services.PresenceInternal) ServerOption {
 	return func(s *Server) error {
 		s.storage = service
 		return nil

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -127,7 +127,7 @@ func newFixture(t *testing.T) *sshTestFixture {
 	return newCustomFixture(t, func(*auth.TestServerConfig) {})
 }
 
-func newFixtureWithoutDiskBasedLogging(t *testing.T, sshOpts ...ServerOption) *sshTestFixture {
+func newFixtureWithoutDiskBasedLogging(t testing.TB, sshOpts ...ServerOption) *sshTestFixture {
 	t.Helper()
 
 	f := newCustomFixture(t, func(cfg *auth.TestServerConfig) {
@@ -144,7 +144,7 @@ func newFixtureWithoutDiskBasedLogging(t *testing.T, sshOpts ...ServerOption) *s
 	return f
 }
 
-func (f *sshTestFixture) newSSHClient(ctx context.Context, t *testing.T, user *user.User) *tracessh.Client {
+func (f *sshTestFixture) newSSHClient(ctx context.Context, t testing.TB, user *user.User) *tracessh.Client {
 	// set up SSH client using the user private key for signing
 	up, err := newUpack(f.testSrv, user.Username, []string{user.Username}, wildcardAllow)
 	require.NoError(t, err)
@@ -173,7 +173,7 @@ func (f *sshTestFixture) newSSHClient(ctx context.Context, t *testing.T, user *u
 	return client
 }
 
-func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshOpts ...ServerOption) *sshTestFixture {
+func newCustomFixture(t testing.TB, mutateCfg func(*auth.TestServerConfig), sshOpts ...ServerOption) *sshTestFixture {
 	ctx := context.Background()
 
 	u, err := user.Current()
@@ -237,6 +237,7 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 		SetLockWatcher(lockWatcher),
 		SetX11ForwardingConfig(&x11.ServerConfig{}),
 		SetSessionController(sessionController),
+		SetStoragePresenceService(testServer.AuthServer.AuthServer.PresenceInternal),
 	}
 
 	serverOptions = append(serverOptions, sshOpts...)
@@ -2887,6 +2888,7 @@ func newUpack(testSvr *auth.TestServer, username string, allowedLogins []string,
 	role.SetRules(types.Allow, rules)
 	opts := role.GetOptions()
 	opts.PermitX11Forwarding = types.NewBool(true)
+	opts.CreateHostUser = types.NewBoolOption(true)
 	role.SetOptions(opts)
 	role.SetLogins(types.Allow, allowedLogins)
 	role.SetNodeLabels(types.Allow, allowedLabels)
@@ -2935,7 +2937,7 @@ func newUpack(testSvr *auth.TestServer, username string, allowedLogins []string,
 	}, nil
 }
 
-func newLockWatcher(ctx context.Context, t *testing.T, client types.Events) *services.LockWatcher {
+func newLockWatcher(ctx context.Context, t testing.TB, client types.Events) *services.LockWatcher {
 	lockWatcher, err := services.NewLockWatcher(ctx, services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: "test",
@@ -2973,7 +2975,7 @@ func newCertAuthorityWatcher(ctx context.Context, t *testing.T, client types.Eve
 }
 
 // newSigner creates a new SSH signer that can be used by the Server.
-func newSigner(t *testing.T, ctx context.Context, testServer *auth.TestServer) ssh.Signer {
+func newSigner(t testing.TB, ctx context.Context, testServer *auth.TestServer) ssh.Signer {
 	t.Helper()
 
 	priv, pub, err := testauthority.New().GenerateKeyPair()

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -271,6 +271,7 @@ func (s *SessionRegistry) TryCreateHostUser(ctx *ServerContext) error {
 	ui, err := ctx.Identity.AccessChecker.HostUsers(ctx.srv.GetInfo())
 	if err != nil {
 		if trace.IsAccessDenied(err) {
+			log.Warnf("Unable to create host users: %v", err)
 			return nil
 		}
 		log.Debug("Error while checking host users creation permission: ", err)

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -36,11 +36,10 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/services/local"
 )
 
 // NewHostUsers initialize a new HostUsers object
-func NewHostUsers(ctx context.Context, storage *local.PresenceService, uuid string) HostUsers {
+func NewHostUsers(ctx context.Context, storage services.PresenceInternal, uuid string) HostUsers {
 	//nolint:staticcheck // SA4023. False positive on macOS.
 	backend, err := newHostUsersBackend()
 	switch {
@@ -177,7 +176,7 @@ type HostUserManagement struct {
 	backend HostUsersBackend
 	ctx     context.Context
 	cancel  context.CancelFunc
-	storage *local.PresenceService
+	storage services.PresenceInternal
 
 	userGrace time.Duration
 }

--- a/lib/utils/testhelpers.go
+++ b/lib/utils/testhelpers.go
@@ -94,32 +94,32 @@ func RunTestBackgroundTask(ctx context.Context, t *testing.T, task *TestBackgrou
 }
 
 // RequireRoot skips the current test if it is not running as root.
-func RequireRoot(t *testing.T) {
-	t.Helper()
+func RequireRoot(tb testing.TB) {
+	tb.Helper()
 	if os.Geteuid() != 0 {
-		t.Skip("This test will be skipped because tests are not being run as root.")
+		tb.Skip("This test will be skipped because tests are not being run as root.")
 	}
 }
 
-func generateUsername(t *testing.T) string {
+func generateUsername(tb testing.TB) string {
 	suffix := make([]byte, 8)
 	_, err := rand.Read(suffix)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	return fmt.Sprintf("teleport-%x", suffix)
 }
 
 // GenerateLocalUsername generates the username for a local user that does not
 // already exists (but it does not create the user).
-func GenerateLocalUsername(t *testing.T) string {
+func GenerateLocalUsername(tb testing.TB) string {
 	const maxAttempts = 10
 	for i := 0; i < maxAttempts; i++ {
-		login := generateUsername(t)
+		login := generateUsername(tb)
 		_, err := user.Lookup(login)
 		if errors.Is(err, user.UnknownUserError(login)) {
 			return login
 		}
-		require.NoError(t, err)
+		require.NoError(tb, err)
 	}
-	t.Fatalf("Unable to generate unused username after %v attempts", maxAttempts)
+	tb.Fatalf("Unable to generate unused username after %v attempts", maxAttempts)
 	return ""
 }


### PR DESCRIPTION
Includes a new benchmark test meant to cover the performance regression introduced in https://github.com/gravitational/teleport/pull/42884. A few additional tweaks to the ssh test suite were required to use the same fixtures in benchmark and unit tests.