### PR TITLE
Web: Add compact prop for ButtonText and fixes existing uses spacing

### DIFF
--- a/web/packages/design/src/Button/Button.tsx
+++ b/web/packages/design/src/Button/Button.tsx
@@ -17,9 +17,7 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-
-import { CSSObject } from 'styled-components';
+import styled, { CSSObject } from 'styled-components';
 
 import {
   space,
@@ -409,5 +407,12 @@ export const ButtonWarningBorder = <E extends React.ElementType = 'button'>(
   props: ButtonProps<E>
 ) => <Button fill="border" intent="danger" {...props} />;
 export const ButtonText = <E extends React.ElementType = 'button'>(
-  props: ButtonProps<E>
-) => <Button fill="minimal" intent="neutral" {...props} />;
+  props: ButtonProps<E> & { compact?: boolean }
+) => (
+  <Button
+    fill="minimal"
+    intent="neutral"
+    {...(props.compact ? { px: 1 } : {})}
+    {...props}
+  />
+);

--- a/web/packages/design/src/Button/Button.tsx
+++ b/web/packages/design/src/Button/Button.tsx
@@ -62,6 +62,11 @@ export type ButtonProps<E extends React.ElementType> =
       inputAlignment?: boolean;
 
       /**
+       * If set to true, renders a button with the smallest horizontal paddings.
+       */
+      compact?: boolean;
+
+      /**
        * Specifies the case transform of the button text. Default is no
        * transformation.
        */
@@ -286,6 +291,9 @@ const buttonPalette = <E extends React.ElementType>({
 const horizontalPadding = <E extends React.ElementType>(
   props: ButtonProps<E>
 ) => {
+  if (props.compact) {
+    return 4;
+  }
   if (props.inputAlignment) {
     return 16;
   }
@@ -407,12 +415,5 @@ export const ButtonWarningBorder = <E extends React.ElementType = 'button'>(
   props: ButtonProps<E>
 ) => <Button fill="border" intent="danger" {...props} />;
 export const ButtonText = <E extends React.ElementType = 'button'>(
-  props: ButtonProps<E> & { compact?: boolean }
-) => (
-  <Button
-    fill="minimal"
-    intent="neutral"
-    {...(props.compact ? { px: 1 } : {})}
-    {...props}
-  />
-);
+  props: ButtonProps<E>
+) => <Button fill="minimal" intent="neutral" {...props} />;

--- a/web/packages/design/src/Button/Button.tsx
+++ b/web/packages/design/src/Button/Button.tsx
@@ -19,6 +19,8 @@
 import React from 'react';
 import styled, { CSSObject } from 'styled-components';
 
+import { shouldForwardProp as defaultValidatorFn } from 'design/ThemeProvider';
+
 import {
   space,
   width,
@@ -358,7 +360,10 @@ const block = props =>
 const textTransform = props =>
   props.textTransform ? { textTransform: props.textTransform } : null;
 
-const StyledButton = styled.button`
+const StyledButton = styled.button.withConfig({
+  shouldForwardProp: (prop, target) =>
+    !['compact'].includes(prop) && defaultValidatorFn(prop, target),
+})`
   line-height: 1.5;
   margin: 0;
   display: inline-flex;

--- a/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.story.tsx
+++ b/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.story.tsx
@@ -17,6 +17,7 @@
  */
 
 import React, { useState } from 'react';
+import Flex from 'design/Flex';
 
 import { ButtonTextWithAddIcon } from './ButtonTextWithAddIcon';
 
@@ -27,23 +28,31 @@ export default {
 export const Button = () => {
   const [label, setLabel] = useState('Add Item (click me)');
   return (
-    <div style={{ width: '300px' }}>
-      <ButtonTextWithAddIcon label={'Add Item'} onClick={() => null} />
-      <ButtonTextWithAddIcon
-        label={label}
-        onClick={() => setLabel('Add More Item (click me)')}
-      />
-      <ButtonTextWithAddIcon
-        label={'Add Item Disabled'}
-        onClick={() => null}
-        disabled={true}
-      />
-      <ButtonTextWithAddIcon
-        label={'Add Item with Medium Icon Size'}
-        onClick={() => null}
-        iconSize={'medium'}
-      />
-    </div>
+    <Flex gap={2} width="300px" flexWrap={'wrap'}>
+      <div>
+        <ButtonTextWithAddIcon label={'Add Item'} onClick={() => null} />
+      </div>
+      <div>
+        <ButtonTextWithAddIcon
+          label={label}
+          onClick={() => setLabel('Add More Item (click me)')}
+        />
+      </div>
+      <div>
+        <ButtonTextWithAddIcon
+          label={'Add Item Disabled'}
+          onClick={() => null}
+          disabled={true}
+        />
+      </div>
+      <div>
+        <ButtonTextWithAddIcon
+          label={'Add Item with Medium Icon Size'}
+          onClick={() => null}
+          iconSize={'medium'}
+        />
+      </div>
+    </Flex>
   );
 };
 

--- a/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.tsx
+++ b/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.tsx
@@ -32,7 +32,12 @@ export const ButtonTextWithAddIcon = ({
   iconSize?: number | 'small' | 'medium' | 'large' | 'extraLarge';
 }) => {
   return (
-    <ButtonText onClick={onClick} inputAlignment disabled={disabled}>
+    <ButtonText
+      onClick={onClick}
+      inputAlignment
+      disabled={disabled}
+      compact={true}
+    >
       <AddIcon
         className="icon-add"
         size={iconSize}

--- a/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.tsx
+++ b/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.tsx
@@ -32,12 +32,7 @@ export const ButtonTextWithAddIcon = ({
   iconSize?: number | 'small' | 'medium' | 'large' | 'extraLarge';
 }) => {
   return (
-    <ButtonText
-      onClick={onClick}
-      inputAlignment
-      disabled={disabled}
-      compact={true}
-    >
+    <ButtonText onClick={onClick} disabled={disabled} compact>
       <AddIcon
         className="icon-add"
         size={iconSize}

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -17,7 +17,15 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { Box, ButtonPrimary, ButtonText, Link, Text, Toggle } from 'design';
+import {
+  Box,
+  ButtonPrimary,
+  ButtonText,
+  Flex,
+  Link,
+  Text,
+  Toggle,
+} from 'design';
 import styled from 'styled-components';
 import { FetchStatus } from 'design/DataTable/types';
 import { Danger } from 'design/Alert';
@@ -447,27 +455,29 @@ export function EnrollEksCluster(props: AgentStepProps) {
           {!isAutoDiscoveryEnabled && (
             <StyledBox mb={5} mt={5}>
               <Text mb={2}>Automatically enroll selected EKS cluster</Text>
-              <ButtonPrimary
-                width="215px"
-                type="submit"
-                onClick={enroll}
-                disabled={enrollmentNotAllowed}
-                mt={2}
-                mb={2}
-              >
-                Enroll EKS Cluster
-              </ButtonPrimary>
-              <Box>
-                <ButtonText
+              <Flex alignItems="center" flexDirection="column" width="200px">
+                <ButtonPrimary
+                  width="215px"
+                  type="submit"
+                  onClick={enroll}
                   disabled={enrollmentNotAllowed}
-                  onClick={() => {
-                    setIsManualHelmDialogShown(b => !b);
-                  }}
-                  pl={0}
+                  mt={2}
+                  mb={2}
                 >
-                  Or enroll manually
-                </ButtonText>
-              </Box>
+                  Enroll EKS Cluster
+                </ButtonPrimary>
+                <Box>
+                  <ButtonText
+                    width="215px"
+                    disabled={enrollmentNotAllowed}
+                    onClick={() => {
+                      setIsManualHelmDialogShown(b => !b);
+                    }}
+                  >
+                    Or enroll manually
+                  </ButtonText>
+                </Box>
+              </Flex>
             </StyledBox>
           )}
           {isAutoDiscoveryEnabled && (

--- a/web/packages/teleport/src/Discover/Shared/ActionButtons.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ActionButtons.tsx
@@ -86,9 +86,8 @@ export const AlternateInstructionButton: React.FC<
     <ButtonText
       disabled={disabled}
       onClick={onClick}
+      compact={true}
       css={`
-        padding-left: 1px;
-        padding-right: 1px;
         color: ${p => p.theme.colors.buttons.link.default};
         text-decoration: underline;
         font-weight: normal;

--- a/web/packages/teleport/src/Discover/Shared/ActionButtons.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ActionButtons.tsx
@@ -86,7 +86,7 @@ export const AlternateInstructionButton: React.FC<
     <ButtonText
       disabled={disabled}
       onClick={onClick}
-      compact={true}
+      compact
       css={`
         color: ${p => p.theme.colors.buttons.link.default};
         text-decoration: underline;

--- a/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.tsx
@@ -272,7 +272,7 @@ export function AwsAccount() {
                       options={awsIntegrations.map(makeAwsIntegrationOption)}
                     />
                   </Box>
-                  <ButtonText as={Link} to={locationState} pl={2} pr={2}>
+                  <ButtonText as={Link} to={locationState} compact={true}>
                     Or click here to set up a different AWS account
                   </ButtonText>
                 </>

--- a/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.tsx
@@ -272,7 +272,7 @@ export function AwsAccount() {
                       options={awsIntegrations.map(makeAwsIntegrationOption)}
                     />
                   </Box>
-                  <ButtonText as={Link} to={locationState} compact={true}>
+                  <ButtonText as={Link} to={locationState} compact>
                     Or click here to set up a different AWS account
                   </ButtonText>
                 </>

--- a/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
@@ -111,7 +111,7 @@ export const JoinTokenIAMForm = ({
           />
         </RuleBox>
       ))}
-      <ButtonText onClick={addNewRule} compact={true}>
+      <ButtonText onClick={addNewRule} compact>
         <Plus size={16} mr={2} />
         Add another AWS Rule
       </ButtonText>
@@ -221,7 +221,7 @@ export const JoinTokenGCPForm = ({
           />
         </RuleBox>
       ))}
-      <ButtonText onClick={addNewRule} compact={true}>
+      <ButtonText onClick={addNewRule} compact>
         <Plus size={16} mr={2} />
         Add another GCP Rule
       </ButtonText>

--- a/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
@@ -111,7 +111,7 @@ export const JoinTokenIAMForm = ({
           />
         </RuleBox>
       ))}
-      <ButtonText onClick={addNewRule}>
+      <ButtonText onClick={addNewRule} compact={true}>
         <Plus size={16} mr={2} />
         Add another AWS Rule
       </ButtonText>
@@ -221,7 +221,7 @@ export const JoinTokenGCPForm = ({
           />
         </RuleBox>
       ))}
-      <ButtonText onClick={addNewRule}>
+      <ButtonText onClick={addNewRule} compact={true}>
         <Plus size={16} mr={2} />
         Add another GCP Rule
       </ButtonText>


### PR DESCRIPTION
enterprise: https://github.com/gravitational/teleport.e/pull/4855

fixes the weird spacings introduced with the new ButtonText

it's not the best, but better than being too far in the page (previous to the new button change, it was inline with other beginning elements)

an example:

| before | after |
| ------ | ----- |
|<img width="428" alt="image" src="https://github.com/user-attachments/assets/72748dc6-e647-4e07-ba81-b9245140562f"> |<img width="413" alt="image" src="https://github.com/user-attachments/assets/07200a2e-f0d6-42a2-86f8-c25639fd12bb">
