### PR TITLE
[v16] Make the Cloud migration guide more general

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2101,7 +2101,12 @@
     },
     {
       "source": "/choose-an-edition/migrate-to-cloud/",
-      "destination": "/admin-guides/deploy-a-cluster/migrate-to-cloud/",
+      "destination": "/admin-guides/migrate-plans/",
+      "permanent": true
+    },
+    {
+      "source": "/admin-guides/deploy-a-cluster/migrate-to-cloud/",
+      "destination": "/admin-guides/migrate-plans/",
       "permanent": true
     },
     {

--- a/docs/pages/admin-guides/migrate-plans.mdx
+++ b/docs/pages/admin-guides/migrate-plans.mdx
@@ -1,61 +1,89 @@
 ---
-title: Migrating from Self-Hosted to Cloud-Hosted Teleport Enterprise
-description: How to migrate from Teleport Enterprise (self-hosted) to Teleport Enterprise (cloud-hosted).
-h1: Migrate to Cloud-Hosted Teleport Enterprise 
+title: Migrate Between Teleport Plans
+description: Explains how to migrate between Teleport Enterprise (Self-Hosted), Teleport Enterprise (Cloud), and Teleport Community Edition.
 ---
 
-Migrating from a self-hosted Teleport Enterprise deployment to a cloud-hosted
+This guide explains how to migrate from Teleport Community Edition, Teleport
+Enterprise (Self-Hosted) and Teleport Enterprise (Cloud) to another Teleport
+plan. 
 
-Teleport Enterprise deployment offers scalability, reliability, and ease of
-management. By following the steps outlined in this guide, you can transition
-your Teleport deployment to the cloud successfully while ensuring minimal
-disruption to your operations.
+We recommend that you try out a Teleport [demo
+cluster](deploy-a-cluster/linux-demo.mdx) with Teleport Community Edition,
+migrate to [Teleport Enterprise (Cloud)](../get-started.mdx) to roll out
+Teleport across your organization, and deploy a
+[self-hosted](deploy-a-cluster/deploy-a-cluster.mdx) Teleport Enterprise cluster
+if you have security and compliance requirements that Teleport Enterprise
+(Cloud) cannot address.  
 
 ## How it works
 
-While in a cloud-hosted Enterprise Teleport account, Teleport manages the Auth
-Service and Proxy Service for you, you need to migrate dynamic resources and
-Teleport services yourself. 
+While in a cloud-hosted Teleport Enterprise plan, Teleport manages the Auth
+Service and Proxy Service for you, but you need to migrate dynamic resources and
+Teleport services yourself. In a self-hosted Teleport Enterprise plan, as well
+as Teleport Community edition, you must manage all Teleport components.
 
-To migrate a self-hosted Teleport Enterprise cluster to a cloud-hosted Teleport
-Enterprise cluster:
+To migrate between Teleport plans:
 
-1. Set up a separate cloud-hosted Teleport account.
+1. Set up a separate Teleport plan, which is either a new cloud-hosted
+   Teleport Enterprise account or a self-hosted Teleport Enterprise cluster that
+   includes the Auth Service and Proxy Service.
 1. Retrieve dynamic Teleport resources from the Auth Service backend on the
-   self-hosted cluster and apply them against the Auth Service backend on the
-   cloud-hosted cluster.
-1. Reconfigure Teleport agents and plugins to connect to the cloud-hosted
-   Teleport cluster.
+   original cluster and apply them against the Auth Service backend on the
+   new cluster.
+1. Reconfigure Teleport Agents and plugins to connect to the new Teleport
+   cluster.
 1. Verify that the migration has succeeded.
+
+Teleport Community Edition contains a small subset of Teleport features to
+enable users to try out Teleport. This guide assumes that you are *not*
+migrating from Teleport Enterprise to Teleport Community Edition.
 
 ## Prerequisites
 
-- An existing Teleport Enterprise (self-hosted) cluster.
+- An existing Teleport cluster.
+
 - The `tsh` and `tctl` client tools. This guide assumes that you are using
   `tctl` to manage dynamic resources, but it is also possible to use [Teleport
-  Terraform provider](../infrastructure-as-code/terraform-provider.mdx) and
+  Terraform provider](infrastructure-as-code/terraform-provider.mdx) and
   [Kubernetes
-  operator](../infrastructure-as-code/teleport-operator/teleport-operator-standalone.mdx), in
-  addition to custom scripts that use the [Teleport API](../api/api.mdx)
+  operator](infrastructure-as-code/teleport-operator/teleport-operator-standalone.mdx), in
+  addition to custom scripts that use the [Teleport API](api/api.mdx)
   to manage the Teleport Auth Service backend.
-- An account with no trusted clusters enrolled. Trusted clusters are not
-  supported in cloud-hosted Teleport Enterprise accounts. You will not be able
-  to migrate trusted cluster resources.
 
-## Step 1/4. Deploy your cloud-hosted Teleport Enterprise cluster
+  <Notice type="warning">
+
+  If you are using Teleport Community Edition, you must use the Teleport
+  Enterprise editions of `tsh` and `tctl` in order to manage your Teleport
+  Enterprise cluster. See the [Installation](../installation.mdx) page to
+  install these tools on your system.
+
+  </Notice>
+
+- If you are migrating to Teleport Enterprise (Cloud), you must not have an
+  account with trusted clusters enrolled. Trusted clusters are not supported in
+  cloud-hosted Teleport Enterprise accounts. You will not be able to migrate
+  trusted cluster resources.
+
+## Step 1/4. Set up your new Teleport plan
 
 1. Determine the `teleport.sh` subdomain you would like to use for your new
-   cloud-hosted Teleport Enterprise account. 
+   Teleport Enterprise account. 
 
-1. If the license dashboard for your self-hosted Teleport Enterprise cluster is
-   already using your desired subdomain, you can contact Teleport Support to
-   free up the domain for re-use.
+   If you are migrating to Teleport Enterprise (Cloud) and the license dashboard
+   for your self-hosted Teleport Enterprise cluster is already using your
+   desired subdomain, you can contact Teleport Support to free up the domain for
+   reuse.
 
-   [Reach out](https://goteleport.com/signup/enterprise/) to your Account
-   Management team to set up your cloud-hosted Teleport Enterprise tenant.
+1. [Reach out](https://goteleport.com/signup/enterprise/) to your Account
+   Management team to set up your new Teleport Enterprise account.
+
+1. If you are migrating to a self-hosted Teleport Enterprise account, plan and
+   execute the deployment with the help of your Account Management team. To
+   assist with this, read the the documentation on [Self-Hosting
+   Teleport](deploy-a-cluster/deploy-a-cluster.mdx).
 
 1. Ensure you are running Teleport Enterprise agents with versions that are
-   lower than the cloud-hosted Teleport Enterprise tenant version. To check the
+   lower than the new Teleport Enterprise account version. To check the
    versions of your Teleport Enterprise agents, you can use the `tctl` command
    to list the inventory of connected agents and their version:
 
@@ -63,12 +91,11 @@ Enterprise cluster:
    $ tctl inventory ls --older-than=<version>
    ```
 
-Validate connectivity to both the new cloud-hosted Teleport Enterprise cluster
-and your self-hosted Teleport Enterprise cluster. You should be able to connect
-to both Teleport clusters and execute `tctl` commands using your current
-credentials.
+Validate connectivity to both the new Teleport Enterprise cluster and your
+original Teleport Enterprise cluster. You should be able to connect to both
+Teleport clusters and execute `tctl` commands using your current credentials.
 
-1. Log in to the self-hosted Teleport Enterprise cluster:
+1. Log in to the original Teleport cluster:
 
    ```code
    # Use the --auth flag instead of --user to log in with Single Sign-On.
@@ -76,7 +103,7 @@ credentials.
    $ tctl status
    ```
 
-1. Log in to the cloud-hosted Teleport Enterprise cluster:
+1. Log in to the new Teleport Enterprise cluster:
 
    ```code
    # Use the --auth flag instead of --user to log in with Single Sign-On.
@@ -86,34 +113,33 @@ credentials.
 
 1. Subscribe to the [Teleport Enterprise status
    website](https://status.teleport.sh/) to stay current on any issues impacting
-   the performance of your cloud-hosted cluster.
+   the performance of your new cluster.
 
 <Notice
   type="danger"
 >
 
-  Ensure that the recovery codes displayed when you first set up your
-  cloud-hosted Teleport Enterprise tenant are saved securely, so as not to lose
-  access. For your security, Teleport Support cannot assist with resetting
-  passwords or recovering lost credentials.
+  If you are migrating to a Teleport Enterprise (Cloud) cluster, ensure that the
+  recovery codes displayed when you first set up your Teleport Enterprise
+  (Cloud) account are saved securely, so as not to lose access. For your
+  security, Teleport Support cannot assist with resetting passwords or
+  recovering lost credentials.
 
 </Notice>
 
 ## Step 2/4. Migrate Teleport resources
 
-After ensuring that both your self-hosted and cloud-hosted Teleport Enterprise
-clusters are up and running, you can migrate dynamic Teleport resources from one
-cluster to the next.
+After ensuring that both your original and new Teleport clusters are up and
+running, you can migrate dynamic Teleport resources from one cluster to the
+next.
 
 Dynamic Teleport resources such as roles and local users are stored on the
-Teleport Auth Service backend. Since your self-hosted Teleport Enterprise
-cluster uses a separate Auth Service backend from your cloud-hosted cluster, you
-must retrieve the resources on the first backend, then re-apply them against the
-second backend.
+Teleport Auth Service backend. Since your original Teleport cluster uses a
+separate Auth Service backend from your new cluster, you must retrieve the
+resources on the first backend, then re-apply them against the second backend.
 
-Review the [dynamic resources](../../reference/resources.mdx)
-list to see if any other resources need to be migrated. Some common dynamic
-resources includes:
+Review the [dynamic resources](../reference/resources.mdx) list to see if any
+other resources need to be migrated. Some common dynamic resources includes:
 
 - `windows_desktop`
 - `apps`
@@ -123,9 +149,9 @@ resources includes:
 If you are using infrastructure-as-code tools to 
 To achieve this:
 
-1. Log in to your existing Teleport Enterprise (self-hosted) cluster and export
-   a collection of the above-mentioned dynamic resource configuration using the
-   `tctl` administrative tool.  An example is shown below:
+1. Log in to your original Teleport cluster and export a collection of the
+   above-mentioned dynamic resource configuration using the `tctl`
+   administrative tool. An example is shown below:
 
    ```code
    # Use the --auth flag instead of --user to log in with Single Sign-On.
@@ -135,8 +161,8 @@ To achieve this:
    ```
 
 1. Once you have the resource configuration file from the above, proceed to log
-   in to your cloud-hosted Teleport Enterprise tenant with an admin user and
-   create the resources from the exported files:
+   in to your new Teleport Enterprise account with an admin user and create the
+   resources from the exported files:
 
    ```code
    # Use the --auth flag instead of --user to log in with Single Sign-On.
@@ -145,11 +171,18 @@ To achieve this:
    $ tctl create -f user.yaml
    ```
 
+<Notice type="tip">
+
+We recommend managing dynamic resources with the Teleport Terraform provider or
+Kubernetes operator. In this case, you can configure these tools to manage
+dynamic resources on your new Teleport cluster.
+
+</Notice>
+
 For your SSO auth connector, most SSO integrations only work for a single
 configured endpoint. It is recommended to create a separate SSO connector in
-your Identity Provider specifically for the cloud-hosted Teleport Enterprise
-endpoint, and configure a new Auth Connector in the cloud-hosted Teleport
-Enterprise tenant.
+your Identity Provider specifically for the new Teleport Enterprise endpoint,
+and configure a new Auth Connector in the new Teleport Enterprise tenant.
 
 ## Step 3/4. Migrate Teleport services and plugins
 
@@ -162,8 +195,8 @@ resources should be considered for migration:
  - Access Request plugins
  - The Teleport Event Handler
 
-Before migrating services, make sure you are logged in to your new cloud-hosted
-Teleport Enterprise account.
+Before migrating services, make sure you are logged in to your new Teleport
+Enterprise account.
 
 You can migrate Teleport services all at once or gradually, depending on your
 business requirements. If running Teleport at scale, you'll generally want to
@@ -174,9 +207,9 @@ carrying out the actions involved in migrating agent configurations.
 
 To migrate Teleport agents:
 
-1. For each agent and Machine ID bot, obtain a valid join token. We recommend
+1. For each Agent and Machine ID Bot, obtain a valid join token. We recommend
    using a [delegated join
-   method](../../reference/join-methods.mdx).
+   method](../reference/join-methods.mdx).
 
 1. If using ephemeral tokens, ensure you specify the appropriate token type to
    match the Teleport services. Token types can include `node`, `app`, `kube`,
@@ -196,11 +229,11 @@ To migrate Teleport agents:
 
    Copy the token so you can use it later in this guide.
 
-1. Stop Teleport services on the agent (if applicable).
+1. Stop Teleport services on each Agent (if applicable).
 
-1. Update the `proxy_server` or `auth_servers` field in the agent configuration
-   file to point to the address of your cloud-hosted Teleport Enterprise
-   cluster. By default, on Linux servers, the configuration is located in the
+1. Update the `proxy_server` or `auth_servers` field in each Agent configuration
+   file to point to the address of your new Teleport Enterprise cluster. By
+   default, on Linux servers, the configuration is located in the
    `/etc/teleport.yaml` directory:
 
    ```yaml
@@ -209,12 +242,12 @@ To migrate Teleport agents:
       proxy_server: example.teleport.sh:443
    ```
 
-   If your agent configuration does *not* include a `teleport.proxy_server`
+   If your Agent configuration does *not* include a `teleport.proxy_server`
    field, and instead has a `teleport.auth_server` or `teleport.auth_servers`
    field, we recommend migrating your configuration to `version: v3` and using
    `teleport.proxy_server`. 
 
-   With the `teleport.proxy_server` field, the agent attempts to connect to the
+   With the `teleport.proxy_server` field, the Agent attempts to connect to the
    Teleport cluster using a single mode, rather than multiple modes, which takes
    less time and involves less functionality to troubleshoot.
 
@@ -228,31 +261,38 @@ To migrate Teleport agents:
        token_name: new-token-goes-here
    ```
 
-1. On Linux servers, delete the local agent cache to force the agent to rejoin
-   the new cloud-hosted Teleport Enterprise cluster. By default, the data is
-   located in the  `/var/lib/teleport` directory:
+1. On Linux servers, delete the local Agent cache and restart the Teleport process 
+   on each Agent to force the Agent to rejoin the new Teleport Enterprise cluster. 
+   By default, the data is located in the  `/var/lib/teleport` directory:
 
    ```code
    rm -rf /var/lib/teleport
    ```
 
-1. On Linux servers, restart the Teleport process on each agent or, if you are
-   using the `teleport-kube-agent` Helm chart, recycle the Kubernetes pod to
-   apply the new configuration. This will cause the agents to re-register with
-   the cloud-hosted Teleport Enterprise cluster and obtain new certificates
-   signed by the new cluster's certificate authority.
+1. If you are using the `teleport-kube-agent` Helm chart, wipe out existing
+   state and recycle the Kubernetes pod to rejoin the Kubernetes Agent(s) to the
+   new cluster.  This will cause the Agents to re-register with the new Teleport
+   Enterprise cluster and obtain new certificates signed by the new cluster's
+   certificate authority.
 
-### Migrate Machine ID bots
+   ```code
+   # get the release name
+   helm -n <namespace> ls
+   # delete the state secret
+   kubectl -n <namespace> delete secret <release-name>-0-state
+   ```
 
-In general, you can migrate a Machine ID bot using the following steps:
+### Migrate Machine ID Bots
+
+In general, you can migrate a Machine ID Bot using the following steps:
 
 1. Obtain a new join token.
 1. In the `tbot` configuration file, edit the `proxy_server` configuration field
    to point to the new Teleport cluster address and port `443`.
 1. Restart `tbot`.
 
-To learn how to restart and configure a Machine ID bot in your infrastructure,
-read the [full documentation](../../enroll-resources/machine-id/deployment.mdx) on deploying a
+To learn how to restart and configure a Machine ID Bot in your infrastructure,
+read the [full documentation](../enroll-resources/machine-id/deployment.mdx) on deploying a
 Machine ID Bot.
 
 ### Access Request plugins and the Event Handler
@@ -274,8 +314,8 @@ In general, you can migrate Teleport plugins using the following steps:
 
 For specific plugins running in your infrastructure, read the full documentation
 on:
-- [Access Request plugins](../access-controls/access-request-plugins.mdx)
-- The [Teleport Event Handler](../management/export-audit-events.mdx)
+- [Access Request plugins](access-controls/access-request-plugins.mdx)
+- The [Teleport Event Handler](management/export-audit-events.mdx)
 
 ## Step 4/4. Verify end user access and performance
 
@@ -324,7 +364,7 @@ your new Teleport cluster, ensure that the setup is complete.
 1. Ensure that end users have the expected SSO access to your infrastructure.
 
 1. Establish break-glass access procedures to ensure access to infrastructure in
-   case your cloud-hosted Teleport Enterprise cluster becomes unavailable.
+   case your new Teleport Enterprise cluster becomes unavailable.
 
    For example, you can run OpenSSH with a limited key following our best
    practices on [How to SSH
@@ -339,4 +379,7 @@ your new Teleport cluster, ensure that the setup is complete.
 
 For more information on using cloud-hosted Teleport Enterprise, refer to our
 documentation on [signing up for a cloud-hosted Teleport Enterprise
-account](../../get-started.mdx).
+account](../get-started.mdx).
+
+Read the documentation on [Self-Hosting Teleport
+Enterprise](deploy-a-cluster/deploy-a-cluster.mdx).


### PR DESCRIPTION
Backports #46074

Closes #3683

We do not have a guide for moving from Community Edition to Enterprise. The steps are nearly identical to those presented in the guide to migrating from Enterprise (Self-Hosted) to Enterprise (Cloud). This change repurposes the Cloud migration guide so it applies to migrations between Teleport plans in general.

This change also moves the migration guide to the root of Admin Guides, since it's a procedure that we want to make prominent as we encourage OSS users to move to Enterprise.