### PR TITLE
update AWS IAM configurator permissions

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -30,26 +30,6 @@ import (
 var wildcard = "*"
 var allResources = []string{wildcard}
 
-// StatementForIAMEditRolePolicy returns a IAM Policy Statement which allows editting Role Policy
-// of the resources.
-func StatementForIAMEditRolePolicy(resources ...string) *Statement {
-	return &Statement{
-		Effect:    EffectAllow,
-		Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
-		Resources: resources,
-	}
-}
-
-// StatementForIAMEditUserPolicy returns a IAM Policy Statement which allows editting User Policy
-// of the resources.
-func StatementForIAMEditUserPolicy(resources ...string) *Statement {
-	return &Statement{
-		Effect:    EffectAllow,
-		Actions:   []string{"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy"},
-		Resources: resources,
-	}
-}
-
 // StatementForECSManageService returns the statement that allows managing the ECS Service deployed
 // by DeployService (AWS OIDC Integration).
 func StatementForECSManageService() *Statement {

--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -61,8 +61,6 @@ const (
 	databasePolicyDescription = "Used by Teleport database agents for accessing AWS-hosted databases."
 	// discoveryServicePolicyDescription description used on the policy created.
 	discoveryServicePolicyDescription = "Used by Teleport the discovery service to discover AWS-hosted services."
-	// boundarySuffix boundary policies will have this suffix.
-	boundarySuffix = "Boundary"
 	// policyTeleportTagKey key of the tag added to the policies created.
 	policyTeleportTagKey = "teleport"
 	// policyTeleportTagValue value of the tag added to the policies created.
@@ -85,11 +83,10 @@ type databaseActions struct {
 	metadata []string
 	// managedUsers is a list of actions used for managing database users.
 	managedUsers []string
-	// authBoundary is a list of actions for authorization that need to added
-	// to boundary policies.
-	authBoundary []string
+	// additionalSTSActions is a list of additional actions needed when assuming
+	// a role, e.g. passing session tags.
+	additionalSTSActions []string
 
-	requireIAMEdit        bool
 	requireSecretsManager bool
 }
 
@@ -105,9 +102,6 @@ func (a databaseActions) buildStatement(opt databaseActionsBuildOption) *awslib.
 		actions = append(actions, a.iamAuth...)
 		actions = append(actions, a.managedUsers...)
 	}
-	if opt.withAuthBoundary {
-		actions = append(actions, a.authBoundary...)
-	}
 	return &awslib.Statement{
 		Effect:    awslib.EffectAllow,
 		Actions:   apiutils.Deduplicate(actions),
@@ -116,13 +110,12 @@ func (a databaseActions) buildStatement(opt databaseActionsBuildOption) *awslib.
 }
 
 type databaseActionsBuildOption struct {
-	withDiscovery    bool
-	withMetadata     bool
-	withAuth         bool
-	withAuthBoundary bool
+	withDiscovery bool
+	withMetadata  bool
+	withAuth      bool
 }
 
-func makeDatabaseActionsBuildOption(flags configurators.BootstrapFlags, targetCfg targetConfig, boundary bool) databaseActionsBuildOption {
+func makeDatabaseActionsBuildOption(flags configurators.BootstrapFlags) databaseActionsBuildOption {
 	switch flags.Service {
 	case configurators.DiscoveryService:
 		return databaseActionsBuildOption{
@@ -131,9 +124,8 @@ func makeDatabaseActionsBuildOption(flags configurators.BootstrapFlags, targetCf
 
 	case configurators.DatabaseServiceByDiscoveryServiceConfig:
 		return databaseActionsBuildOption{
-			withDiscovery:    false,
-			withAuth:         true,
-			withAuthBoundary: boundary,
+			withDiscovery: false,
+			withAuth:      true,
 			// Discovered databases should be checked by URL validator which
 			// requires same permissions as the metadata service.
 			withMetadata: true,
@@ -141,10 +133,9 @@ func makeDatabaseActionsBuildOption(flags configurators.BootstrapFlags, targetCf
 
 	case configurators.DatabaseService:
 		return databaseActionsBuildOption{
-			withDiscovery:    true,
-			withMetadata:     true,
-			withAuth:         true,
-			withAuthBoundary: boundary,
+			withDiscovery: true,
+			withMetadata:  true,
+			withAuth:      true,
 		}
 
 	default:
@@ -177,11 +168,19 @@ var (
 	// rdsActions contains IAM actions for types.AWSMatcherRDS (RDS
 	// instances and Aurora clusters).
 	rdsActions = databaseActions{
-		discovery:      []string{"rds:DescribeDBInstances", "rds:DescribeDBClusters"},
-		metadata:       []string{"rds:DescribeDBInstances", "rds:DescribeDBClusters"},
-		iamAuth:        []string{"rds:ModifyDBInstance", "rds:ModifyDBCluster"},
-		authBoundary:   []string{"rds-db:connect"},
-		requireIAMEdit: true,
+		discovery: []string{
+			"rds:DescribeDBInstances",
+			"rds:DescribeDBClusters",
+		},
+		metadata: []string{
+			"rds:DescribeDBInstances",
+			"rds:DescribeDBClusters",
+		},
+		iamAuth: []string{
+			"rds:ModifyDBInstance",
+			"rds:ModifyDBCluster",
+			"rds-db:connect",
+		},
 	}
 	// rdsProxyActions contains IAM actions for types.AWSMatcherRDSProxy.
 	rdsProxyActions = databaseActions{
@@ -194,18 +193,15 @@ var (
 			"rds:DescribeDBProxies",
 			"rds:DescribeDBProxyEndpoints",
 		},
-		authBoundary:   []string{"rds-db:connect"},
-		requireIAMEdit: true,
+		iamAuth: []string{
+			"rds-db:connect",
+		},
 	}
 	// redshiftActions contains IAM actions for types.AWSMatcherRedshift.
 	redshiftActions = databaseActions{
 		discovery: []string{"redshift:DescribeClusters"},
 		metadata:  []string{"redshift:DescribeClusters"},
-		authBoundary: append(
-			[]string{"redshift:GetClusterCredentials"},
-			stsActions..., // For IAM-auth-as-IAM-role.
-		),
-		requireIAMEdit: true,
+		iamAuth:   []string{"redshift:GetClusterCredentials"},
 	}
 	// redshiftServerlessActions contains IAM actions for types.AWSMatcherRedshiftServerless.
 	redshiftServerlessActions = databaseActions{
@@ -218,7 +214,6 @@ var (
 			"redshift-serverless:GetEndpointAccess",
 			"redshift-serverless:GetWorkgroup",
 		},
-		authBoundary: stsActions,
 	}
 	// elastiCacheActions contains IAM actions for types.AWSMatcherElastiCache.
 	elastiCacheActions = databaseActions{
@@ -234,10 +229,12 @@ var (
 		managedUsers: []string{
 			"elasticache:DescribeUsers",
 			"elasticache:ModifyUser",
+			"elasticache:ListTagsForResource", // needed to find Teleport managed users
+		},
+		iamAuth: []string{
+			"elasticache:Connect",
 		},
 		requireSecretsManager: true,
-		authBoundary:          []string{"elasticache:Connect"},
-		requireIAMEdit:        true,
 	}
 	// memoryDBActions contains IAM actions for types.AWSMatcherMemoryDB.
 	memoryDBActions = databaseActions{
@@ -252,18 +249,18 @@ var (
 		managedUsers: []string{
 			"memorydb:DescribeUsers",
 			"memorydb:UpdateUser",
+			"memorydb:ListTags", // needed to find Teleport managed users
+		},
+		iamAuth: []string{
+			"memorydb:Connect",
 		},
 		requireSecretsManager: true,
-		authBoundary:          []string{"memorydb:Connect"},
-		requireIAMEdit:        true,
 	}
 	// awsKeyspacesActions contains IAM actions for static AWS Keyspaces databases.
-	awsKeyspacesActions = databaseActions{
-		authBoundary: stsActions,
-	}
+	awsKeyspacesActions = databaseActions{}
 	// dynamodbActions contains IAM actions for static AWS DynamoDB databases.
 	dynamodbActions = databaseActions{
-		authBoundary: append(stsActions, "sts:TagSession"),
+		additionalSTSActions: []string{"sts:TagSession"},
 	}
 	// opensearchActions contains IAM actions for types.AWSMatcherOpenSearch
 	opensearchActions = databaseActions{
@@ -276,13 +273,11 @@ var (
 			// Used for url validation.
 			"es:DescribeDomains",
 		},
-		authBoundary: stsActions,
 	}
 	// docdbActions contains IAM actions for types.AWSMatcherDocumentDB.
 	docdbActions = databaseActions{
-		discovery:    []string{"rds:DescribeDBClusters"},
-		metadata:     []string{"rds:DescribeDBClusters"},
-		authBoundary: stsActions,
+		discovery: []string{"rds:DescribeDBClusters"},
+		metadata:  []string{"rds:DescribeDBClusters"},
 	}
 )
 
@@ -431,8 +426,6 @@ func (a *awsConfigurator) Actions() []configurators.ConfiguratorAction {
 type awsPolicyCreator struct {
 	// policies `Policies` used to upsert the policy document.
 	policies awslib.Policies
-	// isBoundary indicates if the policy created is a boundary or not.
-	isBoundary bool
 	// policy document that will be created on AWS.
 	policy *awslib.Policy
 	// formattedPolicy human-readable representation of the policy document.
@@ -459,19 +452,14 @@ func (a *awsPolicyCreator) Execute(ctx context.Context, actionCtx *configurators
 		return trace.Wrap(err)
 	}
 
-	if a.isBoundary {
-		actionCtx.AWSPolicyBoundaryArn = arn
-	} else {
-		actionCtx.AWSPolicyArn = arn
-	}
-
+	actionCtx.AWSPolicyArn = arn
 	return nil
 }
 
-// awsPoliciesAttacher attach policy and policy boundary to a target. Both
-// policies ARN are retrieved from the `Execute` `context.Context`.
+// awsPoliciesAttacher attaches a policy to a target. The policy ARN is
+// retrieved from the `Execute` `context.Context`.
 type awsPoliciesAttacher struct {
-	// policies `Policies` used to attach policy and policy boundary.
+	// policies `Policies` used to attach policy.
 	policies awslib.Policies
 	// target identity where the policy will be attached to.
 	target awslib.Identity
@@ -488,8 +476,8 @@ func (a *awsPoliciesAttacher) Details() string {
 	return ""
 }
 
-// Execute retrieves policy and policy boundary ARNs from
-// `ConfiguratorActionContext` and attach them to the `target`.
+// Execute retrieves the policy ARN from `ConfiguratorActionContext` and
+// attaches it to the `target`.
 func (a *awsPoliciesAttacher) Execute(ctx context.Context, actionCtx *configurators.ConfiguratorActionContext) error {
 	if a.policies == nil {
 		return trace.BadParameter("policy helper not initialized")
@@ -499,16 +487,7 @@ func (a *awsPoliciesAttacher) Execute(ctx context.Context, actionCtx *configurat
 		return trace.BadParameter("policy ARN not present")
 	}
 
-	if actionCtx.AWSPolicyBoundaryArn == "" {
-		return trace.BadParameter("policy boundary ARN not present")
-	}
-
 	err := a.policies.Attach(ctx, actionCtx.AWSPolicyArn, a.target)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	err = a.policies.AttachBoundary(ctx, actionCtx.AWSPolicyBoundaryArn, a.target)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -533,12 +512,7 @@ func buildDiscoveryActions(config ConfiguratorConfig, targetCfg targetConfig) ([
 
 func buildCommonActions(config ConfiguratorConfig, targetCfg targetConfig) ([]configurators.ConfiguratorAction, error) {
 	// Generate policies.
-	policy, err := buildPolicyDocument(config.Flags, targetCfg, false)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	policyBoundary, err := buildPolicyDocument(config.Flags, targetCfg, true)
+	policy, err := buildPolicyDocument(config.Flags, targetCfg)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -563,19 +537,7 @@ func buildCommonActions(config ConfiguratorConfig, targetCfg targetConfig) ([]co
 		formattedPolicy: formattedPolicy,
 	})
 
-	formattedPolicyBoundary, err := policyBoundary.Document.Marshal()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	// Create IAM Policy boundary.
-	actions = append(actions, &awsPolicyCreator{
-		policies:        config.Policies,
-		policy:          policyBoundary,
-		formattedPolicy: formattedPolicyBoundary,
-		isBoundary:      true,
-	})
-
-	// Attach both policies to the target.
+	// Attach the policy to the target.
 	actions = append(actions, &awsPoliciesAttacher{policies: config.Policies, target: targetCfg.identity})
 	return actions, nil
 }
@@ -690,14 +652,10 @@ func getRoleARNForAssumedRole(iamClient iamiface.IAMAPI, identity awslib.Identit
 }
 
 // buildPolicyDocument builds the policy document.
-func buildPolicyDocument(flags configurators.BootstrapFlags, targetCfg targetConfig, boundary bool) (*awslib.Policy, error) {
+func buildPolicyDocument(flags configurators.BootstrapFlags, targetCfg targetConfig) (*awslib.Policy, error) {
 	policyDoc := awslib.NewPolicyDocument()
 	policyDescription := databasePolicyDescription
 	policyName := flags.PolicyName
-
-	if boundary {
-		policyName += boundarySuffix
-	}
 
 	if flags.Service.IsDiscovery() {
 		policyDescription = discoveryServicePolicyDescription
@@ -709,7 +667,7 @@ func buildPolicyDocument(flags configurators.BootstrapFlags, targetCfg targetCon
 
 	// Build statements for databases.
 	// TODO(greedy52) remove discovery permissions for static databases.
-	var requireSecretsManager, requireIAMEdit bool
+	var requireSecretsManager bool
 	var allActions []databaseActions
 	if hasRDSDatabases(flags, targetCfg) {
 		allActions = append(allActions, rdsActions)
@@ -742,16 +700,27 @@ func buildPolicyDocument(flags configurators.BootstrapFlags, targetCfg targetCon
 		allActions = append(allActions, docdbActions)
 	}
 
-	dbOption := makeDatabaseActionsBuildOption(flags, targetCfg, boundary)
+	dbOption := makeDatabaseActionsBuildOption(flags)
 	for _, dbActions := range allActions {
 		policyDoc.EnsureStatements(dbActions.buildStatement(dbOption))
 		if dbOption.withAuth {
 			requireSecretsManager = requireSecretsManager || dbActions.requireSecretsManager
-			requireIAMEdit = requireIAMEdit || dbActions.requireIAMEdit
 		}
+
+		// some databases require additional STS actions, e.g. sts:TagSession
+		// for DynamoDB.
+		stsAssumeRoleStatements, err := buildSTSAssumeRoleStatements(targetCfg, dbActions.additionalSTSActions...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		policyDoc.EnsureStatements(stsAssumeRoleStatements...)
 	}
 
-	stsAssumeRoleStatements, err := buildSTSAssumeRoleStatements(flags, targetCfg, boundary)
+	// In some configurations there are no db action permissions, but we still
+	// need to attach STS permissions to assume roles, for example if every
+	// resource has an associated role to assume and the target identity is not
+	// any of those roles. This handles that case.
+	stsAssumeRoleStatements, err := buildSTSAssumeRoleStatements(targetCfg)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -760,15 +729,6 @@ func buildPolicyDocument(flags configurators.BootstrapFlags, targetCfg targetCon
 	// For databases that need to access SecretsManager (and KMS).
 	if requireSecretsManager {
 		policyDoc.EnsureStatements(buildSecretsManagerStatements(targetCfg.databases, targetCfg.identity)...)
-	}
-	// For databases that need to edit IAM user/role policy.
-	if requireIAMEdit {
-		targetStatements, err := buildIAMEditStatements(targetCfg.identity)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		policyDoc.EnsureStatements(targetStatements...)
 	}
 
 	return awslib.NewPolicy(
@@ -1006,25 +966,6 @@ func isRDSProxyEndpoint(uri string) bool {
 	return details.IsProxy()
 }
 
-// buildIAMEditStatements returns IAM statements necessary for the Teleport
-// agent to edit user/role permissions.
-func buildIAMEditStatements(target awslib.Identity) ([]*awslib.Statement, error) {
-	switch target.(type) {
-	case awslib.User, *awslib.User:
-		return []*awslib.Statement{
-			awslib.StatementForIAMEditUserPolicy(target.String()),
-		}, nil
-
-	case awslib.Role, *awslib.Role:
-		return []*awslib.Statement{
-			awslib.StatementForIAMEditRolePolicy(target.String()),
-		}, nil
-
-	default:
-		return nil, trace.BadParameter("policies target must be an user or role, received %T", target)
-	}
-}
-
 // buildEC2AutoDiscoveryStatements returns IAM statements necessary for
 // EC2 instance auto-discovery.
 func buildEC2AutoDiscoveryStatements() []*awslib.Statement {
@@ -1088,20 +1029,13 @@ func buildSecretsManagerStatements(databases []*servicecfg.Database, target awsl
 
 // buildSTSAssumeRoleStatements returns AWS IAM statements necessary for
 // assuming AWS IAM roles.
-func buildSTSAssumeRoleStatements(flags configurators.BootstrapFlags, targetCfg targetConfig, boundary bool) ([]*awslib.Statement, error) {
+func buildSTSAssumeRoleStatements(targetCfg targetConfig, additionalSTSActions ...string) ([]*awslib.Statement, error) {
 	if len(targetCfg.assumesAWSRoles) == 0 {
 		return nil, nil
 	}
-	if boundary {
-		return []*awslib.Statement{{
-			Effect:    awslib.EffectAllow,
-			Actions:   stsActions,
-			Resources: []string{"*"},
-		}}, nil
-	}
 	return []*awslib.Statement{{
 		Effect:    awslib.EffectAllow,
-		Actions:   stsActions,
+		Actions:   append(stsActions, additionalSTSActions...),
 		Resources: targetCfg.assumesAWSRoles,
 	}}, nil
 }
@@ -1190,7 +1124,7 @@ func getTargetConfig(flags configurators.BootstrapFlags, cfg *servicecfg.Config,
 	awsMatchers := awsMatchersFromConfig(flags, cfg)
 	databases := databasesFromConfig(flags, cfg)
 	resourceMatchers := resourceMatchersFromConfig(flags, cfg)
-	targetIsAssumeRole := isTargetAWSAssumeRole(flags, awsMatchers, databases, resourceMatchers, target)
+	targetIsAssumeRole := isTargetAWSAssumeRole(awsMatchers, databases, resourceMatchers, target)
 	targetAssumesRoles := rolesForTarget(forcedRoles, awsMatchers, databases, resourceMatchers, targetIsAssumeRole)
 	err = checkStubRoleAssumingRolesFromConfig(forcedRoles, targetAssumesRoles, target)
 	if err != nil {
@@ -1272,7 +1206,7 @@ func resourceMatchersFromConfig(flags configurators.BootstrapFlags, cfg *service
 
 // isTargetAWSAssumeRole determines if the target identity exists in config or cli
 // flags as an AWS IAM role arn that will be assumed by the database agent.
-func isTargetAWSAssumeRole(flags configurators.BootstrapFlags, matchers []types.AWSMatcher, databases []*servicecfg.Database, resourceMatchers []services.ResourceMatcher, target awslib.Identity) bool {
+func isTargetAWSAssumeRole(matchers []types.AWSMatcher, databases []*servicecfg.Database, resourceMatchers []services.ResourceMatcher, target awslib.Identity) bool {
 	switch target.(type) {
 	case awslib.Role, *awslib.Role:
 	default:

--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -68,16 +68,12 @@ func TestAWSIAMDocuments(t *testing.T) {
 	roleTarget, err := awslib.IdentityFromArn("arn:aws:iam::123456789012:role/target-role")
 	require.NoError(t, err)
 
-	unknownIdentity, err := awslib.IdentityFromArn("arn:aws:iam::123456789012:ec2/example-ec2")
-	require.NoError(t, err)
-
 	tests := map[string]struct {
-		returnError        bool
-		flags              configurators.BootstrapFlags
-		fileConfig         *config.FileConfig
-		target             awslib.Identity
-		statements         []*awslib.Statement
-		boundaryStatements []*awslib.Statement
+		returnError bool
+		flags       configurators.BootstrapFlags
+		fileConfig  *config.FileConfig
+		target      awslib.Identity
+		statements  []*awslib.Statement
 	}{
 		"RDSAutoDiscoveryToUser": {
 			target: userTarget,
@@ -91,21 +87,9 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBInstances", "rds:ModifyDBInstance",
-					"rds:DescribeDBClusters", "rds:ModifyDBCluster",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
-					"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy",
-				}},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBInstances", "rds:ModifyDBInstance",
-					"rds:DescribeDBClusters", "rds:ModifyDBCluster",
 					"rds-db:connect",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
-					"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy",
+					"rds:DescribeDBInstances", "rds:ModifyDBInstance",
+					"rds:DescribeDBClusters", "rds:ModifyDBCluster",
 				}},
 			},
 		},
@@ -121,21 +105,9 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBInstances", "rds:ModifyDBInstance",
-					"rds:DescribeDBClusters", "rds:ModifyDBCluster",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
-				}},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBInstances", "rds:ModifyDBInstance",
-					"rds:DescribeDBClusters", "rds:ModifyDBCluster",
 					"rds-db:connect",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+					"rds:DescribeDBInstances", "rds:ModifyDBInstance",
+					"rds:DescribeDBClusters", "rds:ModifyDBCluster",
 				}},
 			},
 		},
@@ -155,21 +127,9 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBInstances", "rds:ModifyDBInstance",
-					"rds:DescribeDBClusters", "rds:ModifyDBCluster",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
-				}},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBInstances", "rds:ModifyDBInstance",
-					"rds:DescribeDBClusters", "rds:ModifyDBCluster",
 					"rds-db:connect",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+					"rds:DescribeDBInstances", "rds:ModifyDBInstance",
+					"rds:DescribeDBClusters", "rds:ModifyDBCluster",
 				}},
 			},
 		},
@@ -186,17 +146,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
 					"redshift:DescribeClusters",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
-					"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy",
-				}},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"redshift:DescribeClusters", "redshift:GetClusterCredentials", "sts:AssumeRole",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
-					"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy",
+					"redshift:GetClusterCredentials",
 				}},
 			},
 		},
@@ -213,17 +163,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
 					"redshift:DescribeClusters",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
-				}},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"redshift:DescribeClusters", "redshift:GetClusterCredentials", "sts:AssumeRole",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+					"redshift:GetClusterCredentials",
 				}},
 			},
 		},
@@ -244,17 +184,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
 					"redshift:DescribeClusters",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
-				}},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"redshift:DescribeClusters", "redshift:GetClusterCredentials", "sts:AssumeRole",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+					"redshift:GetClusterCredentials",
 				}},
 			},
 		},
@@ -270,36 +200,13 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"elasticache:ListTagsForResource",
-					"elasticache:DescribeReplicationGroups",
-					"elasticache:DescribeCacheClusters",
-					"elasticache:DescribeCacheSubnetGroups",
-					"elasticache:DescribeUsers",
-					"elasticache:ModifyUser",
-				}},
-				{
-					Effect: awslib.EffectAllow,
-					Actions: []string{
-						"secretsmanager:DescribeSecret", "secretsmanager:CreateSecret",
-						"secretsmanager:UpdateSecret", "secretsmanager:DeleteSecret",
-						"secretsmanager:GetSecretValue", "secretsmanager:PutSecretValue",
-						"secretsmanager:TagResource",
-					},
-					Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
-				},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
-				}},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"elasticache:ListTagsForResource",
-					"elasticache:DescribeReplicationGroups",
-					"elasticache:DescribeCacheClusters",
-					"elasticache:DescribeCacheSubnetGroups",
-					"elasticache:DescribeUsers",
-					"elasticache:ModifyUser",
 					"elasticache:Connect",
+					"elasticache:ListTagsForResource",
+					"elasticache:DescribeReplicationGroups",
+					"elasticache:DescribeCacheClusters",
+					"elasticache:DescribeCacheSubnetGroups",
+					"elasticache:DescribeUsers",
+					"elasticache:ModifyUser",
 				}},
 				{
 					Effect: awslib.EffectAllow,
@@ -311,9 +218,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 					},
 					Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
 				},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
-				}},
 			},
 		},
 		"ElastiCache static database": {
@@ -343,46 +247,13 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"elasticache:ListTagsForResource",
-					"elasticache:DescribeReplicationGroups",
-					"elasticache:DescribeCacheClusters",
-					"elasticache:DescribeCacheSubnetGroups",
-					"elasticache:DescribeUsers",
-					"elasticache:ModifyUser",
-				}},
-				{
-					Effect: "Allow",
-					Actions: []string{
-						"secretsmanager:DescribeSecret", "secretsmanager:CreateSecret",
-						"secretsmanager:UpdateSecret", "secretsmanager:DeleteSecret",
-						"secretsmanager:GetSecretValue", "secretsmanager:PutSecretValue",
-						"secretsmanager:TagResource",
-					},
-					Resources: []string{
-						"arn:aws:secretsmanager:*:123456789012:secret:teleport/*",
-						"arn:aws:secretsmanager:*:123456789012:secret:my-prefix/*",
-					},
-				},
-				{
-					Effect:  "Allow",
-					Actions: []string{"kms:GenerateDataKey", "kms:Decrypt"},
-					Resources: []string{
-						"arn:aws:kms:*:123456789012:key/my-kms-id",
-					},
-				},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
-				}},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"elasticache:ListTagsForResource",
-					"elasticache:DescribeReplicationGroups",
-					"elasticache:DescribeCacheClusters",
-					"elasticache:DescribeCacheSubnetGroups",
-					"elasticache:DescribeUsers",
-					"elasticache:ModifyUser",
 					"elasticache:Connect",
+					"elasticache:ListTagsForResource",
+					"elasticache:DescribeReplicationGroups",
+					"elasticache:DescribeCacheClusters",
+					"elasticache:DescribeCacheSubnetGroups",
+					"elasticache:DescribeUsers",
+					"elasticache:ModifyUser",
 				}},
 				{
 					Effect: "Allow",
@@ -404,9 +275,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 						"arn:aws:kms:*:123456789012:key/my-kms-id",
 					},
 				},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
-				}},
 			},
 		},
 		"MemoryDB auto discovery": {
@@ -421,34 +289,12 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"memorydb:ListTags",
-					"memorydb:DescribeClusters",
-					"memorydb:DescribeSubnetGroups",
-					"memorydb:DescribeUsers",
-					"memorydb:UpdateUser",
-				}},
-				{
-					Effect: awslib.EffectAllow,
-					Actions: []string{
-						"secretsmanager:DescribeSecret", "secretsmanager:CreateSecret",
-						"secretsmanager:UpdateSecret", "secretsmanager:DeleteSecret",
-						"secretsmanager:GetSecretValue", "secretsmanager:PutSecretValue",
-						"secretsmanager:TagResource",
-					},
-					Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
-				},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
-				}},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"memorydb:ListTags",
-					"memorydb:DescribeClusters",
-					"memorydb:DescribeSubnetGroups",
-					"memorydb:DescribeUsers",
-					"memorydb:UpdateUser",
 					"memorydb:Connect",
+					"memorydb:ListTags",
+					"memorydb:DescribeClusters",
+					"memorydb:DescribeSubnetGroups",
+					"memorydb:DescribeUsers",
+					"memorydb:UpdateUser",
 				}},
 				{
 					Effect: awslib.EffectAllow,
@@ -460,9 +306,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 					},
 					Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
 				},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
-				}},
 			},
 		},
 		"MemoryDB static database": {
@@ -492,44 +335,12 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"memorydb:ListTags",
-					"memorydb:DescribeClusters",
-					"memorydb:DescribeSubnetGroups",
-					"memorydb:DescribeUsers",
-					"memorydb:UpdateUser",
-				}},
-				{
-					Effect: "Allow",
-					Actions: []string{
-						"secretsmanager:DescribeSecret", "secretsmanager:CreateSecret",
-						"secretsmanager:UpdateSecret", "secretsmanager:DeleteSecret",
-						"secretsmanager:GetSecretValue", "secretsmanager:PutSecretValue",
-						"secretsmanager:TagResource",
-					},
-					Resources: []string{
-						"arn:aws:secretsmanager:*:123456789012:secret:teleport/*",
-						"arn:aws:secretsmanager:*:123456789012:secret:my-prefix/*",
-					},
-				},
-				{
-					Effect:  "Allow",
-					Actions: []string{"kms:GenerateDataKey", "kms:Decrypt"},
-					Resources: []string{
-						"arn:aws:kms:*:123456789012:key/my-kms-id",
-					},
-				},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
-				}},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"memorydb:ListTags",
-					"memorydb:DescribeClusters",
-					"memorydb:DescribeSubnetGroups",
-					"memorydb:DescribeUsers",
-					"memorydb:UpdateUser",
 					"memorydb:Connect",
+					"memorydb:ListTags",
+					"memorydb:DescribeClusters",
+					"memorydb:DescribeSubnetGroups",
+					"memorydb:DescribeUsers",
+					"memorydb:UpdateUser",
 				}},
 				{
 					Effect: "Allow",
@@ -551,9 +362,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 						"arn:aws:kms:*:123456789012:key/my-kms-id",
 					},
 				},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
-				}},
 			},
 		},
 		"AutoDiscovery EC2": {
@@ -590,31 +398,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 					Resources: []string{"*"},
 				},
 			},
-			boundaryStatements: []*awslib.Statement{
-				{
-					Effect: "Allow",
-					Actions: []string{
-						"ec2:DescribeInstances",
-						"ssm:DescribeInstanceInformation",
-						"ssm:GetCommandInvocation",
-						"ssm:ListCommandInvocations",
-						"ssm:SendCommand",
-					},
-					Resources: []string{"*"},
-				},
-			},
-		},
-		"AutoDiscoveryUnknownIdentity": {
-			returnError: true,
-			target:      unknownIdentity,
-			fileConfig: &config.FileConfig{
-				Databases: config.Databases{
-					Service: config.Service{EnabledFlag: "true"},
-					AWSMatchers: []config.AWSMatcher{
-						{Types: []string{types.AWSMatcherRDS}, Regions: []string{"us-west-2"}},
-					},
-				},
-			},
 		},
 		"RDS Proxy discovery": {
 			target: userTarget,
@@ -628,19 +411,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
-					"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy",
-				}},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
-					"rds-db:connect",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
-					"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy",
+					"rds-db:connect", "rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 				}},
 			},
 		},
@@ -660,19 +431,8 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
-					"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy",
-				}},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 					"rds-db:connect",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
-					"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy",
+					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 				}},
 			},
 		},
@@ -691,13 +451,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 					Effect:    awslib.EffectAllow,
 					Resources: awslib.SliceOrString{"*"},
 					Actions:   awslib.SliceOrString{"redshift-serverless:GetEndpointAccess", "redshift-serverless:GetWorkgroup", "redshift-serverless:ListWorkgroups", "redshift-serverless:ListEndpointAccess", "redshift-serverless:ListTagsForResource"},
-				},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{
-					Effect:    awslib.EffectAllow,
-					Resources: awslib.SliceOrString{"*"},
-					Actions:   awslib.SliceOrString{"redshift-serverless:GetEndpointAccess", "redshift-serverless:GetWorkgroup", "redshift-serverless:ListWorkgroups", "redshift-serverless:ListEndpointAccess", "redshift-serverless:ListTagsForResource", "sts:AssumeRole"},
 				},
 			},
 		},
@@ -722,13 +475,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 					Actions:   awslib.SliceOrString{"redshift-serverless:GetEndpointAccess", "redshift-serverless:GetWorkgroup", "redshift-serverless:ListWorkgroups", "redshift-serverless:ListEndpointAccess", "redshift-serverless:ListTagsForResource"},
 				},
 			},
-			boundaryStatements: []*awslib.Statement{
-				{
-					Effect:    awslib.EffectAllow,
-					Resources: awslib.SliceOrString{"*"},
-					Actions:   awslib.SliceOrString{"redshift-serverless:GetEndpointAccess", "redshift-serverless:GetWorkgroup", "redshift-serverless:ListWorkgroups", "redshift-serverless:ListEndpointAccess", "redshift-serverless:ListTagsForResource", "sts:AssumeRole"},
-				},
-			},
 		},
 		"AWS Keyspaces static databases": {
 			target: roleTarget,
@@ -743,13 +489,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 							Region:    "us-west-1",
 						},
 					}},
-				},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{
-					Effect:    awslib.EffectAllow,
-					Resources: awslib.SliceOrString{"*"},
-					Actions:   awslib.SliceOrString{"sts:AssumeRole"},
 				},
 			},
 		},
@@ -768,13 +507,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 					}},
 				},
 			},
-			boundaryStatements: []*awslib.Statement{
-				{
-					Effect:    awslib.EffectAllow,
-					Resources: awslib.SliceOrString{"*"},
-					Actions:   awslib.SliceOrString{"sts:AssumeRole", "sts:TagSession"},
-				},
-			},
 		},
 		"OpenSearch discovery": {
 			target: roleTarget,
@@ -791,13 +523,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 					Effect:    awslib.EffectAllow,
 					Resources: awslib.SliceOrString{"*"},
 					Actions:   awslib.SliceOrString{"es:ListDomainNames", "es:DescribeDomains", "es:ListTags"},
-				},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{
-					Effect:    awslib.EffectAllow,
-					Resources: awslib.SliceOrString{"*"},
-					Actions:   awslib.SliceOrString{"es:ListDomainNames", "es:DescribeDomains", "es:ListTags", "sts:AssumeRole"},
 				},
 			},
 		},
@@ -823,13 +548,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 					Actions:   awslib.SliceOrString{"es:ListDomainNames", "es:DescribeDomains", "es:ListTags"},
 				},
 			},
-			boundaryStatements: []*awslib.Statement{
-				{
-					Effect:    awslib.EffectAllow,
-					Resources: awslib.SliceOrString{"*"},
-					Actions:   awslib.SliceOrString{"es:ListDomainNames", "es:DescribeDomains", "es:ListTags", "sts:AssumeRole"},
-				},
-			},
 		},
 		"DocumentDB static database": {
 			target: roleTarget,
@@ -850,13 +568,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 					Actions:   awslib.SliceOrString{"rds:DescribeDBClusters"},
 				},
 			},
-			boundaryStatements: []*awslib.Statement{
-				{
-					Effect:    awslib.EffectAllow,
-					Resources: awslib.SliceOrString{"*"},
-					Actions:   awslib.SliceOrString{"rds:DescribeDBClusters", "sts:AssumeRole"},
-				},
-			},
 		},
 		"DocumentDB discovery": {
 			target: roleTarget,
@@ -873,13 +584,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 					Effect:    awslib.EffectAllow,
 					Resources: awslib.SliceOrString{"*"},
 					Actions:   awslib.SliceOrString{"rds:DescribeDBClusters"},
-				},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{
-					Effect:    awslib.EffectAllow,
-					Resources: awslib.SliceOrString{"*"},
-					Actions:   awslib.SliceOrString{"rds:DescribeDBClusters", "sts:AssumeRole"},
 				},
 			},
 		},
@@ -915,19 +619,8 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
-				}},
-			},
-			boundaryStatements: []*awslib.Statement{
-				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 					"rds-db:connect",
-				}},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
-					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 				}},
 			},
 		},
@@ -969,41 +662,28 @@ func TestAWSIAMDocuments(t *testing.T) {
 					Actions:   awslib.SliceOrString{"sts:AssumeRole"},
 				},
 			},
-			boundaryStatements: []*awslib.Statement{{
-				Effect:    awslib.EffectAllow,
-				Resources: []string{"*"},
-				Actions: []string{
-					"sts:AssumeRole",
-				}},
-			},
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			targetCfg := mustGetTargetConfig(t, test.flags, test.target, test.fileConfig)
-			policy, policyErr := buildPolicyDocument(test.flags, targetCfg, false)
-			boundary, boundaryErr := buildPolicyDocument(test.flags, targetCfg, true)
+			policy, policyErr := buildPolicyDocument(test.flags, targetCfg)
 
 			if test.returnError {
 				require.Error(t, policyErr)
-				require.Error(t, boundaryErr)
 				return
 			}
 
 			require.NoError(t, policyErr)
-			require.NoError(t, boundaryErr)
 			require.Empty(t, cmp.Diff(test.statements, policy.Document.Statements, sortStringsTrans))
-			require.Empty(t, cmp.Diff(test.boundaryStatements, boundary.Document.Statements, sortStringsTrans))
 		})
 	}
 
 	t.Run("discovery service", func(t *testing.T) {
 		tests := map[string]struct {
-			fileConfig           *config.FileConfig
-			statements           []*awslib.Statement
-			boundaryStatements   []*awslib.Statement
-			wantInlineAsBoundary bool
+			fileConfig *config.FileConfig
+			statements []*awslib.Statement
 		}{
 			"RDS": {
 				fileConfig: &config.FileConfig{
@@ -1021,7 +701,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 						Actions:   awslib.SliceOrString{"rds:DescribeDBInstances", "rds:DescribeDBClusters"},
 					},
 				},
-				wantInlineAsBoundary: true,
 			},
 			"RDS Proxy": {
 				fileConfig: &config.FileConfig{
@@ -1039,7 +718,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 						Actions:   awslib.SliceOrString{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource"},
 					},
 				},
-				wantInlineAsBoundary: true,
 			},
 			"Redshift": {
 				fileConfig: &config.FileConfig{
@@ -1057,7 +735,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 						Actions:   awslib.SliceOrString{"redshift:DescribeClusters"},
 					},
 				},
-				wantInlineAsBoundary: true,
 			},
 			"Redshift Serverless": {
 				fileConfig: &config.FileConfig{
@@ -1075,7 +752,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 						Actions:   awslib.SliceOrString{"redshift-serverless:ListWorkgroups", "redshift-serverless:ListEndpointAccess", "redshift-serverless:ListTagsForResource"},
 					},
 				},
-				wantInlineAsBoundary: true,
 			},
 			"ElastiCache": {
 				fileConfig: &config.FileConfig{
@@ -1093,7 +769,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 						Actions:   awslib.SliceOrString{"elasticache:ListTagsForResource", "elasticache:DescribeReplicationGroups", "elasticache:DescribeCacheClusters", "elasticache:DescribeCacheSubnetGroups"},
 					},
 				},
-				wantInlineAsBoundary: true,
 			},
 			"MemoryDB": {
 				fileConfig: &config.FileConfig{
@@ -1111,7 +786,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 						Actions:   awslib.SliceOrString{"memorydb:ListTags", "memorydb:DescribeClusters", "memorydb:DescribeSubnetGroups"},
 					},
 				},
-				wantInlineAsBoundary: true,
 			},
 			"OpenSearch": {
 				fileConfig: &config.FileConfig{
@@ -1129,7 +803,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 						Actions:   awslib.SliceOrString{"es:DescribeDomains", "es:ListDomainNames", "es:ListTags"},
 					},
 				},
-				wantInlineAsBoundary: true,
 			},
 			"DocumentDB": {
 				fileConfig: &config.FileConfig{
@@ -1147,7 +820,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 						Actions:   awslib.SliceOrString{"rds:DescribeDBClusters"},
 					},
 				},
-				wantInlineAsBoundary: true,
 			},
 			"multiple": {
 				fileConfig: &config.FileConfig{
@@ -1168,26 +840,9 @@ func TestAWSIAMDocuments(t *testing.T) {
 					},
 					{
 						Effect:    awslib.EffectAllow,
-						Resources: awslib.SliceOrString{"*"},
-						Actions:   awslib.SliceOrString{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: awslib.SliceOrString{"*"},
-						Actions:   awslib.SliceOrString{"redshift:DescribeClusters"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
 						Resources: awslib.SliceOrString{role1},
 						Actions:   awslib.SliceOrString{"sts:AssumeRole"},
 					},
-				},
-				boundaryStatements: []*awslib.Statement{
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: awslib.SliceOrString{"*"},
-						Actions:   awslib.SliceOrString{"rds:DescribeDBInstances", "rds:DescribeDBClusters"},
-					},
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: awslib.SliceOrString{"*"},
@@ -1198,13 +853,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 						Resources: awslib.SliceOrString{"*"},
 						Actions:   awslib.SliceOrString{"redshift:DescribeClusters"},
 					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: awslib.SliceOrString{"*"},
-						Actions:   awslib.SliceOrString{"sts:AssumeRole"},
-					},
 				},
-				wantInlineAsBoundary: false,
 			},
 		}
 
@@ -1213,21 +862,15 @@ func TestAWSIAMDocuments(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				targetCfg := mustGetTargetConfig(t, flags, roleTarget, test.fileConfig)
 
-				if test.wantInlineAsBoundary {
-					test.boundaryStatements = test.statements
-				}
-
-				mustBuildPolicyDocument(t, flags, targetCfg, false, test.statements)
-				mustBuildPolicyDocument(t, flags, targetCfg, true, test.boundaryStatements)
+				mustBuildPolicyDocument(t, flags, targetCfg, test.statements)
 			})
 		}
 	})
 
 	t.Run("database service with discovery service config", func(t *testing.T) {
 		tests := map[string]struct {
-			fileConfig         *config.FileConfig
-			statements         []*awslib.Statement
-			boundaryStatements []*awslib.Statement
+			fileConfig *config.FileConfig
+			statements []*awslib.Statement
 		}{
 			"RDS": {
 				fileConfig: &config.FileConfig{
@@ -1242,24 +885,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: []string{"*"},
-						Actions:   []string{"rds:DescribeDBInstances", "rds:DescribeDBClusters", "rds:ModifyDBInstance", "rds:ModifyDBCluster"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{roleTarget.String()},
-						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
-					},
-				},
-				boundaryStatements: []*awslib.Statement{
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{"*"},
 						Actions:   []string{"rds:DescribeDBInstances", "rds:DescribeDBClusters", "rds:ModifyDBInstance", "rds:ModifyDBCluster", "rds-db:connect"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{roleTarget.String()},
-						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
 					},
 				},
 			},
@@ -1276,24 +902,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: []string{"*"},
-						Actions:   []string{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{roleTarget.String()},
-						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
-					},
-				},
-				boundaryStatements: []*awslib.Statement{
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{"*"},
 						Actions:   []string{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds-db:connect"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{roleTarget.String()},
-						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
 					},
 				},
 			},
@@ -1310,24 +919,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: []string{"*"},
-						Actions:   []string{"redshift:DescribeClusters"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{roleTarget.String()},
-						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
-					},
-				},
-				boundaryStatements: []*awslib.Statement{
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{"*"},
-						Actions:   []string{"redshift:DescribeClusters", "redshift:GetClusterCredentials", "sts:AssumeRole"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{roleTarget.String()},
-						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
+						Actions:   []string{"redshift:DescribeClusters", "redshift:GetClusterCredentials"},
 					},
 				},
 			},
@@ -1347,13 +939,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 						Actions:   []string{"redshift-serverless:GetEndpointAccess", "redshift-serverless:GetWorkgroup"},
 					},
 				},
-				boundaryStatements: []*awslib.Statement{
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{"*"},
-						Actions:   []string{"redshift-serverless:GetEndpointAccess", "redshift-serverless:GetWorkgroup", "sts:AssumeRole"},
-					},
-				},
 			},
 			"ElastiCache": {
 				fileConfig: &config.FileConfig{
@@ -1368,7 +953,13 @@ func TestAWSIAMDocuments(t *testing.T) {
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: []string{"*"},
-						Actions:   []string{"elasticache:DescribeReplicationGroups", "elasticache:DescribeUsers", "elasticache:ModifyUser"},
+						Actions: []string{
+							"elasticache:DescribeReplicationGroups",
+							"elasticache:DescribeUsers",
+							"elasticache:ModifyUser",
+							"elasticache:Connect",
+							"elasticache:ListTagsForResource",
+						},
 					},
 					{
 						Effect: awslib.EffectAllow,
@@ -1379,33 +970,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 							"secretsmanager:TagResource",
 						},
 						Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{roleTarget.String()},
-						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
-					},
-				},
-				boundaryStatements: []*awslib.Statement{
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{"*"},
-						Actions:   []string{"elasticache:DescribeReplicationGroups", "elasticache:DescribeUsers", "elasticache:ModifyUser", "elasticache:Connect"},
-					},
-					{
-						Effect: awslib.EffectAllow,
-						Actions: []string{
-							"secretsmanager:DescribeSecret", "secretsmanager:CreateSecret",
-							"secretsmanager:UpdateSecret", "secretsmanager:DeleteSecret",
-							"secretsmanager:GetSecretValue", "secretsmanager:PutSecretValue",
-							"secretsmanager:TagResource",
-						},
-						Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{roleTarget.String()},
-						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
 					},
 				},
 			},
@@ -1422,7 +986,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: []string{"*"},
-						Actions:   []string{"memorydb:DescribeClusters", "memorydb:DescribeUsers", "memorydb:UpdateUser"},
+						Actions:   []string{"memorydb:DescribeClusters", "memorydb:DescribeUsers", "memorydb:UpdateUser", "memorydb:Connect", "memorydb:ListTags"},
 					},
 					{
 						Effect: awslib.EffectAllow,
@@ -1433,33 +997,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 							"secretsmanager:TagResource",
 						},
 						Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{roleTarget.String()},
-						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
-					},
-				},
-				boundaryStatements: []*awslib.Statement{
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{"*"},
-						Actions:   []string{"memorydb:DescribeClusters", "memorydb:DescribeUsers", "memorydb:UpdateUser", "memorydb:Connect"},
-					},
-					{
-						Effect: awslib.EffectAllow,
-						Actions: []string{
-							"secretsmanager:DescribeSecret", "secretsmanager:CreateSecret",
-							"secretsmanager:UpdateSecret", "secretsmanager:DeleteSecret",
-							"secretsmanager:GetSecretValue", "secretsmanager:PutSecretValue",
-							"secretsmanager:TagResource",
-						},
-						Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{roleTarget.String()},
-						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
 					},
 				},
 			},
@@ -1479,13 +1016,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 						Actions:   []string{"es:DescribeDomains"},
 					},
 				},
-				boundaryStatements: []*awslib.Statement{
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{"*"},
-						Actions:   []string{"es:DescribeDomains", "sts:AssumeRole"},
-					},
-				},
 			},
 			"DocumentDB": {
 				fileConfig: &config.FileConfig{
@@ -1501,13 +1031,6 @@ func TestAWSIAMDocuments(t *testing.T) {
 						Effect:    awslib.EffectAllow,
 						Resources: []string{"*"},
 						Actions:   []string{"rds:DescribeDBClusters"},
-					},
-				},
-				boundaryStatements: []*awslib.Statement{
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{"*"},
-						Actions:   []string{"rds:DescribeDBClusters", "sts:AssumeRole"},
 					},
 				},
 			},
@@ -1526,17 +1049,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: []string{"*"},
-						Actions:   []string{"rds:DescribeDBInstances", "rds:DescribeDBClusters", "rds:ModifyDBInstance", "rds:ModifyDBCluster"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{"*"},
-						Actions:   []string{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{"*"},
-						Actions:   []string{"redshift:DescribeClusters"},
+						Actions:   []string{"rds:DescribeDBInstances", "rds:DescribeDBClusters", "rds:ModifyDBInstance", "rds:ModifyDBCluster", "rds-db:connect"},
 					},
 					{
 						Effect:    awslib.EffectAllow,
@@ -1545,30 +1058,13 @@ func TestAWSIAMDocuments(t *testing.T) {
 					},
 					{
 						Effect:    awslib.EffectAllow,
-						Resources: []string{roleTarget.String()},
-						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
-					},
-				},
-				boundaryStatements: []*awslib.Statement{
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{"*"},
-						Actions:   []string{"rds:DescribeDBInstances", "rds:DescribeDBClusters", "rds:ModifyDBInstance", "rds:ModifyDBCluster", "rds-db:connect"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
 						Resources: []string{"*"},
 						Actions:   []string{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints"},
 					},
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: []string{"*"},
-						Actions:   []string{"redshift:DescribeClusters", "redshift:GetClusterCredentials", "sts:AssumeRole"},
-					},
-					{
-						Effect:    awslib.EffectAllow,
-						Resources: []string{roleTarget.String()},
-						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
+						Actions:   []string{"redshift:DescribeClusters", "redshift:GetClusterCredentials"},
 					},
 				},
 			},
@@ -1580,8 +1076,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
 				targetCfg := mustGetTargetConfig(t, flags, roleTarget, test.fileConfig)
-				mustBuildPolicyDocument(t, flags, targetCfg, false, test.statements)
-				mustBuildPolicyDocument(t, flags, targetCfg, true, test.boundaryStatements)
+				mustBuildPolicyDocument(t, flags, targetCfg, test.statements)
 			})
 		}
 	})
@@ -1598,10 +1093,10 @@ func mustGetTargetConfig(t *testing.T, flags configurators.BootstrapFlags, roleT
 	return targetCfg
 }
 
-func mustBuildPolicyDocument(t *testing.T, flags configurators.BootstrapFlags, targetCfg targetConfig, boundary bool, wantStatements []*awslib.Statement) {
+func mustBuildPolicyDocument(t *testing.T, flags configurators.BootstrapFlags, targetCfg targetConfig, wantStatements []*awslib.Statement) {
 	t.Helper()
 
-	policy, policyErr := buildPolicyDocument(flags, targetCfg, boundary)
+	policy, policyErr := buildPolicyDocument(flags, targetCfg)
 	require.NoError(t, policyErr)
 	require.Empty(t, cmp.Diff(wantStatements, policy.Document.Statements, sortStringsTrans))
 }
@@ -1611,16 +1106,9 @@ func TestAWSPolicyCreator(t *testing.T) {
 
 	tests := map[string]struct {
 		returnError bool
-		isBoundary  bool
 		policies    *policiesMock
 	}{
 		"UpsertPolicy": {
-			policies: &policiesMock{
-				upsertArn: "generated-arn",
-			},
-		},
-		"UpsertPolicyBoundary": {
-			isBoundary: true,
 			policies: &policiesMock{
 				upsertArn: "generated-arn",
 			},
@@ -1636,19 +1124,13 @@ func TestAWSPolicyCreator(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			action := &awsPolicyCreator{
-				policies:   test.policies,
-				isBoundary: test.isBoundary,
+				policies: test.policies,
 			}
 
 			actionCtx := &configurators.ConfiguratorActionContext{}
 			err := action.Execute(ctx, actionCtx)
 			if test.returnError {
 				require.Error(t, err)
-				return
-			}
-
-			if test.isBoundary {
-				require.Equal(t, test.policies.upsertArn, actionCtx.AWSPolicyBoundaryArn)
 				return
 			}
 
@@ -1675,33 +1157,21 @@ func TestAWSPoliciesAttacher(t *testing.T) {
 			target:   userTarget,
 			policies: &policiesMock{},
 			actionCtx: &configurators.ConfiguratorActionContext{
-				AWSPolicyArn:         "policy-arn",
-				AWSPolicyBoundaryArn: "policy-boundary-arn",
+				AWSPolicyArn: "policy-arn",
 			},
 		},
 		"AttachPoliciesToRole": {
 			target:   roleTarget,
 			policies: &policiesMock{},
 			actionCtx: &configurators.ConfiguratorActionContext{
-				AWSPolicyArn:         "policy-arn",
-				AWSPolicyBoundaryArn: "policy-boundary-arn",
+				AWSPolicyArn: "policy-arn",
 			},
 		},
 		"MissingPolicyArn": {
 			returnError: true,
 			target:      roleTarget,
 			policies:    &policiesMock{},
-			actionCtx: &configurators.ConfiguratorActionContext{
-				AWSPolicyBoundaryArn: "policy-boundary-arn",
-			},
-		},
-		"MissingPolicyBoundaryArn": {
-			returnError: true,
-			target:      roleTarget,
-			policies:    &policiesMock{},
-			actionCtx: &configurators.ConfiguratorActionContext{
-				AWSPolicyArn: "policy-arn",
-			},
+			actionCtx:   &configurators.ConfiguratorActionContext{},
 		},
 		"AttachPolicyFailure": {
 			returnError: true,
@@ -1710,19 +1180,7 @@ func TestAWSPoliciesAttacher(t *testing.T) {
 				attachError: trace.NotImplemented("attach policy not implemented"),
 			},
 			actionCtx: &configurators.ConfiguratorActionContext{
-				AWSPolicyArn:         "policy-arn",
-				AWSPolicyBoundaryArn: "policy-boundary-arn",
-			},
-		},
-		"AttachPolicyBoundaryFailure": {
-			returnError: true,
-			target:      roleTarget,
-			policies: &policiesMock{
-				attachBoundaryError: trace.NotImplemented("attach policy not implemented"),
-			},
-			actionCtx: &configurators.ConfiguratorActionContext{
-				AWSPolicyArn:         "policy-arn",
-				AWSPolicyBoundaryArn: "policy-boundary-arn",
+				AWSPolicyArn: "policy-arn",
 			},
 		},
 	}
@@ -2385,7 +1843,7 @@ func TestIsTargetAssumeRole(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := isTargetAWSAssumeRole(tt.flags, tt.matchers, tt.databases, tt.resources, tt.target)
+			got := isTargetAWSAssumeRole(tt.matchers, tt.databases, tt.resources, tt.target)
 			require.Equal(t, tt.want, got)
 		})
 	}
@@ -2394,10 +1852,9 @@ func TestIsTargetAssumeRole(t *testing.T) {
 type policiesMock struct {
 	awslib.Policies
 
-	upsertArn           string
-	upsertError         error
-	attachError         error
-	attachBoundaryError error
+	upsertArn   string
+	upsertError error
+	attachError error
 }
 
 func (p *policiesMock) Upsert(context.Context, *awslib.Policy) (string, error) {
@@ -2406,10 +1863,6 @@ func (p *policiesMock) Upsert(context.Context, *awslib.Policy) (string, error) {
 
 func (p *policiesMock) Attach(context.Context, string, awslib.Identity) error {
 	return p.attachError
-}
-
-func (p *policiesMock) AttachBoundary(context.Context, string, awslib.Identity) error {
-	return p.attachBoundaryError
 }
 
 type STSMock struct {

--- a/lib/configurators/common.go
+++ b/lib/configurators/common.go
@@ -114,8 +114,6 @@ type BootstrapFlags struct {
 type ConfiguratorActionContext struct {
 	// AWSPolicyArn AWS ARN of the created policy.
 	AWSPolicyArn string
-	// AWS ARN of the created policy boundary.
-	AWSPolicyBoundaryArn string
 }
 
 // ConfiguratorAction is single configurator action, its details can be retrieved

--- a/tool/teleport/common/configurator.go
+++ b/tool/teleport/common/configurator.go
@@ -238,6 +238,7 @@ type configureDatabaseAWSPrintFlags struct {
 	// policyOnly if "true" will only prints the policy JSON.
 	policyOnly bool
 	// boundaryOnly if "true" will only prints the policy boundary JSON.
+	// TODO(gavin): DELETE IN 18.0.0
 	boundaryOnly bool
 }
 
@@ -315,8 +316,7 @@ func onConfigureDatabasesAWSPrint(flags configureDatabaseAWSPrintFlags) error {
 	}
 
 	if flags.boundaryOnly {
-		// Policy boundary is present at the details of the second instruction.
-		fmt.Println(actions[1].Details())
+		fmt.Println("The --boundary flag is deprecated. The IAM permissions model that Teleport uses no longer requires a boundary policy.")
 		return nil
 	}
 

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -324,7 +324,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dbConfigureAWSPrintIAM.Flag("role", "IAM role name to attach policy to. Mutually exclusive with --user").StringVar(&configureDatabaseAWSPrintFlags.role)
 	dbConfigureAWSPrintIAM.Flag("user", "IAM user name to attach policy to. Mutually exclusive with --role").StringVar(&configureDatabaseAWSPrintFlags.user)
 	dbConfigureAWSPrintIAM.Flag("policy", "Only print IAM policy document.").BoolVar(&configureDatabaseAWSPrintFlags.policyOnly)
-	dbConfigureAWSPrintIAM.Flag("boundary", "Only print IAM boundary policy document.").BoolVar(&configureDatabaseAWSPrintFlags.boundaryOnly)
+	dbConfigureAWSPrintIAM.Flag("boundary", "Only print IAM boundary policy document.").Hidden().BoolVar(&configureDatabaseAWSPrintFlags.boundaryOnly)
 	dbConfigureAWSPrintIAM.Flag("assumes-roles",
 		"Comma-separated list of additional IAM roles that the IAM identity should be able to assume. Each role can be either an IAM role ARN or the name of a role in the identity's account.").
 		StringVar(&configureDatabaseAWSPrintFlags.assumesRoles)


### PR DESCRIPTION
Part of: https://github.com/gravitational/teleport/issues/43829
- https://github.com/gravitational/teleport/issues/43829

This PR:

* replaces the dynamic iam statements (`iam:PutRolePolicy`, `iam:GetRolePolicy`, etc) with static permissions
* adds ListTags permissions for memorydb/elasticache managed users, which is needed to find users managed by Teleport
* removes obsolete boundary policy attachment, since that was only needed to prevent `iam:PutRolePolicy` privilege escalation
* deprecate the --boundary flag by hiding it