### PR TITLE
refactor cryptosuites.GenerateKey

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1736,7 +1736,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 	// authenticate authenticates the specified user, creating a new key pair, a
 	// new pair of certificates, and parsing all relevant responses.
 	authenticate := func(t *testing.T, user, pass string) (tlsRaw, sshRaw []byte, xCert *x509.Certificate, sshCert *ssh.Certificate, identity *tlsca.Identity) {
-		sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, authServer)
+		sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, cryptosuites.GetCurrentSuiteFromAuthPreference(authServer))
 		require.NoError(t, err)
 
 		sshPublicKey, err := ssh.NewPublicKey(sshKey.Public())

--- a/lib/auth/keystore/keystore_test.go
+++ b/lib/auth/keystore/keystore_test.go
@@ -456,6 +456,7 @@ func testAlgorithmSuite(t *testing.T, ctx context.Context, pack *testPack, suite
 		t.Run(backendDesc.name, func(t *testing.T) {
 			authPrefGetter := &fakeAuthPreferenceGetter{suite}
 			backendDesc.opts.AuthPreferenceGetter = authPrefGetter
+			currentSuiteGetter := cryptosuites.GetCurrentSuiteFromAuthPreference(authPrefGetter)
 			manager, err := NewManager(ctx, &backendDesc.config, backendDesc.opts)
 			require.NoError(t, err)
 
@@ -469,7 +470,7 @@ func testAlgorithmSuite(t *testing.T, ctx context.Context, pack *testPack, suite
 			sshPubKey, _, _, _, err := ssh.ParseAuthorizedKey(sshKeyPair.PublicKey)
 			require.NoError(t, err)
 			sshPub := sshPubKey.(ssh.CryptoPublicKey).CryptoPublicKey()
-			expectedAlgorithm, err := cryptosuites.AlgorithmForKey(ctx, authPrefGetter, cryptosuites.UserCASSH)
+			expectedAlgorithm, err := cryptosuites.AlgorithmForKey(ctx, currentSuiteGetter, cryptosuites.UserCASSH)
 			require.NoError(t, err)
 			assertKeyAlgorithm(t, expectedAlgorithm, sshPub)
 
@@ -477,7 +478,7 @@ func testAlgorithmSuite(t *testing.T, ctx context.Context, pack *testPack, suite
 			require.NoError(t, err)
 			tlsCert, err := tlsca.ParseCertificatePEM(tlsKeyPair.Cert)
 			require.NoError(t, err)
-			expectedAlgorithm, err = cryptosuites.AlgorithmForKey(ctx, authPrefGetter, cryptosuites.DatabaseClientCATLS)
+			expectedAlgorithm, err = cryptosuites.AlgorithmForKey(ctx, currentSuiteGetter, cryptosuites.DatabaseClientCATLS)
 			require.NoError(t, err)
 			assertKeyAlgorithm(t, expectedAlgorithm, tlsCert.PublicKey)
 
@@ -485,7 +486,7 @@ func testAlgorithmSuite(t *testing.T, ctx context.Context, pack *testPack, suite
 			require.NoError(t, err)
 			jwtPubKey, err := keys.ParsePublicKey(jwtKeyPair.PublicKey)
 			require.NoError(t, err)
-			expectedAlgorithm, err = cryptosuites.AlgorithmForKey(ctx, authPrefGetter, cryptosuites.JWTCAJWT)
+			expectedAlgorithm, err = cryptosuites.AlgorithmForKey(ctx, currentSuiteGetter, cryptosuites.JWTCAJWT)
 			require.NoError(t, err)
 			assertKeyAlgorithm(t, expectedAlgorithm, jwtPubKey)
 		})

--- a/lib/auth/keystore/manager.go
+++ b/lib/auth/keystore/manager.go
@@ -106,7 +106,7 @@ type Manager struct {
 	// the first element.
 	usableSigningBackends []backend
 
-	authPrefGetter cryptosuites.AuthPreferenceGetter
+	currentSuiteGetter cryptosuites.GetSuiteFunc
 }
 
 // backend is an interface that holds private keys and provides signing
@@ -227,7 +227,7 @@ func NewManager(ctx context.Context, cfg *servicecfg.KeystoreConfig, opts *Optio
 	return &Manager{
 		backendForNewKeys:     backendForNewKeys,
 		usableSigningBackends: usableSigningBackends,
-		authPrefGetter:        opts.AuthPreferenceGetter,
+		currentSuiteGetter:    cryptosuites.GetCurrentSuiteFromAuthPreference(opts.AuthPreferenceGetter),
 	}, nil
 }
 
@@ -454,7 +454,7 @@ func (m *Manager) GetJWTSigner(ctx context.Context, ca types.CertAuthority) (cry
 
 // NewSSHKeyPair generates a new SSH keypair in the keystore backend and returns it.
 func (m *Manager) NewSSHKeyPair(ctx context.Context, purpose cryptosuites.KeyPurpose) (*types.SSHKeyPair, error) {
-	alg, err := cryptosuites.AlgorithmForKey(ctx, m.authPrefGetter, purpose)
+	alg, err := cryptosuites.AlgorithmForKey(ctx, m.currentSuiteGetter, purpose)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -485,7 +485,7 @@ func (m *Manager) newSSHKeyPair(ctx context.Context, alg cryptosuites.Algorithm)
 
 // NewTLSKeyPair creates a new TLS keypair in the keystore backend and returns it.
 func (m *Manager) NewTLSKeyPair(ctx context.Context, clusterName string, purpose cryptosuites.KeyPurpose) (*types.TLSKeyPair, error) {
-	alg, err := cryptosuites.AlgorithmForKey(ctx, m.authPrefGetter, purpose)
+	alg, err := cryptosuites.AlgorithmForKey(ctx, m.currentSuiteGetter, purpose)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -522,7 +522,7 @@ func (m *Manager) newTLSKeyPair(ctx context.Context, clusterName string, alg cry
 // New JWTKeyPair create a new JWT keypair in the keystore backend and returns
 // it.
 func (m *Manager) NewJWTKeyPair(ctx context.Context, purpose cryptosuites.KeyPurpose) (*types.JWTKeyPair, error) {
-	alg, err := cryptosuites.AlgorithmForKey(ctx, m.authPrefGetter, purpose)
+	alg, err := cryptosuites.AlgorithmForKey(ctx, m.currentSuiteGetter, purpose)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/keystore/testhelpers.go
+++ b/lib/auth/keystore/testhelpers.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
@@ -214,7 +215,9 @@ func NewSoftwareKeystoreForTests(_ *testing.T, opts ...TestKeystoreOption) *Mana
 	return &Manager{
 		backendForNewKeys:     softwareBackend,
 		usableSigningBackends: []backend{softwareBackend},
-		authPrefGetter:        &fakeAuthPreferenceGetter{types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1},
+		currentSuiteGetter: cryptosuites.GetSuiteFunc(func(context.Context) (types.SignatureAlgorithmSuite, error) {
+			return types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1, nil
+		}),
 	}
 }
 

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -249,7 +249,7 @@ func (a *Server) newWebSession(
 		}
 		sshKey, tlsKey = req.SSHPrivateKey.Signer, req.TLSPrivateKey.Signer
 	} else {
-		sshKey, tlsKey, err = cryptosuites.GenerateUserSSHAndTLSKey(ctx, a)
+		sshKey, tlsKey, err = cryptosuites.GenerateUserSSHAndTLSKey(ctx, cryptosuites.GetCurrentSuiteFromAuthPreference(a))
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -520,7 +520,7 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 	}
 
 	// Create certificate for this session.
-	priv, err := cryptosuites.GenerateKey(ctx, a, cryptosuites.UserTLS)
+	priv, err := cryptosuites.GenerateKey(ctx, cryptosuites.GetCurrentSuiteFromAuthPreference(a), cryptosuites.UserTLS)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -4249,6 +4249,17 @@ You may use the --skip-version-check flag to bypass this check.
 	return pr, nil
 }
 
+// GetCurrentSignatureAlgorithmSuite returns the current signature algorithm
+// suite configured in the local cluster. It matches [cryptosuites.GetSuiteFunc].
+func (tc *TeleportClient) GetCurrentSignatureAlgorithmSuite(ctx context.Context) (types.SignatureAlgorithmSuite, error) {
+	// Ping is cached between calls.
+	pingResp, err := tc.Ping(ctx)
+	if err != nil {
+		return types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_UNSPECIFIED, trace.Wrap(err)
+	}
+	return pingResp.Auth.SignatureAlgorithmSuite, nil
+}
+
 // ShowMOTD fetches the cluster MotD, displays it (if any) and waits for
 // confirmation from the user.
 func (tc *TeleportClient) ShowMOTD(ctx context.Context) error {

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -150,12 +150,7 @@ func (k *KeyRing) generateSubjectTLSKey(ctx context.Context, tc *TeleportClient,
 		return k.PrivateKey, nil
 	}
 
-	// Ping is cached if called more than once on [tc].
-	pingResp, err := tc.Ping(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	key, err := cryptosuites.GenerateKeyWithSuite(ctx, pingResp.Auth.SignatureAlgorithmSuite, purpose)
+	key, err := cryptosuites.GenerateKey(ctx, tc.GetCurrentSignatureAlgorithmSuite, purpose)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/cryptosuites/suites_test.go
+++ b/lib/cryptosuites/suites_test.go
@@ -36,11 +36,10 @@ func TestSuites(t *testing.T) {
 	for s := range types.SignatureAlgorithmSuite_name {
 		suite := types.SignatureAlgorithmSuite(s)
 		t.Run(suite.String(), func(t *testing.T) {
-			authPrefGetter := &fakeAuthPrefGetter{
-				suite: suite,
-			}
+			authPrefGetter := &fakeAuthPrefGetter{suite}
+			getSuiteFunc := GetCurrentSuiteFromAuthPreference(authPrefGetter)
 			for purpose := KeyPurposeUnspecified + 1; purpose < keyPurposeMax; purpose++ {
-				alg, err := AlgorithmForKey(ctx, authPrefGetter, purpose)
+				alg, err := AlgorithmForKey(ctx, getSuiteFunc, purpose)
 				require.NoError(t, err)
 				assert.Greater(t, alg, algorithmUnspecified)
 				assert.Less(t, alg, algorithmMax)

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -618,7 +618,9 @@ func (s *ProxyServer) getDatabaseServers(ctx context.Context, identity tlsca.Ide
 func (s *ProxyServer) getConfigForServer(ctx context.Context, identity tlsca.Identity, server types.DatabaseServer) (*tls.Config, error) {
 	defer observeLatency(tlsConfigTime.With(getLabelsFromDB(server.GetDatabase())))()
 
-	privateKey, err := cryptosuites.GenerateKey(ctx, s.cfg.AccessPoint, cryptosuites.ProxyToDatabaseAgent)
+	privateKey, err := cryptosuites.GenerateKey(ctx,
+		cryptosuites.GetCurrentSuiteFromAuthPreference(s.cfg.AccessPoint),
+		cryptosuites.ProxyToDatabaseAgent)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -63,7 +63,7 @@ func TestWebauthnLogin_ssh(t *testing.T) {
 	device := clusterMFA.WebDev.Key
 
 	// Prepare keys to be signed.
-	sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, env.server.AuthServer.AuthServer)
+	sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, cryptosuites.GetCurrentSuiteFromAuthPreference(env.server.AuthServer.AuthServer))
 	require.NoError(t, err)
 	sshPubKey, err := ssh.NewPublicKey(sshKey.Public())
 	require.NoError(t, err)
@@ -261,7 +261,7 @@ func TestAuthenticate_passwordless(t *testing.T) {
 	userHandle := wla.UserID
 
 	// Prepare keys to be signed.
-	sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, env.server.AuthServer.AuthServer)
+	sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, cryptosuites.GetCurrentSuiteFromAuthPreference(env.server.AuthServer.AuthServer))
 	require.NoError(t, err)
 	sshPubKey, err := ssh.NewPublicKey(sshKey.Public())
 	require.NoError(t, err)
@@ -467,7 +467,7 @@ func TestPasswordlessProhibitedForSSO(t *testing.T) {
 	require.NoError(t, err, "UpdateAndSwapUser failed")
 
 	// Prepare keys to be signed.
-	sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, env.server.AuthServer.AuthServer)
+	sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, cryptosuites.GetCurrentSuiteFromAuthPreference(env.server.AuthServer.AuthServer))
 	require.NoError(t, err)
 	sshPubKey, err := ssh.NewPublicKey(sshKey.Public())
 	require.NoError(t, err)
@@ -685,7 +685,7 @@ func TestCreateSSHCert(t *testing.T) {
 	proxy.createUser(ctx, t, user, login, pass, otpSecret, roles)
 	clt := proxy.newClient(t)
 
-	sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, pack.server.AuthServer.AuthServer)
+	sshKey, tlsKey, err := cryptosuites.GenerateUserSSHAndTLSKey(ctx, cryptosuites.GetCurrentSuiteFromAuthPreference(pack.server.AuthServer.AuthServer))
 	require.NoError(t, err)
 
 	sshPub, err := ssh.NewPublicKey(sshKey.Public())


### PR DESCRIPTION
This PR refactors `cryptosuites.GenerateKey` (and friends) to accept any function that can return the current signature algorithm suite configured in the cluster, rather than forcing it to come from a `types.AuthPreference`. This will be useful client-side in https://github.com/gravitational/teleport/pull/45995 where we fetch the current suite via a Ping response.