### PR TITLE
[v16] Fix AWS App Access creation for AWS OIDC Integration when using the account number as name

### DIFF
--- a/api/types/app.go
+++ b/api/types/app.go
@@ -359,7 +359,15 @@ func (a *AppV3) CheckAndSetDefaults() error {
 	default:
 		return trace.BadParameter("app %q has unexpected Cloud value %q", a.GetName(), a.Spec.Cloud)
 	}
-	url, err := url.Parse(a.Spec.PublicAddr)
+	publicAddr := a.Spec.PublicAddr
+	// If the public addr has digits in a sub-host and a port, it might cause url.Parse to fail.
+	// Eg of a failing url: 123.teleport.example.com:3080
+	// This is not a valid URL, but we have been using it as such.
+	// To prevent this from failing, we add the `//`.
+	if !strings.Contains(publicAddr, "//") && strings.Contains(publicAddr, ":") {
+		publicAddr = "//" + publicAddr
+	}
+	url, err := url.Parse(publicAddr)
 	if err != nil {
 		return trace.BadParameter("invalid PublicAddr format: %v", err)
 	}

--- a/api/types/app_test.go
+++ b/api/types/app_test.go
@@ -77,6 +77,11 @@ func TestAppPublicAddrValidation(t *testing.T) {
 			publicAddr: "https://" + constants.KubeTeleportProxyALPNPrefix + "example.com:3080",
 			check:      hasErrTypeBadParameter(),
 		},
+		{
+			name:       "addr with numbers in the host",
+			publicAddr: "123456789012.teleport.example.com:3080",
+			check:      hasNoErr(),
+		},
 	}
 
 	for _, tc := range tests {

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -947,7 +947,13 @@ func (h *Handler) awsOIDCCreateAWSAppAccess(w http.ResponseWriter, r *http.Reque
 
 	getUserGroupLookup := h.getUserGroupLookup(r.Context(), clt)
 
-	publicAddr := libutils.DefaultAppPublicAddr(integrationName, h.PublicProxyAddr())
+	// If the integration is numbers only (eg aws account id)
+	// Eg 123456789012.proxy.example.com:443
+	// The public addr fails to parse with "first path segment in URL cannot contain colon"
+	// See https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
+	// Removing the port, if it is the default for HTTPS, ensures this will work for Cloud and most self-hosted deployments.
+	proxyPublicAddr := strings.TrimSuffix(h.PublicProxyAddr(), ":443")
+	publicAddr := libutils.DefaultAppPublicAddr(integrationName, proxyPublicAddr)
 
 	appServer, err := types.NewAppServerForAWSOIDCIntegration(integrationName, h.cfg.HostUUID, publicAddr)
 	if err != nil {

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -947,8 +947,7 @@ func (h *Handler) awsOIDCCreateAWSAppAccess(w http.ResponseWriter, r *http.Reque
 
 	getUserGroupLookup := h.getUserGroupLookup(r.Context(), clt)
 
-	// Prepending the protocol ensures that url.Parse works even if the integration name only contains digits (eg aws account id).
-	publicAddr := "https://" + libutils.DefaultAppPublicAddr(integrationName, h.PublicProxyAddr())
+	publicAddr := libutils.DefaultAppPublicAddr(integrationName, h.PublicProxyAddr())
 
 	appServer, err := types.NewAppServerForAWSOIDCIntegration(integrationName, h.cfg.HostUUID, publicAddr)
 	if err != nil {

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -947,13 +947,8 @@ func (h *Handler) awsOIDCCreateAWSAppAccess(w http.ResponseWriter, r *http.Reque
 
 	getUserGroupLookup := h.getUserGroupLookup(r.Context(), clt)
 
-	// If the integration is numbers only (eg aws account id)
-	// Eg 123456789012.proxy.example.com:443
-	// The public addr fails to parse with "first path segment in URL cannot contain colon"
-	// See https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
-	// Removing the port, if it is the default for HTTPS, ensures this will work for Cloud and most self-hosted deployments.
-	proxyPublicAddr := strings.TrimSuffix(h.PublicProxyAddr(), ":443")
-	publicAddr := libutils.DefaultAppPublicAddr(integrationName, proxyPublicAddr)
+	// Prepending the protocol ensures that url.Parse works even if the integration name only contains digits (eg aws account id).
+	publicAddr := "https://" + libutils.DefaultAppPublicAddr(integrationName, h.PublicProxyAddr())
 
 	appServer, err := types.NewAppServerForAWSOIDCIntegration(integrationName, h.cfg.HostUUID, publicAddr)
 	if err != nil {

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -1022,7 +1022,7 @@ func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 					URI:         "https://console.aws.amazon.com",
 					Integration: "my-integration",
 					Cloud:       "AWS",
-					PublicAddr:  "my-integration." + proxyPublicAddr,
+					PublicAddr:  "https://my-integration." + proxyPublicAddr,
 				},
 			},
 		},
@@ -1041,7 +1041,7 @@ func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, appServers)
 
-	t.Run("using the account id as name", func(t *testing.T) {
+	t.Run("using the account id as name works as expected", func(t *testing.T) {
 		// Creating an Integration using the account id as name should not return an error if the proxy is listening at the default HTTPS port
 		myIntegrationWithAccountID, err := types.NewIntegrationAWSOIDC(types.Metadata{
 			Name: "123456789012",
@@ -1052,23 +1052,8 @@ func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 
 		_, err = env.server.Auth().CreateIntegration(ctx, myIntegrationWithAccountID)
 		require.NoError(t, err)
-
-		t.Run("returns an error if the proxy is not using the default port for HTTPS", func(t *testing.T) {
-			endpoint = pack.clt.Endpoint("webapi", "sites", "localhost", "integrations", "aws-oidc", "123456789012", "aws-app-access")
-			_, err = pack.clt.PostJSON(ctx, endpoint, nil)
-			require.Error(t, err)
-		})
-
-		t.Run("does not return an error, otherwise", func(t *testing.T) {
-			initialAddr := proxy.handler.handler.cfg.PublicProxyAddr
-			t.Cleanup(func() {
-				proxy.handler.handler.cfg.PublicProxyAddr = initialAddr
-			})
-
-			proxy.handler.handler.cfg.PublicProxyAddr = "proxy.example.com:443"
-			endpoint = pack.clt.Endpoint("webapi", "sites", "localhost", "integrations", "aws-oidc", "123456789012", "aws-app-access")
-			_, err = pack.clt.PostJSON(ctx, endpoint, nil)
-			require.NoError(t, err)
-		})
+		endpoint = pack.clt.Endpoint("webapi", "sites", "localhost", "integrations", "aws-oidc", "123456789012", "aws-app-access")
+		_, err = pack.clt.PostJSON(ctx, endpoint, nil)
+		require.NoError(t, err)
 	})
 }

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -1040,4 +1040,35 @@ func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 	appServers, err = env.server.Auth().GetApplicationServers(ctx, "default")
 	require.NoError(t, err)
 	require.Empty(t, appServers)
+
+	t.Run("using the account id as name", func(t *testing.T) {
+		// Creating an Integration using the account id as name should not return an error if the proxy is listening at the default HTTPS port
+		myIntegrationWithAccountID, err := types.NewIntegrationAWSOIDC(types.Metadata{
+			Name: "123456789012",
+		}, &types.AWSOIDCIntegrationSpecV1{
+			RoleARN: "some-arn-role",
+		})
+		require.NoError(t, err)
+
+		_, err = env.server.Auth().CreateIntegration(ctx, myIntegrationWithAccountID)
+		require.NoError(t, err)
+
+		t.Run("returns an error if the proxy is not using the default port for HTTPS", func(t *testing.T) {
+			endpoint = pack.clt.Endpoint("webapi", "sites", "localhost", "integrations", "aws-oidc", "123456789012", "aws-app-access")
+			_, err = pack.clt.PostJSON(ctx, endpoint, nil)
+			require.Error(t, err)
+		})
+
+		t.Run("does not return an error, otherwise", func(t *testing.T) {
+			initialAddr := proxy.handler.handler.cfg.PublicProxyAddr
+			t.Cleanup(func() {
+				proxy.handler.handler.cfg.PublicProxyAddr = initialAddr
+			})
+
+			proxy.handler.handler.cfg.PublicProxyAddr = "proxy.example.com:443"
+			endpoint = pack.clt.Endpoint("webapi", "sites", "localhost", "integrations", "aws-oidc", "123456789012", "aws-app-access")
+			_, err = pack.clt.PostJSON(ctx, endpoint, nil)
+			require.NoError(t, err)
+		})
+	})
 }

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -974,6 +975,7 @@ func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 	require.NoError(t, err)
 
 	proxy := env.proxies[0]
+	proxy.handler.handler.cfg.PublicProxyAddr = strings.TrimPrefix(proxy.handler.handler.cfg.PublicProxyAddr, "https://")
 	proxyPublicAddr := proxy.handler.handler.cfg.PublicProxyAddr
 	pack := proxy.authPack(t, "foo@example.com", []types.Role{roleTokenCRD})
 
@@ -1022,7 +1024,7 @@ func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 					URI:         "https://console.aws.amazon.com",
 					Integration: "my-integration",
 					Cloud:       "AWS",
-					PublicAddr:  "https://my-integration." + proxyPublicAddr,
+					PublicAddr:  "my-integration." + proxyPublicAddr,
 				},
 			},
 		},


### PR DESCRIPTION
Backport #44480 to branch/v16

changelog: Fix an issue that prevented the creation of AWS App Access for an Integration that used digits only (eg, AWS Account ID).
