### PR TITLE
[web] file upload button shared component

### DIFF
--- a/web/packages/design/src/Icon/Icon.tsx
+++ b/web/packages/design/src/Icon/Icon.tsx
@@ -63,8 +63,10 @@ const StyledIcon = styled.span`
   ${borderRadius};
 `;
 
+export type IconSize = 'small' | 'medium' | 'large' | 'extraLarge' | number;
+
 export type IconProps = {
-  size?: 'small' | 'medium' | 'large' | 'extraLarge' | number;
+  size?: IconSize;
   color?: string;
   title?: string;
   m?: number | string;

--- a/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.story.tsx
+++ b/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.story.tsx
@@ -17,6 +17,7 @@
  */
 
 import { useState, useEffect } from 'react';
+import { Box } from 'design';
 
 import { ButtonFileUpload as ButtonFileUploadComponent } from './ButtonFileUpload';
 
@@ -34,20 +35,43 @@ export const ButtonFileUpload = () => {
   }, [selectedFile]);
   return (
     <>
-      <ButtonFileUploadComponent
-        onFileSelect={setSelectedFile}
-        text="Click me to upload a file"
-        errorMessage="No files selected."
-        accept=".txt"
-        disabled={false}
-      />
-      <br />
-      {content && (
-        <p>
-          <b>File content:</b> <br />
-          <code>{content}</code>
-        </p>
-      )}
+      <Box mb={4}>
+        <ButtonFileUploadComponent
+          onFileSelect={setSelectedFile}
+          text="Click me to upload a file "
+          errorMessage="No files selected."
+          accept=".txt"
+          disabled={false}
+        />
+        {content && (
+          <>
+            <br />
+            <p>
+              <b>File content:</b> <br />
+              <code>{content}</code>
+            </p>
+          </>
+        )}
+      </Box>
+      <Box mb={4}>
+        <ButtonFileUploadComponent
+          onFileSelect={setSelectedFile}
+          text="Click me to upload a file (disabled)"
+          errorMessage=""
+          accept=".txt"
+          disabled={true}
+        />
+      </Box>
+      <Box>
+        <ButtonFileUploadComponent
+          onFileSelect={setSelectedFile}
+          text="Click me to upload a file (error)"
+          showValidationError={true}
+          errorMessage="Error rendered"
+          accept=".txt"
+          disabled={false}
+        />
+      </Box>
     </>
   );
 };

--- a/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.story.tsx
+++ b/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.story.tsx
@@ -1,0 +1,53 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState, useEffect } from 'react';
+
+import { ButtonFileUpload as ButtonFileUploadComponent } from './ButtonFileUpload';
+
+export default {
+  title: 'Shared/ButtonFileUpload',
+};
+
+export const ButtonFileUpload = () => {
+  const [selectedFile, setSelectedFile] = useState<File>();
+  const [content, setContent] = useState<string>();
+  useEffect(() => {
+    if (selectedFile) {
+      selectedFile.text().then(data => setContent(data));
+    }
+  }, [selectedFile]);
+  return (
+    <>
+      <ButtonFileUploadComponent
+        setSelectedFile={setSelectedFile}
+        text="Click me to upload a file"
+        errorMessage="No files selected."
+        accept=".txt"
+        disabled={false}
+      />
+      <br />
+      {content && (
+        <p>
+          <b>File content:</b> <br />
+          <code>{content}</code>
+        </p>
+      )}
+    </>
+  );
+};

--- a/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.story.tsx
+++ b/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.story.tsx
@@ -35,7 +35,7 @@ export const ButtonFileUpload = () => {
   return (
     <>
       <ButtonFileUploadComponent
-        setSelectedFile={setSelectedFile}
+        onFileSelect={setSelectedFile}
         text="Click me to upload a file"
         errorMessage="No files selected."
         accept=".txt"

--- a/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.test.tsx
+++ b/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, fireEvent, screen } from 'design/utils/testing';
+
+import { ButtonFileUpload } from './ButtonFileUpload';
+
+test('buttonFileUpload', async () => {
+  const setSelectedFile = jest.fn();
+  const file = new File(['dummy'], 'dummy.text', { type: 'plain/text' });
+  render(
+    <ButtonFileUpload
+      setSelectedFile={setSelectedFile}
+      text="click"
+      errorMessage="No files selected."
+      accept=".txt"
+      disabled={false}
+    />
+  );
+
+  const inputElement: HTMLInputElement =
+    screen.getByTestId('button-file-upload');
+  fireEvent.change(inputElement, { target: { files: [] } });
+  expect(screen.getByText('No files selected.')).toBeInTheDocument();
+
+  fireEvent.change(inputElement, { target: { files: [file] } });
+  expect(screen.getByText('dummy.text')).toBeInTheDocument();
+  expect(inputElement.files[0]).toBe(file);
+  expect(setSelectedFile).toHaveBeenCalledWith(file);
+});

--- a/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.test.tsx
+++ b/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.test.tsx
@@ -25,7 +25,7 @@ test('buttonFileUpload', async () => {
   const file = new File(['dummy'], 'dummy.text', { type: 'plain/text' });
   render(
     <ButtonFileUpload
-      setSelectedFile={setSelectedFile}
+      onFileSelect={setSelectedFile}
       text="click"
       errorMessage="No files selected."
       accept=".txt"

--- a/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.tsx
+++ b/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.tsx
@@ -1,3 +1,21 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import React, { useEffect, useState, useRef } from 'react';
 import styled from 'styled-components';
 import { Upload } from 'design/Icon';
@@ -11,10 +29,11 @@ import type { IconSize } from 'design/Icon/Icon';
  * Only single file can be selected. To support multiple file uploads,
  * update this component with `multiple` attribute.
  * @param text button text.
- * @param errorMessage error message to display when no file is selected.
+ * @param errorMessage error message to display when a file is not selected.
+ * @param showValidationError display errorMessage on file validation error.
  * @param accept whitelist file extension for the file picker.
  * @param disabled enable or disable button.
- * @param setFile callback function to process selected file.
+ * @param onFileSelect callback function to process selected file.
  * @param buttonSize button display size.
  * @param buttonIconSize upload icon display size.
  */
@@ -23,7 +42,8 @@ export function ButtonFileUpload({
   errorMessage,
   accept,
   disabled,
-  setSelectedFile,
+  onFileSelect,
+  showValidationError,
   buttonSize = 'medium',
   buttonIconSize = 'medium',
 }: {
@@ -31,12 +51,19 @@ export function ButtonFileUpload({
   errorMessage: string;
   accept: string;
   disabled: boolean;
-  setSelectedFile: (file: File) => void;
+  onFileSelect: (file: File) => void;
+  showValidationError?: boolean;
   buttonSize?: ButtonSize;
   buttonIconSize?: IconSize;
 }) {
   const fileInputRef = useRef<HTMLInputElement>();
-  const [fileInputError, setFileInputError] = useState<boolean>(false);
+  const [fileInputError, setFileInputError] =
+    useState<boolean>(showValidationError);
+  if (showValidationError !== fileInputError) {
+    if (!fileInputError) {
+      setFileInputError(showValidationError);
+    }
+  }
   const [fileName, setFileName] = useState<string>(null);
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -52,7 +79,7 @@ export function ButtonFileUpload({
     }
     const file = e.target.files[0];
     setFileName(file.name);
-    setSelectedFile(file);
+    onFileSelect(file);
   }
 
   useEffect(() => {

--- a/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.tsx
+++ b/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useState, useRef } from 'react';
+import styled from 'styled-components';
+import { Upload } from 'design/Icon';
+import { ButtonBorder, Flex, LabelInput } from 'design';
+
+import type { ButtonSize } from 'design/Button';
+import type { IconSize } from 'design/Icon/Icon';
+
+/**
+ * ButtonFileUpload let the user choose a file from local filesystem.
+ * Only single file can be selected. To support multiple file uploads,
+ * update this component with `multiple` attribute.
+ * @param text button text.
+ * @param errorMessage error message to display when no file is selected.
+ * @param accept whitelist file extension for the file picker.
+ * @param disabled enable or disable button.
+ * @param setFile callback function to process selected file.
+ * @param buttonSize button display size.
+ * @param buttonIconSize upload icon display size.
+ */
+export function ButtonFileUpload({
+  text,
+  errorMessage,
+  accept,
+  disabled,
+  setSelectedFile,
+  buttonSize = 'medium',
+  buttonIconSize = 'medium',
+}: {
+  text: string;
+  errorMessage: string;
+  accept: string;
+  disabled: boolean;
+  setSelectedFile: (file: File) => void;
+  buttonSize?: ButtonSize;
+  buttonIconSize?: IconSize;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>();
+  const [fileInputError, setFileInputError] = useState<boolean>(false);
+  const [fileName, setFileName] = useState<string>(null);
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    e.stopPropagation();
+    e.preventDefault();
+    setFileInputError(false);
+
+    if (e.target.files.length === 0) {
+      if (!fileName) {
+        setFileInputError(true);
+      }
+      return;
+    }
+    const file = e.target.files[0];
+    setFileName(file.name);
+    setSelectedFile(file);
+  }
+
+  useEffect(() => {
+    /**
+     * cancel event listener is added to show error message
+     * on situation where user cancels file picker without
+     * selecting a file.
+     */
+    fileInputRef.current.addEventListener('cancel', () => {
+      if (!fileName) {
+        setFileInputError(true);
+      }
+    });
+  }, [fileName, fileInputRef]);
+
+  return (
+    <Flex alignItems="center" gap={2}>
+      <ButtonBorder
+        gap={2}
+        onClick={() => fileInputRef.current.click()}
+        size={buttonSize}
+        textTransform="none"
+        px={3}
+        disabled={disabled}
+      >
+        {text}
+        <Upload size={buttonIconSize} />
+      </ButtonBorder>
+      <FileLabel hasError={fileInputError}>
+        {fileInputError ? errorMessage : fileName}
+      </FileLabel>
+      <input
+        disabled={disabled}
+        accept={accept}
+        style={{ display: 'none' }}
+        type="file"
+        onChange={handleFileChange}
+        ref={fileInputRef}
+        data-testid="button-file-upload"
+      />
+    </Flex>
+  );
+}
+
+const FileLabel = styled(LabelInput)`
+  width: auto;
+  margin-bottom: 0;
+`;

--- a/web/packages/shared/components/ButtonFileUpload/index.ts
+++ b/web/packages/shared/components/ButtonFileUpload/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { ButtonFileUpload } from './ButtonFileUpload';

--- a/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.tsx
+++ b/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.tsx
@@ -20,6 +20,8 @@ import React from 'react';
 import { ButtonText } from 'design';
 import { Add as AddIcon } from 'design/Icon';
 
+import type { IconSize } from 'design/Icon/Icon';
+
 export const ButtonTextWithAddIcon = ({
   label,
   onClick,
@@ -29,7 +31,7 @@ export const ButtonTextWithAddIcon = ({
   label: string;
   onClick: () => void;
   disabled?: boolean;
-  iconSize?: number | 'small' | 'medium' | 'large' | 'extraLarge';
+  iconSize?: IconSize;
 }) => {
   return (
     <ButtonText onClick={onClick} disabled={disabled} compact>


### PR DESCRIPTION
A file upload component is added to shared package, which wraps the native `<input type="file">` element. 

This is just a refactor of a component that already exists in the [Entra ID plugin enrollment UI](https://github.com/gravitational/teleport.e/blob/master/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/Entra/RunScript.tsx#L166-L191). I've only updated its state and added configurable props, story and test so the component can be reused in other places. Consequently, the Entra ID plugin is also updated to use this component in https://github.com/gravitational/teleport.e/pull/4916.

The component is required for the Identity center enrollment https://github.com/gravitational/teleport.e/issues/4839 UI which needs a file uploader to upload AWS SAML service provider metadata.  
