### PR TITLE
Fix Vite config

### DIFF
--- a/web/packages/build/vite/tsconfigPaths.mjs
+++ b/web/packages/build/vite/tsconfigPaths.mjs
@@ -26,7 +26,7 @@ import path from 'node:path';
 
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-const rootDirectory = path.resolve(import.meta.dirname, '../../../..');
+const rootDirectory = path.resolve(new URL('../../../..', import.meta.url).pathname);
 
 export function tsconfigPathsPlugin() {
   return tsconfigPaths({


### PR DESCRIPTION
### What 

Fix vite config wrong path encounter during `pnpm storybook`  execution: 

Before: 

```bash
$  pnpm storybook


> teleport-ui@1.0.0 storybook /Users/marek/go/src/github.com/gravitational/teleport
> ./web/scripts/run-storybook.sh

Copying the worker script at "/Users/marek/go/src/github.com/gravitational/teleport/web/.storybook/public"...

Worker script successfully copied!
  - web/.storybook/public

Continue by describing the network in your application:


https://mswjs.io/docs/getting-started

storybook v8.2.9

info => Serving static files from ././web/.storybook/public at /
info => Starting manager..
info => Starting preview..
failed to load config from /Users/marek/go/src/github.com/gravitational/teleport/web/.storybook/vite.config.mts
=> Failed to build the preview
TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received undefined
    at __node_internal_captureLargerStackTrace (node:internal/errors:496:5)
    at new NodeError (node:internal/errors:405:5)
    at validateString (node:internal/validators:162:11)
    at Object.resolve (node:path:1097:7)
    at file://./web/packages/build/vite/tsconfigPaths.mjs:29:28
    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:337:24)
    at async loadConfigFromBundledFile (file://./node_modules/.pnpm/vite@5.4.2_@types+node@20.16.2_terser@5.31.1/node_modules/vite/dist/node/chunks/dep-BzOvws4Y.js:66579:15)
    at async loadConfigFromFile (file://./node_modules/.pnpm/vite@5.4.2_@types+node@20.16.2_terser@5.31.1/node_modules/vite/dist/node/chunks/dep-BzOvws4Y.js:66420:24)
    at async commonConfig (./node_modules/.pnpm/@storybook+builder-vite@8.2.9_storybook@8.2.9_@babel+preset-env@7.25.4_@babel+core@7.25.2___t_nh3fbujfmeryg2z2dgx4nlzd4m/node_modules/@storybook/builder-vite/dist/index.js:55:6379)
    at async createViteServer (./node_modules/.pnpm/@storybook+builder-vite@8.2.9_storybook@8.2.9_@babel+preset-env@7.25.4_@babel+core@7.25.2___t_nh3fbujfmeryg2z2dgx4nlzd4m/node_modules/@storybook/builder-vite/dist/index.js:55:11470)
    at async Module.start (./node_modules/.pnpm/@storybook+builder-vite@8.2.9_storybook@8.2.9_@babel+preset-env@7.25.4_@babel+core@7.25.2___t_nh3fbujfmeryg2z2dgx4nlzd4m/node_modules/@storybook/builder-vite/dist/index.js:58:988)
    at async storybookDevServer (./node_modules/.pnpm/@storybook+core@8.2.9/node_modules/@storybook/core/dist/core-server/index.cjs:255820:11)
    at async buildOrThrow (./node_modules/.pnpm/@storybook+core@8.2.9/node_modules/@storybook/core/dist/core-server/index.cjs:255360:12)
    at async buildDevStandalone (./node_modules/.pnpm/@storybook+core@8.2.9/node_modules/@storybook/core/dist/core-server/index.cjs:257005:79)
    at async withTelemetry (./node_modules/.pnpm/@storybook+core@8.2.9/node_modules/@storybook/core/dist/core-server/index.cjs:255711:12)
    at async dev (./node_modules/.pnpm/storybook@8.2.9_@babel+preset-env@7.25.4_@babel+core@7.25.2_/node_modules/storybook/dist/generate.cjs:738:506)
    at async Command.<anonymous> (./node_modules/.pnpm/storybook@8.2.9_@babel+preset-env@7.25.4_@babel+core@7.25.2_/node_modules/storybook/dist/generate.cjs:740:245)

WARN Broken build, fix the error above.
WARN You may need to refresh the browser.

? Would you like to help improve Storybook by sending anonymous crash reports?
```


After: 
```bash
$ pnpm storybook


> teleport-ui@1.0.0 storybook /Users/marek/go/src/github.com/gravitational/teleport
> ./web/scripts/run-storybook.sh

Copying the worker script at "/Users/marek/go/src/github.com/gravitational/teleport/web/.storybook/public"...

Worker script successfully copied!
  - web/.storybook/public

Continue by describing the network in your application:


https://mswjs.io/docs/getting-started

storybook v8.2.9

info => Serving static files from ././web/.storybook/public at /
info => Starting manager..
info => Starting preview..
info Using tsconfig paths for react-docgen
╭─────────────────────────────────────────────────────╮
│                                                     │
│   Storybook 8.2.9 for react-vite started            │
│   637 ms for manager and 1.08 s for preview         │
│                                                     │
│    Local:            https://localhost:9002/        │
│    On your network:  https://192.168.31.44:9002/    │
│                                                     │
╰─────────────────────────────────────────────────────╯
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Sourcemap for "/virtual:/@storybook/builder-vite/vite-app.js" points to missing source files
Sourcemap for "/virtual:/@storybook/builder-vite/setup-addons.js" points to missing source files
```