### PR TITLE
[v14] get admin from labels for non-cloud databases

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -300,15 +300,13 @@ func (d *DatabaseV3) GetAdminUser() (ret DatabaseAdminUser) {
 		ret = *d.Spec.AdminUser
 	}
 
-	// If it's not in the spec, check labels (for auto-discovered databases).
+	// If it's not in the spec, check labels.
 	// TODO Azure will require different labels.
-	if d.Origin() == OriginCloud {
-		if ret.Name == "" {
-			ret.Name = d.Metadata.Labels[DatabaseAdminLabel]
-		}
-		if ret.DefaultDatabase == "" {
-			ret.DefaultDatabase = d.Metadata.Labels[DatabaseAdminDefaultDatabaseLabel]
-		}
+	if ret.Name == "" {
+		ret.Name = d.Metadata.Labels[DatabaseAdminLabel]
+	}
+	if ret.DefaultDatabase == "" {
+		ret.DefaultDatabase = d.Metadata.Labels[DatabaseAdminDefaultDatabaseLabel]
 	}
 	return
 }


### PR DESCRIPTION
Backport #45863 to branch/v14

changelog: When a database is created manually (without auto-discovery) the teleport.dev/db-admin and teleport.dev/db-admin-default-database labels are no longer ignored and can be used to configure database auto-user provisioning.