### PR TITLE
improve error when proxy has untrusted HTTPS cert

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1143,6 +1143,14 @@ func validatePROXYProtocolValue(p multiplexer.PROXYProtocolMode) error {
 	return nil
 }
 
+const proxyUntrustedTLSCertErrMsg = `The Proxy Service was unable to validate the certificate chain of the
+  configured TLS certificate. The authority that issued this certificate is not
+  trusted on this host. Using an untrusted certificate is likely to cause
+  connection problems when clients and other Teleport services connect to this
+  Proxy Service. To trust a custom certificate authority you may set the
+  SSL_CERT_FILE or SSL_CERT_DIR environment variables to a path with your
+  authority's certificate chain.`
+
 // applyProxyConfig applies file configuration for the "proxy_service" section.
 func applyProxyConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	var err error
@@ -1268,8 +1276,8 @@ func applyProxyConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 			log.Warnf(warningMessage)
 		} else {
 			if err := utils.VerifyCertificateChain(certificateChain); err != nil {
-				return trace.BadParameter("unable to verify HTTPS certificate chain in %v: %s",
-					fc.Proxy.CertFile, utils.UserMessageFromError(err))
+				return trace.BadParameter("unable to verify HTTPS certificate chain in %v:\n\n  %s\n\n  %s",
+					p.Certificate, proxyUntrustedTLSCertErrMsg, err)
 			}
 		}
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -20,6 +20,7 @@ package config
 
 import (
 	"bytes"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"fmt"
 	"net"
@@ -43,14 +44,17 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/installers"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -4927,4 +4931,69 @@ func TestDiscoveryConfig(t *testing.T) {
 			require.Equal(t, testCase.expectedGCPMatchers, cfg.Discovery.GCPMatchers)
 		})
 	}
+}
+
+// TestProxyUntrustedCert tests that configuring a Proxy Service with an HTTPS
+// cert signed by an untrusted cert authority is an error, and returns a helpful
+// error message.
+func TestProxyUntrustedCert(t *testing.T) {
+	t.Parallel()
+
+	caPriv, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+
+	// Generate a CA for the test that will not be trusted.
+	caCert, err := tlsca.GenerateSelfSignedCAWithSigner(
+		caPriv,
+		pkix.Name{
+			CommonName:   "CA",
+			Organization: []string{"teleport"},
+		}, nil, defaults.CATTL)
+	require.NoError(t, err)
+
+	ca, err := tlsca.FromCertAndSigner(caCert, caPriv)
+	require.NoError(t, err)
+
+	// Generate a leaf cert signed by the untrusted CA.
+	leafPriv, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	leafCert, err := ca.GenerateCertificate(tlsca.CertificateRequest{
+		PublicKey: leafPriv.Public(),
+		Subject:   pkix.Name{CommonName: "leaf"},
+		NotAfter:  time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+
+	leafPrivPem, err := keys.MarshalPrivateKey(leafPriv)
+	require.NoError(t, err)
+
+	certDir := t.TempDir()
+	certPath := filepath.Join(certDir, "leaf.crt")
+	keyPath := filepath.Join(certDir, "leaf.key")
+	err = os.WriteFile(certPath, leafCert, 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(keyPath, leafPrivPem, 0600)
+	require.NoError(t, err)
+
+	fc := &FileConfig{
+		Proxy: Proxy{
+			KeyPairs: []KeyPair{
+				{
+					PrivateKey:  keyPath,
+					Certificate: certPath,
+				},
+			},
+		},
+	}
+	cfg := &servicecfg.Config{}
+
+	err = applyProxyConfig(fc, cfg)
+	require.Error(t, err)
+	require.ErrorContains(t, err, certPath)
+	require.ErrorContains(t, err, proxyUntrustedTLSCertErrMsg)
+
+	// We can't test that writing the CA cert to file and setting SSL_CERT_FILE
+	// would fix this error, because:
+	// - the system root certs are loaded exactly once and cached
+	// - it only works on linux
 }


### PR DESCRIPTION
This PR improves the error message printed when the proxy is started up with an HTTPS cert that is not trusted on the proxy host.

Old message:
```
                                unable to verify HTTPS certificate chain in : ERROR: WARNING:

                                  The proxy you are connecting to has presented a certificate signed by a
                                  unknown authority. This is most likely due to either being presented
                                  with a self-signed certificate or the certificate was truly signed by an
                                  authority not known to the client.

                                  If you know the certificate is self-signed and would like to ignore this
                                  error use the --insecure flag.

                                  If you have your own certificate authority that you would like to use to
                                  validate the certificate chain presented by the proxy, set the
                                  SSL_CERT_FILE and SSL_CERT_DIR environment variables respectively and try
                                  again.

                                  If you think something malicious may be occurring, contact your Teleport
                                  system administrator to resolve this issue.
```

It's unfortunate that the error message fails to print the cert path, references "the proxy you are connecting to", recommends an "--insecure" flag that won't help, and doesn't include any details from the actual x509 verification error

New message:
```
                                unable to verify HTTPS certificate chain in /var/folders/x_/33kp49n52rg8hs97k5m96rnw0000gn/T/TestProxyUntrustedCert1933215820/001/leaf.crt:

                                  The Proxy Service was unable to validate the certificate chain of the
                                  configured TLS certificate. The authority that issued this certificate is not
                                  trusted on this host. Using an untrusted certificate is likely to cause
                                  connection problems when clients and other Teleport services connect to this
                                  Proxy Service. To trust a custom certificate authority you may set the
                                  SSL_CERT_FILE or SSL_CERT_DIR environment variables to a path with your
                                  authority's certificate chain.

                                  x509: “leaf” certificate is not trusted
```