### PR TITLE
include instrs to restart db servers for self-hosted in discover

### DIFF
--- a/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
@@ -156,7 +156,7 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
             },
           ]}
         />
-        <Text mb={1}>
+        <Text mt={1}>
           Restart the database server to apply the configuration.
         </Text>
       </Box>
@@ -247,7 +247,7 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                       },
                     ]}
                   />
-                  <Text mb={1}>
+                  <Text mt={1}>
                     Restart the database server to apply the configuration.
                   </Text>
                   <Text mt={2}>
@@ -280,7 +280,7 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                       },
                     ]}
                   />
-                  <Text mb={1}>
+                  <Text mt={1}>
                     Restart the database server to apply the configuration.
                   </Text>
                   <Text mt={2}>

--- a/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
@@ -156,6 +156,7 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
             },
           ]}
         />
+        <Text mb={1}>Restart the database server to apply the configuration.</Text>
       </Box>
     );
   }
@@ -244,6 +245,7 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                       },
                     ]}
                   />
+                  <Text mb={1}>Restart the database server to apply the configuration.</Text>
                   <Text mt={2}>
                     See{' '}
                     <Link
@@ -274,6 +276,7 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                       },
                     ]}
                   />
+                  <Text mb={1}>Restart the database server to apply the configuration.</Text>
                   <Text mt={2}>
                     See{' '}
                     <Link

--- a/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
@@ -156,7 +156,9 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
             },
           ]}
         />
-        <Text mb={1}>Restart the database server to apply the configuration.</Text>
+        <Text mb={1}>
+          Restart the database server to apply the configuration.
+        </Text>
       </Box>
     );
   }
@@ -245,7 +247,9 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                       },
                     ]}
                   />
-                  <Text mb={1}>Restart the database server to apply the configuration.</Text>
+                  <Text mb={1}>
+                    Restart the database server to apply the configuration.
+                  </Text>
                   <Text mt={2}>
                     See{' '}
                     <Link
@@ -276,7 +280,9 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                       },
                     ]}
                   />
-                  <Text mb={1}>Restart the database server to apply the configuration.</Text>
+                  <Text mb={1}>
+                    Restart the database server to apply the configuration.
+                  </Text>
                   <Text mt={2}>
                     See{' '}
                     <Link


### PR DESCRIPTION
Include instructions to restart the database servers to apply configurations. This is included for mongodb but not other dbs.