### PR TITLE
[v16] chore: Bump Go to v1.22.6

### DIFF
--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,8 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.22.0
-
-toolchain go1.22.5
+go 1.22.6
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.22.5
+GOLANG_VERSION ?= go1.22.6
 GOLANGCI_LINT_VERSION ?= v1.59.1
 
 NODE_VERSION ?= 20.14.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.22.0
-
-toolchain go1.22.5
+go 1.22.6
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.9.0

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,8 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.22.0
-
-toolchain go1.22.5
+go 1.22.6
 
 require (
 	github.com/alecthomas/kong v0.9.0

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,8 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.22.0
-
-toolchain go1.22.5
+go 1.22.6
 
 // Doc generation tooling
 require github.com/hashicorp/terraform-plugin-docs v0.0.0 // replaced


### PR DESCRIPTION
Update Go to the latest minor.

* https://go.dev/doc/devel/release#go1.22.6

Changelog: Updated Go to 1.22.6