### PR TITLE
filesessions: continue processing uploads on error

### DIFF
--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -285,7 +285,7 @@ func (u *Uploader) Scan(ctx context.Context) (*ScanStats, error) {
 				u.log.Debugf("Recording %v was uploaded by another process.", fi.Name())
 				continue
 			}
-			if isSessionError(err) {
+			if isSessionError(err) || trace.IsBadParameter(err) {
 				u.log.WithError(err).Warningf("Skipped session recording %v.", fi.Name())
 				stats.Corrupted++
 				continue


### PR DESCRIPTION
If we encounter a BadParameter error, assume something is wrong with the upload, mark it as corrupted, and move on to the next one.

This prevents one bad file from preventing other legitimate uploads from completing.