### PR TITLE
Multi-port TCP app access: Pass target port through SNI (proof of concept)

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -316,6 +316,7 @@ const (
 const (
 	// KubeTeleportProxyALPNPrefix is a SNI Kubernetes prefix used for distinguishing the Kubernetes HTTP traffic.
 	KubeTeleportProxyALPNPrefix = "kube-teleport-proxy-alpn."
+	TargetPortALPNPrefix        = "app-teleport-proxy-target-port-"
 )
 
 // SessionRecordingService is used to differentiate session recording services.

--- a/api/utils/sshutils/conn.go
+++ b/api/utils/sshutils/conn.go
@@ -102,6 +102,8 @@ type DialReq struct {
 	// correct client point of contact through indirect connections inside teleport
 	ClientDstAddr string `json:"client_dst_addr,omitempty"`
 
+	ClientTargetPort int `json:"client_target_port,omitempty"`
+
 	// IsAgentlessNode specifies whether the target is an agentless node.
 	IsAgentlessNode bool `json:"is_agentless_node,omitempty"`
 }

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1360,6 +1360,8 @@ const (
 	// contextClientDstAddr is a client destination address set in the context of the request
 	contextClientDstAddr contextKey = "teleport-client-dst-addr"
 
+	contextClientTargetPort contextKey = "teleport-client-target-port"
+
 	// contextConn is a connection in the context associated with the request
 	contextConn contextKey = "teleport-connection"
 )
@@ -1690,6 +1692,18 @@ func ContextWithClientAddrs(ctx context.Context, src, dst net.Addr) context.Cont
 	return context.WithValue(ctx, contextClientDstAddr, dst)
 }
 
+func ContextWithClientTargetPort(ctx context.Context, targetPort int) context.Context {
+	if ctx == nil {
+		return nil
+	}
+
+	if targetPort == 0 {
+		return ctx
+	}
+
+	return context.WithValue(ctx, contextClientTargetPort, targetPort)
+}
+
 // ClientAddrsFromContext returns the client address from the context.
 func ClientAddrsFromContext(ctx context.Context) (src net.Addr, dst net.Addr) {
 	if ctx == nil {
@@ -1698,6 +1712,15 @@ func ClientAddrsFromContext(ctx context.Context) (src net.Addr, dst net.Addr) {
 	src, _ = ctx.Value(contextClientSrcAddr).(net.Addr)
 	dst, _ = ctx.Value(contextClientDstAddr).(net.Addr)
 	return
+}
+
+func ClientTargetPortFromContext(ctx context.Context) (port int) {
+	if ctx == nil {
+		return 0
+	}
+
+	targetPort, _ := ctx.Value(contextClientTargetPort).(int)
+	return targetPort
 }
 
 func ContextWithConn(ctx context.Context, conn net.Conn) context.Context {

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1070,6 +1070,25 @@ func GetKubeTLSServerName(k8host string) string {
 	return addSubdomainPrefix(k8host, constants.KubeTeleportProxyALPNPrefix)
 }
 
+func GetAppTLSServerNameWithPortPrefix(host string, port int) string {
+	isIPFormat := net.ParseIP(host) != nil
+
+	serverName := host
+
+	if host == "" || host == string(teleport.PrincipalLocalhost) || isIPFormat {
+		serverName = constants.APIDomain
+	}
+
+	if port == 0 {
+		return serverName
+	}
+
+	prefixWithPort := fmt.Sprintf("%s%d.", constants.TargetPortALPNPrefix, port)
+
+	// E.g. app-teleport-proxy-target-port-1337.teleport.cluster.local.
+	return addSubdomainPrefix(serverName, prefixWithPort)
+}
+
 func addSubdomainPrefix(domain, prefix string) string {
 	return fmt.Sprintf("%s%s", prefix, domain)
 }

--- a/lib/resumption/server_exchange.go
+++ b/lib/resumption/server_exchange.go
@@ -134,7 +134,8 @@ func (r *SSHServerWrapper) handleResumptionExchangeV1(conn *multiplexer.Conn, dh
 			}()
 			defer entry.increaseRunning() // stop grace timeouts
 			slog.InfoContext(context.TODO(), "handing resumable connection to the SSH server")
-			r.sshServer(resumableConn)
+			// TODO: Explain why 0 here is fine.
+			r.sshServer(resumableConn, 0 /* targetPort */)
 		}()
 
 		entry.increaseRunning()

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -67,7 +67,7 @@ const (
 // lib/srv in lib/reversetunnel causes a circular import.
 type ServerHandler interface {
 	// HandleConnection performs a handshake then process the connection.
-	HandleConnection(conn net.Conn)
+	HandleConnection(conn net.Conn, targetPort int)
 }
 
 type newAgentFunc func(context.Context, *track.Tracker, *track.Lease) (Agent, error)
@@ -603,7 +603,7 @@ func (p *AgentPool) handleLocalTransport(ctx context.Context, channel ssh.Channe
 		conn = utils.NewConnWithSrcAddr(conn, getTCPAddr(src))
 	}
 
-	p.Server.HandleConnection(conn)
+	p.Server.HandleConnection(conn, dialReq.ClientTargetPort)
 }
 
 // agentPoolRuntimeConfig contains configurations dynamically set and updated
@@ -831,7 +831,7 @@ func NewServerHandlerToListener(tunnelAddr string) ServerHandlerToListener {
 	}
 }
 
-func (l ServerHandlerToListener) HandleConnection(c net.Conn) {
+func (l ServerHandlerToListener) HandleConnection(c net.Conn, targetPort int) {
 	// HandleConnection must block as long as c is used.
 	// Wrap c to only return after c.Close() has been called.
 	cc := newConnCloser(c)

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -586,10 +586,11 @@ func (s *localSite) getConn(params reversetunnelclient.DialParams) (conn net.Con
 	}
 
 	dreq := &sshutils.DialReq{
-		ServerID:      params.ServerID,
-		ConnType:      params.ConnType,
-		ClientSrcAddr: stringOrEmpty(params.From),
-		ClientDstAddr: stringOrEmpty(params.OriginalClientDstAddr),
+		ServerID:         params.ServerID,
+		ConnType:         params.ConnType,
+		ClientSrcAddr:    stringOrEmpty(params.From),
+		ClientDstAddr:    stringOrEmpty(params.OriginalClientDstAddr),
+		ClientTargetPort: params.ClientTargetPort,
 	}
 	if params.To != nil {
 		dreq.Address = params.To.String()

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -202,7 +202,8 @@ func (p *transport) start() {
 			if err == nil {
 				clientConn = utils.NewConnWithSrcAddr(clientConn, getTCPAddr(src))
 			}
-			p.server.HandleConnection(clientConn)
+			// kube doesn't utilize target port, so we always pass 0.
+			p.server.HandleConnection(clientConn, 0)
 			return
 		default:
 			// This must be a proxy.
@@ -245,7 +246,7 @@ func (p *transport) start() {
 			if err == nil {
 				clientConn = utils.NewConnWithSrcAddr(clientConn, getTCPAddr(src))
 			}
-			p.server.HandleConnection(clientConn)
+			p.server.HandleConnection(clientConn, dreq.ClientTargetPort)
 			return
 		}
 		// If this is a proxy and not an SSH node, try finding an inbound

--- a/lib/reversetunnelclient/api.go
+++ b/lib/reversetunnelclient/api.go
@@ -87,6 +87,8 @@ type DialParams struct {
 
 	// OriginalClientDstAddr is used in PROXY headers to show where client originally contacted Teleport infrastructure
 	OriginalClientDstAddr net.Addr
+
+	ClientTargetPort int
 }
 
 func (params DialParams) String() string {

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -546,8 +546,8 @@ func (s *Server) Wait() error {
 
 // HandleConnection takes a connection and wraps it in a listener, so it can
 // be passed to http.Serve to process as a HTTP request.
-func (s *Server) HandleConnection(conn net.Conn) {
-	s.c.ConnectionsHandler.HandleConnection(conn)
+func (s *Server) HandleConnection(conn net.Conn, targetPort int) {
+	s.c.ConnectionsHandler.HandleConnection(conn, targetPort)
 }
 
 // GetAppByPublicAddress returns an application matching the public address. If multiple

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -932,7 +932,7 @@ func (s *Server) ForceHeartbeat() error {
 // HandleConnection accepts the connection coming over reverse tunnel,
 // upgrades it to TLS, extracts identity information from it, performs
 // authorization and dispatches to the appropriate database engine.
-func (s *Server) HandleConnection(conn net.Conn) {
+func (s *Server) HandleConnection(conn net.Conn, _ int) {
 	// Track active connections.
 	s.activeConnections.Add(1)
 	defer s.activeConnections.Add(-1)

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -421,7 +421,7 @@ func (s *Server) Wait() {
 
 // HandleConnection is called after a connection has been accepted and starts
 // to perform the SSH handshake immediately.
-func (s *Server) HandleConnection(conn net.Conn) {
+func (s *Server) HandleConnection(conn net.Conn, targetPort int) {
 	s.srv.HandleConnection(conn)
 }
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -8239,7 +8239,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 
 type mockIntegrationAppHandler struct{}
 
-func (m *mockIntegrationAppHandler) HandleConnection(_ net.Conn) {}
+func (m *mockIntegrationAppHandler) HandleConnection(_ net.Conn, _ int) {}
 
 // webPack represents the state of a single web test.
 // It replicates most of the WebSuite and serves to gradually

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -392,7 +392,11 @@ func onProxyCommandApp(cf *CLIConf) error {
 	}
 
 	proxyApp := newLocalProxyApp(tc, appInfo, cf.LocalProxyPort, cf.InsecureSkipVerify)
-	if err := proxyApp.StartLocalProxy(cf.Context, alpnproxy.WithALPNProtocol(alpnProtocolForApp(app))); err != nil {
+	// TODO: Accept the port through a flag.
+	sni := libclient.GetAppTLSServerNameWithPortPrefix(tc.WebProxyHost(), 5434)
+	if err := proxyApp.StartLocalProxy(cf.Context,
+		alpnproxy.WithALPNProtocol(alpnProtocolForApp(app)),
+		alpnproxy.WithSNI(sni)); err != nil {
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Today, the port the app service is going to use to connect to a TCP app is established by the URI of the app.

```yaml
    apps:
    - name: "tcp-postgres"
      uri: "tcp://localhost:5432"
```

With VNet being a thing, we want to support multiple ports per TCP app. This enables the user to start VNet and then just dial `tcp-postgres.teleport.example.com:1337` (provided this port is configured for this app in the cluster, which is left out of this PR) and the app service is going to dial `localhost:1337`. Alternatively, the user should be able to set up a proxy with `tsh proxy app tcp-postgres --target-port 1337`.

This requires us to pass through some user input from tsh to the app service itself. I believe in any other case where something like this is needed, we pass such values either through a cert (e.g. `RouteToApp`) or they're passed on a protocol level (e.g. different database protocols). Passing the target port through a cert is undesirable as it'll require generating a new cert for each port.

At one point, Nic floated the idea of doing this through SNI used by the local proxy, so I wanted to explore it. On paper it seems pretty nice as we wouldn't need to

1. The ALPN proxy reads the target port from the SNI and adds it to the context (`lib/srv/alpnproxy/proxy.go`).
1. The port is read from the context and added to `reversetunnelclient.DialParams` (`lib/web/app/transport.go`).
1. Then it's added to `sshutils.DialReq` (`lib/reversetunnel/localsite.go`).
1. Then it's read from `sshutils.DialReq` on the other side and passed to the app server (`lib/reversetunnel/transport.go` and `lib/reversetunnel/agentpool.go`).
    * I actually don't quite understand which file is used when, I guess it boils down to running proxy service and app service within the same agent vs running separate agents with those services?).
1. Finally, it's consumed by the app server (`lib/srv/app/tcpserver.go`).

In a local setup it works. I have `tcp-postgres` configured with a bogus port, but I can run `tcp proxy app tcp-postgres` and the connection made through that proxy will be forwarded to the port 5434 hardcoded in the local proxy's SNI (`tool/tsh/common/proxy.go`).

---

I'd like to know how bad this idea is and if it can work in real cluster deployments. Does it go against any principles established by Teleport? As SNI isn't encrypted, wouldn't it be possible for a malicious middleman to rewrite it?

I left a ton of broken tests, but locally `./lib/web ./lib/srv/alpnproxy` and `./integration/proxy -run "TestALPNSNIProxyAppAccess"` are passing.