### PR TITLE
[v16] Update pnpm to 9.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,5 +87,5 @@
     "tslib": "^2.6.3",
     "whatwg-fetch": "^3.6.20"
   },
-  "packageManager": "pnpm@9.6.0"
+  "packageManager": "pnpm@9.7.0"
 }


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/45363 to branch/v16. 