### PR TITLE
[v14] chore: Bump golangci-lint to v1.60.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,8 @@ issues:
     - linters:
       - unused
       path: 'integrations/operator/controllers/resources/(.+)_controller_test\.go'
+    - linters: [govet]
+      text: "non-constant format string in call to github.com/gravitational/trace."
   exclude-use-default: true
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/api/types/matchers_aws.go
+++ b/api/types/matchers_aws.go
@@ -142,7 +142,7 @@ func (m *AWSMatcher) CheckAndSetDefaults() error {
 		}
 	}
 
-	if m.Tags == nil || len(m.Tags) == 0 {
+	if len(m.Tags) == 0 {
 		m.Tags = map[string]apiutils.Strings{Wildcard: {Wildcard}}
 	}
 

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.22.6
-GOLANGCI_LINT_VERSION ?= v1.58.1
+GOLANGCI_LINT_VERSION ?= v1.60.1
 
 NODE_VERSION ?= 20.14.0
 

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -1005,7 +1005,7 @@ func (c *githubAPIClient) getTeams(ctx context.Context) ([]teamResponse, error) 
 				"hit maximum number pages that can be fetched from GitHub."
 
 			// Print warning to Teleport logs as well as the Audit Log.
-			log.Warnf(warningMessage)
+			log.Warn(warningMessage)
 			if err := c.authServer.emitter.EmitAuditEvent(c.authServer.closeCtx, &apievents.UserLogin{
 				Metadata: apievents.Metadata{
 					Type: events.UserLoginEvent,

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -641,7 +641,7 @@ func (ns *NodeSession) watchSignals(shell io.Writer) {
 			case <-ctrlCSignal:
 				_, err := shell.Write([]byte{ctrlCharC})
 				if err != nil {
-					log.Errorf(err.Error())
+					log.Error(err.Error())
 				}
 			case <-ns.closer.C:
 				return
@@ -657,7 +657,7 @@ func (ns *NodeSession) watchSignals(shell io.Writer) {
 			if _, ok := event.(terminal.StopEvent); ok {
 				_, err := shell.Write([]byte{ctrlCharZ})
 				if err != nil {
-					log.Errorf(err.Error())
+					log.Error(err.Error())
 				}
 			}
 		}
@@ -730,7 +730,7 @@ func (ns *NodeSession) pipeInOut(ctx context.Context, shell io.ReadWriteCloser, 
 		defer ns.closer.Close()
 		_, err := io.Copy(ns.terminal.Stdout(), shell)
 		if err != nil {
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 		}
 	}()
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1121,7 +1121,7 @@ func applyProxyConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 			warningMessage := "Starting Teleport with a self-signed TLS certificate, this is " +
 				"not safe for production clusters. Using a self-signed certificate opens " +
 				"Teleport users to Man-in-the-Middle attacks."
-			log.Warnf(warningMessage)
+			log.Warn(warningMessage)
 		} else {
 			if err := utils.VerifyCertificateChain(certificateChain); err != nil {
 				return trace.BadParameter("unable to verify HTTPS certificate chain in %v: %s",

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -657,7 +657,7 @@ proxy_service:
 	}
 
 	for _, tt := range tests {
-		comment := fmt.Sprintf(tt.desc)
+		comment := tt.desc
 
 		_, err := ReadConfig(bytes.NewBufferString(tt.inConfig))
 		if tt.outError {

--- a/lib/events/emitter.go
+++ b/lib/events/emitter.go
@@ -281,7 +281,7 @@ func (l *LoggingEmitter) EmitAuditEvent(ctx context.Context, event apievents.Aud
 	}
 	fields[trace.Component] = teleport.Component(teleport.ComponentAuditLog)
 
-	log.WithFields(fields).Infof(event.GetType())
+	log.WithFields(fields).Info(event.GetType())
 	return nil
 }
 

--- a/lib/joinserver/joinserver_test.go
+++ b/lib/joinserver/joinserver_test.go
@@ -18,7 +18,7 @@ package joinserver
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -396,7 +396,7 @@ func TestJoinServiceGRPCServer_RegisterUsingTPMMethod(t *testing.T) {
 			testPack.mockAuthServer.sendChallenge = tc.challenge
 			testPack.mockAuthServer.returnCerts = tc.certs
 			if tc.authErr != "" {
-				testPack.mockAuthServer.returnError = fmt.Errorf(tc.authErr)
+				testPack.mockAuthServer.returnError = errors.New(tc.authErr)
 			}
 			challengeResponder := func(
 				challenge *proto.TPMEncryptedCredential,

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -998,7 +998,7 @@ func (s *session) join(p *party, emitJoinEvent bool) error {
 				}
 			}()
 		} else if len(s.parties) == 1 {
-			base := "Waiting for required participants..."
+			const base = "Waiting for required participants..."
 
 			if s.displayParticipantRequirements {
 				s.BroadcastMessage(base+"\r\n%v", s.accessEvaluator.PrettyRequirementsList())

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -212,7 +212,7 @@ func TestMux(t *testing.T) {
 					Listener: mux.TLS(),
 					Config: &http.Server{
 						Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-							fmt.Fprintf(w, r.RemoteAddr)
+							fmt.Fprint(w, r.RemoteAddr)
 						}),
 					},
 				}
@@ -264,7 +264,7 @@ func TestMux(t *testing.T) {
 			Listener: mux.TLS(),
 			Config: &http.Server{
 				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					fmt.Fprintf(w, r.RemoteAddr)
+					fmt.Fprint(w, r.RemoteAddr)
 				}),
 			},
 		}
@@ -317,7 +317,7 @@ func TestMux(t *testing.T) {
 			Listener: mux.TLS(),
 			Config: &http.Server{
 				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					fmt.Fprintf(w, r.RemoteAddr)
+					fmt.Fprint(w, r.RemoteAddr)
 				}),
 			},
 		}
@@ -360,7 +360,7 @@ func TestMux(t *testing.T) {
 			Listener: mux.TLS(),
 			Config: &http.Server{
 				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					fmt.Fprintf(w, r.RemoteAddr)
+					fmt.Fprint(w, r.RemoteAddr)
 				}),
 			},
 		}
@@ -410,7 +410,7 @@ func TestMux(t *testing.T) {
 			Listener: mux.TLS(),
 			Config: &http.Server{
 				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					fmt.Fprintf(w, r.RemoteAddr)
+					fmt.Fprint(w, r.RemoteAddr)
 				}),
 			},
 		}
@@ -845,7 +845,7 @@ func TestMux(t *testing.T) {
 
 				Config: &http.Server{
 					Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-						fmt.Fprintf(w, r.RemoteAddr)
+						fmt.Fprint(w, r.RemoteAddr)
 					}),
 				},
 			}

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -2542,7 +2542,7 @@ func TestAccessClickHouse(t *testing.T) {
 	for _, test := range tests {
 		for _, protocol := range []string{defaults.ProtocolClickHouse, defaults.ProtocolClickHouseHTTP} {
 			t.Run(protocol, func(t *testing.T) {
-				t.Run(fmt.Sprintf(test.desc), func(t *testing.T) {
+				t.Run(test.desc, func(t *testing.T) {
 					// Create user/role with the requested permissions.
 					testCtx.createUserAndRole(ctx, t, aliceUser, adminRole, test.allowDbUsers, []string{types.Wildcard})
 

--- a/lib/srv/db/clickhouse/test.go
+++ b/lib/srv/db/clickhouse/test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"database/sql"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -248,7 +247,7 @@ func MakeNativeTestClient(ctx context.Context, config common.TestClientConfig) (
 func MakeDBTestClient(ctx context.Context, config common.TestClientConfig) (*sql.DB, error) {
 	conn := clickhouse.OpenDB(&clickhouse.Options{
 		Protocol: toClickhouseProtocol(config.RouteToDatabase.Protocol),
-		Addr:     []string{fmt.Sprintf(config.Address)},
+		Addr:     []string{config.Address},
 	})
 	if err := conn.Ping(); err != nil {
 		conn.Close()

--- a/lib/srv/discovery/access_graph_test.go
+++ b/lib/srv/discovery/access_graph_test.go
@@ -20,7 +20,7 @@ package discovery
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/jonboulle/clockwork"
@@ -74,7 +74,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						discoveryConfigName: "test",
 					},
 				},
-				pushErr: fmt.Errorf(testErr),
+				pushErr: errors.New(testErr),
 			},
 			want: map[string][]discoveryconfig.Status{
 				"test": {
@@ -94,7 +94,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 					&fakeFetcher{
 						count:               1,
 						discoveryConfigName: "test",
-						err:                 fmt.Errorf(testErr),
+						err:                 errors.New(testErr),
 					},
 				},
 			},

--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -367,7 +367,7 @@ func (cmd *command) sendFile(r *reader, ch io.ReadWriter, fileInfo FileInfo) err
 	// report progress:
 	if cmd.ProgressWriter != nil {
 		statusMessage := fmt.Sprintf("-> %s (%d)", fileInfo.GetPath(), fileInfo.GetSize())
-		defer fmt.Fprintf(cmd.ProgressWriter, utils.EscapeControl(statusMessage)+"\n")
+		defer fmt.Fprint(cmd.ProgressWriter, utils.EscapeControl(statusMessage)+"\n")
 	}
 	if err := sendOK(ch); err != nil {
 		return trace.Wrap(err)
@@ -501,7 +501,7 @@ func (cmd *command) receiveFile(st *state, fc newFileCmd, ch io.ReadWriter) erro
 	// report progress:
 	if cmd.ProgressWriter != nil {
 		statusMessage := fmt.Sprintf("<- %s (%d)", path, fc.Length)
-		defer fmt.Fprintf(cmd.ProgressWriter, utils.EscapeControl(statusMessage)+"\n")
+		defer fmt.Fprint(cmd.ProgressWriter, utils.EscapeControl(statusMessage)+"\n")
 	}
 
 	if err = sendOK(ch); err != nil {

--- a/lib/utils/addr_test.go
+++ b/lib/utils/addr_test.go
@@ -251,7 +251,7 @@ func TestGuessesIPAddress(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		ip := guessHostIP(testCase.addrs)
-		require.Empty(t, cmp.Diff(ip, testCase.expected), fmt.Sprintf(testCase.comment))
+		require.Empty(t, cmp.Diff(ip, testCase.expected), testCase.comment)
 	}
 }
 

--- a/lib/versioncontrol/github/github_test.go
+++ b/lib/versioncontrol/github/github_test.go
@@ -202,7 +202,7 @@ func TestCachedReleases(t *testing.T) {
 		var sec int
 		for iter.Next() {
 			ct++
-			require.NotZero(t, len(iter.Page()), tt.desc)
+			require.NotEmpty(t, iter.Page(), tt.desc)
 			for _, target := range iter.Page() {
 				if target.SecurityPatch() {
 					sec++

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -829,7 +829,7 @@ version: v2`,
 				buf, err := runResourceCommand(t, fileConfig, []string{"get", "cap", "--format=json"})
 				require.NoError(t, err)
 				authPreferences := mustDecodeJSON[[]types.AuthPreferenceV2](t, buf)
-				require.NotZero(t, len(authPreferences))
+				require.NotEmpty(t, authPreferences)
 				tt.expectSecondFactor(t, authPreferences[0].Spec.SecondFactor)
 			}
 		})


### PR DESCRIPTION
Backport #45469 to branch/v14.