### PR TITLE
[v16] Fix debug service not being disabled by configuration

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -268,7 +268,7 @@ type CommandLineFlags struct {
 	ProfileSeconds int
 
 	// DisableDebugService disables the debug service.
-	DisabledDebugService bool
+	DisableDebugService bool
 }
 
 // IntegrationConfAccessGraphAWSSync contains the arguments of
@@ -2650,7 +2650,7 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 		}
 	}
 
-	if clf.DisabledDebugService {
+	if clf.DisableDebugService {
 		cfg.DebugService.Enabled = false
 	}
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -266,6 +266,9 @@ type CommandLineFlags struct {
 
 	// ProfileSeconds defines the time the pprof will be collected.
 	ProfileSeconds int
+
+	// DisableDebugService disables the debug service.
+	DisabledDebugService bool
 }
 
 // IntegrationConfAccessGraphAWSSync contains the arguments of
@@ -462,8 +465,8 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	if fc.WindowsDesktop.Disabled() {
 		cfg.WindowsDesktop.Enabled = false
 	}
-	if fc.Debug.Enabled() {
-		cfg.DebugService.Enabled = true
+	if fc.Debug.Disabled() {
+		cfg.DebugService.Enabled = false
 	}
 
 	if fc.AccessGraph.Enabled {
@@ -2645,6 +2648,10 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 		if err != nil {
 			return trace.Wrap(err, "invalid proxygroup generation %q: %v", proxyGroupGeneration, err)
 		}
+	}
+
+	if clf.DisabledDebugService {
+		cfg.DebugService.Enabled = false
 	}
 
 	return nil

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -4999,3 +4999,39 @@ func TestProxyUntrustedCert(t *testing.T) {
 	// - the system root certs are loaded exactly once and cached
 	// - it only works on linux
 }
+
+func TestDebugServiceConfig(t *testing.T) {
+	for name, tc := range map[string]struct {
+		configFile                string
+		commandLineFlags          *CommandLineFlags
+		expectDebugServiceEnabled bool
+	}{
+		"enabled by default": {configFile: "", expectDebugServiceEnabled: true},
+		"disabled by commandline": {
+			configFile:                "",
+			commandLineFlags:          &CommandLineFlags{DisabledDebugService: true},
+			expectDebugServiceEnabled: false,
+		},
+		"disabled by configuration": {
+			configFile: `
+debug_service:
+  enabled: "no"
+`,
+			expectDebugServiceEnabled: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			filePath := filepath.Join(t.TempDir(), "config.yaml")
+			require.NoError(t, os.WriteFile(filePath, []byte(tc.configFile), 0o777))
+
+			if tc.commandLineFlags == nil {
+				tc.commandLineFlags = &CommandLineFlags{}
+			}
+			tc.commandLineFlags.ConfigFile = filePath
+
+			conf := servicecfg.MakeDefaultConfig()
+			require.NoError(t, Configure(tc.commandLineFlags, conf, false))
+			require.Equal(t, tc.expectDebugServiceEnabled, conf.DebugService.Enabled)
+		})
+	}
+}

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -5009,7 +5009,7 @@ func TestDebugServiceConfig(t *testing.T) {
 		"enabled by default": {configFile: "", expectDebugServiceEnabled: true},
 		"disabled by commandline": {
 			configFile:                "",
-			commandLineFlags:          &CommandLineFlags{DisabledDebugService: true},
+			commandLineFlags:          &CommandLineFlags{DisableDebugService: true},
 			expectDebugServiceEnabled: false,
 		},
 		"disabled by configuration": {
@@ -5024,7 +5024,7 @@ debug_service:
 debug_service:
   enabled: "yes"
 `,
-			commandLineFlags:          &CommandLineFlags{DisabledDebugService: true},
+			commandLineFlags:          &CommandLineFlags{DisableDebugService: true},
 			expectDebugServiceEnabled: false,
 		},
 	} {

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -5019,6 +5019,14 @@ debug_service:
 `,
 			expectDebugServiceEnabled: false,
 		},
+		"commandline flag has priority over config file": {
+			configFile: `
+debug_service:
+  enabled: "yes"
+`,
+			commandLineFlags:          &CommandLineFlags{DisabledDebugService: true},
+			expectDebugServiceEnabled: false,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			filePath := filepath.Join(t.TempDir(), "config.yaml")

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -196,7 +196,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	start.Flag("db-aws-region",
 		"AWS region AWS hosted database instance is running in.").Hidden().
 		StringVar(&ccf.DatabaseAWSRegion)
-	start.Flag("no-debug-service", "Disables debug service.").BoolVar(&ccf.DisabledDebugService)
+	start.Flag("no-debug-service", "Disables debug service.").BoolVar(&ccf.DisableDebugService)
 
 	// define start's usage info (we use kingpin's "alias" field for this)
 	start.Alias(usageNotes + usageExamples)
@@ -220,7 +220,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	appStartCmd.Flag("diag-addr", "Start diagnostic prometheus and healthz endpoint.").StringVar(&ccf.DiagnosticAddr)
 	appStartCmd.Flag("insecure", "Insecure mode disables certificate validation").BoolVar(&ccf.InsecureMode)
 	appStartCmd.Flag("skip-version-check", "Skip version checking between server and client.").Default("false").BoolVar(&ccf.SkipVersionCheck)
-	appStartCmd.Flag("no-debug-service", "Disables debug service.").BoolVar(&ccf.DisabledDebugService)
+	appStartCmd.Flag("no-debug-service", "Disables debug service.").BoolVar(&ccf.DisableDebugService)
 	appStartCmd.Alias(appUsageExamples) // We're using "alias" section to display usage examples.
 
 	// "teleport db" command and its subcommands
@@ -257,7 +257,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dbStartCmd.Flag("diag-addr", "Start diagnostic prometheus and healthz endpoint.").StringVar(&ccf.DiagnosticAddr)
 	dbStartCmd.Flag("insecure", "Insecure mode disables certificate validation").BoolVar(&ccf.InsecureMode)
 	dbStartCmd.Flag("skip-version-check", "Skip version checking between server and client.").Default("false").BoolVar(&ccf.SkipVersionCheck)
-	dbStartCmd.Flag("no-debug-service", "Disables debug service.").BoolVar(&ccf.DisabledDebugService)
+	dbStartCmd.Flag("no-debug-service", "Disables debug service.").BoolVar(&ccf.DisableDebugService)
 	dbStartCmd.Alias(dbUsageExamples) // We're using "alias" section to display usage examples.
 
 	dbConfigure := dbCmd.Command("configure", "Bootstraps database service configuration and cloud permissions.")

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -196,6 +196,9 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	start.Flag("db-aws-region",
 		"AWS region AWS hosted database instance is running in.").Hidden().
 		StringVar(&ccf.DatabaseAWSRegion)
+	start.Flag("disable-debug-service",
+		"Disables debug service.").Hidden().
+		BoolVar(&ccf.DisabledDebugService)
 
 	// define start's usage info (we use kingpin's "alias" field for this)
 	start.Alias(usageNotes + usageExamples)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -196,9 +196,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	start.Flag("db-aws-region",
 		"AWS region AWS hosted database instance is running in.").Hidden().
 		StringVar(&ccf.DatabaseAWSRegion)
-	start.Flag("disable-debug-service",
-		"Disables debug service.").Hidden().
-		BoolVar(&ccf.DisabledDebugService)
+	start.Flag("no-debug-service", "Disables debug service.").BoolVar(&ccf.DisabledDebugService)
 
 	// define start's usage info (we use kingpin's "alias" field for this)
 	start.Alias(usageNotes + usageExamples)
@@ -222,6 +220,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	appStartCmd.Flag("diag-addr", "Start diagnostic prometheus and healthz endpoint.").StringVar(&ccf.DiagnosticAddr)
 	appStartCmd.Flag("insecure", "Insecure mode disables certificate validation").BoolVar(&ccf.InsecureMode)
 	appStartCmd.Flag("skip-version-check", "Skip version checking between server and client.").Default("false").BoolVar(&ccf.SkipVersionCheck)
+	appStartCmd.Flag("no-debug-service", "Disables debug service.").BoolVar(&ccf.DisabledDebugService)
 	appStartCmd.Alias(appUsageExamples) // We're using "alias" section to display usage examples.
 
 	// "teleport db" command and its subcommands
@@ -258,6 +257,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dbStartCmd.Flag("diag-addr", "Start diagnostic prometheus and healthz endpoint.").StringVar(&ccf.DiagnosticAddr)
 	dbStartCmd.Flag("insecure", "Insecure mode disables certificate validation").BoolVar(&ccf.InsecureMode)
 	dbStartCmd.Flag("skip-version-check", "Skip version checking between server and client.").Default("false").BoolVar(&ccf.SkipVersionCheck)
+	dbStartCmd.Flag("no-debug-service", "Disables debug service.").BoolVar(&ccf.DisabledDebugService)
 	dbStartCmd.Alias(dbUsageExamples) // We're using "alias" section to display usage examples.
 
 	dbConfigure := dbCmd.Command("configure", "Bootstraps database service configuration and cloud permissions.")


### PR DESCRIPTION
Backport #46032 to branch/v16

changelog: Fixed debug service not being turned off by configuration; Connect My Computer in Teleport Connect should no longer fail with "bind: invalid argument"
