### PR TITLE
[v16] docs: update device trust macos tsh version

### DIFF
--- a/docs/pages/includes/device-trust/prereqs.mdx
+++ b/docs/pages/includes/device-trust/prereqs.mdx
@@ -1,5 +1,5 @@
 - To enroll a macOS device, you need:
-  - A signed and notarized `tsh` binary, v12.0.0 or newer.
+  - A signed and notarized `tsh` binary.
     [Download the macOS tsh installer](../../installation.mdx#macos).
 - To enroll a Windows device, you need:
   - A device with TPM 2.0.


### PR DESCRIPTION
Backport #45170 to branch/v16