### PR TITLE
docs: update backup and restore

### DIFF
--- a/docs/pages/admin-guides/management/operations/backup-restore.mdx
+++ b/docs/pages/admin-guides/management/operations/backup-restore.mdx
@@ -95,7 +95,7 @@ If you're running Teleport at scale, your teams need to have an automated way to
 <Tabs>
 <TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
-You can quickly export a collection of resources from
+You can export a collection of resources from
 Teleport using the below command. This feature helps for migrating
 from one backend to another.
 
@@ -162,7 +162,7 @@ also apply to a new cluster being bootstrapped from the state of an old cluster:
 </TabItem>
 <TabItem scope={["oss"]} label="Open Source">
 
-You can quickly export a collection of resources from
+You can export a collection of resources from
 Teleport using the below command. This feature helps for migrating
 from one backend to another.
 

--- a/docs/pages/admin-guides/management/operations/backup-restore.mdx
+++ b/docs/pages/admin-guides/management/operations/backup-restore.mdx
@@ -95,9 +95,9 @@ If you're running Teleport at scale, your teams need to have an automated way to
 <Tabs>
 <TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
-As of version v4.1, you can now quickly export a collection of resources from
-Teleport. This feature was designed to help customers migrate from local storage
-to etcd.
+You can quickly export a collection of resources from
+Teleport using the below command. This feature helps for migrating
+from one backend to another.
 
 Using `tctl get all --with-secrets` will retrieve the below items:
 
@@ -162,9 +162,9 @@ also apply to a new cluster being bootstrapped from the state of an old cluster:
 </TabItem>
 <TabItem scope={["oss"]} label="Open Source">
 
-As of version v4.1, you can now quickly export a collection of resources from
-Teleport. This feature was designed to help customers migrate from local storage
-to etcd.
+You can quickly export a collection of resources from
+Teleport using the below command. This feature helps for migrating
+from one backend to another.
 
 Using `tctl get all --with-secrets` will retrieve the below items:
 


### PR DESCRIPTION
Updates language that mentioned v4 and only the local to etcd storage migration for `tctl get all`.