### PR TITLE
[v15] ci: Ensure Helm lint is run on helm changes

### DIFF
--- a/.github/workflows/unit-tests-helm.yaml
+++ b/.github/workflows/unit-tests-helm.yaml
@@ -12,9 +12,34 @@ on:
       - 'examples/chart/**'
 
 jobs:
+  changes:
+    name: Check for relevant changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      changed: ${{ steps.changes.outputs.changed }}
+    steps:
+      - name: Checkout
+        if: ${{ github.event_name == 'merge_group' }}
+        uses: actions/checkout@v4
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          base: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
+          filters: |
+            changed:
+              - '.github/workflows/unit-tests-helm.yaml'
+              - 'examples/chart/**'
+              - 'Makefile'
+              - 'docs/pages/reference/helm-reference/*'
+
   test:
     name: Unit Tests (Helm)
+    needs: changes
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && needs.changes.outputs.changed == 'true' }}
 
     permissions:
       contents: read
@@ -29,6 +54,10 @@ jobs:
       - name: Checkout Teleport
         uses: actions/checkout@v4
 
+      - name: Lint helm
+        timeout-minutes: 10
+        run: make lint-helm
+
       - name: Run tests
-        timeout-minutes: 40
+        timeout-minutes: 10
         run: make test-helm

--- a/Makefile
+++ b/Makefile
@@ -1040,11 +1040,10 @@ e2e-aws: $(TEST_LOG_DIR) ensure-gotestsum
 lint: lint-api lint-go lint-kube-agent-updater lint-tools lint-protos lint-no-actions
 
 #
-# Lints everything but Go sources.
-# Similar to lint.
+# Runs linters without dedicated GitHub Actions.
 #
 .PHONY: lint-no-actions
-lint-no-actions: lint-sh lint-helm lint-license lint-rust
+lint-no-actions: lint-sh lint-license lint-rust
 
 .PHONY: lint-tools
 lint-tools: lint-build-tooling lint-backport

--- a/examples/chart/Makefile
+++ b/examples/chart/Makefile
@@ -37,32 +37,32 @@ check-chart-ref-example:
 	@echo "Checking example chart reference"
 	@cd ../../build.assets/tooling && \
 	go run ./cmd/render-helm-ref -chart ./cmd/render-helm-ref/testdata -output - | diff ../../build.assets/tooling/cmd/render-helm-ref/testdata/expected-output.mdx - || \
-	( echo "Chart values.yaml and reference differ, please run 'make render-chart-ref'" && exit 1 )
+	( echo "Chart values.yaml and reference differ, please run 'make -C examples/chart render-chart-ref'" && exit 1 )
 
 # .PHONY: check-chart-ref-teleport-cluster
 # check-chart-ref-teleport-cluster:
 # 	echo "Checking teleport-cluster reference"
 # 	cd ../../build.assets/tooling && \
 # 	go run ./cmd/render-helm-ref -chart ../../examples/chart/teleport-cluster -output - | diff ../../docs/pages/includes/helm-reference/zz_generated.teleport-cluster.mdx - || \
-# 	( echo "Chart values.yaml and reference differ, please run 'make render-chart-ref'" && exit 1 )
+#	( echo "Chart values.yaml and reference differ, please run 'make -C examples/chart render-chart-ref'" && exit 1 )
 #
 .PHONY: check-chart-ref-teleport-kube-agent
 check-chart-ref-teleport-kube-agent:
 	echo "Checking teleport-kube-agent reference"
 	cd ../../build.assets/tooling && \
 	go run ./cmd/render-helm-ref -chart ../../examples/chart/teleport-kube-agent -output - | diff ../../docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx - || \
-	( echo "Chart values.yaml and reference differ, please run 'make render-chart-ref'" && exit 1 )
+	( echo "Chart values.yaml and reference differ, please run 'make -C examples/chart render-chart-ref'" && exit 1 )
 
 .PHONY: check-chart-ref-teleport-operator
 check-chart-ref-teleport-operator:
 	@echo "Checking teleport-operator reference"
 	@cd ../../build.assets/tooling && \
 	go run ./cmd/render-helm-ref -chart ../../examples/chart/teleport-cluster/charts/teleport-operator -output - | diff ../../docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx - || \
-	( echo "Chart values.yaml and reference differ, please run 'make render-chart-ref'" && exit 1 )
+	( echo "Chart values.yaml and reference differ, please run 'make -C examples/chart render-chart-ref'" && exit 1 )
 
 .PHONY: check-chart-ref-access-slack
 check-chart-ref-access-slack:
 	@echo "Checking access/slack reference"
 	@cd ../../build.assets/tooling && \
 	go run ./cmd/render-helm-ref -chart ../../examples/chart/access/slack -output - | diff ../../docs/pages/includes/helm-reference/zz_generated.access-slack.mdx - || \
-	( echo "Chart values.yaml and reference differ, please run 'make render-chart-ref'" && exit 1 )
+	( echo "Chart values.yaml and reference differ, please run 'make -C examples/chart render-chart-ref'" && exit 1 )


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/46243 to `branch/v15`.