### PR TITLE
[v14] Temporarily disable the `TestDatabases/rds/mysql` e2e test

### DIFF
--- a/e2e/aws/rds_test.go
+++ b/e2e/aws/rds_test.go
@@ -203,6 +203,8 @@ func testRDS(t *testing.T) {
 	})
 
 	t.Run("mysql", func(t *testing.T) {
+		t.Skip("Disabled for now due to https://github.com/gravitational/teleport/issues/45672")
+
 		t.Parallel()
 
 		// wait for the database to be discovered


### PR DESCRIPTION
Backport #45684 to branch/v14