### PR TITLE
docs: update upgrading

### DIFF
--- a/docs/pages/reference/architecture/agent-update-management.mdx
+++ b/docs/pages/reference/architecture/agent-update-management.mdx
@@ -82,7 +82,8 @@ latest agent version.
 If you are self-hosting Teleport Enterprise you can set up automatic agent updates.
 The updater uses a version channel to retrieve the targeted version for an agent.
 The Teleport Proxy Service provides a default version channel that matches to its current version.
-You can add override the default version and set additional channel versions.
+You can configure the default version and set additional channel versions.
+
 You are responsible for ensuring the version channels are compatible with the
 current Teleport Proxy Service and Teleport Auth Service versions. You must also
 monitor the agent's health and rollout status to ensure every agent is healthy

--- a/docs/pages/reference/architecture/agent-update-management.mdx
+++ b/docs/pages/reference/architecture/agent-update-management.mdx
@@ -8,8 +8,8 @@ mode](../../faq.mdx), agent deployments
 are sometimes simpler and more convenient. However, large Teleport deployments
 can create an additional burden: updating all agents.
 
-Starting with version 13, Teleport supports automatic agent updates for systemd-based
-Linux distributions using `apt` or `yum` package managers, and Kubernetes clusters.
+Teleport supports automatic agent updates for systemd-based
+Linux distributions using `apt`, `yum` or `zypper` package managers, and Kubernetes clusters.
 
 ## Update logic and failure modes
 
@@ -41,7 +41,7 @@ applied even if the updater is outside its regular maintenance window.
 ## Security
 
 When updating the agent, the updater will ensure the new version's authenticity
-before deploying it. On Linux distributions using `apt` or `yum`, it relies on
+before deploying it. On Linux distributions using `apt`, `yum` or `zypper`, it relies on
 the existing package signature system. On Kubernetes-based environments, it
 validates the OCI image signature (using [cosign's signature
 ](https://github.com/sigstore/cosign/blob/main/specs/SIGNATURE_SPEC.md)).
@@ -79,11 +79,11 @@ latest agent version.
 
 ### Self-hosted Teleport
 
-Self-hosted Teleport users can set up automatic agent updates. They must host
-their version server and choose their target version. They are responsible for
-ensuring the targeted version is compatible with their current auth/proxy
-versions. They must also monitor the agent's health and rollout status to
-ensure every agent is healthy and running the correct version.
+Self-hosted Teleport Enterprise users can set up automatic agent updates.
+They must host their version server and choose their target version. They
+are responsible for ensuring the targeted version is compatible with their
+current auth/proxy versions. They must also monitor the agent's health and
+rollout status to ensure every agent is healthy and running the correct version.
 
 ## Next steps
 

--- a/docs/pages/reference/architecture/agent-update-management.mdx
+++ b/docs/pages/reference/architecture/agent-update-management.mdx
@@ -80,7 +80,7 @@ latest agent version.
 ### Self-hosted Teleport
 
 If you are self-hosting Teleport Enterprise you can set up automatic agent updates.
-The updater uses a version channel to retrieve the targetted version for an agent.
+The updater uses a version channel to retrieve the targeted version for an agent.
 The Teleport Proxy Service provides a default version channel that matches to its current version.
 You can add override the default version and set additional channel versions.
 You are responsible for ensuring the version channels are compatible with the

--- a/docs/pages/reference/architecture/agent-update-management.mdx
+++ b/docs/pages/reference/architecture/agent-update-management.mdx
@@ -67,22 +67,24 @@ instances, or use the `stable/rolling` channel.
 
 ### Teleport Cloud
 
-Teleport Cloud users can use Teleport Cloud's version server only if their
-instance is enrolled in automatic updates. This version server will always
+If you are using Teleport Cloud you can use Teleport Cloud's version server
+only if an instance is enrolled in automatic updates. This version server will always
 target the best version from a feature, compatibility, security and stability
 point of view.
 
-Teleport Cloud users whose control plane is not automatically updated must not use
-automatic agent updates. This is because their Teleport instance version might
+If your Teleport Cloud control plane is not automatically updated you must not use
+automatic agent updates. This is because your Teleport instance version might
 differ from the other Teleport Cloud instances and might not yet support the
 latest agent version.
 
 ### Self-hosted Teleport
 
-Self-hosted Teleport Enterprise users can set up automatic agent updates.
-They must host their version server and choose their target version. They
-are responsible for ensuring the targeted version is compatible with their
-current auth/proxy versions. They must also monitor the agent's health and
+If you are self-hosting Teleport Enterprise you can set up automatic agent updates.
+A version channel is required to provide agent target version
+which there is a default provided by the Teleport Proxy
+Service. You can add override the default version or set other channel versions.
+You are responsible for ensuring the targeted version is compatible with their
+current auth/proxy versions. You must also monitor the agent's health and
 rollout status to ensure every agent is healthy and running the correct version.
 
 ## Next steps

--- a/docs/pages/reference/architecture/agent-update-management.mdx
+++ b/docs/pages/reference/architecture/agent-update-management.mdx
@@ -80,12 +80,13 @@ latest agent version.
 ### Self-hosted Teleport
 
 If you are self-hosting Teleport Enterprise you can set up automatic agent updates.
-A version channel is required to provide agent target version
-which there is a default provided by the Teleport Proxy
-Service. You can add override the default version or set other channel versions.
-You are responsible for ensuring the targeted version is compatible with their
-current auth/proxy versions. You must also monitor the agent's health and
-rollout status to ensure every agent is healthy and running the correct version.
+The updater uses a version channel to retrieve the targetted version for an agent.
+The Teleport Proxy Service provides a default version channel that matches to its current version.
+You can add override the default version and set additional channel versions.
+You are responsible for ensuring the version channels are compatible with the
+current Teleport Proxy Service and Teleport Auth Service versions. You must also
+monitor the agent's health and rollout status to ensure every agent is healthy
+and running the correct version.
 
 ## Next steps
 

--- a/docs/pages/upgrading.mdx
+++ b/docs/pages/upgrading.mdx
@@ -14,7 +14,7 @@ If you have a Teleport Enterprise (Cloud) account, you **must** [set up automati
 Teleport agent updates](./upgrading/automatic-agent-updates.mdx) to ensure that
 the version of Teleport running on agents is always compatible with that of the
 Teleport cluster. You can also set up automatic agent upgrades in a self-hosted
-cluster.
+Enterprise cluster.
 
 For more information about upgrading, for example, to upgrade manually, read the
 [Upgrading Reference](upgrading/upgrading.mdx).


### PR DESCRIPTION
Updates include:
- including `zypper` package manager
- include that automatic upgrading is enterprise only