### PR TITLE
Add refresh button to unified resources view

### DIFF
--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -31,6 +31,7 @@ import {
   Rows,
   ArrowsIn,
   ArrowsOut,
+  Refresh,
 } from 'design/Icon';
 
 import { ViewMode } from 'gen-proto-ts/teleport/userpreferences/v1/unified_resource_preferences_pb';
@@ -77,6 +78,7 @@ interface FilterPanelProps {
   ClusterDropdown?: JSX.Element;
   availabilityFilter?: ResourceAvailabilityFilter;
   changeAvailableResourceMode(mode: IncludedResourceMode): void;
+  onRefresh(): void;
 }
 
 export function FilterPanel({
@@ -94,6 +96,7 @@ export function FilterPanel({
   hideViewModeOptions,
   changeAvailableResourceMode,
   ClusterDropdown = null,
+  onRefresh,
 }: FilterPanelProps) {
   const { sort, kinds } = params;
 
@@ -149,6 +152,18 @@ export function FilterPanel({
       </Flex>
       <Flex gap={2} alignItems="center">
         <Flex mr={1}>{BulkActions}</Flex>
+        <HoverTooltip tipContent="Refresh">
+          <ButtonBorder
+            onClick={onRefresh}
+            textTransform="none"
+            css={`
+              border-color: ${props => props.theme.colors.spotBackground[2]};
+            `}
+            size="small"
+          >
+            {<Refresh size={12} />}
+          </ButtonBorder>
+        </HoverTooltip>
         {!hideViewModeOptions && (
           <>
             {currentViewMode === ViewMode.LIST && (

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -157,6 +157,7 @@ export function FilterPanel({
             onClick={onRefresh}
             textTransform="none"
             css={`
+              padding: 0 4.5px;
               border-color: ${props => props.theme.colors.spotBackground[2]};
             `}
             size="small"

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -158,7 +158,6 @@ export function FilterPanel({
             textTransform="none"
             css={`
               padding: 0 4.5px;
-              border-color: ${props => props.theme.colors.spotBackground[2]};
             `}
             size="small"
           >

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -161,7 +161,7 @@ export function FilterPanel({
             `}
             size="small"
           >
-            {<Refresh size={12} />}
+            <Refresh size={12} />
           </ButtonBorder>
         </HoverTooltip>
         {!hideViewModeOptions && (

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -139,7 +139,7 @@ export type ResourceAvailabilityFilter =
 export interface UnifiedResourcesProps {
   params: UnifiedResourcesQueryParams;
   resourcesFetchAttempt: Attempt;
-  fetchResources(options?: { force?: boolean }): Promise<void>;
+  fetchResources(options?: { force?: boolean; clear?: boolean }): Promise<void>;
   resources: SharedUnifiedResource[];
   Header?: React.ReactElement;
   /**
@@ -506,6 +506,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
           );
         }}
         hideViewModeOptions={forceCardView}
+        onRefresh={() => fetchResources({ clear: true })}
         BulkActions={
           <>
             {selectedResources.length > 0 && (

--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
@@ -83,7 +83,10 @@ export function useKeyBasedPagination<T>({
   }, [setState]);
 
   const fetch = useCallback(
-    async (options?: { force?: boolean }) => {
+    async (options?: { force?: boolean; clear?: boolean }) => {
+      if (options?.clear) {
+        clear();
+      }
       const { finished, attempt, resources, startKey } = stateRef.current;
       if (
         finished ||
@@ -154,7 +157,7 @@ export function useKeyBasedPagination<T>({
         });
       }
     },
-    [fetchFunc, stateRef, setState, fetchMoreSize, initialFetchSize]
+    [fetchFunc, stateRef, clear, setState, fetchMoreSize, initialFetchSize]
   );
 
   function updateFetchedResources(modifiedResources: T[]) {
@@ -209,12 +212,16 @@ type KeyBasedPagination<T> = {
    * as a mere suggestion to fetch more data and can be called multiple times,
    * for example, when the user scrolls to the bottom of the page.
    *
-   * @param options.force Cancels a pending request, if there is one.
-   * Disregards whether error has previously occurred. Intended for using as an
-   * explicit user's action. Don't call it from `useInfiniteScroll`, or you'll
-   * risk flooding the server with requests!
+   * @param options - Options to control the fetch behavior.
+   * @param options.force - If true, cancels any pending request and
+   * disregards whether an error occurred previously. This option is intended for
+   * explicit user actions. Do not call it from `useInfiniteScroll` to avoid
+   * flooding the server with requests.
+   * @param options.clear - If true, works like `force` but also clears
+   * the state. Similarly, do not call it from `useInfiniteScroll` to avoid
+   * flooding the server with requests.
    */
-  fetch(options?: { force?: boolean }): Promise<void>;
+  fetch(options?: { force?: boolean; clear?: boolean }): Promise<void>;
   /** Aborts a pending request and clears the state. **/
   clear(): void;
   attempt: Attempt;

--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
@@ -217,9 +217,10 @@ type KeyBasedPagination<T> = {
    * disregards whether an error occurred previously. This option is intended for
    * explicit user actions. Do not call it from `useInfiniteScroll` to avoid
    * flooding the server with requests.
-   * @param options.clear - If true, works like `force` but also clears
-   * the state. Similarly, do not call it from `useInfiniteScroll` to avoid
-   * flooding the server with requests.
+   * @param options.clear - If true, cancels any pending request and clears
+   * the state (useful for fetching data from the beginning). Similarly to
+   * `force`, do not call it from `useInfiniteScroll` to avoid flooding
+   * the server with requests.
    */
   fetch(options?: { force?: boolean; clear?: boolean }): Promise<void>;
   /** Aborts a pending request and clears the state. **/

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -259,7 +259,7 @@ const Resources = memo(
   }) => {
     const appContext = useAppContext();
 
-    const { fetch, resources, attempt, clear } = useUnifiedResourcesFetch({
+    const { fetch, resources, attempt } = useUnifiedResourcesFetch({
       fetchFunc: useCallback(
         async (paginationParams, signal) => {
           // Block the call if we don't know yet what resources to show.
@@ -316,11 +316,10 @@ const Resources = memo(
     const { onResourcesRefreshRequest } = props;
     useEffect(() => {
       const { cleanup } = onResourcesRefreshRequest(() => {
-        clear();
-        fetch({ force: true });
+        fetch({ clear: true });
       });
       return cleanup;
-    }, [onResourcesRefreshRequest, fetch, clear]);
+    }, [onResourcesRefreshRequest, fetch]);
 
     const resourceIds =
       props.userPreferences.clusterPreferences?.pinnedResources?.resourceIds;


### PR DESCRIPTION
@roraback please take a look a the UI:

https://github.com/user-attachments/assets/a965d3e2-be72-477b-8753-140e08c0bfe1

-----------
We also [discussed refreshing the view with Cmd+R in Connect](https://gravitational.slack.com/archives/C03FJA391M3/p1721918452424409?thread_ts=1721916999.187949&cid=C03FJA391M3), but I ran into a problem with that.
On Windows/Linux the shortcut should be Ctrl+R, but that would conflict with a bash shortcut. To solve the problem, the shortcut should only work when the resources view is visible.
1. To achieve this, we would need to refactor the `keyboardShortcutService` so that it only stops event propagation when there is a handler registered for a given shortcut (currently we stop propagation for each defined shortcut).
3. The unified view in `DocumentCluster` would have to register a handler only when the document is visible:
```ts
    useKeyboardShortcuts({ 'refresh': () => props.visible ? fetch({ clear: true }) : undefined });
``` 
The only problem is that it would degrade performance on the unified view, since passing `visible` to it would cause re-rendering it when the active document changes. We could workaround this by extracting an intermediate component wrapped in `memo`, but I'm wondering if this also worth the effort ;) Or maybe there is an easier way to solve this problem that I don't see?
