### PR TITLE
update AWS OIDC ECS task role permissions

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -118,6 +118,20 @@ func StatementForRDSDBConnect() *Statement {
 	}
 }
 
+// StatementForRDSMetadata returns a statement that allows describing RDS
+// instances and clusters for metadata import, as in monitoring AWS tags and
+// whether IAM auth is enabled.
+func StatementForRDSMetadata() *Statement {
+	return &Statement{
+		Effect: EffectAllow,
+		Actions: SliceOrString{
+			"rds:DescribeDBInstances",
+			"rds:DescribeDBClusters",
+		},
+		Resources: allResources,
+	}
+}
+
 // StatementForEC2InstanceConnectEndpoint returns the statement that allows the flow for accessing
 // an EC2 instance using its private IP, using EC2 Instance Connect Endpoint.
 func StatementForEC2InstanceConnectEndpoint() *Statement {

--- a/lib/integrations/awsoidc/deployservice_iam_config.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config.go
@@ -228,6 +228,7 @@ func createTaskRole(ctx context.Context, clt DeployServiceIAMConfigureClient, re
 func addPolicyToTaskRole(ctx context.Context, clt DeployServiceIAMConfigureClient, req DeployServiceIAMConfigureRequest) error {
 	taskRolePolicyDocument, err := awslib.NewPolicyDocument(
 		awslib.StatementForRDSDBConnect(),
+		awslib.StatementForRDSMetadata(),
 		awslib.StatementForWritingLogs(),
 	).Marshal()
 	if err != nil {


### PR DESCRIPTION
Add permissions to describe RDS instances and clusters so that the db service can fetch metadata updates and check the IAM auth status of the database