### PR TITLE
[v15] revert from using grpc.NewClient to grpc.Dial

### DIFF
--- a/lib/client/proxy/insecure/insecure.go
+++ b/lib/client/proxy/insecure/insecure.go
@@ -77,7 +77,8 @@ func NewConnection(
 		client.WithALPNConnUpgrade(alpnConnUpgrade),
 	)
 
-	conn, err := grpc.NewClient(
+	//nolint:staticcheck // ignore deprecation until https://github.com/grpc/grpc-go/issues/7556 is fixed, at which point we should switch to grpc.NewClient.
+	conn, err := grpc.Dial(
 		params.ProxyServer,
 		grpc.WithContextDialer(client.GRPCContextDialer(dialer)),
 		grpc.WithUnaryInterceptor(metadata.UnaryClientInterceptor),


### PR DESCRIPTION
Backport #46006 to branch/v15

changelog: fixed a bug where Teleport services could not join the cluster using iam, azure, or tpm methods when the proxy service certificate did not contain IP SANs.
