### PR TITLE
docs: restore create connector instructions in sso

### DIFF
--- a/docs/pages/admin-guides/access-controls/sso.mdx
+++ b/docs/pages/admin-guides/access-controls/sso.mdx
@@ -382,6 +382,12 @@ fetching from a URL.
 </TabItem>
 </Tabs>
 
+Create the connector: 
+
+```code
+$ tctl create -f connector.yaml
+```
+
 ### User logins
 
 Often it is required to restrict SSO users to their unique UNIX logins when they


### PR DESCRIPTION
Did not mean to remove these steps. Will apply to existing backport v16 https://github.com/gravitational/teleport/pull/46170 after approval.