### PR TITLE
[v15] don't allow empty database names or user names for Postgres connections

### DIFF
--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -229,16 +229,6 @@ func TestAccessPostgres(t *testing.T) {
 			err:           "access to db denied",
 		},
 		{
-			desc:         "empty DB name is not allowed",
-			user:         "alice",
-			role:         "admin",
-			allowDbNames: []string{types.Wildcard},
-			allowDbUsers: []string{"postgres"},
-			dbName:       "",
-			dbUser:       "postgres",
-			err:          "database name must not be empty",
-		},
-		{
 			desc:         "empty username is not allowed",
 			user:         "alice",
 			role:         "admin",
@@ -247,6 +237,25 @@ func TestAccessPostgres(t *testing.T) {
 			dbName:       "postgres",
 			dbUser:       "",
 			err:          "user name must not be empty",
+		},
+		{
+			desc:         "empty DB name is set to allowed user name",
+			user:         "alice",
+			role:         "admin",
+			allowDbNames: []string{"postgres"},
+			allowDbUsers: []string{"postgres"},
+			dbName:       "",
+			dbUser:       "postgres",
+		},
+		{
+			desc:         "empty DB name is set to disallowed user name",
+			user:         "alice",
+			role:         "admin",
+			allowDbNames: []string{"non-existent"},
+			allowDbUsers: []string{"postgres"},
+			dbName:       "",
+			dbUser:       "postgres",
+			err:          "access to db denied",
 		},
 	}
 

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -228,6 +228,26 @@ func TestAccessPostgres(t *testing.T) {
 			dbUser:        "alice",
 			err:           "access to db denied",
 		},
+		{
+			desc:         "empty DB name is not allowed",
+			user:         "alice",
+			role:         "admin",
+			allowDbNames: []string{types.Wildcard},
+			allowDbUsers: []string{"postgres"},
+			dbName:       "",
+			dbUser:       "postgres",
+			err:          "database name must not be empty",
+		},
+		{
+			desc:         "empty username is not allowed",
+			user:         "alice",
+			role:         "admin",
+			allowDbNames: []string{types.Wildcard},
+			allowDbUsers: []string{"postgres"},
+			dbName:       "postgres",
+			dbUser:       "",
+			err:          "user name must not be empty",
+		},
 	}
 
 	for _, test := range tests {

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -226,6 +226,18 @@ func (e *Engine) handleStartup(client *pgproto3.Backend, sessionCtx *common.Sess
 }
 
 func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) error {
+	// Don't allow empty database or user names. Postgres will silently use
+	// the user name as the database name if no database name is passed which
+	// can cause Teleport to allow connections that are explicitly blocked by
+	// RBAC rules. To be safe just don't allow either the database or username
+	// to be empty.
+	if sessionCtx.DatabaseName == "" {
+		return trace.BadParameter("database name must not be empty")
+	}
+	if sessionCtx.DatabaseUser == "" {
+		return trace.BadParameter("user name must not be empty")
+	}
+
 	if err := sessionCtx.CheckUsernameForAutoUserProvisioning(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -19,6 +19,7 @@
 package postgres
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"encoding/base64"
@@ -226,17 +227,15 @@ func (e *Engine) handleStartup(client *pgproto3.Backend, sessionCtx *common.Sess
 }
 
 func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) error {
-	// Don't allow empty database or user names. Postgres will silently use
+	// Don't allow an empty user names. Postgres will silently use
 	// the user name as the database name if no database name is passed which
 	// can cause Teleport to allow connections that are explicitly blocked by
-	// RBAC rules. To be safe just don't allow either the database or username
-	// to be empty.
-	if sessionCtx.DatabaseName == "" {
-		return trace.BadParameter("database name must not be empty")
-	}
+	// RBAC rules. Follow Postgres' behavior and use the user name as the
+	// database name if no database name is passed.
 	if sessionCtx.DatabaseUser == "" {
 		return trace.BadParameter("user name must not be empty")
 	}
+	sessionCtx.DatabaseName = cmp.Or(sessionCtx.DatabaseName, sessionCtx.DatabaseUser)
 
 	if err := sessionCtx.CheckUsernameForAutoUserProvisioning(); err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Backport #45178 to branch/v15

changelog: prevent RBAC bypass for new Postgres connections
