### PR TITLE
docs: add note on trusted clusters

### DIFF
--- a/docs/pages/admin-guides/management/admin/trustedclusters.mdx
+++ b/docs/pages/admin-guides/management/admin/trustedclusters.mdx
@@ -3,6 +3,10 @@ title: Configure Trusted Clusters
 description: Explains how you can configure a trust relationship and manage access between two Teleport clusters.
 ---
 
+<Admonition type="note">
+Trusted clusters are only available for self-hosted Teleport clusters.
+</Admonition>
+
 As you learned in [Core Concepts](../../../core-concepts.mdx), a Teleport cluster
 consists of the Teleport Auth Service, the Teleport Proxy Service, and the 
 Teleport services that manage access to resources in your infrastructure.


### PR DESCRIPTION
Add note that Trusted Clusters are only available for self-hosted.