### PR TITLE
Update generic storage service to support validation and custom keys

### DIFF
--- a/lib/services/local/access_graph.go
+++ b/lib/services/local/access_graph.go
@@ -48,23 +48,25 @@ type AccessGraphSecretsService struct {
 // SSH Keys. Future implementations might extend them.
 func NewAccessGraphSecretsService(backend backend.Backend) (*AccessGraphSecretsService, error) {
 	authorizedKeysSvc, err := generic.NewServiceWrapper(
-		backend,
-		types.KindAccessGraphSecretAuthorizedKey,
-		authorizedKeysPrefix,
-		services.MarshalAccessGraphAuthorizedKey,
-		services.UnmarshalAccessGraphAuthorizedKey,
-	)
+		generic.ServiceWrapperConfig[*accessgraphsecretspb.AuthorizedKey]{
+			Backend:       backend,
+			ResourceKind:  types.KindAccessGraphSecretAuthorizedKey,
+			BackendPrefix: authorizedKeysPrefix,
+			MarshalFunc:   services.MarshalAccessGraphAuthorizedKey,
+			UnmarshalFunc: services.UnmarshalAccessGraphAuthorizedKey,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	privateKeysSvc, err := generic.NewServiceWrapper(
-		backend,
-		types.KindAccessGraphSecretPrivateKey,
-		privateKeysPrefix,
-		services.MarshalAccessGraphPrivateKey,
-		services.UnmarshalAccessGraphPrivateKey,
-	)
+		generic.ServiceWrapperConfig[*accessgraphsecretspb.PrivateKey]{
+			Backend:       backend,
+			ResourceKind:  types.KindAccessGraphSecretPrivateKey,
+			BackendPrefix: privateKeysPrefix,
+			MarshalFunc:   services.MarshalAccessGraphPrivateKey,
+			UnmarshalFunc: services.UnmarshalAccessGraphPrivateKey,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/access_monitoring_rules.go
+++ b/lib/services/local/access_monitoring_rules.go
@@ -40,11 +40,15 @@ type AccessMonitoringRulesService struct {
 
 // NewAccessMonitoringRulesService creates a new AccessMonitoringRulesService.
 func NewAccessMonitoringRulesService(backend backend.Backend) (*AccessMonitoringRulesService, error) {
-	service, err := generic.NewServiceWrapper(backend,
-		types.KindAccessMonitoringRule,
-		accessMonitoringRulesPrefix,
-		services.MarshalAccessMonitoringRule,
-		services.UnmarshalAccessMonitoringRule)
+	service, err := generic.NewServiceWrapper(
+		generic.ServiceWrapperConfig[*accessmonitoringrulesv1.AccessMonitoringRule]{
+			Backend:       backend,
+			ResourceKind:  types.KindAccessMonitoringRule,
+			BackendPrefix: accessMonitoringRulesPrefix,
+			MarshalFunc:   services.MarshalAccessMonitoringRule,
+			UnmarshalFunc: services.UnmarshalAccessMonitoringRule,
+			ValidateFunc:  services.ValidateAccessMonitoringRule,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -75,29 +79,18 @@ func (s *AccessMonitoringRulesService) GetAccessMonitoringRule(ctx context.Conte
 
 // CreateAccessMonitoringRule creates a new AccessMonitoringRule resource.
 func (s *AccessMonitoringRulesService) CreateAccessMonitoringRule(ctx context.Context, amr *accessmonitoringrulesv1.AccessMonitoringRule) (*accessmonitoringrulesv1.AccessMonitoringRule, error) {
-	if err := services.ValidateAccessMonitoringRule(amr); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	created, err := s.svc.CreateResource(ctx, amr)
 	return created, trace.Wrap(err)
 }
 
 // UpdateAccessMonitoringRule updates an existing AccessMonitoringRule resource.
 func (s *AccessMonitoringRulesService) UpdateAccessMonitoringRule(ctx context.Context, amr *accessmonitoringrulesv1.AccessMonitoringRule) (*accessmonitoringrulesv1.AccessMonitoringRule, error) {
-	if err := services.ValidateAccessMonitoringRule(amr); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	updated, err := s.svc.UpdateResource(ctx, amr)
 	return updated, trace.Wrap(err)
 }
 
 // UpsertAccessMonitoringRule upserts an existing AccessMonitoringRule resource.
 func (s *AccessMonitoringRulesService) UpsertAccessMonitoringRule(ctx context.Context, amr *accessmonitoringrulesv1.AccessMonitoringRule) (*accessmonitoringrulesv1.AccessMonitoringRule, error) {
-	if err := services.ValidateAccessMonitoringRule(amr); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	upserted, err := s.svc.UpsertResource(ctx, amr)
 	return upserted, trace.Wrap(err)
 }

--- a/lib/services/local/bot_instance.go
+++ b/lib/services/local/bot_instance.go
@@ -44,11 +44,15 @@ type BotInstanceService struct {
 
 // NewBotInstanceService creates a new BotInstanceService with the given backend.
 func NewBotInstanceService(backend backend.Backend, clock clockwork.Clock) (*BotInstanceService, error) {
-	service, err := generic.NewServiceWrapper(backend,
-		types.KindBotInstance,
-		botInstancePrefix,
-		services.MarshalBotInstance,
-		services.UnmarshalBotInstance)
+	service, err := generic.NewServiceWrapper(
+		generic.ServiceWrapperConfig[*machineidv1.BotInstance]{
+			Backend:       backend,
+			ResourceKind:  types.KindBotInstance,
+			BackendPrefix: botInstancePrefix,
+			MarshalFunc:   services.MarshalBotInstance,
+			UnmarshalFunc: services.UnmarshalBotInstance,
+			ValidateFunc:  services.ValidateBotInstance,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -63,10 +67,6 @@ func NewBotInstanceService(backend backend.Backend, clock clockwork.Clock) (*Bot
 // Note that new BotInstances will have their .Metadata.Name overwritten by the
 // instance UUID.
 func (b *BotInstanceService) CreateBotInstance(ctx context.Context, instance *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
-	if err := services.ValidateBotInstance(instance); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	instance.Kind = types.KindBotInstance
 	instance.Version = types.V1
 

--- a/lib/services/local/crown_jewels.go
+++ b/lib/services/local/crown_jewels.go
@@ -38,11 +38,14 @@ const crownJewelsKey = "crown_jewels"
 
 // NewCrownJewelsService creates a new CrownJewelsService.
 func NewCrownJewelsService(backend backend.Backend) (*CrownJewelsService, error) {
-	service, err := generic.NewServiceWrapper(backend,
-		types.KindCrownJewel,
-		crownJewelsKey,
-		services.MarshalCrownJewel,
-		services.UnmarshalCrownJewel)
+	service, err := generic.NewServiceWrapper(
+		generic.ServiceWrapperConfig[*crownjewelv1.CrownJewel]{
+			Backend:       backend,
+			ResourceKind:  types.KindCrownJewel,
+			BackendPrefix: crownJewelsKey,
+			MarshalFunc:   services.MarshalCrownJewel,
+			UnmarshalFunc: services.UnmarshalCrownJewel,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/databaseobject.go
+++ b/lib/services/local/databaseobject.go
@@ -73,14 +73,16 @@ const (
 )
 
 func NewDatabaseObjectService(backend backend.Backend) (*DatabaseObjectService, error) {
-	service, err := generic.NewServiceWrapper(backend,
-		types.KindDatabaseObject,
-		databaseObjectPrefix,
-		//nolint:staticcheck // SA1019. Using this marshaler for json compatibility.
-		services.FastMarshalProtoResourceDeprecated[*dbobjectv1.DatabaseObject],
-		//nolint:staticcheck // SA1019. Using this unmarshaler for json compatibility.
-		services.FastUnmarshalProtoResourceDeprecated[*dbobjectv1.DatabaseObject],
-	)
+	service, err := generic.NewServiceWrapper(
+		generic.ServiceWrapperConfig[*dbobjectv1.DatabaseObject]{
+			Backend:       backend,
+			ResourceKind:  types.KindDatabaseObject,
+			BackendPrefix: databaseObjectPrefix,
+			//nolint:staticcheck // SA1019. Using this marshaler for json compatibility.
+			MarshalFunc: services.FastMarshalProtoResourceDeprecated[*dbobjectv1.DatabaseObject],
+			//nolint:staticcheck // SA1019. Using this unmarshaler for json compatibility.
+			UnmarshalFunc: services.FastUnmarshalProtoResourceDeprecated[*dbobjectv1.DatabaseObject],
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/databaseobjectimportrule.go
+++ b/lib/services/local/databaseobjectimportrule.go
@@ -71,14 +71,16 @@ const (
 )
 
 func NewDatabaseObjectImportRuleService(backend backend.Backend) (services.DatabaseObjectImportRules, error) {
-	service, err := generic.NewServiceWrapper(backend,
-		types.KindDatabaseObjectImportRule,
-		databaseObjectImportRulePrefix,
-		//nolint:staticcheck // SA1019. Using this marshaler for json compatibility.
-		services.FastMarshalProtoResourceDeprecated[*databaseobjectimportrulev1.DatabaseObjectImportRule],
-		//nolint:staticcheck // SA1019. Using this unmarshaler for json compatibility.
-		services.FastUnmarshalProtoResourceDeprecated[*databaseobjectimportrulev1.DatabaseObjectImportRule],
-	)
+	service, err := generic.NewServiceWrapper(
+		generic.ServiceWrapperConfig[*databaseobjectimportrulev1.DatabaseObjectImportRule]{
+			Backend:       backend,
+			ResourceKind:  types.KindDatabaseObjectImportRule,
+			BackendPrefix: databaseObjectImportRulePrefix,
+			//nolint:staticcheck // SA1019. Using this marshaler for json compatibility.
+			MarshalFunc: services.FastMarshalProtoResourceDeprecated[*databaseobjectimportrulev1.DatabaseObjectImportRule],
+			//nolint:staticcheck // SA1019. Using this unmarshaler for json compatibility.
+			UnmarshalFunc: services.FastUnmarshalProtoResourceDeprecated[*databaseobjectimportrulev1.DatabaseObjectImportRule],
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -45,16 +45,28 @@ type UnmarshalFunc[T any] func([]byte, ...services.MarshalOption) (T, error)
 
 // ServiceConfig is the configuration for the service configuration.
 type ServiceConfig[T Resource] struct {
-	Backend       backend.Backend
-	ResourceKind  string
-	PageLimit     uint
+	// Backend used to persist the resource.
+	Backend backend.Backend
+	// ResourceKind is the friendly name of the resource.
+	ResourceKind string
+	// PageLimit
+	PageLimit uint
+	// BackendPrefix used when constructing the [backend.Item.Key].
 	BackendPrefix string
-	MarshalFunc   MarshalFunc[T]
+	// MarshlFunc converts the resource to bytes for persistence.
+	MarshalFunc MarshalFunc[T]
+	// UnmarshalFunc converts the bytes read from the backend to the resource.
 	UnmarshalFunc UnmarshalFunc[T]
+	// ValidateFunc optionally validates the resource prior to persisting it. Any errors
+	// returned from the validation function will prevent writes to the backend.
+	ValidateFunc func(T) error
 	// RunWhileLockedRetryInterval is the interval to retry the RunWhileLocked function.
 	// If set to 0, the default interval of 250ms will be used.
 	// WARNING: If set to a negative value, the RunWhileLocked function will retry immediately.
 	RunWhileLockedRetryInterval time.Duration
+	// KeyFunc optionally allows resource to have a custom key. If not provided the
+	// name of the resource will be used.
+	KeyFunc func(T) string
 }
 
 func (c *ServiceConfig[T]) CheckAndSetDefaults() error {
@@ -78,6 +90,15 @@ func (c *ServiceConfig[T]) CheckAndSetDefaults() error {
 	if c.UnmarshalFunc == nil {
 		return trace.BadParameter("unmarshal func is missing")
 	}
+
+	if c.ValidateFunc == nil {
+		c.ValidateFunc = func(t T) error { return nil }
+	}
+
+	if c.KeyFunc == nil {
+		c.KeyFunc = func(t T) string { return t.GetName() }
+	}
+
 	return nil
 }
 
@@ -89,7 +110,9 @@ type Service[T Resource] struct {
 	backendPrefix               string
 	marshalFunc                 MarshalFunc[T]
 	unmarshalFunc               UnmarshalFunc[T]
+	validateFunc                func(T) error
 	runWhileLockedRetryInterval time.Duration
+	keyFunc                     func(T) string
 }
 
 // NewService will return a new generic service with the given config. This will
@@ -106,7 +129,9 @@ func NewService[T Resource](cfg *ServiceConfig[T]) (*Service[T], error) {
 		backendPrefix:               cfg.BackendPrefix,
 		marshalFunc:                 cfg.MarshalFunc,
 		unmarshalFunc:               cfg.UnmarshalFunc,
+		validateFunc:                cfg.ValidateFunc,
 		runWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+		keyFunc:                     cfg.KeyFunc,
 	}, nil
 }
 
@@ -117,12 +142,15 @@ func (s *Service[T]) WithPrefix(parts ...string) *Service[T] {
 	}
 
 	return &Service[T]{
-		backend:       s.backend,
-		resourceKind:  s.resourceKind,
-		pageLimit:     s.pageLimit,
-		backendPrefix: strings.Join(append([]string{s.backendPrefix}, parts...), string(backend.Separator)),
-		marshalFunc:   s.marshalFunc,
-		unmarshalFunc: s.unmarshalFunc,
+		backend:                     s.backend,
+		resourceKind:                s.resourceKind,
+		pageLimit:                   s.pageLimit,
+		backendPrefix:               strings.Join(append([]string{s.backendPrefix}, parts...), string(backend.Separator)),
+		marshalFunc:                 s.marshalFunc,
+		unmarshalFunc:               s.unmarshalFunc,
+		validateFunc:                s.validateFunc,
+		runWhileLockedRetryInterval: s.runWhileLockedRetryInterval,
+		keyFunc:                     s.keyFunc,
 	}
 }
 
@@ -285,7 +313,11 @@ func (s *Service[T]) GetResource(ctx context.Context, name string) (resource T, 
 // CreateResource creates a new resource.
 func (s *Service[T]) CreateResource(ctx context.Context, resource T) (T, error) {
 	var t T
-	item, err := s.MakeBackendItem(resource, resource.GetName())
+	if err := s.validateFunc(resource); err != nil {
+		return t, trace.Wrap(err)
+	}
+
+	item, err := s.MakeBackendItem(resource, s.keyFunc(resource))
 	if err != nil {
 		return t, trace.Wrap(err)
 	}
@@ -305,7 +337,12 @@ func (s *Service[T]) CreateResource(ctx context.Context, resource T) (T, error) 
 // UpdateResource updates an existing resource.
 func (s *Service[T]) UpdateResource(ctx context.Context, resource T) (T, error) {
 	var t T
-	item, err := s.MakeBackendItem(resource, resource.GetName())
+
+	if err := s.validateFunc(resource); err != nil {
+		return t, trace.Wrap(err)
+	}
+
+	item, err := s.MakeBackendItem(resource, s.keyFunc(resource))
 	if err != nil {
 		return t, trace.Wrap(err)
 	}
@@ -325,7 +362,12 @@ func (s *Service[T]) UpdateResource(ctx context.Context, resource T) (T, error) 
 // ConditionalUpdateResource updates an existing resource if revision matches.
 func (s *Service[T]) ConditionalUpdateResource(ctx context.Context, resource T) (T, error) {
 	var t T
-	item, err := s.MakeBackendItem(resource, resource.GetName())
+
+	if err := s.validateFunc(resource); err != nil {
+		return t, trace.Wrap(err)
+	}
+
+	item, err := s.MakeBackendItem(resource, s.keyFunc(resource))
 	if err != nil {
 		return t, trace.Wrap(err)
 	}
@@ -345,7 +387,12 @@ func (s *Service[T]) ConditionalUpdateResource(ctx context.Context, resource T) 
 // UpsertResource upserts a resource.
 func (s *Service[T]) UpsertResource(ctx context.Context, resource T) (T, error) {
 	var t T
-	item, err := s.MakeBackendItem(resource, resource.GetName())
+
+	if err := s.validateFunc(resource); err != nil {
+		return t, trace.Wrap(err)
+	}
+
+	item, err := s.MakeBackendItem(resource, s.keyFunc(resource))
 	if err != nil {
 		return t, trace.Wrap(err)
 	}
@@ -394,8 +441,11 @@ func (s *Service[T]) UpdateAndSwapResource(ctx context.Context, name string, mod
 		return t, trace.Wrap(err)
 	}
 
-	err = modify(resource)
-	if err != nil {
+	if err := modify(resource); err != nil {
+		return t, trace.Wrap(err)
+	}
+
+	if err := s.validateFunc(resource); err != nil {
 		return t, trace.Wrap(err)
 	}
 

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -435,3 +435,120 @@ func TestGenericListResourcesWithFilter(t *testing.T) {
 	))
 	require.Equal(t, "", nextKey)
 }
+
+func TestGenericValidation(t *testing.T) {
+
+	ctx := context.Background()
+
+	memBackend, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	validationErr := trace.BadParameter("invalid test resource")
+	service, err := NewService(&ServiceConfig[*testResource]{
+		Backend:       memBackend,
+		ResourceKind:  "generic resource",
+		PageLimit:     200,
+		BackendPrefix: "generic_prefix",
+		UnmarshalFunc: unmarshalResource,
+		MarshalFunc:   marshalResource,
+		ValidateFunc:  func(tr *testResource) error { return validationErr },
+	})
+	require.NoError(t, err)
+
+	r1 := newTestResource("r1")
+
+	_, err = service.CreateResource(ctx, r1)
+	require.ErrorIs(t, err, validationErr)
+
+	_, err = service.UpdateResource(ctx, r1)
+	require.ErrorIs(t, err, validationErr)
+
+	_, err = service.UpsertResource(ctx, r1)
+	require.ErrorIs(t, err, validationErr)
+
+}
+
+func TestGenericKeyOverride(t *testing.T) {
+	ctx := context.Background()
+	memBackend, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	service, err := NewService(&ServiceConfig[*testResource]{
+		Backend:       memBackend,
+		ResourceKind:  "generic resource",
+		PageLimit:     200,
+		BackendPrefix: "generic_prefix",
+		UnmarshalFunc: unmarshalResource,
+		MarshalFunc:   marshalResource,
+		KeyFunc:       func(tr *testResource) string { return "llama" },
+	})
+	require.NoError(t, err)
+
+	r1 := newTestResource("r1")
+
+	// Create the test resource
+	created, err := service.CreateResource(ctx, r1)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(r1, created, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+
+	// Validate that the resource is stored under the custom key
+	item, err := memBackend.Get(ctx, backend.NewKey("generic_prefix", "llama"))
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	// Validate that the default key does not exist
+	item, err = memBackend.Get(ctx, backend.NewKey("generic_prefix", r1.GetName()))
+	require.Error(t, err)
+	require.Nil(t, item)
+
+	// Update the test resource
+	updated, err := service.UpdateResource(ctx, created)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(r1, updated, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+
+	// Validate that the resource is stored under the custom key
+	item, err = memBackend.Get(ctx, backend.NewKey("generic_prefix", "llama"))
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	// Validate that the default key still does not exist
+	item, err = memBackend.Get(ctx, backend.NewKey("generic_prefix", r1.GetName()))
+	require.Error(t, err)
+	require.Nil(t, item)
+
+	// Upsert the test resource
+	upserted, err := service.UpsertResource(ctx, updated)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(r1, upserted, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+
+	// Validate that the resource is stored under the custom key
+	item, err = memBackend.Get(ctx, backend.NewKey("generic_prefix", "llama"))
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	// Validate that the default key still does not exist
+	item, err = memBackend.Get(ctx, backend.NewKey("generic_prefix", r1.GetName()))
+	require.Error(t, err)
+	require.Nil(t, item)
+
+	// Compare and swap the resource
+	swapped, err := service.UpdateAndSwapResource(ctx, "llama", func(tr *testResource) error { return nil })
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(r1, swapped, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+
+	// Validate that the resource is stored under the custom key
+	item, err = memBackend.Get(ctx, backend.NewKey("generic_prefix", "llama"))
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	// Validate that the default key still does not exist
+	item, err = memBackend.Get(ctx, backend.NewKey("generic_prefix", r1.GetName()))
+	require.Error(t, err)
+	require.Nil(t, item)
+}

--- a/lib/services/local/generic/generic_wrapper.go
+++ b/lib/services/local/generic/generic_wrapper.go
@@ -71,12 +71,15 @@ func (s ServiceWrapper[T]) WithPrefix(parts ...string) *ServiceWrapper[T] {
 
 	return &ServiceWrapper[T]{
 		service: &Service[resourceMetadataAdapter[T]]{
-			backend:       s.service.backend,
-			resourceKind:  s.service.resourceKind,
-			pageLimit:     s.service.pageLimit,
-			backendPrefix: strings.Join(append([]string{s.service.backendPrefix}, parts...), string(backend.Separator)),
-			marshalFunc:   s.service.marshalFunc,
-			unmarshalFunc: s.service.unmarshalFunc,
+			backend:                     s.service.backend,
+			resourceKind:                s.service.resourceKind,
+			pageLimit:                   s.service.pageLimit,
+			backendPrefix:               strings.Join(append([]string{s.service.backendPrefix}, parts...), string(backend.Separator)),
+			marshalFunc:                 s.service.marshalFunc,
+			unmarshalFunc:               s.service.unmarshalFunc,
+			validateFunc:                s.service.validateFunc,
+			keyFunc:                     s.service.keyFunc,
+			runWhileLockedRetryInterval: s.service.runWhileLockedRetryInterval,
 		},
 	}
 }

--- a/lib/services/local/generic/generic_wrapper.go
+++ b/lib/services/local/generic/generic_wrapper.go
@@ -19,6 +19,7 @@ package generic
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -27,27 +28,62 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
+// ServiceWrapperConfig is the configuration for the service wrapper.
+type ServiceWrapperConfig[T types.ResourceMetadata] struct {
+	// Backend used to persist the resource.
+	Backend backend.Backend
+	// ResourceKind is the friendly name of the resource.
+	ResourceKind string
+	// PageLimit
+	PageLimit uint
+	// BackendPrefix used when constructing the [backend.Item.Key].
+	BackendPrefix string
+	// MarshlFunc converts the resource to bytes for persistence.
+	MarshalFunc MarshalFunc[T]
+	// UnmarshalFunc converts the bytes read from the backend to the resource.
+	UnmarshalFunc UnmarshalFunc[T]
+	// ValidateFunc optionally validates the resource prior to persisting it. Any errors
+	// returned from the validation function will prevent writes to the backend.
+	ValidateFunc func(T) error
+	// RunWhileLockedRetryInterval is the interval to retry the RunWhileLocked function.
+	// If set to 0, the default interval of 250ms will be used.
+	// WARNING: If set to a negative value, the RunWhileLocked function will retry immediately.
+	RunWhileLockedRetryInterval time.Duration
+	// KeyFunc optionally allows resource to have a custom key. If not provided the
+	// name of the resource will be used.
+	KeyFunc func(T) string
+}
+
 // NewServiceWrapper will return a new generic service wrapper. It is compatible with resources aligned with RFD 153.
-func NewServiceWrapper[T types.ResourceMetadata](
-	backend backend.Backend,
-	resourceKind string,
-	backendPrefix string,
-	marshalFunc MarshalFunc[T],
-	unmarshalFunc UnmarshalFunc[T],
-) (*ServiceWrapper[T], error) {
-	cfg := &ServiceConfig[resourceMetadataAdapter[T]]{
-		Backend:       backend,
-		ResourceKind:  resourceKind,
-		BackendPrefix: backendPrefix,
+func NewServiceWrapper[T types.ResourceMetadata](cfg ServiceWrapperConfig[T]) (*ServiceWrapper[T], error) {
+	serviceConfig := &ServiceConfig[resourceMetadataAdapter[T]]{
+		Backend:       cfg.Backend,
+		ResourceKind:  cfg.ResourceKind,
+		PageLimit:     cfg.PageLimit,
+		BackendPrefix: cfg.BackendPrefix,
 		MarshalFunc: func(w resourceMetadataAdapter[T], option ...services.MarshalOption) ([]byte, error) {
-			return marshalFunc(w.resource, option...)
+			return cfg.MarshalFunc(w.resource, option...)
 		},
 		UnmarshalFunc: func(bytes []byte, option ...services.MarshalOption) (resourceMetadataAdapter[T], error) {
-			r, err := unmarshalFunc(bytes, option...)
+			r, err := cfg.UnmarshalFunc(bytes, option...)
 			return newResourceMetadataAdapter(r), trace.Wrap(err)
 		},
+		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
 	}
-	service, err := NewService[resourceMetadataAdapter[T]](cfg)
+
+	if cfg.ValidateFunc != nil {
+		serviceConfig.ValidateFunc = func(rma resourceMetadataAdapter[T]) error {
+			return cfg.ValidateFunc(rma.resource)
+		}
+	}
+
+	if cfg.KeyFunc != nil {
+		serviceConfig.KeyFunc = func(rma resourceMetadataAdapter[T]) string {
+			return cfg.KeyFunc(rma.resource)
+		}
+	}
+
+	service, err := NewService[resourceMetadataAdapter[T]](serviceConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/generic/generic_wrapper_test.go
+++ b/lib/services/local/generic/generic_wrapper_test.go
@@ -104,11 +104,14 @@ func TestGenericWrapperCRUD(t *testing.T) {
 
 	const backendPrefix = "generic_prefix"
 
-	service, err := NewServiceWrapper[*testResource153](memBackend,
-		"generic resource",
-		backendPrefix,
-		marshalResource153,
-		unmarshalResource153)
+	service, err := NewServiceWrapper[*testResource153](
+		ServiceWrapperConfig[*testResource153]{
+			Backend:       memBackend,
+			ResourceKind:  "generic resource",
+			BackendPrefix: backendPrefix,
+			MarshalFunc:   marshalResource153,
+			UnmarshalFunc: unmarshalResource153,
+		})
 	require.NoError(t, err)
 
 	// Create a couple test resources.
@@ -244,11 +247,14 @@ func TestGenericWrapperWithPrefix(t *testing.T) {
 	const initialBackendPrefix = "initial_prefix"
 	const additionalBackendPrefix = "additional_prefix"
 
-	service, err := NewServiceWrapper[*testResource153](memBackend,
-		"generic resource",
-		initialBackendPrefix,
-		marshalResource153,
-		unmarshalResource153)
+	service, err := NewServiceWrapper[*testResource153](
+		ServiceWrapperConfig[*testResource153]{
+			Backend:       memBackend,
+			ResourceKind:  "generic resource",
+			BackendPrefix: initialBackendPrefix,
+			MarshalFunc:   marshalResource153,
+			UnmarshalFunc: unmarshalResource153,
+		})
 	require.NoError(t, err)
 
 	// Verify that the service's backend prefix matches the initial backend prefix.

--- a/lib/services/local/kubewaitingcontainer.go
+++ b/lib/services/local/kubewaitingcontainer.go
@@ -44,12 +44,13 @@ type KubeWaitingContainerService struct {
 // container service.
 func NewKubeWaitingContainerService(backend backend.Backend) (*KubeWaitingContainerService, error) {
 	svc, err := generic.NewServiceWrapper(
-		backend,
-		types.KindKubeWaitingContainer,
-		kubeWaitingContPrefix,
-		services.MarshalKubeWaitingContainer,
-		services.UnmarshalKubeWaitingContainer,
-	)
+		generic.ServiceWrapperConfig[*kubewaitingcontainerpb.KubernetesWaitingContainer]{
+			Backend:       backend,
+			ResourceKind:  types.KindKubeWaitingContainer,
+			BackendPrefix: kubeWaitingContPrefix,
+			MarshalFunc:   services.MarshalKubeWaitingContainer,
+			UnmarshalFunc: services.UnmarshalKubeWaitingContainer,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/notifications.go
+++ b/lib/services/local/notifications.go
@@ -47,22 +47,51 @@ type NotificationsService struct {
 
 // NewNotificationsService returns a new instance of the NotificationService.
 func NewNotificationsService(backend backend.Backend, clock clockwork.Clock) (*NotificationsService, error) {
-	userNotificationService, err := generic.NewServiceWrapper[*notificationsv1.Notification](backend, types.KindNotification, notificationsUserSpecificPrefix, services.MarshalNotification, services.UnmarshalNotification)
+	userNotificationService, err := generic.NewServiceWrapper[*notificationsv1.Notification](
+		generic.ServiceWrapperConfig[*notificationsv1.Notification]{
+			Backend:       backend,
+			ResourceKind:  types.KindNotification,
+			BackendPrefix: notificationsUserSpecificPrefix,
+			MarshalFunc:   services.MarshalNotification,
+			UnmarshalFunc: services.UnmarshalNotification,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	globalNotificationService, err := generic.NewServiceWrapper[*notificationsv1.GlobalNotification](backend, types.KindGlobalNotification, notificationsGlobalPrefix, services.MarshalGlobalNotification, services.UnmarshalGlobalNotification)
+	globalNotificationService, err := generic.NewServiceWrapper[*notificationsv1.GlobalNotification](
+		generic.ServiceWrapperConfig[*notificationsv1.GlobalNotification]{
+			Backend:       backend,
+			ResourceKind:  types.KindGlobalNotification,
+			BackendPrefix: notificationsGlobalPrefix,
+			MarshalFunc:   services.MarshalGlobalNotification,
+			UnmarshalFunc: services.UnmarshalGlobalNotification,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	userNotificationStateService, err := generic.NewServiceWrapper[*notificationsv1.UserNotificationState](backend, types.KindUserNotificationState, notificationsStatePrefix, services.MarshalUserNotificationState, services.UnmarshalUserNotificationState)
+	userNotificationStateService, err := generic.NewServiceWrapper[*notificationsv1.UserNotificationState](
+		generic.ServiceWrapperConfig[*notificationsv1.UserNotificationState]{
+			Backend:       backend,
+			ResourceKind:  types.KindUserNotificationState,
+			BackendPrefix: notificationsStatePrefix,
+			MarshalFunc:   services.MarshalUserNotificationState,
+			UnmarshalFunc: services.UnmarshalUserNotificationState,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	userLastSeenNotificationService, err := generic.NewServiceWrapper[*notificationsv1.UserLastSeenNotification](backend, types.KindUserLastSeenNotification, notificationsUserLastSeenPrefix, services.MarshalUserLastSeenNotification, services.UnmarshalUserLastSeenNotification)
+	userLastSeenNotificationService, err := generic.NewServiceWrapper[*notificationsv1.UserLastSeenNotification](
+		generic.ServiceWrapperConfig[*notificationsv1.UserLastSeenNotification]{
+			Backend:       backend,
+			ResourceKind:  types.KindUserLastSeenNotification,
+			BackendPrefix: notificationsUserLastSeenPrefix,
+			MarshalFunc:   services.MarshalUserLastSeenNotification,
+			UnmarshalFunc: services.UnmarshalUserLastSeenNotification,
+			ValidateFunc:  services.ValidateUserLastSeenNotification,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/spiffe_federations.go
+++ b/lib/services/local/spiffe_federations.go
@@ -42,12 +42,15 @@ type SPIFFEFederationService struct {
 func NewSPIFFEFederationService(
 	backend backend.Backend,
 ) (*SPIFFEFederationService, error) {
-	service, err := generic.NewServiceWrapper(backend,
-		types.KindSPIFFEFederation,
-		spiffeFederationPrefix,
-		services.MarshalSPIFFEFederation,
-		services.UnmarshalSPIFFEFederation,
-	)
+	service, err := generic.NewServiceWrapper(
+		generic.ServiceWrapperConfig[*machineidv1.SPIFFEFederation]{
+			Backend:       backend,
+			ResourceKind:  types.KindSPIFFEFederation,
+			BackendPrefix: spiffeFederationPrefix,
+			MarshalFunc:   services.MarshalSPIFFEFederation,
+			UnmarshalFunc: services.UnmarshalSPIFFEFederation,
+			ValidateFunc:  services.ValidateSPIFFEFederation,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -60,9 +63,6 @@ func NewSPIFFEFederationService(
 func (b *SPIFFEFederationService) CreateSPIFFEFederation(
 	ctx context.Context, federation *machineidv1.SPIFFEFederation,
 ) (*machineidv1.SPIFFEFederation, error) {
-	if err := services.ValidateSPIFFEFederation(federation); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	created, err := b.service.CreateResource(ctx, federation)
 	return created, trace.Wrap(err)
 }
@@ -104,9 +104,6 @@ func (b *SPIFFEFederationService) DeleteAllSPIFFEFederations(
 func (b *SPIFFEFederationService) UpsertSPIFFEFederation(
 	ctx context.Context, federation *machineidv1.SPIFFEFederation,
 ) (*machineidv1.SPIFFEFederation, error) {
-	if err := services.ValidateSPIFFEFederation(federation); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	upserted, err := b.service.UpsertResource(ctx, federation)
 	return upserted, trace.Wrap(err)
 }
@@ -115,9 +112,6 @@ func (b *SPIFFEFederationService) UpsertSPIFFEFederation(
 func (b *SPIFFEFederationService) UpdateSPIFFEFederation(
 	ctx context.Context, federation *machineidv1.SPIFFEFederation,
 ) (*machineidv1.SPIFFEFederation, error) {
-	if err := services.ValidateSPIFFEFederation(federation); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	updated, err := b.service.ConditionalUpdateResource(ctx, federation)
 	return updated, trace.Wrap(err)
 }

--- a/lib/services/local/statichostuser.go
+++ b/lib/services/local/statichostuser.go
@@ -42,12 +42,14 @@ type StaticHostUserService struct {
 // NewStaticHostUserService creates a new static host user service.
 func NewStaticHostUserService(bk backend.Backend) (*StaticHostUserService, error) {
 	svc, err := generic.NewServiceWrapper(
-		bk,
-		types.KindStaticHostUser,
-		staticHostUserPrefix,
-		services.MarshalProtoResource[*userprovisioningpb.StaticHostUser],
-		services.UnmarshalProtoResource[*userprovisioningpb.StaticHostUser],
-	)
+		generic.ServiceWrapperConfig[*userprovisioningpb.StaticHostUser]{
+			Backend:       bk,
+			ResourceKind:  types.KindStaticHostUser,
+			BackendPrefix: staticHostUserPrefix,
+			MarshalFunc:   services.MarshalProtoResource[*userprovisioningpb.StaticHostUser],
+			UnmarshalFunc: services.UnmarshalProtoResource[*userprovisioningpb.StaticHostUser],
+			ValidateFunc:  services.ValidateStaticHostUser,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -73,27 +75,18 @@ func (s *StaticHostUserService) GetStaticHostUser(ctx context.Context, name stri
 
 // CreateStaticHostUser creates a static host user.
 func (s *StaticHostUserService) CreateStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error) {
-	if err := services.ValidateStaticHostUser(in); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	out, err := s.svc.CreateResource(ctx, in)
 	return out, trace.Wrap(err)
 }
 
 // UpdateStaticHostUser updates a static host user.
 func (s *StaticHostUserService) UpdateStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error) {
-	if err := services.ValidateStaticHostUser(in); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	out, err := s.svc.ConditionalUpdateResource(ctx, in)
 	return out, trace.Wrap(err)
 }
 
 // UpsertStaticHostUser upserts a static host user.
 func (s *StaticHostUserService) UpsertStaticHostUser(ctx context.Context, in *userprovisioningpb.StaticHostUser) (*userprovisioningpb.StaticHostUser, error) {
-	if err := services.ValidateStaticHostUser(in); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	out, err := s.svc.UpsertResource(ctx, in)
 	return out, trace.Wrap(err)
 }

--- a/lib/services/local/vnet_config.go
+++ b/lib/services/local/vnet_config.go
@@ -46,12 +46,14 @@ type VnetConfigService struct {
 // NewVnetConfigService returns a new VnetConfig storage service.
 func NewVnetConfigService(backend backend.Backend) (*VnetConfigService, error) {
 	svc, err := generic.NewServiceWrapper(
-		backend,
-		types.KindVnetConfig,
-		vnetConfigPrefix,
-		services.MarshalProtoResource[*vnet.VnetConfig],
-		services.UnmarshalProtoResource[*vnet.VnetConfig],
-	)
+		generic.ServiceWrapperConfig[*vnet.VnetConfig]{
+			Backend:       backend,
+			ResourceKind:  types.KindVnetConfig,
+			BackendPrefix: vnetConfigPrefix,
+			MarshalFunc:   services.MarshalProtoResource[*vnet.VnetConfig],
+			UnmarshalFunc: services.UnmarshalProtoResource[*vnet.VnetConfig],
+			ValidateFunc:  validateVnetConfig,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -70,27 +72,18 @@ func (s *VnetConfigService) GetVnetConfig(ctx context.Context) (*vnet.VnetConfig
 
 // CreateVnetConfig does basic validation and creates a VnetConfig resource.
 func (s *VnetConfigService) CreateVnetConfig(ctx context.Context, vnetConfig *vnet.VnetConfig) (*vnet.VnetConfig, error) {
-	if err := validateVnetConfig(vnetConfig); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	vnetConfig, err := s.svc.CreateResource(ctx, vnetConfig)
 	return vnetConfig, trace.Wrap(err)
 }
 
 // UpdateVnetConfig does basic validation and updates a VnetConfig resource.
 func (s *VnetConfigService) UpdateVnetConfig(ctx context.Context, vnetConfig *vnet.VnetConfig) (*vnet.VnetConfig, error) {
-	if err := validateVnetConfig(vnetConfig); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	vnetConfig, err := s.svc.ConditionalUpdateResource(ctx, vnetConfig)
 	return vnetConfig, trace.Wrap(err)
 }
 
 // UpsertVnetConfig does basic validation and upserts a VnetConfig resource.
 func (s *VnetConfigService) UpsertVnetConfig(ctx context.Context, vnetConfig *vnet.VnetConfig) (*vnet.VnetConfig, error) {
-	if err := validateVnetConfig(vnetConfig); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	vnetConfig, err := s.svc.UpsertResource(ctx, vnetConfig)
 	return vnetConfig, trace.Wrap(err)
 }


### PR DESCRIPTION
Adds two new optional configuration options to the generic.Service: ValidateFunc and KeyFunc.

ValidateFunc is a custom function that is called prior to persisting a resource in the backend. If the function returns an error, the resource is not stored and the error is returned to users.

KeyFunc is a custom function used to derive the key for a particular resource. By default the generic service uses the metadata name as the key, however, in some scenarios more control over the key might be desired. For instance, a singleton resource might want to enforce that the key is also a static value instead of something that a user may supply.

`generic.NewServiceWrapper` was also updated to take a configuration object instead of individual parameters to make it easier to provide these new functions. Additionally, existing users of the generic service that performed manual validation are now making use of ValidateFunc.