### PR TITLE
disable JamfSpec secrets validation

### DIFF
--- a/api/types/jamf.go
+++ b/api/types/jamf.go
@@ -44,13 +44,6 @@ func ValidateJamfSpecV1(s *JamfSpecV1) error {
 		return trace.BadParameter("spec required")
 	}
 
-	// Jamf can handle both credential sets being present, so we let it pass.
-	hasUserPass := s.Username != "" && s.Password != ""
-	hasAPICreds := s.ClientId != "" && s.ClientSecret != ""
-	if !hasUserPass && !hasAPICreds {
-		return trace.BadParameter("either username+password or clientID+clientSecret must be provided")
-	}
-
 	switch u, err := url.Parse(s.ApiEndpoint); {
 	case err != nil:
 		return trace.BadParameter("invalid API endpoint: %v", err)

--- a/api/types/jamf_test.go
+++ b/api/types/jamf_test.go
@@ -126,38 +126,6 @@ func TestValidateJamfSpecV1(t *testing.T) {
 			wantErr: "missing hostname",
 		},
 		{
-			name: "username empty",
-			spec: modify(func(spec *types.JamfSpecV1) {
-				spec.Username = ""
-			}),
-			wantErr: "username",
-		},
-		{
-			name: "password empty",
-			spec: modify(func(spec *types.JamfSpecV1) {
-				spec.Password = ""
-			}),
-			wantErr: "password",
-		},
-		{
-			name: "client_id empty",
-			spec: modify(func(spec *types.JamfSpecV1) {
-				spec.Username = ""
-				spec.Password = ""
-				spec.ClientSecret = "supersecretsecret!!1!"
-			}),
-			wantErr: "clientID",
-		},
-		{
-			name: "client_secret empty",
-			spec: modify(func(spec *types.JamfSpecV1) {
-				spec.Username = ""
-				spec.Password = ""
-				spec.ClientId = "llama-UUID"
-			}),
-			wantErr: "clientSecret",
-		},
-		{
 			name: "inventory nil entry",
 			spec: modify(func(spec *types.JamfSpecV1) {
 				spec.Inventory = []*types.JamfInventoryEntry{


### PR DESCRIPTION
This PR removes the validation of `username`, `password`, `client_secret` and `client_id` fields from JamfSpec because they are now stored in `servicecfg.JamfCredentials` structure.

The above mentioned fields will be soon removed. 