### PR TITLE
prevent running script in wrong account

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -276,6 +276,8 @@ type CommandLineFlags struct {
 type IntegrationConfAccessGraphAWSSync struct {
 	// Role is the AWS Role associated with the Integration
 	Role string
+	// AccountID is the AWS account ID.
+	AccountID string
 }
 
 // IntegrationConfAzureOIDC contains the arguments of
@@ -307,6 +309,8 @@ type IntegrationConfDeployServiceIAM struct {
 	Role string
 	// TaskRole is the AWS Role to be used by the deployed service.
 	TaskRole string
+	// AccountID is the AWS account ID.
+	AccountID string
 }
 
 // IntegrationConfEICEIAM contains the arguments of
@@ -316,6 +320,8 @@ type IntegrationConfEICEIAM struct {
 	Region string
 	// Role is the AWS Role associated with the Integration
 	Role string
+	// AccountID is the AWS account ID.
+	AccountID string
 }
 
 // IntegrationConfAWSAppAccessIAM contains the arguments of
@@ -323,6 +329,8 @@ type IntegrationConfEICEIAM struct {
 type IntegrationConfAWSAppAccessIAM struct {
 	// RoleName is the AWS Role associated with the Integration
 	RoleName string
+	// AccountID is the AWS account ID.
+	AccountID string
 }
 
 // IntegrationConfEC2SSMIAM contains the arguments of
@@ -345,6 +353,8 @@ type IntegrationConfEC2SSMIAM struct {
 	// IntegrationName is the Teleport AWS OIDC Integration name.
 	// Used for resource tagging.
 	IntegrationName string
+	// AccountID is the AWS account ID.
+	AccountID string
 }
 
 // IntegrationConfEKSIAM contains the arguments of
@@ -354,6 +364,8 @@ type IntegrationConfEKSIAM struct {
 	Region string
 	// Role is the AWS Role associated with the Integration
 	Role string
+	// AccountID is the AWS account ID.
+	AccountID string
 }
 
 // IntegrationConfAWSOIDCIdP contains the arguments of
@@ -377,6 +389,8 @@ type IntegrationConfListDatabasesIAM struct {
 	Region string
 	// Role is the AWS Role associated with the Integration
 	Role string
+	// AccountID is the AWS account ID.
+	AccountID string
 }
 
 // ReadConfigFile reads /etc/teleport.yaml (or whatever is passed via --config flag)

--- a/lib/integrations/awsoidc/access_graph_aws_sync_test.go
+++ b/lib/integrations/awsoidc/access_graph_aws_sync_test.go
@@ -33,6 +33,7 @@ func TestAccessGraphIAMConfigReqDefaults(t *testing.T) {
 	baseReq := func() AccessGraphAWSIAMConfigureRequest {
 		return AccessGraphAWSIAMConfigureRequest{
 			IntegrationRole: "integrationrole",
+			AccountID:       "123456789012",
 		}
 	}
 
@@ -49,9 +50,9 @@ func TestAccessGraphIAMConfigReqDefaults(t *testing.T) {
 			expected: AccessGraphAWSIAMConfigureRequest{
 				IntegrationRole:          "integrationrole",
 				IntegrationRoleTAGPolicy: "AccessGraphSyncAccess",
+				AccountID:                "123456789012",
 			},
 		},
-
 		{
 			name: "missing integration role",
 			req: func() AccessGraphAWSIAMConfigureRequest {
@@ -60,6 +61,19 @@ func TestAccessGraphIAMConfigReqDefaults(t *testing.T) {
 				return req
 			},
 			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing account id is ok",
+			req: func() AccessGraphAWSIAMConfigureRequest {
+				req := baseReq()
+				req.AccountID = ""
+				return req
+			},
+			errCheck: require.NoError,
+			expected: AccessGraphAWSIAMConfigureRequest{
+				IntegrationRole:          "integrationrole",
+				IntegrationRoleTAGPolicy: "AccessGraphSyncAccess",
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -80,11 +94,13 @@ func TestAccessGraphAWSIAMConfig(t *testing.T) {
 	baseReq := func() AccessGraphAWSIAMConfigureRequest {
 		return AccessGraphAWSIAMConfigureRequest{
 			IntegrationRole: "integrationrole",
+			AccountID:       "123456789012",
 		}
 	}
 
 	for _, tt := range []struct {
 		name              string
+		mockAccountID     string
 		mockExistingRoles []string
 		req               func() AccessGraphAWSIAMConfigureRequest
 		errCheck          require.ErrorAssertionFunc
@@ -92,19 +108,29 @@ func TestAccessGraphAWSIAMConfig(t *testing.T) {
 		{
 			name:              "valid",
 			req:               baseReq,
+			mockAccountID:     "123456789012",
 			mockExistingRoles: []string{"integrationrole"},
 			errCheck:          require.NoError,
 		},
 		{
 			name:              "integration role does not exist",
+			mockAccountID:     "123456789012",
 			mockExistingRoles: []string{},
 			req:               baseReq,
 			errCheck:          notFoundCheck,
 		},
+		{
+			name:              "account does not match expected account",
+			req:               baseReq,
+			mockAccountID:     "222222222222",
+			mockExistingRoles: []string{"integrationrole"},
+			errCheck:          badParameterCheck,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			clt := mockAccessGraphAWSAMConfigClient{
-				existingRoles: tt.mockExistingRoles,
+				callerIdentityGetter: mockSTSClient{accountID: tt.mockAccountID},
+				existingRoles:        tt.mockExistingRoles,
 			}
 
 			err := ConfigureAccessGraphSyncIAM(ctx, &clt, tt.req())
@@ -114,6 +140,7 @@ func TestAccessGraphAWSIAMConfig(t *testing.T) {
 }
 
 type mockAccessGraphAWSAMConfigClient struct {
+	callerIdentityGetter
 	existingRoles []string
 }
 

--- a/lib/integrations/awsoidc/aws_app_access_iam_config.go
+++ b/lib/integrations/awsoidc/aws_app_access_iam_config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
 
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
@@ -45,6 +46,9 @@ type AWSAppAccessConfigureRequest struct {
 	// IntegrationRoleAWSAppAccessPolicy is the Policy Name that is created to allow access to call AWS APIs.
 	// Defaults to AWSAppAccess
 	IntegrationRoleAWSAppAccessPolicy string
+
+	// AccountID is the AWS Account ID.
+	AccountID string
 }
 
 // CheckAndSetDefaults ensures the required fields are present.
@@ -66,8 +70,14 @@ func (r *AWSAppAccessConfigureRequest) CheckAndSetDefaults() error {
 
 // AWSAppAccessConfigureClient describes the required methods to create the IAM Policies required for AWS App Access.
 type AWSAppAccessConfigureClient interface {
+	callerIdentityGetter
 	// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
 	PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
+}
+
+type defaultAWSAppAccessConfigureClient struct {
+	*iam.Client
+	callerIdentityGetter
 }
 
 // NewAWSAppAccessConfigureClient creates a new AWSAppAccessConfigureClient.
@@ -89,7 +99,10 @@ func NewAWSAppAccessConfigureClient(ctx context.Context) (AWSAppAccessConfigureC
 		cfg.Region = " "
 	}
 
-	return iam.NewFromConfig(cfg), nil
+	return &defaultAWSAppAccessConfigureClient{
+		Client:               iam.NewFromConfig(cfg),
+		callerIdentityGetter: sts.NewFromConfig(cfg),
+	}, nil
 }
 
 // ConfigureAWSAppAccess set ups the roles required for AWS App Access.
@@ -100,6 +113,10 @@ func NewAWSAppAccessConfigureClient(ctx context.Context) (AWSAppAccessConfigureC
 //   - iam:PutRolePolicy
 func ConfigureAWSAppAccess(ctx context.Context, awsClient AWSAppAccessConfigureClient, req AWSAppAccessConfigureRequest) error {
 	if err := req.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := checkAccountID(ctx, awsClient, req.AccountID); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/integrations/awsoidc/aws_app_access_iam_config_test.go
+++ b/lib/integrations/awsoidc/aws_app_access_iam_config_test.go
@@ -33,6 +33,7 @@ func TestAWSAppAccessConfigReqDefaults(t *testing.T) {
 	baseReq := func() AWSAppAccessConfigureRequest {
 		return AWSAppAccessConfigureRequest{
 			IntegrationRole: "integrationrole",
+			AccountID:       "123456789012",
 		}
 	}
 
@@ -47,6 +48,7 @@ func TestAWSAppAccessConfigReqDefaults(t *testing.T) {
 			req:      baseReq,
 			errCheck: require.NoError,
 			expected: AWSAppAccessConfigureRequest{
+				AccountID:                         "123456789012",
 				IntegrationRole:                   "integrationrole",
 				IntegrationRoleAWSAppAccessPolicy: "AWSAppAccess",
 			},
@@ -59,6 +61,19 @@ func TestAWSAppAccessConfigReqDefaults(t *testing.T) {
 				return req
 			},
 			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing account id is ok",
+			req: func() AWSAppAccessConfigureRequest {
+				req := baseReq()
+				req.AccountID = ""
+				return req
+			},
+			expected: AWSAppAccessConfigureRequest{
+				IntegrationRole:                   "integrationrole",
+				IntegrationRoleAWSAppAccessPolicy: "AWSAppAccess",
+			},
+			errCheck: require.NoError,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -79,11 +94,13 @@ func TestAWSAppAccessConfig(t *testing.T) {
 	baseReq := func() AWSAppAccessConfigureRequest {
 		return AWSAppAccessConfigureRequest{
 			IntegrationRole: "integrationrole",
+			AccountID:       "123456789012",
 		}
 	}
 
 	for _, tt := range []struct {
 		name              string
+		mockAccountID     string
 		mockExistingRoles []string
 		req               func() AWSAppAccessConfigureRequest
 		errCheck          require.ErrorAssertionFunc
@@ -91,19 +108,29 @@ func TestAWSAppAccessConfig(t *testing.T) {
 		{
 			name:              "valid",
 			req:               baseReq,
+			mockAccountID:     "123456789012",
 			mockExistingRoles: []string{"integrationrole"},
 			errCheck:          require.NoError,
 		},
 		{
 			name:              "integration role does not exist",
+			mockAccountID:     "123456789012",
 			mockExistingRoles: []string{},
 			req:               baseReq,
 			errCheck:          notFoundCheck,
 		},
+		{
+			name:              "account does not match expected account",
+			req:               baseReq,
+			mockAccountID:     "222222222222",
+			mockExistingRoles: []string{"integrationrole"},
+			errCheck:          badParameterCheck,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			awsClient := &mockAWSAppAccessConfigClient{
-				existingRoles: tt.mockExistingRoles,
+				callerIdentityGetter: mockSTSClient{accountID: tt.mockAccountID},
+				existingRoles:        tt.mockExistingRoles,
 			}
 
 			err := ConfigureAWSAppAccess(ctx, awsClient, tt.req())
@@ -113,6 +140,7 @@ func TestAWSAppAccessConfig(t *testing.T) {
 }
 
 type mockAWSAppAccessConfigClient struct {
+	callerIdentityGetter
 	existingRoles []string
 }
 

--- a/lib/integrations/awsoidc/deployservice_iam_config.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config.go
@@ -61,7 +61,6 @@ type DeployServiceIAMConfigureRequest struct {
 	TaskRole string
 
 	// AccountID is the AWS Account ID.
-	// Optional. sts.GetCallerIdentity is used if not provided.
 	AccountID string
 
 	// ResourceCreationTags is used to add tags when creating resources in AWS.
@@ -114,8 +113,7 @@ func (r *DeployServiceIAMConfigureRequest) CheckAndSetDefaults() error {
 
 // DeployServiceIAMConfigureClient describes the required methods to create the IAM Roles/Policies required for the DeployService action.
 type DeployServiceIAMConfigureClient interface {
-	// GetCallerIdentity returns information about the caller identity.
-	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+	callerIdentityGetter
 
 	// CreateRole creates a new IAM Role.
 	CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error)
@@ -126,7 +124,7 @@ type DeployServiceIAMConfigureClient interface {
 
 type defaultDeployServiceIAMConfigureClient struct {
 	*iam.Client
-	stsClient *sts.Client
+	callerIdentityGetter
 }
 
 // NewDeployServiceIAMConfigureClient creates a new DeployServiceIAMConfigureClient.
@@ -141,14 +139,9 @@ func NewDeployServiceIAMConfigureClient(ctx context.Context, region string) (Dep
 	}
 
 	return &defaultDeployServiceIAMConfigureClient{
-		Client:    iam.NewFromConfig(cfg),
-		stsClient: sts.NewFromConfig(cfg),
+		Client:               iam.NewFromConfig(cfg),
+		callerIdentityGetter: sts.NewFromConfig(cfg),
 	}, nil
-}
-
-// GetCallerIdentity returns details about the IAM user or role whose credentials are used to call the operation.
-func (d defaultDeployServiceIAMConfigureClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
-	return d.stsClient.GetCallerIdentity(ctx, params, optFns...)
 }
 
 // ConfigureDeployServiceIAM set ups the roles required for calling the DeployService action.
@@ -176,6 +169,8 @@ func ConfigureDeployServiceIAM(ctx context.Context, clt DeployServiceIAMConfigur
 			return trace.Wrap(err)
 		}
 		req.AccountID = aws.ToString(callerIdentity.Account)
+	} else if err := checkAccountID(ctx, clt, req.AccountID); err != nil {
+		return trace.Wrap(err)
 	}
 
 	if err := createTaskRole(ctx, clt, req); err != nil {

--- a/lib/integrations/awsoidc/ec2_ssm_iam_config.go
+++ b/lib/integrations/awsoidc/ec2_ssm_iam_config.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
 
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
@@ -68,6 +69,8 @@ type EC2SSMIAMConfigureRequest struct {
 	// IntegrationName is the Teleport AWS OIDC Integration name.
 	// Used for resource tagging.
 	IntegrationName string
+	// AccountID is the AWS Account ID.
+	AccountID string
 }
 
 // CheckAndSetDefaults ensures the required fields are present.
@@ -105,6 +108,8 @@ func (r *EC2SSMIAMConfigureRequest) CheckAndSetDefaults() error {
 
 // EC2SSMConfigureClient describes the required methods to create the IAM Policies and SSM Document required for installing Teleport in EC2 instances.
 type EC2SSMConfigureClient interface {
+	callerIdentityGetter
+
 	// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
 	PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
 
@@ -115,6 +120,7 @@ type EC2SSMConfigureClient interface {
 type defaultEC2SSMConfigureClient struct {
 	*iam.Client
 	ssmClient *ssm.Client
+	callerIdentityGetter
 }
 
 // CreateDocument creates a Amazon Web Services Systems Manager (SSM document).
@@ -134,8 +140,9 @@ func NewEC2SSMConfigureClient(ctx context.Context, region string) (EC2SSMConfigu
 	}
 
 	return &defaultEC2SSMConfigureClient{
-		Client:    iam.NewFromConfig(cfg),
-		ssmClient: ssm.NewFromConfig(cfg),
+		Client:               iam.NewFromConfig(cfg),
+		ssmClient:            ssm.NewFromConfig(cfg),
+		callerIdentityGetter: sts.NewFromConfig(cfg),
 	}, nil
 }
 
@@ -157,6 +164,10 @@ func NewEC2SSMConfigureClient(ctx context.Context, region string) (EC2SSMConfigu
 // This SSM Document downloads and runs the Teleport Installer Script, which installs teleport in the target EC2 instance.
 func ConfigureEC2SSM(ctx context.Context, clt EC2SSMConfigureClient, req EC2SSMIAMConfigureRequest) error {
 	if err := req.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := checkAccountID(ctx, clt, req.AccountID); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/integrations/awsoidc/ec2_ssm_iam_config_test.go
+++ b/lib/integrations/awsoidc/ec2_ssm_iam_config_test.go
@@ -41,6 +41,7 @@ func TestEC2SSMIAMConfigReqDefaults(t *testing.T) {
 			ProxyPublicURL:  "https://proxy.example.com",
 			ClusterName:     "my-cluster",
 			IntegrationName: "my-integration",
+			AccountID:       "123456789012",
 		}
 	}
 
@@ -62,6 +63,7 @@ func TestEC2SSMIAMConfigReqDefaults(t *testing.T) {
 				ProxyPublicURL:              "https://proxy.example.com",
 				ClusterName:                 "my-cluster",
 				IntegrationName:             "my-integration",
+				AccountID:                   "123456789012",
 			},
 		},
 		{
@@ -118,6 +120,24 @@ func TestEC2SSMIAMConfigReqDefaults(t *testing.T) {
 			},
 			errCheck: badParameterCheck,
 		},
+		{
+			name: "missing account id is ok",
+			req: func() EC2SSMIAMConfigureRequest {
+				req := baseReq()
+				req.AccountID = ""
+				return req
+			},
+			errCheck: require.NoError,
+			expected: EC2SSMIAMConfigureRequest{
+				Region:                      "us-east-1",
+				IntegrationRole:             "integrationrole",
+				IntegrationRoleEC2SSMPolicy: "EC2DiscoverWithSSM",
+				SSMDocumentName:             "MyDoc",
+				ProxyPublicURL:              "https://proxy.example.com",
+				ClusterName:                 "my-cluster",
+				IntegrationName:             "my-integration",
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			req := tt.req()
@@ -142,11 +162,13 @@ func TestEC2SSMIAMConfig(t *testing.T) {
 			ProxyPublicURL:  "https://proxy.example.com",
 			ClusterName:     "my-cluster",
 			IntegrationName: "my-integration",
+			AccountID:       "123456789012",
 		}
 	}
 
 	for _, tt := range []struct {
 		name                string
+		mockAccountID       string
 		mockExistingRoles   []string
 		mockExistingSSMDocs []string
 		req                 func() EC2SSMIAMConfigureRequest
@@ -155,12 +177,14 @@ func TestEC2SSMIAMConfig(t *testing.T) {
 		{
 			name:                "valid",
 			req:                 baseReq,
+			mockAccountID:       "123456789012",
 			mockExistingRoles:   []string{"integrationrole"},
 			mockExistingSSMDocs: []string{},
 			errCheck:            require.NoError,
 		},
 		{
 			name:                "integration role does not exist",
+			mockAccountID:       "123456789012",
 			mockExistingRoles:   []string{},
 			mockExistingSSMDocs: []string{},
 			req:                 baseReq,
@@ -168,15 +192,25 @@ func TestEC2SSMIAMConfig(t *testing.T) {
 		},
 		{
 			name:                "ssm document already exists",
+			mockAccountID:       "123456789012",
 			mockExistingRoles:   []string{},
 			mockExistingSSMDocs: []string{"MyDoc"},
 			req:                 baseReq,
 			errCheck:            require.Error,
 		},
+		{
+			name:                "account does not match expected account",
+			req:                 baseReq,
+			mockAccountID:       "222222222222",
+			mockExistingRoles:   []string{"integrationrole"},
+			mockExistingSSMDocs: []string{},
+			errCheck:            badParameterCheck,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			clt := mockEC2SSMIAMConfigClient{
-				existingRoles: tt.mockExistingRoles,
+				callerIdentityGetter: mockSTSClient{accountID: tt.mockAccountID},
+				existingRoles:        tt.mockExistingRoles,
 			}
 
 			err := ConfigureEC2SSM(ctx, &clt, tt.req())
@@ -194,6 +228,7 @@ func TestEC2SSMIAMConfig(t *testing.T) {
 }
 
 type mockEC2SSMIAMConfigClient struct {
+	callerIdentityGetter
 	existingRoles []string
 	existingDocs  map[string][]ssmtypes.Tag
 }

--- a/lib/integrations/awsoidc/eice_iam_config_test.go
+++ b/lib/integrations/awsoidc/eice_iam_config_test.go
@@ -34,6 +34,7 @@ func TestEICEIAMConfigReqDefaults(t *testing.T) {
 		return EICEIAMConfigureRequest{
 			Region:          "us-east-1",
 			IntegrationRole: "integrationrole",
+			AccountID:       "123456789012",
 		}
 	}
 
@@ -48,6 +49,7 @@ func TestEICEIAMConfigReqDefaults(t *testing.T) {
 			req:      baseReq,
 			errCheck: require.NoError,
 			expected: EICEIAMConfigureRequest{
+				AccountID:                 "123456789012",
 				Region:                    "us-east-1",
 				IntegrationRole:           "integrationrole",
 				IntegrationRoleEICEPolicy: "EC2InstanceConnectEndpoint",
@@ -71,6 +73,20 @@ func TestEICEIAMConfigReqDefaults(t *testing.T) {
 			},
 			errCheck: badParameterCheck,
 		},
+		{
+			name: "missing account id is ok",
+			req: func() EICEIAMConfigureRequest {
+				req := baseReq()
+				req.AccountID = ""
+				return req
+			},
+			errCheck: require.NoError,
+			expected: EICEIAMConfigureRequest{
+				Region:                    "us-east-1",
+				IntegrationRole:           "integrationrole",
+				IntegrationRoleEICEPolicy: "EC2InstanceConnectEndpoint",
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			req := tt.req()
@@ -91,11 +107,13 @@ func TestEICEIAMConfig(t *testing.T) {
 		return EICEIAMConfigureRequest{
 			Region:          "us-east-1",
 			IntegrationRole: "integrationrole",
+			AccountID:       "123456789012",
 		}
 	}
 
 	for _, tt := range []struct {
 		name              string
+		mockAccountID     string
 		mockExistingRoles []string
 		req               func() EICEIAMConfigureRequest
 		errCheck          require.ErrorAssertionFunc
@@ -103,19 +121,29 @@ func TestEICEIAMConfig(t *testing.T) {
 		{
 			name:              "valid",
 			req:               baseReq,
+			mockAccountID:     "123456789012",
 			mockExistingRoles: []string{"integrationrole"},
 			errCheck:          require.NoError,
 		},
 		{
 			name:              "integration role does not exist",
+			mockAccountID:     "123456789012",
 			mockExistingRoles: []string{},
 			req:               baseReq,
 			errCheck:          notFoundCheck,
 		},
+		{
+			name:              "account does not match expected account",
+			req:               baseReq,
+			mockAccountID:     "222222222222",
+			mockExistingRoles: []string{"integrationrole"},
+			errCheck:          badParameterCheck,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			clt := mockEICEIAMConfigClient{
-				existingRoles: tt.mockExistingRoles,
+				callerIdentityGetter: mockSTSClient{accountID: tt.mockAccountID},
+				existingRoles:        tt.mockExistingRoles,
 			}
 
 			err := ConfigureEICEIAM(ctx, &clt, tt.req())
@@ -125,6 +153,7 @@ func TestEICEIAMConfig(t *testing.T) {
 }
 
 type mockEICEIAMConfigClient struct {
+	callerIdentityGetter
 	existingRoles []string
 }
 

--- a/lib/integrations/awsoidc/eks_iam_config.go
+++ b/lib/integrations/awsoidc/eks_iam_config.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
 
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
@@ -46,6 +47,9 @@ type EKSIAMConfigureRequest struct {
 	// IntegrationRoleEKSPolicy is the Policy Name that is created to allow access to call AWS APIs.
 	// Defaults to "EKSAccess"
 	IntegrationRoleEKSPolicy string
+
+	// AccountID is the AWS Account ID.
+	AccountID string
 }
 
 // CheckAndSetDefaults ensures the required fields are present.
@@ -67,11 +71,13 @@ func (r *EKSIAMConfigureRequest) CheckAndSetDefaults() error {
 
 // EKSIAMConfigureClient describes the required methods to create the IAM Policies required for enrolling EKS clusters into Teleport.
 type EKSIAMConfigureClient interface {
+	callerIdentityGetter
 	// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
 	PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
 }
 
 type defaultEKSEIAMConfigureClient struct {
+	callerIdentityGetter
 	*iam.Client
 }
 
@@ -87,7 +93,8 @@ func NewEKSIAMConfigureClient(ctx context.Context, region string) (EKSIAMConfigu
 	}
 
 	return &defaultEKSEIAMConfigureClient{
-		Client: iam.NewFromConfig(cfg),
+		Client:               iam.NewFromConfig(cfg),
+		callerIdentityGetter: sts.NewFromConfig(cfg),
 	}, nil
 }
 
@@ -108,6 +115,10 @@ func NewEKSIAMConfigureClient(ctx context.Context, region string) (EKSIAMConfigu
 //   - iam:PutRolePolicy
 func ConfigureEKSIAM(ctx context.Context, clt EKSIAMConfigureClient, req EKSIAMConfigureRequest) error {
 	if err := req.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := checkAccountID(ctx, clt, req.AccountID); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/integrations/awsoidc/eks_iam_config_test.go
+++ b/lib/integrations/awsoidc/eks_iam_config_test.go
@@ -39,11 +39,13 @@ func TestEKSIAMConfigReqDefaults(t *testing.T) {
 		{
 			name: "set defaults",
 			req: EKSIAMConfigureRequest{
+				AccountID:       "123456789012",
 				Region:          "us-east-1",
 				IntegrationRole: "integrationRole",
 			},
 			errCheck: require.NoError,
 			expected: EKSIAMConfigureRequest{
+				AccountID:                "123456789012",
 				Region:                   "us-east-1",
 				IntegrationRole:          "integrationRole",
 				IntegrationRoleEKSPolicy: "EKSAccess",
@@ -52,6 +54,7 @@ func TestEKSIAMConfigReqDefaults(t *testing.T) {
 		{
 			name: "missing region",
 			req: EKSIAMConfigureRequest{
+				AccountID:       "123456789012",
 				IntegrationRole: "integrationRole",
 			},
 			errCheck: badParameterCheck,
@@ -59,9 +62,23 @@ func TestEKSIAMConfigReqDefaults(t *testing.T) {
 		{
 			name: "missing integration role",
 			req: EKSIAMConfigureRequest{
-				Region: "us-east-1",
+				AccountID: "123456789012",
+				Region:    "us-east-1",
 			},
 			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing account id is ok",
+			req: EKSIAMConfigureRequest{
+				IntegrationRole: "integrationRole",
+				Region:          "us-east-1",
+			},
+			errCheck: require.NoError,
+			expected: EKSIAMConfigureRequest{
+				Region:                   "us-east-1",
+				IntegrationRole:          "integrationRole",
+				IntegrationRoleEKSPolicy: "EKSAccess",
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -82,6 +99,7 @@ func TestEKSAMConfig(t *testing.T) {
 
 	for _, tt := range []struct {
 		name              string
+		mockAccountID     string
 		mockExistingRoles []string
 		req               EKSIAMConfigureRequest
 		errCheck          require.ErrorAssertionFunc
@@ -91,23 +109,39 @@ func TestEKSAMConfig(t *testing.T) {
 			req: EKSIAMConfigureRequest{
 				Region:          "us-east-1",
 				IntegrationRole: "integrationRole",
+				AccountID:       "123456789012",
 			},
+			mockAccountID:     "123456789012",
 			mockExistingRoles: []string{"integrationRole"},
 			errCheck:          require.NoError,
 		},
 		{
 			name:              "integration role does not exist",
+			mockAccountID:     "123456789012",
 			mockExistingRoles: []string{},
 			req: EKSIAMConfigureRequest{
 				Region:          "us-east-1",
 				IntegrationRole: "integrationRole",
+				AccountID:       "123456789012",
 			},
 			errCheck: notFoundCheck,
+		},
+		{
+			name: "account does not match expected account",
+			req: EKSIAMConfigureRequest{
+				Region:          "us-east-1",
+				IntegrationRole: "integrationRole",
+				AccountID:       "123456789012",
+			},
+			mockAccountID:     "222222222222",
+			mockExistingRoles: []string{"integrationRole"},
+			errCheck:          badParameterCheck,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			clt := mockEKSIAMConfigClient{
-				existingRoles: tt.mockExistingRoles,
+				callerIdentityGetter: mockSTSClient{accountID: tt.mockAccountID},
+				existingRoles:        tt.mockExistingRoles,
 			}
 
 			err := ConfigureEKSIAM(ctx, &clt, tt.req)
@@ -117,6 +151,7 @@ func TestEKSAMConfig(t *testing.T) {
 }
 
 type mockEKSIAMConfigClient struct {
+	callerIdentityGetter
 	existingRoles []string
 }
 

--- a/lib/integrations/awsoidc/idp_iam_config.go
+++ b/lib/integrations/awsoidc/idp_iam_config.go
@@ -108,8 +108,7 @@ func (r *IdPIAMConfigureRequest) CheckAndSetDefaults() error {
 // IdPIAMConfigureClient describes the required methods to create the AWS OIDC IdP and a Role that trusts that identity provider.
 // There is no guarantee that the client is thread safe.
 type IdPIAMConfigureClient interface {
-	// GetCallerIdentity returns information about the caller identity.
-	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+	callerIdentityGetter
 
 	// CreateOpenIDConnectProvider creates an IAM OIDC IdP.
 	CreateOpenIDConnectProvider(ctx context.Context, params *iam.CreateOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error)
@@ -132,12 +131,7 @@ type defaultIdPIAMConfigureClient struct {
 
 	*iam.Client
 	awsConfig aws.Config
-	stsClient *sts.Client
-}
-
-// GetCallerIdentity returns details about the IAM user or role whose credentials are used to call the operation.
-func (d *defaultIdPIAMConfigureClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
-	return d.stsClient.GetCallerIdentity(ctx, params, optFns...)
+	callerIdentityGetter
 }
 
 // NewIdPIAMConfigureClient creates a new IdPIAMConfigureClient.
@@ -158,10 +152,10 @@ func NewIdPIAMConfigureClient(ctx context.Context) (IdPIAMConfigureClient, error
 	}
 
 	return &defaultIdPIAMConfigureClient{
-		httpClient: httpClient,
-		awsConfig:  cfg,
-		Client:     iam.NewFromConfig(cfg),
-		stsClient:  sts.NewFromConfig(cfg),
+		httpClient:           httpClient,
+		awsConfig:            cfg,
+		Client:               iam.NewFromConfig(cfg),
+		callerIdentityGetter: sts.NewFromConfig(cfg),
 	}, nil
 }
 

--- a/lib/integrations/awsoidc/listdatabases_iam_config_test.go
+++ b/lib/integrations/awsoidc/listdatabases_iam_config_test.go
@@ -40,15 +40,29 @@ func TestListDatabasesIAMConfigReqDefaults(t *testing.T) {
 			name: "missing region",
 			req: ConfigureIAMListDatabasesRequest{
 				IntegrationRole: "integrationrole",
+				AccountID:       "123456789012",
 			},
 			errCheck: badParameterCheck,
 		},
 		{
 			name: "missing integration role",
 			req: ConfigureIAMListDatabasesRequest{
-				IntegrationRole: "integrationrole",
+				Region:    "us-east-1",
+				AccountID: "123456789012",
 			},
 			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing account id is ok",
+			req: ConfigureIAMListDatabasesRequest{
+				Region:          "us-east-1",
+				IntegrationRole: "integrationrole",
+			},
+			errCheck: require.NoError,
+			expected: ConfigureIAMListDatabasesRequest{
+				Region:          "us-east-1",
+				IntegrationRole: "integrationrole",
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -68,11 +82,13 @@ func TestListDatabasesIAMConfig(t *testing.T) {
 	baseReq := ConfigureIAMListDatabasesRequest{
 		Region:          "us-east-1",
 		IntegrationRole: "integrationrole",
+		AccountID:       "123456789012",
 	}
 
 	for _, tt := range []struct {
 		name              string
 		mockExistingRoles []string
+		mockAccountID     string
 		req               ConfigureIAMListDatabasesRequest
 		errCheck          require.ErrorAssertionFunc
 	}{
@@ -80,18 +96,28 @@ func TestListDatabasesIAMConfig(t *testing.T) {
 			name:              "valid",
 			req:               baseReq,
 			mockExistingRoles: []string{"integrationrole"},
+			mockAccountID:     "123456789012",
 			errCheck:          require.NoError,
+		},
+		{
+			name:              "account does not match expected account",
+			req:               baseReq,
+			mockExistingRoles: []string{"integrationrole"},
+			mockAccountID:     "222222222222",
+			errCheck:          badParameterCheck,
 		},
 		{
 			name:              "integration role does not exist",
 			mockExistingRoles: []string{},
+			mockAccountID:     "123456789012",
 			req:               baseReq,
 			errCheck:          notFoundCheck,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			clt := mockListDatabasesIAMConfigClient{
-				existingRoles: tt.mockExistingRoles,
+				callerIdentityGetter: mockSTSClient{accountID: tt.mockAccountID},
+				existingRoles:        tt.mockExistingRoles,
 			}
 
 			err := ConfigureListDatabasesIAM(ctx, &clt, tt.req)
@@ -101,6 +127,7 @@ func TestListDatabasesIAMConfig(t *testing.T) {
 }
 
 type mockListDatabasesIAMConfigClient struct {
+	callerIdentityGetter
 	existingRoles []string
 }
 

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -281,6 +281,11 @@ func (h *Handler) awsOIDCConfigureDeployServiceIAM(w http.ResponseWriter, r *htt
 		return nil, trace.BadParameter("invalid awsRegion")
 	}
 
+	awsAccountID := queryParams.Get("awsAccountID")
+	if err := aws.IsValidAccountID(awsAccountID); err != nil {
+		return nil, trace.Wrap(err, "invalid awsAccountID")
+	}
+
 	role := queryParams.Get("role")
 	if err := aws.IsValidIAMRoleName(role); err != nil {
 		return nil, trace.BadParameter("invalid role %q", role)
@@ -300,6 +305,7 @@ func (h *Handler) awsOIDCConfigureDeployServiceIAM(w http.ResponseWriter, r *htt
 		fmt.Sprintf("--aws-region=%s", shsprintf.EscapeDefaultContext(awsRegion)),
 		fmt.Sprintf("--role=%s", shsprintf.EscapeDefaultContext(role)),
 		fmt.Sprintf("--task-role=%s", shsprintf.EscapeDefaultContext(taskRole)),
+		fmt.Sprintf("--aws-account-id=%s", shsprintf.EscapeDefaultContext(awsAccountID)),
 	}
 	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
 		TeleportArgs:   strings.Join(argsList, " "),
@@ -325,6 +331,11 @@ func (h *Handler) awsOIDCConfigureEICEIAM(w http.ResponseWriter, r *http.Request
 		return nil, trace.BadParameter("invalid awsRegion")
 	}
 
+	awsAccountID := queryParams.Get("awsAccountID")
+	if err := aws.IsValidAccountID(awsAccountID); err != nil {
+		return nil, trace.Wrap(err, "invalid awsAccountID")
+	}
+
 	role := queryParams.Get("role")
 	if err := aws.IsValidIAMRoleName(role); err != nil {
 		return nil, trace.BadParameter("invalid role %q", role)
@@ -336,6 +347,7 @@ func (h *Handler) awsOIDCConfigureEICEIAM(w http.ResponseWriter, r *http.Request
 		"integration", "configure", "eice-iam",
 		fmt.Sprintf("--aws-region=%s", shsprintf.EscapeDefaultContext(awsRegion)),
 		fmt.Sprintf("--role=%s", shsprintf.EscapeDefaultContext(role)),
+		fmt.Sprintf("--aws-account-id=%s", shsprintf.EscapeDefaultContext(awsAccountID)),
 	}
 	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
 		TeleportArgs:   strings.Join(argsList, " "),
@@ -408,6 +420,11 @@ func (h *Handler) awsOIDCConfigureEC2SSMIAM(w http.ResponseWriter, r *http.Reque
 		return nil, trace.BadParameter("invalid region %q", region)
 	}
 
+	awsAccountID := queryParams.Get("awsAccountID")
+	if err := aws.IsValidAccountID(awsAccountID); err != nil {
+		return nil, trace.Wrap(err, "invalid awsAccountID")
+	}
+
 	ssmDocumentName := queryParams.Get("ssmDocument")
 	if ssmDocumentName == "" {
 		return nil, trace.BadParameter("missing ssmDocument query param")
@@ -434,6 +451,7 @@ func (h *Handler) awsOIDCConfigureEC2SSMIAM(w http.ResponseWriter, r *http.Reque
 		fmt.Sprintf("--proxy-public-url=%s", shsprintf.EscapeDefaultContext(proxyPublicURL)),
 		fmt.Sprintf("--cluster=%s", shsprintf.EscapeDefaultContext(clusterName)),
 		fmt.Sprintf("--name=%s", shsprintf.EscapeDefaultContext(integrationName)),
+		fmt.Sprintf("--aws-account-id=%s", shsprintf.EscapeDefaultContext(awsAccountID)),
 	}
 	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
 		TeleportArgs:   strings.Join(argsList, " "),
@@ -458,6 +476,11 @@ func (h *Handler) awsOIDCConfigureEKSIAM(w http.ResponseWriter, r *http.Request,
 		return nil, trace.BadParameter("invalid aws region")
 	}
 
+	awsAccountID := queryParams.Get("awsAccountID")
+	if err := aws.IsValidAccountID(awsAccountID); err != nil {
+		return nil, trace.Wrap(err, "invalid awsAccountID")
+	}
+
 	role := queryParams.Get("role")
 	if err := aws.IsValidIAMRoleName(role); err != nil {
 		return nil, trace.BadParameter("invalid role %q", role)
@@ -469,6 +492,7 @@ func (h *Handler) awsOIDCConfigureEKSIAM(w http.ResponseWriter, r *http.Request,
 		"integration", "configure", "eks-iam",
 		fmt.Sprintf("--aws-region=%s", shsprintf.EscapeDefaultContext(awsRegion)),
 		fmt.Sprintf("--role=%s", shsprintf.EscapeDefaultContext(role)),
+		fmt.Sprintf("--aws-account-id=%s", shsprintf.EscapeDefaultContext(awsAccountID)),
 	}
 	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
 		TeleportArgs:   strings.Join(argsList, " "),
@@ -1142,6 +1166,11 @@ func (h *Handler) awsOIDCConfigureListDatabasesIAM(w http.ResponseWriter, r *htt
 		return nil, trace.BadParameter("invalid awsRegion")
 	}
 
+	awsAccountID := queryParams.Get("awsAccountID")
+	if err := aws.IsValidAccountID(awsAccountID); err != nil {
+		return nil, trace.Wrap(err, "invalid awsAccountID")
+	}
+
 	role := queryParams.Get("role")
 	if err := aws.IsValidIAMRoleName(role); err != nil {
 		return nil, trace.BadParameter("invalid role %q", role)
@@ -1153,6 +1182,7 @@ func (h *Handler) awsOIDCConfigureListDatabasesIAM(w http.ResponseWriter, r *htt
 		"integration", "configure", "listdatabases-iam",
 		fmt.Sprintf("--aws-region=%s", shsprintf.EscapeDefaultContext(awsRegion)),
 		fmt.Sprintf("--role=%s", shsprintf.EscapeDefaultContext(role)),
+		fmt.Sprintf("--aws-account-id=%s", shsprintf.EscapeDefaultContext(awsAccountID)),
 	}
 	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
 		TeleportArgs:   strings.Join(argsList, " "),
@@ -1188,11 +1218,17 @@ func (h *Handler) awsAccessGraphOIDCSync(w http.ResponseWriter, r *http.Request,
 		return nil, trace.BadParameter("invalid role %q", role)
 	}
 
+	awsAccountID := queryParams.Get("awsAccountID")
+	if err := aws.IsValidAccountID(awsAccountID); err != nil {
+		return nil, trace.Wrap(err, "invalid awsAccountID")
+	}
+
 	// The script must execute the following command:
 	// "teleport integration configure access-graph aws-iam"
 	argsList := []string{
 		"integration", "configure", "access-graph", "aws-iam",
 		fmt.Sprintf("--role=%s", shsprintf.EscapeDefaultContext(role)),
+		fmt.Sprintf("--aws-account-id=%s", shsprintf.EscapeDefaultContext(awsAccountID)),
 	}
 	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
 		TeleportArgs:   strings.Join(argsList, " "),

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -71,6 +71,7 @@ func TestBuildDeployServiceConfigureIAMScript(t *testing.T) {
 		{
 			name: "valid",
 			reqQuery: url.Values{
+				"awsAccountID":    []string{"123456789012"},
 				"awsRegion":       []string{"us-east-1"},
 				"role":            []string{"myRole"},
 				"taskRole":        []string{"taskRole"},
@@ -82,11 +83,13 @@ func TestBuildDeployServiceConfigureIAMScript(t *testing.T) {
 				`--name=myintegration ` +
 				`--aws-region=us-east-1 ` +
 				`--role=myRole ` +
-				`--task-role=taskRole`,
+				`--task-role=taskRole ` +
+				"--aws-account-id=123456789012",
 		},
 		{
 			name: "valid with symbols in role",
 			reqQuery: url.Values{
+				"awsAccountID":    []string{"123456789012"},
 				"awsRegion":       []string{"us-east-1"},
 				"role":            []string{"Test+1=2,3.4@5-6_7"},
 				"taskRole":        []string{"taskRole"},
@@ -98,11 +101,13 @@ func TestBuildDeployServiceConfigureIAMScript(t *testing.T) {
 				`--name=myintegration ` +
 				`--aws-region=us-east-1 ` +
 				`--role=Test\+1=2,3.4\@5-6_7 ` +
-				`--task-role=taskRole`,
+				`--task-role=taskRole ` +
+				"--aws-account-id=123456789012",
 		},
 		{
 			name: "missing aws-region",
 			reqQuery: url.Values{
+				"awsAccountID":    []string{"123456789012"},
 				"role":            []string{"myRole"},
 				"taskRole":        []string{"taskRole"},
 				"integrationName": []string{"myintegration"},
@@ -112,6 +117,7 @@ func TestBuildDeployServiceConfigureIAMScript(t *testing.T) {
 		{
 			name: "missing role",
 			reqQuery: url.Values{
+				"awsAccountID":    []string{"123456789012"},
 				"awsRegion":       []string{"us-east-1"},
 				"taskRole":        []string{"taskRole"},
 				"integrationName": []string{"myintegration"},
@@ -121,6 +127,7 @@ func TestBuildDeployServiceConfigureIAMScript(t *testing.T) {
 		{
 			name: "missing task role",
 			reqQuery: url.Values{
+				"awsAccountID":    []string{"123456789012"},
 				"awsRegion":       []string{"us-east-1"},
 				"role":            []string{"role"},
 				"integrationName": []string{"myintegration"},
@@ -130,15 +137,27 @@ func TestBuildDeployServiceConfigureIAMScript(t *testing.T) {
 		{
 			name: "missing integration name",
 			reqQuery: url.Values{
-				"awsRegion": []string{"us-east-1"},
-				"role":      []string{"role"},
-				"taskRole":  []string{"taskRole"},
+				"awsAccountID": []string{"123456789012"},
+				"awsRegion":    []string{"us-east-1"},
+				"role":         []string{"role"},
+				"taskRole":     []string{"taskRole"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing account id",
+			reqQuery: url.Values{
+				"awsRegion":       []string{"us-east-1"},
+				"role":            []string{"role"},
+				"taskRole":        []string{"taskRole"},
+				"integrationName": []string{"myintegration"},
 			},
 			errCheck: isBadParamErrFn,
 		},
 		{
 			name: "trying to inject escape sequence into query params",
 			reqQuery: url.Values{
+				"awsAccountID":    []string{"123456789012"},
 				"awsRegion":       []string{"us-east-1"},
 				"role":            []string{"role"},
 				"taskRole":        []string{"taskRole"},
@@ -194,44 +213,59 @@ func TestBuildEICEConfigureIAMScript(t *testing.T) {
 		{
 			name: "valid",
 			reqQuery: url.Values{
-				"awsRegion": []string{"us-east-1"},
-				"role":      []string{"myRole"},
+				"awsRegion":    []string{"us-east-1"},
+				"role":         []string{"myRole"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure eice-iam " +
 				"--aws-region=us-east-1 " +
-				"--role=myRole",
+				"--role=myRole " +
+				"--aws-account-id=123456789012",
 		},
 		{
 			name: "valid with symbols in role",
 			reqQuery: url.Values{
-				"awsRegion": []string{"us-east-1"},
-				"role":      []string{"Test+1=2,3.4@5-6_7"},
+				"awsRegion":    []string{"us-east-1"},
+				"role":         []string{"Test+1=2,3.4@5-6_7"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure eice-iam " +
 				"--aws-region=us-east-1 " +
-				"--role=Test\\+1=2,3.4\\@5-6_7",
+				"--role=Test\\+1=2,3.4\\@5-6_7 " +
+				"--aws-account-id=123456789012",
 		},
 		{
 			name: "missing aws-region",
 			reqQuery: url.Values{
-				"role": []string{"myRole"},
+				"role":         []string{"myRole"},
+				"awsAccountID": []string{"123456789012"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing account id",
+			reqQuery: url.Values{
+				"awsRegion": []string{"us-east-1"},
+				"role":      []string{"myRole"},
 			},
 			errCheck: isBadParamErrFn,
 		},
 		{
 			name: "missing role",
 			reqQuery: url.Values{
-				"awsRegion": []string{"us-east-1"},
+				"awsRegion":    []string{"us-east-1"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: isBadParamErrFn,
 		},
 		{
 			name: "trying to inject escape sequence into query params",
 			reqQuery: url.Values{
-				"awsRegion": []string{"'; rm -rf /tmp/dir; echo '"},
-				"role":      []string{"role"},
+				"awsRegion":    []string{"'; rm -rf /tmp/dir; echo '"},
+				"role":         []string{"role"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: isBadParamErrFn,
 		},
@@ -289,6 +323,7 @@ func TestBuildEC2SSMIAMScript(t *testing.T) {
 				"role":            []string{"myRole"},
 				"ssmDocument":     []string{"TeleportDiscoveryInstallerTest"},
 				"integrationName": []string{"my-integration"},
+				"awsAccountID":    []string{"123456789012"},
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure ec2-ssm-iam " +
@@ -297,7 +332,8 @@ func TestBuildEC2SSMIAMScript(t *testing.T) {
 				"--ssm-document-name=TeleportDiscoveryInstallerTest " +
 				"--proxy-public-url=" + proxyPublicURL + " " +
 				"--cluster=localhost " +
-				"--name=my-integration",
+				"--name=my-integration " +
+				"--aws-account-id=123456789012",
 		},
 		{
 			name: "valid with symbols in role",
@@ -306,6 +342,7 @@ func TestBuildEC2SSMIAMScript(t *testing.T) {
 				"role":            []string{"Test+1=2,3.4@5-6_7"},
 				"ssmDocument":     []string{"TeleportDiscoveryInstallerTest"},
 				"integrationName": []string{"my-integration"},
+				"awsAccountID":    []string{"123456789012"},
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure ec2-ssm-iam " +
@@ -314,38 +351,52 @@ func TestBuildEC2SSMIAMScript(t *testing.T) {
 				"--ssm-document-name=TeleportDiscoveryInstallerTest " +
 				"--proxy-public-url=" + proxyPublicURL + " " +
 				"--cluster=localhost " +
-				"--name=my-integration",
+				"--name=my-integration " +
+				"--aws-account-id=123456789012",
 		},
 		{
 			name: "missing aws-region",
 			reqQuery: url.Values{
-				"role":        []string{"myRole"},
-				"ssmDocument": []string{"TeleportDiscoveryInstallerTest"},
+				"role":         []string{"myRole"},
+				"ssmDocument":  []string{"TeleportDiscoveryInstallerTest"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: isBadParamErrFn,
 		},
 		{
 			name: "missing role",
 			reqQuery: url.Values{
-				"awsRegion":   []string{"us-east-1"},
-				"ssmDocument": []string{"TeleportDiscoveryInstallerTest"},
+				"awsRegion":    []string{"us-east-1"},
+				"ssmDocument":  []string{"TeleportDiscoveryInstallerTest"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: isBadParamErrFn,
 		},
 		{
 			name: "missing ssm document",
 			reqQuery: url.Values{
-				"awsRegion": []string{"us-east-1"},
-				"role":      []string{"myRole"},
+				"awsRegion":    []string{"us-east-1"},
+				"role":         []string{"myRole"},
+				"awsAccountID": []string{"123456789012"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing account id",
+			reqQuery: url.Values{
+				"awsRegion":   []string{"us-east-1"},
+				"role":        []string{"myRole"},
+				"ssmDocument": []string{"TeleportDiscoveryInstallerTest"},
 			},
 			errCheck: isBadParamErrFn,
 		},
 		{
 			name: "trying to inject escape sequence into query params",
 			reqQuery: url.Values{
-				"awsRegion":   []string{"'; rm -rf /tmp/dir; echo '"},
-				"role":        []string{"role"},
-				"ssmDocument": []string{"TeleportDiscoveryInstallerTest"},
+				"awsRegion":    []string{"'; rm -rf /tmp/dir; echo '"},
+				"role":         []string{"role"},
+				"ssmDocument":  []string{"TeleportDiscoveryInstallerTest"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: isBadParamErrFn,
 		},
@@ -472,44 +523,59 @@ func TestBuildEKSConfigureIAMScript(t *testing.T) {
 		{
 			name: "valid",
 			reqQuery: url.Values{
-				"awsRegion": []string{"us-east-1"},
-				"role":      []string{"myRole"},
+				"awsRegion":    []string{"us-east-1"},
+				"role":         []string{"myRole"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure eks-iam " +
 				"--aws-region=us-east-1 " +
-				"--role=myRole",
+				"--role=myRole " +
+				"--aws-account-id=123456789012",
 		},
 		{
 			name: "valid with symbols in role",
 			reqQuery: url.Values{
-				"awsRegion": []string{"us-east-1"},
-				"role":      []string{"Test+1=2,3.4@5-6_7"},
+				"awsRegion":    []string{"us-east-1"},
+				"role":         []string{"Test+1=2,3.4@5-6_7"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure eks-iam " +
 				"--aws-region=us-east-1 " +
-				"--role=Test\\+1=2,3.4\\@5-6_7",
+				"--role=Test\\+1=2,3.4\\@5-6_7 " +
+				"--aws-account-id=123456789012",
 		},
 		{
 			name: "missing aws-region",
 			reqQuery: url.Values{
-				"role": []string{"myRole"},
+				"role":         []string{"myRole"},
+				"awsAccountID": []string{"123456789012"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing account id",
+			reqQuery: url.Values{
+				"awsRegion": []string{"us-east-1"},
+				"role":      []string{"myRole"},
 			},
 			errCheck: isBadParamErrFn,
 		},
 		{
 			name: "missing role",
 			reqQuery: url.Values{
-				"awsRegion": []string{"us-east-1"},
+				"awsRegion":    []string{"us-east-1"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: isBadParamErrFn,
 		},
 		{
 			name: "trying to inject escape sequence into query params",
 			reqQuery: url.Values{
-				"awsRegion": []string{"'; rm -rf /tmp/dir; echo '"},
-				"role":      []string{"role"},
+				"awsRegion":    []string{"'; rm -rf /tmp/dir; echo '"},
+				"role":         []string{"role"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: isBadParamErrFn,
 		},
@@ -706,44 +772,59 @@ func TestBuildListDatabasesConfigureIAMScript(t *testing.T) {
 		{
 			name: "valid",
 			reqQuery: url.Values{
-				"awsRegion": []string{"us-east-1"},
-				"role":      []string{"myRole"},
+				"awsRegion":    []string{"us-east-1"},
+				"role":         []string{"myRole"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure listdatabases-iam " +
 				"--aws-region=us-east-1 " +
-				"--role=myRole",
+				"--role=myRole " +
+				"--aws-account-id=123456789012",
 		},
 		{
 			name: "valid with symbols in role",
 			reqQuery: url.Values{
-				"awsRegion": []string{"us-east-1"},
-				"role":      []string{"Test+1=2,3.4@5-6_7"},
+				"awsRegion":    []string{"us-east-1"},
+				"role":         []string{"Test+1=2,3.4@5-6_7"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure listdatabases-iam " +
 				"--aws-region=us-east-1 " +
-				"--role=Test\\+1=2,3.4\\@5-6_7",
+				"--role=Test\\+1=2,3.4\\@5-6_7 " +
+				"--aws-account-id=123456789012",
 		},
 		{
 			name: "missing aws-region",
 			reqQuery: url.Values{
-				"role": []string{"myRole"},
+				"role":         []string{"myRole"},
+				"awsAccountID": []string{"123456789012"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing account id",
+			reqQuery: url.Values{
+				"awsRegion": []string{"us-east-1"},
+				"role":      []string{"myRole"},
 			},
 			errCheck: isBadParamErrFn,
 		},
 		{
 			name: "missing role",
 			reqQuery: url.Values{
-				"awsRegion": []string{"us-east-1"},
+				"awsRegion":    []string{"us-east-1"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: isBadParamErrFn,
 		},
 		{
 			name: "trying to inject escape sequence into query params",
 			reqQuery: url.Values{
-				"awsRegion": []string{"'; rm -rf /tmp/dir; echo '"},
-				"role":      []string{"role"},
+				"awsRegion":    []string{"'; rm -rf /tmp/dir; echo '"},
+				"role":         []string{"role"},
+				"awsAccountID": []string{"123456789012"},
 			},
 			errCheck: isBadParamErrFn,
 		},

--- a/tool/teleport/common/integration_configure.go
+++ b/tool/teleport/common/integration_configure.go
@@ -53,6 +53,7 @@ func onIntegrationConfDeployService(ctx context.Context, params config.Integrati
 	}
 
 	confReq := awsoidc.DeployServiceIAMConfigureRequest{
+		AccountID:       params.AccountID,
 		Cluster:         params.Cluster,
 		IntegrationName: params.Name,
 		Region:          params.Region,
@@ -66,7 +67,7 @@ func onIntegrationConfEICEIAM(ctx context.Context, params config.IntegrationConf
 	// Ensure we print output to the user. LogLevel at this point was set to Error.
 	utils.InitLogger(utils.LoggingForDaemon, slog.LevelInfo)
 
-	iamClient, err := awsoidc.NewEICEIAMConfigureClient(ctx, params.Region)
+	clt, err := awsoidc.NewEICEIAMConfigureClient(ctx, params.Region)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -74,8 +75,9 @@ func onIntegrationConfEICEIAM(ctx context.Context, params config.IntegrationConf
 	confReq := awsoidc.EICEIAMConfigureRequest{
 		Region:          params.Region,
 		IntegrationRole: params.Role,
+		AccountID:       params.AccountID,
 	}
-	return trace.Wrap(awsoidc.ConfigureEICEIAM(ctx, iamClient, confReq))
+	return trace.Wrap(awsoidc.ConfigureEICEIAM(ctx, clt, confReq))
 }
 
 func onIntegrationConfEC2SSMIAM(ctx context.Context, params config.IntegrationConfEC2SSMIAM) error {
@@ -94,6 +96,7 @@ func onIntegrationConfEC2SSMIAM(ctx context.Context, params config.IntegrationCo
 		ProxyPublicURL:  params.ProxyPublicURL,
 		ClusterName:     params.ClusterName,
 		IntegrationName: params.IntegrationName,
+		AccountID:       params.AccountID,
 	}
 	return trace.Wrap(awsoidc.ConfigureEC2SSM(ctx, awsClt, confReq))
 }
@@ -109,6 +112,7 @@ func onIntegrationConfAWSAppAccessIAM(ctx context.Context, params config.Integra
 
 	confReq := awsoidc.AWSAppAccessConfigureRequest{
 		IntegrationRole: params.RoleName,
+		AccountID:       params.AccountID,
 	}
 	return trace.Wrap(awsoidc.ConfigureAWSAppAccess(ctx, iamClient, confReq))
 }
@@ -125,6 +129,7 @@ func onIntegrationConfEKSIAM(ctx context.Context, params config.IntegrationConfE
 	confReq := awsoidc.EKSIAMConfigureRequest{
 		Region:          params.Region,
 		IntegrationRole: params.Role,
+		AccountID:       params.AccountID,
 	}
 	return trace.Wrap(awsoidc.ConfigureEKSIAM(ctx, iamClient, confReq))
 }
@@ -155,22 +160,17 @@ func onIntegrationConfListDatabasesIAM(ctx context.Context, params config.Integr
 	// LogLevel at this point is set to Error.
 	utils.InitLogger(utils.LoggingForDaemon, slog.LevelInfo)
 
-	if params.Region == "" {
-		return trace.BadParameter("region is required")
-	}
-
-	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(params.Region))
+	clt, err := awsoidc.NewListDatabasesIAMConfigureClient(ctx, params.Region)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	iamClient := iam.NewFromConfig(cfg)
-
 	confReq := awsoidc.ConfigureIAMListDatabasesRequest{
 		Region:          params.Region,
 		IntegrationRole: params.Role,
+		AccountID:       params.AccountID,
 	}
-	return trace.Wrap(awsoidc.ConfigureListDatabasesIAM(ctx, iamClient, confReq))
+	return trace.Wrap(awsoidc.ConfigureListDatabasesIAM(ctx, clt, confReq))
 }
 
 func onIntegrationConfExternalAuditCmd(ctx context.Context, params easconfig.ExternalAuditStorageConfiguration) error {
@@ -211,15 +211,16 @@ func onIntegrationConfAccessGraphAWSSync(ctx context.Context, params config.Inte
 	// Ensure we print output to the user. LogLevel at this point was set to Error.
 	utils.InitLogger(utils.LoggingForDaemon, slog.LevelInfo)
 
-	iamClient, err := awsoidc.NewAccessGraphIAMConfigureClient(ctx)
+	clt, err := awsoidc.NewAccessGraphIAMConfigureClient(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	confReq := awsoidc.AccessGraphAWSIAMConfigureRequest{
 		IntegrationRole: params.Role,
+		AccountID:       params.AccountID,
 	}
-	return trace.Wrap(awsoidc.ConfigureAccessGraphSyncIAM(ctx, iamClient, confReq))
+	return trace.Wrap(awsoidc.ConfigureAccessGraphSyncIAM(ctx, clt, confReq))
 }
 
 func onIntegrationConfAzureOIDCCmd(ctx context.Context, params config.IntegrationConfAzureOIDC) error {

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -475,10 +475,12 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfDeployServiceCmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfDeployServiceIAMArguments.Region)
 	integrationConfDeployServiceCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfDeployServiceIAMArguments.Role)
 	integrationConfDeployServiceCmd.Flag("task-role", "The AWS Role to be used by the deployed service.").Required().StringVar(&ccf.IntegrationConfDeployServiceIAMArguments.TaskRole)
+	integrationConfDeployServiceCmd.Flag("aws-account-id", "The AWS account ID.").StringVar(&ccf.IntegrationConfDeployServiceIAMArguments.AccountID)
 
 	integrationConfEICECmd := integrationConfigureCmd.Command("eice-iam", "Adds required IAM permissions to connect to EC2 Instances using EC2 Instance Connect Endpoint.")
 	integrationConfEICECmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfEICEIAMArguments.Region)
 	integrationConfEICECmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfEICEIAMArguments.Role)
+	integrationConfEICECmd.Flag("aws-account-id", "The AWS account ID.").StringVar(&ccf.IntegrationConfEICEIAMArguments.AccountID)
 
 	integrationConfEC2SSMCmd := integrationConfigureCmd.Command("ec2-ssm-iam", "Adds required IAM permissions and SSM Document to enable EC2 Auto Discover using SSM.")
 	integrationConfEC2SSMCmd.Flag("role", "The AWS Role name used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfEC2SSMIAMArguments.RoleName)
@@ -488,17 +490,21 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		IntegrationConfEC2SSMIAMArguments.ProxyPublicURL)
 	integrationConfEC2SSMCmd.Flag("cluster", "Teleport Cluster's name.").Required().StringVar(&ccf.IntegrationConfEC2SSMIAMArguments.ClusterName)
 	integrationConfEC2SSMCmd.Flag("name", "Integration name.").Required().StringVar(&ccf.IntegrationConfEC2SSMIAMArguments.IntegrationName)
+	integrationConfEC2SSMCmd.Flag("aws-account-id", "The AWS account ID.").StringVar(&ccf.IntegrationConfEC2SSMIAMArguments.AccountID)
 
 	integrationConfAWSAppAccessCmd := integrationConfigureCmd.Command("aws-app-access-iam", "Adds required IAM permissions to connect to AWS using App Access.")
 	integrationConfAWSAppAccessCmd.Flag("role", "The AWS Role name used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfAWSAppAccessIAMArguments.RoleName)
+	integrationConfAWSAppAccessCmd.Flag("aws-account-id", "The AWS account ID.").StringVar(&ccf.IntegrationConfAWSAppAccessIAMArguments.AccountID)
 
 	integrationConfEKSCmd := integrationConfigureCmd.Command("eks-iam", "Adds required IAM permissions for enrollment of EKS clusters to Teleport.")
 	integrationConfEKSCmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfEKSIAMArguments.Region)
 	integrationConfEKSCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfEKSIAMArguments.Role)
+	integrationConfEKSCmd.Flag("aws-account-id", "The AWS account ID.").StringVar(&ccf.IntegrationConfEKSIAMArguments.AccountID)
 
 	integrationConfAccessGraphCmd := integrationConfigureCmd.Command("access-graph", "Manages Access Graph configuration.")
 	integrationConfTAGSyncCmd := integrationConfAccessGraphCmd.Command("aws-iam", "Adds required IAM permissions for syncing data into Access Graph service.")
 	integrationConfTAGSyncCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.Role)
+	integrationConfTAGSyncCmd.Flag("aws-account-id", "The AWS account ID.").StringVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.AccountID)
 
 	integrationConfAWSOIDCIdPCmd := integrationConfigureCmd.Command("awsoidc-idp", "Creates an IAM IdP (OIDC) in your AWS account to allow the AWS OIDC Integration to access AWS APIs.")
 	integrationConfAWSOIDCIdPCmd.Flag("cluster", "Teleport Cluster name.").Required().StringVar(&ccf.
@@ -514,6 +520,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfListDatabasesCmd := integrationConfigureCmd.Command("listdatabases-iam", "Adds required IAM permissions to List RDS Databases (Instances and Clusters).")
 	integrationConfListDatabasesCmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfListDatabasesIAMArguments.Region)
 	integrationConfListDatabasesCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfListDatabasesIAMArguments.Role)
+	integrationConfListDatabasesCmd.Flag("aws-account-id", "The AWS account ID.").StringVar(&ccf.IntegrationConfListDatabasesIAMArguments.AccountID)
 
 	integrationConfExternalAuditCmd := integrationConfigureCmd.Command("externalauditstorage", "Bootstraps required infrastructure and adds required IAM permissions for External Audit Storage logs.")
 	integrationConfExternalAuditCmd.Flag("bootstrap", "Bootstrap required infrastructure.").Default("false").BoolVar(&ccf.IntegrationConfExternalAuditStorageArguments.Bootstrap)

--- a/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.tsx
@@ -60,11 +60,11 @@ export function CreateAppAccess() {
     }
   });
 
-  const iamRoleName = splitAwsIamArn(
-    agentMeta.awsIntegration.spec.roleArn
-  ).arnResourceName;
+  const { awsAccountId: accountID, arnResourceName: iamRoleName } =
+    splitAwsIamArn(agentMeta.awsIntegration.spec.roleArn);
   const scriptUrl = cfg.getAwsIamConfigureScriptAppAccessUrl({
     iamRoleName,
+    accountID,
   });
 
   return (

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx
@@ -54,7 +54,7 @@ const mockDbLabels = [{ name: 'env', value: 'prod' }];
 
 const integrationName = 'aws-oidc-integration';
 const region: Regions = 'us-east-2';
-const awsoidcRoleArn = 'role-arn';
+const awsoidcRoleName = 'role-arn';
 
 const mockAwsRdsDb: AwsRdsDatabase = {
   engine: 'postgres',
@@ -74,7 +74,7 @@ const mocKIntegration: Integration = {
   name: integrationName,
   resourceType: 'integration',
   spec: {
-    roleArn: `doncare/${awsoidcRoleArn}`,
+    roleArn: `arn:aws:iam::123456789012:role/${awsoidcRoleName}`,
     issuerS3Bucket: '',
     issuerS3Prefix: '',
   },

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
@@ -390,6 +390,9 @@ const CreateAccessRole = ({
 }) => {
   const [scriptUrl, setScriptUrl] = useState('');
   const { awsIntegration, awsRegion } = dbMeta;
+  const { awsAccountId: accountID } = splitAwsIamArn(
+    awsIntegration.spec.roleArn
+  );
 
   function generateAutoConfigScript() {
     if (!validator.validate()) {
@@ -399,10 +402,11 @@ const CreateAccessRole = ({
     const newScriptUrl = cfg.getDeployServiceIamConfigureScriptUrl({
       integrationName: awsIntegration.name,
       region: awsRegion,
-      // arn's are formatted as `don-care-about-this-part/role-arn`.
+      // arn's are formatted as `don-care-about-this-part/role-name`.
       // We are splitting by slash and getting the last element.
       awsOidcRoleArn: awsIntegration.spec.roleArn.split('/').pop(),
       taskRoleArn,
+      accountID,
     });
 
     setScriptUrl(newScriptUrl);

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
@@ -154,6 +154,7 @@ export function DiscoveryConfigSsm() {
       region: selectedRegion,
       ssmDocument: ssmDocumentName,
       integrationName: agentMeta.awsIntegration.name,
+      accountID: awsAccountId,
     });
     setScriptUrl(scriptUrl);
   }

--- a/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/EnrollEc2Instance.test.tsx
+++ b/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/EnrollEc2Instance.test.tsx
@@ -504,7 +504,7 @@ function getMockedContexts(withAutoDiscovery = false) {
         name: 'test-oidc',
         resourceType: 'integration',
         spec: {
-          roleArn: 'arn-123',
+          roleArn: 'arn:aws:iam::123456789012:role/test-role-arn',
           issuerS3Bucket: '',
           issuerS3Prefix: '',
         },

--- a/web/packages/teleport/src/Discover/Shared/Aws/ConfigureIamPerms.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Aws/ConfigureIamPerms.tsx
@@ -29,6 +29,7 @@ import { CommandBox } from 'teleport/Discover/Shared/CommandBox';
 import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
 import { Regions } from 'teleport/services/integrations';
 import cfg from 'teleport/config';
+import { splitAwsIamArn } from 'teleport/services/integrations/aws';
 
 type AwsResourceKind = 'rds' | 'ec2' | 'eks';
 
@@ -41,9 +42,8 @@ export function ConfigureIamPerms({
   integrationRoleArn: string;
   kind: AwsResourceKind;
 }) {
-  // arn's are formatted as `don-care-about-this-part/role-arn`.
-  // We are splitting by slash and getting the last element.
-  const iamRoleName = integrationRoleArn.split('/').pop();
+  const { awsAccountId: accountID, arnResourceName: iamRoleName } =
+    splitAwsIamArn(integrationRoleArn);
 
   let scriptUrl;
   let msg;
@@ -57,6 +57,7 @@ export function ConfigureIamPerms({
       scriptUrl = cfg.getEc2InstanceConnectIAMConfigureScriptUrl({
         region,
         iamRoleName,
+        accountID,
       });
 
       const json = `{
@@ -97,6 +98,7 @@ export function ConfigureIamPerms({
       scriptUrl = cfg.getEksIamConfigureScriptUrl({
         region,
         iamRoleName,
+        accountID,
       });
 
       const json = `{
@@ -135,6 +137,7 @@ export function ConfigureIamPerms({
       scriptUrl = cfg.getAwsConfigureIamScriptListDatabasesUrl({
         region,
         iamRoleName,
+        accountID,
       });
 
       const json = `{

--- a/web/packages/teleport/src/config.test.ts
+++ b/web/packages/teleport/src/config.test.ts
@@ -28,10 +28,11 @@ test('getDeployServiceIamConfigureScriptPath formatting', async () => {
     region: 'us-east-1',
     awsOidcRoleArn: 'oidc-arn',
     taskRoleArn: 'task-arn',
+    accountID: '123456789012',
   };
   const base =
     'http://localhost/v1/webapi/scripts/integrations/configure/deployservice-iam.sh?';
-  const expected = `integrationName=${'int-name'}&awsRegion=${'us-east-1'}&role=${'oidc-arn'}&taskRole=${'task-arn'}`;
+  const expected = `integrationName=${'int-name'}&awsRegion=${'us-east-1'}&role=${'oidc-arn'}&taskRole=${'task-arn'}&awsAccountID=${'123456789012'}`;
   expect(cfg.getDeployServiceIamConfigureScriptUrl(params)).toBe(
     `${base}${expected}`
   );
@@ -53,10 +54,11 @@ test('getAwsOidcConfigureIdpScriptUrl formatting, without s3 fields', async () =
 test('getAwsIamConfigureScriptAppAccessUrl formatting', async () => {
   const params: Omit<UrlAwsConfigureIamScriptParams, 'region'> = {
     iamRoleName: 'role-arn',
+    accountID: '123456789012',
   };
   const base =
     'http://localhost/v1/webapi/scripts/integrations/configure/aws-app-access-iam.sh?';
-  const expected = `role=role-arn`;
+  const expected = `role=role-arn&awsAccountID=123456789012`;
   expect(cfg.getAwsIamConfigureScriptAppAccessUrl(params)).toBe(
     `${base}${expected}`
   );

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -308,13 +308,13 @@ const cfg = {
     awsConfigureIamScriptOidcIdpPath:
       '/v1/webapi/scripts/integrations/configure/awsoidc-idp.sh?integrationName=:integrationName&role=:roleName',
     awsConfigureIamScriptDeployServicePath:
-      '/v1/webapi/scripts/integrations/configure/deployservice-iam.sh?integrationName=:integrationName&awsRegion=:region&role=:awsOidcRoleArn&taskRole=:taskRoleArn',
+      '/v1/webapi/scripts/integrations/configure/deployservice-iam.sh?integrationName=:integrationName&awsRegion=:region&role=:awsOidcRoleArn&taskRole=:taskRoleArn&awsAccountID=:accountID',
     awsConfigureIamScriptListDatabasesPath:
-      '/v1/webapi/scripts/integrations/configure/listdatabases-iam.sh?awsRegion=:region&role=:iamRoleName',
+      '/v1/webapi/scripts/integrations/configure/listdatabases-iam.sh?awsRegion=:region&role=:iamRoleName&awsAccountID=:accountID',
     awsConfigureIamScriptEc2InstanceConnectPath:
-      '/v1/webapi/scripts/integrations/configure/eice-iam.sh?awsRegion=:region&role=:iamRoleName',
+      '/v1/webapi/scripts/integrations/configure/eice-iam.sh?awsRegion=:region&role=:iamRoleName&awsAccountID=:accountID',
     awsConfigureIamEksScriptPath:
-      '/v1/webapi/scripts/integrations/configure/eks-iam.sh?awsRegion=:region&role=:iamRoleName',
+      '/v1/webapi/scripts/integrations/configure/eks-iam.sh?awsRegion=:region&role=:iamRoleName&awsAccountID=:accountID',
 
     awsRdsDbDeployServicesPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/deploydatabaseservices',
@@ -334,10 +334,10 @@ const cfg = {
     awsAppAccessPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/aws-app-access',
     awsConfigureIamAppAccessPath:
-      '/v1/webapi/scripts/integrations/configure/aws-app-access-iam.sh?role=:iamRoleName',
+      '/v1/webapi/scripts/integrations/configure/aws-app-access-iam.sh?role=:iamRoleName&awsAccountID=:accountID',
 
     awsConfigureIamEc2AutoDiscoverWithSsmPath:
-      '/v1/webapi/scripts/integrations/configure/ec2-ssm-iam.sh?role=:iamRoleName&awsRegion=:region&ssmDocument=:ssmDocument&integrationName=:integrationName',
+      '/v1/webapi/scripts/integrations/configure/ec2-ssm-iam.sh?role=:iamRoleName&awsRegion=:region&ssmDocument=:ssmDocument&integrationName=:integrationName&awsAccountID=:accountID',
 
     eksClustersListPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/eksclusters',
@@ -1237,6 +1237,7 @@ export interface UrlDeployServiceIamConfigureScriptParams {
   region: Regions;
   awsOidcRoleArn: string;
   taskRoleArn: string;
+  accountID: string;
 }
 
 export interface UrlAwsOidcConfigureIdp {
@@ -1249,6 +1250,7 @@ export interface UrlAwsOidcConfigureIdp {
 export interface UrlAwsConfigureIamScriptParams {
   region: Regions;
   iamRoleName: string;
+  accountID: string;
 }
 
 export interface UrlAwsConfigureIamEc2AutoDiscoverWithSsmScriptParams {
@@ -1256,6 +1258,7 @@ export interface UrlAwsConfigureIamEc2AutoDiscoverWithSsmScriptParams {
   iamRoleName: string;
   ssmDocument: string;
   integrationName: string;
+  accountID: string;
 }
 
 export interface UrlGcpWorkforceConfigParam {


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/44367
- https://github.com/gravitational/teleport/issues/44367

This PR catches the case where the user mistakenly opens cloud shell in a different AWS account than the integration. Now the script will catch that mistake early instead of giving a cryptic "role not found" error.