### PR TITLE
re-enable mysql e2e test

### DIFF
--- a/e2e/aws/rds_test.go
+++ b/e2e/aws/rds_test.go
@@ -206,8 +206,6 @@ func testRDS(t *testing.T) {
 	})
 
 	t.Run("mysql", func(t *testing.T) {
-		t.Skip("Disabled for now due to https://github.com/gravitational/teleport/issues/45672")
-
 		t.Parallel()
 
 		// wait for the database to be discovered


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/45672

The issue was a misconfigured security group that didn't allow inbound traffic from GHA runners, which was broken during our migration of the spacelift stack to self-hosted spacelift.