### PR TITLE
[Web] Fix Feature Hiding

### DIFF
--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -152,19 +152,21 @@ export function TopBar({ CustomLogo }: TopBarProps) {
                   Icon={Server}
                 />
               )}
-              <MainNavItem
-                name="Access Management"
-                to={
-                  previousManagementRoute ||
-                  getFirstRouteForCategory(
-                    features,
-                    NavigationCategory.Management
-                  )
-                }
-                size={iconSize}
-                isSelected={managementTabSelected}
-                Icon={SlidersVertical}
-              />
+              {ctx.getFeatureFlags().managementSection && (
+                <MainNavItem
+                  name="Access Management"
+                  to={
+                    previousManagementRoute ||
+                    getFirstRouteForCategory(
+                      features,
+                      NavigationCategory.Management
+                    )
+                  }
+                  size={iconSize}
+                  isSelected={managementTabSelected}
+                  Icon={SlidersVertical}
+                />
+              )}
 
               {topBarLinks.map(({ topMenuItem, navigationItem }) => {
                 const link = navigationItem.getLink(clusterId);

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -147,7 +147,12 @@ class TeleportContext implements types.Context {
         userContext.getIntegrationsAccess().list ||
         userContext.hasDiscoverAccess() ||
         userContext.getDeviceTrustAccess().list ||
-        userContext.getLockAccess().list
+        userContext.getLockAccess().list ||
+        userContext.getAccessListAccess().list ||
+        userContext.getAccessGraphAccess().list ||
+        hasAccessMonitoringAccess() ||
+        userContext.getTokenAccess().create ||
+        userContext.getBotsAccess().list
       );
     }
 


### PR DESCRIPTION
## Purpose

This PR fixes a regression for the `FeatureHiding` feature which, when enabled, is supposed to hide the management tab from users with no access to anything within it.

This regression was introduced in this PR: https://github.com/gravitational/teleport/pull/36368, when we implemented the top bar, we forgot to use the `managementSection` flag to conditionally render the management navigation section.

This PR also adds some missing features to the exclusion list.

### Demo

#### User with no access to any management features & `FeatureHiding` on

![image](https://github.com/user-attachments/assets/6408a854-a7a5-4010-b98a-2d3eee7c2b3c)

changelog: Fixed bug causing FeatureHiding flag to not hide the "Access Management" section in the UI as intended.
