### PR TITLE
Update Vite to 5.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "prettier": "^3.3.3",
     "storybook": "^8.2.7",
     "typescript": "^5.5.4",
-    "vite": "^5.3.5"
+    "vite": "^5.4.1"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
         version: 8.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
       '@storybook/react-vite':
         specifier: ^8.2.7
-        version: 8.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.19.2)(storybook@8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)(vite@5.3.5(@types/node@20.14.11)(terser@5.31.1))
+        version: 8.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.19.2)(storybook@8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)(vite@5.4.1(@types/node@20.14.11)(terser@5.31.1))
       '@testing-library/jest-dom':
         specifier: ^6.4.8
         version: 6.4.8
@@ -162,8 +162,8 @@ importers:
         specifier: ^5.5.4
         version: 5.5.4
       vite:
-        specifier: ^5.3.5
-        version: 5.3.5(@types/node@20.14.11)(terser@5.31.1)
+        specifier: ^5.4.1
+        version: 5.4.1(@types/node@20.14.11)(terser@5.31.1)
 
   e/web/teleport: {}
 
@@ -192,7 +192,7 @@ importers:
         version: 21.1.7
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.0
-        version: 3.7.0(vite@5.3.5(@types/node@22.0.2)(terser@5.31.1))
+        version: 3.7.0(vite@5.4.1(@types/node@22.0.2)(terser@5.31.1))
       babel-plugin-styled-components:
         specifier: ^2.1.4
         version: 2.1.4(@babel/core@7.25.2)(styled-components@6.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -243,10 +243,10 @@ importers:
         version: 7.14.1(eslint@8.57.0)(typescript@5.5.4)
       vite-plugin-wasm:
         specifier: ^3.3.0
-        version: 3.3.0(vite@5.3.5(@types/node@22.0.2)(terser@5.31.1))
+        version: 3.3.0(vite@5.4.1(@types/node@22.0.2)(terser@5.31.1))
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.5.4)(vite@5.3.5(@types/node@22.0.2)(terser@5.31.1))
+        version: 4.3.2(typescript@5.5.4)(vite@5.4.1(@types/node@22.0.2)(terser@5.31.1))
 
   web/packages/design:
     dependencies:
@@ -447,7 +447,7 @@ importers:
         version: 1.2.2
       electron-vite:
         specifier: ^2.3.0
-        version: 2.3.0(@swc/core@1.7.4)(vite@5.3.5(@types/node@22.0.2)(terser@5.31.1))
+        version: 2.3.0(@swc/core@1.7.4)(vite@5.4.1(@types/node@22.0.2)(terser@5.31.1))
       events:
         specifier: 3.3.0
         version: 3.3.0
@@ -5366,8 +5366,8 @@ packages:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.4.40:
-    resolution: {integrity: sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==}
+  postcss@8.4.41:
+    resolution: {integrity: sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -6351,8 +6351,8 @@ packages:
       vite:
         optional: true
 
-  vite@5.3.5:
-    resolution: {integrity: sha512-MdjglKR6AQXQb9JGiS7Rc2wC6uMjcm7Go/NHNO63EwiJXfuk9PgqiP/n5IDJCziMkfw9n4Ubp7lttNwz+8ZVKA==}
+  vite@5.4.1:
+    resolution: {integrity: sha512-1oE6yuNXssjrZdblI9AfBbHCC41nnyoVoEZxQnID6yvQZAFBzxxkqoFLtHUMkYunL8hwOLEjgTuxpkRxvba3kA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -6360,6 +6360,7 @@ packages:
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
+      sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
       terser: ^5.4.0
@@ -6371,6 +6372,8 @@ packages:
       lightningcss:
         optional: true
       sass:
+        optional: true
+      sass-embedded:
         optional: true
       stylus:
         optional: true
@@ -8005,13 +8008,13 @@ snapshots:
       '@types/yargs': 17.0.29
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.3.1(typescript@5.5.4)(vite@5.3.5(@types/node@20.14.11)(terser@5.31.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.3.1(typescript@5.5.4)(vite@5.4.1(@types/node@20.14.11)(terser@5.31.1))':
     dependencies:
       glob: 7.2.3
       glob-promise: 4.2.2(glob@7.2.3)
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.5.4)
-      vite: 5.3.5(@types/node@20.14.11)(terser@5.31.1)
+      vite: 5.4.1(@types/node@20.14.11)(terser@5.31.1)
     optionalDependencies:
       typescript: 5.5.4
 
@@ -8497,7 +8500,7 @@ snapshots:
     dependencies:
       storybook: 8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2))
 
-  '@storybook/builder-vite@8.2.7(storybook@8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)(vite@5.3.5(@types/node@20.14.11)(terser@5.31.1))':
+  '@storybook/builder-vite@8.2.7(storybook@8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)(vite@5.4.1(@types/node@20.14.11)(terser@5.31.1))':
     dependencies:
       '@storybook/csf-plugin': 8.2.7(storybook@8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2)))
       '@types/find-cache-dir': 3.2.1
@@ -8509,7 +8512,7 @@ snapshots:
       magic-string: 0.30.11
       storybook: 8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2))
       ts-dedent: 2.2.0
-      vite: 5.3.5(@types/node@20.14.11)(terser@5.31.1)
+      vite: 5.4.1(@types/node@20.14.11)(terser@5.31.1)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -8582,11 +8585,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2))
 
-  '@storybook/react-vite@8.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.19.2)(storybook@8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)(vite@5.3.5(@types/node@20.14.11)(terser@5.31.1))':
+  '@storybook/react-vite@8.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.19.2)(storybook@8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)(vite@5.4.1(@types/node@20.14.11)(terser@5.31.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.1(typescript@5.5.4)(vite@5.3.5(@types/node@20.14.11)(terser@5.31.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.1(typescript@5.5.4)(vite@5.4.1(@types/node@20.14.11)(terser@5.31.1))
       '@rollup/pluginutils': 5.1.0(rollup@4.19.2)
-      '@storybook/builder-vite': 8.2.7(storybook@8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)(vite@5.3.5(@types/node@20.14.11)(terser@5.31.1))
+      '@storybook/builder-vite': 8.2.7(storybook@8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)(vite@5.4.1(@types/node@20.14.11)(terser@5.31.1))
       '@storybook/react': 8.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2)))(typescript@5.5.4)
       find-up: 5.0.0
       magic-string: 0.30.11
@@ -8596,7 +8599,7 @@ snapshots:
       resolve: 1.22.8
       storybook: 8.2.7(@babel/preset-env@7.25.3(@babel/core@7.25.2))
       tsconfig-paths: 4.2.0
-      vite: 5.3.5(@types/node@20.14.11)(terser@5.31.1)
+      vite: 5.4.1(@types/node@20.14.11)(terser@5.31.1)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - rollup
@@ -9238,10 +9241,10 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-react-swc@3.7.0(vite@5.3.5(@types/node@22.0.2)(terser@5.31.1))':
+  '@vitejs/plugin-react-swc@3.7.0(vite@5.4.1(@types/node@22.0.2)(terser@5.31.1))':
     dependencies:
       '@swc/core': 1.7.4
-      vite: 5.3.5(@types/node@22.0.2)(terser@5.31.1)
+      vite: 5.4.1(@types/node@22.0.2)(terser@5.31.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -10426,7 +10429,7 @@ snapshots:
 
   electron-to-chromium@1.5.4: {}
 
-  electron-vite@2.3.0(@swc/core@1.7.4)(vite@5.3.5(@types/node@22.0.2)(terser@5.31.1)):
+  electron-vite@2.3.0(@swc/core@1.7.4)(vite@5.4.1(@types/node@22.0.2)(terser@5.31.1)):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.25.2)
@@ -10434,7 +10437,7 @@ snapshots:
       esbuild: 0.21.5
       magic-string: 0.30.11
       picocolors: 1.0.1
-      vite: 5.3.5(@types/node@22.0.2)(terser@5.31.1)
+      vite: 5.4.1(@types/node@22.0.2)(terser@5.31.1)
     optionalDependencies:
       '@swc/core': 1.7.4
     transitivePeerDependencies:
@@ -12750,7 +12753,7 @@ snapshots:
       picocolors: 1.0.1
       source-map-js: 1.2.0
 
-  postcss@8.4.40:
+  postcss@8.4.41:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.0.1
@@ -13890,35 +13893,35 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite-plugin-wasm@3.3.0(vite@5.3.5(@types/node@22.0.2)(terser@5.31.1)):
+  vite-plugin-wasm@3.3.0(vite@5.4.1(@types/node@22.0.2)(terser@5.31.1)):
     dependencies:
-      vite: 5.3.5(@types/node@22.0.2)(terser@5.31.1)
+      vite: 5.4.1(@types/node@22.0.2)(terser@5.31.1)
 
-  vite-tsconfig-paths@4.3.2(typescript@5.5.4)(vite@5.3.5(@types/node@22.0.2)(terser@5.31.1)):
+  vite-tsconfig-paths@4.3.2(typescript@5.5.4)(vite@5.4.1(@types/node@22.0.2)(terser@5.31.1)):
     dependencies:
       debug: 4.3.6
       globrex: 0.1.2
       tsconfck: 3.1.0(typescript@5.5.4)
     optionalDependencies:
-      vite: 5.3.5(@types/node@22.0.2)(terser@5.31.1)
+      vite: 5.4.1(@types/node@22.0.2)(terser@5.31.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.3.5(@types/node@20.14.11)(terser@5.31.1):
+  vite@5.4.1(@types/node@20.14.11)(terser@5.31.1):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.40
+      postcss: 8.4.41
       rollup: 4.19.2
     optionalDependencies:
       '@types/node': 20.14.11
       fsevents: 2.3.3
       terser: 5.31.1
 
-  vite@5.3.5(@types/node@22.0.2)(terser@5.31.1):
+  vite@5.4.1(@types/node@22.0.2)(terser@5.31.1):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.40
+      postcss: 8.4.41
       rollup: 4.19.2
     optionalDependencies:
       '@types/node': 22.0.2


### PR DESCRIPTION
Recently Teleport Connect started having problems loading the UI in dev mode:

>The file does not exist at "/Users/grzegorz/code/teleport/web/packages/teleterm/node_modules/.vite/deps/chunk-EEQKDUH2.js?v=abb2e80d" which is in the optimize deps directory. The dependency might be incompatible with the dep optimizer. Try adding it to `optimizeDeps.exclude`

This chunk is loaded by `react-select`:
 <img width="721" alt="image" src="https://github.com/user-attachments/assets/ea36e067-4e9b-4435-899f-896ef9814bcb">

```ts
import {
  CacheProvider,
  Select,
  _classCallCheck,
  _createClass,
  _getPrototypeOf,
  _inherits,
  _possibleConstructorReturn,
  cache_browser_esm_default,
  components,
  createFilter,
  defaultTheme,
  manageState,
  memoize_one_esm_default,
  mergeStyles,
  require_AutosizeInput
} from "/node_modules/.vite/deps/chunk-EEQKDUH2.js?v=abb2e80d";
```

I guess `react-select` has a weird dependency that causes problems, but I didn't dig into it. Instead, I tried updating `vite` and it seems this resolves the issue.

Tested on dev & build versions of Connect and Web UI.
