### PR TITLE
Handle expired certs in Connect when confirming device trust for web

### DIFF
--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -1115,13 +1115,19 @@ func (s *Service) AuthenticateWebDevice(ctx context.Context, rootClusterURI uri.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	devicesClient := proxyClient.CurrentCluster().DevicesClient()
 
-	ceremony := dtauthn.NewCeremony()
-	confirmationToken, err := ceremony.RunWeb(ctx, devicesClient, &devicepb.DeviceWebToken{
-		Id:    req.DeviceWebToken.Id,
-		Token: req.DeviceWebToken.Token,
+	var confirmationToken *devicepb.DeviceConfirmationToken
+	err = clusters.AddMetadataToRetryableError(ctx, func() error {
+		devicesClient := proxyClient.CurrentCluster().DevicesClient()
+
+		ceremony := dtauthn.NewCeremony()
+		confirmationToken, err = ceremony.RunWeb(ctx, devicesClient, &devicepb.DeviceWebToken{
+			Id:    req.DeviceWebToken.Id,
+			Token: req.DeviceWebToken.Token,
+		})
+		return trace.Wrap(err)
 	})
+
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/AuthenticateWebDevice/AuthenticateWebDevice.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/AuthenticateWebDevice/AuthenticateWebDevice.tsx
@@ -24,22 +24,22 @@ import { useAsync } from 'shared/hooks/useAsync';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { RootClusterUri, routing } from 'teleterm/ui/uri';
-
-type Props = {
-  rootClusterUri: RootClusterUri;
-  onCancel(): void;
-  onClose(): void;
-  onAuthorize(): Promise<void>;
-};
+import { retryWithRelogin } from 'teleterm/ui/utils';
 
 export const AuthenticateWebDevice = ({
   onAuthorize,
   onClose,
   onCancel,
   rootClusterUri,
-}: Props) => {
+}: {
+  rootClusterUri: RootClusterUri;
+  onCancel(): void;
+  onClose(): void;
+  onAuthorize(): Promise<void>;
+}) => {
+  const ctx = useAppContext();
   const [attempt, run] = useAsync(async () => {
-    await onAuthorize();
+    await retryWithRelogin(ctx, rootClusterUri, onAuthorize);
     onClose();
   });
   const { clustersService } = useAppContext();


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/43328

changelog: When confirming device trust for web in Teleport Connect, a relogin dialog is shown if the session is expired

@avatus could you please verify if this PR fixes the issue? I have to finally set up my environment for TouchID/device trust development 🙈 (initially I thought this would be a fix for the frontend, so I wouldn't have to build tsh). 