### PR TITLE
docs: remove installer tmpl link for default installer

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
@@ -306,5 +306,3 @@ logs can be found on the targeted VM at
   for more information on Azure tokens.
 - Full documentation on Azure discovery configuration can be found through the [
   config file reference documentation](../../../reference/config.mdx).
-- The complete default installer can be found [with the Teleport source
-](https://github.com/gravitational/teleport/blob/branch/v(=teleport.major_version=)/api/types/installers/installer.sh.tmpl).

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery.mdx
@@ -352,5 +352,3 @@ Manager can be found for in the [AWS Cloud Operations & Migrations Blog
 ](https://aws.amazon.com/blogs/mt/applying-managed-instance-policy-best-practices/).
 - Full documentation on EC2 discovery configuration can be found through the [
 config file reference documentation](../../../reference/config.mdx).
-- The complete default installer can be found [with the Teleport source
-](https://github.com/gravitational/teleport/blob/branch/v(=teleport.major_version=)/api/types/installers/installer.sh.tmpl).

--- a/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
@@ -276,5 +276,3 @@ for details on alternate methods.
   for more information on GCP tokens.
 - Full documentation on GCP discovery configuration can be found through the [
   config file reference documentation](../../../reference/config.mdx).
-- The complete default installer can be found [with the Teleport source
-](https://github.com/gravitational/teleport/blob/branch/v(=teleport.major_version=)/api/types/installers/installer.sh.tmpl).


### PR DESCRIPTION
As of v16 the default installer is programmatically generated, there is not a `tmpl` file anymore.  This results in a 404 in v16+. 

The earlier optional commands show how to get the default installer script.