### PR TITLE
[v15] Eliminate `services.Services` interface and `XXXClient()` methods on `auth.Services` (#45058)

### DIFF
--- a/lib/auth/access.go
+++ b/lib/auth/access.go
@@ -142,7 +142,7 @@ func (a *Server) DeleteRole(ctx context.Context, name string) error {
 	for {
 		var accessLists []*accesslist.AccessList
 		var err error
-		accessLists, nextToken, err = a.Services.AccessListClient().ListAccessLists(ctx, 0 /* default page size */, nextToken)
+		accessLists, nextToken, err = a.Services.AccessLists.ListAccessLists(ctx, 0 /* default page size */, nextToken)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/auth/accesspoint/accesspoint.go
+++ b/lib/auth/accesspoint/accesspoint.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// package accesspoint provides helpers for configuring caches in the context of
+// Package accesspoint provides helpers for configuring caches in the context of
 // setting up service-level auth access points. this logic has been moved out of
 // lib/service in order to facilitate better testing practices.
 package accesspoint
@@ -31,6 +31,7 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/cache"
@@ -38,22 +39,19 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
-// AccessCacheConfig holds parameters used to confiure a cache to
+// Config holds parameters used to configure a cache to
 // serve as an auth access point for a teleport service.
-type AccessCacheConfig struct {
+type Config struct {
 	// Context is the base context used to propagate closure to
 	// cache components.
 	Context context.Context
-	// Services is a collection of upstream services from which
-	// the access cache will derive its state.
-	Services services.Services
 	// Setup is a function that takes cache configuration and
 	// modifies it to support a specific teleport service.
 	Setup cache.SetupConfigFn
 	// CacheName identifies the cache in logs.
 	CacheName []string
-	// Events is true if cache should have the events system enabled.
-	Events bool
+	// EventsSystem is true if cache should have the events system enabled.
+	EventsSystem bool
 	// Unstarted is true if the cache should not be started.
 	Unstarted bool
 	// MaxRetryPeriod is the max retry period between connection attempts
@@ -65,12 +63,45 @@ type AccessCacheConfig struct {
 	// TracingProvider is the provider to be used for exporting
 	// traces. No-op tracers will be used if no provider is set.
 	TracingProvider *tracing.Provider
+
+	// The following services are provided to the Cache to allow it to
+	// populate its resource collections. They will either be the local service
+	// directly or a client that can be used to fetch the resources from the
+	// remote service.
+
+	Access                  services.Access
+	AccessLists             services.AccessLists
+	AccessMonitoringRules   services.AccessMonitoringRules
+	AppSession              services.AppSession
+	Apps                    services.Apps
+	ClusterConfig           services.ClusterConfiguration
+	CrownJewels             services.CrownJewels
+	DatabaseServices        services.DatabaseServices
+	Databases               services.Databases
+	DiscoveryConfigs        services.DiscoveryConfigs
+	DynamicAccess           services.DynamicAccessCore
+	Events                  types.Events
+	Integrations            services.Integrations
+	KubeWaitingContainers   services.KubeWaitingContainer
+	Kubernetes              services.Kubernetes
+	Okta                    services.Okta
+	Presence                services.Presence
+	Provisioner             services.Provisioner
+	Restrictions            services.Restrictions
+	SAMLIdPServiceProviders services.SAMLIdPServiceProviders
+	SAMLIdPSession          services.SAMLIdPSession
+	SecReports              services.SecReports
+	SnowflakeSession        services.SnowflakeSession
+	Trust                   services.Trust
+	UserGroups              services.UserGroups
+	UserLoginStates         services.UserLoginStates
+	Users                   services.UsersService
+	WebSession              types.WebSessionInterface
+	WebToken                types.WebTokenInterface
+	WindowsDesktops         services.WindowsDesktops
 }
 
-func (c *AccessCacheConfig) CheckAndSetDefaults() error {
-	if c.Services == nil {
-		return trace.BadParameter("missing parameter Services")
-	}
+func (c *Config) CheckAndSetDefaults() error {
 	if c.Setup == nil {
 		return trace.BadParameter("missing parameter Setup")
 	}
@@ -83,16 +114,14 @@ func (c *AccessCacheConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
-// NewAccessCache builds a cache.Cache instance for a teleport service. This logic has been
-// broken out of lib/service in order to support easier unit testing of process components.
-func NewAccessCache(cfg AccessCacheConfig) (*cache.Cache, error) {
+func NewCache(cfg Config) (*cache.Cache, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	log.Debugf("Creating in-memory backend for %v.", cfg.CacheName)
 	mem, err := memory.New(memory.Config{
 		Context:   cfg.Context,
-		EventsOff: !cfg.Events,
+		EventsOff: !cfg.EventsSystem,
 		Mirror:    true,
 	})
 	if err != nil {
@@ -119,43 +148,46 @@ func NewAccessCache(cfg AccessCacheConfig) (*cache.Cache, error) {
 	component = append(component, teleport.ComponentCache)
 	metricComponent := append(slices.Clone(cfg.CacheName), teleport.ComponentCache)
 
-	return cache.New(cfg.Setup(cache.Config{
-		Context:                 cfg.Context,
-		Backend:                 reporter,
-		Events:                  cfg.Services,
-		ClusterConfig:           cfg.Services,
-		Provisioner:             cfg.Services,
-		Trust:                   cfg.Services,
-		Users:                   cfg.Services,
-		Access:                  cfg.Services,
-		DynamicAccess:           cfg.Services,
-		Presence:                cfg.Services,
-		Restrictions:            cfg.Services,
-		Apps:                    cfg.Services,
-		Kubernetes:              cfg.Services,
-		CrownJewels:             cfg.Services.CrownJewelClient(),
-		DatabaseServices:        cfg.Services,
-		Databases:               cfg.Services,
-		AppSession:              cfg.Services,
-		SnowflakeSession:        cfg.Services,
-		SAMLIdPSession:          cfg.Services,
-		WindowsDesktops:         cfg.Services,
-		SAMLIdPServiceProviders: cfg.Services,
-		UserGroups:              cfg.Services,
-		Okta:                    cfg.Services.OktaClient(),
-		AccessLists:             cfg.Services.AccessListClient(),
-		AccessMonitoringRules:   cfg.Services.AccessMonitoringRuleClient(),
-		SecReports:              cfg.Services.SecReportsClient(),
-		UserLoginStates:         cfg.Services.UserLoginStateClient(),
-		Integrations:            cfg.Services,
-		DiscoveryConfigs:        cfg.Services.DiscoveryConfigClient(),
-		WebSession:              cfg.Services.WebSessions(),
-		WebToken:                cfg.Services.WebTokens(),
-		KubeWaitingContainers:   cfg.Services,
-		Component:               teleport.Component(component...),
-		MetricComponent:         teleport.Component(metricComponent...),
-		Tracer:                  tracer,
-		MaxRetryPeriod:          cfg.MaxRetryPeriod,
-		Unstarted:               cfg.Unstarted,
-	}))
+	cacheCfg := &cache.Config{
+		Context:         cfg.Context,
+		Backend:         reporter,
+		Component:       teleport.Component(component...),
+		MetricComponent: teleport.Component(metricComponent...),
+		Tracer:          tracer,
+		MaxRetryPeriod:  cfg.MaxRetryPeriod,
+		Unstarted:       cfg.Unstarted,
+
+		Access:                  cfg.Access,
+		AccessLists:             cfg.AccessLists,
+		AccessMonitoringRules:   cfg.AccessMonitoringRules,
+		AppSession:              cfg.AppSession,
+		Apps:                    cfg.Apps,
+		ClusterConfig:           cfg.ClusterConfig,
+		CrownJewels:             cfg.CrownJewels,
+		DatabaseServices:        cfg.DatabaseServices,
+		Databases:               cfg.Databases,
+		DiscoveryConfigs:        cfg.DiscoveryConfigs,
+		DynamicAccess:           cfg.DynamicAccess,
+		Events:                  cfg.Events,
+		Integrations:            cfg.Integrations,
+		KubeWaitingContainers:   cfg.KubeWaitingContainers,
+		Kubernetes:              cfg.Kubernetes,
+		Okta:                    cfg.Okta,
+		Presence:                cfg.Presence,
+		Provisioner:             cfg.Provisioner,
+		Restrictions:            cfg.Restrictions,
+		SAMLIdPServiceProviders: cfg.SAMLIdPServiceProviders,
+		SAMLIdPSession:          cfg.SAMLIdPSession,
+		SecReports:              cfg.SecReports,
+		SnowflakeSession:        cfg.SnowflakeSession,
+		Trust:                   cfg.Trust,
+		UserGroups:              cfg.UserGroups,
+		UserLoginStates:         cfg.UserLoginStates,
+		Users:                   cfg.Users,
+		WebSession:              cfg.WebSession,
+		WebToken:                cfg.WebToken,
+		WindowsDesktops:         cfg.WindowsDesktops,
+	}
+
+	return cache.New(cfg.Setup(*cacheCfg))
 }

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -61,7 +61,6 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/client/secreport"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/gen/proto/go/assist/v1"
@@ -574,6 +573,11 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 	return &as, nil
 }
 
+// Services is a collection of services that are used by the auth server.
+// Avoid using this type as a dependency and instead depend on the actual
+// methods/services you need. It should really only be necessary to directly
+// reference this type on auth.Server itself and on code that manages
+// the lifecycle of the auth server.
 type Services struct {
 	services.TrustInternal
 	services.PresenceInternal
@@ -616,11 +620,6 @@ type Services struct {
 	services.CrownJewels
 }
 
-// SecReportsClient returns the security reports client.
-func (r *Services) SecReportsClient() *secreport.Client {
-	return nil
-}
-
 // GetWebSession returns existing web session described by req.
 // Implements ReadAccessPoint
 func (r *Services) GetWebSession(ctx context.Context, req types.GetWebSessionRequest) (types.WebSession, error) {
@@ -636,49 +635,6 @@ func (r *Services) GetWebToken(ctx context.Context, req types.GetWebTokenRequest
 // GenerateAWSOIDCToken generates a token to be used to execute an AWS OIDC Integration action.
 func (r *Services) GenerateAWSOIDCToken(ctx context.Context, integration string) (string, error) {
 	return r.IntegrationsTokenGenerator.GenerateAWSOIDCToken(ctx, integration)
-}
-
-// OktaClient returns the okta client.
-func (r *Services) OktaClient() services.Okta {
-	return r
-}
-
-// SCIMClient returns a client for the SCIM service. Note that in an OSS
-// Teleport cluster, or an Enterprise cluster with IGS disabled, the SCIM
-// service on the other end will return "NotImplemented" for every call.
-func (r *Services) SCIMClient() services.SCIM {
-	return r.SCIM
-}
-
-// AccessListClient returns the access list client.
-func (r *Services) AccessListClient() services.AccessLists {
-	return r
-}
-
-// AccessMonitoringRuleClient returns the access monitoring rules client.
-func (r *Services) AccessMonitoringRuleClient() services.AccessMonitoringRules {
-	return r
-}
-
-// DiscoveryConfigClient returns the DiscoveryConfig client.
-func (r *Services) DiscoveryConfigClient() services.DiscoveryConfigs {
-	return r
-}
-
-// CrownJewelClient returns the CrownJewels client.
-func (r *Services) CrownJewelClient() services.CrownJewels {
-	return r
-}
-
-// UserLoginStateClient returns the user login state client.
-func (r *Services) UserLoginStateClient() services.UserLoginStates {
-	return r
-}
-
-// KubernetesWaitingContainerClient returns the Kubernetes waiting
-// container client.
-func (r *Services) KubernetesWaitingContainerClient() services.KubeWaitingContainer {
-	return r
 }
 
 var (
@@ -4777,7 +4733,7 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 	if req.GetDryRun() {
 		_, promotions := a.generateAccessRequestPromotions(ctx, req)
 		// update the request with additional reviewers if possible.
-		updateAccessRequestWithAdditionalReviewers(ctx, req, a.AccessListClient(), promotions)
+		updateAccessRequestWithAdditionalReviewers(ctx, req, a.AccessLists, promotions)
 		// Made it this far with no errors, return before creating the request
 		// if this is a dry run.
 		return req, nil

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -323,13 +323,44 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 	srv.AuthServer.bcryptCostOverride = &minCost
 
 	if cfg.CacheEnabled {
-		srv.AuthServer.Cache, err = accesspoint.NewAccessCache(accesspoint.AccessCacheConfig{
-			Context:   srv.AuthServer.CloseContext(),
-			Services:  srv.AuthServer.Services,
-			Setup:     cache.ForAuth,
-			CacheName: []string{teleport.ComponentAuth},
-			Events:    true,
-			Unstarted: true,
+		svces := srv.AuthServer.Services
+		srv.AuthServer.Cache, err = accesspoint.NewCache(accesspoint.Config{
+			Context:      srv.AuthServer.CloseContext(),
+			Setup:        cache.ForAuth,
+			CacheName:    []string{teleport.ComponentAuth},
+			EventsSystem: true,
+			Unstarted:    true,
+
+			Access:                  svces.Access,
+			AccessLists:             svces.AccessLists,
+			AccessMonitoringRules:   svces.AccessMonitoringRules,
+			AppSession:              svces.Identity,
+			Apps:                    svces.Apps,
+			ClusterConfig:           svces.ClusterConfiguration,
+			CrownJewels:             svces.CrownJewels,
+			DatabaseServices:        svces.DatabaseServices,
+			Databases:               svces.Databases,
+			DiscoveryConfigs:        svces.DiscoveryConfigs,
+			DynamicAccess:           svces.DynamicAccessExt,
+			Events:                  svces.Events,
+			Integrations:            svces.Integrations,
+			KubeWaitingContainers:   svces.KubeWaitingContainer,
+			Kubernetes:              svces.Kubernetes,
+			Okta:                    svces.Okta,
+			Presence:                svces.PresenceInternal,
+			Provisioner:             svces.Provisioner,
+			Restrictions:            svces.Restrictions,
+			SAMLIdPServiceProviders: svces.SAMLIdPServiceProviders,
+			SAMLIdPSession:          svces.Identity,
+			SecReports:              svces.SecReports,
+			SnowflakeSession:        svces.Identity,
+			Trust:                   svces.TrustInternal,
+			UserGroups:              svces.UserGroups,
+			UserLoginStates:         svces.UserLoginStates,
+			Users:                   svces.Identity,
+			WebSession:              svces.Identity.WebSessions(),
+			WebToken:                svces.WebTokens(),
+			WindowsDesktops:         svces.WindowsDesktops,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2039,13 +2039,12 @@ func (process *TeleportProcess) initAuthService() error {
 				return nil
 			}
 
-			cache, err := process.newAccessCache(accesspoint.AccessCacheConfig{
-				Services:  as.Services,
-				Setup:     cache.ForAuth,
-				CacheName: []string{teleport.ComponentAuth},
-				Events:    true,
-				Unstarted: true,
-			})
+			cache, err := process.newAccessCacheForServices(accesspoint.Config{
+				Setup:        cache.ForAuth,
+				CacheName:    []string{teleport.ComponentAuth},
+				EventsSystem: true,
+				Unstarted:    true,
+			}, as.Services)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -2461,13 +2460,84 @@ func (process *TeleportProcess) OnExit(serviceName string, callback func(interfa
 }
 
 // newAccessCache returns new local cache access point
-func (process *TeleportProcess) newAccessCache(cfg accesspoint.AccessCacheConfig) (*cache.Cache, error) {
+func (process *TeleportProcess) newAccessCacheForServices(cfg accesspoint.Config, services *auth.Services) (*cache.Cache, error) {
 	cfg.Context = process.ExitContext()
 	cfg.ProcessID = process.id
 	cfg.TracingProvider = process.TracingProvider
 	cfg.MaxRetryPeriod = process.Config.CachePolicy.MaxRetryPeriod
 
-	return accesspoint.NewAccessCache(cfg)
+	cfg.Access = services.Access
+	cfg.AccessLists = services.AccessLists
+	cfg.AccessMonitoringRules = services.AccessMonitoringRules
+	cfg.AppSession = services.Identity
+	cfg.Apps = services.Apps
+	cfg.ClusterConfig = services.ClusterConfiguration
+	cfg.CrownJewels = services.CrownJewels
+	cfg.DatabaseServices = services.DatabaseServices
+	cfg.Databases = services.Databases
+	cfg.DiscoveryConfigs = services.DiscoveryConfigs
+	cfg.DynamicAccess = services.DynamicAccessExt
+	cfg.Events = services.Events
+	cfg.Integrations = services.Integrations
+	cfg.KubeWaitingContainers = services.KubeWaitingContainer
+	cfg.Kubernetes = services.Kubernetes
+	cfg.Okta = services.Okta
+	cfg.Presence = services.PresenceInternal
+	cfg.Provisioner = services.Provisioner
+	cfg.Restrictions = services.Restrictions
+	cfg.SAMLIdPServiceProviders = services.SAMLIdPServiceProviders
+	cfg.SAMLIdPSession = services.Identity
+	cfg.SecReports = services.SecReports
+	cfg.SnowflakeSession = services.Identity
+	cfg.Trust = services.TrustInternal
+	cfg.UserGroups = services.UserGroups
+	cfg.UserLoginStates = services.UserLoginStates
+	cfg.Users = services.Identity
+	cfg.WebSession = services.Identity.WebSessions()
+	cfg.WebToken = services.Identity.WebTokens()
+	cfg.WindowsDesktops = services.WindowsDesktops
+
+	return accesspoint.NewCache(cfg)
+}
+
+func (process *TeleportProcess) newAccessCacheForClient(cfg accesspoint.Config, client authclient.ClientI) (*cache.Cache, error) {
+	cfg.Context = process.ExitContext()
+	cfg.ProcessID = process.id
+	cfg.TracingProvider = process.TracingProvider
+	cfg.MaxRetryPeriod = process.Config.CachePolicy.MaxRetryPeriod
+
+	cfg.Access = client
+	cfg.AccessLists = client.AccessListClient()
+	cfg.AccessMonitoringRules = client.AccessMonitoringRuleClient()
+	cfg.AppSession = client
+	cfg.Apps = client
+	cfg.ClusterConfig = client
+	cfg.CrownJewels = client.CrownJewelServiceClient()
+	cfg.DatabaseServices = client
+	cfg.Databases = client
+	cfg.DiscoveryConfigs = client.DiscoveryConfigClient()
+	cfg.DynamicAccess = client
+	cfg.Events = client
+	cfg.Integrations = client
+	cfg.KubeWaitingContainers = client
+	cfg.Kubernetes = client
+	cfg.Okta = client.OktaClient()
+	cfg.Presence = client
+	cfg.Provisioner = client
+	cfg.Restrictions = client
+	cfg.SAMLIdPServiceProviders = client
+	cfg.SAMLIdPSession = client
+	cfg.SecReports = client.SecReportsClient()
+	cfg.SnowflakeSession = client
+	cfg.Trust = client
+	cfg.UserGroups = client
+	cfg.UserLoginStates = client.UserLoginStateClient()
+	cfg.Users = client
+	cfg.WebSession = client.WebSessions()
+	cfg.WebToken = client.WebTokens()
+	cfg.WindowsDesktops = client
+
+	return accesspoint.NewCache(cfg)
 }
 
 // newLocalCacheForNode returns new instance of access point configured for a local proxy.
@@ -2628,29 +2698,12 @@ func (process *TeleportProcess) newLocalCacheForWindowsDesktop(clt authclient.Cl
 	return authclient.NewWindowsDesktopWrapper(clt, cache), nil
 }
 
-// accessPointWrapper is a wrapper around auth.ClientI that reduces the surface area of the
-// auth.ClientI.DiscoveryConfigClient interface to services.DiscoveryConfigs.
-// Cache doesn't implement the full auth.ClientI interface, so we need to wrap auth.ClientI
-// to make it compatible with the services.DiscoveryConfigs interface.
-type accessPointWrapper struct {
-	authclient.ClientI
-}
-
-func (a accessPointWrapper) CrownJewelClient() services.CrownJewels {
-	return a.ClientI.CrownJewelServiceClient()
-}
-
-func (a accessPointWrapper) DiscoveryConfigClient() services.DiscoveryConfigs {
-	return a.ClientI.DiscoveryConfigClient()
-}
-
 // NewLocalCache returns new instance of access point
 func (process *TeleportProcess) NewLocalCache(clt authclient.ClientI, setupConfig cache.SetupConfigFn, cacheName []string) (*cache.Cache, error) {
-	return process.newAccessCache(accesspoint.AccessCacheConfig{
-		Services:  &accessPointWrapper{ClientI: clt},
+	return process.newAccessCacheForClient(accesspoint.Config{
 		Setup:     setupConfig,
 		CacheName: cacheName,
-	})
+	}, clt)
 }
 
 // GetRotation returns the process rotation.

--- a/lib/services/services.go
+++ b/lib/services/services.go
@@ -19,44 +19,8 @@
 package services
 
 import (
-	"github.com/gravitational/teleport/api/client/secreport"
 	"github.com/gravitational/teleport/api/types"
 )
-
-// Services collects all services
-type Services interface {
-	UsersService
-	Provisioner
-	Trust
-	types.Events
-	ClusterConfiguration
-	Access
-	DynamicAccessCore
-	Presence
-	Restrictions
-	Apps
-	Databases
-	DatabaseServices
-	Kubernetes
-	AppSession
-	SnowflakeSession
-	SAMLIdPSession
-	types.WebSessionsGetter
-	types.WebTokensGetter
-	WindowsDesktops
-	SAMLIdPServiceProviders
-	UserGroups
-	Integrations
-	KubeWaitingContainer
-
-	OktaClient() Okta
-	AccessListClient() AccessLists
-	AccessMonitoringRuleClient() AccessMonitoringRules
-	UserLoginStateClient() UserLoginStates
-	DiscoveryConfigClient() DiscoveryConfigs
-	SecReportsClient() *secreport.Client
-	CrownJewelClient() CrownJewels
-}
 
 // RotationGetter returns the rotation state.
 type RotationGetter func(role types.SystemRole) (*types.Rotation, error)

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -578,7 +578,7 @@ func TestDiscoveryServer(t *testing.T) {
 			tc.emitter.t = t
 
 			if tc.discoveryConfig != nil {
-				_, err := tlsServer.Auth().DiscoveryConfigClient().CreateDiscoveryConfig(ctx, tc.discoveryConfig)
+				_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, tc.discoveryConfig)
 				require.NoError(t, err)
 			}
 
@@ -1956,7 +1956,7 @@ func TestDiscoveryDatabase(t *testing.T) {
 			// Add Dynamic Matchers and wait for reconcile again
 			if tc.discoveryConfigs != nil {
 				for _, dc := range tc.discoveryConfigs(t) {
-					_, err := tlsServer.Auth().DiscoveryConfigClient().CreateDiscoveryConfig(ctx, dc)
+					_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, dc)
 					require.NoError(t, err)
 				}
 
@@ -2081,7 +2081,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		_, err = tlsServer.Auth().DiscoveryConfigClient().CreateDiscoveryConfig(ctx, dc1)
+		_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, dc1)
 		require.NoError(t, err)
 
 		actualDatabases, err := tlsServer.Auth().GetDatabases(ctx)
@@ -2107,7 +2107,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Zero(t, reporter.DiscoveryFetchEventCount())
-		_, err = tlsServer.Auth().DiscoveryConfigClient().CreateDiscoveryConfig(ctx, dc1)
+		_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, dc1)
 		require.NoError(t, err)
 
 		// Check for new resource in reconciler
@@ -2137,7 +2137,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 
 		t.Run("removing the DiscoveryConfig: fetcher is removed and database is removed", func(t *testing.T) {
 			// Remove DiscoveryConfig
-			err = tlsServer.Auth().DiscoveryConfigClient().DeleteDiscoveryConfig(ctx, dc1.GetName())
+			err = tlsServer.Auth().DiscoveryConfigs.DeleteDiscoveryConfig(ctx, dc1.GetName())
 			require.NoError(t, err)
 
 			currentEmittedEvents := reporter.DiscoveryFetchEventCount()
@@ -2489,7 +2489,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 			emitter.t = t
 
 			if tc.discoveryConfig != nil {
-				_, err := tlsServer.Auth().DiscoveryConfigClient().CreateDiscoveryConfig(ctx, tc.discoveryConfig)
+				_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, tc.discoveryConfig)
 				require.NoError(t, err)
 
 				// Wait for the DiscoveryConfig to be added to the dynamic matchers
@@ -2754,7 +2754,7 @@ func TestGCPVMDiscovery(t *testing.T) {
 			emitter.t = t
 
 			if tc.discoveryConfig != nil {
-				_, err := tlsServer.Auth().DiscoveryConfigClient().CreateDiscoveryConfig(ctx, tc.discoveryConfig)
+				_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, tc.discoveryConfig)
 				require.NoError(t, err)
 
 				// Wait for the DiscoveryConfig to be added to the dynamic matchers

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -458,7 +458,7 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 
 			if tc.discoveryConfig != nil {
 				dc := tc.discoveryConfig(t)
-				_, err := tlsServer.Auth().DiscoveryConfigClient().CreateDiscoveryConfig(ctx, dc)
+				_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, dc)
 				require.NoError(t, err)
 
 				// Wait for the DiscoveryConfig to be added to the dynamic fetchers


### PR DESCRIPTION
Backports #45058