### PR TITLE
[v15] Remove strict constraint on kernel version for backported BPF

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2841,7 +2841,11 @@ func (process *TeleportProcess) initSSH() error {
 		// return a NOP struct that can be used to discard BPF data.
 		ebpf, err := bpf.New(cfg.SSH.BPF)
 		if err != nil {
-			return trace.Wrap(err)
+			// Check kernel version if the host can run BPF programs.
+			return trace.NewAggregate(
+				trace.Wrap(bpf.IsHostCompatible()),
+				trace.Wrap(err),
+			)
 		}
 		defer func() { warnOnErr(process.ExitContext(), ebpf.Close(restartingOnGracefulShutdown), logger) }()
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/45018 to branch/v15
changelog: Fixed kernel version check of Enhanced Session Recording for distributions with backported BPF