### PR TITLE
[v16] Respect proxy templates in tsh puttyconfig

### DIFF
--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -1289,37 +1289,37 @@ func TestGetTargetNodes(t *testing.T) {
 		host      string
 		port      int
 		clt       fakeResourceClient
-		expected  []targetNode
+		expected  []TargetNode
 	}{
 		{
 			name: "options override",
 			options: SSHOptions{
 				HostAddress: "test:1234",
 			},
-			expected: []targetNode{{hostname: "test:1234", addr: "test:1234"}},
+			expected: []TargetNode{{Hostname: "test:1234", Addr: "test:1234"}},
 		},
 		{
 			name:     "explicit target",
 			host:     "test",
 			port:     1234,
-			expected: []targetNode{{hostname: "test", addr: "test:1234"}},
+			expected: []TargetNode{{Hostname: "test", Addr: "test:1234"}},
 		},
 		{
 			name:     "labels",
 			labels:   map[string]string{"foo": "bar"},
-			expected: []targetNode{{hostname: "labels", addr: "abcd:0"}},
+			expected: []TargetNode{{Hostname: "labels", Addr: "abcd:0"}},
 			clt:      fakeResourceClient{nodes: []*types.ServerV2{{Metadata: types.Metadata{Name: "abcd"}, Spec: types.ServerSpecV2{Hostname: "labels"}}}},
 		},
 		{
 			name:     "search",
 			search:   []string{"foo", "bar"},
-			expected: []targetNode{{hostname: "search", addr: "abcd:0"}},
+			expected: []TargetNode{{Hostname: "search", Addr: "abcd:0"}},
 			clt:      fakeResourceClient{nodes: []*types.ServerV2{{Metadata: types.Metadata{Name: "abcd"}, Spec: types.ServerSpecV2{Hostname: "search"}}}},
 		},
 		{
 			name:      "predicate",
 			predicate: `resource.spec.hostname == "test"`,
-			expected:  []targetNode{{hostname: "predicate", addr: "abcd:0"}},
+			expected:  []TargetNode{{Hostname: "predicate", Addr: "abcd:0"}},
 			clt:       fakeResourceClient{nodes: []*types.ServerV2{{Metadata: types.Metadata{Name: "abcd"}, Spec: types.ServerSpecV2{Hostname: "predicate"}}}},
 		},
 	}
@@ -1337,7 +1337,7 @@ func TestGetTargetNodes(t *testing.T) {
 				},
 			}
 
-			match, err := clt.getTargetNodes(context.Background(), test.clt, test.options)
+			match, err := clt.GetTargetNodes(context.Background(), test.clt, test.options)
 			require.NoError(t, err)
 			require.EqualValues(t, test.expected, match)
 		})

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -243,13 +243,13 @@ func (a sharedAuthClient) Close() error {
 }
 
 // nodeName removes the port number from the hostname, if present
-func nodeName(node targetNode) string {
-	if node.hostname != "" {
-		return node.hostname
+func nodeName(node TargetNode) string {
+	if node.Hostname != "" {
+		return node.Hostname
 	}
-	n, _, err := net.SplitHostPort(node.addr)
+	n, _, err := net.SplitHostPort(node.Addr)
 	if err != nil {
-		return node.addr
+		return node.Addr
 	}
 	return n
 }
@@ -273,7 +273,7 @@ type NodeDetails struct {
 
 // String returns a user-friendly name
 func (n NodeDetails) String() string {
-	parts := []string{nodeName(targetNode{addr: n.Addr})}
+	parts := []string{nodeName(TargetNode{Addr: n.Addr})}
 	if n.Cluster != "" {
 		parts = append(parts, "on cluster", n.Cluster)
 	}

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -40,9 +40,9 @@ import (
 )
 
 func TestHelperFunctions(t *testing.T) {
-	assert.Equal(t, "one", nodeName(targetNode{addr: "one"}))
-	assert.Equal(t, "one", nodeName(targetNode{addr: "one:22"}))
-	assert.Equal(t, "example.com", nodeName(targetNode{addr: "one", hostname: "example.com"}))
+	assert.Equal(t, "one", nodeName(TargetNode{Addr: "one"}))
+	assert.Equal(t, "one", nodeName(TargetNode{Addr: "one:22"}))
+	assert.Equal(t, "example.com", nodeName(TargetNode{Addr: "one", Hostname: "example.com"}))
 }
 
 func TestNewSession(t *testing.T) {

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -302,7 +302,7 @@ func (c *ClusterClient) SessionSSHConfig(ctx context.Context, user string, targe
 	key, err = c.performMFACeremony(ctx,
 		mfaClt,
 		ReissueParams{
-			NodeName:       nodeName(targetNode{addr: target.Addr}),
+			NodeName:       nodeName(TargetNode{Addr: target.Addr}),
 			RouteToCluster: target.Cluster,
 			MFACheck:       target.MFACheck,
 		},

--- a/tool/tsh/common/putty_config_windows.go
+++ b/tool/tsh/common/putty_config_windows.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/utils/keypaths"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/puttyhosts"
 	"github.com/gravitational/teleport/lib/utils/registry"
 )
@@ -254,10 +255,32 @@ func onPuttyConfig(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
+	// connect to proxy to fetch cluster info
+	clusterClient, err := tc.ConnectToCluster(cf.Context)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer clusterClient.Close()
+
+	matches, err := tc.GetTargetNodes(cf.Context, clusterClient.AuthClient, client.SSHOptions{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	switch len(matches) {
+	case 0:
+		return trace.NotFound("no matching hosts found")
+	case 1:
+		log.Debugf("Using host %v", matches[0])
+	default:
+		log.Debugf("found multiple matching hosts %v %v", matches[0], matches[1])
+		return trace.BadParameter("multiple matching hosts found")
+	}
+
 	// remove any spaces from the provided hostname. if the hostname contains a colon, it will be a
 	// hostname:port combination so we split it. this is useful as shorthand when adding OpenSSH hosts
 	// with `tsh puttyconfig user@host:22`, rather than using the longer `tsh puttyconfig --port 22 user@host`
-	hostname := strings.TrimSpace(tc.Config.Host)
+	hostname := strings.TrimSpace(matches[0].Hostname)
 	port := tc.Config.HostPort
 	if splitHost, splitPort, err := net.SplitHostPort(hostname); err == nil {
 		hostname = splitHost
@@ -279,13 +302,6 @@ func onPuttyConfig(cf *CLIConf) error {
 		login = strings.ReplaceAll(tc.Config.HostLogin, " ", "")
 		userHostString = fmt.Sprintf("%v@%v", login, userHostString)
 	}
-
-	// connect to proxy to fetch cluster info
-	clusterClient, err := tc.ConnectToCluster(cf.Context)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer clusterClient.Close()
 
 	// parse out proxy details
 	proxyHost, _, err := net.SplitHostPort(tc.Config.SSHProxyAddr)


### PR DESCRIPTION
Backport #46291 to branch/v16

changelog: Update tsh puttyconfig to respect any defined proxy templates
