### PR TITLE
[v14] Remove tcp app session recording

### DIFF
--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -1121,25 +1121,9 @@ func (s *Server) newHTTPServer(clusterName string) *http.Server {
 // newTCPServer creates a server that proxies TCP applications.
 func (s *Server) newTCPServer() (*tcpServer, error) {
 	return &tcpServer{
-		newAudit: func(ctx context.Context, sessionID string) (common.Audit, error) {
-			// Audit stream is using server context, not session context,
-			// to make sure that session is uploaded even after it is closed.
-			rec, err := s.newSessionRecorder(s.closeContext, s.sessionStartTime(ctx), sessionID)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			audit, err := common.NewAudit(common.AuditConfig{
-				Emitter:  s.c.Emitter,
-				Recorder: rec,
-			})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			return audit, nil
-		},
-		hostID: s.c.HostID,
-		log:    s.log,
+		emitter: s.c.Emitter,
+		hostID:  s.c.HostID,
+		log:     s.log,
 	}, nil
 }
 

--- a/lib/srv/app/tcpserver.go
+++ b/lib/srv/app/tcpserver.go
@@ -25,15 +25,17 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	apitypes "github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
 type tcpServer struct {
-	newAudit func(ctx context.Context, sessionID string) (common.Audit, error)
-	hostID   string
-	log      logrus.FieldLogger
+	emitter apievents.Emitter
+	hostID  string
+	log     logrus.FieldLogger
 }
 
 // handleConnection handles connection from a TCP application.
@@ -53,14 +55,20 @@ func (s *tcpServer) handleConnection(ctx context.Context, clientConn net.Conn, i
 		return trace.Wrap(err)
 	}
 
-	audit, err := s.newAudit(ctx, identity.RouteToApp.SessionID)
+	audit, err := common.NewAudit(common.AuditConfig{
+		Emitter:  s.emitter,
+		Recorder: events.WithNoOpPreparer(events.NewDiscardRecorder()),
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
 	if err := audit.OnSessionStart(ctx, s.hostID, identity, app); err != nil {
 		return trace.Wrap(err)
 	}
 	defer func() {
+		// The connection context may be closed once the connection is closed.
+		ctx := context.Background()
 		if err := audit.OnSessionEnd(ctx, s.hostID, identity, app); err != nil {
 			s.log.WithError(err).Warnf("Failed to emit session end event for app %v.", app.GetName())
 		}


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/45576 to branch/v14

changelog: Remove empty tcp app session recordings.