### PR TITLE
get admin from labels for non-cloud databases

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -295,15 +295,13 @@ func (d *DatabaseV3) GetAdminUser() (ret DatabaseAdminUser) {
 		ret = *d.Spec.AdminUser
 	}
 
-	// If it's not in the spec, check labels (for auto-discovered databases).
+	// If it's not in the spec, check labels.
 	// TODO Azure will require different labels.
-	if d.Origin() == OriginCloud {
-		if ret.Name == "" {
-			ret.Name = d.Metadata.Labels[DatabaseAdminLabel]
-		}
-		if ret.DefaultDatabase == "" {
-			ret.DefaultDatabase = d.Metadata.Labels[DatabaseAdminDefaultDatabaseLabel]
-		}
+	if ret.Name == "" {
+		ret.Name = d.Metadata.Labels[DatabaseAdminLabel]
+	}
+	if ret.DefaultDatabase == "" {
+		ret.DefaultDatabase = d.Metadata.Labels[DatabaseAdminDefaultDatabaseLabel]
 	}
 	return
 }

--- a/api/types/database_test.go
+++ b/api/types/database_test.go
@@ -1120,3 +1120,57 @@ func TestDatabaseGCPCloudSQL(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAdminUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc      string
+		specAdmin *DatabaseAdminUser
+		labels    map[string]string
+		want      DatabaseAdminUser
+	}{
+		{
+			desc: "no admin",
+			want: DatabaseAdminUser{},
+		},
+		{
+			desc:      "gets admin from spec",
+			specAdmin: &DatabaseAdminUser{Name: "llama", DefaultDatabase: "hill"},
+			want:      DatabaseAdminUser{Name: "llama", DefaultDatabase: "hill"},
+		},
+		{
+			desc: "gets admin from labels",
+			labels: map[string]string{
+				DatabaseAdminLabel:                "llama",
+				DatabaseAdminDefaultDatabaseLabel: "hill",
+			},
+			want: DatabaseAdminUser{Name: "llama", DefaultDatabase: "hill"},
+		},
+		{
+			desc:      "gets admin from spec ignoring labels",
+			specAdmin: &DatabaseAdminUser{Name: "llama", DefaultDatabase: "hill"},
+			labels: map[string]string{
+				DatabaseAdminLabel:                "horse",
+				DatabaseAdminDefaultDatabaseLabel: "pasture",
+			},
+			want: DatabaseAdminUser{Name: "llama", DefaultDatabase: "hill"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			meta := Metadata{
+				Name:   "example",
+				Labels: test.labels,
+			}
+			spec := DatabaseSpecV3{
+				Protocol:  "postgres",
+				URI:       "aurora-instance-1.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432",
+				AdminUser: test.specAdmin,
+			}
+			d, err := NewDatabaseV3(meta, spec)
+			require.NoError(t, err)
+			require.Equal(t, test.want, d.GetAdminUser())
+		})
+	}
+}


### PR DESCRIPTION
Changelog: When a database is created manually (without auto-discovery) the teleport.dev/db-admin and teleport.dev/db-admin-default-database labels are no longer ignored and can be used to configure database auto-user provisioning.

Closes https://github.com/gravitational/teleport/issues/41256

- https://github.com/gravitational/teleport/issues/41256