### PR TITLE
[v15] docs: include amazon linux 2023 in supported ec2 instances for auto enrollment

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery.mdx
@@ -18,7 +18,7 @@ the Teleport cluster for the lifetime of the token.
 
 - AWS account with EC2 instances and permissions to create and attach IAM
 policies.
-- EC2 instances running Ubuntu/Debian/RHEL/Amazon Linux 2 and SSM agent version 3.1 or greater if making use of the
+- EC2 instances running Ubuntu/Debian/RHEL/Amazon Linux 2/Amazon Linux 2023 and SSM agent version 3.1 or greater if making use of the
 default Teleport install script. (For other Linux distributions, you can
 install Teleport manually.)
 - (!docs/pages/includes/tctl.mdx!)


### PR DESCRIPTION
Backport #46212 to branch/v15