### PR TITLE
Fix the Okta SSO guide

### DIFF
--- a/docs/pages/admin-guides/access-controls/sso/okta.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/okta.mdx
@@ -13,7 +13,6 @@ Teleport administrators to define policies like:
 - Developers must never SSH into production servers.
 - Members of the HR group can view audit logs but not production environments.
 
-
 <Details title="Automated SSO connection with Okta integration" open={false}>
 
 In Teleport Enterprise Cloud and Self-Hosted Teleport Enterprise, Teleport can
@@ -26,7 +25,7 @@ Visit the Teleport Web UI and find the dropdown menu on the upper left of the
 screen. Select the **Management** option.
 
 On the left sidebar, click **Enroll New Integration** to visit the "Enroll New
-Integration" page: 
+Integration" page:
 
 ![Enroll an Access Request plugin](../../../../img/enterprise/plugins/enroll.png)
 
@@ -57,10 +56,12 @@ guide you through configuring the Okta integration.
 
 ## Step 1/4. Create & assign groups
 
-Okta indicates a user's group membership as a SAML assertion in the data it provides
-to Teleport. We will configure Teleport to assign roles (called "dev" and "admin") based on these groups.
+Okta indicates a user's group membership as a SAML assertion in the data it
+provides to Teleport. We will configure Teleport to assign the "dev" role to
+members of the `okta-dev` Okta group, and the prest "editor" role to members of
+the `okta-admin` group.
 
-If you already have Okta groups you want to assign to "dev" and "admin" roles in
+If you already have Okta groups you want to assign to "dev" and "editor" roles in
 Teleport, you can skip to the [next step](#step-24-configure-okta).
 
 ### Create Groups
@@ -76,8 +77,9 @@ Repeat for the admin group:
 
 ## Step 2/4. Configure Okta
 
-In this section we will create an application in the Okta dashboard to allow our Teleport cluster to access Okta as an IdP provider. We'll also
-locate the address that Okta uses to provides their IdP metadata to Teleport.
+In this section we will create an application in the Okta dashboard to allow our
+Teleport cluster to access Okta as an IdP provider. We'll also locate the
+address that Okta uses to provides their IdP metadata to Teleport.
 
 First, create a SAML 2.0 Web App in Okta:
 
@@ -173,7 +175,7 @@ flags for this command:
 $ tctl sso configure saml --preset=okta \
 --entity-descriptor <Var name="https://example.okta.com/app/000000/sso/saml/metadata"/> \
 --attributes-to-roles=groups,okta-admin,editor \
---attributes-to-roles=groups,okta-dev,access > okta.yaml
+--attributes-to-roles=groups,okta-dev,dev > okta.yaml
 ```
 
 The contents of `okta.yaml` should resemble the following:
@@ -191,7 +193,7 @@ spec:
     value: okta-admin
   - name: groups
     roles:
-    - access
+    - dev
     value: okta-dev
   audience: https://teleport.example.com:443/v1/webapi/saml/acs/okta
   cert: ""
@@ -221,7 +223,7 @@ Success! Logged in as: alice@example.com
 Authentication details:
    roles:
    - editor
-   - access
+   - dev
    traits:
      groups:
      - Everyone
@@ -238,7 +240,7 @@ Authentication details:
   value: okta-admin
 - name: groups
   roles:
-  - access
+  - dev
   value: okta-dev
 
 --------------------------------------------------------------------------------
@@ -264,8 +266,8 @@ $ tctl create okta-connector.yaml
 
 ## Step 4/4. Create a developer Teleport role
 
-Now let's create a new role to pull in external information from Okta.
-Create the local file `dev.yaml` with the content below.
+Now let's create the Teleport role that we will assign to members of the
+`okta-dev` group. Create the local file `dev.yaml` with the content below.
 
 ```yaml
 kind: role
@@ -296,16 +298,19 @@ leave the username prefix. For full details on how variable expansion works in
 Teleport roles, see the [Teleport Access Controls
 Reference](../../../reference/access-controls/roles.mdx).
 
-Use tctl to create this role in the Teleport Auth Service:
+Use `tctl` to create this role in the Teleport Auth Service:
 
 ```code
 $ tctl create dev.yaml
 ```
 
+We don't need to repeat this process for the "editor" role because this is a
+preset role that is available by default in all Teleport clusters.
+
 ## Testing
 
-The Web UI now contains a new "Okta" button at the login screen. To 
-authenticate via the `tsh` CLI, specify the Proxy Service address and `tsh` will 
+The Web UI now contains a new "Okta" button at the login screen. To
+authenticate via the `tsh` CLI, specify the Proxy Service address and `tsh` will
 automatically use the default authentication type:
 
 ```code


### PR DESCRIPTION
It looks like the guide intends for you to set up two Okta groups (okta-dev and okta-admin) that map to Teleport roles.

The Teleport roles that the guide refers to are incorrect though. For the okta-dev group, the guide has to create a "dev" role, but then configures an SSO connector to assign you the preset "access" role and the "dev" role goes unused.

Additionally, the okta-admin group refers to an "admin" role, but the SSO connector that you set up maps users to the "editor" role.

Correct the guide to properly use the "dev" role that it asks you to create and to replace mentions of "admin" with "editor".

Closes #28660