### PR TITLE
revert from using grpc.NewClient to grpc.Dial

### DIFF
--- a/lib/client/proxy/insecure/insecure.go
+++ b/lib/client/proxy/insecure/insecure.go
@@ -81,7 +81,8 @@ func NewConnection(
 		client.WithALPNConnUpgrade(alpnConnUpgrade),
 	)
 
-	conn, err := grpc.NewClient(
+	//nolint:staticcheck // ignore deprecation until https://github.com/grpc/grpc-go/issues/7556 is fixed, at which point we should switch to grpc.NewClient.
+	conn, err := grpc.Dial(
 		params.ProxyServer,
 		grpc.WithContextDialer(client.GRPCContextDialer(dialer)),
 		grpc.WithUnaryInterceptor(metadata.UnaryClientInterceptor),


### PR DESCRIPTION
Changelog: fixed a bug where Teleport services could not join the cluster using iam, azure, or tpm methods when the proxy service certificate did not contain IP SANs.

This PR reverts the change from `grpc.Dial` to `grpc.NewClient` in https://github.com/gravitational/teleport/pull/44324
- https://github.com/gravitational/teleport/pull/44324

`grpc.Dial` is being deprecated in favor of `grpc.NewClient`, but there's an issue where `grpc.NewClient` resolves the proxy address to an IP and then fails to verify the proxy cert if it does not contain the IP SAN: https://github.com/grpc/grpc-go/issues/7556
- https://github.com/grpc/grpc-go/issues/7556