### PR TITLE
[v16] chore: Bump golangci-lint to v1.60.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,6 +55,8 @@ issues:
     - path: provider/provider.go # integrations/terraform
       linters: [staticcheck]
       text: "grpc.WithReturnConnectionError is deprecated"
+    - linters: [govet]
+      text: "non-constant format string in call to github.com/gravitational/trace."
   exclude-use-default: true
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/api/types/matchers_aws.go
+++ b/api/types/matchers_aws.go
@@ -152,7 +152,7 @@ func (m *AWSMatcher) CheckAndSetDefaults() error {
 		}
 	}
 
-	if m.Tags == nil || len(m.Tags) == 0 {
+	if len(m.Tags) == 0 {
 		m.Tags = map[string]apiutils.Strings{Wildcard: {Wildcard}}
 	}
 

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.22.6
-GOLANGCI_LINT_VERSION ?= v1.59.1
+GOLANGCI_LINT_VERSION ?= v1.60.1
 
 NODE_VERSION ?= 20.14.0
 

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -1112,7 +1112,7 @@ func (c *githubAPIClient) getTeams(ctx context.Context) ([]teamResponse, error) 
 				"hit maximum number pages that can be fetched from GitHub."
 
 			// Print warning to Teleport logs as well as the Audit Log.
-			log.Warnf(warningMessage)
+			log.Warn(warningMessage)
 			if err := c.authServer.emitter.EmitAuditEvent(c.authServer.closeCtx, &apievents.UserLogin{
 				Metadata: apievents.Metadata{
 					Type: events.UserLoginEvent,

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -647,7 +647,7 @@ func (ns *NodeSession) watchSignals(shell io.Writer) {
 			case <-ctrlCSignal:
 				_, err := shell.Write([]byte{ctrlCharC})
 				if err != nil {
-					log.Errorf(err.Error())
+					log.Error(err.Error())
 				}
 			case <-ns.closer.C:
 				return
@@ -663,7 +663,7 @@ func (ns *NodeSession) watchSignals(shell io.Writer) {
 			if _, ok := event.(terminal.StopEvent); ok {
 				_, err := shell.Write([]byte{ctrlCharZ})
 				if err != nil {
-					log.Errorf(err.Error())
+					log.Error(err.Error())
 				}
 			}
 		}
@@ -736,7 +736,7 @@ func (ns *NodeSession) pipeInOut(ctx context.Context, shell io.ReadWriteCloser, 
 		defer ns.closer.Close()
 		_, err := io.Copy(ns.terminal.Stdout(), shell)
 		if err != nil {
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 		}
 	}()
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1256,7 +1256,7 @@ func applyProxyConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 			warningMessage := "Starting Teleport with a self-signed TLS certificate, this is " +
 				"not safe for production clusters. Using a self-signed certificate opens " +
 				"Teleport users to Man-in-the-Middle attacks."
-			log.Warnf(warningMessage)
+			log.Warn(warningMessage)
 		} else {
 			if err := utils.VerifyCertificateChain(certificateChain); err != nil {
 				return trace.BadParameter("unable to verify HTTPS certificate chain in %v: %s",

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -675,7 +675,7 @@ proxy_service:
 	}
 
 	for _, tt := range tests {
-		comment := fmt.Sprintf(tt.desc)
+		comment := tt.desc
 
 		_, err := ReadConfig(bytes.NewBufferString(tt.inConfig))
 		if tt.outError {

--- a/lib/events/emitter.go
+++ b/lib/events/emitter.go
@@ -285,7 +285,7 @@ func (l *LoggingEmitter) EmitAuditEvent(ctx context.Context, event apievents.Aud
 	}
 	fields[teleport.ComponentKey] = teleport.Component(teleport.ComponentAuditLog)
 
-	log.WithFields(fields).Infof(event.GetType())
+	log.WithFields(fields).Info(event.GetType())
 	return nil
 }
 

--- a/lib/joinserver/joinserver_test.go
+++ b/lib/joinserver/joinserver_test.go
@@ -20,7 +20,7 @@ package joinserver
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -398,7 +398,7 @@ func TestJoinServiceGRPCServer_RegisterUsingTPMMethod(t *testing.T) {
 			testPack.mockAuthServer.sendChallenge = tc.challenge
 			testPack.mockAuthServer.returnCerts = tc.certs
 			if tc.authErr != "" {
-				testPack.mockAuthServer.returnError = fmt.Errorf(tc.authErr)
+				testPack.mockAuthServer.returnError = errors.New(tc.authErr)
 			}
 			challengeResponder := func(
 				challenge *proto.TPMEncryptedCredential,

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -1013,7 +1013,7 @@ func (s *session) join(p *party, emitJoinEvent bool) error {
 				}
 			}()
 		} else if len(s.parties) == 1 {
-			base := "Waiting for required participants..."
+			const base = "Waiting for required participants..."
 
 			if s.displayParticipantRequirements {
 				s.BroadcastMessage(base+"\r\n%v", s.accessEvaluator.PrettyRequirementsList())

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -215,7 +215,7 @@ func TestMux(t *testing.T) {
 					Listener: mux.TLS(),
 					Config: &http.Server{
 						Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-							fmt.Fprintf(w, r.RemoteAddr)
+							fmt.Fprint(w, r.RemoteAddr)
 						}),
 					},
 				}
@@ -267,7 +267,7 @@ func TestMux(t *testing.T) {
 			Listener: mux.TLS(),
 			Config: &http.Server{
 				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					fmt.Fprintf(w, r.RemoteAddr)
+					fmt.Fprint(w, r.RemoteAddr)
 				}),
 			},
 		}
@@ -320,7 +320,7 @@ func TestMux(t *testing.T) {
 			Listener: mux.TLS(),
 			Config: &http.Server{
 				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					fmt.Fprintf(w, r.RemoteAddr)
+					fmt.Fprint(w, r.RemoteAddr)
 				}),
 			},
 		}
@@ -363,7 +363,7 @@ func TestMux(t *testing.T) {
 			Listener: mux.TLS(),
 			Config: &http.Server{
 				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					fmt.Fprintf(w, r.RemoteAddr)
+					fmt.Fprint(w, r.RemoteAddr)
 				}),
 			},
 		}
@@ -413,7 +413,7 @@ func TestMux(t *testing.T) {
 			Listener: mux.TLS(),
 			Config: &http.Server{
 				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					fmt.Fprintf(w, r.RemoteAddr)
+					fmt.Fprint(w, r.RemoteAddr)
 				}),
 			},
 		}
@@ -852,7 +852,7 @@ func TestMux(t *testing.T) {
 
 				Config: &http.Server{
 					Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-						fmt.Fprintf(w, r.RemoteAddr)
+						fmt.Fprint(w, r.RemoteAddr)
 					}),
 				},
 			}

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -2611,7 +2611,7 @@ func TestAccessClickHouse(t *testing.T) {
 	for _, test := range tests {
 		for _, protocol := range []string{defaults.ProtocolClickHouse, defaults.ProtocolClickHouseHTTP} {
 			t.Run(protocol, func(t *testing.T) {
-				t.Run(fmt.Sprintf(test.desc), func(t *testing.T) {
+				t.Run(test.desc, func(t *testing.T) {
 					// Create user/role with the requested permissions.
 					testCtx.createUserAndRole(ctx, t, aliceUser, adminRole, test.allowDbUsers, []string{types.Wildcard})
 

--- a/lib/srv/db/clickhouse/test.go
+++ b/lib/srv/db/clickhouse/test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"crypto/tls"
 	"database/sql"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -251,7 +250,7 @@ func MakeNativeTestClient(ctx context.Context, config common.TestClientConfig) (
 func MakeDBTestClient(ctx context.Context, config common.TestClientConfig) (*sql.DB, error) {
 	conn := clickhouse.OpenDB(&clickhouse.Options{
 		Protocol: toClickhouseProtocol(config.RouteToDatabase.Protocol),
-		Addr:     []string{fmt.Sprintf(config.Address)},
+		Addr:     []string{config.Address},
 	})
 	if err := conn.Ping(); err != nil {
 		conn.Close()

--- a/lib/srv/discovery/access_graph_test.go
+++ b/lib/srv/discovery/access_graph_test.go
@@ -20,6 +20,7 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -74,7 +75,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						discoveryConfigName: "test",
 					},
 				},
-				pushErr: fmt.Errorf(testErr),
+				pushErr: errors.New(testErr),
 			},
 			want: map[string][]discoveryconfig.Status{
 				"test": {
@@ -94,7 +95,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 					&fakeFetcher{
 						count:               1,
 						discoveryConfigName: "test",
-						err:                 fmt.Errorf(testErr),
+						err:                 errors.New(testErr),
 					},
 				},
 			},

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -350,7 +350,9 @@ func (u *HostUserManagement) UpsertUser(name string, ui *services.HostUsersInfo)
 
 	var home string
 	if ui.Mode != types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP {
+		//nolint:staticcheck // SA4023. False positive on macOS.
 		home, err = readDefaultHome(name)
+		//nolint:staticcheck // SA4023. False positive on macOS.
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/usermgmt_other.go
+++ b/lib/srv/usermgmt_other.go
@@ -35,6 +35,7 @@ func newHostSudoersBackend(_ string) (HostSudoersBackend, error) {
 	return nil, trace.NotImplemented("Host user creation management is only supported on linux")
 }
 
+//nolint:staticcheck // intended to always return an error for non-linux builds
 func readDefaultHome(user string) (string, error) {
 	return "", trace.NotImplemented("readDefaultHome is only supported on linux")
 }

--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -370,7 +370,7 @@ func (cmd *command) sendFile(r *reader, ch io.ReadWriter, fileInfo FileInfo) err
 	// report progress:
 	if cmd.ProgressWriter != nil {
 		statusMessage := fmt.Sprintf("-> %s (%d)", fileInfo.GetPath(), fileInfo.GetSize())
-		defer fmt.Fprintf(cmd.ProgressWriter, utils.EscapeControl(statusMessage)+"\n")
+		defer fmt.Fprint(cmd.ProgressWriter, utils.EscapeControl(statusMessage)+"\n")
 	}
 	if err := sendOK(ch); err != nil {
 		return trace.Wrap(err)
@@ -504,7 +504,7 @@ func (cmd *command) receiveFile(st *state, fc newFileCmd, ch io.ReadWriter) erro
 	// report progress:
 	if cmd.ProgressWriter != nil {
 		statusMessage := fmt.Sprintf("<- %s (%d)", path, fc.Length)
-		defer fmt.Fprintf(cmd.ProgressWriter, utils.EscapeControl(statusMessage)+"\n")
+		defer fmt.Fprint(cmd.ProgressWriter, utils.EscapeControl(statusMessage)+"\n")
 	}
 
 	if err = sendOK(ch); err != nil {

--- a/lib/versioncontrol/github/github_test.go
+++ b/lib/versioncontrol/github/github_test.go
@@ -204,7 +204,7 @@ func TestCachedReleases(t *testing.T) {
 		var sec int
 		for iter.Next() {
 			ct++
-			require.NotZero(t, len(iter.Page()), tt.desc)
+			require.NotEmpty(t, iter.Page(), tt.desc)
 			for _, target := range iter.Page() {
 				if target.SecurityPatch() {
 					sec++

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -841,7 +841,7 @@ version: v2`,
 				buf, err := runResourceCommand(t, clt, []string{"get", "cap", "--format=json"})
 				require.NoError(t, err)
 				authPreferences := mustDecodeJSON[[]types.AuthPreferenceV2](t, buf)
-				require.NotZero(t, len(authPreferences))
+				require.NotEmpty(t, authPreferences)
 				tt.expectSecondFactor(t, authPreferences[0].Spec.SecondFactor)
 			}
 		})


### PR DESCRIPTION
Backport #45469 to branch/v16.