### PR TITLE
[v16] Fixed an issue WebSocket upgrade fails with MiTM proxies that can remask payloads

### DIFF
--- a/api/client/alpn_websocket.go
+++ b/api/client/alpn_websocket.go
@@ -117,6 +117,7 @@ func (c *websocketALPNClientConn) readLocked(b []byte) (int, error) {
 
 		switch frame.Header.OpCode {
 		case ws.OpClose:
+			// TODO(greedy52) properly exchange close message.
 			return 0, io.EOF
 		case ws.OpPing:
 			pong := ws.NewPongFrame(frame.Payload)
@@ -140,6 +141,9 @@ func (c *websocketALPNClientConn) writeFrame(frame ws.Frame) error {
 	defer c.writeMutex.Unlock()
 	// By RFC standard, all client frames must be masked:
 	// https://datatracker.ietf.org/doc/html/rfc6455#section-5.1
+	// TODO(greedy52) properly mask the frame with ws.MaskFrame once server
+	// side is updated to properly unmask the frame. Currently a zero-mask is
+	// used and the XOR operation does not alter the payload at all.
 	frame.Header.Masked = true
 	return trace.Wrap(ws.WriteFrame(c.Conn, frame))
 }

--- a/lib/web/conn_upgrade.go
+++ b/lib/web/conn_upgrade.go
@@ -305,6 +305,11 @@ func (c *websocketALPNServerConn) readLocked(b []byte) (int, error) {
 			return 0, trace.Wrap(err)
 		}
 
+		// All client frames should be masked.
+		if frame.Header.Masked {
+			frame = ws.UnmaskFrame(frame)
+		}
+
 		c.logger.Log(c.logContext, logutils.TraceLevel, "Read websocket frame.", "op", frame.Header.OpCode, "payload_len", len(frame.Payload))
 
 		switch frame.Header.OpCode {
@@ -325,7 +330,7 @@ func (c *websocketALPNServerConn) writeFrame(frame ws.Frame) error {
 	c.writeMutex.Lock()
 	defer c.writeMutex.Unlock()
 
-	frame.Header.Masked = true
+	// There is no need to mask from server to client.
 	return trace.Wrap(ws.WriteFrame(c.Conn, frame))
 }
 

--- a/lib/web/conn_upgrade_test.go
+++ b/lib/web/conn_upgrade_test.go
@@ -270,8 +270,8 @@ func (c *websocketALPNClientConn) Read(b []byte) (int, error) {
 }
 
 func (c *websocketALPNClientConn) Write(b []byte) (int, error) {
-	frame := ws.NewFrame(ws.OpBinary, true, b)
-	frame.Header.Masked = true
+	// Remember to use a proper mask on client side.
+	frame := ws.MaskFrame(ws.NewFrame(ws.OpBinary, true, b))
 	if err := ws.WriteFrame(c.Conn, frame); err != nil {
 		return 0, trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport #45858 to branch/v16

changelog: Fixed an issue WebSocket upgrade fails with MiTM proxies that can remask payloads
