### PR TITLE
update language on deleting token

### DIFF
--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -392,8 +392,9 @@ function TokenDelete({
             {` ${token.safeName}`}
           </Text>
           This will not remove any resources that used this token to join the
-          cluster. This will remove the ability for any new resources
-          or resources using non-renewable certificates from joining with this token.
+          cluster. This will remove the ability for any new resources or
+          resources using non-renewable certificates from joining with this
+          token.
         </Text>
       </DialogContent>
       <DialogFooter>

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -391,7 +391,7 @@ function TokenDelete({
           <Text bold as="span">
             {` ${token.safeName}`}
           </Text>
-          This will not remove any resources that used this token to join the
+          . This will not remove any resources that used this token to join the
           cluster. This will remove the ability for any new resources or
           resources using non-renewable certificates from joining with this
           token.

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -391,9 +391,9 @@ function TokenDelete({
           <Text bold as="span">
             {` ${token.safeName}`}
           </Text>
-          . This will not remove any resources that used this token to join the
-          cluster. This will remove the ability for any new resources or
-          non-renewable resources from joining with this token.
+          This will not remove any resources that used this token to join the
+          cluster. This will remove the ability for any new resources
+          or resources using non-renewable certificates from joining with this token.
         </Text>
       </DialogContent>
       <DialogFooter>

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -392,8 +392,8 @@ function TokenDelete({
             {` ${token.safeName}`}
           </Text>
           . This will not remove any resources that used this token to join the
-          cluster. This will remove the ability for any new resources to join
-          with this token and any non-renewable resource from renewing.
+          cluster. This will remove the ability for any new resources or
+          non-renewable resources from joining with this token.
         </Text>
       </DialogContent>
       <DialogFooter>


### PR DESCRIPTION
Having the language "any non-renewable resource from renewing" is confusing if they can't renew. Matching this to the language at https://goteleport.com/docs/reference/join-methods/#renewable-vs-non-renewable that they join.