### PR TITLE
Restore enterprise auth connectors in tctl get all output

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -562,6 +562,44 @@ func init() {
 		return githubConnector, nil
 	})
 
+	RegisterResourceMarshaler(types.KindSAMLConnector, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
+		samlConnector, ok := resource.(types.SAMLConnector)
+		if !ok {
+			return nil, trace.BadParameter("expected SAMLConnector, got %T", resource)
+		}
+		bytes, err := MarshalSAMLConnector(samlConnector, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return bytes, nil
+	})
+	RegisterResourceUnmarshaler(types.KindSAMLConnector, func(bytes []byte, opts ...MarshalOption) (types.Resource, error) {
+		samlConnector, err := UnmarshalSAMLConnector(bytes, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return samlConnector, nil
+	})
+
+	RegisterResourceMarshaler(types.KindOIDCConnector, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
+		oidConnector, ok := resource.(types.OIDCConnector)
+		if !ok {
+			return nil, trace.BadParameter("expected OIDCConnector, got %T", resource)
+		}
+		bytes, err := MarshalOIDCConnector(oidConnector, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return bytes, nil
+	})
+	RegisterResourceUnmarshaler(types.KindOIDCConnector, func(bytes []byte, opts ...MarshalOption) (types.Resource, error) {
+		oidcConnector, err := UnmarshalOIDCConnector(bytes, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return oidcConnector, nil
+	})
+
 	RegisterResourceMarshaler(types.KindRole, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
 		role, ok := resource.(types.Role)
 		if !ok {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -294,7 +294,7 @@ func (rc *ResourceCommand) GetMany(ctx context.Context, client *authclient.Clien
 		}
 		resources = append(resources, collection.resources()...)
 	}
-	if err := utils.WriteYAML(os.Stdout, resources); err != nil {
+	if err := utils.WriteYAML(rc.stdout, resources); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -1411,6 +1412,17 @@ func TestCreateResources(t *testing.T) {
 			test.create(t, rootClient)
 		})
 	}
+
+	// Verify that the created resources appear in tctl get all
+	out, err := runResourceCommand(t, rootClient, []string{"get", "all"})
+	require.NoError(t, err)
+	s := out.String()
+	require.NotEmpty(t, s)
+	assert.Contains(t, s, "kind: github")
+	assert.Contains(t, s, "kind: cluster_auth_preference")
+	assert.Contains(t, s, "kind: cluster_networking_config")
+	assert.Contains(t, s, "kind: user")
+	assert.Contains(t, s, "kind: role")
 }
 
 func testCreateGithubConnector(t *testing.T, clt *authclient.Client) {
@@ -2051,6 +2063,13 @@ func TestCreateEnterpriseResources(t *testing.T) {
 		})
 	}
 
+	// Verify that the created resources appear in tctl get all
+	out, err := runResourceCommand(t, clt, []string{"get", "all"})
+	require.NoError(t, err)
+	s := out.String()
+	require.NotEmpty(t, s)
+	assert.Contains(t, s, "kind: saml")
+	assert.Contains(t, s, "kind: oidc")
 }
 
 func testCreateOIDCConnector(t *testing.T, clt *authclient.Client) {


### PR DESCRIPTION
When enterprise tctl was removed in v16 the ability to retrieve SAML and OIDC connectors via tctl get all was inadvertently removed. This ensures a resource marshaler and unmarshaler is registered for the two types so that the tctl get all machinery includes them in the group of resources retrieved. Tests were updated to ensure that tctl get all output contains the expected resource types.

Changelog: Fix `tctl get all` not returning SAML or OIDC auth connectors 