### PR TITLE
Use 'sts.PresignClient' for EKS cluster enrollment.

### DIFF
--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -487,11 +487,6 @@ func (s *AWSOIDCService) EnrollEKSClusters(ctx context.Context, req *integration
 		return nil, trace.Wrap(err)
 	}
 
-	credsProvider, err := awsoidc.NewAWSCredentialsProvider(ctx, awsClientReq)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	enrollEKSClient, err := awsoidc.NewEnrollEKSClustersClient(ctx, awsClientReq, s.cache.UpsertToken)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -499,7 +494,7 @@ func (s *AWSOIDCService) EnrollEKSClusters(ctx context.Context, req *integration
 
 	features := modules.GetModules().Features()
 
-	enrollmentResponse, err := awsoidc.EnrollEKSClusters(ctx, s.logger, s.clock, publicProxyAddr, credsProvider, enrollEKSClient, awsoidc.EnrollEKSClustersRequest{
+	enrollmentResponse, err := awsoidc.EnrollEKSClusters(ctx, s.logger, s.clock, publicProxyAddr, enrollEKSClient, awsoidc.EnrollEKSClustersRequest{
 		Region:             req.Region,
 		ClusterNames:       req.GetEksClusterNames(),
 		EnableAppDiscovery: req.EnableAppDiscovery,

--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -23,17 +23,17 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	eksTypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/coreos/go-semver/semver"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -66,6 +66,7 @@ const (
 	agentName                   = "teleport-kube-agent"
 	awsKubePrefix               = "k8s-aws-v1."
 	awsHeaderClusterName        = "x-k8s-aws-id"
+	awsHeaderExpires            = "X-Amz-Expires"
 	concurrentEKSEnrollingLimit = 5
 )
 
@@ -117,6 +118,9 @@ type EnrollEKSCLusterClient interface {
 
 	// CreateToken creates provisioning token on the auth server. That token can be used to install kube agent to an EKS cluster.
 	CreateToken(context.Context, types.ProvisionToken) error
+
+	// PresignGetCallerIdentityURL creates a presigned URL for the GetCallerIdentity action, that can be used for accessing EKS cluster.
+	PresignGetCallerIdentityURL(context.Context, string) (string, error)
 }
 
 type defaultEnrollEKSClustersClient struct {
@@ -128,6 +132,10 @@ type defaultEnrollEKSClustersClient struct {
 // GetCallerIdentity returns details about the IAM user or role whose credentials are used to call the operation.
 func (d *defaultEnrollEKSClustersClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
 	return d.stsClient.GetCallerIdentity(ctx, params, optFns...)
+}
+
+func (d *defaultEnrollEKSClustersClient) PresignGetCallerIdentityURL(ctx context.Context, clusterName string) (string, error) {
+	return presignCallerIdentityURL(ctx, d.stsClient, clusterName)
 }
 
 // CheckAgentAlreadyInstalled checks if teleport-kube-agent Helm chart is already installed on the EKS cluster.
@@ -263,7 +271,7 @@ func (e *EnrollEKSClustersRequest) CheckAndSetDefaults() error {
 // During enrollment we create access entry for an EKS cluster if needed and cluster admin policy is associated with that entry,
 // so our AWS integration can access the target EKS cluster during the chart installation. After enrollment is done we remove
 // the access entry (if it was created by us), since we don't need it anymore.
-func EnrollEKSClusters(ctx context.Context, log *slog.Logger, clock clockwork.Clock, proxyAddr string, credsProvider aws.CredentialsProvider, clt EnrollEKSCLusterClient, req EnrollEKSClustersRequest) (*EnrollEKSClusterResponse, error) {
+func EnrollEKSClusters(ctx context.Context, log *slog.Logger, clock clockwork.Clock, proxyAddr string, clt EnrollEKSCLusterClient, req EnrollEKSClustersRequest) (*EnrollEKSClusterResponse, error) {
 	var mu sync.Mutex
 	var results []EnrollEKSClusterResult
 
@@ -278,7 +286,7 @@ func EnrollEKSClusters(ctx context.Context, log *slog.Logger, clock clockwork.Cl
 		eksClusterName := eksClusterName
 
 		group.Go(func() error {
-			resourceId, err := enrollEKSCluster(ctx, log, clock, credsProvider, clt, proxyAddr, eksClusterName, req)
+			resourceId, err := enrollEKSCluster(ctx, log, clock, clt, proxyAddr, eksClusterName, req)
 			if err != nil {
 				log.WarnContext(ctx, "Failed to enroll EKS cluster",
 					"error", err,
@@ -299,7 +307,37 @@ func EnrollEKSClusters(ctx context.Context, log *slog.Logger, clock clockwork.Cl
 	return &EnrollEKSClusterResponse{Results: results}, nil
 }
 
-func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clock, credsProvider aws.CredentialsProvider, clt EnrollEKSCLusterClient, proxyAddr, clusterName string, req EnrollEKSClustersRequest) (string, error) {
+func presignCallerIdentityURL(ctx context.Context, stsClient *sts.Client, clusterName string) (string, error) {
+	presignClient := sts.NewPresignClient(stsClient)
+
+	// This function adds required headers for accessing an EKS cluster to the presigned URL.
+	addEKSHeaders := func(ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler) (
+		out middleware.BuildOutput, metadata middleware.Metadata, err error,
+	) {
+		req, ok := in.Request.(*smithyhttp.Request)
+		if !ok {
+			return out, metadata, fmt.Errorf("unknown transport type %T", req)
+		}
+
+		req.Header.Add(awsHeaderClusterName, clusterName)
+		req.Header.Add(awsHeaderExpires, "60")
+		return next.HandleBuild(ctx, in)
+	}
+
+	presigned, err := presignClient.PresignGetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}, func(options *sts.PresignOptions) {
+		options.ClientOptions = append(options.ClientOptions,
+			sts.WithAPIOptions(func(stack *middleware.Stack) error {
+				return stack.Build.Add(middleware.BuildMiddlewareFunc("AddEKSHeaders", addEKSHeaders), 0)
+			}))
+	})
+	if err != nil {
+		return "", trace.Wrap(err, "failed to presign caller identity")
+	}
+
+	return presigned.URL, nil
+}
+
+func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clock, clt EnrollEKSCLusterClient, proxyAddr, clusterName string, req EnrollEKSClustersRequest) (string, error) {
 	eksClusterInfo, err := clt.DescribeCluster(ctx, &eks.DescribeClusterInput{
 		Name: aws.String(clusterName),
 	})
@@ -350,7 +388,12 @@ func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clo
 		return "", trace.Wrap(err, "unable to associate EKS Access Policy to cluster %q", clusterName)
 	}
 
-	kubeClientGetter, err := getKubeClientGetter(ctx, clock.Now(), credsProvider, clusterName, req.Region,
+	presignedURL, err := clt.PresignGetCallerIdentityURL(ctx, clusterName)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	kubeClientGetter, err := getKubeClientGetter(presignedURL,
 		aws.ToString(eksCluster.CertificateAuthority.Data), aws.ToString(eksCluster.Endpoint))
 	if err != nil {
 		return "", trace.Wrap(err, "unable to build kubernetes client for EKS cluster %q", clusterName)
@@ -415,42 +458,9 @@ func maybeAddAccessEntry(ctx context.Context, clusterName, roleArn string, clt E
 	return err == nil, trace.Wrap(err)
 }
 
-// getPresignURL returns a specially formatted URL that can be presigned and used in EKS authentication.
-func getPresignURL() url.URL {
-	endpoint := "sts.amazonaws.com"
-	q := url.Values{}
-	q.Set("Action", "GetCallerIdentity")
-	q.Set("Version", "2011-06-15")
-	q.Set("X-Amz-Expires", "60")
-
-	return url.URL{
-		Scheme:   "https",
-		Host:     endpoint,
-		Path:     "/",
-		RawQuery: q.Encode(),
-	}
-}
-
 // getKubeClientGetter returns client getter for kube that can be used to access target EKS cluster
-func getKubeClientGetter(ctx context.Context, timestamp time.Time, credsProvider aws.CredentialsProvider, clusterName, region, clusterCA, clusterEndpoint string) (*genericclioptions.ConfigFlags, error) {
-	targetUrl := getPresignURL()
-
-	r, err := http.NewRequest(http.MethodGet, targetUrl.String(), nil)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	r.Header.Add(awsHeaderClusterName, clusterName)
-	creds, err := credsProvider.Retrieve(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	signer := v4.NewSigner()
-	presigned, _, err := signer.PresignHTTP(ctx, creds, r, hashForGetRequests, "sts", region, timestamp)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	kubeToken := awsKubePrefix + base64.RawURLEncoding.EncodeToString([]byte(presigned))
+func getKubeClientGetter(presignedUrl, clusterCA, clusterEndpoint string) (*genericclioptions.ConfigFlags, error) {
+	kubeToken := awsKubePrefix + base64.RawURLEncoding.EncodeToString([]byte(presignedUrl))
 
 	eksClusterCA, err := base64.StdEncoding.DecodeString(clusterCA)
 	if err != nil {

--- a/lib/integrations/awsoidc/eks_enroll_clusters_test.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters_test.go
@@ -81,7 +81,6 @@ func TestEnrollEKSClusters(t *testing.T) {
 
 	ctx := context.Background()
 	proxyAddr := "https://example.com"
-	credsProvider := &mockCredentialsProvider{}
 	awsAccountID := "880713328506"
 	awsUserID := "AIDAJQABLZS4A3QDU576Q"
 	clustersBaseArn := "arn:aws:eks:us-east-1:880713328506:cluster/EKS"
@@ -288,7 +287,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 			}
 
 			response, err := EnrollEKSClusters(
-				ctx, utils.NewSlogLoggerForTests().With("test", t.Name()), clock, proxyAddr, credsProvider, tc.enrollClient(t, tc.eksClusters), req)
+				ctx, utils.NewSlogLoggerForTests().With("test", t.Name()), clock, proxyAddr, tc.enrollClient(t, tc.eksClusters), req)
 			require.NoError(t, err)
 
 			tc.responseCheck(t, response)
@@ -312,7 +311,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 		}
 
 		response, err := EnrollEKSClusters(
-			ctx, utils.NewSlogLoggerForTests().With("test", t.Name()), clock, proxyAddr, credsProvider, mockClt, req)
+			ctx, utils.NewSlogLoggerForTests().With("test", t.Name()), clock, proxyAddr, mockClt, req)
 		require.NoError(t, err)
 		require.Len(t, response.Results, 1)
 		require.Equal(t, "EKS1", response.Results[0].ClusterName)
@@ -322,14 +321,12 @@ func TestEnrollEKSClusters(t *testing.T) {
 }
 
 func TestGetKubeClientGetter(t *testing.T) {
-	credsProvider := &mockCredentialsProvider{}
 	testCAData := "VGVzdENBREFUQQ=="
 
 	testCases := []struct {
 		endpoint      string
 		region        string
 		caData        string
-		timestamp     time.Time
 		expectedToken string
 		errorCheck    require.ErrorAssertionFunc
 	}{
@@ -337,35 +334,30 @@ func TestGetKubeClientGetter(t *testing.T) {
 			endpoint:      "https://test.example.com",
 			region:        "us-east-1",
 			caData:        testCAData,
-			timestamp:     time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-			expectedToken: "k8s-aws-v1.aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8_QWN0aW9uPUdldENhbGxlcklkZW50aXR5JlZlcnNpb249MjAxMS0wNi0xNSZYLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPSUyRjIwMjMwMTAxJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMzAxMDFUMDAwMDAwWiZYLUFtei1FeHBpcmVzPTYwJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCUzQngtazhzLWF3cy1pZCZYLUFtei1TaWduYXR1cmU9N2RiNWZlMWNjNDBhNzc4MTQ2MWJkMzkzMmE2NzBhNmVhNDFhNDNlZjEwZWQxZjMzNDE3NjI1ZDhkMTQ1Njg4NQ",
+			expectedToken: "k8s-aws-v1.cHJlc2lnbmVkVVJM",
 		},
 		{
 			endpoint:      "https://test2.example.com",
 			region:        "us-east-1",
 			caData:        testCAData,
-			timestamp:     time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-			expectedToken: "k8s-aws-v1.aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8_QWN0aW9uPUdldENhbGxlcklkZW50aXR5JlZlcnNpb249MjAxMS0wNi0xNSZYLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPSUyRjIwMjMwMTAxJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMzAxMDFUMDAwMDAwWiZYLUFtei1FeHBpcmVzPTYwJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCUzQngtazhzLWF3cy1pZCZYLUFtei1TaWduYXR1cmU9N2RiNWZlMWNjNDBhNzc4MTQ2MWJkMzkzMmE2NzBhNmVhNDFhNDNlZjEwZWQxZjMzNDE3NjI1ZDhkMTQ1Njg4NQ",
+			expectedToken: "k8s-aws-v1.cHJlc2lnbmVkVVJM",
 		},
 		{
 			endpoint:      "https://test.example.com",
 			region:        "us-east-2",
 			caData:        testCAData,
-			timestamp:     time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-			expectedToken: "k8s-aws-v1.aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8_QWN0aW9uPUdldENhbGxlcklkZW50aXR5JlZlcnNpb249MjAxMS0wNi0xNSZYLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPSUyRjIwMjMwMTAxJTJGdXMtZWFzdC0yJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMzAxMDFUMDAwMDAwWiZYLUFtei1FeHBpcmVzPTYwJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCUzQngtazhzLWF3cy1pZCZYLUFtei1TaWduYXR1cmU9ZmE2MGNiYjRlMGNkYTNhMDU5ZmRlNWMwNjgzMGZlYTc4NTVkNTcwMTg4MWE4MzMzNmIwYjg0MjliYWIyMGYwNQ",
+			expectedToken: "k8s-aws-v1.cHJlc2lnbmVkVVJM",
 		},
 		{
 			endpoint:      "https://test.example.com",
 			region:        "us-east-1",
 			caData:        testCAData,
-			timestamp:     time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
-			expectedToken: "k8s-aws-v1.aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8_QWN0aW9uPUdldENhbGxlcklkZW50aXR5JlZlcnNpb249MjAxMS0wNi0xNSZYLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPSUyRjIwMjIwMTAxJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMjAxMDFUMDAwMDAwWiZYLUFtei1FeHBpcmVzPTYwJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCUzQngtazhzLWF3cy1pZCZYLUFtei1TaWduYXR1cmU9YmE3ZTA5ZTcyZTUzNDIzNjRiNDZlZmQzOTViNmU1MjU5YWU1YmFjMTY1YmViYWVmNDMyZDA5MmVmZWI0ZDBkOA",
+			expectedToken: "k8s-aws-v1.cHJlc2lnbmVkVVJM",
 		},
 		{
 			endpoint:      "https://test.example.com",
 			region:        "us-east-1",
 			caData:        "badCA",
-			timestamp:     time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
 			expectedToken: "",
 			errorCheck: func(t require.TestingT, err error, i ...interface{}) {
 				require.ErrorContains(t, err, "illegal base64 data")
@@ -375,7 +367,7 @@ func TestGetKubeClientGetter(t *testing.T) {
 
 	for c, tc := range testCases {
 		t.Run(fmt.Sprintf("test#%d", c), func(t *testing.T) {
-			config, err := getKubeClientGetter(context.Background(), tc.timestamp, credsProvider, "EKS1", tc.region, tc.caData, tc.endpoint)
+			config, err := getKubeClientGetter("presignedURL", tc.caData, tc.endpoint)
 
 			if tc.errorCheck == nil {
 				cfg, err := config.ToRESTConfig()
@@ -438,26 +430,17 @@ func TestGetAccessEntryPrincipalArn(t *testing.T) {
 	}
 }
 
-// mockCredentialsProvider mocks AWS credentials.Provider interface.
-type mockCredentialsProvider struct {
-	retrieveValue aws.Credentials
-	retrieveError error
-}
-
-func (m *mockCredentialsProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
-	return m.retrieveValue, m.retrieveError
-}
-
 type mockEnrollEKSClusterClient struct {
-	createAccessEntry          func(context.Context, *eks.CreateAccessEntryInput, ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error)
-	associateAccessPolicy      func(context.Context, *eks.AssociateAccessPolicyInput, ...func(*eks.Options)) (*eks.AssociateAccessPolicyOutput, error)
-	listAccessEntries          func(context.Context, *eks.ListAccessEntriesInput, ...func(*eks.Options)) (*eks.ListAccessEntriesOutput, error)
-	deleteAccessEntry          func(context.Context, *eks.DeleteAccessEntryInput, ...func(*eks.Options)) (*eks.DeleteAccessEntryOutput, error)
-	describeCluster            func(context.Context, *eks.DescribeClusterInput, ...func(*eks.Options)) (*eks.DescribeClusterOutput, error)
-	getCallerIdentity          func(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
-	checkAgentAlreadyInstalled func(context.Context, genericclioptions.RESTClientGetter, *slog.Logger) (bool, error)
-	installKubeAgent           func(context.Context, *eksTypes.Cluster, string, string, string, genericclioptions.RESTClientGetter, *slog.Logger, EnrollEKSClustersRequest) error
-	createToken                func(ctx context.Context, token types.ProvisionToken) error
+	createAccessEntry           func(context.Context, *eks.CreateAccessEntryInput, ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error)
+	associateAccessPolicy       func(context.Context, *eks.AssociateAccessPolicyInput, ...func(*eks.Options)) (*eks.AssociateAccessPolicyOutput, error)
+	listAccessEntries           func(context.Context, *eks.ListAccessEntriesInput, ...func(*eks.Options)) (*eks.ListAccessEntriesOutput, error)
+	deleteAccessEntry           func(context.Context, *eks.DeleteAccessEntryInput, ...func(*eks.Options)) (*eks.DeleteAccessEntryOutput, error)
+	describeCluster             func(context.Context, *eks.DescribeClusterInput, ...func(*eks.Options)) (*eks.DescribeClusterOutput, error)
+	getCallerIdentity           func(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+	checkAgentAlreadyInstalled  func(context.Context, genericclioptions.RESTClientGetter, *slog.Logger) (bool, error)
+	installKubeAgent            func(context.Context, *eksTypes.Cluster, string, string, string, genericclioptions.RESTClientGetter, *slog.Logger, EnrollEKSClustersRequest) error
+	createToken                 func(ctx context.Context, token types.ProvisionToken) error
+	presignGetCallerIdentityURL func(ctx context.Context, clusterName string) (string, error)
 }
 
 func (m *mockEnrollEKSClusterClient) CreateAccessEntry(ctx context.Context, params *eks.CreateAccessEntryInput, optFns ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error) {
@@ -521,6 +504,13 @@ func (m *mockEnrollEKSClusterClient) CreateToken(ctx context.Context, token type
 		return m.createToken(ctx, token)
 	}
 	return nil
+}
+
+func (m *mockEnrollEKSClusterClient) PresignGetCallerIdentityURL(ctx context.Context, clusterName string) (string, error) {
+	if m.presignGetCallerIdentityURL != nil {
+		return m.presignGetCallerIdentityURL(ctx, clusterName)
+	}
+	return "", nil
 }
 
 var _ EnrollEKSCLusterClient = &mockEnrollEKSClusterClient{}

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -572,15 +572,16 @@ func (m *mockIntegrationsTokenGenerator) GenerateAWSOIDCToken(ctx context.Contex
 }
 
 type mockEnrollEKSClusterClient struct {
-	createAccessEntry          func(context.Context, *eks.CreateAccessEntryInput, ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error)
-	associateAccessPolicy      func(context.Context, *eks.AssociateAccessPolicyInput, ...func(*eks.Options)) (*eks.AssociateAccessPolicyOutput, error)
-	listAccessEntries          func(context.Context, *eks.ListAccessEntriesInput, ...func(*eks.Options)) (*eks.ListAccessEntriesOutput, error)
-	deleteAccessEntry          func(context.Context, *eks.DeleteAccessEntryInput, ...func(*eks.Options)) (*eks.DeleteAccessEntryOutput, error)
-	describeCluster            func(context.Context, *eks.DescribeClusterInput, ...func(*eks.Options)) (*eks.DescribeClusterOutput, error)
-	getCallerIdentity          func(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
-	checkAgentAlreadyInstalled func(context.Context, genericclioptions.RESTClientGetter, *slog.Logger) (bool, error)
-	installKubeAgent           func(context.Context, *eksTypes.Cluster, string, string, string, genericclioptions.RESTClientGetter, *slog.Logger, awsoidc.EnrollEKSClustersRequest) error
-	createToken                func(context.Context, types.ProvisionToken) error
+	createAccessEntry           func(context.Context, *eks.CreateAccessEntryInput, ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error)
+	associateAccessPolicy       func(context.Context, *eks.AssociateAccessPolicyInput, ...func(*eks.Options)) (*eks.AssociateAccessPolicyOutput, error)
+	listAccessEntries           func(context.Context, *eks.ListAccessEntriesInput, ...func(*eks.Options)) (*eks.ListAccessEntriesOutput, error)
+	deleteAccessEntry           func(context.Context, *eks.DeleteAccessEntryInput, ...func(*eks.Options)) (*eks.DeleteAccessEntryOutput, error)
+	describeCluster             func(context.Context, *eks.DescribeClusterInput, ...func(*eks.Options)) (*eks.DescribeClusterOutput, error)
+	getCallerIdentity           func(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+	checkAgentAlreadyInstalled  func(context.Context, genericclioptions.RESTClientGetter, *slog.Logger) (bool, error)
+	installKubeAgent            func(context.Context, *eksTypes.Cluster, string, string, string, genericclioptions.RESTClientGetter, *slog.Logger, awsoidc.EnrollEKSClustersRequest) error
+	createToken                 func(context.Context, types.ProvisionToken) error
+	presignGetCallerIdentityURL func(ctx context.Context, clusterName string) (string, error)
 }
 
 func (m *mockEnrollEKSClusterClient) CreateAccessEntry(ctx context.Context, params *eks.CreateAccessEntryInput, optFns ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error) {
@@ -644,6 +645,13 @@ func (m *mockEnrollEKSClusterClient) CreateToken(ctx context.Context, token type
 		return m.createToken(ctx, token)
 	}
 	return nil
+}
+
+func (m *mockEnrollEKSClusterClient) PresignGetCallerIdentityURL(ctx context.Context, clusterName string) (string, error) {
+	if m.presignGetCallerIdentityURL != nil {
+		return m.presignGetCallerIdentityURL(ctx, clusterName)
+	}
+	return "", nil
 }
 
 var _ awsoidc.EnrollEKSCLusterClient = &mockEnrollEKSClusterClient{}


### PR DESCRIPTION
This PR changes the way we presign `GetCallerIdentity` action, which later is used for accessing EKS cluster. We used default host for the AWS STS service, but that didn't work for all regions. Here we change to the `PresignClient` from the SDK that would take care of the host automatically.

Fixes: https://github.com/gravitational/teleport/issues/44977

Changelog: Fix EKS cluster enrollment in the Discover UI for AWS regions other than us-east-1.