### PR TITLE
docs: update web application guide

### DIFF
--- a/docs/pages/enroll-resources/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/connecting-apps.mdx
@@ -2,31 +2,13 @@
 title: Web Application Access
 description: In this getting started guide, learn how to connect an application to your Teleport cluster by running the Teleport Application Service.
 ---
+## Prerequisites
 
-Download the latest version of Teleport for your platform from the [downloads page](https://goteleport.com/download)
-and follow the installation [instructions](../../../installation.mdx).
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-## Start Auth/Proxy service
-
-Create a configuration file for a Teleport service that will be running
-the Auth and Proxy Services:
-
-```yaml
-teleport:
-  data_dir: /var/lib/teleport
-auth_service:
-  enabled: "yes"
-proxy_service:
-  enabled: "yes"
-  # Set public address proxy will be reachable at.
-  public_addr: teleport.example.com:3080
-ssh_service:
-  enabled: "no"
-```
-
-(!docs/pages/includes/permission-warning.mdx!)
-
-(!docs/pages/includes/start-teleport.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
+- Web application to connect to such as Grafana.
+- Host where you will run the Teleport Application Service.
 
 ### Generate a token
 
@@ -36,8 +18,6 @@ in `/tmp/token`:
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
-# You can also run tctl on your Auth Service host without running "tsh login"
-# first.
 $ tsh login --user=<Var name="myuser"/> --proxy=<Var name="teleport.example.com"/>
 $ tctl tokens add \
     --type=app \
@@ -70,7 +50,7 @@ A Teleport user needs their role's permission to access an application. Teleport
 comes with a built-in `access` role that grants access to all apps:
 
 ```code
-$ tctl --config=/path/to/teleport.yaml users add --roles=access appuser
+$ tctl users add --roles=access appuser
 ```
 
 ## Start the Application Service with CLI flags


### PR DESCRIPTION
The guide recommended setting up a standalone Teleport proxy/auth then using a existing Teleport instance like others. Updated to use the same pre-reqs as other guides.