### PR TITLE
Try to narrow down TestTrustBundleCache_Run flake

### DIFF
--- a/lib/tbot/spiffe/trust_bundle_cache.go
+++ b/lib/tbot/spiffe/trust_bundle_cache.go
@@ -473,6 +473,11 @@ func (m *TrustBundleCache) processEvent(ctx context.Context, event types.Event) 
 				)
 				return
 			}
+			log.DebugContext(
+				ctx,
+				"Processing update for local trust bundle",
+				"trusted_tls_key_pairs", len(ca.GetTrustedTLSKeyPairs()),
+			)
 
 			bundle, err := convertSPIFFECAToBundle(ca)
 			if err != nil {
@@ -494,7 +499,11 @@ func (m *TrustBundleCache) processEvent(ctx context.Context, event types.Event) 
 				)
 				return
 			}
-			log.InfoContext(ctx, "Processed update for local trust bundle")
+			log.InfoContext(
+				ctx,
+				"Processed update for local trust bundle",
+				"x509_authorities", len(bundle.X509Authorities()),
+			)
 			bundleSet.Local = bundle
 			m.setAndBroadcastBundleSet(bundleSet)
 		case types.KindSPIFFEFederation:
@@ -516,6 +525,11 @@ func (m *TrustBundleCache) processEvent(ctx context.Context, event types.Event) 
 				)
 				return
 			}
+			log.DebugContext(
+				ctx,
+				"Processing update for federated trust bundle",
+			)
+
 			bundle, err := convertSPIFFEFederationToBundle(federation)
 			if err != nil {
 				// TODO: Should we match the behavior for the local trust
@@ -538,7 +552,9 @@ func (m *TrustBundleCache) processEvent(ctx context.Context, event types.Event) 
 				return
 			}
 			log.InfoContext(
-				ctx, "Processed update for federated trust bundle",
+				ctx,
+				"Processed update for federated trust bundle",
+				"x509_authorities", len(bundle.X509Authorities()),
 			)
 			bundleSet.Federated[federation.Metadata.Name] = bundle
 			m.setAndBroadcastBundleSet(bundleSet)

--- a/lib/tbot/spiffe/trust_bundle_cache_test.go
+++ b/lib/tbot/spiffe/trust_bundle_cache_test.go
@@ -250,6 +250,7 @@ func TestTrustBundleCache_Run(t *testing.T) {
 	require.True(t, gotFederatedBundle.Equal(preInitFed))
 
 	// Update the local bundle with a new additional cert
+	ca = ca.Clone()
 	additionalCAKey, additionalCACertPEM, err := tlsca.GenerateSelfSignedCA(pkix.Name{}, []string{}, time.Hour)
 	require.NoError(t, err)
 	additionalCACert, err := tlsca.ParseCertificatePEM(additionalCACertPEM)


### PR DESCRIPTION
Can't repro locally even with CPU limits applied. This adds a little more logging (that'll be useful anyway, and see if that helps narrow it down in the CI as well)

https://github.com/gravitational/teleport.e/actions/runs/10758968887/job/29835068933