### PR TITLE
DiscoveryConfigStatus: summary for AWS EC2 instances found

### DIFF
--- a/api/types/discoveryconfig/convert/v1/discoveryconfig.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig.go
@@ -89,10 +89,11 @@ func StatusFromProto(msg *discoveryconfigv1.DiscoveryConfigStatus) discoveryconf
 		lastSyncTime = msg.LastSyncTime.AsTime()
 	}
 	return discoveryconfig.Status{
-		State:               discoveryconfigv1.DiscoveryConfigState_name[int32(msg.State)],
-		ErrorMessage:        msg.ErrorMessage,
-		DiscoveredResources: msg.DiscoveredResources,
-		LastSyncTime:        lastSyncTime,
+		State:                     discoveryconfigv1.DiscoveryConfigState_name[int32(msg.State)],
+		ErrorMessage:              msg.ErrorMessage,
+		DiscoveredResources:       msg.DiscoveredResources,
+		LastSyncTime:              lastSyncTime,
+		AWSEC2InstancesDiscovered: msg.AwsEc2ResourcesDiscovered,
 	}
 }
 
@@ -141,9 +142,10 @@ func StatusToProto(status discoveryconfig.Status) *discoveryconfigv1.DiscoveryCo
 	}
 
 	return &discoveryconfigv1.DiscoveryConfigStatus{
-		State:               discoveryconfigv1.DiscoveryConfigState(discoveryconfigv1.DiscoveryConfigState_value[status.State]),
-		ErrorMessage:        status.ErrorMessage,
-		DiscoveredResources: status.DiscoveredResources,
-		LastSyncTime:        lastSyncTime,
+		State:                     discoveryconfigv1.DiscoveryConfigState(discoveryconfigv1.DiscoveryConfigState_value[status.State]),
+		ErrorMessage:              status.ErrorMessage,
+		DiscoveredResources:       status.DiscoveredResources,
+		LastSyncTime:              lastSyncTime,
+		AwsEc2ResourcesDiscovered: status.AWSEC2InstancesDiscovered,
 	}
 }

--- a/api/types/discoveryconfig/convert/v1/discoveryconfig.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig.go
@@ -89,11 +89,11 @@ func StatusFromProto(msg *discoveryconfigv1.DiscoveryConfigStatus) discoveryconf
 		lastSyncTime = msg.LastSyncTime.AsTime()
 	}
 	return discoveryconfig.Status{
-		State:                     discoveryconfigv1.DiscoveryConfigState_name[int32(msg.State)],
-		ErrorMessage:              msg.ErrorMessage,
-		DiscoveredResources:       msg.DiscoveredResources,
-		LastSyncTime:              lastSyncTime,
-		AWSEC2InstancesDiscovered: msg.AwsEc2ResourcesDiscovered,
+		State:                          discoveryconfigv1.DiscoveryConfigState_name[int32(msg.State)],
+		ErrorMessage:                   msg.ErrorMessage,
+		DiscoveredResources:            msg.DiscoveredResources,
+		LastSyncTime:                   lastSyncTime,
+		IntegrationDiscoveredResources: msg.IntegrationDiscoveredResources,
 	}
 }
 
@@ -142,10 +142,10 @@ func StatusToProto(status discoveryconfig.Status) *discoveryconfigv1.DiscoveryCo
 	}
 
 	return &discoveryconfigv1.DiscoveryConfigStatus{
-		State:                     discoveryconfigv1.DiscoveryConfigState(discoveryconfigv1.DiscoveryConfigState_value[status.State]),
-		ErrorMessage:              status.ErrorMessage,
-		DiscoveredResources:       status.DiscoveredResources,
-		LastSyncTime:              lastSyncTime,
-		AwsEc2ResourcesDiscovered: status.AWSEC2InstancesDiscovered,
+		State:                          discoveryconfigv1.DiscoveryConfigState(discoveryconfigv1.DiscoveryConfigState_value[status.State]),
+		ErrorMessage:                   status.ErrorMessage,
+		DiscoveredResources:            status.DiscoveredResources,
+		LastSyncTime:                   lastSyncTime,
+		IntegrationDiscoveredResources: status.IntegrationDiscoveredResources,
 	}
 }

--- a/api/types/discoveryconfig/convert/v1/discoveryconfig_test.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig_test.go
@@ -76,11 +76,14 @@ func newDiscoveryConfig(t *testing.T, name string) *discoveryconfig.DiscoveryCon
 	discoveryConfig.Status.LastSyncTime = now
 	errMsg := "error message"
 	discoveryConfig.Status.ErrorMessage = &errMsg
-	discoveryConfig.Status.AWSEC2InstancesDiscovered = []*discoveryconfigv1.AWSResourcesDiscoveredSummary{{
-		Integration: "my-integration",
-		Found:       3,
-		Enrolled:    2,
-		Failed:      1,
-	}}
+	discoveryConfig.Status.IntegrationDiscoveredResources = map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+		"my-integration": {
+			AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{
+				Found:    3,
+				Enrolled: 2,
+				Failed:   1,
+			},
+		},
+	}
 	return discoveryConfig
 }

--- a/api/types/discoveryconfig/convert/v1/discoveryconfig_test.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig_test.go
@@ -76,5 +76,11 @@ func newDiscoveryConfig(t *testing.T, name string) *discoveryconfig.DiscoveryCon
 	discoveryConfig.Status.LastSyncTime = now
 	errMsg := "error message"
 	discoveryConfig.Status.ErrorMessage = &errMsg
+	discoveryConfig.Status.AWSEC2InstancesDiscovered = []*discoveryconfigv1.AWSResourcesDiscoveredSummary{{
+		Integration: "my-integration",
+		Found:       3,
+		Enrolled:    2,
+		Failed:      1,
+	}}
 	return discoveryConfig
 }

--- a/api/types/discoveryconfig/discoveryconfig.go
+++ b/api/types/discoveryconfig/discoveryconfig.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/compare"
 	"github.com/gravitational/teleport/api/types/header"
@@ -82,6 +83,8 @@ type Status struct {
 	DiscoveredResources uint64 `json:"discovered_resources" yaml:"discovered_resources"`
 	// LastSyncTime is the timestamp when the Discovery Config was last sync.
 	LastSyncTime time.Time `json:"last_sync_time,omitempty" yaml:"last_sync_time,omitempty"`
+	// AWSEC2InstancesDiscovered contains the list of AWS EC2 discovered instances.
+	AWSEC2InstancesDiscovered []*discoveryconfigv1.AWSResourcesDiscoveredSummary `json:"aws_ec2_instances_discovered,omitempty" yaml:"aws_ec2_instances_discovered,omitempty"`
 }
 
 // NewDiscoveryConfig will create a new discovery config.

--- a/api/types/discoveryconfig/discoveryconfig.go
+++ b/api/types/discoveryconfig/discoveryconfig.go
@@ -83,8 +83,8 @@ type Status struct {
 	DiscoveredResources uint64 `json:"discovered_resources" yaml:"discovered_resources"`
 	// LastSyncTime is the timestamp when the Discovery Config was last sync.
 	LastSyncTime time.Time `json:"last_sync_time,omitempty" yaml:"last_sync_time,omitempty"`
-	// AWSEC2InstancesDiscovered contains the list of AWS EC2 discovered instances.
-	AWSEC2InstancesDiscovered []*discoveryconfigv1.AWSResourcesDiscoveredSummary `json:"aws_ec2_instances_discovered,omitempty" yaml:"aws_ec2_instances_discovered,omitempty"`
+	// IntegrationDiscoveredResources maps an integration to a summary of resources that were found using that integration.
+	IntegrationDiscoveredResources map[string]*discoveryconfigv1.IntegrationDiscoveredSummary `json:"integration_discovered_resources,omitempty" yaml:"integration_discovered_resources,omitempty"`
 }
 
 // NewDiscoveryConfig will create a new discovery config.

--- a/lib/srv/discovery/access_graph_test.go
+++ b/lib/srv/discovery/access_graph_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
 )
@@ -57,10 +58,11 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 			want: map[string][]discoveryconfig.Status{
 				"test": {
 					{
-						State:               "DISCOVERY_CONFIG_STATE_RUNNING",
-						ErrorMessage:        nil,
-						DiscoveredResources: 1,
-						LastSyncTime:        clock.Now(),
+						State:                          "DISCOVERY_CONFIG_STATE_RUNNING",
+						ErrorMessage:                   nil,
+						DiscoveredResources:            1,
+						LastSyncTime:                   clock.Now(),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
 					},
 				},
 			},
@@ -80,10 +82,11 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 			want: map[string][]discoveryconfig.Status{
 				"test": {
 					{
-						State:               "DISCOVERY_CONFIG_STATE_ERROR",
-						ErrorMessage:        &testErr,
-						DiscoveredResources: 1,
-						LastSyncTime:        clock.Now(),
+						State:                          "DISCOVERY_CONFIG_STATE_ERROR",
+						ErrorMessage:                   &testErr,
+						DiscoveredResources:            1,
+						LastSyncTime:                   clock.Now(),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
 					},
 				},
 			},
@@ -102,10 +105,11 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 			want: map[string][]discoveryconfig.Status{
 				"test": {
 					{
-						State:               "DISCOVERY_CONFIG_STATE_ERROR",
-						ErrorMessage:        &testErr,
-						DiscoveredResources: 1,
-						LastSyncTime:        clock.Now(),
+						State:                          "DISCOVERY_CONFIG_STATE_ERROR",
+						ErrorMessage:                   &testErr,
+						DiscoveredResources:            1,
+						LastSyncTime:                   clock.Now(),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
 					},
 				},
 			},
@@ -134,10 +138,11 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 			want: map[string][]discoveryconfig.Status{
 				"test": {
 					{
-						State:               "DISCOVERY_CONFIG_STATE_SYNCING",
-						ErrorMessage:        nil,
-						DiscoveredResources: 0,
-						LastSyncTime:        clock.Now(),
+						State:                          "DISCOVERY_CONFIG_STATE_SYNCING",
+						ErrorMessage:                   nil,
+						DiscoveredResources:            0,
+						LastSyncTime:                   clock.Now(),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
 					},
 				},
 			},
@@ -163,18 +168,20 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 			want: map[string][]discoveryconfig.Status{
 				"test1": {
 					{
-						State:               "DISCOVERY_CONFIG_STATE_RUNNING",
-						ErrorMessage:        nil,
-						DiscoveredResources: 2,
-						LastSyncTime:        clock.Now(),
+						State:                          "DISCOVERY_CONFIG_STATE_RUNNING",
+						ErrorMessage:                   nil,
+						DiscoveredResources:            2,
+						LastSyncTime:                   clock.Now(),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
 					},
 				},
 				"test2": {
 					{
-						State:               "DISCOVERY_CONFIG_STATE_RUNNING",
-						ErrorMessage:        nil,
-						DiscoveredResources: 1,
-						LastSyncTime:        clock.Now(),
+						State:                          "DISCOVERY_CONFIG_STATE_RUNNING",
+						ErrorMessage:                   nil,
+						DiscoveredResources:            1,
+						LastSyncTime:                   clock.Now(),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
 					},
 				},
 			},
@@ -196,9 +203,10 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 			want: map[string][]discoveryconfig.Status{
 				"test1": {
 					{
-						State:        "DISCOVERY_CONFIG_STATE_ERROR",
-						ErrorMessage: stringPointer("error in fetcher 1\nerror in fetcher 2"),
-						LastSyncTime: clock.Now(),
+						State:                          "DISCOVERY_CONFIG_STATE_ERROR",
+						ErrorMessage:                   stringPointer("error in fetcher 1\nerror in fetcher 2"),
+						LastSyncTime:                   clock.Now(),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
 					},
 				},
 			},
@@ -220,10 +228,11 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 			want: map[string][]discoveryconfig.Status{
 				"test1": {
 					{
-						State:               "DISCOVERY_CONFIG_STATE_ERROR",
-						ErrorMessage:        stringPointer("error in fetcher 1"),
-						DiscoveredResources: 2,
-						LastSyncTime:        clock.Now(),
+						State:                          "DISCOVERY_CONFIG_STATE_ERROR",
+						ErrorMessage:                   stringPointer("error in fetcher 1"),
+						DiscoveredResources:            2,
+						LastSyncTime:                   clock.Now(),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
 					},
 				},
 			},

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -327,7 +327,8 @@ type Server struct {
 
 	dynamicDiscoveryConfig map[string]*discoveryconfig.DiscoveryConfig
 
-	awsSyncStatus awsSyncStatus
+	awsSyncStatus         awsSyncStatus
+	awsEC2ResourcesStatus awsResourcesStatus
 
 	// caRotationCh receives nodes that need to have their CAs rotated.
 	caRotationCh chan []types.Server
@@ -447,7 +448,8 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 		return matcherType == types.AWSMatcherEC2
 	})
 
-	s.staticServerAWSFetchers, err = server.MatchersToEC2InstanceFetchers(s.ctx, ec2Matchers, s.CloudClients)
+	const noDiscoveryConfig = ""
+	s.staticServerAWSFetchers, err = server.MatchersToEC2InstanceFetchers(s.ctx, ec2Matchers, s.CloudClients, noDiscoveryConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -456,6 +458,9 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 		s.ctx, s.getAllAWSServerFetchers, s.caRotationCh,
 		server.WithPollInterval(s.PollInterval),
 		server.WithTriggerFetchC(s.newDiscoveryConfigChangedSub()),
+		server.WithPreFetchHookFn(func() {
+			s.awsEC2ResourcesStatus.iterationStarted()
+		}),
 	)
 	if err != nil {
 		return trace.Wrap(err)
@@ -465,7 +470,7 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 
 	if s.ec2Installer == nil {
 		ec2installer, err := server.NewSSMInstaller(server.SSMInstallerConfig{
-			Emitter: s.Emitter,
+			ReportSSMInstallationResultFunc: s.ReportEC2SSMInstallationResult,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -528,12 +533,12 @@ func (s *Server) initKubeAppWatchers(matchers []types.KubernetesMatcher) error {
 }
 
 // awsServerFetchersFromMatchers converts Matchers into a set of AWS EC2 Fetchers.
-func (s *Server) awsServerFetchersFromMatchers(ctx context.Context, matchers []types.AWSMatcher) ([]server.Fetcher, error) {
+func (s *Server) awsServerFetchersFromMatchers(ctx context.Context, matchers []types.AWSMatcher, discoveryConfig string) ([]server.Fetcher, error) {
 	serverMatchers, _ := splitMatchers(matchers, func(matcherType string) bool {
 		return matcherType == types.AWSMatcherEC2
 	})
 
-	fetchers, err := server.MatchersToEC2InstanceFetchers(ctx, serverMatchers, s.CloudClients)
+	fetchers, err := server.MatchersToEC2InstanceFetchers(ctx, serverMatchers, s.CloudClients, discoveryConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -825,9 +830,17 @@ func (s *Server) handleEC2Instances(instances *server.EC2Instances) error {
 	// they all need to have the command run on them
 	//
 	// EICE Nodes must never be filtered, so that we can extend their expiration and sync labels.
+	totalInstancesFound := len(instances.Instances)
 	if !instances.Rotation && instances.EnrollMode != types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_EICE {
 		s.filterExistingEC2Nodes(instances)
 	}
+
+	instancesAlreadyEnrolled := totalInstancesFound - len(instances.Instances)
+	s.awsEC2ResourcesStatus.incrementEnrolled(awsResourceGroup{
+		discoveryConfig: instances.DiscoveryConfig,
+		integration:     instances.Integration,
+	}, instancesAlreadyEnrolled)
+
 	if len(instances.Instances) == 0 {
 		return trace.NotFound("all fetched nodes already enrolled")
 	}
@@ -865,6 +878,11 @@ func (s *Server) heartbeatEICEInstance(instances *server.EC2Instances) {
 		eiceNode, err := common.NewAWSNodeFromEC2v1Instance(ec2Instance.OriginalInstance, awsInfo)
 		if err != nil {
 			s.Log.WithField("instance_id", ec2Instance.InstanceID).Warnf("Error converting to Teleport EICE Node: %v", err)
+
+			s.awsEC2ResourcesStatus.incrementFailed(awsResourceGroup{
+				discoveryConfig: instances.DiscoveryConfig,
+				integration:     instances.Integration,
+			}, 1)
 			continue
 		}
 
@@ -903,6 +921,10 @@ func (s *Server) heartbeatEICEInstance(instances *server.EC2Instances) {
 		if _, err := s.AccessPoint.UpsertNode(s.ctx, eiceNode); err != nil {
 			instanceID := eiceNode.GetAWSInstanceID()
 			s.Log.WithField("instance_id", instanceID).Warnf("Error upserting EC2 instance: %v", err)
+			s.awsEC2ResourcesStatus.incrementFailed(awsResourceGroup{
+				discoveryConfig: instances.DiscoveryConfig,
+				integration:     instances.Integration,
+			}, 1)
 		}
 	})
 	if err != nil {
@@ -924,14 +946,20 @@ func (s *Server) handleEC2RemoteInstallation(instances *server.EC2Instances) err
 		instances.AccountID, genEC2InstancesLogStr(instances.Instances))
 
 	req := server.SSMRunRequest{
-		DocumentName: instances.DocumentName,
-		SSM:          ec2Client,
-		Instances:    instances.Instances,
-		Params:       instances.Parameters,
-		Region:       instances.Region,
-		AccountID:    instances.AccountID,
+		DocumentName:    instances.DocumentName,
+		SSM:             ec2Client,
+		Instances:       instances.Instances,
+		Params:          instances.Parameters,
+		Region:          instances.Region,
+		AccountID:       instances.AccountID,
+		IntegrationName: instances.Integration,
+		DiscoveryConfig: instances.DiscoveryConfig,
 	}
 	if err := s.ec2Installer.Run(s.ctx, req); err != nil {
+		s.awsEC2ResourcesStatus.incrementFailed(awsResourceGroup{
+			discoveryConfig: instances.DiscoveryConfig,
+			integration:     instances.Integration,
+		}, len(req.Instances))
 		return trace.Wrap(err)
 	}
 	return nil
@@ -1034,9 +1062,16 @@ func (s *Server) handleEC2Discovery() {
 			s.Log.Debugf("EC2 instances discovered (AccountID: %s, Instances: %v), starting installation",
 				ec2Instances.AccountID, genEC2InstancesLogStr(ec2Instances.Instances))
 
+			s.awsEC2ResourcesStatus.incrementFound(awsResourceGroup{
+				discoveryConfig: instances.EC2.DiscoveryConfig,
+				integration:     instances.EC2.Integration,
+			}, len(instances.EC2.Instances))
+
 			if err := s.handleEC2Instances(ec2Instances); err != nil {
 				s.logHandleInstancesErr(err)
 			}
+
+			s.updateDiscoveryConfigStatus(instances.EC2.DiscoveryConfig)
 		case <-s.ctx.Done():
 			s.ec2Watcher.Stop()
 			return
@@ -1512,7 +1547,7 @@ func (s *Server) upsertDynamicMatchers(ctx context.Context, dc *discoveryconfig.
 	}
 	s.discardUnsupportedMatchers(&matchers)
 
-	awsServerFetchers, err := s.awsServerFetchersFromMatchers(s.ctx, matchers.AWS)
+	awsServerFetchers, err := s.awsServerFetchersFromMatchers(s.ctx, matchers.AWS, dc.GetName())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -526,12 +526,15 @@ func TestDiscoveryServer(t *testing.T) {
 				ErrorMessage:        nil,
 				DiscoveredResources: 1,
 				LastSyncTime:        fakeClock.Now().UTC(),
-				AWSEC2InstancesDiscovered: []*discoveryconfigv1.AWSResourcesDiscoveredSummary{{
-					Integration: "my-integration",
-					Found:       1,
-					Enrolled:    0,
-					Failed:      0,
-				}},
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					"my-integration": {
+						AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{
+							Found:    1,
+							Enrolled: 0,
+							Failed:   0,
+						},
+					},
+				},
 			},
 			wantInstalledInstances: []string{"instance-id-1"},
 		},
@@ -630,7 +633,7 @@ func TestDiscoveryServer(t *testing.T) {
 				require.Eventually(t, func() bool {
 					storedDiscoveryConfig, err := tlsServer.Auth().DiscoveryConfigs.GetDiscoveryConfig(ctx, tc.discoveryConfig.GetName())
 					require.NoError(t, err)
-					if len(storedDiscoveryConfig.Status.AWSEC2InstancesDiscovered) == 0 {
+					if len(storedDiscoveryConfig.Status.IntegrationDiscoveredResources) == 0 {
 						return false
 					}
 					require.Equal(t, *tc.wantDiscoveryConfigStatus, storedDiscoveryConfig.Status)

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -63,6 +63,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
@@ -222,6 +223,8 @@ func (m *mockSSMInstaller) GetInstalledInstances() []string {
 func TestDiscoveryServer(t *testing.T) {
 	t.Parallel()
 
+	fakeClock := clockwork.NewFakeClock()
+
 	defaultDiscoveryGroup := "dc001"
 	defaultStaticMatcher := Matchers{
 		AWS: []types.AWSMatcher{{
@@ -269,13 +272,14 @@ func TestDiscoveryServer(t *testing.T) {
 	tcs := []struct {
 		name string
 		// presentInstances is a list of servers already present in teleport
-		presentInstances       []types.Server
-		foundEC2Instances      []*ec2.Instance
-		ssm                    *mockSSMClient
-		emitter                *mockEmitter
-		discoveryConfig        *discoveryconfig.DiscoveryConfig
-		staticMatchers         Matchers
-		wantInstalledInstances []string
+		presentInstances          []types.Server
+		foundEC2Instances         []*ec2.Instance
+		ssm                       *mockSSMClient
+		emitter                   *mockEmitter
+		discoveryConfig           *discoveryconfig.DiscoveryConfig
+		staticMatchers            Matchers
+		wantInstalledInstances    []string
+		wantDiscoveryConfigStatus *discoveryconfig.Status
 	}{
 		{
 			name:             "no nodes present, 1 found ",
@@ -515,8 +519,20 @@ func TestDiscoveryServer(t *testing.T) {
 					}, ae)
 				},
 			},
-			staticMatchers:         Matchers{},
-			discoveryConfig:        dcForEC2SSMWithIntegration,
+			staticMatchers:  Matchers{},
+			discoveryConfig: dcForEC2SSMWithIntegration,
+			wantDiscoveryConfigStatus: &discoveryconfig.Status{
+				State:               "DISCOVERY_CONFIG_STATE_SYNCING",
+				ErrorMessage:        nil,
+				DiscoveredResources: 1,
+				LastSyncTime:        fakeClock.Now().UTC(),
+				AWSEC2InstancesDiscovered: []*discoveryconfigv1.AWSResourcesDiscoveredSummary{{
+					Integration: "my-integration",
+					Found:       1,
+					Enrolled:    0,
+					Failed:      0,
+				}},
+			},
 			wantInstalledInstances: []string{"instance-id-1"},
 		},
 	}
@@ -569,6 +585,12 @@ func TestDiscoveryServer(t *testing.T) {
 				installedInstances: make(map[string]struct{}),
 			}
 			tlsServer.Auth().SetUsageReporter(reporter)
+
+			if tc.discoveryConfig != nil {
+				_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, tc.discoveryConfig)
+				require.NoError(t, err)
+			}
+
 			server, err := New(authz.ContextWithUser(context.Background(), identity.I), &Config{
 				CloudClients:     testCloudClients,
 				ClusterFeatures:  func() proto.Features { return proto.Features{} },
@@ -578,16 +600,12 @@ func TestDiscoveryServer(t *testing.T) {
 				Emitter:          tc.emitter,
 				Log:              logger,
 				DiscoveryGroup:   defaultDiscoveryGroup,
+				clock:            fakeClock,
 			})
 			require.NoError(t, err)
 			server.ec2Installer = installer
 			tc.emitter.server = server
 			tc.emitter.t = t
-
-			if tc.discoveryConfig != nil {
-				_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, tc.discoveryConfig)
-				require.NoError(t, err)
-			}
 
 			go server.Start()
 			t.Cleanup(server.Stop)
@@ -605,6 +623,20 @@ func TestDiscoveryServer(t *testing.T) {
 				}, 500*time.Millisecond, 50*time.Millisecond)
 			}
 			require.GreaterOrEqual(t, reporter.DiscoveryFetchEventCount(), 1)
+
+			// Discovery Config Status is updated accordingly
+			if tc.wantDiscoveryConfigStatus != nil {
+				// It can take a while for the status to be updated.
+				require.Eventually(t, func() bool {
+					storedDiscoveryConfig, err := tlsServer.Auth().DiscoveryConfigs.GetDiscoveryConfig(ctx, tc.discoveryConfig.GetName())
+					require.NoError(t, err)
+					if len(storedDiscoveryConfig.Status.AWSEC2InstancesDiscovered) == 0 {
+						return false
+					}
+					require.Equal(t, *tc.wantDiscoveryConfigStatus, storedDiscoveryConfig.Status)
+					return true
+				}, 500*time.Millisecond, 50*time.Millisecond)
+			}
 		})
 	}
 }

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -28,12 +28,15 @@ import (
 
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	libevents "github.com/gravitational/teleport/lib/events"
 	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
+	"github.com/gravitational/teleport/lib/srv/server"
 )
 
 // updateDiscoveryConfigStatus updates the DiscoveryConfig Status field with the current in-memory status.
 // The status will be updated with the following matchers:
 // - AWS Sync (TAG) status
+// - AWS EC2 Auto Discover status
 func (s *Server) updateDiscoveryConfigStatus(discoveryConfigName string) {
 	discoveryConfigStatus := discoveryconfig.Status{
 		State:        discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_SYNCING.String(),
@@ -42,6 +45,9 @@ func (s *Server) updateDiscoveryConfigStatus(discoveryConfigName string) {
 
 	// Merge AWS Sync (TAG) status
 	discoveryConfigStatus = s.awsSyncStatus.mergeIntoGlobalStatus(discoveryConfigName, discoveryConfigStatus)
+
+	// Merge AWS EC2 Instances (auto discovery) status
+	discoveryConfigStatus = s.awsEC2ResourcesStatus.mergeEC2IntoGlobalStatus(discoveryConfigName, discoveryConfigStatus)
 
 	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
 	defer cancel()
@@ -175,4 +181,112 @@ func (d *awsSyncStatus) mergeIntoGlobalStatus(discoveryConfigName string, existi
 	}
 
 	return existingStatus
+}
+
+// awsResourcesStatus contains all the status for AWS Matchers grouped by DiscoveryConfig for a specific matcher type.
+type awsResourcesStatus struct {
+	mu sync.RWMutex
+	// awsResourcesResults maps the DiscoveryConfig name and integration to a summary of discovered/enrolled resources.
+	awsResourcesResults map[awsResourceGroup]awsResourceGroupResult
+}
+
+// awsResourceGroup is the key for the summary
+type awsResourceGroup struct {
+	discoveryConfig string
+	integration     string
+}
+
+// awsResourceGroupResult stores the result of the aws_sync Matchers for a given DiscoveryConfig.
+type awsResourceGroupResult struct {
+	found    int
+	enrolled int
+	failed   int
+}
+
+func (d *awsResourcesStatus) iterationStarted() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.awsResourcesResults = make(map[awsResourceGroup]awsResourceGroupResult)
+}
+
+func (ars *awsResourcesStatus) mergeEC2IntoGlobalStatus(discoveryConfigName string, existingStatus discoveryconfig.Status) discoveryconfig.Status {
+	ars.mu.RLock()
+	defer ars.mu.RUnlock()
+
+	for group, groupResult := range ars.awsResourcesResults {
+		if group.discoveryConfig != discoveryConfigName {
+			continue
+		}
+
+		// Update global discovered resources count.
+		existingStatus.DiscoveredResources = existingStatus.DiscoveredResources + uint64(groupResult.found)
+
+		// Update counters specific to AWS resources discovered.
+		existingStatus.AWSEC2InstancesDiscovered = append(existingStatus.AWSEC2InstancesDiscovered, &discoveryconfigv1.AWSResourcesDiscoveredSummary{
+			Integration: group.integration,
+			Found:       uint64(groupResult.found),
+			Enrolled:    uint64(groupResult.enrolled),
+			Failed:      uint64(groupResult.failed),
+		})
+	}
+
+	return existingStatus
+}
+
+func (ars *awsResourcesStatus) incrementFailed(g awsResourceGroup, count int) {
+	ars.mu.Lock()
+	defer ars.mu.Unlock()
+	if ars.awsResourcesResults == nil {
+		ars.awsResourcesResults = make(map[awsResourceGroup]awsResourceGroupResult)
+	}
+	groupStats := ars.awsResourcesResults[g]
+	groupStats.failed = groupStats.failed + count
+	ars.awsResourcesResults[g] = groupStats
+}
+
+func (ars *awsResourcesStatus) incrementFound(g awsResourceGroup, count int) {
+	ars.mu.Lock()
+	defer ars.mu.Unlock()
+	if ars.awsResourcesResults == nil {
+		ars.awsResourcesResults = make(map[awsResourceGroup]awsResourceGroupResult)
+	}
+	groupStats := ars.awsResourcesResults[g]
+	groupStats.found = groupStats.found + count
+	ars.awsResourcesResults[g] = groupStats
+}
+
+func (ars *awsResourcesStatus) incrementEnrolled(g awsResourceGroup, count int) {
+	ars.mu.Lock()
+	defer ars.mu.Unlock()
+	if ars.awsResourcesResults == nil {
+		ars.awsResourcesResults = make(map[awsResourceGroup]awsResourceGroupResult)
+	}
+	groupStats := ars.awsResourcesResults[g]
+	groupStats.enrolled = groupStats.enrolled + count
+	ars.awsResourcesResults[g] = groupStats
+}
+
+// ReportEC2SSMInstallationResult is called when discovery gets the result of running the installation script in a EC2 instance.
+// It will emit an audit event with the result and update the DiscoveryConfig status
+func (s *Server) ReportEC2SSMInstallationResult(ctx context.Context, result *server.SSMInstallationResult) error {
+	if err := s.Emitter.EmitAuditEvent(ctx, result.SSMRunEvent); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Only failed runs are counted.
+	// Successful ones only mean that the teleport was installed in the target host.
+	// If they succeed in joining the cluster, during the next iteration, they will be countd as "enrolled"
+	if result.SSMRunEvent.Metadata.Code == libevents.SSMRunSuccessCode {
+		return nil
+	}
+
+	s.awsEC2ResourcesStatus.incrementFailed(awsResourceGroup{
+		discoveryConfig: result.DiscoveryConfig,
+		integration:     result.IntegrationName,
+	}, 1)
+
+	s.updateDiscoveryConfigStatus(result.DiscoveryConfig)
+
+	return nil
 }

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -239,8 +239,9 @@ func TestEC2Watcher(t *testing.T) {
 	}
 	clients.ec2Client.output = &output
 
+	const noDiscoveryConfig = ""
 	fetchersFn := func() []Fetcher {
-		fetchers, err := MatchersToEC2InstanceFetchers(ctx, matchers, &clients)
+		fetchers, err := MatchersToEC2InstanceFetchers(ctx, matchers, &clients, noDiscoveryConfig)
 		require.NoError(t, err)
 
 		return fetchers


### PR DESCRIPTION
This PR adds the summary for AWS EC2 instances found for a given DiscoveryConfig.
This is going to be part of the AWS OIDC Integration dashboard.

Demo:
`$ tctl get discovery_config/dc001 | yq .status`
```yaml
discovered_resources: 3
integration_discovered_resources:
  teleportdev:
    aws_ec2:
      enrolled: 1
      failed: 2
      found: 3
last_sync_time: "2024-08-27T10:09:09.912702Z"
state: DISCOVERY_CONFIG_STATE_SYNCING

```

Context: https://github.com/gravitational/teleport/issues/41909