### PR TITLE
[v14] fix duplicate session recording creation

### DIFF
--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -538,7 +538,12 @@ func (u *Uploader) upload(ctx context.Context, up *upload) error {
 		}
 
 		return trace.ConnectionProblem(nil, "upload stream terminated unexpectedly")
-	case <-stream.Status():
+	case status := <-stream.Status():
+		if err := up.writeStatus(status); err != nil {
+			// all other stream status writes are optimistic, but we want to make sure the initial
+			// status is written to disk so that we don't create orphaned multipart uploads.
+			return trace.Errorf("failed to write initial stream status: %v", err)
+		}
 	case <-time.After(events.NetworkRetryDuration):
 		return trace.ConnectionProblem(nil, "timeout waiting for stream status update")
 	case <-ctx.Done():

--- a/lib/events/s3sessions/s3handler_thirdparty_test.go
+++ b/lib/events/s3sessions/s3handler_thirdparty_test.go
@@ -67,6 +67,9 @@ func TestThirdpartyStreams(t *testing.T) {
 	t.Run("UploadDownload", func(t *testing.T) {
 		test.UploadDownload(t, handler)
 	})
+	t.Run("StreamEmpty", func(t *testing.T) {
+		test.StreamEmpty(t, handler)
+	})
 	t.Run("DownloadNotFound", func(t *testing.T) {
 		test.DownloadNotFound(t, handler)
 	})

--- a/lib/events/test/streamsuite.go
+++ b/lib/events/test/streamsuite.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/session"
 )
 
@@ -147,6 +148,41 @@ func StreamWithPermutedParameters(t *testing.T, handler events.MultipartHandler,
 			StreamWithParameters(t, handler, pc)
 		})
 	}
+}
+
+// StreamEmpty verifies stream upload with zero events gets correctly discarded. This behavior is
+// necessary in order to prevent a bug where agents might think they have failed to create a multipart
+// upload and create a new one, resulting in duplicate recordings overwriiting each other.
+func StreamEmpty(t *testing.T, handler events.MultipartHandler) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sid := session.NewID()
+
+	streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
+		Uploader:          handler,
+		MinUploadBytes:    1024,
+		ConcurrentUploads: 2,
+	})
+	require.NoError(t, err)
+
+	stream, err := streamer.CreateAuditStream(ctx, sid)
+	require.NoError(t, err)
+
+	select {
+	case status := <-stream.Status():
+		require.Equal(t, status.LastEventIndex, int64(-1))
+	case <-time.After(time.Second):
+		t.Fatalf("Timed out waiting for status update.")
+	}
+
+	require.NoError(t, stream.Complete(ctx))
+
+	f, err := os.CreateTemp("", string(sid))
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	fixtures.AssertNotFound(t, handler.Download(ctx, sid, f))
 }
 
 // StreamWithParameters tests stream upload and subsequent download and reads the results


### PR DESCRIPTION
Backport #45877 to branch/v14

changelog: fixed an issue that could result in duplicate session recordings being created
