### PR TITLE
docs: update second_factor references

### DIFF
--- a/docs/pages/admin-guides/management/security/reduce-blast-radius.mdx
+++ b/docs/pages/admin-guides/management/security/reduce-blast-radius.mdx
@@ -69,17 +69,12 @@ The `second_factor` options are:
 - `webauthn`
 - `on`
 
-Choose `on` if you would like to let them choose an OTP or WebAuthn device. The other options restrict users to a single type of MFA device, which is useful for enforcing a particular standard of security. Once you start the Teleport Proxy Service with the `second_factor` configuration option set to one of these values, Teleport will mandate MFA by:
+Choose `on` if you would like to let them choose an OTP or WebAuthn device. The other options restrict users to a single type of MFA device, which is useful for enforcing a particular standard of security. Once you start the Teleport Auth Service with the `second_factor` configuration option set to one of these values, Teleport will mandate MFA by:
 
 - Adjusting the Teleport signup page so a user must enroll an MFA device of the kind you have selected. If the value of `second_factor` is `on`, users will have the option to select from multiple device types.
 - Presenting the user with an MFA challenge when they run `tsh login`.
 
 If you have enabled SSO in your Teleport environment, MFA challenges at login only apply for local users, but the IdP may apply its own MFA checks.
-
-<Admonition type="warning">
-Multi-factor authentication is now required for local users as of v16 for self-hosted. See this [guidance](../../../changelog.mdx#multi-factor-authentication-is-now-required-for-local-users) 
-on handling users prior to upgrading if MFA was not required for local users. 
-</Admonition>
 
 ## Present an MFA challenge for every attempt to access a resource
 After a user logs into a Teleport cluster, they can request access to a particular resource, e.g., a node, database, application, or Kubernetes cluster. In this case, the Teleport Auth Service issues a single-use certificate for accessing that resource. You can prevent attackers from doing damage with a compromised certificate by enabling per-session MFA. With this setting, whenever a user requests a one-time certificate to access a resource, the Teleport Auth Service will issue an MFA challenge, even if the user has already begun a Teleport session via `tsh login`.

--- a/docs/pages/admin-guides/management/security/reduce-blast-radius.mdx
+++ b/docs/pages/admin-guides/management/security/reduce-blast-radius.mdx
@@ -17,7 +17,7 @@ Teleport encourages users to practice defense in depth so that every component o
 
 If a user sets up an account to authenticate to their Teleport cluster with only a password, an adversary can gain access to the password using brute-force attacks, person-in-the-middle attacks, or phishing. But even if a user's password is compromised, you can stop an attacker from authenticating with it when they run `tsh login`.
 
-Teleport lets you make it mandatory for a user to enroll an MFA device when they create an account, and to authenticate using that device when they begin a new Teleport session.
+Teleport lets you set the type of MFA device required when they create an account, and to authenticate using that device when they begin a new Teleport session.
 
 To do so, make the following changes depending on your environment:
 
@@ -63,13 +63,13 @@ $ tctl create -f cap.yaml
 </TabItem>
 </Tabs>
 
-To make MFA mandatory for all users, `second_factor` must be set to one of the following values:
+The `second_factor` options are:
 
 - `otp`
 - `webauthn`
 - `on`
 
-Choose `on` if you would like to require MFA for all users while letting them choose an OTP or WebAuthn device. The other options restrict users to a single type of MFA device, which is useful for enforcing a particular standard of security. Once you start the Teleport Proxy Service with the `second_factor` configuration option set to one of these values, Teleport will mandate MFA by:
+Choose `on` if you would like to let them choose an OTP or WebAuthn device. The other options restrict users to a single type of MFA device, which is useful for enforcing a particular standard of security. Once you start the Teleport Proxy Service with the `second_factor` configuration option set to one of these values, Teleport will mandate MFA by:
 
 - Adjusting the Teleport signup page so a user must enroll an MFA device of the kind you have selected. If the value of `second_factor` is `on`, users will have the option to select from multiple device types.
 - Presenting the user with an MFA challenge when they run `tsh login`.
@@ -77,9 +77,8 @@ Choose `on` if you would like to require MFA for all users while letting them ch
 If you have enabled SSO in your Teleport environment, MFA challenges at login only apply for local users, but the IdP may apply its own MFA checks.
 
 <Admonition type="warning">
-If your `second_factor` configuration is set to `off` and a user creates an account without a second factor, changing `second_factor` to a value that requires MFA will force that user to authenticate with a credential they have not registered. This will lock them out of their account. You have two ways to avoid this scenario:
-- Set `second_factor` to `optional` until you have confirmed that existing users have enrolled their MFA devices.
-- Run the `tctl users reset <account>` command to force a user to enter new credentials, including any required MFA device.
+Multi-factor authentication is now required for local users as of v16 for self-hosted. See this [guidance](../../../changelog.mdx#multi-factor-authentication-is-now-required-for-local-users) 
+on handling users prior to upgrading if MFA was not required for local users. 
 </Admonition>
 
 ## Present an MFA challenge for every attempt to access a resource

--- a/docs/pages/admin-guides/management/security/reduce-blast-radius.mdx
+++ b/docs/pages/admin-guides/management/security/reduce-blast-radius.mdx
@@ -13,28 +13,12 @@ Teleport encourages users to practice defense in depth so that every component o
 - [Set up your RBAC without admin roles](#set-up-your-rbac-without-admin-roles)
 - (!docs/pages/includes/tctl.mdx!)
 
-## Make MFA mandatory for `tsh login`
+## Use MFA for local user authentication
 
-If a user sets up an account to authenticate to their Teleport cluster with only a password, an adversary can gain access to the password using brute-force attacks, person-in-the-middle attacks, or phishing. But even if a user's password is compromised, you can stop an attacker from authenticating with it when they run `tsh login`.
+For local users Teleport requires using a MFA device or One-time password (OTP) when they register their user. An OTP is considered a less secure option
+as they are easier to copy and not physical devices.  With MFA Teleport allows for further options of allowing or denying device models. 
 
-Teleport lets you set the type of MFA device required when they create an account, and to authenticate using that device when they begin a new Teleport session.
-
-To do so, make the following changes depending on your environment:
-
-<Tabs>
-<TabItem label="Self-Hosted" scope={["oss","enterprise"]}>
-
-Ensure that the value of `auth_service.authentication.second_factor` is `otp`,
-`webauthn`, or `on`:
-
-```yaml
-auth_service:
-  authentication:
-    second_factor: webauthn
-```
-
-</TabItem>
-<TabItem label="Cloud-Hosted" scope={["cloud","team"]}>
+To set MFA as the required option, make the following changes depending on your environment:
 
 Obtain your existing `cluster_auth_preference` resource:
 
@@ -51,7 +35,7 @@ version: v2
 metadata:
   name: cluster-auth-preference
 spec:
-  second_factor: "otp"
+  second_factor: "webauthn"
 ```
 
 Apply your change:
@@ -59,20 +43,6 @@ Apply your change:
 ```code
 $ tctl create -f cap.yaml
 ```
-
-</TabItem>
-</Tabs>
-
-The `second_factor` options are:
-
-- `otp`
-- `webauthn`
-- `on`
-
-Choose `on` if you would like to let them choose an OTP or WebAuthn device. The other options restrict users to a single type of MFA device, which is useful for enforcing a particular standard of security. Once you start the Teleport Auth Service with the `second_factor` configuration option set to one of these values, Teleport will mandate MFA by:
-
-- Adjusting the Teleport signup page so a user must enroll an MFA device of the kind you have selected. If the value of `second_factor` is `on`, users will have the option to select from multiple device types.
-- Presenting the user with an MFA challenge when they run `tsh login`.
 
 If you have enabled SSO in your Teleport environment, MFA challenges at login only apply for local users, but the IdP may apply its own MFA checks.
 

--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -188,8 +188,7 @@ auth_service:
         # Defaults to "local".
         #connector_name: local
 
-        # this section is used if second_factor is set to 'on', 'optional' or
-        # 'webauthn'.
+        # this section is used if second_factor is set to 'on' or 'webauthn'.
         webauthn:
           # public domain of the Teleport proxy, *excluding* protocol
           # (`https://`) and port number.

--- a/docs/pages/reference/access-controls/authentication.mdx
+++ b/docs/pages/reference/access-controls/authentication.mdx
@@ -24,13 +24,6 @@ possible values (types) of MFA:
   instructions on setting up WebAuthn for Teleport.
 - `on` enables both TOTP and WebAuthn, and all local users are required to have at least one MFA device registered.
 
-<Admonition type="note">
-
-  As of v16 `optional` and `off` are not supported as [multi-factor authentication is now required for local users](../../changelog.mdx#multi-factor-authentication-is-now-required-for-local-users).
-
-  If you are using Teleport with a Single Sign-On solution, users can also register MFA devices, but Teleport will not prompt them for MFA during login. MFA for SSO users should be handled by the SSO provider.
-</Admonition>
-
 <Tabs>
 <TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
 

--- a/docs/pages/reference/access-controls/authentication.mdx
+++ b/docs/pages/reference/access-controls/authentication.mdx
@@ -23,12 +23,11 @@ possible values (types) of MFA:
   See our [Second Factor - WebAuthn](../../admin-guides/access-controls/guides/webauthn.mdx) guide for detailed
   instructions on setting up WebAuthn for Teleport.
 - `on` enables both TOTP and WebAuthn, and all local users are required to have at least one MFA device registered.
-- `optional` enables both TOTP and WebAuthn but makes it optional for users. Local users that register a MFA device will
-  be prompted for it during login. This option is useful when you need to gradually enable MFA usage before switching
-  the value to `on`.
-- `off` turns off multi-factor authentication.
 
 <Admonition type="note">
+
+  As of v16 `optional` and `off` are not supported as [multi-factor authentication is now required for local users](../../changelog.mdx#multi-factor-authentication-is-now-required-for-local-users).
+
   If you are using Teleport with a Single Sign-On solution, users can also register MFA devices, but Teleport will not prompt them for MFA during login. MFA for SSO users should be handled by the SSO provider.
 </Admonition>
 


### PR DESCRIPTION
Updates to areas where `second_factor` didn't show MFA as mandatory for v16+ for local users.