### PR TITLE
docs: architecture link fix

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -122,4 +122,4 @@ role-based access controls.
 Learn more:
 
 - [Teleport Core Concepts](./core-concepts.mdx)
-- [Architecture Guides](index.mdx)
+- [Architecture Guides](./reference/architecture/architecture.mdx)


### PR DESCRIPTION
The link given did not go to the arch guides.