### PR TITLE
chore: Bump Buf to v1.40.0

### DIFF
--- a/buf-legacy.yaml
+++ b/buf-legacy.yaml
@@ -13,7 +13,7 @@ deps:
 
 lint:
   use:
-    - DEFAULT
+    - STANDARD
     - PACKAGE_NO_IMPORT_CYCLE
     # Top-level types require comments.
     # TODO(codingllama): Fix messages and enable linters below.
@@ -28,7 +28,7 @@ lint:
     - ENUM_VALUE_UPPER_SNAKE_CASE
     - FIELD_LOWER_SNAKE_CASE
     - ONEOF_LOWER_SNAKE_CASE
-    # DEFAULT
+    # STANDARD
     - ENUM_VALUE_PREFIX
     - ENUM_ZERO_VALUE_SUFFIX
     - PACKAGE_VERSION_SUFFIX

--- a/buf.yaml
+++ b/buf.yaml
@@ -11,11 +11,11 @@ deps:
 
 lint:
   use:
+    - STANDARD
     - COMMENT_ENUM
     - COMMENT_MESSAGE
     - COMMENT_RPC
     - COMMENT_SERVICE
-    - DEFAULT
     - PACKAGE_NO_IMPORT_CYCLE
     - UNARY_RPC
   except:

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -17,7 +17,7 @@ LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 DEVTOOLSET ?= devtoolset-12
 
 # Protogen related versions.
-BUF_VERSION ?= v1.39.0
+BUF_VERSION ?= v1.40.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4


### PR DESCRIPTION
Update to the latest release.

- https://github.com/bufbuild/buf/releases/tag/v1.40.0