### PR TITLE
Release notes generation now supports adding security labels to releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1789,8 +1789,9 @@ changelog: $(CHANGELOG)
 # For more information on release notes generation see ./build.assets/tooling/cmd/release-notes
 .PHONY: create-github-release
 create-github-release: LATEST = false
+create-github-release: GITHUB_RELEASE_LABELS = ""
 create-github-release: $(RELEASE_NOTES_GEN)
-	@NOTES=$$($(RELEASE_NOTES_GEN) $(VERSION) CHANGELOG.md) && gh release create v$(VERSION) \
+	@NOTES=$$($(RELEASE_NOTES_GEN) --labels=$(GITHUB_RELEASE_LABELS) $(VERSION) CHANGELOG.md) && gh release create v$(VERSION) \
 	-t "Teleport $(VERSION)" \
 	--latest=$(LATEST) \
 	--verify-tag \

--- a/build.assets/tooling/cmd/release-notes/main.go
+++ b/build.assets/tooling/cmd/release-notes/main.go
@@ -29,6 +29,7 @@ import (
 var (
 	version   = kingpin.Arg("version", "Version to be released").Required().String()
 	changelog = kingpin.Arg("changelog", "Path to CHANGELOG.md").Required().String()
+	labels    = kingpin.Flag("labels", "Labels to apply to the end of a release, e.g. security labels").String()
 )
 
 func main() {
@@ -42,6 +43,7 @@ func main() {
 
 	gen := &releaseNotesGenerator{
 		releaseVersion: *version,
+		labels:         *labels,
 	}
 
 	notes, err := gen.generateReleaseNotes(clFile)

--- a/build.assets/tooling/cmd/release-notes/release_notes.go
+++ b/build.assets/tooling/cmd/release-notes/release_notes.go
@@ -36,6 +36,7 @@ var tmpl string
 type tmplInfo struct {
 	Version     string
 	Description string
+	Labels      string
 }
 
 var (
@@ -46,6 +47,13 @@ type releaseNotesGenerator struct {
 	// releaseVersion is the version for the release.
 	// This will be compared against the version present in the changelog.
 	releaseVersion string
+	// labels is a string applied to the end of the release description
+	// that will be picked up by other automation.
+	//
+	// It won't be validated but it is expected to be a comma separated list of
+	// entries in the format
+	// 	label=key
+	labels string
 }
 
 func (r *releaseNotesGenerator) generateReleaseNotes(md io.Reader) (string, error) {
@@ -57,6 +65,7 @@ func (r *releaseNotesGenerator) generateReleaseNotes(md io.Reader) (string, erro
 	info := tmplInfo{
 		Version:     r.releaseVersion,
 		Description: desc,
+		Labels:      r.labels,
 	}
 	var buff bytes.Buffer
 	if err := releaseNotesTemplate.Execute(&buff, info); err != nil {

--- a/build.assets/tooling/cmd/release-notes/release_notes_test.go
+++ b/build.assets/tooling/cmd/release-notes/release_notes_test.go
@@ -47,7 +47,7 @@ func Test_generateReleaseNotes(t *testing.T) {
 		{
 			name:           "with labels",
 			releaseVersion: "16.0.1",
-			labels:         "security-path=yes, security-patch-alts=v16.0.0,v16.0.1",
+			labels:         "security-patch=yes, security-patch-alts=v16.0.0,v16.0.1",
 			clFile:         mustOpen(t, "test-changelog.md"),
 			want:           mustRead(t, "expected-with-labels.md"),
 			wantErr:        false,

--- a/build.assets/tooling/cmd/release-notes/release_notes_test.go
+++ b/build.assets/tooling/cmd/release-notes/release_notes_test.go
@@ -32,6 +32,7 @@ func Test_generateReleaseNotes(t *testing.T) {
 	tests := []struct {
 		name           string
 		releaseVersion string
+		labels         string
 		clFile         *os.File
 		want           string
 		wantErr        bool
@@ -41,6 +42,14 @@ func Test_generateReleaseNotes(t *testing.T) {
 			releaseVersion: "16.0.1",
 			clFile:         mustOpen(t, "test-changelog.md"),
 			want:           mustRead(t, "expected-release-notes.md"),
+			wantErr:        false,
+		},
+		{
+			name:           "with labels",
+			releaseVersion: "16.0.1",
+			labels:         "security-path=yes, security-patch-alts=v16.0.0,v16.0.1",
+			clFile:         mustOpen(t, "test-changelog.md"),
+			want:           mustRead(t, "expected-with-labels.md"),
 			wantErr:        false,
 		},
 		{
@@ -55,6 +64,7 @@ func Test_generateReleaseNotes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &releaseNotesGenerator{
 				releaseVersion: tt.releaseVersion,
+				labels:         tt.labels,
 			}
 
 			got, err := r.generateReleaseNotes(tt.clFile)

--- a/build.assets/tooling/cmd/release-notes/template/release-notes.md.tmpl
+++ b/build.assets/tooling/cmd/release-notes/template/release-notes.md.tmpl
@@ -18,3 +18,9 @@ Download the current release of Teleport plugins from the links below.
 * Jira [Linux amd64](https://cdn.teleport.dev/teleport-access-jira-v{{ .Version }}-linux-amd64-bin.tar.gz) | [Linux arm64](https://cdn.teleport.dev/teleport-access-jira-v{{ .Version }}-linux-arm64-bin.tar.gz)
 * Email [Linux amd64](https://cdn.teleport.dev/teleport-access-email-v{{ .Version }}-linux-amd64-bin.tar.gz) | [Linux arm64](https://cdn.teleport.dev/teleport-access-email-v{{ .Version }}-linux-arm64-bin.tar.gz)
 * Microsoft Teams [Linux amd64](https://cdn.teleport.dev/teleport-access-msteams-v{{ .Version }}-linux-amd64-bin.tar.gz) | [Linux arm64](https://cdn.teleport.dev/teleport-access-msteams-v{{ .Version }}-linux-arm64-bin.tar.gz)
+{{- if .Labels }}
+
+---
+
+labels: {{ .Labels }}
+{{- end }}

--- a/build.assets/tooling/cmd/release-notes/testdata/expected-with-labels.md
+++ b/build.assets/tooling/cmd/release-notes/testdata/expected-with-labels.md
@@ -27,4 +27,4 @@ Download the current release of Teleport plugins from the links below.
 
 ---
 
-labels: security-path=yes, security-patch-alts=v16.0.0,v16.0.1
+labels: security-patch=yes, security-patch-alts=v16.0.0,v16.0.1

--- a/build.assets/tooling/cmd/release-notes/testdata/expected-with-labels.md
+++ b/build.assets/tooling/cmd/release-notes/testdata/expected-with-labels.md
@@ -24,3 +24,7 @@ Download the current release of Teleport plugins from the links below.
 * Jira [Linux amd64](https://cdn.teleport.dev/teleport-access-jira-v16.0.1-linux-amd64-bin.tar.gz) | [Linux arm64](https://cdn.teleport.dev/teleport-access-jira-v16.0.1-linux-arm64-bin.tar.gz)
 * Email [Linux amd64](https://cdn.teleport.dev/teleport-access-email-v16.0.1-linux-amd64-bin.tar.gz) | [Linux arm64](https://cdn.teleport.dev/teleport-access-email-v16.0.1-linux-arm64-bin.tar.gz)
 * Microsoft Teams [Linux amd64](https://cdn.teleport.dev/teleport-access-msteams-v16.0.1-linux-amd64-bin.tar.gz) | [Linux arm64](https://cdn.teleport.dev/teleport-access-msteams-v16.0.1-linux-arm64-bin.tar.gz)
+
+---
+
+labels: security-path=yes, security-patch-alts=v16.0.0,v16.0.1


### PR DESCRIPTION
Release notes generation tool now supports adding labels to releases.

The new variable can be used with the `create-github-release` target like this:
```
make -s create-github-release GITHUB_RELEASE_LABEL="security-patch=yes, security-patch-alts=v16.1.5"
```

Should now result in an output that looks similar this: https://github.com/gravitational/teleport/blob/89a781a7cfda7d5755ddf79713fa67c0f8c8b864/build.assets/tooling/cmd/release-notes/testdata/expected-with-labels.md