### PR TITLE
Discover: Show external link icon on unguided discover resource tiles

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
@@ -28,6 +28,8 @@ import { UserPreferences } from 'gen-proto-ts/teleport/userpreferences/v1/userpr
 
 import { Resource } from 'gen-proto-ts/teleport/userpreferences/v1/onboard_pb';
 
+import { NewTab } from 'design/Icon';
+
 import useTeleport from 'teleport/useTeleport';
 import { ToolTipNoPermBadge } from 'teleport/components/ToolTipNoPermBadge';
 import { Acl, AuthType, OnboardDiscover } from 'teleport/services/user';
@@ -55,6 +57,7 @@ import { DiscoverIcon } from './icons';
 import { PrioritizedResources, SearchResource } from './types';
 import { SAML_APPLICATIONS } from './resourcesE';
 
+import type { ComponentPropsWithoutRef } from 'react';
 import type { ResourceSpec } from './types';
 
 interface SelectResourceProps {
@@ -170,30 +173,28 @@ export function SelectResource({ onSelect }: SelectResourceProps) {
       </Box>
       {resources && resources.length > 0 && (
         <>
-          <Grid>
+          <Grid role="grid">
             {resources.map((r, index) => {
               const title = r.name;
               const pretitle = getResourcePretitle(r);
+              const select = () => {
+                if (!r.hasAccess) {
+                  return;
+                }
 
-              let resourceCardProps:
-                | {
-                    onClick?: () => void;
-                  }
-                | {
-                    as: typeof Link;
-                    href: string | null;
-                    target: string;
-                    style: Record<string, string>;
-                  };
+                setShowApp(true);
+                onSelect(r);
+              };
+
+              let resourceCardProps: ComponentPropsWithoutRef<
+                'button' | typeof Link
+              >;
 
               if (r.kind === ResourceKind.Application && r.isDialog) {
                 resourceCardProps = {
-                  onClick: () => {
-                    if (r.hasAccess) {
-                      setShowApp(true);
-                      onSelect(r);
-                    }
-                  },
+                  onClick: select,
+                  onKeyUp: (e: KeyboardEvent) => e.key === 'Enter' && select(),
+                  role: 'button',
                 };
               } else if (r.unguidedLink) {
                 resourceCardProps = {
@@ -201,10 +202,17 @@ export function SelectResource({ onSelect }: SelectResourceProps) {
                   href: r.hasAccess ? r.unguidedLink : null,
                   target: '_blank',
                   style: { textDecoration: 'none' },
+                  role: 'link',
                 };
               } else {
                 resourceCardProps = {
                   onClick: () => r.hasAccess && onSelect(r),
+                  onKeyUp: (e: KeyboardEvent) => {
+                    if (e.key === 'Enter' && r.hasAccess) {
+                      onSelect(r);
+                    }
+                  },
+                  role: 'button',
                 };
               }
 
@@ -221,6 +229,7 @@ export function SelectResource({ onSelect }: SelectResourceProps) {
                   data-testid={r.kind}
                   key={`${index}${pretitle}${title}`}
                   hasAccess={r.hasAccess}
+                  aria-label={`${pretitle} ${title}`}
                   {...resourceCardProps}
                 >
                   {!r.unguidedLink && r.hasAccess && (
@@ -231,7 +240,7 @@ export function SelectResource({ onSelect }: SelectResourceProps) {
                       children={<PermissionsErrorMessage resource={r} />}
                     />
                   )}
-                  <Flex px={2} alignItems="center">
+                  <Flex px={2} alignItems="center" height="48px">
                     <Flex mr={3} justifyContent="center" width="24px">
                       <DiscoverIcon name={r.icon} />
                     </Flex>
@@ -250,6 +259,10 @@ export function SelectResource({ onSelect }: SelectResourceProps) {
                       )}
                     </Box>
                   </Flex>
+
+                  {r.unguidedLink && (
+                    <NewTabInCorner color="text.muted" size={18} />
+                  )}
                 </ResourceCard>
               );
             })}
@@ -608,23 +621,42 @@ const Grid = styled.div`
   row-gap: 15px;
 `;
 
-const ResourceCard = styled.div<{ hasAccess?: boolean }>`
-  display: flex;
+const NewTabInCorner = styled(NewTab)`
+  position: absolute;
+  top: ${props => props.theme.space[3]}px;
+  right: ${props => props.theme.space[3]}px;
+  transition: color 0.3s;
+`;
+
+const ResourceCard = styled.button<{ hasAccess?: boolean }>`
   position: relative;
-  align-items: center;
+  text-align: left;
   background: ${props => props.theme.colors.spotBackground[0]};
   transition: all 0.3s;
 
+  border: none;
   border-radius: 8px;
-  padding: 12px 12px 12px 12px;
+  padding: 12px;
   color: ${props => props.theme.colors.text.main};
+  line-height: inherit;
+  font-size: inherit;
+  font-family: inherit;
   cursor: pointer;
-  height: 48px;
 
   opacity: ${props => (props.hasAccess ? '1' : '0.45')};
 
-  &:hover {
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px ${props => props.theme.colors.brand};
+  }
+
+  &:hover,
+  &:focus-visible {
     background: ${props => props.theme.colors.spotBackground[1]};
+
+    ${NewTabInCorner} {
+      color: ${props => props.theme.colors.text.slightlyMuted};
+    }
   }
 `;
 
@@ -638,15 +670,17 @@ const BadgeGuided = styled.div`
   top: 0px;
   right: 0px;
   font-size: 10px;
+  line-height: 24px;
 `;
 
 const InputWrapper = styled.div`
   border-radius: 200px;
   height: 40px;
   border: 1px solid ${props => props.theme.colors.spotBackground[2]};
+  transition: all 0.1s;
 
   &:hover,
-  &:focus,
+  &:focus-within,
   &:active {
     background: ${props => props.theme.colors.spotBackground[0]};
   }


### PR DESCRIPTION
Resolves #44669 

## Changes
* Show `ExternalLinkIcon` on hovered/focused unguided discover resource tiles to make more evident they link out to docs
* Make Add guided discover resource tiles proper buttons
* Add focus styling, roles to grid items

## Preview
<img width="700" alt="Screenshot 2024-08-12 at 2 42 42 PM" src="https://github.com/user-attachments/assets/d89a22f1-6aa0-4505-96b5-46584a8333ac">
