### PR TITLE
Fix terraform provider reference index

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -59,6 +59,7 @@ jobs:
               - 'integrations/terraform/examples/**'
               - 'integrations/terraform/templates/**'
               # rendered doc changes
+              - 'docs/pages/reference/terraform-provider.mdx'
               - 'docs/pages/reference/terraform-provider/**'
 
   lint-go:

--- a/integrations/terraform/templates/index.md.tmpl
+++ b/integrations/terraform/templates/index.md.tmpl
@@ -14,9 +14,9 @@ It lists all the supported resources and their fields.
 
 <Admonition type="tip">
 To get started with the Terraform provider, you must start with [the installation
-guide](../management/dynamic-resources/terraform-provider.mdx).
+guide](../admin-guides/infrastructure-as-code/terraform-provider.mdx).
 Once you got a working provider, we recommend you to follow the
-["Managing users and roles with IaC"](../management/dynamic-resources/user-and-role.mdx) guide.
+["Managing users and roles with IaC"](../admin-guides/infrastructure-as-code/user-and-role.mdx) guide.
 </Admonition>
 
 The provider exposes Teleport resources both as Terraform data-sources and Terraform resources.
@@ -62,7 +62,7 @@ Tbot relies on [MachineID](../enroll-resources/machine-id/introduction.mdx) to o
 Such credentials are harder to exfiltrate, and you can control more precisely who has access to which roles
 (e.g. you can allow only GitHub Actions pipelines targeting the `prod` environment to get certificates).
 
-You can follow [the Terraform Provider guide](../management/dynamic-resources/terraform-provider.mdx) to achieve this setup.
+You can follow [the Terraform Provider guide](../admin-guides/infrastructure-as-code/terraform-provider.mdx) to achieve this setup.
 
 #### Obtaining an identity file via `tctl auth sign`
 
@@ -76,7 +76,7 @@ This auth method has the following limitations:
 - Such credentials are high-privileged and long-lived. They must be protected and rotated.
 - This auth method does not work against Teleport clusters with MFA set to `webauthn`.
   On such clusters, Teleport will reject any long-lived certificate and require
-  [an additional MFA challenge for administrative actions](../access-controls/guides/mfa-for-admin-actions.mdx).
+  [an additional MFA challenge for administrative actions](../admin-guides/access-controls/guides/mfa-for-admin-actions.mdx).
 
 ### With key, certificate, and CA certificate
 
@@ -92,7 +92,7 @@ This auth method has the following limitations:
 - Such credentials are high-privileged and long-lived. They must be protected and rotated.
 - This auth method does not work against Teleport clusters with MFA set to `webauthn`.
   On such clusters, Teleport will reject any long-lived certificate and require
-  [an additional MFA challenge for administrative actions](../access-controls/guides/mfa-for-admin-actions.mdx).
+  [an additional MFA challenge for administrative actions](../admin-guides/access-controls/guides/mfa-for-admin-actions.mdx).
 
 {{ .SchemaMarkdown | trimspace }}
 


### PR DESCRIPTION
This PR reconciles the manually edited TF provider doc file with its template.

It also fixes the root cause: the CI checked TF docs rendering if a resource file is edited, but not if the index is edited.