### PR TITLE
[v15] Correct Arch Linux spelling

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -22,7 +22,6 @@
     "Addrs",
     "Afax",
     "Aqxs",
-    "Archlinux",
     "Authy",
     "BDRVJUSUZ",
     "BSFD",

--- a/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
@@ -86,7 +86,7 @@ Teleport supports enhanced session recording with BPF on `amd64` and `arm64` arc
 |:------------------------|:---------------|:---------------|
 | Ubuntu "Groovy Gorilla" | 20.10          | 5.8+           |
 | Fedora                  | 33             | 5.8+           |
-| Archlinux               | 2020.09.01     | 5.8.5+         |
+| Arch Linux              | 2020.09.01     | 5.8.5+         |
 | Flatcar                 | 2765.2.2       | 5.10.25+       |
 | Amazon Linux            | 2              | 5.10+          |
 


### PR DESCRIPTION
Backport #46062 to branch/v15