### PR TITLE
Update get-started.mdx to quote roles and prevent helm error

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/get-started.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/get-started.mdx
@@ -68,7 +68,7 @@ join token you created earlier:
 
 ```code
 $ helm install teleport-agent teleport/teleport-kube-agent \
-  --set roles=kube\,app\,discovery \
+  --set roles="kube\,app\,discovery" \
   --set kubeClusterName=main-cluster \
   --set proxyAddr=<Var name="proxy-address" /> \
   --set authToken=<Var name="token" /> \


### PR DESCRIPTION
The guide should be updated as running the helm command as is results in an error.

```
❯ helm version
version.BuildInfo{Version:"v3.15.4", GitCommit:"fa9efb07d9d8debbb4306d72af76a383895aa8c4", GitTreeState:"clean", GoVersion:"go1.22.6"}
❯ helm install teleport-agent teleport/teleport-kube-agent \
  --set roles=kube\,app\,discovery \
  --set kubeClusterName=teleport-cluster \
  --set proxyAddr=example.com:443 \
  --set authToken=\
  --create-namespace \
  --namespace=teleport-agent
Error: INSTALLATION FAILED: failed parsing --set data: key "app" has no value (cannot end with ,)
```

The correct syntax is shown in the output of the `tctl tokens add --type=kube,app,discovery` command. Creating this PR to update the helm command to the following
```
helm install teleport-agent teleport/teleport-kube-agent \
  --set roles="kube\,app\,discovery" \
  --set kubeClusterName=teleport-cluster \
  --set proxyAddr=example.com:443 \
  --set authToken=\
  --create-namespace \
  --namespace=teleport-agent
```