### PR TITLE
[v16] support non-RSA SSH signatures

### DIFF
--- a/lib/auth/keystore/manager.go
+++ b/lib/auth/keystore/manager.go
@@ -305,6 +305,9 @@ func publicKeyFromSSHAuthorizedKey(sshAuthorizedKey []byte) (crypto.PublicKey, e
 // toRSASHA512Signer forces an ssh.MultiAlgorithmSigner into using
 // "rsa-sha2-sha512" (instead of its SHA256 default).
 func toRSASHA512Signer(signer ssh.Signer) ssh.Signer {
+	if signer.PublicKey().Type() != ssh.KeyAlgoRSA {
+		return signer
+	}
 	ss, ok := signer.(ssh.MultiAlgorithmSigner)
 	if !ok {
 		return signer


### PR DESCRIPTION
This PR adds support for signing SSH certs with non-RSA keys. We don't generate any non-RSA keys in v16, but it's possible for a user to import them into a CA manually.

changelog: add support for non-RSA SSH signatures with imported CA keys