### PR TITLE
[v16] ci: Ensure Helm lint is run on helm changes

### DIFF
--- a/.github/workflows/unit-tests-helm.yaml
+++ b/.github/workflows/unit-tests-helm.yaml
@@ -26,6 +26,8 @@ jobs:
             changed:
               - '.github/workflows/unit-tests-helm.yaml'
               - 'examples/chart/**'
+              - 'Makefile'
+              - 'docs/pages/reference/helm-reference/*'
 
   test:
     name: Unit Tests (Helm)
@@ -46,6 +48,10 @@ jobs:
       - name: Checkout Teleport
         uses: actions/checkout@v4
 
+      - name: Lint helm
+        timeout-minutes: 10
+        run: make lint-helm
+
       - name: Run tests
-        timeout-minutes: 40
+        timeout-minutes: 10
         run: make test-helm

--- a/Makefile
+++ b/Makefile
@@ -1102,11 +1102,10 @@ e2e-aws: $(TEST_LOG_DIR) ensure-gotestsum
 lint: lint-api lint-go lint-kube-agent-updater lint-tools lint-protos lint-no-actions
 
 #
-# Lints everything but Go sources.
-# Similar to lint.
+# Runs linters without dedicated GitHub Actions.
 #
 .PHONY: lint-no-actions
-lint-no-actions: lint-sh lint-helm lint-license
+lint-no-actions: lint-sh lint-license
 
 .PHONY: lint-tools
 lint-tools: lint-build-tooling lint-backport

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -1499,7 +1499,7 @@ for more information.
 | `object` | `{}` |
 
 `extraLabels.pod` are labels to set on the Pods created by the
-Deployment or StatefulSet.
+Deployment, StatefulSet, or Job.
 
 ### `extraLabels.podDisruptionBudget`
 

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -1499,7 +1499,7 @@ for more information.
 | `object` | `{}` |
 
 `extraLabels.pod` are labels to set on the Pods created by the
-Deployment, StatefulSet, or Job.
+Deployment or StatefulSet.
 
 ### `extraLabels.podDisruptionBudget`
 

--- a/examples/chart/Makefile
+++ b/examples/chart/Makefile
@@ -43,32 +43,32 @@ check-chart-ref-example:
 	@ echo "Checking example chart reference"
 	@ cd ../../build.assets/tooling && \
 	go run ./cmd/render-helm-ref -chart ./cmd/render-helm-ref/testdata -output - | diff ../../build.assets/tooling/cmd/render-helm-ref/testdata/expected-output.mdx - || \
-	( echo "Chart values.yaml and reference differ, please run 'make render-chart-ref'" && exit 1 )
+	( echo "Chart values.yaml and reference differ, please run 'make -C examples/chart render-chart-ref'" && exit 1 )
 
 # .PHONY: check-chart-ref-teleport-cluster
 # check-chart-ref-teleport-cluster:
 # 	echo "Checking teleport-cluster reference"
 # 	cd ../../build.assets/tooling && \
 # 	go run ./cmd/render-helm-ref -chart ../../examples/chart/teleport-cluster -output - | diff ../../docs/pages/includes/helm-reference/zz_generated.teleport-cluster.mdx - || \
-# 	( echo "Chart values.yaml and reference differ, please run 'make render-chart-ref'" && exit 1 )
+#	( echo "Chart values.yaml and reference differ, please run 'make -C examples/chart render-chart-ref'" && exit 1 )
 #
 .PHONY: check-chart-ref-teleport-kube-agent
 check-chart-ref-teleport-kube-agent:
 	@ echo "Checking teleport-kube-agent reference"
 	@ cd ../../build.assets/tooling && \
 	go run ./cmd/render-helm-ref -chart ../../examples/chart/teleport-kube-agent -output - | diff ../../docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx - || \
-	( echo "Chart values.yaml and reference differ, please run 'make render-chart-ref'" && exit 1 )
+	( echo "Chart values.yaml and reference differ, please run 'make -C examples/chart render-chart-ref'" && exit 1 )
 
 .PHONY: check-chart-ref-teleport-operator
 check-chart-ref-teleport-operator:
 	@echo "Checking teleport-operator reference"
 	@ cd ../../build.assets/tooling && \
 	go run ./cmd/render-helm-ref -chart ../../examples/chart/teleport-cluster/charts/teleport-operator -output - | diff ../../docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx - || \
-	( echo "Chart values.yaml and reference differ, please run 'make render-chart-ref'" && exit 1 )
+	( echo "Chart values.yaml and reference differ, please run 'make -C examples/chart render-chart-ref'" && exit 1 )
 
 .PHONY: check-chart-ref-access-%
 check-chart-ref-access-%:
 	@echo "Checking access/$* reference"
 	@ cd ../../build.assets/tooling && \
 	go run ./cmd/render-helm-ref -chart ../../examples/chart/access/$* -output - | diff ../../docs/pages/includes/helm-reference/zz_generated.access-$*.mdx - || \
-	( echo "Chart values.yaml and reference differ, please run 'make render-chart-ref'" && exit 1 )
+	( echo "Chart values.yaml and reference differ, please run 'make -C examples/chart render-chart-ref'" && exit 1 )


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/46243 to `branch/v16`.