### PR TITLE
feat: Record/backfill BE and BS flags

### DIFF
--- a/lib/auth/mocku2f/mocku2f.go
+++ b/lib/auth/mocku2f/mocku2f.go
@@ -66,6 +66,10 @@ type Key struct {
 	// SetUV should be paired only with WebAuthn login/registration methods, as
 	// it makes Key mimic a WebAuthn device.
 	SetUV bool
+	// SetBackupFlags sets BE=1 and BS=1 in assertion responses.
+	// - https://w3c.github.io/webauthn/#authdata-flags-be
+	// - https://w3c.github.io/webauthn/#authdata-flags-bs
+	SetBackupFlags bool
 	// AllowResidentKey allows creation of resident credentials.
 	// There's no actual change in Key's behavior other than allowing such requests
 	// to proceed.
@@ -184,6 +188,10 @@ func (muk *Key) signRegister(appIDHash, clientDataHash []byte) (*signRegisterRes
 		// Mimic WebAuthn flags if SetUV is true.
 		flags = uint8(protocol.FlagUserPresent | protocol.FlagUserVerified | protocol.FlagAttestedCredentialData)
 	}
+	if muk.SetBackupFlags {
+		flags |= uint8(protocol.FlagBackupEligible)
+		flags |= uint8(protocol.FlagBackupState)
+	}
 
 	cap = 1 + len(pubKey) + 1 + len(muk.KeyHandle) + len(muk.Cert) + len(sig)
 	regData := make([]byte, 0, cap)
@@ -230,6 +238,10 @@ func (muk *Key) signAuthn(appIDHash, clientDataHash []byte) (*signAuthnResult, e
 	flags := uint8(protocol.FlagUserPresent)
 	if muk.SetUV {
 		flags |= uint8(protocol.FlagUserVerified)
+	}
+	if muk.SetBackupFlags {
+		flags |= uint8(protocol.FlagBackupEligible)
+		flags |= uint8(protocol.FlagBackupState)
 	}
 
 	var authData []byte

--- a/lib/auth/webauthn/login.go
+++ b/lib/auth/webauthn/login.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/go-webauthn/webauthn/protocol"
 	wan "github.com/go-webauthn/webauthn/webauthn"
+	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 
@@ -294,6 +295,10 @@ func (f *loginFlow) finish(ctx context.Context, user string, resp *wantypes.Cred
 		name:    user,
 		webID:   webID,
 		devices: []*types.MFADevice{dev},
+		currentFlags: &credentialFlags{
+			BE: parsedResp.Response.AuthenticatorData.Flags.HasBackupEligible(),
+			BS: parsedResp.Response.AuthenticatorData.Flags.HasBackupState(),
+		},
 	})
 
 	// Fetch the previously-stored SessionData, so it's checked against the user
@@ -366,7 +371,7 @@ func (f *loginFlow) finish(ctx context.Context, user string, resp *wantypes.Cred
 	}
 
 	// Update last used timestamp and device counter.
-	if err := setCounterAndTimestamps(dev, credential); err != nil {
+	if err := updateCredentialAndTimestamps(dev, credential); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	// Retroactively write the credential RPID, now that it cleared authn.
@@ -429,15 +434,37 @@ func findDeviceByID(devices []*types.MFADevice, id []byte) (*types.MFADevice, bo
 	return nil, false
 }
 
-func setCounterAndTimestamps(dev *types.MFADevice, credential *wan.Credential) error {
-	switch d := dev.Device.(type) {
+func updateCredentialAndTimestamps(dest *types.MFADevice, credential *wan.Credential) error {
+	switch d := dest.Device.(type) {
 	case *types.MFADevice_U2F:
 		d.U2F.Counter = credential.Authenticator.SignCount
+
 	case *types.MFADevice_Webauthn:
 		d.Webauthn.SignatureCounter = credential.Authenticator.SignCount
+
+		// Backfill BE/BS bits.
+		if d.Webauthn.CredentialBackupEligible == nil {
+			d.Webauthn.CredentialBackupEligible = &gogotypes.BoolValue{
+				Value: credential.Flags.BackupEligible,
+			}
+			log.WithFields(log.Fields{
+				"device": dest.GetName(),
+				"be":     credential.Flags.BackupEligible,
+			}).Debug("Backfilled Webauthn device BE flag")
+		}
+		if d.Webauthn.CredentialBackedUp == nil {
+			d.Webauthn.CredentialBackedUp = &gogotypes.BoolValue{
+				Value: credential.Flags.BackupState,
+			}
+			log.WithFields(log.Fields{
+				"device": dest.GetName(),
+				"bs":     credential.Flags.BackupState,
+			}).Debug("Backfilled Webauthn device BS flag")
+		}
+
 	default:
 		return trace.BadParameter("unexpected device type for webauthn: %T", d)
 	}
-	dev.LastUsed = time.Now()
+	dest.LastUsed = time.Now()
 	return nil
 }

--- a/lib/auth/webauthn/login.go
+++ b/lib/auth/webauthn/login.go
@@ -130,7 +130,12 @@ func (f *loginFlow) begin(ctx context.Context, user string, challengeExtensions 
 			return !resident1 && resident2
 		})
 
-		u = newWebUser(user, webID, true /* credentialIDOnly */, devices)
+		u = newWebUser(webUserOpts{
+			name:             user,
+			webID:            webID,
+			devices:          devices,
+			credentialIDOnly: true,
+		})
 
 		// Let's make sure we have at least one registered credential here, since we
 		// have to allow zero credentials for passwordless below.
@@ -285,7 +290,11 @@ func (f *loginFlow) finish(ctx context.Context, user string, resp *wantypes.Cred
 	case dev.GetU2F() != nil:
 		rpID = f.U2F.AppID
 	}
-	u := newWebUser(user, webID, false /* credentialIDOnly */, []*types.MFADevice{dev})
+	u := newWebUser(webUserOpts{
+		name:    user,
+		webID:   webID,
+		devices: []*types.MFADevice{dev},
+	})
 
 	// Fetch the previously-stored SessionData, so it's checked against the user
 	// response.

--- a/lib/auth/webauthn/login_test.go
+++ b/lib/auth/webauthn/login_test.go
@@ -1018,6 +1018,74 @@ func TestLoginFlow_userVerification(t *testing.T) {
 	}
 }
 
+func TestCredentialBackupFlags(t *testing.T) {
+	t.Parallel()
+
+	key, err := mocku2f.Create()
+	require.NoError(t, err, "Create failed")
+	key.SetPasswordless()
+	key.SetBackupFlags = true // BE=1 and BS=1
+
+	const user = "llama"
+	const origin = "https://example.com"
+	webIdentity := newFakeIdentity(user)
+	webConfig := &types.Webauthn{RPID: "example.com"}
+	ctx := context.Background()
+
+	t.Run("register", func(t *testing.T) {
+		rf := &wanlib.RegistrationFlow{
+			Webauthn: webConfig,
+			Identity: webIdentity,
+		}
+		cc, err := rf.Begin(ctx, user, true /* passwordless */)
+		require.NoError(t, err, "Begin failed")
+		ccr, err := key.SignCredentialCreation(origin, cc)
+		require.NoError(t, err, "SignCredentialCreation failed")
+		_, err = rf.Finish(ctx, wanlib.RegisterResponse{
+			User:             user,
+			DeviceName:       "mydevice",
+			CreationResponse: ccr,
+			Passwordless:     true,
+		})
+		require.NoError(t, err, "SignCredentialCreation failed")
+	})
+
+	// Erase BE/BS from storage device. Simulates a legacy device.
+	require.Len(t,
+		webIdentity.UpdatedDevices, 1,
+		"Unexpected number of registered devices, aborting test",
+	)
+	webIdentity.UpdatedDevices[0].GetWebauthn().CredentialBackupEligible = nil
+	webIdentity.UpdatedDevices[0].GetWebauthn().CredentialBackedUp = nil
+
+	lf := &wanlib.PasswordlessFlow{
+		Webauthn: webConfig,
+		Identity: webIdentity,
+	}
+
+	t.Run("login legacy", func(t *testing.T) {
+		assertion, err := lf.Begin(ctx)
+		require.NoError(t, err, "Begin")
+		assertionResp, err := key.SignAssertion(origin, assertion)
+		require.NoError(t, err, "SignAssertion failed")
+
+		// Sanity check BE/BS in the authenticator response.
+		var ad protocol.AuthenticatorData
+		require.NoError(t,
+			ad.Unmarshal(assertionResp.AssertionResponse.AuthenticatorData),
+			"AuthenticatorData.Unmarshal failed",
+		)
+		require.True(t,
+			ad.Flags.HasBackupEligible() && ad.Flags.HasBackupState(),
+			"AuthenticatorData BE or BS flags not true",
+			ad.Flags.HasBackupEligible(),
+			ad.Flags.HasBackupState())
+
+		_, err = lf.Finish(ctx, assertionResp)
+		require.NoError(t, err, "Finish failed")
+	})
+}
+
 type fakeIdentity struct {
 	User *types.UserV2
 	// MappedUser is used as the reply to GetTeleportUserByWebauthnID.

--- a/lib/auth/webauthn/login_test.go
+++ b/lib/auth/webauthn/login_test.go
@@ -1059,7 +1059,7 @@ func TestCredentialBackupFlags(t *testing.T) {
 			CreationResponse: ccr,
 			Passwordless:     true,
 		})
-		require.NoError(t, err, "SignCredentialCreation failed")
+		require.NoError(t, err, "Finish failed")
 
 		// Assert backup flags after registration.
 		assertBackupFlags(t, mfaDev, true /* wantBE */, true /* wantBS */)

--- a/lib/auth/webauthn/register.go
+++ b/lib/auth/webauthn/register.go
@@ -174,7 +174,11 @@ func (f *RegistrationFlow) Begin(ctx context.Context, user string, passwordless 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	u := newWebUser(user, webID, true /* credentialIDOnly */, nil /* devices */)
+	u := newWebUser(webUserOpts{
+		name:             user,
+		webID:            webID,
+		credentialIDOnly: true,
+	})
 
 	web, err := newWebAuthn(webAuthnParams{
 		cfg:                     f.Webauthn,
@@ -282,7 +286,11 @@ func (f *RegistrationFlow) Finish(ctx context.Context, req RegisterResponse) (*t
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	u := newWebUser(req.User, wla.UserID, true /* credentialIDOnly */, nil /* devices */)
+	u := newWebUser(webUserOpts{
+		name:             req.User,
+		webID:            wla.UserID,
+		credentialIDOnly: true,
+	})
 
 	sd, err := f.Identity.GetWebauthnSessionData(ctx, req.User, scopeSession)
 	if err != nil {

--- a/lib/auth/webauthn/register.go
+++ b/lib/auth/webauthn/register.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/go-webauthn/webauthn/protocol"
 	wan "github.com/go-webauthn/webauthn/webauthn"
+	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
@@ -160,7 +161,7 @@ func (f *RegistrationFlow) Begin(ctx context.Context, user string, passwordless 
 			continue
 		}
 
-		cred, ok := deviceToCredential(dev, true /* idOnly */)
+		cred, ok := deviceToCredential(dev, true /* idOnly */, nil /* currentFlags */)
 		if !ok {
 			continue
 		}
@@ -348,6 +349,12 @@ func (f *RegistrationFlow) Finish(ctx context.Context, req RegisterResponse) (*t
 			AttestationObject: req.CreationResponse.AttestationResponse.AttestationObject,
 			ResidentKey:       req.Passwordless,
 			CredentialRpId:    f.Webauthn.RPID,
+			CredentialBackupEligible: &gogotypes.BoolValue{
+				Value: credential.Flags.BackupEligible,
+			},
+			CredentialBackedUp: &gogotypes.BoolValue{
+				Value: credential.Flags.BackupState,
+			},
 		},
 	}
 	// We delegate a few checks to identity, including:

--- a/lib/auth/webauthn/register_test.go
+++ b/lib/auth/webauthn/register_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/go-webauthn/webauthn/protocol"
+	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -118,14 +119,16 @@ func TestRegistrationFlow_BeginFinish(t *testing.T) {
 			require.NotNil(t, gotDevice)
 			require.NotEmpty(t, gotDevice.PublicKeyCbor) // validated indirectly via authentication
 			wantDevice := &types.WebauthnDevice{
-				CredentialId:      dev.KeyHandle,
-				PublicKeyCbor:     gotDevice.PublicKeyCbor,
-				AttestationType:   gotDevice.AttestationType,
-				Aaguid:            make([]byte, 16), // 16 zeroes
-				SignatureCounter:  0,
-				AttestationObject: ccr.AttestationResponse.AttestationObject,
-				ResidentKey:       test.wantResidentKey,
-				CredentialRpId:    rpID,
+				CredentialId:             dev.KeyHandle,
+				PublicKeyCbor:            gotDevice.PublicKeyCbor,
+				AttestationType:          gotDevice.AttestationType,
+				Aaguid:                   make([]byte, 16), // 16 zeroes
+				SignatureCounter:         0,
+				AttestationObject:        ccr.AttestationResponse.AttestationObject,
+				ResidentKey:              test.wantResidentKey,
+				CredentialRpId:           rpID,
+				CredentialBackupEligible: &gogotypes.BoolValue{Value: false},
+				CredentialBackedUp:       &gogotypes.BoolValue{Value: false},
 			}
 			if diff := cmp.Diff(wantDevice, gotDevice); diff != "" {
 				t.Errorf("Finish() mismatch (-want +got):\n%s", diff)

--- a/lib/auth/webauthn/user.go
+++ b/lib/auth/webauthn/user.go
@@ -38,12 +38,13 @@ type webUserOpts struct {
 	webID            []byte
 	devices          []*types.MFADevice
 	credentialIDOnly bool
+	currentFlags     *credentialFlags
 }
 
 func newWebUser(opts webUserOpts) *webUser {
 	var credentials []wan.Credential
 	for _, dev := range opts.devices {
-		c, ok := deviceToCredential(dev, opts.credentialIDOnly)
+		c, ok := deviceToCredential(dev, opts.credentialIDOnly, opts.currentFlags)
 		if ok {
 			credentials = append(credentials, c)
 		}

--- a/lib/auth/webauthn/user.go
+++ b/lib/auth/webauthn/user.go
@@ -33,18 +33,25 @@ type webUser struct {
 	webID       []byte
 }
 
-func newWebUser(name string, webID []byte, credentialIDOnly bool, devices []*types.MFADevice) *webUser {
+type webUserOpts struct {
+	name             string
+	webID            []byte
+	devices          []*types.MFADevice
+	credentialIDOnly bool
+}
+
+func newWebUser(opts webUserOpts) *webUser {
 	var credentials []wan.Credential
-	for _, dev := range devices {
-		c, ok := deviceToCredential(dev, credentialIDOnly)
+	for _, dev := range opts.devices {
+		c, ok := deviceToCredential(dev, opts.credentialIDOnly)
 		if ok {
 			credentials = append(credentials, c)
 		}
 	}
 	return &webUser{
 		credentials: credentials,
-		name:        name,
-		webID:       webID,
+		name:        opts.name,
+		webID:       opts.webID,
 	}
 }
 


### PR DESCRIPTION
Record/backfill authenticator Backup Eligible and Backup State flags.

Partly feature, partly fix for #45029. Fixes "BackupEligible flag inconsistency detected during login validation" errors from go-webauthn/webauthn.

- https://w3c.github.io/webauthn/#authdata-flags-be
- https://w3c.github.io/webauthn/#authdata-flags-bs

Changelog: Record WebAuthn authenticator BE/BS flags.