### PR TITLE
Add backend.NewKey function

### DIFF
--- a/lib/auth/migration/migration.go
+++ b/lib/auth/migration/migration.go
@@ -163,7 +163,7 @@ type migrationStatus struct {
 	Completed time.Time      `json:"completed"`
 }
 
-var key = backend.Key("migrations", "current")
+var key = backend.NewKey("migrations", "current")
 
 func setCurrentMigration(ctx context.Context, b backend.Backend, status migrationStatus) error {
 	value, err := json.Marshal(status)

--- a/lib/auth/storage/storage.go
+++ b/lib/auth/storage/storage.go
@@ -88,7 +88,7 @@ func (p *ProcessStorage) Close() error {
 
 // GetState reads rotation state from disk.
 func (p *ProcessStorage) GetState(ctx context.Context, role types.SystemRole) (*state.StateV2, error) {
-	item, err := p.stateStorage.Get(ctx, backend.Key(statesPrefix, strings.ToLower(role.String()), stateName))
+	item, err := p.stateStorage.Get(ctx, backend.NewKey(statesPrefix, strings.ToLower(role.String()), stateName))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -121,7 +121,7 @@ func (p *ProcessStorage) CreateState(role types.SystemRole, state state.StateV2)
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:   backend.Key(statesPrefix, strings.ToLower(role.String()), stateName),
+		Key:   backend.NewKey(statesPrefix, strings.ToLower(role.String()), stateName),
 		Value: value,
 	}
 	_, err = p.stateStorage.Create(context.TODO(), item)
@@ -141,7 +141,7 @@ func (p *ProcessStorage) WriteState(role types.SystemRole, state state.StateV2) 
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:   backend.Key(statesPrefix, strings.ToLower(role.String()), stateName),
+		Key:   backend.NewKey(statesPrefix, strings.ToLower(role.String()), stateName),
 		Value: value,
 	}
 	_, err = p.stateStorage.Put(context.TODO(), item)
@@ -156,7 +156,7 @@ func (p *ProcessStorage) ReadIdentity(name string, role types.SystemRole) (*stat
 	if name == "" {
 		return nil, trace.BadParameter("missing parameter name")
 	}
-	item, err := p.stateStorage.Get(context.TODO(), backend.Key(idsPrefix, strings.ToLower(role.String()), name))
+	item, err := p.stateStorage.Get(context.TODO(), backend.NewKey(idsPrefix, strings.ToLower(role.String()), name))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -201,7 +201,7 @@ func (p *ProcessStorage) WriteIdentity(name string, id state.Identity) error {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:   backend.Key(idsPrefix, strings.ToLower(id.ID.Role.String()), name),
+		Key:   backend.NewKey(idsPrefix, strings.ToLower(id.ID.Role.String()), name),
 		Value: value,
 	}
 	_, err = p.stateStorage.Put(context.TODO(), item)
@@ -210,7 +210,7 @@ func (p *ProcessStorage) WriteIdentity(name string, id state.Identity) error {
 
 // GetTeleportVersion reads the last known Teleport version from storage.
 func (p *ProcessStorage) GetTeleportVersion(ctx context.Context) (*semver.Version, error) {
-	item, err := p.stateStorage.Get(ctx, backend.Key(teleportPrefix, lastKnownVersion))
+	item, err := p.stateStorage.Get(ctx, backend.NewKey(teleportPrefix, lastKnownVersion))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -223,7 +223,7 @@ func (p *ProcessStorage) WriteTeleportVersion(ctx context.Context, version *semv
 		return trace.BadParameter("wrong version parameter")
 	}
 	item := backend.Item{
-		Key:   backend.Key(teleportPrefix, lastKnownVersion),
+		Key:   backend.NewKey(teleportPrefix, lastKnownVersion),
 		Value: []byte(version.String()),
 	}
 	_, err := p.stateStorage.Put(ctx, item)

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -437,6 +437,12 @@ const Separator = '/'
 // Key joins parts into path separated by Separator,
 // makes sure path always starts with Separator ("/")
 func Key(parts ...string) []byte {
+	return NewKey(parts...)
+}
+
+// NewKey joins parts into path separated by Separator,
+// makes sure path always starts with Separator ("/")
+func NewKey(parts ...string) []byte {
 	return internalKey("", parts...)
 }
 
@@ -445,7 +451,7 @@ func Key(parts ...string) []byte {
 // math child paths and not other paths that have the resulting path
 // as a prefix.
 func ExactKey(parts ...string) []byte {
-	return append(Key(parts...), Separator)
+	return append(NewKey(parts...), Separator)
 }
 
 func internalKey(internalPrefix string, parts ...string) []byte {

--- a/lib/backend/clone.go
+++ b/lib/backend/clone.go
@@ -52,7 +52,7 @@ type CloneConfig struct {
 func Clone(ctx context.Context, src, dst Backend, parallel int, force bool) error {
 	log := slog.With(teleport.ComponentKey, "clone")
 	itemC := make(chan Item, bufferSize)
-	start := Key("")
+	start := NewKey("")
 	migrated := &atomic.Int32{}
 
 	if parallel <= 0 {

--- a/lib/backend/clone_test.go
+++ b/lib/backend/clone_test.go
@@ -44,7 +44,7 @@ func TestClone(t *testing.T) {
 
 	for i := 0; i < itemCount; i++ {
 		item := backend.Item{
-			Key:   backend.Key(fmt.Sprintf("key-%05d", i)),
+			Key:   backend.NewKey(fmt.Sprintf("key-%05d", i)),
 			Value: []byte(fmt.Sprintf("value-%d", i)),
 		}
 		_, err := src.Put(ctx, item)
@@ -55,7 +55,7 @@ func TestClone(t *testing.T) {
 	err = backend.Clone(ctx, src, dst, 10, false)
 	require.NoError(t, err)
 
-	start := backend.Key("")
+	start := backend.NewKey("")
 	result, err := dst.GetRange(ctx, start, backend.RangeEnd(start), 0)
 	require.NoError(t, err)
 
@@ -80,7 +80,7 @@ func TestCloneForce(t *testing.T) {
 
 	for i := 0; i < itemCount; i++ {
 		item := backend.Item{
-			Key:   backend.Key(fmt.Sprintf("key-%05d", i)),
+			Key:   backend.NewKey(fmt.Sprintf("key-%05d", i)),
 			Value: []byte(fmt.Sprintf("value-%d", i)),
 		}
 		_, err := src.Put(ctx, item)
@@ -97,7 +97,7 @@ func TestCloneForce(t *testing.T) {
 	err = backend.Clone(ctx, src, dst, 10, true)
 	require.NoError(t, err)
 
-	start := backend.Key("")
+	start := backend.NewKey("")
 	result, err := dst.GetRange(ctx, start, backend.RangeEnd(start), 0)
 	require.NoError(t, err)
 

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -219,7 +219,7 @@ func TestLeaseBucketing(t *testing.T) {
 
 	buckets := make(map[int64]struct{})
 	for i := 0; i < count; i++ {
-		key := backend.Key(pfx, fmt.Sprintf("%d", i))
+		key := backend.NewKey(pfx, fmt.Sprintf("%d", i))
 		_, err := bk.Put(ctx, backend.Item{
 			Key:     key,
 			Value:   []byte(fmt.Sprintf("val-%d", i)),
@@ -234,7 +234,7 @@ func TestLeaseBucketing(t *testing.T) {
 		time.Sleep(time.Millisecond * 200)
 	}
 
-	start := backend.Key(pfx, "")
+	start := backend.NewKey(pfx, "")
 
 	rslt, err := bk.GetRange(ctx, start, backend.RangeEnd(start), backend.NoLimit)
 	require.NoError(t, err)

--- a/lib/backend/kubernetes/kubernetes_test.go
+++ b/lib/backend/kubernetes/kubernetes_test.go
@@ -160,7 +160,7 @@ func TestBackend_Get(t *testing.T) {
 				replicaName: "agent-0",
 			},
 			args: args{
-				key: backend.Key("ids", "kube", "current"),
+				key: backend.NewKey("ids", "kube", "current"),
 			},
 			want: nil,
 
@@ -169,7 +169,7 @@ func TestBackend_Get(t *testing.T) {
 		{
 			name: "secret exists and key is present",
 			args: args{
-				key: backend.Key("ids", "kube", "current"),
+				key: backend.NewKey("ids", "kube", "current"),
 			},
 			fields: fields{
 				objects: []runtime.Object{
@@ -177,7 +177,7 @@ func TestBackend_Get(t *testing.T) {
 						"agent-0-state",
 						"test",
 						map[string][]byte{
-							backendKeyToSecret(backend.Key("ids", "kube", "current")): payloadTestData,
+							backendKeyToSecret(backend.NewKey("ids", "kube", "current")): payloadTestData,
 						},
 					),
 				},
@@ -189,7 +189,7 @@ func TestBackend_Get(t *testing.T) {
 		{
 			name: "secret exists and key is present but empty",
 			args: args{
-				key: backend.Key("ids", "kube", "current"),
+				key: backend.NewKey("ids", "kube", "current"),
 			},
 			fields: fields{
 				objects: []runtime.Object{
@@ -197,7 +197,7 @@ func TestBackend_Get(t *testing.T) {
 						"agent-0-state",
 						"test",
 						map[string][]byte{
-							backendKeyToSecret(backend.Key("ids", "kube", "current")): payloadEmpty,
+							backendKeyToSecret(backend.NewKey("ids", "kube", "current")): payloadEmpty,
 						},
 					),
 				},
@@ -210,7 +210,7 @@ func TestBackend_Get(t *testing.T) {
 		{
 			name: "secret exists but key not present",
 			args: args{
-				key: backend.Key("ids", "kube", "replacement"),
+				key: backend.NewKey("ids", "kube", "replacement"),
 			},
 			fields: fields{
 				objects: []runtime.Object{
@@ -218,7 +218,7 @@ func TestBackend_Get(t *testing.T) {
 						"agent-0-state",
 						"test",
 						map[string][]byte{
-							backendKeyToSecret(backend.Key("ids", "kube", "current")): payloadTestData,
+							backendKeyToSecret(backend.NewKey("ids", "kube", "current")): payloadTestData,
 						},
 					),
 				},
@@ -283,7 +283,7 @@ func TestBackend_Put(t *testing.T) {
 			},
 			args: args{
 				item: backend.Item{
-					Key:   backend.Key("ids", "kube", "current"),
+					Key:   backend.NewKey("ids", "kube", "current"),
 					Value: payloadTestData,
 				},
 			},
@@ -291,7 +291,7 @@ func TestBackend_Put(t *testing.T) {
 				"agent-0-state",
 				"test",
 				map[string][]byte{
-					backendKeyToSecret(backend.Key("ids", "kube", "current")): payloadTestData,
+					backendKeyToSecret(backend.NewKey("ids", "kube", "current")): payloadTestData,
 				},
 			),
 		},
@@ -299,7 +299,7 @@ func TestBackend_Put(t *testing.T) {
 			name: "secret exists and has keys",
 			args: args{
 				item: backend.Item{
-					Key:   backend.Key("ids", "kube", "current2"),
+					Key:   backend.NewKey("ids", "kube", "current2"),
 					Value: payloadTestData,
 				},
 			},
@@ -309,7 +309,7 @@ func TestBackend_Put(t *testing.T) {
 						"agent-0-state",
 						"test",
 						map[string][]byte{
-							backendKeyToSecret(backend.Key("ids", "kube", "current")): payloadTestData,
+							backendKeyToSecret(backend.NewKey("ids", "kube", "current")): payloadTestData,
 						},
 					),
 				},
@@ -320,8 +320,8 @@ func TestBackend_Put(t *testing.T) {
 				"agent-0-state",
 				"test",
 				map[string][]byte{
-					backendKeyToSecret(backend.Key("ids", "kube", "current")):  payloadTestData,
-					backendKeyToSecret(backend.Key("ids", "kube", "current2")): payloadTestData,
+					backendKeyToSecret(backend.NewKey("ids", "kube", "current")):  payloadTestData,
+					backendKeyToSecret(backend.NewKey("ids", "kube", "current2")): payloadTestData,
 				},
 			),
 		},

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -3442,7 +3442,7 @@ func TestInvalidDatabases(t *testing.T) {
 				value, err := services.MarshalDatabase(db)
 				require.NoError(t, err)
 				_, err = b.Create(ctx, backend.Item{
-					Key:     backend.Key("db", db.GetName()),
+					Key:     backend.NewKey("db", db.GetName()),
 					Value:   value,
 					Expires: db.Expiry(),
 				})
@@ -3464,7 +3464,7 @@ func TestInvalidDatabases(t *testing.T) {
 				marshalledDB, err := services.MarshalDatabase(validDB)
 				require.NoError(t, err)
 				_, err = b.Create(ctx, backend.Item{
-					Key:     backend.Key("db", validDB.GetName()),
+					Key:     backend.NewKey("db", validDB.GetName()),
 					Value:   marshalledDB,
 					Expires: validDB.Expiry(),
 				})
@@ -3484,7 +3484,7 @@ func TestInvalidDatabases(t *testing.T) {
 				value, err := services.MarshalDatabase(invalidDB)
 				require.NoError(t, err)
 				_, err = b.Update(ctx, backend.Item{
-					Key:     backend.Key("db", cacheDB.GetName()),
+					Key:     backend.NewKey("db", cacheDB.GetName()),
 					Value:   value,
 					Expires: invalidDB.Expiry(),
 				})

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6505,7 +6505,7 @@ func persistHostIDToStorages(ctx context.Context, cfg *servicecfg.Config, kubeBa
 // loadHostIDFromKubeSecret reads the host_uuid from the Kubernetes secret with
 // the expected key: `/host_uuid`.
 func loadHostIDFromKubeSecret(ctx context.Context, kubeBackend kubernetesBackend) (string, error) {
-	item, err := kubeBackend.Get(ctx, backend.Key(utils.HostUUIDFile))
+	item, err := kubeBackend.Get(ctx, backend.NewKey(utils.HostUUIDFile))
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -6518,7 +6518,7 @@ func writeHostIDToKubeSecret(ctx context.Context, kubeBackend kubernetesBackend,
 	_, err := kubeBackend.Put(
 		ctx,
 		backend.Item{
-			Key:   backend.Key(utils.HostUUIDFile),
+			Key:   backend.NewKey(utils.HostUUIDFile),
 			Value: []byte(id),
 		},
 	)

--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -50,7 +50,7 @@ func NewAccessService(backend backend.Backend) *AccessService {
 
 // DeleteAllRoles deletes all roles
 func (s *AccessService) DeleteAllRoles(ctx context.Context) error {
-	startKey := backend.Key(rolesPrefix)
+	startKey := backend.NewKey(rolesPrefix)
 	endKey := backend.RangeEnd(startKey)
 	return s.DeleteRange(ctx, startKey, endKey)
 }
@@ -101,7 +101,7 @@ func (s *AccessService) ListRoles(ctx context.Context, req *proto.ListRolesReque
 
 	startKey := backend.ExactKey(rolesPrefix)
 	if req.StartKey != "" {
-		startKey = backend.Key(rolesPrefix, req.StartKey, paramsPrefix)
+		startKey = backend.NewKey(rolesPrefix, req.StartKey, paramsPrefix)
 	}
 
 	endKey := backend.RangeEnd(backend.ExactKey(rolesPrefix))
@@ -168,7 +168,7 @@ func (s *AccessService) CreateRole(ctx context.Context, role types.Role) (types.
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(rolesPrefix, role.GetName(), paramsPrefix),
+		Key:      backend.NewKey(rolesPrefix, role.GetName(), paramsPrefix),
 		Value:    value,
 		Expires:  role.Expiry(),
 		Revision: rev,
@@ -196,7 +196,7 @@ func (s *AccessService) UpdateRole(ctx context.Context, role types.Role) (types.
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(rolesPrefix, role.GetName(), paramsPrefix),
+		Key:      backend.NewKey(rolesPrefix, role.GetName(), paramsPrefix),
 		Value:    value,
 		Expires:  role.Expiry(),
 		Revision: rev,
@@ -224,7 +224,7 @@ func (s *AccessService) UpsertRole(ctx context.Context, role types.Role) (types.
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(rolesPrefix, role.GetName(), paramsPrefix),
+		Key:      backend.NewKey(rolesPrefix, role.GetName(), paramsPrefix),
 		Value:    value,
 		Expires:  role.Expiry(),
 		Revision: rev,
@@ -243,7 +243,7 @@ func (s *AccessService) GetRole(ctx context.Context, name string) (types.Role, e
 	if name == "" {
 		return nil, trace.BadParameter("missing role name")
 	}
-	item, err := s.Get(ctx, backend.Key(rolesPrefix, name, paramsPrefix))
+	item, err := s.Get(ctx, backend.NewKey(rolesPrefix, name, paramsPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("role %v is not found", name)
@@ -259,7 +259,7 @@ func (s *AccessService) DeleteRole(ctx context.Context, name string) error {
 	if name == "" {
 		return trace.BadParameter("missing role name")
 	}
-	err := s.Delete(ctx, backend.Key(rolesPrefix, name, paramsPrefix))
+	err := s.Delete(ctx, backend.NewKey(rolesPrefix, name, paramsPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("role %q is not found", name)
@@ -273,7 +273,7 @@ func (s *AccessService) GetLock(ctx context.Context, name string) (types.Lock, e
 	if name == "" {
 		return nil, trace.BadParameter("missing lock name")
 	}
-	item, err := s.Get(ctx, backend.Key(locksPrefix, name))
+	item, err := s.Get(ctx, backend.NewKey(locksPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("lock %q is not found", name)
@@ -324,7 +324,7 @@ func (s *AccessService) UpsertLock(ctx context.Context, lock types.Lock) error {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(locksPrefix, lock.GetName()),
+		Key:      backend.NewKey(locksPrefix, lock.GetName()),
 		Value:    value,
 		Expires:  lock.Expiry(),
 		Revision: rev,
@@ -341,7 +341,7 @@ func (s *AccessService) DeleteLock(ctx context.Context, name string) error {
 	if name == "" {
 		return trace.BadParameter("missing lock name")
 	}
-	err := s.Delete(ctx, backend.Key(locksPrefix, name))
+	err := s.Delete(ctx, backend.NewKey(locksPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("lock %q is not found", name)
@@ -382,7 +382,7 @@ func (s *AccessService) ReplaceRemoteLocks(ctx context.Context, clusterName stri
 				return trace.Wrap(err)
 			}
 			item := backend.Item{
-				Key:      backend.Key(locksPrefix, lock.GetName()),
+				Key:      backend.NewKey(locksPrefix, lock.GetName()),
 				Value:    value,
 				Expires:  lock.Expiry(),
 				Revision: rev,

--- a/lib/services/local/apps.go
+++ b/lib/services/local/apps.go
@@ -59,7 +59,7 @@ func (s *AppService) GetApps(ctx context.Context) ([]types.Application, error) {
 
 // GetApp returns the specified application resource.
 func (s *AppService) GetApp(ctx context.Context, name string) (types.Application, error) {
-	item, err := s.Get(ctx, backend.Key(appPrefix, name))
+	item, err := s.Get(ctx, backend.NewKey(appPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("application %q doesn't exist", name)
@@ -84,7 +84,7 @@ func (s *AppService) CreateApp(ctx context.Context, app types.Application) error
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(appPrefix, app.GetName()),
+		Key:     backend.NewKey(appPrefix, app.GetName()),
 		Value:   value,
 		Expires: app.Expiry(),
 	}
@@ -110,7 +110,7 @@ func (s *AppService) UpdateApp(ctx context.Context, app types.Application) error
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(appPrefix, app.GetName()),
+		Key:      backend.NewKey(appPrefix, app.GetName()),
 		Value:    value,
 		Expires:  app.Expiry(),
 		Revision: rev,
@@ -128,7 +128,7 @@ func (s *AppService) UpdateApp(ctx context.Context, app types.Application) error
 
 // DeleteApp removes the specified application resource.
 func (s *AppService) DeleteApp(ctx context.Context, name string) error {
-	err := s.Delete(ctx, backend.Key(appPrefix, name))
+	err := s.Delete(ctx, backend.NewKey(appPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("application %q doesn't exist", name)

--- a/lib/services/local/assertion_replay.go
+++ b/lib/services/local/assertion_replay.go
@@ -46,7 +46,7 @@ func NewAssertionReplayService(bk backend.Backend) *AssertionReplayService {
 // `safeAfter` must be either at or after the point in time that a given SSO assertion becomes invalid in order to mitigate replay attacks.
 // This function shouldn't be used if the assertion never verifiably expires.
 func (s *AssertionReplayService) RecognizeSSOAssertion(ctx context.Context, connectorID string, assertionID string, user string, safeAfter time.Time) error {
-	key := backend.Key(assertionReplayPrefix, connectorID, assertionID)
+	key := backend.NewKey(assertionReplayPrefix, connectorID, assertionID)
 	item := backend.Item{Key: key, Value: []byte(user), Expires: safeAfter}
 	_, err := s.bk.Create(ctx, item)
 	switch {

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -62,7 +62,7 @@ func NewClusterConfigurationService(backend backend.Backend) (*ClusterConfigurat
 
 // GetClusterName gets the name of the cluster from the backend.
 func (s *ClusterConfigurationService) GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error) {
-	item, err := s.Get(context.TODO(), backend.Key(clusterConfigPrefix, namePrefix))
+	item, err := s.Get(context.TODO(), backend.NewKey(clusterConfigPrefix, namePrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			clusterNameNotFound.Inc()
@@ -76,7 +76,7 @@ func (s *ClusterConfigurationService) GetClusterName(opts ...services.MarshalOpt
 
 // DeleteClusterName deletes types.ClusterName from the backend.
 func (s *ClusterConfigurationService) DeleteClusterName() error {
-	err := s.Delete(context.TODO(), backend.Key(clusterConfigPrefix, namePrefix))
+	err := s.Delete(context.TODO(), backend.NewKey(clusterConfigPrefix, namePrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("cluster configuration not found")
@@ -96,7 +96,7 @@ func (s *ClusterConfigurationService) SetClusterName(c types.ClusterName) error 
 	}
 
 	_, err = s.Create(context.TODO(), backend.Item{
-		Key:      backend.Key(clusterConfigPrefix, namePrefix),
+		Key:      backend.NewKey(clusterConfigPrefix, namePrefix),
 		Value:    value,
 		Expires:  c.Expiry(),
 		Revision: rev,
@@ -117,7 +117,7 @@ func (s *ClusterConfigurationService) UpsertClusterName(c types.ClusterName) err
 	}
 
 	_, err = s.Put(context.TODO(), backend.Item{
-		Key:      backend.Key(clusterConfigPrefix, namePrefix),
+		Key:      backend.NewKey(clusterConfigPrefix, namePrefix),
 		Value:    value,
 		Expires:  c.Expiry(),
 		Revision: rev,
@@ -131,7 +131,7 @@ func (s *ClusterConfigurationService) UpsertClusterName(c types.ClusterName) err
 
 // GetStaticTokens gets the list of static tokens used to provision nodes.
 func (s *ClusterConfigurationService) GetStaticTokens() (types.StaticTokens, error) {
-	item, err := s.Get(context.TODO(), backend.Key(clusterConfigPrefix, staticTokensPrefix))
+	item, err := s.Get(context.TODO(), backend.NewKey(clusterConfigPrefix, staticTokensPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("static tokens not found")
@@ -150,7 +150,7 @@ func (s *ClusterConfigurationService) SetStaticTokens(c types.StaticTokens) erro
 		return trace.Wrap(err)
 	}
 	_, err = s.Put(context.TODO(), backend.Item{
-		Key:      backend.Key(clusterConfigPrefix, staticTokensPrefix),
+		Key:      backend.NewKey(clusterConfigPrefix, staticTokensPrefix),
 		Value:    value,
 		Expires:  c.Expiry(),
 		Revision: rev,
@@ -164,7 +164,7 @@ func (s *ClusterConfigurationService) SetStaticTokens(c types.StaticTokens) erro
 
 // DeleteStaticTokens deletes static tokens
 func (s *ClusterConfigurationService) DeleteStaticTokens() error {
-	err := s.Delete(context.TODO(), backend.Key(clusterConfigPrefix, staticTokensPrefix))
+	err := s.Delete(context.TODO(), backend.NewKey(clusterConfigPrefix, staticTokensPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("static tokens are not found")
@@ -177,7 +177,7 @@ func (s *ClusterConfigurationService) DeleteStaticTokens() error {
 // GetAuthPreference fetches the cluster authentication preferences
 // from the backend and return them.
 func (s *ClusterConfigurationService) GetAuthPreference(ctx context.Context) (types.AuthPreference, error) {
-	item, err := s.Get(ctx, backend.Key(authPrefix, preferencePrefix, generalPrefix))
+	item, err := s.Get(ctx, backend.NewKey(authPrefix, preferencePrefix, generalPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("authentication preference not found")
@@ -201,7 +201,7 @@ func (s *ClusterConfigurationService) CreateAuthPreference(ctx context.Context, 
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(authPrefix, preferencePrefix, generalPrefix),
+		Key:   backend.NewKey(authPrefix, preferencePrefix, generalPrefix),
 		Value: value,
 	}
 
@@ -228,7 +228,7 @@ func (s *ClusterConfigurationService) UpdateAuthPreference(ctx context.Context, 
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(authPrefix, preferencePrefix, generalPrefix),
+		Key:      backend.NewKey(authPrefix, preferencePrefix, generalPrefix),
 		Value:    value,
 		Revision: rev,
 	}
@@ -256,7 +256,7 @@ func (s *ClusterConfigurationService) UpsertAuthPreference(ctx context.Context, 
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(authPrefix, preferencePrefix, generalPrefix),
+		Key:      backend.NewKey(authPrefix, preferencePrefix, generalPrefix),
 		Value:    value,
 		Revision: rev,
 	}
@@ -272,7 +272,7 @@ func (s *ClusterConfigurationService) UpsertAuthPreference(ctx context.Context, 
 
 // DeleteAuthPreference deletes types.AuthPreference from the backend.
 func (s *ClusterConfigurationService) DeleteAuthPreference(ctx context.Context) error {
-	err := s.Delete(ctx, backend.Key(authPrefix, preferencePrefix, generalPrefix))
+	err := s.Delete(ctx, backend.NewKey(authPrefix, preferencePrefix, generalPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("auth preference not found")
@@ -284,7 +284,7 @@ func (s *ClusterConfigurationService) DeleteAuthPreference(ctx context.Context) 
 
 // GetClusterAuditConfig gets cluster audit config from the backend.
 func (s *ClusterConfigurationService) GetClusterAuditConfig(ctx context.Context) (types.ClusterAuditConfig, error) {
-	item, err := s.Get(ctx, backend.Key(clusterConfigPrefix, auditPrefix))
+	item, err := s.Get(ctx, backend.NewKey(clusterConfigPrefix, auditPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("cluster audit config not found")
@@ -308,7 +308,7 @@ func (s *ClusterConfigurationService) CreateClusterAuditConfig(ctx context.Conte
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(clusterConfigPrefix, auditPrefix),
+		Key:   backend.NewKey(clusterConfigPrefix, auditPrefix),
 		Value: value,
 	}
 
@@ -330,7 +330,7 @@ func (s *ClusterConfigurationService) UpdateClusterAuditConfig(ctx context.Conte
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(clusterConfigPrefix, auditPrefix),
+		Key:      backend.NewKey(clusterConfigPrefix, auditPrefix),
 		Value:    value,
 		Revision: rev,
 	}
@@ -351,7 +351,7 @@ func (s *ClusterConfigurationService) UpsertClusterAuditConfig(ctx context.Conte
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(clusterConfigPrefix, auditPrefix),
+		Key:   backend.NewKey(clusterConfigPrefix, auditPrefix),
 		Value: value,
 	}
 
@@ -366,7 +366,7 @@ func (s *ClusterConfigurationService) UpsertClusterAuditConfig(ctx context.Conte
 
 // DeleteClusterAuditConfig deletes ClusterAuditConfig from the backend.
 func (s *ClusterConfigurationService) DeleteClusterAuditConfig(ctx context.Context) error {
-	err := s.Delete(ctx, backend.Key(clusterConfigPrefix, auditPrefix))
+	err := s.Delete(ctx, backend.NewKey(clusterConfigPrefix, auditPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("cluster audit config not found")
@@ -378,7 +378,7 @@ func (s *ClusterConfigurationService) DeleteClusterAuditConfig(ctx context.Conte
 
 // GetClusterNetworkingConfig gets cluster networking config from the backend.
 func (s *ClusterConfigurationService) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
-	item, err := s.Get(ctx, backend.Key(clusterConfigPrefix, networkingPrefix))
+	item, err := s.Get(ctx, backend.NewKey(clusterConfigPrefix, networkingPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("cluster networking config not found")
@@ -401,7 +401,7 @@ func (s *ClusterConfigurationService) CreateClusterNetworkingConfig(ctx context.
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(clusterConfigPrefix, networkingPrefix),
+		Key:   backend.NewKey(clusterConfigPrefix, networkingPrefix),
 		Value: value,
 	}
 
@@ -428,7 +428,7 @@ func (s *ClusterConfigurationService) UpdateClusterNetworkingConfig(ctx context.
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(clusterConfigPrefix, networkingPrefix),
+		Key:      backend.NewKey(clusterConfigPrefix, networkingPrefix),
 		Value:    value,
 		Revision: rev,
 	}
@@ -455,7 +455,7 @@ func (s *ClusterConfigurationService) UpsertClusterNetworkingConfig(ctx context.
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(clusterConfigPrefix, networkingPrefix),
+		Key:      backend.NewKey(clusterConfigPrefix, networkingPrefix),
 		Value:    value,
 		Revision: rev,
 	}
@@ -471,7 +471,7 @@ func (s *ClusterConfigurationService) UpsertClusterNetworkingConfig(ctx context.
 
 // DeleteClusterNetworkingConfig deletes ClusterNetworkingConfig from the backend.
 func (s *ClusterConfigurationService) DeleteClusterNetworkingConfig(ctx context.Context) error {
-	err := s.Delete(ctx, backend.Key(clusterConfigPrefix, networkingPrefix))
+	err := s.Delete(ctx, backend.NewKey(clusterConfigPrefix, networkingPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("cluster networking config not found")
@@ -483,7 +483,7 @@ func (s *ClusterConfigurationService) DeleteClusterNetworkingConfig(ctx context.
 
 // GetSessionRecordingConfig gets session recording config from the backend.
 func (s *ClusterConfigurationService) GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error) {
-	item, err := s.Get(ctx, backend.Key(clusterConfigPrefix, sessionRecordingPrefix))
+	item, err := s.Get(ctx, backend.NewKey(clusterConfigPrefix, sessionRecordingPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("session recording config not found")
@@ -506,7 +506,7 @@ func (s *ClusterConfigurationService) CreateSessionRecordingConfig(ctx context.C
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(clusterConfigPrefix, sessionRecordingPrefix),
+		Key:   backend.NewKey(clusterConfigPrefix, sessionRecordingPrefix),
 		Value: value,
 	}
 
@@ -533,7 +533,7 @@ func (s *ClusterConfigurationService) UpdateSessionRecordingConfig(ctx context.C
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(clusterConfigPrefix, sessionRecordingPrefix),
+		Key:      backend.NewKey(clusterConfigPrefix, sessionRecordingPrefix),
 		Value:    value,
 		Revision: rev,
 	}
@@ -561,7 +561,7 @@ func (s *ClusterConfigurationService) UpsertSessionRecordingConfig(ctx context.C
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(clusterConfigPrefix, sessionRecordingPrefix),
+		Key:      backend.NewKey(clusterConfigPrefix, sessionRecordingPrefix),
 		Value:    value,
 		Revision: rev,
 	}
@@ -577,7 +577,7 @@ func (s *ClusterConfigurationService) UpsertSessionRecordingConfig(ctx context.C
 
 // DeleteSessionRecordingConfig deletes SessionRecordingConfig from the backend.
 func (s *ClusterConfigurationService) DeleteSessionRecordingConfig(ctx context.Context) error {
-	err := s.Delete(ctx, backend.Key(clusterConfigPrefix, sessionRecordingPrefix))
+	err := s.Delete(ctx, backend.NewKey(clusterConfigPrefix, sessionRecordingPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("session recording config not found")
@@ -607,7 +607,7 @@ func (s *ClusterConfigurationService) GetInstallers(ctx context.Context) ([]type
 }
 
 func (s *ClusterConfigurationService) GetUIConfig(ctx context.Context) (types.UIConfig, error) {
-	item, err := s.Get(ctx, backend.Key(clusterConfigPrefix, uiPrefix))
+	item, err := s.Get(ctx, backend.NewKey(clusterConfigPrefix, uiPrefix))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -622,7 +622,7 @@ func (s *ClusterConfigurationService) SetUIConfig(ctx context.Context, uic types
 	}
 
 	_, err = s.Put(ctx, backend.Item{
-		Key:      backend.Key(clusterConfigPrefix, uiPrefix),
+		Key:      backend.NewKey(clusterConfigPrefix, uiPrefix),
 		Value:    value,
 		Revision: rev,
 	})
@@ -630,12 +630,12 @@ func (s *ClusterConfigurationService) SetUIConfig(ctx context.Context, uic types
 }
 
 func (s *ClusterConfigurationService) DeleteUIConfig(ctx context.Context) error {
-	return trace.Wrap(s.Delete(ctx, backend.Key(clusterConfigPrefix, uiPrefix)))
+	return trace.Wrap(s.Delete(ctx, backend.NewKey(clusterConfigPrefix, uiPrefix)))
 }
 
 // GetInstaller gets the script of the cluster from the backend.
 func (s *ClusterConfigurationService) GetInstaller(ctx context.Context, name string) (types.Installer, error) {
-	item, err := s.Get(ctx, backend.Key(clusterConfigPrefix, scriptsPrefix, installerPrefix, name))
+	item, err := s.Get(ctx, backend.NewKey(clusterConfigPrefix, scriptsPrefix, installerPrefix, name))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -651,7 +651,7 @@ func (s *ClusterConfigurationService) SetInstaller(ctx context.Context, ins type
 	}
 
 	_, err = s.Put(ctx, backend.Item{
-		Key:      backend.Key(clusterConfigPrefix, scriptsPrefix, installerPrefix, ins.GetName()),
+		Key:      backend.NewKey(clusterConfigPrefix, scriptsPrefix, installerPrefix, ins.GetName()),
 		Value:    value,
 		Expires:  ins.Expiry(),
 		Revision: rev,
@@ -662,7 +662,7 @@ func (s *ClusterConfigurationService) SetInstaller(ctx context.Context, ins type
 // DeleteInstaller sets the installer script to default script in the backend.
 func (s *ClusterConfigurationService) DeleteInstaller(ctx context.Context, name string) error {
 	return trace.Wrap(
-		s.Delete(ctx, backend.Key(clusterConfigPrefix, scriptsPrefix, installerPrefix, name)))
+		s.Delete(ctx, backend.NewKey(clusterConfigPrefix, scriptsPrefix, installerPrefix, name)))
 }
 
 // DeleteAllInstallers removes all installer resources.
@@ -677,7 +677,7 @@ func (s *ClusterConfigurationService) DeleteAllInstallers(ctx context.Context) e
 
 // GetClusterMaintenanceConfig loads the maintenance config singleton resource.
 func (s *ClusterConfigurationService) GetClusterMaintenanceConfig(ctx context.Context) (types.ClusterMaintenanceConfig, error) {
-	item, err := s.Get(ctx, backend.Key(clusterConfigPrefix, maintenancePrefix))
+	item, err := s.Get(ctx, backend.NewKey(clusterConfigPrefix, maintenancePrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("no maintenance config has been created")
@@ -702,7 +702,7 @@ func (s *ClusterConfigurationService) UpdateClusterMaintenanceConfig(ctx context
 	err := generic.FastUpdateNonceProtectedResource(
 		ctx,
 		s.Backend,
-		backend.Key(clusterConfigPrefix, maintenancePrefix),
+		backend.NewKey(clusterConfigPrefix, maintenancePrefix),
 		cmc,
 	)
 
@@ -715,7 +715,7 @@ func (s *ClusterConfigurationService) UpdateClusterMaintenanceConfig(ctx context
 
 // DeleteClusterMaintenanceConfig deletes the maintenance config singleton resource.
 func (s *ClusterConfigurationService) DeleteClusterMaintenanceConfig(ctx context.Context) error {
-	err := s.Delete(ctx, backend.Key(clusterConfigPrefix, maintenancePrefix))
+	err := s.Delete(ctx, backend.NewKey(clusterConfigPrefix, maintenancePrefix))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -724,7 +724,7 @@ func (s *ClusterConfigurationService) DeleteClusterMaintenanceConfig(ctx context
 
 // GetAccessGraphSettings fetches the cluster *clusterconfigpb.AccessGraphSettings from the backend and return them.
 func (s *ClusterConfigurationService) GetAccessGraphSettings(ctx context.Context) (*clusterconfigpb.AccessGraphSettings, error) {
-	item, err := s.Get(ctx, backend.Key(clusterConfigPrefix, accessGraphSettingsPrefix))
+	item, err := s.Get(ctx, backend.NewKey(clusterConfigPrefix, accessGraphSettingsPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("AccessGraphSettings preference not found")
@@ -743,7 +743,7 @@ func (s *ClusterConfigurationService) CreateAccessGraphSettings(ctx context.Cont
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(clusterConfigPrefix, accessGraphSettingsPrefix),
+		Key:   backend.NewKey(clusterConfigPrefix, accessGraphSettingsPrefix),
 		Value: value,
 	}
 
@@ -766,7 +766,7 @@ func (s *ClusterConfigurationService) UpdateAccessGraphSettings(ctx context.Cont
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(clusterConfigPrefix, accessGraphSettingsPrefix),
+		Key:      backend.NewKey(clusterConfigPrefix, accessGraphSettingsPrefix),
 		Value:    value,
 		Revision: rev,
 	}
@@ -789,7 +789,7 @@ func (s *ClusterConfigurationService) UpsertAccessGraphSettings(ctx context.Cont
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(clusterConfigPrefix, accessGraphSettingsPrefix),
+		Key:      backend.NewKey(clusterConfigPrefix, accessGraphSettingsPrefix),
 		Value:    value,
 		Revision: rev,
 	}
@@ -805,7 +805,7 @@ func (s *ClusterConfigurationService) UpsertAccessGraphSettings(ctx context.Cont
 
 // DeleteAccessGraphSettings deletes *clusterconfigpb.AccessGraphSettings from the backend.
 func (s *ClusterConfigurationService) DeleteAccessGraphSettings(ctx context.Context) error {
-	err := s.Delete(ctx, backend.Key(clusterConfigPrefix, accessGraphSettingsPrefix))
+	err := s.Delete(ctx, backend.NewKey(clusterConfigPrefix, accessGraphSettingsPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("access graph settings not found")

--- a/lib/services/local/connection_diagnostic.go
+++ b/lib/services/local/connection_diagnostic.go
@@ -54,7 +54,7 @@ func (s *ConnectionDiagnosticService) CreateConnectionDiagnostic(ctx context.Con
 	}
 
 	item := backend.Item{
-		Key:     backend.Key(connectionDiagnosticPrefix, connectionDiagnostic.GetName()),
+		Key:     backend.NewKey(connectionDiagnosticPrefix, connectionDiagnostic.GetName()),
 		Value:   value,
 		Expires: connectionDiagnostic.Expiry(),
 	}
@@ -74,7 +74,7 @@ func (s *ConnectionDiagnosticService) UpdateConnectionDiagnostic(ctx context.Con
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(connectionDiagnosticPrefix, connectionDiagnostic.GetName()),
+		Key:      backend.NewKey(connectionDiagnosticPrefix, connectionDiagnostic.GetName()),
 		Value:    value,
 		Expires:  connectionDiagnostic.Expiry(),
 		Revision: rev,
@@ -87,7 +87,7 @@ func (s *ConnectionDiagnosticService) UpdateConnectionDiagnostic(ctx context.Con
 // AppendDiagnosticTrace adds a Trace into the ConnectionDiagnostics.
 // It does a CompareAndSwap to ensure atomicity.
 func (s *ConnectionDiagnosticService) AppendDiagnosticTrace(ctx context.Context, name string, t *types.ConnectionDiagnosticTrace) (types.ConnectionDiagnostic, error) {
-	existing, err := s.Get(ctx, backend.Key(connectionDiagnosticPrefix, name))
+	existing, err := s.Get(ctx, backend.NewKey(connectionDiagnosticPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("connection diagnostic %q doesn't exist", name)
@@ -109,7 +109,7 @@ func (s *ConnectionDiagnosticService) AppendDiagnosticTrace(ctx context.Context,
 	}
 
 	newItem := backend.Item{
-		Key:      backend.Key(connectionDiagnosticPrefix, connectionDiagnostic.GetName()),
+		Key:      backend.NewKey(connectionDiagnosticPrefix, connectionDiagnostic.GetName()),
 		Value:    value,
 		Expires:  connectionDiagnostic.Expiry(),
 		Revision: existing.Revision,
@@ -127,7 +127,7 @@ func (s *ConnectionDiagnosticService) AppendDiagnosticTrace(ctx context.Context,
 //
 // If not found, a `trace.NotFound` error is returned
 func (s *ConnectionDiagnosticService) GetConnectionDiagnostic(ctx context.Context, name string) (types.ConnectionDiagnostic, error) {
-	item, err := s.Get(ctx, backend.Key(connectionDiagnosticPrefix, name))
+	item, err := s.Get(ctx, backend.NewKey(connectionDiagnosticPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("connection diagnostic %q doesn't exist", name)

--- a/lib/services/local/databases.go
+++ b/lib/services/local/databases.go
@@ -59,7 +59,7 @@ func (s *DatabaseService) GetDatabases(ctx context.Context) ([]types.Database, e
 
 // GetDatabase returns the specified database resource.
 func (s *DatabaseService) GetDatabase(ctx context.Context, name string) (types.Database, error) {
-	item, err := s.Get(ctx, backend.Key(databasesPrefix, name))
+	item, err := s.Get(ctx, backend.NewKey(databasesPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("database %q doesn't exist", name)
@@ -84,7 +84,7 @@ func (s *DatabaseService) CreateDatabase(ctx context.Context, database types.Dat
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(databasesPrefix, database.GetName()),
+		Key:     backend.NewKey(databasesPrefix, database.GetName()),
 		Value:   value,
 		Expires: database.Expiry(),
 	}
@@ -110,7 +110,7 @@ func (s *DatabaseService) UpdateDatabase(ctx context.Context, database types.Dat
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(databasesPrefix, database.GetName()),
+		Key:      backend.NewKey(databasesPrefix, database.GetName()),
 		Value:    value,
 		Expires:  database.Expiry(),
 		Revision: rev,
@@ -128,7 +128,7 @@ func (s *DatabaseService) UpdateDatabase(ctx context.Context, database types.Dat
 
 // DeleteDatabase removes the specified database resource.
 func (s *DatabaseService) DeleteDatabase(ctx context.Context, name string) error {
-	err := s.Delete(ctx, backend.Key(databasesPrefix, name))
+	err := s.Delete(ctx, backend.NewKey(databasesPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("database %q doesn't exist", name)

--- a/lib/services/local/databaseservice.go
+++ b/lib/services/local/databaseservice.go
@@ -50,7 +50,7 @@ func (s *DatabaseServicesService) UpsertDatabaseService(ctx context.Context, ser
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(databaseServicePrefix, service.GetName()),
+		Key:      backend.NewKey(databaseServicePrefix, service.GetName()),
 		Value:    value,
 		Expires:  service.Expiry(),
 		Revision: rev,
@@ -73,7 +73,7 @@ func (s *DatabaseServicesService) UpsertDatabaseService(ctx context.Context, ser
 
 // DeleteDatabaseService removes the specified DatabaseService resource.
 func (s *DatabaseServicesService) DeleteDatabaseService(ctx context.Context, name string) error {
-	err := s.Delete(ctx, backend.Key(databaseServicePrefix, name))
+	err := s.Delete(ctx, backend.NewKey(databaseServicePrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("databaseService %q doesn't exist", name)

--- a/lib/services/local/desktops.go
+++ b/lib/services/local/desktops.go
@@ -76,7 +76,7 @@ func (s *WindowsDesktopService) CreateWindowsDesktop(ctx context.Context, deskto
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(windowsDesktopsPrefix, desktop.GetHostID(), desktop.GetName()),
+		Key:     backend.NewKey(windowsDesktopsPrefix, desktop.GetHostID(), desktop.GetName()),
 		Value:   value,
 		Expires: desktop.Expiry(),
 	}
@@ -102,7 +102,7 @@ func (s *WindowsDesktopService) UpdateWindowsDesktop(ctx context.Context, deskto
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(windowsDesktopsPrefix, desktop.GetHostID(), desktop.GetName()),
+		Key:      backend.NewKey(windowsDesktopsPrefix, desktop.GetHostID(), desktop.GetName()),
 		Value:    value,
 		Expires:  desktop.Expiry(),
 		Revision: rev,
@@ -129,7 +129,7 @@ func (s *WindowsDesktopService) UpsertWindowsDesktop(ctx context.Context, deskto
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(windowsDesktopsPrefix, desktop.GetHostID(), desktop.GetName()),
+		Key:      backend.NewKey(windowsDesktopsPrefix, desktop.GetHostID(), desktop.GetName()),
 		Value:    value,
 		Expires:  desktop.Expiry(),
 		Revision: rev,
@@ -147,7 +147,7 @@ func (s *WindowsDesktopService) DeleteWindowsDesktop(ctx context.Context, hostID
 		return trace.Errorf("name must not be empty")
 	}
 
-	key := backend.Key(windowsDesktopsPrefix, hostID, name)
+	key := backend.NewKey(windowsDesktopsPrefix, hostID, name)
 
 	err := s.Delete(ctx, key)
 	if err != nil {
@@ -176,7 +176,7 @@ func (s *WindowsDesktopService) ListWindowsDesktops(ctx context.Context, req typ
 		return nil, trace.BadParameter("nonpositive parameter limit")
 	}
 
-	rangeStart := backend.Key(windowsDesktopsPrefix, req.StartKey)
+	rangeStart := backend.NewKey(windowsDesktopsPrefix, req.StartKey)
 	rangeEnd := backend.RangeEnd(backend.ExactKey(windowsDesktopsPrefix))
 	filter := services.MatchResourceFilter{
 		ResourceKind:   types.KindWindowsDesktop,
@@ -248,7 +248,7 @@ func (s *WindowsDesktopService) ListWindowsDesktopServices(ctx context.Context, 
 		return nil, trace.BadParameter("nonpositive parameter limit")
 	}
 
-	rangeStart := backend.Key(windowsDesktopServicesPrefix, req.StartKey)
+	rangeStart := backend.NewKey(windowsDesktopServicesPrefix, req.StartKey)
 	rangeEnd := backend.RangeEnd(backend.ExactKey(windowsDesktopServicesPrefix))
 	filter := services.MatchResourceFilter{
 		ResourceKind:   types.KindWindowsDesktopService,

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -331,7 +331,7 @@ func (s *DynamicAccessService) ListAccessRequests(ctx context.Context, req *prot
 
 	startKey := backend.ExactKey(accessRequestsPrefix)
 	if req.StartKey != "" {
-		startKey = backend.Key(accessRequestsPrefix, req.StartKey)
+		startKey = backend.NewKey(accessRequestsPrefix, req.StartKey)
 	}
 	endKey := backend.RangeEnd(backend.ExactKey(accessRequestsPrefix))
 
@@ -486,11 +486,11 @@ func itemToAccessRequest(item backend.Item, opts ...services.MarshalOption) (*ty
 }
 
 func accessRequestKey(name string) []byte {
-	return backend.Key(accessRequestsPrefix, name, paramsPrefix)
+	return backend.NewKey(accessRequestsPrefix, name, paramsPrefix)
 }
 
 func AccessRequestAllowedPromotionKey(name string) []byte {
-	return backend.Key(accessRequestPromotionPrefix, name, paramsPrefix)
+	return backend.NewKey(accessRequestPromotionPrefix, name, paramsPrefix)
 }
 
 const (

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -394,7 +394,7 @@ func newCertAuthorityParser(loadSecrets bool, filter map[string]string) *certAut
 	caFilter.FromMap(filter)
 	return &certAuthorityParser{
 		loadSecrets: loadSecrets,
-		baseParser:  newBaseParser(backend.Key(authoritiesPrefix)),
+		baseParser:  newBaseParser(backend.NewKey(authoritiesPrefix)),
 		filter:      caFilter,
 	}
 }
@@ -441,7 +441,7 @@ func (p *certAuthorityParser) parse(event backend.Event) (types.Resource, error)
 
 func newProvisionTokenParser() *provisionTokenParser {
 	return &provisionTokenParser{
-		baseParser: newBaseParser(backend.Key(tokensPrefix)),
+		baseParser: newBaseParser(backend.NewKey(tokensPrefix)),
 	}
 }
 
@@ -469,7 +469,7 @@ func (p *provisionTokenParser) parse(event backend.Event) (types.Resource, error
 
 func newStaticTokensParser() *staticTokensParser {
 	return &staticTokensParser{
-		baseParser: newBaseParser(backend.Key(clusterConfigPrefix, staticTokensPrefix)),
+		baseParser: newBaseParser(backend.NewKey(clusterConfigPrefix, staticTokensPrefix)),
 	}
 }
 
@@ -502,7 +502,7 @@ func (p *staticTokensParser) parse(event backend.Event) (types.Resource, error) 
 
 func newClusterAuditConfigParser() *clusterAuditConfigParser {
 	return &clusterAuditConfigParser{
-		baseParser: newBaseParser(backend.Key(clusterConfigPrefix, auditPrefix)),
+		baseParser: newBaseParser(backend.NewKey(clusterConfigPrefix, auditPrefix)),
 	}
 }
 
@@ -536,7 +536,7 @@ func (p *clusterAuditConfigParser) parse(event backend.Event) (types.Resource, e
 
 func newClusterNetworkingConfigParser() *clusterNetworkingConfigParser {
 	return &clusterNetworkingConfigParser{
-		baseParser: newBaseParser(backend.Key(clusterConfigPrefix, networkingPrefix)),
+		baseParser: newBaseParser(backend.NewKey(clusterConfigPrefix, networkingPrefix)),
 	}
 }
 
@@ -570,7 +570,7 @@ func (p *clusterNetworkingConfigParser) parse(event backend.Event) (types.Resour
 
 func newAuthPreferenceParser() *authPreferenceParser {
 	return &authPreferenceParser{
-		baseParser: newBaseParser(backend.Key(authPrefix, preferencePrefix, generalPrefix)),
+		baseParser: newBaseParser(backend.NewKey(authPrefix, preferencePrefix, generalPrefix)),
 	}
 }
 
@@ -604,7 +604,7 @@ func (p *authPreferenceParser) parse(event backend.Event) (types.Resource, error
 
 func newUIConfigParser() *uiConfigParser {
 	return &uiConfigParser{
-		baseParser: newBaseParser(backend.Key(clusterConfigPrefix, uiPrefix)),
+		baseParser: newBaseParser(backend.NewKey(clusterConfigPrefix, uiPrefix)),
 	}
 }
 
@@ -638,7 +638,7 @@ func (p *uiConfigParser) parse(event backend.Event) (types.Resource, error) {
 
 func newSessionRecordingConfigParser() *sessionRecordingConfigParser {
 	return &sessionRecordingConfigParser{
-		baseParser: newBaseParser(backend.Key(clusterConfigPrefix, sessionRecordingPrefix)),
+		baseParser: newBaseParser(backend.NewKey(clusterConfigPrefix, sessionRecordingPrefix)),
 	}
 }
 
@@ -672,7 +672,7 @@ func (p *sessionRecordingConfigParser) parse(event backend.Event) (types.Resourc
 
 func newClusterNameParser() *clusterNameParser {
 	return &clusterNameParser{
-		baseParser: newBaseParser(backend.Key(clusterConfigPrefix, namePrefix)),
+		baseParser: newBaseParser(backend.NewKey(clusterConfigPrefix, namePrefix)),
 	}
 }
 
@@ -704,9 +704,9 @@ func (p *clusterNameParser) parse(event backend.Event) (types.Resource, error) {
 }
 
 func newNamespaceParser(name string) *namespaceParser {
-	prefix := backend.Key(namespacesPrefix)
+	prefix := backend.NewKey(namespacesPrefix)
 	if name != "" {
-		prefix = backend.Key(namespacesPrefix, name, paramsPrefix)
+		prefix = backend.NewKey(namespacesPrefix, name, paramsPrefix)
 	}
 	return &namespaceParser{
 		baseParser: newBaseParser(prefix),
@@ -745,7 +745,7 @@ func (p *namespaceParser) parse(event backend.Event) (types.Resource, error) {
 
 func newRoleParser() *roleParser {
 	return &roleParser{
-		baseParser: newBaseParser(backend.Key(rolesPrefix)),
+		baseParser: newBaseParser(backend.NewKey(rolesPrefix)),
 	}
 }
 
@@ -778,8 +778,8 @@ func newAccessRequestParser(m map[string]string) (*accessRequestParser, error) {
 	}
 	return &accessRequestParser{
 		filter:      filter,
-		matchPrefix: backend.Key(accessRequestsPrefix),
-		matchSuffix: backend.Key(paramsPrefix),
+		matchPrefix: backend.NewKey(accessRequestsPrefix),
+		matchSuffix: backend.NewKey(paramsPrefix),
 	}, nil
 }
 
@@ -823,7 +823,7 @@ func (p *accessRequestParser) parse(event backend.Event) (types.Resource, error)
 
 func newUserParser() *userParser {
 	return &userParser{
-		baseParser: newBaseParser(backend.Key(webPrefix, usersPrefix)),
+		baseParser: newBaseParser(backend.NewKey(webPrefix, usersPrefix)),
 	}
 }
 
@@ -859,7 +859,7 @@ func (p *userParser) parse(event backend.Event) (types.Resource, error) {
 
 func newNodeParser() *nodeParser {
 	return &nodeParser{
-		baseParser: newBaseParser(backend.Key(nodesPrefix, apidefaults.Namespace)),
+		baseParser: newBaseParser(backend.NewKey(nodesPrefix, apidefaults.Namespace)),
 	}
 }
 
@@ -873,7 +873,7 @@ func (p *nodeParser) parse(event backend.Event) (types.Resource, error) {
 
 func newProxyParser() *proxyParser {
 	return &proxyParser{
-		baseParser: newBaseParser(backend.Key(proxiesPrefix)),
+		baseParser: newBaseParser(backend.NewKey(proxiesPrefix)),
 	}
 }
 
@@ -887,7 +887,7 @@ func (p *proxyParser) parse(event backend.Event) (types.Resource, error) {
 
 func newAuthServerParser() *authServerParser {
 	return &authServerParser{
-		baseParser: newBaseParser(backend.Key(authServersPrefix)),
+		baseParser: newBaseParser(backend.NewKey(authServersPrefix)),
 	}
 }
 
@@ -901,7 +901,7 @@ func (p *authServerParser) parse(event backend.Event) (types.Resource, error) {
 
 func newTunnelConnectionParser() *tunnelConnectionParser {
 	return &tunnelConnectionParser{
-		baseParser: newBaseParser(backend.Key(tunnelConnectionsPrefix)),
+		baseParser: newBaseParser(backend.NewKey(tunnelConnectionsPrefix)),
 	}
 }
 
@@ -941,7 +941,7 @@ func (p *tunnelConnectionParser) parse(event backend.Event) (types.Resource, err
 
 func newReverseTunnelParser() *reverseTunnelParser {
 	return &reverseTunnelParser{
-		baseParser: newBaseParser(backend.Key(reverseTunnelsPrefix)),
+		baseParser: newBaseParser(backend.NewKey(reverseTunnelsPrefix)),
 	}
 }
 
@@ -969,7 +969,7 @@ func (p *reverseTunnelParser) parse(event backend.Event) (types.Resource, error)
 
 func newAppServerV3Parser() *appServerV3Parser {
 	return &appServerV3Parser{
-		baseParser: newBaseParser(backend.Key(appServersPrefix, apidefaults.Namespace)),
+		baseParser: newBaseParser(backend.NewKey(appServersPrefix, apidefaults.Namespace)),
 	}
 }
 
@@ -1005,7 +1005,7 @@ func (p *appServerV3Parser) parse(event backend.Event) (types.Resource, error) {
 
 func newSAMLIdPSessionParser(loadSecrets bool) *webSessionParser {
 	return &webSessionParser{
-		baseParser:  newBaseParser(backend.Key(samlIdPPrefix, sessionsPrefix)),
+		baseParser:  newBaseParser(backend.NewKey(samlIdPPrefix, sessionsPrefix)),
 		loadSecrets: loadSecrets,
 		hdr: types.ResourceHeader{
 			Kind:    types.KindWebSession,
@@ -1017,7 +1017,7 @@ func newSAMLIdPSessionParser(loadSecrets bool) *webSessionParser {
 
 func newSnowflakeSessionParser(loadSecrets bool) *webSessionParser {
 	return &webSessionParser{
-		baseParser:  newBaseParser(backend.Key(snowflakePrefix, sessionsPrefix)),
+		baseParser:  newBaseParser(backend.NewKey(snowflakePrefix, sessionsPrefix)),
 		loadSecrets: loadSecrets,
 		hdr: types.ResourceHeader{
 			Kind:    types.KindWebSession,
@@ -1029,7 +1029,7 @@ func newSnowflakeSessionParser(loadSecrets bool) *webSessionParser {
 
 func newAppSessionParser(loadSecrets bool) *webSessionParser {
 	return &webSessionParser{
-		baseParser:  newBaseParser(backend.Key(appsPrefix, sessionsPrefix)),
+		baseParser:  newBaseParser(backend.NewKey(appsPrefix, sessionsPrefix)),
 		loadSecrets: loadSecrets,
 		hdr: types.ResourceHeader{
 			Kind:    types.KindWebSession,
@@ -1041,7 +1041,7 @@ func newAppSessionParser(loadSecrets bool) *webSessionParser {
 
 func newWebSessionParser(loadSecrets bool) *webSessionParser {
 	return &webSessionParser{
-		baseParser:  newBaseParser(backend.Key(webPrefix, sessionsPrefix)),
+		baseParser:  newBaseParser(backend.NewKey(webPrefix, sessionsPrefix)),
 		loadSecrets: loadSecrets,
 		hdr: types.ResourceHeader{
 			Kind:    types.KindWebSession,
@@ -1080,7 +1080,7 @@ func (p *webSessionParser) parse(event backend.Event) (types.Resource, error) {
 
 func newWebTokenParser() *webTokenParser {
 	return &webTokenParser{
-		baseParser: newBaseParser(backend.Key(webPrefix, tokensPrefix)),
+		baseParser: newBaseParser(backend.NewKey(webPrefix, tokensPrefix)),
 	}
 }
 
@@ -1108,7 +1108,7 @@ func (p *webTokenParser) parse(event backend.Event) (types.Resource, error) {
 
 func newKubeServerParser() *kubeServerParser {
 	return &kubeServerParser{
-		baseParser: newBaseParser(backend.Key(kubeServersPrefix)),
+		baseParser: newBaseParser(backend.NewKey(kubeServersPrefix)),
 	}
 }
 
@@ -1145,7 +1145,7 @@ func (p *kubeServerParser) parse(event backend.Event) (types.Resource, error) {
 
 func newDatabaseServerParser() *databaseServerParser {
 	return &databaseServerParser{
-		baseParser: newBaseParser(backend.Key(dbServersPrefix, apidefaults.Namespace)),
+		baseParser: newBaseParser(backend.NewKey(dbServersPrefix, apidefaults.Namespace)),
 	}
 }
 
@@ -1182,7 +1182,7 @@ func (p *databaseServerParser) parse(event backend.Event) (types.Resource, error
 
 func newDatabaseServiceParser() *databaseServiceParser {
 	return &databaseServiceParser{
-		baseParser: newBaseParser(backend.Key(databaseServicePrefix)),
+		baseParser: newBaseParser(backend.NewKey(databaseServicePrefix)),
 	}
 }
 
@@ -1207,7 +1207,7 @@ func (p *databaseServiceParser) parse(event backend.Event) (types.Resource, erro
 
 func newKubeClusterParser() *kubeClusterParser {
 	return &kubeClusterParser{
-		baseParser: newBaseParser(backend.Key(kubernetesPrefix)),
+		baseParser: newBaseParser(backend.NewKey(kubernetesPrefix)),
 	}
 }
 
@@ -1231,7 +1231,7 @@ func (p *kubeClusterParser) parse(event backend.Event) (types.Resource, error) {
 
 func newCrownJewelParser() *crownJewelParser {
 	return &crownJewelParser{
-		baseParser: newBaseParser(backend.Key(crownJewelsKey)),
+		baseParser: newBaseParser(backend.NewKey(crownJewelsKey)),
 	}
 }
 
@@ -1259,7 +1259,7 @@ func (p *crownJewelParser) parse(event backend.Event) (types.Resource, error) {
 
 func newAppParser() *appParser {
 	return &appParser{
-		baseParser: newBaseParser(backend.Key(appPrefix)),
+		baseParser: newBaseParser(backend.NewKey(appPrefix)),
 	}
 }
 
@@ -1283,7 +1283,7 @@ func (p *appParser) parse(event backend.Event) (types.Resource, error) {
 
 func newDatabaseParser() *databaseParser {
 	return &databaseParser{
-		baseParser: newBaseParser(backend.Key(databasesPrefix)),
+		baseParser: newBaseParser(backend.NewKey(databasesPrefix)),
 	}
 }
 
@@ -1307,7 +1307,7 @@ func (p *databaseParser) parse(event backend.Event) (types.Resource, error) {
 
 func newDatabaseObjectParser() *databaseObjectParser {
 	return &databaseObjectParser{
-		baseParser: newBaseParser(backend.Key(databaseObjectPrefix)),
+		baseParser: newBaseParser(backend.NewKey(databaseObjectPrefix)),
 	}
 }
 
@@ -1355,7 +1355,7 @@ func parseServer(event backend.Event, kind string) (types.Resource, error) {
 
 func newRemoteClusterParser() *remoteClusterParser {
 	return &remoteClusterParser{
-		matchPrefix: backend.Key(remoteClustersPrefix),
+		matchPrefix: backend.NewKey(remoteClustersPrefix),
 	}
 }
 
@@ -1391,7 +1391,7 @@ func (p *remoteClusterParser) parse(event backend.Event) (types.Resource, error)
 
 func newLockParser() *lockParser {
 	return &lockParser{
-		baseParser: newBaseParser(backend.Key(locksPrefix)),
+		baseParser: newBaseParser(backend.NewKey(locksPrefix)),
 	}
 }
 
@@ -1416,7 +1416,7 @@ func (p *lockParser) parse(event backend.Event) (types.Resource, error) {
 
 func newNetworkRestrictionsParser() *networkRestrictionsParser {
 	return &networkRestrictionsParser{
-		matchPrefix: backend.Key(restrictionsPrefix, network),
+		matchPrefix: backend.NewKey(restrictionsPrefix, network),
 	}
 }
 
@@ -1452,7 +1452,7 @@ func (p *networkRestrictionsParser) parse(event backend.Event) (types.Resource, 
 
 func newWindowsDesktopServicesParser() *windowsDesktopServicesParser {
 	return &windowsDesktopServicesParser{
-		baseParser: newBaseParser(backend.Key(windowsDesktopServicesPrefix, "")),
+		baseParser: newBaseParser(backend.NewKey(windowsDesktopServicesPrefix, "")),
 	}
 }
 
@@ -1477,7 +1477,7 @@ func (p *windowsDesktopServicesParser) parse(event backend.Event) (types.Resourc
 
 func newWindowsDesktopsParser() *windowsDesktopsParser {
 	return &windowsDesktopsParser{
-		baseParser: newBaseParser(backend.Key(windowsDesktopsPrefix, "")),
+		baseParser: newBaseParser(backend.NewKey(windowsDesktopsPrefix, "")),
 	}
 }
 
@@ -1518,7 +1518,7 @@ type installerParser struct {
 
 func newInstallerParser() *installerParser {
 	return &installerParser{
-		baseParser: newBaseParser(backend.Key(clusterConfigPrefix, scriptsPrefix, installerPrefix)),
+		baseParser: newBaseParser(backend.NewKey(clusterConfigPrefix, scriptsPrefix, installerPrefix)),
 	}
 }
 
@@ -1551,7 +1551,7 @@ type pluginParser struct {
 
 func newPluginParser(loadSecrets bool) *pluginParser {
 	return &pluginParser{
-		baseParser:  newBaseParser(backend.Key(pluginsPrefix)),
+		baseParser:  newBaseParser(backend.NewKey(pluginsPrefix)),
 		loadSecrets: loadSecrets,
 	}
 }
@@ -1580,7 +1580,7 @@ func (p *pluginParser) parse(event backend.Event) (types.Resource, error) {
 
 func newSAMLIDPServiceProviderParser() *samlIDPServiceProviderParser {
 	return &samlIDPServiceProviderParser{
-		baseParser: newBaseParser(backend.Key(samlIDPServiceProviderPrefix)),
+		baseParser: newBaseParser(backend.NewKey(samlIDPServiceProviderPrefix)),
 	}
 }
 
@@ -1604,7 +1604,7 @@ func (p *samlIDPServiceProviderParser) parse(event backend.Event) (types.Resourc
 
 func newUserGroupParser() *userGroupParser {
 	return &userGroupParser{
-		baseParser: newBaseParser(backend.Key(userGroupPrefix)),
+		baseParser: newBaseParser(backend.NewKey(userGroupPrefix)),
 	}
 }
 
@@ -1628,7 +1628,7 @@ func (p *userGroupParser) parse(event backend.Event) (types.Resource, error) {
 
 func newOktaImportRuleParser() *oktaImportRuleParser {
 	return &oktaImportRuleParser{
-		baseParser: newBaseParser(backend.Key(oktaImportRulePrefix)),
+		baseParser: newBaseParser(backend.NewKey(oktaImportRulePrefix)),
 	}
 }
 
@@ -1652,7 +1652,7 @@ func (p *oktaImportRuleParser) parse(event backend.Event) (types.Resource, error
 
 func newOktaAssignmentParser() *oktaAssignmentParser {
 	return &oktaAssignmentParser{
-		baseParser: newBaseParser(backend.Key(oktaAssignmentPrefix)),
+		baseParser: newBaseParser(backend.NewKey(oktaAssignmentPrefix)),
 	}
 }
 
@@ -1676,7 +1676,7 @@ func (p *oktaAssignmentParser) parse(event backend.Event) (types.Resource, error
 
 func newIntegrationParser() *integrationParser {
 	return &integrationParser{
-		baseParser: newBaseParser(backend.Key(integrationsPrefix)),
+		baseParser: newBaseParser(backend.NewKey(integrationsPrefix)),
 	}
 }
 
@@ -1700,7 +1700,7 @@ func (p *integrationParser) parse(event backend.Event) (types.Resource, error) {
 
 func newDiscoveryConfigParser() *discoveryConfigParser {
 	return &discoveryConfigParser{
-		baseParser: newBaseParser(backend.Key(discoveryConfigPrefix)),
+		baseParser: newBaseParser(backend.NewKey(discoveryConfigPrefix)),
 	}
 }
 
@@ -1729,7 +1729,7 @@ func newHeadlessAuthenticationParser(m map[string]string) (*headlessAuthenticati
 	}
 
 	return &headlessAuthenticationParser{
-		baseParser: newBaseParser(backend.Key(headlessAuthenticationPrefix)),
+		baseParser: newBaseParser(backend.NewKey(headlessAuthenticationPrefix)),
 		filter:     filter,
 	}, nil
 }
@@ -1783,7 +1783,7 @@ func (p *accessListParser) parse(event backend.Event) (types.Resource, error) {
 
 func newAuditQueryParser() *auditQueryParser {
 	return &auditQueryParser{
-		baseParser: newBaseParser(backend.Key(AuditQueryPrefix)),
+		baseParser: newBaseParser(backend.NewKey(AuditQueryPrefix)),
 	}
 }
 
@@ -1806,7 +1806,7 @@ func (p *auditQueryParser) parse(event backend.Event) (types.Resource, error) {
 
 func newSecurityReportParser() *securityReportParser {
 	return &securityReportParser{
-		baseParser: newBaseParser(backend.Key(SecurityReportPrefix)),
+		baseParser: newBaseParser(backend.NewKey(SecurityReportPrefix)),
 	}
 }
 
@@ -1829,7 +1829,7 @@ func (p *securityReportParser) parse(event backend.Event) (types.Resource, error
 
 func newSecurityReportStateParser() *securityReportStateParser {
 	return &securityReportStateParser{
-		baseParser: newBaseParser(backend.Key(SecurityReportStatePrefix)),
+		baseParser: newBaseParser(backend.NewKey(SecurityReportStatePrefix)),
 	}
 }
 
@@ -1852,7 +1852,7 @@ func (p *securityReportStateParser) parse(event backend.Event) (types.Resource, 
 
 func newUserLoginStateParser() *userLoginStateParser {
 	return &userLoginStateParser{
-		baseParser: newBaseParser(backend.Key(userLoginStatePrefix)),
+		baseParser: newBaseParser(backend.NewKey(userLoginStatePrefix)),
 	}
 }
 
@@ -1948,7 +1948,7 @@ func (p *accessListReviewParser) parse(event backend.Event) (types.Resource, err
 
 func newKubeWaitingContainerParser() *kubeWaitingContainerParser {
 	return &kubeWaitingContainerParser{
-		baseParser: newBaseParser(backend.Key(kubeWaitingContPrefix)),
+		baseParser: newBaseParser(backend.NewKey(kubeWaitingContPrefix)),
 	}
 }
 
@@ -2031,7 +2031,7 @@ func (p *AccessMonitoringRuleParser) parse(event backend.Event) (types.Resource,
 
 func newUserNotificationParser() *userNotificationParser {
 	return &userNotificationParser{
-		baseParser: newBaseParser(backend.Key(notificationsUserSpecificPrefix)),
+		baseParser: newBaseParser(backend.NewKey(notificationsUserSpecificPrefix)),
 	}
 }
 
@@ -2079,7 +2079,7 @@ func (p *userNotificationParser) parse(event backend.Event) (types.Resource, err
 
 func newGlobalNotificationParser() *globalNotificationParser {
 	return &globalNotificationParser{
-		baseParser: newBaseParser(backend.Key(notificationsGlobalPrefix)),
+		baseParser: newBaseParser(backend.NewKey(notificationsGlobalPrefix)),
 	}
 }
 
@@ -2130,7 +2130,7 @@ func (p *globalNotificationParser) parse(event backend.Event) (types.Resource, e
 
 func newBotInstanceParser() *botInstanceParser {
 	return &botInstanceParser{
-		baseParser: newBaseParser(backend.Key(botInstancePrefix)),
+		baseParser: newBaseParser(backend.NewKey(botInstancePrefix)),
 	}
 }
 
@@ -2181,7 +2181,7 @@ func (p *botInstanceParser) parse(event backend.Event) (types.Resource, error) {
 
 func newInstanceParser() *instanceParser {
 	return &instanceParser{
-		baseParser: newBaseParser(backend.Key(instancePrefix)),
+		baseParser: newBaseParser(backend.NewKey(instancePrefix)),
 	}
 }
 
@@ -2206,7 +2206,7 @@ func (p *instanceParser) parse(event backend.Event) (types.Resource, error) {
 
 func newStaticHostUserParser() *staticHostUserParser {
 	return &staticHostUserParser{
-		baseParser: newBaseParser(backend.Key(staticHostUserPrefix)),
+		baseParser: newBaseParser(backend.NewKey(staticHostUserPrefix)),
 	}
 }
 
@@ -2302,7 +2302,7 @@ func WaitForEvent(ctx context.Context, watcher types.Watcher, m EventMatcher, cl
 
 func newDeviceParser() *deviceParser {
 	return &deviceParser{
-		baseParser: newBaseParser(backend.Key(devicetrust.DevicesIDPrefix...)),
+		baseParser: newBaseParser(backend.NewKey(devicetrust.DevicesIDPrefix...)),
 	}
 }
 
@@ -2346,7 +2346,7 @@ func (p *deviceParser) parse(event backend.Event) (types.Resource, error) {
 
 func newAccessGraphSecretPrivateKeyParser() *accessGraphSecretPrivateKeyParser {
 	return &accessGraphSecretPrivateKeyParser{
-		baseParser: newBaseParser(backend.Key(privateKeysPrefix)),
+		baseParser: newBaseParser(backend.NewKey(privateKeysPrefix)),
 	}
 }
 
@@ -2390,7 +2390,7 @@ func (p *accessGraphSecretPrivateKeyParser) parse(event backend.Event) (types.Re
 
 func newAccessGraphSecretAuthorizedKeyParser() *accessGraphSecretAuthorizedKeyParser {
 	return &accessGraphSecretAuthorizedKeyParser{
-		baseParser: newBaseParser(backend.Key(authorizedKeysPrefix)),
+		baseParser: newBaseParser(backend.NewKey(authorizedKeysPrefix)),
 	}
 }
 
@@ -2470,7 +2470,7 @@ func baseTwoKeys(key []byte) (string, string, error) {
 
 func newAccessGraphSettingsParser() *accessGraphSettingsParser {
 	return &accessGraphSettingsParser{
-		baseParser: newBaseParser(backend.Key(clusterConfigPrefix, accessGraphSettingsPrefix)),
+		baseParser: newBaseParser(backend.NewKey(clusterConfigPrefix, accessGraphSettingsPrefix)),
 	}
 }
 
@@ -2504,7 +2504,7 @@ func (p *accessGraphSettingsParser) parse(event backend.Event) (types.Resource, 
 
 func newSPIFFEFederationParser() *spiffeFederationParser {
 	return &spiffeFederationParser{
-		baseParser: newBaseParser(backend.Key(spiffeFederationPrefix)),
+		baseParser: newBaseParser(backend.NewKey(spiffeFederationPrefix)),
 	}
 }
 

--- a/lib/services/local/externalauditstorage.go
+++ b/lib/services/local/externalauditstorage.go
@@ -38,8 +38,8 @@ const (
 )
 
 var (
-	draftExternalAuditStorageBackendKey   = backend.Key(externalAuditStoragePrefix, externalAuditStorageDraftName)
-	clusterExternalAuditStorageBackendKey = backend.Key(externalAuditStoragePrefix, externalAuditStorageClusterName)
+	draftExternalAuditStorageBackendKey   = backend.NewKey(externalAuditStoragePrefix, externalAuditStorageDraftName)
+	clusterExternalAuditStorageBackendKey = backend.NewKey(externalAuditStoragePrefix, externalAuditStorageClusterName)
 )
 
 // ExternalAuditStorageService manages External Audit Storage resources in the Backend.

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -177,7 +177,7 @@ func (s *Service[T]) ListResourcesReturnNextResource(ctx context.Context, pageSi
 	return resources, next, trace.Wrap(err)
 }
 func (s *Service[T]) listResourcesReturnNextResourceWithKey(ctx context.Context, pageSize int, pageToken string) ([]T, *T, string, error) {
-	rangeStart := backend.Key(s.backendPrefix, pageToken)
+	rangeStart := backend.NewKey(s.backendPrefix, pageToken)
 	rangeEnd := backend.RangeEnd(backend.ExactKey(s.backendPrefix))
 
 	// Adjust page size, so it can't be too large.
@@ -220,7 +220,7 @@ func (s *Service[T]) listResourcesReturnNextResourceWithKey(ctx context.Context,
 
 // ListResourcesWithFilter returns a paginated list of resources that match the given filter.
 func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, pageToken string, matcher func(T) bool) ([]T, string, error) {
-	rangeStart := backend.Key(s.backendPrefix, pageToken)
+	rangeStart := backend.NewKey(s.backendPrefix, pageToken)
 	rangeEnd := backend.RangeEnd(backend.ExactKey(s.backendPrefix))
 
 	// Adjust page size, so it can't be too large.
@@ -444,7 +444,7 @@ func (s *Service[T]) MakeBackendItem(resource T, name string) (backend.Item, err
 
 // MakeKey will make a key for the service given a name.
 func (s *Service[T]) MakeKey(name string) []byte {
-	return backend.Key(s.backendPrefix, name)
+	return backend.NewKey(s.backendPrefix, name)
 }
 
 // RunWhileLocked will run the given function in a backend lock. This is a wrapper around the backend.RunWhileLocked function.

--- a/lib/services/local/headlessauthn.go
+++ b/lib/services/local/headlessauthn.go
@@ -158,5 +158,5 @@ func unmarshalHeadlessAuthentication(data []byte) (*types.HeadlessAuthentication
 const headlessAuthenticationPrefix = "headless_authentication"
 
 func headlessAuthenticationKey(username, name string) []byte {
-	return backend.Key(headlessAuthenticationPrefix, usersPrefix, username, name)
+	return backend.NewKey(headlessAuthenticationPrefix, usersPrefix, username, name)
 }

--- a/lib/services/local/headlessauthn_watcher.go
+++ b/lib/services/local/headlessauthn_watcher.go
@@ -205,7 +205,7 @@ func (h *HeadlessAuthenticationWatcher) newWatcher(ctx context.Context) (backend
 	watcher, err := h.identityService.NewWatcher(ctx, backend.Watch{
 		Name:            types.KindHeadlessAuthentication,
 		MetricComponent: types.KindHeadlessAuthentication,
-		Prefixes:        [][]byte{backend.Key(headlessAuthenticationPrefix)},
+		Prefixes:        [][]byte{backend.NewKey(headlessAuthenticationPrefix)},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/inventory.go
+++ b/lib/services/local/inventory.go
@@ -70,7 +70,7 @@ func (s *PresenceService) GetInstances(ctx context.Context, req types.InstanceFi
 
 // getInstance gets an instance resource by server ID.
 func (s *PresenceService) getInstance(ctx context.Context, serverID string) (types.Instance, error) {
-	item, err := s.Get(ctx, backend.Key(instancePrefix, serverID))
+	item, err := s.Get(ctx, backend.NewKey(instancePrefix, serverID))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -105,7 +105,7 @@ func (s *PresenceService) UpsertInstance(ctx context.Context, instance types.Ins
 		return trace.BadParameter("unexpected type %T, expected %T", instance, v1)
 	}
 
-	item, err := generic.FastMarshal(backend.Key(instancePrefix, instance.GetName()), v1)
+	item, err := generic.FastMarshal(backend.NewKey(instancePrefix, instance.GetName()), v1)
 	if err != nil {
 		return trace.Errorf("failed to marshal Instance: %v", err)
 	}

--- a/lib/services/local/kube.go
+++ b/lib/services/local/kube.go
@@ -59,7 +59,7 @@ func (s *KubernetesService) GetKubernetesClusters(ctx context.Context) ([]types.
 
 // GetKubernetesCluster returns the specified kubernetes cluster resource.
 func (s *KubernetesService) GetKubernetesCluster(ctx context.Context, name string) (types.KubeCluster, error) {
-	item, err := s.Get(ctx, backend.Key(kubernetesPrefix, name))
+	item, err := s.Get(ctx, backend.NewKey(kubernetesPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("kubernetes cluster %q doesn't exist", name)
@@ -84,7 +84,7 @@ func (s *KubernetesService) CreateKubernetesCluster(ctx context.Context, cluster
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(kubernetesPrefix, cluster.GetName()),
+		Key:     backend.NewKey(kubernetesPrefix, cluster.GetName()),
 		Value:   value,
 		Expires: cluster.Expiry(),
 	}
@@ -110,7 +110,7 @@ func (s *KubernetesService) UpdateKubernetesCluster(ctx context.Context, cluster
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(kubernetesPrefix, cluster.GetName()),
+		Key:      backend.NewKey(kubernetesPrefix, cluster.GetName()),
 		Value:    value,
 		Expires:  cluster.Expiry(),
 		Revision: rev,
@@ -127,7 +127,7 @@ func (s *KubernetesService) UpdateKubernetesCluster(ctx context.Context, cluster
 
 // DeleteKubernetesCluster removes the specified kubernetes cluster resource.
 func (s *KubernetesService) DeleteKubernetesCluster(ctx context.Context, name string) error {
-	err := s.Delete(ctx, backend.Key(kubernetesPrefix, name))
+	err := s.Delete(ctx, backend.NewKey(kubernetesPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("kubernetes cluster %q doesn't exist", name)

--- a/lib/services/local/plugin_data.go
+++ b/lib/services/local/plugin_data.go
@@ -249,7 +249,7 @@ func itemToPluginData(item backend.Item) (types.PluginData, error) {
 }
 
 func pluginDataKey(kind string, name string) []byte {
-	return backend.Key(pluginDataPrefix, kind, name, paramsPrefix)
+	return backend.NewKey(pluginDataPrefix, kind, name, paramsPrefix)
 }
 
 const (

--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -48,7 +48,7 @@ func (s *PluginsService) CreatePlugin(ctx context.Context, plugin types.Plugin) 
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(pluginsPrefix, plugin.GetName()),
+		Key:     backend.NewKey(pluginsPrefix, plugin.GetName()),
 		Value:   value,
 		Expires: plugin.Expiry(),
 	}
@@ -62,7 +62,7 @@ func (s *PluginsService) CreatePlugin(ctx context.Context, plugin types.Plugin) 
 
 // DeletePlugin implements service.Plugins
 func (s *PluginsService) DeletePlugin(ctx context.Context, name string) error {
-	err := s.backend.Delete(ctx, backend.Key(pluginsPrefix, name))
+	err := s.backend.Delete(ctx, backend.NewKey(pluginsPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("plugin %q doesn't exist", name)
@@ -82,7 +82,7 @@ func (s *PluginsService) UpdatePlugin(ctx context.Context, plugin types.Plugin) 
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(pluginsPrefix, plugin.GetName()),
+		Key:      backend.NewKey(pluginsPrefix, plugin.GetName()),
 		Value:    value,
 		Expires:  plugin.Expiry(),
 		Revision: plugin.GetRevision(),
@@ -109,7 +109,7 @@ func (s *PluginsService) DeleteAllPlugins(ctx context.Context) error {
 
 // GetPlugin implements services.Plugins
 func (s *PluginsService) GetPlugin(ctx context.Context, name string, withSecrets bool) (types.Plugin, error) {
-	item, err := s.backend.Get(ctx, backend.Key(pluginsPrefix, name))
+	item, err := s.backend.Get(ctx, backend.NewKey(pluginsPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("plugin %q doesn't exist", name)
@@ -159,7 +159,7 @@ func (s *PluginsService) ListPlugins(ctx context.Context, limit int, startKey st
 	// Get at most limit+1 results to determine if there will be a next key.
 	maxLimit := limit + 1
 
-	startKeyBytes := backend.Key(pluginsPrefix, startKey)
+	startKeyBytes := backend.NewKey(pluginsPrefix, startKey)
 	endKey := backend.RangeEnd(backend.ExactKey(pluginsPrefix))
 	result, err := s.backend.GetRange(ctx, startKeyBytes, endKey, maxLimit)
 	if err != nil {
@@ -218,7 +218,7 @@ func (s *PluginsService) SetPluginStatus(ctx context.Context, name string, statu
 }
 
 func (s *PluginsService) updateAndSwap(ctx context.Context, name string, modify func(types.Plugin) error) error {
-	key := backend.Key(pluginsPrefix, name)
+	key := backend.NewKey(pluginsPrefix, name)
 	item, err := s.backend.Get(ctx, key)
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -247,7 +247,7 @@ func (s *PluginsService) updateAndSwap(ctx context.Context, name string, modify 
 	}
 
 	_, err = s.backend.CompareAndSwap(ctx, *item, backend.Item{
-		Key:      backend.Key(pluginsPrefix, plugin.GetName()),
+		Key:      backend.NewKey(pluginsPrefix, plugin.GetName()),
 		Value:    value,
 		Expires:  plugin.Expiry(),
 		Revision: rev,

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -104,7 +104,7 @@ func (s *PresenceService) UpsertNamespace(n types.Namespace) error {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(namespacesPrefix, n.Metadata.Name, paramsPrefix),
+		Key:      backend.NewKey(namespacesPrefix, n.Metadata.Name, paramsPrefix),
 		Value:    value,
 		Expires:  n.Metadata.Expiry(),
 		Revision: rev,
@@ -122,7 +122,7 @@ func (s *PresenceService) GetNamespace(name string) (*types.Namespace, error) {
 	if name == "" {
 		return nil, trace.BadParameter("missing namespace name")
 	}
-	item, err := s.Get(context.TODO(), backend.Key(namespacesPrefix, name, paramsPrefix))
+	item, err := s.Get(context.TODO(), backend.NewKey(namespacesPrefix, name, paramsPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("namespace %q is not found", name)
@@ -138,7 +138,7 @@ func (s *PresenceService) DeleteNamespace(namespace string) error {
 	if namespace == "" {
 		return trace.BadParameter("missing namespace name")
 	}
-	err := s.Delete(context.TODO(), backend.Key(namespacesPrefix, namespace, paramsPrefix))
+	err := s.Delete(context.TODO(), backend.NewKey(namespacesPrefix, namespace, paramsPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("namespace %q is not found", namespace)
@@ -229,9 +229,9 @@ func (s *PresenceService) DeleteServerInfo(ctx context.Context, name string) err
 func serverInfoKey(subkind, name string) []byte {
 	switch subkind {
 	case types.SubKindCloudInfo:
-		return backend.Key(serverInfoPrefix, cloudLabelsPrefix, name)
+		return backend.NewKey(serverInfoPrefix, cloudLabelsPrefix, name)
 	default:
-		return backend.Key(serverInfoPrefix, name)
+		return backend.NewKey(serverInfoPrefix, name)
 	}
 }
 
@@ -266,7 +266,7 @@ func (s *PresenceService) upsertServer(ctx context.Context, prefix string, serve
 		return trace.Wrap(err)
 	}
 	_, err = s.Put(ctx, backend.Item{
-		Key:      backend.Key(prefix, server.GetName()),
+		Key:      backend.NewKey(prefix, server.GetName()),
 		Value:    value,
 		Expires:  server.Expiry(),
 		Revision: rev,
@@ -282,7 +282,7 @@ func (s *PresenceService) DeleteAllNodes(ctx context.Context, namespace string) 
 
 // DeleteNode deletes node
 func (s *PresenceService) DeleteNode(ctx context.Context, namespace string, name string) error {
-	key := backend.Key(nodesPrefix, namespace, name)
+	key := backend.NewKey(nodesPrefix, namespace, name)
 	return s.Delete(ctx, key)
 }
 
@@ -294,7 +294,7 @@ func (s *PresenceService) GetNode(ctx context.Context, namespace, name string) (
 	if name == "" {
 		return nil, trace.BadParameter("missing parameter name")
 	}
-	item, err := s.Get(ctx, backend.Key(nodesPrefix, namespace, name))
+	item, err := s.Get(ctx, backend.NewKey(nodesPrefix, namespace, name))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -354,7 +354,7 @@ func (s *PresenceService) UpsertNode(ctx context.Context, server types.Server) (
 		return nil, trace.Wrap(err)
 	}
 	_, err = s.Put(ctx, backend.Item{
-		Key:      backend.Key(nodesPrefix, server.GetNamespace(), server.GetName()),
+		Key:      backend.NewKey(nodesPrefix, server.GetNamespace(), server.GetName()),
 		Value:    value,
 		Expires:  server.Expiry(),
 		Revision: rev,
@@ -390,7 +390,7 @@ func (s *PresenceService) DeleteAllAuthServers() error {
 
 // DeleteAuthServer deletes auth server by name
 func (s *PresenceService) DeleteAuthServer(name string) error {
-	key := backend.Key(authServersPrefix, name)
+	key := backend.NewKey(authServersPrefix, name)
 	return s.Delete(context.TODO(), key)
 }
 
@@ -413,7 +413,7 @@ func (s *PresenceService) DeleteAllProxies() error {
 
 // DeleteProxy deletes proxy
 func (s *PresenceService) DeleteProxy(ctx context.Context, name string) error {
-	key := backend.Key(proxiesPrefix, name)
+	key := backend.NewKey(proxiesPrefix, name)
 	return s.Delete(ctx, key)
 }
 
@@ -434,7 +434,7 @@ func (s *PresenceService) UpsertReverseTunnel(tunnel types.ReverseTunnel) error 
 		return trace.Wrap(err)
 	}
 	_, err = s.Put(context.TODO(), backend.Item{
-		Key:      backend.Key(reverseTunnelsPrefix, tunnel.GetName()),
+		Key:      backend.NewKey(reverseTunnelsPrefix, tunnel.GetName()),
 		Value:    value,
 		Expires:  tunnel.Expiry(),
 		Revision: rev,
@@ -444,7 +444,7 @@ func (s *PresenceService) UpsertReverseTunnel(tunnel types.ReverseTunnel) error 
 
 // GetReverseTunnel returns reverse tunnel by name
 func (s *PresenceService) GetReverseTunnel(name string, opts ...services.MarshalOption) (types.ReverseTunnel, error) {
-	item, err := s.Get(context.TODO(), backend.Key(reverseTunnelsPrefix, name))
+	item, err := s.Get(context.TODO(), backend.NewKey(reverseTunnelsPrefix, name))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -478,7 +478,7 @@ func (s *PresenceService) GetReverseTunnels(ctx context.Context, opts ...service
 
 // DeleteReverseTunnel deletes reverse tunnel by it's cluster name
 func (s *PresenceService) DeleteReverseTunnel(clusterName string) error {
-	err := s.Delete(context.TODO(), backend.Key(reverseTunnelsPrefix, clusterName))
+	err := s.Delete(context.TODO(), backend.NewKey(reverseTunnelsPrefix, clusterName))
 	return trace.Wrap(err)
 }
 
@@ -509,7 +509,7 @@ func (s *PresenceService) AcquireSemaphore(ctx context.Context, req types.Acquir
 	leaseID := uuid.New().String()
 
 	// key is not modified, so allocate it once
-	key := backend.Key(semaphoresPrefix, req.SemaphoreKind, req.SemaphoreName)
+	key := backend.NewKey(semaphoresPrefix, req.SemaphoreKind, req.SemaphoreName)
 
 Acquire:
 	for i := int64(0); i < leaseRetryAttempts; i++ {
@@ -636,7 +636,7 @@ func (s *PresenceService) KeepAliveSemaphoreLease(ctx context.Context, lease typ
 		return trace.BadParameter("lease %v has expired at %v", lease.LeaseID, lease.Expires)
 	}
 
-	key := backend.Key(semaphoresPrefix, lease.SemaphoreKind, lease.SemaphoreName)
+	key := backend.NewKey(semaphoresPrefix, lease.SemaphoreKind, lease.SemaphoreName)
 	item, err := s.Get(ctx, key)
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -703,7 +703,7 @@ func (s *PresenceService) CancelSemaphoreLease(ctx context.Context, lease types.
 			}
 		}
 
-		key := backend.Key(semaphoresPrefix, lease.SemaphoreKind, lease.SemaphoreName)
+		key := backend.NewKey(semaphoresPrefix, lease.SemaphoreKind, lease.SemaphoreName)
 		item, err := s.Get(ctx, key)
 		if err != nil {
 			return trace.Wrap(err)
@@ -751,7 +751,7 @@ func (s *PresenceService) GetSemaphores(ctx context.Context, filter types.Semaph
 	var items []backend.Item
 	if filter.SemaphoreKind != "" && filter.SemaphoreName != "" {
 		// special case: filter corresponds to a single semaphore
-		item, err := s.Get(ctx, backend.Key(semaphoresPrefix, filter.SemaphoreKind, filter.SemaphoreName))
+		item, err := s.Get(ctx, backend.NewKey(semaphoresPrefix, filter.SemaphoreKind, filter.SemaphoreName))
 		if err != nil {
 			if trace.IsNotFound(err) {
 				return nil, nil
@@ -796,7 +796,7 @@ func (s *PresenceService) DeleteSemaphore(ctx context.Context, filter types.Sema
 	if filter.SemaphoreKind == "" || filter.SemaphoreName == "" {
 		return trace.BadParameter("semaphore kind and name must be specified for deletion")
 	}
-	return trace.Wrap(s.Delete(ctx, backend.Key(semaphoresPrefix, filter.SemaphoreKind, filter.SemaphoreName)))
+	return trace.Wrap(s.Delete(ctx, backend.NewKey(semaphoresPrefix, filter.SemaphoreKind, filter.SemaphoreName)))
 }
 
 // UpsertKubernetesServer registers an kubernetes server.
@@ -814,7 +814,7 @@ func (s *PresenceService) UpsertKubernetesServer(ctx context.Context, server typ
 	// the following path in the backend:
 	//   /kubeServers/<host-uuid>/<name>
 	_, err = s.Put(ctx, backend.Item{
-		Key: backend.Key(kubeServersPrefix,
+		Key: backend.NewKey(kubeServersPrefix,
 			server.GetHostID(),
 			server.GetName()),
 		Value:    value,
@@ -844,7 +844,7 @@ func (s *PresenceService) DeleteKubernetesServer(ctx context.Context, hostID, na
 	if hostID == "" {
 		return trace.BadParameter("no hostID specified for kubernetes server deletion")
 	}
-	key := backend.Key(kubeServersPrefix, hostID, name)
+	key := backend.NewKey(kubeServersPrefix, hostID, name)
 	return s.Delete(ctx, key)
 }
 
@@ -919,7 +919,7 @@ func (s *PresenceService) UpsertDatabaseServer(ctx context.Context, server types
 	// they are stored under the following path in the backend:
 	//   /databaseServers/<namespace>/<host-uuid>/<name>
 	_, err = s.Put(ctx, backend.Item{
-		Key: backend.Key(dbServersPrefix,
+		Key: backend.NewKey(dbServersPrefix,
 			server.GetNamespace(),
 			server.GetHostID(),
 			server.GetName()),
@@ -953,7 +953,7 @@ func (s *PresenceService) DeleteDatabaseServer(ctx context.Context, namespace, h
 	if name == "" {
 		return trace.BadParameter("missing database server name")
 	}
-	key := backend.Key(dbServersPrefix, namespace, hostID, name)
+	key := backend.NewKey(dbServersPrefix, namespace, hostID, name)
 	return s.Delete(ctx, key)
 }
 
@@ -1013,7 +1013,7 @@ func (s *PresenceService) UpsertApplicationServer(ctx context.Context, server ty
 	// the following path in the backend:
 	//   /appServers/<namespace>/<host-uuid>/<name>
 	_, err = s.Put(ctx, backend.Item{
-		Key: backend.Key(appServersPrefix,
+		Key: backend.NewKey(appServersPrefix,
 			server.GetNamespace(),
 			server.GetHostID(),
 			server.GetName()),
@@ -1038,7 +1038,7 @@ func (s *PresenceService) UpsertApplicationServer(ctx context.Context, server ty
 
 // DeleteApplicationServer removes specified application server.
 func (s *PresenceService) DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error {
-	key := backend.Key(appServersPrefix, namespace, hostID, name)
+	key := backend.NewKey(appServersPrefix, namespace, hostID, name)
 	return s.Delete(ctx, key)
 }
 
@@ -1058,21 +1058,21 @@ func (s *PresenceService) KeepAliveServer(ctx context.Context, h types.KeepAlive
 	var key []byte
 	switch h.GetType() {
 	case constants.KeepAliveNode:
-		key = backend.Key(nodesPrefix, h.Namespace, h.Name)
+		key = backend.NewKey(nodesPrefix, h.Namespace, h.Name)
 	case constants.KeepAliveApp:
 		if h.HostID != "" {
-			key = backend.Key(appServersPrefix, h.Namespace, h.HostID, h.Name)
+			key = backend.NewKey(appServersPrefix, h.Namespace, h.HostID, h.Name)
 		} else { // DELETE IN 9.0. Legacy app server is heartbeating back.
-			key = backend.Key(appsPrefix, serversPrefix, h.Namespace, h.Name)
+			key = backend.NewKey(appsPrefix, serversPrefix, h.Namespace, h.Name)
 		}
 	case constants.KeepAliveDatabase:
-		key = backend.Key(dbServersPrefix, h.Namespace, h.HostID, h.Name)
+		key = backend.NewKey(dbServersPrefix, h.Namespace, h.HostID, h.Name)
 	case constants.KeepAliveWindowsDesktopService:
-		key = backend.Key(windowsDesktopServicesPrefix, h.Name)
+		key = backend.NewKey(windowsDesktopServicesPrefix, h.Name)
 	case constants.KeepAliveKube:
-		key = backend.Key(kubeServersPrefix, h.HostID, h.Name)
+		key = backend.NewKey(kubeServersPrefix, h.HostID, h.Name)
 	case constants.KeepAliveDatabaseService:
-		key = backend.Key(databaseServicePrefix, h.Name)
+		key = backend.NewKey(databaseServicePrefix, h.Name)
 	default:
 		return trace.BadParameter("unknown keep-alive type %q", h.GetType())
 	}
@@ -1106,7 +1106,7 @@ func (s *PresenceService) GetWindowsDesktopServices(ctx context.Context) ([]type
 }
 
 func (s *PresenceService) GetWindowsDesktopService(ctx context.Context, name string) (types.WindowsDesktopService, error) {
-	result, err := s.Get(ctx, backend.Key(windowsDesktopServicesPrefix, name))
+	result, err := s.Get(ctx, backend.NewKey(windowsDesktopServicesPrefix, name))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1132,7 +1132,7 @@ func (s *PresenceService) UpsertWindowsDesktopService(ctx context.Context, srv t
 		return nil, trace.Wrap(err)
 	}
 	_, err = s.Put(ctx, backend.Item{
-		Key:      backend.Key(windowsDesktopServicesPrefix, srv.GetName()),
+		Key:      backend.NewKey(windowsDesktopServicesPrefix, srv.GetName()),
 		Value:    value,
 		Expires:  srv.Expiry(),
 		Revision: rev,
@@ -1156,7 +1156,7 @@ func (s *PresenceService) DeleteWindowsDesktopService(ctx context.Context, name 
 	if name == "" {
 		return trace.BadParameter("missing windows desktop service name")
 	}
-	key := backend.Key(windowsDesktopServicesPrefix, name)
+	key := backend.NewKey(windowsDesktopServicesPrefix, name)
 	return s.Delete(ctx, key)
 }
 
@@ -1173,7 +1173,7 @@ func (s *PresenceService) UpsertHostUserInteractionTime(ctx context.Context, nam
 		return err
 	}
 	_, err = s.Put(ctx, backend.Item{
-		Key:   backend.Key(loginTimePrefix, name),
+		Key:   backend.NewKey(loginTimePrefix, name),
 		Value: val,
 	})
 	return trace.Wrap(err)
@@ -1181,7 +1181,7 @@ func (s *PresenceService) UpsertHostUserInteractionTime(ctx context.Context, nam
 
 // GetHostUserInteractionTime retrieves a unix user's interaction time
 func (s *PresenceService) GetHostUserInteractionTime(ctx context.Context, name string) (time.Time, error) {
-	item, err := s.Get(ctx, backend.Key(loginTimePrefix, name))
+	item, err := s.Get(ctx, backend.NewKey(loginTimePrefix, name))
 	if err != nil {
 		return time.Time{}, trace.Wrap(err)
 	}
@@ -1285,7 +1285,7 @@ func (s *PresenceService) listResources(ctx context.Context, req proto.ListResou
 		return nil, trace.NotImplemented("%s not implemented at ListResources", req.ResourceType)
 	}
 
-	rangeStart := backend.Key(append(keyPrefix, req.StartKey)...)
+	rangeStart := backend.NewKey(append(keyPrefix, req.StartKey)...)
 	rangeEnd := backend.RangeEnd(backend.ExactKey(keyPrefix...))
 	filter := services.MatchResourceFilter{
 		ResourceKind:   req.ResourceType,

--- a/lib/services/local/provisioning.go
+++ b/lib/services/local/provisioning.go
@@ -77,7 +77,7 @@ func (s *ProvisioningService) tokenToItem(p types.ProvisionToken) (*backend.Item
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:      backend.Key(tokensPrefix, p.GetName()),
+		Key:      backend.NewKey(tokensPrefix, p.GetName()),
 		Value:    data,
 		Expires:  p.Expiry(),
 		Revision: rev,
@@ -87,7 +87,7 @@ func (s *ProvisioningService) tokenToItem(p types.ProvisionToken) (*backend.Item
 
 // DeleteAllTokens deletes all provisioning tokens
 func (s *ProvisioningService) DeleteAllTokens() error {
-	startKey := backend.Key(tokensPrefix)
+	startKey := backend.NewKey(tokensPrefix)
 	return s.DeleteRange(context.TODO(), startKey, backend.RangeEnd(startKey))
 }
 
@@ -96,7 +96,7 @@ func (s *ProvisioningService) GetToken(ctx context.Context, token string) (types
 	if token == "" {
 		return nil, trace.BadParameter("missing parameter token")
 	}
-	item, err := s.Get(ctx, backend.Key(tokensPrefix, token))
+	item, err := s.Get(ctx, backend.NewKey(tokensPrefix, token))
 	if trace.IsNotFound(err) {
 		return nil, trace.NotFound("provisioning token(%s) not found", backend.MaskKeyName(token))
 	} else if err != nil {
@@ -111,7 +111,7 @@ func (s *ProvisioningService) DeleteToken(ctx context.Context, token string) err
 	if token == "" {
 		return trace.BadParameter("missing parameter token")
 	}
-	err := s.Delete(ctx, backend.Key(tokensPrefix, token))
+	err := s.Delete(ctx, backend.NewKey(tokensPrefix, token))
 	if trace.IsNotFound(err) {
 		return trace.NotFound("provisioning token(%s) not found", backend.MaskKeyName(token))
 	}

--- a/lib/services/local/resource.go
+++ b/lib/services/local/resource.go
@@ -133,7 +133,7 @@ func itemFromClusterNetworkingConfig(cnc types.ClusterNetworkingConfig) (*backen
 	}
 
 	item := &backend.Item{
-		Key:      backend.Key(clusterConfigPrefix, networkingPrefix),
+		Key:      backend.NewKey(clusterConfigPrefix, networkingPrefix),
 		Value:    value,
 		Revision: cnc.GetRevision(),
 	}
@@ -152,7 +152,7 @@ func itemFromAuthPreference(ap types.AuthPreference) (*backend.Item, error) {
 	}
 
 	item := &backend.Item{
-		Key:      backend.Key(authPrefix, preferencePrefix, generalPrefix),
+		Key:      backend.NewKey(authPrefix, preferencePrefix, generalPrefix),
 		Value:    value,
 		Revision: ap.GetRevision(),
 	}
@@ -172,7 +172,7 @@ func itemFromUser(user types.User) (*backend.Item, error) {
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:      backend.Key(webPrefix, usersPrefix, user.GetName(), paramsPrefix),
+		Key:      backend.NewKey(webPrefix, usersPrefix, user.GetName(), paramsPrefix),
 		Value:    value,
 		Expires:  user.Expiry(),
 		Revision: rev,
@@ -209,7 +209,7 @@ func itemFromCertAuthority(ca types.CertAuthority) (*backend.Item, error) {
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:      backend.Key(authoritiesPrefix, string(ca.GetType()), ca.GetName()),
+		Key:      backend.NewKey(authoritiesPrefix, string(ca.GetType()), ca.GetName()),
 		Value:    value,
 		Expires:  ca.Expiry(),
 		Revision: rev,
@@ -229,7 +229,7 @@ func itemFromProvisionToken(p types.ProvisionToken) (*backend.Item, error) {
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:      backend.Key(tokensPrefix, p.GetName()),
+		Key:      backend.NewKey(tokensPrefix, p.GetName()),
 		Value:    value,
 		Expires:  p.Expiry(),
 		Revision: rev,
@@ -249,7 +249,7 @@ func itemFromTrustedCluster(tc types.TrustedCluster) (*backend.Item, error) {
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:      backend.Key(trustedClustersPrefix, tc.GetName()),
+		Key:      backend.NewKey(trustedClustersPrefix, tc.GetName()),
 		Value:    value,
 		Expires:  tc.Expiry(),
 		Revision: rev,
@@ -269,7 +269,7 @@ func itemFromGithubConnector(gc types.GithubConnector) (*backend.Item, error) {
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:      backend.Key(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, gc.GetName()),
+		Key:      backend.NewKey(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, gc.GetName()),
 		Value:    value,
 		Expires:  gc.Expiry(),
 		Revision: rev,
@@ -287,7 +287,7 @@ func itemFromRole(role types.Role) (*backend.Item, error) {
 	}
 
 	item := &backend.Item{
-		Key:      backend.Key(rolesPrefix, role.GetName(), paramsPrefix),
+		Key:      backend.NewKey(rolesPrefix, role.GetName(), paramsPrefix),
 		Value:    value,
 		Expires:  role.Expiry(),
 		Revision: rev,
@@ -304,7 +304,7 @@ func itemFromOIDCConnector(connector types.OIDCConnector) (*backend.Item, error)
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:      backend.Key(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, connector.GetName()),
+		Key:      backend.NewKey(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, connector.GetName()),
 		Value:    value,
 		Expires:  connector.Expiry(),
 		Revision: rev,
@@ -324,7 +324,7 @@ func itemFromSAMLConnector(connector types.SAMLConnector) (*backend.Item, error)
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:      backend.Key(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, connector.GetName()),
+		Key:      backend.NewKey(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, connector.GetName()),
 		Value:    value,
 		Expires:  connector.Expiry(),
 		Revision: rev,
@@ -387,7 +387,7 @@ func itemsFromLocalAuthSecrets(user string, auth types.LocalAuthSecrets) ([]back
 	}
 	if len(auth.PasswordHash) > 0 {
 		item := backend.Item{
-			Key:   backend.Key(webPrefix, usersPrefix, user, pwdPrefix),
+			Key:   backend.NewKey(webPrefix, usersPrefix, user, pwdPrefix),
 			Value: auth.PasswordHash,
 		}
 		items = append(items, item)
@@ -398,7 +398,7 @@ func itemsFromLocalAuthSecrets(user string, auth types.LocalAuthSecrets) ([]back
 			return nil, trace.Wrap(err)
 		}
 		items = append(items, backend.Item{
-			Key:   backend.Key(webPrefix, usersPrefix, user, mfaDevicePrefix, mfa.Id),
+			Key:   backend.NewKey(webPrefix, usersPrefix, user, mfaDevicePrefix, mfa.Id),
 			Value: value,
 		})
 	}
@@ -417,7 +417,7 @@ func itemFromLock(l types.Lock) (*backend.Item, error) {
 		return nil, trace.Wrap(err)
 	}
 	return &backend.Item{
-		Key:      backend.Key(locksPrefix, l.GetName()),
+		Key:      backend.NewKey(locksPrefix, l.GetName()),
 		Value:    value,
 		Expires:  l.Expiry(),
 		Revision: rev,
@@ -428,7 +428,7 @@ func itemFromLock(l types.Lock) (*backend.Item, error) {
 // has order N cost.
 
 // fullUsersPrefix is the entire string preceding the name of a user in a key
-var fullUsersPrefix = string(backend.Key(webPrefix, usersPrefix)) + "/"
+var fullUsersPrefix = string(backend.NewKey(webPrefix, usersPrefix)) + "/"
 
 // splitUsernameAndSuffix is a helper for extracting usernames and suffixes from
 // backend key values.

--- a/lib/services/local/restrictions.go
+++ b/lib/services/local/restrictions.go
@@ -50,7 +50,7 @@ func (s *RestrictionsService) SetNetworkRestrictions(ctx context.Context, nr typ
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(restrictionsPrefix, network),
+		Key:      backend.NewKey(restrictionsPrefix, network),
 		Value:    value,
 		Expires:  nr.Expiry(),
 		Revision: rev,
@@ -64,7 +64,7 @@ func (s *RestrictionsService) SetNetworkRestrictions(ctx context.Context, nr typ
 }
 
 func (s *RestrictionsService) GetNetworkRestrictions(ctx context.Context) (types.NetworkRestrictions, error) {
-	item, err := s.Get(context.TODO(), backend.Key(restrictionsPrefix, network))
+	item, err := s.Get(context.TODO(), backend.NewKey(restrictionsPrefix, network))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -74,7 +74,7 @@ func (s *RestrictionsService) GetNetworkRestrictions(ctx context.Context) (types
 
 // SetNetworkRestrictions upserts NetworkRestrictions
 func (s *RestrictionsService) DeleteNetworkRestrictions(ctx context.Context) error {
-	return trace.Wrap(s.Delete(ctx, backend.Key(restrictionsPrefix, network)))
+	return trace.Wrap(s.Delete(ctx, backend.NewKey(restrictionsPrefix, network)))
 }
 
 const (

--- a/lib/services/local/session.go
+++ b/lib/services/local/session.go
@@ -59,7 +59,7 @@ func (s *IdentityService) GetSAMLIdPSession(ctx context.Context, req types.GetSA
 }
 
 func (s *IdentityService) getSession(ctx context.Context, keyParts ...string) (types.WebSession, error) {
-	item, err := s.Get(ctx, backend.Key(keyParts...))
+	item, err := s.Get(ctx, backend.NewKey(keyParts...))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -106,7 +106,7 @@ func (s *IdentityService) ListSAMLIdPSessions(ctx context.Context, pageSize int,
 
 // listSessions gets a paginated list of sessions.
 func (s *IdentityService) listSessions(ctx context.Context, pageSize int, pageToken, user string, keyPrefix ...string) ([]types.WebSession, string, error) {
-	rangeStart := backend.Key(append(keyPrefix, pageToken)...)
+	rangeStart := backend.NewKey(append(keyPrefix, pageToken)...)
 	rangeEnd := backend.RangeEnd(backend.ExactKey(keyPrefix...))
 
 	// Adjust page size, so it can't be too large.
@@ -192,7 +192,7 @@ func (s *IdentityService) upsertSession(ctx context.Context, session types.WebSe
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(append(keyPrefix, session.GetName())...),
+		Key:      backend.NewKey(append(keyPrefix, session.GetName())...),
 		Value:    value,
 		Expires:  session.GetExpiryTime(),
 		Revision: rev,
@@ -206,7 +206,7 @@ func (s *IdentityService) upsertSession(ctx context.Context, session types.WebSe
 
 // DeleteAppSession removes an application web session.
 func (s *IdentityService) DeleteAppSession(ctx context.Context, req types.DeleteAppSessionRequest) error {
-	if err := s.Delete(ctx, backend.Key(appsPrefix, sessionsPrefix, req.SessionID)); err != nil {
+	if err := s.Delete(ctx, backend.NewKey(appsPrefix, sessionsPrefix, req.SessionID)); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -214,7 +214,7 @@ func (s *IdentityService) DeleteAppSession(ctx context.Context, req types.Delete
 
 // DeleteSnowflakeSession removes a Snowflake web session.
 func (s *IdentityService) DeleteSnowflakeSession(ctx context.Context, req types.DeleteSnowflakeSessionRequest) error {
-	if err := s.Delete(ctx, backend.Key(snowflakePrefix, sessionsPrefix, req.SessionID)); err != nil {
+	if err := s.Delete(ctx, backend.NewKey(snowflakePrefix, sessionsPrefix, req.SessionID)); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -223,7 +223,7 @@ func (s *IdentityService) DeleteSnowflakeSession(ctx context.Context, req types.
 // DeleteSAMLIdPSession removes a SAML IdP session.
 // TODO(Joerger): DELETE IN v18.0.0
 func (s *IdentityService) DeleteSAMLIdPSession(ctx context.Context, req types.DeleteSAMLIdPSessionRequest) error {
-	if err := s.Delete(ctx, backend.Key(samlIdPPrefix, sessionsPrefix, req.SessionID)); err != nil {
+	if err := s.Delete(ctx, backend.NewKey(samlIdPPrefix, sessionsPrefix, req.SessionID)); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -510,9 +510,9 @@ type webTokens struct {
 }
 
 func webSessionKey(sessionID string) (key []byte) {
-	return backend.Key(webPrefix, sessionsPrefix, sessionID)
+	return backend.NewKey(webPrefix, sessionsPrefix, sessionID)
 }
 
 func webTokenKey(token string) (key []byte) {
-	return backend.Key(webPrefix, tokensPrefix, token)
+	return backend.NewKey(webPrefix, tokensPrefix, token)
 }

--- a/lib/services/local/sessiontracker.go
+++ b/lib/services/local/sessiontracker.go
@@ -48,7 +48,7 @@ func NewSessionTrackerService(bk backend.Backend) (services.SessionTrackerServic
 }
 
 func (s *sessionTracker) loadSession(ctx context.Context, sessionID string) (types.SessionTracker, error) {
-	sessionJSON, err := s.bk.Get(ctx, backend.Key(sessionPrefix, sessionID))
+	sessionJSON, err := s.bk.Get(ctx, backend.NewKey(sessionPrefix, sessionID))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -64,7 +64,7 @@ func (s *sessionTracker) loadSession(ctx context.Context, sessionID string) (typ
 // UpdatePresence updates the presence status of a user in a session.
 func (s *sessionTracker) UpdatePresence(ctx context.Context, sessionID, user string) error {
 	for i := 0; i < casRetryLimit; i++ {
-		sessionItem, err := s.bk.Get(ctx, backend.Key(sessionPrefix, sessionID))
+		sessionItem, err := s.bk.Get(ctx, backend.NewKey(sessionPrefix, sessionID))
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -84,7 +84,7 @@ func (s *sessionTracker) UpdatePresence(ctx context.Context, sessionID, user str
 		}
 
 		item := backend.Item{
-			Key:      backend.Key(sessionPrefix, sessionID),
+			Key:      backend.NewKey(sessionPrefix, sessionID),
 			Value:    sessionJSON,
 			Expires:  session.Expiry(),
 			Revision: sessionItem.Revision,
@@ -188,7 +188,7 @@ func (s *sessionTracker) CreateSessionTracker(ctx context.Context, tracker types
 	}
 
 	item := backend.Item{
-		Key:     backend.Key(sessionPrefix, tracker.GetSessionID()),
+		Key:     backend.NewKey(sessionPrefix, tracker.GetSessionID()),
 		Value:   json,
 		Expires: tracker.Expiry(),
 	}
@@ -203,7 +203,7 @@ func (s *sessionTracker) CreateSessionTracker(ctx context.Context, tracker types
 // UpdateSessionTracker updates a tracker resource for an active session.
 func (s *sessionTracker) UpdateSessionTracker(ctx context.Context, req *proto.UpdateSessionTrackerRequest) error {
 	for i := 0; i < casRetryLimit; i++ {
-		sessionItem, err := s.bk.Get(ctx, backend.Key(sessionPrefix, req.SessionID))
+		sessionItem, err := s.bk.Get(ctx, backend.NewKey(sessionPrefix, req.SessionID))
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -263,7 +263,7 @@ func (s *sessionTracker) UpdateSessionTracker(ctx context.Context, req *proto.Up
 		}
 
 		item := backend.Item{
-			Key:      backend.Key(sessionPrefix, req.SessionID),
+			Key:      backend.NewKey(sessionPrefix, req.SessionID),
 			Value:    sessionJSON,
 			Expires:  expiry,
 			Revision: sessionItem.Revision,
@@ -286,5 +286,5 @@ func (s *sessionTracker) UpdateSessionTracker(ctx context.Context, req *proto.Up
 
 // RemoveSessionTracker removes a tracker resource for an active session.
 func (s *sessionTracker) RemoveSessionTracker(ctx context.Context, sessionID string) error {
-	return trace.Wrap(s.bk.Delete(ctx, backend.Key(sessionPrefix, sessionID)))
+	return trace.Wrap(s.bk.Delete(ctx, backend.NewKey(sessionPrefix, sessionID)))
 }

--- a/lib/services/local/status.go
+++ b/lib/services/local/status.go
@@ -102,7 +102,7 @@ func (s *StatusService) getAllClusterAlerts(ctx context.Context) ([]types.Cluste
 }
 
 func (s *StatusService) getClusterAlert(ctx context.Context, alertID string) (types.ClusterAlert, error) {
-	key := backend.Key(clusterAlertPrefix, alertID)
+	key := backend.NewKey(clusterAlertPrefix, alertID)
 	item, err := s.Backend.Get(ctx, key)
 	if err != nil {
 		return types.ClusterAlert{}, trace.Wrap(err)
@@ -136,7 +136,7 @@ func (s *StatusService) UpsertClusterAlert(ctx context.Context, alert types.Clus
 	}
 
 	_, err = s.Backend.Put(ctx, backend.Item{
-		Key:      backend.Key(clusterAlertPrefix, alert.Metadata.Name),
+		Key:      backend.NewKey(clusterAlertPrefix, alert.Metadata.Name),
 		Value:    val,
 		Expires:  alert.Metadata.Expiry(),
 		Revision: rev,
@@ -145,7 +145,7 @@ func (s *StatusService) UpsertClusterAlert(ctx context.Context, alert types.Clus
 }
 
 func (s *StatusService) DeleteClusterAlert(ctx context.Context, alertID string) error {
-	err := s.Backend.Delete(ctx, backend.Key(clusterAlertPrefix, alertID))
+	err := s.Backend.Delete(ctx, backend.NewKey(clusterAlertPrefix, alertID))
 	if trace.IsNotFound(err) {
 		return trace.NotFound("cluster alert %q not found", alertID)
 	}
@@ -164,7 +164,7 @@ func (s *StatusService) CreateAlertAck(ctx context.Context, ack types.AlertAckno
 	}
 
 	_, err = s.Backend.Create(ctx, backend.Item{
-		Key:     backend.Key(alertAckPrefix, ack.AlertID),
+		Key:     backend.NewKey(alertAckPrefix, ack.AlertID),
 		Value:   val,
 		Expires: ack.Expires,
 	})
@@ -205,7 +205,7 @@ func (s *StatusService) ClearAlertAcks(ctx context.Context, req proto.ClearAlert
 		return trace.Wrap(s.Backend.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)))
 	}
 
-	err := s.Backend.Delete(ctx, backend.Key(alertAckPrefix, req.AlertID))
+	err := s.Backend.Delete(ctx, backend.NewKey(alertAckPrefix, req.AlertID))
 	if trace.IsNotFound(err) {
 		return nil
 	}

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -161,7 +161,7 @@ func (s *CA) CompareAndSwapCertAuthority(new, expected types.CertAuthority) erro
 		return trace.Wrap(err)
 	}
 
-	key := backend.Key(authoritiesPrefix, string(new.GetType()), new.GetName())
+	key := backend.NewKey(authoritiesPrefix, string(new.GetType()), new.GetName())
 
 	actualItem, err := s.Get(context.TODO(), key)
 	if err != nil {
@@ -436,7 +436,7 @@ func (s *CA) UpsertTrustedCluster(ctx context.Context, trustedCluster types.Trus
 		return nil, trace.Wrap(err)
 	}
 	_, err = s.Put(ctx, backend.Item{
-		Key:      backend.Key(trustedClustersPrefix, trustedCluster.GetName()),
+		Key:      backend.NewKey(trustedClustersPrefix, trustedCluster.GetName()),
 		Value:    value,
 		Expires:  trustedCluster.Expiry(),
 		Revision: rev,
@@ -452,7 +452,7 @@ func (s *CA) GetTrustedCluster(ctx context.Context, name string) (types.TrustedC
 	if name == "" {
 		return nil, trace.BadParameter("missing trusted cluster name")
 	}
-	item, err := s.Get(ctx, backend.Key(trustedClustersPrefix, name))
+	item, err := s.Get(ctx, backend.NewKey(trustedClustersPrefix, name))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -485,7 +485,7 @@ func (s *CA) DeleteTrustedCluster(ctx context.Context, name string) error {
 	if name == "" {
 		return trace.BadParameter("missing trusted cluster name")
 	}
-	err := s.Delete(ctx, backend.Key(trustedClustersPrefix, name))
+	err := s.Delete(ctx, backend.NewKey(trustedClustersPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("trusted cluster %q is not found", name)
@@ -506,7 +506,7 @@ func (s *CA) UpsertTunnelConnection(conn types.TunnelConnection) error {
 		return trace.Wrap(err)
 	}
 	_, err = s.Put(context.TODO(), backend.Item{
-		Key:      backend.Key(tunnelConnectionsPrefix, conn.GetClusterName(), conn.GetName()),
+		Key:      backend.NewKey(tunnelConnectionsPrefix, conn.GetClusterName(), conn.GetName()),
 		Value:    value,
 		Expires:  conn.Expiry(),
 		Revision: rev,
@@ -519,7 +519,7 @@ func (s *CA) UpsertTunnelConnection(conn types.TunnelConnection) error {
 
 // GetTunnelConnection returns connection by cluster name and connection name
 func (s *CA) GetTunnelConnection(clusterName, connectionName string, opts ...services.MarshalOption) (types.TunnelConnection, error) {
-	item, err := s.Get(context.TODO(), backend.Key(tunnelConnectionsPrefix, clusterName, connectionName))
+	item, err := s.Get(context.TODO(), backend.NewKey(tunnelConnectionsPrefix, clusterName, connectionName))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("trusted cluster connection %q is not found", connectionName)
@@ -588,7 +588,7 @@ func (s *CA) DeleteTunnelConnection(clusterName, connectionName string) error {
 	if connectionName == "" {
 		return trace.BadParameter("missing connection name")
 	}
-	return s.Delete(context.TODO(), backend.Key(tunnelConnectionsPrefix, clusterName, connectionName))
+	return s.Delete(context.TODO(), backend.NewKey(tunnelConnectionsPrefix, clusterName, connectionName))
 }
 
 // DeleteTunnelConnections deletes all tunnel connections for cluster
@@ -617,7 +617,7 @@ func (s *CA) CreateRemoteCluster(
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(remoteClustersPrefix, rc.GetName()),
+		Key:     backend.NewKey(remoteClustersPrefix, rc.GetName()),
 		Value:   value,
 		Expires: rc.Expiry(),
 	}
@@ -658,7 +658,7 @@ func (s *CA) UpdateRemoteCluster(ctx context.Context, rc types.RemoteCluster) (t
 		}
 
 		lease, err := s.ConditionalUpdate(ctx, backend.Item{
-			Key:      backend.Key(remoteClustersPrefix, existing.GetName()),
+			Key:      backend.NewKey(remoteClustersPrefix, existing.GetName()),
 			Value:    updateValue,
 			Expires:  existing.Expiry(),
 			Revision: existing.GetRevision(),
@@ -713,7 +713,7 @@ func (s *CA) PatchRemoteCluster(
 		}
 
 		lease, err := s.ConditionalUpdate(ctx, backend.Item{
-			Key:      backend.Key(remoteClustersPrefix, name),
+			Key:      backend.NewKey(remoteClustersPrefix, name),
 			Value:    updatedValue,
 			Expires:  updated.Expiry(),
 			Revision: updated.GetRevision(),
@@ -759,7 +759,7 @@ func (s *CA) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, erro
 func (s *CA) ListRemoteClusters(
 	ctx context.Context, pageSize int, pageToken string,
 ) ([]types.RemoteCluster, string, error) {
-	rangeStart := backend.Key(remoteClustersPrefix, pageToken)
+	rangeStart := backend.NewKey(remoteClustersPrefix, pageToken)
 	rangeEnd := backend.RangeEnd(backend.ExactKey(remoteClustersPrefix))
 
 	// Adjust page size, so it can't be too large.
@@ -804,7 +804,7 @@ func (s *CA) GetRemoteCluster(
 	if clusterName == "" {
 		return nil, trace.BadParameter("missing parameter cluster name")
 	}
-	item, err := s.Get(ctx, backend.Key(remoteClustersPrefix, clusterName))
+	item, err := s.Get(ctx, backend.NewKey(remoteClustersPrefix, clusterName))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("remote cluster %q is not found", clusterName)
@@ -828,7 +828,7 @@ func (s *CA) DeleteRemoteCluster(
 	if clusterName == "" {
 		return trace.BadParameter("missing parameter cluster name")
 	}
-	return s.Delete(ctx, backend.Key(remoteClustersPrefix, clusterName))
+	return s.Delete(ctx, backend.NewKey(remoteClustersPrefix, clusterName))
 }
 
 // DeleteAllRemoteClusters deletes all remote clusters
@@ -855,12 +855,12 @@ func caToItem(key []byte, ca types.CertAuthority) (backend.Item, error) {
 
 // activeCAKey builds the active key variant for the supplied ca id.
 func activeCAKey(id types.CertAuthID) []byte {
-	return backend.Key(authoritiesPrefix, string(id.Type), id.DomainName)
+	return backend.NewKey(authoritiesPrefix, string(id.Type), id.DomainName)
 }
 
 // inactiveCAKey builds the inactive key variant for the supplied ca id.
 func inactiveCAKey(id types.CertAuthID) []byte {
-	return backend.Key(authoritiesPrefix, deactivatedPrefix, string(id.Type), id.DomainName)
+	return backend.NewKey(authoritiesPrefix, deactivatedPrefix, string(id.Type), id.DomainName)
 }
 
 const (

--- a/lib/services/local/unstable.go
+++ b/lib/services/local/unstable.go
@@ -111,7 +111,7 @@ func (s UnstableService) GetSystemRoleAssertions(ctx context.Context, serverID s
 }
 
 func systemRoleAssertionsKey(serverID string, assertionID string) []byte {
-	return backend.Key(systemRoleAssertionsPrefix, serverID, assertionID)
+	return backend.NewKey(systemRoleAssertionsPrefix, serverID, assertionID)
 }
 
 const (

--- a/lib/services/local/userpreferences.go
+++ b/lib/services/local/userpreferences.go
@@ -118,7 +118,7 @@ func (u *UserPreferencesService) getUserPreferences(ctx context.Context, usernam
 
 // backendKey returns the backend key for the user preferences for the given username.
 func backendKey(username string) []byte {
-	return backend.Key(userPreferencesPrefix, username)
+	return backend.NewKey(userPreferencesPrefix, username)
 }
 
 // validatePreferences validates the given preferences.
@@ -132,7 +132,7 @@ func validatePreferences(preferences *userpreferencesv1.UserPreferences) error {
 
 // createBackendItem creates a backend.Item for the given username and user preferences.
 func createBackendItem(username string, preferences *userpreferencesv1.UserPreferences) (backend.Item, error) {
-	settingsKey := backend.Key(userPreferencesPrefix, username)
+	settingsKey := backend.NewKey(userPreferencesPrefix, username)
 
 	payload, err := json.Marshal(preferences)
 	if err != nil {

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -97,7 +97,7 @@ func (s *IdentityService) DeleteAllUsers(ctx context.Context) error {
 
 // ListUsers returns a page of users.
 func (s *IdentityService) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*userspb.ListUsersResponse, error) {
-	rangeStart := backend.Key(webPrefix, usersPrefix, req.PageToken)
+	rangeStart := backend.NewKey(webPrefix, usersPrefix, req.PageToken)
 	rangeEnd := backend.RangeEnd(backend.ExactKey(webPrefix, usersPrefix))
 	pageSize := req.PageSize
 
@@ -319,7 +319,7 @@ func (s *IdentityService) CreateUser(ctx context.Context, user types.User) (type
 	}
 
 	item := backend.Item{
-		Key:     backend.Key(webPrefix, usersPrefix, user.GetName(), paramsPrefix),
+		Key:     backend.NewKey(webPrefix, usersPrefix, user.GetName(), paramsPrefix),
 		Value:   value,
 		Expires: user.Expiry(),
 	}
@@ -356,7 +356,7 @@ func (s *IdentityService) LegacyUpdateUser(ctx context.Context, user types.User)
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(webPrefix, usersPrefix, user.GetName(), paramsPrefix),
+		Key:      backend.NewKey(webPrefix, usersPrefix, user.GetName(), paramsPrefix),
 		Value:    value,
 		Expires:  user.Expiry(),
 		Revision: rev,
@@ -386,7 +386,7 @@ func (s *IdentityService) UpdateUser(ctx context.Context, user types.User) (type
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(webPrefix, usersPrefix, user.GetName(), paramsPrefix),
+		Key:      backend.NewKey(webPrefix, usersPrefix, user.GetName(), paramsPrefix),
 		Value:    value,
 		Expires:  user.Expiry(),
 		Revision: rev,
@@ -450,7 +450,7 @@ func (s *IdentityService) UpsertUser(ctx context.Context, user types.User) (type
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(webPrefix, usersPrefix, user.GetName(), paramsPrefix),
+		Key:      backend.NewKey(webPrefix, usersPrefix, user.GetName(), paramsPrefix),
 		Value:    value,
 		Expires:  user.Expiry(),
 		Revision: rev,
@@ -490,7 +490,7 @@ func (s *IdentityService) CompareAndSwapUser(ctx context.Context, new, existing 
 	}
 
 	item := backend.Item{
-		Key:      backend.Key(webPrefix, usersPrefix, new.GetName(), paramsPrefix),
+		Key:      backend.NewKey(webPrefix, usersPrefix, new.GetName(), paramsPrefix),
 		Value:    nil, // avoid marshaling new until we pass one comparison
 		Expires:  new.Expiry(),
 		Revision: "",
@@ -557,7 +557,7 @@ func (s *IdentityService) getUser(ctx context.Context, user string, withSecrets 
 		return u, items, trace.Wrap(err)
 	}
 
-	item, err := s.Get(ctx, backend.Key(webPrefix, usersPrefix, user, paramsPrefix))
+	item, err := s.Get(ctx, backend.NewKey(webPrefix, usersPrefix, user, paramsPrefix))
 	if err != nil {
 		return nil, nil, trace.NotFound("user %q not found", user)
 	}
@@ -686,7 +686,7 @@ func (s *IdentityService) upsertPasswordHash(username string, hash []byte) error
 		}
 	}
 	item := backend.Item{
-		Key:   backend.Key(webPrefix, usersPrefix, username, pwdPrefix),
+		Key:   backend.NewKey(webPrefix, usersPrefix, username, pwdPrefix),
 		Value: hash,
 	}
 	_, err = s.Put(context.TODO(), item)
@@ -701,7 +701,7 @@ func (s *IdentityService) GetPasswordHash(user string) ([]byte, error) {
 	if user == "" {
 		return nil, trace.BadParameter("missing user name")
 	}
-	item, err := s.Get(context.TODO(), backend.Key(webPrefix, usersPrefix, user, pwdPrefix))
+	item, err := s.Get(context.TODO(), backend.NewKey(webPrefix, usersPrefix, user, pwdPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("user %q is not found", user)
@@ -718,7 +718,7 @@ func (s *IdentityService) UpsertUsedTOTPToken(user string, otpToken string) erro
 		return trace.BadParameter("missing user name")
 	}
 	item := backend.Item{
-		Key:     backend.Key(webPrefix, usersPrefix, user, usedTOTPPrefix),
+		Key:     backend.NewKey(webPrefix, usersPrefix, user, usedTOTPPrefix),
 		Value:   []byte(otpToken),
 		Expires: s.Clock().Now().UTC().Add(usedTOTPTTL),
 	}
@@ -734,7 +734,7 @@ func (s *IdentityService) GetUsedTOTPToken(user string) (string, error) {
 	if user == "" {
 		return "", trace.BadParameter("missing user name")
 	}
-	item, err := s.Get(context.TODO(), backend.Key(webPrefix, usersPrefix, user, usedTOTPPrefix))
+	item, err := s.Get(context.TODO(), backend.NewKey(webPrefix, usersPrefix, user, usedTOTPPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return "0", nil
@@ -751,7 +751,7 @@ func (s *IdentityService) DeleteUsedTOTPToken(user string) error {
 	if user == "" {
 		return trace.BadParameter("missing user name")
 	}
-	return s.Delete(context.TODO(), backend.Key(webPrefix, usersPrefix, user, usedTOTPPrefix))
+	return s.Delete(context.TODO(), backend.NewKey(webPrefix, usersPrefix, user, usedTOTPPrefix))
 }
 
 // AddUserLoginAttempt logs user login attempt
@@ -764,7 +764,7 @@ func (s *IdentityService) AddUserLoginAttempt(user string, attempt services.Logi
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(webPrefix, usersPrefix, user, attemptsPrefix, uuid.New().String()),
+		Key:     backend.NewKey(webPrefix, usersPrefix, user, attemptsPrefix, uuid.New().String()),
 		Value:   value,
 		Expires: backend.Expiry(s.Clock(), ttl),
 	}
@@ -851,7 +851,7 @@ func (s *IdentityService) DeletePassword(ctx context.Context, user string) error
 		return trace.BadParameter("missing username")
 	}
 
-	delErr := s.Delete(ctx, backend.Key(webPrefix, usersPrefix, user, pwdPrefix))
+	delErr := s.Delete(ctx, backend.NewKey(webPrefix, usersPrefix, user, pwdPrefix))
 	// Don't bail out just yet if the error is "not found"; the password state
 	// flag may still be unspecified, and we want to make it UNSET.
 	if delErr != nil && !trace.IsNotFound(delErr) {
@@ -966,12 +966,12 @@ type webauthnUser struct {
 }
 
 func webauthnLocalAuthKey(user string) []byte {
-	return backend.Key(webPrefix, usersPrefix, user, webauthnLocalAuthPrefix)
+	return backend.NewKey(webPrefix, usersPrefix, user, webauthnLocalAuthPrefix)
 }
 
 func webauthnUserKey(id []byte) []byte {
 	key := base64.RawURLEncoding.EncodeToString(id)
-	return backend.Key(webauthnPrefix, usersPrefix, key)
+	return backend.NewKey(webauthnPrefix, usersPrefix, key)
 }
 
 func (s *IdentityService) UpsertWebauthnSessionData(ctx context.Context, user, sessionID string, sd *wantypes.SessionData) error {
@@ -1024,7 +1024,7 @@ func (s *IdentityService) DeleteWebauthnSessionData(ctx context.Context, user, s
 }
 
 func sessionDataKey(user, sessionID string) []byte {
-	return backend.Key(webPrefix, usersPrefix, user, webauthnSessionData, sessionID)
+	return backend.NewKey(webPrefix, usersPrefix, user, webauthnSessionData, sessionID)
 }
 
 // globalSessionDataLimiter keeps a count of in-flight session data challenges
@@ -1135,7 +1135,7 @@ func (s *IdentityService) DeleteGlobalWebauthnSessionData(ctx context.Context, s
 }
 
 func globalSessionDataKey(scope, id string) []byte {
-	return backend.Key(webauthnPrefix, webauthnGlobalSessionData, scope, id)
+	return backend.NewKey(webauthnPrefix, webauthnGlobalSessionData, scope, id)
 }
 
 func (s *IdentityService) UpsertMFADevice(ctx context.Context, user string, d *types.MFADevice) error {
@@ -1183,7 +1183,7 @@ func (s *IdentityService) UpsertMFADevice(ctx context.Context, user string, d *t
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(webPrefix, usersPrefix, user, mfaDevicePrefix, d.Id),
+		Key:      backend.NewKey(webPrefix, usersPrefix, user, mfaDevicePrefix, d.Id),
 		Value:    value,
 		Revision: rev,
 	}
@@ -1212,7 +1212,7 @@ func (s *IdentityService) DeleteMFADevice(ctx context.Context, user, id string) 
 		return trace.BadParameter("missing parameter id")
 	}
 
-	err := s.Delete(ctx, backend.Key(webPrefix, usersPrefix, user, mfaDevicePrefix, id))
+	err := s.Delete(ctx, backend.NewKey(webPrefix, usersPrefix, user, mfaDevicePrefix, id))
 	return trace.Wrap(err)
 }
 
@@ -1255,7 +1255,7 @@ func (s *IdentityService) UpsertOIDCConnector(ctx context.Context, connector typ
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, connector.GetName()),
+		Key:      backend.NewKey(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, connector.GetName()),
 		Value:    value,
 		Expires:  connector.Expiry(),
 		Revision: rev,
@@ -1278,7 +1278,7 @@ func (s *IdentityService) CreateOIDCConnector(ctx context.Context, connector typ
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, connector.GetName()),
+		Key:     backend.NewKey(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, connector.GetName()),
 		Value:   value,
 		Expires: connector.Expiry(),
 	}
@@ -1300,7 +1300,7 @@ func (s *IdentityService) UpdateOIDCConnector(ctx context.Context, connector typ
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, connector.GetName()),
+		Key:      backend.NewKey(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, connector.GetName()),
 		Value:    value,
 		Expires:  connector.Expiry(),
 		Revision: connector.GetRevision(),
@@ -1318,7 +1318,7 @@ func (s *IdentityService) DeleteOIDCConnector(ctx context.Context, name string) 
 	if name == "" {
 		return trace.BadParameter("missing parameter name")
 	}
-	err := s.Delete(ctx, backend.Key(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, name))
+	err := s.Delete(ctx, backend.NewKey(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, name))
 	return trace.Wrap(err)
 }
 
@@ -1328,7 +1328,7 @@ func (s *IdentityService) GetOIDCConnector(ctx context.Context, name string, wit
 	if name == "" {
 		return nil, trace.BadParameter("missing parameter name")
 	}
-	item, err := s.Get(ctx, backend.Key(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, name))
+	item, err := s.Get(ctx, backend.NewKey(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("OpenID connector '%v' is not configured", name)
@@ -1382,7 +1382,7 @@ func (s *IdentityService) CreateOIDCAuthRequest(ctx context.Context, req types.O
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(webPrefix, connectorsPrefix, oidcPrefix, requestsPrefix, req.StateToken),
+		Key:     backend.NewKey(webPrefix, connectorsPrefix, oidcPrefix, requestsPrefix, req.StateToken),
 		Value:   buf.Bytes(),
 		Expires: backend.Expiry(s.Clock(), ttl),
 	}
@@ -1397,7 +1397,7 @@ func (s *IdentityService) GetOIDCAuthRequest(ctx context.Context, stateToken str
 	if stateToken == "" {
 		return nil, trace.BadParameter("missing parameter stateToken")
 	}
-	item, err := s.Get(ctx, backend.Key(webPrefix, connectorsPrefix, oidcPrefix, requestsPrefix, stateToken))
+	item, err := s.Get(ctx, backend.NewKey(webPrefix, connectorsPrefix, oidcPrefix, requestsPrefix, stateToken))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1419,7 +1419,7 @@ func (s *IdentityService) UpsertSAMLConnector(ctx context.Context, connector typ
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, connector.GetName()),
+		Key:      backend.NewKey(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, connector.GetName()),
 		Value:    value,
 		Expires:  connector.Expiry(),
 		Revision: rev,
@@ -1442,7 +1442,7 @@ func (s *IdentityService) UpdateSAMLConnector(ctx context.Context, connector typ
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, connector.GetName()),
+		Key:      backend.NewKey(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, connector.GetName()),
 		Value:    value,
 		Expires:  connector.Expiry(),
 		Revision: connector.GetRevision(),
@@ -1465,7 +1465,7 @@ func (s *IdentityService) CreateSAMLConnector(ctx context.Context, connector typ
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, connector.GetName()),
+		Key:     backend.NewKey(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, connector.GetName()),
 		Value:   value,
 		Expires: connector.Expiry(),
 	}
@@ -1482,7 +1482,7 @@ func (s *IdentityService) DeleteSAMLConnector(ctx context.Context, name string) 
 	if name == "" {
 		return trace.BadParameter("missing parameter name")
 	}
-	err := s.Delete(ctx, backend.Key(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, name))
+	err := s.Delete(ctx, backend.NewKey(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, name))
 	return trace.Wrap(err)
 }
 
@@ -1492,7 +1492,7 @@ func (s *IdentityService) GetSAMLConnector(ctx context.Context, name string, wit
 	if name == "" {
 		return nil, trace.BadParameter("missing parameter name")
 	}
-	item, err := s.Get(ctx, backend.Key(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, name))
+	item, err := s.Get(ctx, backend.NewKey(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("SAML connector %q is not configured", name)
@@ -1553,7 +1553,7 @@ func (s *IdentityService) CreateSAMLAuthRequest(ctx context.Context, req types.S
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(webPrefix, connectorsPrefix, samlPrefix, requestsPrefix, req.ID),
+		Key:     backend.NewKey(webPrefix, connectorsPrefix, samlPrefix, requestsPrefix, req.ID),
 		Value:   buf.Bytes(),
 		Expires: backend.Expiry(s.Clock(), ttl),
 	}
@@ -1568,7 +1568,7 @@ func (s *IdentityService) GetSAMLAuthRequest(ctx context.Context, id string) (*t
 	if id == "" {
 		return nil, trace.BadParameter("missing parameter id")
 	}
-	item, err := s.Get(ctx, backend.Key(webPrefix, connectorsPrefix, samlPrefix, requestsPrefix, id))
+	item, err := s.Get(ctx, backend.NewKey(webPrefix, connectorsPrefix, samlPrefix, requestsPrefix, id))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1598,7 +1598,7 @@ func (s *IdentityService) CreateSSODiagnosticInfo(ctx context.Context, authKind 
 	}
 
 	item := backend.Item{
-		Key:     backend.Key(webPrefix, connectorsPrefix, authKind, requestsTracePrefix, authRequestID),
+		Key:     backend.NewKey(webPrefix, connectorsPrefix, authKind, requestsTracePrefix, authRequestID),
 		Value:   jsonValue,
 		Expires: backend.Expiry(s.Clock(), time.Minute*15),
 	}
@@ -1622,7 +1622,7 @@ func (s *IdentityService) GetSSODiagnosticInfo(ctx context.Context, authKind str
 		return nil, trace.BadParameter("unsupported authKind %q", authKind)
 	}
 
-	item, err := s.Get(ctx, backend.Key(webPrefix, connectorsPrefix, authKind, requestsTracePrefix, authRequestID))
+	item, err := s.Get(ctx, backend.NewKey(webPrefix, connectorsPrefix, authKind, requestsTracePrefix, authRequestID))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1646,7 +1646,7 @@ func (s *IdentityService) UpsertGithubConnector(ctx context.Context, connector t
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, connector.GetName()),
+		Key:      backend.NewKey(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, connector.GetName()),
 		Value:    value,
 		Expires:  connector.Expiry(),
 		Revision: rev,
@@ -1669,7 +1669,7 @@ func (s *IdentityService) UpdateGithubConnector(ctx context.Context, connector t
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      backend.Key(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, connector.GetName()),
+		Key:      backend.NewKey(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, connector.GetName()),
 		Value:    value,
 		Expires:  connector.Expiry(),
 		Revision: connector.GetRevision(),
@@ -1692,7 +1692,7 @@ func (s *IdentityService) CreateGithubConnector(ctx context.Context, connector t
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, connector.GetName()),
+		Key:     backend.NewKey(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, connector.GetName()),
 		Value:   value,
 		Expires: connector.Expiry(),
 	}
@@ -1734,7 +1734,7 @@ func (s *IdentityService) GetGithubConnector(ctx context.Context, name string, w
 	if name == "" {
 		return nil, trace.BadParameter("missing parameter name")
 	}
-	item, err := s.Get(ctx, backend.Key(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, name))
+	item, err := s.Get(ctx, backend.NewKey(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("github connector %q is not configured", name)
@@ -1756,7 +1756,7 @@ func (s *IdentityService) DeleteGithubConnector(ctx context.Context, name string
 	if name == "" {
 		return trace.BadParameter("missing parameter name")
 	}
-	return trace.Wrap(s.Delete(ctx, backend.Key(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, name)))
+	return trace.Wrap(s.Delete(ctx, backend.NewKey(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, name)))
 }
 
 // CreateGithubAuthRequest creates a new auth request for Github OAuth2 flow
@@ -1769,7 +1769,7 @@ func (s *IdentityService) CreateGithubAuthRequest(ctx context.Context, req types
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(webPrefix, connectorsPrefix, githubPrefix, requestsPrefix, req.StateToken),
+		Key:     backend.NewKey(webPrefix, connectorsPrefix, githubPrefix, requestsPrefix, req.StateToken),
 		Value:   buf.Bytes(),
 		Expires: req.Expiry(),
 	}
@@ -1784,7 +1784,7 @@ func (s *IdentityService) GetGithubAuthRequest(ctx context.Context, stateToken s
 	if stateToken == "" {
 		return nil, trace.BadParameter("missing parameter stateToken")
 	}
-	item, err := s.Get(ctx, backend.Key(webPrefix, connectorsPrefix, githubPrefix, requestsPrefix, stateToken))
+	item, err := s.Get(ctx, backend.NewKey(webPrefix, connectorsPrefix, githubPrefix, requestsPrefix, stateToken))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1801,7 +1801,7 @@ func (s *IdentityService) GetRecoveryCodes(ctx context.Context, user string, wit
 		return nil, trace.BadParameter("missing parameter user")
 	}
 
-	item, err := s.Get(ctx, backend.Key(webPrefix, usersPrefix, user, recoveryCodesPrefix))
+	item, err := s.Get(ctx, backend.NewKey(webPrefix, usersPrefix, user, recoveryCodesPrefix))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1835,7 +1835,7 @@ func (s *IdentityService) UpsertRecoveryCodes(ctx context.Context, user string, 
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(webPrefix, usersPrefix, user, recoveryCodesPrefix),
+		Key:   backend.NewKey(webPrefix, usersPrefix, user, recoveryCodesPrefix),
 		Value: value,
 	}
 
@@ -1857,7 +1857,7 @@ func (s *IdentityService) UpsertKeyAttestationData(ctx context.Context, attestat
 
 	key := keyAttestationDataFingerprint(attestationData.PublicKeyDER)
 	item := backend.Item{
-		Key:     backend.Key(attestationsPrefix, key),
+		Key:     backend.NewKey(attestationsPrefix, key),
 		Value:   value,
 		Expires: s.Clock().Now().UTC().Add(ttl),
 	}
@@ -1875,7 +1875,7 @@ func (s *IdentityService) GetKeyAttestationData(ctx context.Context, pubDER []by
 	}
 
 	key := keyAttestationDataFingerprint(pubDER)
-	item, err := s.Get(ctx, backend.Key(attestationsPrefix, key))
+	item, err := s.Get(ctx, backend.NewKey(attestationsPrefix, key))
 
 	if trace.IsNotFound(err) {
 		return nil, trace.NotFound("hardware key attestation not found")

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -1305,7 +1305,7 @@ func TestCompareAndSwapUser(t *testing.T) {
 	require.NoError(err)
 	require.True(services.UsersEquals(currentBob, bob2))
 
-	item, err := identity.Backend.Get(ctx, backend.Key(local.WebPrefix, local.UsersPrefix, "bob", local.ParamsPrefix))
+	item, err := identity.Backend.Get(ctx, backend.NewKey(local.WebPrefix, local.UsersPrefix, "bob", local.ParamsPrefix))
 	require.NoError(err)
 	var m map[string]any
 	require.NoError(json.Unmarshal(item.Value, &m))

--- a/lib/services/local/usertoken.go
+++ b/lib/services/local/usertoken.go
@@ -71,7 +71,7 @@ func (s *IdentityService) DeleteUserToken(ctx context.Context, tokenID string) e
 
 // GetUserToken returns a token by its ID.
 func (s *IdentityService) GetUserToken(ctx context.Context, tokenID string) (types.UserToken, error) {
-	item, err := s.Get(ctx, backend.Key(userTokenPrefix, tokenID, paramsPrefix))
+	item, err := s.Get(ctx, backend.NewKey(userTokenPrefix, tokenID, paramsPrefix))
 	switch {
 	case trace.IsNotFound(err):
 		return nil, trace.NotFound("user token(%s) not found", backend.MaskKeyName(tokenID))
@@ -99,7 +99,7 @@ func (s *IdentityService) CreateUserToken(ctx context.Context, token types.UserT
 	}
 
 	item := backend.Item{
-		Key:     backend.Key(userTokenPrefix, token.GetName(), paramsPrefix),
+		Key:     backend.NewKey(userTokenPrefix, token.GetName(), paramsPrefix),
 		Value:   value,
 		Expires: token.Expiry(),
 	}
@@ -113,7 +113,7 @@ func (s *IdentityService) CreateUserToken(ctx context.Context, token types.UserT
 
 // GetUserTokenSecrets returns token secrets.
 func (s *IdentityService) GetUserTokenSecrets(ctx context.Context, tokenID string) (types.UserTokenSecrets, error) {
-	item, err := s.Get(ctx, backend.Key(userTokenPrefix, tokenID, secretsPrefix))
+	item, err := s.Get(ctx, backend.NewKey(userTokenPrefix, tokenID, secretsPrefix))
 	switch {
 	case trace.IsNotFound(err):
 		return nil, trace.NotFound("user token(%s) secrets not found", backend.MaskKeyName(tokenID))
@@ -140,7 +140,7 @@ func (s *IdentityService) UpsertUserTokenSecrets(ctx context.Context, secrets ty
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(userTokenPrefix, secrets.GetName(), secretsPrefix),
+		Key:     backend.NewKey(userTokenPrefix, secrets.GetName(), secretsPrefix),
 		Value:   value,
 		Expires: secrets.Expiry(),
 	}

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -220,10 +220,10 @@ func (c *UnifiedResourceCache) getRange(ctx context.Context, startKey []byte, ma
 		var endKey []byte
 		if req.SortBy.IsDesc {
 			iterateRange = tree.DescendRange
-			endKey = backend.Key(prefix)
+			endKey = backend.NewKey(prefix)
 		} else {
 			iterateRange = tree.AscendRange
-			endKey = backend.RangeEnd(backend.Key(prefix))
+			endKey = backend.RangeEnd(backend.NewKey(prefix))
 		}
 		var iteratorErr error
 		iterateRange(&item{Key: startKey}, &item{Key: endKey}, func(item *item) bool {
@@ -276,10 +276,10 @@ func getStartKey(req *proto.ListUnifiedResourcesRequest) []byte {
 	// if startkey doesnt exist, we check the sort direction.
 	// If sort is descending, startkey is end of the list
 	if req.SortBy.IsDesc {
-		return backend.RangeEnd(backend.Key(prefix))
+		return backend.RangeEnd(backend.NewKey(prefix))
 	}
 	// return start of the list
-	return backend.Key(prefix)
+	return backend.NewKey(prefix)
 }
 
 func (c *UnifiedResourceCache) IterateUnifiedResources(ctx context.Context, matchFn func(types.ResourceWithLabels) (bool, error), req *proto.ListUnifiedResourcesRequest) ([]types.ResourceWithLabels, string, error) {
@@ -300,7 +300,7 @@ func (c *UnifiedResourceCache) IterateUnifiedResources(ctx context.Context, matc
 // GetUnifiedResources returns a list of all resources stored in the current unifiedResourceCollector tree in ascending order
 func (c *UnifiedResourceCache) GetUnifiedResources(ctx context.Context) ([]types.ResourceWithLabels, error) {
 	req := &proto.ListUnifiedResourcesRequest{Limit: backend.NoLimit, SortBy: types.SortBy{IsDesc: false, Field: sortByName}}
-	result, _, err := c.getRange(ctx, backend.Key(prefix), func(rwl types.ResourceWithLabels) (bool, error) { return true, nil }, req)
+	result, _, err := c.getRange(ctx, backend.NewKey(prefix), func(rwl types.ResourceWithLabels) (bool, error) { return true, nil }, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -319,7 +319,7 @@ func (c *UnifiedResourceCache) GetUnifiedResourcesByIDs(ctx context.Context, ids
 
 	err := c.read(ctx, func(cache *UnifiedResourceCache) error {
 		for _, id := range ids {
-			key := backend.Key(prefix, id)
+			key := backend.NewKey(prefix, id)
 			res, found := cache.nameTree.Get(&item{Key: key})
 			if !found || res == nil {
 				continue
@@ -418,8 +418,8 @@ func makeResourceSortKey(resource types.Resource) resourceSortKey {
 	return resourceSortKey{
 		// names should be stored as lowercase to keep items sorted as
 		// expected, regardless of case
-		byName: backend.Key(prefix, strings.ToLower(name), kind),
-		byType: backend.Key(prefix, kind, strings.ToLower(name)),
+		byName: backend.NewKey(prefix, strings.ToLower(name), kind),
+		byType: backend.NewKey(prefix, kind, strings.ToLower(name)),
 	}
 }
 

--- a/lib/usagereporter/teleport/aggregating/service.go
+++ b/lib/usagereporter/teleport/aggregating/service.go
@@ -48,7 +48,7 @@ const (
 // a given UUID and start time, such that reports with an earlier start time
 // will appear earlier in lexicographic ordering.
 func userActivityReportKey(reportUUID uuid.UUID, startTime time.Time) []byte {
-	return backend.Key(userActivityReportsPrefix, startTime.Format(time.RFC3339), reportUUID.String())
+	return backend.NewKey(userActivityReportsPrefix, startTime.Format(time.RFC3339), reportUUID.String())
 }
 
 func prepareUserActivityReports(
@@ -84,7 +84,7 @@ func prepareUserActivityReports(
 // a given UUID and start time, such that reports with an earlier start time
 // will appear earlier in lexicographic ordering.
 func resourcePresenceReportKey(reportUUID uuid.UUID, startTime time.Time) []byte {
-	return backend.Key(ResourcePresenceReportsPrefix, startTime.Format(time.RFC3339), reportUUID.String())
+	return backend.NewKey(ResourcePresenceReportsPrefix, startTime.Format(time.RFC3339), reportUUID.String())
 }
 
 // prepareResourcePresenceReport prepares a resource presence report for storage.
@@ -240,7 +240,7 @@ func (r reportService) createUserActivityReportsLock(ctx context.Context, ttl ti
 	if len(payload) == 0 {
 		payload = []byte("null")
 	}
-	lockKey := backend.Key(userActivityReportsLock)
+	lockKey := backend.NewKey(userActivityReportsLock)
 	// HACK(espadolini): dynamodbbk doesn't let you Create over an expired item
 	// but it will explicitly delete expired items on a Get; in addition, reads
 	// are cheaper than writes in most backends, so we do a Get here first


### PR DESCRIPTION
Refactoring in preparation for creating a concrete backend.Key type instead of using []byte for keys. The backend.Key function still exists and was not deprecated because it is still consumed in e. It will be removed when the e ref is updated after e uses backend.NewKey.

Enterprise companion https://github.com/gravitational/teleport.e/pull/4889