### PR TITLE
Fix empty join token ui state

### DIFF
--- a/web/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.ts
@@ -73,7 +73,7 @@ class JoinTokenService {
   fetchJoinTokens(signal: AbortSignal = null): Promise<{ items: JoinToken[] }> {
     return api.get(cfg.getJoinTokensUrl(), signal).then(resp => {
       return {
-        items: resp.items.map(makeJoinToken),
+        items: resp.items?.map(makeJoinToken) || [],
       };
     });
   }


### PR DESCRIPTION
Empty join token responses would show an error instead of an empty list message

![Screenshot 2024-08-13 at 8 41 35 AM](https://github.com/user-attachments/assets/83ab14aa-aca2-4ddb-94d5-ea0e54b9548d)
