### PR TITLE
[v15] kube: expose cluster domain to statefulset pod 

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -146,6 +146,10 @@ spec:
           - name: TELEPORT_EXT_UPGRADER_VERSION
             value: {{ include "teleport-kube-agent.version" . }}
           {{- end }}
+          {{- if .Values.clusterDomain }}
+          - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+            value: {{ .Values.clusterDomain | quote }}
+          {{- end }}
           {{- if .Values.tls.existingCASecretName }}
           - name: SSL_CERT_FILE
             value: /etc/teleport-tls-ca/ca.pem

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -16,6 +16,8 @@ sets Pod annotations when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -84,6 +86,8 @@ sets Pod labels when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -176,6 +180,8 @@ sets StatefulSet labels when specified:
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
+            - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+              value: cluster.local
             image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
             imagePullPolicy: IfNotPresent
             livenessProbe:
@@ -272,6 +278,8 @@ should add insecureSkipProxyTLSVerify to args when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -340,6 +348,8 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -428,6 +438,8 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
+            - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+              value: cluster.local
             image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
             imagePullPolicy: IfNotPresent
             livenessProbe:
@@ -506,6 +518,8 @@ should add volumeMount for data volume when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -574,6 +588,8 @@ should expose diag port:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -642,6 +658,8 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -724,6 +742,8 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -804,6 +824,8 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -872,6 +894,8 @@ should have one replica when replicaCount is not set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -940,6 +964,8 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1010,6 +1036,8 @@ should mount extraVolumes and extraVolumeMounts:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1083,6 +1111,8 @@ should mount tls.existingCASecretName and set environment when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
@@ -1161,6 +1191,8 @@ should mount tls.existingCASecretName and set extra environment when set in valu
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
@@ -1241,6 +1273,8 @@ should not add emptyDir for data when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1309,6 +1343,8 @@ should provision initContainer correctly when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1413,6 +1449,8 @@ should set SecurityContext:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1501,6 +1539,8 @@ should set affinity when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1569,6 +1609,8 @@ should set default serviceAccountName when not set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1648,6 +1690,8 @@ should set environment when extraEnv set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
@@ -1718,6 +1762,8 @@ should set image and tag correctly:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:12.2.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1786,6 +1832,8 @@ should set imagePullPolicy when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: Always
       livenessProbe:
@@ -1854,6 +1902,8 @@ should set nodeSelector if set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1936,6 +1986,8 @@ should set preferred affinity when more than one replica is used:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -2004,6 +2056,8 @@ should set probeTimeoutSeconds when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -2082,6 +2136,8 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -2150,6 +2206,8 @@ should set resources when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -2225,6 +2283,8 @@ should set serviceAccountName when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -2293,6 +2353,8 @@ should set storage.requests when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -2361,6 +2423,8 @@ should set storage.storageClassName when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -2429,6 +2493,8 @@ should set tolerations when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.4.17
       imagePullPolicy: IfNotPresent
       livenessProbe:


### PR DESCRIPTION
Backport #46144 to branch/v15

Changelog: Extend Teleport ability to use non-default cluster domains in Kubernetes, avoiding the assumption of `cluster.local`.