### PR TITLE
Signing And Notarizing Plugins Targetting Darwin

### DIFF
--- a/integrations/event-handler/Makefile
+++ b/integrations/event-handler/Makefile
@@ -46,8 +46,18 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 build:
 	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -o $(BUILDDIR)/teleport-event-handler $(BUILDFLAGS)
 
+# darwin-signed-build is a wrapper around the build target that ensures it is codesigned
+include ../../darwin-signing.mk
+.PHONY: darwin-signed-build
+darwin-signed-build: build
+	$(NOTARIZE_BINARIES)
+
 .PHONY: release
+ifeq ($(OS),darwin)
+release: darwin-signed-build
+else
 release: build
+endif
 	@echo "---> $(RELEASE_MESSAGE)"
 	mkdir $(RELEASE_NAME)
 	cp -rf $(BINARY) \

--- a/integrations/event-handler/Makefile
+++ b/integrations/event-handler/Makefile
@@ -49,6 +49,7 @@ build:
 # darwin-signed-build is a wrapper around the build target that ensures it is codesigned
 include ../../darwin-signing.mk
 .PHONY: darwin-signed-build
+darwin-signed-build: BINARIES=$(BINARY)
 darwin-signed-build: build
 	$(NOTARIZE_BINARIES)
 

--- a/integrations/terraform/Makefile
+++ b/integrations/terraform/Makefile
@@ -113,9 +113,20 @@ endif
 	rm -r ./tfschema/github.com/
 	@go run ./gen/main.go
 
-.PHONY: release
+# darwin-signed-build is a wrapper around the build target that ensures it is codesigned
+include ../../darwin-signing.mk
+.PHONY: darwin-signed-build
+darwin-signed-build: BINARIES=$(BUILDDIR)/terraform-provider-teleport
 ifeq ($(OS)-$(ARCH),darwin-universal)
-release: build-darwin-universal
+darwin-signed-build: build-darwin-universal
+else
+darwin-signed-build: build
+endif
+	$(NOTARIZE_BINARIES)
+
+.PHONY: release
+ifeq ($(OS),darwin)
+release: darwin-signed-build
 else
 release: build
 endif


### PR DESCRIPTION
# Purpose

Plugins that are build for darwin should be signed and notarized.

# Implementation

Plugins that build for mac will now include the `darwin-signing.mk` at the root of the repository and use the function defined there for signing.

```diff
codesign -dvv /Users/gusrivera/terraform-provider-teleport
--- terraform-provider-teleport-v16.1.14
+++ terraform-provider-teleport-v17.0.0
Executable=/Users/gusrivera/terraform-provider-teleport
+Identifier=terraform-provider-teleport
-Identifier=a.out
Format=Mach-O thin (x86_64)
+CodeDirectory v=20500 size=672999 flags=0x10000(runtime) hashes=21025+2 location=embedded
-CodeDirectory v=20400 size=311998 flags=0x20002(adhoc,linker-signed) hashes=9747+0 location=embedded
+Signature size=8964
-Signature=adhoc
+Authority=Developer ID Application: Ada Lin (K497G57PDJ)
+Authority=Developer ID Certification Authority
+Authority=Apple Root CA
+Timestamp=Aug 15, 2024 at 5:57:41 PM
Info.plist=not bound
+TeamIdentifier=K497G57PDJ
-TeamIdentifier=not set
+Runtime Version=10.13.0
Sealed Resources=none
Internal requirements count=1 size=188
```

changelog: Terraform provider plugin and event handler plugin are now signed and notarized for darwin releases.