### PR TITLE
[v16] Don't try to enroll private EKS clusters if running in Teleport Cloud.

### DIFF
--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -314,7 +314,7 @@ func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clo
 
 	// We can't discover private EKS clusters for cloud clients, since we know that auth server is running in our VPC.
 	if req.IsCloud && !eksCluster.ResourcesVpcConfig.EndpointPublicAccess {
-		return "", trace.AccessDenied(`can't enroll %q because it is not accessible from Teleport Cloud, please enable endpoint public access in your EKS cluster and try again`, clusterName)
+		return "", trace.AccessDenied(`can't enroll %q because it is not accessible from Teleport Cloud, please enable endpoint public access in your EKS cluster and try again.`, clusterName)
 	}
 
 	principalArn, err := getAccessEntryPrincipalArn(ctx, clt.GetCallerIdentity)

--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -312,6 +312,11 @@ func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clo
 		return "", trace.BadParameter(`can't enroll EKS cluster %q - expected "ACTIVE" state, got %q.`, clusterName, eksCluster.Status)
 	}
 
+	// We can't discover private EKS clusters for cloud clients, since we know that auth server is running in our VPC.
+	if req.IsCloud && !eksCluster.ResourcesVpcConfig.EndpointPublicAccess {
+		return "", trace.AccessDenied(`can't enroll EKS cluster %q - no public access endpoint while auth is running in Teleport Cloud.`, clusterName)
+	}
+
 	principalArn, err := getAccessEntryPrincipalArn(ctx, clt.GetCallerIdentity)
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -314,7 +314,7 @@ func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clo
 
 	// We can't discover private EKS clusters for cloud clients, since we know that auth server is running in our VPC.
 	if req.IsCloud && !eksCluster.ResourcesVpcConfig.EndpointPublicAccess {
-		return "", trace.AccessDenied(`can't enroll EKS cluster %q - no public access endpoint while auth is running in Teleport Cloud.`, clusterName)
+		return "", trace.AccessDenied(`can't enroll %q because it is not accessible from Teleport Cloud, please enable endpoint public access in your EKS cluster and try again`, clusterName)
 	}
 
 	principalArn, err := getAccessEntryPrincipalArn(ctx, clt.GetCallerIdentity)

--- a/lib/integrations/awsoidc/eks_enroll_clusters_test.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters_test.go
@@ -259,7 +259,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 			responseCheck: func(t *testing.T, response *EnrollEKSClusterResponse) {
 				require.Len(t, response.Results, 1)
 				require.ErrorContains(t, response.Results[0].Error,
-					`can't enroll EKS cluster "EKS3" - no public access endpoint while auth is running in Teleport Cloud.`)
+					`can't enroll "EKS3" because it is not accessible from Teleport Cloud, please enable endpoint public access in your EKS cluster and try again.`)
 			},
 		},
 		{

--- a/lib/integrations/awsoidc/eks_enroll_clusters_test.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters_test.go
@@ -263,6 +263,31 @@ func TestEnrollEKSClusters(t *testing.T) {
 			},
 		},
 		{
+			name:         "private cluster not in cloud is enrolled",
+			enrollClient: baseClient,
+			eksClusters: []eksTypes.Cluster{
+				{
+					Name: aws.String("EKS3"),
+					ResourcesVpcConfig: &eksTypes.VpcConfigResponse{
+						EndpointPublicAccess: false,
+					},
+					Arn:                  aws.String(clustersBaseArn + "3"),
+					Tags:                 map[string]string{"label3": "value3"},
+					CertificateAuthority: &eksTypes.Certificate{Data: aws.String(testCAData)},
+					Status:               eksTypes.ClusterStatusActive,
+				},
+			},
+			request: EnrollEKSClustersRequest{
+				Region:       "us-east-1",
+				AgentVersion: "1.2.3",
+			},
+			requestClusterNames: []string{"EKS3"},
+			responseCheck: func(t *testing.T, response *EnrollEKSClusterResponse) {
+				require.Len(t, response.Results, 1)
+				require.NoError(t, response.Results[0].Error)
+			},
+		},
+		{
 			name: "cluster with already present agent is not enrolled",
 			enrollClient: func(t *testing.T, clusters []eksTypes.Cluster) EnrollEKSCLusterClient {
 				clt := baseClient(t, clusters)

--- a/lib/integrations/awsoidc/eks_enroll_clusters_test.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters_test.go
@@ -242,7 +242,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 				{
 					Name: aws.String("EKS3"),
 					ResourcesVpcConfig: &eksTypes.VpcConfigResponse{
-						EndpointPrivateAccess: true,
+						EndpointPublicAccess: false,
 					},
 					Arn:                  aws.String(clustersBaseArn + "3"),
 					Tags:                 map[string]string{"label3": "value3"},


### PR DESCRIPTION
Backport #45589 to branch/v16