### PR TITLE
Fix session host connection context being intertwined with the session/shell

### DIFF
--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -102,8 +102,13 @@ func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet) *S
 
 	scx.killShellr, scx.killShellw, err = os.Pipe()
 	require.NoError(t, err)
+	scx.AddCloser(scx.killShellw)
 
-	t.Cleanup(func() { require.NoError(t, scx.Close()) })
+	// TODO (joerger): check the error coming from Close once the logic around
+	// closing open files has been fixed to fail with "close |1: file already closed".
+	// Note that outside of tests, we never check the error form scx.Close because this
+	// error is a part of normal execution currently.
+	t.Cleanup(func() { scx.Close() })
 
 	return scx
 }

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -92,11 +92,7 @@ func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet) *S
 	err = scx.SetExecRequest(&localExec{Ctx: scx})
 	require.NoError(t, err)
 
-	// TODO (joerger): check the error coming from Close once the logic around
-	// closing open files has been fixed to fail with "close |1: file already closed".
-	// Note that outside of tests, we never check the error form scx.Close because this
-	// error is a part of normal execution currently.
-	t.Cleanup(func() { scx.Close() })
+	t.Cleanup(func() { require.NoError(t, scx.Close()) })
 
 	return scx
 }

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -100,9 +100,9 @@ func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet) *S
 	scx.readyr, scx.readyw, err = os.Pipe()
 	require.NoError(t, err)
 
-	scx.killShellr, scx.killShellw, err = os.Pipe()
+	scx.termr, scx.termw, err = os.Pipe()
 	require.NoError(t, err)
-	scx.AddCloser(scx.killShellw)
+	scx.AddCloser(scx.termw)
 
 	// TODO (joerger): check the error coming from Close once the logic around
 	// closing open files has been fixed to fail with "close |1: file already closed".

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -1159,7 +1159,7 @@ func ConfigureCommand(ctx *ServerContext, extraFiles ...*os.File) (*exec.Cmd, er
 			ctx.cmdr,
 			ctx.contr,
 			ctx.readyw,
-			ctx.killShellr,
+			ctx.termr,
 		},
 	}
 	// Add extra files if applicable.

--- a/lib/srv/reexec_test.go
+++ b/lib/srv/reexec_test.go
@@ -230,7 +230,7 @@ func testNetworkingCommand(t *testing.T, login string) {
 	ctx := context.Background()
 	srv := newMockServer(t)
 
-	scx := newExecServerContext(t, srv)
+	scx := newTestServerContext(t, srv, nil)
 	scx.ExecType = teleport.NetworkingSubCommand
 	if login != "" {
 		scx.Identity.Login = login

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -266,8 +266,10 @@ func TestSession_newRecorder(t *testing.T) {
 				},
 			},
 			sctx: &ServerContext{
-				SessionRecordingConfig: proxyRecording,
-				term:                   &terminal{},
+				ServerContextConfig: ServerContextConfig{
+					SessionRecordingConfig: proxyRecording,
+				},
+				term: &terminal{},
 			},
 			errAssertion: require.NoError,
 			recAssertion: isNotSessionWriter,
@@ -286,8 +288,10 @@ func TestSession_newRecorder(t *testing.T) {
 				},
 			},
 			sctx: &ServerContext{
-				SessionRecordingConfig: proxyRecordingSync,
-				term:                   &terminal{},
+				ServerContextConfig: ServerContextConfig{
+					SessionRecordingConfig: proxyRecordingSync,
+				},
+				term: &terminal{},
 			},
 			errAssertion: require.NoError,
 			recAssertion: isNotSessionWriter,
@@ -306,27 +310,29 @@ func TestSession_newRecorder(t *testing.T) {
 				},
 			},
 			sctx: &ServerContext{
-				SessionRecordingConfig: nodeRecordingSync,
-				srv: &mockServer{
-					component: teleport.ComponentNode,
-				},
-				term: &terminal{},
-				Identity: IdentityContext{
-					AccessChecker: services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
-						Roles: []string{"dev"},
-					}, "test", services.RoleSet{
-						&types.RoleV6{
-							Metadata: types.Metadata{Name: "dev", Namespace: apidefaults.Namespace},
-							Spec: types.RoleSpecV6{
-								Options: types.RoleOptions{
-									RecordSession: &types.RecordSession{
-										SSH: constants.SessionRecordingModeStrict,
+				ServerContextConfig: ServerContextConfig{
+					SessionRecordingConfig: nodeRecordingSync,
+					srv: &mockServer{
+						component: teleport.ComponentNode,
+					},
+					Identity: IdentityContext{
+						AccessChecker: services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
+							Roles: []string{"dev"},
+						}, "test", services.RoleSet{
+							&types.RoleV6{
+								Metadata: types.Metadata{Name: "dev", Namespace: apidefaults.Namespace},
+								Spec: types.RoleSpecV6{
+									Options: types.RoleOptions{
+										RecordSession: &types.RecordSession{
+											SSH: constants.SessionRecordingModeStrict,
+										},
 									},
 								},
 							},
-						},
-					}),
+						}),
+					},
 				},
+				term: &terminal{},
 			},
 			errAssertion: require.Error,
 			recAssertion: require.Nil,
@@ -345,27 +351,29 @@ func TestSession_newRecorder(t *testing.T) {
 				},
 			},
 			sctx: &ServerContext{
-				ClusterName:            "test",
-				SessionRecordingConfig: nodeRecordingSync,
-				srv: &mockServer{
-					component: teleport.ComponentNode,
-					datadir:   t.TempDir(),
-				},
-				Identity: IdentityContext{
-					AccessChecker: services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
-						Roles: []string{"dev"},
-					}, "test", services.RoleSet{
-						&types.RoleV6{
-							Metadata: types.Metadata{Name: "dev", Namespace: apidefaults.Namespace},
-							Spec: types.RoleSpecV6{
-								Options: types.RoleOptions{
-									RecordSession: &types.RecordSession{
-										SSH: constants.SessionRecordingModeBestEffort,
+				ServerContextConfig: ServerContextConfig{
+					ClusterName:            "test",
+					SessionRecordingConfig: nodeRecordingSync,
+					srv: &mockServer{
+						component: teleport.ComponentNode,
+						datadir:   t.TempDir(),
+					},
+					Identity: IdentityContext{
+						AccessChecker: services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
+							Roles: []string{"dev"},
+						}, "test", services.RoleSet{
+							&types.RoleV6{
+								Metadata: types.Metadata{Name: "dev", Namespace: apidefaults.Namespace},
+								Spec: types.RoleSpecV6{
+									Options: types.RoleOptions{
+										RecordSession: &types.RecordSession{
+											SSH: constants.SessionRecordingModeBestEffort,
+										},
 									},
 								},
 							},
-						},
-					}),
+						}),
+					},
 				},
 				term: &terminal{},
 			},
@@ -391,11 +399,13 @@ func TestSession_newRecorder(t *testing.T) {
 				},
 			},
 			sctx: &ServerContext{
-				ClusterName:            "test",
-				SessionRecordingConfig: nodeRecordingSync,
-				srv: &mockServer{
-					MockRecorderEmitter: &eventstest.MockRecorderEmitter{},
-					datadir:             t.TempDir(),
+				ServerContextConfig: ServerContextConfig{
+					ClusterName:            "test",
+					SessionRecordingConfig: nodeRecordingSync,
+					srv: &mockServer{
+						MockRecorderEmitter: &eventstest.MockRecorderEmitter{},
+						datadir:             t.TempDir(),
+					},
 				},
 				term: &terminal{},
 			},
@@ -1221,9 +1231,11 @@ func TestSessionRecordingMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sess := session{
 				scx: &ServerContext{
-					SessionRecordingConfig: &types.SessionRecordingConfigV2{
-						Spec: types.SessionRecordingConfigSpecV2{
-							Mode: tt.mode,
+					ServerContextConfig: ServerContextConfig{
+						SessionRecordingConfig: &types.SessionRecordingConfigV2{
+							Spec: types.SessionRecordingConfigSpecV2{
+								Mode: tt.mode,
+							},
 						},
 					},
 				},

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -139,10 +139,6 @@ type terminal struct {
 	pty *os.File
 	tty *os.File
 
-	// terminateFD when closed informs the terminal that
-	// the process running in the shell should be killed.
-	terminateFD *os.File
-
 	pid int
 
 	termType string
@@ -158,7 +154,6 @@ func newLocalTerminal(ctx *ServerContext) (*terminal, error) {
 			teleport.ComponentKey: teleport.ComponentLocalTerm,
 		}),
 		serverContext: ctx,
-		terminateFD:   ctx.killShellw,
 	}
 
 	// Open PTY and corresponding TTY.
@@ -268,7 +263,7 @@ func (t *terminal) Continue() {
 
 // KillUnderlyingShell tries to kill the shell/bash process and waits for the process PID to be released.
 func (t *terminal) KillUnderlyingShell(ctx context.Context) error {
-	if err := t.terminateFD.Close(); err != nil {
+	if err := t.serverContext.termw.Close(); err != nil {
 		if !errors.Is(err, os.ErrClosed) {
 			t.log.WithError(err).Debug("Failed to close the shell file descriptor")
 		}


### PR DESCRIPTION
WIP: instead of trying to "fix" `ServerContext`, which is really connection context, I'm going to add a separate "CommandContext" or similar struct to handle the execution of the teleport reexec command. This will be owned by the session rather than the session host (connection context).

Fixes https://github.com/gravitational/teleport/issues/46308