### PR TITLE
tsh requests ls truncate roles

### DIFF
--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -368,7 +368,7 @@ func showRequestTable(cf *CLIConf, reqs []types.AccessRequest) error {
 		FootnoteLabel: "[+]",
 	})
 	table.AddFootnote("[+]",
-		"Roles and requested resources are truncated, use `tsh request show <request-id>` to view the full list")
+		"Columns are truncated, use `tsh request show <request-id>` to view the full list")
 	table.AddColumn(asciitable.Column{Title: "Created At (UTC)"})
 	table.AddColumn(asciitable.Column{Title: "Request TTL"})
 	table.AddColumn(asciitable.Column{Title: "Session TTL"})

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -356,14 +356,19 @@ func showRequestTable(cf *CLIConf, reqs []types.AccessRequest) error {
 		return reqs[i].GetCreationTime().After(reqs[j].GetCreationTime())
 	})
 
-	table := asciitable.MakeTable([]string{"ID", "User", "Roles"})
+	table := asciitable.MakeTable([]string{"ID", "User"})
+	table.AddColumn(asciitable.Column{
+		Title:         "Roles",
+		MaxCellLength: 20,
+		FootnoteLabel: "[+]",
+	})
 	table.AddColumn(asciitable.Column{
 		Title:         "Resources",
 		MaxCellLength: 20,
 		FootnoteLabel: "[+]",
 	})
 	table.AddFootnote("[+]",
-		"Requested resources truncated, use `tsh request show <request-id>` to view the full list")
+		"Roles and requested resources are truncated, use `tsh request show <request-id>` to view the full list")
 	table.AddColumn(asciitable.Column{Title: "Created At (UTC)"})
 	table.AddColumn(asciitable.Column{Title: "Request TTL"})
 	table.AddColumn(asciitable.Column{Title: "Session TTL"})


### PR DESCRIPTION
If the Access Request has a big number of roles, when running `tsh requests ls` the output is barely readable. 

![Screenshot 2024-08-09 at 14 56 43](https://github.com/user-attachments/assets/5a31f9a8-438a-4263-9b68-9e0069aff06b)

In this PR, I suggest truncate the `roles` column, similar to the `resources` one and update the `[+]` message.

![image](https://github.com/user-attachments/assets/07c1e4d9-4d0d-486a-99dc-b62a9e06e757)
