### PR TITLE
AWS OIDC: Token Request now requires the integration name

### DIFF
--- a/api/gen/proto/go/teleport/integration/v1/integration_service.pb.go
+++ b/api/gen/proto/go/teleport/integration/v1/integration_service.pb.go
@@ -412,8 +412,7 @@ type GenerateAWSOIDCTokenRequest struct {
 	// Deprecated: Marked as deprecated in teleport/integration/v1/integration_service.proto.
 	Issuer string `protobuf:"bytes,1,opt,name=issuer,proto3" json:"issuer,omitempty"`
 	// Integration is the AWS OIDC Integration name.
-	// If not provided, it will use the Teleport's Proxy Public URL as issuer.
-	// Optional.
+	// Required.
 	Integration string `protobuf:"bytes,2,opt,name=integration,proto3" json:"integration,omitempty"`
 }
 

--- a/api/proto/teleport/integration/v1/integration_service.proto
+++ b/api/proto/teleport/integration/v1/integration_service.proto
@@ -102,8 +102,7 @@ message GenerateAWSOIDCTokenRequest {
   string issuer = 1 [deprecated = true];
 
   // Integration is the AWS OIDC Integration name.
-  // If not provided, it will use the Teleport's Proxy Public URL as issuer.
-  // Optional.
+  // Required.
   string integration = 2;
 }
 


### PR DESCRIPTION
We added the integration field as optional in v15 in server side. All clients were also updated to send the integration during v15. As of v16, all clients send the integration.

For v17, on server side, Integration is now a required field.