### PR TITLE
[v16] Web onboarding: Add SAML applications to resource checking

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -783,6 +783,8 @@ func (h *Handler) bindDefaultEndpoints() {
 
 	// web context
 	h.GET("/webapi/sites/:site/context", h.WithClusterAuth(h.getUserContext))
+	// Deprecated: Use `/webapi/sites/:site/resources` instead.
+	// TODO(kiosion): DELETE in 18.0
 	h.GET("/webapi/sites/:site/resources/check", h.WithClusterAuth(h.checkAccessToRegisteredResource))
 
 	// Database access handlers.

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3664,6 +3664,7 @@ func TestSignMTLS_failsAccessDenied(t *testing.T) {
 
 // TestCheckAccessToRegisteredResource_AccessDenied tests that access denied error
 // is ignored.
+// TODO(kiosion): DELETE in 18.0
 func TestCheckAccessToRegisteredResource_AccessDenied(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -3706,6 +3707,7 @@ func TestCheckAccessToRegisteredResource_AccessDenied(t *testing.T) {
 	require.False(t, resp.HasResource)
 }
 
+// TODO(kiosion): DELETE in 18.0
 func TestCheckAccessToRegisteredResource(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -42,6 +42,9 @@ import (
 )
 
 // checkAccessToRegisteredResource checks if calling user has access to at least one registered resource.
+//
+// Deprecated: Use `clusterUnifiedResourcesGet` instead.
+// TODO(kiosion): DELETE in 18.0
 func (h *Handler) checkAccessToRegisteredResource(w http.ResponseWriter, r *http.Request, p httprouter.Params, c *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	// Get a client to the Auth Server with the logged in user's identity. The
 	// identity of the logged in user is used to fetch the list of resources.
@@ -50,7 +53,15 @@ func (h *Handler) checkAccessToRegisteredResource(w http.ResponseWriter, r *http
 		return nil, trace.Wrap(err)
 	}
 
-	resourceKinds := []string{types.KindNode, types.KindDatabaseServer, types.KindAppServer, types.KindKubeServer, types.KindWindowsDesktop}
+	resourceKinds := []string{
+		types.KindNode,
+		types.KindDatabaseServer,
+		types.KindAppServer,
+		types.KindKubeServer,
+		types.KindWindowsDesktop,
+		types.KindAppOrSAMLIdPServiceProvider,
+	}
+
 	for _, kind := range resourceKinds {
 		res, err := clt.ListResources(r.Context(), proto.ListResourcesRequest{
 			ResourceType: kind,

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -204,7 +204,6 @@ const cfg = {
     clusterEventsRecordingsPath: `/v1/webapi/sites/:clusterId/events/search/sessions?from=:start?&to=:end?&limit=:limit?&startKey=:startKey?`,
 
     connectionDiagnostic: `/v1/webapi/sites/:clusterId/diagnostics/connections`,
-    checkAccessToRegisteredResource: `/v1/webapi/sites/:clusterId/resources/check`,
 
     scp: '/v1/webapi/sites/:clusterId/nodes/:serverId/:login/scp?location=:location&filename=:filename&moderatedSessionId=:moderatedSessionId?&fileTransferRequestId=:fileTransferRequestId?',
     webRenewTokenPath: '/v1/webapi/sessions/web/renew',
@@ -632,13 +631,6 @@ const cfg = {
   getMfaRequiredUrl() {
     const clusterId = cfg.proxyCluster;
     return generatePath(cfg.api.mfaRequired, { clusterId });
-  },
-
-  getCheckAccessToRegisteredResourceUrl() {
-    const clusterId = cfg.proxyCluster;
-    return generatePath(cfg.api.checkAccessToRegisteredResource, {
-      clusterId,
-    });
   },
 
   getUserContextUrl() {

--- a/web/packages/teleport/src/services/user/user.ts
+++ b/web/packages/teleport/src/services/user/user.ts
@@ -121,10 +121,27 @@ const service = {
     await session.renewSession({ reloadUser: true }, signal);
   },
 
-  checkUserHasAccessToRegisteredResource(): Promise<boolean> {
-    return api
-      .get(cfg.getCheckAccessToRegisteredResourceUrl())
-      .then(res => Boolean(res.hasResource));
+  async checkUserHasAccessToAnyRegisteredResource() {
+    const clusterId = cfg.proxyCluster;
+
+    const res = await api
+      .get(
+        cfg.getUnifiedResourcesUrl(clusterId, {
+          limit: 1,
+          sort: {
+            fieldName: 'name',
+            dir: 'ASC',
+          },
+          includedResourceMode: 'all',
+        })
+      )
+      .catch(err => {
+        // eslint-disable-next-line no-console
+        console.error('Error checking access to registered resources', err);
+        return { items: [] };
+      });
+
+    return !!res?.items?.some?.(Boolean);
   },
 
   fetchConnectMyComputerLogins(signal?: AbortSignal): Promise<Array<string>> {

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -104,7 +104,7 @@ class TeleportContext implements types.Context {
       !storageService.getOnboardDiscover()
     ) {
       const hasResource =
-        await userService.checkUserHasAccessToRegisteredResource();
+        await userService.checkUserHasAccessToAnyRegisteredResource();
       storageService.setOnboardDiscover({ hasResource });
     }
 


### PR DESCRIPTION
Backport #45355 to branch/v16

Manually edited to use `KindAppOrSAMLIdPServiceProvider` in `checkAccessToRegisteredResource` endpoint since `KindSAMLIdPServiceProvider` isn't handled within the presence service's `listResources` func in v16.
