### PR TITLE
Temporarily disable the `TestDatabases/rds/mysql` e2e test

### DIFF
--- a/e2e/aws/rds_test.go
+++ b/e2e/aws/rds_test.go
@@ -206,6 +206,8 @@ func testRDS(t *testing.T) {
 	})
 
 	t.Run("mysql", func(t *testing.T) {
+		t.Skip("Disabled for now due to https://github.com/gravitational/teleport/issues/45672")
+
 		t.Parallel()
 
 		// wait for the database to be discovered


### PR DESCRIPTION
This test is failing consistently and blocking other fixes from merging.

See also: https://github.com/gravitational/teleport/issues/45672