### PR TITLE
[v16] docs: remove v12 references

### DIFF
--- a/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
@@ -15,6 +15,14 @@ The `tctl` tool is used to manage the device inventory. A device admin is
 responsible for managing devices, adding new devices to the inventory and
 removing devices that are no longer in use.
 
+<Admonition type="tip" title="Self enrollment">
+  Users with the preset `editor` or `device-admin` role
+  can register and enroll their device in a single step with the following command:
+  ```code
+  $ tsh device enroll --current-device
+  ```
+</Admonition>
+
 <Admonition type="tip" title="Sync with Jamf Pro">
 Teleport supports device synchronization with [Jamf Pro](./jamf-integration.mdx). Once configured, devices
 are automatically updated in Teleport's device inventory.

--- a/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
@@ -82,11 +82,8 @@ Asset Tag    OS    Enroll Status Device ID
 ```
 
 <Admonition type="warning" title="Device Role">
-  For clusters created after v13.3.6, Teleport supports preset `device-admin` role to manage devices.
-
-  For clusters created using Teleport v12 or newer, the preset `editor` role has
-  the necessary permissions to manage devices. For clusters created before v12, you may want
-  to create a dedicated [`device-admin`](#dedicated-device-admin-role) role.
+  For clusters created after v13.3.6, Teleport supports preset `device-admin` role to manage devices
+  and the the preset `editor` role has the necessary permissions to manage devices.
 </Admonition>
 
 ## Create a device enrollment token

--- a/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
@@ -15,14 +15,6 @@ The `tctl` tool is used to manage the device inventory. A device admin is
 responsible for managing devices, adding new devices to the inventory and
 removing devices that are no longer in use.
 
-<Admonition type="tip" title="Self enrollment: v13.3.5+">
-  Users with the preset `editor` or `device-admin` role (since v13.3.6)
-  can register and enroll their device in a single step with the following command:
-  ```code
-  $ tsh device enroll --current-device
-  ```
-</Admonition>
-
 <Admonition type="tip" title="Sync with Jamf Pro">
 Teleport supports device synchronization with [Jamf Pro](./jamf-integration.mdx). Once configured, devices
 are automatically updated in Teleport's device inventory.
@@ -80,11 +72,6 @@ Asset Tag    OS    Enroll Status Device ID
 ------------ ----- ------------- ------------------------------------
 (=devicetrust.asset_tag=) macOS not enrolled  (=devicetrust.device_id=)
 ```
-
-<Admonition type="warning" title="Device Role">
-  For clusters created after v13.3.6, Teleport supports preset `device-admin` role to manage devices
-  and the the preset `editor` role has the necessary permissions to manage devices.
-</Admonition>
 
 ## Create a device enrollment token
 
@@ -233,8 +220,8 @@ Device "c9cbb327-68a8-497e-b820-6a4b2bf58269" removed
 We recommend creating a dedicated `device-admin` role for device inventory
 management.
 
-<Admonition type="tip" title="v13.3.6+">
-  Teleport version 13.3.6 and above has the preset `device-admin` role, which
+<Admonition type="tip" title="Preset Device Administration role">
+  Teleport has the preset `device-admin` role, which
   is a substitute for the role described below.
 </Admonition>
 

--- a/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
@@ -223,51 +223,6 @@ $ tctl devices rm --device-id=c9cbb327-68a8-497e-b820-6a4b2bf58269
 Device "c9cbb327-68a8-497e-b820-6a4b2bf58269" removed
 ```
 
-## Dedicated device admin role
-
-We recommend creating a dedicated `device-admin` role for device inventory
-management.
-
-<Admonition type="tip" title="Preset Device Administration role">
-  Teleport has the preset `device-admin` role, which
-  is a substitute for the role described below.
-</Admonition>
-
-Following is an example of a role that grants permissions for the `device` resource is necessary to manage
-the inventory. Save the yaml below as `device-admin.yaml`:
-
-```yaml
-version: v7
-kind: role
-metadata:
-  name: device-admin
-spec:
-  allow:
-    rules:
-    - resources: ["device"]
-      verbs:
-      - create
-      - read
-      - list
-      - update
-      - delete
-      - create_enroll_token
-      - enroll
-```
-
-Create the role:
-
-```code
-$ tctl create -f device-admin.yaml
-role 'device-admin' has been created
-```
-
-Note that in addition to the usual CRUD verbs (create, read, list, update and
-delete), we have also included `create_enroll_token` and `enroll`. The
-`create_enroll_token` verb is necessary to execute the `tctl devices enroll`
-command; `enroll` is necessary to execute `tsh device enroll`.
-
-
 ## Configuring a TPM EKCert CA allow-list
 
 This advice only applies to Device Trust on platforms that use TPMs, such as

--- a/docs/pages/admin-guides/access-controls/guides/headless.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/headless.mdx
@@ -25,17 +25,17 @@ For example:
 
 ## Prerequisites
 
-- A v12.2+ Teleport cluster with WebAuthn configured.
+- A Teleport cluster with WebAuthn configured.
   See the [Second Factor: WebAuthn](./webauthn.mdx) guide.
 - WebAuthn hardware device, such as YubiKey.
-- Machines for Headless WebAuthn activities have [Linux](../../../installation.mdx), [macOS](../../../installation.mdx) or [Windows](../../../installation.mdx) `tsh` binary v12.2+ installed.
+- Machines for Headless WebAuthn activities have [Linux](../../../installation.mdx), [macOS](../../../installation.mdx) or [Windows](../../../installation.mdx) `tsh` binary installed.
 - Machines used to approve Headless WebAuthn requests have a Web browser with [WebAuthn support](
-  https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/) or `tsh` binary v12.2+ installed.
+  https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/) or `tsh` binary installed.
 - Optional: Teleport Connect v13.3.1+ for [seamless Headless WebAuthn approval](#optional-teleport-connect).
 
 ## Step 1/3. Configuration
 
-A v12.2+ Teleport cluster capable of WebAuthn is automatically capable of
+A Teleport cluster capable of WebAuthn is automatically capable of
 Headless WebAuthn without any additional configuration.
 
 <Details title="Optional: make Headless WebAuthn the default auth connector">
@@ -99,14 +99,6 @@ $ tctl create -f cap.yaml
 </Details>
 
 ## Step 2/3. Initiate Headless WebAuthn
-
-First open a terminal on the remote machine and confirm the `tsh` binary
-is v12.2+ with `tsh version`.
-
-```code
-$ tsh version
-Teleport v(=teleport.version=) git: go(=teleport.golang=)
-```
 
 Run a headless `tsh` command with the `--headless` flag. This will initiate
 headless authentication, printing a URL and `tsh` command.

--- a/docs/pages/admin-guides/infrastructure-as-code/managing-resources/login-rules-operator.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/managing-resources/login-rules-operator.mdx
@@ -74,7 +74,6 @@ This guide is applicable if you self-host Teleport in Kubernetes using the
 
   If this fails, you may not have installed the Teleport Operator, or you may have
   installed an older version.
-  The minimum version for Login Rule support is `v12.1.5`.
 
 ## Step 1/2. Create a Login Rule using `kubectl`
 

--- a/docs/pages/enroll-resources/machine-id/deployment/gitlab.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/gitlab.mdx
@@ -17,8 +17,6 @@ control.
 
 ## Prerequisites
 
-Machine ID for GitLab is available starting from Teleport `v12.2`.
-
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)


### PR DESCRIPTION
Backport #45356 to branch/v16