### PR TITLE
Proof-of-concept draft for teleport-update binary implementation

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -68,6 +68,9 @@ type Config struct {
 	Timeout time.Duration
 	// TraceProvider is used to retrieve a Tracer for creating spans
 	TraceProvider oteltrace.TracerProvider
+	// Group is an optional agent group identifier that modulates
+	// the returned desired agent version update information.
+	Group string
 }
 
 // CheckAndSetDefaults checks and sets defaults
@@ -170,6 +173,10 @@ func Find(cfg *Config) (*PingResponse, error) {
 	defer span.End()
 
 	endpoint := fmt.Sprintf("https://%s/webapi/find", cfg.ProxyAddr)
+
+	if cfg.Group != "" {
+		endpoint = fmt.Sprintf("%s?group=%s", endpoint, cfg.Group)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {

--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -295,6 +295,8 @@ type PingResponse struct {
 	Proxy ProxySettings `json:"proxy"`
 	// ServerVersion is the version of Teleport that is running.
 	ServerVersion string `json:"server_version"`
+	// ServerVersion is the version of Teleport that is running.
+	ServerEdition string `json:"server_edition"`
 	// MinClientVersion is the minimum client version required by the server.
 	MinClientVersion string `json:"min_client_version"`
 	// ClusterName contains the name of the Teleport cluster.
@@ -303,6 +305,10 @@ type PingResponse struct {
 	// reserved: license_warnings ([]string)
 	// AutomaticUpgrades describes whether agents should automatically upgrade.
 	AutomaticUpgrades bool `json:"automatic_upgrades"`
+
+	AgentAutoupdate          bool `json:"agent_autoupdate"`
+	AgentVersion             bool `json:"agent_version"`
+	AgentUpdateJitterSeconds int  `json:"agent_update_jitter_seconds"`
 }
 
 // PingErrorResponse contains the error from /webapi/ping.

--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -306,9 +306,9 @@ type PingResponse struct {
 	// AutomaticUpgrades describes whether agents should automatically upgrade.
 	AutomaticUpgrades bool `json:"automatic_upgrades"`
 
-	AgentAutoupdate          bool `json:"agent_autoupdate"`
-	AgentVersion             bool `json:"agent_version"`
-	AgentUpdateJitterSeconds int  `json:"agent_update_jitter_seconds"`
+	AgentAutoupdate          bool   `json:"agent_autoupdate"`
+	AgentVersion             string `json:"agent_version"`
+	AgentUpdateJitterSeconds int    `json:"agent_update_jitter_seconds"`
 }
 
 // PingErrorResponse contains the error from /webapi/ping.

--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -313,9 +313,12 @@ type PingResponse struct {
 	// AutomaticUpgrades describes whether agents should automatically upgrade.
 	AutomaticUpgrades bool `json:"automatic_upgrades"`
 
-	AgentAutoupdate          bool   `json:"agent_autoupdate"`
-	AgentVersion             string `json:"agent_version"`
-	AgentUpdateJitterSeconds int    `json:"agent_update_jitter_seconds"`
+	// AgentAutoupdate specifies whether an agent should update now (not implemented).
+	AgentAutoupdate bool `json:"agent_autoupdate"`
+	// AgentVersion contains the target agent version (not implemented).
+	AgentVersion string `json:"agent_version"`
+	// AgentUpdateJitterSeconds specifies the amount of jitter to wait before updating (not implemented).
+	AgentUpdateJitterSeconds int `json:"agent_update_jitter_seconds"`
 }
 
 // PingErrorResponse contains the error from /webapi/ping.

--- a/constants.go
+++ b/constants.go
@@ -280,6 +280,9 @@ const (
 	// ComponentProxySecureGRPC represents a secure gRPC server running on Proxy (used for Kube).
 	ComponentProxySecureGRPC = "proxy:secure-grpc"
 
+	// ComponentUpdater represents the agent updater.
+	ComponentUpdater = "updater"
+
 	// VerboseLogsEnvVar forces all logs to be verbose (down to DEBUG level)
 	VerboseLogsEnvVar = "TELEPORT_DEBUG"
 

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -414,6 +414,8 @@ func cmdUpdate(ctx context.Context, ccfg *cliConfig) error {
 
 	resp.AgentVersion = "16.2.0" // FIXME: for testing
 	if cfg.Spec.ActiveVersion != resp.AgentVersion {
+		time.Sleep(time.Duration(resp.AgentUpdateJitterSeconds) * time.Second)
+
 		client, err := newClient(&downloadConfig{
 			Pool: certPool,
 		})

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -183,6 +183,13 @@ func doEnable(ctx context.Context, cf *cliConfig) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	if resp.AgentVersion != cfg.Spec.ActiveVersion {
+
+		cfg.Spec.ActiveVersion = resp.AgentVersion
+	}
+	if cf.Group !=
+	cfg.Spec.Group = cf.Group
+	cfg.Spec.Enabled = true
 
 }
 

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -19,30 +19,23 @@
 package main
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
-	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/hex"
 	"errors"
-	"io"
 	"io/fs"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
-	"runtime"
 	"syscall"
-	"text/template"
 	"time"
 
 	"github.com/google/renameio/v2"
 	"github.com/gravitational/trace"
 	"golang.org/x/net/http/httpproxy"
-	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v3"
 
 	"github.com/gravitational/teleport"
@@ -69,9 +62,13 @@ const (
 	templateEnvVar    = "TELEPORT_URL_TEMPLATE"
 	proxyServerEnvVar = "TELEPORT_PROXY"
 	updateGroupEnvVar = "TELEPORT_UPDATE_GROUP"
-)
 
-const cdnURITemplate = "https://cdn.teleport.dev/teleport-v{{.Version}}-{{.OS}}-{{.Arch}}-bin.tar.gz"
+	cdnURITemplate = "https://cdn.teleport.dev/teleport-v{{.Version}}-{{.OS}}-{{.Arch}}-bin.tar.gz"
+
+	versionsDirName = "versions"
+	updatesFileName = "updates.yaml"
+	lockFileName    = ".lock"
+)
 
 var plog = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentUpdater)
 
@@ -97,6 +94,7 @@ type cliConfig struct {
 func Run(args []string) error {
 	var ccfg cliConfig
 	ctx := context.Background()
+	ctx, _ = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 
 	app := libutils.InitCLIParser("teleport-updater", appHelp).Interspersed(false)
 	app.Flag("debug", "Verbose logging to stdout.").Short('d').BoolVar(&ccfg.Debug)
@@ -129,7 +127,7 @@ func Run(args []string) error {
 		return trace.Errorf("setting up logger")
 	}
 
-	err = validate(&ccfg)
+	err = validateCLIConfig(&ccfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -138,9 +136,9 @@ func Run(args []string) error {
 	case enableCmd.FullCommand():
 		err = doEnable(ctx, &ccfg)
 	case disableCmd.FullCommand():
-		err = doDisable()
+		err = doDisable(ctx, &ccfg)
 	case updateCmd.FullCommand():
-		err = doUpdate(ctx)
+		err = doUpdate(ctx, &ccfg)
 	case versionCmd.FullCommand():
 		modules.GetModules().PrintVersion()
 	default:
@@ -168,27 +166,23 @@ func setupLogger(debug bool, format string) error {
 	return nil
 }
 
-// TODO: should be configurable?
-var (
-	versionsDir = filepath.Join(libdefaults.DataDir, "versions")
-	updatesYAML = filepath.Join(versionsDir, "updates.yaml")
-)
-
 const (
 	updatesVersion = "v1"
 	updatesKind    = "agent_versions"
 )
 
 type UpdatesConfig struct {
-	Version string `yaml:"version"`
-	Kind    string `yaml:"kind"`
-	Spec    struct {
-		Proxy         string `yaml:"proxy"`
-		Group         string `yaml:"group"`
-		URITemplate   string `yaml:"uri_template"`
-		Enabled       bool   `yaml:"enabled"`
-		ActiveVersion string `yaml:"active_version"`
-	} `yaml:"spec"`
+	Version string      `yaml:"version"`
+	Kind    string      `yaml:"kind"`
+	Spec    UpdatesSpec `yaml:"spec"`
+}
+
+type UpdatesSpec struct {
+	Proxy         string `yaml:"proxy"`
+	Group         string `yaml:"group"`
+	URITemplate   string `yaml:"uri_template"`
+	Enabled       bool   `yaml:"enabled"`
+	ActiveVersion string `yaml:"active_version"`
 }
 
 func readUpdatesConfig(path string) (*UpdatesConfig, error) {
@@ -233,7 +227,16 @@ func writeUpdatesConfig(filename string, cfg *UpdatesConfig) error {
 	return trace.Wrap(t.CloseAtomicallyReplace())
 }
 
-func doDisable() error {
+func doDisable(ctx context.Context, ccfg *cliConfig) error {
+	var (
+		versionsDir = filepath.Join(ccfg.DataDir, versionsDirName)
+		updatesYAML = filepath.Join(versionsDir, updatesFileName)
+	)
+	unlock, err := lock(filepath.Join(versionsDir, lockFileName))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer unlock()
 	cfg, err := readUpdatesConfig(updatesYAML)
 	if err != nil {
 		return trace.Wrap(err)
@@ -249,7 +252,11 @@ func doDisable() error {
 }
 
 func doEnable(ctx context.Context, ccfg *cliConfig) error {
-	unlock, err := lock()
+	var (
+		versionsDir = filepath.Join(ccfg.DataDir, versionsDirName)
+		updatesYAML = filepath.Join(versionsDir, updatesFileName)
+	)
+	unlock, err := lock(filepath.Join(versionsDir, lockFileName))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -269,7 +276,13 @@ func doEnable(ctx context.Context, ccfg *cliConfig) error {
 		cfg.Spec.URITemplate = ccfg.Template
 	}
 	cfg.Spec.Enabled = true
-
+	if err := validateUpdatesSpec(&cfg.Spec); err != nil {
+		return trace.Wrap(err)
+	}
+	certPool, err := x509.SystemCertPool()
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	addr, err := libutils.ParseAddr(cfg.Spec.Proxy)
 	if err != nil {
 		return trace.Errorf("failed to parse proxy server address: %w", err)
@@ -279,12 +292,29 @@ func doEnable(ctx context.Context, ccfg *cliConfig) error {
 		ProxyAddr: addr.Addr,
 		Timeout:   30 * time.Second,
 		Group:     cfg.Spec.Group,
+		Pool:      certPool,
 	})
 	if err != nil {
 		return trace.Errorf("failed to request version from proxy: %w", err)
 	}
+	resp.AgentVersion = "16.1.0"
 	if cfg.Spec.ActiveVersion != resp.AgentVersion {
-		err = createVersion(ctx, cfg.Spec.URITemplate, resp.AgentVersion)
+		client, err := newClient(&downloadConfig{
+			Pool: certPool,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer client.CloseIdleConnections()
+		tv := TeleportVersion{
+			VersionsDir:    filepath.Join(ccfg.DataDir, "versions"),
+			DownloadClient: client,
+		}
+		template := cfg.Spec.URITemplate
+		if template == "" {
+			template = cdnURITemplate
+		}
+		err = tv.Create(ctx, template, resp.AgentVersion)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -296,8 +326,12 @@ func doEnable(ctx context.Context, ccfg *cliConfig) error {
 	return nil
 }
 
-func doUpdate(ctx context.Context) error {
-	unlock, err := lock()
+func doUpdate(ctx context.Context, ccfg *cliConfig) error {
+	var (
+		versionsDir = filepath.Join(ccfg.DataDir, versionsDirName)
+		updatesYAML = filepath.Join(versionsDir, updatesFileName)
+	)
+	unlock, err := lock(filepath.Join(versionsDir, lockFileName))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -311,6 +345,10 @@ func doUpdate(ctx context.Context) error {
 		return trace.Errorf("updates disabled")
 	}
 
+	certPool, err := x509.SystemCertPool()
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	addr, err := libutils.ParseAddr(cfg.Spec.Proxy)
 	if err != nil {
 		return trace.Errorf("failed to parse proxy server address: %w", err)
@@ -320,13 +358,30 @@ func doUpdate(ctx context.Context) error {
 		ProxyAddr: addr.Addr,
 		Timeout:   30 * time.Second,
 		Group:     cfg.Spec.Group,
+		Pool:      certPool,
 	})
 	if err != nil {
 		return trace.Errorf("failed to request version from proxy: %w", err)
 	}
 
+	resp.AgentVersion = "16.1.0"
 	if cfg.Spec.ActiveVersion != resp.AgentVersion {
-		err := createVersion(ctx, cfg.Spec.URITemplate, resp.AgentVersion)
+		client, err := newClient(&downloadConfig{
+			Pool: certPool,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer client.CloseIdleConnections()
+		tv := TeleportVersion{
+			VersionsDir:    filepath.Join(ccfg.DataDir, "versions"),
+			DownloadClient: client,
+		}
+		template := cfg.Spec.URITemplate
+		if template == "" {
+			template = cdnURITemplate
+		}
+		err = tv.Create(ctx, template, resp.AgentVersion)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -338,224 +393,10 @@ func doUpdate(ctx context.Context) error {
 	return nil
 }
 
-func download(ctx context.Context, url string) (r io.ReadSeekCloser, sum []byte, err error) {
-	f, err := os.CreateTemp("", "teleport-update-")
-	if err != nil {
-		return nil, nil, trace.Errorf("failed to create temporary file: %w", err)
-	}
-	defer func() {
-		if err != nil {
-			f.Close()
-			if err := os.Remove(f.Name()); err != nil {
-				plog.WarnContext(ctx, "Failed to cleanup temporary download after error", "error", err)
-			}
-		}
-	}()
-	free, err := freeDisk(os.TempDir())
-	if err != nil {
-		return nil, nil, trace.Errorf("failed to calculate free disk: %w", err)
-	}
-
-	client, err := newClient(&downloadConfig{})
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	defer client.CloseIdleConnections()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	defer resp.Body.Close()
-
-	if resp.ContentLength < 0 {
-		plog.Warn("Content length missing from response, unable to verify Teleport download size")
-	} else if resp.ContentLength > free {
-		return nil, nil, trace.Errorf("size of download exceeds available disk space")
-	}
-	shaReader := sha256.New()
-	n, err := io.Copy(f, io.TeeReader(resp.Body, shaReader))
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	if resp.ContentLength >= 0 && n != resp.ContentLength {
-		return nil, nil, trace.Errorf("mismatch in Teleport download size")
-	}
-	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		return nil, nil, trace.Errorf("failed seek to start of download: %w", err)
-	}
-	return rmCloser{f}, shaReader.Sum(nil), nil
-}
-
-type rmCloser struct {
-	*os.File
-}
-
-func (r rmCloser) Close() error {
-	err := r.File.Close()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	err = os.Remove(r.File.Name())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
-}
-
-func getChecksum(ctx context.Context, url string) ([]byte, error) {
-	client, err := newClient(&downloadConfig{})
-	if err != nil {
+func lock(lockFile string) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(lockFile), 0755); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer client.CloseIdleConnections()
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer resp.Body.Close()
-
-	r := io.LimitReader(resp.Body, 64)
-	var buf bytes.Buffer
-	_, err = io.Copy(&buf, r)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	sum, err := hex.DecodeString(buf.String())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return sum, nil
-}
-
-func removeVersion(version string) error {
-	versionPath := filepath.Join(versionsDir, version)
-	sumPath := filepath.Join(versionPath, "sha256")
-
-	// invalidate checksum first, to protect against partially-removed
-	// directory with valid checksum
-	if err := os.Remove(sumPath); err != nil {
-		return trace.Wrap(err)
-	}
-	if err := os.RemoveAll(versionPath); err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
-}
-
-type TeleportVersion struct {
-	VersionsDir    string
-	DownloadClient *http.Client
-}
-
-func createVersion(ctx context.Context, uriTmpl, version string) error {
-	versionPath := filepath.Join(versionsDir, version)
-	sumPath := filepath.Join(versionPath, "sha256")
-
-	tmpl, err := template.New("uri").Parse(uriTmpl)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	var uriBuf bytes.Buffer
-	params := struct {
-		OS, Version, Arch string
-	}{runtime.GOOS, version, runtime.GOARCH}
-	err = tmpl.Execute(&uriBuf, params)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	uri := uriBuf.String()
-
-	sum, err := getChecksum(ctx, uri)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	existSum, err := readChecksum(sumPath)
-	if err == nil {
-		if bytes.Equal(existSum, sum) {
-			plog.InfoContext(ctx, "Version already present", "version", version)
-			return nil
-		}
-		plog.WarnContext(ctx, "Removing version that does not match checksum", "version", version)
-		if err := removeVersion(version); err != nil {
-			return trace.Wrap(err)
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return trace.Wrap(err)
-	}
-	tgz, pathSum, err := download(ctx, uri)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer func() {
-		if err := tgz.Close(); err != nil {
-			plog.WarnContext(ctx, "Failed to cleanup temporary download after error", "error", err)
-		}
-	}()
-
-	if !bytes.Equal(sum, pathSum) {
-		return trace.Errorf("mismatched checksum, download possibly corrupt")
-	}
-	// avoid gzip bomb by validating checksum before decompression
-	n, err := uncompressedSize(tgz)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if _, err := tgz.Seek(0, io.SeekStart); err != nil {
-		return trace.Errorf("failed seek to start: %w", err)
-	}
-	if err := os.MkdirAll(versionPath, 0755); err != nil {
-		return trace.Wrap(err)
-	}
-	free, err := freeDisk(versionPath)
-	if err != nil {
-		return trace.Errorf("failed to calculate free disk in %q: %w", versionPath, err)
-	}
-	if d := free - n; d < 0 {
-		return trace.Errorf("%q needs %d additional bytes of disk space for download", versionsDir, -d)
-	}
-	err = untar(tgz, versionPath)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	err = os.WriteFile(sumPath, sum, 0755)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
-}
-
-func readChecksum(path string) ([]byte, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer f.Close()
-	var buf bytes.Buffer
-	n, err := io.Copy(&buf, io.LimitReader(f, 65))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if n != 64 {
-		return nil, trace.Errorf("mismatch in checksum size")
-	}
-	return buf.Bytes(), nil
-}
-
-func lock() (func(), error) {
-	// Build the path to the lock file that will be used by flock.
-	lockFile := filepath.Join(versionsDir, ".lock")
-
-	// Create the advisory lock using flock.
 	lf, err := os.OpenFile(lockFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -602,42 +443,16 @@ func newClient(cfg *downloadConfig) (*http.Client, error) {
 	}, nil
 }
 
-const reservedFreeDisk = 10_000_000 // 10 MiB
-
-func freeDisk(dir string) (int64, error) {
-	var stat unix.Statfs_t
-	err := unix.Statfs(dir, &stat)
-	if err != nil {
-		return 0, trace.Wrap(err)
+func validateCLIConfig(cfg *cliConfig) error {
+	if cfg.DataDir == "" {
+		cfg.DataDir = libdefaults.DataDir
 	}
-	if int64(stat.Bavail) < 0 {
-		return 0, trace.Errorf("invalid size")
-	}
-	return int64(stat.Bavail) - reservedFreeDisk, nil
+	return nil
 }
 
-func uncompressedSize(f io.Reader) (int64, error) {
-	// NOTE: The gzip length trailer is very unreliable,
-	//   but we could optimize this in the future if
-	//   we are willing to verify that all published
-	//   Teleport tarballs have valid trailers.
-	r, err := gzip.NewReader(f)
-	if err != nil {
-		return 0, trace.Wrap(err)
-	}
-	n, err := io.Copy(io.Discard, r)
-	if err != nil {
-		return 0, trace.Wrap(err)
-	}
-	return n, nil
-}
-
-func validate(cf *cliConfig) error {
-	if cf.Template == "" {
-		cf.Template = cdnURITemplate
-	}
-	if cf.DataDir == "" {
-		cf.DataDir = libdefaults.DataDir
+func validateUpdatesSpec(spec *UpdatesSpec) error {
+	if spec.Proxy == "" {
+		return trace.Errorf("proxy URL must be specified with --proxy or present in updates.yaml")
 	}
 	return nil
 }

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -143,8 +143,7 @@ func Run(args []string) error {
 		return trace.Errorf("setting up logger")
 	}
 
-	err = validateCLIConfig(&ccfg)
-	if err != nil {
+	if err := validateCLIConfig(&ccfg); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/tool/teleport-update/untar.go
+++ b/tool/teleport-update/untar.go
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package main
 
 import (

--- a/tool/teleport-update/untar.go
+++ b/tool/teleport-update/untar.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// From: https://github.com/golang/build/blob/8ac64ccecd1b81ab8fee4b64bc46b21913564767/internal/untar/untar.go
+
+func untar(r io.Reader, dir string) (err error) {
+	t0 := time.Now()
+	nFiles := 0
+	madeDir := map[string]bool{}
+	defer func() {
+		td := time.Since(t0)
+		if err == nil {
+			log.Printf("extracted tarball into %s: %d files, %d dirs (%v)", dir, nFiles, len(madeDir), td)
+		} else {
+			log.Printf("error extracting tarball into %s after %d files, %d dirs, %v: %v", dir, nFiles, len(madeDir), td, err)
+		}
+	}()
+	zr, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("requires gzip-compressed body: %v", err)
+	}
+	tr := tar.NewReader(zr)
+	loggedChtimesError := false
+	for {
+		f, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Printf("tar reading error: %v", err)
+			return fmt.Errorf("tar error: %v", err)
+		}
+		if !validRelPath(f.Name) {
+			return fmt.Errorf("tar contained invalid name error %q", f.Name)
+		}
+		rel := filepath.FromSlash(f.Name)
+		abs := filepath.Join(dir, rel)
+
+		mode := f.FileInfo().Mode()
+		switch f.Typeflag {
+		case tar.TypeReg:
+			// Make the directory. This is redundant because it should
+			// already be made by a directory entry in the tar
+			// beforehand. Thus, don't check for errors; the next
+			// write will fail with the same error.
+			dir := filepath.Dir(abs)
+			if !madeDir[dir] {
+				if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil {
+					return err
+				}
+				madeDir[dir] = true
+			}
+			if runtime.GOOS == "darwin" && mode&0111 != 0 {
+				// The darwin kernel caches binary signatures
+				// and SIGKILLs binaries with mismatched
+				// signatures. Overwriting a binary with
+				// O_TRUNC does not clear the cache, rendering
+				// the new copy unusable. Removing the original
+				// file first does clear the cache. See #54132.
+				err := os.Remove(abs)
+				if err != nil && !errors.Is(err, fs.ErrNotExist) {
+					return err
+				}
+			}
+			wf, err := os.OpenFile(abs, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode.Perm())
+			if err != nil {
+				return err
+			}
+			n, err := io.Copy(wf, tr)
+			if closeErr := wf.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+			if err != nil {
+				return fmt.Errorf("error writing to %s: %v", abs, err)
+			}
+			if n != f.Size {
+				return fmt.Errorf("only wrote %d bytes to %s; expected %d", n, abs, f.Size)
+			}
+			modTime := f.ModTime
+			if modTime.After(t0) {
+				// Clamp modtimes at system time. See
+				// golang.org/issue/19062 when clock on
+				// buildlet was behind the gitmirror server
+				// doing the git-archive.
+				modTime = t0
+			}
+			if !modTime.IsZero() {
+				if err := os.Chtimes(abs, modTime, modTime); err != nil && !loggedChtimesError {
+					// benign error. Gerrit doesn't even set the
+					// modtime in these, and we don't end up relying
+					// on it anywhere (the gomote push command relies
+					// on digests only), so this is a little pointless
+					// for now.
+					log.Printf("error changing modtime: %v (further Chtimes errors suppressed)", err)
+					loggedChtimesError = true // once is enough
+				}
+			}
+			nFiles++
+		case tar.TypeDir:
+			if err := os.MkdirAll(abs, 0755); err != nil {
+				return err
+			}
+			madeDir[abs] = true
+		case tar.TypeXGlobalHeader:
+			// git archive generates these. Ignore them.
+		default:
+			return fmt.Errorf("tar file entry %s contained unsupported file type %v", f.Name, mode)
+		}
+	}
+	return nil
+}
+
+func validRelPath(p string) bool {
+	if p == "" || strings.Contains(p, `\`) || strings.HasPrefix(p, "/") || strings.Contains(p, "../") {
+		return false
+	}
+	return true
+}

--- a/tool/teleport-update/untar.go
+++ b/tool/teleport-update/untar.go
@@ -34,6 +34,9 @@ import (
 )
 
 // From: https://github.com/golang/build/blob/8ac64ccecd1b81ab8fee4b64bc46b21913564767/internal/untar/untar.go
+// Untarring in Go can be risky. E.g., it's easy to construct a tarball that writes to arbitrary FS locations using symlinks.
+// Various operating systems and version control systems may react poorly to unusual permissions or future timestamps due to clock skew.
+// This battle-tested implementation is copied directly from Go's build repository and fails on symlinks.
 
 func untar(r io.Reader, dir string) (err error) {
 	t0 := time.Now()

--- a/tool/teleport-update/versions.go
+++ b/tool/teleport-update/versions.go
@@ -1,0 +1,283 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"text/template"
+	"time"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	checksumType = "sha256"
+)
+
+type TeleportVersion struct {
+	VersionsDir    string
+	DownloadClient *http.Client
+}
+
+func (tv *TeleportVersion) Remove(version string) error {
+	versionPath := filepath.Join(tv.VersionsDir, version)
+	sumPath := filepath.Join(versionPath, checksumType)
+
+	// invalidate checksum first, to protect against partially-removed
+	// directory with valid checksum
+	if err := os.Remove(sumPath); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := os.RemoveAll(versionPath); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func (tv *TeleportVersion) Create(ctx context.Context, uriTmpl, version string) error {
+	versionPath := filepath.Join(tv.VersionsDir, version)
+	sumPath := filepath.Join(versionPath, checksumType)
+
+	tmpl, err := template.New("uri").Parse(uriTmpl)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	var uriBuf bytes.Buffer
+	params := struct {
+		OS, Version, Arch string
+	}{runtime.GOOS, version, runtime.GOARCH}
+	err = tmpl.Execute(&uriBuf, params)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	uri := uriBuf.String()
+
+	sum, err := tv.getChecksum(ctx, uri+"."+checksumType)
+	if err != nil {
+		return trace.Errorf("failed to download checksum from %s: %w", uri, err)
+	}
+	existSum, err := readChecksum(ctx, sumPath)
+	if err == nil {
+		if bytes.Equal(existSum, sum) {
+			plog.InfoContext(ctx, "Version already present", "version", version)
+			return nil
+		}
+		plog.WarnContext(ctx, "Removing version that does not match checksum", "version", version)
+		if err := tv.Remove(version); err != nil {
+			return trace.Wrap(err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return trace.Wrap(err)
+	}
+	tgz, pathSum, err := tv.download(ctx, uri)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer func() {
+		if err := tgz.Close(); err != nil {
+			plog.WarnContext(ctx, "Failed to cleanup temporary download after error", "error", err)
+		}
+	}()
+
+	if !bytes.Equal(sum, pathSum) {
+		return trace.Errorf("mismatched checksum, download possibly corrupt")
+	}
+	// avoid gzip bomb by validating checksum before decompression
+	n, err := uncompressedSize(tgz)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if _, err := tgz.Seek(0, io.SeekStart); err != nil {
+		return trace.Errorf("failed seek to start: %w", err)
+	}
+	if err := os.MkdirAll(versionPath, 0755); err != nil {
+		return trace.Wrap(err)
+	}
+	free, err := freeDisk(versionPath)
+	if err != nil {
+		return trace.Errorf("failed to calculate free disk in %q: %w", versionPath, err)
+	}
+	if d := free - n; d < 0 {
+		return trace.Errorf("%q needs %d additional bytes of disk space for download", versionPath, -d)
+	}
+	err = untar(tgz, versionPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = os.WriteFile(sumPath, []byte(hex.EncodeToString(sum)), 0755)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func readChecksum(ctx context.Context, path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer f.Close()
+	var buf bytes.Buffer
+	n, err := io.Copy(&buf, io.LimitReader(f, 65))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	raw := buf.String()
+	if n != 64 {
+		plog.WarnContext(ctx, "unexpected checksum size", "size", n, "checksum", raw)
+	}
+	sum, err := hex.DecodeString(raw)
+	if err != nil {
+		plog.WarnContext(ctx, "corrupt checksum detected", "size", n, "checksum", raw)
+		return nil, nil
+	}
+	return sum, nil
+}
+
+func (tv *TeleportVersion) download(ctx context.Context, url string) (r io.ReadSeekCloser, sum []byte, err error) {
+	f, err := os.CreateTemp("", "teleport-update-")
+	if err != nil {
+		return nil, nil, trace.Errorf("failed to create temporary file: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			f.Close()
+			if err := os.Remove(f.Name()); err != nil {
+				plog.WarnContext(ctx, "Failed to cleanup temporary download after error", "error", err)
+			}
+		}
+	}()
+	free, err := freeDisk(os.TempDir())
+	if err != nil {
+		return nil, nil, trace.Errorf("failed to calculate free disk: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	resp, err := tv.DownloadClient.Do(req)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	defer resp.Body.Close()
+	plog.InfoContext(ctx, "Downloading Teleport tarball", "path", f.Name(), "size", resp.ContentLength)
+
+	if resp.ContentLength < 0 {
+		plog.Warn("Content length missing from response, unable to verify Teleport download size")
+	} else if resp.ContentLength > free {
+		return nil, nil, trace.Errorf("size of download (%d bytes) exceeds available disk space (%d bytes)", resp.ContentLength, free)
+	}
+	shaReader := sha256.New()
+	n, err := io.Copy(f, io.TeeReader(resp.Body, shaReader))
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	if resp.ContentLength >= 0 && n != resp.ContentLength {
+		return nil, nil, trace.Errorf("mismatch in Teleport download size")
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return nil, nil, trace.Errorf("failed seek to start of download: %w", err)
+	}
+	return rmCloser{f}, shaReader.Sum(nil), nil
+}
+
+type rmCloser struct {
+	*os.File
+}
+
+func (r rmCloser) Close() error {
+	err := r.File.Close()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = os.Remove(r.File.Name())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+const reservedFreeDisk = 10_000_000 // 10 MiB
+
+func freeDisk(dir string) (int64, error) {
+	var stat unix.Statfs_t
+	err := unix.Statfs(dir, &stat)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	avail := int64(stat.Bavail * uint64(stat.Bsize))
+	if avail < 0 {
+		return 0, trace.Errorf("invalid size")
+	}
+	return avail - reservedFreeDisk, nil
+}
+
+func uncompressedSize(f io.Reader) (int64, error) {
+	// NOTE: The gzip length trailer is very unreliable,
+	//   but we could optimize this in the future if
+	//   we are willing to verify that all published
+	//   Teleport tarballs have valid trailers.
+	r, err := gzip.NewReader(f)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	n, err := io.Copy(io.Discard, r)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	return n, nil
+}
+
+func (tv *TeleportVersion) getChecksum(ctx context.Context, url string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	resp, err := tv.DownloadClient.Do(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer resp.Body.Close()
+
+	r := io.LimitReader(resp.Body, 64)
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	sum, err := hex.DecodeString(buf.String())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return sum, nil
+}

--- a/tool/teleport-update/versions.go
+++ b/tool/teleport-update/versions.go
@@ -125,7 +125,7 @@ func (tv *TeleportVersion) Create(ctx context.Context, uriTmpl, version string) 
 	}
 	// Bail if there's not enough free disk space at the target
 	if d := free - n; d < 0 {
-		return trace.Errorf("%q needs %d additional bytes of disk space for download", versionPath, -d)
+		return trace.Errorf("%q needs %d additional bytes of disk space for decompression", versionPath, -d)
 	}
 	err = untar(tgz, versionPath)
 	if err != nil {

--- a/tool/teleport-update/versions.go
+++ b/tool/teleport-update/versions.go
@@ -103,7 +103,7 @@ func (tv *TeleportVersion) Create(ctx context.Context, uriTmpl, version string) 
 		}
 	}()
 
-	// Avoid gzip bomb by validating checksum before any decompression
+	// Check integrity before decompression
 	if !bytes.Equal(newSum, pathSum) {
 		return trace.Errorf("mismatched checksum, download possibly corrupt")
 	}

--- a/tool/teleport-updater/main.go
+++ b/tool/teleport-updater/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/tool/teleport-updater/main.go
+++ b/tool/teleport-updater/main.go
@@ -1,5 +1,187 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package main
 
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gravitational/trace"
+	"gopkg.in/yaml.v3"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/webclient"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
+)
+
+const appHelp = `Teleport Updater
+
+The Teleport Updater updates the version a Teleport agent on a Linux server
+that is being used as agent to provide connectivity to Teleport resources.
+
+The Teleport Updater supports upgrade schedules and automated rollbacks. 
+
+Find out more at https://goteleport.com/docs/updater`
+
+const (
+	templateEnvVar    = "TELEPORT_URL_TEMPLATE"
+	proxyServerEnvVar = "TELEPORT_PROXY"
+)
+
+var log = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentTBot)
+
 func main() {
+	if err := Run(os.Args[1:], os.Stdout); err != nil {
+		utils.FatalError(err)
+	}
+}
+
+type cliConfig struct {
+	Debug bool
+
+	ProxyServer string
+	Template    string
+
+	// LogFormat controls the format of logging. Can be either `json` or `text`.
+	// By default, this is `text`.
+	LogFormat string
+}
+
+func Run(args []string, stdout io.Writer) error {
+	var cf cliConfig
+	ctx := context.Background()
+
+	app := utils.InitCLIParser("teleport-updater", appHelp).Interspersed(false)
+	app.Flag("debug", "Verbose logging to stdout.").Short('d').BoolVar(&cf.Debug)
+	app.HelpFlag.Short('h')
+
+	versionCmd := app.Command("version", "Print the version of your teleport-updater binary.")
+
+	enableCmd := app.Command("enable", "Enable agent auto-updates and perform initial updates.")
+	enableCmd.Flag("proxy", "Address of the Teleport Proxy.").Short('p').Envar(proxyServerEnvVar).StringVar(&cf.ProxyServer)
+	enableCmd.Flag("template", "Go template to override Teleport tgz download URL.").Short('t').Envar(templateEnvVar).StringVar(&cf.Template)
+
+	updateCmd := app.Command("update", "Update agent to the latest version, if a new version is available.")
+
+	utils.UpdateAppUsageTemplate(app, args)
+	command, err := app.Parse(args)
+	if err != nil {
+		app.Usage(args)
+		return trace.Wrap(err)
+	}
+	// Logging must be configured as early as possible to ensure all log
+	// message are formatted correctly.
+	if err := setupLogger(cf.Debug, cf.LogFormat); err != nil {
+		return trace.Wrap(err, "setting up logger")
+	}
+
+	err = validate(&cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	switch command {
+	case enableCmd.FullCommand():
+		err = doEnable(ctx, &cf)
+	case updateCmd.FullCommand():
+		err = doUpdate(ctx, &cf)
+	case versionCmd.FullCommand():
+		err = outputVersion(ctx)
+	default:
+		// This should only happen when there's a missing switch case above.
+		err = trace.BadParameter("command %q not configured", command)
+	}
+
+	return err
+}
+
+func setupLogger(debug bool, format string) error {
+	level := slog.LevelInfo
+	if debug {
+		level = slog.LevelDebug
+	}
+
+	switch format {
+	case utils.LogFormatJSON:
+	case utils.LogFormatText, "":
+	default:
+		return trace.BadParameter("unsupported log format %q", format)
+	}
+
+	utils.InitLogger(utils.LoggingForDaemon, level, utils.WithLogFormat(format))
+	return nil
+}
+
+var (
+	versionsDir = filepath.Join(defaults.DataDir, "versions")
+	updatesYAML = filepath.Join(versionsDir, "updates.yaml")
+)
+
+type UpdatesConfig struct {
+	Version string `yaml:"version"`
+	Kind    string `yaml:"kind"`
+	Spec    struct {
+		Proxy         string `yaml:"proxy"`
+		Enabled       bool   `yaml:"enabled"`
+		ActiveVersion string `yaml:"active_version"`
+	} `yaml:"spec"`
+}
+
+func readUpdatesConfig(path string) (*UpdatesConfig, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to open updates.yaml")
+	}
+	defer f.Close()
+	var cfg UpdatesConfig
+	if err := yaml.NewDecoder(f).Decode(&cfg); err != nil {
+		return nil, trace.Wrap(err, "failed to parse updates.yaml")
+	}
+	return &cfg, nil
+}
+
+func doEnable(ctx context.Context, cf *cliConfig) error {
+	addr, err := utils.ParseAddr(cf.ProxyServer)
+	if err != nil {
+		return trace.Wrap(err, "failed to parse proxy server address")
+	}
+	resp, err := webclient.Find(&webclient.Config{
+		Context:   ctx,
+		ProxyAddr: addr.Addr,
+		Timeout:   30 * time.Second,
+	})
+	if err != nil {
+		return trace.Wrap(err, "failed to request version from proxy")
+	}
+	cfg, err := readUpdatesConfig(updatesYAML)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+}
+
+func validate(cf *cliConfig) error {
 
 }

--- a/tool/teleport-updater/main.go
+++ b/tool/teleport-updater/main.go
@@ -48,6 +48,7 @@ Find out more at https://goteleport.com/docs/updater`
 const (
 	templateEnvVar    = "TELEPORT_URL_TEMPLATE"
 	proxyServerEnvVar = "TELEPORT_PROXY"
+	updateGroupEnvVar = "TELEPORT_UPDATE_GROUP"
 )
 
 var log = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentTBot)
@@ -62,6 +63,7 @@ type cliConfig struct {
 	Debug bool
 
 	ProxyServer string
+	Group       string
 	Template    string
 
 	// LogFormat controls the format of logging. Can be either `json` or `text`.
@@ -81,6 +83,7 @@ func Run(args []string, stdout io.Writer) error {
 
 	enableCmd := app.Command("enable", "Enable agent auto-updates and perform initial updates.")
 	enableCmd.Flag("proxy", "Address of the Teleport Proxy.").Short('p').Envar(proxyServerEnvVar).StringVar(&cf.ProxyServer)
+	enableCmd.Flag("group", "Update group, for staged updates.").Short('g').Envar(updateGroupEnvVar).StringVar(&cf.Group)
 	enableCmd.Flag("template", "Go template to override Teleport tgz download URL.").Short('t').Envar(templateEnvVar).StringVar(&cf.Template)
 
 	updateCmd := app.Command("update", "Update agent to the latest version, if a new version is available.")
@@ -144,6 +147,7 @@ type UpdatesConfig struct {
 	Kind    string `yaml:"kind"`
 	Spec    struct {
 		Proxy         string `yaml:"proxy"`
+		Group         string `yaml:"group"`
 		Enabled       bool   `yaml:"enabled"`
 		ActiveVersion string `yaml:"active_version"`
 	} `yaml:"spec"`


### PR DESCRIPTION
This PR contains an initial draft of the `teleport-update` binary described in https://github.com/gravitational/teleport/pull/40190.

Not all functionality is implemented, only:
- Atomic downloading and extraction of the Teleport tgz to `/var/lib/teleport/versions/X.Y.Z`, with disk space checks, checksum verification, and protection against power loss scenarios.
- Atomic configuration management of `updates.yaml`

This PR will not be merged as-is, and is only open for early review of the approach.

I plan to break this download into separate, tested PRs if this initial version looks good.

```shell
root@71aeb39eabec:/# ./teleport/teleport-update enable --proxy levine.teleport.sh --debug
2024-09-06T20:09:50Z DEBU  Attempting request to Proxy web api method:GET host:levine.teleport.sh path:/webapi/find webclient/webclient.go:134
2024-09-06T20:09:51Z INFO [UPDATER]   Downloading Teleport tarball path:/tmp/teleport-update-1578638652 size:153512064 teleport-update/versions.go:210
2024-09-06T20:10:01Z INFO  extracted tarball into /var/lib/teleport/versions/16.2.0: 582 files, 93 dirs (2.678702627s)
```