### PR TITLE
docs: correct Teleport config default reference

### DIFF
--- a/docs/pages/includes/diagnostics/teleport-debug-config.mdx
+++ b/docs/pages/includes/diagnostics/teleport-debug-config.mdx
@@ -1,6 +1,6 @@
 <Admonition type="tip" title="Specify your Teleport configuration path">
 If your Teleport configuration is not placed on the default path
-(`/var/lib/teleport`), you must to specify its location to the CLI command
+(`/etc/teleport.yaml`), you must to specify its location to the CLI command
 using the `-c/--config` flag.
 </Admonition>
 

--- a/docs/pages/includes/diagnostics/teleport-debug-config.mdx
+++ b/docs/pages/includes/diagnostics/teleport-debug-config.mdx
@@ -1,6 +1,6 @@
 <Admonition type="tip" title="Specify your Teleport configuration path">
 If your Teleport configuration is not placed on the default path
-(`/etc/teleport.yaml`), you must to specify its location to the CLI command
+(`/etc/teleport.yaml`), you must specify its location to the CLI command
 using the `-c/--config` flag.
 </Admonition>
 


### PR DESCRIPTION
Corrects to the default configuration file, not default data directory.