### PR TITLE
[web] Clear all roles/reviewers in new Access Request

### DIFF
--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -21,6 +21,7 @@ import styled from 'styled-components';
 import {
   Alert,
   Box,
+  ButtonBorder,
   ButtonIcon,
   ButtonPrimary,
   ButtonSecondary,
@@ -487,14 +488,25 @@ function ResourceRequestRoles({
             border-color: ${props => props.theme.colors.spotBackground[1]};
           `}
         >
-          <Flex flexDirection="column" width="100%">
-            <LabelInput mb={0} style={{ cursor: 'pointer' }}>
-              Roles
-            </LabelInput>
-            <Text typography="body4" mb={2}>
-              {selectedRoles.length} role{selectedRoles.length !== 1 ? 's' : ''}{' '}
-              selected
-            </Text>
+          <Flex alignItems="center" gap={2}>
+            <Flex flexDirection="column" width="100%">
+              <LabelInput mb={0} style={{ cursor: 'pointer' }}>
+                Roles
+              </LabelInput>
+              <Text typography="body4" mb={2}>
+                {selectedRoles.length} role
+                {selectedRoles.length !== 1 ? 's' : ''} selected
+              </Text>
+            </Flex>
+            {selectedRoles.length ? (
+              <ButtonBorder
+                onClick={() => setSelectedRoles([])}
+                size="small"
+                width="50px"
+              >
+                Clear
+              </ButtonBorder>
+            ) : null}
           </Flex>
           {fetchAttempt.status === 'processing' ? (
             <Flex

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/SelectReviewers.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/SelectReviewers.tsx
@@ -242,10 +242,8 @@ function Reviewers({
           border-color: ${props => props.theme.colors.spotBackground[1]};
         `}
       >
-        <Flex alignItems="baseline">
-          <Text mr={2} typography="body3">
-            Reviewers (optional)
-          </Text>
+        <Flex alignItems="baseline" gap={2}>
+          <Text typography="body3">Reviewers (optional)</Text>
           <ButtonBorder
             onClick={e => {
               // By stopping propagation,
@@ -258,6 +256,15 @@ function Reviewers({
           >
             {btnTxt}
           </ButtonBorder>
+          {reviewers.length > 0 ? (
+            <ButtonBorder
+              onClick={() => updateReviewers([])}
+              size="small"
+              width="50px"
+            >
+              Clear
+            </ButtonBorder>
+          ) : null}
         </Flex>
         {reviewers.length > 0 && (
           <ButtonIcon onClick={() => setExpanded(e => !e)}>


### PR DESCRIPTION
Resolves #39390 

Allow clearing all selected roles/reviewers at once while creating new Access Request. Useful for when there are many pre-selected.

<img width="459" alt="Screenshot 2024-08-26 at 2 23 51 PM" src="https://github.com/user-attachments/assets/9bff5a7a-da9f-4850-a6e7-35f818dfd648">

changelog: Add buttons to clear all selected Roles/Reviewers in new Access Requests
