### PR TITLE
Fix typo in PagerDuty plugin docs

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -56,7 +56,7 @@ Access Request Notifications` service when certain users create an Access
 Request.
 
 For users on the on-call team for `My Critical Service` (in this case, your
-PagerDuty user), we will configure the PagerDuy plugin to approve Access
+PagerDuty user), we will configure the PagerDuty plugin to approve Access
 Requests automatically, letting them investigate incidents on the service
 quickly.
 


### PR DESCRIPTION
Fixing minor typo in https://goteleport.com/docs/access-controls/access-request-plugins/ssh-approval-pagerduty/#step-18-create-services