### PR TITLE
Fix flaky test `TestRootNetworkingCommand/x11_forward`

### DIFF
--- a/lib/sshutils/x11/server.go
+++ b/lib/sshutils/x11/server.go
@@ -60,7 +60,7 @@ func OpenNewXServerListener(displayOffset int, maxDisplay int, screen uint32) (n
 		display := Display{DisplayNumber: displayNumber, ScreenNumber: int(screen)}
 		if l, err := display.Listen(); err == nil {
 			return l, display, nil
-		} else if !errors.Is(err, syscall.EADDRINUSE) {
+		} else if !errors.Is(err, syscall.EADDRINUSE) && !errors.Is(err, syscall.EACCES) {
 			return nil, Display{}, trace.Wrap(err)
 		}
 	}


### PR DESCRIPTION
Fix an issue with multiple networking processes trying to listen on the same X11 display address resulting in an unexpected permission denied error - the process should just try the next address.

```
=== RUN   TestRootNetworkingCommand/x11_forward
{"timestamp":"2024-08-14T10:25:47Z","level":"debug","caller":"networking/networking.go:263","message":"Sending networking request to child process","request":{"Operation":"listen-x11","Network":"","Address":"","X11Request":{"SingleConnection":false,"AuthProtocol":"MIT-MAGIC-COOKIE-1","AuthCookie":"ed17fc80555a6181e95ada5b833b91f5","ScreenNumber":0,"DisplayOffset":10,"MaxDisplay":1000,"XauthFile":"/tmp/xauth-temp1783098412/.Xauthority"}}}
    reexec_test.go:371: 
        	Error Trace:	/__w/teleport.e/teleport.e/lib/srv/reexec_test.go:371
        	            				/__w/teleport.e/teleport.e/lib/srv/reexec_test.go:259
        	Error:      	Received unexpected error:
        	            	error returned by networking process: failed to create networking file
        	            		listen unix /tmp/.X11-unix/X16: bind: permission denied
        	Test:       	TestRootNetworkingCommand/x11_forward
--- FAIL: TestRootNetworkingCommand/x11_forward (0.00s)
```