### PR TITLE
Update pnpm to 9.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "tslib": "^2.6.3",
     "whatwg-fetch": "^3.6.20"
   },
-  "packageManager": "pnpm@9.6.0",
+  "packageManager": "pnpm@9.7.0",
   "msw": {
     "workerDirectory": [
       "web/.storybook/public"


### PR DESCRIPTION
https://github.com/pnpm/pnpm/releases

A cool thing is that pnpm now can download the correct version of itself based on `packageManager` field in `package.json` (just like corepack). This will be useful when we switch to Node.js version management via pnpm https://github.com/gravitational/teleport/issues/45055.