### PR TITLE
update referring to local users in tctl users command

### DIFF
--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -81,7 +81,7 @@ type UserCommand struct {
 
 // Initialize allows UserCommand to plug itself into the CLI parser
 func (u *UserCommand) Initialize(app *kingpin.Application, config *servicecfg.Config) {
-	const helpPrefix string = "[Teleport DB users only]"
+	const helpPrefix string = "[Teleport local users only]"
 
 	u.config = config
 	users := app.Command("users", "Manage user accounts.")


### PR DESCRIPTION
Updates to match language in docs for local users for `tctl users` commands. The term "Teleport DB user" is not in our docs that I can find. Docs page referring to Teleport local users. https://goteleport.com/docs/management/admin/users/

from:
```bash
  users add    Generate a user invitation token [Teleport DB users only].
  users reset  Reset user password and generate a new token [Teleport DB users only].
```

to 
```bash
  users add    Generate a user invitation token [Teleport local users only].
  users reset  Reset user password and generate a new token [Teleport local users only].
```