### PR TITLE
Mention SSO users in SSH getting started guide

### DIFF
--- a/docs/pages/enroll-resources/server-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/server-access/getting-started.mdx
@@ -127,7 +127,8 @@ configuration:
 
 ### Access the Web UI
 
-Run the following command to create a user that can access the Teleport Web UI:
+Run the following command to create a local user that can access the Teleport
+Web UI:
 
 ```code
 $ tctl users add myuser --roles=editor,access --logins=root,ubuntu,ec2-user
@@ -374,6 +375,10 @@ further Getting Started exercises.
 
 ## Next steps
 
+- While this guide shows you how to create a local user in order to access a
+  server, you can also enable Teleport users to authenticate through a single
+  sign-on provider. Read the
+  [documentation](../../admin-guides/access-controls/sso.mdx) to learn more.
 - Learn more about Teleport `tsh` through the [reference documentation](../../reference/cli/tsh.mdx#tsh-ssh).
 - For a complete list of ports used by Teleport, read the [Networking Guide](../../reference/networking.mdx).
 


### PR DESCRIPTION
Closes #44902

Add a quick note to the Next Steps section that you can configure SSO in order to avoid the impression that server access only works with local users.