### PR TITLE
fix incorrect usage of `time.Timer`

### DIFF
--- a/lib/secretsscanner/authorizedkeys/authorized_keys.go
+++ b/lib/secretsscanner/authorizedkeys/authorized_keys.go
@@ -210,7 +210,10 @@ func (w *Watcher) start(ctx context.Context) error {
 		}
 
 		if !timer.Stop() {
-			<-timer.Chan()
+			select {
+			case <-timer.Chan():
+			default:
+			}
 		}
 		timer.Reset(jitterFunc(maxReSendInterval))
 


### PR DESCRIPTION
Invoking `timer.Stop` on a timer that has already fired causes `Stop` to return false, and any subsequent drain operation will block because the channel remains open.

This PR addresses the blocking issue by wrapping the drain operation in a non-blocking select.