### PR TITLE
support file configuration of  `signature_algorithm_suite`

### DIFF
--- a/api/types/signaturealgorithmsuite.go
+++ b/api/types/signaturealgorithmsuite.go
@@ -46,7 +46,7 @@ func (s *SignatureAlgorithmSuite) UnmarshalJSON(data []byte) error {
 	}
 	switch v := val.(type) {
 	case string:
-		return trace.Wrap(s.setFromString(v))
+		return trace.Wrap(s.UnmarshalText([]byte(v)))
 	case float64:
 		// json.Unmarshal is documented to unmarshal any JSON number into an
 		// int64 when unmarshaling into an interface.
@@ -56,7 +56,11 @@ func (s *SignatureAlgorithmSuite) UnmarshalJSON(data []byte) error {
 	}
 }
 
-func (s *SignatureAlgorithmSuite) setFromString(str string) error {
+// UnmarshalText unmarshals a SignatureAlgorithmSuite from text and supports the
+// custom string format or the proto enum values. This is used by JSON and YAML
+// unmarshallers.
+func (s *SignatureAlgorithmSuite) UnmarshalText(text []byte) error {
+	str := string(text)
 	switch str {
 	case "":
 		*s = SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_UNSPECIFIED

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1031,6 +1031,9 @@ type AuthenticationConfig struct {
 	// HardwareKey holds settings related to hardware key support.
 	// Requires Teleport Enterprise.
 	HardwareKey *HardwareKey `yaml:"hardware_key,omitempty"`
+
+	// SignatureAlgorithmSuite is the configured signature algorithm suite for the cluster.
+	SignatureAlgorithmSuite types.SignatureAlgorithmSuite `yaml:"signature_algorithm_suite"`
 }
 
 // Parse returns valid types.AuthPreference instance.
@@ -1078,20 +1081,21 @@ func (a *AuthenticationConfig) Parse() (types.AuthPreference, error) {
 	}
 
 	return types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
-		Type:              a.Type,
-		SecondFactor:      a.SecondFactor,
-		ConnectorName:     a.ConnectorName,
-		U2F:               u,
-		Webauthn:          w,
-		RequireMFAType:    a.RequireMFAType,
-		LockingMode:       a.LockingMode,
-		AllowLocalAuth:    a.LocalAuth,
-		AllowPasswordless: a.Passwordless,
-		AllowHeadless:     a.Headless,
-		DeviceTrust:       dt,
-		DefaultSessionTTL: a.DefaultSessionTTL,
-		PIVSlot:           string(a.PIVSlot),
-		HardwareKey:       h,
+		Type:                    a.Type,
+		SecondFactor:            a.SecondFactor,
+		ConnectorName:           a.ConnectorName,
+		U2F:                     u,
+		Webauthn:                w,
+		RequireMFAType:          a.RequireMFAType,
+		LockingMode:             a.LockingMode,
+		AllowLocalAuth:          a.LocalAuth,
+		AllowPasswordless:       a.Passwordless,
+		AllowHeadless:           a.Headless,
+		DeviceTrust:             dt,
+		DefaultSessionTTL:       a.DefaultSessionTTL,
+		PIVSlot:                 string(a.PIVSlot),
+		HardwareKey:             h,
+		SignatureAlgorithmSuite: a.SignatureAlgorithmSuite,
 	})
 }
 

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -470,6 +470,7 @@ func TestAuthenticationSection(t *testing.T) {
 				tt.expectError(t, err)
 				return
 			}
+			require.NoError(t, err)
 
 			require.Empty(t, cmp.Diff(cfg.Auth.Authentication, tt.expected))
 		})

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -212,7 +212,6 @@ func TestAuthenticationSection(t *testing.T) {
 					"second_factor": "otp",
 				}
 			},
-			expectError: require.NoError,
 			expected: &AuthenticationConfig{
 				Type:         "local",
 				SecondFactor: "otp",
@@ -225,7 +224,6 @@ func TestAuthenticationSection(t *testing.T) {
 					"second_factor": "off",
 				}
 			},
-			expectError: require.NoError,
 			expected: &AuthenticationConfig{
 				Type:         "local",
 				SecondFactor: "off",
@@ -246,7 +244,6 @@ func TestAuthenticationSection(t *testing.T) {
 					},
 				}
 			},
-			expectError: require.NoError,
 			expected: &AuthenticationConfig{
 				Type:         "local",
 				SecondFactor: "u2f",
@@ -280,7 +277,6 @@ func TestAuthenticationSection(t *testing.T) {
 					},
 				}
 			},
-			expectError: require.NoError,
 			expected: &AuthenticationConfig{
 				Type:         "local",
 				SecondFactor: "webauthn",
@@ -313,7 +309,6 @@ func TestAuthenticationSection(t *testing.T) {
 					},
 				}
 			},
-			expectError: require.NoError,
 			expected: &AuthenticationConfig{
 				Type:         "local",
 				SecondFactor: "on",
@@ -338,7 +333,6 @@ func TestAuthenticationSection(t *testing.T) {
 					"connector_name": "passwordless",
 				}
 			},
-			expectError: require.NoError,
 			expected: &AuthenticationConfig{
 				Type:         "local",
 				SecondFactor: "on",
@@ -361,7 +355,6 @@ func TestAuthenticationSection(t *testing.T) {
 					"connector_name": "headless",
 				}
 			},
-			expectError: require.NoError,
 			expected: &AuthenticationConfig{
 				Type:         "local",
 				SecondFactor: "on",
@@ -383,7 +376,6 @@ func TestAuthenticationSection(t *testing.T) {
 					},
 				}
 			},
-			expectError: require.NoError,
 			expected: &AuthenticationConfig{
 				DeviceTrust: &DeviceTrust{
 					Mode: "required",
@@ -402,12 +394,71 @@ func TestAuthenticationSection(t *testing.T) {
 					},
 				}
 			},
-			expectError: require.NoError,
 			expected: &AuthenticationConfig{
 				DeviceTrust: &DeviceTrust{
 					Mode:       "required",
 					AutoEnroll: "yes",
 				},
+			},
+		}, {
+			desc: "signature suite empty",
+			mutate: func(cfg cfgMap) {
+				cfg["auth_service"].(cfgMap)["authentication"] = cfgMap{
+					"signature_algorithm_suite": "",
+				}
+			},
+			expected: &AuthenticationConfig{
+				SignatureAlgorithmSuite: types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_UNSPECIFIED,
+			},
+		}, {
+			desc: "signature suite legacy",
+			mutate: func(cfg cfgMap) {
+				cfg["auth_service"].(cfgMap)["authentication"] = cfgMap{
+					"signature_algorithm_suite": "legacy",
+				}
+			},
+			expected: &AuthenticationConfig{
+				SignatureAlgorithmSuite: types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_LEGACY,
+			},
+		}, {
+			desc: "signature suite balanced-v1",
+			mutate: func(cfg cfgMap) {
+				cfg["auth_service"].(cfgMap)["authentication"] = cfgMap{
+					"signature_algorithm_suite": "balanced-v1",
+				}
+			},
+			expected: &AuthenticationConfig{
+				SignatureAlgorithmSuite: types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1,
+			},
+		}, {
+			desc: "signature suite fips-v1",
+			mutate: func(cfg cfgMap) {
+				cfg["auth_service"].(cfgMap)["authentication"] = cfgMap{
+					"signature_algorithm_suite": "fips-v1",
+				}
+			},
+			expected: &AuthenticationConfig{
+				SignatureAlgorithmSuite: types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_FIPS_V1,
+			},
+		}, {
+			desc: "signature suite hsm-v1",
+			mutate: func(cfg cfgMap) {
+				cfg["auth_service"].(cfgMap)["authentication"] = cfgMap{
+					"signature_algorithm_suite": "hsm-v1",
+				}
+			},
+			expected: &AuthenticationConfig{
+				SignatureAlgorithmSuite: types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_HSM_V1,
+			},
+		}, {
+			desc: "signature suite typo",
+			mutate: func(cfg cfgMap) {
+				cfg["auth_service"].(cfgMap)["authentication"] = cfgMap{
+					"signature_algorithm_suite": "balanced-v0",
+				}
+			},
+			expectError: func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+				require.ErrorContains(t, err, "invalid value: balanced-v0")
 			},
 		},
 	}
@@ -415,7 +466,10 @@ func TestAuthenticationSection(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			text := bytes.NewBuffer(editConfig(t, tt.mutate))
 			cfg, err := ReadConfig(text)
-			tt.expectError(t, err)
+			if tt.expectError != nil {
+				tt.expectError(t, err)
+				return
+			}
 
 			require.Empty(t, cmp.Diff(cfg.Auth.Authentication, tt.expected))
 		})


### PR DESCRIPTION
This is currently only configurable via the dynamic `cluster_auth_preference` resource, this PR makes it configurable in the config file as well. This is very useful for starting up new clusters and making sure the initial generated keys (including the CA keys) have the right algorithms.

Part of [RFD 136](https://github.com/gravitational/teleport/blob/master/rfd/0136-modern-signature-algorithms.md).