### PR TITLE
[v15][buddy] Truncate AssumeRole session name to API limits

### DIFF
--- a/lib/srv/app/cloud.go
+++ b/lib/srv/app/cloud.go
@@ -191,7 +191,7 @@ func (c *cloud) getAWSSigninToken(ctx context.Context, req *AWSSigninRequest, en
 	options = append(options, func(creds *stscreds.AssumeRoleProvider) {
 		// Setting role session name to Teleport username will allow to
 		// associate CloudTrail events with the Teleport user.
-		creds.RoleSessionName = req.Identity.Username
+		creds.RoleSessionName = awsutils.MaybeHashRoleSessionName(req.Identity.Username)
 
 		// Setting web console session duration through AssumeRole call for AWS
 		// sessions with temporary credentials.

--- a/lib/utils/aws/aws_test.go
+++ b/lib/utils/aws/aws_test.go
@@ -493,3 +493,33 @@ func TestResourceARN(t *testing.T) {
 		})
 	}
 }
+
+func TestMaybeHashRoleSessionName(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		role     string
+		expected string
+	}{
+		{
+			name:     "role session name not hashed, less than 64 characters",
+			role:     "MyRole",
+			expected: "MyRole",
+		},
+		{
+			name:     "role session name not hashed, exactly 64 characters",
+			role:     "Role123456789012345678901234567890123456789012345678901234567890",
+			expected: "Role123456789012345678901234567890123456789012345678901234567890",
+		},
+		{
+			name:     "role session name hashed, longer than 64 characters",
+			role:     "remote-raimundo.oliveira@abigcompany.com-teleport.abigcompany.com",
+			expected: "remote-raimundo.oliveira@abigcompany.com-telepo-8fe1f87e599b043e",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := MaybeHashRoleSessionName(tt.role)
+			require.Equal(t, tt.expected, actual)
+			require.LessOrEqual(t, len(actual), MaxRoleSessionNameLength)
+		})
+	}
+}

--- a/lib/utils/aws/credentials.go
+++ b/lib/utils/aws/credentials.go
@@ -74,7 +74,7 @@ func (g *credentialsGetter) Get(_ context.Context, request GetCredentialsRequest
 	logrus.Debugf("Creating STS session %q for %q.", request.SessionName, request.RoleARN)
 	return stscreds.NewCredentials(request.Provider, request.RoleARN,
 		func(cred *stscreds.AssumeRoleProvider) {
-			cred.RoleSessionName = request.SessionName
+			cred.RoleSessionName = MaybeHashRoleSessionName(request.SessionName)
 			cred.Expiry.SetExpiration(request.Expiry, 0)
 
 			if request.ExternalID != "" {


### PR DESCRIPTION
backport of #45202 to branch/v15

changelog: Fixed an issue AWS access fails when the username is longer than 64 characters

no conflict.
