### PR TITLE
Add `tctl` support for static host users

### DIFF
--- a/api/types/userprovisioning/convert/v1/statichostuser.go
+++ b/api/types/userprovisioning/convert/v1/statichostuser.go
@@ -1,12 +1,28 @@
+// Copyright 2024 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package v1
 
 import (
+	"github.com/gravitational/trace"
+
 	userprovisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/userprovisioning"
-	"github.com/gravitational/trace"
 )
 
+// FromProto converts a v1 static host user into an internal static host user.
 func FromProto(msg *userprovisioningv1.StaticHostUser) (*userprovisioning.StaticHostUser, error) {
 	if msg == nil {
 		return nil, trace.BadParameter("static host user message is missing")
@@ -37,6 +53,7 @@ func FromProto(msg *userprovisioningv1.StaticHostUser) (*userprovisioning.Static
 	return u, nil
 }
 
+// ToProto converts an internal static host user into a v1 static host user.
 func ToProto(hostUser *userprovisioning.StaticHostUser) *userprovisioningv1.StaticHostUser {
 	u := &userprovisioningv1.StaticHostUser{
 		Kind:     hostUser.GetKind(),

--- a/api/types/userprovisioning/convert/v1/statichostuser.go
+++ b/api/types/userprovisioning/convert/v1/statichostuser.go
@@ -3,7 +3,6 @@ package v1
 import (
 	userprovisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
 	"github.com/gravitational/teleport/api/types"
-	headerv1 "github.com/gravitational/teleport/api/types/header/convert/v1"
 	"github.com/gravitational/teleport/api/types/userprovisioning"
 	"github.com/gravitational/trace"
 )
@@ -26,7 +25,7 @@ func FromProto(msg *userprovisioningv1.StaticHostUser) (*userprovisioning.Static
 		}
 	}
 
-	return userprovisioning.NewStaticHostUser(headerv1.FromMetadataProto(msg.GetMetadata()), userprovisioning.Spec{
+	u := userprovisioning.NewStaticHostUser(msg.GetMetadata(), userprovisioning.Spec{
 		Login:                msg.Spec.Login,
 		Groups:               msg.Spec.Groups,
 		Sudoers:              msg.Spec.Sudoers,
@@ -34,15 +33,16 @@ func FromProto(msg *userprovisioningv1.StaticHostUser) (*userprovisioning.Static
 		Gid:                  msg.Spec.Gid,
 		NodeLabels:           labels,
 		NodeLabelsExpression: msg.Spec.NodeLabelsExpression,
-	}), nil
+	})
+	return u, nil
 }
 
 func ToProto(hostUser *userprovisioning.StaticHostUser) *userprovisioningv1.StaticHostUser {
-	return &userprovisioningv1.StaticHostUser{
+	u := &userprovisioningv1.StaticHostUser{
 		Kind:     hostUser.GetKind(),
 		SubKind:  hostUser.GetSubKind(),
 		Version:  hostUser.GetVersion(),
-		Metadata: headerv1.ToMetadataProto(hostUser.Metadata),
+		Metadata: hostUser.GetMetadata(),
 		Spec: &userprovisioningv1.StaticHostUserSpec{
 			Login:                hostUser.Spec.Login,
 			Groups:               hostUser.Spec.Groups,
@@ -53,4 +53,5 @@ func ToProto(hostUser *userprovisioning.StaticHostUser) *userprovisioningv1.Stat
 			NodeLabelsExpression: hostUser.Spec.NodeLabelsExpression,
 		},
 	}
+	return u
 }

--- a/api/types/userprovisioning/convert/v1/statichostuser.go
+++ b/api/types/userprovisioning/convert/v1/statichostuser.go
@@ -1,0 +1,56 @@
+package v1
+
+import (
+	userprovisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
+	"github.com/gravitational/teleport/api/types"
+	headerv1 "github.com/gravitational/teleport/api/types/header/convert/v1"
+	"github.com/gravitational/teleport/api/types/userprovisioning"
+	"github.com/gravitational/trace"
+)
+
+func FromProto(msg *userprovisioningv1.StaticHostUser) (*userprovisioning.StaticHostUser, error) {
+	if msg == nil {
+		return nil, trace.BadParameter("static host user message is missing")
+	}
+	if msg.Spec == nil {
+		return nil, trace.BadParameter("spec is missing")
+	}
+	if msg.Spec.Login == "" {
+		return nil, trace.BadParameter("login is missing")
+	}
+
+	labels := make(types.Labels)
+	if msgLabels := msg.Spec.NodeLabels; msgLabels != nil {
+		for k, v := range msgLabels.Values {
+			labels[k] = v.Values
+		}
+	}
+
+	return userprovisioning.NewStaticHostUser(headerv1.FromMetadataProto(msg.GetMetadata()), userprovisioning.Spec{
+		Login:                msg.Spec.Login,
+		Groups:               msg.Spec.Groups,
+		Sudoers:              msg.Spec.Sudoers,
+		Uid:                  msg.Spec.Uid,
+		Gid:                  msg.Spec.Gid,
+		NodeLabels:           labels,
+		NodeLabelsExpression: msg.Spec.NodeLabelsExpression,
+	}), nil
+}
+
+func ToProto(hostUser *userprovisioning.StaticHostUser) *userprovisioningv1.StaticHostUser {
+	return &userprovisioningv1.StaticHostUser{
+		Kind:     hostUser.GetKind(),
+		SubKind:  hostUser.GetSubKind(),
+		Version:  hostUser.GetVersion(),
+		Metadata: headerv1.ToMetadataProto(hostUser.Metadata),
+		Spec: &userprovisioningv1.StaticHostUserSpec{
+			Login:                hostUser.Spec.Login,
+			Groups:               hostUser.Spec.Groups,
+			Sudoers:              hostUser.Spec.Sudoers,
+			Uid:                  hostUser.Spec.Uid,
+			Gid:                  hostUser.Spec.Gid,
+			NodeLabels:           hostUser.Spec.NodeLabels.ToProto(),
+			NodeLabelsExpression: hostUser.Spec.NodeLabelsExpression,
+		},
+	}
+}

--- a/api/types/userprovisioning/convert/v1/statichostuser_test.go
+++ b/api/types/userprovisioning/convert/v1/statichostuser_test.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/userprovisioning"
+)
+
+func TestRoundtrip(t *testing.T) {
+	t.Parallel()
+	hostUser := newStaticHostUser()
+	converted, err := FromProto(ToProto(hostUser))
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(hostUser, converted,
+		cmpopts.IgnoreUnexported(headerv1.ResourceHeader{}, headerv1.Metadata{})))
+}
+
+func TestNoPanicOnNilSpec(t *testing.T) {
+	hostUser := ToProto(newStaticHostUser())
+	hostUser.Spec = nil
+	_, err := FromProto(hostUser)
+	require.Error(t, err)
+}
+
+func newStaticHostUser() *userprovisioning.StaticHostUser {
+	return userprovisioning.NewStaticHostUser(&headerv1.Metadata{
+		Name: "test-user",
+	}, userprovisioning.Spec{
+		Login:   "alice",
+		Groups:  []string{"foo", "bar"},
+		Sudoers: []string{"abcd1234"},
+		Uid:     "1234",
+		Gid:     "5678",
+		NodeLabels: types.Labels{
+			"foo": {"bar"},
+		},
+		NodeLabelsExpression: "labels['foo'] == labels['bar']",
+	})
+}

--- a/api/types/userprovisioning/statichostuser.go
+++ b/api/types/userprovisioning/statichostuser.go
@@ -21,12 +21,10 @@ package userprovisioning
 import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/header"
-	convertv1 "github.com/gravitational/teleport/api/types/header/convert/v1"
 )
 
 type StaticHostUser struct {
-	header.ResourceHeader
+	headerv1.ResourceHeader
 
 	Spec Spec
 }
@@ -42,19 +40,13 @@ type Spec struct {
 }
 
 // NewStaticHostUser creates a new host user to be applied to matching SSH nodes.
-func NewStaticHostUser(metadata header.Metadata, spec Spec) *StaticHostUser {
+func NewStaticHostUser(metadata *headerv1.Metadata, spec Spec) *StaticHostUser {
 	return &StaticHostUser{
-		ResourceHeader: header.ResourceHeader{
+		ResourceHeader: headerv1.ResourceHeader{
 			Kind:     types.KindStaticHostUser,
 			Version:  types.V1,
 			Metadata: metadata,
 		},
 		Spec: spec,
 	}
-}
-
-// GetMetadata returns metadata. This is specifically for conforming to the
-// ResourceMetadata interface.
-func (u *StaticHostUser) GetMetadata() *headerv1.Metadata {
-	return convertv1.ToMetadataProto(u.Metadata)
 }

--- a/api/types/userprovisioning/statichostuser.go
+++ b/api/types/userprovisioning/statichostuser.go
@@ -23,20 +23,32 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+// StaticHostUser is a resource that represents host users that should be
+// created on matching nodes.
 type StaticHostUser struct {
 	headerv1.ResourceHeader
-
+	// Spec is the static host user spec.
 	Spec Spec
 }
 
+// Spec is the static host user spec.
 type Spec struct {
-	Login                string       `json:"login"`
-	Groups               []string     `json:"groups"`
-	Sudoers              []string     `json:"sudoers"`
-	Uid                  string       `json:"uid"`
-	Gid                  string       `json:"gid"`
-	NodeLabels           types.Labels `json:"node_labels"`
-	NodeLabelsExpression string       `json:"node_labels_expression"`
+	// Login is the login to create on the node.
+	Login string `json:"login"`
+	// Groups is a list of additional groups to add the user to.
+	Groups []string `json:"groups"`
+	// Sudoers is a list of sudoer entries to add.
+	Sudoers []string `json:"sudoers"`
+	// Uid is the new user's uid.
+	Uid string `json:"uid"`
+	// Gid is the new user's gid.
+	Gid string `json:"gid"`
+	// NodeLabels is a map of node labels that will create a user from this
+	// resource.
+	NodeLabels types.Labels `json:"node_labels"`
+	// NodeLabelsExpression is a predicate expression to create a user from
+	// this resource.
+	NodeLabelsExpression string `json:"node_labels_expression"`
 }
 
 // NewStaticHostUser creates a new host user to be applied to matching SSH nodes.

--- a/api/types/userprovisioning/statichostuser.go
+++ b/api/types/userprovisioning/statichostuser.go
@@ -20,18 +20,41 @@ package userprovisioning
 
 import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
-	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/header"
+	convertv1 "github.com/gravitational/teleport/api/types/header/convert/v1"
 )
 
+type StaticHostUser struct {
+	header.ResourceHeader
+
+	Spec Spec
+}
+
+type Spec struct {
+	Login                string       `json:"login"`
+	Groups               []string     `json:"groups"`
+	Sudoers              []string     `json:"sudoers"`
+	Uid                  string       `json:"uid"`
+	Gid                  string       `json:"gid"`
+	NodeLabels           types.Labels `json:"node_labels"`
+	NodeLabelsExpression string       `json:"node_labels_expression"`
+}
+
 // NewStaticHostUser creates a new host user to be applied to matching SSH nodes.
-func NewStaticHostUser(name string, spec *userprovisioningpb.StaticHostUserSpec) *userprovisioningpb.StaticHostUser {
-	return &userprovisioningpb.StaticHostUser{
-		Kind:    types.KindStaticHostUser,
-		Version: types.V1,
-		Metadata: &headerv1.Metadata{
-			Name: name,
+func NewStaticHostUser(metadata header.Metadata, spec Spec) *StaticHostUser {
+	return &StaticHostUser{
+		ResourceHeader: header.ResourceHeader{
+			Kind:     types.KindStaticHostUser,
+			Version:  types.V1,
+			Metadata: metadata,
 		},
 		Spec: spec,
 	}
+}
+
+// GetMetadata returns metadata. This is specifically for conforming to the
+// ResourceMetadata interface.
+func (u *StaticHostUser) GetMetadata() *headerv1.Metadata {
+	return convertv1.ToMetadataProto(u.Metadata)
 }

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -33,11 +33,11 @@ import (
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
-	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	"github.com/gravitational/teleport/api/types/userprovisioning"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -1186,9 +1186,9 @@ type Cache interface {
 	ListSPIFFEFederations(ctx context.Context, pageSize int, lastToken string) ([]*machineidv1.SPIFFEFederation, string, error)
 
 	// ListStaticHostUsers lists static host users.
-	ListStaticHostUsers(ctx context.Context, pageSize int, startKey string) ([]*userprovisioningpb.StaticHostUser, string, error)
+	ListStaticHostUsers(ctx context.Context, pageSize int, startKey string) ([]*userprovisioning.StaticHostUser, string, error)
 	// GetStaticHostUser returns a static host user by name.
-	GetStaticHostUser(ctx context.Context, name string) (*userprovisioningpb.StaticHostUser, error)
+	GetStaticHostUser(ctx context.Context, name string) (*userprovisioning.StaticHostUser, error)
 }
 
 type NodeWrapper struct {

--- a/lib/auth/statichostuser/service_test.go
+++ b/lib/auth/statichostuser/service_test.go
@@ -25,9 +25,9 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/userprovisioning"
 	convertv1 "github.com/gravitational/teleport/api/types/userprovisioning/convert/v1"
 	"github.com/gravitational/teleport/lib/authz"
@@ -44,7 +44,7 @@ func staticHostUserName(i int) string {
 
 func makeStaticHostUser(i int) *userprovisioningpb.StaticHostUser {
 	name := staticHostUserName(i)
-	return convertv1.ToProto(userprovisioning.NewStaticHostUser(header.Metadata{
+	return convertv1.ToProto(userprovisioning.NewStaticHostUser(&headerv1.Metadata{
 		Name: name,
 	}, userprovisioning.Spec{
 		Login:  name,

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -43,7 +43,6 @@ import (
 	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
-	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"
@@ -52,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/secreports"
 	"github.com/gravitational/teleport/api/types/userloginstate"
+	"github.com/gravitational/teleport/api/types/userprovisioning"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -2310,7 +2310,7 @@ func (c *Cache) GetKubernetesWaitingContainer(ctx context.Context, req *kubewait
 }
 
 // ListStaticHostUsers lists static host users.
-func (c *Cache) ListStaticHostUsers(ctx context.Context, pageSize int, pageToken string) ([]*userprovisioningpb.StaticHostUser, string, error) {
+func (c *Cache) ListStaticHostUsers(ctx context.Context, pageSize int, pageToken string) ([]*userprovisioning.StaticHostUser, string, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/ListStaticHostUsers")
 	defer span.End()
 
@@ -2323,7 +2323,7 @@ func (c *Cache) ListStaticHostUsers(ctx context.Context, pageSize int, pageToken
 }
 
 // GetStaticHostUser returns a static host user by name.
-func (c *Cache) GetStaticHostUser(ctx context.Context, name string) (*userprovisioningpb.StaticHostUser, error) {
+func (c *Cache) GetStaticHostUser(ctx context.Context, name string) (*userprovisioning.StaticHostUser, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetStaticHostUser")
 	defer span.End()
 

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -49,7 +49,6 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
-	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/clusterconfig"
@@ -2695,19 +2694,19 @@ func TestStaticHostUsers(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*userprovisioningpb.StaticHostUser]{
-		newResource: func(name string) (*userprovisioningpb.StaticHostUser, error) {
+	testResources153(t, p, testFuncs153[*userprovisioning.StaticHostUser]{
+		newResource: func(name string) (*userprovisioning.StaticHostUser, error) {
 			return newStaticHostUser(t, name), nil
 		},
-		create: func(ctx context.Context, item *userprovisioningpb.StaticHostUser) error {
+		create: func(ctx context.Context, item *userprovisioning.StaticHostUser) error {
 			_, err := p.staticHostUsers.CreateStaticHostUser(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: func(ctx context.Context) ([]*userprovisioningpb.StaticHostUser, error) {
+		list: func(ctx context.Context) ([]*userprovisioning.StaticHostUser, error) {
 			items, _, err := p.staticHostUsers.ListStaticHostUsers(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
-		cacheList: func(ctx context.Context) ([]*userprovisioningpb.StaticHostUser, error) {
+		cacheList: func(ctx context.Context) ([]*userprovisioning.StaticHostUser, error) {
 			items, _, err := p.cache.ListStaticHostUsers(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
@@ -3820,9 +3819,11 @@ func newAccessMonitoringRule(t *testing.T) *accessmonitoringrulesv1.AccessMonito
 	return notification
 }
 
-func newStaticHostUser(t *testing.T, name string) *userprovisioningpb.StaticHostUser {
+func newStaticHostUser(t *testing.T, name string) *userprovisioning.StaticHostUser {
 	t.Helper()
-	return userprovisioning.NewStaticHostUser(name, &userprovisioningpb.StaticHostUserSpec{
+	return userprovisioning.NewStaticHostUser(&headerv1.Metadata{
+		Name: name,
+	}, userprovisioning.Spec{
 		Login:  "foo",
 		Groups: []string{"bar", "baz"},
 	})

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -35,13 +35,13 @@ import (
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
-	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/secreports"
 	"github.com/gravitational/teleport/api/types/userloginstate"
+	"github.com/gravitational/teleport/api/types/userprovisioning"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -717,7 +717,7 @@ func setupCollections(c *Cache, watches []types.WatchKind) (*cacheCollections, e
 			if c.StaticHostUsers == nil {
 				return nil, trace.BadParameter("missing parameter StaticHostUsers")
 			}
-			collections.staticHostUsers = &genericCollection[*userprovisioningpb.StaticHostUser, staticHostUserGetter, staticHostUserExecutor]{
+			collections.staticHostUsers = &genericCollection[*userprovisioning.StaticHostUser, staticHostUserGetter, staticHostUserExecutor]{
 				cache: c,
 				watch: watch,
 			}
@@ -2338,10 +2338,10 @@ var _ executor[*kubewaitingcontainerpb.KubernetesWaitingContainer, kubernetesWai
 
 type staticHostUserExecutor struct{}
 
-func (staticHostUserExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]*userprovisioningpb.StaticHostUser, error) {
+func (staticHostUserExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]*userprovisioning.StaticHostUser, error) {
 	var (
 		startKey string
-		allUsers []*userprovisioningpb.StaticHostUser
+		allUsers []*userprovisioning.StaticHostUser
 	)
 	for {
 		users, nextKey, err := cache.StaticHostUsers.ListStaticHostUsers(ctx, 0, startKey)
@@ -2359,7 +2359,7 @@ func (staticHostUserExecutor) getAll(ctx context.Context, cache *Cache, loadSecr
 	return allUsers, nil
 }
 
-func (staticHostUserExecutor) upsert(ctx context.Context, cache *Cache, resource *userprovisioningpb.StaticHostUser) error {
+func (staticHostUserExecutor) upsert(ctx context.Context, cache *Cache, resource *userprovisioning.StaticHostUser) error {
 	_, err := cache.staticHostUsersCache.UpsertStaticHostUser(ctx, resource)
 	return trace.Wrap(err)
 }
@@ -2369,10 +2369,10 @@ func (staticHostUserExecutor) deleteAll(ctx context.Context, cache *Cache) error
 }
 
 func (staticHostUserExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
-	var hostUser *userprovisioningpb.StaticHostUser
+	var hostUser *userprovisioning.StaticHostUser
 	r, ok := resource.(types.Resource153Unwrapper)
 	if ok {
-		hostUser, ok = r.Unwrap().(*userprovisioningpb.StaticHostUser)
+		hostUser, ok = r.Unwrap().(*userprovisioning.StaticHostUser)
 		if ok {
 			err := cache.staticHostUsersCache.DeleteStaticHostUser(ctx, hostUser.Metadata.Name)
 			return trace.Wrap(err)
@@ -2391,8 +2391,8 @@ func (staticHostUserExecutor) getReader(cache *Cache, cacheOK bool) staticHostUs
 }
 
 type staticHostUserGetter interface {
-	ListStaticHostUsers(ctx context.Context, pageSize int, pageToken string) ([]*userprovisioningpb.StaticHostUser, string, error)
-	GetStaticHostUser(ctx context.Context, name string) (*userprovisioningpb.StaticHostUser, error)
+	ListStaticHostUsers(ctx context.Context, pageSize int, pageToken string) ([]*userprovisioning.StaticHostUser, string, error)
+	GetStaticHostUser(ctx context.Context, name string) (*userprovisioning.StaticHostUser, error)
 }
 
 type crownJewelsExecutor struct{}

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -35,7 +35,6 @@ import (
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
-	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/kubewaitingcontainer"
 	"github.com/gravitational/teleport/lib/backend"
@@ -2219,7 +2218,7 @@ func (p *staticHostUserParser) parse(event backend.Event) (types.Resource, error
 	case types.OpDelete:
 		return resourceHeader(event, types.KindStaticHostUser, types.V1, 0)
 	case types.OpPut:
-		resource, err := services.UnmarshalProtoResource[*userprovisioningpb.StaticHostUser](
+		resource, err := services.UnmarshalStaticHostUser(
 			event.Item.Value,
 			services.WithExpires(event.Item.Expires),
 			services.WithRevision(event.Item.Revision),

--- a/lib/services/local/statichostuser.go
+++ b/lib/services/local/statichostuser.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/gravitational/trace"
 
-	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/userprovisioning"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
@@ -36,17 +36,18 @@ const (
 
 // StaticHostUserService manages host users that should be created on SSH nodes.
 type StaticHostUserService struct {
-	svc *generic.ServiceWrapper[*userprovisioningpb.StaticHostUser]
+	svc *generic.Service[*userprovisioning.StaticHostUser]
 }
 
 // NewStaticHostUserService creates a new static host user service.
 func NewStaticHostUserService(bk backend.Backend) (*StaticHostUserService, error) {
-	svc, err := generic.NewServiceWrapper(
-		bk,
-		types.KindStaticHostUser,
-		staticHostUserPrefix,
-		services.MarshalProtoResource[*userprovisioningpb.StaticHostUser],
-		services.UnmarshalProtoResource[*userprovisioningpb.StaticHostUser],
+	svc, err := generic.NewService(&generic.ServiceConfig[*userprovisioning.StaticHostUser]{
+		Backend:       bk,
+		ResourceKind:  types.KindStaticHostUser,
+		BackendPrefix: staticHostUserPrefix,
+		MarshalFunc:   services.MarshalStaticHostUser,
+		UnmarshalFunc: services.UnmarshalStaticHostUser,
+	},
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -57,7 +58,7 @@ func NewStaticHostUserService(bk backend.Backend) (*StaticHostUserService, error
 }
 
 // ListStaticHostUsers lists static host users.
-func (s *StaticHostUserService) ListStaticHostUsers(ctx context.Context, pageSize int, pageToken string) ([]*userprovisioningpb.StaticHostUser, string, error) {
+func (s *StaticHostUserService) ListStaticHostUsers(ctx context.Context, pageSize int, pageToken string) ([]*userprovisioning.StaticHostUser, string, error) {
 	out, nextToken, err := s.svc.ListResources(ctx, pageSize, pageToken)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -66,13 +67,13 @@ func (s *StaticHostUserService) ListStaticHostUsers(ctx context.Context, pageSiz
 }
 
 // GetStaticHostUser returns a static host user by name.
-func (s *StaticHostUserService) GetStaticHostUser(ctx context.Context, name string) (*userprovisioningpb.StaticHostUser, error) {
+func (s *StaticHostUserService) GetStaticHostUser(ctx context.Context, name string) (*userprovisioning.StaticHostUser, error) {
 	out, err := s.svc.GetResource(ctx, name)
 	return out, trace.Wrap(err)
 }
 
 // CreateStaticHostUser creates a static host user.
-func (s *StaticHostUserService) CreateStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error) {
+func (s *StaticHostUserService) CreateStaticHostUser(ctx context.Context, in *userprovisioning.StaticHostUser) (*userprovisioning.StaticHostUser, error) {
 	if err := services.ValidateStaticHostUser(in); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -81,7 +82,7 @@ func (s *StaticHostUserService) CreateStaticHostUser(ctx context.Context, in *us
 }
 
 // UpdateStaticHostUser updates a static host user.
-func (s *StaticHostUserService) UpdateStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error) {
+func (s *StaticHostUserService) UpdateStaticHostUser(ctx context.Context, in *userprovisioning.StaticHostUser) (*userprovisioning.StaticHostUser, error) {
 	if err := services.ValidateStaticHostUser(in); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -90,7 +91,7 @@ func (s *StaticHostUserService) UpdateStaticHostUser(ctx context.Context, in *us
 }
 
 // UpsertStaticHostUser upserts a static host user.
-func (s *StaticHostUserService) UpsertStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error) {
+func (s *StaticHostUserService) UpsertStaticHostUser(ctx context.Context, in *userprovisioning.StaticHostUser) (*userprovisioning.StaticHostUser, error) {
 	if err := services.ValidateStaticHostUser(in); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/statichostuser.go
+++ b/lib/services/local/statichostuser.go
@@ -36,18 +36,17 @@ const (
 
 // StaticHostUserService manages host users that should be created on SSH nodes.
 type StaticHostUserService struct {
-	svc *generic.Service[*userprovisioning.StaticHostUser]
+	svc *generic.ServiceWrapper[*userprovisioning.StaticHostUser]
 }
 
 // NewStaticHostUserService creates a new static host user service.
 func NewStaticHostUserService(bk backend.Backend) (*StaticHostUserService, error) {
-	svc, err := generic.NewService(&generic.ServiceConfig[*userprovisioning.StaticHostUser]{
-		Backend:       bk,
-		ResourceKind:  types.KindStaticHostUser,
-		BackendPrefix: staticHostUserPrefix,
-		MarshalFunc:   services.MarshalStaticHostUser,
-		UnmarshalFunc: services.UnmarshalStaticHostUser,
-	},
+	svc, err := generic.NewServiceWrapper(
+		bk,
+		types.KindStaticHostUser,
+		staticHostUserPrefix,
+		services.MarshalStaticHostUser,
+		services.UnmarshalStaticHostUser,
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/statichostuser_test.go
+++ b/lib/services/local/statichostuser_test.go
@@ -128,7 +128,7 @@ func TestUpdateStaticHostUser(t *testing.T) {
 	service := getStaticHostUserService(t)
 	prepopulateStaticHostUsers(t, service, 1)
 
-	expiry := timestamppb.New(clock.Now().UTC().Add(30 * time.Minute))
+	expiry := timestamppb.New(clock.Now().Add(30 * time.Minute))
 
 	// Fetch the object from the backend so the revision is populated.
 	key := getStaticHostUser(0).GetMetadata().Name
@@ -152,7 +152,7 @@ func TestUpdateStaticHostUserMissingRevision(t *testing.T) {
 	service := getStaticHostUserService(t)
 	prepopulateStaticHostUsers(t, service, 1)
 
-	expiry := timestamppb.New(clock.Now().UTC().Add(30 * time.Minute))
+	expiry := timestamppb.New(clock.Now().Add(30 * time.Minute))
 
 	obj := getStaticHostUser(0)
 	obj.Metadata.Expires = expiry

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -180,6 +180,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindAccessGraphSettings, RW()),
 					types.NewRule(types.KindSPIFFEFederation, RW()),
 					types.NewRule(types.KindNotification, RW()),
+					types.NewRule(types.KindStaticHostUser, RW()),
 				},
 			},
 		},

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -241,6 +241,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindPlugin, nil
 	case types.KindAccessGraphSettings, "ags":
 		return types.KindAccessGraphSettings, nil
+	case types.KindStaticHostUser, types.KindStaticHostUser + "s", "host_user", "host_users":
+		return types.KindStaticHostUser, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }

--- a/lib/services/statichostuser.go
+++ b/lib/services/statichostuser.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/userprovisioning"
@@ -53,7 +54,7 @@ func MarshalStaticHostUser(hostUser *userprovisioning.StaticHostUser, opts ...Ma
 	}
 	if !cfg.PreserveRevision {
 		copy := *hostUser
-		copy.SetRevision("")
+		copy.GetMetadata().Revision = ""
 		hostUser = &copy
 	}
 	return utils.FastMarshal(hostUser)
@@ -72,10 +73,10 @@ func UnmarshalStaticHostUser(data []byte, opts ...MarshalOption) (*userprovision
 		return nil, trace.BadParameter(err.Error())
 	}
 	if cfg.Revision != "" {
-		hostUser.SetRevision(cfg.Revision)
+		hostUser.GetMetadata().Revision = cfg.Revision
 	}
 	if !cfg.Expires.IsZero() {
-		hostUser.SetExpiry(cfg.Expires)
+		hostUser.GetMetadata().Expires = timestamppb.New(cfg.Expires)
 	}
 	return &hostUser, nil
 }

--- a/lib/services/statichostuser.go
+++ b/lib/services/statichostuser.go
@@ -24,25 +24,60 @@ import (
 
 	"github.com/gravitational/trace"
 
-	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/userprovisioning"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // StaticHostUserService manages host users that should be created on SSH nodes.
 type StaticHostUser interface {
 	// ListStaticHostUsers lists static host users.
-	ListStaticHostUsers(ctx context.Context, pageSize int, pageToken string) ([]*userprovisioningpb.StaticHostUser, string, error)
+	ListStaticHostUsers(ctx context.Context, pageSize int, pageToken string) ([]*userprovisioning.StaticHostUser, string, error)
 	// GetStaticHostUser returns a static host user by name.
-	GetStaticHostUser(ctx context.Context, name string) (*userprovisioningpb.StaticHostUser, error)
+	GetStaticHostUser(ctx context.Context, name string) (*userprovisioning.StaticHostUser, error)
 	// CreateStaticHostUser creates a static host user.
-	CreateStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error)
+	CreateStaticHostUser(ctx context.Context, in *userprovisioning.StaticHostUser) (*userprovisioning.StaticHostUser, error)
 	// UpdateStaticHostUser updates a static host user.
-	UpdateStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error)
+	UpdateStaticHostUser(ctx context.Context, in *userprovisioning.StaticHostUser) (*userprovisioning.StaticHostUser, error)
 	// UpsertStaticHostUser upserts a static host user.
-	UpsertStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error)
+	UpsertStaticHostUser(ctx context.Context, in *userprovisioning.StaticHostUser) (*userprovisioning.StaticHostUser, error)
 	// DeleteStaticHostUser deletes a static host user. Note that this does not
 	// remove any host users created on nodes from the resource.
 	DeleteStaticHostUser(ctx context.Context, name string) error
+}
+
+func MarshalStaticHostUser(hostUser *userprovisioning.StaticHostUser, opts ...MarshalOption) ([]byte, error) {
+	cfg, err := CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if !cfg.PreserveRevision {
+		copy := *hostUser
+		copy.SetRevision("")
+		hostUser = &copy
+	}
+	return utils.FastMarshal(hostUser)
+}
+
+func UnmarshalStaticHostUser(data []byte, opts ...MarshalOption) (*userprovisioning.StaticHostUser, error) {
+	if len(data) == 0 {
+		return nil, trace.BadParameter("missing static host user data")
+	}
+	cfg, err := CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var hostUser userprovisioning.StaticHostUser
+	if err := utils.FastUnmarshal(data, &hostUser); err != nil {
+		return nil, trace.BadParameter(err.Error())
+	}
+	if cfg.Revision != "" {
+		hostUser.SetRevision(cfg.Revision)
+	}
+	if !cfg.Expires.IsZero() {
+		hostUser.SetExpiry(cfg.Expires)
+	}
+	return &hostUser, nil
 }
 
 func isValidUidOrGid(s string) bool {
@@ -58,25 +93,19 @@ func isValidUidOrGid(s string) bool {
 
 // ValidateStaticHostUser checks that required parameters are set for the
 // specified StaticHostUser.
-func ValidateStaticHostUser(u *userprovisioningpb.StaticHostUser) error {
+func ValidateStaticHostUser(u *userprovisioning.StaticHostUser) error {
 	if u == nil {
 		return trace.BadParameter("StaticHostUser is nil")
 	}
-	if u.Metadata == nil {
-		return trace.BadParameter("Metadata is nil")
-	}
 	if u.Metadata.Name == "" {
 		return trace.BadParameter("missing name")
-	}
-	if u.Spec == nil {
-		return trace.BadParameter("Spec is nil")
 	}
 	if u.Spec.Login == "" {
 		return trace.BadParameter("missing login")
 	}
 	if u.Spec.NodeLabels != nil {
-		for key, value := range u.Spec.NodeLabels.Values {
-			if key == types.Wildcard && !(len(value.Values) == 1 && value.Values[0] == types.Wildcard) {
+		for key, values := range u.Spec.NodeLabels {
+			if key == types.Wildcard && !(len(values) == 1 && values[0] == types.Wildcard) {
 				return trace.BadParameter("selector *:<val> is not supported")
 			}
 		}

--- a/lib/services/statichostuser.go
+++ b/lib/services/statichostuser.go
@@ -47,6 +47,7 @@ type StaticHostUser interface {
 	DeleteStaticHostUser(ctx context.Context, name string) error
 }
 
+// MarshalStaticHostUser marshals the StaticHostUser object into a JSON byte array.
 func MarshalStaticHostUser(hostUser *userprovisioning.StaticHostUser, opts ...MarshalOption) ([]byte, error) {
 	cfg, err := CollectOptions(opts)
 	if err != nil {
@@ -60,6 +61,8 @@ func MarshalStaticHostUser(hostUser *userprovisioning.StaticHostUser, opts ...Ma
 	return utils.FastMarshal(hostUser)
 }
 
+// UnmarshalStaticHostUser unmarshals the StaticHostUser object from a JSON
+// byte array.
 func UnmarshalStaticHostUser(data []byte, opts ...MarshalOption) (*userprovisioning.StaticHostUser, error) {
 	if len(data) == 0 {
 		return nil, trace.BadParameter("missing static host user data")

--- a/lib/services/statichostuser_test.go
+++ b/lib/services/statichostuser_test.go
@@ -23,33 +23,17 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/userprovisioning"
-	"github.com/gravitational/teleport/api/types/wrappers"
 )
 
 func TestValidateStaticHostUser(t *testing.T) {
 	t.Parallel()
 
-	nodeLabels := func(labels map[string]string) *wrappers.LabelValues {
-		if len(labels) == 0 {
-			return nil
-		}
-		values := &wrappers.LabelValues{
-			Values: make(map[string]wrappers.StringValues, len(labels)),
-		}
-		for k, v := range labels {
-			values.Values[k] = wrappers.StringValues{
-				Values: []string{v},
-			}
-		}
-		return values
-	}
-
 	tests := []struct {
 		name     string
-		hostUser *userprovisioningpb.StaticHostUser
+		hostUser *userprovisioning.StaticHostUser
 		assert   require.ErrorAssertionFunc
 	}{
 		{
@@ -58,32 +42,27 @@ func TestValidateStaticHostUser(t *testing.T) {
 		},
 		{
 			name: "no name",
-			hostUser: userprovisioning.NewStaticHostUser("", &userprovisioningpb.StaticHostUserSpec{
+			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{}, userprovisioning.Spec{
 				Login: "alice",
 			}),
 			assert: require.Error,
 		},
 		{
-			name:     "no spec",
-			hostUser: userprovisioning.NewStaticHostUser("alice_user", nil),
-			assert:   require.Error,
-		},
-		{
 			name:     "missing login",
-			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{}),
+			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{}),
 			assert:   require.Error,
 		},
 		{
 			name: "invalid node labels",
-			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{
+			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{
 				Login:      "alice",
-				NodeLabels: nodeLabels(map[string]string{types.Wildcard: "bar"}),
+				NodeLabels: types.Labels{types.Wildcard: {"bar"}},
 			}),
 			assert: require.Error,
 		},
 		{
 			name: "invalid node labels expression",
-			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{
+			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{
 				Login:                "alice",
 				NodeLabelsExpression: "foo bar xyz",
 			}),
@@ -91,45 +70,42 @@ func TestValidateStaticHostUser(t *testing.T) {
 		},
 		{
 			name: "valid wildcard labels",
-			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{
-				Login: "alice",
-				NodeLabels: nodeLabels(map[string]string{
-					"foo":          types.Wildcard,
-					types.Wildcard: types.Wildcard,
-				}),
+			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{
+				Login:      "alice",
+				NodeLabels: types.Labels{"foo": {types.Wildcard}, types.Wildcard: {types.Wildcard}},
 			}),
 			assert: require.NoError,
 		},
 		{
 			name: "non-numeric uid",
-			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{
+			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{
 				Login:      "alice",
 				Groups:     []string{"foo", "bar"},
 				Uid:        "abcd",
 				Gid:        "1234",
-				NodeLabels: nodeLabels(map[string]string{"foo": "bar"}),
+				NodeLabels: types.Labels{"foo": {"bar"}},
 			}),
 			assert: require.Error,
 		},
 		{
 			name: "non-numeric gid",
-			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{
+			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{
 				Login:      "alice",
 				Groups:     []string{"foo", "bar"},
 				Uid:        "1234",
 				Gid:        "abcd",
-				NodeLabels: nodeLabels(map[string]string{"foo": "bar"}),
+				NodeLabels: types.Labels{"foo": {"bar"}},
 			}),
 			assert: require.Error,
 		},
 		{
 			name: "ok",
-			hostUser: userprovisioning.NewStaticHostUser("alice_user", &userprovisioningpb.StaticHostUserSpec{
+			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{
 				Login:                "alice",
 				Groups:               []string{"foo", "bar"},
 				Uid:                  "1234",
 				Gid:                  "5678",
-				NodeLabels:           nodeLabels(map[string]string{"foo": "bar"}),
+				NodeLabels:           types.Labels{"foo": {"bar"}},
 				NodeLabelsExpression: `labels["env"] == "staging" || labels["env"] == "test"`,
 			}),
 			assert: require.NoError,

--- a/lib/services/statichostuser_test.go
+++ b/lib/services/statichostuser_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/userprovisioning"
 )
 
@@ -42,19 +42,19 @@ func TestValidateStaticHostUser(t *testing.T) {
 		},
 		{
 			name: "no name",
-			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{}, userprovisioning.Spec{
+			hostUser: userprovisioning.NewStaticHostUser(&headerv1.Metadata{}, userprovisioning.Spec{
 				Login: "alice",
 			}),
 			assert: require.Error,
 		},
 		{
 			name:     "missing login",
-			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{}),
+			hostUser: userprovisioning.NewStaticHostUser(&headerv1.Metadata{Name: "alice_user"}, userprovisioning.Spec{}),
 			assert:   require.Error,
 		},
 		{
 			name: "invalid node labels",
-			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{
+			hostUser: userprovisioning.NewStaticHostUser(&headerv1.Metadata{Name: "alice_user"}, userprovisioning.Spec{
 				Login:      "alice",
 				NodeLabels: types.Labels{types.Wildcard: {"bar"}},
 			}),
@@ -62,7 +62,7 @@ func TestValidateStaticHostUser(t *testing.T) {
 		},
 		{
 			name: "invalid node labels expression",
-			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{
+			hostUser: userprovisioning.NewStaticHostUser(&headerv1.Metadata{Name: "alice_user"}, userprovisioning.Spec{
 				Login:                "alice",
 				NodeLabelsExpression: "foo bar xyz",
 			}),
@@ -70,7 +70,7 @@ func TestValidateStaticHostUser(t *testing.T) {
 		},
 		{
 			name: "valid wildcard labels",
-			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{
+			hostUser: userprovisioning.NewStaticHostUser(&headerv1.Metadata{Name: "alice_user"}, userprovisioning.Spec{
 				Login:      "alice",
 				NodeLabels: types.Labels{"foo": {types.Wildcard}, types.Wildcard: {types.Wildcard}},
 			}),
@@ -78,7 +78,7 @@ func TestValidateStaticHostUser(t *testing.T) {
 		},
 		{
 			name: "non-numeric uid",
-			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{
+			hostUser: userprovisioning.NewStaticHostUser(&headerv1.Metadata{Name: "alice_user"}, userprovisioning.Spec{
 				Login:      "alice",
 				Groups:     []string{"foo", "bar"},
 				Uid:        "abcd",
@@ -89,7 +89,7 @@ func TestValidateStaticHostUser(t *testing.T) {
 		},
 		{
 			name: "non-numeric gid",
-			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{
+			hostUser: userprovisioning.NewStaticHostUser(&headerv1.Metadata{Name: "alice_user"}, userprovisioning.Spec{
 				Login:      "alice",
 				Groups:     []string{"foo", "bar"},
 				Uid:        "1234",
@@ -100,7 +100,7 @@ func TestValidateStaticHostUser(t *testing.T) {
 		},
 		{
 			name: "ok",
-			hostUser: userprovisioning.NewStaticHostUser(header.Metadata{Name: "alice_user"}, userprovisioning.Spec{
+			hostUser: userprovisioning.NewStaticHostUser(&headerv1.Metadata{Name: "alice_user"}, userprovisioning.Spec{
 				Login:                "alice",
 				Groups:               []string{"foo", "bar"},
 				Uid:                  "1234",

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1712,18 +1712,6 @@ func (c *spiffeFederationCollection) resources() []types.Resource {
 	return r
 }
 
-type staticHostUserCollection struct {
-	items []*userprovisioning.StaticHostUser
-}
-
-func (c *staticHostUserCollection) resources() []types.Resource {
-	r := make([]types.Resource, 0, len(c.items))
-	for _, resource := range c.items {
-		r = append(r, types.Resource153ToLegacy(resource))
-	}
-	return r
-}
-
 func (c *spiffeFederationCollection) writeText(w io.Writer, verbose bool) error {
 	headers := []string{"Name", "Last synced at"}
 
@@ -1745,6 +1733,18 @@ func (c *spiffeFederationCollection) writeText(w io.Writer, verbose bool) error 
 	t.SortRowsBy([]int{0}, true)
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)
+}
+
+type staticHostUserCollection struct {
+	items []*userprovisioning.StaticHostUser
+}
+
+func (c *staticHostUserCollection) resources() []types.Resource {
+	r := make([]types.Resource, 0, len(c.items))
+	for _, resource := range c.items {
+		r = append(r, types.Resource153ToLegacy(resource))
+	}
+	return r
 }
 
 func (c *staticHostUserCollection) writeText(w io.Writer, verbose bool) error {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -59,6 +59,7 @@ import (
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/api/types/secreports"
+	"github.com/gravitational/teleport/api/types/userprovisioning"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -166,6 +167,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *servicec
 		types.KindAccessGraphSettings:      rc.upsertAccessGraphSettings,
 		types.KindPlugin:                   rc.createPlugin,
 		types.KindSPIFFEFederation:         rc.createSPIFFEFederation,
+		types.KindStaticHostUser:           rc.createStaticHostUser,
 	}
 	rc.UpdateHandlers = map[ResourceKind]ResourceCreateHandler{
 		types.KindUser:                    rc.updateUser,
@@ -181,6 +183,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *servicec
 		types.KindVnetConfig:              rc.updateVnetConfig,
 		types.KindAccessGraphSettings:     rc.updateAccessGraphSettings,
 		types.KindPlugin:                  rc.updatePlugin,
+		types.KindStaticHostUser:          rc.updateStaticHostUser,
 	}
 	rc.config = config
 
@@ -1419,6 +1422,39 @@ func (rc *ResourceCommand) createServerInfo(ctx context.Context, client *authcli
 	return nil
 }
 
+func (rc *ResourceCommand) createStaticHostUser(ctx context.Context, client *authclient.Client, resource services.UnknownResource) error {
+	hostUser, err := services.UnmarshalStaticHostUser(resource.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	c := client.StaticHostUserClient()
+	if rc.force {
+		if _, err := c.UpsertStaticHostUser(ctx, hostUser); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("static host user %q has been updated\n", hostUser.GetMetadata().Name)
+	} else {
+		if _, err := c.CreateStaticHostUser(ctx, hostUser); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("static host user %q has been created\n", hostUser.GetMetadata().Name)
+	}
+
+	return nil
+}
+
+func (rc *ResourceCommand) updateStaticHostUser(ctx context.Context, client *authclient.Client, resource services.UnknownResource) error {
+	hostUser, err := services.UnmarshalStaticHostUser(resource.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if _, err := client.StaticHostUserClient().UpdateStaticHostUser(ctx, hostUser); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("static host user %q has been updated\n", hostUser.GetMetadata().Name)
+	return nil
+}
+
 // Delete deletes resource by name
 func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client) (err error) {
 	singletonResources := []string{
@@ -1812,6 +1848,11 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		fmt.Printf("SPIFFE federation %q has been deleted\n", rc.ref.Name)
+	case types.KindStaticHostUser:
+		if err := client.StaticHostUserClient().DeleteStaticHostUser(ctx, rc.ref.Name); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("static host user %q has been deleted\n", rc.ref.Name)
 	default:
 		return trace.BadParameter("deleting resources of type %q is not supported", rc.ref.Kind)
 	}
@@ -2929,6 +2970,31 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 
 		return &botInstanceCollection{items: instances}, nil
+	case types.KindStaticHostUser:
+		hostUserClient := client.StaticHostUserClient()
+		if rc.ref.Name != "" {
+			hostUser, err := hostUserClient.GetStaticHostUser(ctx, rc.ref.Name)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			return &staticHostUserCollection{items: []*userprovisioning.StaticHostUser{hostUser}}, nil
+		}
+
+		var hostUsers []*userprovisioning.StaticHostUser
+		var nextToken string
+		for {
+			resp, token, err := hostUserClient.ListStaticHostUsers(ctx, 0, nextToken)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			hostUsers = append(hostUsers, resp...)
+			if token == "" {
+				break
+			}
+			nextToken = token
+		}
+		return &staticHostUserCollection{items: hostUsers}, nil
 	}
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }


### PR DESCRIPTION
This change adds support in `tctl` for the static host user resource.

It also adds an internal `StaticHostUser` type to use where possible instead of the proto type. This makes working with the resource less painful for the end user. The new format is identical to role labels.

Original:
```yaml
# ...
node_labels:
  Values:
    foo:
      Values:
        - bar
```

New:
```yaml
# ...
node_labels:
  foo: bar
```

The new serialization is a breaking change in the backend. However, no part of static host users has been backported, so no one will be affected.

Part of #42712.

Changelog: Added StaticHostUser resource