### PR TITLE
Allow access requests with Opsgenie to set alert priority

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -770,6 +770,7 @@ const (
 	ReqAnnotationNotifySchedulesLabel = "/notify-services"
 	// ReqAnnotationTeamsLabel is the request annotation key at which teams are stored for access plugins.
 	ReqAnnotationTeamsLabel = "/teams"
+	ReqAnnotationPriority   = "/priority"
 
 	// CloudAWS identifies that a resource was discovered in AWS.
 	CloudAWS = "AWS"

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/opsgenie.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/opsgenie.mdx
@@ -76,6 +76,7 @@ spec:
         teleport.dev/notify-services: ['teleport-access-request-notifications']
         teleport.dev/teams: ['teleport-team']
         teleport.dev/schedules: ['teleport-access-alert-schedules']
+        teleport.dev/priority: "P2"
 ```
 
 The `teleport.dev/notify-services` annotation specifies the schedules the alert will be created for.
@@ -83,6 +84,7 @@ The `teleport.dev/teams` annotation specifies the teams the alert will be create
 have multiple schedules with escalations or an Opsgenie integration that only works with teams.
 The `teleport.dev/schedules` annotation specifies the schedules the alert will check, and auto approve the
 Access Request if the requesting user is on-call.
+The `teleport.dev/priority` annotation specifies the priority of the Opsgenie alert.
 
 ### Create a user who will request access
 

--- a/integrations/access/opsgenie/app.go
+++ b/integrations/access/opsgenie/app.go
@@ -309,13 +309,13 @@ func (a *App) getNotifySchedulesAndTeams(ctx context.Context, req types.AccessRe
 	scheduleAnnotationKey := types.TeleportNamespace + types.ReqAnnotationNotifySchedulesLabel
 	schedules, err = common.GetServiceNamesFromAnnotations(req, scheduleAnnotationKey)
 	if err != nil {
-		log.Debugf("No schedules to notifiy in %s", scheduleAnnotationKey)
+		log.Debugf("No schedules to notify in %s", scheduleAnnotationKey)
 	}
 
 	teamAnnotationKey := types.TeleportNamespace + types.ReqAnnotationTeamsLabel
 	teams, err = common.GetServiceNamesFromAnnotations(req, teamAnnotationKey)
 	if err != nil {
-		log.Debugf("No teams to notifiy in %s", teamAnnotationKey)
+		log.Debugf("No teams to notify in %s", teamAnnotationKey)
 	}
 
 	if len(schedules) == 0 && len(teams) == 0 {

--- a/integrations/access/opsgenie/client.go
+++ b/integrations/access/opsgenie/client.go
@@ -147,7 +147,7 @@ func (og Client) CreateAlert(ctx context.Context, reqID string, reqData RequestD
 		Alias:       fmt.Sprintf("%s/%s", alertKeyPrefix, reqID),
 		Description: bodyDetails,
 		Responders:  og.getResponders(reqData),
-		Priority:    og.Priority,
+		Priority:    og.getPriority(reqData),
 	}
 
 	var result CreateAlertResult
@@ -226,6 +226,13 @@ func (og Client) getResponders(reqData RequestData) []Responder {
 		responders = append(responders, createResponder(ResponderTypeTeam, t))
 	}
 	return responders
+}
+
+func (og Client) getPriority(reqData RequestData) string {
+	if priority, ok := reqData.SystemAnnotations[types.TeleportNamespace+types.ReqAnnotationPriority]; ok {
+		return strings.Join(priority, "")
+	}
+	return og.Priority
 }
 
 // Check if the responder is a UUID. If it is, then it is an ID; otherwise, it is a name.

--- a/integrations/access/opsgenie/client_test.go
+++ b/integrations/access/opsgenie/client_test.go
@@ -61,6 +61,7 @@ func TestCreateAlert(t *testing.T) {
 		SystemAnnotations: types.Labels{
 			types.TeleportNamespace + types.ReqAnnotationNotifySchedulesLabel: {"responder@example.com", "bb4d9938-c3c2-455d-aaab-727aa701c0d8"},
 			types.TeleportNamespace + types.ReqAnnotationTeamsLabel:           {"MyOpsGenieTeam", "aee8a0de-c80f-4515-a232-501c0bc9d715"},
+			types.TeleportNamespace + types.ReqAnnotationPriority:             {"P2"},
 		},
 	})
 	assert.NoError(t, err)
@@ -75,7 +76,7 @@ func TestCreateAlert(t *testing.T) {
 			{Type: "team", Name: "MyOpsGenieTeam"},
 			{Type: "team", ID: "aee8a0de-c80f-4515-a232-501c0bc9d715"},
 		},
-		Priority: "somePriority",
+		Priority: "P2",
 	}
 	var got AlertBody
 	err = json.Unmarshal([]byte(recievedReq), &got)

--- a/integrations/access/opsgenie/testlib/suite.go
+++ b/integrations/access/opsgenie/testlib/suite.go
@@ -44,7 +44,7 @@ const (
 	PriorityAnnotation         = types.TeleportNamespace + types.ReqAnnotationPriority
 )
 
-// OpsgenieBaseSuite is the OpsGenie access plugin test suite.
+// OpsgenieBaseSuite is the Opsgenie access plugin test suite.
 // It implements the testify.TestingSuite interface.
 type OpsgenieBaseSuite struct {
 	*integration.AccessRequestSuite
@@ -144,7 +144,7 @@ func (s *OpsgenieSuiteOSS) TestAlertCreationForSchedules() {
 	req := s.CreateAccessRequest(ctx, integration.RequesterOSSUserName, nil)
 
 	// Validate the alert has been created in OpsGenie and its ID is stored in
-	// the plugin_data.
+	// the plugin data.
 	pluginData := s.checkPluginData(ctx, req.GetName(), func(data opsgenie.PluginData) bool {
 		return data.AlertID != ""
 	})
@@ -188,8 +188,7 @@ func (s *OpsgenieSuiteOSS) TestAlertCreationForTeams() {
 
 func (s *OpsgenieSuiteOSS) TestPriorityOverride() {
 	t := s.T()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	t.Cleanup(cancel)
+	ctx := context.Background()
 
 	s.AnnotateRequesterRoleAccessRequests(
 		ctx,


### PR DESCRIPTION
Adds the ability to override Opsgenie alert priority when creating an access request, by using `teleport.dev/priority` annotation. 

This is useful when creating multiple roles for access requests, eg: staging can be P3 but production P4.

Example. For
```yaml
kind: role
metadata:
  name: prod-write-access-request
spec:
  allow:
    request:
      annotations:
        teleport.dev/notify-services:
        - "Teleport Notifications One"
        - "Teleport Notifications Two"
        teleport.dev/teams:
        - "My Team"
        teleport.dev/priority:
        - "P2"
      roles:
      - prod-write-role
```

It will send to Opsgenie
```json
{
   "message": "Access request from requester-oss@example.com",
   "alias": "teleport-access-request/01915148-d4e1-70a7-8e65-389524e8ed36",
   "description": "requester-oss@example.com requested permissions for roles editor on Teleport at 14 Aug 24 14:26 UTC.\nReason: because of\n\n",
   "responders": [
      {
         "name": "Teleport Notifications One",
         "type": "schedule"
      },
      {
         "name": "Teleport Notifications Two",
         "type": "schedule"
      },
      {
         "name": "My Team",
         "type": "team"
      }
   ],
   "priority": "P2"
}
```