### PR TITLE
[v15] fix duplicate session recording creation

### DIFF
--- a/lib/events/s3sessions/s3handler_thirdparty_test.go
+++ b/lib/events/s3sessions/s3handler_thirdparty_test.go
@@ -68,6 +68,9 @@ func TestThirdpartyStreams(t *testing.T) {
 	t.Run("UploadDownload", func(t *testing.T) {
 		test.UploadDownload(t, handler)
 	})
+	t.Run("StreamEmpty", func(t *testing.T) {
+		test.StreamEmpty(t, handler)
+	})
 	t.Run("DownloadNotFound", func(t *testing.T) {
 		test.DownloadNotFound(t, handler)
 	})

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -535,7 +535,7 @@ func (w *sliceWriter) receiveAndUpload() error {
 			return nil
 		case <-w.proto.completeCtx.Done():
 			// if present, send remaining data for upload
-			if w.current != nil {
+			if w.current != nil && !w.current.isEmpty() {
 				// mark that the current part is last (last parts are allowed to be
 				// smaller than the certain size, otherwise the padding
 				// have to be added (this is due to S3 API limits)
@@ -574,7 +574,7 @@ func (w *sliceWriter) receiveAndUpload() error {
 				// there is no need to schedule a timer until the next
 				// event occurs, set the timer channel to nil
 				flushCh = nil
-				if w.current != nil {
+				if w.current != nil && !w.current.isEmpty() {
 					log.Debugf("Inactivity timer ticked at %v, inactivity period: %v exceeded threshold and have data. Flushing.", now, inactivityPeriod)
 					if err := w.startUploadCurrentSlice(); err != nil {
 						return trace.Wrap(err)
@@ -855,6 +855,7 @@ type slice struct {
 	buffer         *bytes.Buffer
 	isLast         bool
 	lastEventIndex int64
+	eventCount     uint64
 }
 
 // reader returns a reader for the bytes written, no writes should be done after this
@@ -897,10 +898,18 @@ func (s *slice) shouldUpload() bool {
 	return int64(s.buffer.Len()) >= s.proto.cfg.MinUploadBytes
 }
 
+// isEmpty returns true if the slice hasn't had any events written to
+// it yet.
+func (s *slice) isEmpty() bool {
+	return s.eventCount == 0
+}
+
 // recordEvent emits a single session event to the stream
 func (s *slice) recordEvent(event protoEvent) error {
 	bytes := s.proto.cfg.SlicePool.Get()
 	defer s.proto.cfg.SlicePool.Put(bytes)
+
+	s.eventCount++
 
 	messageSize := event.oneof.Size()
 	recordSize := ProtoStreamV1RecordHeaderSize + messageSize
@@ -909,6 +918,7 @@ func (s *slice) recordEvent(event protoEvent) error {
 		return trace.BadParameter(
 			"error in buffer allocation, expected size to be >= %v, got %v", recordSize, len(bytes))
 	}
+
 	binary.BigEndian.PutUint32(bytes, uint32(messageSize))
 	_, err := event.oneof.MarshalTo(bytes[Int32Size:])
 	if err != nil {


### PR DESCRIPTION
Backport #45877 to branch/v15

changelog: fixed an issue that could result in duplicate session recordings being created
