### PR TITLE
[v15] disable Access Graph secret scanner feature

### DIFF
--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -31,6 +31,7 @@ import (
 	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
+	secscanconstants "github.com/gravitational/teleport/lib/secretsscanner/constants"
 	"github.com/gravitational/teleport/lib/services/readonly"
 )
 
@@ -938,11 +939,13 @@ func (s *Service) GetClusterAccessGraphConfig(ctx context.Context, _ *clustercon
 	}
 
 	var sshScanEnabled bool
-	switch obj, err := s.readOnlyCache.GetReadOnlyAccessGraphSettings(ctx); {
-	case err != nil && !trace.IsNotFound(err):
-		return nil, trace.Wrap(err)
-	case err == nil:
-		sshScanEnabled = obj.SecretsScanConfig() == clusterconfigpb.AccessGraphSecretsScanConfig_ACCESS_GRAPH_SECRETS_SCAN_CONFIG_ENABLED
+	if secscanconstants.Enabled {
+		switch obj, err := s.readOnlyCache.GetReadOnlyAccessGraphSettings(ctx); {
+		case err != nil && !trace.IsNotFound(err):
+			return nil, trace.Wrap(err)
+		case err == nil:
+			sshScanEnabled = obj.SecretsScanConfig() == clusterconfigpb.AccessGraphSecretsScanConfig_ACCESS_GRAPH_SECRETS_SCAN_CONFIG_ENABLED
+		}
 	}
 
 	return &clusterconfigpb.GetClusterAccessGraphConfigResponse{

--- a/lib/auth/clusterconfig/clusterconfigv1/service_test.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
+	secscanconstants "github.com/gravitational/teleport/lib/secretsscanner/constants"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -1944,8 +1945,13 @@ func TestGetAccessGraphConfig(t *testing.T) {
 
 			got, err := env.GetClusterAccessGraphConfig(context.Background(), &clusterconfigpb.GetClusterAccessGraphConfigRequest{})
 			test.errorAssertion(t, err)
-
-			require.Empty(t, cmp.Diff(test.responseAssertion, got, protocmp.Transform()))
+			opts := []cmp.Option{
+				protocmp.Transform(),
+			}
+			if !secscanconstants.Enabled {
+				opts = append(opts, protocmp.IgnoreFields(&clusterconfigpb.AccessGraphSecretsScanConfiguration{}, "ssh_scan_enabled"))
+			}
+			require.Empty(t, cmp.Diff(test.responseAssertion, got, opts...))
 		})
 	}
 }

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -60,6 +60,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
+	secscanconstants "github.com/gravitational/teleport/lib/secretsscanner/constants"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/srv/db/common/databaseobjectimportrule"
@@ -447,11 +448,13 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 		return trace.Wrap(initializeSessionRecordingConfig(ctx, asrv, cfg.SessionRecordingConfig))
 	})
 
-	g.Go(func() error {
-		ctx, span := cfg.Tracer.Start(gctx, "auth/InitializeAccessGraphSettings")
-		defer span.End()
-		return trace.Wrap(initializeAccessGraphSettings(ctx, asrv))
-	})
+	if secscanconstants.Enabled {
+		g.Go(func() error {
+			ctx, span := cfg.Tracer.Start(gctx, "auth/InitializeAccessGraphSettings")
+			defer span.End()
+			return trace.Wrap(initializeAccessGraphSettings(ctx, asrv))
+		})
+	}
 
 	g.Go(func() error {
 		ctx, span := cfg.Tracer.Start(gctx, "auth/initializeAuthPreference")

--- a/lib/secretsscanner/constants/enabled.go
+++ b/lib/secretsscanner/constants/enabled.go
@@ -1,0 +1,23 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package constants
+
+// Enabled is a constant that is used to enable or disable the feature.
+// TODO(tigrato): remove this constant and use a feature flag instead.
+const Enabled = false

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/devicetrust"
+	secscanconstants "github.com/gravitational/teleport/lib/secretsscanner/constants"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 )
@@ -210,10 +211,19 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 		case types.KindInstance:
 			parser = newInstanceParser()
 		case types.KindDevice:
+			if !secscanconstants.Enabled {
+				continue
+			}
 			parser = newDeviceParser()
 		case types.KindAccessGraphSecretPrivateKey:
+			if !secscanconstants.Enabled {
+				continue
+			}
 			parser = newAccessGraphSecretPrivateKeyParser()
 		case types.KindAccessGraphSecretAuthorizedKey:
+			if !secscanconstants.Enabled {
+				continue
+			}
 			parser = newAccessGraphSecretAuthorizedKeyParser()
 		case types.KindAccessGraphSettings:
 			parser = newAccessGraphSettingsParser()

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -64,6 +64,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	authorizedkeysreporter "github.com/gravitational/teleport/lib/secretsscanner/authorizedkeys"
+	secscanconstants "github.com/gravitational/teleport/lib/secretsscanner/constants"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv"
@@ -882,7 +883,7 @@ func New(
 	}
 	s.srv = server
 
-	if !s.proxyMode {
+	if !s.proxyMode && secscanconstants.Enabled {
 		if err := s.startAuthorizedKeysManager(ctx, auth); err != nil {
 			log.WithError(err).Infof("Failed to start authorized keys manager.")
 		}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -62,6 +62,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/devicetrust"
+	secscanconstants "github.com/gravitational/teleport/lib/secretsscanner/constants"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -2819,6 +2820,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &pluginCollection{plugins: plugins}, nil
 	case types.KindAccessGraphSettings:
+		if !secscanconstants.Enabled {
+			return nil, trace.BadParameter("access graph settings are not supported")
+		}
 		settings, err := client.ClusterConfigClient().GetAccessGraphSettings(ctx, &clusterconfigpb.GetAccessGraphSettingsRequest{})
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -3117,6 +3121,9 @@ func (rc *ResourceCommand) createPlugin(ctx context.Context, client *authclient.
 }
 
 func (rc *ResourceCommand) upsertAccessGraphSettings(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+	if !secscanconstants.Enabled {
+		return trace.BadParameter("access graph settings are not supported")
+	}
 	settings, err := clusterconfigrec.UnmarshalAccessGraphSettings(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3131,6 +3138,9 @@ func (rc *ResourceCommand) upsertAccessGraphSettings(ctx context.Context, client
 }
 
 func (rc *ResourceCommand) updateAccessGraphSettings(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+	if !secscanconstants.Enabled {
+		return trace.BadParameter("access graph settings are not supported")
+	}
 	settings, err := clusterconfigrec.UnmarshalAccessGraphSettings(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tsh/common/scan.go
+++ b/tool/tsh/common/scan.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/lib/devicetrust/assert"
 	dtnative "github.com/gravitational/teleport/lib/devicetrust/native"
 	secretsscannerclient "github.com/gravitational/teleport/lib/secretsscanner/client"
+	secscanconstants "github.com/gravitational/teleport/lib/secretsscanner/constants"
 	secretsreporter "github.com/gravitational/teleport/lib/secretsscanner/reporter"
 	secretsscanner "github.com/gravitational/teleport/lib/secretsscanner/scaner"
 )
@@ -42,7 +43,7 @@ type scanCommand struct {
 }
 
 func newScanCommand(app *kingpin.Application) scanCommand {
-	scan := app.Command("scan", "Scan the local machine for Secrets and report findings to Teleport")
+	scan := app.Command("scan", "Scan the local machine for Secrets and report findings to Teleport").Hidden()
 	cmd := scanCommand{
 		keys: newScanKeysCommand(scan),
 	}
@@ -76,6 +77,9 @@ func defaultDirValues() string {
 }
 
 func (c *scanKeysCommand) run(cf *CLIConf) error {
+	if !secscanconstants.Enabled {
+		return trace.BadParameter("scan feature is disabled")
+	}
 	if len(c.dirs) == 0 {
 		return trace.BadParameter("no directories to scan")
 	}


### PR DESCRIPTION
This PR replaces https://github.com/gravitational/teleport/pull/45434 and will be reverted once all v15 releases are out.