### PR TITLE
[v14] Prevent group reconciliation for existing users

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1161,10 +1161,14 @@ var KubernetesClusterWideResourceKinds = []string{
 }
 
 const (
-	// TeleportServiceGroup is a default group that users of the
-	// teleport automated user provisioning system get added to so
-	// already existing users are not deleted
-	TeleportServiceGroup = "teleport-system"
+	// TeleportDropGroup is a default group that users of the teleport automated user
+	// provisioning system get added to when provisioned in INSECURE_DROP mode. This
+	// prevents already existing users from being tampered with or deleted.
+	TeleportDropGroup = "teleport-system"
+	// TeleportKeepGroup is a default group that users of the teleport automated user
+	// provisioning system get added to when provisioned in KEEP mode. This prevents
+	// already existing users from being tampered with or deleted.
+	TeleportKeepGroup = "teleport-keep"
 )
 
 const (

--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -219,7 +219,7 @@ func TestRootHostUsers(t *testing.T) {
 		closer, err := users.UpsertUser(testuser, services.HostUsersInfo{Groups: testGroups, Mode: types.CreateHostUserMode_HOST_USER_MODE_DROP})
 		require.NoError(t, err)
 
-		testGroups = append(testGroups, types.TeleportServiceGroup)
+		testGroups = append(testGroups, types.TeleportDropGroup)
 		t.Cleanup(cleanupUsersAndGroups([]string{testuser}, testGroups))
 
 		u, err := user.Lookup(testuser)
@@ -241,7 +241,7 @@ func TestRootHostUsers(t *testing.T) {
 		closer, err := users.UpsertUser(testuser, services.HostUsersInfo{Groups: testGroups, Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP})
 		require.NoError(t, err)
 
-		testGroups = append(testGroups, types.TeleportServiceGroup)
+		testGroups = append(testGroups, types.TeleportDropGroup)
 		t.Cleanup(cleanupUsersAndGroups([]string{testuser}, testGroups))
 
 		u, err := user.Lookup(testuser)
@@ -270,7 +270,7 @@ func TestRootHostUsers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		t.Cleanup(cleanupUsersAndGroups([]string{testuser}, []string{types.TeleportServiceGroup}))
+		t.Cleanup(cleanupUsersAndGroups([]string{testuser}, []string{types.TeleportDropGroup}))
 
 		group, err := user.LookupGroupId(testGID)
 		require.NoError(t, err)
@@ -295,7 +295,7 @@ func TestRootHostUsers(t *testing.T) {
 		closer, err := users.UpsertUser(testuser, services.HostUsersInfo{Mode: types.CreateHostUserMode_HOST_USER_MODE_KEEP})
 		require.NoError(t, err)
 		require.Nil(t, closer)
-		t.Cleanup(cleanupUsersAndGroups([]string{testuser}, nil))
+		t.Cleanup(cleanupUsersAndGroups([]string{testuser}, []string{types.TeleportKeepGroup}))
 
 		u, err := user.Lookup(testuser)
 		require.NoError(t, err)
@@ -366,7 +366,7 @@ func TestRootHostUsers(t *testing.T) {
 
 		t.Cleanup(cleanupUsersAndGroups(
 			[]string{"teleport-user1", "teleport-user2", "teleport-user3", "teleport-user4"},
-			[]string{types.TeleportServiceGroup}))
+			[]string{types.TeleportDropGroup, types.TeleportKeepGroup}))
 
 		err = users.DeleteAllUsers()
 		require.NoError(t, err)

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -567,9 +567,9 @@ func (o *osWrapper) startNewParker(ctx context.Context, credential *syscall.Cred
 		return nil
 	}
 
-	group, err := o.LookupGroup(types.TeleportServiceGroup)
+	group, err := o.LookupGroup(types.TeleportDropGroup)
 	if err != nil {
-		if isUnknownGroupError(err, types.TeleportServiceGroup) {
+		if isUnknownGroupError(err, types.TeleportDropGroup) {
 			// The service group doesn't exist. Auto-provision is disabled, do nothing.
 			return nil
 		}
@@ -590,7 +590,7 @@ func (o *osWrapper) startNewParker(ctx context.Context, credential *syscall.Cred
 	}
 
 	if !found {
-		// Check if the new user guid matches the TeleportServiceGroup. If not
+		// Check if the new user guid matches the TeleportDropGroup. If not
 		// this user hasn't been created by Teleport, and we don't need the parker.
 		return nil
 	}

--- a/lib/srv/reexec_test.go
+++ b/lib/srv/reexec_test.go
@@ -85,8 +85,8 @@ func TestStartNewParker(t *testing.T) {
 			newOsPack: func(t *testing.T) (*osWrapper, func()) {
 				return &osWrapper{
 					LookupGroup: func(name string) (*user.Group, error) {
-						require.Equal(t, types.TeleportServiceGroup, name)
-						return nil, user.UnknownGroupError(types.TeleportServiceGroup)
+						require.Equal(t, types.TeleportDropGroup, name)
+						return nil, user.UnknownGroupError(types.TeleportDropGroup)
 					},
 				}, func() {}
 			},
@@ -97,7 +97,7 @@ func TestStartNewParker(t *testing.T) {
 			newOsPack: func(t *testing.T) (*osWrapper, func()) {
 				return &osWrapper{
 					LookupGroup: func(name string) (*user.Group, error) {
-						require.Equal(t, types.TeleportServiceGroup, name)
+						require.Equal(t, types.TeleportDropGroup, name)
 						return &user.Group{Gid: "1234"}, nil
 					},
 					CommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {
@@ -123,7 +123,7 @@ func TestStartNewParker(t *testing.T) {
 
 				return &osWrapper{
 						LookupGroup: func(name string) (*user.Group, error) {
-							require.Equal(t, types.TeleportServiceGroup, name)
+							require.Equal(t, types.TeleportDropGroup, name)
 							return &user.Group{Gid: currentUser.Gid}, nil
 						},
 						CommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -286,10 +286,15 @@ func (s *SessionRegistry) TryCreateHostUser(identityContext IdentityContext) (cr
 	if trace.IsAccessDenied(err) && existsErr != nil {
 		return false, nil, trace.WrapWithMessage(err, "Insufficient permission for host user creation")
 	}
+
 	userCloser, err := s.users.UpsertUser(identityContext.Login, *ui)
-	if err != nil && !trace.IsAlreadyExists(err) {
+	if err != nil && !trace.IsAlreadyExists(err) && !errors.Is(err, unmanagedUserErr) {
 		log.Debugf("Error creating user %s: %s", identityContext.Login, err)
 		return false, nil, trace.Wrap(err)
+	}
+
+	if errors.Is(err, unmanagedUserErr) {
+		log.Warnf("User %q is not managed by teleport. Either manually delete the user from this machine or update the host_groups defined in their role to include %q. https://goteleport.com/docs/enroll-resources/server-access/guides/host-user-creation/#migrating-unmanaged-users", identityContext.Login, types.TeleportKeepGroup)
 	}
 
 	return true, userCloser, nil

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -46,7 +46,8 @@ type testHostUserBackend struct {
 	// userGID: user -> gid
 	userGID map[string]string
 
-	setUserGroupsCalls int
+	setUserGroupsCalls       int
+	createHomeDirectoryCalls int
 }
 
 func newTestUserMgmt() *testHostUserBackend {
@@ -158,6 +159,7 @@ func (tm *testHostUserBackend) DeleteUser(user string) error {
 }
 
 func (tm *testHostUserBackend) CreateHomeDirectory(user, uid, gid string) error {
+	tm.createHomeDirectoryCalls++
 	return nil
 }
 
@@ -225,7 +227,7 @@ func TestUserMgmt_CreateTemporaryUser(t *testing.T) {
 
 	// temproary users must always include the teleport-service group
 	require.Equal(t, []string{
-		"hello", "sudo", types.TeleportServiceGroup,
+		"hello", "sudo", types.TeleportDropGroup,
 	}, backend.users["bob"])
 
 	// try create the same user again
@@ -240,10 +242,10 @@ func TestUserMgmt_CreateTemporaryUser(t *testing.T) {
 	backend.CreateGroup("testgroup", "")
 	backend.CreateUser("simon", []string{}, "", "", "")
 
-	// try to create a temporary user for simon
+	// an existing, unmanaged user should not be changed
 	closer, err = users.UpsertUser("simon", userinfo)
-	require.NoError(t, err)
-	require.NotEqual(t, nil, closer)
+	require.ErrorIs(t, err, unmanagedUserErr)
+	require.Equal(t, nil, closer)
 }
 
 func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
@@ -288,12 +290,12 @@ func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 		_, err := users.UpsertUser("testuser", services.HostUsersInfo{
 			Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
 		})
-		require.NoError(t, err)
-		backend.CreateGroup(types.TeleportServiceGroup, "")
+		require.ErrorIs(t, err, unmanagedUserErr)
+		backend.CreateGroup(types.TeleportDropGroup, "")
 		_, err = users.UpsertUser("testuser", services.HostUsersInfo{
 			Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
 		})
-		require.NoError(t, err)
+		require.ErrorIs(t, err, unmanagedUserErr)
 	})
 }
 
@@ -306,8 +308,8 @@ func TestUserMgmt_DeleteAllTeleportSystemUsers(t *testing.T) {
 	}
 
 	usersDB := []userAndGroups{
-		{"fgh", []string{types.TeleportServiceGroup}},
-		{"xyz", []string{types.TeleportServiceGroup}},
+		{"fgh", []string{types.TeleportDropGroup}},
+		{"xyz", []string{types.TeleportDropGroup}},
 		{"pqr", []string{"not-deleted"}},
 		{"abc", []string{"not-deleted"}},
 	}
@@ -328,7 +330,7 @@ func TestUserMgmt_DeleteAllTeleportSystemUsers(t *testing.T) {
 		for _, group := range user.groups {
 			mgmt.CreateGroup(group, "")
 		}
-		if slices.Contains(user.groups, types.TeleportServiceGroup) {
+		if slices.Contains(user.groups, types.TeleportDropGroup) {
 			users.UpsertUser(user.user, services.HostUsersInfo{
 				Groups: user.groups,
 				Mode:   types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
@@ -398,9 +400,8 @@ func TestIsUnknownGroupError(t *testing.T) {
 	}
 }
 
-func TestUpdateUserGroups(t *testing.T) {
+func Test_UpdateUserGroups_Keep(t *testing.T) {
 	t.Parallel()
-
 	backend := newTestUserMgmt()
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
@@ -416,35 +417,107 @@ func TestUpdateUserGroups(t *testing.T) {
 	}
 
 	userinfo := services.HostUsersInfo{
-		Groups: allGroups[:2],
+		Groups: slices.Clone(allGroups[:2]),
 		Mode:   types.CreateHostUserMode_HOST_USER_MODE_KEEP,
 	}
 
-	// Create a user with some groups.
+	// Create user
 	closer, err := users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	assert.Zero(t, backend.setUserGroupsCalls)
-	assert.ElementsMatch(t, userinfo.Groups, backend.users["alice"])
+	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportKeepGroup), backend.users["alice"])
+	assert.NotContains(t, backend.users["alice"], types.TeleportDropGroup)
 
 	// Update user with new groups.
-	userinfo.Groups = allGroups[2:]
+	userinfo.Groups = slices.Clone(allGroups[2:])
 
 	closer, err = users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 1, backend.setUserGroupsCalls)
-	assert.ElementsMatch(t, userinfo.Groups, backend.users["alice"])
+	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportKeepGroup), backend.users["alice"])
+	assert.NotContains(t, backend.users["alice"], types.TeleportDropGroup)
 
 	// Upsert again with same groups should not call SetUserGroups.
 	closer, err = users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 1, backend.setUserGroupsCalls)
-	assert.ElementsMatch(t, userinfo.Groups, backend.users["alice"])
+	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportKeepGroup), backend.users["alice"])
+	assert.NotContains(t, backend.users["alice"], types.TeleportDropGroup)
+
+	// Updates with INSECURE_DROP mode should convert the managed user
+	userinfo.Mode = types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP
+	userinfo.Groups = slices.Clone(allGroups[:2])
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.NotEqual(t, nil, closer)
+	assert.Equal(t, 2, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportDropGroup), backend.users["alice"])
+	assert.NotContains(t, backend.users["alice"], types.TeleportKeepGroup)
 }
 
-func Test_DontDropExistingUser(t *testing.T) {
+func Test_UpdateUserGroups_Drop(t *testing.T) {
+	t.Parallel()
+	backend := newTestUserMgmt()
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	pres := local.NewPresenceService(bk)
+	users := HostUserManagement{
+		backend: backend,
+		storage: pres,
+	}
+
+	allGroups := []string{"foo", "bar", "baz", "quux"}
+	for _, group := range allGroups {
+		require.NoError(t, backend.CreateGroup(group, ""))
+	}
+
+	userinfo := services.HostUsersInfo{
+		Groups: slices.Clone(allGroups[:2]),
+		Mode:   types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
+	}
+
+	// Create user
+	closer, err := users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.NotEqual(t, nil, closer)
+	assert.Zero(t, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportDropGroup), backend.users["alice"])
+	assert.NotContains(t, backend.users["alice"], types.TeleportKeepGroup)
+
+	// Update user with new groups.
+	userinfo.Groups = slices.Clone(allGroups[2:])
+
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.NotEqual(t, nil, closer)
+	assert.Equal(t, 1, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportDropGroup), backend.users["alice"])
+	assert.NotContains(t, backend.users["alice"], types.TeleportKeepGroup)
+
+	// Upsert again with same groups should not call SetUserGroups.
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.NotEqual(t, nil, closer)
+	assert.Equal(t, 1, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportDropGroup), backend.users["alice"])
+	assert.NotContains(t, backend.users["alice"], types.TeleportKeepGroup)
+
+	// Updates with KEEP mode should convert the ephemeral user
+	userinfo.Mode = types.CreateHostUserMode_HOST_USER_MODE_KEEP
+	userinfo.Groups = slices.Clone(allGroups[:2])
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, closer)
+	assert.Equal(t, 2, backend.setUserGroupsCalls)
+	assert.Equal(t, 1, backend.createHomeDirectoryCalls)
+	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportKeepGroup), backend.users["alice"])
+	assert.NotContains(t, backend.users["alice"], types.TeleportDropGroup)
+}
+
+func Test_DontManageExistingUser(t *testing.T) {
 	t.Parallel()
 
 	backend := newTestUserMgmt()
@@ -461,25 +534,122 @@ func Test_DontDropExistingUser(t *testing.T) {
 		require.NoError(t, backend.CreateGroup(group, ""))
 	}
 
+	assert.NoError(t, backend.CreateUser("alice", allGroups, "", "", ""))
+
+	userinfo := services.HostUsersInfo{
+		Groups: allGroups[:2],
+		Mode:   types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
+	}
+
+	// Update user in DROP mode
+	closer, err := users.UpsertUser("alice", userinfo)
+	assert.ErrorIs(t, err, unmanagedUserErr)
+	assert.Equal(t, nil, closer)
+	assert.Zero(t, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, allGroups, backend.users["alice"])
+
+	// Update user in KEEP mode
+	userinfo.Mode = types.CreateHostUserMode_HOST_USER_MODE_KEEP
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.ErrorIs(t, err, unmanagedUserErr)
+	assert.Equal(t, nil, closer)
+	assert.Zero(t, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, allGroups, backend.users["alice"])
+}
+
+func Test_DontUpdateUnmanagedUsers(t *testing.T) {
+	t.Parallel()
+
+	backend := newTestUserMgmt()
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	pres := local.NewPresenceService(bk)
+	users := HostUserManagement{
+		backend: backend,
+		storage: pres,
+	}
+
+	allGroups := []string{"foo", "bar", "baz", "quux"}
+	for _, group := range allGroups {
+		require.NoError(t, backend.CreateGroup(group, ""))
+	}
+
+	assert.NoError(t, backend.CreateUser("alice", allGroups[2:], "", "", ""))
 	userinfo := services.HostUsersInfo{
 		Groups: allGroups[:2],
 		Mode:   types.CreateHostUserMode_HOST_USER_MODE_KEEP,
 	}
 
-	// Create a user with some groups.
+	// Try to update existing, unmanaged user in KEEP mode
 	closer, err := users.UpsertUser("alice", userinfo)
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, unmanagedUserErr)
 	assert.Equal(t, nil, closer)
 	assert.Zero(t, backend.setUserGroupsCalls)
-	assert.ElementsMatch(t, userinfo.Groups, backend.users["alice"])
+	assert.ElementsMatch(t, allGroups[2:], backend.users["alice"])
 
-	// Upserting an existing user in INSECURE_DROP mode shouldn't make them ephemeral
-	userinfo.Mode = types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP
-	userinfo.Groups = allGroups[2:]
+	userinfo = services.HostUsersInfo{
+		Groups: allGroups[:2],
+		Mode:   types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
+	}
+
+	// Try to update existing, unmanaged user in DROP mode
 	closer, err = users.UpsertUser("alice", userinfo)
+	assert.ErrorIs(t, err, unmanagedUserErr)
+	assert.Equal(t, nil, closer)
+	assert.Zero(t, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, allGroups[2:], backend.users["alice"])
+}
+
+// teleport-keep can be included explicitly in the Groups slice in order to flag an
+// existing user as being managed by teleport
+func Test_AllowExplicitlyManageExistingUsers(t *testing.T) {
+	t.Parallel()
+
+	backend := newTestUserMgmt()
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	pres := local.NewPresenceService(bk)
+	users := HostUserManagement{
+		backend: backend,
+		storage: pres,
+	}
+
+	allGroups := []string{"foo", types.TeleportKeepGroup, types.TeleportDropGroup}
+	for _, group := range allGroups {
+		require.NoError(t, backend.CreateGroup(group, ""))
+	}
+
+	assert.NoError(t, backend.CreateUser("alice-keep", []string{}, "", "", ""))
+	assert.NoError(t, backend.CreateUser("alice-drop", []string{}, "", "", ""))
+	userinfo := services.HostUsersInfo{
+		Groups: slices.Clone(allGroups),
+		Mode:   types.CreateHostUserMode_HOST_USER_MODE_KEEP,
+	}
+
+	// Take ownership of existing user when in KEEP mode
+	closer, err := users.UpsertUser("alice-keep", userinfo)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, closer)
+	assert.Equal(t, 1, backend.setUserGroupsCalls)
+	// slice off the end because teleport-system should be explicitly excluded
+	assert.ElementsMatch(t, allGroups[:2], backend.users["alice-keep"])
+	assert.NotContains(t, backend.users["alice-keep"], types.TeleportDropGroup)
+
+	// Don't take ownership of existing user when in DROP mode
+	userinfo.Mode = types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP
+	closer, err = users.UpsertUser("alice-drop", userinfo)
+	assert.ErrorIs(t, err, unmanagedUserErr)
+	assert.Equal(t, nil, closer)
+	assert.Equal(t, 1, backend.setUserGroupsCalls)
+	assert.Empty(t, backend.users["alice-drop"])
+
+	// Don't assign teleport-keep to users created in DROP mode
+	userinfo.Mode = types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP
+	closer, err = users.UpsertUser("bob", userinfo)
 	assert.NoError(t, err)
 	assert.NotEqual(t, nil, closer)
 	assert.Equal(t, 1, backend.setUserGroupsCalls)
-	assert.ElementsMatch(t, userinfo.Groups, backend.users["alice"])
-	assert.NotContains(t, backend.users["alice"], types.TeleportServiceGroup)
+	assert.ElementsMatch(t, []string{"foo", types.TeleportDropGroup}, backend.users["bob"])
+	assert.NotContains(t, backend.users["bob"], types.TeleportKeepGroup)
+
 }


### PR DESCRIPTION
Backport #45612 to branch/v14

changelog: Fixed an issue where Teleport could modify group assignments for users not managed by Teleport. This will require a migration of host users created with create_host_user_mode: keep in order to maintain Teleport management. More info can be found at https://goteleport.com/docs/enroll-resources/server-access/guides/host-user-creation/#migrating-unmanaged-users.

