### PR TITLE
web: fix inconsistent button use

### DIFF
--- a/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
+++ b/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
@@ -66,7 +66,10 @@ export function AuthConnectors(props: State) {
       <ResponsiveFeatureHeader>
         <FeatureHeaderTitle>Auth Connectors</FeatureHeaderTitle>
         <MobileDescription>{description}</MobileDescription>
-        <ResponsiveAddButton onClick={() => resources.create('github')}>
+        <ResponsiveAddButton
+          fill="border"
+          onClick={() => resources.create('github')}
+        >
           New GitHub Connector
         </ResponsiveAddButton>
       </ResponsiveFeatureHeader>

--- a/web/packages/teleport/src/AuthConnectors/styles/AuthConnectors.styles.ts
+++ b/web/packages/teleport/src/AuthConnectors/styles/AuthConnectors.styles.ts
@@ -17,7 +17,7 @@
  */
 
 import styled from 'styled-components';
-import { Box, ButtonPrimary, Subtitle1 } from 'design';
+import { Box, Button, Subtitle1 } from 'design';
 
 import { FeatureHeader } from 'teleport/components/Layout';
 
@@ -51,7 +51,7 @@ export const DesktopDescription = styled(Box)`
   }
 `;
 
-export const ResponsiveAddButton = styled(ButtonPrimary)`
+export const ResponsiveAddButton = styled(Button)`
   width: 240px;
   @media screen and (max-width: ${p => p.theme.breakpoints.tablet}px) {
     width: 100%;

--- a/web/packages/teleport/src/Integrations/IntegrationsAddButton.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationsAddButton.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { ButtonPrimary } from 'design';
+import { Button } from 'design';
 
 import cfg from 'teleport/config';
 
@@ -28,7 +28,9 @@ export function IntegrationsAddButton({
   canCreate: boolean;
 }) {
   return (
-    <ButtonPrimary
+    <Button
+      intent="primary"
+      fill="border"
       as={Link}
       ml="auto"
       width="240px"
@@ -36,7 +38,7 @@ export function IntegrationsAddButton({
       to={cfg.getIntegrationEnrollRoute()}
       title={canCreate ? '' : 'You do not have access to add new integrations'}
     >
-      Enroll new integration
-    </ButtonPrimary>
+      Enroll New Integration
+    </Button>
   );
 }

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -147,7 +147,7 @@ export const JoinTokens = () => {
             width="240px"
             onClick={() => setCreatingToken(true)}
           >
-            Create new Token
+            Create New Token
           </Button>
         )}
       </FeatureHeader>


### PR DESCRIPTION
During the recent button redesign we intended to make the top right button a border button as it's not the single primary action on the page. We missed a few cases where we used wrapper components.

In addition, use title case consistently for these buttons.