### PR TITLE
[v15] Remove tcp app session recording

### DIFF
--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -384,25 +384,9 @@ func (c *ConnectionsHandler) sessionStartTime(ctx context.Context) time.Time {
 // newTCPServer creates a server that proxies TCP applications.
 func (c *ConnectionsHandler) newTCPServer() (*tcpServer, error) {
 	return &tcpServer{
-		newAudit: func(ctx context.Context, sessionID string) (common.Audit, error) {
-			// Audit stream is using server context, not session context,
-			// to make sure that session is uploaded even after it is closed.
-			rec, err := c.newSessionRecorder(c.closeContext, c.sessionStartTime(ctx), sessionID)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			audit, err := common.NewAudit(common.AuditConfig{
-				Emitter:  c.cfg.Emitter,
-				Recorder: rec,
-			})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			return audit, nil
-		},
-		hostID: c.cfg.HostID,
-		log:    c.log,
+		emitter: c.cfg.Emitter,
+		hostID:  c.cfg.HostID,
+		log:     c.log,
 	}, nil
 }
 

--- a/lib/srv/app/tcpserver.go
+++ b/lib/srv/app/tcpserver.go
@@ -27,15 +27,17 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	apitypes "github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
 type tcpServer struct {
-	newAudit func(ctx context.Context, sessionID string) (common.Audit, error)
-	hostID   string
-	log      *slog.Logger
+	emitter apievents.Emitter
+	hostID  string
+	log     *slog.Logger
 }
 
 // handleConnection handles connection from a TCP application.
@@ -55,10 +57,14 @@ func (s *tcpServer) handleConnection(ctx context.Context, clientConn net.Conn, i
 		return trace.Wrap(err)
 	}
 
-	audit, err := s.newAudit(ctx, identity.RouteToApp.SessionID)
+	audit, err := common.NewAudit(common.AuditConfig{
+		Emitter:  s.emitter,
+		Recorder: events.WithNoOpPreparer(events.NewDiscardRecorder()),
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
 	if err := audit.OnSessionStart(ctx, s.hostID, identity, app); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/app/tcpserver.go
+++ b/lib/srv/app/tcpserver.go
@@ -69,6 +69,8 @@ func (s *tcpServer) handleConnection(ctx context.Context, clientConn net.Conn, i
 		return trace.Wrap(err)
 	}
 	defer func() {
+		// The connection context may be closed once the connection is closed.
+		ctx := context.Background()
 		if err := audit.OnSessionEnd(ctx, s.hostID, identity, app); err != nil {
 			s.log.WarnContext(ctx, "Failed to emit session end event for app.", "app", app.GetName(), "error", err)
 		}


### PR DESCRIPTION
Backport #45576 to branch/v15

changelog: Remove empty tcp app session recordings.
