### PR TITLE
Set the key id in JWT

### DIFF
--- a/lib/jwt/jwt.go
+++ b/lib/jwt/jwt.go
@@ -216,7 +216,15 @@ func (k *Key) Sign(p SignParams) (string, error) {
 		Traits:   p.Traits,
 	}
 
-	return k.sign(claims, nil)
+	// grab the key id
+	publicKey := k.config.PublicKey
+	kid, _ := KeyID(publicKey)
+
+	// RFC 7517 requires that `kid` be present in the JWT header if there are multiple keys in the JWKS.
+	// go-jose will explicitly omit the `kid` if it is set to an empty string.
+	opts := (&jose.SignerOptions{}).
+		WithHeader(jose.HeaderKey("kid"), kid)
+	return k.sign(claims, opts)
 }
 
 // awsOIDCCustomClaims defines the require claims for the JWT token used in AWS OIDC Integration.

--- a/lib/jwt/jwt.go
+++ b/lib/jwt/jwt.go
@@ -219,7 +219,7 @@ func (k *Key) Sign(p SignParams) (string, error) {
 	// RFC 7517 requires that `kid` be present in the JWT header if there are multiple keys in the JWKS.
 	// We ignore the error because go-jose omits the kid if it is empty.
 	kid, _ := KeyID(k.config.PublicKey)
-	return k.sign(claims, WithHeader(jose.HeaderKey("kid"), kid)
+	return k.sign(claims, (&jose.SignerOptions{}).WithHeader("kid", kid))
 }
 
 // awsOIDCCustomClaims defines the require claims for the JWT token used in AWS OIDC Integration.

--- a/lib/jwt/jwt.go
+++ b/lib/jwt/jwt.go
@@ -216,15 +216,10 @@ func (k *Key) Sign(p SignParams) (string, error) {
 		Traits:   p.Traits,
 	}
 
-	// grab the key id
-	publicKey := k.config.PublicKey
-	kid, _ := KeyID(publicKey)
-
 	// RFC 7517 requires that `kid` be present in the JWT header if there are multiple keys in the JWKS.
-	// go-jose will explicitly omit the `kid` if it is set to an empty string.
-	opts := (&jose.SignerOptions{}).
-		WithHeader(jose.HeaderKey("kid"), kid)
-	return k.sign(claims, opts)
+	// We ignore the error because go-jose omits the kid if it is empty.
+	kid, _ := KeyID(k.config.PublicKey)
+	return k.sign(claims, WithHeader(jose.HeaderKey("kid"), kid)
 }
 
 // awsOIDCCustomClaims defines the require claims for the JWT token used in AWS OIDC Integration.

--- a/lib/jwt/jwt_test.go
+++ b/lib/jwt/jwt_test.go
@@ -61,6 +61,13 @@ func TestSignAndVerify(t *testing.T) {
 			})
 			require.NoError(t, err)
 
+			//decode the signed token
+			decodedToken, err := josejwt.ParseSigned(token)
+			require.NoError(t, err)
+
+			// verify that the kid header is present, and not empty
+			require.NotEmpty(t, decodedToken.Headers[0].KeyID)
+
 			// Verify that the token can be validated and values match expected values.
 			claims, err := key.Verify(VerifyParams{
 				Username: "foo@example.com",


### PR DESCRIPTION
Some JWT libraries panic with multiple keys present in the JWKS. A second JWKS key entry was added in #40998

Fixes #44245