### PR TITLE
docs: include description in role reference

### DIFF
--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -3,6 +3,7 @@ kind: role
 version: v7
 metadata:
   name: example
+  description: This is a example role.
 spec:
   # options specify connection, in case if user has multiple non-default
   # conflicting options, teleport chooses the least permissive value.

--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -3,7 +3,7 @@ kind: role
 version: v7
 metadata:
   name: example
-  description: This is a example role.
+  description: This is an example role.
 spec:
   # options specify connection, in case if user has multiple non-default
   # conflicting options, teleport chooses the least permissive value.


### PR DESCRIPTION
`description` not included in the role reference. This is a supported field.