### PR TITLE
chore: Bump golangci-lint to v1.60.2

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.22.6
-GOLANGCI_LINT_VERSION ?= v1.60.1
+GOLANGCI_LINT_VERSION ?= v1.60.2
 
 NODE_VERSION ?= 20.14.0
 


### PR DESCRIPTION
Update golangci-lint to the latest patch.

- https://github.com/golangci/golangci-lint/releases/tag/v1.60.2