### PR TITLE
Log version when starting VNet daemon

### DIFF
--- a/lib/vnet/daemon/service_darwin.go
+++ b/lib/vnet/daemon/service_darwin.go
@@ -30,6 +30,8 @@ import (
 	"unsafe"
 
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
 )
 
 // Start starts an XPC listener and waits for it to receive a message with VNet config.
@@ -40,7 +42,7 @@ func Start(ctx context.Context, workFn func(context.Context, Config) error) erro
 		return trace.Wrap(err)
 	}
 
-	log.InfoContext(ctx, "Starting daemon", "bundle_path", bundlePath)
+	log.InfoContext(ctx, "Starting daemon", "version", teleport.Version, "bundle_path", bundlePath)
 
 	cBundlePath := C.CString(bundlePath)
 	defer C.free(unsafe.Pointer(cBundlePath))


### PR DESCRIPTION
I forgot to put it in there. It will surely be useful when someone sends us their logs.

This is printed only when running the launch daemon, which means you need to build a signed version of tsh.app, which is rather complex. But I did test this change on my setup.