### PR TITLE
[v14] Adding extra pod labels to post-upgrade and post-delete hook job pods

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
+++ b/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
@@ -73,6 +73,15 @@ spec:
   template:
     metadata:
       name: {{ .Release.Name }}-delete-hook
+{{- if .Values.annotations.pod }}
+      annotations:
+  {{- toYaml .Values.annotations.pod | nindent 8 }}
+{{- end }}
+      labels:
+        app: {{ .Release.Name }}
+{{- if .Values.extraLabels.pod }}
+  {{- toYaml .Values.extraLabels.pod | nindent 8 }}
+{{- end }}
     spec:
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/examples/chart/teleport-kube-agent/templates/hook.yaml
+++ b/examples/chart/teleport-kube-agent/templates/hook.yaml
@@ -63,6 +63,15 @@ spec:
   template:
     metadata:
       name: {{ .Release.Name }}-hook
+{{- if .Values.annotations.pod }}
+      annotations:
+  {{- toYaml .Values.annotations.pod | nindent 8 }}
+{{- end }}
+      labels:
+        app: {{ .Release.Name }}
+{{- if .Values.extraLabels.pod }}
+  {{- toYaml .Values.extraLabels.pod | nindent 8 }}
+{{- end }}
     spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -89,6 +89,8 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
     spec:
       template:
         metadata:
+          labels:
+            app: RELEASE-NAME
           name: RELEASE-NAME-delete-hook
         spec:
           containers:

--- a/examples/chart/teleport-kube-agent/tests/job_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/job_test.yaml
@@ -258,3 +258,20 @@ tests:
           apiVersion: rbac.authorization.k8s.io/v1
       - matchSnapshot:
           path: spec.template.spec
+
+  - it: should contain pod labels in the Job's pod spec if extraLabels.pod is set
+    template: delete_hook.yaml
+    # documentIndex: 0=ServiceAccount 1=Role 2=RoleBinding 3=Job
+    documentIndex: 3
+    values:
+      - ../.lint/backwards-compatibility.yaml
+    set:
+      extraLabels:
+        pod:
+          testLabel: testValue
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels
+          value:
+            app: RELEASE-NAME
+            testLabel: testValue

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -405,7 +405,7 @@ extraLabels:
   deployment: {}
   # Labels to set on the post-delete Job created by the chart.
   job: {}
-  # Labels for each Pod in the Deployment/StatefulSet
+  # Labels for each Pod in the Deployment, StatefulSet,  or Job
   pod: {}
   # Labels for the Pod Disruption Budget (ignored when disabled)
   podDisruptionBudget: {}


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/46029 to branch/v14

changelog: Ensure that additional pod labels are carried over to post-upgrade and post-delete hook job pods when using the teleport-kube-agent Helm chart.