### PR TITLE
Check if integration is present when deciding if we should setup access entry.

### DIFF
--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -364,7 +364,7 @@ func (a *eksFetcher) getMatchingKubeCluster(ctx context.Context, clusterName str
 	}
 
 	// If no access configuration is required, return the cluster.
-	if a.SetupAccessForARN == "" || rsp.Cluster.AccessConfig == nil {
+	if a.SetupAccessForARN == "" || rsp.Cluster.AccessConfig == nil || a.Integration != "" {
 		return cluster, nil
 	}
 


### PR DESCRIPTION
If fetcher is using AWS integration, we don't need to setup access entry at this stage, it will be handled when enrolling the cluster. This was causing permissions problem for Discover flow auto-discovery since integration didn't have required "eks:DescribeAccessEntry" permissions that was used to setup access entry here. But we don't need it in case of integration-based auto-discovery.

Changelog: Fix access entry handling permission error when EKS auto-discovery was set up in the Discover UI.