### PR TITLE
Prevent interactive sessions from hanging on exit

### DIFF
--- a/15.4.16.txt
+++ b/15.4.16.txt
@@ -1,0 +1,25 @@
+goos: linux
+goarch: arm64
+pkg: github.com/gravitational/teleport/lib/srv/regular
+BenchmarkRootExecCommand/no_user_creation-8         	      13	 134262518 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       6	 217362772 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       7	 153602860 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       8	 185105462 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       7	 144329214 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       9	 155066377 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       8	 199718599 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       8	 160881101 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       7	 143515344 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       8	 143615740 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       7	 202673489 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	      14	 144461032 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       7	 146921593 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       7	 152671911 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       9	 142310995 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       7	 151259212 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	      15	 179676980 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       7	 153557055 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       7	 154048472 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       8	 190006718 ns/op
+PASS
+ok  	github.com/gravitational/teleport/lib/srv/regular	56.035s

--- a/15.4.4.txt
+++ b/15.4.4.txt
@@ -1,0 +1,25 @@
+goos: linux
+goarch: arm64
+pkg: github.com/gravitational/teleport/lib/srv/regular
+BenchmarkRootExecCommand/no_user_creation-8         	      13	 163282343 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       8	 141444738 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       8	 160784186 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       6	 178221694 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       8	 173295081 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       8	 155775851 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       8	 135069175 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       6	 174801818 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       7	 164910029 ns/op
+BenchmarkRootExecCommand/no_user_creation-8         	       7	 155281726 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       1	5467460653 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       1	15321284630 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       1	30298102742 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       1	30271422282 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       1	50090893112 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       1	30081195130 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       1	30083961796 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       1	30082514412 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       1	15307496068 ns/op
+BenchmarkRootExecCommand/with_user_creation-8       	       1	50108341460 ns/op
+PASS
+ok  	github.com/gravitational/teleport/lib/srv/regular	314.586s

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -1118,7 +1118,7 @@ func buildEnvironment(ctx *ServerContext) []string {
 	if session != nil {
 		if session.term != nil {
 			env.AddTrusted("TERM", session.term.GetTermType())
-			env.AddTrusted("SSH_TTY", session.term.TTY().Name())
+			env.AddTrusted("SSH_TTY", session.term.TTYName())
 		}
 		if session.id != "" {
 			env.AddTrusted(teleport.SSHSessionID, string(session.id))

--- a/lib/srv/exec_linux_test.go
+++ b/lib/srv/exec_linux_test.go
@@ -51,7 +51,7 @@ func TestOSCommandPrep(t *testing.T) {
 		"SSH_CLIENT=10.0.0.5 4817 3022",
 		"SSH_CONNECTION=10.0.0.5 4817 127.0.0.1 3022",
 		"TERM=xterm",
-		fmt.Sprintf("SSH_TTY=%v", scx.session.term.TTY().Name()),
+		fmt.Sprintf("SSH_TTY=%v", scx.session.term.TTYName()),
 		"SSH_SESSION_ID=xxx",
 		"SSH_TELEPORT_HOST_UUID=testID",
 		"SSH_TELEPORT_CLUSTER_NAME=localhost",
@@ -62,7 +62,7 @@ func TestOSCommandPrep(t *testing.T) {
 	execCmd, err := scx.ExecCommand()
 	require.NoError(t, err)
 
-	cmd, err := buildCommand(execCmd, usr, nil, nil, nil)
+	cmd, err := buildCommand(execCmd, usr, nil, nil)
 	require.NoError(t, err)
 
 	require.NotNil(t, cmd)
@@ -77,7 +77,7 @@ func TestOSCommandPrep(t *testing.T) {
 	execCmd, err = scx.ExecCommand()
 	require.NoError(t, err)
 
-	cmd, err = buildCommand(execCmd, usr, nil, nil, nil)
+	cmd, err = buildCommand(execCmd, usr, nil, nil)
 	require.NoError(t, err)
 
 	require.NotNil(t, cmd)
@@ -92,7 +92,7 @@ func TestOSCommandPrep(t *testing.T) {
 	execCmd, err = scx.ExecCommand()
 	require.NoError(t, err)
 
-	cmd, err = buildCommand(execCmd, usr, nil, nil, nil)
+	cmd, err = buildCommand(execCmd, usr, nil, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, "/bin/sh", cmd.Path)
@@ -108,7 +108,7 @@ func TestOSCommandPrep(t *testing.T) {
 	usr.HomeDir = "/wrong/place"
 	root := string(os.PathSeparator)
 	expectedEnv[2] = "HOME=/wrong/place"
-	cmd, err = buildCommand(execCmd, usr, nil, nil, nil)
+	cmd, err = buildCommand(execCmd, usr, nil, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, root, cmd.Dir)

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -78,8 +78,10 @@ const (
 	// to pid 1 and "live forever". Killing the shell should not prevent processes
 	// preventing SIGHUP to be reassigned (ex. processes running with nohup).
 	TerminateFile
-	// PTYFile is a PTY the parent process passes to the child process.
-	PTYFile
+	// PTYFileDeprecated is a placeholder for the unused PTY file that
+	// was passed to the child process. The PTY should only be used in the
+	// the parent process but was left here for compatibility purposes.
+	PTYFileDeprecated
 	// TTYFile is a TTY the parent process passes to the child process.
 	TTYFile
 
@@ -266,17 +268,15 @@ func RunCommand() (errw io.Writer, code int, err error) {
 	}()
 
 	var tty *os.File
-	var pty *os.File
 	uaccEnabled := false
 
-	// If a terminal was requested, file descriptors 6 and 7 always point to the
-	// PTY and TTY. Extract them and set the controlling TTY. Otherwise, connect
+	// If a terminal was requested, file descriptor 7 always points to the
+	// TTY. Extract it and set the controlling TTY. Otherwise, connect
 	// std{in,out,err} directly.
 	if c.Terminal {
-		pty = os.NewFile(PTYFile, fdName(PTYFile))
 		tty = os.NewFile(TTYFile, fdName(TTYFile))
-		if pty == nil || tty == nil {
-			return errorWriter, teleport.RemoteCommandFailure, trace.BadParameter("pty and tty not found")
+		if tty == nil {
+			return errorWriter, teleport.RemoteCommandFailure, trace.BadParameter("tty not found")
 		}
 		errorWriter = tty
 	}
@@ -353,7 +353,7 @@ func RunCommand() (errw io.Writer, code int, err error) {
 	}
 
 	// Build the actual command that will launch the shell.
-	cmd, err := buildCommand(&c, localUser, tty, pty, pamEnvironment)
+	cmd, err := buildCommand(&c, localUser, tty, pamEnvironment)
 	if err != nil {
 		return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
 	}
@@ -930,7 +930,7 @@ func IsReexec() bool {
 
 // buildCommand constructs a command that will execute the users shell. This
 // function is run by Teleport while it's re-executing.
-func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, _ *os.File, pamEnvironment []string) (*exec.Cmd, error) {
+func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pamEnvironment []string) (*exec.Cmd, error) {
 	var cmd exec.Cmd
 	isReexec := false
 

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -80,8 +80,8 @@ type Terminal interface {
 	// PTY returns the PTY backing the terminal.
 	PTY() io.ReadWriter
 
-	// TTY returns the TTY backing the terminal.
-	TTY() *os.File
+	// TTYName returns the name of TTY backing the terminal.
+	TTYName() string
 
 	// PID returns the PID of the Teleport process that was re-execed.
 	PID() int
@@ -136,8 +136,9 @@ type terminal struct {
 	cmd           *exec.Cmd
 	serverContext *ServerContext
 
-	pty *os.File
-	tty *os.File
+	pty     *os.File
+	tty     *os.File
+	ttyName string
 
 	// terminateFD when closed informs the terminal that
 	// the process running in the shell should be killed.
@@ -151,7 +152,13 @@ type terminal struct {
 
 // NewLocalTerminal creates and returns a local PTY.
 func newLocalTerminal(ctx *ServerContext) (*terminal, error) {
-	var err error
+
+	// Open PTY and corresponding TTY.
+	pty, tty, err := pty.Open()
+	if err != nil {
+		log.Warnf("Could not start PTY: %v", err)
+		return nil, err
+	}
 
 	t := &terminal{
 		log: log.WithFields(log.Fields{
@@ -159,13 +166,9 @@ func newLocalTerminal(ctx *ServerContext) (*terminal, error) {
 		}),
 		serverContext: ctx,
 		terminateFD:   ctx.killShellw,
-	}
-
-	// Open PTY and corresponding TTY.
-	t.pty, t.tty, err = pty.Open()
-	if err != nil {
-		log.Warnf("Could not start PTY: %v", err)
-		return nil, err
+		pty:           pty,
+		tty:           tty,
+		ttyName:       tty.Name(),
 	}
 
 	// Set the TTY owner. Failure is not fatal, for example Teleport is running
@@ -201,16 +204,23 @@ func (t *terminal) Run(ctx context.Context) error {
 
 	// we need the lock here to protect from concurrent calls to Close()
 	t.mu.Lock()
-	pty, tty := t.pty, t.tty
+	tty := t.tty
 	t.mu.Unlock()
 
-	// Pass PTY and TTY to child as well since a terminal is attached.
-	t.cmd.ExtraFiles = append(t.cmd.ExtraFiles, pty)
+	// Intentionally passing a nil value instead of the PTY. The child
+	// process does not need the PTY, but for compatibility purposes the
+	// first ExtraFiles is left for the PTY descriptor.
+	t.cmd.ExtraFiles = append(t.cmd.ExtraFiles, nil)
+	// Pass the TTY to the child since a terminal is attached.
 	t.cmd.ExtraFiles = append(t.cmd.ExtraFiles, tty)
 
+	// Close the TTY before returning to ensure that our half of the pipe is
+	// closed. This ensures that reading from the PTY will unblock when the
+	// child process exits.
+	defer t.closeTTY()
+
 	// Start the process.
-	err = t.cmd.Start()
-	if err != nil {
+	if err := t.cmd.Start(); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -317,11 +327,9 @@ func (t *terminal) PTY() io.ReadWriter {
 	return t.pty
 }
 
-// TTY returns the TTY backing the terminal.
-func (t *terminal) TTY() *os.File {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.tty
+// TTYName returns the name of the TTY backing the terminal.
+func (t *terminal) TTYName() string {
+	return t.ttyName
 }
 
 // PID returns the PID of the Teleport process that was re-execed.
@@ -339,17 +347,16 @@ func (t *terminal) Close() error {
 }
 
 func (t *terminal) closeTTY() error {
-	t.log.Debugf("Closing TTY")
-	defer t.log.Debugf("Closed TTY")
-
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	if t.tty == nil {
-		t.log.Debugf("TTY already closed")
+		t.log.Debug("TTY already closed")
 		return nil
 	}
 
+	t.log.Debug("Closing TTY")
+	defer t.log.Debug("Closed TTY")
 	err := t.tty.Close()
 	t.tty = nil
 
@@ -361,7 +368,7 @@ func (t *terminal) closeTTY() error {
 }
 
 func (t *terminal) closePTY() {
-	defer t.log.Debugf("Closed PTY")
+	defer t.log.Debug("Closed PTY")
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -640,8 +647,8 @@ func (t *remoteTerminal) PTY() io.ReadWriter {
 	return t.ptyBuffer
 }
 
-func (t *remoteTerminal) TTY() *os.File {
-	return nil
+func (t *remoteTerminal) TTYName() string {
+	return ""
 }
 
 // PID returns the PID of the Teleport process that was re-execed. Always

--- a/lib/srv/termhandlers.go
+++ b/lib/srv/termhandlers.go
@@ -89,9 +89,7 @@ func (t *TermHandlers) HandlePTYReq(ctx context.Context, ch ssh.Channel, req *ss
 		}
 		scx.SetTerm(term)
 		scx.termAllocated = true
-		if term.TTY() != nil {
-			scx.ttyName = term.TTY().Name()
-		}
+		scx.ttyName = term.TTYName()
 	}
 	if err := term.SetWinSize(ctx, *params); err != nil {
 		scx.Errorf("Failed setting window size: %v", err)


### PR DESCRIPTION
The TTY allocated for interactive sessions was not being handled properly. The parent process was never closing its half of the TTY, which prevented the PTY read from unblocking when the child process terminated. This became more noticeable after #45223 landed because interactive sessions were now properly waiting for the PTY copying to be completed before exiting.

Additionally, the PTY is no longer being provided to the child reexec process since it should be only be used by the parent process.

Closes #45878.


Changelog: Prevent interactive sessions from hanging on exit