### PR TITLE
Remove `/ver/` segments from Web UI docs links

### DIFF
--- a/web/packages/teleport/src/Support/Support.tsx
+++ b/web/packages/teleport/src/Support/Support.tsx
@@ -167,23 +167,13 @@ const getDocUrls = (version = '', isEnterprise: boolean) => {
   const withUTM = (url = '', anchorHash = '') =>
     `${url}?product=teleport&version=${verPrefix}_${version}${anchorHash}`;
 
-  let docVer = '';
-  if (version && version.length > 0) {
-    const major = version.split('.')[0];
-    docVer = `/ver/${major}.x`;
-  }
-
   return {
-    getStarted: withUTM(`https://goteleport.com/docs${docVer}`),
-    tshGuide: withUTM(
-      `https://goteleport.com/docs${docVer}/connect-your-client/tsh/`
-    ),
-    adminGuide: withUTM(
-      `https://goteleport.com/docs${docVer}/management/admin/`
-    ),
-    faq: withUTM(`https://goteleport.com/docs${docVer}/faq`),
+    getStarted: withUTM(`https://goteleport.com/docs/get-started/`),
+    tshGuide: withUTM(`https://goteleport.com/docs/connect-your-client/tsh/`),
+    adminGuide: withUTM(`https://goteleport.com/docs/management/admin/`),
+    faq: withUTM(`https://goteleport.com/docs/faq`),
     troubleshooting: withUTM(
-      `https://goteleport.com/docs${docVer}/management/admin/troubleshooting/`
+      `https://goteleport.com/docs/management/admin/troubleshooting/`
     ),
 
     // there isn't a version-specific changelog page


### PR DESCRIPTION
The Support component is the only Web UI component that renders docs links that include the `/ver/` path segment. This change removes the `/ver/` path segment from these links so they point to the default version of the docs. The user can use the version dropdown within the docs site to adjust the version. This change does not alter UTM parameters.

With this change, we only need to manage redirects in the default version of the docs site. This makes it less likely that users will encounter 404 errors. And since the docs site only displays the current version and previous two versions, link targets with the `/ver/` segment will 404 in EOL Teleport versions. This change also prevents that scenario.