### PR TITLE
Web: stricter icon name guessing

### DIFF
--- a/web/packages/shared/components/UnifiedResources/shared/guessAppIcon.test.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/guessAppIcon.test.ts
@@ -66,6 +66,14 @@ const testCases: { name: string; app: App; expectedIcon: string }[] = [
     expectedIcon: 'outreach.io',
   },
   {
+    name: 'match by label - default value',
+    app: makeApp({
+      name: 'no-match',
+      labels: [{ name: 'teleport.icon', value: 'default' }],
+    }),
+    expectedIcon: 'application',
+  },
+  {
     name: 'no matches',
     app: makeApp({
       name: 'no-match',
@@ -78,6 +86,27 @@ const testCases: { name: string; app: App; expectedIcon: string }[] = [
       name: 'Something MicroSoft and stuff',
     }),
     expectedIcon: 'microsoft',
+  },
+  {
+    name: 'match by name with paranthesis and brackets',
+    app: makeApp({
+      name: 'Clearfeed (adobe) [adobe]',
+    }),
+    expectedIcon: 'clearfeed',
+  },
+  {
+    name: 'match by name if whole text starts and ends with paranthesis',
+    app: makeApp({
+      name: '(clearfeed)',
+    }),
+    expectedIcon: 'clearfeed',
+  },
+  {
+    name: 'match by name if whole text starts and ends with bracket',
+    app: makeApp({
+      name: '[clearfeed]',
+    }),
+    expectedIcon: 'clearfeed',
   },
 ];
 


### PR DESCRIPTION
- Ignores paranthesis and brackets and any words inside of them
- Allow adding a `default` value checking for `teleport.icon` label

Fixes edge cases like below. Google icon was used b/c we check for google first before other icons.

![image](https://github.com/user-attachments/assets/03423914-b61e-425e-a217-0ed143bfd76b)
