### PR TITLE
adds check for blank data directory for debug level

### DIFF
--- a/tool/teleport/common/debug.go
+++ b/tool/teleport/common/debug.go
@@ -176,9 +176,10 @@ func newDebugClient(configPath string) (DebugClient, string, string, error) {
 	}
 
 	// ReadConfigFile returns nil configuration if the file doesn't exists.
-	// In that case, fallback to default data dir path.
+	// In that case, fallback to default data dir path. The data directory
+	// is not required so should use the default if not specified.
 	dataDir := defaults.DataDir
-	if cfg != nil {
+	if cfg == nil || cfg.DataDir != "" {
 		dataDir = cfg.DataDir
 	}
 

--- a/tool/teleport/common/debug.go
+++ b/tool/teleport/common/debug.go
@@ -179,7 +179,7 @@ func newDebugClient(configPath string) (DebugClient, string, string, error) {
 	// In that case, fallback to default data dir path. The data directory
 	// is not required so should use the default if not specified.
 	dataDir := defaults.DataDir
-	if cfg == nil || cfg.DataDir != "" {
+	if cfg != nil && cfg.DataDir != "" {
 		dataDir = cfg.DataDir
 	}
 


### PR DESCRIPTION
A configuration file does not require the data directory. If it is not set then it is set as `""` and should be treated as the default dir `/var/lib/teleport`.

changelog: update teleport debug commands to handle data dir not set