### PR TITLE
Login redirect changes

### DIFF
--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -85,6 +85,10 @@ const cfg = {
 
   baseUrl: window.location.origin,
 
+  // enterprise non-exact routes will be merged into this
+  // see `getNonExactRoutes` for details about non-exact routes
+  nonExactRoutes: [],
+
   // featureLimits define limits for features.
   /** @deprecated Use entitlements instead. */
   featureLimits: {
@@ -378,6 +382,19 @@ const cfg = {
   },
 
   playable_db_protocols: [],
+
+  getNonExactRoutes() {
+    // These routes will not be exact matched when deciding if it is a valid route
+    // to redirect to when a user is unauthenticated.
+    // This is useful for routes that can be infinitely nested, e.g. `
+    // /web/accessgraph` and `/web/accessgraph/integrations/new`
+    // (`/web/accessgraph/*` wouldn't work as it doesn't match `/web/accessgraph`)
+
+    return [
+      // at the moment, only `e` has an exempt route, which is merged in on `cfg.init()`
+      ...this.nonExactRoutes,
+    ];
+  },
 
   getPlayableDatabaseProtocols() {
     return cfg.playable_db_protocols;

--- a/web/packages/teleport/src/services/history/history.ts
+++ b/web/packages/teleport/src/services/history/history.ts
@@ -91,7 +91,7 @@ const history = {
   },
 
   getRoutes() {
-    return Object.getOwnPropertyNames(cfg.routes).map(p => cfg.routes[p]);
+    return collectAllValues(cfg.routes);
   },
 
   getLocation() {
@@ -118,6 +118,24 @@ const history = {
     window.location.href = this.ensureBaseUrl(route);
   },
 };
+
+interface RouteRecord {
+  [key: string]: string | RouteRecord;
+}
+
+function collectAllValues(record: RouteRecord) {
+  const result: string[] = [];
+
+  for (const key in record) {
+    if (typeof record[key] === 'string') {
+      result.push(record[key]);
+    } else {
+      result.push(...collectAllValues(record[key]));
+    }
+  }
+
+  return result;
+}
 
 export default history;
 

--- a/web/packages/teleport/src/services/history/history.ts
+++ b/web/packages/teleport/src/services/history/history.ts
@@ -100,13 +100,15 @@ const history = {
 
   _canPush(route: string) {
     const knownRoutes = this.getRoutes();
+    const nonExactRoutes = cfg.getNonExactRoutes();
+
     const { pathname } = new URL(this.ensureBaseUrl(route));
 
     const match = (known: string) =>
       // only match against pathname
       matchPath(pathname, {
         path: known,
-        exact: true,
+        exact: !nonExactRoutes.includes(known),
       });
 
     return knownRoutes.some(match);


### PR DESCRIPTION
When an authenticated user goes to a route, such as `/web/accessgraph/sql`, we look we look at all the `cfg.route` values and do an exact match against them to verify if we can set the pathname as the `redirect_url`. 

This means that `/web/accessgraph` would be redirected successfully, but `/web/accessgraph/sql` wouldn't. As far as I can tell, you can't have an optional wildcard in route path in React Router 5, so setting access graph's route to `/web/accessgraph/*` would no longer match `/web/accessgraph`. Setting `/web/accessgraph/:path?` would only match one level of routes, so `/web/accessgraph/integrations/new` wouldn't work.

This adds the concept of "non-exact" routes to the config, so we can programatically mark some defined route paths to be non-exact matched. I couldn't think of a better way to do this without redefining the route object. Unfortunately, we store the logic around whether a route is actually matched exactly in the `Feature` instance, which isn't calculated until a user is authenticated.

I also noticed we were only getting the routes one level deep, so access monitoring that defines `cfg.routes.accessMonitoring.{base|queryEditor|report}` wouldn't have been redirected to if a user tries to go to the URLs unauthenticated.