### PR TITLE
[v16] Workload Identity: Support Envoy SDS API (#43958)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -307,7 +307,7 @@ require (
 	github.com/dvsekhvalnov/jose2go v1.6.0 // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.3 // indirect
-	github.com/envoyproxy/go-control-plane v0.12.0 // indirect
+	github.com/envoyproxy/go-control-plane v0.12.0
 	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/Microsoft/hcsshim v0.11.4 // indirect
+	github.com/Microsoft/hcsshim v0.11.5 // indirect
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2 // indirect
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
@@ -113,7 +113,9 @@ require (
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/cloudflare/cfssl v1.6.4 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
-	github.com/containerd/containerd v1.7.12 // indirect
+	github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b // indirect
+	github.com/containerd/containerd v1.7.18 // indirect
+	github.com/containerd/errdefs v0.1.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/coreos/go-oidc v2.2.1+incompatible // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -1,3 +1,5 @@
+cel.dev/expr v0.15.0 h1:O1jzfJCQBfL5BFoYktaxwIhuttaQPsVWerH9/EEKx0w=
+cel.dev/expr v0.15.0/go.mod h1:TRSuuV7DlVCE/uwv5QbAiW/v8l5O8C4eEPHeu7gf7Sg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -707,8 +709,8 @@ github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jB
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
-github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
+github.com/Microsoft/hcsshim v0.11.5 h1:haEcLNpj9Ka1gd3B3tAEs9CpE0c+1IhoL59w/exYU38=
+github.com/Microsoft/hcsshim v0.11.5/go.mod h1:MV8xMfmECjl5HdO7U/3/hFVnkmSBjAjmA09d4bExKcU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
@@ -902,14 +904,16 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20230105202645-06c439db220b/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20240318125728-8a4994d93e50 h1:DBmgJDC9dTfkVyGgipamEh2BpGYxScCH1TOF1LL1cXc=
-github.com/cncf/xds/go v0.0.0-20240318125728-8a4994d93e50/go.mod h1:5e1+Vvlzido69INQaVO6d87Qn543Xr6nooe9Kz7oBFM=
+github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b h1:ga8SEFjZ60pxLcmhnThWgvH2wg8376yUJmPhEH4H3kw=
+github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
-github.com/containerd/containerd v1.7.12 h1:+KQsnv4VnzyxWcfO9mlxxELaoztsDEjOuCMPAuPqgU0=
-github.com/containerd/containerd v1.7.12/go.mod h1:/5OMpE1p0ylxtEUGY8kuCYkDRzJm9NO1TFMWjUpdevk=
+github.com/containerd/containerd v1.7.18 h1:jqjZTQNfXGoEaZdW1WwPU0RqSn1Bm2Ay/KJPUuO8nao=
+github.com/containerd/containerd v1.7.18/go.mod h1:IYEk9/IO6wAPUz2bCMVUbsfXjzw5UNP5fLz4PsUygQ4=
 github.com/containerd/continuity v0.4.2 h1:v3y/4Yz5jwnvqPKJJ+7Wf93fyWoCB3F5EclWG023MDM=
 github.com/containerd/continuity v0.4.2/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
+github.com/containerd/errdefs v0.1.0 h1:m0wCRBiu1WJT/Fr+iOoQHMQS/eP5myQ8lCv4Dz5ZURM=
+github.com/containerd/errdefs v0.1.0/go.mod h1:YgWiiHtLmSeBrvpw+UfPijzbLaB77mEG1WwJTDETIV0=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/lib/tbot/service_spiffe_workload_api.go
+++ b/lib/tbot/service_spiffe_workload_api.go
@@ -19,7 +19,6 @@
 package tbot
 
 import (
-	"bytes"
 	"context"
 	"crypto/x509"
 	"encoding/pem"
@@ -34,10 +33,13 @@ import (
 	"sync"
 	"time"
 
+	secretv3pb "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
 	"github.com/gravitational/trace"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
 	workloadpb "github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -86,17 +88,17 @@ type SPIFFEWorkloadAPIService struct {
 	// client holds the impersonated client for the service
 	client *authclient.Client
 
-	trustDomain string
+	trustDomain spiffeid.TrustDomain
 
 	attestor *workloadattest.Attestor
 
 	// trustBundle is protected by trustBundleMu. Use setTrustBundle and
 	// getTrustBundle to access it.
-	trustBundle   []byte
+	trustBundle   *x509bundle.Bundle
 	trustBundleMu sync.Mutex
 }
 
-func (s *SPIFFEWorkloadAPIService) setTrustBundle(trustBundle []byte) {
+func (s *SPIFFEWorkloadAPIService) setTrustBundle(trustBundle *x509bundle.Bundle) {
 	s.trustBundleMu.Lock()
 	s.trustBundle = trustBundle
 	s.trustBundleMu.Unlock()
@@ -104,29 +106,45 @@ func (s *SPIFFEWorkloadAPIService) setTrustBundle(trustBundle []byte) {
 	s.trustBundleBroadcast.broadcast()
 }
 
-func (s *SPIFFEWorkloadAPIService) getTrustBundle() []byte {
+func (s *SPIFFEWorkloadAPIService) getTrustBundle() *x509bundle.Bundle {
 	s.trustBundleMu.Lock()
 	defer s.trustBundleMu.Unlock()
 	return s.trustBundle
 }
 
+// trustBundleToRawCerts converts a trust bundle's certs to raw bytes.
+// What's particularly special is that the certs are not pem encoded and
+// are appended directly to one another. This is the way that the SPIFFE
+// workload API clients expect.
+func trustBundleToRawCerts(bundle *x509bundle.Bundle) []byte {
+	out := []byte{}
+	for _, cert := range bundle.X509Authorities() {
+		out = append(out, cert.Raw...)
+	}
+	return out
+}
+
 func (s *SPIFFEWorkloadAPIService) fetchBundle(ctx context.Context) error {
-	cas, err := s.botClient.GetCertAuthorities(ctx, types.SPIFFECA, false)
+	ca, err := s.botClient.GetCertAuthority(ctx, types.CertAuthID{
+		Type:       types.SPIFFECA,
+		DomainName: s.trustDomain.Name(),
+	}, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	trustBundleBytes := &bytes.Buffer{}
-	for _, ca := range cas {
-		for _, cert := range services.GetTLSCerts(ca) {
-			// The values from GetTLSCerts are PEM encoded. We need them to be
-			// the bare ASN.1 DER encoded certificate.
-			block, _ := pem.Decode(cert)
-			trustBundleBytes.Write(block.Bytes)
+
+	bundle := x509bundle.New(s.trustDomain)
+	for _, certBytes := range services.GetTLSCerts(ca) {
+		block, _ := pem.Decode(certBytes)
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return trace.Wrap(err, "parsing cert")
 		}
+		bundle.AddX509Authority(cert)
 	}
 
 	s.log.InfoContext(ctx, "Fetched new trust bundle")
-	s.setTrustBundle(trustBundleBytes.Bytes())
+	s.setTrustBundle(bundle)
 	return nil
 }
 
@@ -164,14 +182,14 @@ func (s *SPIFFEWorkloadAPIService) setup(ctx context.Context) (err error) {
 		}
 	}()
 
-	if err := s.fetchBundle(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-	authPing, err := client.Ping(ctx)
+	s.trustDomain, err = spiffeid.TrustDomainFromString(facade.Get().ClusterName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	s.trustDomain = authPing.ClusterName
+
+	if err := s.fetchBundle(ctx); err != nil {
+		return trace.Wrap(err)
+	}
 
 	s.attestor, err = workloadattest.NewAttestor(s.log, s.cfg.Attestors)
 	if err != nil {
@@ -272,6 +290,17 @@ func (s *SPIFFEWorkloadAPIService) Run(ctx context.Context) error {
 		grpc.MaxConcurrentStreams(defaults.GRPCMaxConcurrentStreams),
 	)
 	workloadpb.RegisterSpiffeWorkloadAPIServer(srv, s)
+	sdsHandler := &spiffeSDSHandler{
+		log:    s.log,
+		cfg:    s.cfg,
+		botCfg: s.botCfg,
+
+		clientAuthenticator:         s.authenticateClient,
+		trustBundleGetter:           s.getTrustBundle,
+		trustBundleUpdateSubscriber: s.trustBundleBroadcast.subscribe,
+		svidFetcher:                 s.fetchX509SVIDs,
+	}
+	secretv3pb.RegisterSecretDiscoveryServiceServer(srv, sdsHandler)
 
 	lis, err := createListener(ctx, s.log, s.cfg.Listen)
 	if err != nil {
@@ -364,6 +393,7 @@ func (s *SPIFFEWorkloadAPIService) fetchX509SVIDs(
 	// contention on the mutex and to ensure that all SVIDs are using the
 	// same trust bundle.
 	trustBundle := s.getTrustBundle()
+	bundleRawCerts := trustBundleToRawCerts(trustBundle)
 
 	// TODO(noah): We should probably take inspiration from SPIRE agent's
 	// behavior of pre-fetching the SVIDs rather than doing this for
@@ -398,7 +428,7 @@ func (s *SPIFFEWorkloadAPIService) fetchX509SVIDs(
 			// Required. ASN.1 DER encoded PKCS#8 private key. MUST be unencrypted.
 			X509SvidKey: pkcs8PrivateKey,
 			// Required. ASN.1 DER encoded X.509 bundle for the trust domain.
-			Bundle: trustBundle,
+			Bundle: bundleRawCerts,
 			Hint:   svidRes.Hint,
 		}
 		cert, err := x509.ParseCertificate(svidRes.Certificate)
@@ -604,7 +634,7 @@ func (s *SPIFFEWorkloadAPIService) FetchX509SVID(
 
 	log, creds, err := s.authenticateClient(ctx)
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.Wrap(err, "authenticating client")
 	}
 
 	log.InfoContext(ctx, "FetchX509SVID stream opened by workload")
@@ -677,10 +707,11 @@ func (s *SPIFFEWorkloadAPIService) FetchX509Bundles(
 
 	for {
 		s.log.InfoContext(ctx, "Sending X.509 trust bundles to workload")
+		tb := s.getTrustBundle()
 		err := srv.Send(&workloadpb.X509BundlesResponse{
 			// Bundles keyed by trust domain
 			Bundles: map[string][]byte{
-				s.trustDomain: s.getTrustBundle(),
+				tb.TrustDomain().IDString(): trustBundleToRawCerts(tb),
 			},
 		})
 		if err != nil {

--- a/lib/tbot/service_spiffe_workload_api_sds.go
+++ b/lib/tbot/service_spiffe_workload_api_sds.go
@@ -1,0 +1,567 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"context"
+	"encoding/pem"
+	"errors"
+	"io"
+	"log/slog"
+	"time"
+
+	corev3pb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	tlsv3pb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	discoveryv3pb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	secretv3pb "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
+	"github.com/gravitational/trace"
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	workloadpb "github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"golang.org/x/exp/maps"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/spiffe/workloadattest"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// The following constants allow querying this API for SVIDs and trust bundles
+// without knowing their names. These special values are relied upon by tools
+// like Istio.
+const (
+	// envoyDefaultSVIDName indicates that the first available SVID should be
+	// returned.
+	envoyDefaultSVIDName = "default"
+	// envoyDefaultBundleName indicates that the default trust bundle should be
+	// returned, e.g the one for the trust domain that the workload is part of.
+	envoyDefaultBundleName = "ROOTCA"
+	// envoyAllBundlesName indicates that all available trust bundles,
+	// including federated ones, should be returned.
+	envoyAllBundlesName = "ALL"
+)
+
+// spiffeSDSHandler implements an Envoy SDS API.
+//
+// This effectively replaces the Workload API for Envoy, but functions in a
+// very similar way.
+type spiffeSDSHandler struct {
+	log    *slog.Logger
+	cfg    *config.SPIFFEWorkloadAPIService
+	botCfg *config.BotConfig
+
+	clientAuthenticator         func(ctx context.Context) (*slog.Logger, workloadattest.Attestation, error)
+	trustBundleGetter           func() *x509bundle.Bundle
+	trustBundleUpdateSubscriber func() (ch chan struct{}, unsubscribe func())
+	svidFetcher                 func(
+		ctx context.Context,
+		log *slog.Logger,
+		svidRequests []config.SVIDRequest,
+	) ([]*workloadpb.X509SVID, error)
+}
+
+// FetchSecrets implements
+// envoy.service.secret.v3/SecretDiscoveryService.FetchSecrets.
+// This should return the current SVIDs and trust bundles.
+//
+// See:
+// - DiscoveryRequest - https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/discovery/v3/discovery.proto#service-discovery-v3-discoveryrequest
+// - DiscoveryResponse - https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/discovery/v3/discovery.proto#service-discovery-v3-discoveryresponse
+func (s *spiffeSDSHandler) FetchSecrets(
+	ctx context.Context,
+	req *discoveryv3pb.DiscoveryRequest,
+) (*discoveryv3pb.DiscoveryResponse, error) {
+	if err := enforceMinimumEnvoyVersion(req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	log, creds, err := s.clientAuthenticator(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err, "authenticating client")
+	}
+
+	log.DebugContext(
+		ctx,
+		"SecretDiscoveryService.FetchSecrets request received from workload",
+		slog.Group("req", "resource_names", req.ResourceNames),
+	)
+	defer log.DebugContext(ctx, "SecretDiscoveryService.FetchSecrets request handled")
+
+	return s.generateResponse(
+		ctx,
+		log,
+		creds,
+		s.trustBundleGetter(),
+		req,
+	)
+}
+
+// StreamSecrets implements
+// envoy.service.secret.v3/SecretDiscoveryService.StreamSecrets.
+// This should return the current SVIDs and CAs, and stream any future updates.
+//
+// This is a little more complex than one might expect since Envoy provides
+// an ACK/NACK mechanism to indicate that the config included within a response
+// was successfully applied.
+//
+// From the docs on the request version_info field:
+//
+//	The version_info provided in the request messages will be the
+//	version_info received with the most recent successfully processed
+//	response or empty on the first request. It is expected that no new
+//	request is sent after a response is received until the Envoy
+//	instance is ready to ACK/NACK the new configuration. ACK/NACK takes
+//	place by returning the new API config version as applied or the
+//	previous API config version respectively.
+//
+// From the docs on the DiscoveryRequest.response_nonce field:
+//
+//	nonce corresponding to DiscoveryResponse being ACK/NACKed. See above
+//	discussion on version_info and the DiscoveryResponse nonce comment
+//
+// From the docs on the DiscoveryResponse.nonce field:
+//
+//	For gRPC based subscriptions, the nonce provides a way to explicitly ack a
+//	specific DiscoveryResponse in a following DiscoveryRequest. Additional
+//	messages may have been sent by Envoy to the management server for the
+//	previous version on the stream prior to this DiscoveryResponse, that were
+//	unprocessed at response send time. The nonce allows the management server to
+//	ignore any further DiscoveryRequests for the previous version until a
+//	DiscoveryRequest bearing the nonce.
+//
+// See also:
+// - DiscoveryRequest - https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/discovery/v3/discovery.proto#service-discovery-v3-discoveryrequest
+// - DiscoveryResponse - https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/discovery/v3/discovery.proto#service-discovery-v3-discoveryresponse
+//
+// TODO: We could probably be smarter about how we handle the version e.g,
+// do we need to send another response if we're just going to send identical
+// certificates ??
+func (s *spiffeSDSHandler) StreamSecrets(
+	srv secretv3pb.SecretDiscoveryService_StreamSecretsServer,
+) error {
+	ctx := srv.Context()
+	log, creds, err := s.clientAuthenticator(ctx)
+	if err != nil {
+		return trace.Wrap(err, "authenticating client")
+	}
+
+	reloadCh, unsubscribe := s.trustBundleUpdateSubscriber()
+	defer unsubscribe()
+
+	log.DebugContext(
+		ctx,
+		"SecretDiscoveryService.StreamSecrets stream started",
+	)
+	defer log.DebugContext(ctx, "SecretDiscoveryService.FetchSecrets stream finished")
+
+	// Push incoming messages into a chan for the main loop to handle
+	recvCh := make(chan *discoveryv3pb.DiscoveryRequest, 1)
+	recvErrCh := make(chan error, 1)
+	go func() {
+		for {
+			req, err := srv.Recv()
+			if err != nil {
+				// It's worth noting that we'll receive an IOF/Canceled error
+				// here once the main goroutine has exited or the client goes
+				// away.
+				select {
+				case recvErrCh <- err:
+				default:
+				}
+				return
+			}
+			recvCh <- req
+		}
+	}()
+
+	renewalTimer := time.NewTimer(s.botCfg.RenewalInterval)
+	// Stop the timer immediately so we can start timing after the first
+	// response is sent.
+	renewalTimer.Stop()
+	defer renewalTimer.Stop()
+
+	// Track the last response and last request to allow us to handle ACK/NACK
+	// and versioning.
+	var (
+		lastResp *discoveryv3pb.DiscoveryResponse
+		lastReq  *discoveryv3pb.DiscoveryRequest
+	)
+	for {
+		select {
+		case err := <-recvErrCh:
+			// If we receive an error from the read side, we should exit.
+			// This error could be an EOF/Canceled error if the client
+			// goes away.
+			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return trace.Wrap(err)
+		case newReq := <-recvCh:
+			log.DebugContext(
+				ctx,
+				"Received StreamSecrets DiscoveryRequest",
+				slog.Group(
+					"req",
+					"resource_names", newReq.ResourceNames,
+					"version_info", newReq.VersionInfo,
+					"response_nonce", newReq.ResponseNonce,
+					"node_id", newReq.Node.GetId(),
+				),
+			)
+
+			shouldRespond := true
+
+			// If we've sent a response, then this request ought to be a reply
+			// We should check the nonces/versions to ensure it's successfully
+			// applied
+			if lastResp != nil {
+				// Envoy can send an "ErrorDetails" which indicates that the
+				// previously sent response could not be applied.
+				if newReq.ErrorDetail != nil {
+					log.WarnContext(
+						ctx,
+						"Envoy was unable to apply previous discovery response",
+						"error", newReq.ErrorDetail.Message,
+					)
+				}
+
+				if lastResp.Nonce != newReq.ResponseNonce {
+					log.WarnContext(
+						ctx,
+						"Envoy sent a nonce which does not match the last response, ignoring request",
+						"want", lastResp.Nonce,
+						"got", newReq.ResponseNonce,
+					)
+					// We want to ignore this request because it's been sent
+					// before Envoy has processed our last response.
+					continue
+				}
+
+				// Since we've already sent them a response, we should only
+				// respond again if they've changed what they've requested.
+				shouldRespond = !elementsMatch(
+					lastReq.ResourceNames, newReq.ResourceNames,
+				)
+				// TODO(noah): SPIRE's implementation seems to check the last
+				// requests resource names - but I wonder if it makes more sense
+				// to compare the requests resource names against those sent in
+				// the last response.
+			}
+
+			lastReq = newReq
+			if !shouldRespond {
+				continue
+			}
+
+		case <-reloadCh:
+			// If there's been a CA rotation, we need to send a new response.
+		case <-renewalTimer.C:
+			// Handle renewal time!
+			log.DebugContext(ctx, "Renewing SVIDs for StreamSecrets stream")
+		}
+
+		resp, err := s.generateResponse(
+			ctx, log, creds, s.trustBundleGetter(), lastReq,
+		)
+		if err != nil {
+			return trace.Wrap(err, "generating response")
+		}
+
+		// Decorate the generated response with the stream ACK/NACK and
+		// versioning fields.
+		nonce, err := utils.CryptoRandomHex(4)
+		if err != nil {
+			return trace.Wrap(err, "generating nonce")
+		}
+		resp.Nonce = nonce
+		resp.VersionInfo = time.Now().UTC().Format(time.RFC3339Nano)
+		if err := srv.Send(resp); err != nil {
+			return trace.Wrap(err, "sending response")
+		}
+		lastResp = resp
+		log.DebugContext(
+			ctx,
+			"Sent StreamSecrets DiscoveryResponse",
+			slog.Group(
+				"resp",
+				"resources_len", len(resp.Resources),
+				"nonce", resp.Nonce,
+				"version_info", resp.VersionInfo,
+			),
+		)
+
+		renewalTimer.Reset(s.botCfg.RenewalInterval)
+	}
+}
+
+// elementsMatch compares two string slices for equality, ignoring order.
+func elementsMatch(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := map[string]bool{}
+	for _, v := range a {
+		seen[v] = true
+	}
+	for _, v := range b {
+		if !seen[v] {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *spiffeSDSHandler) generateResponse(
+	ctx context.Context,
+	log *slog.Logger,
+	attest workloadattest.Attestation,
+	tb *x509bundle.Bundle,
+	req *discoveryv3pb.DiscoveryRequest,
+) (*discoveryv3pb.DiscoveryResponse, error) {
+	// names holds all names requested by the client
+	// if this is nothing, we assume they want everything available to them.
+	// it's worth keeping in mind that there's some special names we need to
+	// handle.
+	names := map[string]bool{}
+	for _, name := range req.ResourceNames {
+		// Ignore empty string
+		if name != "" {
+			names[name] = true
+		}
+	}
+	returnAll := len(names) == 0
+
+	var resources []*anypb.Any
+
+	// Filter SVIDs down to those accessible to this workload
+	availableSVIDs := filterSVIDRequests(ctx, log, s.cfg.SVIDs, attest)
+	// Fetch the SVIDs and convert them into the SDS cert type.
+	svids, err := s.svidFetcher(ctx, log, availableSVIDs)
+	if err != nil {
+		return nil, trace.Wrap(err, "fetching X509 SVIDs")
+	}
+	for i, svid := range svids {
+		// Now we need to filter the SVIDs down to those requested by the
+		// client.
+		// There's a special case here, if they've requested the default SVID,
+		// we want to ensure that the first SVID is returned and it's name
+		// overrridden.
+
+		switch {
+		case returnAll || names[svid.SpiffeId]:
+			secret, err := newTLSV3Certificate(svid, "")
+			if err != nil {
+				return nil, trace.Wrap(err, "creating TLS certificate")
+			}
+			resources = append(resources, secret)
+			delete(names, svid.SpiffeId)
+		case names[envoyDefaultSVIDName] && i == 0:
+			secret, err := newTLSV3Certificate(svid, envoyDefaultSVIDName)
+			if err != nil {
+				return nil, trace.Wrap(err, "creating TLS certificate")
+			}
+			resources = append(resources, secret)
+			delete(names, envoyDefaultSVIDName)
+		}
+	}
+
+	// Convert trust bundle to SDS validator type.
+	switch {
+	case returnAll || names[tb.TrustDomain().IDString()]:
+		// If this name was explicitly specified or no names were specified,
+		// we use the proper trust domain ID as the resource name.
+		validator, err := newTLSV3ValidationContext(
+			tb, "",
+		)
+		if err != nil {
+			return nil, trace.Wrap(err, "creating TLS validation context")
+		}
+		resources = append(resources, validator)
+		delete(names, tb.TrustDomain().IDString())
+	case names[envoyDefaultBundleName]:
+		// If they've requested the default bundle, we send the connected trust
+		// domain's bundle - but - we override the name to match what they
+		// expect.
+		validator, err := newTLSV3ValidationContext(
+			tb, envoyDefaultBundleName,
+		)
+		if err != nil {
+			return nil, trace.Wrap(err, "creating TLS validation context")
+		}
+		resources = append(resources, validator)
+		delete(names, envoyDefaultBundleName)
+	case names[envoyAllBundlesName]:
+		// TODO: When federation support is added, the behavior of this case
+		// shall change to return the connected trust domain's bundle
+		// concatenated with all federated bundles. For now, we return the
+		// connected trust domain's bundle - but - we override the name to
+		// match what they expect.
+		validator, err := newTLSV3ValidationContext(
+			tb, envoyAllBundlesName,
+		)
+		if err != nil {
+			return nil, trace.Wrap(err, "creating TLS validation context")
+		}
+		resources = append(resources, validator)
+		delete(names, envoyAllBundlesName)
+	}
+
+	// TODO: When federation support is added, return any federated bundles
+	// if named or returnAll.
+
+	// If any names are left-over, we've not been able to service them so
+	// we should return an explicit error rather than omitting data.
+	if len(names) > 0 {
+		return nil, trace.BadParameter("unknown resource names: %v", maps.Keys(names))
+	}
+
+	return &discoveryv3pb.DiscoveryResponse{
+		// Copy in requested type from req
+		TypeUrl:   req.TypeUrl,
+		Resources: resources,
+	}, nil
+}
+
+func enforceMinimumEnvoyVersion(req *discoveryv3pb.DiscoveryRequest) error {
+	// Envoy 1.18 introduced the SPIFFE specific tls context validator - so
+	// that's our minimum supported version.
+	buildVersion := req.Node.GetUserAgentBuildVersion()
+	// If not specified, let's assume that it's recent enough.
+	if buildVersion == nil {
+		return nil
+	}
+	if buildVersion.Version.MajorNumber > 1 {
+		return nil
+	}
+	if buildVersion.Version.MinorNumber >= 18 {
+		return nil
+	}
+	return trace.BadParameter("minimum supported version of envoy supported by the tbot SDS API is 1.18")
+}
+
+func newTLSV3Certificate(
+	svid *workloadpb.X509SVID, overrideResourceName string,
+) (*anypb.Any, error) {
+	// noah: This section of code does not currently support intermediate
+	// certificates, but, we don't currently use them.
+	certBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: svid.X509Svid,
+	})
+	privateKeyBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: svid.X509SvidKey,
+	})
+
+	// https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-msg-extensions-transport-sockets-tls-v3-tlscertificate
+	secret := &tlsv3pb.Secret{
+		Name: svid.SpiffeId,
+		Type: &tlsv3pb.Secret_TlsCertificate{
+			TlsCertificate: &tlsv3pb.TlsCertificate{
+				CertificateChain: &corev3pb.DataSource{
+					Specifier: &corev3pb.DataSource_InlineBytes{
+						// Must be appended PEM-wrapped X509 certificates
+						InlineBytes: certBytes,
+					},
+				},
+				PrivateKey: &corev3pb.DataSource{
+					Specifier: &corev3pb.DataSource_InlineBytes{
+						// Must be PKCS8 PEM-wrapped private key
+						InlineBytes: privateKeyBytes,
+					},
+				},
+			},
+		},
+	}
+	if overrideResourceName != "" {
+		secret.Name = overrideResourceName
+	}
+
+	return anypb.New(secret)
+}
+
+const envoySPIFFECertValidator = "envoy.tls.cert_validator.spiffe"
+
+func newTLSV3ValidationContext(
+	tb *x509bundle.Bundle, overrideResourceName string,
+) (*anypb.Any, error) {
+	caBytes, err := tb.Marshal()
+	if err != nil {
+		return nil, trace.Wrap(err, "marshaling trust bundle")
+	}
+
+	// https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls_spiffe_validator_config.proto#extensions-transport-sockets-tls-v3-spiffecertvalidatorconfig-trustdomain
+	trustDomains := []*tlsv3pb.SPIFFECertValidatorConfig_TrustDomain{
+		{
+			// From API reference:
+			//   Note that this must not have “spiffe://” prefix.
+			Name: tb.TrustDomain().Name(),
+			TrustBundle: &corev3pb.DataSource{
+				Specifier: &corev3pb.DataSource_InlineBytes{
+					// Must be concatenated PEM-wrapped X509 certificates
+					InlineBytes: caBytes,
+				},
+			},
+		},
+	}
+
+	// Generate the typed config for the SPIFFE TLS cert validator extension
+	// https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls_spiffe_validator_config.proto
+	extConfig, err := anypb.New(&tlsv3pb.SPIFFECertValidatorConfig{
+		TrustDomains: trustDomains,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-certificatevalidationcontext
+	secret := &tlsv3pb.Secret{
+		// We intentionally use the full IDString here in contrast to the
+		// short name used in the TrustDomain config block.
+		Name: tb.TrustDomain().IDString(),
+		Type: &tlsv3pb.Secret_ValidationContext{
+			ValidationContext: &tlsv3pb.CertificateValidationContext{
+				// We use a custom validation context for SPIFFE to provide
+				// greater usability than a plain TLS CA.
+				CustomValidatorConfig: &corev3pb.TypedExtensionConfig{
+					Name:        envoySPIFFECertValidator,
+					TypedConfig: extConfig,
+				},
+			},
+		},
+	}
+	if overrideResourceName != "" {
+		secret.Name = overrideResourceName
+	}
+
+	return anypb.New(secret)
+}
+
+// DeltaSecrets implements
+// envoy.service.secret.v3/SecretDiscoveryService.DeltaSecrets.
+// We do not implement this method.
+func (s *spiffeSDSHandler) DeltaSecrets(
+	_ secretv3pb.SecretDiscoveryService_DeltaSecretsServer,
+) error {
+	return status.Error(
+		codes.Unimplemented,
+		"method not implemented",
+	)
+}

--- a/lib/tbot/service_spiffe_workload_api_sds_test.go
+++ b/lib/tbot/service_spiffe_workload_api_sds_test.go
@@ -1,0 +1,452 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"log/slog"
+	"os"
+	"path"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	tlsv3pb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	discoveryv3pb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	secretv3pb "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	workloadpb "github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/spiffe/workloadattest"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/golden"
+	"github.com/gravitational/teleport/tool/teleport/testenv"
+)
+
+// TestSDS_FetchSecrets performs a unit-test over the FetchSecrets method.
+// It tests the generation of the DiscoveryResponses and that authentication
+// is enforced.
+func TestSDS_FetchSecrets(t *testing.T) {
+	log := utils.NewSlogLoggerForTests()
+	ctx := context.Background()
+
+	td, err := spiffeid.TrustDomainFromString("example.com")
+	require.NoError(t, err)
+
+	b, _ := pem.Decode([]byte(fixtures.TLSCACertPEM))
+	require.NotNil(t, b, "Decode failed")
+	ca, err := x509.ParseCertificate(b.Bytes)
+	require.NoError(t, err)
+
+	uid := 100
+	notUID := 200
+	clientAuthenticator := func(ctx context.Context) (*slog.Logger, workloadattest.Attestation, error) {
+		return log, workloadattest.Attestation{
+			Unix: workloadattest.UnixAttestation{
+				Attested: true,
+				UID:      uid,
+			},
+		}, nil
+	}
+
+	bundle := x509bundle.New(td)
+	bundle.AddX509Authority(ca)
+	trustBundleGetter := func() *x509bundle.Bundle {
+		return bundle
+	}
+	trustBundleUpdateSubscriber := func() (ch chan struct{}, unsubscribe func()) {
+		return nil, func() {}
+	}
+	svidFetcher := func(
+		ctx context.Context,
+		log *slog.Logger,
+		svidRequests []config.SVIDRequest,
+	) ([]*workloadpb.X509SVID, error) {
+		if len(svidRequests) != 2 {
+			return nil, trace.BadParameter("expected 2 svids requested")
+		}
+		return []*workloadpb.X509SVID{
+			{
+				SpiffeId:    "spiffe://example.com/default",
+				X509Svid:    []byte("CERT-spiffe://example.com/default"),
+				X509SvidKey: []byte("KEY-spiffe://example.com/default"),
+			},
+			{
+				SpiffeId:    "spiffe://example.com/second",
+				X509Svid:    []byte("CERT-spiffe://example.com/second"),
+				X509SvidKey: []byte("KEY-spiffe://example.com/second"),
+			},
+		}, nil
+	}
+	botConfig := &config.BotConfig{
+		RenewalInterval: time.Minute,
+	}
+	cfg := &config.SPIFFEWorkloadAPIService{
+		SVIDs: []config.SVIDRequestWithRules{
+			{
+				SVIDRequest: config.SVIDRequest{
+					Path: "/default",
+				},
+				Rules: []config.SVIDRequestRule{
+					{
+						Unix: config.SVIDRequestRuleUnix{
+							UID: &uid,
+						},
+					},
+				},
+			},
+			{
+				SVIDRequest: config.SVIDRequest{
+					Path: "/second",
+				},
+				Rules: []config.SVIDRequestRule{
+					{
+						Unix: config.SVIDRequestRuleUnix{
+							UID: &uid,
+						},
+					},
+				},
+			},
+			{
+				SVIDRequest: config.SVIDRequest{
+					Path: "/not-matching",
+				},
+				Rules: []config.SVIDRequestRule{
+					{
+						Unix: config.SVIDRequestRuleUnix{
+							UID: &notUID,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+
+		svids         []config.SVIDRequestWithRules
+		resourceNames []string
+
+		wantErr string
+	}{
+		{
+			name:          "all",
+			resourceNames: []string{},
+		},
+		{
+			name: "specific svid",
+			resourceNames: []string{
+				"spiffe://example.com/second",
+			},
+		},
+		{
+			name: "specific ca",
+			resourceNames: []string{
+				"spiffe://example.com",
+			},
+		},
+		{
+			name: "special default",
+			resourceNames: []string{
+				envoyDefaultSVIDName,
+			},
+		},
+		{
+			name: "special ROOTCA",
+			resourceNames: []string{
+				envoyDefaultBundleName,
+			},
+		},
+		{
+			name: "special ALL",
+			resourceNames: []string{
+				envoyAllBundlesName,
+			},
+		},
+		{
+			name:          "no results",
+			resourceNames: []string{"spiffe://example.com/not-matching"},
+			wantErr:       "unknown resource names: [spiffe://example.com/not-matching]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sds := &spiffeSDSHandler{
+				log:    log,
+				cfg:    cfg,
+				botCfg: botConfig,
+
+				clientAuthenticator:         clientAuthenticator,
+				trustBundleGetter:           trustBundleGetter,
+				trustBundleUpdateSubscriber: trustBundleUpdateSubscriber,
+				svidFetcher:                 svidFetcher,
+			}
+
+			req := &discoveryv3pb.DiscoveryRequest{
+				TypeUrl:       "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+				ResourceNames: tt.resourceNames,
+			}
+
+			res, err := sds.FetchSecrets(ctx, req)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if golden.ShouldSet() {
+				resBytes, err := protojson.MarshalOptions{
+					Multiline: true,
+				}.Marshal(res)
+				require.NoError(t, err)
+				golden.Set(t, resBytes)
+			}
+
+			want := &discoveryv3pb.DiscoveryResponse{}
+			require.NoError(t, protojson.Unmarshal(golden.Get(t), want))
+			require.Empty(t, cmp.Diff(res, want, protocmp.Transform()))
+		})
+	}
+}
+
+// Test_E2E_SPIFFE_SDS is an end-to-end test of Workload ID's ability
+// to issue a SPIFFE SVID to a workload connecting via the SDS API
+func Test_E2E_SPIFFE_SDS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+	t.Parallel()
+	ctx := context.Background()
+	log := utils.NewSlogLoggerForTests()
+
+	// Make a new auth server.
+	process := testenv.MakeTestServer(t, defaultTestServerOpts(t, log))
+	rootClient := testenv.MakeDefaultAuthClient(t, process)
+
+	// Create a role that allows the bot to issue a SPIFFE SVID.
+	role, err := types.NewRole("spiffe-issuer", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			SPIFFE: []*types.SPIFFERoleCondition{
+				{
+					Path: "/*",
+					DNSSANs: []string{
+						"*",
+					},
+					IPSANs: []string{
+						"0.0.0.0/0",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	role, err = rootClient.UpsertRole(ctx, role)
+	require.NoError(t, err)
+
+	pid := os.Getpid()
+
+	tempDir := t.TempDir()
+	socketPath := "unix://" + path.Join(tempDir, "sock")
+	onboarding, _ := makeBot(t, rootClient, "test", role.GetName())
+	botConfig := defaultBotConfig(
+		t, process, onboarding, config.ServiceConfigs{
+			&config.SPIFFEWorkloadAPIService{
+				Listen: socketPath,
+				SVIDs: []config.SVIDRequestWithRules{
+					// Intentionally unmatching PID to ensure this SVID
+					// is not issued.
+					{
+						SVIDRequest: config.SVIDRequest{
+							Path: "/bar",
+						},
+						Rules: []config.SVIDRequestRule{
+							{
+								Unix: config.SVIDRequestRuleUnix{
+									PID: ptr(0),
+								},
+							},
+						},
+					},
+					// SVID with rule that matches on PID.
+					{
+						SVIDRequest: config.SVIDRequest{
+							Path: "/foo",
+							Hint: "hint",
+							SANS: config.SVIDRequestSANs{
+								DNS: []string{"example.com"},
+								IP:  []string{"10.0.0.1"},
+							},
+						},
+						Rules: []config.SVIDRequestRule{
+							{
+								Unix: config.SVIDRequestRuleUnix{
+									PID: &pid,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		defaultBotConfigOpts{
+			useAuthServer: true,
+			insecure:      true,
+		},
+	)
+	botConfig.Oneshot = false
+	b := New(botConfig, log)
+
+	// Spin up goroutine for bot to run in
+	botCtx, cancelBot := context.WithCancel(ctx)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := b.Run(botCtx)
+		assert.NoError(t, err, "bot should not exit with error")
+		cancelBot()
+	}()
+	t.Cleanup(func() {
+		// Shut down bot and make sure it exits.
+		cancelBot()
+		wg.Wait()
+	})
+
+	// Wait for the socket to come up.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := os.Stat(filepath.Join(tempDir, "sock"))
+		assert.NoError(t, err)
+	}, 10*time.Second, 100*time.Millisecond)
+
+	conn, err := grpc.NewClient(
+		socketPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		conn.Close()
+	})
+
+	client := secretv3pb.NewSecretDiscoveryServiceClient(conn)
+	stream, err := client.StreamSecrets(ctx)
+	require.NoError(t, err)
+
+	// Request all secrets.
+	typeUrl := "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+	err = stream.Send(&discoveryv3pb.DiscoveryRequest{
+		TypeUrl:       typeUrl,
+		ResourceNames: []string{},
+	})
+	require.NoError(t, err)
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.VersionInfo)
+	assert.NotEmpty(t, resp.Nonce)
+	assert.Equal(t, typeUrl, resp.TypeUrl)
+	// We should expect to find two resources within the response
+	assert.Len(t, resp.Resources, 2)
+	// There's no specific order we should expect, so we'll need to assert that
+	// each actually exists
+
+	// First check we got our certificate...
+	checkSVID := func(secret *tlsv3pb.Secret) {
+		tlsCert := secret.GetTlsCertificate()
+		require.NotNil(t, tlsCert)
+		require.NotNil(t, tlsCert.CertificateChain)
+		tlsCertBytes := tlsCert.CertificateChain.GetInlineBytes()
+		require.NotEmpty(t, tlsCertBytes)
+		require.NotNil(t, tlsCert.PrivateKey)
+		privateKeyBytes := tlsCert.PrivateKey.GetInlineBytes()
+		require.NotEmpty(t, privateKeyBytes)
+		_, err = tls.X509KeyPair(tlsCertBytes, privateKeyBytes)
+		require.NoError(t, err)
+	}
+	checkSVID(findSecret(t, resp.Resources, "spiffe://root/foo"))
+
+	// Now check we got the CA
+	caSecret := findSecret(t, resp.Resources, "spiffe://root")
+	validationContext := caSecret.GetValidationContext()
+	require.NotNil(t, validationContext.CustomValidatorConfig)
+	require.Equal(t, envoySPIFFECertValidator, validationContext.CustomValidatorConfig.Name)
+	spiffeValidatorConfig := &tlsv3pb.SPIFFECertValidatorConfig{}
+	require.NoError(t, validationContext.CustomValidatorConfig.TypedConfig.UnmarshalTo(spiffeValidatorConfig))
+	require.Len(t, spiffeValidatorConfig.TrustDomains, 1)
+	require.Equal(t, "root", spiffeValidatorConfig.TrustDomains[0].Name)
+	block, _ := pem.Decode(spiffeValidatorConfig.TrustDomains[0].TrustBundle.GetInlineBytes())
+	require.Equal(t, "CERTIFICATE", block.Type)
+	_, err = x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	// We should send the response ACK we expect envoy to send.
+	err = stream.Send(&discoveryv3pb.DiscoveryRequest{
+		TypeUrl:       typeUrl,
+		VersionInfo:   resp.VersionInfo,
+		ResponseNonce: resp.Nonce,
+		ResourceNames: []string{},
+	})
+	require.NoError(t, err)
+
+	// Try specifying a specific resource
+	err = stream.Send(&discoveryv3pb.DiscoveryRequest{
+		TypeUrl: typeUrl,
+		ResourceNames: []string{
+			"spiffe://root/foo",
+		},
+		VersionInfo:   resp.VersionInfo,
+		ResponseNonce: resp.Nonce,
+	})
+	require.NoError(t, err)
+
+	resp, err = stream.Recv()
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.VersionInfo)
+	assert.NotEmpty(t, resp.Nonce)
+	assert.Len(t, resp.Resources, 1)
+	checkSVID(findSecret(t, resp.Resources, "spiffe://root/foo"))
+}
+
+func findSecret(t *testing.T, resources []*anypb.Any, name string) *tlsv3pb.Secret {
+	for _, a := range resources {
+		secret := &tlsv3pb.Secret{}
+		require.NoError(t, a.UnmarshalTo(secret))
+		if secret.Name == name {
+			return secret
+		}
+	}
+	return nil
+}

--- a/lib/tbot/testdata/TestSDS_FetchSecrets/all.golden
+++ b/lib/tbot/testdata/TestSDS_FetchSecrets/all.golden
@@ -1,0 +1,49 @@
+{
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+      "name": "spiffe://example.com/default",
+      "tlsCertificate": {
+        "certificateChain": {
+          "inlineBytes": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tClEwVlNWQzF6Y0dsbVptVTZMeTlsZUdGdGNHeGxMbU52YlM5a1pXWmhkV3gwCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+        },
+        "privateKey": {
+          "inlineBytes": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tClMwVlpMWE53YVdabVpUb3ZMMlY0WVcxd2JHVXVZMjl0TDJSbFptRjFiSFE9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K"
+        }
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+      "name": "spiffe://example.com/second",
+      "tlsCertificate": {
+        "certificateChain": {
+          "inlineBytes": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tClEwVlNWQzF6Y0dsbVptVTZMeTlsZUdGdGNHeGxMbU52YlM5elpXTnZibVE9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+        },
+        "privateKey": {
+          "inlineBytes": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tClMwVlpMWE53YVdabVpUb3ZMMlY0WVcxd2JHVXVZMjl0TDNObFkyOXVaQT09Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K"
+        }
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+      "name": "spiffe://example.com",
+      "validationContext": {
+        "customValidatorConfig": {
+          "name": "envoy.tls.cert_validator.spiffe",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig",
+            "trustDomains": [
+              {
+                "name": "example.com",
+                "trustBundle": {
+                  "inlineBytes": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lRSnRKREpaWkJrZy9hZk04ZDJaSkNUakFOQmdrcWhraUc5dzBCQVFzRkFEQkEKTVJVd0V3WURWUVFLRXd4VVpXeGxjRzl5ZENCUFUxTXhKekFsQmdOVkJBTVRIblJsYkdWd2IzSjBMbXh2WTJGcwphRzl6ZEM1c2IyTmhiR1J2YldGcGJqQWVGdzB4TnpBMU1Ea3hPVFF3TXpaYUZ3MHlOekExTURjeE9UUXdNelphCk1FQXhGVEFUQmdOVkJBb1RERlJsYkdWd2IzSjBJRTlUVXpFbk1DVUdBMVVFQXhNZWRHVnNaWEJ2Y25RdWJHOWoKWVd4b2IzTjBMbXh2WTJGc1pHOXRZV2x1TUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQwpBUUVBdUtGTGFmMmlJSS94RFIrbTJZajZQblVFYStxenF3eHNkTFVqbnVuRlphQVhHK2habTRNbDgwU0NpQmdJCmdUSFFsSnlMSWtUdHVSb0g1YWVNeXoxRVJVQ3RpaTRac1RxRHJqalV5YnhQNHIrNEhWWDZtMzRzNmh3RXI4RmkKZnRzOXBNcDRpUzN0UWd1UmMyOGdQZERvL1Q2VnJKVFZZVWZVVXNORFJ0SXJsQjVPOWlncXFMbnVhWTllcUdpNApQVXgwRzB3UllKcFJ5d29qOEcwSWtwZlFUaVgrQ0FDN2R0NXdzN1pybkdxQ05CTEdpNWJHc2FNbXB0VmJzU0VwCjFUZW5udEY1NFYxaVI0OUlWNUpxRGhtMVMwSG1rbGVvSnpLZGMrNnNQL3hOZXB6OVBKenVGOWQ5TnViVExXZ0IKc0syOFlJdGNtV0hkSFhEL09EeFZhZWhSandJREFRQUJveUF3SGpBT0JnTlZIUThCQWY4RUJBTUNCNEF3REFZRApWUjBUQVFIL0JBSXdBREFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQVZVNnNOQmRqNzZzYUh3T3hHU2RuRXFRCm8ydE11UjNtc1NNNEY2d0ZLMlVrS2Vwc0Q3Q1lJZi9Qek5TTlVxQTVKSUVVVmVNcUd5aUh1QWJVNEM2NTVuVDEKSXlKWDFELytyNzNzU3A1amJJcFFtMnhvUUdabmo2Zy9LbHR3OE9TT0F3K0RzTUYvUExWcW9XSnAwN3U2ZXcvbQpOeFdzSktjWjVrK3E0ZU14Y2k5bUtSSEhxc3F1V0tYelFsVVJNTkZJK21HYUZ3cktNNGRtemFSMEJFYytpbFN4ClFxVXZRNzRzbXNMSyt6aE5pa21namxHQzVvYjlnOFhraFZBa0pNQWgycmI5b25ETmlSbDY4aUFnY3pQODhtWHUKdk4vbzk4ZHlwenNQeFhtdzZ0a0RxSVJQVUFVYmg0NjVybFk1c0tNbVJnWGkyclVmbC9RVjVuYm96VW8vSFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+}

--- a/lib/tbot/testdata/TestSDS_FetchSecrets/special_ALL.golden
+++ b/lib/tbot/testdata/TestSDS_FetchSecrets/special_ALL.golden
@@ -1,0 +1,25 @@
+{
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+      "name": "ALL",
+      "validationContext": {
+        "customValidatorConfig": {
+          "name": "envoy.tls.cert_validator.spiffe",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig",
+            "trustDomains": [
+              {
+                "name": "example.com",
+                "trustBundle": {
+                  "inlineBytes": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lRSnRKREpaWkJrZy9hZk04ZDJaSkNUakFOQmdrcWhraUc5dzBCQVFzRkFEQkEKTVJVd0V3WURWUVFLRXd4VVpXeGxjRzl5ZENCUFUxTXhKekFsQmdOVkJBTVRIblJsYkdWd2IzSjBMbXh2WTJGcwphRzl6ZEM1c2IyTmhiR1J2YldGcGJqQWVGdzB4TnpBMU1Ea3hPVFF3TXpaYUZ3MHlOekExTURjeE9UUXdNelphCk1FQXhGVEFUQmdOVkJBb1RERlJsYkdWd2IzSjBJRTlUVXpFbk1DVUdBMVVFQXhNZWRHVnNaWEJ2Y25RdWJHOWoKWVd4b2IzTjBMbXh2WTJGc1pHOXRZV2x1TUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQwpBUUVBdUtGTGFmMmlJSS94RFIrbTJZajZQblVFYStxenF3eHNkTFVqbnVuRlphQVhHK2habTRNbDgwU0NpQmdJCmdUSFFsSnlMSWtUdHVSb0g1YWVNeXoxRVJVQ3RpaTRac1RxRHJqalV5YnhQNHIrNEhWWDZtMzRzNmh3RXI4RmkKZnRzOXBNcDRpUzN0UWd1UmMyOGdQZERvL1Q2VnJKVFZZVWZVVXNORFJ0SXJsQjVPOWlncXFMbnVhWTllcUdpNApQVXgwRzB3UllKcFJ5d29qOEcwSWtwZlFUaVgrQ0FDN2R0NXdzN1pybkdxQ05CTEdpNWJHc2FNbXB0VmJzU0VwCjFUZW5udEY1NFYxaVI0OUlWNUpxRGhtMVMwSG1rbGVvSnpLZGMrNnNQL3hOZXB6OVBKenVGOWQ5TnViVExXZ0IKc0syOFlJdGNtV0hkSFhEL09EeFZhZWhSandJREFRQUJveUF3SGpBT0JnTlZIUThCQWY4RUJBTUNCNEF3REFZRApWUjBUQVFIL0JBSXdBREFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQVZVNnNOQmRqNzZzYUh3T3hHU2RuRXFRCm8ydE11UjNtc1NNNEY2d0ZLMlVrS2Vwc0Q3Q1lJZi9Qek5TTlVxQTVKSUVVVmVNcUd5aUh1QWJVNEM2NTVuVDEKSXlKWDFELytyNzNzU3A1amJJcFFtMnhvUUdabmo2Zy9LbHR3OE9TT0F3K0RzTUYvUExWcW9XSnAwN3U2ZXcvbQpOeFdzSktjWjVrK3E0ZU14Y2k5bUtSSEhxc3F1V0tYelFsVVJNTkZJK21HYUZ3cktNNGRtemFSMEJFYytpbFN4ClFxVXZRNzRzbXNMSyt6aE5pa21namxHQzVvYjlnOFhraFZBa0pNQWgycmI5b25ETmlSbDY4aUFnY3pQODhtWHUKdk4vbzk4ZHlwenNQeFhtdzZ0a0RxSVJQVUFVYmg0NjVybFk1c0tNbVJnWGkyclVmbC9RVjVuYm96VW8vSFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+}

--- a/lib/tbot/testdata/TestSDS_FetchSecrets/special_ROOTCA.golden
+++ b/lib/tbot/testdata/TestSDS_FetchSecrets/special_ROOTCA.golden
@@ -1,0 +1,25 @@
+{
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+      "name": "ROOTCA",
+      "validationContext": {
+        "customValidatorConfig": {
+          "name": "envoy.tls.cert_validator.spiffe",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig",
+            "trustDomains": [
+              {
+                "name": "example.com",
+                "trustBundle": {
+                  "inlineBytes": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lRSnRKREpaWkJrZy9hZk04ZDJaSkNUakFOQmdrcWhraUc5dzBCQVFzRkFEQkEKTVJVd0V3WURWUVFLRXd4VVpXeGxjRzl5ZENCUFUxTXhKekFsQmdOVkJBTVRIblJsYkdWd2IzSjBMbXh2WTJGcwphRzl6ZEM1c2IyTmhiR1J2YldGcGJqQWVGdzB4TnpBMU1Ea3hPVFF3TXpaYUZ3MHlOekExTURjeE9UUXdNelphCk1FQXhGVEFUQmdOVkJBb1RERlJsYkdWd2IzSjBJRTlUVXpFbk1DVUdBMVVFQXhNZWRHVnNaWEJ2Y25RdWJHOWoKWVd4b2IzTjBMbXh2WTJGc1pHOXRZV2x1TUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQwpBUUVBdUtGTGFmMmlJSS94RFIrbTJZajZQblVFYStxenF3eHNkTFVqbnVuRlphQVhHK2habTRNbDgwU0NpQmdJCmdUSFFsSnlMSWtUdHVSb0g1YWVNeXoxRVJVQ3RpaTRac1RxRHJqalV5YnhQNHIrNEhWWDZtMzRzNmh3RXI4RmkKZnRzOXBNcDRpUzN0UWd1UmMyOGdQZERvL1Q2VnJKVFZZVWZVVXNORFJ0SXJsQjVPOWlncXFMbnVhWTllcUdpNApQVXgwRzB3UllKcFJ5d29qOEcwSWtwZlFUaVgrQ0FDN2R0NXdzN1pybkdxQ05CTEdpNWJHc2FNbXB0VmJzU0VwCjFUZW5udEY1NFYxaVI0OUlWNUpxRGhtMVMwSG1rbGVvSnpLZGMrNnNQL3hOZXB6OVBKenVGOWQ5TnViVExXZ0IKc0syOFlJdGNtV0hkSFhEL09EeFZhZWhSandJREFRQUJveUF3SGpBT0JnTlZIUThCQWY4RUJBTUNCNEF3REFZRApWUjBUQVFIL0JBSXdBREFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQVZVNnNOQmRqNzZzYUh3T3hHU2RuRXFRCm8ydE11UjNtc1NNNEY2d0ZLMlVrS2Vwc0Q3Q1lJZi9Qek5TTlVxQTVKSUVVVmVNcUd5aUh1QWJVNEM2NTVuVDEKSXlKWDFELytyNzNzU3A1amJJcFFtMnhvUUdabmo2Zy9LbHR3OE9TT0F3K0RzTUYvUExWcW9XSnAwN3U2ZXcvbQpOeFdzSktjWjVrK3E0ZU14Y2k5bUtSSEhxc3F1V0tYelFsVVJNTkZJK21HYUZ3cktNNGRtemFSMEJFYytpbFN4ClFxVXZRNzRzbXNMSyt6aE5pa21namxHQzVvYjlnOFhraFZBa0pNQWgycmI5b25ETmlSbDY4aUFnY3pQODhtWHUKdk4vbzk4ZHlwenNQeFhtdzZ0a0RxSVJQVUFVYmg0NjVybFk1c0tNbVJnWGkyclVmbC9RVjVuYm96VW8vSFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+}

--- a/lib/tbot/testdata/TestSDS_FetchSecrets/special_default.golden
+++ b/lib/tbot/testdata/TestSDS_FetchSecrets/special_default.golden
@@ -1,0 +1,17 @@
+{
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+      "name": "default",
+      "tlsCertificate": {
+        "certificateChain": {
+          "inlineBytes": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tClEwVlNWQzF6Y0dsbVptVTZMeTlsZUdGdGNHeGxMbU52YlM5a1pXWmhkV3gwCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+        },
+        "privateKey": {
+          "inlineBytes": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tClMwVlpMWE53YVdabVpUb3ZMMlY0WVcxd2JHVXVZMjl0TDJSbFptRjFiSFE9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K"
+        }
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+}

--- a/lib/tbot/testdata/TestSDS_FetchSecrets/specific_ca.golden
+++ b/lib/tbot/testdata/TestSDS_FetchSecrets/specific_ca.golden
@@ -1,0 +1,25 @@
+{
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+      "name": "spiffe://example.com",
+      "validationContext": {
+        "customValidatorConfig": {
+          "name": "envoy.tls.cert_validator.spiffe",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig",
+            "trustDomains": [
+              {
+                "name": "example.com",
+                "trustBundle": {
+                  "inlineBytes": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lRSnRKREpaWkJrZy9hZk04ZDJaSkNUakFOQmdrcWhraUc5dzBCQVFzRkFEQkEKTVJVd0V3WURWUVFLRXd4VVpXeGxjRzl5ZENCUFUxTXhKekFsQmdOVkJBTVRIblJsYkdWd2IzSjBMbXh2WTJGcwphRzl6ZEM1c2IyTmhiR1J2YldGcGJqQWVGdzB4TnpBMU1Ea3hPVFF3TXpaYUZ3MHlOekExTURjeE9UUXdNelphCk1FQXhGVEFUQmdOVkJBb1RERlJsYkdWd2IzSjBJRTlUVXpFbk1DVUdBMVVFQXhNZWRHVnNaWEJ2Y25RdWJHOWoKWVd4b2IzTjBMbXh2WTJGc1pHOXRZV2x1TUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQwpBUUVBdUtGTGFmMmlJSS94RFIrbTJZajZQblVFYStxenF3eHNkTFVqbnVuRlphQVhHK2habTRNbDgwU0NpQmdJCmdUSFFsSnlMSWtUdHVSb0g1YWVNeXoxRVJVQ3RpaTRac1RxRHJqalV5YnhQNHIrNEhWWDZtMzRzNmh3RXI4RmkKZnRzOXBNcDRpUzN0UWd1UmMyOGdQZERvL1Q2VnJKVFZZVWZVVXNORFJ0SXJsQjVPOWlncXFMbnVhWTllcUdpNApQVXgwRzB3UllKcFJ5d29qOEcwSWtwZlFUaVgrQ0FDN2R0NXdzN1pybkdxQ05CTEdpNWJHc2FNbXB0VmJzU0VwCjFUZW5udEY1NFYxaVI0OUlWNUpxRGhtMVMwSG1rbGVvSnpLZGMrNnNQL3hOZXB6OVBKenVGOWQ5TnViVExXZ0IKc0syOFlJdGNtV0hkSFhEL09EeFZhZWhSandJREFRQUJveUF3SGpBT0JnTlZIUThCQWY4RUJBTUNCNEF3REFZRApWUjBUQVFIL0JBSXdBREFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQVZVNnNOQmRqNzZzYUh3T3hHU2RuRXFRCm8ydE11UjNtc1NNNEY2d0ZLMlVrS2Vwc0Q3Q1lJZi9Qek5TTlVxQTVKSUVVVmVNcUd5aUh1QWJVNEM2NTVuVDEKSXlKWDFELytyNzNzU3A1amJJcFFtMnhvUUdabmo2Zy9LbHR3OE9TT0F3K0RzTUYvUExWcW9XSnAwN3U2ZXcvbQpOeFdzSktjWjVrK3E0ZU14Y2k5bUtSSEhxc3F1V0tYelFsVVJNTkZJK21HYUZ3cktNNGRtemFSMEJFYytpbFN4ClFxVXZRNzRzbXNMSyt6aE5pa21namxHQzVvYjlnOFhraFZBa0pNQWgycmI5b25ETmlSbDY4aUFnY3pQODhtWHUKdk4vbzk4ZHlwenNQeFhtdzZ0a0RxSVJQVUFVYmg0NjVybFk1c0tNbVJnWGkyclVmbC9RVjVuYm96VW8vSFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+}

--- a/lib/tbot/testdata/TestSDS_FetchSecrets/specific_svid.golden
+++ b/lib/tbot/testdata/TestSDS_FetchSecrets/specific_svid.golden
@@ -1,0 +1,17 @@
+{
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+      "name": "spiffe://example.com/second",
+      "tlsCertificate": {
+        "certificateChain": {
+          "inlineBytes": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tClEwVlNWQzF6Y0dsbVptVTZMeTlsZUdGdGNHeGxMbU52YlM5elpXTnZibVE9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+        },
+        "privateKey": {
+          "inlineBytes": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tClMwVlpMWE53YVdabVpUb3ZMMlY0WVcxd2JHVXVZMjl0TDNObFkyOXVaQT09Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K"
+        }
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+}


### PR DESCRIPTION
Backports #43958

changelog: Introduce support for Envoy SDS into the Machine ID spiffe-workload-api service.