### PR TITLE
[v16] docs: removing tctl and tsh version from pre-reqs partial block

### DIFF
--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -1,7 +1,7 @@
 - A running Teleport cluster. If you want to get started with Teleport, [sign
   up](https://goteleport.com/signup) for a free trial.
 
-- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
+- The `tctl` admin tool and `tsh` client tool.
 
   Visit [Installation](../installation.mdx) for instructions on downloading
   `tctl` and `tsh`.


### PR DESCRIPTION
Backport #46204 to branch/v16