### PR TITLE
Bump Go to 1.23.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -227,6 +227,6 @@ output:
   uniq-by-line: false
 
 run:
-  go: '1.22'
+  go: '1.23'
   build-tags: []
   timeout: 15m

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.22
+FROM docker.io/golang:1.23
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.22.6
+go 1.23.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.23.0
+go 1.23.1
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.23.0
+GOLANG_VERSION ?= go1.23.1
 GOLANGCI_LINT_VERSION ?= v1.60.3
 
 NODE_VERSION ?= 20.14.0

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.22.6
+GOLANG_VERSION ?= go1.23.0
 GOLANGCI_LINT_VERSION ?= v1.60.3
 
 NODE_VERSION ?= 20.14.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.23.0
+go 1.23.1
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.22.6
+go 1.23.0
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.12.0

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.22.6
+go 1.23.0
 
 require (
 	github.com/alecthomas/kong v0.9.0

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.23.0
+go 1.23.1
 
 require (
 	github.com/alecthomas/kong v0.9.0

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.23.0
+go 1.23.1
 
 // Doc generation tooling
 require github.com/hashicorp/terraform-plugin-docs v0.0.0 // replaced

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.22.6
+go 1.23.0
 
 // Doc generation tooling
 require github.com/hashicorp/terraform-plugin-docs v0.0.0 // replaced


### PR DESCRIPTION
Restores Go 1.23 to both toolchain and module and update it to 1.23.1.

- Announcement: https://groups.google.com/g/golang-announce/c/K-cEzDeCtpc/m/OYKru5vTAQAJ
- database/sql fix: https://github.com/golang/go/commit/6de5a7180cc6459235895c76c792a7f15be5625d (see the [go1.23.1 tag][])

[go1.23.1 tag]: https://github.com/golang/go/commits/go1.23.1/

Related PRs: #45473 (restored), #45530 (restored) and #45593 (reverted).

Changelog: Updated Go to 1.23