### PR TITLE
remove lib/client dependency on lib/devicetrust/authn

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -147,6 +147,37 @@ linters-settings:
           - pkg: github.com/gravitational/teleport/lib/web$
             desc: 'lib/web should not be imported to prevent increasing binary size'
         list-mode: lax
+      # Prevent importing dependencies that require CGO into tools that are
+      # meant to be built with CGO_ENABLED=0
+      cgo:
+        files:
+          # Tests can do anything
+          - "!$test"
+          - '**/tool/tbot/**'
+          - '**/lib/client/**'
+        deny:
+          - pkg: github.com/gravitational/teleport/lib/devicetrust/authn$
+            desc: '"devicetrust/authn" requires CGO on darwin'
+          - pkg: github.com/gravitational/teleport/lib/devicetrust/enroll
+            desc: '"devicetrust/enroll" requires CGO on darwin'
+          - pkg: github.com/gravitational/teleport/lib/devicetrust/native
+            desc: '"devicetrust/native" requires CGO on darwin'
+          - pkg: github.com/gravitational/teleport/lib/lib/bpf
+            desc: '"lib/bpf" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/vnet/daemon
+            desc: '"vnet/daemon" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/system/signal
+            desc: '"lib/system/signal" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/inventory/metadata
+            desc: '"lib/inventory/metadata" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/desktop/rdp/rdpclient
+            desc: '"lib/desktop/rdp/rdpclient" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/pam
+            desc: '"lib/pam" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/srv/uacc
+            desc: '"lib/srv/uacc" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/cgroup
+            desc: '"lib/cgroup" requires CGO'
   errorlint:
     comparison: true
     asserts: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -162,7 +162,7 @@ linters-settings:
             desc: '"devicetrust/enroll" requires CGO on darwin'
           - pkg: github.com/gravitational/teleport/lib/devicetrust/native
             desc: '"devicetrust/native" requires CGO on darwin'
-          - pkg: github.com/gravitational/teleport/lib/lib/bpf
+          - pkg: github.com/gravitational/teleport/lib/bpf
             desc: '"lib/bpf" requires CGO'
           - pkg: github.com/gravitational/teleport/lib/vnet/daemon
             desc: '"vnet/daemon" requires CGO'

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -78,7 +78,7 @@ import (
 	"github.com/gravitational/teleport/lib/client/terminal"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/devicetrust"
-	dtauthn "github.com/gravitational/teleport/lib/devicetrust/authn"
+	dtauthntypes "github.com/gravitational/teleport/lib/devicetrust/authn/types"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
@@ -1127,7 +1127,7 @@ func (c *Config) ResourceFilter(kind string) *proto.ListResourcesRequest {
 }
 
 // DTAuthnRunCeremonyFunc matches the signature of [dtauthn.Ceremony.Run].
-type DTAuthnRunCeremonyFunc func(context.Context, *dtauthn.CeremonyRunParams) (*devicepb.UserCertificates, error)
+type DTAuthnRunCeremonyFunc func(context.Context, *dtauthntypes.CeremonyRunParams) (*devicepb.UserCertificates, error)
 
 // DTAutoEnrollFunc matches the signature of [dtenroll.AutoEnroll].
 type DTAutoEnrollFunc func(context.Context, devicepb.DeviceTrustServiceClient) (*devicepb.Device, error)
@@ -3377,7 +3377,7 @@ func (tc *TeleportClient) AttemptDeviceLogin(ctx context.Context, keyRing *KeyRi
 		return nil
 	}
 
-	newCerts, err := tc.DeviceLogin(ctx, &dtauthn.CeremonyRunParams{
+	newCerts, err := tc.DeviceLogin(ctx, &dtauthntypes.CeremonyRunParams{
 		DevicesClient: rootAuthClient.DevicesClient(),
 		Certs: &devicepb.UserCertificates{
 			// Augment the SSH certificate.
@@ -3438,7 +3438,7 @@ func (tc *TeleportClient) AttemptDeviceLogin(ctx context.Context, keyRing *KeyRi
 // `tsh login`).
 //
 // Device Trust is a Teleport Enterprise feature.
-func (tc *TeleportClient) DeviceLogin(ctx context.Context, params *dtauthn.CeremonyRunParams) (*devicepb.UserCertificates, error) {
+func (tc *TeleportClient) DeviceLogin(ctx context.Context, params *dtauthntypes.CeremonyRunParams) (*devicepb.UserCertificates, error) {
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/DeviceLogin",

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -52,7 +52,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/cloud/imds"
 	"github.com/gravitational/teleport/lib/defaults"
-	dtauthn "github.com/gravitational/teleport/lib/devicetrust/authn"
+	dtauthntypes "github.com/gravitational/teleport/lib/devicetrust/authn/types"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -363,7 +363,7 @@ func TestTeleportClient_DeviceLogin(t *testing.T) {
 		// validatingRunCeremony checks the parameters passed to dtAuthnRunCeremony
 		// and returns validCerts on success.
 		var runCeremonyCalls int
-		validatingRunCeremony := func(_ context.Context, params *dtauthn.CeremonyRunParams) (*devicepb.UserCertificates, error) {
+		validatingRunCeremony := func(_ context.Context, params *dtauthntypes.CeremonyRunParams) (*devicepb.UserCertificates, error) {
 			runCeremonyCalls++
 			switch {
 			case params.DevicesClient == nil:
@@ -387,7 +387,7 @@ func TestTeleportClient_DeviceLogin(t *testing.T) {
 		require.NoError(t, authenticatedAction(), "Authenticated action failed *before* AttemptDeviceLogin")
 
 		// Test! Exercise DeviceLogin.
-		got, err := teleportClient.DeviceLogin(ctx, &dtauthn.CeremonyRunParams{
+		got, err := teleportClient.DeviceLogin(ctx, &dtauthntypes.CeremonyRunParams{
 			DevicesClient: rootAuthClient.DevicesClient(),
 			Certs: &devicepb.UserCertificates{
 				SshAuthorizedKey: keyRing.Cert,
@@ -412,7 +412,7 @@ func TestTeleportClient_DeviceLogin(t *testing.T) {
 	t.Run("attempt login respects ping", func(t *testing.T) {
 		runCeremonyCalled := false
 		teleportClient.SetDTAttemptLoginIgnorePing(false)
-		teleportClient.SetDTAuthnRunCeremony(func(_ context.Context, _ *dtauthn.CeremonyRunParams) (*devicepb.UserCertificates, error) {
+		teleportClient.SetDTAuthnRunCeremony(func(_ context.Context, _ *dtauthntypes.CeremonyRunParams) (*devicepb.UserCertificates, error) {
 			runCeremonyCalled = true
 			return nil, errors.New("dtAuthnRunCeremony called unexpectedly")
 		})
@@ -439,7 +439,7 @@ func TestTeleportClient_DeviceLogin(t *testing.T) {
 		var enrolled bool
 		var runCeremonyCalls, autoEnrollCalls int
 		teleportClient.SetDTAutoEnrollIgnorePing(true)
-		teleportClient.SetDTAuthnRunCeremony(func(_ context.Context, _ *dtauthn.CeremonyRunParams) (*devicepb.UserCertificates, error) {
+		teleportClient.SetDTAuthnRunCeremony(func(_ context.Context, _ *dtauthntypes.CeremonyRunParams) (*devicepb.UserCertificates, error) {
 			runCeremonyCalls++
 			if !enrolled {
 				return nil, errors.New("device not enrolled")
@@ -463,7 +463,7 @@ func TestTeleportClient_DeviceLogin(t *testing.T) {
 		defer rootAuthClient.Close()
 
 		// Test!
-		got, err := teleportClient.DeviceLogin(ctx, &dtauthn.CeremonyRunParams{
+		got, err := teleportClient.DeviceLogin(ctx, &dtauthntypes.CeremonyRunParams{
 			DevicesClient: rootAuthClient.DevicesClient(),
 			Certs: &devicepb.UserCertificates{
 				SshAuthorizedKey: keyRing.Cert,

--- a/lib/devicetrust/assert/assert.go
+++ b/lib/devicetrust/assert/assert.go
@@ -24,6 +24,7 @@ import (
 
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/lib/devicetrust/authn"
+	authntypes "github.com/gravitational/teleport/lib/devicetrust/authn/types"
 )
 
 // AssertDeviceClientStream is the client-side device assertion stream.
@@ -81,7 +82,7 @@ func (c *Ceremony) Run(ctx context.Context, stream AssertDeviceClientStream) err
 	// Implement Assertion in terms of Authentication, so we borrow both the
 	// Secure Enclave and TPM branches from it.
 	// TODO(codingllama): Refactor so we don't need so many adapters?
-	_, err := newAuthn().Run(ctx, &authn.CeremonyRunParams{
+	_, err := newAuthn().Run(ctx, &authntypes.CeremonyRunParams{
 		DevicesClient: devices,
 		Certs:         &devicepb.UserCertificates{}, // required but not used.
 	})

--- a/lib/devicetrust/authn/authn.go
+++ b/lib/devicetrust/authn/authn.go
@@ -28,6 +28,7 @@ import (
 
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/lib/devicetrust"
+	dtauthntypes "github.com/gravitational/teleport/lib/devicetrust/authn/types"
 	"github.com/gravitational/teleport/lib/devicetrust/challenge"
 	"github.com/gravitational/teleport/lib/devicetrust/native"
 )
@@ -57,19 +58,6 @@ func NewCeremony() *Ceremony {
 	}
 }
 
-// CeremonyRunParams holds parameters for [Ceremony.Run].
-type CeremonyRunParams struct {
-	// DevicesClient is a client to the DeviceTrustService.
-	DevicesClient devicepb.DeviceTrustServiceClient
-	// Certs holds user certs to be augmented by the authn ceremony. Only the
-	// SSH certificate will be forwarded, the TLS identity is part of the
-	// mTLS connection.
-	Certs *devicepb.UserCertificates
-	// SSHSigner, if specified, will be used to prove ownership of the SSH
-	// certificate subject key by signing a challenge.
-	SSHSigner crypto.Signer
-}
-
 // Run performs the client-side device authentication ceremony.
 //
 // Device authentication requires a previously registered and enrolled device
@@ -79,7 +67,7 @@ type CeremonyRunParams struct {
 // augmented with device extensions.
 func (c *Ceremony) Run(
 	ctx context.Context,
-	params *CeremonyRunParams,
+	params *dtauthntypes.CeremonyRunParams,
 ) (*devicepb.UserCertificates, error) {
 	switch {
 	case params.DevicesClient == nil:

--- a/lib/devicetrust/authn/authn_test.go
+++ b/lib/devicetrust/authn/authn_test.go
@@ -28,6 +28,7 @@ import (
 
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/lib/devicetrust/authn"
+	authntypes "github.com/gravitational/teleport/lib/devicetrust/authn/types"
 	"github.com/gravitational/teleport/lib/devicetrust/testenv"
 )
 
@@ -63,7 +64,7 @@ func TestCeremony_Run(t *testing.T) {
 	sshCert, sshSigner, err := testenv.NewSelfSignedSSHCert()
 	require.NoError(t, err)
 
-	runParams := &authn.CeremonyRunParams{
+	runParams := &authntypes.CeremonyRunParams{
 		DevicesClient: devices,
 		Certs: &devicepb.UserCertificates{
 			SshAuthorizedKey: sshCert,

--- a/lib/devicetrust/authn/types/types.go
+++ b/lib/devicetrust/authn/types/types.go
@@ -1,0 +1,38 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package types includes types that need to be passed to lib/devicetrust/authn
+// by packages that should not depend on lib/devicetrust/authn.
+package types
+
+import (
+	"crypto"
+
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+)
+
+// CeremonyRunParams holds parameters for [lib/devicetrust/authn.(*Ceremony).Run].
+type CeremonyRunParams struct {
+	// DevicesClient is a client to the DeviceTrustService.
+	DevicesClient devicepb.DeviceTrustServiceClient
+	// Certs holds user certs to be augmented by the authn ceremony. Only the
+	// SSH certificate will be forwarded, the TLS identity is part of the
+	// mTLS connection.
+	Certs *devicepb.UserCertificates
+	// SSHSigner, if specified, will be used to prove ownership of the SSH
+	// certificate subject key by signing a challenge.
+	SSHSigner crypto.Signer
+}


### PR DESCRIPTION
In https://github.com/gravitational/teleport/pull/45546 I accidentally introduced a dependency on `lib/devicetrust/native` via `lib/devicetrust/authn` to `lib/client`. This cause builds of `tbot` to break with `CGO_ENABLED=0` (among other things, I assume).

This PR removes the dependency by moving the common type to a new package that does not depend on `lib/devicetrust/native`

```
Nics-MacBook-Pro:tbot nic$ git switch master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Nics-MacBook-Pro:tbot nic$ go list -deps | grep devicetrust
github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1
github.com/gravitational/teleport/lib/devicetrust/config
github.com/gravitational/teleport/lib/devicetrust/authz
github.com/gravitational/teleport/lib/devicetrust
github.com/gravitational/teleport/lib/devicetrust/challenge
github.com/gravitational/teleport/lib/devicetrust/native
github.com/gravitational/teleport/lib/devicetrust/authn
Nics-MacBook-Pro:tbot nic$ git switch nklaassen/dt-deps
Switched to branch 'nklaassen/dt-deps'
Your branch is up to date with 'origin/nklaassen/dt-deps'.
Nics-MacBook-Pro:tbot nic$ go list -deps | grep devicetrust
github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1
github.com/gravitational/teleport/lib/devicetrust/config
github.com/gravitational/teleport/lib/devicetrust/authz
github.com/gravitational/teleport/lib/devicetrust
github.com/gravitational/teleport/lib/devicetrust/authn/types
```