### PR TITLE
Clarify TLS paths in the database GUI guide

### DIFF
--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -149,9 +149,9 @@ the `tsh proxy db` command you ran earlier:
 
 |Field|Path|
 |---|---|
+|Certificate Authority|`ca_file`|
 |Client Certificate|`cert_file`|
 |Client Private Key|`key_file`|
-|Certificate Authority|`ca_file`|
 
 Click on the "Connect" button.
 
@@ -206,8 +206,8 @@ proxy db` command you ran earlier:
 
 |Field|Path|
 |---|---|
-|SSL CERT File|`cert_file`|
 |SSL Key File|`key_file`|
+|SSL CERT File|`cert_file`|
 |SSL CA File|`ca_file`|
 
 Optionally, click "Test Connection" to verify connectivity:
@@ -344,16 +344,16 @@ Provide your Redis username as `Username` and password as `Password`.
 
 ![Redis Insight Configuration](../../img/database-access/guides/redis/redisinsight-add-config.png)
 
-Next, check the `Use TLS` and `Verify TLS Certificates` boxes. Copy the files at
-the paths returned by the `tsh proxy db` command you ran earlier and paste them
-into their corresponding fields. See the table below for the Redis Insight
-fields that correspond to each path:
+Next, check the `Use TLS` and `Verify TLS Certificates` boxes. Copy the contents
+of the files at the paths returned by the `tsh proxy db` command you ran earlier
+and paste them into their corresponding fields. See the table below for the
+Redis Insight fields that correspond to each path:
 
 |Field|Path|
 |---|---|
+|CA Certificate|`ca_file`|
 |Client Certificate|`cert_file`|
 |Private Key|`key_file`|
-|CA Certificate|`ca_file`|
 
 Click `Add Redis Database`.
 

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -144,6 +144,15 @@ Proxy Service's web endpoint.
 
 ![MongoDB Compass more options](../../img/database-access/compass-more-options@2x.png)
 
+The following fields in the More Options tab must correspond to paths printed by
+the `tsh proxy db` command you ran earlier:
+
+|Field|Path|
+|---|---|
+|Client Certificate|`cert_file`|
+|Client Private Key|`key_file`|
+|Certificate Authority|`ca_file`|
+
 Click on the "Connect" button.
 
 ## MySQL DBeaver
@@ -191,6 +200,15 @@ paths to your CA, certificate, and private key files (see
 [Get connection information](./gui-clients.mdx#get-connection-information)):
 
 ![MySQL Workbench SSL](../../img/database-access/workbench-ssl@2x.png)
+
+The following fields in the SSL tab must correspond to paths printed by the `tsh
+proxy db` command you ran earlier:
+
+|Field|Path|
+|---|---|
+|SSL CERT File|`cert_file`|
+|SSL Key File|`key_file`|
+|SSL CA File|`ca_file`|
 
 Optionally, click "Test Connection" to verify connectivity:
 
@@ -270,6 +288,15 @@ certificate, key and root certificate from the configuration above:
 
 ![pgAdmin SSL](../../img/database-access/pgadmin-ssl@2x.png)
 
+The following fields in the SSL tab must correspond to paths printed by the `tsh
+proxy db` command you ran earlier:
+
+|Field|Path|
+|---|---|
+|Client certificate|`cert_file`|
+|Client certificate key|`key_file`|
+|Root certificate|`ca_file`|
+
 Click "Save", and pgAdmin should immediately connect. If pgAdmin prompts you
 for password, leave the password field empty and click OK.
 
@@ -317,8 +344,16 @@ Provide your Redis username as `Username` and password as `Password`.
 
 ![Redis Insight Configuration](../../img/database-access/guides/redis/redisinsight-add-config.png)
 
-Next, check the `Use TLS` and `Verify TLS Certificates` boxes and copy the CA certificate returned by `tsh proxy db`.
-Copy the private key and certificate to corresponding fields.
+Next, check the `Use TLS` and `Verify TLS Certificates` boxes. Copy the files at
+the paths returned by the `tsh proxy db` command you ran earlier and paste them
+into their corresponding fields. See the table below for the Redis Insight
+fields that correspond to each path:
+
+|Field|Path|
+|---|---|
+|Client Certificate|`cert_file`|
+|Private Key|`key_file`|
+|CA Certificate|`ca_file`|
 
 Click `Add Redis Database`.
 


### PR DESCRIPTION
Closes #20344

Make more explicit correspondences between TLS credential paths returned by `tsh proxy db` and configuration fields in four GUI clients.