### PR TITLE
Run integration tests on proto changes

### DIFF
--- a/.github/workflows/unit-tests-integrations.yaml
+++ b/.github/workflows/unit-tests-integrations.yaml
@@ -28,6 +28,8 @@ jobs:
                - 'go.mod'
                - 'go.sum'
                - 'integrations/**'
+               - 'api/proto/**'
+               - 'proto/**'
                - 'api/types/**'
                - 'gen/**'
                - 'lib/tbot/**'

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_accesslists.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_accesslists.yaml
@@ -40,16 +40,37 @@ spec:
                   be audited.
                 nullable: true
                 properties:
-                  frequency:
-                    description: frequency is a duration that describes how often
-                      an access list must be audited.
-                    format: duration
-                    type: string
                   next_audit_date:
                     description: next_audit_date is when the next audit date should
                       be done by.
                     format: date-time
                     type: string
+                  notifications:
+                    description: notifications is the configuration for notifying
+                      users.
+                    nullable: true
+                    properties:
+                      start:
+                        description: start specifies when to start notifying users
+                          that the next audit date is coming up.
+                        format: duration
+                        type: string
+                    type: object
+                  recurrence:
+                    description: recurrence is the recurrence definition
+                    nullable: true
+                    properties:
+                      day_of_month:
+                        description: day_of_month is the day of month that reviews
+                          will be scheduled on. Supported values are 0, 1, 15, and
+                          31.
+                        x-kubernetes-int-or-string: true
+                      frequency:
+                        description: frequency is the frequency of reviews. This represents
+                          the period in months between two reviews. Supported values
+                          are 0, 1, 3, 6, and 12.
+                        x-kubernetes-int-or-string: true
+                    type: object
                 type: object
               description:
                 description: description is an optional plaintext description of the
@@ -76,34 +97,6 @@ spec:
                       are members of the access list.
                     type: object
                 type: object
-              members:
-                description: 'members describes the current members of the access
-                  list. TODO(mdwn): Remove this once members are independent objects.'
-                items:
-                  properties:
-                    added_by:
-                      description: added_by is the user that added this user to the
-                        access list.
-                      type: string
-                    expires:
-                      description: expires is when the user's membership to the access
-                        list expires.
-                      format: date-time
-                      type: string
-                    joined:
-                      description: joined is when the user joined the access list.
-                      format: date-time
-                      type: string
-                    name:
-                      description: name is the name of the member of the access list.
-                      type: string
-                    reason:
-                      description: reason is the reason this user was added to the
-                        access list.
-                      type: string
-                  type: object
-                nullable: true
-                type: array
               membership_requires:
                 description: membership_requires describes the requirements for a
                   user to be a member of the access list. For a membership to an access
@@ -127,6 +120,27 @@ spec:
                       user to obtain access.
                     type: object
                 type: object
+              owner_grants:
+                description: owner_grants describes the access granted by owners to
+                  this access list.
+                nullable: true
+                properties:
+                  roles:
+                    description: roles are the roles that are granted to users who
+                      are members of the access list.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  traits:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: traits are the traits that are granted to users who
+                      are members of the access list.
+                    type: object
+                type: object
               owners:
                 description: owners is a list of owners of the access list.
                 items:
@@ -135,6 +149,10 @@ spec:
                       description: description is the plaintext description of the
                         owner and why they are an owner.
                       type: string
+                    ineligible_status:
+                      description: ineligible_status describes if this owner is eligible
+                        or not and if not, describes how they're lacking eligibility.
+                      x-kubernetes-int-or-string: true
                     name:
                       description: name is the username of the owner.
                       type: string

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_githubconnectors.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_githubconnectors.yaml
@@ -42,6 +42,27 @@ spec:
               client_id:
                 description: ClientID is the Github OAuth app client ID.
                 type: string
+              client_redirect_settings:
+                description: ClientRedirectSettings defines which client redirect
+                  URLs are allowed for non-browser SSO logins other than the standard
+                  localhost ones.
+                nullable: true
+                properties:
+                  allowed_https_hostnames:
+                    description: a list of hostnames allowed for https client redirect
+                      URLs
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  insecure_allowed_cidr_ranges:
+                    description: a list of CIDRs allowed for HTTP or HTTPS client
+                      redirect URLs
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                type: object
               client_secret:
                 description: ClientSecret is the Github OAuth app client secret.
                 type: string

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_oidcconnectors.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_oidcconnectors.yaml
@@ -67,6 +67,27 @@ spec:
                 description: ClientID is the id of the authentication client (Teleport
                   Auth server).
                 type: string
+              client_redirect_settings:
+                description: ClientRedirectSettings defines which client redirect
+                  URLs are allowed for non-browser SSO logins other than the standard
+                  localhost ones.
+                nullable: true
+                properties:
+                  allowed_https_hostnames:
+                    description: a list of hostnames allowed for https client redirect
+                      URLs
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  insecure_allowed_cidr_ranges:
+                    description: a list of CIDRs allowed for HTTP or HTTPS client
+                      redirect URLs
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                type: object
               client_secret:
                 description: ClientSecret is used to authenticate the client.
                 type: string

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_openssheiceserversv2.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_openssheiceserversv2.yaml
@@ -102,10 +102,6 @@ spec:
                   type: string
                 nullable: true
                 type: array
-              public_addr:
-                description: PublicAddr is the public address where this server can
-                  be reached. DELETE IN 15.0. (joerger) Deprecated in favor of public_addrs.
-                type: string
               public_addrs:
                 description: PublicAddrs is a list of public addresses where this
                   server can be reached.

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_opensshserversv2.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_opensshserversv2.yaml
@@ -101,10 +101,6 @@ spec:
                   type: string
                 nullable: true
                 type: array
-              public_addr:
-                description: PublicAddr is the public address where this server can
-                  be reached. DELETE IN 15.0. (joerger) Deprecated in favor of public_addrs.
-                type: string
               public_addrs:
                 description: PublicAddrs is a list of public addresses where this
                   server can be reached.

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_provisiontokens.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_provisiontokens.yaml
@@ -194,6 +194,16 @@ spec:
                       must be accessible over HTTPS at this hostname and the certificate
                       must be trusted by the Auth Server.
                     type: string
+                  enterprise_slug:
+                    description: EnterpriseSlug allows the slug of a GitHub Enterprise
+                      organisation to be included in the expected issuer of the OIDC
+                      tokens. This is for compatibility with the `include_enterprise_slug`
+                      option in GHE.  This field should be set to the slug of your
+                      enterprise if this is enabled. If this is not enabled, then
+                      this field must be left empty. This field cannot be specified
+                      if `enterprise_server_host` is specified.  See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise
+                      for more information about customized issuer values.
+                    type: string
                 type: object
               gitlab:
                 description: GitLab allows the configuration of options specific to
@@ -205,19 +215,37 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
+                        ci_config_ref_uri:
+                          type: string
+                        ci_config_sha:
+                          type: string
+                        deployment_tier:
+                          type: string
                         environment:
                           type: string
+                        environment_protected:
+                          type: boolean
                         namespace_path:
                           type: string
                         pipeline_source:
                           type: string
                         project_path:
                           type: string
+                        project_visibility:
+                          type: string
                         ref:
                           type: string
+                        ref_protected:
+                          type: boolean
                         ref_type:
                           type: string
                         sub:
+                          type: string
+                        user_email:
+                          type: string
+                        user_id:
+                          type: string
+                        user_login:
                           type: string
                       type: object
                     nullable: true
@@ -229,9 +257,9 @@ spec:
                     type: string
                 type: object
               join_method:
-                description: JoinMethod is the joining method required in order to
-                  use this token. Supported joining methods include "token", "ec2",
-                  and "iam".
+                description: 'JoinMethod is the joining method required in order to
+                  use this token. Supported joining methods include: azure, circleci,
+                  ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm'
                 type: string
               kubernetes:
                 description: Kubernetes allows the configuration of options specific
@@ -248,6 +276,19 @@ spec:
                       type: object
                     nullable: true
                     type: array
+                  static_jwks:
+                    description: StaticJWKS is the configuration specific to the `static_jwks`
+                      type.
+                    nullable: true
+                    properties:
+                      jwks:
+                        type: string
+                    type: object
+                  type:
+                    description: 'Type controls which behavior should be used for
+                      validating the Kubernetes Service Account token. Support values:
+                      - `in_cluster` - `static_jwks` If unset, this defaults to `in_cluster`.'
+                    type: string
                 type: object
               roles:
                 description: Roles is a list of roles associated with the token, that
@@ -257,6 +298,32 @@ spec:
                   type: string
                 nullable: true
                 type: array
+              spacelift:
+                description: Spacelift allows the configuration of options specific
+                  to the "spacelift" join method.
+                nullable: true
+                properties:
+                  allow:
+                    description: Allow is a list of Rules, nodes using this token
+                      must match one allow rule to use this token.
+                    items:
+                      properties:
+                        caller_id:
+                          type: string
+                        caller_type:
+                          type: string
+                        scope:
+                          type: string
+                        space_id:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  hostname:
+                    description: Hostname is the hostname of the Spacelift tenant
+                      that tokens will originate from. E.g `example.app.spacelift.io`
+                    type: string
+                type: object
               suggested_agent_matcher_labels:
                 additionalProperties:
                   x-kubernetes-preserve-unknown-fields: true
@@ -273,6 +340,74 @@ spec:
                 description: SuggestedLabels is a set of labels that resources should
                   set when using this token to enroll themselves in the cluster. Currently,
                   only node-join scripts create a configuration according to the suggestion.
+                type: object
+              terraform_cloud:
+                description: TerraformCloud allows the configuration of options specific
+                  to the "terraform_cloud" join method.
+                nullable: true
+                properties:
+                  allow:
+                    description: Allow is a list of Rules, nodes using this token
+                      must match one allow rule to use this token.
+                    items:
+                      properties:
+                        organization_id:
+                          type: string
+                        organization_name:
+                          type: string
+                        project_id:
+                          type: string
+                        project_name:
+                          type: string
+                        run_phase:
+                          type: string
+                        workspace_id:
+                          type: string
+                        workspace_name:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  audience:
+                    description: Audience is the JWT audience as configured in the
+                      TFC_WORKLOAD_IDENTITY_AUDIENCE(_$TAG) variable in Terraform
+                      Cloud. If unset, defaults to the Teleport cluster name. For
+                      example, if `TFC_WORKLOAD_IDENTITY_AUDIENCE_TELEPORT=foo` is
+                      set in Terraform Cloud, this value should be `foo`. If the variable
+                      is set to match the cluster name, it does not need to be set
+                      here.
+                    type: string
+                type: object
+              tpm:
+                description: TPM allows the configuration of options specific to the
+                  "tpm" join method.
+                nullable: true
+                properties:
+                  allow:
+                    description: Allow is a list of Rules, the presented delegated
+                      identity must match one allow rule to permit joining.
+                    items:
+                      properties:
+                        description:
+                          type: string
+                        ek_certificate_serial:
+                          type: string
+                        ek_public_hash:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  ekcert_allowed_cas:
+                    description: EKCertAllowedCAs is a list of CA certificates that
+                      will be used to validate TPM EKCerts. When specified, joining
+                      TPMs must present an EKCert signed by one of the specified CAs.
+                      TPMs that do not present an EKCert will be not permitted to
+                      join. When unspecified, TPMs will be allowed to join with either
+                      an EKCert or an EKPubHash.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
                 type: object
             type: object
           status:

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_roles.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_roles.yaml
@@ -86,6 +86,28 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  db_permissions:
+                    description: DatabasePermissions specifies a set of permissions
+                      that will be granted to the database user when using automatic
+                      database user provisioning.
+                    items:
+                      properties:
+                        match:
+                          additionalProperties:
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: Match is a list of object labels that must
+                            be matched for the permission to be granted.
+                          type: object
+                        permissions:
+                          description: Permission is the list of string representations
+                            of the permission to be given, e.g. SELECT, INSERT, UPDATE,
+                            ...
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
                   db_roles:
                     description: DatabaseRoles is a list of databases roles for automatic
                       user creation.
@@ -473,6 +495,49 @@ spec:
                           description: Where specifies optional advanced matcher
                           type: string
                       type: object
+                    type: array
+                  spiffe:
+                    description: SPIFFE is used to allow or deny access to a role
+                      holder to generating a SPIFFE SVID.
+                    items:
+                      properties:
+                        dns_sans:
+                          description: 'DNSSANs specifies matchers for the SPIFFE
+                            ID DNS SANs.  Each requested DNS SAN is compared against
+                            all matchers configured and if any match, the condition
+                            is considered to be met.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: *.example.com would
+                            match foo.example.com'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        ip_sans:
+                          description: 'IPSANs specifies matchers for the SPIFFE ID
+                            IP SANs.  Each requested IP SAN is compared against all
+                            matchers configured and if any match, the condition is
+                            considered to be met.  The matchers should be specified
+                            using CIDR notation, it supports IPv4 and IPv6.  Examples:
+                            - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 -
+                            10.0.0.42/32 would match only 10.0.0.42'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        path:
+                          description: 'Path specifies a matcher for the SPIFFE ID
+                            path. It should not include the trust domain and should
+                            start with a leading slash.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: - /svc/foo/*/bar
+                            would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would
+                            match /svc/foo/baz/bar'
+                          type: string
+                      type: object
+                    nullable: true
                     type: array
                   windows_desktop_labels:
                     additionalProperties:
@@ -547,6 +612,28 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  db_permissions:
+                    description: DatabasePermissions specifies a set of permissions
+                      that will be granted to the database user when using automatic
+                      database user provisioning.
+                    items:
+                      properties:
+                        match:
+                          additionalProperties:
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: Match is a list of object labels that must
+                            be matched for the permission to be granted.
+                          type: object
+                        permissions:
+                          description: Permission is the list of string representations
+                            of the permission to be given, e.g. SELECT, INSERT, UPDATE,
+                            ...
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
                   db_roles:
                     description: DatabaseRoles is a list of databases roles for automatic
                       user creation.
@@ -935,6 +1022,49 @@ spec:
                           type: string
                       type: object
                     type: array
+                  spiffe:
+                    description: SPIFFE is used to allow or deny access to a role
+                      holder to generating a SPIFFE SVID.
+                    items:
+                      properties:
+                        dns_sans:
+                          description: 'DNSSANs specifies matchers for the SPIFFE
+                            ID DNS SANs.  Each requested DNS SAN is compared against
+                            all matchers configured and if any match, the condition
+                            is considered to be met.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: *.example.com would
+                            match foo.example.com'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        ip_sans:
+                          description: 'IPSANs specifies matchers for the SPIFFE ID
+                            IP SANs.  Each requested IP SAN is compared against all
+                            matchers configured and if any match, the condition is
+                            considered to be met.  The matchers should be specified
+                            using CIDR notation, it supports IPv4 and IPv6.  Examples:
+                            - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 -
+                            10.0.0.42/32 would match only 10.0.0.42'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        path:
+                          description: 'Path specifies a matcher for the SPIFFE ID
+                            path. It should not include the trust domain and should
+                            start with a leading slash.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: - /svc/foo/*/bar
+                            would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would
+                            match /svc/foo/baz/bar'
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
                   windows_desktop_labels:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
@@ -962,7 +1092,7 @@ spec:
                       properties:
                         mode:
                           description: Mode is the type of extension to be used --
-                            currently critical-option is not supported
+                            currently critical-option is not supported. 0 is "extension".
                           x-kubernetes-int-or-string: true
                         name:
                           description: Name specifies the key to be used in the cert
@@ -970,7 +1100,7 @@ spec:
                           type: string
                         type:
                           description: Type represents the certificate type being
-                            extended, only ssh is supported at this time.
+                            extended, only ssh is supported at this time. 0 is "ssh".
                           x-kubernetes-int-or-string: true
                         value:
                           description: Value specifies the value to be used in the
@@ -993,6 +1123,11 @@ spec:
                     description: CreateDatabaseUser enabled automatic database user
                       creation.
                     type: boolean
+                  create_db_user_mode:
+                    description: CreateDatabaseUserMode allows users to be automatically
+                      created on a database when not set to off. 0 is "unspecified",
+                      1 is "off", 2 is "keep", 3 is "best_effort_drop".
+                    x-kubernetes-int-or-string: true
                   create_desktop_user:
                     description: CreateDesktopUser allows users to be automatically
                       created on a Windows desktop
@@ -1003,7 +1138,9 @@ spec:
                     type: boolean
                   create_host_user_mode:
                     description: CreateHostUserMode allows users to be automatically
-                      created on a host when not set to off
+                      created on a host when not set to off. 0 is "unspecified"; 1
+                      is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep";
+                      4 is "insecure-drop".
                     x-kubernetes-int-or-string: true
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
@@ -1018,7 +1155,6 @@ spec:
                   device_trust_mode:
                     description: DeviceTrustMode is the device authorization mode
                       used for the resources associated with the role. See DeviceTrust.Mode.
-                      Reserved for future use, not yet used by Teleport.
                     type: string
                   disconnect_expired_cert:
                     description: DisconnectExpiredCert sets disconnect clients on
@@ -1074,6 +1210,16 @@ spec:
                       sessions per connection.
                     format: int64
                     type: integer
+                  mfa_verification_interval:
+                    description: MFAVerificationInterval optionally defines the maximum
+                      duration that can elapse between successive MFA verifications.
+                      This variable is used to ensure that users are periodically
+                      prompted to verify their identity, enhancing security by preventing
+                      prolonged sessions without re-authentication when using tsh
+                      proxy * derivatives. It's only effective if the session requires
+                      MFA. If not set, defaults to `max_session_ttl`.
+                    format: duration
+                    type: string
                   permit_x11_forwarding:
                     description: PermitX11Forwarding authorizes use of X11 forwarding.
                     type: boolean
@@ -1105,8 +1251,8 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the access request strategy
-                      (optional|note|always) where optional is the default.
+                    description: RequestAccess defines the request strategy (optional|note|always)
+                      where optional is the default.
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells
@@ -1114,7 +1260,8 @@ spec:
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
-                      for this user.
+                      for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY",
+                      3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
                     x-kubernetes-int-or-string: true
                   ssh_file_copy:
                     description: SSHFileCopy indicates whether remote file operations
@@ -1280,6 +1427,28 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  db_permissions:
+                    description: DatabasePermissions specifies a set of permissions
+                      that will be granted to the database user when using automatic
+                      database user provisioning.
+                    items:
+                      properties:
+                        match:
+                          additionalProperties:
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: Match is a list of object labels that must
+                            be matched for the permission to be granted.
+                          type: object
+                        permissions:
+                          description: Permission is the list of string representations
+                            of the permission to be given, e.g. SELECT, INSERT, UPDATE,
+                            ...
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
                   db_roles:
                     description: DatabaseRoles is a list of databases roles for automatic
                       user creation.
@@ -1667,6 +1836,49 @@ spec:
                           description: Where specifies optional advanced matcher
                           type: string
                       type: object
+                    type: array
+                  spiffe:
+                    description: SPIFFE is used to allow or deny access to a role
+                      holder to generating a SPIFFE SVID.
+                    items:
+                      properties:
+                        dns_sans:
+                          description: 'DNSSANs specifies matchers for the SPIFFE
+                            ID DNS SANs.  Each requested DNS SAN is compared against
+                            all matchers configured and if any match, the condition
+                            is considered to be met.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: *.example.com would
+                            match foo.example.com'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        ip_sans:
+                          description: 'IPSANs specifies matchers for the SPIFFE ID
+                            IP SANs.  Each requested IP SAN is compared against all
+                            matchers configured and if any match, the condition is
+                            considered to be met.  The matchers should be specified
+                            using CIDR notation, it supports IPv4 and IPv6.  Examples:
+                            - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 -
+                            10.0.0.42/32 would match only 10.0.0.42'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        path:
+                          description: 'Path specifies a matcher for the SPIFFE ID
+                            path. It should not include the trust domain and should
+                            start with a leading slash.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: - /svc/foo/*/bar
+                            would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would
+                            match /svc/foo/baz/bar'
+                          type: string
+                      type: object
+                    nullable: true
                     type: array
                   windows_desktop_labels:
                     additionalProperties:
@@ -1741,6 +1953,28 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  db_permissions:
+                    description: DatabasePermissions specifies a set of permissions
+                      that will be granted to the database user when using automatic
+                      database user provisioning.
+                    items:
+                      properties:
+                        match:
+                          additionalProperties:
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: Match is a list of object labels that must
+                            be matched for the permission to be granted.
+                          type: object
+                        permissions:
+                          description: Permission is the list of string representations
+                            of the permission to be given, e.g. SELECT, INSERT, UPDATE,
+                            ...
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
                   db_roles:
                     description: DatabaseRoles is a list of databases roles for automatic
                       user creation.
@@ -2129,6 +2363,49 @@ spec:
                           type: string
                       type: object
                     type: array
+                  spiffe:
+                    description: SPIFFE is used to allow or deny access to a role
+                      holder to generating a SPIFFE SVID.
+                    items:
+                      properties:
+                        dns_sans:
+                          description: 'DNSSANs specifies matchers for the SPIFFE
+                            ID DNS SANs.  Each requested DNS SAN is compared against
+                            all matchers configured and if any match, the condition
+                            is considered to be met.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: *.example.com would
+                            match foo.example.com'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        ip_sans:
+                          description: 'IPSANs specifies matchers for the SPIFFE ID
+                            IP SANs.  Each requested IP SAN is compared against all
+                            matchers configured and if any match, the condition is
+                            considered to be met.  The matchers should be specified
+                            using CIDR notation, it supports IPv4 and IPv6.  Examples:
+                            - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 -
+                            10.0.0.42/32 would match only 10.0.0.42'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        path:
+                          description: 'Path specifies a matcher for the SPIFFE ID
+                            path. It should not include the trust domain and should
+                            start with a leading slash.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: - /svc/foo/*/bar
+                            would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would
+                            match /svc/foo/baz/bar'
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
                   windows_desktop_labels:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
@@ -2156,7 +2433,7 @@ spec:
                       properties:
                         mode:
                           description: Mode is the type of extension to be used --
-                            currently critical-option is not supported
+                            currently critical-option is not supported. 0 is "extension".
                           x-kubernetes-int-or-string: true
                         name:
                           description: Name specifies the key to be used in the cert
@@ -2164,7 +2441,7 @@ spec:
                           type: string
                         type:
                           description: Type represents the certificate type being
-                            extended, only ssh is supported at this time.
+                            extended, only ssh is supported at this time. 0 is "ssh".
                           x-kubernetes-int-or-string: true
                         value:
                           description: Value specifies the value to be used in the
@@ -2187,6 +2464,11 @@ spec:
                     description: CreateDatabaseUser enabled automatic database user
                       creation.
                     type: boolean
+                  create_db_user_mode:
+                    description: CreateDatabaseUserMode allows users to be automatically
+                      created on a database when not set to off. 0 is "unspecified",
+                      1 is "off", 2 is "keep", 3 is "best_effort_drop".
+                    x-kubernetes-int-or-string: true
                   create_desktop_user:
                     description: CreateDesktopUser allows users to be automatically
                       created on a Windows desktop
@@ -2197,7 +2479,9 @@ spec:
                     type: boolean
                   create_host_user_mode:
                     description: CreateHostUserMode allows users to be automatically
-                      created on a host when not set to off
+                      created on a host when not set to off. 0 is "unspecified"; 1
+                      is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep";
+                      4 is "insecure-drop".
                     x-kubernetes-int-or-string: true
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
@@ -2212,7 +2496,6 @@ spec:
                   device_trust_mode:
                     description: DeviceTrustMode is the device authorization mode
                       used for the resources associated with the role. See DeviceTrust.Mode.
-                      Reserved for future use, not yet used by Teleport.
                     type: string
                   disconnect_expired_cert:
                     description: DisconnectExpiredCert sets disconnect clients on
@@ -2268,6 +2551,16 @@ spec:
                       sessions per connection.
                     format: int64
                     type: integer
+                  mfa_verification_interval:
+                    description: MFAVerificationInterval optionally defines the maximum
+                      duration that can elapse between successive MFA verifications.
+                      This variable is used to ensure that users are periodically
+                      prompted to verify their identity, enhancing security by preventing
+                      prolonged sessions without re-authentication when using tsh
+                      proxy * derivatives. It's only effective if the session requires
+                      MFA. If not set, defaults to `max_session_ttl`.
+                    format: duration
+                    type: string
                   permit_x11_forwarding:
                     description: PermitX11Forwarding authorizes use of X11 forwarding.
                     type: boolean
@@ -2299,8 +2592,8 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the access request strategy
-                      (optional|note|always) where optional is the default.
+                    description: RequestAccess defines the request strategy (optional|note|always)
+                      where optional is the default.
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells
@@ -2308,7 +2601,8 @@ spec:
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
-                      for this user.
+                      for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY",
+                      3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
                     x-kubernetes-int-or-string: true
                   ssh_file_copy:
                     description: SSHFileCopy indicates whether remote file operations

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_rolesv6.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_rolesv6.yaml
@@ -89,6 +89,28 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  db_permissions:
+                    description: DatabasePermissions specifies a set of permissions
+                      that will be granted to the database user when using automatic
+                      database user provisioning.
+                    items:
+                      properties:
+                        match:
+                          additionalProperties:
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: Match is a list of object labels that must
+                            be matched for the permission to be granted.
+                          type: object
+                        permissions:
+                          description: Permission is the list of string representations
+                            of the permission to be given, e.g. SELECT, INSERT, UPDATE,
+                            ...
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
                   db_roles:
                     description: DatabaseRoles is a list of databases roles for automatic
                       user creation.
@@ -476,6 +498,49 @@ spec:
                           description: Where specifies optional advanced matcher
                           type: string
                       type: object
+                    type: array
+                  spiffe:
+                    description: SPIFFE is used to allow or deny access to a role
+                      holder to generating a SPIFFE SVID.
+                    items:
+                      properties:
+                        dns_sans:
+                          description: 'DNSSANs specifies matchers for the SPIFFE
+                            ID DNS SANs.  Each requested DNS SAN is compared against
+                            all matchers configured and if any match, the condition
+                            is considered to be met.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: *.example.com would
+                            match foo.example.com'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        ip_sans:
+                          description: 'IPSANs specifies matchers for the SPIFFE ID
+                            IP SANs.  Each requested IP SAN is compared against all
+                            matchers configured and if any match, the condition is
+                            considered to be met.  The matchers should be specified
+                            using CIDR notation, it supports IPv4 and IPv6.  Examples:
+                            - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 -
+                            10.0.0.42/32 would match only 10.0.0.42'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        path:
+                          description: 'Path specifies a matcher for the SPIFFE ID
+                            path. It should not include the trust domain and should
+                            start with a leading slash.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: - /svc/foo/*/bar
+                            would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would
+                            match /svc/foo/baz/bar'
+                          type: string
+                      type: object
+                    nullable: true
                     type: array
                   windows_desktop_labels:
                     additionalProperties:
@@ -550,6 +615,28 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  db_permissions:
+                    description: DatabasePermissions specifies a set of permissions
+                      that will be granted to the database user when using automatic
+                      database user provisioning.
+                    items:
+                      properties:
+                        match:
+                          additionalProperties:
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: Match is a list of object labels that must
+                            be matched for the permission to be granted.
+                          type: object
+                        permissions:
+                          description: Permission is the list of string representations
+                            of the permission to be given, e.g. SELECT, INSERT, UPDATE,
+                            ...
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
                   db_roles:
                     description: DatabaseRoles is a list of databases roles for automatic
                       user creation.
@@ -938,6 +1025,49 @@ spec:
                           type: string
                       type: object
                     type: array
+                  spiffe:
+                    description: SPIFFE is used to allow or deny access to a role
+                      holder to generating a SPIFFE SVID.
+                    items:
+                      properties:
+                        dns_sans:
+                          description: 'DNSSANs specifies matchers for the SPIFFE
+                            ID DNS SANs.  Each requested DNS SAN is compared against
+                            all matchers configured and if any match, the condition
+                            is considered to be met.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: *.example.com would
+                            match foo.example.com'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        ip_sans:
+                          description: 'IPSANs specifies matchers for the SPIFFE ID
+                            IP SANs.  Each requested IP SAN is compared against all
+                            matchers configured and if any match, the condition is
+                            considered to be met.  The matchers should be specified
+                            using CIDR notation, it supports IPv4 and IPv6.  Examples:
+                            - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 -
+                            10.0.0.42/32 would match only 10.0.0.42'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        path:
+                          description: 'Path specifies a matcher for the SPIFFE ID
+                            path. It should not include the trust domain and should
+                            start with a leading slash.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: - /svc/foo/*/bar
+                            would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would
+                            match /svc/foo/baz/bar'
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
                   windows_desktop_labels:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
@@ -965,7 +1095,7 @@ spec:
                       properties:
                         mode:
                           description: Mode is the type of extension to be used --
-                            currently critical-option is not supported
+                            currently critical-option is not supported. 0 is "extension".
                           x-kubernetes-int-or-string: true
                         name:
                           description: Name specifies the key to be used in the cert
@@ -973,7 +1103,7 @@ spec:
                           type: string
                         type:
                           description: Type represents the certificate type being
-                            extended, only ssh is supported at this time.
+                            extended, only ssh is supported at this time. 0 is "ssh".
                           x-kubernetes-int-or-string: true
                         value:
                           description: Value specifies the value to be used in the
@@ -996,6 +1126,11 @@ spec:
                     description: CreateDatabaseUser enabled automatic database user
                       creation.
                     type: boolean
+                  create_db_user_mode:
+                    description: CreateDatabaseUserMode allows users to be automatically
+                      created on a database when not set to off. 0 is "unspecified",
+                      1 is "off", 2 is "keep", 3 is "best_effort_drop".
+                    x-kubernetes-int-or-string: true
                   create_desktop_user:
                     description: CreateDesktopUser allows users to be automatically
                       created on a Windows desktop
@@ -1006,7 +1141,9 @@ spec:
                     type: boolean
                   create_host_user_mode:
                     description: CreateHostUserMode allows users to be automatically
-                      created on a host when not set to off
+                      created on a host when not set to off. 0 is "unspecified"; 1
+                      is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep";
+                      4 is "insecure-drop".
                     x-kubernetes-int-or-string: true
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
@@ -1021,7 +1158,6 @@ spec:
                   device_trust_mode:
                     description: DeviceTrustMode is the device authorization mode
                       used for the resources associated with the role. See DeviceTrust.Mode.
-                      Reserved for future use, not yet used by Teleport.
                     type: string
                   disconnect_expired_cert:
                     description: DisconnectExpiredCert sets disconnect clients on
@@ -1077,6 +1213,16 @@ spec:
                       sessions per connection.
                     format: int64
                     type: integer
+                  mfa_verification_interval:
+                    description: MFAVerificationInterval optionally defines the maximum
+                      duration that can elapse between successive MFA verifications.
+                      This variable is used to ensure that users are periodically
+                      prompted to verify their identity, enhancing security by preventing
+                      prolonged sessions without re-authentication when using tsh
+                      proxy * derivatives. It's only effective if the session requires
+                      MFA. If not set, defaults to `max_session_ttl`.
+                    format: duration
+                    type: string
                   permit_x11_forwarding:
                     description: PermitX11Forwarding authorizes use of X11 forwarding.
                     type: boolean
@@ -1108,8 +1254,8 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the access request strategy
-                      (optional|note|always) where optional is the default.
+                    description: RequestAccess defines the request strategy (optional|note|always)
+                      where optional is the default.
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells
@@ -1117,7 +1263,8 @@ spec:
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
-                      for this user.
+                      for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY",
+                      3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
                     x-kubernetes-int-or-string: true
                   ssh_file_copy:
                     description: SSHFileCopy indicates whether remote file operations

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_rolesv7.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_rolesv7.yaml
@@ -89,6 +89,28 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  db_permissions:
+                    description: DatabasePermissions specifies a set of permissions
+                      that will be granted to the database user when using automatic
+                      database user provisioning.
+                    items:
+                      properties:
+                        match:
+                          additionalProperties:
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: Match is a list of object labels that must
+                            be matched for the permission to be granted.
+                          type: object
+                        permissions:
+                          description: Permission is the list of string representations
+                            of the permission to be given, e.g. SELECT, INSERT, UPDATE,
+                            ...
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
                   db_roles:
                     description: DatabaseRoles is a list of databases roles for automatic
                       user creation.
@@ -476,6 +498,49 @@ spec:
                           description: Where specifies optional advanced matcher
                           type: string
                       type: object
+                    type: array
+                  spiffe:
+                    description: SPIFFE is used to allow or deny access to a role
+                      holder to generating a SPIFFE SVID.
+                    items:
+                      properties:
+                        dns_sans:
+                          description: 'DNSSANs specifies matchers for the SPIFFE
+                            ID DNS SANs.  Each requested DNS SAN is compared against
+                            all matchers configured and if any match, the condition
+                            is considered to be met.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: *.example.com would
+                            match foo.example.com'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        ip_sans:
+                          description: 'IPSANs specifies matchers for the SPIFFE ID
+                            IP SANs.  Each requested IP SAN is compared against all
+                            matchers configured and if any match, the condition is
+                            considered to be met.  The matchers should be specified
+                            using CIDR notation, it supports IPv4 and IPv6.  Examples:
+                            - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 -
+                            10.0.0.42/32 would match only 10.0.0.42'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        path:
+                          description: 'Path specifies a matcher for the SPIFFE ID
+                            path. It should not include the trust domain and should
+                            start with a leading slash.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: - /svc/foo/*/bar
+                            would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would
+                            match /svc/foo/baz/bar'
+                          type: string
+                      type: object
+                    nullable: true
                     type: array
                   windows_desktop_labels:
                     additionalProperties:
@@ -550,6 +615,28 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  db_permissions:
+                    description: DatabasePermissions specifies a set of permissions
+                      that will be granted to the database user when using automatic
+                      database user provisioning.
+                    items:
+                      properties:
+                        match:
+                          additionalProperties:
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: Match is a list of object labels that must
+                            be matched for the permission to be granted.
+                          type: object
+                        permissions:
+                          description: Permission is the list of string representations
+                            of the permission to be given, e.g. SELECT, INSERT, UPDATE,
+                            ...
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
                   db_roles:
                     description: DatabaseRoles is a list of databases roles for automatic
                       user creation.
@@ -938,6 +1025,49 @@ spec:
                           type: string
                       type: object
                     type: array
+                  spiffe:
+                    description: SPIFFE is used to allow or deny access to a role
+                      holder to generating a SPIFFE SVID.
+                    items:
+                      properties:
+                        dns_sans:
+                          description: 'DNSSANs specifies matchers for the SPIFFE
+                            ID DNS SANs.  Each requested DNS SAN is compared against
+                            all matchers configured and if any match, the condition
+                            is considered to be met.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: *.example.com would
+                            match foo.example.com'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        ip_sans:
+                          description: 'IPSANs specifies matchers for the SPIFFE ID
+                            IP SANs.  Each requested IP SAN is compared against all
+                            matchers configured and if any match, the condition is
+                            considered to be met.  The matchers should be specified
+                            using CIDR notation, it supports IPv4 and IPv6.  Examples:
+                            - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 -
+                            10.0.0.42/32 would match only 10.0.0.42'
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        path:
+                          description: 'Path specifies a matcher for the SPIFFE ID
+                            path. It should not include the trust domain and should
+                            start with a leading slash.  The matcher by default allows
+                            ''*'' to be used to indicate zero or more of any character.
+                            Prepend ''^'' and append ''$'' to instead switch to matching
+                            using the Go regex syntax.  Example: - /svc/foo/*/bar
+                            would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would
+                            match /svc/foo/baz/bar'
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
                   windows_desktop_labels:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
@@ -965,7 +1095,7 @@ spec:
                       properties:
                         mode:
                           description: Mode is the type of extension to be used --
-                            currently critical-option is not supported
+                            currently critical-option is not supported. 0 is "extension".
                           x-kubernetes-int-or-string: true
                         name:
                           description: Name specifies the key to be used in the cert
@@ -973,7 +1103,7 @@ spec:
                           type: string
                         type:
                           description: Type represents the certificate type being
-                            extended, only ssh is supported at this time.
+                            extended, only ssh is supported at this time. 0 is "ssh".
                           x-kubernetes-int-or-string: true
                         value:
                           description: Value specifies the value to be used in the
@@ -996,6 +1126,11 @@ spec:
                     description: CreateDatabaseUser enabled automatic database user
                       creation.
                     type: boolean
+                  create_db_user_mode:
+                    description: CreateDatabaseUserMode allows users to be automatically
+                      created on a database when not set to off. 0 is "unspecified",
+                      1 is "off", 2 is "keep", 3 is "best_effort_drop".
+                    x-kubernetes-int-or-string: true
                   create_desktop_user:
                     description: CreateDesktopUser allows users to be automatically
                       created on a Windows desktop
@@ -1006,7 +1141,9 @@ spec:
                     type: boolean
                   create_host_user_mode:
                     description: CreateHostUserMode allows users to be automatically
-                      created on a host when not set to off
+                      created on a host when not set to off. 0 is "unspecified"; 1
+                      is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep";
+                      4 is "insecure-drop".
                     x-kubernetes-int-or-string: true
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
@@ -1021,7 +1158,6 @@ spec:
                   device_trust_mode:
                     description: DeviceTrustMode is the device authorization mode
                       used for the resources associated with the role. See DeviceTrust.Mode.
-                      Reserved for future use, not yet used by Teleport.
                     type: string
                   disconnect_expired_cert:
                     description: DisconnectExpiredCert sets disconnect clients on
@@ -1077,6 +1213,16 @@ spec:
                       sessions per connection.
                     format: int64
                     type: integer
+                  mfa_verification_interval:
+                    description: MFAVerificationInterval optionally defines the maximum
+                      duration that can elapse between successive MFA verifications.
+                      This variable is used to ensure that users are periodically
+                      prompted to verify their identity, enhancing security by preventing
+                      prolonged sessions without re-authentication when using tsh
+                      proxy * derivatives. It's only effective if the session requires
+                      MFA. If not set, defaults to `max_session_ttl`.
+                    format: duration
+                    type: string
                   permit_x11_forwarding:
                     description: PermitX11Forwarding authorizes use of X11 forwarding.
                     type: boolean
@@ -1108,8 +1254,8 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the access request strategy
-                      (optional|note|always) where optional is the default.
+                    description: RequestAccess defines the request strategy (optional|note|always)
+                      where optional is the default.
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells
@@ -1117,7 +1263,8 @@ spec:
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
-                      for this user.
+                      for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY",
+                      3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
                     x-kubernetes-int-or-string: true
                   ssh_file_copy:
                     description: SSHFileCopy indicates whether remote file operations

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_samlconnectors.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_samlconnectors.yaml
@@ -80,8 +80,29 @@ spec:
                 type: string
               cert:
                 description: Cert is the identity provider certificate PEM. IDP signs
-                  <Response> responses using this certificate.
+                  `<Response>` responses using this certificate.
                 type: string
+              client_redirect_settings:
+                description: ClientRedirectSettings defines which client redirect
+                  URLs are allowed for non-browser SSO logins other than the standard
+                  localhost ones.
+                nullable: true
+                properties:
+                  allowed_https_hostnames:
+                    description: a list of hostnames allowed for https client redirect
+                      URLs
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  insecure_allowed_cidr_ranges:
+                    description: a list of CIDRs allowed for HTTP or HTTPS client
+                      redirect URLs
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                type: object
               display:
                 description: Display controls how this connector is displayed.
                 type: string
@@ -115,6 +136,10 @@ spec:
                     description: PrivateKey is a PEM encoded x509 private key.
                     type: string
                 type: object
+              single_logout_url:
+                description: SingleLogoutURL is the SAML Single log-out URL to initiate
+                  SAML SLO (single log-out). If this is not provided, SLO is disabled.
+                type: string
               sso:
                 description: SSO is the URL of the identity provider's SSO service.
                 type: string

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_users.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_users.yaml
@@ -53,6 +53,10 @@ spec:
                       description: ConnectorID is id of registered OIDC connector,
                         e.g. 'google-example.com'
                       type: string
+                    samlSingleLogoutUrl:
+                      description: SAMLSingleLogoutURL is the SAML Single log-out
+                        URL to initiate SAML SLO (single log-out), if applicable.
+                      type: string
                     username:
                       description: Username is username supplied by external identity
                         provider
@@ -67,6 +71,10 @@ spec:
                     connector_id:
                       description: ConnectorID is id of registered OIDC connector,
                         e.g. 'google-example.com'
+                      type: string
+                    samlSingleLogoutUrl:
+                      description: SAMLSingleLogoutURL is the SAML Single log-out
+                        URL to initiate SAML SLO (single log-out), if applicable.
                       type: string
                     username:
                       description: Username is username supplied by external identity
@@ -89,6 +97,10 @@ spec:
                       description: ConnectorID is id of registered OIDC connector,
                         e.g. 'google-example.com'
                       type: string
+                    samlSingleLogoutUrl:
+                      description: SAMLSingleLogoutURL is the SAML Single log-out
+                        URL to initiate SAML SLO (single log-out), if applicable.
+                      type: string
                     username:
                       description: Username is username supplied by external identity
                         provider
@@ -107,8 +119,12 @@ spec:
                 type: object
               trusted_device_ids:
                 description: TrustedDeviceIDs contains the IDs of trusted devices
-                  enrolled by the user. Managed by the Device Trust subsystem, avoid
-                  manual edits.
+                  enrolled by the user.  Note that SSO users are transient and thus
+                  may contain an empty TrustedDeviceIDs field, even though the user->device
+                  association exists under the Device Trust subsystem. Do not rely
+                  on this field to determine device associations or ownership, it
+                  exists for legacy/informative purposes only.  Managed by the Device
+                  Trust subsystem, avoid manual edits.
                 items:
                   type: string
                 nullable: true

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/accesslist/v1/accesslist.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/accesslist/v1/accesslist.proto
@@ -32,10 +32,16 @@ message AccessList {
 
   // spec is the specification for the access list.
   AccessListSpec spec = 2;
+
+  // status contains dynamically calculated fields.
+  AccessListStatus status = 3;
 }
 
 // AccessListSpec is the specification for an access list.
 message AccessListSpec {
+  reserved 7, 9, 10;
+  reserved "members", "membership", "ownership";
+
   // description is an optional plaintext description of the access list.
   string description = 1;
 
@@ -45,25 +51,26 @@ message AccessListSpec {
   // audit describes the frequency that this access list must be audited.
   AccessListAudit audit = 3;
 
-  // membership_requires describes the requirements for a user to be a member of the access list.
-  // For a membership to an access list to be effective, the user must meet the requirements of
-  // Membership_requires and must be in the members list.
+  // membership_requires describes the requirements for a user to be a member of
+  // the access list. For a membership to an access list to be effective, the
+  // user must meet the requirements of Membership_requires and must be in the
+  // members list.
   AccessListRequires membership_requires = 4;
 
-  // ownership_requires describes the requirements for a user to be an owner of the access list.
-  // For ownership of an access list to be effective, the user must meet the requirements of
-  // ownership_requires and must be in the owners list.
+  // ownership_requires describes the requirements for a user to be an owner of
+  // the access list. For ownership of an access list to be effective, the user
+  // must meet the requirements of ownership_requires and must be in the owners
+  // list.
   AccessListRequires ownership_requires = 5;
 
   // grants describes the access granted by membership to this access list.
   AccessListGrants grants = 6;
 
-  // members describes the current members of the access list.
-  // TODO(mdwn): Remove this once members are independent objects.
-  repeated AccessListMember members = 7;
-
   // title is a plaintext short description of the access list.
   string title = 8;
+
+  // owner_grants describes the access granted by owners to this access list.
+  AccessListGrants owner_grants = 11;
 }
 
 // AccessListOwner is an owner of an access list.
@@ -71,55 +78,88 @@ message AccessListOwner {
   // name is the username of the owner.
   string name = 1;
 
-  // description is the plaintext description of the owner and why they are an owner.
+  // description is the plaintext description of the owner and why they are an
+  // owner.
   string description = 2;
+
+  // ineligible_status describes if this owner is eligible or not
+  // and if not, describes how they're lacking eligibility.
+  IneligibleStatus ineligible_status = 3;
 }
 
 // AccessListAudit describes the audit configuration for an access list.
 message AccessListAudit {
-  // frequency is a duration that describes how often an access list must be audited.
-  google.protobuf.Duration frequency = 1;
+  reserved 1;
+  reserved "frequency";
 
   // next_audit_date is when the next audit date should be done by.
   google.protobuf.Timestamp next_audit_date = 2;
+
+  // recurrence is the recurrence definition
+  Recurrence recurrence = 3;
+
+  // notifications is the configuration for notifying users.
+  Notifications notifications = 4;
 }
 
-// AccessListRequires describes a requirement section for an access list. A user must
-// meet the following criteria to obtain the specific access to the list.
+// ReviewFrequency is the frequency of reviews.
+enum ReviewFrequency {
+  REVIEW_FREQUENCY_UNSPECIFIED = 0;
+  REVIEW_FREQUENCY_ONE_MONTH = 1;
+  REVIEW_FREQUENCY_THREE_MONTHS = 3;
+  REVIEW_FREQUENCY_SIX_MONTHS = 6;
+  REVIEW_FREQUENCY_ONE_YEAR = 12;
+}
+
+// ReviewDayOfMonth is the day of month that reviews will repeat on.
+enum ReviewDayOfMonth {
+  REVIEW_DAY_OF_MONTH_UNSPECIFIED = 0;
+  REVIEW_DAY_OF_MONTH_FIRST = 1;
+  REVIEW_DAY_OF_MONTH_FIFTEENTH = 15;
+  REVIEW_DAY_OF_MONTH_LAST = 31;
+}
+
+// Recurrence is the definition for when reviews will be scheduled.
+message Recurrence {
+  // frequency is the frequency of reviews. This represents the period in months
+  // between two reviews.
+  // Supported values are 0, 1, 3, 6, and 12.
+  ReviewFrequency frequency = 1;
+
+  // day_of_month is the day of month that reviews will be scheduled on.
+  // Supported values are 0, 1, 15, and 31.
+  ReviewDayOfMonth day_of_month = 2;
+}
+
+// Notifications contains the configuration for notifying users of a nearing
+// next audit date.
+message Notifications {
+  // start specifies when to start notifying users that the next audit date is
+  // coming up.
+  google.protobuf.Duration start = 1;
+}
+
+// AccessListRequires describes a requirement section for an access list. A user
+// must meet the following criteria to obtain the specific access to the list.
 message AccessListRequires {
-  // roles are the user roles that must be present for the user to obtain access.
+  // roles are the user roles that must be present for the user to obtain
+  // access.
   repeated string roles = 1;
 
   // traits are the traits that must be present for the user to obtain access.
   repeated teleport.trait.v1.Trait traits = 2;
 }
 
-// AccessListGrants describes what access is granted by membership to the access list.
+// AccessListGrants describes what access is granted by membership to the access
+// list.
 message AccessListGrants {
-  // roles are the roles that are granted to users who are members of the access list.
+  // roles are the roles that are granted to users who are members of the access
+  // list.
   repeated string roles = 1;
 
-  // traits are the traits that are granted to users who are members of the access list.
+  // traits are the traits that are granted to users who are members of the
+  // access list.
   repeated teleport.trait.v1.Trait traits = 2;
-}
-
-// AccessListMember describes a member of an access list.
-// TODO(mdwn): Remove this once members are independent objects.
-message AccessListMember {
-  // name is the name of the member of the access list.
-  string name = 1;
-
-  // joined is when the user joined the access list.
-  google.protobuf.Timestamp joined = 2;
-
-  // expires is when the user's membership to the access list expires.
-  google.protobuf.Timestamp expires = 3;
-
-  // reason is the reason this user was added to the access list.
-  string reason = 4;
-
-  // added_by is the user that added this user to the access list.
-  string added_by = 5;
 }
 
 // Member describes a member of an access list.
@@ -133,6 +173,9 @@ message Member {
 
 // MemberSpec is the specification for an access list member.
 message MemberSpec {
+  reserved 8;
+  reserved "membership";
+
   // associated access list
   string access_list = 1;
 
@@ -150,4 +193,81 @@ message MemberSpec {
 
   // added_by is the user that added this user to the access list.
   string added_by = 6;
+
+  // ineligible_status describes if this member is eligible or not
+  // and if not, describes how they're lacking eligibility.
+  IneligibleStatus ineligible_status = 7;
+}
+
+// IneligibleStatus describes how the user is ineligible.
+enum IneligibleStatus {
+  // INELIGIBLE_STATUS_UNSPECIFIED means eligiblity is unknown.
+  INELIGIBLE_STATUS_UNSPECIFIED = 0;
+  // INELIGIBLE_STATUS_ELIGIBLE means checks were done and user met all
+  // requirements.
+  INELIGIBLE_STATUS_ELIGIBLE = 1;
+  // INELIGIBLE_STATUS_USER_NOT_EXIST means user was not found in backend.
+  INELIGIBLE_STATUS_USER_NOT_EXIST = 2;
+  // INELIGIBLE_STATUS_MISSING_REQUIREMENTS means user is missing some
+  // requirements defined by AccessListRequires (fields can be either
+  // ownership_requires or membership_requires)
+  INELIGIBLE_STATUS_MISSING_REQUIREMENTS = 3;
+  // INELIGIBLE_STATUS_EXPIRED means user is expired.
+  // Only applicable to members.
+  INELIGIBLE_STATUS_EXPIRED = 4;
+}
+
+// Review is a review of an access list.
+message Review {
+  // header is the header for the resource.
+  teleport.header.v1.ResourceHeader header = 1;
+
+  // spec is the specification for the access list review.
+  ReviewSpec spec = 2;
+}
+
+// ReviewSpec is the specification for an access list review.
+message ReviewSpec {
+  // access_list is the name of the access list that this review is for.
+  string access_list = 1;
+
+  // reviewers are the users who performed the review.
+  repeated string reviewers = 2;
+
+  // review_date is the date that this review was created.
+  google.protobuf.Timestamp review_date = 3;
+
+  // notes is an optional plaintext attached to the review that can be used by
+  // the review for arbitrary note taking on the review.
+  string notes = 4;
+
+  // changes are the changes made as part of the review.
+  ReviewChanges changes = 5;
+}
+
+// ReviewChanges are the changes that were made as part of the review.
+message ReviewChanges {
+  reserved 1;
+  reserved "frequency_changed";
+
+  // membership_requirements_changed is populated if the requirements were
+  // changed as part of this review.
+  AccessListRequires membership_requirements_changed = 2;
+
+  // removed_members contains the members that were removed as part of this
+  // review.
+  repeated string removed_members = 3;
+
+  // review_frequency_changed is populated if the review frequency has changed.
+  ReviewFrequency review_frequency_changed = 4;
+
+  // review_day_of_month_changed is populated if the review day of month has
+  // changed.
+  ReviewDayOfMonth review_day_of_month_changed = 5;
+}
+
+// AccessListStatus contains dynamic fields calculated during retrieval.
+message AccessListStatus {
+  // member_count is the number of members in the in the access list.
+  optional uint32 member_count = 1;
 }

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/attestation/v1/attestation.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/attestation/v1/attestation.proto
@@ -1,20 +1,16 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/header/v1/metadata.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/header/v1/metadata.proto
@@ -22,6 +22,8 @@ option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport
 
 // Metadata is resource metadata.
 message Metadata {
+  reserved 7; // id
+  reserved "id";
   // name is an object name.
   string name = 1;
   // namespace is object namespace. The field should be called "namespace"
@@ -34,6 +36,8 @@ message Metadata {
   // expires is a global expiry time header can be set on any resource in the
   // system.
   google.protobuf.Timestamp expires = 6;
-  // ID is a record ID
-  int64 id = 7;
+  // revision is an opaque identifier which tracks the versions of a resource
+  // over time. Clients should ignore and not alter its value but must return
+  // the revision in any updates of a resource.
+  string revision = 8;
 }

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/header/v1/resourceheader.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/header/v1/resourceheader.proto
@@ -26,7 +26,10 @@ message ResourceHeader {
   string kind = 1;
   // sub_kind is an optional resource sub kind, used in some resources.
   string sub_kind = 2;
-  // version is version.
+  // Version is the API version used to create the resource. It must be
+  // specified. Based on this version, Teleport will apply different defaults on
+  // resource creation or deletion. It must be an integer prefixed by "v".
+  // For example: `v1`
   string version = 3;
   // metadata is resource metadata.
   Metadata metadata = 4;

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/client/proto/authservice.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/client/proto/authservice.proto
@@ -1,20 +1,16 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2021-2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 
@@ -30,6 +26,7 @@ import "teleport/legacy/types/events/events.proto";
 import "teleport/legacy/types/types.proto";
 import "teleport/legacy/types/webauthn/webauthn.proto";
 import "teleport/legacy/types/wrappers/wrappers.proto";
+import "teleport/mfa/v1/mfa.proto";
 import "teleport/usageevents/v1/usageevents.proto";
 
 option go_package = "github.com/gravitational/teleport/api/client/proto";
@@ -52,7 +49,6 @@ message Watch {
 message HostCertsRequest {
   reserved 12; // system_role_assertion_id
   reserved "UnstableSystemRoleAssertionID";
-
   // HostID is a unique ID of the host.
   string HostID = 1 [(gogoproto.jsontag) = "host_id"];
   // NodeName is a user-friendly host name.
@@ -90,6 +86,11 @@ message HostCertsRequest {
     (gogoproto.jsontag) = "system_roles,omitempty",
     (gogoproto.casttype) = "github.com/gravitational/teleport/api/types.SystemRole"
   ];
+  // SystemRoleAssertionID is used by agents to prove that they have a given system role when
+  // their credentials originate from multiple separate join tokens so that they can be issued
+  // an instance certificate that encompasses all of their capabilities. This field will be
+  // deprecated once we have a more comprehensive model for join token joining/replacement.
+  string SystemRoleAssertionID = 13 [(gogoproto.jsontag) = "system_role_assertion_id,omitempty"];
 }
 
 // OpenSSHCertRequest specifies certificate-generation parameters
@@ -122,7 +123,12 @@ message OpenSSHCert {
 // for a user.
 message UserCertsRequest {
   // PublicKey is a public key to be signed.
-  bytes PublicKey = 1 [(gogoproto.jsontag) = "public_key"];
+  //
+  // Deprecated: Prefer SSHPublicKey and/or TLSPublicKey.
+  bytes PublicKey = 1 [
+    (gogoproto.jsontag) = "public_key",
+    deprecated = true
+  ];
   // Username of key owner.
   string Username = 2 [(gogoproto.jsontag) = "username"];
   // Expires is a desired time of the expiry of the certificate, could
@@ -231,6 +237,10 @@ message UserCertsRequest {
     TSH_DB_LOCAL_PROXY_TUNNEL = 1;
     // TSH_KUBE_LOCAL_PROXY is set when the request was sent by a tsh kube local proxy.
     TSH_KUBE_LOCAL_PROXY = 2;
+    // TSH_KUBE_LOCAL_PROXY_HEADLESS is set when the request was sent by a tsh kube local proxy in headless mode.
+    TSH_KUBE_LOCAL_PROXY_HEADLESS = 3;
+    // TSH_APP_LOCAL_PROXY is set when the request was sent by a tsh app local proxy.
+    TSH_APP_LOCAL_PROXY = 4;
   }
   // RequesterName identifies who sent the request.
   Requester RequesterName = 17 [(gogoproto.jsontag) = "requester_name"];
@@ -246,7 +256,41 @@ message UserCertsRequest {
   string SSHLogin = 19;
 
   // AttestationStatement is an attestation statement for the given public key.
-  teleport.attestation.v1.AttestationStatement attestation_statement = 20;
+  //
+  // Deprecated: prefer SSHPublicKeyAttestationStatement and/or
+  // TLSPublicKeyAttestationStatement.
+  teleport.attestation.v1.AttestationStatement attestation_statement = 20 [deprecated = true];
+
+  // CertPurpose complements CertUsage by informing Teleport of the intended use
+  // for the certificates.
+  enum CertPurpose {
+    // Purpose not specified.
+    // Interpreted as CERT_PURPOSE_LOGIN_CERTS.
+    CERT_PURPOSE_UNSPECIFIED = 0;
+
+    // Generate login certificates, both SSH and TLS, as well as CA certs.
+    CERT_PURPOSE_LOGIN_CERTS = 1;
+
+    // Generate single-user certificates, either SSH or TLS, depending on the
+    // specified Usage.
+    CERT_PURPOSE_SINGLE_USE_CERTS = 2;
+  }
+  // Purpose is the intended purpose of the certificates.
+  CertPurpose Purpose = 21 [(gogoproto.jsontag) = "purpose,omitempty"];
+
+  // SSHPublicKey is a public key in SSH authorized_keys format, to be used as
+  // the subject for the issued SSH certificate. If omitted, only a TLS cert
+  // will be returned.
+  bytes SSHPublicKey = 22 [(gogoproto.jsontag) = "ssh_public_key,omitempty"];
+  // TLSPublicKey is a public key in PEM-encoded PKCS#1 or PKIX format, to be used as
+  // the subject for the issued TLS certificate. If omitted, only an SSH cert
+  // will be returned.
+  bytes TLSPublicKey = 23 [(gogoproto.jsontag) = "tls_public_key,omitempty"];
+
+  // SSHPublicKeyAttestationStatement is an attestation statement for SSHPublicKey.
+  teleport.attestation.v1.AttestationStatement SSHPublicKeyAttestationStatement = 25 [(gogoproto.jsontag) = "ssh_public_key_attestation_statement,omitempty"];
+  // TLSPublicKeyAttestationStatement is an attestation statement for TLSPublicKey.
+  teleport.attestation.v1.AttestationStatement TLSPublicKeyAttestationStatement = 26 [(gogoproto.jsontag) = "tls_public_key_attestation_statement,omitempty"];
 }
 
 // RouteToDatabase combines parameters for database service routing information.
@@ -259,6 +303,8 @@ message RouteToDatabase {
   string Username = 3 [(gogoproto.jsontag) = "username,omitempty"];
   // Database is an optional database name to embed.
   string Database = 4 [(gogoproto.jsontag) = "database,omitempty"];
+  // Roles is an optional list of database roles to embed.
+  repeated string Roles = 5 [(gogoproto.jsontag) = "roles,omitempty"];
 }
 
 // RouteToWindowsDesktop combines parameters for windows desktop routing information.
@@ -274,7 +320,12 @@ message RouteToApp {
   // Name is the application name certificate is being requested for.
   string Name = 1 [(gogoproto.jsontag) = "name"];
   // SessionID is the ID of the application session.
-  string SessionID = 2 [(gogoproto.jsontag) = "session_id"];
+  // DEPRECATED: Automatically generated by server.
+  // TODO (Joerger): DELETE IN v17.0.0
+  string SessionID = 2 [
+    (gogoproto.jsontag) = "session_id",
+    deprecated = true
+  ];
   // PublicAddr is the application public address.
   string PublicAddr = 3 [(gogoproto.jsontag) = "public_addr"];
   // ClusterName is the cluster where the application resides.
@@ -285,6 +336,8 @@ message RouteToApp {
   string AzureIdentity = 6 [(gogoproto.jsontag) = "azure_identity,omitempty"];
   // GCPServiceAccount is the GCP service account to assume when accessing GCP API.
   string GCPServiceAccount = 7 [(gogoproto.jsontag) = "gcp_service_account,omitempty"];
+  // URI is the URI of the app. This is the internal endpoint where the application is running and isn't user-facing.
+  string URI = 8 [(gogoproto.jsontag) = "uri,omitempty"];
 }
 
 // GetUserRequest specifies parameters for the GetUser method.
@@ -340,6 +393,12 @@ message RequestStateSetter {
   // Roles, if present, overrides the existing set of roles associated
   // with the access request.
   repeated string Roles = 6 [(gogoproto.jsontag) = "roles,omitempty"];
+  // AssumeStartTime is the time the requested roles can be assumed.
+  google.protobuf.Timestamp AssumeStartTime = 7 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = true,
+    (gogoproto.jsontag) = "assume_start_time,omitempty"
+  ];
 }
 
 // RequestID is the unique identifier of an access request.
@@ -375,67 +434,6 @@ message RenewableCertsRequest {
   bytes PublicKey = 2 [(gogoproto.jsontag) = "public_key"];
 }
 
-// CreateBotRequest is used to create a bot User and associated resources.
-message CreateBotRequest {
-  // Name is the name of the bot, i.e. the unprefixed User name.
-  string Name = 1 [(gogoproto.jsontag) = "name"];
-
-  // TTL is the desired TTL for the token if one is created. If unset, a
-  // server default is used.
-  int64 TTL = 2 [
-    (gogoproto.jsontag) = "ttl",
-    (gogoproto.casttype) = "Duration"
-  ];
-
-  // TokenID is an optional token name of an EC2/IAM join token should be
-  // used. If unset, a new random token is created and its name returned.
-  string TokenID = 3 [(gogoproto.jsontag) = "token_id"];
-
-  // Roles is a list of roles the created bot should be allowed to assume
-  // via role impersonation.
-  repeated string Roles = 4 [(gogoproto.jsontag) = "roles"];
-
-  // Traits are used to populate role variables. These will propagate to
-  // role impersonated certificates generated by the bot.
-  wrappers.LabelValues Traits = 5 [
-    (gogoproto.nullable) = false,
-    (gogoproto.jsontag) = "traits,omitempty",
-    (gogoproto.customtype) = "github.com/gravitational/teleport/api/types/wrappers.Traits"
-  ];
-}
-
-// CreateBotResponse returns details for bootstrapping a new bot.
-message CreateBotResponse {
-  // UserName is the name of the associated bot user.
-  string UserName = 1 [(gogoproto.jsontag) = "user_name"];
-  // RoleName is the name of the associated bot role.
-  string RoleName = 2 [(gogoproto.jsontag) = "role_name"];
-  // TokenID is the name of the join token for the bot.
-  string TokenID = 3 [(gogoproto.jsontag) = "token_id"];
-  // TokenTTL is the TTL for the token. If it differs from the requested TTL,
-  // it may have been limited by server policy.
-  int64 TokenTTL = 4 [
-    (gogoproto.jsontag) = "ttl",
-    (gogoproto.casttype) = "Duration"
-  ];
-  // JoinMethod is the join method the bot must use to join the cluster.
-  string JoinMethod = 5 [
-    (gogoproto.jsontag) = "join_method",
-    (gogoproto.casttype) = "github.com/gravitational/teleport/api/types.JoinMethod"
-  ];
-}
-
-// DeleteBotRequest is a request to delete a bot user
-message DeleteBotRequest {
-  // Name is the name of the bot, i.e. the unprefixed User name.
-  string Name = 1 [(gogoproto.jsontag) = "name"];
-}
-
-// GetBotUsersRequest specifies parameters for the GetUsers method.
-message GetBotUsersRequest {
-  // GetBotUsers currently takes no parameters.
-}
-
 // PingRequest is the input value for the Ping method.
 message PingRequest {
   // Ping method currently takes no parameters
@@ -464,27 +462,52 @@ message PingResponse {
   reserved "LicenseWarnings";
 }
 
+// ProductType is the type of product.
+enum ProductType {
+  PRODUCT_TYPE_UNKNOWN = 0;
+  // PRODUCT_TYPE_TEAM is Teleport Team product.
+  PRODUCT_TYPE_TEAM = 1;
+  // PRODUCT_TYPE_EUB is Teleport Enterprise Usage Based product.
+  PRODUCT_TYPE_EUB = 2;
+}
+
+// SupportType if the type of support offered.
+enum SupportType {
+  SUPPORT_TYPE_UNSPECIFIED = 0;
+  // SUPPORT_TYPE_FREE is the free tier support
+  SUPPORT_TYPE_FREE = 1;
+  // SUPPORT_TYPE_PREMIUM is the premium tier support
+  SUPPORT_TYPE_PREMIUM = 2;
+}
+
 // Features are auth server features.
 message Features {
   // Kubernetes enables Kubernetes Access product
+  // Deprecated remove in v18; leverage entitlements
   bool Kubernetes = 1 [(gogoproto.jsontag) = "kubernetes"];
   // App enables Application Access product
+  // Deprecated remove in v18; leverage entitlements
   bool App = 2 [(gogoproto.jsontag) = "app"];
   // DB enables database access product
+  // Deprecated remove in v18; leverage entitlements
   bool DB = 3 [(gogoproto.jsontag) = "db"];
   // OIDC enables OIDC connectors
+  // Deprecated remove in v18; leverage entitlements
   bool OIDC = 4 [(gogoproto.jsontag) = "oidc"];
   // SAML enables SAML connectors
+  // Deprecated remove in v18; leverage entitlements
   bool SAML = 5 [(gogoproto.jsontag) = "saml"];
   // AccessControls enables FIPS access controls
   bool AccessControls = 6 [(gogoproto.jsontag) = "access_controls"];
-  // AdvancedAccessWorkflows enables advanced access workflows
+  // AdvancedAccessWorkflows is currently set to the value of the Cloud AccessRequests entitlement
   bool AdvancedAccessWorkflows = 7 [(gogoproto.jsontag) = "advanced_access_workflows"];
   // Cloud enables some cloud-related features
   bool Cloud = 8 [(gogoproto.jsontag) = "cloud"];
   // HSM enables PKCS#11 HSM support
+  // Deprecated remove in v18; leverage entitlements
   bool HSM = 9 [(gogoproto.jsontag) = "hsm"];
   // Desktop enables desktop access product
+  // Deprecated remove in v18; leverage entitlements
   bool Desktop = 10 [(gogoproto.jsontag) = "desktop"];
   reserved 11; // bool ModeratedSessions
   reserved 12; // bool MachineID
@@ -498,39 +521,121 @@ message Features {
   // IsUsageBased enables some usage-based billing features
   bool IsUsageBased = 17 [(gogoproto.jsontag) = "is_usage_based"];
   // Assist enables the Assistant feature
+  // Deprecated remove in v18; leverage entitlements
   bool Assist = 18 [(gogoproto.jsontag) = "assist"];
   // DeviceTrust holds its namesake feature settings.
+  // Deprecated remove in v18; leverage entitlements
   DeviceTrustFeature DeviceTrust = 19 [(gogoproto.jsontag) = "device_trust,omitempty"];
   // FeatureHiding enables hiding features from being discoverable for users who don't have the necessary permissions.
+  // Deprecated remove in v18; leverage entitlements
   bool FeatureHiding = 20 [(gogoproto.jsontag) = "feature_hiding,omitempty"];
   // AccessRequests holds its namesake feature settings.
+  // Deprecated remove in v18; leverage entitlements
   AccessRequestsFeature AccessRequests = 21 [(gogoproto.jsontag) = "access_requests,omitempty"];
   // CustomTheme holds the name of WebUI custom theme.
   string CustomTheme = 22 [(gogoproto.jsontag) = "custom_theme,omitempty"];
+  // IdentityGovernance indicates whether IGS related features are enabled:
+  // access list, access request, access monitoring, device trust.
+  // Deprecated remove in v18; leverage entitlements
+  bool IdentityGovernance = 23 [(gogoproto.jsontag) = "identity_governance,omitempty"];
+  // AccessGraph enables the usage of access graph.
+  // NOTE: this is a legacy flag that is currently used to signal
+  // that Access Graph integration is *enabled* on a cluster.
+  // *Access* to the feature is gated on the `Policy` flag.
+  // TODO(justinas): remove this field once "TAG enabled" status is moved to a resource in the backend.
+  bool AccessGraph = 24 [(gogoproto.jsontag) = "access_graph,omitempty"];
+  // AccessListFeature holds its namesake feature settings.
+  // Deprecated remove in v18; leverage entitlements
+  AccessListFeature AccessList = 25 [(gogoproto.jsontag) = "access_list,omitempty"];
+  // AccessMonitoringFeature holds its namesake feature settings.
+  // Deprecated remove in v18; leverage entitlements for access and AccessMonitoringConfigured for enabled
+  AccessMonitoringFeature AccessMonitoring = 26 [(gogoproto.jsontag) = "access_monitoring,omitempty"];
+  // ProductType describes the product being used.
+  ProductType ProductType = 27 [(gogoproto.jsontag) = "product_type,omitempty"];
+  // Policy enables the Teleport Policy feature set.
+  // At the time of writing, this includes Teleport Access Graph (TAG).
+  // Deprecated remove in v18; leverage entitlements
+  PolicyFeature Policy = 28 [(gogoproto.jsontag) = "policy,omitempty"];
+  // Questionnaire indicates whether cluster users should get an onboarding questionnaire
+  bool Questionnaire = 29 [(gogoproto.jsontag) = "questionnaire,omitempty"];
+  // IsStripeManaged indicates if the cluster billing is managed via Stripe
+  bool IsStripeManaged = 30 [(gogoproto.jsontag) = "is_stripe_managed,omitempty"];
+  // ExternalAuditStorage indicates whether the EAS feature is enabled in the cluster.
+  // Deprecated remove in v18; leverage entitlements
+  bool ExternalAuditStorage = 31 [(gogoproto.jsontag) = "external_audit_storage,omitempty"];
+  // SupportType indicates the type of the customer's support
+  SupportType SupportType = 32 [(gogoproto.jsontag) = "support_type,omitempty"];
+  // JoinActiveSessions indicates whether joining active sessions via web UI is enabled
+  // Deprecated remove in v18; leverage entitlements
+  bool JoinActiveSessions = 33 [(gogoproto.jsontag) = "join_active_sessions,omitempty"];
+  // MobileDeviceManagement indicates whether endpoint management (like Jamf Plugin) can be used in the cluster
+  // Deprecated remove in v18; leverage entitlements
+  bool MobileDeviceManagement = 34 [(gogoproto.jsontag) = "mobile_device_management,omitempty"];
+  // entitlements define a customer’s access to a specific features
+  map<string, EntitlementInfo> entitlements = 35;
+  // AccessMonitoringConfigured contributes to the enablement of access monitoring.
+  // NOTE: this flag is used to signal that Access Monitoring is *enabled* on a cluster.
+  // *Access* to the feature is gated on the `AccessMonitoring` entitlement.
+  bool AccessMonitoringConfigured = 36;
+}
+
+// EntitlementInfo is the state and limits of a particular entitlement
+message EntitlementInfo {
+  // enabled indicates the feature is 'on' if true
+  bool enabled = 1;
+  // limit indicates the allotted amount of use when limited
+  int32 limit = 2;
 }
 
 // DeviceTrustFeature holds the Device Trust feature general and usage-based
 // settings.
-// Requires Teleport Enterprise.
+// Limits have no affect if [Features.IdentityGovernance] is enabled.
 message DeviceTrustFeature {
-  // True if the Device Trust feature is enabled.
+  // Currently this flag is to gate actions from OSS clusters.
+  //
+  // Determining support for device trust is currently determined by:
+  //   1) Enterprise + [Features.IdentityGovernanceSecurity] == true, new flag
+  //   introduced with Enterprise Usage Based (EUB) product.
+  //   2) Enterprise + [Features.IsUsageBasedBilling] == false, legacy support
+  //   where before EUB, it was unlimited.
   bool enabled = 1 [(gogoproto.jsontag) = "enabled,omitempty"];
   // Usage-based limit for the number of registered/enrolled devices, at the
   // implementation's discretion.
-  // Meant for usage-based accounts, like Teleport Team. Has no effect if
-  // [Features.IsUsageBased] is `false`.
   int32 devices_usage_limit = 2 [(gogoproto.jsontag) = "devices_usage_limit,omitempty"];
 }
 
 // AccessRequestsFeature holds the AccessRequest feature general and usage-based
 // settings.
-// Requires Teleport Enterprise.
+// Limits have no affect if [Features.IdentityGovernance] is enabled.
 message AccessRequestsFeature {
   // Usage-based limit for the number of limit for the number of
   // access requests created in a calendar month.
-  // Meant for usage-based accounts, like Teleport Team. Has no effect if
-  // [Features.IsUsageBased] is `false`.
   int32 monthly_request_limit = 1 [(gogoproto.jsontag) = "monthly_request_limit"];
+  reserved 2;
+  reserved "enabled";
+}
+
+// AccessListFeature holds the Access List feature settings.
+// Limits have no affect if [Features.IdentityGovernance] is enabled.
+message AccessListFeature {
+  // Limit for the number of access list creatable when feature is
+  // not enabled.
+  int32 create_limit = 1 [(gogoproto.jsontag) = "create_limit,omitempty"];
+}
+
+// AccessMonitoringFeature holds the Access Monitoring feature settings.
+// Limits have no affect if [Features.IdentityGovernance] is enabled.
+message AccessMonitoringFeature {
+  // True if enabled in the auth service config: [auth_service.access_monitoring.enabled].
+  bool enabled = 1 [(gogoproto.jsontag) = "enabled,omitempty"];
+  // Defines the max number of days to include in an access report.
+  int32 max_report_range_limit = 2 [(gogoproto.jsontag) = "max_report_range_limit,omitempty"];
+}
+
+// PolicyFeature holds the Teleport Policy feature set settings.
+message PolicyFeature {
+  // True if Teleport Policy is enabled in the license.
+  bool enabled = 1 [(gogoproto.jsontag) = "enabled,omitempty"];
 }
 
 // DeleteUserRequest is the input value for the DeleteUser method.
@@ -725,6 +830,16 @@ message CreateAppSessionRequest {
   string AzureIdentity = 6 [(gogoproto.jsontag) = "azure_identity"];
   // GCPServiceAccount is the GCP service account the user wants to assume.
   string GCPServiceAccount = 7 [(gogoproto.jsontag) = "gcp_service_account"];
+  // MFAResponse is a response to a challenge from a user's MFA device.
+  // An optional field, that when provided, the response will be validated and
+  // the ID of the validated MFA device will be stored in session's certificate.
+  MFAAuthenticateResponse MFAResponse = 8 [(gogoproto.jsontag) = "mfa_response,omitempty"];
+  // AppName is the name of the application.
+  string AppName = 9 [(gogoproto.jsontag) = "app_name"];
+  // URI is the URI of the app. This is the internal endpoint where the application is running and isn't user-facing.
+  string URI = 10 [(gogoproto.jsontag) = "uri"];
+  // ClientAddr is a client (user's) address.
+  string ClientAddr = 11 [(gogoproto.jsontag) = "client_addr,omitempty"];
 }
 
 // CreateAppSessionResponse contains the requested application web session.
@@ -988,6 +1103,47 @@ message GetRolesResponse {
   repeated types.RoleV6 Roles = 1;
 }
 
+// ListRolesRequest encodes parameters for paginated role lookup.
+message ListRolesRequest {
+  // Limit is the maximum amount of roles per page.
+  int32 Limit = 1;
+
+  // StartKey is used to resume a query in order to enable pagination.
+  // If the previous response had LastKey set then this should be
+  // set to its value. Otherwise leave empty.
+  string StartKey = 2;
+
+  // Filter matches roles.
+  types.RoleFilter Filter = 3;
+}
+
+// ListRolesResponse is a page of roles.
+message ListRolesResponse {
+  // Roles is a page of roles.
+  repeated types.RoleV6 Roles = 1;
+
+  // NextKey will serve as the StartKey for the next page of roles.
+  string NextKey = 2;
+}
+
+// Request for CreateRole.
+message CreateRoleRequest {
+  // Role to be created.
+  types.RoleV6 Role = 1;
+}
+
+// Request for UpdateRole.
+message UpdateRoleRequest {
+  // Role to be updated.
+  types.RoleV6 Role = 1;
+}
+
+// Request for UpsertRole.
+message UpsertRoleRequest {
+  // Role to be upserted.
+  types.RoleV6 Role = 1;
+}
+
 // DeleteRoleRequest is a request to delete a role.
 message DeleteRoleRequest {
   // Name is the role name to delete.
@@ -1049,9 +1205,11 @@ message MFAAuthenticateChallenge {
   // registered by the user).
   webauthn.CredentialAssertion WebauthnChallenge = 3;
   // MFRequired indicates whether proceeding with the MFA ceremony will
-  // grant access to the resource. If `MFA_REQUIRED_NO` is returned by the
-  // server then the stream will be terminated to prevent a fruitless MFA ceremony from
-  // proceeding.
+  // grant access to the resource.
+  //
+  // If `MFA_REQUIRED_NO` is returned then the server may opt to end ongoing
+  // communications, in case of streaming RPCs. It may also return empty
+  // challenges for all other fields.
   MFARequired MFARequired = 4;
 }
 
@@ -1114,105 +1272,88 @@ message TOTPRegisterChallenge {
   // QRCode is an optional field for the QR code in PNG format. Used to display a QR code
   // image in the UI.
   bytes QRCode = 7;
+  // ID of the TOTP challenge.
+  // Send this back in the TOTPRegisterResponse.
+  string ID = 8;
 }
 
 // TOTPRegisterResponse is a response to TOTPRegisterChallenge.
 message TOTPRegisterResponse {
   string Code = 1;
+  // ID of the TOTP challenge, as informed by the TOTPRegisterChallenge.
+  string ID = 2;
 }
 
-// AddMFADeviceRequest is a message sent by the client during AddMFADevice RPC.
+// Deprecated: Use [AuthService.AddMFADeviceSync] instead.
 message AddMFADeviceRequest {
-  oneof Request {
-    // Init describes the new device.
-    AddMFADeviceRequestInit Init = 1;
-    // ExistingMFAResponse is a response to ExistingMFAChallenge auth
-    // challenge.
-    MFAAuthenticateResponse ExistingMFAResponse = 2;
-    // NewMFARegisterResponse is a response to NewMFARegisterChallenge
-    // registration challenge.
-    MFARegisterResponse NewMFARegisterResponse = 3;
-  }
+  reserved 1; // AddMFADeviceRequestInit Init;
+  reserved "Init";
+  reserved 2; // MFAAuthenticateResponse ExistingMFAResponse;
+  reserved "ExistingMFAResponse";
+  reserved 3; // MFARegisterResponse NewMFARegisterResponse;
+  reserved "NewMFARegisterResponse";
 }
 
-// AddMFADeviceResponse is a message sent by the server during AddMFADevice
-// RPC.
+// Deprecated: Use [AuthService.AddMFADeviceSync] instead.
 message AddMFADeviceResponse {
-  oneof Response {
-    // ExistingMFAChallenge is an auth challenge using an existing MFA
-    // device.
-    MFAAuthenticateChallenge ExistingMFAChallenge = 1;
-    // NewMFARegisterChallenge is a registration challenge for a new MFA
-    // device.
-    MFARegisterChallenge NewMFARegisterChallenge = 2;
-    // Ack is a confirmation of successful device registration.
-    AddMFADeviceResponseAck Ack = 3;
-  }
+  reserved 1; // MFAAuthenticateChallenge ExistingMFAChallenge;
+  reserved "ExistingMFAChallenge";
+  reserved 2; // MFARegisterChallenge NewMFARegisterChallenge;
+  reserved "NewMFARegisterChallenge";
+  reserved 3; // AddMFADeviceResponseAck Ack;
+  reserved "Ack";
 }
 
-// AddMFADeviceRequestInit describes the new MFA device.
-message AddMFADeviceRequestInit {
-  string DeviceName = 1;
-  reserved 2; // LegacyDeviceType LegacyType
-  DeviceType DeviceType = 3;
-  // DeviceUsage is the requested usage for the device.
-  // Defaults to DEVICE_USAGE_MFA.
-  DeviceUsage DeviceUsage = 4 [(gogoproto.jsontag) = "device_usage,omitempty"];
-}
-
-// AddMFADeviceResponseAck is a confirmation of successful device registration.
-message AddMFADeviceResponseAck {
-  types.MFADevice Device = 1;
-}
-
-// DeleteMFADeviceRequest is a message sent by the client during
-// DeleteMFADevice RPC.
+// Deprecated: Use [AuthService.DeleteMFADeviceSync] instead.
 message DeleteMFADeviceRequest {
-  oneof Request {
-    // Init describes the device to be deleted.
-    DeleteMFADeviceRequestInit Init = 1;
-    // MFAResponse is a response to MFAChallenge auth challenge.
-    MFAAuthenticateResponse MFAResponse = 2;
-  }
+  reserved 1; // DeleteMFADeviceRequestInit Init;
+  reserved "Init";
+  reserved 2; // MFAAuthenticateResponse MFAResponse;
+  reserved "MFAResponse";
 }
 
+// Deprecated: Use [AuthService.DeleteMFADeviceSync] instead.
 message DeleteMFADeviceResponse {
-  oneof Response {
-    // MFAChallenge is an auth challenge using any existing MFA device.
-    MFAAuthenticateChallenge MFAChallenge = 1;
-    // Ack is a confirmation of successful device deletion.
-    DeleteMFADeviceResponseAck Ack = 2;
-  }
-}
-
-// DeleteMFADeviceRequestInit describes the device to be deleted.
-message DeleteMFADeviceRequestInit {
-  // DeviceName is an MFA device name or ID to be deleted.
-  string DeviceName = 1;
-}
-
-// DeleteMFADeviceResponseAck is a confirmation of successful device deletion.
-message DeleteMFADeviceResponseAck {
-  types.MFADevice Device = 1;
+  reserved 1; // MFAAuthenticateChallenge MFAChallenge;
+  reserved "MFAChallenge";
+  reserved 2; // DeleteMFADeviceResponseAck Ack;
+  reserved "Ack";
 }
 
 // DeleteMFADeviceSyncRequest is a request to delete a MFA device (nonstream).
 message DeleteMFADeviceSyncRequest {
   // TokenID is the ID of a user token that will be used to verify this request.
+  //
   // Token types accepted are:
   //   - Recovery approved token that is obtained with RPC VerifyAccountRecovery
   //   - Privilege token that is obtained with RPC CreatePrivilegeToken
+  //
+  // Authenticated users can delete a device by providing an ExistingMFAResponse
+  // instead.
   string TokenID = 1 [(gogoproto.jsontag) = "token_id"];
   // DeviceName is the name of the device to delete.
   string DeviceName = 2 [(gogoproto.jsontag) = "device_name"];
+  // ExistingMFAResponse is an MFA response from an existing device.
+  //
+  // May be provided as an alternative to TokenID.
+  MFAAuthenticateResponse ExistingMFAResponse = 3 [(gogoproto.jsontag) = "existing_mfa_response,omitempty"];
 }
 
 // AddMFADeviceSyncRequest is a request to add a MFA device (nonstream).
 message AddMFADeviceSyncRequest {
   // TokenID is the ID of a user token that will be used to verify this request.
+  //
   // Token types accepted are:
   //  - Privilege token that is obtained with RPC CreatePrivilegeToken
+  //
+  // An authenticated user can register a new device using only a
+  // NewMFAResponse. See [ContextUser].
   string TokenID = 1 [(gogoproto.jsontag) = "token_id"];
+  // ContextUser allows registering a device for the authenticated user.
+  //
+  // Default option if no other is provided.
+  ContextUser ContextUser = 5 [(gogoproto.jsontag) = "context_user,omitempty"];
+
   // NewDeviceName is the name of a new mfa device.
   string NewDeviceName = 2 [(gogoproto.jsontag) = "new_device_name,omitempty"];
   // NewMFAResponse is a user's new mfa response to a mfa register challenge.
@@ -1244,20 +1385,20 @@ message GetMFADevicesResponse {
   repeated types.MFADevice Devices = 1;
 }
 
-// UserSingleUseCertsRequest is a request for a single-use user certificate.
+// Deprecated: Use [AuthService.GenerateUserCerts] instead.
 message UserSingleUseCertsRequest {
-  oneof Request {
-    UserCertsRequest Init = 1;
-    MFAAuthenticateResponse MFAResponse = 2;
-  }
+  reserved 1; // UserCertsRequest Init;
+  reserved "Init";
+  reserved 2; // MFAAuthenticateResponse MFAResponse;
+  reserved "MFAResponse";
 }
 
-// UserSingleUseCertsResponse is a response with a single-use user certificate.
+// Deprecated: Use [AuthService.GenerateUserCerts] instead.
 message UserSingleUseCertsResponse {
-  oneof Response {
-    MFAAuthenticateChallenge MFAChallenge = 1;
-    SingleUseUserCert Cert = 2;
-  }
+  reserved 1; // MFAAuthenticateChallenge MFAChallenge;
+  reserved "MFAChallenge";
+  reserved 2; // SingleUseUserCert Cert;
+  reserved "Cert";
 }
 
 // IsMFARequiredRequest is a request to check whether MFA is required to access
@@ -1272,6 +1413,10 @@ message IsMFARequiredRequest {
     NodeLogin Node = 3;
     // WindowsDesktop specifies the target Windows Desktop.
     RouteToWindowsDesktop WindowsDesktop = 4;
+    // AdminAction specifies an admin action.
+    AdminAction AdminAction = 5;
+    // App specifies the target App.
+    RouteToApp App = 6;
   }
 }
 
@@ -1292,17 +1437,19 @@ message NodeLogin {
   string Login = 2;
 }
 
-// IsMFARequiredResponse is a response for MFA requirement check.
-message IsMFARequiredResponse {
-  bool Required = 1;
+// AdminAction specifies an admin action.
+message AdminAction {
+  reserved 1;
+  reserved "Name";
 }
 
-// SingleUseUserCert is a single-use user certificate, either SSH or TLS.
-message SingleUseUserCert {
-  oneof Cert {
-    bytes SSH = 1;
-    bytes TLS = 2;
-  }
+// IsMFARequiredResponse is a response for MFA requirement check.
+message IsMFARequiredResponse {
+  // Required is a simplified view over [MFARequired].
+  bool Required = 1;
+  // MFARequired informs whether MFA is required to access the corresponding
+  // resource.
+  MFARequired MFARequired = 2;
 }
 
 // Order specifies any ordering of some objects as returned in regards to some aspect
@@ -1454,6 +1601,12 @@ message WindowsDesktopCertRequest {
 message WindowsDesktopCertResponse {
   // Cert is the signed certificate in PEM format.
   bytes Cert = 1;
+}
+
+// Response message for GetDesktopBootstrapScript.
+message DesktopBootstrapScriptResponse {
+  // The PowerShell script content.
+  string Script = 1 [(gogoproto.jsontag) = "script"];
 }
 
 // ListSAMLIdPServiceProvidersRequest is a request for a paginated list of SAML IdP service providers.
@@ -1696,6 +1849,20 @@ message CreateAuthenticateChallengeRequest {
     // required).
     Passwordless Passwordless = 4 [(gogoproto.jsontag) = "passwordless,omitempty"];
   }
+  // MFARequiredCheck, if set, is used to verify if MFA is necessary for the
+  // request. It's akin to a call to [AuthService.IsMFARequired].
+  //
+  // If MFA is not required, then no challenges are issued in the
+  // [MFAAuthenticateResponse].
+  //
+  // MFA verification should run in the cluster that holds the target resource.
+  // If you are issuing challenges from the root cluster, but accessing a leaf,
+  // call [AuthService.IsMFARequired] in the leaf instead of setting this field.
+  IsMFARequiredRequest MFARequiredCheck = 5 [(gogoproto.jsontag) = "mfa_required_check,omitempty"];
+  // ChallengeExtensions are extensions that will be apply to the issued MFA challenge.
+  // ChallengeExtensions only apply to webauthn challenges currently. Required, except
+  // for v15 clients and older.
+  teleport.mfa.v1.ChallengeExtensions ChallengeExtensions = 6 [(gogoproto.jsontag) = "challenge_extensions,omitempty"];
 }
 
 // CreatePrivilegeTokenRequest defines a request to obtain a privilege token.
@@ -1713,8 +1880,22 @@ message CreatePrivilegeTokenRequest {
 // new MFA device.
 message CreateRegisterChallengeRequest {
   // TokenID is the ID of a user token that will be used to verify this request.
+  // Either TokenID or ExistingMFAResponse are required.
+  //
   // All user token types are accepted except UserTokenTypeRecoveryStart.
+  //
+  // An authenticated user can create challenges without a token by supplying an
+  // ExistingMFAResponse.
   string TokenID = 1 [(gogoproto.jsontag) = "token_id"];
+  // ExistingMFAResponse is a response to ExistingMFAChallenge auth challenge.
+  // Either ExistingMFAResponse or TokenID are required.
+  //
+  // Note that a user with no devices can create the initial register challenge,
+  // in the same manner that they could create a privilege token.
+  //
+  // See the [AuthService.CreateAuthenticateChallenge] RPC.
+  MFAAuthenticateResponse ExistingMFAResponse = 4;
+
   // DeviceType is the type of MFA device to make a register challenge for.
   DeviceType DeviceType = 2 [(gogoproto.jsontag) = "device_type"];
   // DeviceUsage is the requested usage for the device.
@@ -1745,8 +1926,18 @@ message PaginatedResource {
     // UserGroup represents a UserGroup resource.
     types.UserGroupV1 UserGroup = 10 [(gogoproto.jsontag) = "user_group,omitempty"];
     // AppServerOrSAMLIdPServiceProvider represents either an AppServer or a SAML IdP Service Provider resource.
-    types.AppServerOrSAMLIdPServiceProviderV1 AppServerOrSAMLIdPServiceProvider = 11;
+    //
+    // DEPRECATED: Use AppServer and SAMLIdPServiceProvider type individually.
+    types.AppServerOrSAMLIdPServiceProviderV1 AppServerOrSAMLIdPServiceProvider = 11 [deprecated = true];
+    // SAMLIdPServiceProvider represents a SAML IdP service provider resource.
+    types.SAMLIdPServiceProviderV1 SAMLIdPServiceProvider = 12 [(gogoproto.jsontag) = "saml_idp_service_provider,omitempty"];
   }
+
+  // Logins allowed for the included resource. Only to be populated for SSH and Desktops.
+  repeated string Logins = 13 [(gogoproto.jsontag) = "logins,omitempty"];
+  // RequiresRequest indicates if a resource requires an access request to access. Only populated with requests
+  // that IncludeRequestable.
+  bool RequiresRequest = 14 [(gogoproto.jsontag) = "requires_request,omitempty"];
 
   reserved 4;
   reserved "KubeService";
@@ -1785,6 +1976,14 @@ message ListUnifiedResourcesRequest {
   // UsePreviewAsRoles indicates that the response should include all resources
   // the caller would be able to access with their preview_as_roles
   bool UsePreviewAsRoles = 10 [(gogoproto.jsontag) = "use_preview_as_roles,omitempty"];
+  // PinnedOnly indicates that the request will pull only the pinned resources
+  // of the requesting user
+  bool PinnedOnly = 11 [(gogoproto.jsontag) = "pinned_only,omitempty"];
+  // IncludeLogins indicates that the response should include a users allowed logins
+  // for all returned resources.
+  bool IncludeLogins = 12 [(gogoproto.jsontag) = "include_logins,omitempty"];
+  // IncludeRequestable indicates that the response should include resources that the user must request access to.
+  bool IncludeRequestable = 14 [(gogoproto.jsontag) = "include_proto,omitempty"];
 }
 
 // ListUnifiedResourceResponse response of ListUnifiedResources.
@@ -1844,6 +2043,9 @@ message ListResourcesRequest {
   // UsePreviewAsRoles indicates that the response should include all resources
   // the caller would be able to access with their preview_as_roles
   bool UsePreviewAsRoles = 12 [(gogoproto.jsontag) = "use_preview_as_roles,omitempty"];
+  // IncludeLogins indicates that the response should include a users allowed logins
+  // for all returned resources.
+  bool IncludeLogins = 13 [(gogoproto.jsontag) = "include_logins,omitempty"];
 }
 
 // GetSSHTargetsRequest gets all servers that might match an equivalent ssh dial request.
@@ -1986,12 +2188,101 @@ message GetGithubAuthRequestRequest {
   string StateToken = 1 [(gogoproto.jsontag) = "state_token"];
 }
 
+// CreateOIDCConnectorRequest is a request for CreateOIDCConnector.
+message CreateOIDCConnectorRequest {
+  // Connector to be created.
+  types.OIDCConnectorV3 Connector = 1 [(gogoproto.jsontag) = "connector"];
+}
+
+// UpdateOIDCConnectorRequest is a request for UpdateOIDCConnector.
+message UpdateOIDCConnectorRequest {
+  // Connector to be updated.
+  types.OIDCConnectorV3 Connector = 1 [(gogoproto.jsontag) = "connector"];
+}
+
+// UpsertOIDCConnectorRequest is a request for UpsertOIDCConnector.
+message UpsertOIDCConnectorRequest {
+  // Connector to be created or updated.
+  types.OIDCConnectorV3 Connector = 1 [(gogoproto.jsontag) = "connector"];
+}
+
+// CreateSAMLConnectorRequest is a request for CreateSAMLConnector.
+message CreateSAMLConnectorRequest {
+  // Connector to be created.
+  types.SAMLConnectorV2 Connector = 1 [(gogoproto.jsontag) = "connector"];
+}
+
+// UpdateSAMLConnectorRequest is a request for UpdateSAMLConnector.
+message UpdateSAMLConnectorRequest {
+  // Connector to be updated.
+  types.SAMLConnectorV2 Connector = 1 [(gogoproto.jsontag) = "connector"];
+}
+
+// UpsertSAMLConnectorRequest is a request for UpsertSAMLConnector.
+message UpsertSAMLConnectorRequest {
+  // Connector to be created or updated.
+  types.SAMLConnectorV2 Connector = 1 [(gogoproto.jsontag) = "connector"];
+}
+
+// CreateGithubConnectorRequest is a request for CreateGithubConnector.
+message CreateGithubConnectorRequest {
+  // Connector to be created.
+  types.GithubConnectorV3 Connector = 1 [(gogoproto.jsontag) = "connector"];
+}
+
+// UpdateGithubConnectorRequest is a request for UpdateGithubConnector.
+message UpdateGithubConnectorRequest {
+  // Connector to be updated.
+  types.GithubConnectorV3 Connector = 1 [(gogoproto.jsontag) = "connector"];
+}
+
+// UpsertGithubConnectorRequest is a request for UpsertGithubConnector.
+message UpsertGithubConnectorRequest {
+  // Connector to be created or updated.
+  types.GithubConnectorV3 Connector = 1 [(gogoproto.jsontag) = "connector"];
+}
+
 // GetSSODiagnosticInfoRequest is a request for GetSSODiagnosticInfo.
 message GetSSODiagnosticInfoRequest {
   // AuthRequestKind is the SSO Auth Request kind (oidc, saml, or github).
   string AuthRequestKind = 1 [(gogoproto.jsontag) = "auth_request_kind"];
   // AuthRequestID is the SSO Auth Request id or state token.
   string AuthRequestID = 2 [(gogoproto.jsontag) = "auth_request_id"];
+}
+
+// SystemRoleAssertion is used by agents to prove that they have a given system role when their
+// credentials originate from multiple separate join tokens so that they can be issued an
+// instance certificate that encompasses all of their capabilities. This type will be
+// deprecated once we have a more comprehensive model for join token joining/replacement.
+message SystemRoleAssertion {
+  // ServerID is the server ID of the instance that the assertion is for. Assertions are
+  // only accepted if the calling agent's certificate matches this server id.
+  string ServerID = 1 [(gogoproto.jsontag) = "server_id,omitempty"];
+  // AssertionID is a random UUID that uniquely identifies a set of assertions
+  // as originating from the same teleport process.
+  string AssertionID = 2 [(gogoproto.jsontag) = "assertion_id,omitempty"];
+  // SystemRole is the system role being asserted. Assertions are only accepted if
+  // the calling agent's certificate authorizes it for this system role.
+  string SystemRole = 3 [
+    (gogoproto.jsontag) = "system_role,omitempty",
+    (gogoproto.casttype) = "github.com/gravitational/teleport/api/types.SystemRole"
+  ];
+}
+
+// SystemRoleAssertionSet is an aggregate generated as a result of one or more successful
+// assertions. This type will be deprecated once we have a more comprehensive model for
+// join token joining/replacement.
+message SystemRoleAssertionSet {
+  // ServerID is the server ID of the agent that generated the assertions.
+  string ServerID = 1 [(gogoproto.jsontag) = "server_id,omitempty"];
+  // AssertionID is a random UUID that identified all constituent assertions as originating
+  // from the same teleport process.
+  string AssertionID = 2 [(gogoproto.jsontag) = "assertion_id,omitempty"];
+  // SystemRoles is the set of system roles that the agent has successfully asserted.
+  repeated string SystemRoles = 3 [
+    (gogoproto.jsontag) = "system_roles,omitempty",
+    (gogoproto.casttype) = "github.com/gravitational/teleport/api/types.SystemRole"
+  ];
 }
 
 // UpstreamInventoryOneOf is the upstream message for the inventory control stream,
@@ -2006,6 +2297,8 @@ message UpstreamInventoryOneOf {
     UpstreamInventoryPong Pong = 3;
     // UpstreamInventoryAgentMetadata advertises instance metadata.
     UpstreamInventoryAgentMetadata AgentMetadata = 4;
+    // UpstreamInventoryGoodbye advertises that the instance is terminating.
+    UpstreamInventoryGoodbye Goodbye = 5;
   }
 }
 
@@ -2054,6 +2347,8 @@ message UpstreamInventoryHello {
   // ExternalUpgrader identifies the external upgrader that the instance is configured to
   // export schedules to (e.g. 'kube'). Empty if no upgrader is defined.
   string ExternalUpgrader = 5;
+  // ExternalUpgraderVersion identifies the external upgrader version. Empty if no upgrader is defined.
+  string ExternalUpgraderVersion = 6;
 }
 
 // UpstreamInventoryAgentMetadata is the message sent up the inventory control stream containing
@@ -2084,6 +2379,51 @@ message DownstreamInventoryHello {
   string Version = 1;
   // ServerID advertises the server ID of the auth server.
   string ServerID = 2;
+
+  // SupportedCapabilities indicate which features of the ICS that
+  // the connect auth server supports. This allows agents to determine
+  // how they should interact with the auth server to maintain compatibility.
+  message SupportedCapabilities {
+    // ProxyHeartbeats indicates the ICS supports heartbeating proxy servers.
+    bool ProxyHeartbeats = 1;
+    // ProxyCleanup indicates the ICS supports deleting proxies when UpstreamInventoryGoodbye.DeleteResources is set.
+    bool ProxyCleanup = 2;
+    // ProxyHeartbeats indicates the ICS supports heartbeating proxy servers.
+    bool AuthHeartbeats = 3;
+    // ProxyCleanup indicates the ICS supports deleting proxies when UpstreamInventoryGoodbye.DeleteResources is set.
+    bool AuthCleanup = 4;
+    // NodeHeartbeats indicates the ICS supports heartbeating ssh servers.
+    bool NodeHeartbeats = 5;
+    // NodeCleanup indicates the ICS supports deleting nodes when UpstreamInventoryGoodbye.DeleteResources is set.
+    bool NodeCleanup = 6;
+    // AppHeartbeats indicates the ICS supports heartbeating app servers.
+    bool AppHeartbeats = 7;
+    // AppCleanup indicates the ICS supports deleting apps when UpstreamInventoryGoodbye.DeleteResources is set.
+    bool AppCleanup = 8;
+    // DatabaseHeartbeats indicates the ICS supports heartbeating databases.
+    bool DatabaseHeartbeats = 9;
+    // DatabaseCleanup indicates the ICS supports deleting databases when UpstreamInventoryGoodbye.DeleteResources is set.
+    bool DatabaseCleanup = 10;
+    // DatabaseServiceHeartbeats indicates the ICS supports heartbeating databse services.
+    bool DatabaseServiceHeartbeats = 11;
+    // DatabaseServiceCleanup indicates the ICS supports deleting database services when UpstreamInventoryGoodbye.DeleteResources is set.
+    bool DatabaseServiceCleanup = 12;
+    // WindowsDesktopHeartbeats indicates the ICS supports heartbeating windows desktop servers.
+    bool WindowsDesktopHeartbeats = 13;
+    // WindowsDesktopCleanup indicates the ICS supports deleting windows desktops when UpstreamInventoryGoodbye.DeleteResources is set.
+    bool WindowsDesktopCleanup = 14;
+    // WindowsDesktopHeartbeats indicates the ICS supports heartbeating windows desktop services.
+    bool WindowsDesktopServiceHeartbeats = 15;
+    // WindowsDesktopCleanup indicates the ICS supports deleting windows desktop services when UpstreamInventoryGoodbye.DeleteResources is set.
+    bool WindowsDesktopServiceCleanup = 16;
+    // KubernetesHeartbeats indicates the ICS supports heartbeating kubernetes clusters.
+    bool KubernetesHeartbeats = 17;
+    // KubernetesCleanup indicates the ICS supports deleting kubernetes clusters when UpstreamInventoryGoodbye.DeleteResources is set.
+    bool KubernetesCleanup = 18;
+  }
+
+  // SupportedCapabilities advertises the supported features of the auth server.
+  SupportedCapabilities Capabilities = 3;
 }
 
 // LabelUpdateKind is the type of service to update labels for.
@@ -2122,6 +2462,16 @@ message InventoryHeartbeat {
   // we should be able to cut down on network usage fairly significantly by moving static values
   // to the hello message and only heartbeating dynamic values here).
   types.ServerV2 SSHServer = 1;
+  // AppServer is a complete app server spec to be heartbeated.
+  types.AppServerV3 AppServer = 2;
+}
+
+// UpstreamInventoryGoodbye informs the upstream service that instance
+// is terminating
+message UpstreamInventoryGoodbye {
+  // DeleteResources indicates that any heartbeats received from
+  // the instance should be terminated when the stream is closed.
+  bool DeleteResources = 1;
 }
 
 // InventoryStatusRequest requests inventory status info.
@@ -2301,6 +2651,66 @@ message ExportUpgradeWindowsResponse {
   string SystemdUnitSchedule = 3;
 }
 
+// AccessRequestSort determines access request sort index.
+enum AccessRequestSort {
+  // DEFAULT sorts access requests by their native backend index. this is currently equivalent
+  // to sorting by request ID, but that is subject to change.
+  DEFAULT = 0;
+
+  // CREATED sorts access requests by creation time (this is the sort index typically used in
+  // user interfaces since most users are looking for recently-created requests).
+  CREATED = 1;
+
+  // STATE sorts access requests by their state (PENDING, APPROVED, etc).
+  STATE = 2;
+
+  // USER sorts access requests by their creator's teleport username
+  USER = 3;
+}
+
+// ListAccessRequestsRequest encodes the parameters for a paginated access request lookup.
+message ListAccessRequestsRequest {
+  // Filter matches access requests.
+  types.AccessRequestFilter Filter = 1;
+
+  // Sort determines the sort order of returned access requests.
+  AccessRequestSort Sort = 2;
+
+  // Descending requests descending sort order if true (teleport APIs generally always
+  // defaults to ascending sort order since that is the native sort order used in the
+  // teleport backend).
+  bool Descending = 3;
+
+  // Limit is the maximum amount of requests per page.
+  int32 Limit = 4;
+
+  // StartKey is used to resume a query in order to enable pagination.
+  // If the previous response had NextKey set then this should be
+  // set to its value. Otherwise leave empty.
+  string StartKey = 5;
+}
+
+// ListAccessRequestsResponse is a page of access requests.
+message ListAccessRequestsResponse {
+  // AccessRequests is a page of access requests.
+  repeated types.AccessRequestV3 AccessRequests = 1;
+
+  // NextKey will serve as the StartKey for the next page of requests.
+  string NextKey = 2;
+}
+
+// AccessRequestAllowedPromotionRequest is the request to AccessRequestAllowedPromotion RPC call.
+message AccessRequestAllowedPromotionRequest {
+  // AccessRequest is the access request to get promotions for.
+  string accessRequestID = 1;
+}
+
+// AccessRequestAllowedPromotionResponse is the response to AccessRequestAllowedPromotion RPC call.
+message AccessRequestAllowedPromotionResponse {
+  // allowedPromotions is the list of allowed promotions for the access request.
+  types.AccessRequestAllowedPromotions allowedPromotions = 1;
+}
+
 // AuthService is authentication/authorization service implementation
 service AuthService {
   // InventoryControlStream is the per-instance stream used to advertise teleport instance
@@ -2374,9 +2784,10 @@ service AuthService {
   rpc GenerateUserCerts(UserCertsRequest) returns (Certs);
   // GenerateHostCerts generates a set of host certificates.
   rpc GenerateHostCerts(HostCertsRequest) returns (Certs);
-  // GenerateUserSingleUseCerts generates a set of single-use user
-  // certificates.
-  rpc GenerateUserSingleUseCerts(stream UserSingleUseCertsRequest) returns (stream UserSingleUseCertsResponse);
+  // Deprecated: Superseded by GenerateUserCerts.
+  rpc GenerateUserSingleUseCerts(stream UserSingleUseCertsRequest) returns (stream UserSingleUseCertsResponse) {
+    option deprecated = true;
+  }
   // GenerateOpenSSHCert signs a SSH certificate that can be used
   // to connect to Agentless nodes.
   rpc GenerateOpenSSHCert(OpenSSHCertRequest) returns (OpenSSHCert);
@@ -2386,6 +2797,10 @@ service AuthService {
 
   // GetAccessRequestsV2 gets all pending access requests.
   rpc GetAccessRequestsV2(types.AccessRequestFilter) returns (stream types.AccessRequestV3);
+
+  // ListAccessRequests gets access requests with pagination and sorting.
+  rpc ListAccessRequests(ListAccessRequestsRequest) returns (ListAccessRequestsResponse);
+
   // CreateAccessRequest creates a new access request.
   // Deprecated: use CreateAccessRequestV2 instead.
   // DELETE IN v15.0.0.
@@ -2398,8 +2813,11 @@ service AuthService {
   rpc SetAccessRequestState(RequestStateSetter) returns (google.protobuf.Empty);
   // SubmitAccessReview applies a review to a request and returns the post-application state.
   rpc SubmitAccessReview(types.AccessReviewSubmission) returns (types.AccessRequestV3);
-  // GetAccessCapabilities requests the access capabilites of a user.
+  // GetAccessCapabilities requests the access capabilities of a user.
   rpc GetAccessCapabilities(types.AccessCapabilitiesRequest) returns (types.AccessCapabilities);
+
+  // GetAccessRequestAllowedPromotions returns a list of allowed promotions from an access request to an access list.
+  rpc GetAccessRequestAllowedPromotions(AccessRequestAllowedPromotionRequest) returns (AccessRequestAllowedPromotionResponse);
 
   // GetPluginData gets all plugin data matching the supplied filter.
   rpc GetPluginData(types.PluginDataFilter) returns (PluginDataSeq);
@@ -2414,31 +2832,52 @@ service AuthService {
   rpc GetResetPasswordToken(GetResetPasswordTokenRequest) returns (types.UserTokenV3);
   // CreateResetPasswordToken resets users current password and second factors and creates a reset
   // password token.
+  //
+  // Only local users may be reset.
   rpc CreateResetPasswordToken(CreateResetPasswordTokenRequest) returns (types.UserTokenV3);
 
-  // CreateBot creates a new bot user.
-  rpc CreateBot(CreateBotRequest) returns (CreateBotResponse);
-  // DeleteBot deletes a bot user.
-  rpc DeleteBot(DeleteBotRequest) returns (google.protobuf.Empty);
-  // GetBotUsers gets all users with bot labels.
-  rpc GetBotUsers(GetBotUsersRequest) returns (stream types.UserV2);
-
   // GetUser gets a user resource by name.
-  rpc GetUser(GetUserRequest) returns (types.UserV2);
+  //
+  // Deprecated: Use [teleport.users.v1.UsersService] instead.
+  rpc GetUser(GetUserRequest) returns (types.UserV2) {
+    option deprecated = true;
+  }
   // GetCurrentUser returns current user as seen by the server.
   // Useful especially in the context of remote clusters which perform role and trait mapping.
-  rpc GetCurrentUser(google.protobuf.Empty) returns (types.UserV2);
+  //
+  // Deprecated: Use [teleport.users.v1.UsersService] instead.
+  rpc GetCurrentUser(google.protobuf.Empty) returns (types.UserV2) {
+    option deprecated = true;
+  }
   // GetCurrentUserRoles returns current user's roles.
   rpc GetCurrentUserRoles(google.protobuf.Empty) returns (stream types.RoleV6);
   // GetUsers gets all current user resources.
-  rpc GetUsers(GetUsersRequest) returns (stream types.UserV2);
+  //
+  // Deprecated: Use [teleport.users.v1.UsersService] instead.
+  rpc GetUsers(GetUsersRequest) returns (stream types.UserV2) {
+    option deprecated = true;
+  }
   // CreateUser inserts a new user entry to a backend.
-  rpc CreateUser(types.UserV2) returns (google.protobuf.Empty);
+  //
+  // Deprecated: Use [teleport.users.v1.UsersService] instead.
+  rpc CreateUser(types.UserV2) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
   // UpdateUser updates an existing user in a backend.
-  rpc UpdateUser(types.UserV2) returns (google.protobuf.Empty);
+  //
+  // Deprecated: Use [teleport.users.v1.UsersService] instead.
+  rpc UpdateUser(types.UserV2) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
   // DeleteUser deletes an existing user in a backend by username.
-  rpc DeleteUser(DeleteUserRequest) returns (google.protobuf.Empty);
+  //
+  // Deprecated: Use [teleport.users.v1.UsersService] instead.
+  rpc DeleteUser(DeleteUserRequest) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
   // ChangePassword allows a user to change their own password.
+  //
+  // Only local users may change their password.
   rpc ChangePassword(ChangePasswordRequest) returns (google.protobuf.Empty);
 
   // AcquireSemaphore acquires lease with requested resources from semaphore.
@@ -2494,17 +2933,29 @@ service AuthService {
   rpc DeleteAllSnowflakeSessions(google.protobuf.Empty) returns (google.protobuf.Empty);
 
   // CreateSAMLIdPSession creates web session with sub kind saml_idp used by the SAML IdP.
-  rpc CreateSAMLIdPSession(CreateSAMLIdPSessionRequest) returns (CreateSAMLIdPSessionResponse);
+  rpc CreateSAMLIdPSession(CreateSAMLIdPSessionRequest) returns (CreateSAMLIdPSessionResponse) {
+    option deprecated = true;
+  }
   // GetSAMLIdPSession returns a SAML IdP session with sub kind saml_idp.
-  rpc GetSAMLIdPSession(GetSAMLIdPSessionRequest) returns (GetSAMLIdPSessionResponse);
+  rpc GetSAMLIdPSession(GetSAMLIdPSessionRequest) returns (GetSAMLIdPSessionResponse) {
+    option deprecated = true;
+  }
   // ListSAMLIdPSessions gets all SAML IdP sessions.
-  rpc ListSAMLIdPSessions(ListSAMLIdPSessionsRequest) returns (ListSAMLIdPSessionsResponse);
+  rpc ListSAMLIdPSessions(ListSAMLIdPSessionsRequest) returns (ListSAMLIdPSessionsResponse) {
+    option deprecated = true;
+  }
   // DeleteSAMLIdPSession removes a SAML IdP session.
-  rpc DeleteSAMLIdPSession(DeleteSAMLIdPSessionRequest) returns (google.protobuf.Empty);
+  rpc DeleteSAMLIdPSession(DeleteSAMLIdPSessionRequest) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
   // DeleteAllSAMLIdPSessions removes all SAML IdP sessions.
-  rpc DeleteAllSAMLIdPSessions(google.protobuf.Empty) returns (google.protobuf.Empty);
+  rpc DeleteAllSAMLIdPSessions(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
   // DeleteUserSAMLIdPSessions deletes all user’s SAML IdP sessions.
-  rpc DeleteUserSAMLIdPSessions(DeleteUserSAMLIdPSessionsRequest) returns (google.protobuf.Empty);
+  rpc DeleteUserSAMLIdPSessions(DeleteUserSAMLIdPSessionsRequest) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
 
   // GetWebSession gets a web session.
   rpc GetWebSession(types.GetWebSessionRequest) returns (GetWebSessionResponse);
@@ -2562,9 +3013,23 @@ service AuthService {
   // GetRole retrieves a role described by the given request.
   rpc GetRole(GetRoleRequest) returns (types.RoleV6);
   // GetRole retrieves all roles.
+  //
+  // DELETE IN 17.0
   rpc GetRoles(google.protobuf.Empty) returns (GetRolesResponse);
+  // ListRoles is a paginated role getter.
+  rpc ListRoles(ListRolesRequest) returns (ListRolesResponse);
+  // CreateRole creates a new role.
+  rpc CreateRole(CreateRoleRequest) returns (types.RoleV6);
+  // UpdateRole updates an existing role.
+  rpc UpdateRole(UpdateRoleRequest) returns (types.RoleV6);
+  // UpsertRoleV2 creates or overwrites an existing role.
+  rpc UpsertRoleV2(UpsertRoleRequest) returns (types.RoleV6);
   // UpsertRole upserts a role in a backend.
-  rpc UpsertRole(types.RoleV6) returns (google.protobuf.Empty);
+  //
+  // Deprecated: use UpsertRoleV2 instead.
+  rpc UpsertRole(types.RoleV6) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
   // DeleteRole deletes an existing role in a backend described by the given request.
   rpc DeleteRole(DeleteRoleRequest) returns (google.protobuf.Empty);
 
@@ -2578,7 +3043,11 @@ service AuthService {
   // <- NewMFARegisterChallenge
   // -> NewMFARegisterResponse
   // <- Ack
-  rpc AddMFADevice(stream AddMFADeviceRequest) returns (stream AddMFADeviceResponse);
+  //
+  // Deprecated: Use [AddMFADeviceSync] instead.
+  rpc AddMFADevice(stream AddMFADeviceRequest) returns (stream AddMFADeviceResponse) {
+    option deprecated = true;
+  }
   // DeleteMFADevice deletes an MFA device for the user calling this RPC.
   //
   // The RPC is streaming both ways and the message sequence is:
@@ -2587,10 +3056,29 @@ service AuthService {
   // <- MFAChallenge
   // -> MFAResponse
   // <- Ack
-  rpc DeleteMFADevice(stream DeleteMFADeviceRequest) returns (stream DeleteMFADeviceResponse);
-  // AddMFADeviceSync adds a new MFA device (nonstream).
+  //
+  // Deprecated: Use [DeleteMFADeviceSync] instead.
+  rpc DeleteMFADevice(stream DeleteMFADeviceRequest) returns (stream DeleteMFADeviceResponse) {
+    option deprecated = true;
+  }
+  // AddMFADeviceSync adds a new MFA device.
+  //
+  // A typical MFA registration sequence calls the following RPCs:
+  //
+  // 1. CreateAuthenticateChallenge (necessary for registration challenge)
+  // 2. (optional) CreatePrivilegeToken
+  // 3. CreateRegisterChallenge (uses authn challenge and optionally a token)
+  // 4. AddMFADeviceSync
   rpc AddMFADeviceSync(AddMFADeviceSyncRequest) returns (AddMFADeviceSyncResponse);
   // DeleteMFADeviceSync deletes a users MFA device (nonstream).
+  //
+  // A typical MFA deletion sequence calls the following RPCs:
+  //
+  // 1. (optional) CreateAuthenticateChallenge
+  //    (may be skipped depending on the token used, but is usually called
+  //    regardless)
+  // 2. (optional) CreatePrivilegeToken
+  // 3. DeleteMFADeviceSync (using either authn challenge or token)
   rpc DeleteMFADeviceSync(DeleteMFADeviceSyncRequest) returns (google.protobuf.Empty);
   // GetMFADevices returns all MFA devices registered for the user calling
   // this RPC.
@@ -2605,8 +3093,18 @@ service AuthService {
   rpc GetOIDCConnector(types.ResourceWithSecretsRequest) returns (types.OIDCConnectorV3);
   // GetOIDCConnectors gets all current OIDC connector resources.
   rpc GetOIDCConnectors(types.ResourcesWithSecretsRequest) returns (types.OIDCConnectorV3List);
+  // UpsertOIDCConnector creates a new OIDC connector in the backend.
+  rpc CreateOIDCConnector(CreateOIDCConnectorRequest) returns (types.OIDCConnectorV3);
+  // UpsertOIDCConnector updates an existing OIDC connector in the backend.
+  rpc UpdateOIDCConnector(UpdateOIDCConnectorRequest) returns (types.OIDCConnectorV3);
   // UpsertOIDCConnector upserts an OIDC connector in a backend.
-  rpc UpsertOIDCConnector(types.OIDCConnectorV3) returns (google.protobuf.Empty);
+  //
+  // Deprecated: Use UpsertOIDCConnectorV2 instead.
+  rpc UpsertOIDCConnector(types.OIDCConnectorV3) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
+  // UpsertOIDCConnectorV2 upserts an OIDC connector in the backend.
+  rpc UpsertOIDCConnectorV2(UpsertOIDCConnectorRequest) returns (types.OIDCConnectorV3);
   // DeleteOIDCConnector deletes an existing OIDC connector in a backend by name.
   rpc DeleteOIDCConnector(types.ResourceRequest) returns (google.protobuf.Empty);
   // CreateOIDCAuthRequest creates OIDCAuthRequest.
@@ -2618,8 +3116,18 @@ service AuthService {
   rpc GetSAMLConnector(types.ResourceWithSecretsRequest) returns (types.SAMLConnectorV2);
   // GetSAMLConnectors gets all current SAML connector resources.
   rpc GetSAMLConnectors(types.ResourcesWithSecretsRequest) returns (types.SAMLConnectorV2List);
+  // CreateSAMLConnector creates a new SAML connector in the backend.
+  rpc CreateSAMLConnector(CreateSAMLConnectorRequest) returns (types.SAMLConnectorV2);
+  // UpdateSAMLConnector updates an existing SAML connector in the backend.
+  rpc UpdateSAMLConnector(UpdateSAMLConnectorRequest) returns (types.SAMLConnectorV2);
   // UpsertSAMLConnector upserts a SAML connector in a backend.
-  rpc UpsertSAMLConnector(types.SAMLConnectorV2) returns (google.protobuf.Empty);
+  //
+  // Deprecated: Use UpsertSAMLConnectorV2 instead.
+  rpc UpsertSAMLConnector(types.SAMLConnectorV2) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
+  // UpsertSAMLConnectorV2 upserts a SAML connector in a backend.
+  rpc UpsertSAMLConnectorV2(UpsertSAMLConnectorRequest) returns (types.SAMLConnectorV2);
   // DeleteSAMLConnector deletes an existing SAML connector in a backend by name.
   rpc DeleteSAMLConnector(types.ResourceRequest) returns (google.protobuf.Empty);
   // CreateSAMLAuthRequest creates SAMLAuthRequest.
@@ -2631,8 +3139,18 @@ service AuthService {
   rpc GetGithubConnector(types.ResourceWithSecretsRequest) returns (types.GithubConnectorV3);
   // GetGithubConnectors gets all current Github connector resources.
   rpc GetGithubConnectors(types.ResourcesWithSecretsRequest) returns (types.GithubConnectorV3List);
+  // CreateGithubConnector creates a new Github connector in the backend.
+  rpc CreateGithubConnector(CreateGithubConnectorRequest) returns (types.GithubConnectorV3);
+  // UpdateGithubConnector updates an existing Github connector in the backend.
+  rpc UpdateGithubConnector(UpdateGithubConnectorRequest) returns (types.GithubConnectorV3);
   // UpsertGithubConnector upserts a Github connector in a backend.
-  rpc UpsertGithubConnector(types.GithubConnectorV3) returns (google.protobuf.Empty);
+  //
+  // Deprecated: Use UpsertGithubConnectorV2 instead.
+  rpc UpsertGithubConnector(types.GithubConnectorV3) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
+  // UpsertGithubConnectorV2 upserts a Github connector in a backend.
+  rpc UpsertGithubConnectorV2(UpsertGithubConnectorRequest) returns (types.GithubConnectorV3);
   // DeleteGithubConnector deletes an existing Github connector in a backend by name.
   rpc DeleteGithubConnector(types.ResourceRequest) returns (google.protobuf.Empty);
   // CreateGithubAuthRequest creates GithubAuthRequest.
@@ -2678,25 +3196,52 @@ service AuthService {
   rpc GetClusterAuditConfig(google.protobuf.Empty) returns (types.ClusterAuditConfigV2);
 
   // GetClusterNetworkingConfig gets cluster networking configuration.
-  rpc GetClusterNetworkingConfig(google.protobuf.Empty) returns (types.ClusterNetworkingConfigV2);
+  // Deprecated: Use clusterconfigv1.Service.GetClusterNetworkingConfig instead.
+  rpc GetClusterNetworkingConfig(google.protobuf.Empty) returns (types.ClusterNetworkingConfigV2) {
+    option deprecated = true;
+  }
   // SetClusterNetworkingConfig sets cluster networking configuration.
-  rpc SetClusterNetworkingConfig(types.ClusterNetworkingConfigV2) returns (google.protobuf.Empty);
+  // Deprecated: Use clusterconfigv1.Service.Update/UpsertClusterNetworkingConfig instead.
+  rpc SetClusterNetworkingConfig(types.ClusterNetworkingConfigV2) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
   // ResetClusterNetworkingConfig resets cluster networking configuration to defaults.
-  rpc ResetClusterNetworkingConfig(google.protobuf.Empty) returns (google.protobuf.Empty);
+  // Deprecated: Use clusterconfigv1.Service.ResetClusterNetworkingConfig instead.
+  rpc ResetClusterNetworkingConfig(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
 
   // GetSessionRecordingConfig gets session recording configuration.
-  rpc GetSessionRecordingConfig(google.protobuf.Empty) returns (types.SessionRecordingConfigV2);
+  // Deprecated: Use clusterconfigv1.Service.GetSessionRecordingConfig instead.
+  rpc GetSessionRecordingConfig(google.protobuf.Empty) returns (types.SessionRecordingConfigV2) {
+    option deprecated = true;
+  }
   // SetSessionRecordingConfig sets session recording configuration.
-  rpc SetSessionRecordingConfig(types.SessionRecordingConfigV2) returns (google.protobuf.Empty);
+  // Deprecated: Use clusterconfigv1.Service.Upsert/UpdateSessionRecordingConfig instead.
+  rpc SetSessionRecordingConfig(types.SessionRecordingConfigV2) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
   // ResetSessionRecordingConfig resets session recording configuration to defaults.
-  rpc ResetSessionRecordingConfig(google.protobuf.Empty) returns (google.protobuf.Empty);
+  // Deprecated: Use clusterconfigv1.Service.ResetSessionRecordingConfig instead.
+  rpc ResetSessionRecordingConfig(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
 
   // GetAuthPreference gets cluster auth preference.
-  rpc GetAuthPreference(google.protobuf.Empty) returns (types.AuthPreferenceV2);
+  // Deprecated: Use clusterconfigv1.Service.GetAuthPreference instead.
+  rpc GetAuthPreference(google.protobuf.Empty) returns (types.AuthPreferenceV2) {
+    option deprecated = true;
+  }
   // SetAuthPreference sets cluster auth preference.
-  rpc SetAuthPreference(types.AuthPreferenceV2) returns (google.protobuf.Empty);
+  // Deprecated: Use clusterconfigv1.Service.Create/Update/UpsertAuthPreference instead.
+  rpc SetAuthPreference(types.AuthPreferenceV2) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
   // ResetAuthPreference resets cluster auth preference to defaults.
-  rpc ResetAuthPreference(google.protobuf.Empty) returns (google.protobuf.Empty);
+  // Deprecated: Use clusterconfigv1.Service.ResetAuthPreference instead.
+  rpc ResetAuthPreference(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
 
   // GetUIConfig gets the configuration for the UI served by the proxy service
   rpc GetUIConfig(google.protobuf.Empty) returns (types.UIConfigV1);
@@ -2800,6 +3345,8 @@ service AuthService {
   rpc GenerateWindowsDesktopCert(WindowsDesktopCertRequest) returns (WindowsDesktopCertResponse);
   // GenerateCertAuthorityCRL creates an empty CRL for the specified CA.
   rpc GenerateCertAuthorityCRL(CertAuthorityRequest) returns (CRL);
+  // GetDesktopBootstrapScript returns a PowerShell script to bootstrap Active Directory.
+  rpc GetDesktopBootstrapScript(google.protobuf.Empty) returns (DesktopBootstrapScriptResponse);
 
   // CreateConnectionDiagnostic creates a new connection diagnostic.
   rpc CreateConnectionDiagnostic(types.ConnectionDiagnosticV1) returns (google.protobuf.Empty);
@@ -2814,6 +3361,8 @@ service AuthService {
   // also adds a new MFA device. After successful invocation, a new web session is created as well
   // as a new set of recovery codes (if user meets the requirements to receive them), invalidating
   // any existing codes the user previously had.
+  //
+  // Only local users may be targeted by this RPC.
   rpc ChangeUserAuthentication(ChangeUserAuthenticationRequest) returns (ChangeUserAuthenticationResponse);
 
   // StartAccountRecovery (exclusive to cloud users) is the first out of two step user
@@ -2827,6 +3376,8 @@ service AuthService {
   // user account gets temporarily locked from further recovery attempts and from logging in.
   //
   // Start tokens last RecoveryStartTokenTTL.
+  //
+  // Only local users may perform account recovery
   rpc StartAccountRecovery(StartAccountRecoveryRequest) returns (types.UserTokenV3);
   // VerifyAccountRecovery (exclusive to cloud users) is the second step of the two step
   // verification needed to allow a user to recover their account, after RPC StartAccountRecovery.
@@ -2907,6 +3458,12 @@ service AuthService {
   // without signing keys. If the cluster has multiple TLS certs, they will
   // all be appended.
   rpc GetClusterCACert(google.protobuf.Empty) returns (GetClusterCACertResponse);
+
+  // AssertSystemRole is used by agents to prove that they have a given system role when their
+  // credentials originate from multiple separate join tokens so that they can be issued an instance
+  // certificate that encompasses all of their capabilities. This method will be deprecated once we
+  // have a more comprehensive model for join token joining/replacement.
+  rpc AssertSystemRole(SystemRoleAssertion) returns (google.protobuf.Empty);
 
   // SubmitUsageEvent submits an external usage event.
   rpc SubmitUsageEvent(SubmitUsageEventRequest) returns (google.protobuf.Empty);

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/client/proto/certs.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/client/proto/certs.proto
@@ -1,20 +1,16 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 
@@ -29,9 +25,9 @@ option (gogoproto.unmarshaler_all) = true;
 
 // Set of certificates corresponding to a single public key.
 message Certs {
-  // SSH X509 cert (PEM-encoded).
+  // SSH certificate marshaled in the authorized key format.
   bytes SSH = 1 [(gogoproto.jsontag) = "ssh,omitempty"];
-  // TLS X509 cert (PEM-encoded).
+  // TLS X.509 certificate (PEM-encoded).
   bytes TLS = 2 [(gogoproto.jsontag) = "tls,omitempty"];
   // TLSCACerts is a list of TLS certificate authorities.
   repeated bytes TLSCACerts = 3 [(gogoproto.jsontag) = "tls_ca_certs,omitempty"];

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/client/proto/event.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/client/proto/event.proto
@@ -1,28 +1,35 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 
 package proto;
 
 import "teleport/accesslist/v1/accesslist.proto";
+import "teleport/accessmonitoringrules/v1/access_monitoring_rules.proto";
+import "teleport/clusterconfig/v1/access_graph_settings.proto";
+import "teleport/crownjewel/v1/crownjewel.proto";
+import "teleport/dbobject/v1/dbobject.proto";
+import "teleport/discoveryconfig/v1/discoveryconfig.proto";
+import "teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto";
 import "teleport/legacy/types/types.proto";
+import "teleport/machineid/v1/bot_instance.proto";
+import "teleport/machineid/v1/federation.proto";
+import "teleport/notifications/v1/notifications.proto";
+import "teleport/secreports/v1/secreports.proto";
 import "teleport/userloginstate/v1/userloginstate.proto";
+import "teleport/userprovisioning/v1/statichostuser.proto";
 
 option go_package = "github.com/gravitational/teleport/api/client/proto";
 
@@ -40,6 +47,8 @@ enum Operation {
 // Event returns cluster event
 message Event {
   reserved 7;
+  reserved 49;
+  reserved "ExternalCloudAudit";
 
   // Operation identifies operation
   Operation Type = 1;
@@ -137,5 +146,36 @@ message Event {
     teleport.userloginstate.v1.UserLoginState UserLoginState = 46;
     // AccessListMember is an access list member resource.
     teleport.accesslist.v1.Member AccessListMember = 47;
+    // DiscoveryConfig contains a list of matchers to be loaded dynamically by Discovery Services.
+    teleport.discoveryconfig.v1.DiscoveryConfig DiscoveryConfig = 48;
+    // AuditQuery is an audit query resource.
+    teleport.secreports.v1.AuditQuery AuditQuery = 50;
+    // SecurityReport is a security report resource.
+    teleport.secreports.v1.Report Report = 51;
+    // SecurityReportState is a security report state resource.
+    teleport.secreports.v1.ReportState ReportState = 52;
+    // AccessListReview is an access list review resource.
+    teleport.accesslist.v1.Review AccessListReview = 53;
+    // AccessMonitoringRule is an access monitoring rule resource.
+    teleport.accessmonitoringrules.v1.AccessMonitoringRule AccessMonitoringRule = 54;
+    // KubernetesWaitingContainer is a Kubernetes ephemeral container
+    // waiting to be created.
+    teleport.kubewaitingcontainer.v1.KubernetesWaitingContainer KubernetesWaitingContainer = 55;
+    // UserNotification is a user notification resource.
+    teleport.notifications.v1.Notification UserNotification = 56;
+    // GlobalNotification is a global notification resource.
+    teleport.notifications.v1.GlobalNotification GlobalNotification = 57;
+    // CrownJewel is a Crown Jewel resource.
+    teleport.crownjewel.v1.CrownJewel CrownJewel = 58;
+    // DatabaseObject is a database object resource.
+    teleport.dbobject.v1.DatabaseObject DatabaseObject = 59;
+    // BotInstance is a Machine ID bot instance.
+    teleport.machineid.v1.BotInstance BotInstance = 60;
+    // AccessGraphSettings is a resource for access graph settings.
+    teleport.clusterconfig.v1.AccessGraphSettings AccessGraphSettings = 61;
+    // SPIFFEFederation is a resource for SPIFFE federation.
+    teleport.machineid.v1.SPIFFEFederation SPIFFEFederation = 62;
+    // StaticHostUser is a resource for static host users.
+    teleport.userprovisioning.v1.StaticHostUser StaticHostUser = 63;
   }
 }

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/client/proto/joinservice.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/client/proto/joinservice.proto
@@ -1,20 +1,16 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 
@@ -71,6 +67,96 @@ message RegisterUsingAzureMethodResponse {
   Certs certs = 2;
 }
 
+// The enrollment challenge response containing the solution returned by
+// calling the TPM2.0 `ActivateCredential` command on the client with the
+// parameters provided in `TPMEncryptedCredential`.
+message RegisterUsingTPMMethodChallengeResponse {
+  // The client's solution to `TPMEncryptedCredential` included in
+  // `TPMEncryptedCredential` using ActivateCredential.
+  bytes solution = 1;
+}
+
+// The initial payload sent from the client to the server during a TPM join
+// request.
+message RegisterUsingTPMMethodInitialRequest {
+  // Holds the registration parameters shared by all join methods.
+  types.RegisterUsingTokenRequest join_request = 1;
+  oneof ek {
+    // The device's endorsement certificate in X509, ASN.1 DER form. This
+    // certificate contains the public key of the endorsement key. This is
+    // preferred to ek_key.
+    bytes ek_cert = 2;
+    // The device's public endorsement key in PKIX, ASN.1 DER form. This is
+    // used when a TPM does not contain any endorsement certificates.
+    bytes ek_key = 3;
+  }
+  // The attestation key and the parameters necessary to remotely verify it as
+  // related to the endorsement key.
+  TPMAttestationParameters attestation_params = 4;
+}
+
+// RegisterUsingTPMMethodRequest is the streaming request type for the
+// RegisterUsingTPMMethod RPC.
+message RegisterUsingTPMMethodRequest {
+  oneof payload {
+    // Initial information sent from the client to the server.
+    RegisterUsingTPMMethodInitialRequest init = 1;
+    // The challenge response required to complete the TPM join process. This is
+    // sent in response to the servers challenge.
+    RegisterUsingTPMMethodChallengeResponse challenge_response = 2;
+  }
+}
+
+// RegisterUsingTPMMethodResponse is the streaming response type for the
+// RegisterUsingTPMMethod RPC.
+message RegisterUsingTPMMethodResponse {
+  oneof payload {
+    // The challenge required to complete the TPM join process. This is sent to
+    // the client in response to the initial request.
+    TPMEncryptedCredential challenge_request = 1;
+    // The signed certificates resulting from the join process.
+    Certs certs = 2;
+  }
+}
+
+// The attestation key and the parameters necessary to remotely verify it as
+// related to the endorsement key.
+// See https://pkg.go.dev/github.com/google/go-attestation/attest#AttestationParameters.
+// This message excludes the `UseTCSDActivationFormat` field from the link above
+// as it is TMP 1.x specific and always false.
+message TPMAttestationParameters {
+  // The encoded TPMT_PUBLIC structure containing the attestation public key
+  // and signing parameters.
+  bytes public = 1;
+  // The properties of the attestation key, encoded as a TPMS_CREATION_DATA
+  // structure.
+  bytes create_data = 2;
+  // An assertion as to the details of the key, encoded as a TPMS_ATTEST
+  // structure.
+  bytes create_attestation = 3;
+  // A signature of create_attestation, encoded as a TPMT_SIGNATURE structure.
+  bytes create_signature = 4;
+}
+
+// These values are used by the TPM2.0 `ActivateCredential` command to produce
+// the solution which proves possession of the EK and AK.
+//
+// For a more in-depth description see:
+// - https://pkg.go.dev/github.com/google/go-attestation/attest#EncryptedCredential
+// - https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_code_pub.pdf (Heading 12.5.1 "TPM2_ActivateCredential" "General Description")
+// - https://github.com/google/go-attestation/blob/v0.4.3/attest/activation.go#L199
+// - https://github.com/google/go-tpm/blob/v0.3.3/tpm2/credactivation/credential_activation.go#L61
+message TPMEncryptedCredential {
+  // The `credential_blob` parameter to be used with the `ActivateCredential`
+  // command. This is used with the decrypted value of `secret` in a
+  // cryptographic process to decrypt the solution.
+  bytes credential_blob = 1;
+  // The `secret` parameter to be used with `ActivateCredential`. This is a
+  // seed which can be decrypted with the EK. The decrypted seed is then used
+  // when decrypting `credential_blob`.
+  bytes secret = 2;
+}
+
 // JoinService provides methods which allow Teleport nodes, proxies, and other
 // services to join the Teleport cluster by fetching signed cluster
 // certificates. It is implemented on both the Auth and Proxy servers to serve
@@ -83,4 +169,7 @@ service JoinService {
   // RegisterUsingAzureMethod is used to register a new node to the cluster
   // using the Azure join method.
   rpc RegisterUsingAzureMethod(stream RegisterUsingAzureMethodRequest) returns (stream RegisterUsingAzureMethodResponse);
+  // RegisterUsingTPMMethod allows registration of a new agent or Bot to the
+  // cluster using a known TPM.
+  rpc RegisterUsingTPMMethod(stream RegisterUsingTPMMethodRequest) returns (stream RegisterUsingTPMMethodResponse);
 }

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/client/proto/proxyservice.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/client/proto/proxyservice.proto
@@ -1,20 +1,16 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/types/device.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/types/device.proto
@@ -1,20 +1,16 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 
@@ -101,6 +97,7 @@ message DeviceCollectedData {
   string system_serial_number = 12 [(gogoproto.jsontag) = "system_serial_number,omitempty"];
   string base_board_serial_number = 13 [(gogoproto.jsontag) = "base_board_serial_number,omitempty"];
   TPMPlatformAttestation tpm_platform_attestation = 14 [(gogoproto.jsontag) = "tpm_platform_attestation,omitempty"];
+  string os_id = 15 [(gogoproto.jsontag) = "os_id,omitempty"];
 }
 
 // TPMPCR is the resource representation of teleport.devicetrust.v1.TPMPCR.
@@ -152,4 +149,5 @@ message DeviceProfile {
   string jamf_binary_version = 6 [(gogoproto.jsontag) = "jamf_binary_version,omitempty"];
   string external_id = 7 [(gogoproto.jsontag) = "external_id,omitempty"];
   string os_build_supplemental = 8 [(gogoproto.jsontag) = "os_build_supplemental,omitempty"];
+  string os_id = 9 [(gogoproto.jsontag) = "os_id,omitempty"];
 }

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/types/events/athena.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/types/events/athena.proto
@@ -1,20 +1,16 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/types/events/events.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/types/events/events.proto
@@ -1,20 +1,16 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 
@@ -63,6 +59,23 @@ message SessionMetadata {
   string SessionID = 1 [(gogoproto.jsontag) = "sid"];
   // WithMFA is a UUID of an MFA device used to start this session.
   string WithMFA = 2 [(gogoproto.jsontag) = "with_mfa,omitempty"];
+  // PrivateKeyPolicy is the private key policy of the private key used to start this session.
+  string PrivateKeyPolicy = 3 [(gogoproto.jsontag) = "private_key_policy,omitempty"];
+}
+
+// The kind of user a given username refers to. Usernames should always refer to
+// a valid cluster user (even if temporary, e.g. SSO), but may be Machine ID
+// bot users.
+enum UserKind {
+  // Indicates a legacy cluster emitting events without a defined user kind.
+  USER_KIND_UNSPECIFIED = 0;
+
+  // Indicates the user associated with this event is human, either created
+  // locally or via SSO.
+  USER_KIND_HUMAN = 1;
+
+  // Indicates the user associated with this event is a Machine ID bot user.
+  USER_KIND_BOT = 2;
 }
 
 // UserMetadata is a common user event metadata
@@ -91,6 +104,20 @@ message UserMetadata {
   // TrustedDevice contains information about the users' trusted device.
   // Requires a registered and enrolled device to be used during authentication.
   DeviceMetadata TrustedDevice = 8 [(gogoproto.jsontag) = "trusted_device,omitempty"];
+
+  // RequiredPrivateKeyPolicy is the private key policy enforced for this login.
+  string RequiredPrivateKeyPolicy = 9 [(gogoproto.jsontag) = "required_private_key_policy,omitempty"];
+
+  // UserKind indicates what type of user this is, e.g. a human or Machine ID
+  // bot user.
+  UserKind UserKind = 10 [(gogoproto.jsontag) = "user_kind,omitempty"];
+
+  // BotName is the name of the Bot if this action is associated with one.
+  string BotName = 11 [(gogoproto.jsontag) = "bot_name,omitempty"];
+
+  // BotInstanceID is the ID of the Bot Instance if this action is associated
+  // with one.
+  string BotInstanceID = 12 [(gogoproto.jsontag) = "bot_instance_id,omitempty"];
 }
 
 // Server is a server metadata
@@ -121,6 +148,9 @@ message ServerMetadata {
 
   // ServerSubKind is the sub kind of the server the session occurred on.
   string ServerSubKind = 7 [(gogoproto.jsontag) = "server_sub_kind,omitempty"];
+
+  // ServerVersion is the component version the session occurred on.
+  string ServerVersion = 8 [(gogoproto.jsontag) = "server_version,omitempty"];
 }
 
 // Connection contains connection info
@@ -177,6 +207,8 @@ message SAMLIdPServiceProviderMetadata {
   string ServiceProviderEntityID = 1 [(gogoproto.jsontag) = "service_provider_entity_id,omitempty"];
   // ServiceProviderShortcut is the shortcut name of a service provider.
   string ServiceProviderShortcut = 2 [(gogoproto.jsontag) = "service_provider_shortcut,omitempty"];
+  // AttributeMapping is a map of attribute name and value which will be asserted in SAML response.
+  map<string, string> AttributeMapping = 3 [(gogoproto.jsontag) = "attribute_mapping,omitempty"];
 }
 
 // OktaResourcesUpdatedMetadata contains common metadata for Okta resources updated events.
@@ -216,6 +248,77 @@ message OktaAssignmentMetadata {
 
   // EndingStatus is the ending status of the assignment.
   string EndingStatus = 4 [(gogoproto.jsontag) = "ending_status,omitempty"];
+}
+
+// AccessListMemberMetadata contains common metadata for access list member resource events.
+message AccessListMemberMetadata {
+  // AccessListName is the name of the access list the members are being added to or removed from.
+  string AccessListName = 1 [(gogoproto.jsontag) = "access_list_name,omitempty"];
+
+  // Members are all members affected by the access list membership change.
+  repeated AccessListMember Members = 2 [(gogoproto.jsontag) = "members,omitempty"];
+}
+
+// AccessListMember is metadata surrounding an individual access list member.
+message AccessListMember {
+  // JoinedOn is the date that the member joined.
+  google.protobuf.Timestamp JoinedOn = 1 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "joined_on,omitempty"
+  ];
+
+  // RemovedOn is the date that the access list member was removed. Will only be populated for deletion.
+  google.protobuf.Timestamp RemovedOn = 2 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "removed_on,omitempty"
+  ];
+
+  // Reason is the reason that the member was added, modified, or removed.
+  string Reason = 3 [(gogoproto.jsontag) = "reason,omitempty"];
+
+  // MemberName is the name of the member.
+  string MemberName = 4 [(gogoproto.jsontag) = "member_name,omitempty"];
+}
+
+// AccessListReviewMembershipRequirementsChanged contains information for when membership requirements change as part of a review.
+message AccessListReviewMembershipRequirementsChanged {
+  // Roles are the roles that changed as part of a review.
+  repeated string Roles = 1 [(gogoproto.jsontag) = "roles,omitempty"];
+
+  // Traits are the traits that changed as part of a review.
+  map<string, string> Traits = 2 [(gogoproto.jsontag) = "traits,omitempty"];
+}
+
+// AccessListReviewMetadata contains metadata for access list review events.
+message AccessListReviewMetadata {
+  // Message is the message that was supplied during the review.
+  string Message = 1 [(gogoproto.jsontag) = "message,omitempty"];
+
+  // ReviewID is the ID of the review.
+  string ReviewID = 2 [(gogoproto.jsontag) = "review_id,omitempty"];
+
+  // MembershipRequirementsChanged is populated if the memrship requirements have changed..
+  AccessListReviewMembershipRequirementsChanged MembershipRequirementsChanged = 3 [(gogoproto.jsontag) = "membership_requirements_changed,omitempty"];
+
+  // ReviewFrequencyChanged is populated if the review frequency has changed.
+  string ReviewFrequencyChanged = 4 [(gogoproto.jsontag) = "review_frequency_changed,omitempty"];
+
+  // ReviewDayOfMonthChanged is populated if the review day of month has changed.
+  string ReviewDayOfMonthChanged = 5 [(gogoproto.jsontag) = "review_day_of_month_changed,omitempty"];
+
+  // RemovedMembers are the members that were removed as part of the review.
+  repeated string RemovedMembers = 6 [(gogoproto.jsontag) = "removed_members,omitempty"];
+}
+
+// LockMetadata contains common metadata for lock resource events.
+message LockMetadata {
+  // Target describes the set of interactions that the lock applies to
+  types.LockTarget Target = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "target"
+  ];
 }
 
 // SessionStart is a session start event
@@ -1147,6 +1250,64 @@ message UserLogin {
   repeated string AppliedLoginRules = 9 [(gogoproto.jsontag) = "applied_login_rules,omitempty"];
 }
 
+// CreateMFAAuthChallenge records the creation of an MFA auth challenge.
+message CreateMFAAuthChallenge {
+  // Metadata is a common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata.
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Scope is the authorization scope for this MFA challenge.
+  // Only applies to WebAuthn challenges.
+  string ChallengeScope = 3 [(gogoproto.jsontag) = "challenge_scope"];
+
+  // ChallengeAllowReuse defines whether the MFA challenge allows reuse.
+  bool ChallengeAllowReuse = 4 [(gogoproto.jsontag) = "challenge_allow_reuse"];
+}
+
+// ValidateMFAAuthResponse records the validation of an MFA auth callenge response.
+message ValidateMFAAuthResponse {
+  // Metadata is a common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata.
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status contains common command or operation status fields
+  Status Status = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // MFADevice is the MFA device used.
+  MFADeviceMetadata MFADevice = 4 [(gogoproto.jsontag) = "mfa_device,omitempty"];
+
+  // ChallengeScope is the authorization scope of the MFA challenge used for authentication.
+  // Only applies to WebAuthn challenges.
+  string ChallengeScope = 5 [(gogoproto.jsontag) = "challenge_scope"];
+
+  // ChallengeAllowReuse defines whether the MFA challenge used for authentication can be reused.
+  bool ChallengeAllowReuse = 6 [(gogoproto.jsontag) = "challenge_allow_reuse"];
+}
+
 // ResourceMetadata is a common resource metadata
 message ResourceMetadata {
   // ResourceName is a resource name
@@ -1168,7 +1329,7 @@ message ResourceMetadata {
   string TTL = 4 [(gogoproto.jsontag) = "ttl,omitempty"];
 }
 
-// UserCreate is emitted when the user is created or updated (upsert).
+// UserCreate is emitted when the user is created or upserted.
 message UserCreate {
   // Metadata is a common event metadata
   Metadata Metadata = 1 [
@@ -1196,6 +1357,50 @@ message UserCreate {
 
   // Connector is the connector used to create the user.
   string Connector = 5 [(gogoproto.jsontag) = "connector"];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 6 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// UserUpdate is emitted when the user is updated.
+message UserUpdate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata
+  ResourceMetadata Resource = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Roles is a list of roles for the user.
+  repeated string Roles = 4 [(gogoproto.jsontag) = "roles"];
+
+  // Connector is the connector used to create the user.
+  string Connector = 5 [(gogoproto.jsontag) = "connector"];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 6 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
 }
 
 // UserDelete is emitted when a user gets deleted
@@ -1220,6 +1425,13 @@ message UserDelete {
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
   ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
 }
 
 // UserPasswordChange is emitted when the user changes their own password.
@@ -1233,6 +1445,13 @@ message UserPasswordChange {
 
   // User is a common user event metadata
   UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 3 [
     (gogoproto.nullable) = false,
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
@@ -1305,6 +1524,21 @@ message AccessRequestCreate {
     (gogoproto.stdtime) = true,
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "max_duration,omitempty"
+  ];
+
+  reserved "PromotedAccessListTitle";
+  reserved 14;
+
+  // PromotedAccessListName is the name of the access list that this request
+  // was promoted to.
+  // This field is only populated when the request is in the PROMOTED state.
+  string PromotedAccessListName = 15 [(gogoproto.jsontag) = "promoted_access_list_name,omitempty"];
+
+  // AssumeStartTime is the time the requested roles can be assumed.
+  google.protobuf.Timestamp AssumeStartTime = 16 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = true,
+    (gogoproto.jsontag) = "assume_start_time,omitempty"
   ];
 }
 
@@ -1801,10 +2035,127 @@ message RoleCreate {
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
   ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// RoleUpdate is emitted when a role is updated.
+message RoleUpdate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
 }
 
 // RoleDelete is emitted when a role is deleted
 message RoleDelete {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// BotCreate is emitted when a bot is created/upserted.
+message BotCreate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// BotCreate is emitted when a bot is created/updated.
+message BotUpdate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// BotDelete is emitted when a bot is deleted.
+message BotDelete {
   // Metadata is a common event metadata
   Metadata Metadata = 1 [
     (gogoproto.nullable) = false,
@@ -1849,6 +2200,13 @@ message TrustedClusterCreate {
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
   ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
 }
 
 // TrustedClusterDelete is the event for removing a trusted cluster.
@@ -1869,6 +2227,13 @@ message TrustedClusterDelete {
 
   // User is a common user event metadata
   UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
     (gogoproto.nullable) = false,
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
@@ -1934,7 +2299,7 @@ message TrustedClusterTokenCreate {
   ];
 }
 
-// GithubConnectorCreate fires when a Github connector is created/updated.
+// GithubConnectorCreate fires when a Github connector is created.
 message GithubConnectorCreate {
   // Metadata is a common event metadata
   Metadata Metadata = 1 [
@@ -1952,6 +2317,44 @@ message GithubConnectorCreate {
 
   // User is a common user event metadata
   UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// GithubConnectorUpdate fires when a Github connector is updated.
+message GithubConnectorUpdate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
     (gogoproto.nullable) = false,
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
@@ -1980,10 +2383,41 @@ message GithubConnectorDelete {
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
   ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
 }
 
-// OIDCConnectorCreate fires when OIDC connector is created/updated.
+// OIDCConnectorCreate fires when OIDC connector is created.
 message OIDCConnectorCreate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// OIDCConnectorUpdate fires when OIDC connector is updated.
+message OIDCConnectorUpdate {
   // Metadata is a common event metadata
   Metadata Metadata = 1 [
     (gogoproto.nullable) = false,
@@ -2052,6 +2486,36 @@ message SAMLConnectorCreate {
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
   ];
+
+  // Connector is the new SAML connector
+  types.SAMLConnectorV2 Connector = 4 [(gogoproto.jsontag) = "connector"];
+}
+
+// SAMLConnectorUpdate fires when SAML connector is updated.
+message SAMLConnectorUpdate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Connector is the updated SAML connector
+  types.SAMLConnectorV2 Connector = 4 [(gogoproto.jsontag) = "connector"];
 }
 
 // SAMLConnectorDelete fires when SAML connector is deleted.
@@ -2125,6 +2589,13 @@ message KubeRequest {
 
   // Kubernetes has information about a kubernetes cluster, if applicable.
   KubernetesClusterMetadata Kubernetes = 12 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // SessionMetadata is a common event session metadata.
+  SessionMetadata Session = 13 [
     (gogoproto.nullable) = false,
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
@@ -2610,6 +3081,173 @@ message DatabaseSessionQuery {
   ];
 }
 
+// DatabaseSessionCommandResult represents the result of a user command. It is
+// expected that for each user command/query there will be a corresponding
+// result.
+message DatabaseSessionCommandResult {
+  // Metadata is a common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // User is a common user event metadata.
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // SessionMetadata is a common event session metadata.
+  SessionMetadata Session = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Database contains database related metadata.
+  DatabaseMetadata Database = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Status indicates if the command was successful or not.
+  Status Status = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // AfftectedRecords represents the number of records that were affected by the
+  // command.
+  uint64 AffectedRecords = 6 [(gogoproto.jsontag) = "affected_records,omitempty"];
+}
+
+// DatabasePermissionUpdate is emitted when a user database permissions are updated.
+message DatabasePermissionUpdate {
+  // Metadata is a common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // User is a common user event metadata.
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // SessionMetadata is a common event session metadata.
+  SessionMetadata Session = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Database contains database related metadata.
+  DatabaseMetadata Database = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // PermissionSummary is a summary of applied permissions.
+  repeated DatabasePermissionEntry PermissionSummary = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "permission_summary"
+  ];
+  // AffectedObjectCounts counts how many distinct objects of each kind were affected.
+  map<string, int32> AffectedObjectCounts = 6 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "affected_object_counts"
+  ];
+}
+
+// DatabasePermissionEntry is a summary of permissions, scoped to a particular permission.
+message DatabasePermissionEntry {
+  // Permission is a particular database-level permission, e.g. "SELECT".
+  string Permission = 1 [(gogoproto.jsontag) = "permission"];
+  // Counts stores information how many objects of particular kind (e.g. "table") were affected.
+  map<string, int32> Counts = 2 [(gogoproto.jsontag) = "counts"];
+}
+
+// DatabaseUserCreate is emitted when a database user is provisioned.
+message DatabaseUserCreate {
+  // Metadata is a common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // User is a common user event metadata.
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // SessionMetadata is a common event session metadata.
+  SessionMetadata Session = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Database contains database related metadata.
+  DatabaseMetadata Database = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Status indicates whether the operation was successful.
+  Status Status = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Username is the username chosen for the database user. Due to database limitations (e.g. username length, allowed charset)
+  // it may differ from Teleport username.
+  string Username = 6 [(gogoproto.jsontag) = "username"];
+
+  // Roles is an optional list of granted database roles.
+  repeated string Roles = 7 [(gogoproto.jsontag) = "roles"];
+}
+
+// DatabaseUserDeactivate is emitted when a database user is disabled or deleted.
+message DatabaseUserDeactivate {
+  // Metadata is a common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // User is a common user event metadata.
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // SessionMetadata is a common event session metadata.
+  SessionMetadata Session = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Database contains database related metadata.
+  DatabaseMetadata Database = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Status indicates whether the operation was successful.
+  Status Status = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Username is the username chosen for the database user. Due to database limitations (e.g. username length, allowed charset)
+  // it may differ from Teleport username.
+  string Username = 6 [(gogoproto.jsontag) = "username"];
+
+  // Delete indicates if the user was deleted entirely or merely disabled.
+  bool Delete = 7 [(gogoproto.jsontag) = "delete"];
+}
+
 // PostgresParse is emitted when a Postgres client creates a prepared statement
 // using extended query protocol.
 message PostgresParse {
@@ -2819,6 +3457,9 @@ message WindowsDesktopSessionStart {
   map<string, string> DesktopLabels = 10 [(gogoproto.jsontag) = "desktop_labels"];
   // DesktopName is the name of the desktop resource.
   string DesktopName = 11 [(gogoproto.jsontag) = "desktop_name"];
+  // AllowUserCreation indicates whether automatic local user creation
+  // is allowed for this session.
+  bool AllowUserCreation = 12 [(gogoproto.jsontag) = "allow_user_creation"];
 }
 
 // DatabaseSessionEnd is emitted when a user ends the database session.
@@ -2846,6 +3487,20 @@ message DatabaseSessionEnd {
     (gogoproto.nullable) = false,
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
+  ];
+
+  // StartTime is the timestamp at which the session began.
+  google.protobuf.Timestamp StartTime = 5 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "session_start,omitempty"
+  ];
+
+  // EndTime is the timestamp at which the session ended.
+  google.protobuf.Timestamp EndTime = 6 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "session_stop,omitempty"
   ];
 }
 
@@ -2879,6 +3534,12 @@ message MFADeviceAdd {
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
   ];
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
 }
 
 // MFADeviceDelete is emitted when a user deletes an MFA device.
@@ -2897,6 +3558,12 @@ message MFADeviceDelete {
   ];
   // Device is the MFA device deleted by the user.
   MFADeviceMetadata Device = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
     (gogoproto.nullable) = false,
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
@@ -2978,9 +3645,17 @@ message LockCreate {
   ];
 
   // Target describes the set of interactions that the lock applies to
+  // Deprecated: use Lock instead.
   types.LockTarget Target = 4 [
+    deprecated = true,
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "target"
+  ];
+
+  // Lock is a common lock event metadata
+  LockMetadata Lock = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "lock"
   ];
 }
 
@@ -3005,6 +3680,12 @@ message LockDelete {
     (gogoproto.nullable) = false,
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
+  ];
+
+  // Lock is a common lock event metadata
+  LockMetadata Lock = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "lock"
   ];
 }
 
@@ -3111,6 +3792,13 @@ message CertificateCreate {
 
   // Identity is the identity associated with the certificate, as interpreted by Teleport.
   Identity Identity = 3 [(gogoproto.jsontag) = "identity"];
+
+  // Client is the common client event metadata
+  ClientMetadata Client = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
 }
 
 // RenewableCertificateGenerationMismatch is emitted when a renewable
@@ -3157,6 +3845,16 @@ message BotJoin {
     (gogoproto.jsontag) = "attributes,omitempty",
     (gogoproto.casttype) = "Struct"
   ];
+  // UserName is the name of the user associated with the bot which has joined.
+  string UserName = 7 [(gogoproto.jsontag) = "user_name,omitempty"];
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 8 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // BotInstanceID is the ID of the bot instance which has joined or renewed.
+  string BotInstanceID = 9 [(gogoproto.jsontag) = "bot_instance_id,omitempty"];
 }
 
 // InstanceJoin records an instance join event.
@@ -3196,6 +3894,12 @@ message InstanceJoin {
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "token_expires"
   ];
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 10 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
 }
 
 // Unknown is a fallback event used when we don't recognize an event from the backend.
@@ -3229,8 +3933,27 @@ enum OSType {
   OS_TYPE_WINDOWS = 3;
 }
 
+// DeviceOrigin is the same as teleport.devicetrust.v1.DeviceOrigin.
+// Duplicated because gogo doesn't play well with protoc-gen-go.
+enum DeviceOrigin {
+  // Unspecified or absent origin.
+  DEVICE_ORIGIN_UNSPECIFIED = 0;
+
+  // Devices originated from direct API usage.
+  DEVICE_ORIGIN_API = 1;
+
+  // Devices originated from Jamf sync.
+  DEVICE_ORIGIN_JAMF = 2;
+
+  // Source originated from Microsoft Intune sync.
+  DEVICE_ORIGIN_INTUNE = 3;
+}
+
 // DeviceMetadata groups device information for events.
 message DeviceMetadata {
+  reserved 7; // string web_session_id
+  reserved "web_session_id";
+
   // ID of the device.
   string device_id = 1 [(gogoproto.jsontag) = "device_id"];
   // OS of the device.
@@ -3239,6 +3962,15 @@ message DeviceMetadata {
   string asset_tag = 3 [(gogoproto.jsontag) = "asset_tag,omitempty"];
   // Device credential identifier.
   string credential_id = 4 [(gogoproto.jsontag) = "credential_id,omitempty"];
+  // Device origin.
+  DeviceOrigin device_origin = 5 [(gogoproto.jsontag) = "device_origin,omitempty"];
+  // True if web authentication, aka on-behalf-of device authentication, was
+  // performed.
+  // Only present in "device.authenticate" type events.
+  bool web_authentication = 6 [(gogoproto.jsontag) = "web_authentication,omitempty"];
+  // Device web authentication attempt ID.
+  // Present in events related to device web authentication.
+  string web_authentication_id = 8 [(gogoproto.jsontag) = "web_authentication_id,omitempty"];
 }
 
 // DeviceEvent is a device-related event.
@@ -3292,6 +4024,391 @@ message DeviceEvent2 {
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
   ];
+}
+
+// DiscoveryConfigCreate is emitted when a discovery config is created.
+message DiscoveryConfigCreate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata
+  ResourceMetadata Resource = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// DiscoveryConfigUpdate is emitted when a discovery config is updated.
+message DiscoveryConfigUpdate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata
+  ResourceMetadata Resource = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// DiscoveryConfigDelete is emitted when a discovery config is deleted.
+message DiscoveryConfigDelete {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata
+  ResourceMetadata Resource = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// DiscoveryConfigDeleteAll is emitted when all discovery configs are deleted.
+message DiscoveryConfigDeleteAll {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// IntegrationCreate is emitted when an integration resource is created.
+message IntegrationCreate {
+  // Metadata is a common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata.
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata.
+  ResourceMetadata Resource = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  IntegrationMetadata Integration = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection.
+  ConnectionMetadata Connection = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// IntegrationUpdate is emitted when an integration resource is updated.
+message IntegrationUpdate {
+  // Metadata is a common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata.
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata.
+  ResourceMetadata Resource = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  IntegrationMetadata Integration = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection.
+  ConnectionMetadata Connection = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// IntegrationDelete is emitted when an integration is deleted.
+message IntegrationDelete {
+  // Metadata is a common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata.
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata.
+  ResourceMetadata Resource = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  IntegrationMetadata Integration = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection.
+  ConnectionMetadata Connection = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// IntegrationMetadata contains information about integration resources.
+message IntegrationMetadata {
+  // SubKind is the sub kind of the integration resource.
+  string SubKind = 1 [(gogoproto.jsontag) = "sub_kind"];
+
+  // AWSOIDC contains metadata for AWS OIDC integrations.
+  AWSOIDCIntegrationMetadata AWSOIDC = 2 [(gogoproto.jsontag) = "aws_oidc,omitempty"];
+  // AzureOIDC contains metadata for Azure OIDC integrations.
+  AzureOIDCIntegrationMetadata AzureOIDC = 3 [(gogoproto.jsontag) = "azure_oidc,omitempty"];
+}
+
+// AWSOIDCIntegrationMetadata contains metadata for AWS OIDC integrations.
+message AWSOIDCIntegrationMetadata {
+  // RoleARN contains the Role ARN used to set up the Integration.
+  // This is the AWS Role that Teleport will use to issue tokens for API Calls.
+  string RoleARN = 1 [(gogoproto.jsontag) = "role_arn,omitempty"];
+
+  // IssuerS3URI is the Identity Provider that was configured in AWS.
+  string IssuerS3URI = 2 [(gogoproto.jsontag) = "issuer_s3_uri,omitempty"];
+}
+
+// AzureOIDCIntegrationMetadata contains metadata for Azure OIDC integrations.
+message AzureOIDCIntegrationMetadata {
+  // TenantID specifies the ID of Entra Tenant (Directory).
+  string TenantID = 1 [(gogoproto.jsontag) = "tenant_id,omitempty"];
+
+  // ClientID specifies the ID of Azure enterprise application (client).
+  string ClientID = 2 [(gogoproto.jsontag) = "client_id,omitempty"];
+}
+
+// PluginCreate is emitted when a plugin resource is created.
+message PluginCreate {
+  // Metadata is a common event metadata.
+  Metadata metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata.
+  UserMetadata user = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata.
+  ResourceMetadata resource = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  PluginMetadata plugin = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection.
+  ConnectionMetadata connection = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// PluginUpdate is emitted when a plugin resource is updated.
+message PluginUpdate {
+  // Metadata is a common event metadata.
+  Metadata metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata.
+  UserMetadata user = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata.
+  ResourceMetadata resource = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  PluginMetadata plugin = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection.
+  ConnectionMetadata connection = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// PluginDelete is emitted when a plugin is deleted.
+message PluginDelete {
+  // metadata is a common event metadata.
+  Metadata metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata.
+  UserMetadata user = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata.
+  ResourceMetadata resource = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  PluginMetadata plugin = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection.
+  ConnectionMetadata connection = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// PluginMetadata contains information about plugin resources.
+message PluginMetadata {
+  // plugin_type is the plugin type of the plugin resource.
+  // The value matches the types.PluginV1.Spec.Type field.
+  string plugin_type = 1 [(gogoproto.jsontag) = "plugin_type"];
+
+  // plugin is the resource without secrets.
+  types.PluginV1 plugin = 2 [(gogoproto.jsontag) = "plugin,omitempty"];
+
+  // has_credentials indicates whether the plugin has credentials.
+  bool has_credentials = 3 [(gogoproto.jsontag) = "has_credentials"];
+
+  // reuses_credentials indicates whether the plugin reuses credentials.
+  bool reuses_credentials = 4 [(gogoproto.jsontag) = "reuses_credentials"];
 }
 
 // OneOf is a union of one of audit events submitted to the auth service
@@ -3422,6 +4539,53 @@ message OneOf {
     events.OktaSyncFailure OktaSyncFailure = 123;
     events.OktaAssignmentResult OktaAssignmentResult = 124;
     events.ProvisionTokenCreate ProvisionTokenCreate = 125;
+    events.AccessListCreate AccessListCreate = 126;
+    events.AccessListUpdate AccessListUpdate = 127;
+    events.AccessListDelete AccessListDelete = 128;
+    events.AccessListReview AccessListReview = 129;
+    events.AccessListMemberCreate AccessListMemberCreate = 130;
+    events.AccessListMemberUpdate AccessListMemberUpdate = 131;
+    events.AccessListMemberDelete AccessListMemberDelete = 132;
+    events.AccessListMemberDeleteAllForAccessList AccessListMemberDeleteAllForAccessList = 133;
+    events.AuditQueryRun AuditQueryRun = 134;
+    events.SecurityReportRun SecurityReportRun = 135;
+    events.GithubConnectorUpdate GithubConnectorUpdate = 136;
+    events.OIDCConnectorUpdate OIDCConnectorUpdate = 137;
+    events.SAMLConnectorUpdate SAMLConnectorUpdate = 138;
+    events.RoleUpdate RoleUpdate = 139;
+    events.UserUpdate UserUpdate = 140;
+    events.ExternalAuditStorageEnable ExternalAuditStorageEnable = 141;
+    events.ExternalAuditStorageDisable ExternalAuditStorageDisable = 142;
+    events.BotCreate BotCreate = 143;
+    events.BotDelete BotDelete = 144;
+    events.BotUpdate BotUpdate = 145;
+    events.CreateMFAAuthChallenge CreateMFAAuthChallenge = 146;
+    events.ValidateMFAAuthResponse ValidateMFAAuthResponse = 147;
+    events.OktaAccessListSync OktaAccessListSync = 148;
+    events.DatabasePermissionUpdate DatabasePermissionUpdate = 149;
+    events.SPIFFESVIDIssued SPIFFESVIDIssued = 150;
+    events.OktaUserSync OktaUserSync = 151;
+    events.AuthPreferenceUpdate AuthPreferenceUpdate = 152;
+    events.SessionRecordingConfigUpdate SessionRecordingConfigUpdate = 153;
+    events.ClusterNetworkingConfigUpdate ClusterNetworkingConfigUpdate = 154;
+    events.DatabaseUserCreate DatabaseUserCreate = 155;
+    events.DatabaseUserDeactivate DatabaseUserDeactivate = 156;
+    events.AccessPathChanged AccessPathChanged = 157;
+    events.SpannerRPC SpannerRPC = 158;
+    events.DatabaseSessionCommandResult DatabaseSessionCommandResult = 159;
+    events.DiscoveryConfigCreate DiscoveryConfigCreate = 160;
+    events.DiscoveryConfigUpdate DiscoveryConfigUpdate = 161;
+    events.DiscoveryConfigDelete DiscoveryConfigDelete = 162;
+    events.DiscoveryConfigDeleteAll DiscoveryConfigDeleteAll = 163;
+    events.AccessGraphSettingsUpdate AccessGraphSettingsUpdate = 164;
+    events.IntegrationCreate IntegrationCreate = 165;
+    events.IntegrationUpdate IntegrationUpdate = 166;
+    events.IntegrationDelete IntegrationDelete = 167;
+    events.SPIFFEFederationCreate SPIFFEFederationCreate = 168;
+    events.SPIFFEFederationDelete SPIFFEFederationDelete = 169;
+    events.PluginCreate PluginCreate = 170;
+    events.PluginUpdate PluginUpdate = 171;
+    events.PluginDelete PluginDelete = 172;
   }
 }
 
@@ -3544,6 +4708,17 @@ message Identity {
   repeated string AzureIdentities = 24 [(gogoproto.jsontag) = "azure_identities,omitempty"];
   // GCPServiceAccounts is a list of allowed GCP service accounts user can assume.
   repeated string GCPServiceAccounts = 25 [(gogoproto.jsontag) = "gcp_service_accounts,omitempty"];
+  // PrivateKeyPolicy is the private key policy of the user's private key.
+  string PrivateKeyPolicy = 26 [(gogoproto.jsontag) = "private_key_policy,omitempty"];
+  // BotName indicates the name of the Machine ID bot this identity was issued
+  // to, if any.
+  string BotName = 27 [(gogoproto.jsontag) = "bot_name,omitempty"];
+  // DeviceExtensions holds the device trust device extensions for the identity,
+  // if any.
+  DeviceExtensions DeviceExtensions = 28 [(gogoproto.jsontag) = "device_extensions,omitempty"];
+  // BotInstanceID indicates the name of the Machine ID bot instance this
+  // identity was issued to, if any.
+  string BotInstanceID = 29 [(gogoproto.jsontag) = "bot_instance_id,omitempty"];
 }
 
 // RouteToApp contains parameters for application access certificate requests.
@@ -3576,6 +4751,22 @@ message RouteToDatabase {
   string Username = 3 [(gogoproto.jsontag) = "username,omitempty"];
   // Database is an optional database name to embed.
   string Database = 4 [(gogoproto.jsontag) = "database,omitempty"];
+  // Roles is an optional list of database roles to embed.
+  repeated string Roles = 5 [(gogoproto.jsontag) = "roles,omitempty"];
+}
+
+// DeviceExtensions holds certificate extensions (X.509 and SSH) for device
+// trust.
+//
+// Mimics tlsca.DeviceExtensions.
+message DeviceExtensions {
+  // DeviceID is the trusted device identifier.
+  string device_id = 1 [(gogoproto.jsontag) = "device_id,omitempty"];
+  // AssetTag is the device inventory identifier.
+  string asset_tag = 2 [(gogoproto.jsontag) = "asset_tag,omitempty"];
+  // CredentialID is the identifier for the credential used by the device to
+  // authenticate itself.
+  string credential_id = 3 [(gogoproto.jsontag) = "credential_id,omitempty"];
 }
 
 // AccessRequestResourceSearch is emitted when a user searches for resources as
@@ -4500,6 +5691,18 @@ message SSMRun {
 
   // Region is the AWS region the command was ran in.
   string Region = 7 [(gogoproto.jsontag) = "region"];
+
+  // StandardOutput contains the stdout of the executed command.
+  // Only the first 24000 chars are returned.
+  string StandardOutput = 8 [(gogoproto.jsontag) = "stdout"];
+
+  // StandardError contains the stderr of the executed command.
+  // Only the first 24000 chars are returned.
+  string StandardError = 9 [(gogoproto.jsontag) = "stderr"];
+
+  // InvocationURL is a link to AWS Web Console for this invocation.
+  // An invocation is the execution of a Command in an Instance.
+  string InvocationURL = 10 [(gogoproto.jsontag) = "invocation_url"];
 }
 
 // CassandraSession is emitted when a Cassandra client sends
@@ -4904,6 +6107,752 @@ message OktaAssignmentResult {
 
   // OktaAssignmentMetadata is common Okta assignment metadata.
   OktaAssignmentMetadata OktaAssignment = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// AccessListCreate is emitted when an access list is created.
+message AccessListCreate {
+  // Metadata is common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Resource is common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the resource operation was successful.
+  Status Status = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// AccessListUpdate is emitted when an access list is updated.
+message AccessListUpdate {
+  // Metadata is common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Resource is common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the resource operation was successful.
+  Status Status = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// AccessListDelete is emitted when an access list is deleted.
+message AccessListDelete {
+  // Metadata is common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Resource is common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the resource operation was successful.
+  Status Status = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// AccessListMemberCreate is emitted when an access list member is created.
+message AccessListMemberCreate {
+  // Metadata is common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Resource is common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // AccessListMember is common access list member metadata.
+  AccessListMemberMetadata AccessListMember = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the resource operation was successful.
+  Status Status = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// AccessListMemberUpdate is emitted when an access list member is updated.
+message AccessListMemberUpdate {
+  // Metadata is common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Resource is common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // AccessListMember is common access list member metadata.
+  AccessListMemberMetadata AccessListMember = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the resource operation was successful.
+  Status Status = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// AccessListMemberDelete is emitted when an access list member is deleted.
+message AccessListMemberDelete {
+  // Metadata is common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Resource is common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // AccessListMember is common access list member metadata.
+  AccessListMemberMetadata AccessListMember = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the resource operation was successful.
+  Status Status = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// AccessListMemberDeleteAllForAccessList is emitted when all members are deleted for an access list.
+message AccessListMemberDeleteAllForAccessList {
+  // Metadata is common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Resource is common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // AccessListMember is common access list member metadata.
+  AccessListMemberMetadata AccessListMember = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the resource operation was successful.
+  Status Status = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// AccessListReview is emitted when an access list is reviewed.
+message AccessListReview {
+  // Metadata is common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Resource is common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Review is metadata for the access list review.
+  AccessListReviewMetadata Review = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the review operation was successful.
+  Status status = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// AuditQueryRun is emitted when a user runs an audit query.
+message AuditQueryRun {
+  // Metadata is common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // User is common user event metadata.
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the read was successful.
+  Status Status = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Query contains additional query information.
+  AuditQueryDetails Query = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// AuditQueryDetails contains additional query information.
+message AuditQueryDetails {
+  // Name is the name of the query.
+  string Name = 1 [(gogoproto.jsontag) = "name,omitempty"];
+  // Query is the query that was run.
+  string Query = 2 [(gogoproto.jsontag) = "query,omitempty"];
+  // Days is the number of days time range for the query.
+  int32 Days = 3 [(gogoproto.jsontag) = "days,omitempty"];
+  // ExecutionTimeInMillis is the total execution time of the query.
+  int64 ExecutionTimeInMillis = 4 [(gogoproto.jsontag) = "total_execution_time_in_millis,omitempty"];
+  // DataScannedInBytes is the amount of data scanned by the query.
+  int64 DataScannedInBytes = 5 [(gogoproto.jsontag) = "data_scanned_in_bytes"];
+}
+
+// SecurityReportRun is emitted when a user runs an audit query.
+message SecurityReportRun {
+  // Metadata is common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // User is common user event metadata.
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the read was successful.
+  Status Status = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Query is the query that was run.
+  string Name = 4 [(gogoproto.jsontag) = "name,omitempty"];
+  // Version is the version of security report.
+  string Version = 5 [(gogoproto.jsontag) = "version,omitempty"];
+  // TotalExecutionTimeInMillis is the total execution time of the query.
+  int64 TotalExecutionTimeInMillis = 6 [(gogoproto.jsontag) = "total_execution_time_in_millis,omitempty"];
+  // TotalDataScannedInBytes is the amount of data scanned by the query.
+  int64 TotalDataScannedInBytes = 7 [(gogoproto.jsontag) = "total_data_scanned_in_bytes"];
+  // AuditQueries is the list of audit queries that were run.
+  repeated AuditQueryDetails AuditQueries = 8 [(gogoproto.jsontag) = "audit_queries,omitempty"];
+}
+
+// ExternalAuditStorageEnableEvent is emitted when External Audit Storage is
+// enabled.
+message ExternalAuditStorageEnable {
+  // Metadata is common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Resource is common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Details holds details about the External Audit Storage configuration that
+  // was enabled.
+  ExternalAuditStorageDetails details = 3;
+}
+
+// ExternalAuditStorageDisableEvent is emitted when External Audit Storage is
+// disabled.
+message ExternalAuditStorageDisable {
+  // Metadata is common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Resource is common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Details holds details about the External Audit Storage configuration that
+  // was disabled.
+  ExternalAuditStorageDetails details = 3;
+}
+
+// Details holds details about the External Audit Storage configuration.
+message ExternalAuditStorageDetails {
+  // IntegrationName is the name of the AWS OIDC integration used.
+  string integration_name = 3;
+  // SessionsRecordingsURI is the S3 path used to store session recordings.
+  string session_recordings_uri = 4;
+  // AthenaWorkgroup is the workgroup used for Athena audit log queries.
+  string athena_workgroup = 5;
+  // GlueDatabase is the database used for Athena audit log queries.
+  string glue_database = 6;
+  // GlueTable is the table used for Athena audit log queries.
+  string glue_table = 7;
+  // AuditEventsLongTermURI is the S3 path used to store batched parquet files
+  // with audit events, partitioned by event date.
+  string audit_events_long_term_uri = 8;
+  // AthenaResultsURI is the S3 path used to store temporary results generated
+  // by Athena.
+  string athena_results_uri = 9;
+  // PolicyName is the name of the IAM policy attached to the OIDC integration
+  // role.
+  string policy_name = 10;
+  // Region is the AWS region where the infrastructure is hosted.
+  string region = 11;
+}
+
+// OktaAccessListSync records an access list sync event.
+message OktaAccessListSync {
+  // Metadata is a common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Status contains common command or operation status fields.
+  Status Status = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // NumAppFilters is the number of application filters used for this sync.
+  int32 num_app_filters = 3;
+
+  // NumGroupFilters is the number of group filters used for this sync.
+  int32 num_group_filters = 4;
+
+  // NumApps is the number of apps that were synchronized from this sync event.
+  int32 num_apps = 5;
+
+  // NumGroups is the number of groups that were synchronized from this sync event.
+  int32 num_groups = 6;
+
+  // NumRoles are the number of roles that were created/updated.
+  int32 numRoles = 7;
+
+  // NumAccessLists are the number of access lists that were created/updated.
+  int32 numAccessLists = 8;
+
+  // NumAccessListMembers are the number of access list members that were created/updated.
+  int32 numAccessListMembers = 9;
+}
+
+// OktaUserSync records an Okta user sync event.
+message OktaUserSync {
+  // Metadata is a common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Status contains common command or operation status fields.
+  Status Status = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // OrgUrl is the URL of the Okta organization being synced to
+  string org_url = 3;
+
+  // AppId is the optional ID of an Okta Application that Teleport is using as
+  // its gateway into Okta. The list of potential Teleport users are drawn from
+  // the list of Okta users assigned to this app - either directly or via a group
+  // assignement. If not set, the Okta sync service is drawing its user list from
+  // the whole organization.
+  string app_id = 4;
+
+  // NumUsersCreated is the number of Teleport users created in this
+  // synchronization pass.
+  int32 num_users_created = 5 [(gogoproto.jsontag) = "num_users_created"];
+
+  // NumUsersDeleted is the number of Teleport users deleted in this
+  // synchronization pass.
+  int32 num_users_deleted = 6 [(gogoproto.jsontag) = "num_users_deleted"];
+
+  // NumUserModified is the number of Teleport users modified in this
+  // synchronization pass.
+  int32 num_users_modified = 7 [(gogoproto.jsontag) = "num_users_modified"];
+
+  // NumUsersTotal is the total number of Teleport users managed by the Okta
+  // integration at the end of the synchronzaton pass.
+  int32 num_users_total = 8 [(gogoproto.jsontag) = "num_users_total"];
+}
+
+// SPIFFESVIDIssued is an event recorded when a SPIFFE SVID is issued.
+message SPIFFESVIDIssued {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // SPIFFEID is the SPIFFE ID of the issued SVID
+  string SPIFFEID = 4 [(gogoproto.jsontag) = "spiffe_id"];
+  // DNSSANs is the list of DNS SANs in the issued SVID
+  repeated string DNSSANs = 5 [(gogoproto.jsontag) = "dns_sans"];
+  // IPSANs is the list of IP SANs in the issued SVID
+  repeated string IPSANs = 6 [(gogoproto.jsontag) = "ip_sans"];
+  // SVIDType is `jwt` or `x509
+  string SVIDType = 7 [(gogoproto.jsontag) = "svid_type"];
+  // SerialNumber is the serial number of the issued SVID
+  string SerialNumber = 8 [(gogoproto.jsontag) = "serial_number"];
+  // Hint is the hint of the issued SVID
+  string Hint = 9 [(gogoproto.jsontag) = "hint"];
+}
+
+// AuthPreferenceUpdate is emitted when the auth preference is updated.
+message AuthPreferenceUpdate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the update was successful.
+  Status Status = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // AdminActionsMFA indicates whether MFA for admin actions was altered
+  // while updating the authentication preference.
+  AdminActionsMFAStatus AdminActionsMFA = 5 [(gogoproto.jsontag) = "admin_actions_mfa_changed"];
+}
+
+enum AdminActionsMFAStatus {
+  ADMIN_ACTIONS_MFA_STATUS_UNSPECIFIED = 0;
+  ADMIN_ACTIONS_MFA_STATUS_UNCHANGED = 1;
+  ADMIN_ACTIONS_MFA_STATUS_ENABLED = 2;
+  ADMIN_ACTIONS_MFA_STATUS_DISABLED = 3;
+}
+
+// ClusterNetworkingConfigUpdate is emitted when the cluster networking config is updated.
+message ClusterNetworkingConfigUpdate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the update was successful.
+  Status Status = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// SessionRecordingConfigUpdate is emitted when the session recording config is updated.
+message SessionRecordingConfigUpdate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the update was successful.
+  Status Status = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// AccessPathChanged is emitted when access graph detects a change in a access path.
+message AccessPathChanged {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ChangeID is the id of the change.
+  string ChangeID = 2 [(gogoproto.jsontag) = "change_id"];
+
+  // AffectedResourceID is the name of the affected resource.
+  string AffectedResourceName = 3 [(gogoproto.jsontag) = "affected_resource_name"];
+
+  // AffectedResourceSource is the source of the affected resource, ex: Teleport, AWS, GitLab, etc.
+  string AffectedResourceSource = 4 [(gogoproto.jsontag) = "affected_resource_source"];
+
+  // AffectedResourceType is the type of the affected resource, ex: user, role, etc.
+  string AffectedResourceType = 5 [(gogoproto.jsontag) = "affected_resource_type"];
+}
+
+// SpannerRPC is an event emitted when a Spanner client calls a Spanner RPC.
+message SpannerRPC {
+  // Metadata is a common event metadata.
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // User is a common user event metadata.
+  UserMetadata User = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // SessionMetadata is a common event session metadata.
+  SessionMetadata Session = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Database contains database related metadata.
+  DatabaseMetadata Database = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Status indicates whether the RPC was successfully sent to the database.
+  Status Status = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+  // Procedure is the name of the remote procedure.
+  string Procedure = 6 [(gogoproto.jsontag) = "procedure,omitempty"];
+  // Args are the RPC arguments.
+  google.protobuf.Struct Args = 7 [
+    (gogoproto.jsontag) = "args,omitempty",
+    (gogoproto.casttype) = "Struct"
+  ];
+}
+
+// AccessGraphSettingsUpdate is emitted when the Access Graph Settings config is updated.
+message AccessGraphSettingsUpdate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // Status indicates whether the update was successful.
+  Status Status = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// SPIFFEFederationCreate is emitted when a SPIFFE federation is created.
+message SPIFFEFederationCreate {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+}
+
+// SPIFFEFederationDelete is emitted when a SPIFFE federation is deleted.
+message SPIFFEFederationDelete {
+  // Metadata is a common event metadata
+  Metadata Metadata = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ResourceMetadata is a common resource event metadata
+  ResourceMetadata Resource = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // User is a common user event metadata
+  UserMetadata User = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.embed) = true,
+    (gogoproto.jsontag) = ""
+  ];
+
+  // ConnectionMetadata holds information about the connection
+  ConnectionMetadata Connection = 4 [
     (gogoproto.nullable) = false,
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/types/types.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/types/types.proto
@@ -1,27 +1,25 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 
 package types;
 
 import "gogoproto/gogo.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
 import "teleport/attestation/v1/attestation.proto";
 import "teleport/legacy/types/wrappers/wrappers.proto";
 
@@ -31,12 +29,13 @@ option (gogoproto.marshaler_all) = true;
 option (gogoproto.unmarshaler_all) = true;
 
 message KeepAlive {
+  reserved 3; // LeaseID
+  reserved "LeaseID";
+
   // Name of the resource to keep alive.
   string Name = 1 [(gogoproto.jsontag) = "server_name"];
   // Namespace is the namespace of the resource.
   string Namespace = 2 [(gogoproto.jsontag) = "namespace"];
-  // LeaseID is ID of the lease.
-  int64 LeaseID = 3 [(gogoproto.jsontag) = "lease_id"];
   // Expires is set to update expiry time of the resource.
   google.protobuf.Timestamp Expires = 4 [
     (gogoproto.stdtime) = true,
@@ -73,6 +72,9 @@ message KeepAlive {
 
 // Metadata is resource metadata
 message Metadata {
+  reserved 7; // ID
+  reserved "ID";
+
   // Name is an object name
   string Name = 1 [(gogoproto.jsontag) = "name"];
   // Namespace is object namespace. The field should be called "namespace"
@@ -88,12 +90,6 @@ message Metadata {
     (gogoproto.stdtime) = true,
     (gogoproto.nullable) = true,
     (gogoproto.jsontag) = "expires,omitempty"
-  ];
-  // ID is a record ID.
-  // Deprecated: Use revision instead.
-  int64 ID = 7 [
-    deprecated = true,
-    (gogoproto.jsontag) = "id,omitempty"
   ];
   // Revision is an opaque identifier which tracks the versions of a resource
   // over time. Clients should ignore and not alter its value but must return
@@ -172,7 +168,10 @@ message ResourceHeader {
   string Kind = 1 [(gogoproto.jsontag) = "kind,omitempty"];
   // SubKind is an optional resource sub kind, used in some resources
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is version
+  // Version is the API version used to create the resource. It must be
+  // specified. Based on this version, Teleport will apply different defaults on
+  // resource creation or deletion. It must be an integer prefixed by "v".
+  // For example: `v1`
   string Version = 3 [(gogoproto.jsontag) = "version,omitempty"];
   // Metadata is resource metadata
   Metadata Metadata = 4 [
@@ -253,7 +252,8 @@ message DatabaseV3 {
   string Kind = 1 [(gogoproto.jsontag) = "kind"];
   // SubKind is an optional resource subkind.
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is the resource version.
+  // Version is the resource version. It must be specified.
+  // Supported values are: `v3`.
   string Version = 3 [(gogoproto.jsontag) = "version"];
   // Metadata is the database metadata.
   Metadata Metadata = 4 [
@@ -340,6 +340,12 @@ message DatabaseSpecV3 {
 message DatabaseAdminUser {
   // Name is the username of the privileged database user.
   string Name = 1 [(gogoproto.jsontag) = "name"];
+  // DefaultDatabase is the database that the privileged database user logs
+  // into by default.
+  //
+  // Depending on the database type, this database may be used to store
+  // procedures or data for managing database users.
+  string DefaultDatabase = 2 [(gogoproto.jsontag) = "default_database"];
 }
 
 // OracleOptions contains information about privileged database user used
@@ -460,6 +466,14 @@ message AWS {
   // If not, the user must update the AWS profile identity to allow access to the Database.
   // Eg for an RDS Database: the underlying AWS profile allows for `rds-db:connect` for the Database.
   IAMPolicyStatus IAMPolicyStatus = 14 [(gogoproto.jsontag) = "iam_policy_status"];
+  // SessionTags is a list of AWS STS session tags.
+  map<string, string> SessionTags = 15 [(gogoproto.jsontag) = "session_tags,omitempty"];
+
+  // DocumentDB contains AWS DocumentDB specific metadata.
+  DocumentDB DocumentDB = 16 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "docdb,omitempty"
+  ];
 }
 
 // SecretStore contains secret store configurations.
@@ -546,6 +560,16 @@ message OpenSearch {
   string EndpointType = 3 [(gogoproto.jsontag) = "endpoint_type,omitempty"];
 }
 
+// DocumentDB contains AWS DocumentDB specific metadata.
+message DocumentDB {
+  // ClusterID is the cluster identifier.
+  string ClusterID = 1 [(gogoproto.jsontag) = "cluster_id,omitempty"];
+  // InstanceID is the instance identifier.
+  string InstanceID = 2 [(gogoproto.jsontag) = "instance_id,omitempty"];
+  // EndpointType is the type of the endpoint.
+  string EndpointType = 3 [(gogoproto.jsontag) = "endpoint_type,omitempty"];
+}
+
 // GCPCloudSQL contains parameters specific to GCP Cloud SQL databases.
 message GCPCloudSQL {
   // ProjectID is the GCP project ID the Cloud SQL instance resides in.
@@ -604,7 +628,8 @@ enum DatabaseTLSMode {
 
 // DatabaseTLS contains TLS configuration options.
 message DatabaseTLS {
-  // Mode is a TLS connection mode. See DatabaseTLSMode for details.
+  // Mode is a TLS connection mode.
+  // 0 is "verify-full"; 1 is "verify-ca", 2 is "insecure".
   DatabaseTLSMode Mode = 1 [(gogoproto.jsontag) = "mode"];
   // CACert is an optional user provided CA certificate used for verifying
   // database TLS connection.
@@ -612,6 +637,13 @@ message DatabaseTLS {
   // ServerName allows to provide custom hostname. This value will override the
   // servername/hostname on a certificate during validation.
   string ServerName = 3 [(gogoproto.jsontag) = "server_name,omitempty"];
+  // TrustSystemCertPool allows Teleport to trust certificate authorities
+  // available on the host system. If not set (by default), Teleport only
+  // trusts self-signed databases with TLS certificates signed by Teleport's
+  // Database Server CA or the ca_cert specified in this TLS setting. For
+  // cloud-hosted databases, Teleport downloads the corresponding required CAs
+  // for validation.
+  bool TrustSystemCertPool = 4 [(gogoproto.jsontag) = "trust_system_cert_pool,omitempty"];
 }
 
 // MySQLOptions are additional MySQL database options.
@@ -674,6 +706,9 @@ message InstanceSpecV1 {
   // ExternalUpgrader identifies the external upgrader that the instance is configured to
   // export schedules to (e.g. 'kube'). Empty if no upgrader is defined.
   string ExternalUpgrader = 7 [(gogoproto.jsontag) = "ext_upgrader,omitempty"];
+
+  // ExternalUpgraderVersion identifies the external upgrader version. Empty if no upgrader is defined.
+  string ExternalUpgraderVersion = 8 [(gogoproto.jsontag) = "ext_upgrader_version,omitempty"];
 }
 
 // InstanceControlLogEntry represents an entry in a given instance's control log. The control log of
@@ -773,11 +808,11 @@ message ServerV2 {
 
 // ServerSpecV2 is a specification for V2 Server
 message ServerSpecV2 {
+  reserved 2;
+  reserved "PublicAddr";
+
   // Addr is a host:port address where this server can be reached.
   string Addr = 1 [(gogoproto.jsontag) = "addr"];
-  // PublicAddr is the public address where this server can be reached.
-  // DELETE IN 15.0. (joerger) Deprecated in favor of public_addrs.
-  string PublicAddr = 2 [(gogoproto.jsontag) = "public_addr,omitempty"];
   // Hostname is server hostname
   string Hostname = 3 [(gogoproto.jsontag) = "hostname"];
   // CmdLabels is server dynamic labels
@@ -895,7 +930,8 @@ message AppV3 {
   string Kind = 1 [(gogoproto.jsontag) = "kind"];
   // SubKind is an optional resource subkind.
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is the resource version.
+  // Version is the resource version. It must be specified.
+  // Supported values are:`v3`.
   string Version = 3 [(gogoproto.jsontag) = "version"];
   // Metadata is the app resource metadata.
   Metadata Metadata = 4 [
@@ -930,11 +966,18 @@ message AppSpecV3 {
   string Cloud = 7 [(gogoproto.jsontag) = "cloud,omitempty"];
   // UserGroups are a list of user group IDs that this app is associated with.
   repeated string UserGroups = 8;
+  // Integration is the integration name that must be used to access this Application.
+  // Only applicable to AWS App Access.
+  // If present, the Application must use the Integration's credentials instead of ambient credentials to access Cloud APIs.
+  string Integration = 9 [(gogoproto.jsontag) = "integration,omitempty"];
 }
 
 // AppServerOrSAMLIdPServiceProviderV1 holds either an AppServerV3 or a SAMLIdPServiceProviderV1 resource (never both).
 // Used in application listings that request both app servers and saml apps.
+//
+// DEPRECATED: Use AppServer and SAMLIdPServiceProvider type individually.
 message AppServerOrSAMLIdPServiceProviderV1 {
+  option deprecated = true;
   option (gogoproto.goproto_stringer) = false;
   option (gogoproto.stringer) = false;
   // Kind is the resource kind. Always "app_server_saml_idp_sp".
@@ -996,6 +1039,8 @@ enum PrivateKeyType {
   PKCS11 = 1;
   // GCP_KMS is a private key backed by GCP KMS.
   GCP_KMS = 2;
+  // AWS_KMS is a private key backed by AWS KMS.
+  AWS_KMS = 3;
 }
 
 // SSHKeyPair is an SSH CA key pair.
@@ -1059,12 +1104,7 @@ message CertAuthoritySpecV2 {
     (gogoproto.jsontag) = "type",
     (gogoproto.casttype) = "CertAuthType"
   ];
-  // DELETE IN(2.7.0) this field is deprecated,
-  // as resource name matches cluster name after migrations.
-  // and this property is enforced by the auth server code.
-  // ClusterName identifies cluster name this authority serves,
-  // for host authorities that means base hostname of all servers,
-  // for user authorities that means organization name
+  // ClusterName identifies the cluster name this authority serves.
   string ClusterName = 2 [(gogoproto.jsontag) = "cluster_name"];
   // Roles is a list of roles assumed by users signed by this CA
   repeated string Roles = 5 [(gogoproto.jsontag) = "roles,omitempty"];
@@ -1078,15 +1118,23 @@ message CertAuthoritySpecV2 {
     (gogoproto.nullable) = true,
     (gogoproto.jsontag) = "rotation,omitempty"
   ];
-  // SigningAlg is the algorithm used for signing new SSH certificates using
-  // SigningKeys.
+  // SigningAlgType is unused.
+  //
+  // Deprecated: SigningAlgType is unused.
   enum SigningAlgType {
+    option deprecated = true;
     UNKNOWN = 0;
     RSA_SHA1 = 1;
     RSA_SHA2_256 = 2;
     RSA_SHA2_512 = 3;
   }
-  SigningAlgType SigningAlg = 9 [(gogoproto.jsontag) = "signing_alg,omitempty"];
+  // SigningAlg is unused.
+  //
+  // Deprecated: SigningAlg is unused.
+  SigningAlgType SigningAlg = 9 [
+    (gogoproto.jsontag) = "signing_alg,omitempty",
+    deprecated = true
+  ];
   // ActiveKeys are the CA key sets used to sign any new certificates.
   CAKeySet ActiveKeys = 11 [
     (gogoproto.nullable) = false,
@@ -1152,7 +1200,8 @@ message ProvisionTokenV2 {
   string Kind = 1 [(gogoproto.jsontag) = "kind"];
   // SubKind is an optional resource sub kind, used in some resources
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is version
+  // Version is the resource version. It must be specified.
+  // Supported values are:`v2`.
   string Version = 3 [(gogoproto.jsontag) = "version"];
   // Metadata is resource metadata
   Metadata Metadata = 4 [
@@ -1207,7 +1256,7 @@ message ProvisionTokenSpecV2 {
     (gogoproto.casttype) = "Duration"
   ];
   // JoinMethod is the joining method required in order to use this token.
-  // Supported joining methods include "token", "ec2", and "iam".
+  // Supported joining methods include: azure, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm
   string JoinMethod = 4 [
     (gogoproto.jsontag) = "join_method",
     (gogoproto.casttype) = "JoinMethod"
@@ -1243,6 +1292,49 @@ message ProvisionTokenSpecV2 {
   ProvisionTokenSpecV2GitLab GitLab = 12 [(gogoproto.jsontag) = "gitlab,omitempty"];
   // GCP allows the configuration of options specific to the "gcp" join method.
   ProvisionTokenSpecV2GCP GCP = 13 [(gogoproto.jsontag) = "gcp,omitempty"];
+  // Spacelift allows the configuration of options specific to the "spacelift" join method.
+  ProvisionTokenSpecV2Spacelift Spacelift = 14 [(gogoproto.jsontag) = "spacelift,omitempty"];
+  // TPM allows the configuration of options specific to the "tpm" join method.
+  ProvisionTokenSpecV2TPM TPM = 15 [(gogoproto.jsontag) = "tpm,omitempty"];
+  // TerraformCloud allows the configuration of options specific to the "terraform_cloud" join method.
+  ProvisionTokenSpecV2TerraformCloud TerraformCloud = 16 [(gogoproto.jsontag) = "terraform_cloud,omitempty"];
+}
+
+// ProvisionTokenSpecV2TPM contains the TPM-specific part of the
+// ProvisionTokenSpecV2
+message ProvisionTokenSpecV2TPM {
+  message Rule {
+    reserved 2, 3;
+    reserved "EKPubHash", "EKCertSerial";
+    // Description is a human-readable description of the rule. It has no
+    // bearing on whether or not a TPM is allowed to join, but can be used
+    // to associate a rule with a specific host (e.g the asset tag of the server
+    // in which the TPM resides).
+    // Example: "build-server-100"
+    string Description = 1 [(gogoproto.jsontag) = "description,omitempty"];
+    // EKPublicHash is the SHA256 hash of the EKPub marshaled in PKIX format
+    // and encoded in hexadecimal. This value will also be checked when a TPM
+    // has submitted an EKCert, and the public key in the EKCert will be used
+    // for this check.
+    // Example: d4b45864d9d6fabfc568d74f26c35ababde2105337d7af9a6605e1c56c891aa6
+    string EKPublicHash = 4 [(gogoproto.jsontag) = "ek_public_hash,omitempty"];
+    // EKCertificateSerial is the serial number of the EKCert in hexadecimal
+    // with colon separated nibbles. This value will not be checked when a TPM
+    // does not have an EKCert configured.
+    // Example: 73:df:dc:bd:af:ef:8a:d8:15:2e:96:71:7a:3e:7f:a4
+    string EKCertificateSerial = 5 [(gogoproto.jsontag) = "ek_certificate_serial,omitempty"];
+  }
+  // Allow is a list of Rules, the presented delegated identity must match one
+  // allow rule to permit joining.
+  repeated Rule Allow = 1 [(gogoproto.jsontag) = "allow,omitempty"];
+  // EKCertAllowedCAs is a list of CA certificates that will be used to validate
+  // TPM EKCerts.
+  // When specified, joining TPMs must present an EKCert signed by one of the
+  // specified CAs. TPMs that do not present an EKCert will be not permitted to
+  // join.
+  // When unspecified, TPMs will be allowed to join with either an EKCert or an
+  // EKPubHash.
+  repeated string EKCertAllowedCAs = 2 [(gogoproto.jsontag) = "ekcert_allowed_cas,omitempty"];
 }
 
 // ProvisionTokenSpecV2Github contains the GitHub-specific part of the
@@ -1285,6 +1377,17 @@ message ProvisionTokenSpecV2GitHub {
   // include the scheme or a path. The instance must be accessible over HTTPS
   // at this hostname and the certificate must be trusted by the Auth Server.
   string EnterpriseServerHost = 2 [(gogoproto.jsontag) = "enterprise_server_host,omitempty"];
+  // EnterpriseSlug allows the slug of a GitHub Enterprise organisation to be
+  // included in the expected issuer of the OIDC tokens. This is for
+  // compatibility with the `include_enterprise_slug` option in GHE.
+  //
+  // This field should be set to the slug of your enterprise if this is enabled. If
+  // this is not enabled, then this field must be left empty. This field cannot
+  // be specified if `enterprise_server_host` is specified.
+  //
+  // See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise
+  // for more information about customized issuer values.
+  string EnterpriseSlug = 3 [(gogoproto.jsontag) = "enterprise_slug,omitempty"];
 }
 
 // ProvisionTokenSpecV2GitLab contains the GitLab-specific part of the
@@ -1293,10 +1396,18 @@ message ProvisionTokenSpecV2GitLab {
   message Rule {
     // Sub roughly uniquely identifies the workload. Example:
     // `project_path:mygroup/my-project:ref_type:branch:ref:main`
-    // project_path:{group}/{project}:ref_type:{type}:ref:{branch_name}
+    // project_path:GROUP/PROJECT:ref_type:TYPE:ref:BRANCH_NAME
+    //
+    // This field supports simple "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
     string Sub = 1 [(gogoproto.jsontag) = "sub,omitempty"];
     // Ref allows access to be limited to jobs triggered by a specific git ref.
     // Ensure this is used in combination with ref_type.
+    //
+    // This field supports simple "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
     string Ref = 2 [(gogoproto.jsontag) = "ref,omitempty"];
     // RefType allows access to be limited to jobs triggered by a specific git
     // ref type. Example:
@@ -1306,10 +1417,18 @@ message ProvisionTokenSpecV2GitLab {
     // projects.
     // Example:
     // `mygroup`
+    //
+    // This field supports simple "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
     string NamespacePath = 4 [(gogoproto.jsontag) = "namespace_path,omitempty"];
     // ProjectPath is used to limit access to jobs belonging to an individual
     // project. Example:
     // `mygroup/myproject`
+    //
+    // This field supports simple "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
     string ProjectPath = 5 [(gogoproto.jsontag) = "project_path,omitempty"];
     // PipelineSource limits access by the job pipeline source type.
     // https://docs.gitlab.com/ee/ci/jobs/job_control.html#common-if-clauses-for-rules
@@ -1318,6 +1437,34 @@ message ProvisionTokenSpecV2GitLab {
     // Environment limits access by the environment the job deploys to
     // (if one is associated)
     string Environment = 7 [(gogoproto.jsontag) = "environment,omitempty"];
+    // UserLogin is the username of the user executing the job
+    string UserLogin = 8 [(gogoproto.jsontag) = "user_login,omitempty"];
+    // UserID is the ID of the user executing the job
+    string UserID = 9 [(gogoproto.jsontag) = "user_id,omitempty"];
+    // UserEmail is the email of the user executing the job
+    string UserEmail = 10 [(gogoproto.jsontag) = "user_email,omitempty"];
+    // RefProtected is true if the Git ref is protected, false otherwise.
+    BoolValue RefProtected = 11 [
+      (gogoproto.nullable) = true,
+      (gogoproto.jsontag) = "ref_protected,omitempty",
+      (gogoproto.customtype) = "BoolOption"
+    ];
+    // EnvironmentProtected is true if the Git ref is protected, false otherwise.
+    BoolValue EnvironmentProtected = 12 [
+      (gogoproto.nullable) = true,
+      (gogoproto.jsontag) = "environment_protected,omitempty",
+      (gogoproto.customtype) = "BoolOption"
+    ];
+    // CIConfigSHA is the git commit SHA for the ci_config_ref_uri.
+    string CIConfigSHA = 13 [(gogoproto.jsontag) = "ci_config_sha,omitempty"];
+    // CIConfigRefURI is the ref path to the top-level pipeline definition, for example,
+    // gitlab.example.com/my-group/my-project//.gitlab-ci.yml@refs/heads/main.
+    string CIConfigRefURI = 14 [(gogoproto.jsontag) = "ci_config_ref_uri,omitempty"];
+    // DeploymentTier is the deployment tier of the environment the job specifies
+    string DeploymentTier = 15 [(gogoproto.jsontag) = "deployment_tier,omitempty"];
+    // ProjectVisibility is the visibility of the project where the pipeline is running.
+    // Can be internal, private, or public.
+    string ProjectVisibility = 16 [(gogoproto.jsontag) = "project_visibility,omitempty"];
   }
   // Allow is a list of TokenRules, nodes using this token must match one
   // allow rule to use this token.
@@ -1341,9 +1488,40 @@ message ProvisionTokenSpecV2CircleCI {
   string OrganizationID = 2 [(gogoproto.jsontag) = "organization_id,omitempty"];
 }
 
+// ProvisionTokenSpecV2Spacelift contains the Spacelift-specific part of the
+// ProvisionTokenSpecV2
+message ProvisionTokenSpecV2Spacelift {
+  message Rule {
+    // SpaceID is the ID of the space in which the run that owns the token was
+    // executed.
+    string SpaceID = 1 [(gogoproto.jsontag) = "space_id,omitempty"];
+    // CallerID is the ID of the caller, ie. the stack or module that generated
+    // the run.
+    string CallerID = 2 [(gogoproto.jsontag) = "caller_id,omitempty"];
+    // CallerType is the type of the caller, ie. the entity that owns the run -
+    // either `stack` or `module`.
+    string CallerType = 3 [(gogoproto.jsontag) = "caller_type,omitempty"];
+    // Scope is the scope of the token - either `read` or `write`.
+    // See https://docs.spacelift.io/integrations/cloud-providers/oidc/#about-scopes
+    string Scope = 4 [(gogoproto.jsontag) = "scope,omitempty"];
+  }
+  // Allow is a list of Rules, nodes using this token must match one
+  // allow rule to use this token.
+  repeated Rule Allow = 1 [(gogoproto.jsontag) = "allow,omitempty"];
+  // Hostname is the hostname of the Spacelift tenant that tokens
+  // will originate from. E.g `example.app.spacelift.io`
+  string Hostname = 2 [(gogoproto.jsontag) = "hostname,omitempty"];
+}
+
 // ProvisionTokenSpecV2Kubernetes contains the Kubernetes-specific part of the
 // ProvisionTokenSpecV2
 message ProvisionTokenSpecV2Kubernetes {
+  message StaticJWKSConfig {
+    // JWKS should be the JSON Web Key Set formatted public keys of that the
+    // Kubernetes Cluster uses to sign service account tokens.
+    // This can be fetched from /openid/v1/jwks on the Kubernetes API Server.
+    string JWKS = 1 [(gogoproto.jsontag) = "jwks,omitempty"];
+  }
   // Rule is a set of properties the Kubernetes-issued token might have to be
   // allowed to use this ProvisionToken
   message Rule {
@@ -1354,6 +1532,17 @@ message ProvisionTokenSpecV2Kubernetes {
   // Allow is a list of Rules, nodes using this token must match one
   // allow rule to use this token.
   repeated Rule Allow = 1 [(gogoproto.jsontag) = "allow,omitempty"];
+  // Type controls which behavior should be used for validating the Kubernetes
+  // Service Account token. Support values:
+  // - `in_cluster`
+  // - `static_jwks`
+  // If unset, this defaults to `in_cluster`.
+  string Type = 2 [
+    (gogoproto.jsontag) = "type,omitempty",
+    (gogoproto.casttype) = "KubernetesJoinType"
+  ];
+  // StaticJWKS is the configuration specific to the `static_jwks` type.
+  StaticJWKSConfig StaticJWKS = 3 [(gogoproto.jsontag) = "static_jwks,omitempty"];
 }
 
 // ProvisionTokenSpecV2Azure contains the Azure-specific part of the
@@ -1379,18 +1568,67 @@ message ProvisionTokenSpecV2GCP {
   // Rule is a set of properties the GCP-ussued token might have to be allowed
   // to use this ProvisionToken.
   message Rule {
-    // ProjectIDs is a list of project IDs (e.g. "<example-id-123456>").
+    // ProjectIDs is a list of project IDs (e.g. `<example-id-123456>`).
     repeated string ProjectIDs = 1 [(gogoproto.jsontag) = "project_ids,omitempty"];
     // Locations is a list of regions (e.g. "us-west1") and/or zones (e.g.
     // "us-west1-b").
     repeated string Locations = 2 [(gogoproto.jsontag) = "locations,omitempty"];
     // ServiceAccounts is a list of service account emails (e.g.
-    // "<project-number>-compute@developer.gserviceaccount.com").
+    // `<project-number>-compute@developer.gserviceaccount.com`).
     repeated string ServiceAccounts = 3 [(gogoproto.jsontag) = "service_accounts,omitempty"];
   }
   // Allow is a list of Rules, nodes using this token must match one
   // allow rule to use this token.
   repeated Rule Allow = 1 [(gogoproto.jsontag) = "allow,omitempty"];
+}
+
+// ProvisionTokenSpecV2Terraform contains Terraform-specific parts of the
+// ProvisionTokenSpecV2.
+message ProvisionTokenSpecV2TerraformCloud {
+  // Rule is a set of properties the Terraform-issued token might have to be
+  // allowed to use this ProvisionToken.
+  message Rule {
+    // OrganizationID is the ID of the HCP Terraform organization. At least
+    // one organization value is required, either ID or name.
+    string OrganizationID = 1 [(gogoproto.jsontag) = "organization_id,omitempty"];
+
+    // OrganizationName is the human-readable name of the HCP Terraform
+    // organization. At least one organization value is required, either ID or
+    // name.
+    string OrganizationName = 2 [(gogoproto.jsontag) = "organization_name,omitempty"];
+
+    // ProjectID is the ID of the HCP Terraform project. At least one project or
+    // workspace value is required, either ID or name.
+    string ProjectID = 3 [(gogoproto.jsontag) = "project_id,omitempty"];
+
+    // ProjectName is the human-readable name for the HCP Terraform project. At
+    // least one project or workspace value is required, either ID or name.
+    string ProjectName = 4 [(gogoproto.jsontag) = "project_name,omitempty"];
+
+    // WorkspaceID is the ID of the HCP Terraform workspace. At least one
+    // project or workspace value is required, either ID or name.
+    string WorkspaceID = 5 [(gogoproto.jsontag) = "workspace_id,omitempty"];
+
+    // WorkspaceName is the human-readable name of the HCP Terraform workspace.
+    // At least one project or workspace value is required, either ID or name.
+    string WorkspaceName = 6 [(gogoproto.jsontag) = "workspace_name,omitempty"];
+
+    // RunPhase is the phase of the run the token was issued for, e.g. `plan` or
+    // `apply`
+    string RunPhase = 7 [(gogoproto.jsontag) = "run_phase,omitempty"];
+  }
+
+  // Allow is a list of Rules, nodes using this token must match one
+  // allow rule to use this token.
+  repeated Rule Allow = 1 [(gogoproto.jsontag) = "allow,omitempty"];
+
+  // Audience is the JWT audience as configured in the
+  // TFC_WORKLOAD_IDENTITY_AUDIENCE(_$TAG) variable in Terraform Cloud. If
+  // unset, defaults to the Teleport cluster name.
+  // For example, if `TFC_WORKLOAD_IDENTITY_AUDIENCE_TELEPORT=foo` is set in
+  // Terraform Cloud, this value should be `foo`. If the variable is set to
+  // match the cluster name, it does not need to be set here.
+  string Audience = 2 [(gogoproto.jsontag) = "audience,omitempty"];
 }
 
 // StaticTokensV2 implements the StaticTokens interface.
@@ -1543,7 +1781,8 @@ message ClusterNetworkingConfigV2 {
   string Kind = 1 [(gogoproto.jsontag) = "kind"];
   // SubKind is an optional resource sub kind, used in some resources
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is a resource version
+  // Version is the resource version. It must be specified.
+  // Supported values are:`v2`.
   string Version = 3 [(gogoproto.jsontag) = "version"];
   // Metadata is resource metadata
   Metadata Metadata = 4 [
@@ -1597,9 +1836,11 @@ message ClusterNetworkingConfigSpecV2 {
   ];
 
   // ProxyListenerMode is proxy listener mode used by Teleport Proxies.
+  // 0 is "separate"; 1 is "multiplex".
   ProxyListenerMode ProxyListenerMode = 7 [(gogoproto.jsontag) = "proxy_listener_mode,omitempty"];
 
   // RoutingStrategy determines the strategy used to route to nodes.
+  // 0 is "unambiguous_match"; 1 is "most_recent".
   RoutingStrategy RoutingStrategy = 8 [(gogoproto.jsontag) = "routing_strategy,omitempty"];
 
   // TunnelStrategyV1 determines the tunnel strategy used in the cluster.
@@ -1619,6 +1860,13 @@ message ClusterNetworkingConfigSpecV2 {
 
   // CaseInsensitiveRouting causes proxies to use case-insensitive hostname matching.
   bool CaseInsensitiveRouting = 12 [(gogoproto.jsontag) = "case_insensitive_routing,omitempty"];
+
+  // SSHDialTimeout is a custom dial timeout used when establishing
+  // SSH connections. If not set, the default timeout of 30s will be used.
+  int64 SSHDialTimeout = 13 [
+    (gogoproto.jsontag) = "ssh_dial_timeout,omitempty",
+    (gogoproto.casttype) = "Duration"
+  ];
 }
 
 // TunnelStrategyV1 defines possible tunnel strategy types.
@@ -1662,7 +1910,8 @@ message SessionRecordingConfigV2 {
   string Kind = 1 [(gogoproto.jsontag) = "kind"];
   // SubKind is an optional resource sub kind, used in some resources
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is a resource version
+  // Version is the resource version. It must be specified.
+  // Supported values are:`v2`.
   string Version = 3 [(gogoproto.jsontag) = "version"];
   // Metadata is resource metadata
   Metadata Metadata = 4 [
@@ -1700,7 +1949,8 @@ message AuthPreferenceV2 {
   string Kind = 1 [(gogoproto.jsontag) = "kind"];
   // SubKind is an optional resource sub kind, used in some resources
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is a resource version
+  // Version is the resource version. It must be specified.
+  // Supported values are: `v2`.
   string Version = 3 [(gogoproto.jsontag) = "version"];
   // Metadata is resource metadata
   Metadata Metadata = 4 [
@@ -1775,6 +2025,8 @@ message AuthPreferenceSpecV2 {
   ];
 
   // RequireMFAType is the type of MFA requirement enforced for this cluster.
+  // 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH",
+  // 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
   RequireMFAType RequireMFAType = 12 [(gogoproto.jsontag) = "require_session_mfa,omitempty"];
 
   // DeviceTrust holds settings related to trusted device verification.
@@ -1805,6 +2057,20 @@ message AuthPreferenceSpecV2 {
   // Okta is a set of options related to the Okta service in Teleport.
   // Requires Teleport Enterprise.
   OktaOptions Okta = 17 [(gogoproto.jsontag) = "okta,omitempty"];
+
+  // TODO(Joerger): DELETE IN 17.0.0
+  // Deprecated, replaced by HardwareKey settings.
+  string PIVSlot = 18 [
+    (gogoproto.jsontag) = "piv_slot,omitempty",
+    deprecated = true
+  ];
+
+  // HardwareKey are the settings for hardware key support.
+  HardwareKey HardwareKey = 19 [(gogoproto.jsontag) = "hardware_key,omitempty"];
+
+  // SignatureAlgorithmSuite is the configured signature algorithm suite for the cluster.
+  // The current default value is "legacy". This field is not yet fully supported.
+  SignatureAlgorithmSuite signature_algorithm_suite = 20;
 }
 
 // U2F defines settings for U2F device.
@@ -1892,6 +2158,30 @@ message DeviceTrust {
   // If not present, then the CA of TPM EKCerts will not be checked during
   // enrollment, this allows any device to enroll.
   repeated string EKCertAllowedCAs = 3 [(gogoproto.jsontag) = "ekcert_allowed_cas,omitempty"];
+}
+
+// HardwareKey holds settings related to hardware key support.
+// Requires Teleport Enterprise.
+message HardwareKey {
+  // PIVSlot is a PIV slot that Teleport clients should use instead of the
+  // default based on private key policy. For example, "9a" or "9e".
+  string PIVSlot = 1 [(gogoproto.jsontag) = "piv_slot,omitempty"];
+
+  // SerialNumberValidation holds settings for hardware key serial number validation.
+  // By default, serial number validation is disabled.
+  HardwareKeySerialNumberValidation SerialNumberValidation = 2 [(gogoproto.jsontag) = "serial_number_validation,omitempty"];
+}
+
+message HardwareKeySerialNumberValidation {
+  // Enabled indicates whether hardware key serial number validation is enabled.
+  bool Enabled = 1 [(gogoproto.jsontag) = "enabled,omitempty"];
+
+  // SerialNumberTraitName is an optional custom user trait name for hardware key
+  // serial numbers to replace the default: "hardware_key_serial_numbers".
+  //
+  // Note: Values for this user trait should be a comma-separated list of serial numbers,
+  // or a list of comm-separated lists. e.g ["123", "345,678"]
+  string SerialNumberTraitName = 2 [(gogoproto.jsontag) = "serial_number_trait_name,omitempty"];
 }
 
 // Namespace represents namespace resource specification
@@ -2041,6 +2331,15 @@ message AccessReviewThreshold {
   uint32 Deny = 4 [(gogoproto.jsontag) = "deny,omitempty"];
 }
 
+// PromotedAccessList is a minimal access list representation used for
+// promoting access requests to access lists.
+message PromotedAccessList {
+  // Name is the name of the access list.
+  string Name = 1 [(gogoproto.jsontag) = "name"];
+  // Title is the title of the access list.
+  string Title = 2 [(gogoproto.jsontag) = "title"];
+}
+
 // AccessReview is a review to be applied to an access request.
 message AccessReview {
   // Author is the teleport username of the review author.
@@ -2068,6 +2367,20 @@ message AccessReview {
   // ThresholdIndexes stores the indexes of thresholds which this review matches
   // (internal use only).
   repeated uint32 ThresholdIndexes = 7 [(gogoproto.jsontag) = "i,omitempty"];
+
+  reserved "PromotedAccessListTitle";
+  reserved 8;
+
+  // AccessList is the access list that this request was promoted to.
+  // This field is only populated when the request is in the PROMOTED state.
+  PromotedAccessList accessList = 9 [(gogoproto.jsontag) = "access_list,omitempty"];
+
+  // AssumeStartTime is the time the requested roles can be assumed.
+  google.protobuf.Timestamp AssumeStartTime = 10 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = true,
+    (gogoproto.jsontag) = "assume_start_time,omitempty"
+  ];
 }
 
 // AccessReviewSubmission encodes the necessary parameters for submitting
@@ -2096,6 +2409,9 @@ enum RequestState {
   // DENIED variant indicates that a request has been rejected by
   // an administrating party.
   DENIED = 3;
+  // PROMOTED variant indicates that a request has been promoted to
+  // an access list.
+  PROMOTED = 4;
 }
 
 // ThresholdIndexSet encodes a list of threshold indexes. One of the listed thresholds
@@ -2223,6 +2539,35 @@ message AccessRequestSpecV3 {
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "session_ttl,omitempty"
   ];
+
+  reserved "PromotedAccessListTitle";
+  reserved 19;
+
+  // PromotedAccessListTitle is the title of the access list that this request
+  // was promoted to. Used by WebUI to display the title of the access list.
+  // This field is only populated when the request is in the PROMOTED state.
+  PromotedAccessList accessList = 20 [(gogoproto.jsontag) = "access_list,omitempty"];
+
+  // AssumeStartTime is the time the requested roles can be assumed.
+  google.protobuf.Timestamp AssumeStartTime = 21 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = true,
+    (gogoproto.jsontag) = "assume_start_time,omitempty"
+  ];
+}
+
+enum AccessRequestScope {
+  // DEFAULT allows all requests to be viewed
+  DEFAULT = 0;
+  // MY_REQUESTS will return only requests created by the requester
+  MY_REQUESTS = 1;
+  // NEEDS_REVIEW will return only requests that were not created by
+  // the requester and do not include a review made by the requester
+  NEEDS_REVIEW = 2;
+  // REVIEWED will return only requests that were not created by
+  // the requester and have a review submitted by the requester. This
+  // can include requests that have no yet been completely approved/denied.
+  REVIEWED = 3;
 }
 
 // AccessRequestFilter encodes filter params for access requests.
@@ -2233,6 +2578,17 @@ message AccessRequestFilter {
   string User = 2 [(gogoproto.jsontag) = "user,omitempty"];
   // RequestState filters for requests in a specific state.
   RequestState State = 3 [(gogoproto.jsontag) = "state,omitempty"];
+  // SearchKeywords is a list of search keywords to match against resource field values.
+  // The matcher goes through select field values from a resource
+  // and tries to match against the list of search values, ignoring case and order.
+  // Returns true if all search vals were matched (or if nil search vals).
+  // Returns false if no or partial match (or nil field values).
+  repeated string SearchKeywords = 4 [(gogoproto.jsontag) = "search,omitempty"];
+  // Scope is an aditional filter to view requests based on needs review, reviewed, my requests
+  AccessRequestScope Scope = 5 [(gogoproto.jsontag) = "scope,omitempty"];
+  // Requester is the requester of the api call. This is set by the auth server
+  // Use User for the requester of the request.
+  string Requester = 6 [(gogoproto.jsontag) = "requester,omitempty"];
 }
 
 // AccessCapabilities is a summary of capabilities that a user
@@ -2272,6 +2628,12 @@ message AccessCapabilitiesRequest {
     (gogoproto.jsontag) = "resource_ids,omitempty",
     (gogoproto.nullable) = false
   ];
+  // Login is the host login the user is requesting access for.
+  string Login = 5 [(gogoproto.jsontag) = "login,omitempty"];
+  // FilterRequestableRolesByResource is a flag indicating that the returned
+  // list of roles that the user can request should be filtered to only include
+  // roles that allow access to the provided ResourceIDs.
+  bool FilterRequestableRolesByResource = 6 [(gogoproto.jsontag) = "filter_requestable_roles_by_resource,omitempty"];
 }
 
 // ResourceID is a unique identifier for a teleport resource.
@@ -2357,6 +2719,14 @@ message PluginDataUpdateParams {
   map<string, string> Expect = 5 [(gogoproto.jsontag) = "expect,omitempty"];
 }
 
+// RoleFilter matches role resources.
+message RoleFilter {
+  // SearchKeywords is a list of search keywords to match against resource field values.
+  repeated string SearchKeywords = 1 [(gogoproto.jsontag) = "search_keywords,omitempty"];
+  // SkipSystemRoles filters out teleport system roles from the results.
+  bool SkipSystemRoles = 2 [(gogoproto.jsontag) = "skip_system_roles,omitempty"];
+}
+
 // RoleV6 represents role resource specification
 message RoleV6 {
   option (gogoproto.goproto_stringer) = false;
@@ -2366,7 +2736,8 @@ message RoleV6 {
   string Kind = 1 [(gogoproto.jsontag) = "kind"];
   // SubKind is an optional resource sub kind, used in some resources
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is version
+  // Version is the resource version. It must be specified.
+  // Supported values are: `v3`, `v4`, `v5`, `v6`, `v7`.
   string Version = 3 [(gogoproto.jsontag) = "version"];
   // Metadata is resource metadata
   Metadata Metadata = 4 [
@@ -2408,12 +2779,26 @@ enum CreateHostUserMode {
   // HOST_USER_MODE_OFF disables host user creation.
   HOST_USER_MODE_OFF = 1;
   // HOST_USER_MODE_DROP enables host user creation and deletes users at session end.
-  HOST_USER_MODE_DROP = 2;
+  // Deprecated: replaced by HOST_USER_MODE_INSECURE_DROP.
+  HOST_USER_MODE_DROP = 2 [deprecated = true];
   // HOST_USER_MODE_KEEP enables host user creation and leaves users behind at session end.
   HOST_USER_MODE_KEEP = 3;
-  // HOST_USER_MODE_INSECURE enables host user creation without a home directory and deletes
+  // HOST_USER_MODE_INSECURE_DROP enables host user creation without a home directory and deletes
   // users at session end.
   HOST_USER_MODE_INSECURE_DROP = 4;
+}
+
+// CreateDatabaseUserMode determines whether database user creation should be
+// disabled or if users should be cleaned up or kept after sessions end.
+enum CreateDatabaseUserMode {
+  DB_USER_MODE_UNSPECIFIED = 0;
+  // DB_USER_MODE_OFF disables user creation.
+  DB_USER_MODE_OFF = 1;
+  // DB_USER_MODE_KEEP allows user creation and disable users at session end.
+  DB_USER_MODE_KEEP = 2;
+  // DB_USER_MODE_BEST_EFFORT_DROP allows user creation and tries to drop user
+  // at session end. If the drop fails, fallback to disabling them.
+  DB_USER_MODE_BEST_EFFORT_DROP = 3;
 }
 
 // RoleOptions is a set of role options
@@ -2477,7 +2862,7 @@ message RoleOptions {
   // concurrent sessions per connection.
   int64 MaxSessions = 10 [(gogoproto.jsontag) = "max_sessions,omitempty"];
 
-  // RequestAccess defines the access request strategy (optional|note|always)
+  // RequestAccess defines the request strategy (optional|note|always)
   // where optional is the default.
   string RequestAccess = 11 [
     (gogoproto.jsontag) = "request_access,omitempty",
@@ -2548,12 +2933,13 @@ message RoleOptions {
   ];
 
   // RequireMFAType is the type of MFA requirement enforced for this user.
+  // 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH",
+  // 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
   RequireMFAType RequireMFAType = 23 [(gogoproto.jsontag) = "require_session_mfa,omitempty"];
 
   // DeviceTrustMode is the device authorization mode used for the resources
   // associated with the role.
   // See DeviceTrust.Mode.
-  // Reserved for future use, not yet used by Teleport.
   string DeviceTrustMode = 24 [(gogoproto.jsontag) = "device_trust_mode,omitempty"];
 
   // IDP is a set of options related to accessing IdPs within Teleport.
@@ -2575,8 +2961,28 @@ message RoleOptions {
   ];
 
   // CreateHostUserMode allows users to be automatically created on a
-  // host when not set to off
+  // host when not set to off.
+  // 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above),
+  // 3 is "keep"; 4 is "insecure-drop".
   CreateHostUserMode CreateHostUserMode = 28 [(gogoproto.jsontag) = "create_host_user_mode,omitempty"];
+
+  // CreateDatabaseUserMode allows users to be automatically created on a
+  // database when not set to off.
+  // 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop".
+  CreateDatabaseUserMode CreateDatabaseUserMode = 29 [(gogoproto.jsontag) = "create_db_user_mode,omitempty"];
+
+  // MFAVerificationInterval optionally defines the maximum duration that can elapse
+  // between successive MFA verifications. This variable is used to ensure
+  // that users are periodically prompted to verify their identity, enhancing
+  // security by preventing prolonged sessions without re-authentication when using
+  // tsh proxy * derivatives.
+  // It's only effective if the session requires MFA.
+  // If not set, defaults to `max_session_ttl`.
+  google.protobuf.Duration MFAVerificationInterval = 30 [
+    (gogoproto.jsontag) = "mfa_verification_interval,omitempty",
+    (gogoproto.nullable) = false,
+    (gogoproto.stdduration) = true
+  ];
 }
 
 message RecordSession {
@@ -2619,9 +3025,11 @@ enum CertExtensionType {
 message CertExtension {
   // Type represents the certificate type being extended, only ssh
   // is supported at this time.
+  // 0 is "ssh".
   CertExtensionType Type = 1 [(gogoproto.jsontag) = "type"];
   // Mode is the type of extension to be used -- currently
-  // critical-option is not supported
+  // critical-option is not supported.
+  // 0 is "extension".
   CertExtensionMode Mode = 2 [(gogoproto.jsontag) = "mode"];
   // Name specifies the key to be used in the cert extension.
   string Name = 3 [(gogoproto.jsontag) = "name"];
@@ -2783,6 +3191,72 @@ message RoleConditions {
   // GroupLabelsExpression is a predicate expression used to allow/deny
   // access to user groups.
   string GroupLabelsExpression = 37 [(gogoproto.jsontag) = "group_labels_expression,omitempty"];
+  // DatabasePermissions specifies a set of permissions that will be granted
+  // to the database user when using automatic database user provisioning.
+  repeated DatabasePermission DatabasePermissions = 38 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "db_permissions,omitempty"
+  ];
+  // SPIFFE is used to allow or deny access to a role holder to generating a
+  // SPIFFE SVID.
+  repeated SPIFFERoleCondition SPIFFE = 39 [(gogoproto.jsontag) = "spiffe,omitempty"];
+  reserved 40; // removed saml_idp_service_provider_labels in favor of using app_labels.
+  reserved "SAMLIdPServiceProviderLabels";
+  reserved 41; // removed saml_idp_service_provider_labels_expression in favor of using app_labels_expression.
+  reserved "SAMLIdPServiceProviderLabelsExpression";
+}
+
+// SPIFFERoleCondition sets out which SPIFFE identities this role is allowed or
+// denied to generate. The Path matcher is required, and is evaluated first. If,
+// the Path does not match then the other matcher fields are not evaluated.
+message SPIFFERoleCondition {
+  // Path specifies a matcher for the SPIFFE ID path. It should not include the
+  // trust domain and should start with a leading slash.
+  //
+  // The matcher by default allows '*' to be used to indicate zero or more of
+  // any character. Prepend '^' and append '$' to instead switch to matching
+  // using the Go regex syntax.
+  //
+  // Example:
+  // - /svc/foo/*/bar would match /svc/foo/baz/bar
+  // - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar
+  string Path = 1 [(gogoproto.jsontag) = "path,omitempty"];
+  // DNSSANs specifies matchers for the SPIFFE ID DNS SANs.
+  //
+  // Each requested DNS SAN is compared against all matchers configured and if
+  // any match, the condition is considered to be met.
+  //
+  // The matcher by default allows '*' to be used to indicate zero or more of
+  // any character. Prepend '^' and append '$' to instead switch to matching
+  // using the Go regex syntax.
+  //
+  // Example: *.example.com would match foo.example.com
+  repeated string DNSSANs = 2 [(gogoproto.jsontag) = "dns_sans,omitempty"];
+  // IPSANs specifies matchers for the SPIFFE ID IP SANs.
+  //
+  // Each requested IP SAN is compared against all matchers configured and if
+  // any match, the condition is considered to be met.
+  //
+  // The matchers should be specified using CIDR notation, it supports IPv4 and
+  // IPv6.
+  //
+  // Examples:
+  // - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255
+  // - 10.0.0.42/32 would match only 10.0.0.42
+  repeated string IPSANs = 3 [(gogoproto.jsontag) = "ip_sans,omitempty"];
+}
+
+// DatabasePermission specifies the database object permission for the user.
+message DatabasePermission {
+  // Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...
+  repeated string Permissions = 1 [(gogoproto.jsontag) = "permissions"];
+
+  // Match is a list of object labels that must be matched for the permission to be granted.
+  wrappers.LabelValues Match = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "match",
+    (gogoproto.customtype) = "Labels"
+  ];
 }
 
 // KubernetesResource is the Kubernetes resource identifier.
@@ -2912,6 +3386,19 @@ message AccessReviewConditions {
   repeated string PreviewAsRoles = 4 [(gogoproto.jsontag) = "preview_as_roles,omitempty"];
 }
 
+// AccessRequestAllowedPromotion describes an allowed promotion to an access list.
+message AccessRequestAllowedPromotion {
+  // associated access list
+  string accessListName = 1;
+}
+
+// AccessRequestAllowedPromotions describes an valid promotion from an access request
+// to an access list.
+message AccessRequestAllowedPromotions {
+  // suggestions is a list of allowed access lists promotions.
+  repeated AccessRequestAllowedPromotion promotions = 1;
+}
+
 // ClaimMapping maps a claim to teleport roles.
 message ClaimMapping {
   // Claim is a claim name.
@@ -2963,6 +3450,12 @@ message BoolValue {
   bool Value = 1;
 }
 
+// UserFilter matches user resources.
+message UserFilter {
+  // SearchKeywords is a list of search keywords to match against resource field values.
+  repeated string SearchKeywords = 1 [(gogoproto.jsontag) = "search_keywords,omitempty"];
+}
+
 // UserV2 is version 2 resource spec of the user
 message UserV2 {
   option (gogoproto.goproto_stringer) = false;
@@ -2972,7 +3465,8 @@ message UserV2 {
   string Kind = 1 [(gogoproto.jsontag) = "kind"];
   // SubKind is an optional resource sub kind, used in some resources
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is version
+  // Version is the resource version. It must be specified.
+  // Supported values are: `v2`.
   string Version = 3 [(gogoproto.jsontag) = "version"];
   // Metadata is resource metadata
   Metadata Metadata = 4 [
@@ -2984,6 +3478,30 @@ message UserV2 {
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "spec"
   ];
+  UserStatusV2 Status = 6 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "status,omitempty"
+  ];
+}
+
+// UserStatusV2 is a dynamic state of UserV2.
+message UserStatusV2 {
+  // password_state reflects what the system knows about the user's password.
+  // Note that this is a "best effort" property, in that it can be UNSPECIFIED
+  // for users who were created before this property was introduced and didn't
+  // perform any password-related activity since then. See RFD 0159 for
+  // details. Do NOT use this value for authentication purposes!
+  PasswordState password_state = 1 [(gogoproto.jsontag) = "password_state,omitempty"];
+}
+
+// PasswordState indicates what is known about existence of user's password.
+enum PasswordState {
+  // Unable to tell whether the password has been configured.
+  PASSWORD_STATE_UNSPECIFIED = 0;
+  // Password is known to be not configured.
+  PASSWORD_STATE_UNSET = 1;
+  // Password is known to be configured.
+  PASSWORD_STATE_SET = 2;
 }
 
 // UserSpecV2 is a specification for V2 user
@@ -3045,6 +3563,13 @@ message UserSpecV2 {
   LocalAuthSecrets LocalAuth = 9 [(gogoproto.jsontag) = "local_auth,omitempty"];
 
   // TrustedDeviceIDs contains the IDs of trusted devices enrolled by the user.
+  //
+  // Note that SSO users are transient and thus may contain an empty
+  // TrustedDeviceIDs field, even though the user->device association exists
+  // under the Device Trust subsystem. Do not rely on this field to determine
+  // device associations or ownership, it exists for legacy/informative purposes
+  // only.
+  //
   // Managed by the Device Trust subsystem, avoid manual edits.
   repeated string TrustedDeviceIDs = 10 [(gogoproto.jsontag) = "trusted_device_ids,omitempty"];
 }
@@ -3061,6 +3586,9 @@ message ExternalIdentity {
 
   // Username is username supplied by external identity provider
   string Username = 2 [(gogoproto.jsontag) = "username,omitempty"];
+
+  // SAMLSingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out), if applicable.
+  string SAMLSingleLogoutURL = 3 [(gogoproto.jsontag) = "samlSingleLogoutUrl,omitempty"];
 }
 
 // LoginStatus is a login status of the user
@@ -3081,7 +3609,7 @@ message LoginStatus {
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "lock_expires,omitempty"
   ];
-  reserved 5;  // removed "google.protobuf.Timestamp RecoveryAttemptLockExpires" after lockout was removed
+  reserved 5; // removed "google.protobuf.Timestamp RecoveryAttemptLockExpires" after lockout was removed
   reserved "RecoveryAttemptLockExpires";
 }
 
@@ -3204,6 +3732,14 @@ message WebauthnDevice {
   // If an RPID change does happen, this helps Teleport detect it and react
   // accordingly.
   string credential_rp_id = 8;
+  // Authenticator Backup Eligibility (BE) bit, recorded during registration or
+  // backfill (for older authenticators).
+  // https://w3c.github.io/webauthn/#authdata-flags-be
+  google.protobuf.BoolValue credential_backup_eligible = 9;
+  // Authenticator Backup State (BS) bit, recorded during registration or
+  // backfill (for older authenticators).
+  // https://w3c.github.io/webauthn/#authdata-flags-bs
+  google.protobuf.BoolValue credential_backed_up = 10;
 }
 
 // WebauthnLocalAuth holds settings necessary for local webauthn use.
@@ -3425,11 +3961,13 @@ message WebSessionV2 {
 message WebSessionSpecV2 {
   // User is the identity of the user to which the web session belongs.
   string User = 1 [(gogoproto.jsontag) = "user"];
-  // Pub is the SSH certificate for the user.
+  // Pub is the SSH certificate for the user, marshaled in the authorized key
+  // format.
   bytes Pub = 2 [(gogoproto.jsontag) = "pub"];
-  // Priv is the SSH private key for the user.
+  // Priv is the SSH private key for the user, in PEM-encoded PKCS#1 or PKCS#8
+  // format. If TLSPriv is unset, this is also the TLS private key.
   bytes Priv = 3 [(gogoproto.jsontag) = "priv,omitempty"];
-  // TLSCert is the TLS certificate for the user.
+  // TLSCert is the X.509 certificate for the user (PEM-encoded).
   bytes TLSCert = 4 [(gogoproto.jsontag) = "tls_cert,omitempty"];
   // BearerToken is a token that is paired with the session cookie for
   // authentication. It is periodically rotated so a stolen cookie itself
@@ -3464,6 +4002,45 @@ message WebSessionSpecV2 {
   string ConsumedAccessRequestID = 10 [(gogoproto.jsontag) = "consumed_access_request_id,omitempty"];
   // SAMLSession is data associated with a SAML IdP session.
   SAMLSessionData SAMLSession = 11 [(gogoproto.jsontag) = "saml_session,omitempty"];
+  // Device trust web authentication token.
+  // May be exchanged for a single on-behalf-of device authentication attempt
+  // (typically performed by Connect).
+  // Only present if on-behalf-of device authentication is possible.
+  DeviceWebToken DeviceWebToken = 12 [(gogoproto.jsontag) = "device_web_token,omitempty"];
+  // HasDeviceExtensions is true if the session's TLS and SSH certificates are
+  // augmented with device extensions.
+  bool HasDeviceExtensions = 13 [(gogoproto.jsontag) = "has_device_extensions,omitempty"];
+  // TrustedDeviceRequirement indicates whether access may be hindered by the
+  // lack of a trusted device.
+  //
+  // If during login a device is required and DeviceWebToken is nil, then it's
+  // likely the user needs to enroll their device to avoid impacting access.
+  TrustedDeviceRequirement TrustedDeviceRequirement = 14 [(gogoproto.jsontag) = "trusted_device_requirement,omitempty"];
+  // TLSPriv is the TLS private key for the user, in PEM-encoded PKCS#1 or PKCS#8
+  // format. If unset, then Priv is used as both the SSH and TLS private key.
+  bytes TLSPriv = 15 [(gogoproto.jsontag) = "tls_priv,omitempty"];
+}
+
+// TrustedDeviceRequirement indicates whether access may be hindered by the lack
+// of a trusted device.
+enum TrustedDeviceRequirement {
+  // Device requirement not determined.
+  // Does not mean that a device is not required, only that the necessary data
+  // was not considered.
+  TRUSTED_DEVICE_REQUIREMENT_UNSPECIFIED = 0;
+  // Trusted device not required.
+  TRUSTED_DEVICE_REQUIREMENT_NOT_REQUIRED = 1;
+  // Trusted device required by either cluster mode or user roles.
+  TRUSTED_DEVICE_REQUIREMENT_REQUIRED = 2;
+}
+
+// Web-focused view of teleport.devicetrust.v1.DeviceWebToken.
+message DeviceWebToken {
+  // Opaque token identifier.
+  string id = 1;
+  // Opaque device web token, in plaintext, encoded in base64.RawURLEncoding
+  // (so it is inherently safe for URl use).
+  string token = 2;
 }
 
 // WebSessionFilter encodes cache watch parameters for filtering web sessions.
@@ -3847,7 +4424,8 @@ message OIDCConnectorV3 {
   string Kind = 1 [(gogoproto.jsontag) = "kind"];
   // SubKind is an optional resource sub kind, used in some resources.
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is a resource version.
+  // Version is the resource version. It must be specified.
+  // Supported values are: `v3`.
   string Version = 3 [(gogoproto.jsontag) = "version"];
   // Metadata holds resource metadata.
   Metadata Metadata = 4 [
@@ -3924,6 +4502,9 @@ message OIDCConnectorSpecV3 {
     (gogoproto.jsontag) = "",
     (gogoproto.embed) = true
   ];
+  // ClientRedirectSettings defines which client redirect URLs are allowed for
+  // non-browser SSO logins other than the standard localhost ones.
+  SSOClientRedirectSettings ClientRedirectSettings = 18 [(gogoproto.jsontag) = "client_redirect_settings,omitempty"];
 }
 
 // MaxAge allows the max_age parameter to be nullable to preserve backwards
@@ -3933,6 +4514,15 @@ message MaxAge {
     (gogoproto.jsontag) = "max_age",
     (gogoproto.casttype) = "Duration"
   ];
+}
+
+// SSOClientRedirectSettings contains settings to define which additional client
+// redirect URLs should be allowed for non-browser SSO logins.
+message SSOClientRedirectSettings {
+  // a list of hostnames allowed for https client redirect URLs
+  repeated string allowed_https_hostnames = 1;
+  // a list of CIDRs allowed for HTTP or HTTPS client redirect URLs
+  repeated string insecure_allowed_cidr_ranges = 2;
 }
 
 // OIDCAuthRequest is a request to authenticate with OIDC
@@ -4003,6 +4593,10 @@ message OIDCAuthRequest {
 
   // ClientLoginIP specifies IP address of the client for login, it will be written to the user's certificates.
   string ClientLoginIP = 18 [(gogoproto.jsontag) = "client_login_ip,omitempty"];
+
+  // ClientUserAgent is the user agent of the Web browser, used for issuing a
+  // DeviceWebToken.
+  string ClientUserAgent = 19 [(gogoproto.jsontag) = "client_user_agent,omitempty"];
 }
 
 // SAMLConnectorV2 represents a SAML connector.
@@ -4011,7 +4605,8 @@ message SAMLConnectorV2 {
   string Kind = 1 [(gogoproto.jsontag) = "kind"];
   // SubKind is an optional resource sub kind, used in some resources.
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is a resource version.
+  // Version is the resource version. It must be specified.
+  // Supported values are: `v2`.
   string Version = 3 [(gogoproto.jsontag) = "version"];
   // Metadata holds resource metadata.
   Metadata Metadata = 4 [
@@ -4038,7 +4633,7 @@ message SAMLConnectorSpecV2 {
   // SSO is the URL of the identity provider's SSO service.
   string SSO = 2 [(gogoproto.jsontag) = "sso"];
   // Cert is the identity provider certificate PEM.
-  // IDP signs <Response> responses using this certificate.
+  // IDP signs `<Response>` responses using this certificate.
   string Cert = 3 [(gogoproto.jsontag) = "cert"];
   // Display controls how this connector is displayed.
   string Display = 4 [(gogoproto.jsontag) = "display"];
@@ -4077,6 +4672,11 @@ message SAMLConnectorSpecV2 {
     (gogoproto.nullable) = true,
     (gogoproto.jsontag) = "allow_idp_initiated,omitempty"
   ];
+  // ClientRedirectSettings defines which client redirect URLs are allowed for
+  // non-browser SSO logins other than the standard localhost ones.
+  SSOClientRedirectSettings ClientRedirectSettings = 15 [(gogoproto.jsontag) = "client_redirect_settings,omitempty"];
+  // SingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out). If this is not provided, SLO is disabled.
+  string SingleLogoutURL = 16 [(gogoproto.jsontag) = "single_logout_url,omitempty"];
 }
 
 // SAMLAuthRequest is a request to authenticate with SAML
@@ -4139,6 +4739,10 @@ message SAMLAuthRequest {
 
   // ClientLoginIP specifies IP address of the client for login, it will be written to the user's certificates.
   string ClientLoginIP = 17 [(gogoproto.jsontag) = "client_login_ip,omitempty"];
+
+  // ClientUserAgent is the user agent of the Web browser, used for issuing a
+  // DeviceWebToken.
+  string ClientUserAgent = 18 [(gogoproto.jsontag) = "client_user_agent,omitempty"];
 }
 
 // AttributeMapping maps a SAML attribute statement to teleport roles.
@@ -4166,7 +4770,8 @@ message GithubConnectorV3 {
   string Kind = 1 [(gogoproto.jsontag) = "kind"];
   // SubKind is an optional resource sub kind, used in some resources.
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is a resource version.
+  // Version is the resource version. It must be specified.
+  // Supported values are: `v3`.
   string Version = 3 [(gogoproto.jsontag) = "version"];
   // Metadata holds resource metadata.
   Metadata Metadata = 4 [
@@ -4214,6 +4819,9 @@ message GithubConnectorSpecV3 {
   // APIEndpointURL is the URL of the API endpoint of the Github instance
   // this connector is for.
   string APIEndpointURL = 8 [(gogoproto.jsontag) = "api_endpoint_url"];
+  // ClientRedirectSettings defines which client redirect URLs are allowed for
+  // non-browser SSO logins other than the standard localhost ones.
+  SSOClientRedirectSettings ClientRedirectSettings = 9 [(gogoproto.jsontag) = "client_redirect_settings,omitempty"];
 }
 
 // GithubAuthRequest is the request to start Github OAuth2 flow.
@@ -4261,6 +4869,9 @@ message GithubAuthRequest {
   teleport.attestation.v1.AttestationStatement attestation_statement = 16 [(gogoproto.jsontag) = "attestation_statement,omitempty"];
   // ClientLoginIP specifies IP address of the client for login, it will be written to the user's certificates.
   string ClientLoginIP = 17 [(gogoproto.jsontag) = "client_login_ip,omitempty"];
+  // ClientUserAgent is the user agent of the Web browser, used for issuing
+  // a DeviceWebToken.
+  string ClientUserAgent = 18 [(gogoproto.jsontag) = "client_user_agent,omitempty"];
 }
 
 // SSOWarnings conveys a user-facing main message along with auxiliary warnings.
@@ -4466,7 +5077,8 @@ message TrustedClusterV2 {
   string Kind = 1 [(gogoproto.jsontag) = "kind"];
   // SubKind is an optional resource sub kind, used in some resources.
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is a resource version.
+  // Version is the resource version. It must be specified.
+  // Supported values are: `v2`.
   string Version = 3 [(gogoproto.jsontag) = "version"];
   // Metadata holds resource metadata.
   Metadata Metadata = 4 [
@@ -4497,10 +5109,10 @@ message TrustedClusterSpecV2 {
   // Token is the authorization token provided by another cluster needed by this cluster to join.
   string Token = 3 [(gogoproto.jsontag) = "token"];
   // ProxyAddress is the address of the web proxy server of the cluster to join. If not set,
-  // it is derived from <metadata.name>:<default web proxy server port>.
+  // it is derived from `<metadata.name>:<default web proxy server port>`.
   string ProxyAddress = 4 [(gogoproto.jsontag) = "web_proxy_addr"];
   // ReverseTunnelAddress is the address of the SSH proxy server of the cluster to join. If
-  // not set, it is derived from <metadata.name>:<default reverse tunnel port>.
+  // not set, it is derived from `<metadata.name>:<default reverse tunnel port>`.
   string ReverseTunnelAddress = 5 [(gogoproto.jsontag) = "tunnel_addr"];
   // RoleMap specifies role mappings to remote roles.
   repeated RoleMapping RoleMap = 6 [
@@ -4518,7 +5130,8 @@ message LockV2 {
   string Kind = 1 [(gogoproto.jsontag) = "kind"];
   // SubKind is an optional resource sub kind, used in some resources.
   string SubKind = 2 [(gogoproto.jsontag) = "sub_kind,omitempty"];
-  // Version is a resource version.
+  // Version is the resource version. It must be specified.
+  // Supported values are: `v2`.
   string Version = 3 [(gogoproto.jsontag) = "version"];
   // Metadata holds resource metadata.
   Metadata Metadata = 4 [
@@ -4702,6 +5315,15 @@ message WindowsDesktopSpecV3 {
   // NonAD marks this desktop as a standalone host that is
   // not joined to an Active Directory domain.
   bool NonAD = 4 [(gogoproto.jsontag) = "non_ad"];
+  // ScreenSize specifies the size of the screen to use for sessions
+  // on this host. In most cases this should be unspecified, in which
+  // case Teleport will fill the browser window.
+  Resolution ScreenSize = 5 [(gogoproto.jsontag) = "screen_size,omitempty"];
+}
+
+message Resolution {
+  uint32 Width = 1 [(gogoproto.jsontag) = "width,omitempty"];
+  uint32 Height = 2 [(gogoproto.jsontag) = "height,omitempty"];
 }
 
 // RegisterUsingTokenRequest is a request to register with the auth server using
@@ -4745,6 +5367,16 @@ message RegisterUsingTokenRequest {
     (gogoproto.stdtime) = true,
     (gogoproto.jsontag) = "expires,omitempty"
   ];
+  // BotInstanceID is a trusted instance identifier for a Machine ID bot,
+  // provided when rejoining. This parameters may only be provided by the join
+  // service and is ignored otherwise; bots should otherwise rejoin with their
+  // existing client certificate to prove their instance identity.
+  string BotInstanceID = 13 [(gogoproto.jsontag) = "bot_instance_id"];
+  // BotGeneration is a trusted generation counter value for Machine ID bots,
+  // provided to Auth by the Join Service when bots rejoin via a streamed/gRPC
+  // join method. Rejoining bots supply this value via a client certificate
+  // extension; it is ignored from other sources.
+  int32 BotGeneration = 14 [(gogoproto.jsontag) = "bot_generation"];
 }
 
 // RecoveryCodes holds a user's recovery code information. Recovery codes allows users to regain
@@ -4867,8 +5499,8 @@ message SessionTrackerSpecV1 {
   // purpose.
   string Reason = 7 [(gogoproto.jsontag) = "reason,omitempty"];
 
-  // Invited is a list of invited users, this field is interpreted by different
-  // clients on a best-effort basis and used for delivering notifications to invited users.
+  // Invited is a list of invited users, this field can be used by
+  // clients to deliver notifications to invited users.
   repeated string Invited = 8 [(gogoproto.jsontag) = "invited,omitempty"];
 
   // Hostname identifies the target this session is connected to.
@@ -4918,6 +5550,12 @@ message SessionTrackerSpecV1 {
   // It's useful for Kubernetes moderated sessions when running in high availabilty
   // otherwise kube proxy is not able to know which agent runs the session.
   string HostID = 21 [(gogoproto.jsontag) = "host_id,omitempty"];
+
+  // TargetSubKind is the sub kind of the target server.
+  string TargetSubKind = 22 [(gogoproto.jsontag) = "target_sub_kind,omitempty"];
+
+  // InitialCommand is the command that was executed to start this session.
+  repeated string InitialCommand = 23 [(gogoproto.jsontag) = "initial_command,omitempty"];
 }
 
 // SessionTrackerPolicySet is a set of RBAC policies held by the session tracker
@@ -4969,7 +5607,15 @@ message UIConfigV1 {
 
 // UIConfigSpecV1 is the specification for a UIConfig
 message UIConfigSpecV1 {
+  // ScrollbackLines is the max number of lines the UI terminal can display in its history.
   int32 ScrollbackLines = 1 [(gogoproto.jsontag) = "scrollback_lines"];
+  // ShowResources determines which resources are shown in the web UI. Default if unset is "requestable"
+  // which means resources the user has access to and resources they can request will be shown in the
+  // resources UI. If set to `accessible_only`, only resources the user already has access to will be shown.
+  string ShowResources = 2 [
+    (gogoproto.jsontag) = "show_resources,omitempty",
+    (gogoproto.casttype) = "github.com/gravitational/teleport/api/constants.ShowResources"
+  ];
 }
 
 // InstallerV1 represents an installer script resource. Used to
@@ -5121,6 +5767,8 @@ message DatabaseServiceV1 {
 message DatabaseServiceSpecV1 {
   // ResourceMatchers is the configured match for Database resources.
   repeated DatabaseResourceMatcher ResourceMatchers = 1 [(gogoproto.jsontag) = "resources"];
+  // Hostname is the hostname where this service is running.
+  string Hostname = 2 [(gogoproto.jsontag) = "hostname"];
 }
 
 // DatabaseResourceMatcher is a set of properties that is used to match on resources.
@@ -5267,10 +5915,38 @@ enum RequireMFAType {
   // and login sessions must use a private key backed by a hardware key.
   SESSION_AND_HARDWARE_KEY = 2;
   // HARDWARE_KEY_TOUCH means login sessions must use a hardware private key that
-  // requires touch to be used. This touch requirement applies to all API requests
-  // rather than only session requests. This touch is different from MFA, so to prevent
-  // requiring double touch on session requests, normal Session MFA is disabled.
+  // requires touch to be used.
   HARDWARE_KEY_TOUCH = 3;
+  // HARDWARE_KEY_PIN means login sessions must use a hardware private key that
+  // requires pin to be used.
+  HARDWARE_KEY_PIN = 4;
+  // HARDWARE_KEY_TOUCH_AND_PIN means login sessions must use a hardware private key that
+  // requires touch and pin to be used.
+  HARDWARE_KEY_TOUCH_AND_PIN = 5;
+}
+
+// SignatureAlgorithmSuite represents the suite of cryptographic signature algorithms used in the cluster.
+enum SignatureAlgorithmSuite {
+  // SIGNATURE_ALGORITHM_SUITE_UNSPECIFIED represents an unspecified signature algorithm suite.
+  SIGNATURE_ALGORITHM_SUITE_UNSPECIFIED = 0;
+  // SIGNATURE_ALGORITHM_SUITE_LEGACY is the original algorithm suite used in
+  // Teleport, it almost exclusively uses 2048-bit RSA.
+  SIGNATURE_ALGORITHM_SUITE_LEGACY = 1;
+  // SIGNATURE_ALGORITHM_SUITE_BALANCED_V1 aims to strikes a balance between
+  // security, compatibility, and performance. It uses Ed25519 for most SSH
+  // keys, ECDSA on the NIST P256 curve for most TLS keys, and 2048-bit RSA
+  // where necessary for compatibility with third-party software.
+  SIGNATURE_ALGORITHM_SUITE_BALANCED_V1 = 2;
+  // SIGNATURE_ALGORITHM_SUITE_FIPS_V1 is tailored for FIPS compliance. It is
+  // based on the BALANCED_V1 suite but replaces all instances of Ed25519 with
+  // ECDSA on the NIST P256 curve.
+  SIGNATURE_ALGORITHM_SUITE_FIPS_V1 = 3;
+  // SIGNATURE_ALGORITHM_SUITE_HSM_V1 is tailored for clusters using an HSM or
+  // KMS service to back CA private material. It is based on the BALANCED suite
+  // but replaces Ed25519 with ECDSA on the NIST P256 curve for CA keys only,
+  // not for server or client keys. It is also valid to use the LEGACY for FIPS
+  // suites if your cluster uses an HSM or KMS.
+  SIGNATURE_ALGORITHM_SUITE_HSM_V1 = 4;
 }
 
 // Plugin describes a single instance of a Teleport Plugin
@@ -5317,13 +5993,35 @@ message PluginSpecV1 {
     PluginJiraSettings jira = 8;
     // Settings for the Discord plugin
     PluginDiscordSettings discord = 9;
+    // Settings for the ServiceNow plugin
+    PluginServiceNowSettings serviceNow = 10;
+    // Settings for the Gitlab plugin.
+    PluginGitlabSettings gitlab = 12;
+    // Settings for the Entra ID plugin
+    PluginEntraIDSettings entra_id = 13;
+    // Settings for the SCIM plugin
+    PluginSCIMSettings scim = 14;
   }
+
+  // generation contains a unique ID that should:
+  // - Be created by the backend on plugin creation.
+  // - Be updated by the backend if the plugin is updated in any way.
+  //
+  // For older plugins, it's possible for this to be empty.
+  string generation = 11;
 }
 
 message PluginSlackAccessSettings {
   option (gogoproto.equal) = true;
 
   string fallback_channel = 1;
+}
+
+message PluginGitlabSettings {
+  option (gogoproto.equal) = true;
+
+  // APIEndpoint is the address of Gitlab API.
+  string api_endpoint = 1;
 }
 
 message PluginOpsgenieAccessSettings {
@@ -5340,6 +6038,20 @@ message PluginOpsgenieAccessSettings {
   repeated string default_schedules = 4;
   // APIEndpoint is the address of Opsgenie API.
   string api_endpoint = 5;
+}
+
+// PluginServiceNowSettings are the settings for the serviceNow plugin
+message PluginServiceNowSettings {
+  option (gogoproto.equal) = true;
+
+  // ApiEndpoint is the ServiceNow API endpoint.
+  string api_endpoint = 1 [(gogoproto.jsontag) = "api_endpoint,omitempty"];
+  // Username is the ServiceNow API username.
+  string username = 2 [(gogoproto.jsontag) = "username,omitempty"];
+  // Password is the ServiceNow API password.
+  string password = 3 [(gogoproto.jsontag) = "password,omitempty"];
+  // CloseCode is the close code that ServiceNow incidents will use.
+  string close_code = 4 [(gogoproto.jsontag) = "close_code,omitempty"];
 }
 
 message PluginPagerDutySettings {
@@ -5403,6 +6115,59 @@ message PluginOktaSettings {
 
   // OrgUrl is the Okta organization URL to use for API communication.
   string org_url = 1;
+
+  // EnableUserSync controls the user sync in the Okta integration service. Deprecated.
+  // TODO(mdwn): Remove once e changes have been made.
+  bool enable_user_sync = 2;
+
+  // SSOConnectorID (deprecated)
+  // TODO(mdwn): Remove once e changes have been made.
+  string sso_connector_id = 3;
+
+  // Sync settings controls the user and access list sync settings for Okta.
+  PluginOktaSyncSettings sync_settings = 4;
+}
+
+// Defines settings for syncing users and access lists from Okta.
+message PluginOktaSyncSettings {
+  option (gogoproto.equal) = true;
+
+  // SyncUsers controls the user sync in the Okta integration service.
+  bool sync_users = 1;
+
+  // SSOConnectorID is the name of the Teleport SSO connector created and used by the Okta plugin
+  string sso_connector_id = 2;
+
+  // SyncAccessLists controls the access list sync in the Okta integration service.
+  bool sync_access_lists = 3;
+
+  // DefaultOwners are the default owners for all imported access lists.
+  repeated string default_owners = 4;
+
+  // AppID is the Okta-assigned ID of the Okta App that Teleport uses as a
+  // gateway to interact with Okta for SAML login, SCIM provisioning and user
+  // sync. When set, user sync will pull users from the assignment list for this
+  // app. When empty the plugin will fall back to the legacy behaviour of syncing
+  // users from the entre organization.
+  string app_id = 5;
+
+  // GroupFilters are filters for which Okta groups to synchronize as access lists.
+  // Filters can be globs, for example:
+  //   group*
+  //   *service*
+  // Or regexes if they're prefixed and suffixed with ^ and $, for example:
+  //   ^group.*$
+  //   ^.*service.*$
+  repeated string group_filters = 6;
+
+  // AppFilters are filters for which Okta applications to synchronize as access lists.
+  // Filters can be globs, for example:
+  //   app*
+  //   *service*
+  // Or regexes if they're prefixed and suffixed with ^ and $, for example:
+  //   ^app.*$
+  //   ^.*service.*$
+  repeated string app_filters = 7;
 }
 
 // Defines a set of discord channel IDs
@@ -5419,6 +6184,66 @@ message PluginDiscordSettings {
   // channel IDs that will receive notifications and requests regarding that
   // that Role.
   map<string, DiscordChannels> role_to_recipients = 1;
+}
+
+// PluginEntraIDSettings defines settings for the Entra ID sync plugin
+message PluginEntraIDSettings {
+  option (gogoproto.equal) = true;
+
+  // SyncSettings controls the user and access list sync settings for EntraID.
+  PluginEntraIDSyncSettings sync_settings = 1;
+
+  // AccessGraphSettings controls settings for syncing access graph specific data.
+  // When this is null, Entra ID integration with Access Graph is disabled.
+  PluginEntraIDAccessGraphSettings access_graph_settings = 2;
+}
+
+// Defines settings for syncing users and access lists from Entra ID.
+message PluginEntraIDSyncSettings {
+  option (gogoproto.equal) = true;
+
+  // DefaultOwners are the default owners for all imported access lists.
+  repeated string default_owners = 1;
+
+  // SSOConnectorID is the name of the Teleport SSO connector created and used by the Entra ID plugin
+  string sso_connector_id = 2;
+}
+
+// AccessGraphSettings controls settings for syncing access graph specific data.
+message PluginEntraIDAccessGraphSettings {
+  option (gogoproto.equal) = true;
+
+  // AppSsoSettingsCache is an array of single sign-on settings for Entra enterprise applications.
+  //
+  // This data is stored here because it is not available through traditional methods (MS Graph API).
+  // Instead, it is fetched once during the plugin's set up using the user's credentials to connect to Azure's private API.
+  repeated PluginEntraIDAppSSOSettings app_sso_settings_cache = 1;
+}
+
+// PluginEntraIDAppSSOSettings is a container for a single Entra ID enterprise application's
+// cached SSO settings.
+// As this data is only parsed by TAG, each value is stored as an opaque JSON blob.
+message PluginEntraIDAppSSOSettings {
+  option (gogoproto.equal) = true;
+
+  // AppID is the `AppID` property of Entra application.
+  string app_id = 1;
+
+  // FederatedSSOV2 contains the cached, gzip-compressed payload from the /ApplicationSso/{servicePrincipalId}/FederatedSSOV2 endpoint.
+  bytes federated_sso_v2 = 2;
+}
+
+// PluginSCIMSettings defines the settings for a SCIM integration plugin
+message PluginSCIMSettings {
+  option (gogoproto.equal) = true;
+
+  // SamlConnectorName is the name of the SAML Connector that users provisioned
+  // by this SCIM plugin will use to log in to Teleport.
+  string saml_connector_name = 1;
+
+  // DefaultRole is the default role assigned to users provisioned by this
+  // plugin.
+  string default_role = 2;
 }
 
 message PluginBootstrapCredentialsV1 {
@@ -5443,6 +6268,45 @@ message PluginOAuth2AuthorizationCodeCredentials {
 // PluginStatus is the user-facing status for the plugin instance.
 message PluginStatusV1 {
   PluginStatusCode code = 1;
+  // error_message is a human-readable error message that can be displayed to the user.
+  string error_message = 2;
+  // last_sync_time is the last time the plugin was run.
+  google.protobuf.Timestamp last_sync_time = 3 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = false
+  ];
+  // details contains provider-specific plugin status details.
+  oneof details {
+    // gitlab is the status details for the Gitlab plugin.
+    PluginGitlabStatusV1 gitlab = 4;
+    PluginEntraIDStatusV1 entra_id = 5;
+    // Okta holds status details for the Okta plugin
+    PluginOktaStatusV1 okta = 7;
+  }
+
+  // last_raw_error variable stores the most recent raw error message received from an API or service.
+  // It is intended to capture the original error message without any modifications or formatting.
+  // This can be useful for debugging purposes, providing detailed information about what went wrong
+  // in the interaction with the external service.
+  string last_raw_error = 6;
+}
+
+// PluginGitlabStatusV1 is the status details for the Gitlab plugin.
+message PluginGitlabStatusV1 {
+  // imported_users is the number of users imported from Gitlab.
+  uint32 imported_users = 1;
+  // imported_groups is the number of groups imported from Gitlab.
+  uint32 imported_groups = 2;
+  // imported_projects is the number of projects imported from Gitlab.
+  uint32 imported_projects = 3;
+}
+
+// PluginEntraIDStatusV1 is the status details for the Entra ID plugin.
+message PluginEntraIDStatusV1 {
+  // imported_users is the number of users imported from Entra ID.
+  uint32 imported_users = 1;
+  // imported_groups is the number of groups imported from Entra ID.
+  uint32 imported_groups = 2;
 }
 
 enum PluginStatusCode {
@@ -5459,6 +6323,171 @@ enum PluginStatusCode {
   // SLACK_NOT_IN_CHANNEL is a Slack-specific status code that indicates
   // that the bot has not been invited to a channel that it is configured to post in.
   SLACK_NOT_IN_CHANNEL = 10;
+}
+
+// OktaPluginSyncStatusCode indicates the possible states of an Okta
+// synchronization service.
+enum OktaPluginSyncStatusCode {
+  // OKTA_PLUGIN_SYNC_STATUS_CODE_UNSPECIFIED is the status code zero value,
+  // indicating that the service has not yet reported a status code.
+  OKTA_PLUGIN_SYNC_STATUS_CODE_UNSPECIFIED = 0;
+
+  // OKTA_PLUGIN_SYNC_STATUS_CODE_SUCCESS indicates that the service is running
+  // without error
+  OKTA_PLUGIN_SYNC_STATUS_CODE_SUCCESS = 1;
+
+  // OKTA_PLUGIN_SYNC_STATUS_CODE_ERROR indicates that the service is currently
+  // in an error state.
+  OKTA_PLUGIN_SYNC_STATUS_CODE_ERROR = 2;
+}
+
+// PluginOktaStatusV1 contains the details for the running Okta plugin.
+message PluginOktaStatusV1 {
+  // SSODetails are status details relating to SSO.
+  PluginOktaStatusDetailsSSO sso_details = 1;
+
+  // AppGroupSyncDetails are status details relating to synchronizing apps and
+  // groups from Okta.
+  PluginOktaStatusDetailsAppGroupSync app_group_sync_details = 2;
+
+  // UsersSyncDetails are status details relating to synchronizing users from
+  // Okta.
+  PluginOktaStatusDetailsUsersSync users_sync_details = 3;
+
+  // ScimDetails are status details relating to SCIM integration with
+  // Okta.
+  PluginOktaStatusDetailsSCIM scim_details = 4;
+
+  // AccessListSyncDetails are status details relating to synchronizing access
+  // lists from Okta.
+  PluginOktaStatusDetailsAccessListsSync access_lists_sync_details = 5;
+}
+
+// PluginOktaStatusDetailsSSO are details related to the
+// current status of the Okta integration w/r/t SSO.
+message PluginOktaStatusDetailsSSO {
+  // Enabled indicates whether SSO login is enabled.
+  bool enabled = 1;
+
+  // AppId is the unique Okta application ID of the Okta Applicaion used for
+  // SSO login.
+  string app_id = 2;
+
+  // AppName is the human-readable name of the Okta Applicaion used for SSO.
+  string app_name = 3;
+}
+
+// PluginOktaStatusDetailsAppGroupSync are details related to the
+// current status of the Okta integration w/r/t application and group
+// sync.
+message PluginOktaStatusDetailsAppGroupSync {
+  // Enabled is whether the users sync is enabled.
+  bool enabled = 1;
+
+  // StatusCode indicates the current state of the App & Group sync service
+  OktaPluginSyncStatusCode status_code = 2;
+
+  // LastSuccessful is the date of the last successful run.
+  google.protobuf.Timestamp last_successful = 3 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = true,
+    (gogoproto.jsontag) = "last_successful"
+  ];
+
+  // LastFailed is the date of the last failed run.
+  google.protobuf.Timestamp last_failed = 4 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = true,
+    (gogoproto.jsontag) = "last_failed"
+  ];
+
+  // NumAppsSynced is the total number of apps synchronized.
+  int32 num_apps_synced = 5;
+
+  // NumAppsSynced is the total number of groups synchronized.
+  int32 num_groups_synced = 6;
+
+  // Error contains a textual description of the reason the last synchronization
+  // failed. Only valid when StatusCode is OKTA_PLUGIN_SYNC_STATUS_CODE_ERROR.
+  string error = 7;
+}
+
+// PluginOktaStatusDetailsUsersSync are details related to the
+// current status of the Okta integration w/r/t users sync.
+message PluginOktaStatusDetailsUsersSync {
+  // Enabled is whether the users sync is enabled.
+  bool enabled = 1;
+
+  // StatusCode indicates the current state of the User sync service
+  OktaPluginSyncStatusCode status_code = 2;
+
+  // LastSuccessful is the date of the last successful run.
+  google.protobuf.Timestamp last_successful = 3 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = true,
+    (gogoproto.jsontag) = "last_successful"
+  ];
+
+  // LastFailed is the date of the last failed run.
+  google.protobuf.Timestamp last_failed = 4 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = true,
+    (gogoproto.jsontag) = "last_failed"
+  ];
+
+  // NumUsersSynced is the total number of users synchronized.
+  int32 num_users_synced = 5;
+
+  // Error contains a textual description of the reason the last synchronization
+  // failed. Only valid when StatusCode is OKTA_PLUGIN_SYNC_STATUS_CODE_ERROR.
+  string error = 6;
+}
+
+// PluginOktaStatusDetailsSCIM are details related to the
+// current status of the Okta integration w/r/t SCIM.
+message PluginOktaStatusDetailsSCIM {
+  // Enabled is whether SCIM is enabled.
+  bool enabled = 1;
+}
+
+// PluginOktaStatusDetailsAccessListsSync are details related to the
+// current status of the Okta integration w/r/t access list sync.
+message PluginOktaStatusDetailsAccessListsSync {
+  // Enabled is whether access lists sync is enabled.
+  bool enabled = 1;
+
+  // StatusCode indicates the current state of the AccessList sync service
+  OktaPluginSyncStatusCode status_code = 2;
+
+  // LastSuccessful is the date of the last successful run.
+  google.protobuf.Timestamp last_successful = 3 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = true,
+    (gogoproto.jsontag) = "last_successful"
+  ];
+
+  // LastFailed is the date of the last failed run.
+  google.protobuf.Timestamp last_failed = 4 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = true,
+    (gogoproto.jsontag) = "last_failed"
+  ];
+
+  // AppFilters are the app filters used for the access list sync.
+  repeated string app_filters = 5;
+
+  // NumAppsSynced are the number of applications synchronized as access lists.
+  int32 num_apps_synced = 6;
+
+  // GroupFilters are the group filters used for the access list sync.
+  repeated string group_filters = 7;
+
+  // NumGroupsSynced are the number of groups synchronized as access lists.
+  int32 num_groups_synced = 8;
+
+  // Error contains a textual description of the reason the last synchronization
+  // failed. Only valid when StatusCode is OKTA_PLUGIN_SYNC_STATUS_CODE_ERROR.
+  string error = 9;
 }
 
 // PluginCredentialsV1 represents "live" credentials
@@ -5565,10 +6594,34 @@ message SAMLIdPServiceProviderV1 {
 message SAMLIdPServiceProviderSpecV1 {
   // EntityDescriptor is the entity descriptor for the service provider
   string EntityDescriptor = 1 [(gogoproto.jsontag) = "entity_descriptor"];
-  // EntityID is the entity ID for the entity descriptor. This ID is checked that it matches
-  // the entity ID in the entity descriptor at upsert time to avoid having to parse the
-  // XML blob in the entity descriptor every time we need to use this resource.
+  // EntityID is the entity ID for the entity descriptor. If entity descriptor is provided,
+  // this value is checked that it matches the entity ID in the entity descriptor
+  // at upsert time to avoid having to parse the XML blob in the entity descriptor
+  // every time we need to use this resource.
   string EntityID = 2 [(gogoproto.jsontag) = "entity_id"];
+  // ACSURL is the endpoint where SAML authentication response will be redirected.
+  string ACSURL = 3 [(gogoproto.jsontag) = "acs_url"];
+  // AttributeMapping is used to map service provider requested attributes to
+  // username, role and traits in Teleport.
+  repeated SAMLAttributeMapping AttributeMapping = 4 [(gogoproto.jsontag) = "attribute_mapping"];
+  // Preset is used to define service provider profile that will have a custom behavior
+  // processed by Teleport.
+  string Preset = 5 [(gogoproto.jsontag) = "preset"];
+  // RelayState is used to add custom value in the SAML response as a relay_state HTTP parameter.
+  // The value can contain service provider specific redirect URL, static state token etc.
+  // The value is only applied in the IdP initiated SSO flow.
+  string RelayState = 6 [(gogoproto.jsontag) = "relay_state"];
+}
+
+// SAMLAttributeMapping represents SAML service provider requested attribute
+// name, format and its values.
+message SAMLAttributeMapping {
+  //  name is an attribute name.
+  string name = 1 [(gogoproto.jsontag) = "name"];
+  //  name_format is an attribute name format.
+  string name_format = 2 [(gogoproto.jsontag) = "name_format"];
+  //  value is an attribute value definable with predicate expression.
+  string value = 3 [(gogoproto.jsontag) = "value"];
 }
 
 // IdPOptions specify options related to access Teleport IdPs.
@@ -5853,6 +6906,8 @@ message IntegrationSpecV1 {
   oneof SubKindSpec {
     // AWSOIDC contains the specific fields to handle the AWS OIDC Integration subkind
     AWSOIDCIntegrationSpecV1 AWSOIDC = 1 [(gogoproto.jsontag) = "aws_oidc,omitempty"];
+    // AzureOIDC contains the specific fields to handle the Azure OIDC Integration subkind
+    AzureOIDCIntegrationSpecV1 AzureOIDC = 2 [(gogoproto.jsontag) = "azure_oidc,omitempty"];
   }
 }
 
@@ -5861,6 +6916,33 @@ message AWSOIDCIntegrationSpecV1 {
   // RoleARN contains the Role ARN used to set up the Integration.
   // This is the AWS Role that Teleport will use to issue tokens for API Calls.
   string RoleARN = 1 [(gogoproto.jsontag) = "role_arn,omitempty"];
+
+  // IssuerS3URI is the Identity Provider that was configured in AWS.
+  // This bucket/prefix/* files must be publicly accessible and contain the following:
+  // > .well-known/openid-configuration
+  // > .well-known/jwks
+  // Format: s3://<bucket>/<prefix>
+  // Optional. The proxy's endpoint is used if it is not specified.
+  //
+  // DEPRECATED: Thumbprint validation requires the issuer to update the IdP in AWS everytime the issuer changes the certificate.
+  // Amazon had some whitelisted providers where the thumbprint was ignored. S3 hosted providers was in that list.
+  // Amazon is now trusting all the root certificate authorities, and this workaround is no longer needed.
+  // DELETE IN 18.0.
+  string IssuerS3URI = 2 [
+    (gogoproto.jsontag) = "issuer_s3_uri,omitempty",
+    deprecated = true
+  ];
+}
+
+// AzureOIDCIntegrationSpecV1 contains the spec properties for the Azure OIDC SubKind Integration.
+message AzureOIDCIntegrationSpecV1 {
+  // TenantID specifies the ID of Entra Tenant (Directory)
+  // that this plugin integrates with.
+  string TenantID = 1 [(gogoproto.jsontag) = "tenant_id,omitempty"];
+
+  // ClientID specifies the ID of Azure enterprise application (client)
+  // that corresponds to this plugin.
+  string ClientID = 2 [(gogoproto.jsontag) = "client_id,omitempty"];
 }
 
 // HeadlessAuthentication holds data for an ongoing headless authentication attempt.
@@ -5875,7 +6957,9 @@ message HeadlessAuthentication {
   string user = 2;
 
   // PublicKey is an ssh public key to sign in case of successful auth.
-  bytes public_key = 3;
+  //
+  // Deprecated: prefer SshPublicKey and/or TlsPublicKey.
+  bytes public_key = 3 [deprecated = true];
 
   // State is the headless authentication request state.
   HeadlessAuthenticationState state = 4;
@@ -5885,6 +6969,14 @@ message HeadlessAuthentication {
 
   // ClientIPAddress is the IP address of the client being authenticated.
   string client_ip_address = 6;
+
+  // SshPublicKey is a public key that will be used as the subject of the issued
+  // SSH certificate in case of successful auth. It must be in SSH authorized_keys format.
+  bytes ssh_public_key = 7;
+  // TlsPublicKey is a public key that will be used as the subject of the issued
+  // TLS certificate in case of successful auth. It must be in PEM-encoded
+  // PKCS#1 or PKIX format.
+  bytes tls_public_key = 8;
 }
 
 // HeadlessAuthenticationState is a headless authentication state.
@@ -5980,6 +7072,8 @@ message ServerInfoSpecV1 {
 
 // JamfSpecV1 is the base configuration for the Jamf MDM service.
 message JamfSpecV1 {
+  reserved 5, 6, 8, 9;
+  reserved "username", "password", "client_id", "client_secret";
   option (gogoproto.equal) = true;
   // Enabled toggles the service on or off.
   bool enabled = 1 [(gogoproto.jsontag) = "enabled,omitempty"];
@@ -5998,16 +7092,6 @@ message JamfSpecV1 {
   // Example: "https://yourtenant.jamfcloud.com/api".
   // Required.
   string api_endpoint = 4 [(gogoproto.jsontag) = "api_endpoint,omitempty"];
-  // Jamf API username.
-  // Username and password are used to acquire short-lived Jamf Pro API tokens.
-  // See https://developer.jamf.com/jamf-pro/docs/jamf-pro-api-overview.
-  // Required.
-  string username = 5 [(gogoproto.jsontag) = "username,omitempty"];
-  // Jamf API password.
-  // Username and password are used to acquire short-lived Jamf Pro API tokens.
-  // See https://developer.jamf.com/jamf-pro/docs/jamf-pro-api-overview.
-  // Required.
-  string password = 6 [(gogoproto.jsontag) = "password,omitempty"];
   // Inventory sync entries.
   // If empty a default sync configuration is used.
   repeated JamfInventoryEntry inventory = 7 [(gogoproto.jsontag) = "inventory,omitempty"];
@@ -6044,6 +7128,9 @@ message JamfInventoryEntry {
   // Must be either "NOOP" or "DELETE".
   // Defaults to "NOOP".
   string on_missing = 4 [(gogoproto.jsontag) = "on_missing,omitempty"];
+  // Custom page size for inventory queries.
+  // A server default is used if zeroed or negative.
+  int32 page_size = 5 [(gogoproto.jsontag) = "page_size,omitempty"];
 }
 
 // MessageWithHeader is a message with a resource header. This is used primarily
@@ -6095,6 +7182,16 @@ message AWSMatcher {
   // SSM provides options to use when sending a document command to
   // an EC2 node
   AWSSSM SSM = 6 [(gogoproto.jsontag) = "ssm,omitempty"];
+  // Integration is the integration name used to generate credentials to interact with AWS APIs.
+  // Environment credentials will not be used when this value is set.
+  string Integration = 7 [(gogoproto.jsontag) = "integration,omitempty"];
+  // KubeAppDiscovery controls whether Kubernetes App Discovery will be enabled for agents running on
+  // discovered clusters, currently only affects AWS EKS discovery in integration mode.
+  bool KubeAppDiscovery = 8 [(gogoproto.jsontag) = "kube_app_discovery,omitempty"];
+  // SetupAccessForARN is the role that the discovery service should create EKS Access Entries for.
+  // This value should match the IAM identity that Teleport Kubernetes Service uses.
+  // If this value is empty, the discovery service will attempt to set up access for its own identity (self).
+  string SetupAccessForARN = 9 [(gogoproto.jsontag) = "setup_access_for_arn,omitempty"];
 }
 
 // AssumeRole provides a role ARN and ExternalID to assume an AWS role
@@ -6123,8 +7220,27 @@ message InstallerParams {
   // SSHDConfig provides the path to write sshd configuration changes
   string SSHDConfig = 5 [(gogoproto.jsontag) = "sshd_config,omitempty"];
   // PublicProxyAddr is the address of the proxy the discovered node should use
-  // to connect to the cluster. Used only in Azure.
+  // to connect to the cluster.
   string PublicProxyAddr = 6 [(gogoproto.jsontag) = "proxy_addr,omitempty"];
+  // Azure is the set of Azure-specific installation parameters.
+  AzureInstallerParams Azure = 7 [(gogoproto.jsontag) = "azure,omitempty"];
+  // EnrollMode indicates the enrollment mode to be used when adding a node.
+  // Valid values:
+  // 0: uses eice for EC2 matchers which use an integration and script for all the other methods
+  // 1: uses script mode
+  // 2: uses eice mode
+  InstallParamEnrollMode EnrollMode = 8 [(gogoproto.jsontag) = "enroll_mode,omitempty"];
+}
+
+// InstallParamEnrollMode is the mode used to enroll the node into the cluster.
+enum InstallParamEnrollMode {
+  // INSTALL_PARAM_ENROLL_MODE_UNSPECIFIED uses the EICE mode for EC2 Matchers with an Integration and SCRIPT mode otherwise.
+  INSTALL_PARAM_ENROLL_MODE_UNSPECIFIED = 0;
+  // INSTALL_PARAM_ENROLL_MODE_SCRIPT runs a script on the target host.
+  INSTALL_PARAM_ENROLL_MODE_SCRIPT = 1;
+  // INSTALL_PARAM_ENROLL_MODE_EICE uses EC2 Instance Connect Endpoint to access the node and DiscoveryService handles the heartbeat.
+  // Only available for AWS EC2 instances.
+  INSTALL_PARAM_ENROLL_MODE_EICE = 2;
 }
 
 // AWSSSM provides options to use when executing SSM documents
@@ -6132,6 +7248,13 @@ message AWSSSM {
   // DocumentName is the name of the document to use when executing an
   // SSM command
   string DocumentName = 1 [(gogoproto.jsontag) = "document_name,omitempty"];
+}
+
+// AzureInstallerParams is the set of Azure-specific installation parameters.
+message AzureInstallerParams {
+  // ClientID is the client ID of the managed identity discovered nodes
+  // should use to join the cluster.
+  string ClientID = 1 [(gogoproto.jsontag) = "client_id,omitempty"];
 }
 
 // AzureMatcher matches Azure resources.
@@ -6162,7 +7285,7 @@ message GCPMatcher {
   repeated string Types = 1 [(gogoproto.jsontag) = "types,omitempty"];
   // Locations are GKE locations to search resources for.
   repeated string Locations = 2 [(gogoproto.jsontag) = "locations,omitempty"];
-  // Tags are GCP labels to match.
+  // Tags is obsolete and only exists for backwards compatibility. Use Labels instead.
   wrappers.LabelValues Tags = 3 [
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "tags,omitempty",
@@ -6175,6 +7298,12 @@ message GCPMatcher {
   // Params sets the join method when installing on
   // discovered GCP nodes.
   InstallerParams Params = 6 [(gogoproto.jsontag) = "install_params,omitempty"];
+  // Labels are GCP labels to match.
+  wrappers.LabelValues Labels = 7 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "labels,omitempty",
+    (gogoproto.customtype) = "Labels"
+  ];
 }
 
 // KubernetesMatcher matches Kubernetes services.
@@ -6198,4 +7327,20 @@ message OktaOptions {
     (gogoproto.jsontag) = "sync_period,omitempty",
     (gogoproto.casttype) = "Duration"
   ];
+}
+
+// AccessGraphSync is a configuration for Access Graph service.
+message AccessGraphSync {
+  // AWS is a configuration for AWS Access Graph service poll service.
+  repeated AccessGraphAWSSync AWS = 1 [(gogoproto.jsontag) = "aws,omitempty"];
+}
+
+// AccessGraphAWSSync is a configuration for AWS Access Graph service poll service.
+message AccessGraphAWSSync {
+  // Regions are AWS regions to import resources from.
+  repeated string Regions = 1 [(gogoproto.jsontag) = "regions,omitempty"];
+  // AssumeRoleARN is the AWS role to assume for database discovery.
+  AssumeRole AssumeRole = 3 [(gogoproto.jsontag) = "assume_role,omitempty"];
+  // Integration is the integration name used to generate credentials to interact with AWS APIs.
+  string Integration = 4 [(gogoproto.jsontag) = "integration,omitempty"];
 }

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/types/webauthn/webauthn.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/types/webauthn/webauthn.proto
@@ -1,20 +1,16 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 
@@ -40,34 +36,6 @@ import "gogoproto/gogo.proto";
 option go_package = "github.com/gravitational/teleport/api/types/webauthn;webauthnpb";
 option (gogoproto.marshaler_all) = true;
 option (gogoproto.unmarshaler_all) = true;
-
-// -----------------------------------------------------------------------------
-// WebAuthn messages used by server storage.
-// -----------------------------------------------------------------------------
-
-// SessionData stored by the Relying Party during authentication ceremonies.
-// Mirrors https://pkg.go.dev/github.com/go-webauthn/webauthn/webauthn#SessionData.
-message SessionData {
-  // Raw challenge used for the ceremony.
-  bytes challenge = 1 [(gogoproto.jsontag) = "challenge,omitempty"];
-  // Raw User ID.
-  bytes user_id = 2 [(gogoproto.jsontag) = "userId,omitempty"];
-  // Raw Credential IDs of the credentials allowed for the ceremony.
-  repeated bytes allow_credentials = 3 [(gogoproto.jsontag) = "allowCredentials,omitempty"];
-  // True if resident keys were required by the server / Relying Party.
-  bool resident_key = 4 [(gogoproto.jsontag) = "residentKey,omitempty"];
-  // Requested user verification requirement, either "discouraged" or
-  // "required".
-  // An empty value is treated equivalently to "discouraged".
-  string user_verification = 5 [(gogoproto.jsontag) = "userVerification,omitempty"];
-}
-
-// User represents a WebAuthn user.
-// Used mainly to correlated a WebAuthn user handle with a Teleport user.
-message User {
-  // Teleport user ID.
-  string teleport_user = 1;
-}
 
 // -----------------------------------------------------------------------------
 // Assertion (aka login).
@@ -205,6 +173,10 @@ message AuthenticationExtensionsClientInputs {
   // Only available if using U2F compatibility mode.
   // https://www.w3.org/TR/webauthn-2/#sctn-appid-extension.
   string app_id = 1;
+
+  // Enables the credProps extension.
+  // https://w3c.github.io/webauthn/#sctn-authenticator-credential-properties-extension
+  bool cred_props = 2;
 }
 
 // Extensions supplied by the authenticator to the Relying Party, during
@@ -215,6 +187,18 @@ message AuthenticationExtensionsClientOutputs {
   // the rpIdHash accordingly.
   // https://www.w3.org/TR/webauthn-2/#sctn-appid-extension.
   bool app_id = 1;
+
+  // Credential properties per credProps extension.
+  // https://w3c.github.io/webauthn/#sctn-authenticator-credential-properties-extension.
+  CredentialPropertiesOutput cred_props = 2;
+}
+
+// CredentialPropertiesOutput is the output of the credProps extension.
+message CredentialPropertiesOutput {
+  // If true, the created credential is a resident key (regardless of the
+  // AuthenticatorSelection.require_resident_key value).
+  // OPTIONAL by specification.
+  bool rk = 1;
 }
 
 // Authenticator selection criteria.

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/types/wrappers/wrappers.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/legacy/types/wrappers/wrappers.proto
@@ -1,20 +1,16 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/loginrule/v1/loginrule.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/loginrule/v1/loginrule.proto
@@ -1,20 +1,16 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 

--- a/integrations/operator/crdgen/testdata/protofiles/teleport/loginrule/v1/loginrule_service.proto
+++ b/integrations/operator/crdgen/testdata/protofiles/teleport/loginrule/v1/loginrule_service.proto
@@ -1,26 +1,23 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
 
 package teleport.loginrule.v1;
 
 import "google/protobuf/empty.proto";
+import "teleport/legacy/types/wrappers/wrappers.proto";
 import "teleport/loginrule/v1/loginrule.proto";
 
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1;loginrulev1";
@@ -43,6 +40,11 @@ service LoginRuleService {
 
   // DeleteLoginRule deletes an existing login rule.
   rpc DeleteLoginRule(DeleteLoginRuleRequest) returns (google.protobuf.Empty);
+
+  // TestLoginRule evaluates login rules against provided user traits
+  // to test that the output matches expectations prior to them being enforced and
+  // potentially locking out users.
+  rpc TestLoginRule(TestLoginRuleRequest) returns (TestLoginRuleResponse);
 }
 
 // CreateLoginRuleRequest is a request to create a login rule.
@@ -88,4 +90,21 @@ message ListLoginRulesResponse {
 message DeleteLoginRuleRequest {
   // Name is the name of the login rule to delete.
   string name = 1;
+}
+
+// TestLoginRuleRequest is a request to test a login rule against traits.
+message TestLoginRuleRequest {
+  // LoginRules is the list of the rules to evaluate.
+  repeated LoginRule login_rules = 1;
+  // Traits are the user traits to test the login rule against.
+  map<string, wrappers.StringValues> traits = 4;
+  // LoadFromCluster indicates if existing login rules should be included
+  // when evaluating rules.
+  bool load_from_cluster = 3;
+}
+
+// TestLoginRuleResponse is a response to a login rule test.
+message TestLoginRuleResponse {
+  // Traits contain the output from evaluating the login rules.
+  map<string, wrappers.StringValues> traits = 4;
 }


### PR DESCRIPTION
Integration tests only run on `api/types` changes so they don't end up validating if the crds are out of sync with protos.