### PR TITLE
support split SSH/TLS keys in `/webapi/mfa/login/finish`

### DIFF
--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -155,18 +155,10 @@ type CreateSSHCertReq struct {
 	OTPToken string `json:"otp_token"`
 	// HeadlessAuthenticationID is a headless authentication resource id.
 	HeadlessAuthenticationID string `json:"headless_id"`
-	// PubKey is a public key user wishes to sign.
-	//
-	// Deprecated: prefer SSHPubKey and/or TLSPubKey.
-	PubKey []byte `json:"pub_key"`
-	// SSHPubKey is an SSH public key the user wants as the subject of their SSH
-	// certificate. It must be in SSH authorized_keys format.
-	SSHPubKey []byte `json:"ssh_pub_key"`
-	// TLSPubKey is a TLS public key the user wants as the subject of their TLS
-	// certificate. It must be in PEM-encoded PKCS#1 or PKIX format.
-	TLSPubKey []byte `json:"tls_pub_key"`
-	// TTL is a desired TTL for the cert (max is still capped by server,
-	// however user can shorten the time)
+	// UserPublicKeys is embedded and holds user SSH and TLS public keys that
+	// should be used as the subject of issued certificates, and optional
+	// hardware key attestation statements for each key.
+	UserPublicKeys
 	TTL time.Duration `json:"ttl"`
 	// Compatibility specifies OpenSSH compatibility flags.
 	Compatibility string `json:"compatibility,omitempty"`
@@ -176,6 +168,28 @@ type CreateSSHCertReq struct {
 	// KubernetesCluster is an optional k8s cluster name to route the response
 	// credentials to.
 	KubernetesCluster string
+}
+
+// CheckAndSetDefaults checks and sets default values.
+func (r *CreateSSHCertReq) CheckAndSetDefaults() error {
+	return trace.Wrap(r.UserPublicKeys.CheckAndSetDefaults())
+}
+
+// UserPublicKeys holds user-submitted public keys and attestation statements
+// used in login requests.
+type UserPublicKeys struct {
+	// PubKey is a public key the user wants as the subject of their SSH and TLS
+	// certificates. It must be in SSH authorized_keys format.
+	//
+	// Deprecated: prefer SSHPubKey and/or TLSPubKey.
+	PubKey []byte `json:"pub_key,omitempty"`
+	// SSHPubKey is an SSH public key the user wants as the subject of their SSH
+	// certificate. It must be in SSH authorized_keys format.
+	SSHPubKey []byte `json:"ssh_pub_key,omitempty"`
+	// TLSPubKey is a TLS public key the user wants as the subject of their TLS
+	// certificate. It must be in PEM-encoded PKCS#1 or PKIX format.
+	TLSPubKey []byte `json:"tls_pub_key,omitempty"`
+
 	// AttestationStatement is an attestation statement associated with the given public key.
 	//
 	// Deprecated: prefer SSHAttestationStatement and/or TLSAttestationStatement.
@@ -189,44 +203,44 @@ type CreateSSHCertReq struct {
 }
 
 // CheckAndSetDefaults checks and sets default values.
-func (r *CreateSSHCertReq) CheckAndSetDefaults() error {
+func (k *UserPublicKeys) CheckAndSetDefaults() error {
 	switch {
-	case len(r.PubKey) > 0 && len(r.SSHPubKey) > 0:
+	case len(k.PubKey) > 0 && len(k.SSHPubKey) > 0:
 		return trace.BadParameter("'pub_key' and 'ssh_pub_key' cannot both be set")
-	case len(r.PubKey) > 0 && len(r.TLSPubKey) > 0:
+	case len(k.PubKey) > 0 && len(k.TLSPubKey) > 0:
 		return trace.BadParameter("'pub_key' and 'tls_pub_key' cannot both be set")
-	case len(r.PubKey)+len(r.SSHPubKey)+len(r.TLSPubKey) == 0:
+	case len(k.PubKey)+len(k.SSHPubKey)+len(k.TLSPubKey) == 0:
 		return trace.BadParameter("'ssh_pub_key' or 'tls_pub_key' must be set")
-	case r.AttestationStatement != nil && r.SSHAttestationStatement != nil:
+	case k.AttestationStatement != nil && k.SSHAttestationStatement != nil:
 		return trace.BadParameter("'attestation_statement' and 'ssh_attestation_statement' cannot both be set")
-	case r.AttestationStatement != nil && r.TLSAttestationStatement != nil:
+	case k.AttestationStatement != nil && k.TLSAttestationStatement != nil:
 		return trace.BadParameter("'attestation_statement' and 'tls_attestation_statement' cannot both be set")
 	}
-	if len(r.PubKey) > 0 {
+	if len(k.PubKey) > 0 {
 		// Normalize by splitting PubKey to SSHPubKey and TLSPubKey to reduce
 		// special case handling elsewhere. PubKey is deprecated.
 		// TODO(nklaassen): DELETE IN 18.0.0 after all clients should be using
 		// the separated keys.
-		r.SSHPubKey = r.PubKey
-		cryptoPubKey, err := sshutils.CryptoPublicKey(r.PubKey)
+		k.SSHPubKey = k.PubKey
+		cryptoPubKey, err := sshutils.CryptoPublicKey(k.PubKey)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		r.TLSPubKey, err = keys.MarshalPublicKey(cryptoPubKey)
+		k.TLSPubKey, err = keys.MarshalPublicKey(cryptoPubKey)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		r.PubKey = nil
+		k.PubKey = nil
 	}
-	if r.AttestationStatement != nil {
+	if k.AttestationStatement != nil {
 		// Normalize by splitting AttestationStatement to
 		// SSHAttestationStatement and TLSAttestationStatement to reduce special
 		// case handling elsewhere. AttestationStatement is deprecated.
 		// TODO(nklaassen): DELETE IN 18.0.0 after all clients should be using
 		// the separated attestation statements.
-		r.SSHAttestationStatement = r.AttestationStatement
-		r.TLSAttestationStatement = r.AttestationStatement
-		r.AttestationStatement = nil
+		k.SSHAttestationStatement = k.AttestationStatement
+		k.TLSAttestationStatement = k.AttestationStatement
+		k.AttestationStatement = nil
 	}
 	return nil
 }
@@ -243,8 +257,10 @@ type AuthenticateSSHUserRequest struct {
 	WebauthnChallengeResponse *wantypes.CredentialAssertionResponse `json:"webauthn_challenge_response"`
 	// TOTPCode is a code from the TOTP device.
 	TOTPCode string `json:"totp_code"`
-	// PubKey is a public key user wishes to sign
-	PubKey []byte `json:"pub_key"`
+	// UserPublicKeys is embedded and holds user SSH and TLS public keys that
+	// should be used as the subject of issued certificates, and optional
+	// hardware key attestation statements for each key.
+	UserPublicKeys
 	// TTL is a desired TTL for the cert (max is still capped by server,
 	// however user can shorten the time)
 	TTL time.Duration `json:"ttl"`
@@ -256,8 +272,10 @@ type AuthenticateSSHUserRequest struct {
 	// KubernetesCluster is an optional k8s cluster name to route the response
 	// credentials to.
 	KubernetesCluster string
-	// AttestationStatement is an attestation statement associated with the given public key.
-	AttestationStatement *keys.AttestationStatement `json:"attestation_statement,omitempty"`
+}
+
+func (r *AuthenticateSSHUserRequest) CheckAndSetDefaults() error {
+	return trace.Wrap(r.UserPublicKeys.CheckAndSetDefaults())
 }
 
 type AuthenticateWebUserRequest struct {
@@ -516,15 +534,17 @@ func SSHAgentLogin(ctx context.Context, login SSHLoginDirect) (*authclient.SSHLo
 	}
 
 	re, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "ssh", "certs"), CreateSSHCertReq{
-		User:                 login.User,
-		Password:             login.Password,
-		OTPToken:             login.OTPToken,
-		PubKey:               login.PubKey,
-		TTL:                  login.TTL,
-		Compatibility:        login.Compatibility,
-		RouteToCluster:       login.RouteToCluster,
-		KubernetesCluster:    login.KubernetesCluster,
-		AttestationStatement: login.AttestationStatement,
+		User:     login.User,
+		Password: login.Password,
+		OTPToken: login.OTPToken,
+		UserPublicKeys: UserPublicKeys{
+			PubKey:               login.PubKey,
+			AttestationStatement: login.AttestationStatement,
+		},
+		TTL:               login.TTL,
+		Compatibility:     login.Compatibility,
+		RouteToCluster:    login.RouteToCluster,
+		KubernetesCluster: login.KubernetesCluster,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -586,12 +606,14 @@ func SSHAgentHeadlessLogin(ctx context.Context, login SSHLoginHeadless) (*authcl
 	re, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "ssh", "certs"), CreateSSHCertReq{
 		User:                     login.User,
 		HeadlessAuthenticationID: login.HeadlessAuthenticationID,
-		PubKey:                   login.PubKey,
-		TTL:                      login.TTL,
-		Compatibility:            login.Compatibility,
-		RouteToCluster:           login.RouteToCluster,
-		KubernetesCluster:        login.KubernetesCluster,
-		AttestationStatement:     login.AttestationStatement,
+		UserPublicKeys: UserPublicKeys{
+			PubKey:               login.PubKey,
+			AttestationStatement: login.AttestationStatement,
+		},
+		TTL:               login.TTL,
+		Compatibility:     login.Compatibility,
+		RouteToCluster:    login.RouteToCluster,
+		KubernetesCluster: login.KubernetesCluster,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -665,12 +687,14 @@ func SSHAgentPasswordlessLogin(ctx context.Context, login SSHLoginPasswordless) 
 		&AuthenticateSSHUserRequest{
 			User:                      "", // User carried on WebAuthn assertion.
 			WebauthnChallengeResponse: wantypes.CredentialAssertionResponseFromProto(mfaResp.GetWebauthn()),
-			PubKey:                    login.PubKey,
-			TTL:                       login.TTL,
-			Compatibility:             login.Compatibility,
-			RouteToCluster:            login.RouteToCluster,
-			KubernetesCluster:         login.KubernetesCluster,
-			AttestationStatement:      login.AttestationStatement,
+			UserPublicKeys: UserPublicKeys{
+				PubKey:               login.PubKey,
+				AttestationStatement: login.AttestationStatement,
+			},
+			TTL:               login.TTL,
+			Compatibility:     login.Compatibility,
+			RouteToCluster:    login.RouteToCluster,
+			KubernetesCluster: login.KubernetesCluster,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -727,14 +751,16 @@ func SSHAgentMFALogin(ctx context.Context, login SSHLoginMFA) (*authclient.SSHLo
 	}
 
 	challengeResp := AuthenticateSSHUserRequest{
-		User:                 login.User,
-		Password:             login.Password,
-		PubKey:               login.PubKey,
-		TTL:                  login.TTL,
-		Compatibility:        login.Compatibility,
-		RouteToCluster:       login.RouteToCluster,
-		KubernetesCluster:    login.KubernetesCluster,
-		AttestationStatement: login.AttestationStatement,
+		User:     login.User,
+		Password: login.Password,
+		UserPublicKeys: UserPublicKeys{
+			PubKey:               login.PubKey,
+			AttestationStatement: login.AttestationStatement,
+		},
+		TTL:               login.TTL,
+		Compatibility:     login.Compatibility,
+		RouteToCluster:    login.RouteToCluster,
+		KubernetesCluster: login.KubernetesCluster,
 	}
 	// Convert back from auth gRPC proto response.
 	switch r := respPB.Response.(type) {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2595,6 +2595,9 @@ func (h *Handler) mfaLoginFinish(w http.ResponseWriter, r *http.Request, p httpr
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	clientMeta := clientMetaFromReq(r)
 	cert, err := h.auth.AuthenticateSSHUser(r.Context(), *req, clientMeta)

--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -761,9 +761,7 @@ func validateSSHLoginResponse(t *testing.T, resp []byte, expectedSubjectSSHPub s
 	t.Helper()
 
 	var loginResp authclient.SSHLoginResponse
-	if err := json.Unmarshal(resp, &loginResp); !assert.NoError(t, err) {
-		return nil
-	}
+	require.NoError(t, json.Unmarshal(resp, &loginResp))
 	assert.NotEmpty(t, loginResp.Username)
 	assert.NotEmpty(t, loginResp.HostSigners)
 

--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -20,9 +20,7 @@ package web
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
+	"crypto"
 	"encoding/json"
 	"testing"
 	"time"
@@ -39,15 +37,19 @@ import (
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
+	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 func TestWebauthnLogin_ssh(t *testing.T) {
+	ctx := context.Background()
 	env := newWebPack(t, 1)
 	clusterMFA := configureClusterForMFA(t, env, &types.AuthPreferenceSpecV2{
 		Type:         constants.Local,
@@ -60,46 +62,94 @@ func TestWebauthnLogin_ssh(t *testing.T) {
 	password := clusterMFA.Password
 	device := clusterMFA.WebDev.Key
 
+	// Prepare keys to be signed.
+	sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, env.server.AuthServer.AuthServer)
+	require.NoError(t, err)
+	sshPubKey, err := ssh.NewPublicKey(sshKey.Public())
+	require.NoError(t, err)
+	sshPubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
+	tlsPubKeyBytes, err := keys.MarshalPublicKey(tlsKey.Public())
+	require.NoError(t, err)
+
 	clt, err := client.NewWebClient(env.proxies[0].webURL.String(), roundtrip.HTTPClient(client.NewInsecureWebClient()))
 	require.NoError(t, err)
 
-	// 1st login step: request challenge.
-	ctx := context.Background()
-	beginResp, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "mfa", "login", "begin"), &client.MFAChallengeRequest{
-		User: user,
-		Pass: password,
-	})
-	require.NoError(t, err)
-	authChallenge := &client.MFAAuthenticateChallenge{}
-	require.NoError(t, json.Unmarshal(beginResp.Bytes(), authChallenge))
-	require.NotNil(t, authChallenge.WebauthnChallenge)
+	for _, tc := range []struct {
+		desc                string
+		pubKey              []byte
+		sshPubKey           []byte
+		tlsPubKey           []byte
+		expectError         string
+		expectSubjectSSHPub ssh.PublicKey
+		expectSubjectTLSPub crypto.PublicKey
+	}{
+		{
+			// TODO(nklaassen): DELETE IN 18.0.0 when all clients should be
+			// using split keys.
+			desc:                "single key",
+			pubKey:              sshPubKeyBytes,
+			expectSubjectSSHPub: sshPubKey,
+			expectSubjectTLSPub: sshKey.Public(),
+		},
+		{
+			desc:                "split keys",
+			sshPubKey:           sshPubKeyBytes,
+			tlsPubKey:           tlsPubKeyBytes,
+			expectSubjectSSHPub: sshPubKey,
+			expectSubjectTLSPub: tlsKey.Public(),
+		},
+		{
+			desc:                "only SSH",
+			sshPubKey:           sshPubKeyBytes,
+			expectSubjectSSHPub: sshPubKey,
+		},
+		{
+			desc:                "only TLS",
+			tlsPubKey:           tlsPubKeyBytes,
+			expectSubjectTLSPub: tlsKey.Public(),
+		},
+		{
+			desc:        "no key",
+			expectError: "'ssh_pub_key' or 'tls_pub_key' must be set",
+		},
+	} {
+		// 1st login step: request challenge.
+		ctx := context.Background()
+		beginResp, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "mfa", "login", "begin"), &client.MFAChallengeRequest{
+			User: user,
+			Pass: password,
+		})
+		require.NoError(t, err)
+		authChallenge := &client.MFAAuthenticateChallenge{}
+		require.NoError(t, json.Unmarshal(beginResp.Bytes(), authChallenge))
+		require.NotNil(t, authChallenge.WebauthnChallenge)
 
-	// Sign Webauthn challenge (requires user interaction in real-world
-	// scenarios).
-	assertionResp, err := device.SignAssertion("https://"+env.server.TLS.ClusterName(), authChallenge.WebauthnChallenge)
-	require.NoError(t, err)
+		// Sign Webauthn challenge (requires user interaction in real-world
+		// scenarios).
+		assertionResp, err := device.SignAssertion("https://"+env.server.TLS.ClusterName(), authChallenge.WebauthnChallenge)
+		require.NoError(t, err)
 
-	// Prepare SSH key to be signed.
-	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	sshPubKey, err := ssh.NewPublicKey(&privKey.PublicKey)
-	require.NoError(t, err)
-	sshPubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
+		// 2nd login step: reply with signed challenged.
+		finishResp, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "mfa", "login", "finish"), &client.AuthenticateSSHUserRequest{
+			User:                      user,
+			WebauthnChallengeResponse: assertionResp,
+			UserPublicKeys: client.UserPublicKeys{
+				PubKey:    tc.pubKey,
+				SSHPubKey: tc.sshPubKey,
+				TLSPubKey: tc.tlsPubKey,
+			},
+			TTL: 24 * time.Hour,
+		})
+		if tc.expectError != "" {
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.expectError)
+			return
+		}
+		require.NoError(t, err)
 
-	// 2nd login step: reply with signed challenged.
-	finishResp, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "mfa", "login", "finish"), &client.AuthenticateSSHUserRequest{
-		User:                      user,
-		WebauthnChallengeResponse: assertionResp,
-		PubKey:                    sshPubKeyBytes,
-		TTL:                       24 * time.Hour,
-	})
-	require.NoError(t, err)
-	loginResp := &authclient.SSHLoginResponse{}
-	require.NoError(t, json.Unmarshal(finishResp.Bytes(), loginResp))
-	require.Equal(t, user, loginResp.Username)
-	require.NotEmpty(t, loginResp.Cert)
-	require.NotEmpty(t, loginResp.TLSCert)
-	require.NotEmpty(t, loginResp.HostSigners)
+		loginResp := validateSSHLoginResponse(t, finishResp.Bytes(), tc.expectSubjectSSHPub, tc.expectSubjectTLSPub)
+		require.Equal(t, user, loginResp.Username)
+	}
 }
 
 func TestWebauthnLogin_web(t *testing.T) {
@@ -210,12 +260,14 @@ func TestAuthenticate_passwordless(t *testing.T) {
 	require.NoError(t, err)
 	userHandle := wla.UserID
 
-	// Prepare SSH key to be signed.
-	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	// Prepare keys to be signed.
+	sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, env.server.AuthServer.AuthServer)
 	require.NoError(t, err)
-	pub, err := ssh.NewPublicKey(&priv.PublicKey)
+	sshPubKey, err := ssh.NewPublicKey(sshKey.Public())
 	require.NoError(t, err)
-	pubBytes := ssh.MarshalAuthorizedKey(pub)
+	sshPubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
+	tlsPubKeyBytes, err := keys.MarshalPublicKey(tlsKey.Public())
+	require.NoError(t, err)
 
 	clt, err := client.NewWebClient(env.proxies[0].webURL.String(), roundtrip.HTTPClient(client.NewInsecureWebClient()))
 	require.NoError(t, err)
@@ -225,17 +277,69 @@ func TestAuthenticate_passwordless(t *testing.T) {
 		login func(t *testing.T, assertionResp *wantypes.CredentialAssertionResponse)
 	}{
 		{
-			name: "ssh",
+			// TODO(nklaassen): DELETE IN 18.0.0 when all clients should be
+			// using split keys.
+			name: "ssh single key",
 			login: func(t *testing.T, assertionResp *wantypes.CredentialAssertionResponse) {
 				ep := clt.Endpoint("webapi", "mfa", "login", "finish")
 				sshResp, err := clt.PostJSON(ctx, ep, &client.AuthenticateSSHUserRequest{
 					WebauthnChallengeResponse: assertionResp, // no username
-					PubKey:                    pubBytes,
-					TTL:                       24 * time.Hour,
+					UserPublicKeys: client.UserPublicKeys{
+						PubKey: sshPubKeyBytes,
+					},
+					TTL: 24 * time.Hour,
 				})
 				require.NoError(t, err, "Passwordless authentication failed")
-				loginResp := &authclient.SSHLoginResponse{}
-				require.NoError(t, json.Unmarshal(sshResp.Bytes(), loginResp))
+				loginResp := validateSSHLoginResponse(t, sshResp.Bytes(), sshPubKey, sshKey.Public())
+				require.Equal(t, user, loginResp.Username)
+			},
+		},
+		{
+			name: "ssh split keys",
+			login: func(t *testing.T, assertionResp *wantypes.CredentialAssertionResponse) {
+				ep := clt.Endpoint("webapi", "mfa", "login", "finish")
+				sshResp, err := clt.PostJSON(ctx, ep, &client.AuthenticateSSHUserRequest{
+					WebauthnChallengeResponse: assertionResp, // no username
+					UserPublicKeys: client.UserPublicKeys{
+						SSHPubKey: sshPubKeyBytes,
+						TLSPubKey: tlsPubKeyBytes,
+					},
+					TTL: 24 * time.Hour,
+				})
+				require.NoError(t, err, "Passwordless authentication failed")
+				loginResp := validateSSHLoginResponse(t, sshResp.Bytes(), sshPubKey, tlsKey.Public())
+				require.Equal(t, user, loginResp.Username)
+			},
+		},
+		{
+			name: "ssh ssh key only",
+			login: func(t *testing.T, assertionResp *wantypes.CredentialAssertionResponse) {
+				ep := clt.Endpoint("webapi", "mfa", "login", "finish")
+				sshResp, err := clt.PostJSON(ctx, ep, &client.AuthenticateSSHUserRequest{
+					WebauthnChallengeResponse: assertionResp, // no username
+					UserPublicKeys: client.UserPublicKeys{
+						SSHPubKey: sshPubKeyBytes,
+					},
+					TTL: 24 * time.Hour,
+				})
+				require.NoError(t, err, "Passwordless authentication failed")
+				loginResp := validateSSHLoginResponse(t, sshResp.Bytes(), sshPubKey, nil)
+				require.Equal(t, user, loginResp.Username)
+			},
+		},
+		{
+			name: "ssh tls key only",
+			login: func(t *testing.T, assertionResp *wantypes.CredentialAssertionResponse) {
+				ep := clt.Endpoint("webapi", "mfa", "login", "finish")
+				sshResp, err := clt.PostJSON(ctx, ep, &client.AuthenticateSSHUserRequest{
+					WebauthnChallengeResponse: assertionResp, // no username
+					UserPublicKeys: client.UserPublicKeys{
+						TLSPubKey: tlsPubKeyBytes,
+					},
+					TTL: 24 * time.Hour,
+				})
+				require.NoError(t, err, "Passwordless authentication failed")
+				loginResp := validateSSHLoginResponse(t, sshResp.Bytes(), nil, tlsKey.Public())
 				require.Equal(t, user, loginResp.Username)
 			},
 		},
@@ -362,12 +466,14 @@ func TestPasswordlessProhibitedForSSO(t *testing.T) {
 	})
 	require.NoError(t, err, "UpdateAndSwapUser failed")
 
-	// Prepare SSH key to be signed.
-	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err, "GenerateKey failed")
-	pub, err := ssh.NewPublicKey(&priv.PublicKey)
-	require.NoError(t, err, "NewPublicKey failed")
-	pubBytes := ssh.MarshalAuthorizedKey(pub)
+	// Prepare keys to be signed.
+	sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, env.server.AuthServer.AuthServer)
+	require.NoError(t, err)
+	sshPubKey, err := ssh.NewPublicKey(sshKey.Public())
+	require.NoError(t, err)
+	sshPubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
+	tlsPubKeyBytes, err := keys.MarshalPublicKey(tlsKey.Public())
+	require.NoError(t, err)
 
 	webClient, err := client.NewWebClient(
 		proxyServer.webURL.String(),
@@ -395,8 +501,11 @@ func TestPasswordlessProhibitedForSSO(t *testing.T) {
 				ep := webClient.Endpoint("webapi", "mfa", "login", "finish")
 				_, err := webClient.PostJSON(ctx, ep, &client.AuthenticateSSHUserRequest{
 					WebauthnChallengeResponse: chalResp,
-					PubKey:                    pubBytes,
-					TTL:                       12 * time.Hour,
+					UserPublicKeys: client.UserPublicKeys{
+						SSHPubKey: sshPubKeyBytes,
+						TLSPubKey: tlsPubKeyBytes,
+					},
+					TTL: 12 * time.Hour,
 				})
 				return err
 			},
@@ -554,4 +663,125 @@ func configureClusterForMFA(t *testing.T, env *webPack, spec *types.AuthPreferen
 		Password: password,
 		WebDev:   webDev,
 	}
+}
+
+// TestCreateSSHCert tests the login endpoint /webapi/ssh/certs with different
+// options for subject SSH and TLS keys.
+func TestCreateSSHCert(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	pack := newWebPack(t, 1)
+	proxy := pack.proxies[0]
+
+	const (
+		user      = "alice"
+		login     = "root"
+		pass      = "password1234"
+		otpSecret = ""
+	)
+	var roles []types.Role
+
+	proxy.createUser(ctx, t, user, login, pass, otpSecret, roles)
+	clt := proxy.newClient(t)
+
+	sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, pack.server.AuthServer.AuthServer)
+	require.NoError(t, err)
+
+	sshPub, err := ssh.NewPublicKey(sshKey.Public())
+	require.NoError(t, err)
+	sshPubKey := ssh.MarshalAuthorizedKey(sshPub)
+	tlsPubKey, err := keys.MarshalPublicKey(tlsKey.Public())
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		desc                string
+		pubKey              []byte
+		sshPubKey           []byte
+		tlsPubKey           []byte
+		expectError         string
+		expectSubjectSSHPub ssh.PublicKey
+		expectSubjectTLSPub crypto.PublicKey
+	}{
+		{
+			// TODO(nklaassen): DELETE IN 18.0.0 when all clients should be
+			// using split keys.
+			desc:                "single key",
+			pubKey:              sshPubKey,
+			expectSubjectSSHPub: sshPub,
+			expectSubjectTLSPub: sshKey.Public(),
+		},
+		{
+			desc:                "split keys",
+			sshPubKey:           sshPubKey,
+			tlsPubKey:           tlsPubKey,
+			expectSubjectSSHPub: sshPub,
+			expectSubjectTLSPub: tlsKey.Public(),
+		},
+		{
+			desc:                "only SSH",
+			sshPubKey:           sshPubKey,
+			expectSubjectSSHPub: sshPub,
+		},
+		{
+			desc:                "only TLS",
+			tlsPubKey:           tlsPubKey,
+			expectSubjectTLSPub: tlsKey.Public(),
+		},
+		{
+			desc:        "no key",
+			expectError: "'ssh_pub_key' or 'tls_pub_key' must be set",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			req := &client.CreateSSHCertReq{
+				User:     user,
+				Password: pass,
+				UserPublicKeys: client.UserPublicKeys{
+					PubKey:    tc.pubKey,
+					SSHPubKey: tc.sshPubKey,
+					TLSPubKey: tc.tlsPubKey,
+				},
+			}
+			resp, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "ssh", "certs"), req)
+			if tc.expectError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectError)
+				return
+			}
+			require.NoError(t, err)
+
+			validateSSHLoginResponse(t, resp.Bytes(), tc.expectSubjectSSHPub, tc.expectSubjectTLSPub)
+		})
+	}
+
+}
+
+func validateSSHLoginResponse(t *testing.T, resp []byte, expectedSubjectSSHPub ssh.PublicKey, expectedSubjectTLSPub crypto.PublicKey) *authclient.SSHLoginResponse {
+	t.Helper()
+
+	var loginResp authclient.SSHLoginResponse
+	if err := json.Unmarshal(resp, &loginResp); !assert.NoError(t, err) {
+		return nil
+	}
+	assert.NotEmpty(t, loginResp.Username)
+	assert.NotEmpty(t, loginResp.HostSigners)
+
+	if expectedSubjectSSHPub != nil {
+		if sshCert, err := apisshutils.ParseCertificate(loginResp.Cert); assert.NoError(t, err) {
+			assert.Equal(t, expectedSubjectSSHPub, sshCert.Key)
+		}
+	} else {
+		assert.Empty(t, loginResp.Cert)
+	}
+
+	if expectedSubjectTLSPub != nil {
+		if tlsCert, err := tlsca.ParseCertificatePEM(loginResp.TLSCert); assert.NoError(t, err) {
+			assert.Equal(t, expectedSubjectTLSPub, tlsCert.PublicKey)
+		}
+	} else {
+		assert.Empty(t, loginResp.TLSCert)
+	}
+
+	return &loginResp
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -96,7 +95,6 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 	"github.com/gravitational/teleport/api/utils/keys"
-	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/agentless"
@@ -113,7 +111,6 @@ import (
 	"github.com/gravitational/teleport/lib/bpf"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/conntest"
-	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
@@ -11034,113 +11031,4 @@ func Test_setEntitlementsWithLegacyLogic(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.config)
 		})
 	}
-}
-
-// TestCreateSSHCert tests the login endpoint /webapi/ssh/certs with different
-// options for subject SSH and TLS keys.
-func TestCreateSSHCert(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	pack := newWebPack(t, 1)
-	proxy := pack.proxies[0]
-
-	const (
-		user      = "alice"
-		login     = "root"
-		pass      = "password1234"
-		otpSecret = ""
-	)
-	var roles []types.Role
-
-	proxy.createUser(ctx, t, user, login, pass, otpSecret, roles)
-	clt := proxy.newClient(t)
-
-	sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, pack.server.AuthServer.AuthServer)
-	require.NoError(t, err)
-
-	sshPub, err := ssh.NewPublicKey(sshKey.Public())
-	require.NoError(t, err)
-	sshPubKey := ssh.MarshalAuthorizedKey(sshPub)
-	tlsPubKey, err := keys.MarshalPublicKey(tlsKey.Public())
-	require.NoError(t, err)
-
-	for _, tc := range []struct {
-		desc                string
-		pubKey              []byte
-		sshPubKey           []byte
-		tlsPubKey           []byte
-		expectError         string
-		expectSubjectSSHPub ssh.PublicKey
-		expectSubjectTLSPub crypto.PublicKey
-	}{
-		{
-			// TODO(nklaassen): DELETE IN 18.0.0 when all clients should be
-			// using split keys.
-			desc:                "single key",
-			pubKey:              sshPubKey,
-			expectSubjectSSHPub: sshPub,
-			expectSubjectTLSPub: sshKey.Public(),
-		},
-		{
-			desc:                "split keys",
-			sshPubKey:           sshPubKey,
-			tlsPubKey:           tlsPubKey,
-			expectSubjectSSHPub: sshPub,
-			expectSubjectTLSPub: tlsKey.Public(),
-		},
-		{
-			desc:                "only SSH",
-			sshPubKey:           sshPubKey,
-			expectSubjectSSHPub: sshPub,
-		},
-		{
-			desc:                "only TLS",
-			tlsPubKey:           tlsPubKey,
-			expectSubjectTLSPub: tlsKey.Public(),
-		},
-		{
-			desc:        "no key",
-			expectError: "'ssh_pub_key' or 'tls_pub_key' must be set",
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			req := &client.CreateSSHCertReq{
-				User:      user,
-				Password:  pass,
-				PubKey:    tc.pubKey,
-				SSHPubKey: tc.sshPubKey,
-				TLSPubKey: tc.tlsPubKey,
-			}
-			resp, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "ssh", "certs"), req)
-			if tc.expectError != "" {
-				require.Error(t, err)
-				require.ErrorContains(t, err, tc.expectError)
-				return
-			}
-			require.NoError(t, err)
-
-			var out authclient.SSHLoginResponse
-			err = json.Unmarshal(resp.Bytes(), &out)
-			require.NoError(t, err)
-
-			if tc.expectSubjectSSHPub != nil {
-				fmt.Println(string(out.Cert))
-				sshCert, err := apisshutils.ParseCertificate(out.Cert)
-				require.NoError(t, err)
-				assert.Equal(t, tc.expectSubjectSSHPub, sshCert.Key)
-			} else {
-				assert.Empty(t, out.Cert)
-			}
-
-			if tc.expectSubjectTLSPub != nil {
-				tlsCert, err := tlsca.ParseCertificatePEM(out.TLSCert)
-				require.NoError(t, err)
-				assert.Equal(t, tc.expectSubjectTLSPub, tlsCert.PublicKey)
-			} else {
-				assert.Empty(t, out.TLSCert)
-			}
-		})
-	}
-
 }

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -948,7 +948,8 @@ func (s *sessionCache) AuthenticateSSHUser(
 	authReq := authclient.AuthenticateUserRequest{
 		Username:       c.User,
 		ClientMetadata: clientMeta,
-		PublicKey:      c.PubKey,
+		SSHPublicKey:   c.UserPublicKeys.SSHPubKey,
+		TLSPublicKey:   c.UserPublicKeys.TLSPubKey,
 	}
 	if c.Password != "" {
 		authReq.Pass = &authclient.PassCreds{Password: []byte(c.Password)}
@@ -968,7 +969,8 @@ func (s *sessionCache) AuthenticateSSHUser(
 		TTL:                     c.TTL,
 		RouteToCluster:          c.RouteToCluster,
 		KubernetesCluster:       c.KubernetesCluster,
-		AttestationStatement:    c.AttestationStatement,
+		SSHAttestationStatement: c.UserPublicKeys.SSHAttestationStatement,
+		TLSAttestationStatement: c.UserPublicKeys.TLSAttestationStatement,
 	})
 }
 


### PR DESCRIPTION
This PR adds support for split SSH/TLS keys to the `/webapi/mfa/login/finish` endpoint used for local user logins with MFA or passwordless. It does not update any clients to use this ability yet.

Part of [RFD 136](https://github.com/gravitational/teleport/blob/master/rfd/0136-modern-signature-algorithms.md)