### PR TITLE
Fix token name cell

### DIFF
--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -325,11 +325,8 @@ const NameCell = ({ token }: { token: JoinToken }) => {
     <Cell
       align="left"
       style={{
-        minWidth: '320px',
+        maxWidth: '320px',
         fontFamily: 'monospace',
-        whiteSpace: 'nowrap',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
       }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
@@ -337,13 +334,18 @@ const NameCell = ({ token }: { token: JoinToken }) => {
       <Flex alignItems="center" gap={2}>
         <Text
           css={`
-            text-overflow: clip;
-            overflow-x: auto;
+            overflow-wrap: break-word;
           `}
         >
           {method !== 'token' ? id : safeName}
         </Text>
-        {hovered && <CopyButton name={id} />}
+        <Box
+          css={`
+            visibility: ${hovered ? 'visible' : 'hidden'};
+          `}
+        >
+          <CopyButton name={id} />
+        </Box>
       </Flex>
     </Cell>
   );


### PR DESCRIPTION
This will prevent long token names from causing the table to jitter when hovered. After pairing with the design team, they preferred a wrapping of the text instead of a scroll bar for long token names (to be consistent with other tables).

Fixes: https://github.com/gravitational/teleport/issues/45946


https://github.com/user-attachments/assets/045dcc01-f4b0-4858-898d-cf6c724e1cc6

