### PR TITLE
docs: removing tctl and tsh version from pre-reqs partial block

### DIFF
--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -1,7 +1,7 @@
 - A running Teleport cluster. If you want to get started with Teleport, [sign
   up](https://goteleport.com/signup) for a free trial.
 
-- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
+- The `tctl` admin tool and `tsh` client tool.
 
   Visit [Installation](../installation.mdx) for instructions on downloading
   `tctl` and `tsh`.


### PR DESCRIPTION
Adding embedded version here can conflict with verbiage on specific pages, for example https://goteleport.com/docs/admin-guides/deploy-a-cluster/aws-kms/. Even when it doesn't, when customers are on a particular version of the docs, the link will take them to the correct installation page, e.g. `docs/ver/15.x/installation`.