### PR TITLE
docs: change spiffe role name to match surrounding docs

### DIFF
--- a/docs/pages/enroll-resources/machine-id/workload-identity/getting-started.mdx
+++ b/docs/pages/enroll-resources/machine-id/workload-identity/getting-started.mdx
@@ -45,7 +45,7 @@ Create a new file named `spiffe-issuer-role.yaml`:
 kind: role
 version: v6
 metadata:
-  name: svid-issuer
+  name: spiffe-issuer
 spec:
   allow:
     spiffe:


### PR DESCRIPTION
Following example `tctl` command specify `spiffe-issuer`.