### PR TITLE
[v15] Add ownership tags to AWS OIDC EKS Enrollment

### DIFF
--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -498,13 +498,20 @@ func (s *AWSOIDCService) EnrollEKSClusters(ctx context.Context, req *integration
 
 	features := modules.GetModules().Features()
 
+	clusterName, err := s.cache.GetClusterName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	enrollmentResponse, err := awsoidc.EnrollEKSClusters(ctx, s.logger, s.clock, publicProxyAddr, credsProvider, enrollEKSClient, awsoidc.EnrollEKSClustersRequest{
-		Region:             req.Region,
-		ClusterNames:       req.GetEksClusterNames(),
-		EnableAppDiscovery: req.EnableAppDiscovery,
-		EnableAutoUpgrades: features.AutomaticUpgrades,
-		IsCloud:            features.Cloud,
-		AgentVersion:       req.AgentVersion,
+		Region:              req.Region,
+		ClusterNames:        req.GetEksClusterNames(),
+		EnableAppDiscovery:  req.EnableAppDiscovery,
+		EnableAutoUpgrades:  features.AutomaticUpgrades,
+		IsCloud:             features.Cloud,
+		AgentVersion:        req.AgentVersion,
+		TeleportClusterName: clusterName.GetClusterName(),
+		IntegrationName:     req.Integration,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -186,6 +186,7 @@ func StatementForEKSAccess() *Statement {
 			"eks:CreateAccessEntry",
 			"eks:DeleteAccessEntry",
 			"eks:AssociateAccessPolicy",
+			"eks:TagResource",
 		},
 		Resources: allResources,
 	}

--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -52,6 +52,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/utils"
@@ -224,6 +225,14 @@ type EnrollEKSClustersRequest struct {
 	// ClusterNames is name of the EKS cluster to enroll.
 	ClusterNames []string
 
+	// TeleportClusterName is the name of the Teleport cluster.
+	// Used to tag resources created during enrollment.
+	TeleportClusterName string
+
+	// IntegrationName is the name of the integration.
+	// Used to tag resources created during enrollment.
+	IntegrationName string
+
 	// EnableAppDiscovery specifies if we should enable Kubernetes App Discovery inside the enrolled EKS cluster.
 	EnableAppDiscovery bool
 
@@ -249,6 +258,14 @@ func (e *EnrollEKSClustersRequest) CheckAndSetDefaults() error {
 
 	if e.AgentVersion == "" {
 		return trace.BadParameter("agent version is required")
+	}
+
+	if e.TeleportClusterName == "" {
+		return trace.BadParameter("teleport cluster name is required")
+	}
+
+	if e.IntegrationName == "" {
+		return trace.BadParameter("integration name is required")
 	}
 
 	return nil
@@ -322,7 +339,9 @@ func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clo
 		return "", trace.Wrap(err)
 	}
 
-	wasAdded, err := maybeAddAccessEntry(ctx, clusterName, principalArn, clt)
+	ownershipTags := tags.DefaultResourceCreationTags(req.TeleportClusterName, req.IntegrationName)
+
+	wasAdded, err := maybeAddAccessEntry(ctx, log, clusterName, principalArn, clt, ownershipTags)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -399,7 +418,7 @@ func getAccessEntryPrincipalArn(ctx context.Context, identityGetter IdentityGett
 
 // maybeAddAccessEntry checks list of access entries for the EKS cluster and adds one for Teleport if it's missing.
 // If access entry was added by this function it will return true as a first value.
-func maybeAddAccessEntry(ctx context.Context, clusterName, roleArn string, clt EnrollEKSCLusterClient) (bool, error) {
+func maybeAddAccessEntry(ctx context.Context, log *slog.Logger, clusterName, roleArn string, clt EnrollEKSCLusterClient, ownershipTags tags.AWSTags) (bool, error) {
 	entries, err := clt.ListAccessEntries(ctx, &eks.ListAccessEntriesInput{
 		ClusterName: aws.String(clusterName),
 	})
@@ -413,10 +432,31 @@ func maybeAddAccessEntry(ctx context.Context, clusterName, roleArn string, clt E
 		}
 	}
 
-	_, err = clt.CreateAccessEntry(ctx, &eks.CreateAccessEntryInput{
+	createAccessEntryReq := &eks.CreateAccessEntryInput{
 		ClusterName:  aws.String(clusterName),
 		PrincipalArn: aws.String(roleArn),
-	})
+		Tags:         ownershipTags.ToMap(),
+	}
+
+	_, err = clt.CreateAccessEntry(ctx, createAccessEntryReq)
+	if err != nil {
+		convertedError := awslib.ConvertIAMv2Error(err)
+		if !trace.IsAccessDenied(convertedError) {
+			return false, trace.Wrap(err)
+		}
+		// Adding tags requires the `eks:TagResource` action.
+		// This action is now part of the added policies, for previous set ups we didn't include the tag resource action in the policy document.
+		// See lib/cloud/aws.StatementForEKSAccess
+		// Instead of failing with an error, the Access Entry is created anyway without tags.
+		// This resource is meant to be deleted right after the teleport agent is installed.
+		createAccessEntryReq.Tags = nil
+
+		log.WarnContext(ctx, "Failed to tag EKS Access Entry, please add eks:TagResource action in IAM Role. Continuing without tags.",
+			"principal", roleArn,
+			"cluster", clusterName,
+		)
+		_, err = clt.CreateAccessEntry(ctx, createAccessEntryReq)
+	}
 	return err == nil, trace.Wrap(err)
 }
 

--- a/lib/integrations/awsoidc/eks_enroll_clusters_test.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 	"testing"
@@ -137,9 +138,11 @@ func TestEnrollEKSClusters(t *testing.T) {
 		return clt
 	}
 	baseRequest := EnrollEKSClustersRequest{
-		Region:             "us-east-1",
-		AgentVersion:       "1.2.3",
-		EnableAppDiscovery: true,
+		Region:              "us-east-1",
+		AgentVersion:        "1.2.3",
+		EnableAppDiscovery:  true,
+		IntegrationName:     "my-integration",
+		TeleportClusterName: "my-teleport-cluster",
 	}
 
 	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -251,9 +254,11 @@ func TestEnrollEKSClusters(t *testing.T) {
 				},
 			},
 			request: EnrollEKSClustersRequest{
-				Region:       "us-east-1",
-				AgentVersion: "1.2.3",
-				IsCloud:      true,
+				Region:              "us-east-1",
+				AgentVersion:        "1.2.3",
+				IsCloud:             true,
+				IntegrationName:     "my-integration",
+				TeleportClusterName: "my-teleport-cluster",
 			},
 			requestClusterNames: []string{"EKS3"},
 			responseCheck: func(t *testing.T, response *EnrollEKSClusterResponse) {
@@ -278,8 +283,10 @@ func TestEnrollEKSClusters(t *testing.T) {
 				},
 			},
 			request: EnrollEKSClustersRequest{
-				Region:       "us-east-1",
-				AgentVersion: "1.2.3",
+				Region:              "us-east-1",
+				AgentVersion:        "1.2.3",
+				IntegrationName:     "my-integration",
+				TeleportClusterName: "my-teleport-cluster",
 			},
 			requestClusterNames: []string{"EKS3"},
 			responseCheck: func(t *testing.T, response *EnrollEKSClusterResponse) {
@@ -360,8 +367,10 @@ func TestEnrollEKSClusters(t *testing.T) {
 		mockClt, ok := client.(*mockEnrollEKSClusterClient)
 		require.True(t, ok)
 		createCalled, deleteCalled := false, false
+		createTags := make(map[string]string)
 		mockClt.createAccessEntry = func(ctx context.Context, input *eks.CreateAccessEntryInput, f ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error) {
 			createCalled = true
+			createTags = maps.Clone(input.Tags)
 			return nil, nil
 		}
 		mockClt.deleteAccessEntry = func(ctx context.Context, input *eks.DeleteAccessEntryInput, f ...func(*eks.Options)) (*eks.DeleteAccessEntryOutput, error) {
@@ -375,6 +384,11 @@ func TestEnrollEKSClusters(t *testing.T) {
 		require.Len(t, response.Results, 1)
 		require.Equal(t, "EKS1", response.Results[0].ClusterName)
 		require.True(t, createCalled)
+		require.Equal(t, map[string]string{
+			"teleport.dev/cluster":     "my-teleport-cluster",
+			"teleport.dev/integration": "my-integration",
+			"teleport.dev/origin":      "integration_awsoidc",
+		}, createTags)
 		require.True(t, deleteCalled)
 	})
 }

--- a/lib/integrations/awsoidc/eks_iam_config.go
+++ b/lib/integrations/awsoidc/eks_iam_config.go
@@ -99,6 +99,7 @@ func NewEKSIAMConfigureClient(ctx context.Context, region string) (EKSIAMConfigu
 // - eks:CreateAccessEntry
 // - eks:DeleteAccessEntry
 // - eks:AssociateAccessPolicy
+// - eks:TagResource
 //
 // For more info about EKS access entries see:
 // https://aws.amazon.com/blogs/containers/a-deep-dive-into-simplified-amazon-eks-access-management-controls/

--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -416,6 +416,7 @@ func (a *eksFetcher) checkOrSetupAccessForARN(ctx context.Context, client eksifa
 				"eks:CreateAccessEntry",
 				"eks:DeleteAccessEntry",
 				"eks:AssociateAccessPolicy",
+				"eks:TagResource",
 			})
 		return nil
 	case err == nil:
@@ -438,6 +439,7 @@ func (a *eksFetcher) checkOrSetupAccessForARN(ctx context.Context, client eksifa
 					"eks:CreateAccessEntry",
 					"eks:DeleteAccessEntry",
 					"eks:AssociateAccessPolicy",
+					"eks:TagResource",
 				})
 			return nil
 		} else if err != nil {
@@ -457,6 +459,7 @@ func (a *eksFetcher) checkOrSetupAccessForARN(ctx context.Context, client eksifa
 					"eks:CreateAccessEntry",
 					"eks:DeleteAccessEntry",
 					"eks:AssociateAccessPolicy",
+					"eks:TagResource",
 				})
 			return nil
 		}

--- a/rfd/0157-aws-eks-discover.md
+++ b/rfd/0157-aws-eks-discover.md
@@ -56,7 +56,8 @@ associate access policies for an EKS cluster (details [below](#eks-access-entrie
                 "eks:ListAccessEntries",
                 "eks:CreateAccessEntry",
                 "eks:DeleteAccessEntry",
-                "eks:AssociateAccessPolicy"
+                "eks:AssociateAccessPolicy",
+                "eks:TagResource"
             ],
             "Resource": "*"
         }

--- a/web/packages/teleport/src/Discover/Shared/Aws/ConfigureIamPerms.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Aws/ConfigureIamPerms.tsx
@@ -109,6 +109,7 @@ export function ConfigureIamPerms({
         "eks:CreateAccessEntry",
         "eks:DeleteAccessEntry",
         "eks:AssociateAccessPolicy",
+        "eks:TagResource"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
Backport #44736 to v15

changelog: For new EKS Cluster auto-enroll configurations, the temporary Access Entry is tagged with `teleport.dev/` namespaced tags. For existing set ups, please add the `eks:TagResource` action to the Integration IAM Role to get the same behavior.