### PR TITLE
[v14] Preserve non drop users

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -280,7 +280,7 @@ func (s *SessionRegistry) TryCreateHostUser(ctx *ServerContext) error {
 	if trace.IsAccessDenied(err) && existsErr != nil {
 		return trace.WrapWithMessage(err, "Insufficient permission for host user creation")
 	}
-	userCloser, err := s.users.UpsertUser(ctx.Identity.Login, ui)
+	userCloser, err := s.users.UpsertUser(ctx.Identity.Login, *ui)
 	if userCloser != nil {
 		ctx.AddCloser(userCloser)
 	}

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -21,8 +21,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os/user"
 	"regexp"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -99,11 +101,13 @@ type HostUsersBackend interface {
 	// CreateGroup creates a group on a host.
 	CreateGroup(group string, gid string) error
 	// CreateUser creates a user on a host.
-	CreateUser(name string, groups []string, uid, gid string) error
+	CreateUser(name string, groups []string, home, uid, gid string) error
 	// DeleteUser deletes a user from a host.
 	DeleteUser(name string) error
 	// CreateHomeDirectory creates the users home directory and copies in /etc/skel
-	CreateHomeDirectory(user string, uid, gid string) error
+	CreateHomeDirectory(userHome string, uid, gid string) error
+	// GetDefaultHomeDirectory returns the default home directory path for the given user
+	GetDefaultHomeDirectory(user string) (string, error)
 }
 
 type userCloser struct {
@@ -146,7 +150,7 @@ func (*HostSudoersNotImplemented) RemoveSudoers(name string) error {
 
 type HostUsers interface {
 	// UpsertUser creates a temporary Teleport user in the TeleportServiceGroup
-	UpsertUser(name string, hostRoleInfo *services.HostUsersInfo) (io.Closer, error)
+	UpsertUser(name string, hostRoleInfo services.HostUsersInfo) (io.Closer, error)
 	// DeleteUser deletes a temporary Teleport user only if they are
 	// in a specified group
 	DeleteUser(name string, gid string) error
@@ -221,106 +225,71 @@ func (u *HostSudoersManagement) RemoveSudoers(name string) error {
 	return nil
 }
 
-// UpsertUser creates a temporary Teleport user in the TeleportServiceGroup
-func (u *HostUserManagement) UpsertUser(name string, ui *services.HostUsersInfo) (io.Closer, error) {
-	if ui.Mode == types.CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED {
-		return nil, trace.BadParameter("Mode is a required argument to CreateUser")
+func (u *HostUserManagement) updateUser(name string, ui services.HostUsersInfo) error {
+	existingUser, err := u.backend.Lookup(name)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
-	groups := make([]string, 0, len(ui.Groups))
+	currentGroups := make(map[string]struct{}, len(ui.Groups))
+	groupIDs, err := u.backend.UserGIDs(existingUser)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	for _, groupID := range groupIDs {
+		group, err := u.backend.LookupGroupByID(groupID)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		currentGroups[group.Name] = struct{}{}
+	}
+
+	_, hasSystemGroup := currentGroups[types.TeleportServiceGroup]
+	if hasSystemGroup && (ui.Mode == types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP || ui.Mode == types.CreateHostUserMode_HOST_USER_MODE_DROP) {
+		ui.Groups = append(ui.Groups, types.TeleportServiceGroup)
+	}
+
+	finalGroups := make(map[string]struct{}, len(ui.Groups))
 	for _, group := range ui.Groups {
-		if group == name {
-			// this causes an error as useradd expects the group with the same name as the user to be available
-			log.Debugf("Skipping group creation with name the same as login user (%q, %q).", name, group)
-			continue
-		}
-		groups = append(groups, group)
-	}
-	if ui.Mode == types.CreateHostUserMode_HOST_USER_MODE_DROP || ui.Mode == types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP {
-		groups = append(groups, types.TeleportServiceGroup)
-	}
-	var errs []error
-	for _, group := range groups {
-		if err := u.createGroupIfNotExist(group); err != nil {
-			errs = append(errs, err)
-			continue
-		}
-	}
-	if err := trace.NewAggregate(errs...); err != nil {
-		return nil, trace.WrapWithMessage(err, "error while creating groups")
+		finalGroups[group] = struct{}{}
 	}
 
-	tempUser, err := u.backend.Lookup(name)
-	if err != nil && !errors.Is(err, user.UnknownUserError(name)) {
-		return nil, trace.Wrap(err)
+	primaryGroup, err := u.backend.LookupGroupByID(existingUser.Gid)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	finalGroups[primaryGroup.Name] = struct{}{}
+
+	if !maps.Equal(currentGroups, finalGroups) {
+		return trace.Wrap(u.doWithUserLock(func(_ types.SemaphoreLease) error {
+			return trace.Wrap(u.backend.SetUserGroups(name, ui.Groups))
+		}))
 	}
 
-	if tempUser != nil {
-		// Collect actions that need to be done together under a lock on the user.
-		actionsUnderLock := []func() error{
-			func() error {
-				// If the user exists, set user groups again as they might have changed.
-				return trace.Wrap(u.backend.SetUserGroups(name, groups))
-			},
-		}
-		doWithUserLock := func() error {
-			return trace.Wrap(u.doWithUserLock(func(_ types.SemaphoreLease) error {
-				for _, action := range actionsUnderLock {
-					if err := action(); err != nil {
-						return trace.Wrap(err)
-					}
-				}
-				return nil
-			}))
-		}
+	return nil
+}
 
-		systemGroup, err := u.backend.LookupGroup(types.TeleportServiceGroup)
+func (u *HostUserManagement) createUser(name string, ui services.HostUsersInfo) error {
+	var home string
+	var err error
+	if ui.Mode == types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP || ui.Mode == types.CreateHostUserMode_HOST_USER_MODE_DROP {
+		ui.Groups = append(ui.Groups, types.TeleportServiceGroup)
+	} else {
+		home, err = u.backend.GetDefaultHomeDirectory(name)
 		if err != nil {
-			if isUnknownGroupError(err, types.TeleportServiceGroup) {
-				// Teleport service group doesn't exist, so we don't need to update interaction time.
-				return nil, trace.Wrap(doWithUserLock())
-			}
-			return nil, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
-		gids, err := u.backend.UserGIDs(tempUser)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		var found bool
-		for _, gid := range gids {
-			if gid == systemGroup.Gid {
-				found = true
-				break
-			}
-		}
-		if !found {
-			// User isn't managed by Teleport, so we don't need to update interaction time.
-			return nil, trace.Wrap(doWithUserLock())
-		}
-
-		actionsUnderLock = append(actionsUnderLock, func() error {
-			return trace.Wrap(u.storage.UpsertHostUserInteractionTime(u.ctx, name, time.Now()))
-		})
-		if err := doWithUserLock(); err != nil {
-			return nil, trace.Wrap(err)
-		}
-		// try to delete even if the user already exists as only users
-		// in the teleport-system group will be deleted and this way
-		// if a user creates multiple sessions the account will
-		// succeed in deletion
-		return &userCloser{
-			username: name,
-			users:    u,
-			backend:  u.backend,
-		}, nil
 	}
 
-	err = u.doWithUserLock(func(_ types.SemaphoreLease) error {
+	return trace.Wrap(u.doWithUserLock(func(_ types.SemaphoreLease) error {
 		if ui.Mode != types.CreateHostUserMode_HOST_USER_MODE_KEEP {
 			if err := u.storage.UpsertHostUserInteractionTime(u.ctx, name, time.Now()); err != nil {
 				return trace.Wrap(err)
 			}
 		}
+
 		if ui.GID != "" {
 			// if gid is specified a group must already exist
 			err := u.backend.CreateGroup(name, ui.GID)
@@ -329,7 +298,7 @@ func (u *HostUserManagement) UpsertUser(name string, ui *services.HostUsersInfo)
 			}
 		}
 
-		err = u.backend.CreateUser(name, groups, ui.UID, ui.GID)
+		err = u.backend.CreateUser(name, ui.Groups, home, ui.UID, ui.GID)
 		if err != nil && !trace.IsAlreadyExists(err) {
 			return trace.WrapWithMessage(err, "error while creating user")
 		}
@@ -346,22 +315,44 @@ func (u *HostUserManagement) UpsertUser(name string, ui *services.HostUsersInfo)
 		}
 
 		return nil
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
+	}))
+}
+
+// UpsertUser creates a temporary Teleport user in the TeleportServiceGroup
+func (u *HostUserManagement) UpsertUser(name string, ui services.HostUsersInfo) (io.Closer, error) {
+	var groupErrs []error
+	// cloning to prevent unintended mutation of passed in Groups slice
+	ui.Groups = slices.Clone(ui.Groups)
+	for _, group := range append(ui.Groups, types.TeleportServiceGroup) {
+		if err := u.createGroupIfNotExist(group); err != nil {
+			groupErrs = append(groupErrs, err)
+		}
 	}
 
-	if ui.Mode == types.CreateHostUserMode_HOST_USER_MODE_KEEP {
-		return nil, nil
+	if err := trace.NewAggregate(groupErrs...); err != nil {
+		return nil, trace.WrapWithMessage(err, "error while creating groups")
 	}
 
-	closer := &userCloser{
-		username: name,
-		users:    u,
-		backend:  u.backend,
+	var closer io.Closer
+	if ui.Mode == types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP || ui.Mode == types.CreateHostUserMode_HOST_USER_MODE_DROP {
+		closer = &userCloser{
+			username: name,
+			users:    u,
+			backend:  u.backend,
+		}
 	}
 
-	return closer, trace.Wrap(err)
+	if err := u.updateUser(name, ui); err != nil {
+		if !errors.Is(err, user.UnknownUserError(name)) {
+			return nil, trace.Wrap(err)
+		}
+
+		if err := u.createUser(name, ui); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return closer, nil
 }
 
 func (u *HostUserManagement) doWithUserLock(f func(types.SemaphoreLease) error) error {

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -44,6 +45,8 @@ type testHostUserBackend struct {
 	userUID map[string]string
 	// userGID: user -> gid
 	userGID map[string]string
+
+	setUserGroupsCalls int
 }
 
 func newTestUserMgmt() *testHostUserBackend {
@@ -66,28 +69,40 @@ func (tm *testHostUserBackend) GetAllUsers() ([]string, error) {
 
 func (tm *testHostUserBackend) Lookup(username string) (*user.User, error) {
 	if _, ok := tm.users[username]; !ok {
-		return nil, nil
+		return nil, user.UnknownUserError(username)
 	}
 	return &user.User{
 		Username: username,
+		Uid:      tm.userUID[username],
+		Gid:      tm.userGID[username],
 	}, nil
 }
 
 func (tm *testHostUserBackend) LookupGroup(groupname string) (*user.Group, error) {
+	gid, ok := tm.groups[groupname]
+	if !ok {
+		return nil, user.UnknownGroupError(groupname)
+	}
 	return &user.Group{
-		Gid:  tm.groups[groupname],
+		Gid:  gid,
 		Name: groupname,
 	}, nil
 }
 
 func (tm *testHostUserBackend) LookupGroupByID(gid string) (*user.Group, error) {
-	return &user.Group{
-		Gid:  tm.groups[gid],
-		Name: gid,
-	}, nil
+	for groupName, groupGid := range tm.groups {
+		if groupGid == gid {
+			return &user.Group{
+				Gid:  gid,
+				Name: groupName,
+			}, nil
+		}
+	}
+	return nil, user.UnknownGroupIdError(gid)
 }
 
 func (tm *testHostUserBackend) SetUserGroups(name string, groups []string) error {
+	tm.setUserGroupsCalls++
 	if _, ok := tm.users[name]; !ok {
 		return trace.NotFound("User %q doesn't exist", name)
 	}
@@ -96,10 +111,12 @@ func (tm *testHostUserBackend) SetUserGroups(name string, groups []string) error
 }
 
 func (tm *testHostUserBackend) UserGIDs(u *user.User) ([]string, error) {
-	ids := make([]string, 0, len(tm.users[u.Username]))
+	ids := make([]string, 0, len(tm.users[u.Username])+1)
 	for _, id := range tm.users[u.Username] {
 		ids = append(ids, tm.groups[id])
 	}
+	// Include primary group.
+	ids = append(ids, u.Gid)
 	return ids, nil
 }
 
@@ -108,15 +125,27 @@ func (tm *testHostUserBackend) CreateGroup(group, gid string) error {
 	if ok {
 		return trace.AlreadyExists("Group %q, already exists", group)
 	}
-	tm.groups[group] = fmt.Sprint(len(tm.groups) + 1)
+	if gid == "" {
+		gid = fmt.Sprint(len(tm.groups) + 1)
+	}
+	tm.groups[group] = gid
 	return nil
 }
 
-func (tm *testHostUserBackend) CreateUser(user string, groups []string, uid, gid string) error {
+func (tm *testHostUserBackend) CreateUser(user string, groups []string, home, uid, gid string) error {
 	_, ok := tm.users[user]
 	if ok {
 		return trace.AlreadyExists("Group %q, already exists", user)
 	}
+
+	if uid == "" {
+		uid = fmt.Sprint(len(tm.users) + 1)
+	}
+	if gid == "" {
+		gid = fmt.Sprint(len(tm.groups) + 1)
+	}
+	// Ensure that the user has a primary group. It's OK if it already exists.
+	_ = tm.CreateGroup(user, gid)
 	tm.users[user] = groups
 	tm.userUID[user] = uid
 	tm.userGID[user] = gid
@@ -130,6 +159,10 @@ func (tm *testHostUserBackend) DeleteUser(user string) error {
 
 func (tm *testHostUserBackend) CreateHomeDirectory(user, uid, gid string) error {
 	return nil
+}
+
+func (tm *testHostUserBackend) GetDefaultHomeDirectory(user string) (string, error) {
+	return "", nil
 }
 
 // RemoveSudoersFile implements HostUsersBackend
@@ -176,36 +209,41 @@ func TestUserMgmt_CreateTemporaryUser(t *testing.T) {
 		storage: pres,
 	}
 
-	userinfo := &services.HostUsersInfo{
+	userinfo := services.HostUsersInfo{
 		Groups: []string{"hello", "sudo"},
 		Mode:   types.CreateHostUserMode_HOST_USER_MODE_DROP,
 	}
 	// create a user with some groups
 	closer, err := users.UpsertUser("bob", userinfo)
 	require.NoError(t, err)
-	require.NotNil(t, closer, "user closer was nil")
+	// NOTE (eriktate): assert.Nil and assert.NotNil will pass for nil interfaces where nilInterface != nil.
+	// assert.Equal and assert.NotEqual perform the same comparisons we would in non-test code and are safer
+	// for interface types.
+	//
+	// https://glucn.com/posts/2019-05-20-golang-an-interface-holding-a-nil-value-is-not-nil
+	require.NotEqual(t, nil, closer, "user closer was nil")
 
 	// temproary users must always include the teleport-service group
 	require.Equal(t, []string{
 		"hello", "sudo", types.TeleportServiceGroup,
 	}, backend.users["bob"])
 
-	// try creat the same user again
+	// try create the same user again
 	secondCloser, err := users.UpsertUser("bob", userinfo)
 	require.NoError(t, err)
-	require.NotNil(t, secondCloser)
+	require.NotEqual(t, nil, secondCloser)
 
 	// Close will remove the user if the user is in the teleport-system group
 	require.NoError(t, closer.Close())
 	require.NotContains(t, backend.users, "bob")
 
 	backend.CreateGroup("testgroup", "")
-	backend.CreateUser("simon", []string{}, "", "")
+	backend.CreateUser("simon", []string{}, "", "", "")
 
 	// try to create a temporary user for simon
 	closer, err = users.UpsertUser("simon", userinfo)
 	require.NoError(t, err)
-	require.Nil(t, closer)
+	require.NotEqual(t, nil, closer)
 }
 
 func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
@@ -223,12 +261,12 @@ func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 		backend: backend,
 	}
 
-	closer, err := users.UpsertUser("bob", &services.HostUsersInfo{
+	closer, err := users.UpsertUser("bob", services.HostUsersInfo{
 		Groups: []string{"hello", "sudo"},
 		Mode:   types.CreateHostUserMode_HOST_USER_MODE_DROP,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, closer)
+	require.NotEqual(t, nil, closer)
 
 	require.Empty(t, backend.sudoers)
 	sudoers.WriteSudoers("bob", []string{"validsudoers"})
@@ -246,13 +284,13 @@ func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 		}
 		// test user already exists but teleport-service group has not yet
 		// been created
-		backend.CreateUser("testuser", nil, "", "")
-		_, err := users.UpsertUser("testuser", &services.HostUsersInfo{
+		backend.CreateUser("testuser", nil, "", "", "")
+		_, err := users.UpsertUser("testuser", services.HostUsersInfo{
 			Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
 		})
 		require.NoError(t, err)
 		backend.CreateGroup(types.TeleportServiceGroup, "")
-		_, err = users.UpsertUser("testuser", &services.HostUsersInfo{
+		_, err = users.UpsertUser("testuser", services.HostUsersInfo{
 			Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
 		})
 		require.NoError(t, err)
@@ -291,9 +329,12 @@ func TestUserMgmt_DeleteAllTeleportSystemUsers(t *testing.T) {
 			mgmt.CreateGroup(group, "")
 		}
 		if slices.Contains(user.groups, types.TeleportServiceGroup) {
-			users.UpsertUser(user.user, &services.HostUsersInfo{Groups: user.groups})
+			users.UpsertUser(user.user, services.HostUsersInfo{
+				Groups: user.groups,
+				Mode:   types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
+			})
 		} else {
-			mgmt.CreateUser(user.user, user.groups, "", "")
+			mgmt.CreateUser(user.user, user.groups, "", "", "")
 		}
 	}
 	require.NoError(t, users.DeleteAllUsers())
@@ -355,4 +396,90 @@ func TestIsUnknownGroupError(t *testing.T) {
 	} {
 		require.Equal(t, tc.isUnknownGroupError, isUnknownGroupError(tc.err, unknownGroupName))
 	}
+}
+
+func TestUpdateUserGroups(t *testing.T) {
+	t.Parallel()
+
+	backend := newTestUserMgmt()
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	pres := local.NewPresenceService(bk)
+	users := HostUserManagement{
+		backend: backend,
+		storage: pres,
+	}
+
+	allGroups := []string{"foo", "bar", "baz", "quux"}
+	for _, group := range allGroups {
+		require.NoError(t, backend.CreateGroup(group, ""))
+	}
+
+	userinfo := services.HostUsersInfo{
+		Groups: allGroups[:2],
+		Mode:   types.CreateHostUserMode_HOST_USER_MODE_KEEP,
+	}
+
+	// Create a user with some groups.
+	closer, err := users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, closer)
+	assert.Zero(t, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, userinfo.Groups, backend.users["alice"])
+
+	// Update user with new groups.
+	userinfo.Groups = allGroups[2:]
+
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, closer)
+	assert.Equal(t, 1, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, userinfo.Groups, backend.users["alice"])
+
+	// Upsert again with same groups should not call SetUserGroups.
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, closer)
+	assert.Equal(t, 1, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, userinfo.Groups, backend.users["alice"])
+}
+
+func Test_DontDropExistingUser(t *testing.T) {
+	t.Parallel()
+
+	backend := newTestUserMgmt()
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	pres := local.NewPresenceService(bk)
+	users := HostUserManagement{
+		backend: backend,
+		storage: pres,
+	}
+
+	allGroups := []string{"foo", "bar", "baz", "quux"}
+	for _, group := range allGroups {
+		require.NoError(t, backend.CreateGroup(group, ""))
+	}
+
+	userinfo := services.HostUsersInfo{
+		Groups: allGroups[:2],
+		Mode:   types.CreateHostUserMode_HOST_USER_MODE_KEEP,
+	}
+
+	// Create a user with some groups.
+	closer, err := users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, closer)
+	assert.Zero(t, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, userinfo.Groups, backend.users["alice"])
+
+	// Upserting an existing user in INSECURE_DROP mode shouldn't make them ephemeral
+	userinfo.Mode = types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP
+	userinfo.Groups = allGroups[2:]
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.NotEqual(t, nil, closer)
+	assert.Equal(t, 1, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, userinfo.Groups, backend.users["alice"])
+	assert.NotContains(t, backend.users["alice"], types.TeleportServiceGroup)
 }


### PR DESCRIPTION
Backport #45446 to branch/v14

changelog: Fixed an issue where users created in keep mode could effectively become insecure_drop and get cleaned up as a result
