### PR TITLE
Discover: Hide new tab icon in SelectResource when lacking access

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
@@ -260,9 +260,9 @@ export function SelectResource({ onSelect }: SelectResourceProps) {
                     </Box>
                   </Flex>
 
-                  {r.unguidedLink && (
+                  {r.unguidedLink && r.hasAccess ? (
                     <NewTabInCorner color="text.muted" size={18} />
-                  )}
+                  ) : null}
                 </ResourceCard>
               );
             })}


### PR DESCRIPTION
Tiny fix - when lacking access to a resource, the new tab icon I added to non-guided resources overlaps the 'Lacking Perissions' badge.

## Before / after
<img width="48%" alt="Screenshot 2024-08-21 at 6 06 48 PM" src="https://github.com/user-attachments/assets/3966baf4-a23e-4f21-a1ac-84eaf6b09fb5"> <img width="48%" alt="Screenshot 2024-08-21 at 6 07 02 PM" src="https://github.com/user-attachments/assets/6f441ec1-3a35-4b45-975c-02dea2a5d84b">
