### PR TITLE
[Web] Implement basic sidenav

### DIFF
--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -27,7 +27,7 @@ import React, {
   useState,
 } from 'react';
 import styled from 'styled-components';
-import { Box, Indicator } from 'design';
+import { Box, Flex, Indicator } from 'design';
 import { Failed } from 'design/CardError';
 
 import useAttempt from 'shared/hooks/useAttemptNext';
@@ -35,13 +35,13 @@ import useAttempt from 'shared/hooks/useAttemptNext';
 import { matchPath, useHistory } from 'react-router';
 
 import Dialog from 'design/Dialog';
-import { sharedStyles } from 'design/theme/themes/sharedStyles';
 
 import { Redirect, Route, Switch } from 'teleport/components/Router';
 import { CatchError } from 'teleport/components/CatchError';
 import cfg from 'teleport/config';
 import useTeleport from 'teleport/useTeleport';
 import { TopBar } from 'teleport/TopBar';
+import { TopBar as TopBarSideNav } from 'teleport/TopBar/TopBarSideNav';
 import { BannerList } from 'teleport/components/BannerList';
 import { storageService } from 'teleport/services/storageService';
 import {
@@ -51,11 +51,9 @@ import {
 } from 'teleport/services/alerts/alerts';
 import { useAlerts } from 'teleport/components/BannerList/useAlerts';
 import { FeaturesContextProvider, useFeatures } from 'teleport/FeaturesContext';
-import {
-  getFirstRouteForCategory,
-  Navigation,
-} from 'teleport/Navigation/Navigation';
-import { NavigationCategory } from 'teleport/Navigation/categories';
+
+import { Navigation as SideNavigation } from 'teleport/Navigation/SideNavigation/Navigation';
+import { Navigation } from 'teleport/Navigation';
 import { TopBarProps } from 'teleport/TopBar/TopBar';
 import { useUser } from 'teleport/User/UserContext';
 import { QuestionnaireProps } from 'teleport/Welcome/NewCredentials';
@@ -84,6 +82,13 @@ export function Main(props: MainProps) {
 
   const { preferences } = useUser();
 
+  const isTopBarView = storageService.getIsTopBarView();
+  const TopBarComponent =
+    //TODO(rudream): Add sidenav dashboard view.
+    isTopBarView || cfg.isDashboard ? TopBar : TopBarSideNav;
+  const NavigationComponent =
+    isTopBarView || cfg.isDashboard ? Navigation : SideNavigation;
+
   useEffect(() => {
     if (ctx.storeUser.state) {
       setAttempt({ status: 'success' });
@@ -99,14 +104,6 @@ export function Main(props: MainProps) {
     () => props.features.filter(feature => feature.hasAccess(featureFlags)),
     [featureFlags, props.features]
   );
-  const feature = features
-    .filter(feature => Boolean(feature.route))
-    .find(f =>
-      matchPath(history.location.pathname, {
-        path: f.route.path,
-        exact: f.route.exact ?? false,
-      })
-    );
 
   const { alerts, dismissAlert } = useAlerts(props.initialAlerts);
 
@@ -168,7 +165,7 @@ export function Main(props: MainProps) {
 
     const indexRoute = cfg.isDashboard
       ? cfg.routes.downloadCenter
-      : getFirstRouteForCategory(features, NavigationCategory.Resources);
+      : cfg.getUnifiedResourcesRoute(cfg.proxyCluster);
 
     return <Redirect to={indexRoute} />;
   }
@@ -199,13 +196,10 @@ export function Main(props: MainProps) {
   const requiresOnboarding =
     onboard && !onboard.hasResource && !onboard.notified;
   const displayOnboardDiscover = requiresOnboarding && showOnboardDiscover;
-  const hasSidebar =
-    feature?.category === NavigationCategory.Management &&
-    !feature?.hideNavigation;
 
   return (
     <FeaturesContextProvider value={features}>
-      <TopBar
+      <TopBarComponent
         CustomLogo={
           props.topBarProps?.showPoweredByLogo
             ? props.topBarProps.CustomLogo
@@ -214,8 +208,8 @@ export function Main(props: MainProps) {
       />
       <Wrapper>
         <MainContainer>
-          <Navigation />
-          <HorizontalSplit hasSidebar={hasSidebar}>
+          <NavigationComponent />
+          <ContentWrapper>
             <ContentMinWidth>
               <BannerList
                 banners={banners}
@@ -227,7 +221,7 @@ export function Main(props: MainProps) {
                 <FeatureRoutes lockedFeatures={ctx.lockedFeatures} />
               </Suspense>
             </ContentMinWidth>
-          </HorizontalSplit>
+          </ContentWrapper>
         </MainContainer>
       </Wrapper>
       {displayOnboardDiscover && (
@@ -353,23 +347,15 @@ export const ContentMinWidth = ({ children }: { children: ReactNode }) => {
   );
 };
 
-function getWidth(hasSidebar?: boolean) {
-  const { sidebarWidth } = sharedStyles;
-  if (hasSidebar) {
-    return `max-width: calc(100% - ${sidebarWidth}px);`;
-  }
-  return 'max-width: 100%;';
-}
-
-export const HorizontalSplit = styled.div<{ hasSidebar?: boolean }>`
+export const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1;
-  ${props => getWidth(props.hasSidebar)}
   overflow-x: auto;
+  max-width: 100%;
 `;
 
-export const StyledIndicator = styled(HorizontalSplit)`
+export const StyledIndicator = styled(Flex)`
   align-items: center;
   justify-content: center;
   position: absolute;
@@ -382,5 +368,5 @@ const Wrapper = styled(Box)`
   display: flex;
   height: 100vh;
   flex-direction: column;
-  width: 100vw;
+  max-width: 100vw;
 `;

--- a/web/packages/teleport/src/Main/MainContainer.tsx
+++ b/web/packages/teleport/src/Main/MainContainer.tsx
@@ -26,8 +26,9 @@ import styled from 'styled-components';
 export const MainContainer = styled.div`
   display: flex;
   flex: 1;
-  min-height: 0;
   --sidebar-width: 256px;
+  --sidenav-width: 76px;
+  --sidenav-panel-width: 224px;
   margin-top: ${p => p.theme.topBarHeight[0]}px;
   @media screen and (min-width: ${p => p.theme.breakpoints.small}px) {
     margin-top: ${p => p.theme.topBarHeight[1]}px;

--- a/web/packages/teleport/src/Navigation/SideNavigation/CategoryIcon.tsx
+++ b/web/packages/teleport/src/Navigation/SideNavigation/CategoryIcon.tsx
@@ -1,0 +1,42 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+
+import * as Icons from 'design/Icon';
+
+import { NavigationCategory } from './categories';
+
+export function CategoryIcon({ category }: { category: NavigationCategory }) {
+  switch (category) {
+    case NavigationCategory.Resources:
+      return <Icons.Server />;
+    case NavigationCategory.Access:
+      return <Icons.Lock />;
+    case NavigationCategory.Identity:
+      return <Icons.FingerprintSimple />;
+    case NavigationCategory.Policy:
+      return <Icons.ShieldCheck />;
+    case NavigationCategory.Audit:
+      return <Icons.ListMagnifyingGlass />;
+    case NavigationCategory.AddNew:
+      return <Icons.AddCircle />;
+    default:
+      return null;
+  }
+}

--- a/web/packages/teleport/src/Navigation/SideNavigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/SideNavigation/Navigation.tsx
@@ -1,0 +1,570 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useState, useCallback } from 'react';
+import styled, { css } from 'styled-components';
+import { matchPath, useHistory } from 'react-router';
+import { NavLink } from 'react-router-dom';
+import { Text, Flex, Box } from 'design';
+import * as Icons from 'design/Icon';
+import { Theme } from 'design/theme/themes/types';
+
+import cfg from 'teleport/config';
+
+import { useFeatures } from 'teleport/FeaturesContext';
+
+import {
+  NavigationCategory,
+  NAVIGATION_CATEGORIES,
+  STANDALONE_CATEGORIES,
+} from './categories';
+import { CategoryIcon } from './CategoryIcon';
+
+import type * as history from 'history';
+
+import type { TeleportFeature } from 'teleport/types';
+
+export const zIndexMap = {
+  topBar: 23,
+  sideNavButtons: 22,
+  sideNavContainer: 21,
+  sideNavExpandedPanel: 20,
+};
+
+const SideNavContainer = styled(Flex).attrs({
+  gap: 2,
+  pt: 2,
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'start',
+  bg: 'levels.surface',
+})`
+  height: 100vh;
+  width: var(--sidenav-width);
+  position: fixed;
+  overflow: visible;
+`;
+
+const verticalPadding = '12px';
+
+const rightPanelWidth = '236px';
+
+const PanelBackground = styled.div`
+  width: 100%;
+  height: 100%;
+  background: ${p => p.theme.colors.levels.surface};
+  position: absolute;
+  top: 0;
+  z-index: ${zIndexMap.sideNavContainer};
+  border-right: 1px solid ${p => p.theme.colors.spotBackground[1]};
+`;
+
+const RightPanel = styled(Box).attrs({ pt: 2, px: 2 })<{
+  isVisible: boolean;
+  skipAnimation: boolean;
+}>`
+  position: fixed;
+  left: var(--sidenav-width);
+  height: 100%;
+  scrollbar-gutter: auto;
+  overflow: visible;
+  width: ${rightPanelWidth};
+  background: ${p => p.theme.colors.levels.surface};
+  z-index: ${zIndexMap.sideNavExpandedPanel};
+  border-right: 1px solid ${p => p.theme.colors.spotBackground[1]};
+
+  ${props =>
+    props.isVisible
+      ? `
+      ${props.skipAnimation ? '' : 'transition: transform .15s ease-out;'}
+      transform: translateX(0);
+      `
+      : `
+      ${props.skipAnimation ? '' : 'transition: transform .15s ease-in;'}
+      transform: translateX(-100%);
+      `}
+
+  top: ${p => p.theme.topBarHeight[0]}px;
+  padding-bottom: ${p => p.theme.topBarHeight[0] + p.theme.space[2]}px;
+  @media screen and (min-width: ${p => p.theme.breakpoints.small}px) {
+    top: ${p => p.theme.topBarHeight[1]}px;
+    padding-bottom: ${p => p.theme.topBarHeight[1] + p.theme.space[2]}px;
+  }
+  @media screen and (min-width: ${p => p.theme.breakpoints.large}px) {
+    top: ${p => p.theme.topBarHeight[2]}px;
+    padding-bottom: ${p => p.theme.topBarHeight[3] + p.theme.space[2]}px;
+  }
+`;
+
+type NavigationSection = {
+  category: NavigationCategory;
+  subsections: NavigationSubsection[];
+  standalone?: boolean;
+};
+
+type NavigationSubsection = {
+  category: NavigationCategory;
+  title: string;
+  route: string;
+  exact: boolean;
+  icon: (props) => JSX.Element;
+  parent?: TeleportFeature;
+};
+
+function getNavigationSections(
+  features: TeleportFeature[]
+): NavigationSection[] {
+  const navigationSections = NAVIGATION_CATEGORIES.map(category => ({
+    category,
+    subsections: getSubsectionsForCategory(category, features),
+    standalone: STANDALONE_CATEGORIES.indexOf(category) !== -1,
+  }));
+
+  return navigationSections;
+}
+
+function getSubsectionsForCategory(
+  category: NavigationCategory,
+  features: TeleportFeature[]
+): NavigationSubsection[] {
+  const filteredFeatures = features.filter(
+    feature =>
+      feature.sideNavCategory === category &&
+      !!feature.navigationItem &&
+      !feature.parent
+  );
+
+  return filteredFeatures.map(feature => {
+    return {
+      category,
+      title: feature.navigationItem.title,
+      route: feature.navigationItem.getLink(cfg.proxyCluster),
+      exact: feature.navigationItem.exact,
+      icon: feature.navigationItem.icon,
+    };
+  });
+}
+
+function getNavSubsectionForRoute(
+  features: TeleportFeature[],
+  route: history.Location<unknown> | Location
+): NavigationSubsection {
+  const feature = features
+    .filter(feature => Boolean(feature.route))
+    .find(feature =>
+      matchPath(route.pathname, {
+        path: feature.route.path,
+        exact: false,
+      })
+    );
+
+  if (!feature || !feature.sideNavCategory) {
+    return;
+  }
+
+  return {
+    category: feature.sideNavCategory,
+    title: feature.navigationItem.title,
+    route: feature.navigationItem.getLink(cfg.proxyCluster),
+    exact: feature.navigationItem.exact,
+    icon: feature.navigationItem.icon,
+  };
+}
+
+export function Navigation() {
+  const features = useFeatures();
+  const history = useHistory();
+  const [expandedSection, setExpandedSection] =
+    useState<NavigationSection | null>(null);
+  const currentView = getNavSubsectionForRoute(features, history.location);
+  const [previousExpandedSection, setPreviousExpandedSection] =
+    useState<NavigationSection | null>();
+
+  const navSections = getNavigationSections(features).filter(
+    section => section.subsections.length
+  );
+
+  const handleSetExpandedSection = useCallback(
+    (section: NavigationSection) => {
+      if (!section.standalone) {
+        setPreviousExpandedSection(expandedSection);
+        setExpandedSection(section);
+      } else {
+        setPreviousExpandedSection(null);
+        setExpandedSection(null);
+      }
+    },
+    [expandedSection]
+  );
+
+  const resetExpandedSection = useCallback(() => {
+    setPreviousExpandedSection(null);
+    setExpandedSection(null);
+  }, []);
+
+  return (
+    <Box
+      onMouseLeave={() => resetExpandedSection()}
+      onKeyUp={e => e.key === 'Escape' && resetExpandedSection()}
+      onBlur={(event: React.FocusEvent<HTMLDivElement, Element>) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          resetExpandedSection();
+        }
+      }}
+      css={`
+        position: relative;
+        width: var(--sidenav-width);
+        z-index: ${zIndexMap.sideNavContainer};
+      `}
+    >
+      <SideNavContainer>
+        <PanelBackground />
+        {navSections.map(section => (
+          <Section
+            key={section.category}
+            section={section}
+            $active={section.category === currentView?.category}
+            setExpandedSection={() => handleSetExpandedSection(section)}
+            aria-controls={`panel-${expandedSection?.category}`}
+            onClick={() => {
+              if (section.standalone) {
+                history.push(section.subsections[0].route);
+              }
+            }}
+            isExpanded={
+              !!expandedSection &&
+              !expandedSection.standalone &&
+              section.category === expandedSection?.category
+            }
+          >
+            <RightPanel
+              isVisible={
+                !!expandedSection &&
+                !expandedSection.standalone &&
+                section.category === expandedSection?.category
+              }
+              skipAnimation={!!previousExpandedSection}
+              id={`panel-${section.category}`}
+              onFocus={() => handleSetExpandedSection(section)}
+            >
+              <Flex
+                flexDirection="column"
+                justifyContent="space-between"
+                height="100%"
+              >
+                <Box
+                  css={`
+                    overflow-y: scroll;
+                    padding: 3px;
+                  `}
+                >
+                  <Flex py={verticalPadding} px={3}>
+                    <Text typography="h2" color="text.slightlyMuted">
+                      {section.category}
+                    </Text>
+                  </Flex>
+                  {!section.standalone &&
+                    section.subsections.map(section => (
+                      <SubsectionItem
+                        $active={currentView?.route === section.route}
+                        to={section.route}
+                        exact={section.exact}
+                        key={section.title}
+                      >
+                        <section.icon size={16} />
+                        <Text typography="body2">{section.title}</Text>
+                      </SubsectionItem>
+                    ))}
+                </Box>
+                {cfg.edition === 'oss' && <AGPLFooter />}
+                {cfg.edition === 'community' && <CommunityFooter />}
+              </Flex>
+            </RightPanel>
+          </Section>
+        ))}
+      </SideNavContainer>
+    </Box>
+  );
+}
+
+function SubsectionItem({
+  $active,
+  to,
+  exact,
+  children,
+}: {
+  $active: boolean;
+  to: string;
+  exact: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <StyledSubsectionItem $active={$active} to={to} exact={exact} tabIndex={0}>
+      {children}
+    </StyledSubsectionItem>
+  );
+}
+
+const StyledSubsectionItem = styled(NavLink)<{
+  $active: boolean;
+}>`
+  display: flex;
+  position: relative;
+  color: ${props => props.theme.colors.text.slightlyMuted};
+  text-decoration: none;
+  user-select: none;
+  gap: ${props => props.theme.space[2]}px;
+  padding-top: ${verticalPadding};
+  padding-bottom: ${verticalPadding};
+  padding-left: ${props => props.theme.space[3]}px;
+  padding-right: ${props => props.theme.space[3]}px;
+  border-radius: ${props => props.theme.radii[2]}px;
+  cursor: pointer;
+
+  ${props => getSubsectionStyles(props.theme, props.$active)}
+`;
+
+function Section({
+  section,
+  $active,
+  setExpandedSection,
+  onClick,
+  children,
+  isExpanded,
+}: {
+  section: NavigationSection;
+  $active: boolean;
+  setExpandedSection: () => void;
+  onClick: (event: React.MouseEvent) => void;
+  isExpanded?: boolean;
+  children?: JSX.Element;
+}) {
+  return (
+    <>
+      <CategoryButton
+        $active={$active}
+        onMouseEnter={setExpandedSection}
+        onFocus={setExpandedSection}
+        onClick={onClick}
+        isExpanded={isExpanded}
+        tabIndex={section.standalone ? 0 : -1}
+      >
+        <CategoryIcon category={section.category} />
+        {section.category}
+      </CategoryButton>
+      {children}
+    </>
+  );
+}
+
+const CategoryButton = styled.button<{ $active: boolean; isExpanded: boolean }>`
+  height: 60px;
+  width: 60px;
+  cursor: pointer;
+  outline: hidden;
+  border: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border-radius: ${props => props.theme.radii[2]}px;
+  z-index: ${zIndexMap.sideNavButtons};
+
+  font-size: ${props => props.theme.typography.body4.fontSize};
+  font-weight: ${props => props.theme.typography.body4.fontWeight};
+  letter-spacing: ${props => props.theme.typography.body4.letterSpacing};
+  line-height: ${props => props.theme.typography.body4.lineHeight};
+
+  ${props => getCategoryStyles(props.theme, props.$active, props.isExpanded)}
+`;
+
+function getCategoryStyles(theme: Theme, active: boolean, isExpanded: boolean) {
+  if (active) {
+    return css`
+      color: ${theme.colors.brand};
+      background: ${theme.colors.interactive.tonal.primary[0].background};
+      &:hover,
+      &:focus-visible {
+        background: ${theme.colors.interactive.tonal.primary[1].background};
+        color: ${theme.colors.interactive.tonal.primary[0].text};
+      }
+      &:active {
+        background: ${theme.colors.interactive.tonal.primary[2].background};
+        color: ${theme.colors.interactive.tonal.primary[1].text};
+      }
+      ${isExpanded &&
+      `
+        background: ${theme.colors.interactive.tonal.primary[1].background};
+        color: ${theme.colors.interactive.tonal.primary[0].text};
+        `}
+    `;
+  }
+
+  return css`
+    background: transparent;
+    color: ${theme.colors.text.slightlyMuted};
+    &:hover,
+    &:focus-visible {
+      background: ${theme.colors.interactive.tonal.neutral[0].background};
+      color: ${theme.colors.text.main};
+    }
+    &:active {
+      background: ${theme.colors.interactive.tonal.neutral[1].background};
+      color: ${theme.colors.text.main};
+    }
+    ${isExpanded &&
+    `
+      background: ${theme.colors.interactive.tonal.neutral[0].background};
+      color: ${theme.colors.text.main};
+      `}
+  `;
+}
+
+function getSubsectionStyles(theme: Theme, active: boolean) {
+  if (active) {
+    return css`
+      color: ${theme.colors.brand};
+      background: ${theme.colors.interactive.tonal.primary[0].background};
+      &:focus-visible {
+        outline: 2px solid
+          ${theme.colors.interactive.solid.primary.default.background};
+      }
+      &:hover {
+        background: ${theme.colors.interactive.tonal.primary[1].background};
+        color: ${theme.colors.interactive.tonal.primary[0].text};
+      }
+      &:active {
+        background: ${theme.colors.interactive.tonal.primary[2].background};
+        color: ${theme.colors.interactive.tonal.primary[1].text};
+      }
+    `;
+  }
+
+  return css`
+    color: ${props => props.theme.colors.text.slightlyMuted};
+    &:focus-visible {
+      outline: 2px solid ${theme.colors.text.muted};
+    }
+    &:hover {
+      background: ${props => props.theme.colors.interactive.tonal.neutral[0]};
+      color: ${props => props.theme.colors.text.main};
+    }
+    &:active {
+      background: ${props => props.theme.colors.interactive.tonal.neutral[1]};
+      color: ${props => props.theme.colors.text.main};
+    }
+  `;
+}
+
+function AGPLFooter() {
+  return (
+    <LicenseFooter
+      title="AGPL Edition"
+      subText="Unofficial Version"
+      infoContent={
+        <>
+          {/* This is an independently compiled AGPL-3.0 version of Teleport. You */}
+          {/* can find the official release on{' '} */}
+          This is an independently compiled AGPL-3.0 version of Teleport.
+          <br />
+          Visit{' '}
+          <Text
+            as="a"
+            href="https://goteleport.com/download/?utm_source=oss&utm_medium=in-product&utm_campaign=limited-features"
+            target="_blank"
+          >
+            the Downloads page
+          </Text>{' '}
+          for the official release.
+        </>
+      }
+    />
+  );
+}
+
+function CommunityFooter() {
+  return (
+    <LicenseFooter
+      title="Community Edition"
+      subText="Limited Features"
+      infoContent={
+        <>
+          <Text
+            as="a"
+            href="https://goteleport.com/signup/enterprise/?utm_source=oss&utm_medium=in-product&utm_campaign=limited-features"
+            target="_blank"
+          >
+            Upgrade to Teleport Enterprise
+          </Text>{' '}
+          for SSO, just-in-time access requests, Access Graph, and much more!
+        </>
+      }
+    />
+  );
+}
+
+function LicenseFooter({
+  title,
+  subText,
+  infoContent,
+}: {
+  title: string;
+  subText: string;
+  infoContent: JSX.Element;
+}) {
+  const [opened, setOpened] = useState(false);
+  return (
+    <StyledFooterBox py={3} px={4} onMouseLeave={() => setOpened(false)}>
+      <Flex alignItems="center" gap={2}>
+        <Text>{title}</Text>
+        <FooterContent onMouseEnter={() => setOpened(true)}>
+          <Icons.Info size={16} />
+          {opened && <TooltipContent>{infoContent}</TooltipContent>}
+        </FooterContent>
+      </Flex>
+      <SubText>{subText}</SubText>
+    </StyledFooterBox>
+  );
+}
+
+const StyledFooterBox = styled(Box)`
+  line-height: 20px;
+  border-top: ${props => props.theme.borders[1]}
+    ${props => props.theme.colors.spotBackground[0]};
+`;
+
+const SubText = styled(Text)`
+  color: ${props => props.theme.colors.text.disabled};
+  font-size: ${props => props.theme.fontSizes[1]}px;
+`;
+
+const TooltipContent = styled(Box)`
+  width: max-content;
+  position: absolute;
+  bottom: 0;
+  left: 24px;
+  padding: 12px 16px 12px 16px;
+  box-shadow: ${p => p.theme.boxShadow[1]};
+  background-color: ${props => props.theme.colors.tooltip.background};
+  color: ${props => props.theme.colors.text.primaryInverse};
+  z-index: ${zIndexMap.sideNavExpandedPanel + 1};
+`;
+
+const FooterContent = styled(Flex)`
+  position: relative;
+`;

--- a/web/packages/teleport/src/Navigation/SideNavigation/categories.ts
+++ b/web/packages/teleport/src/Navigation/SideNavigation/categories.ts
@@ -16,10 +16,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export {
-  Main,
-  useContentMinWidthContext,
-  useNoMinWidth,
-  StyledIndicator,
-} from './Main';
-export { MainContainer } from './MainContainer';
+export enum NavigationCategory {
+  Resources = 'Resources',
+  Access = 'Access',
+  Identity = 'Identity',
+  Policy = 'Policy',
+  Audit = 'Audit',
+  AddNew = 'Add New',
+}
+
+export const NAVIGATION_CATEGORIES = [
+  NavigationCategory.Resources,
+  NavigationCategory.Access,
+  NavigationCategory.Identity,
+  NavigationCategory.Policy,
+  NavigationCategory.Audit,
+  NavigationCategory.AddNew,
+];
+
+export const STANDALONE_CATEGORIES = [
+  NavigationCategory.AddNew,
+  // TODO(rudream): Remove this once shortcuts to pinned/nodes/apps/dbs/desktops/kubes are implemented.
+  NavigationCategory.Resources,
+];

--- a/web/packages/teleport/src/Navigation/index.ts
+++ b/web/packages/teleport/src/Navigation/index.ts
@@ -16,4 +16,5 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+export { Navigation as SideNavigation } from './SideNavigation/Navigation';
 export { Navigation } from './Navigation';

--- a/web/packages/teleport/src/TopBar/TopBarSideNav.tsx
+++ b/web/packages/teleport/src/TopBar/TopBarSideNav.tsx
@@ -1,0 +1,167 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import styled, { useTheme } from 'styled-components';
+import { Link } from 'react-router-dom';
+import { Flex, Image, TopNav } from 'design';
+import { matchPath, useHistory } from 'react-router';
+import { Theme } from 'design/theme/themes/types';
+import { HoverTooltip } from 'shared/components/ToolTip';
+
+import useTeleport from 'teleport/useTeleport';
+import { UserMenuNav } from 'teleport/components/UserMenuNav';
+import { useFeatures } from 'teleport/FeaturesContext';
+import cfg from 'teleport/config';
+import { useLayout } from 'teleport/Main/LayoutContext';
+import { logos } from 'teleport/components/LogoHero/LogoHero';
+
+import { Notifications } from 'teleport/Notifications';
+import { zIndexMap } from 'teleport/Navigation/SideNavigation/Navigation';
+
+export function TopBar({ CustomLogo }: TopBarProps) {
+  const ctx = useTeleport();
+  const history = useHistory();
+  const features = useFeatures();
+  const { currentWidth } = useLayout();
+  const theme: Theme = useTheme();
+
+  // find active feature
+  const feature = features.find(
+    f =>
+      f.route &&
+      matchPath(history.location.pathname, {
+        path: f.route.path,
+        exact: f.route.exact ?? false,
+      })
+  );
+
+  const iconSize =
+    currentWidth >= theme.breakpoints.medium
+      ? navigationIconSizeMedium
+      : navigationIconSizeSmall;
+
+  return (
+    <TopBarContainer navigationHidden={feature?.hideNavigation}>
+      <TeleportLogo CustomLogo={CustomLogo} />
+      {!feature?.logoOnlyTopbar && (
+        <Flex height="100%" alignItems="center">
+          <Notifications iconSize={iconSize} />
+          <UserMenuNav username={ctx.storeUser.state.username} />
+        </Flex>
+      )}
+    </TopBarContainer>
+  );
+}
+
+export const TopBarContainer = styled(TopNav)`
+  position: fixed;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  background: ${p => p.theme.colors.levels.surface};
+  overflow-y: initial;
+  overflow-x: none;
+  flex-shrink: 0;
+  z-index: ${zIndexMap.topBar};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.spotBackground[1]};
+
+  height: ${p => p.theme.topBarHeight[0]}px;
+  @media screen and (min-width: ${p => p.theme.breakpoints.small}px) {
+    height: ${p => p.theme.topBarHeight[1]}px;
+  }
+  @media screen and (min-width: ${p => p.theme.breakpoints.large}px) {
+    height: ${p => p.theme.topBarHeight[2]}px;
+  }
+`;
+
+const TeleportLogo = ({ CustomLogo }: TopBarProps) => {
+  const theme = useTheme();
+  const src = logos[cfg.edition][theme.type];
+
+  return (
+    <HoverTooltip
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+      tipContent="Teleport Resources Home"
+      css={`
+        height: 100%;
+        margin-right: 0px;
+        @media screen and (min-width: ${p => p.theme.breakpoints.medium}px) {
+          margin-right: 76px;
+        }
+        @media screen and (min-width: ${p => p.theme.breakpoints.large}px) {
+          margin-right: 67px;
+        }
+      `}
+    >
+      <Link
+        css={`
+          cursor: pointer;
+          display: flex;
+          transition: background-color 0.1s linear;
+          &:hover {
+            background-color: ${p =>
+              p.theme.colors.interactive.tonal.primary[0].background};
+          }
+          align-items: center;
+        `}
+        to={cfg.routes.root}
+      >
+        {CustomLogo ? (
+          <CustomLogo />
+        ) : (
+          <Image
+            data-testid="teleport-logo"
+            src={src}
+            alt="teleport logo"
+            css={`
+              padding-left: ${props => props.theme.space[3]}px;
+              padding-right: ${props => props.theme.space[3]}px;
+              height: 18px;
+              @media screen and (min-width: ${p =>
+                  p.theme.breakpoints.small}px) {
+                height: 28px;
+                padding-left: ${props => props.theme.space[4]}px;
+                padding-right: ${props => props.theme.space[4]}px;
+              }
+              @media screen and (min-width: ${p =>
+                  p.theme.breakpoints.large}px) {
+                height: 30px;
+              }
+            `}
+          />
+        )}
+      </Link>
+    </HoverTooltip>
+  );
+};
+
+export const navigationIconSizeSmall = 20;
+export const navigationIconSizeMedium = 24;
+
+export type NavigationItem = {
+  title: string;
+  path: string;
+  Icon: JSX.Element;
+};
+
+export type TopBarProps = {
+  CustomLogo?: () => React.ReactElement;
+  showPoweredByLogo?: boolean;
+};

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -42,9 +42,10 @@ import {
 import cfg from 'teleport/config';
 
 import {
-  ManagementSection,
   NavigationCategory,
+  ManagementSection,
 } from 'teleport/Navigation/categories';
+import { NavigationCategory as SideNavigationCategory } from 'teleport/Navigation/SideNavigation/categories';
 import { IntegrationEnroll } from '@gravitational/teleport/src/Integrations/Enroll';
 
 import { NavTitle } from './types';
@@ -74,6 +75,7 @@ import type { FeatureFlags, TeleportFeature } from './types';
 
 class AccessRequests implements TeleportFeature {
   category = NavigationCategory.Resources;
+  sideNavCategory = SideNavigationCategory.Resources;
 
   route = {
     title: 'Access Requests',
@@ -101,6 +103,7 @@ class AccessRequests implements TeleportFeature {
 export class FeatureJoinTokens implements TeleportFeature {
   category = NavigationCategory.Management;
   section = ManagementSection.Access;
+  sideNavCategory = SideNavigationCategory.Access;
   navigationItem = {
     title: NavTitle.JoinTokens,
     icon: Key,
@@ -123,6 +126,11 @@ export class FeatureJoinTokens implements TeleportFeature {
 }
 
 export class FeatureUnifiedResources implements TeleportFeature {
+  category = NavigationCategory.Resources;
+  sideNavCategory = SideNavigationCategory.Resources;
+  // TODO(rudream): Remove this once shortcuts to pinned/nodes/apps/dbs/desktops/kubes are implemented.
+  standalone = true;
+
   route = {
     title: 'Resources',
     path: cfg.routes.unifiedResources,
@@ -139,8 +147,6 @@ export class FeatureUnifiedResources implements TeleportFeature {
     },
   };
 
-  category = NavigationCategory.Resources;
-
   hasAccess() {
     return !cfg.isDashboard;
   }
@@ -152,6 +158,7 @@ export class FeatureUnifiedResources implements TeleportFeature {
 
 export class FeatureSessions implements TeleportFeature {
   category = NavigationCategory.Resources;
+  sideNavCategory = SideNavigationCategory.Audit;
 
   route = {
     title: 'Active Sessions',
@@ -184,6 +191,7 @@ export class FeatureSessions implements TeleportFeature {
 export class FeatureUsers implements TeleportFeature {
   category = NavigationCategory.Management;
   section = ManagementSection.Access;
+  sideNavCategory = SideNavigationCategory.Access;
 
   route = {
     title: 'Manage Users',
@@ -213,6 +221,7 @@ export class FeatureUsers implements TeleportFeature {
 export class FeatureBots implements TeleportFeature {
   category = NavigationCategory.Management;
   section = ManagementSection.Access;
+  sideNavCategory = SideNavigationCategory.Access;
 
   route = {
     title: 'Manage Bots',
@@ -242,6 +251,7 @@ export class FeatureBots implements TeleportFeature {
 export class FeatureAddBots implements TeleportFeature {
   category = NavigationCategory.Management;
   section = ManagementSection.Access;
+  sideNavCategory = SideNavigationCategory.Access;
   hideFromNavigation = true;
 
   route = {
@@ -263,6 +273,7 @@ export class FeatureAddBots implements TeleportFeature {
 export class FeatureRoles implements TeleportFeature {
   category = NavigationCategory.Management;
   section = ManagementSection.Permissions;
+  sideNavCategory = SideNavigationCategory.Access;
 
   route = {
     title: 'Manage User Roles',
@@ -288,6 +299,7 @@ export class FeatureRoles implements TeleportFeature {
 export class FeatureAuthConnectors implements TeleportFeature {
   category = NavigationCategory.Management;
   section = ManagementSection.Access;
+  sideNavCategory = SideNavigationCategory.Access;
 
   route = {
     title: 'Manage Auth Connectors',
@@ -313,9 +325,10 @@ export class FeatureAuthConnectors implements TeleportFeature {
 export class FeatureLocks implements TeleportFeature {
   category = NavigationCategory.Management;
   section = ManagementSection.Identity;
+  sideNavCategory = SideNavigationCategory.Identity;
 
   route = {
-    title: 'Manage Session & Identity Locks',
+    title: 'Session & Identity Locks',
     path: cfg.routes.locks,
     exact: true,
     component: Locks,
@@ -355,6 +368,11 @@ export class FeatureNewLock implements TeleportFeature {
 }
 
 export class FeatureDiscover implements TeleportFeature {
+  category = NavigationCategory.Management;
+  section = ManagementSection.Access;
+  sideNavCategory = SideNavigationCategory.AddNew;
+  standalone = true;
+
   route = {
     title: 'Enroll New Resource',
     path: cfg.routes.discover,
@@ -371,9 +389,6 @@ export class FeatureDiscover implements TeleportFeature {
     },
   };
 
-  category = NavigationCategory.Management;
-  section = ManagementSection.Access;
-
   hasAccess(flags: FeatureFlags) {
     return flags.discover;
   }
@@ -384,6 +399,7 @@ export class FeatureDiscover implements TeleportFeature {
 }
 
 export class FeatureIntegrations implements TeleportFeature {
+  sideNavCategory = SideNavigationCategory.Access;
   category = NavigationCategory.Management;
   section = ManagementSection.Access;
 
@@ -415,6 +431,8 @@ export class FeatureIntegrations implements TeleportFeature {
 export class FeatureIntegrationEnroll implements TeleportFeature {
   category = NavigationCategory.Management;
   section = ManagementSection.Access;
+  sideNavCategory = SideNavigationCategory.Access;
+  parent = FeatureIntegrations;
 
   route = {
     title: 'Enroll New Integration',
@@ -447,6 +465,7 @@ export class FeatureIntegrationEnroll implements TeleportFeature {
 export class FeatureRecordings implements TeleportFeature {
   category = NavigationCategory.Management;
   section = ManagementSection.Activity;
+  sideNavCategory = SideNavigationCategory.Audit;
 
   route = {
     title: 'Session Recordings',
@@ -472,6 +491,7 @@ export class FeatureRecordings implements TeleportFeature {
 export class FeatureAudit implements TeleportFeature {
   category = NavigationCategory.Management;
   section = ManagementSection.Activity;
+  sideNavCategory = SideNavigationCategory.Audit;
 
   route = {
     title: 'Audit Log',
@@ -497,6 +517,7 @@ export class FeatureAudit implements TeleportFeature {
 export class FeatureClusters implements TeleportFeature {
   category = NavigationCategory.Management;
   section = ManagementSection.Clusters;
+  sideNavCategory = SideNavigationCategory.Access;
 
   route = {
     title: 'Clusters',
@@ -522,6 +543,7 @@ export class FeatureClusters implements TeleportFeature {
 export class FeatureTrust implements TeleportFeature {
   category = NavigationCategory.Management;
   section = ManagementSection.Clusters;
+  sideNavCategory = SideNavigationCategory.Access;
 
   route = {
     title: 'Trusted Root Clusters',
@@ -545,8 +567,9 @@ export class FeatureTrust implements TeleportFeature {
 class FeatureDeviceTrust implements TeleportFeature {
   category = NavigationCategory.Management;
   section = ManagementSection.Identity;
+  sideNavCategory = SideNavigationCategory.Identity;
   route = {
-    title: 'Manage Trusted Devices',
+    title: 'Trusted Devices',
     path: cfg.routes.deviceTrust,
     exact: true,
     component: DeviceTrustLocked,
@@ -615,37 +638,35 @@ export class FeatureHelpAndSupport implements TeleportFeature {
 export function getOSSFeatures(): TeleportFeature[] {
   return [
     // Resources
+    // TODO(rudream): Implement shortcuts to pinned/nodes/apps/dbs/desktops/kubes.
     new FeatureUnifiedResources(),
-    new AccessRequests(),
-    new FeatureSessions(),
 
     // Management
 
     // - Access
     new FeatureUsers(),
+    new FeatureRoles(),
     new FeatureBots(),
     new FeatureAddBots(),
+    new FeatureJoinTokens(),
     new FeatureAuthConnectors(),
     new FeatureIntegrations(),
-    new FeatureJoinTokens(),
-    new FeatureDiscover(),
     new FeatureIntegrationEnroll(),
-
-    // - Permissions
-    new FeatureRoles(),
+    new FeatureClusters(),
+    new FeatureTrust(),
 
     // - Identity
+    new AccessRequests(),
     new FeatureLocks(),
     new FeatureNewLock(),
     new FeatureDeviceTrust(),
 
-    // - Activity
-    new FeatureRecordings(),
+    // - Audit
     new FeatureAudit(),
+    new FeatureRecordings(),
+    new FeatureSessions(),
 
-    // - Clusters
-    new FeatureClusters(),
-    new FeatureTrust(),
+    new FeatureDiscover(),
 
     // Other
     new FeatureAccount(),

--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -261,4 +261,8 @@ export const storageService = {
   getUseNewRoleEditor(): boolean {
     return this.getParsedJSONValue(KeysEnum.USE_NEW_ROLE_EDITOR, false);
   },
+
+  getIsTopBarView(): boolean {
+    return this.getParsedJSONValue(KeysEnum.USE_TOP_BAR, false);
+  },
 };

--- a/web/packages/teleport/src/services/storageService/types.ts
+++ b/web/packages/teleport/src/services/storageService/types.ts
@@ -39,6 +39,8 @@ export const KeysEnum = {
 
   // TODO(bl-nero): Remove once the new role editor is in acceptable state.
   USE_NEW_ROLE_EDITOR: 'grv_teleport_use_new_role_editor',
+  //TODO(rudream): Remove once sidenav implementation is complete.
+  USE_TOP_BAR: 'grv_teleport_use_topbar',
 };
 
 // SurveyRequest is the request for sending data to the back end

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -25,6 +25,8 @@ import {
   NavigationCategory,
 } from 'teleport/Navigation/categories';
 
+import { NavigationCategory as SideNavigationCategory } from './Navigation/SideNavigation/categories';
+
 export type NavGroup = 'team' | 'activity' | 'clusters' | 'accessrequests';
 
 export interface Context {
@@ -82,7 +84,7 @@ export enum NavTitle {
   AuditLog = 'Audit Log',
 
   // Billing
-  BillingSummary = 'Summary',
+  BillingSummary = 'Billing Summary',
 
   // Clusters
   ManageClusters = 'Manage Clusters',
@@ -106,6 +108,10 @@ export interface TeleportFeatureRoute {
 export interface TeleportFeature {
   parent?: new () => TeleportFeature | null;
   category?: NavigationCategory;
+  // TODO(rudream): Delete category field above and rename sideNavCategory field to category once old nav is removed.
+  sideNavCategory?: SideNavigationCategory;
+  /** standalone is whether this feature has no subsections */
+  standalone?: boolean;
   section?: ManagementSection;
   hasAccess(flags: FeatureFlags): boolean;
   // logoOnlyTopbar is used to optionally hide the elements in the topbar from view except for the logo.


### PR DESCRIPTION
## Purpose

Part of https://github.com/gravitational/teleport.e/issues/3998

`e` counterpart: https://github.com/gravitational/teleport.e/pull/4997

This PR adds the first version of the side navigation with basic functionality.

[Figma designs](https://www.figma.com/design/Gpjs9vjhzUKF1GDbeG9JGE/Application-Design-System?node-id=17877-13603&node-type=section&t=ohTwwWDb6RXRJgdI-0)

To disable the sidenav view (and use the old topbar instead), run the following command in the browser console:

```
localStorage.setItem("grv_teleport_use_topbar", "true")
```
