### PR TITLE
Fix flaky test `TestRootNetworkingCommand`

### DIFF
--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -102,8 +102,13 @@ func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet) *S
 
 	scx.killShellr, scx.killShellw, err = os.Pipe()
 	require.NoError(t, err)
+	scx.AddCloser(scx.killShellw)
 
-	t.Cleanup(func() { require.NoError(t, scx.Close()) })
+	// TODO (joerger): check the error coming from Close once the logic around
+	// closing open files has been fixed to fail with "close |1: file already closed".
+	// Note that outside of tests, we never check the error form scx.Close because this
+	// error is a part of normal execution currently.
+	t.Cleanup(func() { scx.Close() })
 
 	return scx
 }

--- a/lib/srv/reexec_test.go
+++ b/lib/srv/reexec_test.go
@@ -230,7 +230,7 @@ func testNetworkingCommand(t *testing.T, login string) {
 	ctx := context.Background()
 	srv := newMockServer(t)
 
-	scx := newExecServerContext(t, srv)
+	scx := newTestServerContext(t, srv, nil)
 	scx.ExecType = teleport.NetworkingSubCommand
 	if login != "" {
 		scx.Identity.Login = login


### PR DESCRIPTION
This test was flaky because the test did not terminate the networking process as intended. Instead it killed the process, which would then race with `userdel` since a user running a process cannot be deleted.

Note: closing the `killShellw` file to termiante the networking process resulted in an error in the test, due to improper handling of the open files - sometimes we close them early, before `scx.Close` is called, causing `scx.Close` to end in error. In a follow up PR I'll clean up this logic.

Closes https://github.com/gravitational/teleport/issues/45534