### PR TITLE
chore: Bump OpenSSL to 3.0.15

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -46,9 +46,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.11.0 && \
 
 # Install openssl.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.14 && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.15 && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = '9cff14fd97814baf8a9a07d8447960a64d616ada' ] && \
+    [ "$(git rev-parse HEAD)" = 'c523121f902fde2929909dc7f76b13ceb4961efe' ] && \
     ./config --release -fPIC --libdir=/usr/local/lib && \
     make -j"$(nproc)" && \
     make install_sw

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -126,9 +126,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.11.0 && \
 # Specific install arguments used to skip docs.
 # Note that FIPS is enabled as part of this build, but it is unused without the
 # necessary configuration (which is included as part of the separate FIPS buildbox).
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.14 && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.15 && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = '9cff14fd97814baf8a9a07d8447960a64d616ada' ] && \
+    [ "$(git rev-parse HEAD)" = 'c523121f902fde2929909dc7f76b13ceb4961efe' ] && \
     ./config enable-fips --release -fPIC --libdir=/usr/local/lib64 && \
     make -j"$(nproc)" && \
     make install_sw install_ssldirs install_fips

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -23,8 +23,8 @@ fi
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.11.0
 readonly CBOR_COMMIT=170bee2b82cdb7b2ed25af301f62cb6efdd40ec1
-readonly CRYPTO_VERSION=openssl-3.0.14
-readonly CRYPTO_COMMIT=9cff14fd97814baf8a9a07d8447960a64d616ada
+readonly CRYPTO_VERSION=openssl-3.0.15
+readonly CRYPTO_COMMIT=c523121f902fde2929909dc7f76b13ceb4961efe
 readonly FIDO2_VERSION=1.15.0
 readonly FIDO2_COMMIT=f87c19c9487c0131531314d9ccb475ea5325794e
 

--- a/build.assets/buildbox/thirdparty-libs.mk
+++ b/build.assets/buildbox/thirdparty-libs.mk
@@ -139,9 +139,9 @@ tp-build-libudev_zero: fetch-git-libudev_zero
 # -----------------------------------------------------------------------------
 # libcbor
 
-libcbor_VERSION = 0.10.2
+libcbor_VERSION = 0.11.0
 libcbor_GIT_REF = v$(libcbor_VERSION)
-libcbor_GIT_REF_HASH = efa6c0886bae46bdaef9b679f61f4b9d8bc296ae
+libcbor_GIT_REF_HASH = 170bee2b82cdb7b2ed25af301f62cb6efdd40ec1
 libcbor_GIT_REPO = https://github.com/PJK/libcbor
 libcbor_SRCDIR = $(call tp-src-dir,libcbor)
 
@@ -160,9 +160,9 @@ tp-build-libcbor: fetch-git-libcbor
 # -----------------------------------------------------------------------------
 # openssl
 
-openssl_VERSION = 3.0.13
+openssl_VERSION = 3.0.15
 openssl_GIT_REF = openssl-$(openssl_VERSION)
-openssl_GIT_REF_HASH = 85cf92f55d9e2ac5aacf92bedd33fb890b9f8b4c
+openssl_GIT_REF_HASH = c523121f902fde2929909dc7f76b13ceb4961efe
 openssl_GIT_REPO = https://github.com/openssl/openssl
 openssl_SRCDIR = $(call tp-src-dir,openssl)
 
@@ -188,9 +188,9 @@ tp-build-openssl: fetch-git-openssl
 # -----------------------------------------------------------------------------
 # libfido2
 
-libfido2_VERSION = 1.14.0
+libfido2_VERSION = 1.15.0
 libfido2_GIT_REF = $(libfido2_VERSION)
-libfido2_GIT_REF_HASH = 1a9d335c8f0e821f9eff27482fdda96e59a4f577
+libfido2_GIT_REF_HASH = f87c19c9487c0131531314d9ccb475ea5325794e
 libfido2_GIT_REPO = https://github.com/Yubico/libfido2
 libfido2_SRCDIR = $(call tp-src-dir,libfido2)
 

--- a/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libcrypto-static.pc
@@ -7,6 +7,6 @@ modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 3.0.14
+Version: 3.0.15
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
@@ -7,6 +7,6 @@ modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 3.0.14
+Version: 3.0.15
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}


### PR DESCRIPTION
Update to the latest security patch.

- https://github.com/openssl/openssl/blob/openssl-3.0.15/CHANGES.md#openssl-30
- https://openssl-library.org/news/secadv/20240903.txt

Changelog: Updated OpenSSL to 3.0.15