### PR TITLE
[v16] Check if integration is present when deciding if we should setup access entry.

### DIFF
--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -364,7 +364,7 @@ func (a *eksFetcher) getMatchingKubeCluster(ctx context.Context, clusterName str
 	}
 
 	// If no access configuration is required, return the cluster.
-	if a.SetupAccessForARN == "" || rsp.Cluster.AccessConfig == nil {
+	if a.SetupAccessForARN == "" || rsp.Cluster.AccessConfig == nil || a.Integration != "" {
 		return cluster, nil
 	}
 


### PR DESCRIPTION
Backport #45354 to branch/v16

changelog: Fix access entry handling permission error when EKS auto-discovery was set up in the Discover UI.
