### PR TITLE
Fix the alert layout

### DIFF
--- a/web/packages/design/src/Alert/Alert.tsx
+++ b/web/packages/design/src/Alert/Alert.tsx
@@ -205,7 +205,6 @@ export const Alert = ({
 const OuterContainer = styled.div<AlertProps>`
   box-sizing: border-box;
   margin: 0 0 24px 0;
-  min-height: 40px;
 
   border: ${p => p.theme.borders[2]};
   border-radius: ${p => p.theme.radii[3]}px;


### PR DESCRIPTION
This PR fixes the `Alert` component layout when its container is eager to shrink its height. It turned out that the min-height declaration was unnecessary and did more harm than good.

Before:

![Screenshot 2024-09-04 at 17 35 54](https://github.com/user-attachments/assets/4cc3b5fa-4113-40a6-a97a-a9721f2b873c)

After:

![Screenshot 2024-09-04 at 17 37 26](https://github.com/user-attachments/assets/631c7ef1-6292-41bf-8480-200ecfa6d88d)
