### PR TITLE
Fix `Terminal.test.tsx` flakiness 

### DIFF
--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.test.tsx
@@ -110,10 +110,10 @@ test("mouse right click opens context menu when 'terminal.rightClick: menu' is c
 
   await waitFor(() => {
     expect(openContextMenu).toHaveBeenCalledTimes(1);
-    expect(openContextMenu).toHaveBeenCalledWith(
-      expect.objectContaining({ defaultPrevented: true })
-    );
   });
+  expect(openContextMenu).toHaveBeenCalledWith(
+    expect.objectContaining({ defaultPrevented: true })
+  );
 });
 
 function ConfiguredTerminal(props: {

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.test.tsx
@@ -82,7 +82,7 @@ test.each([
   const terminalContent = await screen.findByText('some-command');
 
   await navigator.clipboard.writeText('--flag=test');
-  await userEvent.pointer({ keys: '[MouseRight>]', target: terminalContent });
+  await userEvent.pointer({ keys: '[MouseRight]', target: terminalContent });
 
   await waitFor(() => {
     expect(screen.getByText('some-command --flag=test')).toBeInTheDocument();
@@ -106,7 +106,7 @@ test("mouse right click opens context menu when 'terminal.rightClick: menu' is c
   const terminalContent = await screen.findByText('some-command');
 
   await navigator.clipboard.writeText('--flag=test');
-  await userEvent.pointer({ keys: '[MouseRight>]', target: terminalContent });
+  await userEvent.pointer({ keys: '[MouseRight]', target: terminalContent });
 
   expect(openContextMenu).toHaveBeenCalledTimes(1);
   expect(openContextMenu).toHaveBeenCalledWith(

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.test.tsx
@@ -108,10 +108,12 @@ test("mouse right click opens context menu when 'terminal.rightClick: menu' is c
   await navigator.clipboard.writeText('--flag=test');
   await userEvent.pointer({ keys: '[MouseRight]', target: terminalContent });
 
-  expect(openContextMenu).toHaveBeenCalledTimes(1);
-  expect(openContextMenu).toHaveBeenCalledWith(
-    expect.objectContaining({ defaultPrevented: true })
-  );
+  await waitFor(() => {
+    expect(openContextMenu).toHaveBeenCalledTimes(1);
+    expect(openContextMenu).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPrevented: true })
+    );
+  });
 });
 
 function ConfiguredTerminal(props: {


### PR DESCRIPTION
Unfortunately, I wasn't able to reproduce these failures locally:
https://github.com/gravitational/teleport/actions/runs/10460720829/job/28967501791
https://github.com/gravitational/teleport/actions/runs/10457570078/job/28957497790

So this PR is just my best guess of what might be wrong.