### PR TITLE
fix duplicate session recording creation

### DIFF
--- a/lib/events/s3sessions/s3handler_thirdparty_test.go
+++ b/lib/events/s3sessions/s3handler_thirdparty_test.go
@@ -89,6 +89,9 @@ func TestThirdpartyStreams(t *testing.T) {
 	t.Run("UploadDownload", func(t *testing.T) {
 		test.UploadDownload(t, handler)
 	})
+	t.Run("StreamEmpty", func(t *testing.T) {
+		test.StreamEmpty(t, handler)
+	})
 	t.Run("DownloadNotFound", func(t *testing.T) {
 		test.DownloadNotFound(t, handler)
 	})

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -535,7 +535,7 @@ func (w *sliceWriter) receiveAndUpload() error {
 			return nil
 		case <-w.proto.completeCtx.Done():
 			// if present, send remaining data for upload
-			if w.current != nil {
+			if w.current != nil && !w.current.isEmpty() {
 				// mark that the current part is last (last parts are allowed to be
 				// smaller than the certain size, otherwise the padding
 				// have to be added (this is due to S3 API limits)
@@ -574,7 +574,7 @@ func (w *sliceWriter) receiveAndUpload() error {
 				// there is no need to schedule a timer until the next
 				// event occurs, set the timer channel to nil
 				flushCh = nil
-				if w.current != nil {
+				if w.current != nil && !w.current.isEmpty() {
 					log.Debugf("Inactivity timer ticked at %v, inactivity period: %v exceeded threshold and have data. Flushing.", now, inactivityPeriod)
 					if err := w.startUploadCurrentSlice(); err != nil {
 						return trace.Wrap(err)
@@ -855,6 +855,7 @@ type slice struct {
 	buffer         *bytes.Buffer
 	isLast         bool
 	lastEventIndex int64
+	eventCount     uint64
 }
 
 // reader returns a reader for the bytes written, no writes should be done after this
@@ -897,10 +898,18 @@ func (s *slice) shouldUpload() bool {
 	return int64(s.buffer.Len()) >= s.proto.cfg.MinUploadBytes
 }
 
+// isEmpty returns true if the slice hasn't had any events written to
+// it yet.
+func (s *slice) isEmpty() bool {
+	return s.eventCount == 0
+}
+
 // recordEvent emits a single session event to the stream
 func (s *slice) recordEvent(event protoEvent) error {
 	bytes := s.proto.cfg.SlicePool.Get()
 	defer s.proto.cfg.SlicePool.Put(bytes)
+
+	s.eventCount++
 
 	messageSize := event.oneof.Size()
 	recordSize := ProtoStreamV1RecordHeaderSize + messageSize
@@ -909,6 +918,7 @@ func (s *slice) recordEvent(event protoEvent) error {
 		return trace.BadParameter(
 			"error in buffer allocation, expected size to be >= %v, got %v", recordSize, len(bytes))
 	}
+
 	binary.BigEndian.PutUint32(bytes, uint32(messageSize))
 	_, err := event.oneof.MarshalTo(bytes[Int32Size:])
 	if err != nil {


### PR DESCRIPTION
Fixes an issue where duplicate session recordings could end up being created in teleport clusters experiencing interruptions during session recording upload from agent to auth.  In all observed cases of this bug, it seems to have been produced by a combination of two factors:

- Agents weren't syncing their upload status to disk until after the first successful event submission, increasing the likelihood that agents would create orphaned uploads.
- Auth servers were uploading slices even when empty, increasing the likelihood of orphaned upload attempts resulting in session recordings being created.

Both of the above cases are addressed in this PR.  Note, however, that this PR does not address correctly selecting the non-empty upload for existing recordings affected by this issue.  That will have to be the subject of future work (see https://github.com/gravitational/teleport/issues/45917).  It also doesn't prevent duplicates due to loss of agent-side cursor state or timeout of a partially completed upload attempt (e.g. due to an agent being offline for a prolonged period of tim), both of which were previously known "expected"  cases in which duplicate recordings could be produced.

This issue is loosely related to https://github.com/gravitational/teleport/pull/45786 as the two issues tend to happen together since they are both triggered when the session recording system is under extremely high load.

changelog: fixed an issue that could result in duplicate session recordings being created