### PR TITLE
Do not clear the init message on terminal launch when using ConPTY

### DIFF
--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.ts
@@ -85,6 +85,9 @@ export class PtyProcess extends EventEmitter implements IPtyProcess {
         cwd: this.options.cwd || getDefaultCwd(this.options.env),
         env: this.options.env,
         useConpty: this.options.useConpty,
+        // Do not clear the terminal on launch when using ConPTY.
+        conptyInheritCursor:
+          this.options.useConpty && !!this.options.initMessage,
       });
     } catch (error) {
       this._logger.error(error);


### PR DESCRIPTION
Since we enabled ConPTY the terminal is cleared on launch, so the init message is lost (the message appears for a fraction of a second):

https://github.com/user-attachments/assets/28b71801-42a2-44bd-b973-9318c61ba9be

[The fix](https://github.com/microsoft/node-pty/issues/423#issuecomment-689613661) is to enable `conptyInheritCursor` in `node-pty` (vscode does [the same](https://github.com/microsoft/vscode/blob/e4843ae75e2942ba8249849e62f8a39c053e227f/src/vs/platform/terminal/node/terminalProcess.ts#L167)):

https://github.com/user-attachments/assets/32ad00bc-1eb6-4d90-89ff-61b28d7fe69c

