### PR TITLE
docs: link updates

### DIFF
--- a/docs/pages/admin-guides/api/automatically-register-agents.mdx
+++ b/docs/pages/admin-guides/api/automatically-register-agents.mdx
@@ -953,11 +953,11 @@ discovery solution.
 
 Teleport includes its own automatic resource discovery solution, the Teleport
 Discovery Service, and you can [consult its
-source](https://github.com/gravitational/teleport/tree/master/lib/srv/discovery)
+source](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/lib/srv/discovery)
 to see how Teleport implements its discovery logic.
 
 The Teleport code repository contains [examples of production-ready Teleport API
-clients](https://github.com/gravitational/teleport/tree/(=teleport.version=)/examples/).
+clients](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/).
 While we currently do not maintain plugins that auto-discover resources, you
 can use these examples to see how to implement configuration parsing, retries,
 and other tasks.

--- a/docs/pages/admin-guides/api/rbac.mdx
+++ b/docs/pages/admin-guides/api/rbac.mdx
@@ -963,7 +963,7 @@ provider APIs:
 ### Consult examples
 
 The Teleport code repository contains [examples of production-ready Teleport API
-clients](https://github.com/gravitational/teleport/tree/(=teleport.version=)/examples/).
+clients](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/).
 While we currently do not maintain plugins that generate Teleport
 roles, you can use these examples to see how to implement configuration
 parsing, retries, and other tasks.


### PR DESCRIPTION
- fix 2 broken links to specific version
- change from `master` link to specific version