### PR TITLE
docs: join token step for eks clusters with iam oidc provider

### DIFF
--- a/docs/pages/enroll-resources/machine-id/deployment/kubernetes.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/kubernetes.mdx
@@ -124,6 +124,12 @@ $ kubectl apply -f ./k8s-rbac.yaml
 
 ## Step 3/5. Create a join token
 
+<Admonition type="note">
+If you are using AWS EKS clusters with IAM OIDC enabled, use the JWKS from `https://oidc.eks.REGION.amazonaws.com/id/CLUSTER_ID/keys`. 
+This is because the Kubernetes API server does not use its own JWKS for signing Service Account JWTs; instead, AWS IAM credentials are used.
+
+</Admonition>
+
 Next, a join token needs to be configured. This will be used by `tbot` to join
 the cluster. As the `kubernetes` join method will be used, the public key of the
 Kubernetes cluster must first be determined. The public key used to sign JWTs

--- a/docs/pages/enroll-resources/machine-id/deployment/kubernetes.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/kubernetes.mdx
@@ -125,7 +125,7 @@ $ kubectl apply -f ./k8s-rbac.yaml
 ## Step 3/5. Create a join token
 
 <Admonition type="note">
-If you are using AWS EKS clusters with IAM OIDC enabled, you will need to use [IAM join method](../../../enroll-resources/agents/join-services-to-your-cluster/aws-iam.mdx) 
+If you are using AWS EKS clusters with IAM OIDC enabled, you will need to use the [IAM join method](../../../enroll-resources/agents/join-services-to-your-cluster/aws-iam.mdx) 
 instead of `static_jwks`. This is because the Kubernetes API server does not use its own JWKS for signing Service Account JWTs; instead, AWS IAM credentials are used.
 </Admonition>
 

--- a/docs/pages/enroll-resources/machine-id/deployment/kubernetes.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/kubernetes.mdx
@@ -125,7 +125,7 @@ $ kubectl apply -f ./k8s-rbac.yaml
 ## Step 3/5. Create a join token
 
 <Admonition type="note">
-If you are using AWS EKS clusters with IAM OIDC enabled, you will need to use [`in_cluster`](../../../reference/join-methods.mdx#kubernetes-in-cluster) 
+If you are using AWS EKS clusters with IAM OIDC enabled, you will need to use [IAM join method](../../../enroll-resources/agents/join-services-to-your-cluster/aws-iam.mdx) 
 instead of `static_jwks`. This is because the Kubernetes API server does not use its own JWKS for signing Service Account JWTs; instead, AWS IAM credentials are used.
 </Admonition>
 

--- a/docs/pages/enroll-resources/machine-id/deployment/kubernetes.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/kubernetes.mdx
@@ -125,9 +125,8 @@ $ kubectl apply -f ./k8s-rbac.yaml
 ## Step 3/5. Create a join token
 
 <Admonition type="note">
-If you are using AWS EKS clusters with IAM OIDC enabled, use the JWKS from `https://oidc.eks.REGION.amazonaws.com/id/CLUSTER_ID/keys`. 
-This is because the Kubernetes API server does not use its own JWKS for signing Service Account JWTs; instead, AWS IAM credentials are used.
-
+If you are using AWS EKS clusters with IAM OIDC enabled, you will need to use use [`in_cluster`](../../../reference/join-methods.mdx#kubernetes-in-cluster) 
+instead of `static_jwks`. This is because the Kubernetes API server does not use its own JWKS for signing Service Account JWTs; instead, AWS IAM credentials are used.
 </Admonition>
 
 Next, a join token needs to be configured. This will be used by `tbot` to join

--- a/docs/pages/enroll-resources/machine-id/deployment/kubernetes.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/kubernetes.mdx
@@ -125,7 +125,7 @@ $ kubectl apply -f ./k8s-rbac.yaml
 ## Step 3/5. Create a join token
 
 <Admonition type="note">
-If you are using AWS EKS clusters with IAM OIDC enabled, you will need to use use [`in_cluster`](../../../reference/join-methods.mdx#kubernetes-in-cluster) 
+If you are using AWS EKS clusters with IAM OIDC enabled, you will need to use [`in_cluster`](../../../reference/join-methods.mdx#kubernetes-in-cluster) 
 instead of `static_jwks`. This is because the Kubernetes API server does not use its own JWKS for signing Service Account JWTs; instead, AWS IAM credentials are used.
 </Admonition>
 


### PR DESCRIPTION
Reference 

- [JWKS when on EKS with IAM OIDC provider enabled](https://github.com/gravitational/teleport/issues/37183)

- [Feature request](https://github.com/gravitational/teleport/issues/39170)

This note adds a workaround; Support has received a few tickets around this. 