### PR TITLE
[v14] Remove strict constraint on kernel version for backported BPF

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2732,7 +2732,11 @@ func (process *TeleportProcess) initSSH() error {
 		// return a NOP struct that can be used to discard BPF data.
 		ebpf, err := bpf.New(cfg.SSH.BPF, cfg.SSH.RestrictedSession)
 		if err != nil {
-			return trace.Wrap(err)
+			// Check kernel version if the host can run BPF programs.
+			return trace.NewAggregate(
+				trace.Wrap(bpf.IsHostCompatible()),
+				trace.Wrap(err),
+			)
 		}
 		defer func() { warnOnErr(ebpf.Close(restartingOnGracefulShutdown), log) }()
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/45018 to branch/v14
changelog: Fixed kernel version check of Enhanced Session Recording for distributions with backported BPF