### PR TITLE
Remove deprecated backend.Key function

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -434,12 +434,6 @@ func (p earliest) Swap(i, j int) {
 // Separator is used as a separator between key parts
 const Separator = '/'
 
-// Key joins parts into path separated by Separator,
-// makes sure path always starts with Separator ("/")
-func Key(parts ...string) []byte {
-	return NewKey(parts...)
-}
-
 // NewKey joins parts into path separated by Separator,
 // makes sure path always starts with Separator ("/")
 func NewKey(parts ...string) []byte {

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -249,7 +249,7 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 	if origNumPrefixes != redundantNumPrefixes {
 		// If you've hit this error, the prefixes in two or more of your parsers probably overlap, meaning
 		// one prefix will also contain another as a subset. Look into using backend.ExactKey instead of
-		// backend.Key in your parser.
+		// backend.NewKey in your parser.
 		return nil, trace.BadParameter("redundant prefixes detected in events, which will result in event parsers not aligning with their intended prefix (this is a bug)")
 	}
 


### PR DESCRIPTION
The function was replaced in https://github.com/gravitational/teleport/pull/45611 and all e references were removed in https://github.com/gravitational/teleport.e/pull/4889.