### PR TITLE
Add `host_sudoers` example to role spec documentation

### DIFF
--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -150,6 +150,15 @@ spec:
     # is not 'off'.
     host_groups: [ubuntu, nginx, other]
 
+    # List of entries to include in a temporary sudoers file created in
+    # `/etc/sudoers.d`. The records are removed on session close.
+    host_sudoers: [
+      # This line will allow the login user to run `systemctl restart nginx.service`
+      # as root without requiring a password. The sudoers entry will be prefixed
+      # with the logged in username.
+      "ALL = (root) NOPASSWD: /usr/bin/systemctl restart nginx.service"
+    ]
+
     # kubernetes_groups specifies Kubernetes groups a user with this role will assume.
     # You can refer to a SAML/OIDC trait via the 'external' property bag.
     # This allows you to specify Kubernetes group membership in an identity manager:


### PR DESCRIPTION
Closes #46025

This adds an example for `host_sudoers` in the role spec documentation. The copy is a slightly modified version of the example given in the [host user creation guide](https://goteleport.com/docs/enroll-resources/server-access/guides/host-user-creation/#define-a-teleport-role).
