### PR TITLE
Remove the context menu from the SSH session menu bar

### DIFF
--- a/web/packages/teleport/src/Console/ActionBar/ActionBar.tsx
+++ b/web/packages/teleport/src/Console/ActionBar/ActionBar.tsx
@@ -18,14 +18,10 @@
 
 import React from 'react';
 
-import { NavLink } from 'react-router-dom';
-import { MenuIcon, MenuItem, MenuItemIcon } from 'shared/components/MenuAction';
 import { LatencyDiagnostic } from 'shared/components/LatencyDiagnostic';
 
-import * as Icons from 'design/Icon';
-import { Flex, ButtonPrimary } from 'design';
+import { Flex } from 'design';
 
-import cfg from 'teleport/config';
 import { DocumentSsh } from 'teleport/Console/stores';
 
 export default function ActionBar(props: Props) {
@@ -34,20 +30,6 @@ export default function ActionBar(props: Props) {
       {props.latencyIndicator.isVisible && (
         <LatencyDiagnostic latency={props.latencyIndicator.latency} />
       )}
-      <MenuIcon
-        buttonIconProps={{ mr: 2, ml: 2, size: 0, style: { fontSize: '16px' } }}
-        menuProps={menuProps}
-      >
-        <MenuItem as={NavLink} to={cfg.routes.root}>
-          <MenuItemIcon as={Icons.Home} mr="2" size="medium" />
-          Home
-        </MenuItem>
-        <MenuItem>
-          <ButtonPrimary my={3} block onClick={props.onLogout}>
-            Sign Out
-          </ButtonPrimary>
-        </MenuItem>
-      </MenuIcon>
     </Flex>
   );
 }
@@ -58,13 +40,4 @@ type Props = {
     | {
         isVisible: false;
       };
-  onLogout: VoidFunction;
 };
-
-const menuListCss = () => `
-  width: 250px;
-`;
-
-const menuProps = {
-  menuListCss,
-} as const;

--- a/web/packages/teleport/src/Console/Console.tsx
+++ b/web/packages/teleport/src/Console/Console.tsx
@@ -77,10 +77,6 @@ export default function Console() {
     return consoleCtx.refreshParties();
   }
 
-  function onLogout() {
-    consoleCtx.logout();
-  }
-
   const disableNewTab = storeDocs.getNodeDocuments().length > 0;
   const $docs = documents.map(doc => (
     <MemoizedDocument doc={doc} visible={doc.id === activeDocId} key={doc.id} />
@@ -110,7 +106,6 @@ export default function Console() {
               onNew={onTabNew}
             />
             <ActionBar
-              onLogout={onLogout}
               latencyIndicator={
                 activeDoc?.kind === 'terminal'
                   ? {


### PR DESCRIPTION
There's not a lot of utility in this menu, because dismissing the in-page tab or the window terminates the session, and we've seen some users mistakenly click the sign out button and terminate all of their sessions.

<img width="1422" alt="image" src="https://github.com/user-attachments/assets/2b8fec97-85b0-42a7-bfae-5e66ce41f411">
