### PR TITLE
Update tsh.mdx to include --speed option for tsh play

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -924,7 +924,7 @@ d0a04442-70dc-4be8-9308-7b7901d2d600 ssh  navin        test      Nov 26 16:36:16
 ### Playing recordings
 
 To play a session recording, run the `tsh play` command with the ID of a session
-as returned by `tsh recordings ls`: 
+as returned by `tsh recordings ls`:
 
 ```code
 $ tsh play c0a02222-70dc-4be8-9308-7b7901d2d600
@@ -951,6 +951,18 @@ the `--format` flag of `tsh play`:
 | `pty` (default)  | Servers, Kubernetes clusters | `tsh` opens a pseudo-terminal to play each command executed in the session. |
 | `json` | Servers, Kubernetes clusters, applications, databases | `tsh` prints a JSON-serialized list of audit events, separated by newlines. |
 | `yaml` | Servers, Kubernetes clusters, applications, databases | `tsh` prints a YAML-serialized list of audit events, separated by `---` characters. |
+
+The playback speed can be customized with the `--speed` flag, which must be
+one of `0.5x`, `1x`, `2x`, `4x`, or `8x`.
+
+```code
+tsh play --speed=8x UUID
+```
+
+Another way to speed up playback is to skip idle time in the recording with the
+`--skip-idle-time` flag. When enabled, tsh will respect the configured playback
+speed during active sections of the recording, but it will skip over larger periods
+of inactivity.
 
 ## tsh configuration files
 


### PR DESCRIPTION
In v15 --speed was added for tsh play but is not listed in the docs. Proposing a change to get that added with a small example.