### PR TITLE
Apply static host users to nodes

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1301,6 +1301,9 @@ const (
 	// provisioning system get added to when provisioned in KEEP mode. This prevents
 	// already existing users from being tampered with or deleted.
 	TeleportKeepGroup = "teleport-keep"
+	// TeleportStaticGroup is a default group that static host users get added to. This
+	// prevents already existing users from being tampered with or deleted.
+	TeleportStaticGroup = "teleport-static"
 )
 
 const (

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1007,6 +1007,7 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindLock, services.RO()),
 						types.NewRule(types.KindNetworkRestrictions, services.RO()),
 						types.NewRule(types.KindConnectionDiagnostic, services.RW()),
+						types.NewRule(types.KindStaticHostUser, services.RO()),
 					},
 				},
 			})

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -2369,16 +2369,7 @@ func (staticHostUserExecutor) deleteAll(ctx context.Context, cache *Cache) error
 }
 
 func (staticHostUserExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
-	var hostUser *userprovisioningpb.StaticHostUser
-	r, ok := resource.(types.Resource153Unwrapper)
-	if ok {
-		hostUser, ok = r.Unwrap().(*userprovisioningpb.StaticHostUser)
-		if ok {
-			err := cache.staticHostUsersCache.DeleteStaticHostUser(ctx, hostUser.Metadata.Name)
-			return trace.Wrap(err)
-		}
-	}
-	return trace.BadParameter("unknown StaticHostUser type, expected %T, got %T", hostUser, resource)
+	return trace.Wrap(cache.staticHostUsersCache.DeleteStaticHostUser(ctx, resource.GetName()))
 }
 
 func (staticHostUserExecutor) isSingleton() bool { return false }

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -966,6 +966,34 @@ func (a *accessChecker) DesktopGroups(s types.WindowsDesktop) ([]string, error) 
 	return utils.StringsSliceFromSet(groups), nil
 }
 
+// HostUserMode determines how host users should be created.
+type HostUserMode int
+
+const (
+	// HostUserModeUndefined is the default mode, for when the mode couldn't be
+	// determined from a types.CreateHostUserMode.
+	HostUserModeUndefined HostUserMode = iota
+	// HostUserModeKeep creates a home directory and persists after a session ends.
+	HostUserModeKeep
+	// HostUserModeDrop does not create a home directory, and it is removed after
+	// a session ends.
+	HostUserModeDrop
+	// HostUserModeStatic creates a home directory and exists independently of a
+	// session.
+	HostUserModeStatic
+)
+
+func convertHostUserMode(mode types.CreateHostUserMode) HostUserMode {
+	switch mode {
+	case types.CreateHostUserMode_HOST_USER_MODE_KEEP:
+		return HostUserModeKeep
+	case types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP:
+		return HostUserModeDrop
+	default:
+		return HostUserModeUndefined
+	}
+}
+
 // HostUsersInfo keeps information about groups and sudoers entries
 // for a particular host user
 type HostUsersInfo struct {
@@ -973,7 +1001,7 @@ type HostUsersInfo struct {
 	Groups []string
 	// Mode determines if a host user should be deleted after a session
 	// ends or not.
-	Mode types.CreateHostUserMode
+	Mode HostUserMode
 	// UID is the UID that the host user will be created with
 	UID string
 	// GID is the GID that the host user will be created with
@@ -1052,7 +1080,7 @@ func (a *accessChecker) HostUsers(s types.Server) (*HostUsersInfo, error) {
 
 	return &HostUsersInfo{
 		Groups: utils.StringsSliceFromSet(groups),
-		Mode:   mode,
+		Mode:   convertHostUserMode(mode),
 		UID:    uid,
 		GID:    gid,
 	}, nil

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -2194,7 +2194,7 @@ type staticHostUserParser struct {
 func (p *staticHostUserParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindStaticHostUser, types.V1, 0)
+		return resourceHeader(event, types.KindStaticHostUser, types.V2, 0)
 	case types.OpPut:
 		resource, err := services.UnmarshalProtoResource[*userprovisioningpb.StaticHostUser](
 			event.Item.Value,

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2511,7 +2511,7 @@ func (l *kubernetesClusterLabelMatcher) Match(role types.Role, typ types.RoleCon
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
-	ok, _, err := checkLabelsMatch(typ, labelMatchers, l.userTraits, mapLabelGetter(l.clusterLabels), false)
+	ok, _, err := CheckLabelsMatch(typ, labelMatchers, l.userTraits, mapLabelGetter(l.clusterLabels), false)
 	return ok, trace.Wrap(err)
 }
 
@@ -2734,10 +2734,10 @@ func checkRoleLabelsMatch(
 	if err != nil {
 		return false, "", trace.Wrap(err)
 	}
-	return checkLabelsMatch(condition, labelMatchers, userTraits, resource, debug)
+	return CheckLabelsMatch(condition, labelMatchers, userTraits, resource, debug)
 }
 
-// checkLabelsMatch checks if the [labelMatchers] match the labels of [resource]
+// CheckLabelsMatch checks if the [labelMatchers] match the labels of [resource]
 // for [condition].
 // It considers both [labelMatchers.Labels] and [labelMatchers.Expression].
 //
@@ -2750,7 +2750,7 @@ func checkRoleLabelsMatch(
 // match it's not considered a match.
 //
 // If neither is set, it's not a match in either case.
-func checkLabelsMatch(
+func CheckLabelsMatch(
 	condition types.RoleConditionType,
 	labelMatchers types.LabelMatchers,
 	userTraits wrappers.Traits,

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -8200,7 +8200,7 @@ func TestHostUsers_CanCreateHostUser(t *testing.T) {
 			info, err := accessChecker.HostUsers(tc.server)
 			require.Equal(t, tc.canCreate, err == nil && info != nil)
 			if tc.canCreate {
-				require.Equal(t, tc.expectedMode, info.Mode)
+				require.Equal(t, convertHostUserMode(tc.expectedMode), info.Mode)
 			}
 		})
 	}

--- a/lib/srv/statichostusers.go
+++ b/lib/srv/statichostusers.go
@@ -1,0 +1,266 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package srv
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/label"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const staticHostUserWatcherTimeout = 30 * time.Second
+
+// InfoGetter is an interface for getting up-to-date server info.
+type InfoGetter interface {
+	// GetInfo gets a server, including dynamic labels.
+	GetInfo() types.Server
+}
+
+// StaticHostUserHandler handles watching for static host user resources and
+// applying them to the host.
+type StaticHostUserHandler struct {
+	events         types.Events
+	staticHostUser services.StaticHostUser
+	server         InfoGetter
+	users          HostUsers
+	sudoers        HostSudoers
+	retry          *retryutils.Linear
+}
+
+// StaticHostUserHandlerConfig configures a StaticHostUserHandler.
+type StaticHostUserHandlerConfig struct {
+	// Events is an events interface for creating a watcher.
+	Events types.Events
+	// StaticHostUser is a static host user client.
+	StaticHostUser services.StaticHostUser
+	// Server is a resource to fetch a types.Server for access checks. This is
+	// here instead of a types.Server directly so we can get updated dynamic
+	// labels.
+	Server InfoGetter
+	// Users is a host user backend.
+	Users HostUsers
+	// Sudoers is a host sudoers backend.
+	Sudoers HostSudoers
+}
+
+// NewStaticHostUserHandler creates a new StaticHostUserHandler.
+func NewStaticHostUserHandler(cfg StaticHostUserHandlerConfig) (*StaticHostUserHandler, error) {
+	if cfg.Events == nil {
+		return nil, trace.BadParameter("missing Events")
+	}
+	if cfg.StaticHostUser == nil {
+		return nil, trace.BadParameter("missing StaticHostUser")
+	}
+	if cfg.Server == nil {
+		return nil, trace.BadParameter("missing Server")
+	}
+	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
+		First:  utils.FullJitter(defaults.MaxWatcherBackoff / 10),
+		Step:   defaults.MaxWatcherBackoff / 5,
+		Max:    defaults.MaxWatcherBackoff,
+		Jitter: retryutils.NewHalfJitter(),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &StaticHostUserHandler{
+		events:         cfg.Events,
+		staticHostUser: cfg.StaticHostUser,
+		server:         cfg.Server,
+		users:          cfg.Users,
+		sudoers:        cfg.Sudoers,
+		retry:          retry,
+	}, nil
+}
+
+// Run runs the static host user handler to completion.
+func (s *StaticHostUserHandler) Run(ctx context.Context) error {
+	if s.users == nil {
+		return nil
+	}
+
+	for {
+		err := s.run(ctx)
+		if err == nil {
+			return nil
+		}
+		slog.DebugContext(ctx, "Static host user handler encountered a network error, will restart.", "error", err)
+		s.retry.Inc()
+
+		select {
+		case <-ctx.Done():
+			return trace.Wrap(ctx.Err())
+		case <-s.retry.After():
+		}
+	}
+}
+
+func (s *StaticHostUserHandler) run(ctx context.Context) error {
+	// Start the watcher.
+	watcher, err := s.events.NewWatcher(ctx, types.Watch{
+		Kinds: []types.WatchKind{
+			{
+				Kind: types.KindStaticHostUser,
+			},
+		},
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer watcher.Close()
+
+	select {
+	case event := <-watcher.Events():
+		if event.Type != types.OpInit {
+			return trace.Errorf("missing init event from watcher")
+		}
+		s.retry.Reset()
+	case <-time.After(staticHostUserWatcherTimeout):
+		return trace.LimitExceeded("timed out waiting for static host user watcher to initialize")
+	case <-ctx.Done():
+		return nil
+	}
+
+	// Fetch any host users that existed prior to creating the watcher.
+	var startKey string
+	for {
+		users, nextKey, err := s.staticHostUser.ListStaticHostUsers(ctx, 0, startKey)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		for _, hostUser := range users {
+			if err := s.handleNewHostUser(ctx, hostUser); err != nil {
+				// Log the error so we don't stop the handler.
+				slog.WarnContext(ctx, "Error handling static host user.", "error", err, "login", hostUser.GetMetadata().Name)
+			}
+		}
+		if nextKey == "" {
+			break
+		}
+		startKey = nextKey
+	}
+
+	// Listen for new host users on the watcher.
+	for {
+		select {
+		case event := <-watcher.Events():
+			if event.Type != types.OpPut {
+				continue
+			}
+			r, ok := event.Resource.(types.Resource153Unwrapper)
+			if !ok {
+				slog.WarnContext(ctx, "Unexpected resource type.", "resource", event.Resource)
+				continue
+			}
+			hostUser, ok := r.Unwrap().(*userprovisioningpb.StaticHostUser)
+			if !ok {
+				slog.WarnContext(ctx, "Unexpected resource type.", "resource", event.Resource)
+				continue
+			}
+			if err := s.handleNewHostUser(ctx, hostUser); err != nil {
+				// Log the error so we don't stop the handler.
+				slog.WarnContext(ctx, "Error handling static host user.", "error", err, "login", hostUser.GetMetadata().Name)
+				continue
+			}
+		case <-watcher.Done():
+			return trace.Wrap(watcher.Error())
+		case <-ctx.Done():
+			if !errors.Is(ctx.Err(), context.Canceled) {
+				return trace.Wrap(ctx.Err())
+			}
+			return nil
+		}
+	}
+}
+
+func (s *StaticHostUserHandler) handleNewHostUser(ctx context.Context, hostUser *userprovisioningpb.StaticHostUser) error {
+	var createUser *userprovisioningpb.Matcher
+	login := hostUser.GetMetadata().Name
+	server := s.server.GetInfo()
+	for _, matcher := range hostUser.Spec.Matchers {
+		// Check if this host user applies to this node.
+		nodeLabels := make(types.Labels)
+		for k, v := range label.ToMap(matcher.NodeLabels) {
+			nodeLabels[k] = apiutils.Strings(v)
+		}
+		matched, _, err := services.CheckLabelsMatch(
+			types.Allow,
+			types.LabelMatchers{
+				Labels:     nodeLabels,
+				Expression: matcher.NodeLabelsExpression,
+			},
+			nil, // userTraits
+			server,
+			false, // debug
+		)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if !matched {
+			continue
+		}
+
+		// Matching multiple times is an error.
+		if createUser != nil {
+			const msg = "Multiple matchers matched this node. Please update resource to ensure that each node is matched only once."
+			slog.WarnContext(ctx, msg, slog.String("login", login),
+				slog.Group("first_match", "labels", createUser.NodeLabels, "expression", createUser.NodeLabelsExpression),
+				slog.Group("second_match", "labels", matcher.NodeLabels, "expression", matcher.NodeLabelsExpression),
+			)
+			return trace.BadParameter(msg)
+		}
+		createUser = matcher
+	}
+
+	if createUser == nil {
+		return nil
+	}
+
+	slog.DebugContext(ctx, "Attempt to update matched static host user.", "login", login)
+	ui := services.HostUsersInfo{
+		Groups: createUser.Groups,
+		Mode:   services.HostUserModeStatic,
+	}
+	if createUser.Uid != 0 {
+		ui.UID = strconv.Itoa(int(createUser.Uid))
+	}
+	if createUser.Gid != 0 {
+		ui.GID = strconv.Itoa(int(createUser.Gid))
+	}
+	if _, err := s.users.UpsertUser(login, ui); err != nil {
+		return trace.Wrap(err)
+	}
+	if s.sudoers != nil && len(createUser.Sudoers) != 0 {
+		if err := s.sudoers.WriteSudoers(login, createUser.Sudoers); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -203,18 +203,11 @@ var _ HostSudoersBackend = &testHostUserBackend{}
 func TestUserMgmt_CreateTemporaryUser(t *testing.T) {
 	t.Parallel()
 
-	backend := newTestUserMgmt()
-	bk, err := memory.New(memory.Config{})
-	require.NoError(t, err)
-	pres := local.NewPresenceService(bk)
-	users := HostUserManagement{
-		backend: backend,
-		storage: pres,
-	}
+	users, backend := initBackend(t, nil)
 
 	userinfo := services.HostUsersInfo{
 		Groups: []string{"hello", "sudo"},
-		Mode:   types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
+		Mode:   services.HostUserModeDrop,
 	}
 	// create a user with some groups
 	closer, err := users.UpsertUser("bob", userinfo)
@@ -266,7 +259,7 @@ func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 
 	closer, err := users.UpsertUser("bob", services.HostUsersInfo{
 		Groups: []string{"hello", "sudo"},
-		Mode:   types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
+		Mode:   services.HostUserModeDrop,
 	})
 	require.NoError(t, err)
 	require.NotEqual(t, nil, closer)
@@ -289,12 +282,12 @@ func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 		// been created
 		backend.CreateUser("testuser", nil, "", "", "")
 		_, err := users.UpsertUser("testuser", services.HostUsersInfo{
-			Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
+			Mode: services.HostUserModeDrop,
 		})
 		require.ErrorIs(t, err, unmanagedUserErr)
 		backend.CreateGroup(types.TeleportDropGroup, "")
 		_, err = users.UpsertUser("testuser", services.HostUsersInfo{
-			Mode: types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
+			Mode: services.HostUserModeDrop,
 		})
 		require.ErrorIs(t, err, unmanagedUserErr)
 	})
@@ -334,7 +327,7 @@ func TestUserMgmt_DeleteAllTeleportSystemUsers(t *testing.T) {
 		if slices.Contains(user.groups, types.TeleportDropGroup) {
 			users.UpsertUser(user.user, services.HostUsersInfo{
 				Groups: user.groups,
-				Mode:   types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
+				Mode:   services.HostUserModeDrop,
 			})
 		} else {
 			mgmt.CreateUser(user.user, user.groups, "", "", "")
@@ -403,23 +396,13 @@ func TestIsUnknownGroupError(t *testing.T) {
 
 func Test_UpdateUserGroups_Keep(t *testing.T) {
 	t.Parallel()
-	backend := newTestUserMgmt()
-	bk, err := memory.New(memory.Config{})
-	require.NoError(t, err)
-	pres := local.NewPresenceService(bk)
-	users := HostUserManagement{
-		backend: backend,
-		storage: pres,
-	}
 
 	allGroups := []string{"foo", "bar", "baz", "quux"}
-	for _, group := range allGroups {
-		require.NoError(t, backend.CreateGroup(group, ""))
-	}
+	users, backend := initBackend(t, allGroups)
 
 	userinfo := services.HostUsersInfo{
 		Groups: slices.Clone(allGroups[:2]),
-		Mode:   types.CreateHostUserMode_HOST_USER_MODE_KEEP,
+		Mode:   services.HostUserModeKeep,
 	}
 
 	// Create user
@@ -448,8 +431,16 @@ func Test_UpdateUserGroups_Keep(t *testing.T) {
 	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportKeepGroup), backend.users["alice"])
 	assert.NotContains(t, backend.users["alice"], types.TeleportDropGroup)
 
+	// Do not convert the managed user to static.
+	userinfo.Mode = services.HostUserModeStatic
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, closer)
+	assert.Equal(t, 1, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportKeepGroup), backend.users["alice"])
+
 	// Updates with INSECURE_DROP mode should convert the managed user
-	userinfo.Mode = types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP
+	userinfo.Mode = services.HostUserModeDrop
 	userinfo.Groups = slices.Clone(allGroups[:2])
 	closer, err = users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
@@ -461,23 +452,13 @@ func Test_UpdateUserGroups_Keep(t *testing.T) {
 
 func Test_UpdateUserGroups_Drop(t *testing.T) {
 	t.Parallel()
-	backend := newTestUserMgmt()
-	bk, err := memory.New(memory.Config{})
-	require.NoError(t, err)
-	pres := local.NewPresenceService(bk)
-	users := HostUserManagement{
-		backend: backend,
-		storage: pres,
-	}
 
 	allGroups := []string{"foo", "bar", "baz", "quux"}
-	for _, group := range allGroups {
-		require.NoError(t, backend.CreateGroup(group, ""))
-	}
+	users, backend := initBackend(t, allGroups)
 
 	userinfo := services.HostUsersInfo{
 		Groups: slices.Clone(allGroups[:2]),
-		Mode:   types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
+		Mode:   services.HostUserModeDrop,
 	}
 
 	// Create user
@@ -506,8 +487,16 @@ func Test_UpdateUserGroups_Drop(t *testing.T) {
 	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportDropGroup), backend.users["alice"])
 	assert.NotContains(t, backend.users["alice"], types.TeleportKeepGroup)
 
+	// Do not convert the managed user to static.
+	userinfo.Mode = services.HostUserModeStatic
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, closer)
+	assert.Equal(t, 1, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportDropGroup), backend.users["alice"])
+
 	// Updates with KEEP mode should convert the ephemeral user
-	userinfo.Mode = types.CreateHostUserMode_HOST_USER_MODE_KEEP
+	userinfo.Mode = services.HostUserModeKeep
 	userinfo.Groups = slices.Clone(allGroups[:2])
 	closer, err = users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
@@ -518,28 +507,66 @@ func Test_UpdateUserGroups_Drop(t *testing.T) {
 	assert.NotContains(t, backend.users["alice"], types.TeleportDropGroup)
 }
 
+func Test_UpdateUserGroups_Static(t *testing.T) {
+	t.Parallel()
+
+	allGroups := []string{"foo", "bar", "baz", "quux"}
+	users, backend := initBackend(t, allGroups)
+	userinfo := services.HostUsersInfo{
+		Groups: slices.Clone(allGroups[:2]),
+		Mode:   services.HostUserModeStatic,
+	}
+
+	// Create user.
+	closer, err := users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, closer)
+	assert.Zero(t, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportStaticGroup), backend.users["alice"])
+
+	// Update user with new groups.
+	userinfo.Groups = slices.Clone(allGroups[2:])
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, closer)
+	assert.Equal(t, 1, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportStaticGroup), backend.users["alice"])
+
+	// Upsert again with same groups should not call SetUserGroups.
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, closer)
+	assert.Equal(t, 1, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, append(userinfo.Groups, types.TeleportStaticGroup), backend.users["alice"])
+
+	// Do not convert to KEEP.
+	userinfo.Mode = services.HostUserModeKeep
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, closer)
+	assert.Equal(t, 1, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, append(slices.Clone(allGroups[2:]), types.TeleportStaticGroup), backend.users["alice"])
+
+	// Do not convert to INSECURE_DROP.
+	userinfo.Mode = services.HostUserModeDrop
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, closer)
+	assert.Equal(t, 1, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, append(slices.Clone(allGroups[2:]), types.TeleportStaticGroup), backend.users["alice"])
+}
+
 func Test_DontManageExistingUser(t *testing.T) {
 	t.Parallel()
 
-	backend := newTestUserMgmt()
-	bk, err := memory.New(memory.Config{})
-	require.NoError(t, err)
-	pres := local.NewPresenceService(bk)
-	users := HostUserManagement{
-		backend: backend,
-		storage: pres,
-	}
-
 	allGroups := []string{"foo", "bar", "baz", "quux"}
-	for _, group := range allGroups {
-		require.NoError(t, backend.CreateGroup(group, ""))
-	}
+	users, backend := initBackend(t, allGroups)
 
 	assert.NoError(t, backend.CreateUser("alice", allGroups, "", "", ""))
 
 	userinfo := services.HostUsersInfo{
 		Groups: allGroups[:2],
-		Mode:   types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
+		Mode:   services.HostUserModeDrop,
 	}
 
 	// Update user in DROP mode
@@ -550,7 +577,15 @@ func Test_DontManageExistingUser(t *testing.T) {
 	assert.ElementsMatch(t, allGroups, backend.users["alice"])
 
 	// Update user in KEEP mode
-	userinfo.Mode = types.CreateHostUserMode_HOST_USER_MODE_KEEP
+	userinfo.Mode = services.HostUserModeKeep
+	closer, err = users.UpsertUser("alice", userinfo)
+	assert.ErrorIs(t, err, unmanagedUserErr)
+	assert.Equal(t, nil, closer)
+	assert.Zero(t, backend.setUserGroupsCalls)
+	assert.ElementsMatch(t, allGroups, backend.users["alice"])
+
+	// Update static user
+	userinfo.Mode = services.HostUserModeStatic
 	closer, err = users.UpsertUser("alice", userinfo)
 	assert.ErrorIs(t, err, unmanagedUserErr)
 	assert.Equal(t, nil, closer)
@@ -561,44 +596,45 @@ func Test_DontManageExistingUser(t *testing.T) {
 func Test_DontUpdateUnmanagedUsers(t *testing.T) {
 	t.Parallel()
 
-	backend := newTestUserMgmt()
-	bk, err := memory.New(memory.Config{})
-	require.NoError(t, err)
-	pres := local.NewPresenceService(bk)
-	users := HostUserManagement{
-		backend: backend,
-		storage: pres,
-	}
-
 	allGroups := []string{"foo", "bar", "baz", "quux"}
-	for _, group := range allGroups {
-		require.NoError(t, backend.CreateGroup(group, ""))
-	}
+	users, backend := initBackend(t, allGroups)
 
 	assert.NoError(t, backend.CreateUser("alice", allGroups[2:], "", "", ""))
-	userinfo := services.HostUsersInfo{
-		Groups: allGroups[:2],
-		Mode:   types.CreateHostUserMode_HOST_USER_MODE_KEEP,
+	tests := []struct {
+		name     string
+		userinfo services.HostUsersInfo
+	}{
+		{
+			name: "keep",
+			userinfo: services.HostUsersInfo{
+				Groups: allGroups[:2],
+				Mode:   services.HostUserModeKeep,
+			},
+		},
+		{
+			name: "drop",
+			userinfo: services.HostUsersInfo{
+				Groups: allGroups[:2],
+				Mode:   services.HostUserModeDrop,
+			},
+		},
+		{
+			name: "static",
+			userinfo: services.HostUsersInfo{
+				Groups: allGroups[:2],
+				Mode:   services.HostUserModeStatic,
+			},
+		},
 	}
-
-	// Try to update existing, unmanaged user in KEEP mode
-	closer, err := users.UpsertUser("alice", userinfo)
-	assert.ErrorIs(t, err, unmanagedUserErr)
-	assert.Equal(t, nil, closer)
-	assert.Zero(t, backend.setUserGroupsCalls)
-	assert.ElementsMatch(t, allGroups[2:], backend.users["alice"])
-
-	userinfo = services.HostUsersInfo{
-		Groups: allGroups[:2],
-		Mode:   types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP,
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			closer, err := users.UpsertUser("alice", tc.userinfo)
+			assert.ErrorIs(t, err, unmanagedUserErr)
+			assert.Equal(t, nil, closer)
+			assert.Zero(t, backend.setUserGroupsCalls)
+			assert.ElementsMatch(t, allGroups[2:], backend.users["alice"])
+		})
 	}
-
-	// Try to update existing, unmanaged user in DROP mode
-	closer, err = users.UpsertUser("alice", userinfo)
-	assert.ErrorIs(t, err, unmanagedUserErr)
-	assert.Equal(t, nil, closer)
-	assert.Zero(t, backend.setUserGroupsCalls)
-	assert.ElementsMatch(t, allGroups[2:], backend.users["alice"])
 }
 
 // teleport-keep can be included explicitly in the Groups slice in order to flag an
@@ -606,25 +642,14 @@ func Test_DontUpdateUnmanagedUsers(t *testing.T) {
 func Test_AllowExplicitlyManageExistingUsers(t *testing.T) {
 	t.Parallel()
 
-	backend := newTestUserMgmt()
-	bk, err := memory.New(memory.Config{})
-	require.NoError(t, err)
-	pres := local.NewPresenceService(bk)
-	users := HostUserManagement{
-		backend: backend,
-		storage: pres,
-	}
-
 	allGroups := []string{"foo", types.TeleportKeepGroup, types.TeleportDropGroup}
-	for _, group := range allGroups {
-		require.NoError(t, backend.CreateGroup(group, ""))
-	}
+	users, backend := initBackend(t, allGroups)
 
 	assert.NoError(t, backend.CreateUser("alice-keep", []string{}, "", "", ""))
 	assert.NoError(t, backend.CreateUser("alice-drop", []string{}, "", "", ""))
 	userinfo := services.HostUsersInfo{
 		Groups: slices.Clone(allGroups),
-		Mode:   types.CreateHostUserMode_HOST_USER_MODE_KEEP,
+		Mode:   services.HostUserModeKeep,
 	}
 
 	// Take ownership of existing user when in KEEP mode
@@ -637,7 +662,7 @@ func Test_AllowExplicitlyManageExistingUsers(t *testing.T) {
 	assert.NotContains(t, backend.users["alice-keep"], types.TeleportDropGroup)
 
 	// Don't take ownership of existing user when in DROP mode
-	userinfo.Mode = types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP
+	userinfo.Mode = services.HostUserModeDrop
 	closer, err = users.UpsertUser("alice-drop", userinfo)
 	assert.ErrorIs(t, err, unmanagedUserErr)
 	assert.Equal(t, nil, closer)
@@ -645,12 +670,27 @@ func Test_AllowExplicitlyManageExistingUsers(t *testing.T) {
 	assert.Empty(t, backend.users["alice-drop"])
 
 	// Don't assign teleport-keep to users created in DROP mode
-	userinfo.Mode = types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP
+	userinfo.Mode = services.HostUserModeDrop
 	closer, err = users.UpsertUser("bob", userinfo)
 	assert.NoError(t, err)
 	assert.NotEqual(t, nil, closer)
 	assert.Equal(t, 1, backend.setUserGroupsCalls)
 	assert.ElementsMatch(t, []string{"foo", types.TeleportDropGroup}, backend.users["bob"])
 	assert.NotContains(t, backend.users["bob"], types.TeleportKeepGroup)
+}
 
+func initBackend(t *testing.T, groups []string) (HostUserManagement, *testHostUserBackend) {
+	backend := newTestUserMgmt()
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	pres := local.NewPresenceService(bk)
+	users := HostUserManagement{
+		backend: backend,
+		storage: pres,
+	}
+
+	for _, group := range groups {
+		require.NoError(t, backend.CreateGroup(group, ""))
+	}
+	return users, backend
 }


### PR DESCRIPTION
This change adds functionality to create host users on a node from matching static host user resources.

Part of #42712.

Changelog: Added user provisioning from static host user resources