### PR TITLE
[v16] Add a link text label to the ClusterAlert resource

### DIFF
--- a/api/types/cluster_alert.go
+++ b/api/types/cluster_alert.go
@@ -32,6 +32,7 @@ var matchAlertLabelKey = regexp.MustCompile(`^[a-z0-9\.\-\/]+$`).MatchString
 // matchAlertLabelVal is a slightly more permissive matcher for label values.
 var matchAlertLabelVal = regexp.MustCompile(`^[a-z0-9\.\-_\/:|]+$`).MatchString
 
+// matchAlertLabelCTAVal only allows alphanumeric characters and spaces.
 var matchAlertLabelCTAVal = regexp.MustCompile(`^[a-zA-Z0-9 ]+$`).MatchString
 
 const validLinkDestination = "goteleport.com"

--- a/api/types/cluster_alert.go
+++ b/api/types/cluster_alert.go
@@ -32,8 +32,8 @@ var matchAlertLabelKey = regexp.MustCompile(`^[a-z0-9\.\-\/]+$`).MatchString
 // matchAlertLabelVal is a slightly more permissive matcher for label values.
 var matchAlertLabelVal = regexp.MustCompile(`^[a-z0-9\.\-_\/:|]+$`).MatchString
 
-// matchAlertLabelCTAVal only allows alphanumeric characters and spaces.
-var matchAlertLabelCTAVal = regexp.MustCompile(`^[a-zA-Z0-9 ]+$`).MatchString
+// matchAlertLabelLinkTextVal only allows alphanumeric characters and spaces.
+var matchAlertLabelLinkTextVal = regexp.MustCompile(`^[a-zA-Z0-9 ]+$`).MatchString
 
 const validLinkDestination = "goteleport.com"
 
@@ -164,8 +164,8 @@ func (c *ClusterAlert) CheckAndSetDefaults() error {
 			if u.Hostname() != validLinkDestination {
 				return trace.BadParameter("invalid alert: label link not allowed %q", val)
 			}
-		case AlertLinkCTA:
-			if !matchAlertLabelCTAVal(val) {
+		case AlertLinkText:
+			if !matchAlertLabelLinkTextVal(val) {
 				return trace.BadParameter("invalid alert: label button text not allowed: %q", val)
 			}
 		default:

--- a/api/types/cluster_alert.go
+++ b/api/types/cluster_alert.go
@@ -166,7 +166,7 @@ func (c *ClusterAlert) CheckAndSetDefaults() error {
 			}
 		case AlertLinkCTA:
 			if !matchAlertLabelCTAVal(val) {
-				return trace.BadParameter("invalid alert: label link CTA not allowed: %q", val)
+				return trace.BadParameter("invalid alert: label button text not allowed: %q", val)
 			}
 		default:
 			if !matchAlertLabelVal(val) {

--- a/api/types/cluster_alert_test.go
+++ b/api/types/cluster_alert_test.go
@@ -85,12 +85,11 @@ func TestAlertSorting(t *testing.T) {
 }
 
 // TestCheckAndSetDefaults verifies that only valid URLs are set on the link
-// label and that only valid CTA text can be used.
+// label and that only valid link text can be used.
 func TestCheckAndSetDefaultsWithLink(t *testing.T) {
 	tests := []struct {
 		options []AlertOption
 		name    string
-		cta     string
 		assert  require.ErrorAssertionFunc
 	}{
 		{
@@ -99,10 +98,10 @@ func TestCheckAndSetDefaultsWithLink(t *testing.T) {
 			assert:  require.NoError,
 		},
 		{
-			name: "valid link with CTA",
+			name: "valid link with link text",
 			options: []AlertOption{
 				WithAlertLabel(AlertLink, "https://goteleport.com/support"),
-				WithAlertLabel(AlertLinkCTA, "Contact Support"),
+				WithAlertLabel(AlertLinkText, "Contact Support"),
 			},
 			assert: require.NoError,
 		},
@@ -117,10 +116,10 @@ func TestCheckAndSetDefaultsWithLink(t *testing.T) {
 			assert:  require.Error,
 		},
 		{
-			name: "valid link with invalid CTA",
+			name: "valid link with invalid link text",
 			options: []AlertOption{
 				WithAlertLabel(AlertLink, "https://goteleport.com/support"),
-				WithAlertLabel(AlertLinkCTA, "Contact!Support"),
+				WithAlertLabel(AlertLinkText, "Contact!Support"),
 			},
 			assert: require.Error,
 		},

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -945,6 +945,10 @@ const (
 	// AlertLink is an internal label that indicates that an alert is a link.
 	AlertLink = TeleportInternalLabelPrefix + "link"
 
+	// AlertLinkCTA is a call-to-action text that will be rendered by Web UI on
+	// the CTA button accompanying the alert.
+	AlertLinkCTA = TeleportInternalLabelPrefix + "link-cta"
+
 	// AlertVerbPermit is an internal label that permits a user to view the alert if they
 	// hold a specific resource permission verb (e.g. 'node:list'). Note that this label is
 	// a coarser control than it might initially appear and has the potential for accidental

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -945,9 +945,9 @@ const (
 	// AlertLink is an internal label that indicates that an alert is a link.
 	AlertLink = TeleportInternalLabelPrefix + "link"
 
-	// AlertLinkCTA is a call-to-action text that will be rendered by Web UI on
-	// the CTA button accompanying the alert.
-	AlertLinkCTA = TeleportInternalLabelPrefix + "link-cta"
+	// AlertLinkText is a text that will be rendered by Web UI on the action
+	// button accompanying the alert.
+	AlertLinkText = TeleportInternalLabelPrefix + "link-text"
 
 	// AlertVerbPermit is an internal label that permits a user to view the alert if they
 	// hold a specific resource permission verb (e.g. 'node:list'). Note that this label is

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -144,8 +144,9 @@ const (
 	OSSDesktopsAlertMessage = "Your cluster is beyond its allocation of 5 non-Active Directory Windows desktops. " +
 		"Reach out for unlimited desktops with Teleport Enterprise."
 
-	OSSDesktopAlertLink = "https://goteleport.com/r/upgrade-community?utm_campaign=CTA_windows_local"
-	OSSDesktopsLimit    = 5
+	OSSDesktopsAlertLink    = "https://goteleport.com/r/upgrade-community?utm_campaign=CTA_windows_local"
+	OSSDesktopsAlertLinkCTA = "Contact Sales"
+	OSSDesktopsLimit        = 5
 )
 
 const (
@@ -5555,7 +5556,8 @@ func (a *Server) syncDesktopsLimitAlert(ctx context.Context) {
 		types.WithAlertSeverity(types.AlertSeverity_MEDIUM),
 		types.WithAlertLabel(types.AlertOnLogin, "yes"),
 		types.WithAlertLabel(types.AlertPermitAll, "yes"),
-		types.WithAlertLabel(types.AlertLink, OSSDesktopAlertLink),
+		types.WithAlertLabel(types.AlertLink, OSSDesktopsAlertLink),
+		types.WithAlertLabel(types.AlertLinkCTA, OSSDesktopsAlertLinkCTA),
 		types.WithAlertExpires(time.Now().Add(OSSDesktopsCheckPeriod)))
 	if err != nil {
 		log.Warnf("Can't create OSS non-AD desktops limit alert: %v", err)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -144,9 +144,9 @@ const (
 	OSSDesktopsAlertMessage = "Your cluster is beyond its allocation of 5 non-Active Directory Windows desktops. " +
 		"Reach out for unlimited desktops with Teleport Enterprise."
 
-	OSSDesktopsAlertLink    = "https://goteleport.com/r/upgrade-community?utm_campaign=CTA_windows_local"
-	OSSDesktopsAlertLinkCTA = "Contact Sales"
-	OSSDesktopsLimit        = 5
+	OSSDesktopsAlertLink     = "https://goteleport.com/r/upgrade-community?utm_campaign=CTA_windows_local"
+	OSSDesktopsAlertLinkText = "Contact Sales"
+	OSSDesktopsLimit         = 5
 )
 
 const (
@@ -5557,7 +5557,7 @@ func (a *Server) syncDesktopsLimitAlert(ctx context.Context) {
 		types.WithAlertLabel(types.AlertOnLogin, "yes"),
 		types.WithAlertLabel(types.AlertPermitAll, "yes"),
 		types.WithAlertLabel(types.AlertLink, OSSDesktopsAlertLink),
-		types.WithAlertLabel(types.AlertLinkCTA, OSSDesktopsAlertLinkCTA),
+		types.WithAlertLabel(types.AlertLinkText, OSSDesktopsAlertLinkText),
 		types.WithAlertExpires(time.Now().Add(OSSDesktopsCheckPeriod)))
 	if err != nil {
 		log.Warnf("Can't create OSS non-AD desktops limit alert: %v", err)

--- a/lib/usagereporter/teleport/aggregating/submitter.go
+++ b/lib/usagereporter/teleport/aggregating/submitter.go
@@ -51,6 +51,7 @@ const (
 	alertGraceDuration = alertGraceHours * time.Hour
 	alertName          = "reporting-failed"
 	alertLink          = "https://goteleport.com/support/"
+	alertLinkCTA       = "Contact Support"
 )
 
 const (
@@ -204,6 +205,7 @@ func submitOnce(ctx context.Context, c SubmitterConfig) {
 			types.WithAlertLabel(types.AlertOnLogin, "yes"),
 			types.WithAlertLabel(types.AlertPermitAll, "yes"),
 			types.WithAlertLabel(types.AlertLink, alertLink),
+			types.WithAlertLabel(types.AlertLinkCTA, alertLinkCTA),
 		)
 		if err != nil {
 			c.Log.WithError(err).Errorf("Failed to create cluster alert %v.", alertName)

--- a/lib/usagereporter/teleport/aggregating/submitter.go
+++ b/lib/usagereporter/teleport/aggregating/submitter.go
@@ -51,7 +51,7 @@ const (
 	alertGraceDuration = alertGraceHours * time.Hour
 	alertName          = "reporting-failed"
 	alertLink          = "https://goteleport.com/support/"
-	alertLinkCTA       = "Contact Support"
+	alertLinkText      = "Contact Support"
 )
 
 const (
@@ -205,7 +205,7 @@ func submitOnce(ctx context.Context, c SubmitterConfig) {
 			types.WithAlertLabel(types.AlertOnLogin, "yes"),
 			types.WithAlertLabel(types.AlertPermitAll, "yes"),
 			types.WithAlertLabel(types.AlertLink, alertLink),
-			types.WithAlertLabel(types.AlertLinkCTA, alertLinkCTA),
+			types.WithAlertLabel(types.AlertLinkText, alertLinkText),
 		)
 		if err != nil {
 			c.Log.WithError(err).Errorf("Failed to create cluster alert %v.", alertName)


### PR DESCRIPTION
Backport #45972 to branch/v16

Note: the intended result is for this change to have no impact on the UI, but set the new alert labels so that they are there when the UI that uses it is introduced after update to v17.