### PR TITLE
[v16] exclude alpn upgrade connections from PROXY line enforcement

### DIFF
--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -660,23 +660,16 @@ func (m *Mux) checkPROXYProtocolRequirement(conn net.Conn, unsignedPROXYLineRece
 	return nil
 }
 
-// isInternalConn determines whether the connection is a multiplexer Conn or one originating from a websocket upgrade.
-// If the check is successful, it indicates that the connection was provided by another multiplexer listener or web API,
+// isInternalConn determines if the connection is a multiplexer Conn.
+// If the check is successful, it indicates that the connection was provided by another multiplexer listener,
 // and that the unsigned PROXY protocol requirement has already been handled.
 func isInternalConn(conn net.Conn) bool {
 	type netConn interface {
 		NetConn() net.Conn
 	}
-	type connUpgradedFromWebsocket interface {
-		IsALPNUpgradedConn()
-	}
 
 	for {
 		if _, ok := conn.(*Conn); ok {
-			return true
-		}
-
-		if _, ok := conn.(connUpgradedFromWebsocket); ok {
 			return true
 		}
 

--- a/lib/web/conn_upgrade.go
+++ b/lib/web/conn_upgrade.go
@@ -243,6 +243,12 @@ func (conn *waitConn) Close() error {
 	return trace.Wrap(err)
 }
 
+// IsALPNUpgradedConn is a no-op function to mark this connection as an ALPN upgrade connection.
+// It's used to disable PROXY line enforcement in the muxer when the connection is
+// passed to the ALPN handler and `proxy_protocol` is enabled.
+func (conn *waitConn) IsALPNUpgradedConn() {
+}
+
 type websocketALPNServerConn struct {
 	net.Conn
 	readBuffer []byte

--- a/lib/web/conn_upgrade.go
+++ b/lib/web/conn_upgrade.go
@@ -243,10 +243,8 @@ func (conn *waitConn) Close() error {
 	return trace.Wrap(err)
 }
 
-// IsALPNUpgradedConn is a no-op function to mark this connection as an ALPN upgrade connection.
-// It's used to disable PROXY line enforcement in the muxer when the connection is
-// passed to the ALPN handler and `proxy_protocol` is enabled.
-func (conn *waitConn) IsALPNUpgradedConn() {
+func (conn *waitConn) NetConn() net.Conn {
+	return conn.Conn
 }
 
 type websocketALPNServerConn struct {
@@ -266,6 +264,10 @@ func newWebSocketALPNServerConn(ctx context.Context, conn net.Conn, logger *slog
 		logContext: ctx,
 		logger:     logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentWeb, "alpnws")),
 	}
+}
+
+func (c *websocketALPNServerConn) NetConn() net.Conn {
+	return c.Conn
 }
 
 func (c *websocketALPNServerConn) Read(b []byte) (int, error) {


### PR DESCRIPTION
Backport #45968 to branch/v16

changelog: Prevent connections from being randomly terminated by Teleport proxies when `proxy_protocol` is enabled and TLS is terminated before Teleport Proxy. 
