### PR TITLE
set annotations on teleport-kube-agent statefulset

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -13,6 +13,10 @@ metadata:
   {{- if .Values.extraLabels.deployment }}
     {{- toYaml .Values.extraLabels.deployment | nindent 4 }}
   {{- end }}
+  {{- if .Values.annotations.deployment }}
+  annotations:
+    {{- toYaml .Values.annotations.deployment | nindent 4 }}
+  {{- end }}
 spec:
   serviceName: {{ .Release.Name }}
   replicas: {{ $replicaCount }}

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -44,6 +44,19 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
+  - it: sets StatefulSet annotations when specified
+    template: statefulset.yaml
+    values:
+      - ../.lint/stateful.yaml
+      - ../.lint/annotations.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations.kubernetes\.io/deployment
+          value: test-annotation
+      - equal:
+          path: metadata.annotations.kubernetes\.io/deployment-different
+          value: 3
+
   - it: sets Pod annotations when specified
     template: statefulset.yaml
     values:


### PR DESCRIPTION
Brings it up to parity with the Deployment variant.
(We want this to use https://github.com/stakater/Reloader ).

changelog: The `teleport-kube-agent` chart now correctly propagates configured annotations when deploying a StatefulSet.