### PR TITLE
Update link to docs of local app proxy in Connect

### DIFF
--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/AppGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/AppGateway.tsx
@@ -102,7 +102,7 @@ export function AppGateway(props: {
         The connection is made through an authenticated proxy so no extra
         credentials are necessary. See{' '}
         <Link
-          href="https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-an-application"
+          href="https://goteleport.com/docs/connect-your-client/teleport-connect/#creating-an-authenticated-tunnel"
           target="_blank"
         >
           the documentation


### PR DESCRIPTION
The link used to point to https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-an-application, but since then this section of the docs got a few new subsections. Connect gained the ability to open web apps in the browser and VNet is a thing now. `#connecting-to-an-application` no longer talks only about local proxies, so this PR updates the link to point at a specific subsection.

This link is shown in the tab with a local app proxy:

<img width="1280" alt="local-app-proxy" src="https://github.com/user-attachments/assets/21dee73d-b7e5-4f82-8cd3-2eb4573de089">

v14 doesn't support app access, both v15 and v16 have that section in their docs:

* https://goteleport.com/docs/ver/15.x/connect-your-client/teleport-connect/#creating-an-authenticated-tunnel
* https://goteleport.com/docs/ver/16.x/connect-your-client/teleport-connect/#creating-an-authenticated-tunnel 