### PR TITLE
Fix Machine ID Onboarding UI

### DIFF
--- a/web/packages/teleport/src/Bots/Add/GitHubActions/AddBotToWorkflow.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/AddBotToWorkflow.tsx
@@ -92,39 +92,39 @@ export function getWorkflowExampleYaml(
   includeNameComment: boolean = true
 ): string {
   return `on:
-push:
-  branches:
-  - main
+  push:
+    branches:
+    - main
 jobs:
-demo:
-  permissions:
-    # The "id-token: write" permission is required or Machine ID will not be
-    # able to authenticate with the cluster.
-    id-token: write
-    contents: read
-  ${includeNameComment && '# if you added a workflow name in the previous step, make sure you use the same value here'}
-  name: ${botName}-example
-  runs-on: ubuntu-latest
-  steps:
-  - name: Checkout repository
-    uses: actions/checkout@v3
-  - name: Fetch Teleport binaries
-    uses: teleport-actions/setup@v1
-    with:
-      version: ${version}
-  # server access example
-  - name: Fetch credentials using Machine ID
-    id: auth
-    uses: teleport-actions/auth@v2
-    with:
-      proxy: ${proxyAddr}
-      token: ${tokenName}
-      # Enable the submission of anonymous usage telemetry. This
-      # helps us shape the future development of \`tbot\`. You can disable this
-      # by omitting this.
-      anonymous-telemetry: 1
-  - name: List nodes (tsh)
-    # Enters a command from the cluster, in this case "tsh ls" using Machine
-    # ID credentials to list remote SSH nodes.
-    run: tsh ls`;
+  demo:
+    permissions:
+      # The "id-token: write" permission is required or Machine ID will not be
+      # able to authenticate with the cluster.
+      id-token: write
+      contents: read
+    ${includeNameComment && '# if you added a workflow name in the previous step, make sure you use the same value here'}
+    name: ${botName}-example
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Fetch Teleport binaries
+      uses: teleport-actions/setup@v1
+      with:
+        version: ${version}
+    # server access example
+    - name: Fetch credentials using Machine ID
+      id: auth
+      uses: teleport-actions/auth@v2
+      with:
+        proxy: ${proxyAddr}
+        token: ${tokenName}
+        # Enable the submission of anonymous usage telemetry. This
+        # helps us shape the future development of \`tbot\`. You can disable this
+        # by omitting this.
+        anonymous-telemetry: 1
+    - name: List nodes (tsh)
+      # Enters a command from the cluster, in this case "tsh ls" using Machine
+      # ID credentials to list remote SSH nodes.
+      run: tsh ls`;
 }

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/useGitHubFlow.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/useGitHubFlow.tsx
@@ -125,6 +125,7 @@ export function GitHubFlowProvider({
             },
           }).then(token => {
             setTokenName(token.id);
+            createBotRequest.roles = [createBotRequest.botName];
             return serviceCreateBot(createBotRequest);
           });
         })

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/useGitHubFlow.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/useGitHubFlow.tsx
@@ -125,8 +125,10 @@ export function GitHubFlowProvider({
             },
           }).then(token => {
             setTokenName(token.id);
-            createBotRequest.roles = [createBotRequest.botName];
-            return serviceCreateBot(createBotRequest);
+            return serviceCreateBot({
+              ...createBotRequest,
+              roles: [createBotRequest.botName],
+            });
           });
         })
     );


### PR DESCRIPTION
I was recording a demo reel that included this feature and I noticed two problems:

- The Bot was not actually assigned the role that was created.
- The example output YAML was malformed.

I appreciate I may not have fixed this in the most "correct" way so I'm open to feedback 😓  It's been a long time since I've dived into the frontend.

changelog: Fixed the "Create A Bot" flow for GitHub Actions and SSH. It now correctly grants the bot the role created during the flow, and the example YAML is now correctly formatted.