### PR TITLE
docs: include restart for self-hosted dbs

### DIFF
--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
@@ -110,6 +110,7 @@ Follow the instructions for your database to enable TLS communication with your 
       cipher_suites: [TLS_RSA_WITH_AES_256_CBC_SHA]
     ```
     In the configuration above, replace `"password"` with the value generated in the previous step by the `tctl auth sign` command.
+    Restart the Cassandra instance to enable this configuration.
 
   </TabItem>
   <TabItem label="Scylla">
@@ -122,6 +123,7 @@ Follow the instructions for your database to enable TLS communication with your 
       truststore:  /path/to/server.cas
       require_client_auth: True
     ```
+    Restart the Scylla instance to enable this configuration.
   </TabItem>
 </Tabs>
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
@@ -81,6 +81,7 @@ Use the generated secrets to enable mutual TLS in your `clickhouse-server/config
 </openSSL>
 ```
 
+Restart the ClickHouse Server to enable this configuration.
 Additionally, your ClickHouse database user accounts must be configured to require a valid client certificate:
 
 ```sql

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/elastic.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/elastic.mdx
@@ -116,10 +116,10 @@ xpack.security.authc.realms.pki.pki1:
   certificate_authorities: /path/to/server.cas
 ```
 
-Once mutual TLS has been enabled, you will no longer be able to connect to the cluster without
-providing a valid client certificate. You can set `xpack.security.http.ssl.client_authentication`
-to `optional` to allow connections from clients that do not present a certificate, using other
-methods like username and password.
+Restart Elasticsearch to enable this configuration. Once mutual TLS has been enabled, you will no
+longer be able to connect to the cluster without providing a valid client certificate. You can set
+`xpack.security.http.ssl.client_authentication` to `optional` to allow connections from clients
+that do not present a certificate, using other methods like username and password.
 
 ## Step 5/5. Connect
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
@@ -69,7 +69,8 @@ ssl-key=/path/to/server.key
 </TabItem>
 </Tabs>
 
-Additionally, your MySQL/MariaDB database user accounts must be configured to require a
+Restart the database instance to enable this configuration. Additionally,
+your MySQL/MariaDB database user accounts must be configured to require a
 valid client certificate.
 
 <Tabs>

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
@@ -57,6 +57,8 @@ ssl_key_file = '/path/to/server.key'
 ssl_ca_file = '/path/to/server.cas'
 ```
 
+Restart the PostgreSQL instance to enable this configuration.
+
 See [Secure TCP/IP Connections with
 SSL](https://www.postgresql.org/docs/current/ssl-tcp.html) in the PostgreSQL
 documentation for more details.

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/vitess.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/vitess.mdx
@@ -116,7 +116,7 @@ vtgate ...                                      \
 ```
 
 The files `server.cas`, `server.crt` and `server.key` must be in a location
-accessible by the `vtgate` service.
+accessible by the `vtgate` service. Restart the Vitess service to apply these flags.
 
 For more details about `vtgate` and Vitess configuration, please see the
 [documentation](https://vitess.io/docs/18.0/user-guides/configuration-basic/vtgate/).


### PR DESCRIPTION
Inconsistent mentioning of restarting dbs to apply TLS for self-hosted dbs.