### PR TITLE
Rollback Go to 1.22.6

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -196,6 +196,6 @@ output:
   uniq-by-line: false
 
 run:
-  go: '1.23'
+  go: '1.22'
   build-tags: []
   timeout: 15m

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.23
+FROM docker.io/golang:1.22
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.23.0
+go 1.22.6
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.23.0
+GOLANG_VERSION ?= go1.22.6
 GOLANGCI_LINT_VERSION ?= v1.60.1
 
 NODE_VERSION ?= 20.14.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.23.0
+go 1.22.6
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.11.1

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.23.0
+go 1.22.6
 
 require (
 	github.com/alecthomas/kong v0.9.0

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.23.0
+go 1.22.6
 
 // Doc generation tooling
 require github.com/hashicorp/terraform-plugin-docs v0.0.0 // replaced


### PR DESCRIPTION
Rollback module and toolchain to 1.22.6 until https://github.com/golang/go/issues/68949 is solved (or somehow mitigated).

Previous Go 1.23 PRs:

- #45530
- #45473