### PR TITLE
Add documentation for the log configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2392,6 +2392,11 @@
       "permanent": true
     },
     {
+      "source": "/management/diagnostics/logging/",
+      "destination": "/admin-guides/management/diagnostics/logging/",
+      "permanent": true
+    },
+    {
       "source": "/management/diagnostics/metrics/",
       "destination": "/admin-guides/management/diagnostics/metrics/",
       "permanent": true

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -684,6 +684,7 @@
     "noout",
     "noprompt",
     "nosql",
+    "notifempty",
     "nowait",
     "ntauth",
     "nvme",

--- a/docs/pages/admin-guides/management/admin/logging.mdx
+++ b/docs/pages/admin-guides/management/admin/logging.mdx
@@ -24,7 +24,7 @@ If the output parameter is not defined or set as empty, `stderr` (aliases `err` 
 Other available options for defining the output include `stdout` (aliases `out` or `1`), `syslog` for writing
 to the syslog file, or a filepath for direct writing to a log file destination.
 
-Severity has several levels, which are sorted by increasing priority (means that if `info` is selected, `warn` and `err` also applied):
+Severity has several levels, which are sorted by decreasing priority (means that if `info` is selected, `warn` and `err` also applied):
  - `err`, `error` - used for errors that should definitely be noted.
  - `warn`, `warning` - non-critical entries that deserve attention.
  - `info` or empty value - general operational entries about what's going on inside the application.

--- a/docs/pages/admin-guides/management/admin/logging.mdx
+++ b/docs/pages/admin-guides/management/admin/logging.mdx
@@ -1,0 +1,71 @@
+---
+title: Logger configuration
+description: Logger configuration for Teleport instance
+---
+
+## Configuration
+
+In the configuration file of the Teleport instance, you can configure the logger's behavior by defining the output
+destination, severity level, and output format.
+
+Sample of `/etc/teleport.yaml` configuration for defining the logger settings.
+
+```yaml
+teleport:
+  log:
+    output: stderr
+    severity: INFO
+    format:
+      output: text
+      extra_fields: [caller, level]
+```
+
+If the output parameter is not defined or set as empty, `stderr` (aliases `err` or `2`) is used by default.
+Other available options for defining the output include `stdout` (aliases `out` or `1`), `syslog` for writing
+to the syslog file, or a filepath for direct writing to a log file destination.
+
+Severity has several levels, which are sorted by increasing priority (means that if `info` is selected, `warn` and `err` also applied):
+ - `err`, `error` - used for errors that should definitely be noted.
+ - `warn`, `warning` - non-critical entries that deserve attention.
+ - `info` or empty value - general operational entries about what's going on inside the application.
+ - `debug` - usually only enabled when debugging, verbose logging.
+ - `trace` - designates more detailed informational events than the debug.
+
+The default format for log output is `text`. Another available format is `json`, which may simplify log
+parsing for systems like Logstash, Loki, or other log aggregators.
+
+Format `extra_fields` defines additional fields which must be added to the log output:
+ - `level` is the log field that stores the verbosity.
+ - `component` is the log field that stores the calling component.
+ - `caller` is the log field that stores the calling file and line number.
+ - `timestamp` is the field that stores the timestamp the log was emitted.
+
+On systemd-based distributions you can watch the log output by running the following command:
+
+```code
+$ teleport install systemd -o /etc/systemd/system/teleport.service
+$ systemctl enable teleport
+$ journalctl -fu teleport
+```
+
+To store logs as a file, the filepath should be set in the `log.output` configuration.
+
+```yaml
+teleport:
+  log:
+    output: /var/lib/teleport/log/output.log
+```
+
+When Teleport open or create a new log file, a filesystem watcher is launched in the background to monitor modifications.
+If the file is renamed, moved, or deleted, a new one is created using the path defined in the configuration.
+This is useful for implementing log rotation without needing to restart or interrupt the main service.
+
+In this case, the log rotation configuration might look like the following sample `/etc/logrotate.d/teleport.conf`:
+
+```
+/var/lib/teleport/log/output.log {
+    weekly
+    compress
+    notifempty
+}
+```

--- a/docs/pages/admin-guides/management/diagnostics/logging.mdx
+++ b/docs/pages/admin-guides/management/diagnostics/logging.mdx
@@ -63,7 +63,7 @@ This is useful for implementing log rotation without needing to restart or inter
 Using `logrotate` as an example, you may define the following config `/etc/logrotate.d/teleport.conf`
 to rotate Teleport log file weekly:
 
-```
+```code
 /var/lib/teleport/log/output.log {
     weekly
     compress

--- a/docs/pages/admin-guides/management/diagnostics/logging.mdx
+++ b/docs/pages/admin-guides/management/diagnostics/logging.mdx
@@ -1,14 +1,10 @@
 ---
-title: Logger configuration
-description: Logger configuration for Teleport instance
+title: Logger Configuration
+description: Explains how to configure the logger on a Teleport instance.
 ---
 
-## Configuration
-
-In the configuration file of the Teleport instance, you can configure the logger's behavior by defining the output
+In the configuration file of a Teleport instance, you can configure the logger's behavior by defining the output
 destination, severity level, and output format.
-
-Sample of `/etc/teleport.yaml` configuration for defining the logger settings.
 
 ```yaml
 teleport:
@@ -24,12 +20,14 @@ If the output parameter is not defined or set as empty, `stderr` (aliases `err` 
 Other available options for defining the output include `stdout` (aliases `out` or `1`), `syslog` for writing
 to the syslog file, or a filepath for direct writing to a log file destination.
 
-Severity has several levels, which are sorted by decreasing priority (means that if `info` is selected, `warn` and `err` also applied):
- - `err`, `error` - used for errors that should definitely be noted.
+Severity has several levels, which are sorted by decreasing priority:
+ - `err`, `error` - used for errors that require action from the user.
  - `warn`, `warning` - non-critical entries that deserve attention.
  - `info` or empty value - general operational entries about what's going on inside the application.
  - `debug` - usually only enabled when debugging, verbose logging.
- - `trace` - designates more detailed informational events than the debug.
+ - `trace` - designates more detailed information about actions and events.
+
+When we choose `info` severity level, `warning` and `error` are also applied by priority rule.
 
 The default format for log output is `text`. Another available format is `json`, which may simplify log
 parsing for systems like Logstash, Loki, or other log aggregators.
@@ -48,6 +46,8 @@ $ systemctl enable teleport
 $ journalctl -fu teleport
 ```
 
+## Log rotation support
+
 To store logs as a file, the filepath should be set in the `log.output` configuration.
 
 ```yaml
@@ -56,11 +56,12 @@ teleport:
     output: /var/lib/teleport/log/output.log
 ```
 
-When Teleport open or create a new log file, a filesystem watcher is launched in the background to monitor modifications.
-If the file is renamed, moved, or deleted, a new one is created using the path defined in the configuration.
+When Teleport opens or creates a new log file, a filesystem watcher is launched in the background to monitor the file modifications.
+If the log file is renamed, moved, or deleted, Teleport automatically creates a new one.
 This is useful for implementing log rotation without needing to restart or interrupt the main service.
 
-In this case, the log rotation configuration might look like the following sample `/etc/logrotate.d/teleport.conf`:
+Using `logrotate` as an example, you may define the following config `/etc/logrotate.d/teleport.conf`
+to rotate Teleport log file weekly:
 
 ```
 /var/lib/teleport/log/output.log {


### PR DESCRIPTION
In this PR added documentation for the logger configuration in Teleport, since filesystem watcher added for the log file we should noted about new behaviour in case of move/rename/delete the log file. Also sample configuration for logrotate is added.

Related: https://github.com/gravitational/teleport/pull/43359