### PR TITLE
Add app session recordings to `tsh recordings ls`, `tctl recordings ls`, and the WebUI

### DIFF
--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -828,6 +828,7 @@ var (
 	// recorings.
 	SessionRecordingEvents = []string{
 		SessionEndEvent,
+		AppSessionEndEvent,
 		WindowsDesktopSessionEndEvent,
 		DatabaseSessionEndEvent,
 	}

--- a/lib/events/athena/querier_test.go
+++ b/lib/events/athena/querier_test.go
@@ -191,8 +191,8 @@ func TestSearchEvents(t *testing.T) {
 			check: func(t *testing.T, mock *mockAthenaExecutor, paginationKey string) {
 				wantSingleCallToAthena(t, mock)
 				wantQuery(t, mock, selectFromPrefix+whereTimeRange+
-					` AND session_id = ? AND event_type IN (?,?,?) ORDER BY event_time ASC, uid ASC LIMIT 100;`)
-				wantQueryParams(t, mock, append(timeRangeParams, "'9762a4fe-ac4b-47b5-ba4f-5f70d065849a'", "'session.end'", "'windows.desktop.session.end'", "'db.session.end'")...)
+					` AND session_id = ? AND event_type IN (?,?,?,?) ORDER BY event_time ASC, uid ASC LIMIT 100;`)
+				wantQueryParams(t, mock, append(timeRangeParams, "'9762a4fe-ac4b-47b5-ba4f-5f70d065849a'", "'session.end'", "'app.session.end'", "'windows.desktop.session.end'", "'db.session.end'")...)
 			},
 		},
 		{

--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -26,11 +26,11 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/dustin/go-humanize"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/asciitable"
@@ -65,24 +65,25 @@ func (e *SessionsCollection) WriteText(w io.Writer) error {
 			typ = session.Protocol
 			participants = strings.Join(session.Participants, ", ")
 			hostname = session.ServerAddr
-			timestamp = session.GetTime().Format(constants.HumanDateFormatSeconds)
+			timestamp = humanize.Time(session.GetTime())
 		case *events.WindowsDesktopSessionEnd:
 			id = session.GetSessionID()
 			typ = "windows"
 			participants = strings.Join(session.Participants, ", ")
 			hostname = session.DesktopName
-			timestamp = session.GetTime().Format(constants.HumanDateFormatSeconds)
+			timestamp = humanize.Time(session.GetTime())
 		case *events.DatabaseSessionEnd:
 			id = session.GetSessionID()
 			typ = session.DatabaseProtocol
 			participants = session.GetUser()
 			hostname = session.DatabaseService
+			timestamp = humanize.Time(session.GetTime())
 		case *events.AppSessionEnd:
 			id = session.GetSessionID()
 			typ = "app"
 			participants = session.User
 			hostname = session.AppName
-			timestamp = session.GetTime().Format(constants.HumanDateFormatSeconds)
+			timestamp = humanize.Time(session.GetTime())
 		default:
 			log.Warn(trace.BadParameter("unsupported event type: expected SessionEnd, WindowsDesktopSessionEnd, DatabaseSessionEnd, or AppSessionEnd: got: %T", event))
 			continue

--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -77,9 +77,14 @@ func (e *SessionsCollection) WriteText(w io.Writer) error {
 			typ = session.DatabaseProtocol
 			participants = session.GetUser()
 			hostname = session.DatabaseService
+		case *events.AppSessionEnd:
+			id = session.GetSessionID()
+			typ = "app"
+			participants = session.User
+			hostname = session.AppName
 			timestamp = session.GetTime().Format(constants.HumanDateFormatSeconds)
 		default:
-			log.Warn(trace.BadParameter("unsupported event type: expected SessionEnd, WindowsDesktopSessionEnd or DatabaseSessionEnd: got: %T", event))
+			log.Warn(trace.BadParameter("unsupported event type: expected SessionEnd, WindowsDesktopSessionEnd, DatabaseSessionEnd, or AppSessionEnd: got: %T", event))
 			continue
 		}
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5102,8 +5102,19 @@ func TestShowSessions(t *testing.T) {
         "sid": "",
         "db_protocol": "postgres",
         "db_uri": "",
+        "db_name": "db-name",
         "session_start": "0001-01-01T00:00:00Z",
         "session_stop": "0001-01-01T00:00:00Z"
+    },
+    {
+        "ei": 0,
+        "event": "",
+        "uid": "someID5",
+        "time": "0001-01-01T00:00:00Z",
+        "user": "someUser",
+        "sid": "",
+        "server_id": "",
+        "app_name": "app-name"
     }
 ]`
 	sessions := []events.AuditEvent{
@@ -5139,10 +5150,23 @@ func TestShowSessions(t *testing.T) {
 				User: "someUser",
 			},
 			DatabaseMetadata: events.DatabaseMetadata{
+				DatabaseName:     "db-name",
 				DatabaseProtocol: "postgres",
 			},
 			StartTime: time.Time{},
 			EndTime:   time.Time{},
+		},
+		&events.AppSessionEnd{
+			Metadata: events.Metadata{
+				ID:   "someID5",
+				Time: time.Time{},
+			},
+			UserMetadata: events.UserMetadata{
+				User: "someUser",
+			},
+			AppMetadata: events.AppMetadata{
+				AppName: "app-name",
+			},
 		},
 	}
 	var buf bytes.Buffer

--- a/web/packages/teleport/src/Recordings/RecordingsList.tsx
+++ b/web/packages/teleport/src/Recordings/RecordingsList.tsx
@@ -111,6 +111,8 @@ const renderIconCell = (type: RecordingType) => {
     Icon = Icons.Kubernetes;
   } else if (type === 'database') {
     Icon = Icons.Database;
+  } else if (type === 'app') {
+    Icon = Icons.Application;
   }
 
   return (

--- a/web/packages/teleport/src/services/recordings/makeRecording.ts
+++ b/web/packages/teleport/src/services/recordings/makeRecording.ts
@@ -30,6 +30,8 @@ export function makeRecording(event: any): Recording {
     return makeDesktopRecording(event);
   } else if (event.code === eventCodes.DATABASE_SESSION_ENDED) {
     return makeDatabaseRecording(event);
+  } else if (event.code === eventCodes.APP_SESSION_END) {
+    return makeAppRecording(event);
   } else {
     return makeSshOrKubeRecording(event);
   }
@@ -157,6 +159,24 @@ function makeDatabaseRecording({
     description,
     recordingType: 'database',
     playable: description === 'play',
+  } as Recording;
+}
+
+function makeAppRecording({ time, user, sid, app_name }) {
+  // App recordings all not playable from the webUI, but we still want to display
+  // them as they can be viewed through `tsh play --format=json`.
+  const description = 'non-interactive';
+
+  return {
+    duration: 0,
+    durationText: '-',
+    sid,
+    createdDate: time,
+    users: user,
+    hostname: app_name,
+    description,
+    recordingType: 'app',
+    playable: false,
   } as Recording;
 }
 

--- a/web/packages/teleport/src/services/recordings/types.ts
+++ b/web/packages/teleport/src/services/recordings/types.ts
@@ -28,7 +28,7 @@ export type RecordingsResponse = {
   startKey: string;
 };
 
-export type RecordingType = 'ssh' | 'desktop' | 'k8s' | 'database';
+export type RecordingType = 'ssh' | 'desktop' | 'k8s' | 'database' | 'app';
 
 export type Recording = {
   duration: number;


### PR DESCRIPTION
~Changelog: Add App session recordings to tsh recordings ls, tctl recordings ls, and The WebUI.~ reverted before release

Also humanized the timestamps for listed recordings.

```
ID                                   Type Participants Hostname  Timestamp      
------------------------------------ ---- ------------ --------- -------------- 
e4627fe8-cec2-41d0-b87f-5b2d655f8207 ssh  dev          [::]:3022 43 minutes ago 
dc4ac4b9-9e56-4afc-b398-49eef711145b app  dev          postgres  56 minutes ago 
```

App sessions will also appear in the WebUI as non-interactive sessions.