### PR TITLE
Add Envoy SDS support info to the `spiffe-workload-api` reference

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -785,6 +785,7 @@
     "rolebindings",
     "rolesanywhere",
     "rollouts",
+    "rootca",
     "rootcluster",
     "rtrzn",
     "runcommand",

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -537,8 +537,11 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               common_tls_context:
+                # configure the certificate that the reverse proxy should present.
                 tls_certificate_sds_secret_configs:
-                  - name: "default" # This can be replaced with the desired SPIFFE ID.
+                  # `name` can be replaced with the desired SPIFFE ID if  multiple
+                  # SVIDs are available.
+                  - name: "default"
                     sds_config:
                       resource_api_version: V3
                       api_config_source:
@@ -552,8 +555,9 @@ static_resources:
                 # from the SDS source.
                 combined_validation_context:
                   default_validation_context:
+                    # You can use match_typed_subject_alt_names to configure
+                    # rules that only allow connections from specific SPIFFE IDs.
                     match_typed_subject_alt_names: []
-                  # obtain the trust bundle from SDS
                   validation_context_sds_secret_config:
                     name: "ALL" # This can also be replaced with the trust domain name
                     sds_config:
@@ -565,6 +569,7 @@ static_resources:
                           envoy_grpc:
                             cluster_name: tbot_agent
   clusters:
+    # my_service is the example service that Envoy will forward traffic to.
     - name: my_service
       type: strict_dns
       load_assignment:
@@ -585,6 +590,8 @@ static_resources:
               - endpoint:
                   address:
                     pipe:
+                      # Configure the path to the socket that `tbot` is
+                      # listening on.
                       path: /opt/machine-id/workload.sock
 ```
 

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -460,6 +460,134 @@ svids:
           gid: 50
 ```
 
+#### Envoy SDS
+
+The `spiffe-workload-api` service endpoint also implements the Envoy SDS API.
+This allows it to act as a source of certificates and certificate authorities
+for the Envoy proxy.
+
+As a forward proxy, Envoy can be used to attach an X.509 SVID to an outgoing
+connection from a workload that is not SPIFFE-enabled.
+
+As a reverse proxy, Envoy can be used to terminate mTLS connections from
+SPIFFE-enabled clients. Envoy can validate that the client has presented a valid
+X.509 SVID and perform enforcement of authorization policies based on the SPIFFE
+ID contained within the SVID.
+
+When acting as a reverse proxy for certain protocols, Envoy can be configured
+to attach a header indicating the identity of the client to a request before
+forwarding it to the service. This can then be used by the service to make
+authorization decisions based on the client's identity.
+
+When configuring Envoy to use the SDS API exposed by the `spiffe-workload-api`
+service, three additional special names can be used to aid configuration:
+
+- `default`: `tbot` will return the default SVID for the workload.
+- `ROOTCA`: `tbot` will return the trust bundle for the trust domain that the
+   workload is a member of.
+- `ALL`: `tbot` will return the trust bundle for the trust domain that the
+  workload is a member of, as well as the trust bundles of any trust domain
+  that the trust domain is federated with.
+
+The following is an example Envoy configuration that sources a certificate
+and trust bundle from the `spiffe-workload-api` service listening on
+`unix:///opt/machine-id/workload.sock`. It requires that a connecting client
+presents a valid SPIFFE SVID and forwards this information to the backend
+service in the `x-forwarded-client-cert` header.
+
+```yaml
+node:
+  id: "my-envoy-proxy"
+  cluster: "my-cluster"
+static_resources:
+  listeners:
+    - name: test_listener
+      enable_reuse_port: false
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8080
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                common_http_protocol_options:
+                  idle_timeout: 1s
+                forward_client_cert_details: sanitize_set
+                set_current_client_cert_details:
+                  uri: true
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: my_service
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: my_service
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              common_tls_context:
+                tls_certificate_sds_secret_configs:
+                  - name: "default" # This can be replaced with the desired SPIFFE ID.
+                    sds_config:
+                      resource_api_version: V3
+                      api_config_source:
+                        api_type: GRPC
+                        transport_api_version: V3
+                        grpc_services:
+                          envoy_grpc:
+                            cluster_name: tbot_agent
+                # combined validation context "melds" two validation contexts
+                # together. This is handy for extending the validation context
+                # from the SDS source.
+                combined_validation_context:
+                  default_validation_context:
+                    match_typed_subject_alt_names: []
+                  # obtain the trust bundle from SDS
+                  validation_context_sds_secret_config:
+                    name: "ALL" # This can also be replaced with the trust domain name
+                    sds_config:
+                      resource_api_version: V3
+                      api_config_source:
+                        api_type: GRPC
+                        transport_api_version: V3
+                        grpc_services:
+                          envoy_grpc:
+                            cluster_name: tbot_agent
+  clusters:
+    - name: my_service
+      type: strict_dns
+      load_assignment:
+        cluster_name: my_service
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8090
+    - name: tbot_agent
+      http2_protocol_options: {}
+      load_assignment:
+        cluster_name: tbot_agent
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    pipe:
+                      path: /opt/machine-id/workload.sock
+```
+
 ### `database-tunnel`
 
 The `database-tunnel` service opens a listener for a service that tunnels


### PR DESCRIPTION
Documents the feature introduced by https://github.com/gravitational/teleport/pull/43958

I'd like to do a full blown guide for this at some point with a lot more detail, but, I've not got time to fit that in at the moment. This should at least expose the fact that we support it and give folks some pointers towards how to implement it.