### PR TITLE
[docs] fix elasticache/memorydb permissions reference

### DIFF
--- a/docs/pages/includes/database-access/reference/aws-iam/redis/auto-password-access-policy.mdx
+++ b/docs/pages/includes/database-access/reference/aws-iam/redis/auto-password-access-policy.mdx
@@ -1,4 +1,4 @@
-{{ dbType="ElastiCache" permissionType="elasticache" }}
+{{ dbType="ElastiCache" permissionType="elasticache" updateUserPermission="ModifyUser" listTagsPermission="ListTagsForResource" }}
 
 <Notice type="note">
 The recommended way to configure Teleport access to {{ dbType }} is to use IAM
@@ -19,7 +19,8 @@ IAM permissions required for managing the {{ dbType }} users:
             "Effect": "Allow",
             "Action": [
                 "{{ permissionType }}:DescribeUsers",
-                "{{ permissionType }}:ModifyUser"
+                "{{ permissionType }}:{{ updateUserPermission }}",
+                "{{ permissionType }}:{{ listTagsPermission }}"
             ],
             "Resource": "*"
         },

--- a/docs/pages/reference/agent-services/database-access-reference/aws.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/aws.mdx
@@ -46,7 +46,7 @@ the related section below.
 
 ### ElastiCache managed users
 
-(!docs/pages/includes/database-access/reference/aws-iam/redis/auto-password-access-policy.mdx dbType="ElastiCache" permissionType="elasticache"!)
+(!docs/pages/includes/database-access/reference/aws-iam/redis/auto-password-access-policy.mdx dbType="ElastiCache" permissionType="elasticache" updateUserPermission="ModifyUser" listTagsPermission="ListTagsForResource"!)
 
 ## Keyspaces
 
@@ -64,7 +64,7 @@ the related section below.
 
 ### MemoryDB managed users
 
-(!docs/pages/includes/database-access/reference/aws-iam/redis/auto-password-access-policy.mdx dbType="MemoryDB" permissionType="memorydb"!)
+(!docs/pages/includes/database-access/reference/aws-iam/redis/auto-password-access-policy.mdx dbType="MemoryDB" permissionType="memorydb" updateUserPermission="UpdateUser" listTagsPermission="ListTags"!)
 
 ## OpenSearch
 


### PR DESCRIPTION
This PR fixes the permissions reference for managed users:
1. The permission for memorydb is `memorydb:UpdateUser`, not `memorydb:ModifyUser`
2. The db service needs permissions to list tags to find teleport managed users, so I added that.