### PR TITLE
docs: include GCP web console with cloud APIs

### DIFF
--- a/docs/pages/enroll-resources/application-access/introduction.mdx
+++ b/docs/pages/enroll-resources/application-access/introduction.mdx
@@ -7,7 +7,7 @@ Teleport can provide secure access to applications and cloud provider APIs.
 
 Examples include: 
 
-- The AWS management console.
+- The AWS management and GCP web console.
 - The `aws`, `gcloud`, `gsutil`, and `az` CLIs.
 - Applications configured for single sign-on through Okta.
 - Internal control panels.
@@ -39,6 +39,7 @@ CLI tools with the same RBAC system you use to protect your infrastructure.
 
 - [AWS Console and CLI Applications](./cloud-apis/aws-console.mdx): How to access
   AWS Management Console, AWS CLI, and AWS SDKs with Teleport.
+- [Google Cloud Web Console](../../admin-guides/access-controls/idps/saml-gcp-workforce-identity-federation.mdx): How to access Google Cloud web console with Teleport.
 - [Google Cloud CLI Applications](./cloud-apis/google-cloud.mdx): How to access
   Google Cloud CLI applications and SDKs with Teleport.
 - [Azure CLI Applications](./cloud-apis/azure.mdx): How to access Azure CLI

--- a/docs/pages/enroll-resources/application-access/introduction.mdx
+++ b/docs/pages/enroll-resources/application-access/introduction.mdx
@@ -7,7 +7,7 @@ Teleport can provide secure access to applications and cloud provider APIs.
 
 Examples include: 
 
-- The AWS management and GCP web console.
+- The AWS and GCP management consoles.
 - The `aws`, `gcloud`, `gsutil`, and `az` CLIs.
 - Applications configured for single sign-on through Okta.
 - Internal control panels.
@@ -39,7 +39,7 @@ CLI tools with the same RBAC system you use to protect your infrastructure.
 
 - [AWS Console and CLI Applications](./cloud-apis/aws-console.mdx): How to access
   AWS Management Console, AWS CLI, and AWS SDKs with Teleport.
-- [Google Cloud Web Console](../../admin-guides/access-controls/idps/saml-gcp-workforce-identity-federation.mdx): How to access Google Cloud web console with Teleport.
+- [Google Cloud Web Console](../../admin-guides/access-controls/idps/saml-gcp-workforce-identity-federation.mdx): How to access the Google Cloud web console with Teleport.
 - [Google Cloud CLI Applications](./cloud-apis/google-cloud.mdx): How to access
   Google Cloud CLI applications and SDKs with Teleport.
 - [Azure CLI Applications](./cloud-apis/azure.mdx): How to access Azure CLI


### PR DESCRIPTION
often missed that Teleport supports the GCP web console too in addition to cli.