### PR TITLE
Discover: Don't prompt on leaving completed Discover Enroll flow

### DIFF
--- a/web/packages/teleport/src/Discover/AwsMangementConsole/index.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/index.tsx
@@ -28,8 +28,10 @@ import { TestConnection } from './TestConnection/TestConnection';
 
 export const AwsMangementConsole: ResourceViewConfig<ResourceSpec> = {
   kind: ResourceKind.Application,
-  shouldPrompt(currentStep) {
-    return currentStep !== 0;
+  shouldPrompt(currentStep, currentView) {
+    return (
+      currentStep > 0 && currentView?.eventName !== DiscoverEvent.Completed
+    );
   },
   views() {
     return [

--- a/web/packages/teleport/src/Discover/Database/index.tsx
+++ b/web/packages/teleport/src/Discover/Database/index.tsx
@@ -44,7 +44,7 @@ export const DatabaseResource: ResourceViewConfig<ResourceSpec> = {
   wrapper(component: React.ReactNode) {
     return <DatabaseWrapper>{component}</DatabaseWrapper>;
   },
-  shouldPrompt(currentStep, resourceSpec) {
+  shouldPrompt(currentStep, currentView, resourceSpec) {
     if (resourceSpec.dbMeta?.location === DatabaseLocation.Aws) {
       // Allow user to bypass prompting on this step (Connect AWS Connect)
       // on exit because users might need to change route to setup an
@@ -53,7 +53,7 @@ export const DatabaseResource: ResourceViewConfig<ResourceSpec> = {
         return false;
       }
     }
-    return true;
+    return currentView?.eventName !== DiscoverEvent.Completed;
   },
   views(resource) {
     let configureResourceViews;

--- a/web/packages/teleport/src/Discover/Discover.tsx
+++ b/web/packages/teleport/src/Discover/Discover.tsx
@@ -27,6 +27,8 @@ import { SelectResource } from 'teleport/Discover/SelectResource/SelectResource'
 import cfg from 'teleport/config';
 import { findViewAtIndex } from 'teleport/components/Wizard/flow';
 
+import { DiscoverEvent } from 'teleport/services/userEvent';
+
 import { EViewConfigs } from './types';
 
 import {
@@ -35,6 +37,8 @@ import {
   DiscoverUpdateProps,
 } from './useDiscover';
 import { DiscoverIcon } from './SelectResource/icons';
+
+import type { View } from 'teleport/Discover/flow';
 
 function DiscoverContent() {
   const {
@@ -45,12 +49,15 @@ function DiscoverContent() {
     ...agentProps
   } = useDiscover();
 
-  let content;
-  const hasSelectedResource = Boolean(viewConfig);
-  if (hasSelectedResource) {
-    const view = findViewAtIndex(indexedViews, currentStep);
+  let currentView: View | undefined;
+  let content: React.ReactNode;
 
-    const Component = view.component;
+  const hasSelectedResource = Boolean(viewConfig);
+
+  if (hasSelectedResource) {
+    currentView = findViewAtIndex(indexedViews, currentStep);
+
+    const Component = currentView.component;
 
     content = <Component {...agentProps} />;
 
@@ -58,6 +65,8 @@ function DiscoverContent() {
       content = viewConfig.wrapper(content);
     }
   } else {
+    currentView = undefined;
+
     content = (
       <SelectResource onSelect={resource => onSelectResource(resource)} />
     );
@@ -89,8 +98,12 @@ function DiscoverContent() {
           }}
           when={
             viewConfig.shouldPrompt
-              ? viewConfig.shouldPrompt(currentStep, agentProps.resourceSpec)
-              : true
+              ? viewConfig.shouldPrompt(
+                  currentStep,
+                  currentView,
+                  agentProps.resourceSpec
+                )
+              : currentView?.eventName !== DiscoverEvent.Completed
           }
         />
       )}

--- a/web/packages/teleport/src/Discover/Kubernetes/index.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/index.tsx
@@ -34,7 +34,7 @@ export const KubernetesResource: ResourceViewConfig = {
   wrapper: (component: React.ReactNode) => (
     <KubeWrapper>{component}</KubeWrapper>
   ),
-  shouldPrompt(currentStep, resourceSpec) {
+  shouldPrompt(currentStep, currentView, resourceSpec) {
     if (resourceSpec?.kubeMeta?.location === KubeLocation.Aws) {
       // Allow user to bypass prompting on this step (Connect AWS Account)
       // on exit because users might need to change route to setup an
@@ -43,7 +43,7 @@ export const KubernetesResource: ResourceViewConfig = {
         return false;
       }
     }
-    return true;
+    return currentView?.eventName !== DiscoverEvent.Completed;
   },
   views(resource: ResourceSpec) {
     let configuredResourceViews = [

--- a/web/packages/teleport/src/Discover/Server/index.tsx
+++ b/web/packages/teleport/src/Discover/Server/index.tsx
@@ -43,7 +43,7 @@ export const ServerResource: ResourceViewConfig<ResourceSpec> = {
   wrapper: (component: React.ReactNode) => (
     <ServerWrapper>{component}</ServerWrapper>
   ),
-  shouldPrompt(currentStep, resourceSpec) {
+  shouldPrompt(currentStep, currentView, resourceSpec) {
     if (resourceSpec?.nodeMeta?.location === ServerLocation.Aws) {
       // Allow user to bypass prompting on this step (Connect AWS Connect)
       // on exit because users might need to change route to setup an
@@ -52,7 +52,7 @@ export const ServerResource: ResourceViewConfig<ResourceSpec> = {
         return false;
       }
     }
-    return true;
+    return currentView?.eventName !== DiscoverEvent.Completed;
   },
 
   views(resource) {

--- a/web/packages/teleport/src/Discover/flow.tsx
+++ b/web/packages/teleport/src/Discover/flow.tsx
@@ -48,9 +48,14 @@ export interface ResourceViewConfig<T = any> {
    * depending on what step in the flow a user is in (indicated
    * by "currentStep" param).
    * Not supplying a function is equivalent to always prompting
-   * on exit or changing route.
+   * on exit or changing route when not on a step with the
+   * eventName `DiscoverEvent.Completed`.
    */
-  shouldPrompt?: (currentStep: number, resourceSpec: ResourceSpec) => boolean;
+  shouldPrompt?: (
+    currentStep: number,
+    currentView: View | undefined,
+    resourceSpec: ResourceSpec
+  ) => boolean;
 }
 
 export type View = BaseView<{


### PR DESCRIPTION
Resolves #42901 

## Changes
* Check for `eventName` == `DiscoverEvent.Completed` on current step to determine whether to prompt on route change
