### PR TITLE
Deflake TestRemoteBuiltinRole

### DIFF
--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -170,11 +170,21 @@ func TestRemoteBuiltinRole(t *testing.T) {
 	require.NoError(t, err)
 
 	// re initialize client with trust established.
-	remoteProxy, err = remoteServer.NewRemoteClient(
-		TestBuiltin(types.RoleProxy), testSrv.Addr(), certPool)
-	require.NoError(t, err)
+	//
+	// not using Eventually(WithT) because almost all the time the first try
+	// will work and Eventually will always wait for the interval to happen, and
+	// there's also no reason to retry if somehow we fail to build the client
+	for range 50 {
+		remoteProxy, err = remoteServer.NewRemoteClient(
+			TestBuiltin(types.RoleProxy), testSrv.Addr(), certPool)
+		require.NoError(t, err)
 
-	_, err = remoteProxy.GetNodes(ctx, apidefaults.Namespace)
+		_, err = remoteProxy.GetNodes(ctx, apidefaults.Namespace)
+		if err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 	require.NoError(t, err)
 
 	// remote auth server will get rejected even with established trust
@@ -2915,7 +2925,6 @@ func TestGenerateCerts(t *testing.T) {
 				}
 			})
 		}
-
 	})
 }
 


### PR DESCRIPTION
The changes to support reloadless have slightly changed the way we validate client certificates; I will investigate whether or not the changes that led to this new flaky behavior should actually be considered a regression, but for now just waiting and reconnecting fixes the issue (as it's likely just cache propagation time).

Fixes #45833