### PR TITLE
Restore host user creation for exec requests

### DIFF
--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1697,6 +1697,12 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 	}
 	switch req.Type {
 	case sshutils.ExecRequest:
+		if err := s.termHandlers.SessionRegistry.TryCreateHostUser(serverContext); err != nil {
+			return trace.Wrap(err)
+		}
+		if err := s.termHandlers.SessionRegistry.TryWriteSudoersFile(serverContext); err != nil {
+			return trace.Wrap(err)
+		}
 		return s.termHandlers.HandleExec(ctx, ch, req, serverContext)
 	case sshutils.PTYRequest:
 		return s.termHandlers.HandlePTYReq(ctx, ch, req, serverContext)


### PR DESCRIPTION
I accidentally removed host user creation from exec requests when I added it to X11, Agent, and Port forwarding requests - https://github.com/gravitational/teleport/pull/43756/commits/925a7d8039aa9bdd9e5712ad7f8c8e1179facf62. https://github.com/gravitational/teleport/pull/43756 has not been backported yet, so I will include this fix with it.

TODO: add regression test. This was caught by `BenchmarkRootExecCommand` which isn't run in CI.