### PR TITLE
[v15] Fixed typo in Google Cloud KMS documentation.

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/gcp-kms.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/gcp-kms.mdx
@@ -211,7 +211,7 @@ auth_service:
   # ...
   ca_key_params:
     gcp_kms:
-      keyring: "projects/<your-gcp-project>/locations/<location>/keyRing/<your-teleport-keyring>"
+      keyring: "projects/<your-gcp-project>/locations/<location>/keyRings/<your-teleport-keyring>"
       protection_level: "SOFTWARE"
 ```
 


### PR DESCRIPTION
Backport #45089 to branch/v15