### PR TITLE
Fix disappearing integrations submenu

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2003,7 +2003,7 @@
     },
     {
       "source": "/access-controls/teleport-policy/policy-integrations/",
-      "destination": "/admin-guides/teleport-policy/integrations/integrations/",
+      "destination": "/admin-guides/teleport-policy/integrations/",
       "permanent": true
     },
     {

--- a/docs/pages/admin-guides/teleport-policy/integrations.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations.mdx
@@ -18,7 +18,7 @@ visualize role-based access controls from third-party services:
 The Integrations page shows integrations that can be enabled or are already
 enabled in Access Graph.
 
-![Integrations](../../../../img/access-graph/integrations.png)
+![Integrations](../../../img/access-graph/integrations.png)
 
 Resources imported into Teleport through Teleport-enabled integrations are
 automatically imported into Teleport Policy without any additional
@@ -49,12 +49,12 @@ Visit the Teleport Web UI and click **Access Management** on the menu bar at the
 top of the screen. 
 
 On the left sidebar, click **Access Graph**. Click the connection icon: 
-![Connection view](../../../../img/access-graph/connection_view.png) 
+![Connection view](../../../img/access-graph/connection_view.png) 
 Choose an application to integrate with.
 
 Teleport can also import and grant access to resources from Okta organizations,
 such as user profiles, groups and applications. You can view connection data in
 Access Graph. Follow the steps here to add an [Okta
-integration](../../../enroll-resources/application-access/okta/hosted-guide.mdx)
+integration](../../enroll-resources/application-access/okta/hosted-guide.mdx)
 in your cluster.
 


### PR DESCRIPTION
Working locally, this is current version:

![image](https://github.com/user-attachments/assets/fb196e01-d4ea-4b28-adce-d80b34259528)

After the fix:

![image](https://github.com/user-attachments/assets/5da05381-6a22-49b5-a2eb-5cc4f441306d)

Somewhat puzzlingly the public docs appear fine: https://goteleport.com/docs/admin-guides/teleport-policy/integrations/entra-id/