### PR TITLE
[v16] web: be more explicit about root/leaf clusters

### DIFF
--- a/web/packages/teleport/src/Clusters/ClusterList/ClusterList.tsx
+++ b/web/packages/teleport/src/Clusters/ClusterList/ClusterList.tsx
@@ -22,7 +22,7 @@ import styled from 'styled-components';
 
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
 import Table, { Cell } from 'design/DataTable';
-import { Primary } from 'design/Label';
+import { Primary, Secondary } from 'design/Label';
 
 import { Cluster } from 'teleport/services/clusters';
 import cfg from 'teleport/config';
@@ -61,7 +61,9 @@ export default function ClustersList(props: Props) {
 function renderRootLabelCell({ clusterId }: Cluster) {
   const isRoot = cfg.proxyCluster === clusterId;
   return (
-    <Cell style={{ width: '40px' }}>{isRoot && <Primary>ROOT</Primary>}</Cell>
+    <Cell style={{ width: '40px' }}>
+      {isRoot ? <Primary>ROOT</Primary> : <Secondary>LEAF</Secondary>}
+    </Cell>
   );
 }
 

--- a/web/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
+++ b/web/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
@@ -92,6 +92,20 @@ exports[`render clusters 1`] = `
   color: #000000;
 }
 
+.c20 {
+  box-sizing: border-box;
+  border-radius: 10px;
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  margin: 1px 0;
+  vertical-align: middle;
+  background-color: rgba(255,255,255,0.07);
+  color: #FFFFFF;
+  font-weight: 400;
+}
+
 .c1 {
   display: flex;
 }
@@ -402,7 +416,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           nidvojik
         </td>
@@ -438,7 +459,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           lidtabih
         </td>
@@ -474,7 +502,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           farovluv
         </td>
@@ -510,7 +545,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           rozpaari
         </td>
@@ -546,7 +588,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           wetjolune
         </td>
@@ -582,7 +631,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           dashawic
         </td>
@@ -618,7 +674,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           jesushenry58
         </td>
@@ -654,7 +717,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           jordansimpson35
         </td>
@@ -690,7 +760,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           leonamann249
         </td>
@@ -726,7 +803,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           bessiecohen207
         </td>
@@ -762,7 +846,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           philipjohnson10
         </td>
@@ -798,7 +889,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           teresastone14
         </td>
@@ -834,7 +932,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           connorsharp137
         </td>
@@ -870,7 +975,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           ricardosingleton242
         </td>
@@ -906,7 +1018,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           rozpaari
         </td>
@@ -942,7 +1061,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           wetjolune
         </td>
@@ -978,7 +1104,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           dashawic
         </td>
@@ -1014,7 +1147,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           williepayne223
         </td>
@@ -1050,7 +1190,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           samlewis176
         </td>
@@ -1086,7 +1233,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           nellwheeler72
         </td>
@@ -1122,7 +1276,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           albertowens200
         </td>
@@ -1158,7 +1319,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           beatricecarson171
         </td>
@@ -1194,7 +1362,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           besscarroll152
         </td>
@@ -1230,7 +1405,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           hannahsutton232
         </td>
@@ -1266,7 +1448,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           barrynelson110
         </td>
@@ -1302,7 +1491,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           rozpaari
         </td>
@@ -1338,7 +1534,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           wetjolune
         </td>
@@ -1374,7 +1577,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           dashawic
         </td>
@@ -1410,7 +1620,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           henriettarios78
         </td>
@@ -1446,7 +1663,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           josephinewolfe55
         </td>
@@ -1482,7 +1706,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           jaysandoval137
         </td>
@@ -1518,7 +1749,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           isabellekim81
         </td>
@@ -1554,7 +1792,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           francismoran134
         </td>
@@ -1590,7 +1835,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           theodorefrazier78
         </td>
@@ -1626,7 +1878,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           hattiestanley34
         </td>
@@ -1662,7 +1921,14 @@ exports[`render clusters 1`] = `
       <tr>
         <td
           style="width: 40px;"
-        />
+        >
+          <div
+            class="c20"
+            kind="secondary"
+          >
+            LEAF
+          </div>
+        </td>
         <td>
           tommybrooks146
         </td>

--- a/web/packages/teleport/src/TrustedClusters/TrustedClusters.tsx
+++ b/web/packages/teleport/src/TrustedClusters/TrustedClusters.tsx
@@ -45,8 +45,8 @@ export default function TrustedClusters() {
 
   const title =
     resources.status === 'creating'
-      ? 'Add a new trusted cluster'
-      : 'Edit trusted cluster';
+      ? 'Add a new trusted root cluster'
+      : 'Edit trusted root cluster';
 
   function onRemove() {
     return remove(resources.item.name);
@@ -61,7 +61,7 @@ export default function TrustedClusters() {
   return (
     <FeatureBox>
       <FeatureHeader alignItems="center">
-        <FeatureHeaderTitle>Trusted Clusters</FeatureHeaderTitle>
+        <FeatureHeaderTitle>Trusted Root Clusters</FeatureHeaderTitle>
         {hasClusters && (
           <ButtonPrimary
             disabled={!canCreate}
@@ -131,8 +131,8 @@ const Info = props => (
     <Text typography="subtitle1" mb={3}>
       Trusted Clusters allow Teleport administrators to connect multiple
       clusters together and establish trust between them. Users of Trusted
-      Clusters can seamlessly access the nodes of the cluster from the root
-      cluster.
+      Clusters can seamlessly access the resources of the leaf cluster from the
+      root cluster.
     </Text>
     <Text typography="subtitle1" mb={2}>
       Please{' '}

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -523,7 +523,7 @@ export class FeatureTrust implements TeleportFeature {
   section = ManagementSection.Clusters;
 
   route = {
-    title: 'Trusted Clusters',
+    title: 'Trusted Root Clusters',
     path: cfg.routes.trustedClusters,
     component: TrustedClusters,
   };

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -87,7 +87,7 @@ export enum NavTitle {
 
   // Clusters
   ManageClusters = 'Manage Clusters',
-  TrustedClusters = 'Trusted Clusters',
+  TrustedClusters = 'Trusted Root Clusters',
 
   // Account
   AccountSettings = 'Account Settings',


### PR DESCRIPTION
We use the terms "root" and "leaf" pervasively in our docs and our conversations with customers, but the web UI tends to refer to everything as a "trusted cluster" without distinguishing between root and leaf. After noticing us incorrectly describing which clusters are roots and which are leafs, I decided we should make the UI self-explanatory.

- change sidebar title to indicate that the Trusted Clusters page is listing trusted *root* clusters
- update the manage clusters page to label leaf clusters in addition to roots

Backports #45531 