### PR TITLE
[v15] Replace erroneous links to "index.mdx"

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-controls.mdx
+++ b/docs/pages/admin-guides/access-controls/access-controls.mdx
@@ -4,10 +4,6 @@ description: How to provide role-based access control (RBAC) for servers, databa
 layout: tocless-doc
 ---
 
-After [deploying a Teleport cluster](../../index.mdx), the
-next step is to manage the access that Teleport users have to resources in your
-infrastructure.
-
 Teleport's role-based access control (RBAC) enables you to set fine-grained
 policies for who can perform certain actions against specific resources. For
 example:

--- a/docs/pages/admin-guides/deploy-a-cluster/high-availability.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/high-availability.mdx
@@ -353,7 +353,7 @@ Create a configuration file and provide it to each of your Proxy Service
 instances at `/etc/teleport.yaml`. We will explain the required configuration
 fields for a high-availability Teleport deployment below. These are the minimum
 requirements, and when planning your high-availability deployment, you will want
-to follow a more specific [deployment guide](../../index.mdx) for your
+to follow a more specific [deployment guide](deployments.mdx) for your
 environment. 
 
 #### `proxy_service` and `auth_service`
@@ -467,7 +467,7 @@ Create a configuration file and provide it to each of your Auth Service
 instances at `/etc/teleport.yaml`. We will explain the required configuration
 fields for a high-availability Teleport deployment below. These are the minimum
 requirements, and when planning your high-availability deployment, you will want
-to follow a more specific [deployment guide](../../index.mdx) for your
+to follow a more specific [deployment guide](deployments.mdx) for your
 environment.
 
 #### `storage`

--- a/docs/pages/admin-guides/management/admin/troubleshooting.mdx
+++ b/docs/pages/admin-guides/management/admin/troubleshooting.mdx
@@ -149,7 +149,7 @@ through the [Teleport support portal](https://support.goteleport.com).
 <TabItem scope={["oss"]} label="Teleport Community Edition">
 If you need help, please ask on our [community forum](https://github.com/gravitational/teleport/discussions). You can also open an [issue on GitHub](https://github.com/gravitational/teleport/issues).
 
-For more information about custom features, or to try our [Enterprise edition](../../../index.mdx) of Teleport, please reach out to us at [sales](https://goteleport.com/signup/enterprise/).
+For more information about custom features, or to try the [self-hosted Enterprise edition](../../deploy-a-cluster/deploy-a-cluster.mdx) of Teleport, reach out to us at [sales](https://goteleport.com/signup/enterprise/).
 </TabItem>
 </Tabs>
 

--- a/docs/pages/admin-guides/management/operations/proxy-peering.mdx
+++ b/docs/pages/admin-guides/management/operations/proxy-peering.mdx
@@ -11,7 +11,7 @@ and Teleport services like the Database Service and Application Service.
 
 ## Prerequisites
 
-An existing Teleport Enterprise cluster. See [introduction to Teleport Enterprise](../../../index.mdx) to get started.
+An existing self-hosted Teleport Enterprise cluster. See the documentation on [self-hosting Teleport](../../deploy-a-cluster/deploy-a-cluster.mdx) to get started.
 
 Teleport Proxy Service instances must be able to reach each other over the network on port
 `3021` by default. Ensure there are no firewall policies that would block communication

--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -129,8 +129,9 @@ source core, which is available at the
 [`gravitational/teleport`](https://github.com/gravitational/teleport) repository
 on GitHub.
 
-You can find a detailed comparison of the features available in each Teleport 
-edition in [Choose an edition](index.mdx).
+You can find a detailed comparison of the features available in each Teleport
+edition in [Frequently Asked
+Questions](./faq.mdx#how-is-open-source-different-from-enterprise).
 
 ### Teleport Enterprise Cloud
 
@@ -152,8 +153,8 @@ advanced security needs, such as support for Federal Information Processing
 Standards (FIPS) and a hardware security module (HSM). Teleport Enterprise
 includes a support agreement with Teleport.
 
-Read more in our [Teleport Enterprise
-guide](index.mdx).
+[Read the documentation](admin-guides/deploy-a-cluster/deploy-a-cluster.mdx) on
+self-hosting Teleport.
 
 ### Teleport Community Edition
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -14,7 +14,7 @@ including:
 - `tbot`
 
 If you are new to Teleport, we recommend following our [getting started
-guide](./index.mdx).
+guide](./get-started.mdx).
 
 For best results, Teleport clients (`tsh`, `tctl`, `tbot`) should be the same major
 version as the cluster they are connecting to. Teleport servers are compatible
@@ -74,7 +74,7 @@ agents by:
 
 If you are running a self-hosted Teleport Enterprise cluster, read our guidance
 in [Deploying a High-Availability Teleport
-Cluster](index.mdx), which provides full requirements
+Cluster](admin-guides/deploy-a-cluster/deploy-a-cluster.mdx), which provides full requirements
 and Terraform modules for deploying Teleport Enterprise on your infrastructure.
 
 Self-hosted Teleport Enterprise clusters require a license file. Read [Teleport


### PR DESCRIPTION
Backports #45994

These links were updated to include incorrect targets during the reorganization work in #44327.