### PR TITLE
[v14] fix local re-register

### DIFF
--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -43,7 +43,9 @@ func LocalRegister(id state.IdentityID, authServer *Server, additionalPrincipals
 	}
 
 	// If local registration is happening and no remote address was passed in
-	// (which means no advertise IP was set), use localhost.
+	// (which means no advertise IP was set), use localhost. This behavior must
+	// be kept consistent with the equivalen behavior in cert rotation/re-register
+	// logic in lib/service.
 	if remoteAddr == "" {
 		remoteAddr = defaults.Localhost
 	}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -404,7 +405,11 @@ func (process *TeleportProcess) reRegister(conn *Connector, additionalPrincipals
 
 	if srv := process.getLocalAuth(); srv != nil {
 		clt = srv
-		remoteAddr = process.Config.AdvertiseIP
+		// auth server typically extracts remote addr from conn. since we're using the local auth
+		// directly we must supply a reasonable remote addr value. preferably the advertise IP, but
+		// otherwise localhost. this behavior must be kept consistent with the equivalent behavior
+		// in LocalRegister.
+		remoteAddr = cmp.Or(process.Config.AdvertiseIP, defaults.Localhost)
 	}
 
 	identity, err := auth.ReRegister(ctx, auth.ReRegisterParams{


### PR DESCRIPTION
Backport #46087 to branch/v14

changelog: fixed an issue that would cause reissue of certificates to fail in some scenarios where a local auth service was present.
