### PR TITLE
prevent writing to sudoers or creating host users when running as a proxy server

### DIFF
--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -300,7 +300,8 @@ func (s *Server) GetLockWatcher() *services.LockWatcher {
 // GetCreateHostUser determines whether users should be created on the
 // host automatically
 func (s *Server) GetCreateHostUser() bool {
-	return s.createHostUser
+	// we shouldn't allow creating host users on a proxy server
+	return !s.proxyMode && s.createHostUser
 }
 
 // GetHostUsers returns the HostUsers instance being used to manage
@@ -312,6 +313,11 @@ func (s *Server) GetHostUsers() srv.HostUsers {
 // GetHostSudoers returns the HostSudoers instance being used to manage
 // sudoers file provisioning
 func (s *Server) GetHostSudoers() srv.HostSudoers {
+	// we shouldn't allow modifying sudoers on a proxy server
+	if s.proxyMode {
+		return nil
+	}
+
 	if s.sudoers == nil {
 		return &srv.HostSudoersNotImplemented{}
 	}

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -239,7 +239,12 @@ func (sc *sudoersCloser) Close() error {
 // file, if any. If the returned closer is not nil, it must be called at the
 // end of the session to cleanup the sudoers file.
 func (s *SessionRegistry) TryWriteSudoersFile(identityContext IdentityContext) (io.Closer, error) {
-	if s.sudoers == nil {
+	// Pulling sudoers directly from the Srv so TryWriteSudoersFile always
+	// respects the invariant that we shouldn't write sudoers on proxy servers.
+	// This might invalidate the cached sudoers field on SessionRegistry, so
+	// we may be able to remove that in a future PR
+	sudoWriter := s.Srv.GetHostSudoers()
+	if sudoWriter == nil {
 		return nil, nil
 	}
 
@@ -251,7 +256,7 @@ func (s *SessionRegistry) TryWriteSudoersFile(identityContext IdentityContext) (
 		// not an error, sudoers may not be configured.
 		return nil, nil
 	}
-	if err := s.sudoers.WriteSudoers(identityContext.Login, sudoers); err != nil {
+	if err := sudoWriter.WriteSudoers(identityContext.Login, sudoers); err != nil {
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
This fixes an issue where it was possible to write `host_sudoers` to proxy servers in versions of Teleport still performing ssh handshakes rather than gRPC.

changelog: Fixed an issue where `host_sudoers` could be written to Teleport proxy server sudoer lists in Teleport v14 and v15
