### PR TITLE
Fix asciitable representation for big cell contents

### DIFF
--- a/lib/asciitable/table.go
+++ b/lib/asciitable/table.go
@@ -188,9 +188,18 @@ func (t *Table) AsBuffer() *bytes.Buffer {
 			}
 			rowi = append(rowi, cell)
 		}
+		const cellMaxLength = 120
+		var formatStrings []string
+		for _, v := range rowi {
+			if str, ok := v.(string); ok && len(str) > cellMaxLength {
+				formatStrings = append(formatStrings, "%v")
+			} else {
+				formatStrings = append(formatStrings, "%v\t")
+			}
+		}
+		template := strings.Join(formatStrings, "")
 		fmt.Fprintf(writer, template+"\n", rowi...)
 	}
-
 	// Footnotes.
 	for label := range footnoteLabels {
 		fmt.Fprintln(writer)

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -243,11 +243,11 @@ func printRequest(cf *CLIConf, req types.AccessRequest) error {
 	}
 
 	printReviewBlock := func(title string, revs []types.AccessReview) error {
-		fmt.Fprint(cf.Stdout(), "------------------------------------------------")
+		fmt.Fprint(cf.Stdout(), "------------------------------------------------\n")
 		fmt.Fprintf(cf.Stdout(), "%s:\n", title)
 
 		for _, rev := range revs {
-			fmt.Fprint(cf.Stdout(), "  ----------------------------------------------")
+			fmt.Fprint(cf.Stdout(), "  ----------------------------------------------\n")
 
 			revReason := "[none]"
 			if rev.Reason != "" {


### PR DESCRIPTION
Similar to https://github.com/gravitational/teleport/pull/45316, when the list of roles are too big, outputs that uses the asciitable are messed up.

Example when listing access request
![Screenshot 2024-08-14 at 15 01 49](https://github.com/user-attachments/assets/56cceace-26e1-4696-be7a-f3ce3c5482a7)

Another example when creating an access request with `tsh`
![Screenshot 2024-08-14 at 15 03 53](https://github.com/user-attachments/assets/decfb61a-a24a-4948-b13f-a1e6781b6c79)

Or when `tsh request show`. In here the Denials/Approvers section is also weird.
![Screenshot 2024-08-14 at 15 06 17](https://github.com/user-attachments/assets/58b84cf0-a979-4991-99ee-2d10e476d882)

In this PR, I suggest to set a max limit to the column, and if the cell content is bigger, it will not add the last  `\t` for the table.

Output is:

Listing access request
![Screenshot 2024-08-14 at 15 08 53](https://github.com/user-attachments/assets/208c40d1-ca8f-4644-9e8d-4feecba7d91c)

Creating an access request with `tsh`
![Screenshot 2024-08-14 at 15 10 07](https://github.com/user-attachments/assets/30b0c92b-8d30-4296-9e82-35f6d0762293)

`tsh request show`
![Screenshot 2024-08-14 at 15 11 30](https://github.com/user-attachments/assets/6a31603a-e5c4-439a-997f-430c1e8a393d)

I have tested other usage of asciitable such as `tsh db ls`, `tsh ls`, and it continuous the same.

I'm not sure if this is the best approach to fix the issue. If not, please consider this PR as a starting point and I'm open for another suggestions. 