### PR TITLE
Return better error during group creation with invalid group name

### DIFF
--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -451,11 +451,13 @@ func (u *HostUserManagement) createGroupIfNotExist(group string) error {
 	if err != nil && !isUnknownGroupError(err, group) {
 		return trace.Wrap(err)
 	}
+
 	err = u.backend.CreateGroup(group, "")
 	if trace.IsAlreadyExists(err) {
 		return nil
 	}
-	return trace.Wrap(err)
+
+	return trace.Wrap(err, "%q", group)
 }
 
 // isUnknownGroupError returns whether the error from LookupGroup is an unknown group error.

--- a/lib/utils/host/hostusers.go
+++ b/lib/utils/host/hostusers.go
@@ -32,6 +32,7 @@ import (
 
 // man GROUPADD(8), exit codes section
 const GroupExistExit = 9
+const GroupInvalidArg = 3
 
 // man USERADD(8), exit codes section
 const UserExistExit = 9
@@ -53,10 +54,19 @@ func GroupAdd(groupname string, gid string) (exitCode int, err error) {
 	cmd := exec.Command(groupaddBin, args...)
 	output, err := cmd.CombinedOutput()
 	log.Debugf("%s output: %s", cmd.Path, string(output))
-	if cmd.ProcessState.ExitCode() == GroupExistExit {
-		return cmd.ProcessState.ExitCode(), trace.AlreadyExists("group already exists")
+
+	switch code := cmd.ProcessState.ExitCode(); code {
+	case GroupExistExit:
+		return code, trace.AlreadyExists("group already exists")
+	case GroupInvalidArg:
+		errMsg := "bad parameter"
+		if strings.Contains(string(output), "not a valid group name") {
+			errMsg = "invalid group name"
+		}
+		return code, trace.BadParameter(errMsg)
+	default:
+		return code, trace.Wrap(err)
 	}
-	return cmd.ProcessState.ExitCode(), trace.Wrap(err)
 }
 
 // UserAdd creates a user on a host using `useradd`


### PR DESCRIPTION
Fixes #21165

Returns a `trace.BadParameter` error when `groupadd` fails with exit code 3 ("invalid argument to option"). If the command output contains "not a valid group name" then the message wrapped by `trace.BadParameter` specifies that. Otherwise we just report there was an invalid parameter. Regardless of which specific error message is resolved, adding the group name to the error returned in `createGroupIfNotExists` should help make it more obvious that a role's `host_groups` array has an invalid entry when session creation fails.
