### PR TITLE
Fix error reporting for EKS enrollment in Discover UI.

### DIFF
--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -293,7 +293,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
         );
       } else if (
         result.error &&
-        !result.error.message.includes(
+        !result.error.includes(
           'teleport-kube-agent is already installed on the cluster'
         )
       ) {

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -392,7 +392,7 @@ export type EnrollEksClustersResponse = {
   results: {
     clusterName: string;
     resourceId: string;
-    error: { message: string };
+    error: string;
   }[];
 };
 


### PR DESCRIPTION
This PR fixes error message reporting when enrolling EKS clusters in the Discover UI. The remnants of previous design for the enrollment result were used when showing modal with the error message, here we make types in Typescript up to date with the data sent from the backend.

Fixes https://github.com/gravitational/teleport/issues/44730

Changelog: Fix showing error message when enrolling EKS clusters in the Discover UI.