### PR TITLE
Add expiry to global notification wrapper metadata

### DIFF
--- a/lib/services/local/notifications.go
+++ b/lib/services/local/notifications.go
@@ -229,15 +229,20 @@ func (s *NotificationsService) CreateGlobalNotification(ctx context.Context, glo
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	globalNotification.Metadata = &headerv1.Metadata{Name: uuid.String()}
-	globalNotification.Spec.Notification.Metadata.Name = uuid.String()
 
 	if err := CheckAndSetExpiry(globalNotification.Spec.Notification, s.clock); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	globalNotification.Spec.Notification.Spec.Created = timestamppb.New(s.clock.Now())
+	globalNotification.Metadata = &headerv1.Metadata{
+		Name: uuid.String(),
+		// Set the same expiry on the outer GlobalNotification wrapper's metadata. This is necessary for the sqlite cleanup routine
+		// to be able to delete this notification when it expires.
+		Expires: globalNotification.GetSpec().GetNotification().GetMetadata().Expires,
+	}
 
+	globalNotification.Spec.Notification.Spec.Created = timestamppb.New(s.clock.Now())
+	globalNotification.Spec.Notification.Metadata.Name = uuid.String()
 	globalNotification.Spec.Notification.Metadata.Labels[types.NotificationScope] = "global"
 
 	created, err := s.globalNotificationService.CreateResource(ctx, globalNotification)

--- a/lib/services/local/notifications_test.go
+++ b/lib/services/local/notifications_test.go
@@ -160,6 +160,9 @@ func TestGlobalNotificationCRUD(t *testing.T) {
 	_, err = service.CreateGlobalNotification(ctx, globalNotificationLateExpiry)
 	require.True(t, trace.IsBadParameter(err), "got error %T, expected a bad parameter error due to notification-late-expiry having an expiry date more than 90 days later", err)
 
+	// Verify that the Metada.Expires on the global notification wrapper is the same as in the inner notification.
+	require.Equal(t, notification.Metadata.Expires, notification.Spec.Notification.Metadata.Expires)
+
 	// Test deleting a notification.
 	err = service.DeleteGlobalNotification(ctx, globalNotification1Id)
 	require.NoError(t, err)


### PR DESCRIPTION
## Purpose

This PR fixes a bug where the sqlite cleanup routine doesn't delete expired global notifications because it looks for the expiry in `Metadata.Expires`, however we were only storing it in the inner notification's metadata (`Spec.Notification.Metadata.Expires`).