### PR TITLE
Mention modifying the role when configuring Workload Identity IP/DNS SANs

### DIFF
--- a/docs/pages/enroll-resources/machine-id/workload-identity/getting-started.mdx
+++ b/docs/pages/enroll-resources/machine-id/workload-identity/getting-started.mdx
@@ -123,6 +123,22 @@ services:
       - 10.0.0.1
 ```
 
+You will also need to modify the Role to explicitly grant the Bot permission to
+request an SVID including a DNS or IP SAN. For example:
+
+```yaml
+kind: role
+version: v6
+metadata:
+  name: spiffe-issuer
+spec:
+  allow:
+    spiffe:
+    - path: "/svc/foo"
+      dns_sans: ["example.com"]
+      ip_sans: ["10.0.0.1/32"]
+```
+
 ### Configuring Unix Workload Attestation
 
 By default, an SVID listed under the Workload API service will be issued to any

--- a/docs/pages/enroll-resources/machine-id/workload-identity/getting-started.mdx
+++ b/docs/pages/enroll-resources/machine-id/workload-identity/getting-started.mdx
@@ -123,7 +123,7 @@ services:
       - 10.0.0.1
 ```
 
-You will also need to modify the Role to explicitly grant the Bot permission to
+You will also need to modify the role to explicitly grant the Bot permission to
 request an SVID including a DNS or IP SAN. For example:
 
 ```yaml

--- a/docs/pages/enroll-resources/machine-id/workload-identity/getting-started.mdx
+++ b/docs/pages/enroll-resources/machine-id/workload-identity/getting-started.mdx
@@ -135,7 +135,13 @@ spec:
   allow:
     spiffe:
     - path: "/svc/foo"
+      # Replace with the DNS SANs that you wish your Bot to be able to include
+      # in SVIDs.
       dns_sans: ["example.com"]
+      # Replace with the IP SANs that you wish your Bot to be able to include
+      # in SVIDs. You can remove this if you do not wish to include IP SANs.
+      # IPs must be specified using CIDR notation, which allows you to specify
+      # a single IP or a range of IPs.
       ip_sans: ["10.0.0.1/32"]
 ```
 


### PR DESCRIPTION
This was missing from the guide and leads you to run into the "access denied to generate SVID" error.