### PR TITLE
[Web] Log user out if one of their roles is not found

### DIFF
--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -246,6 +246,7 @@ func (s *AccessService) GetRole(ctx context.Context, name string) (types.Role, e
 	item, err := s.Get(ctx, backend.Key(rolesPrefix, name, paramsPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
+			// This error message format should be kept in sync with web/packages/teleport/src/services/api/api.isRoleNotFoundError
 			return nil, trace.NotFound("role %v is not found", name)
 		}
 		return nil, trace.Wrap(err)

--- a/web/packages/teleport/src/Login/Login.test.tsx
+++ b/web/packages/teleport/src/Login/Login.test.tsx
@@ -33,6 +33,7 @@ beforeEach(() => {
   jest.restoreAllMocks();
   jest.spyOn(history, 'push').mockImplementation();
   jest.spyOn(history, 'getRedirectParam').mockImplementation(() => '/');
+  jest.spyOn(history, 'hasAccessChangedParam').mockImplementation(() => false);
   user = userEvent.setup();
 });
 
@@ -183,5 +184,14 @@ describe('test MOTD', () => {
     expect(
       screen.queryByText('Welcome to cluster, your activity will be recorded.')
     ).not.toBeInTheDocument();
+  });
+
+  test('access changed message renders when the URL param is set', () => {
+    jest.spyOn(history, 'hasAccessChangedParam').mockImplementation(() => true);
+
+    render(<Login />);
+
+    expect(screen.getByText(/sign in to teleport/i)).toBeInTheDocument();
+    expect(screen.getByText(/Your access has changed/i)).toBeInTheDocument();
   });
 });

--- a/web/packages/teleport/src/components/Authenticated/ErrorDialogue.tsx
+++ b/web/packages/teleport/src/components/Authenticated/ErrorDialogue.tsx
@@ -42,7 +42,11 @@ export function ErrorDialog({ errMsg }: { errMsg: string }) {
       </DialogContent>
       <DialogFooter>
         <ButtonSecondary
-          onClick={() => history.goToLogin(true /* rememberLocation */)}
+          onClick={() =>
+            history.goToLogin({
+              rememberLocation: true,
+            })
+          }
         >
           Go to Login
         </ButtonSecondary>

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
@@ -20,7 +20,14 @@ import React from 'react';
 
 import { render, fireEvent, screen } from 'design/utils/testing';
 
+import history from 'teleport/services/history';
+
 import FormLogin, { Props } from './FormLogin';
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  jest.spyOn(history, 'hasAccessChangedParam').mockImplementation(() => false);
+});
 
 test('primary username and password with mfa off', () => {
   const onLogin = jest.fn();

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
@@ -50,6 +50,7 @@ import { StepSlider, StepComponentProps } from 'design/StepSlider';
 import { P } from 'design/Text/Text';
 
 import { UserCredentials } from 'teleport/services/auth';
+import history from 'teleport/services/history';
 
 import { PasskeyIcons } from '../Passkeys';
 
@@ -87,6 +88,8 @@ export default function LoginForm(props: Props) {
     errorMessage = attempt.message;
   }
 
+  const showAccessChangedMessage = history.hasAccessChangedParam();
+
   // Everything below requires local auth to be enabled.
   return (
     <Card my="5" mx="auto" width={500} py={4}>
@@ -94,6 +97,11 @@ export default function LoginForm(props: Props) {
         Sign in to Teleport
       </Text>
       {errorMessage && <Alerts.Danger m={4}>{errorMessage}</Alerts.Danger>}
+      {showAccessChangedMessage && (
+        <Alerts.Warning m={4}>
+          Your access has changed. Please re-login.
+        </Alerts.Warning>
+      )}
       {allowedAuthTypes.length > 0 ? (
         <StepSlider<typeof loginViews>
           flows={loginViews}

--- a/web/packages/teleport/src/services/api/api.test.ts
+++ b/web/packages/teleport/src/services/api/api.test.ts
@@ -16,7 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import api, { MFA_HEADER, defaultRequestOptions, getAuthHeaders } from './api';
+import api, {
+  MFA_HEADER,
+  defaultRequestOptions,
+  getAuthHeaders,
+  isRoleNotFoundError,
+} from './api';
 
 describe('api.fetch', () => {
   const mockedFetch = jest.spyOn(global, 'fetch').mockResolvedValue({} as any); // we don't care about response
@@ -174,4 +179,15 @@ test('fetchJson does not return any', () => {
   };
 
   expect(true).toBe(true);
+});
+
+test('isRoleNotFoundError correctly identifies role not found errors', () => {
+  const errorMessage1 = 'role admin is not found';
+  expect(isRoleNotFoundError(errorMessage1)).toBe(true);
+
+  const errorMessage2 = '    role test-role is not found ';
+  expect(isRoleNotFoundError(errorMessage2)).toBe(true);
+
+  const errorMessage3 = 'failed to list access lists';
+  expect(isRoleNotFoundError(errorMessage3)).toBe(false);
 });

--- a/web/packages/teleport/src/services/history/history.test.ts
+++ b/web/packages/teleport/src/services/history/history.test.ts
@@ -118,10 +118,62 @@ describe('services/history', () => {
         .spyOn(history, 'getRoutes')
         .mockReturnValue(['/web/login', '/current-location']);
       history.original().location.pathname = '/current-location';
-      history.goToLogin(true);
+      history.goToLogin({ rememberLocation: true });
 
       const expected =
         '/web/login?redirect_uri=http://localhost/current-location';
+      expect(history._pageRefresh).toHaveBeenCalledWith(expected);
+    });
+
+    it('should navigate to login with access_changed param and no redirect_uri', () => {
+      jest
+        .spyOn(history, 'getRoutes')
+        .mockReturnValue(['/web/login', '/current-location']);
+      history.original().location.pathname = '/current-location';
+      history.goToLogin({ withAccessChangedMessage: true });
+
+      const expected = '/web/login?access_changed';
+      expect(history._pageRefresh).toHaveBeenCalledWith(expected);
+    });
+
+    it('should navigate to login with access_changed param and redirect_uri', () => {
+      jest
+        .spyOn(history, 'getRoutes')
+        .mockReturnValue(['/web/login', '/current-location']);
+      history.original().location.pathname = '/current-location';
+      history.goToLogin({
+        rememberLocation: true,
+        withAccessChangedMessage: true,
+      });
+
+      const expected =
+        '/web/login?access_changed&redirect_uri=http://localhost/current-location';
+      expect(history._pageRefresh).toHaveBeenCalledWith(expected);
+    });
+
+    it('should navigate to login with no params', () => {
+      jest
+        .spyOn(history, 'getRoutes')
+        .mockReturnValue(['/web/login', '/current-location']);
+      history.original().location.pathname = '/current-location';
+      history.goToLogin();
+
+      const expected = '/web/login';
+      expect(history._pageRefresh).toHaveBeenCalledWith(expected);
+    });
+
+    it('should preserve query params in the redirect_uri', () => {
+      jest
+        .spyOn(history, 'getRoutes')
+        .mockReturnValue(['/web/login', '/current-location']);
+      history.original().location.pathname = '/current-location?test=value';
+      history.goToLogin({
+        rememberLocation: true,
+        withAccessChangedMessage: true,
+      });
+
+      const expected =
+        '/web/login?access_changed&redirect_uri=http://localhost/current-location?test=value';
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
   });

--- a/web/packages/teleport/src/services/history/history.ts
+++ b/web/packages/teleport/src/services/history/history.ts
@@ -53,22 +53,40 @@ const history = {
     window.location.reload();
   },
 
-  goToLogin(rememberLocation = false) {
-    let url = cfg.routes.login;
+  goToLogin({
+    rememberLocation = false,
+    withAccessChangedMessage = false,
+  } = {}) {
+    const params: string[] = [];
+
+    // withAccessChangedMessage determines whether the login page the user is redirected to should include a notice that
+    // they were logged out due to their roles having changed.
+    if (withAccessChangedMessage) {
+      params.push('access_changed');
+    }
+
     if (rememberLocation) {
       const { search, pathname } = _inst.location;
       const knownRoute = this.ensureKnownRoute(pathname);
       const knownRedirect = this.ensureBaseUrl(knownRoute);
       const query = search ? encodeURIComponent(search) : '';
-
-      url = `${url}?redirect_uri=${knownRedirect}${query}`;
+      params.push(`redirect_uri=${knownRedirect}${query}`);
     }
+
+    const queryString = params.join('&');
+    const url = queryString
+      ? `${cfg.routes.login}?${queryString}`
+      : cfg.routes.login;
 
     this._pageRefresh(url);
   },
 
   getRedirectParam() {
     return getUrlParameter('redirect_uri', this.original().location.search);
+  },
+
+  hasAccessChangedParam() {
+    return hasUrlParameter('access_changed', this.original().location.search);
   },
 
   ensureKnownRoute(route = '') {
@@ -123,4 +141,9 @@ export function getUrlParameter(name = '', path = '') {
   const params = new URLSearchParams(path);
   const value = params.get(name);
   return value || '';
+}
+
+function hasUrlParameter(name = '', path = '') {
+  const params = new URLSearchParams(path);
+  return params.has(name);
 }

--- a/web/packages/teleport/src/services/websession/websession.ts
+++ b/web/packages/teleport/src/services/websession/websession.ts
@@ -41,20 +41,24 @@ const session = {
       if (response.samlSloUrl) {
         window.open(response.samlSloUrl, '_self');
       } else {
-        history.goToLogin(rememberLocation);
+        history.goToLogin({ rememberLocation });
       }
     });
   },
 
-  logoutWithoutSlo(rememberLocation = false) {
+  logoutWithoutSlo({
+    rememberLocation = false,
+    withAccessChangedMessage = false,
+  } = {}) {
     api.delete(cfg.api.webSessionPath).finally(() => {
-      history.goToLogin(rememberLocation);
+      this.clear();
+      history.goToLogin({ rememberLocation, withAccessChangedMessage });
     });
   },
 
   clearBrowserSession(rememberLocation = false) {
     this.clear();
-    history.goToLogin(rememberLocation);
+    history.goToLogin({ rememberLocation });
   },
 
   clear() {


### PR DESCRIPTION
## Purpose

This PR solves https://github.com/gravitational/teleport/issues/8835
This PR solves https://github.com/gravitational/teleport/issues/41074

`e` counterpart: https://github.com/gravitational/teleport.e/pull/4900

Previously, if a user's role was deleted after they were logged in, all requests in the WebUI would fail with a `role not found` error and the UI would become unusable. With this change, the user will be logged out and redirected to the login page, with a notice on the login screen:

![image](https://github.com/user-attachments/assets/404c22a3-1633-4d46-8faa-507df61011f9)

changelog: Fix bug that renders WebUI unusable if a role is deleted while it is still being in use by the logged in user