### PR TITLE
Deprecate ListResources helpers and migrate to the unified API

### DIFF
--- a/lib/benchmark/db/db.go
+++ b/lib/benchmark/db/db.go
@@ -60,10 +60,10 @@ func retrieveDatabaseCertificates(ctx context.Context, tc *client.TeleportClient
 
 // getDatabase loads the database which the name matches.
 func getDatabase(ctx context.Context, tc *client.TeleportClient, serviceName string, protocol string) (types.Database, error) {
-	databases, err := tc.ListDatabases(ctx, &proto.ListResourcesRequest{
-		Namespace:           tc.Namespace,
-		ResourceType:        types.KindDatabaseServer,
+	databases, err := tc.ListDatabases(ctx, &proto.ListUnifiedResourcesRequest{
+		Kinds:               []string{types.KindDatabaseServer},
 		PredicateExpression: fmt.Sprintf(`name == "%s" && resource.spec.protocol == "%s"`, serviceName, protocol),
+		Limit:               2,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1109,10 +1109,9 @@ func (c *Config) ProxySpecified() bool {
 
 // ResourceFilter returns the default list resource request for the
 // provided resource kind.
-func (c *Config) ResourceFilter(kind string) *proto.ListResourcesRequest {
-	return &proto.ListResourcesRequest{
-		ResourceType:        kind,
-		Namespace:           c.Namespace,
+func (c *Config) ResourceFilter(kind string) proto.ListUnifiedResourcesRequest {
+	return proto.ListUnifiedResourcesRequest{
+		Kinds:               []string{kind},
 		Labels:              c.Labels,
 		SearchKeywords:      c.SearchKeywords,
 		PredicateExpression: c.PredicateExpression,
@@ -1385,7 +1384,7 @@ type targetNode struct {
 
 // getTargetNodes returns a list of node addresses this SSH command needs to
 // operate on.
-func (tc *TeleportClient) getTargetNodes(ctx context.Context, clt client.GetResourcesClient, options SSHOptions) ([]targetNode, error) {
+func (tc *TeleportClient) getTargetNodes(ctx context.Context, clt client.ListUnifiedResourcesClient, options SSHOptions) ([]targetNode, error) {
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/getTargetNodes",
@@ -2526,7 +2525,7 @@ func (tc *TeleportClient) GetClusterAlerts(ctx context.Context, req types.GetClu
 }
 
 // ListAppServersWithFilters returns a list of application servers.
-func (tc *TeleportClient) ListAppServersWithFilters(ctx context.Context, customFilter *proto.ListResourcesRequest) ([]types.AppServer, error) {
+func (tc *TeleportClient) ListAppServersWithFilters(ctx context.Context, customFilter *proto.ListUnifiedResourcesRequest) ([]types.AppServer, error) {
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/ListAppServersWithFilters",
@@ -2542,15 +2541,16 @@ func (tc *TeleportClient) ListAppServersWithFilters(ctx context.Context, customF
 
 	filter := customFilter
 	if filter == nil {
-		filter = tc.ResourceFilter(types.KindAppServer)
+		req := tc.ResourceFilter(types.KindAppServer)
+		filter = &req
 	}
 
-	servers, err := client.GetAllResources[types.AppServer](ctx, clusterClient.AuthClient, filter)
+	servers, err := client.GetAllResources[types.AppServer](ctx, clusterClient.AuthClient, *filter)
 	return servers, trace.Wrap(err)
 }
 
 // ListApps returns all registered applications.
-func (tc *TeleportClient) ListApps(ctx context.Context, customFilter *proto.ListResourcesRequest) ([]types.Application, error) {
+func (tc *TeleportClient) ListApps(ctx context.Context, customFilter *proto.ListUnifiedResourcesRequest) ([]types.Application, error) {
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/ListApps",
@@ -2594,7 +2594,7 @@ func (tc *TeleportClient) DeleteAppSession(ctx context.Context, sessionID string
 }
 
 // ListDatabaseServersWithFilters returns all registered database proxy servers.
-func (tc *TeleportClient) ListDatabaseServersWithFilters(ctx context.Context, customFilter *proto.ListResourcesRequest) ([]types.DatabaseServer, error) {
+func (tc *TeleportClient) ListDatabaseServersWithFilters(ctx context.Context, customFilter *proto.ListUnifiedResourcesRequest) ([]types.DatabaseServer, error) {
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/ListDatabaseServersWithFilters",
@@ -2610,15 +2610,16 @@ func (tc *TeleportClient) ListDatabaseServersWithFilters(ctx context.Context, cu
 
 	filter := customFilter
 	if filter == nil {
-		filter = tc.ResourceFilter(types.KindDatabaseServer)
+		req := tc.ResourceFilter(types.KindDatabaseServer)
+		filter = &req
 	}
 
-	servers, err := client.GetAllResources[types.DatabaseServer](ctx, clusterClient.AuthClient, filter)
+	servers, err := client.GetAllResources[types.DatabaseServer](ctx, clusterClient.AuthClient, *filter)
 	return servers, trace.Wrap(err)
 }
 
 // ListDatabases returns all registered databases.
-func (tc *TeleportClient) ListDatabases(ctx context.Context, customFilter *proto.ListResourcesRequest) ([]types.Database, error) {
+func (tc *TeleportClient) ListDatabases(ctx context.Context, customFilter *proto.ListUnifiedResourcesRequest) ([]types.Database, error) {
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/ListDatabases",

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -1276,18 +1276,18 @@ func TestIsErrorResolvableWithRelogin(t *testing.T) {
 }
 
 type fakeResourceClient struct {
-	apiclient.GetResourcesClient
+	apiclient.ListUnifiedResourcesClient
 
 	nodes []*types.ServerV2
 }
 
-func (f fakeResourceClient) GetResources(ctx context.Context, req *proto.ListResourcesRequest) (*proto.ListResourcesResponse, error) {
+func (f fakeResourceClient) ListUnifiedResources(ctx context.Context, req *proto.ListUnifiedResourcesRequest) (*proto.ListUnifiedResourcesResponse, error) {
 	out := make([]*proto.PaginatedResource, 0, len(f.nodes))
 	for _, n := range f.nodes {
 		out = append(out, &proto.PaginatedResource{Resource: &proto.PaginatedResource_Node{Node: n}})
 	}
 
-	return &proto.ListResourcesResponse{Resources: out}, nil
+	return &proto.ListUnifiedResourcesResponse{Resources: out}, nil
 }
 
 func TestGetTargetNodes(t *testing.T) {

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -189,10 +189,10 @@ func KubeClusters(ctx context.Context, p KubeServicesPresence) ([]types.KubeClus
 
 // ListKubeClustersWithFilters returns a sorted list of unique kubernetes clusters
 // registered in p.
-func ListKubeClustersWithFilters(ctx context.Context, p client.GetResourcesClient, req proto.ListResourcesRequest) ([]types.KubeCluster, error) {
-	req.ResourceType = types.KindKubeServer
+func ListKubeClustersWithFilters(ctx context.Context, p client.ListUnifiedResourcesClient, req proto.ListUnifiedResourcesRequest) ([]types.KubeCluster, error) {
+	req.Kinds = []string{types.KindKubeServer}
 
-	kss, err := client.GetAllResources[types.KubeServer](ctx, p, &req)
+	kss, err := client.GetAllResources[types.KubeServer](ctx, p, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/tbot/database_access.go
+++ b/lib/tbot/database_access.go
@@ -36,9 +36,8 @@ func getDatabase(ctx context.Context, clt *authclient.Client, name string) (type
 	ctx, span := tracer.Start(ctx, "getDatabase")
 	defer span.End()
 
-	servers, err := apiclient.GetAllResources[types.DatabaseServer](ctx, clt, &proto.ListResourcesRequest{
-		Namespace:           defaults.Namespace,
-		ResourceType:        types.KindDatabaseServer,
+	servers, err := apiclient.GetAllResources[types.DatabaseServer](ctx, clt, proto.ListUnifiedResourcesRequest{
+		Kinds:               []string{types.KindDatabaseServer},
 		PredicateExpression: makeNameOrDiscoveredNamePredicate(name),
 		Limit:               int32(defaults.DefaultChunkSize),
 	})

--- a/lib/tbot/service_application_output.go
+++ b/lib/tbot/service_application_output.go
@@ -27,7 +27,6 @@ import (
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -237,9 +236,8 @@ func getApp(ctx context.Context, clt *authclient.Client, appName string) (types.
 	ctx, span := tracer.Start(ctx, "getApp")
 	defer span.End()
 
-	servers, err := apiclient.GetAllResources[types.AppServer](ctx, clt, &proto.ListResourcesRequest{
-		Namespace:           defaults.Namespace,
-		ResourceType:        types.KindAppServer,
+	servers, err := apiclient.GetAllResources[types.AppServer](ctx, clt, proto.ListUnifiedResourcesRequest{
+		Kinds:               []string{types.KindAppServer},
 		PredicateExpression: fmt.Sprintf(`name == "%s"`, appName),
 		Limit:               1,
 	})

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -396,9 +396,8 @@ func getKubeCluster(ctx context.Context, clt *authclient.Client, name string) (t
 	ctx, span := tracer.Start(ctx, "getKubeCluster")
 	defer span.End()
 
-	servers, err := apiclient.GetAllResources[types.KubeServer](ctx, clt, &proto.ListResourcesRequest{
-		Namespace:           defaults.Namespace,
-		ResourceType:        types.KindKubeServer,
+	servers, err := apiclient.GetAllResources[types.KubeServer](ctx, clt, proto.ListUnifiedResourcesRequest{
+		Kinds:               []string{types.KindKubeServer},
 		PredicateExpression: makeNameOrDiscoveredNamePredicate(name),
 		Limit:               int32(defaults.DefaultChunkSize),
 	})

--- a/lib/teleterm/clusters/cluster_apps.go
+++ b/lib/teleterm/clusters/cluster_apps.go
@@ -128,10 +128,10 @@ type GetAppsResponse struct {
 func (c *Cluster) getApp(ctx context.Context, authClient authclient.ClientI, appName string) (types.Application, error) {
 	var app types.Application
 	err := AddMetadataToRetryableError(ctx, func() error {
-		apps, err := apiclient.GetAllResources[types.AppServer](ctx, authClient, &proto.ListResourcesRequest{
-			Namespace:           c.clusterClient.Namespace,
-			ResourceType:        types.KindAppServer,
+		apps, err := apiclient.GetAllResources[types.AppServer](ctx, authClient, proto.ListUnifiedResourcesRequest{
+			Kinds:               []string{types.KindAppServer},
 			PredicateExpression: fmt.Sprintf(`name == "%s"`, appName),
+			Limit:               2,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -52,10 +52,10 @@ func (c *Cluster) GetDatabase(ctx context.Context, authClient authclient.ClientI
 	var database types.Database
 	dbName := dbURI.GetDbName()
 	err := AddMetadataToRetryableError(ctx, func() error {
-		databases, err := apiclient.GetAllResources[types.DatabaseServer](ctx, authClient, &proto.ListResourcesRequest{
-			Namespace:           defaults.Namespace,
-			ResourceType:        types.KindDatabaseServer,
+		databases, err := apiclient.GetAllResources[types.DatabaseServer](ctx, authClient, proto.ListUnifiedResourcesRequest{
+			Kinds:               []string{types.KindDatabaseServer},
 			PredicateExpression: fmt.Sprintf(`name == "%s"`, dbName),
+			Limit:               2,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster_kubes.go
+++ b/lib/teleterm/clusters/cluster_kubes.go
@@ -154,7 +154,7 @@ func (c *Cluster) getKube(ctx context.Context, authClient authclient.ClientI, ku
 	var kubeClusters []types.KubeCluster
 	err := AddMetadataToRetryableError(ctx, func() error {
 		var err error
-		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, authClient, proto.ListResourcesRequest{
+		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, authClient, proto.ListUnifiedResourcesRequest{
 			PredicateExpression: fmt.Sprintf("name == %q", kubeCluster),
 		})
 

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -79,7 +79,7 @@ func (h *Handler) clusterAppsGet(w http.ResponseWriter, r *http.Request, p httpr
 		}
 	}
 
-	userGroups, err := apiclient.GetAllResources[types.UserGroup](r.Context(), clt, &proto.ListResourcesRequest{
+	userGroups, err := apiclient.ListAllResources[types.UserGroup](r.Context(), clt, &proto.ListResourcesRequest{
 		ResourceType:     types.KindUserGroup,
 		Namespace:        apidefaults.Namespace,
 		UseSearchAsRoles: true,

--- a/lib/web/user_groups.go
+++ b/lib/web/user_groups.go
@@ -27,7 +27,6 @@ import (
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/web/ui"
@@ -51,9 +50,8 @@ func (h *Handler) getUserGroups(_ http.ResponseWriter, r *http.Request, params h
 		return nil, trace.Wrap(err)
 	}
 
-	appServers, err := apiclient.GetAllResources[types.AppServer](r.Context(), clt, &proto.ListResourcesRequest{
-		ResourceType:     types.KindAppServer,
-		Namespace:        apidefaults.Namespace,
+	appServers, err := apiclient.GetAllResources[types.AppServer](r.Context(), clt, proto.ListUnifiedResourcesRequest{
+		Kinds:            []string{types.KindAppServer},
 		UseSearchAsRoles: true,
 	})
 	if err != nil {

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -86,8 +86,8 @@ func (c *DBCommand) ListDatabases(ctx context.Context, clt *authclient.Client) e
 		return trace.Wrap(err)
 	}
 
-	servers, err := client.GetAllResources[types.DatabaseServer](ctx, clt, &proto.ListResourcesRequest{
-		ResourceType:        types.KindDatabaseServer,
+	servers, err := client.GetAllResources[types.DatabaseServer](ctx, clt, proto.ListUnifiedResourcesRequest{
+		Kinds:               []string{types.KindDatabaseServer},
 		Labels:              labels,
 		PredicateExpression: c.predicateExpr,
 		SearchKeywords:      libclient.ParseSearchKeywords(c.searchKeywords, ','),

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -86,8 +86,8 @@ func (c *KubeCommand) ListKube(ctx context.Context, clt *authclient.Client) erro
 		return trace.Wrap(err)
 	}
 
-	kubes, err := client.GetAllResources[types.KubeServer](ctx, clt, &proto.ListResourcesRequest{
-		ResourceType:        types.KindKubeServer,
+	kubes, err := client.GetAllResources[types.KubeServer](ctx, clt, proto.ListUnifiedResourcesRequest{
+		Kinds:               []string{types.KindKubeServer},
 		Labels:              labels,
 		PredicateExpression: c.predicateExpr,
 		SearchKeywords:      libclient.ParseSearchKeywords(c.searchKeywords, ','),

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -236,9 +236,8 @@ func (c *NodeCommand) ListActive(ctx context.Context, clt *authclient.Client) er
 		return trace.Wrap(err)
 	}
 
-	nodes, err := client.GetAllResources[types.Server](ctx, clt, &proto.ListResourcesRequest{
-		ResourceType:        types.KindNode,
-		Namespace:           c.namespace,
+	nodes, err := client.GetAllResources[types.Server](ctx, clt, proto.ListUnifiedResourcesRequest{
+		Kinds:               []string{types.KindNode},
 		Labels:              labels,
 		PredicateExpression: c.predicateExpr,
 		SearchKeywords:      libclient.ParseSearchKeywords(c.searchKeywords, ','),

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -620,10 +620,10 @@ func (a *appInfo) GetApp(ctx context.Context, tc *client.TeleportClient) (types.
 func getApp(ctx context.Context, tc *client.TeleportClient, name string) (app types.Application, err error) {
 	var apps []types.Application
 	err = client.RetryWithRelogin(ctx, tc, func() error {
-		apps, err = tc.ListApps(ctx, &proto.ListResourcesRequest{
-			Namespace:           tc.Namespace,
-			ResourceType:        types.KindAppServer,
+		apps, err = tc.ListApps(ctx, &proto.ListUnifiedResourcesRequest{
+			Kinds:               []string{types.KindAppServer},
 			PredicateExpression: fmt.Sprintf(`name == "%s"`, name),
+			Limit:               2,
 		})
 		return trace.Wrap(err)
 	})

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -170,7 +170,7 @@ func listDatabasesAllClusters(cf *CLIConf) error {
 			defer span.End()
 
 			logger := log.WithField("cluster", cluster.name)
-			databases, err := apiclient.GetAllResources[types.DatabaseServer](ctx, cluster.auth, &cluster.req)
+			databases, err := apiclient.GetAllResources[types.DatabaseServer](ctx, cluster.auth, cluster.req)
 			if err != nil {
 				logger.Errorf("Failed to get databases: %v.", err)
 
@@ -1155,9 +1155,8 @@ func listDatabasesWithPredicate(ctx context.Context, tc *client.TeleportClient, 
 		var err error
 		predicate := makePredicateConjunction(predicate, tc.PredicateExpression)
 		log.Debugf("Listing databases with predicate (%v) and labels %v", predicate, tc.Labels)
-		databases, err = tc.ListDatabases(ctx, &proto.ListResourcesRequest{
-			Namespace:           tc.Namespace,
-			ResourceType:        types.KindDatabaseServer,
+		databases, err = tc.ListDatabases(ctx, &proto.ListUnifiedResourcesRequest{
+			Kinds:               []string{types.KindDatabaseServer},
 			PredicateExpression: predicate,
 			Labels:              tc.Labels,
 			UseSearchAsRoles:    tc.UseSearchAsRoles,

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -60,7 +60,6 @@ import (
 	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keypaths"
@@ -1408,7 +1407,7 @@ func fetchKubeClusters(ctx context.Context, tc *client.TeleportClient) (teleport
 		defer clusterClient.Close()
 
 		teleportCluster = clusterClient.ClusterName()
-		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, clusterClient.AuthClient, proto.ListResourcesRequest{
+		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, clusterClient.AuthClient, proto.ListUnifiedResourcesRequest{
 			SearchKeywords:      tc.SearchKeywords,
 			PredicateExpression: tc.PredicateExpression,
 			Labels:              tc.Labels,
@@ -1612,9 +1611,8 @@ func (c *kubeLoginCommand) accessRequestForKubeCluster(ctx context.Context, cf *
 	if shouldLoginToOneKubeCluster(cf) {
 		predicate = makeDiscoveredNameOrNamePredicate(c.kubeCluster)
 	}
-	kubes, err := apiclient.GetAllResources[types.KubeCluster](ctx, clt.AuthClient, &proto.ListResourcesRequest{
-		Namespace:           apidefaults.Namespace,
-		ResourceType:        types.KindKubernetesCluster,
+	kubes, err := apiclient.GetAllResources[types.KubeCluster](ctx, clt.AuthClient, proto.ListUnifiedResourcesRequest{
+		Kinds:               []string{types.KindKubernetesCluster},
 		UseSearchAsRoles:    true,
 		PredicateExpression: makePredicateConjunction(predicate, tc.PredicateExpression),
 		Labels:              tc.Labels,

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2252,7 +2252,7 @@ type clusterClient struct {
 	cluster         *client.ClusterClient
 	auth            authclient.ClientI
 	profile         *client.ProfileStatus
-	req             proto.ListResourcesRequest
+	req             proto.ListUnifiedResourcesRequest
 }
 
 func (c *clusterClient) Close() error {
@@ -2307,7 +2307,7 @@ func getClusterClients(cf *CLIConf, resource string) ([]*clusterClient, error) {
 			cluster: clt,
 			auth:    clt.AuthClient,
 			profile: profile,
-			req:     *tc.ResourceFilter(resource),
+			req:     tc.ResourceFilter(resource),
 		})
 		mu.Unlock()
 
@@ -2337,7 +2337,7 @@ func getClusterClients(cf *CLIConf, resource string) ([]*clusterClient, error) {
 				auth:    auth,
 				profile: profile,
 				name:    clusterName,
-				req:     *tc.ResourceFilter(resource),
+				req:     tc.ResourceFilter(resource),
 			})
 		}
 
@@ -2418,7 +2418,7 @@ func listNodesAllClusters(cf *CLIConf) error {
 			defer span.End()
 
 			logger := log.WithField("cluster", cluster.name)
-			nodes, err := apiclient.GetAllResources[types.Server](ctx, cluster.auth, &cluster.req)
+			nodes, err := apiclient.GetAllResources[types.Server](ctx, cluster.auth, cluster.req)
 			if err != nil {
 				logger.Errorf("Failed to get nodes: %v.", err)
 
@@ -4982,7 +4982,7 @@ func listAppsAllClusters(cf *CLIConf) error {
 
 		logger := log.WithField("cluster", cluster.name)
 		group.Go(func() error {
-			servers, err := apiclient.GetAllResources[types.AppServer](groupCtx, cluster.auth, &cluster.req)
+			servers, err := apiclient.GetAllResources[types.AppServer](groupCtx, cluster.auth, cluster.req)
 			if err != nil {
 				logger.Errorf("Failed to get app servers: %v.", err)
 


### PR DESCRIPTION
While the ListUnifiedResources API was first introduced to support a redesigned Web UI, it has evolved into a more performant and less resource hungry API than the ListResources API. Most of the client tools retrieval of ssh servers has already been converted to use the unified API to reduce resource consumption of Auth and to improve the amount of time it takes to retrieve results, especially in clusters with a large number of servers.

This migrates most of tctl and tsh invocations that looked up resources to use the unified API. Flows that are specific to the Web UI and Connect have been left on the legacy API for one reason: resource counts. The unified API does not return a TotalCount, and there are a few views in both the Web UI and Connect that consume the count. In an effort not to make the UX worse, those cases have been left to use the legacy API and should be converted in the future when the frontend no longer displays a count.

To accomodate these use cases that have not been converted the existing ListResources helpers have been left in place. However, the helpers have been deprecated to signal to any new code that they should use the unified API instead.