### PR TITLE
fix local re-register

### DIFF
--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -45,7 +45,9 @@ func LocalRegister(id state.IdentityID, authServer *Server, additionalPrincipals
 	}
 
 	// If local registration is happening and no remote address was passed in
-	// (which means no advertise IP was set), use localhost.
+	// (which means no advertise IP was set), use localhost. This behavior must
+	// be kept consistent with the equivalen behavior in cert rotation/re-register
+	// logic in lib/service.
 	if remoteAddr == "" {
 		remoteAddr = defaults.Localhost
 	}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -19,6 +19,7 @@
 package service
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -395,7 +396,11 @@ func (process *TeleportProcess) reRegister(conn *Connector, additionalPrincipals
 
 	if srv := process.getLocalAuth(); srv != nil {
 		clt = srv
-		remoteAddr = process.Config.AdvertiseIP
+		// auth server typically extracts remote addr from conn. since we're using the local auth
+		// directly we must supply a reasonable remote addr value. preferably the advertise IP, but
+		// otherwise localhost. this behavior must be kept consistent with the equivalent behavior
+		// in LocalRegister.
+		remoteAddr = cmp.Or(process.Config.AdvertiseIP, defaults.Localhost)
 	}
 
 	identity, err := auth.ReRegister(ctx, auth.ReRegisterParams{


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/gravitational/teleport/pull/41467 which could cause reissue of certificates to fail for a service which was running alongside a local auth server, had a listener bound to `0.0.0.0`, and did not have `advertise_ip` set.  With this change, local re-register takes on the same behavior as local register, using `127.0.0.1` as the default remote address value.

Fixes https://github.com/gravitational/teleport/issues/43856

changelog: fixed an issue that would cause reissue of certificates to fail in some scenarios where a local auth service was present.
