### PR TITLE
Document passkey "upgrade" behavior

### DIFF
--- a/docs/pages/admin-guides/access-controls/guides/passwordless.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/passwordless.mdx
@@ -333,7 +333,7 @@ $ tctl create -f cap.yaml
 
 </Tabs>
 
-### Why did my (MFA) Multi-Factor Authentication device became a passkey?
+### Why did my multi-factor authentication (MFA) device become a passkey?
 
 If your MFA authenticator suddenly started being listed as a passkey, that is
 because it was always a passkey. Certain devices or applications (like Chrome or

--- a/docs/pages/admin-guides/access-controls/guides/passwordless.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/passwordless.mdx
@@ -333,3 +333,14 @@ $ tctl create -f cap.yaml
 
 </Tabs>
 
+### Why did my (MFA) Multi-Factor Authentication device became a passkey?
+
+If your MFA authenticator suddenly started being listed as a passkey, that is
+because it was always a passkey. Certain devices or applications (like Chrome or
+Safari Touch ID keys) are always created as passkeys, despite instructions from
+Teleport.
+
+If an authenticator replies with the [credProps extension](
+https://w3c.github.io/webauthn/#sctn-authenticator-credential-properties-extension)
+during registration, or is used for a successful passwordless login, Teleport
+will automatically mark it as a passkey if that wasn't the case before.


### PR DESCRIPTION
Document why MFA authenticators are sometimes "upgraded" to passkeys, in the hopes that this may answer future questions about the (slightly surprising) behavior.

Related to PRs #45222 and #45252.

#39521