### PR TITLE
storybook: respect VITE_HTTPS_CERT and VITE_HTTPS_KEY

### DIFF
--- a/web/scripts/run-storybook.sh
+++ b/web/scripts/run-storybook.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-if test -f web/certs/server.crt; then
-  storybook dev -p 9002 -c web/.storybook --https --ssl-cert=web/certs/server.crt --ssl-key=web/certs/server.key "$@"
+VITE_HTTPS_CERT="${VITE_HTTPS_CERT:-web/certs/server.crt}"
+VITE_HTTPS_KEY="${VITE_HTTPS_KEY:-web/certs/server.key}"
+
+if test -f $VITE_HTTPS_CERT; then
+  storybook dev -p 9002 -c web/.storybook --https --ssl-cert=$VITE_HTTPS_CERT --ssl-key=$VITE_HTTPS_KEY "$@"
 else
   echo \"Could not find SSL certificates. Please follow web/README.md to generate certificates.\" && false
 fi


### PR DESCRIPTION
At some point, we started looking for certs hard-coded locations and stopped respecting the VITE_HTTPS_CERT and VITE_HTTPS_KEY variables.

This commit restores the original behavior as documented in web/README.md.