### PR TITLE
docs: mention the --days flag when executing an audit log query

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-monitoring.mdx
+++ b/docs/pages/admin-guides/access-controls/access-monitoring.mdx
@@ -543,7 +543,7 @@ ORDER BY
 Run custom audit query using `tctl audit query exec` command:
 
 ```code
-$ tctl audit query exec 'select event_time,identity_user from cert_create order by event_date limit 1;'
+$ tctl audit query exec 'select event_time,identity_user from cert_create order by event_date limit 1;' --days 7
 [
     {
         "data": [

--- a/docs/pages/admin-guides/access-controls/access-monitoring.mdx
+++ b/docs/pages/admin-guides/access-controls/access-monitoring.mdx
@@ -560,5 +560,6 @@ $ tctl audit query exec 'select event_time,identity_user from cert_create order 
 ]
 ```
 
-The query result is returned as a JSON array of arrays. The first array contains the column names, and the subsequent arrays contain the query results. By default, tctl audit query exec will search over the past 7 days.
-You can specify an alternate timeframe with the --days=N flag.
+The query result is returned as a JSON array of arrays. The first array contains the column names, and the subsequent arrays contain the query results.
+
+By default, `tctl audit query exec` will search over the past 7 days. You can specify an alternate time frame with the `--days=N` flag.

--- a/docs/pages/admin-guides/access-controls/access-monitoring.mdx
+++ b/docs/pages/admin-guides/access-controls/access-monitoring.mdx
@@ -543,7 +543,7 @@ ORDER BY
 Run custom audit query using `tctl audit query exec` command:
 
 ```code
-$ tctl audit query exec 'select event_time,identity_user from cert_create order by event_date limit 1;' --days 7
+$ tctl audit query exec 'select event_time,identity_user from cert_create order by event_date limit 1;'
 [
     {
         "data": [
@@ -560,4 +560,5 @@ $ tctl audit query exec 'select event_time,identity_user from cert_create order 
 ]
 ```
 
-The query result is returned as a JSON array of arrays. The first array contains the column names, and the subsequent arrays contain the query results.
+The query result is returned as a JSON array of arrays. The first array contains the column names, and the subsequent arrays contain the query results. By default, tctl audit query exec will search over the past 7 days.
+You can specify an alternate timeframe with the --days=N flag.


### PR DESCRIPTION
Include the default date range in the CLI example. This range is otherwise unclear and is hidden in the tctl audit help menu.