### PR TITLE
Load TAG features asynchronously

### DIFF
--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -110,17 +110,17 @@ class TeleportContext implements types.Context {
 
     if (user.acl.accessGraph.list) {
       // If access graph is enabled, check what features are enabled and store them in local storage.
-      try {
-        const accessGraphFeatures =
-          await userService.fetchAccessGraphFeatures();
-
-        for (let key in accessGraphFeatures) {
-          window.localStorage.setItem(key, accessGraphFeatures[key]);
-        }
-      } catch (e) {
-        // If we fail to fetch access graph features, log the error and continue.
-        console.error('Failed to fetch access graph features', e);
-      }
+      userService
+        .fetchAccessGraphFeatures()
+        .then(features => {
+          for (let key in features) {
+            window.localStorage.setItem(key, features[key]);
+          }
+        })
+        .catch(e => {
+          // If we fail to fetch access graph features, log the error and continue.
+          console.error('Failed to fetch access graph features', e);
+        });
     }
   }
 


### PR DESCRIPTION
This stops the TAG feature loading from blocking the frontend from rendering. Closes https://github.com/gravitational/access-graph/issues/925.