### PR TITLE
docs: remove Var from diff sections

### DIFF
--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
@@ -210,14 +210,14 @@ To configure the Teleport Database Service to trust a custom CA:
 
   ```diff
     roles: db
-    proxyAddr: <Var name="teleport.example.com:443" />
+    proxyAddr: teleport.example.com:443
     # Set to false if using Teleport Community Edition
     enterprise: true
-    authToken: <Var name="JOIN_TOKEN" />
+    authToken: JOIN_TOKEN
     databases:
       - name: example-clickhouse
         uri: clickhouse.example.com:8443
-        protocol: <Var name="protocol" />
+        protocol: <protocol>
   +     tls:
   +       ca_cert_file: "/etc/teleport-tls-db/db-ca/ca.pem"
         static_labels:

--- a/docs/pages/enroll-resources/desktop-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/desktop-access/getting-started.mdx
@@ -192,7 +192,7 @@ following for the Windows Desktop Service:
    For example, the following adds the `cloud: ec2` label to computers that have
    host names ending with `.us-east-2.compute.internal`:
 
-   ```yaml
+   ```diff
    version: v3
    teleport:
      nodename: windows.teleport.example.com

--- a/docs/pages/enroll-resources/desktop-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/desktop-access/getting-started.mdx
@@ -175,9 +175,9 @@ following for the Windows Desktop Service:
    ```diff
    version: v3
    teleport:
-     nodename: <Var name="windows.teleport.example.com" />
-     proxy_server: <Var name="teleport.example.com:443" />
-     auth_token: <Var name="/tmp/token" />
+     nodename: windows.teleport.example.com
+     proxy_server: teleport.example.com:443
+     auth_token: /tmp/token
    windows_desktop_service:
      enabled: yes
      static_hosts:
@@ -192,7 +192,7 @@ following for the Windows Desktop Service:
    For example, the following adds the `cloud: ec2` label to computers that have
    host names ending with `.us-east-2.compute.internal`:
 
-   ```diff
+   ```yaml
    version: v3
    teleport:
      nodename: windows.teleport.example.com

--- a/docs/pages/includes/database-access/self-hosted-db-helm-install.mdx
+++ b/docs/pages/includes/database-access/self-hosted-db-helm-install.mdx
@@ -36,10 +36,10 @@ To configure the Teleport Database Service to trust a custom CA:
 
    ```diff
      roles: db
-     proxyAddr: <Var name="example.teleport.sh" />
+     proxyAddr: example.teleport.sh
      # Set to false if using Teleport Community Edition
      enterprise: true
-     authToken: <Var name="JOIN_TOKEN" />
+     authToken: JOIN_TOKEN
      databases:
        - name: {{ dbName }}
          uri: {{ databaseAddress }}


### PR DESCRIPTION
`diff` sections do not support variables so it gets mangled if used in docs.

![image](https://github.com/user-attachments/assets/84144626-321b-4718-96c7-e12fe437f4dd)

