### PR TITLE
Simplify tctl and tsh partials

### DIFF
--- a/docs/pages/admin-guides/access-controls/sso/okta.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/okta.mdx
@@ -47,10 +47,10 @@ guide you through configuring the Okta integration.
 
 <Tabs>
 <TabItem label="Teleport Enterprise (Self-Hosted)" scope="enterprise">
-- (!docs/pages/includes/enterprise/tctl-tsh-prerequisite.mdx!)
+- (!docs/pages/includes/tctl-tsh-prerequisite.mdx!)
 </TabItem>
 <TabItem label="Teleport Cloud" scope="cloud">
-- (!docs/pages/includes/cloud/tctl-tsh-prerequisite.mdx!)
+- (!docs/pages/includes/tctl-tsh-prerequisite.mdx!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/admin-guides/management/admin/self-signed-certs.mdx
+++ b/docs/pages/admin-guides/management/admin/self-signed-certs.mdx
@@ -71,7 +71,7 @@ For example, this Teleport Proxy Service configuration would use self-signed cer
     acme: {}
   ```
 
-- (!docs/pages/includes/enterprise/tctl-tsh-prerequisite.mdx!)
+- (!docs/pages/includes/tctl-tsh-prerequisite.mdx!)
 
 </TabItem>
 </Tabs>

--- a/docs/pages/includes/cloud/tctl-tsh-prerequisite.mdx
+++ b/docs/pages/includes/cloud/tctl-tsh-prerequisite.mdx
@@ -1,2 +1,0 @@
-The `tctl` and `tsh` client tools version >= (=cloud.version=). To install these
-tools, see the [Installation](../../installation.mdx) page.

--- a/docs/pages/includes/enterprise/tctl-tsh-prerequisite.mdx
+++ b/docs/pages/includes/enterprise/tctl-tsh-prerequisite.mdx
@@ -1,2 +1,0 @@
-The `tctl` and `tsh` client tools version >= (=teleport.version=), which you
-can download by visiting your [Teleport account](https://teleport.sh).


### PR DESCRIPTION
Closes #27252

Consolidate the `tctl-tsh-prerequisite.mdx` partial, which exists for each Teleport edition. Edition-specific variations of this partial are used in only 1-2 guides each, so consolidating these partials helps us take advantage of reusability.