### PR TITLE
remove ability to store Jamf credentials in plugin specification

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2930,7 +2930,7 @@ func applyJamfConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		return trace.Wrap(err)
 	}
 
-	creds, err := fc.Jamf.toJamfCredentials()
+	creds, err := fc.Jamf.readJamfCredentials()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2925,19 +2925,15 @@ func applyJamfConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		return nil
 	}
 
-	jamfSpec, err := fc.Jamf.toJamfSpecV1()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	creds, err := fc.Jamf.readJamfCredentials()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	// TODO(tigrato): DELETE once we remove the fields from the config.
-	jamfSpec.Username, jamfSpec.Password = creds.Username, creds.Password
-	jamfSpec.ClientId, jamfSpec.ClientSecret = creds.ClientID, creds.ClientSecret
+	jamfSpec, err := fc.Jamf.toJamfSpecV1(creds)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 
 	cfg.Jamf = servicecfg.JamfConfig{
 		Spec:        jamfSpec,

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2930,9 +2930,19 @@ func applyJamfConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		return trace.Wrap(err)
 	}
 
+	creds, err := fc.Jamf.toJamfCredentials()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// TODO(tigrato): DELETE once we remove the fields from the config.
+	jamfSpec.Username, jamfSpec.Password = creds.Username, creds.Password
+	jamfSpec.ClientId, jamfSpec.ClientSecret = creds.ClientID, creds.ClientSecret
+
 	cfg.Jamf = servicecfg.JamfConfig{
-		Spec:       jamfSpec,
-		ExitOnSync: fc.Jamf.ExitOnSync,
+		Spec:        jamfSpec,
+		ExitOnSync:  fc.Jamf.ExitOnSync,
+		Credentials: creds,
 	}
 	return nil
 }

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -3428,6 +3428,10 @@ jamf_service:
 					Username:    "llama",
 					Password:    password,
 				},
+				Credentials: &servicecfg.JamfCredentials{
+					Username: "llama",
+					Password: password,
+				},
 			},
 		},
 		{
@@ -3442,6 +3446,10 @@ jamf_service:
 					Enabled:      true,
 					ApiEndpoint:  "https://yourtenant.jamfcloud.com",
 					ClientId:     "llama-UUID",
+					ClientSecret: password,
+				},
+				Credentials: &servicecfg.JamfCredentials{
+					ClientID:     "llama-UUID",
 					ClientSecret: password,
 				},
 			},
@@ -3476,6 +3484,10 @@ jamf_service:
 						},
 						{},
 					},
+				},
+				Credentials: &servicecfg.JamfCredentials{
+					Username: "llama",
+					Password: password,
 				},
 				ExitOnSync: true,
 			},

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2617,7 +2617,6 @@ func (j *JamfService) toJamfSpecV1(creds *servicecfg.JamfCredentials) (*types.Ja
 }
 
 func (j *JamfService) readJamfCredentials() (*servicecfg.JamfCredentials, error) {
-	// Read secrets.
 	password, err := readJamfPasswordFile(j.PasswordFile, "password_file")
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2611,7 +2611,7 @@ func (j *JamfService) toJamfSpecV1() (*types.JamfSpecV1, error) {
 	return spec, nil
 }
 
-func (j *JamfService) toJamfCredentials() (*servicecfg.JamfCredentials, error) {
+func (j *JamfService) readJamfCredentials() (*servicecfg.JamfCredentials, error) {
 	// Read secrets.
 	password, err := readJamfPasswordFile(j.PasswordFile, "password_file")
 	if err != nil {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2576,7 +2576,7 @@ type JamfInventoryEntry struct {
 	PageSize int32 `yaml:"page_size,omitempty"`
 }
 
-func (j *JamfService) toJamfSpecV1() (*types.JamfSpecV1, error) {
+func (j *JamfService) toJamfSpecV1(creds *servicecfg.JamfCredentials) (*types.JamfSpecV1, error) {
 	switch {
 	case j == nil:
 		return nil, trace.BadParameter("jamf_service is nil")
@@ -2601,6 +2601,11 @@ func (j *JamfService) toJamfSpecV1() (*types.JamfSpecV1, error) {
 		SyncDelay:   types.Duration(j.SyncDelay),
 		ApiEndpoint: j.APIEndpoint,
 		Inventory:   inventory,
+		// TODO(tigrato): DELETE once we remove the fields from the config.
+		Username:     creds.Username,
+		Password:     creds.Password,
+		ClientId:     creds.ClientID,
+		ClientSecret: creds.ClientSecret,
 	}
 
 	// Validate.

--- a/lib/service/servicecfg/jamf.go
+++ b/lib/service/servicecfg/jamf.go
@@ -50,7 +50,6 @@ type JamfCredentials struct {
 
 // ValidateJamfCredentials validates the Jamf credentials.
 func ValidateJamfCredentials(j *JamfCredentials) error {
-	// Jamf can handle both credential sets being present, so we let it pass.
 	hasUserPass := j.Username != "" && j.Password != ""
 	hasAPICreds := j.ClientID != "" && j.ClientSecret != ""
 	switch {

--- a/lib/service/servicecfg/jamf.go
+++ b/lib/service/servicecfg/jamf.go
@@ -53,8 +53,6 @@ func ValidateJamfCredentials(j *JamfCredentials) error {
 	hasUserPass := j.Username != "" && j.Password != ""
 	hasAPICreds := j.ClientID != "" && j.ClientSecret != ""
 	switch {
-	case hasUserPass && hasAPICreds:
-		return trace.BadParameter("both username+password and clientID+clientSecret are set, use one or the other")
 	case !hasUserPass && !hasAPICreds:
 		return trace.BadParameter("either username+password or clientID+clientSecret must be provided")
 	}

--- a/lib/service/servicecfg/jamf.go
+++ b/lib/service/servicecfg/jamf.go
@@ -18,12 +18,56 @@
 
 package servicecfg
 
-import "github.com/gravitational/teleport/api/types"
+import (
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// JamfCredentials is the credentials for the Jamf MDM service.
+type JamfCredentials struct {
+	// Username is the Jamf API username.
+	// Username and password are used to acquire short-lived Jamf Pro API tokens.
+	// See https://developer.jamf.com/jamf-pro/docs/jamf-pro-api-overview.
+	// Prefer using client_id and client_secret.
+	// Either username+password or client_id+client_secret are required.
+	Username string
+	// Password is the Jamf API password.
+	// Username and password are used to acquire short-lived Jamf Pro API tokens.
+	// See https://developer.jamf.com/jamf-pro/docs/jamf-pro-api-overview.
+	// Prefer using client_id and client_secret.
+	// Either username+password or client_id+client_secret are required.
+	Password string
+	// ClientID is the Jamf API client ID.
+	// See https://developer.jamf.com/jamf-pro/docs/client-credentials.
+	// Either username+password or client_id+client_secret are required.
+	ClientID string
+	// ClientSecret is the Jamf API client secret.
+	// See https://developer.jamf.com/jamf-pro/docs/client-credentials.
+	// Either username+password or client_id+client_secret are required
+	ClientSecret string
+}
+
+// ValidateJamfCredentials validates the Jamf credentials.
+func ValidateJamfCredentials(j *JamfCredentials) error {
+	// Jamf can handle both credential sets being present, so we let it pass.
+	hasUserPass := j.Username != "" && j.Password != ""
+	hasAPICreds := j.ClientID != "" && j.ClientSecret != ""
+	switch {
+	case hasUserPass && hasAPICreds:
+		return trace.BadParameter("both username+password and clientID+clientSecret are set, use one or the other")
+	case !hasUserPass && !hasAPICreds:
+		return trace.BadParameter("either username+password or clientID+clientSecret must be provided")
+	}
+	return nil
+}
 
 // JamfConfig is the configuration for the Jamf MDM service.
 type JamfConfig struct {
 	// Spec is the configuration spec.
 	Spec *types.JamfSpecV1
+	// Credentials are the Jamf API credentials.
+	Credentials *JamfCredentials
 	// ExitOnSync controls whether the service performs a single sync operation
 	// before exiting.
 	ExitOnSync bool

--- a/lib/service/servicecfg/jamf_test.go
+++ b/lib/service/servicecfg/jamf_test.go
@@ -1,0 +1,105 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package servicecfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateJamfCredentials(t *testing.T) {
+	tests := []struct {
+		name         string
+		creds        *JamfCredentials
+		errAssertion require.ErrorAssertionFunc
+	}{
+		{
+			name: "valid credentials with username and password",
+			creds: &JamfCredentials{
+				Username: "username",
+				Password: "password",
+			},
+			errAssertion: require.NoError,
+		},
+		{
+			name: "valid credentials with client ID and client secret",
+			creds: &JamfCredentials{
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+			},
+			errAssertion: require.NoError,
+		},
+		{
+			name: "invalid credentials with all fields set",
+			creds: &JamfCredentials{
+				Username:     "username",
+				Password:     "password",
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+			},
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "both username+password and clientID+clientSecret are set, use one or the other")
+			},
+		},
+		{
+			name: "invalid credentials missing password",
+			creds: &JamfCredentials{
+				Username: "username",
+			},
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "either username+password or clientID+clientSecret must be provided")
+			},
+		},
+		{
+			name: "invalid credentials missing username",
+			creds: &JamfCredentials{
+				Password: "password",
+			},
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "either username+password or clientID+clientSecret must be provided")
+			},
+		},
+		{
+			name: "invalid credentials missing client secret",
+			creds: &JamfCredentials{
+				ClientID: "id",
+			},
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "either username+password or clientID+clientSecret must be provided")
+			},
+		},
+		{
+			name: "invalid credentials missing client id",
+			creds: &JamfCredentials{
+				ClientSecret: "secret",
+			},
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "either username+password or clientID+clientSecret must be provided")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			err := ValidateJamfCredentials(tt.creds)
+			tt.errAssertion(t, err)
+		})
+	}
+}

--- a/lib/service/servicecfg/jamf_test.go
+++ b/lib/service/servicecfg/jamf_test.go
@@ -54,9 +54,7 @@ func TestValidateJamfCredentials(t *testing.T) {
 				ClientID:     "client-id",
 				ClientSecret: "client-secret",
 			},
-			errAssertion: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "both username+password and clientID+clientSecret are set, use one or the other")
-			},
+			errAssertion: require.NoError,
 		},
 		{
 			name: "invalid credentials missing password",

--- a/lib/service/servicecfg/jamf_test.go
+++ b/lib/service/servicecfg/jamf_test.go
@@ -25,10 +25,11 @@ import (
 )
 
 func TestValidateJamfCredentials(t *testing.T) {
+	const expectedErr = "either username+password or clientID+clientSecret must be provided"
 	tests := []struct {
-		name         string
-		creds        *JamfCredentials
-		errAssertion require.ErrorAssertionFunc
+		name    string
+		creds   *JamfCredentials
+		wantErr string
 	}{
 		{
 			name: "valid credentials with username and password",
@@ -36,7 +37,6 @@ func TestValidateJamfCredentials(t *testing.T) {
 				Username: "username",
 				Password: "password",
 			},
-			errAssertion: require.NoError,
 		},
 		{
 			name: "valid credentials with client ID and client secret",
@@ -44,60 +44,53 @@ func TestValidateJamfCredentials(t *testing.T) {
 				ClientID:     "client-id",
 				ClientSecret: "client-secret",
 			},
-			errAssertion: require.NoError,
 		},
 		{
-			name: "invalid credentials with all fields set",
+			name: "credentials with all fields set",
 			creds: &JamfCredentials{
 				Username:     "username",
 				Password:     "password",
 				ClientID:     "client-id",
 				ClientSecret: "client-secret",
 			},
-			errAssertion: require.NoError,
 		},
 		{
 			name: "invalid credentials missing password",
 			creds: &JamfCredentials{
 				Username: "username",
 			},
-			errAssertion: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "either username+password or clientID+clientSecret must be provided")
-			},
+			wantErr: expectedErr,
 		},
 		{
 			name: "invalid credentials missing username",
 			creds: &JamfCredentials{
 				Password: "password",
 			},
-			errAssertion: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "either username+password or clientID+clientSecret must be provided")
-			},
+			wantErr: expectedErr,
 		},
 		{
 			name: "invalid credentials missing client secret",
 			creds: &JamfCredentials{
 				ClientID: "id",
 			},
-			errAssertion: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "either username+password or clientID+clientSecret must be provided")
-			},
+			wantErr: expectedErr,
 		},
 		{
 			name: "invalid credentials missing client id",
 			creds: &JamfCredentials{
 				ClientSecret: "secret",
 			},
-			errAssertion: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "either username+password or clientID+clientSecret must be provided")
-			},
+			wantErr: expectedErr,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			err := ValidateJamfCredentials(tt.creds)
-			tt.errAssertion(t, err)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.wantErr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR removes the `client_id`, `client_secret`, `username`, and `password` fields from the Jamf plugin.

While we never intended to use these fields for backend credential storage, users who attempt to create the plugin programmatically might inadvertently set them, resulting in insecure storage of their Jamf credentials.