### PR TITLE
[v16] fix incorrect usage of `time.Timer`

### DIFF
--- a/lib/secretsscanner/authorizedkeys/authorized_keys.go
+++ b/lib/secretsscanner/authorizedkeys/authorized_keys.go
@@ -210,7 +210,10 @@ func (w *Watcher) start(ctx context.Context) error {
 		}
 
 		if !timer.Stop() {
-			<-timer.Chan()
+			select {
+			case <-timer.Chan():
+			default:
+			}
 		}
 		timer.Reset(jitterFunc(maxReSendInterval))
 


### PR DESCRIPTION
Backport #45839 to branch/v16