### PR TITLE
docs: use code styling instead of shell

### DIFF
--- a/docs/pages/enroll-resources/machine-id/workload-identity/federation.mdx
+++ b/docs/pages/enroll-resources/machine-id/workload-identity/federation.mdx
@@ -89,7 +89,7 @@ trust domain according to the refresh hint provided by the remote trust domain.
 
 You can check the status of the federation relationship using the `tctl` CLI:
 
-```shell
+```code
 $ tctl get spiffe_federation/example.com
 ```
 

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
@@ -304,7 +304,7 @@ To use this value, you must create a Kubernetes `Secret` containing the CA
 certs in the same namespace as the Teleport Kubernetes Operator using a
 command such as:
 
-```shell
+```code
 $ kubectl create secret generic my-root-ca --from-file=ca.pem=/path/to/root-ca.pem
 ```
 

--- a/examples/chart/teleport-cluster/README.md
+++ b/examples/chart/teleport-cluster/README.md
@@ -45,7 +45,7 @@ or by installing [cert-manager](https://cert-manager.io/docs/) and setting the `
 
 The first user can be created by executing a command in one of the auth pods.
 
-```shell
+```code
 kubectl exec it -n teleport-cluster statefulset/teleport-cluster-auth -- tctl users add my-username --roles=editor,auditor,access
 ```
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/README.md
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/README.md
@@ -13,7 +13,7 @@ operator version is deployed, use the `--version` Helm flag.
 
 The chart can be deployed in two ways:
 - in standalone mode by running
-  ```shell
+  ```code
   helm install teleport/teleport-operator teleport-operator --set authAddr=teleport.example.com:443 --set token=my-operator-token
   ```
   See [the standalone guide](https://goteleport.com/docs/management/dynamic-resources/teleport-operator-standalone/) for more details.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -180,7 +180,7 @@ tls:
   # certs in the same namespace as the Teleport Kubernetes Operator using a
   # command such as:
   #
-  # ```shell
+  # ```code
   # $ kubectl create secret generic my-root-ca --from-file=ca.pem=/path/to/root-ca.pem
   # ```
   existingCASecretName: ""


### PR DESCRIPTION
Using `shell` styling does not handle copy and paste as expected. Terminal starters like `$` can be included.