### PR TITLE
[v16] Auto Discover GCP GCE: add project id label

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -683,10 +683,16 @@ const (
 	// via automatic discovery, to avoid re-running installation commands
 	// on the node.
 	VMIDLabel = TeleportInternalLabelPrefix + "vm-id"
+	// ProjectIDLabelSuffix is the identifier for adding the GCE ProjectID to an instance.
+	projectIDLabelSuffix = "project-id"
 	// ProjectIDLabel is used to identify virtual machines by GCP project
 	// id found via automatic discovery, to avoid re-running
 	// installation commands on the node.
-	ProjectIDLabel = TeleportInternalLabelPrefix + "project-id"
+	ProjectIDLabelDiscovery = TeleportInternalLabelPrefix + projectIDLabelSuffix
+	// ProjectIDLabel is used to identify the project ID for a virtual machine in GCP.
+	// The difference between this and the above, is that this one will be visible to the user
+	// and can be used in RBAC checks.
+	ProjectIDLabel = TeleportNamespace + "/" + projectIDLabelSuffix
 	// RegionLabel is used to identify virtual machines by region found
 	// via automatic discovery, to avoid re-running installation commands
 	// on the node.
@@ -695,14 +701,14 @@ const (
 	// via automatic discovery, to avoid re-running installation commands
 	// on the node.
 	ResourceGroupLabel = TeleportInternalLabelPrefix + "resource-group"
-	// ZoneLabel is used to identify virtual machines by GCP zone
+	// ZoneLabelDiscovery is used to identify virtual machines by GCP zone
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.
-	ZoneLabel = TeleportInternalLabelPrefix + "zone"
-	// NameLabel is used to identify virtual machines by GCP VM name
+	ZoneLabelDiscovery = TeleportInternalLabelPrefix + "zone"
+	// NameLabelDiscovery is used to identify virtual machines by GCP VM name
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.
-	NameLabel = TeleportInternalLabelPrefix + "name"
+	NameLabelDiscovery = TeleportInternalLabelPrefix + "name"
 
 	// CloudLabel is used to identify the cloud where the resource was discovered.
 	CloudLabel = TeleportNamespace + "/cloud"

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -690,7 +690,7 @@ const (
 	// installation commands on the node.
 	ProjectIDLabelDiscovery = TeleportInternalLabelPrefix + projectIDLabelSuffix
 	// ProjectIDLabel is used to identify the project ID for a virtual machine in GCP.
-	// The difference between this and the above, is that this one will be visible to the user
+	// The difference between this and ProjectIDLabelDiscovery, is that this one will be visible to the user
 	// and can be used in RBAC checks.
 	ProjectIDLabel = TeleportNamespace + "/" + projectIDLabelSuffix
 	// RegionLabel is used to identify virtual machines by region found

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -685,7 +685,7 @@ const (
 	VMIDLabel = TeleportInternalLabelPrefix + "vm-id"
 	// projectIDLabelSuffix is the identifier for adding the GCE ProjectID to an instance.
 	projectIDLabelSuffix = "project-id"
-	// ProjectIDLabel is used to identify virtual machines by GCP project
+	// ProjectIDLabelDiscovery is used to identify virtual machines by GCP project
 	// id found via automatic discovery, to avoid re-running
 	// installation commands on the node.
 	ProjectIDLabelDiscovery = TeleportInternalLabelPrefix + projectIDLabelSuffix

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -683,7 +683,7 @@ const (
 	// via automatic discovery, to avoid re-running installation commands
 	// on the node.
 	VMIDLabel = TeleportInternalLabelPrefix + "vm-id"
-	// ProjectIDLabelSuffix is the identifier for adding the GCE ProjectID to an instance.
+	// projectIDLabelSuffix is the identifier for adding the GCE ProjectID to an instance.
 	projectIDLabelSuffix = "project-id"
 	// ProjectIDLabel is used to identify virtual machines by GCP project
 	// id found via automatic discovery, to avoid re-running

--- a/lib/cloud/imds/gcp/imds_test.go
+++ b/lib/cloud/imds/gcp/imds_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeMetadataGetter(values map[string]string) metadataGetter {
+func makeMetadataGetter(values map[string]string) MetadataGetter {
 	return func(ctx context.Context, path string) (string, error) {
 		value, ok := values[path]
 		if ok {
@@ -58,7 +58,7 @@ func TestIsInstanceMetadataAvailable(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		getMetadata metadataGetter
+		getMetadata MetadataGetter
 		assert      require.BoolAssertionFunc
 	}{
 		{
@@ -130,7 +130,7 @@ func TestGetTags(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		getMetadata     metadataGetter
+		getMetadata     MetadataGetter
 		instancesClient *mockInstanceGetter
 		assertErr       require.ErrorAssertionFunc
 		expectedTags    map[string]string

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1135,9 +1135,9 @@ func (s *Server) handleAzureDiscovery() {
 func (s *Server) filterExistingGCPNodes(instances *server.GCPInstances) {
 	nodes := s.nodeWatcher.GetNodes(s.ctx, func(n services.Node) bool {
 		labels := n.GetAllLabels()
-		_, projectIDOK := labels[types.ProjectIDLabel]
-		_, zoneOK := labels[types.ZoneLabel]
-		_, nameOK := labels[types.NameLabel]
+		_, projectIDOK := labels[types.ProjectIDLabelDiscovery]
+		_, zoneOK := labels[types.ZoneLabelDiscovery]
+		_, nameOK := labels[types.NameLabelDiscovery]
 		return projectIDOK && zoneOK && nameOK
 	})
 	var filtered []*gcpimds.Instance
@@ -1145,9 +1145,9 @@ outer:
 	for _, inst := range instances.Instances {
 		for _, node := range nodes {
 			match := types.MatchLabels(node, map[string]string{
-				types.ProjectIDLabel: inst.ProjectID,
-				types.ZoneLabel:      inst.Zone,
-				types.NameLabel:      inst.Name,
+				types.ProjectIDLabelDiscovery: inst.ProjectID,
+				types.ZoneLabelDiscovery:      inst.Zone,
+				types.NameLabelDiscovery:      inst.Name,
 			})
 			if match {
 				continue outer

--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -525,8 +525,9 @@ func fetchNodeAutoDiscoverLabels(ctx context.Context, imdsClient imds.Client) (m
 			return nil, trace.Wrap(err)
 		}
 
-		nodeLabels[types.NameLabel] = name
-		nodeLabels[types.ZoneLabel] = zone
+		nodeLabels[types.NameLabelDiscovery] = name
+		nodeLabels[types.ZoneLabelDiscovery] = zone
+		nodeLabels[types.ProjectIDLabelDiscovery] = projectID
 		nodeLabels[types.ProjectIDLabel] = projectID
 
 	default:

--- a/lib/srv/server/installer/autodiscover_test.go
+++ b/lib/srv/server/installer/autodiscover_test.go
@@ -319,7 +319,7 @@ func TestAutoDiscoverNode(t *testing.T) {
 						case "project/project-id":
 							return "my-project", nil
 						}
-						return "", trace.NotFound("path %q not found in metadata", path)
+						return "", trace.BadParameter("path %q not found in metadata", path)
 					}),
 				)
 			},

--- a/lib/srv/server/installer/autodiscover_test.go
+++ b/lib/srv/server/installer/autodiscover_test.go
@@ -29,11 +29,13 @@ import (
 	"testing"
 
 	"github.com/buildkite/bintest/v3"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/cloud/imds"
 	"github.com/gravitational/teleport/lib/cloud/imds/azure"
+	"github.com/gravitational/teleport/lib/cloud/imds/gcp"
 	"github.com/gravitational/teleport/lib/utils/packagemanager"
 )
 
@@ -85,6 +87,18 @@ func setupDirsForTest(t *testing.T, testTempDir string, distroConfig map[string]
 			require.NoError(t, os.WriteFile(path.Join(testTempDir, fileName), []byte(contents), fs.ModePerm))
 		}
 	}
+}
+
+type mockGCPInstanceGetter struct{}
+
+// GetInstance gets a GCP VM.
+func (m *mockGCPInstanceGetter) GetInstance(ctx context.Context, req *gcp.InstanceRequest) (*gcp.Instance, error) {
+	return nil, trace.NotImplemented("not implemented")
+}
+
+// GetInstanceTags gets the GCP tags for the instance.
+func (m *mockGCPInstanceGetter) GetInstanceTags(ctx context.Context, req *gcp.InstanceRequest) (map[string]string, error) {
+	return nil, trace.NotImplemented("not implemented")
 }
 
 func TestAutoDiscoverNode(t *testing.T) {
@@ -281,6 +295,91 @@ func TestAutoDiscoverNode(t *testing.T) {
 		}
 		require.FileExists(t, testTempDir+"/etc/teleport.yaml")
 		require.FileExists(t, testTempDir+"/etc/teleport.yaml.discover")
+	})
+
+	t.Run("gcp adds a label with the project id", func(t *testing.T) {
+		distroConfig := wellKnownOS["ubuntu"]["24.04"]
+
+		testTempDir := t.TempDir()
+
+		setupDirsForTest(t, testTempDir, distroConfig)
+
+		mockIMDSProviders := []func(ctx context.Context) (imds.Client, error){
+			func(ctx context.Context) (imds.Client, error) {
+				return gcp.NewInstanceMetadataClient(
+					&mockGCPInstanceGetter{},
+					gcp.WithMetadataClient(func(ctx context.Context, path string) (string, error) {
+						switch path {
+						case "instance/id":
+							return "123", nil
+						case "instance/name":
+							return "my-name", nil
+						case "instance/zone":
+							return "my-zone", nil
+						case "project/project-id":
+							return "my-project", nil
+						}
+						return "", trace.NotFound("path %q not found in metadata", path)
+					}),
+				)
+			},
+		}
+
+		installerConfig := &AutoDiscoverNodeInstallerConfig{
+			RepositoryChannel: "stable/rolling",
+			AutoUpgrades:      false,
+			ProxyPublicAddr:   "proxy.example.com",
+			TeleportPackage:   "teleport",
+			TokenName:         "my-token",
+
+			fsRootPrefix:         testTempDir,
+			imdsProviders:        mockIMDSProviders,
+			binariesLocation:     binariesLocation,
+			aptPublicKeyEndpoint: mockRepoKeys.URL,
+		}
+
+		teleportInstaller, err := NewAutoDiscoverNodeInstaller(installerConfig)
+		require.NoError(t, err)
+
+		// package manager is not called in this scenario because teleport binary already exists in the system
+		require.FileExists(t, mockBins["teleport"].Path)
+
+		// create an existing teleport.yaml configuration file
+		require.NoError(t, os.WriteFile(testTempDir+"/etc/teleport.yaml", []byte("has wrong config"), 0o644))
+		// create a teleport.yaml.discover to indicate that this host is controlled by the discover flow
+		require.NoError(t, os.WriteFile(testTempDir+"/etc/teleport.yaml.discover", []byte(""), 0o644))
+
+		// package manager is not called in this scenario because teleport binary already exists in the system
+		require.FileExists(t, mockBins["teleport"].Path)
+
+		mockBins["teleport"].Expect("node",
+			"configure",
+			"--output=file://"+testTempDir+"/etc/teleport.yaml.new",
+			"--proxy=proxy.example.com",
+			"--join-method=gcp",
+			"--token=my-token",
+			"--labels=teleport.dev/project-id=my-project,teleport.internal/name=my-name,teleport.internal/project-id=my-project,teleport.internal/zone=my-zone",
+		).AndCallFunc(func(c *bintest.Call) {
+			// create a teleport.yaml configuration file
+			require.NoError(t, os.WriteFile(testTempDir+"/etc/teleport.yaml.new", []byte("teleport.yaml configuration bytes"), 0o644))
+			c.Exit(0)
+		})
+
+		mockBins["systemctl"].Expect("enable", "teleport")
+		mockBins["systemctl"].Expect("restart", "teleport")
+
+		require.NoError(t, teleportInstaller.Install(ctx))
+
+		for binName, mockBin := range mockBins {
+			require.True(t, mockBin.Check(t), "mismatch between expected invocations and actual calls for %q", binName)
+		}
+
+		require.NoFileExists(t, testTempDir+"/etc/teleport.yaml.new")
+		require.FileExists(t, testTempDir+"/etc/teleport.yaml")
+		require.FileExists(t, testTempDir+"/etc/teleport.yaml.discover")
+		bs, err := os.ReadFile(testTempDir + "/etc/teleport.yaml")
+		require.NoError(t, err)
+		require.Equal(t, "teleport.yaml configuration bytes", string(bs))
 	})
 
 	t.Run("fails when imds server is not available", func(t *testing.T) {

--- a/lib/srv/server/installer/autodiscover_test.go
+++ b/lib/srv/server/installer/autodiscover_test.go
@@ -91,12 +91,10 @@ func setupDirsForTest(t *testing.T, testTempDir string, distroConfig map[string]
 
 type mockGCPInstanceGetter struct{}
 
-// GetInstance gets a GCP VM.
 func (m *mockGCPInstanceGetter) GetInstance(ctx context.Context, req *gcp.InstanceRequest) (*gcp.Instance, error) {
 	return nil, trace.NotImplemented("not implemented")
 }
 
-// GetInstanceTags gets the GCP tags for the instance.
 func (m *mockGCPInstanceGetter) GetInstanceTags(ctx context.Context, req *gcp.InstanceRequest) (map[string]string, error) {
 	return nil, trace.NotImplemented("not implemented")
 }


### PR DESCRIPTION
Backport #45737 to branch/v16

changelog: Add `teleport.dev/project-id` label for auto-enrolled instances in GCP.
