### PR TITLE
[v14] Remove `/ver/` segments from Web UI docs links

### DIFF
--- a/web/packages/teleport/src/Support/Support.tsx
+++ b/web/packages/teleport/src/Support/Support.tsx
@@ -169,23 +169,13 @@ const getDocUrls = (version = '', isEnterprise: boolean) => {
   const withUTM = (url = '', anchorHash = '') =>
     `${url}?product=teleport&version=${verPrefix}_${version}${anchorHash}`;
 
-  let docVer = '';
-  if (version && version.length > 0) {
-    const major = version.split('.')[0];
-    docVer = `/ver/${major}.x`;
-  }
-
   return {
-    getStarted: withUTM(`https://goteleport.com/docs${docVer}/getting-started`),
-    tshGuide: withUTM(
-      `https://goteleport.com/docs${docVer}/server-access/guides/tsh`
-    ),
-    adminGuide: withUTM(
-      `https://goteleport.com/docs${docVer}/management/admin/`
-    ),
-    faq: withUTM(`https://goteleport.com/docs${docVer}/faq`),
+    getStarted: withUTM(`https://goteleport.com/docs/get-started/`),
+    tshGuide: withUTM(`https://goteleport.com/docs/connect-your-client/tsh/`),
+    adminGuide: withUTM(`https://goteleport.com/docs/management/admin/`),
+    faq: withUTM(`https://goteleport.com/docs/faq`),
     troubleshooting: withUTM(
-      `https://goteleport.com/docs${docVer}/management/admin/troubleshooting/`
+      `https://goteleport.com/docs/management/admin/troubleshooting/`
     ),
 
     // there isn't a version-specific changelog page

--- a/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
+++ b/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
@@ -229,7 +229,7 @@ exports[`support Cloud 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/get-started/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -237,7 +237,7 @@ exports[`support Cloud 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/connect-your-client/tsh/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -245,7 +245,7 @@ exports[`support Cloud 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/management/admin/?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/management/admin/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -260,7 +260,7 @@ exports[`support Cloud 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/faq?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/faq?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -296,7 +296,7 @@ exports[`support Cloud 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/management/admin/troubleshooting/?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/management/admin/troubleshooting/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -655,7 +655,7 @@ exports[`support Enterprise 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/get-started/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -663,7 +663,7 @@ exports[`support Enterprise 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/connect-your-client/tsh/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -671,7 +671,7 @@ exports[`support Enterprise 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/management/admin/?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/management/admin/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -687,7 +687,7 @@ exports[`support Enterprise 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/faq?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/faq?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -723,7 +723,7 @@ exports[`support Enterprise 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/management/admin/troubleshooting/?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/management/admin/troubleshooting/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1163,7 +1163,7 @@ exports[`support Enterprise with CTA 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/get-started/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1171,7 +1171,7 @@ exports[`support Enterprise with CTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/connect-your-client/tsh/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1179,7 +1179,7 @@ exports[`support Enterprise with CTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/management/admin/?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/management/admin/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1195,7 +1195,7 @@ exports[`support Enterprise with CTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/faq?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/faq?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1231,7 +1231,7 @@ exports[`support Enterprise with CTA 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/management/admin/troubleshooting/?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/management/admin/troubleshooting/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1582,7 +1582,7 @@ exports[`support OSS 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/get-started/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1590,7 +1590,7 @@ exports[`support OSS 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/connect-your-client/tsh/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1598,7 +1598,7 @@ exports[`support OSS 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/management/admin/?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/management/admin/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1614,7 +1614,7 @@ exports[`support OSS 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/faq?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/faq?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1650,7 +1650,7 @@ exports[`support OSS 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/management/admin/troubleshooting/?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/management/admin/troubleshooting/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2090,7 +2090,7 @@ exports[`support OSSWithCTA 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/get-started/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2098,7 +2098,7 @@ exports[`support OSSWithCTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/connect-your-client/tsh/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2106,7 +2106,7 @@ exports[`support OSSWithCTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/management/admin/?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/management/admin/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2122,7 +2122,7 @@ exports[`support OSSWithCTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/faq?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/faq?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2158,7 +2158,7 @@ exports[`support OSSWithCTA 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/management/admin/troubleshooting/?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/management/admin/troubleshooting/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >


### PR DESCRIPTION
Backports #45474

The Support component is the only Web UI component that renders docs links that include the `/ver/` path segment. This change removes the `/ver/` path segment from these links so they point to the default version of the docs. The user can use the version dropdown within the docs site to adjust the version. This change does not alter UTM parameters.

With this change, we only need to manage redirects in the default version of the docs site. This makes it less likely that users will encounter 404 errors. And since the docs site only displays the current version and previous two versions, link targets with the `/ver/` segment will 404 in EOL Teleport versions. This change also prevents that scenario.