### PR TITLE
Enable running BenchmarkRootExecCommand test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -892,7 +892,7 @@ test-go-bench: | $(TEST_LOG_DIR)
 
 test-go-bench-root: PACKAGES = $(shell grep --exclude-dir api --include "*_test.go" -lr BenchmarkRoot .  | xargs dirname | xargs go list | sort -u)
 test-go-bench-root: BENCHMARK_PATTERN = "^BenchmarkRoot"
-test-go-bench-root: BENCHMARK_SKIP_PATTERN = "^BenchmarkRootExecCommand$$"
+test-go-bench-root: BENCHMARK_SKIP_PATTERN = ""
 test-go-bench-root: | $(TEST_LOG_DIR)
 	go test -run ^$$ -bench $(BENCHMARK_PATTERN) -skip $(BENCHMARK_SKIP_PATTERN) -benchtime 1x $(PACKAGES) \
 		| tee $(TEST_LOG_DIR)/bench.txt


### PR DESCRIPTION
The test was skipped because it was broken. However, it was fixed in https://github.com/gravitational/teleport/pull/45102 and should now be run again to prevent future breakage to the test.