### PR TITLE
[v16] docs: remove tsh tctl ent version advisory for migrating

### DIFF
--- a/docs/pages/admin-guides/migrate-plans.mdx
+++ b/docs/pages/admin-guides/migrate-plans.mdx
@@ -41,7 +41,6 @@ migrating from Teleport Enterprise to Teleport Community Edition.
 ## Prerequisites
 
 - An existing Teleport cluster.
-
 - The `tsh` and `tctl` client tools. This guide assumes that you are using
   `tctl` to manage dynamic resources, but it is also possible to use [Teleport
   Terraform provider](infrastructure-as-code/terraform-provider.mdx) and

--- a/docs/pages/admin-guides/migrate-plans.mdx
+++ b/docs/pages/admin-guides/migrate-plans.mdx
@@ -49,7 +49,6 @@ migrating from Teleport Enterprise to Teleport Community Edition.
   operator](infrastructure-as-code/teleport-operator/teleport-operator-standalone.mdx), in
   addition to custom scripts that use the [Teleport API](api/api.mdx)
   to manage the Teleport Auth Service backend.
-
 - If you are migrating to Teleport Enterprise (Cloud), you must not have an
   account with trusted clusters enrolled. Trusted clusters are not supported in
   cloud-hosted Teleport Enterprise accounts. You will not be able to migrate

--- a/docs/pages/admin-guides/migrate-plans.mdx
+++ b/docs/pages/admin-guides/migrate-plans.mdx
@@ -50,15 +50,6 @@ migrating from Teleport Enterprise to Teleport Community Edition.
   addition to custom scripts that use the [Teleport API](api/api.mdx)
   to manage the Teleport Auth Service backend.
 
-  <Notice type="warning">
-
-  If you are using Teleport Community Edition, you must use the Teleport
-  Enterprise editions of `tsh` and `tctl` in order to manage your Teleport
-  Enterprise cluster. See the [Installation](../installation.mdx) page to
-  install these tools on your system.
-
-  </Notice>
-
 - If you are migrating to Teleport Enterprise (Cloud), you must not have an
   account with trusted clusters enrolled. Trusted clusters are not supported in
   cloud-hosted Teleport Enterprise accounts. You will not be able to migrate


### PR DESCRIPTION
Backport #46328 to branch/v16