### PR TITLE
[docs] Suggests both Authenticated Proxy and TLS routing method for GUI client in cloud

### DIFF
--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -20,9 +20,6 @@ work with Teleport.
 ### Get connection information
 
 <Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-
-<Tabs>
 <TabItem label="Authenticated Proxy">
 Starting the local database proxy with the `--tunnel` flag will create an
 authenticated tunnel that you can use to connect to your database instances.
@@ -67,6 +64,7 @@ Use the displayed local proxy host/port and credentials paths when configuring
 your GUI client below. When entering the hostname, use `localhost` rather than
 `127.0.0.1`.
 </TabItem>
+
 <TabItem label="Separate ports">
 If you're not using TLS routing, run the following command to see the database
 connection information:
@@ -94,31 +92,12 @@ Key:       /Users/alice/.tsh/keys/teleport.example.com/alice
 The displayed `CA`, `Cert`, and `Key` files are used to connect through pgAdmin
 4, MySQL Workbench, and other graphical database clients that support mutual
 TLS authentication.
+
+<Admonition type="note">
+Teleport Enterprise (Cloud) uses TLS routing, so you must use the
+"Authenticated Proxy" or the "TLS routing" options.
+</Admonition>
 </TabItem>
-</Tabs>
-
-</TabItem>
-<TabItem scope="cloud" label="Teleport Enterprise Cloud">
-
-Use the following command to start a local TLS proxy your GUI database client
-will be connecting to:
-
-```code
-$ tsh proxy db <database-name>
-Started DB proxy on 127.0.0.1:61740
-
-Use following credentials to connect to the <database-name> proxy:
-  ca_file=/Users/r0mant/.tsh/keys/root.gravitational.io/certs.pem
-  cert_file=/Users/r0mant/.tsh/keys/root.gravitational.io/alice-db/root/<database-name>-x509.pem
-  key_file=/Users/r0mant/.tsh/keys/root.gravitational.io/alice
-```
-
-Use the displayed local proxy host/port and credentials paths when configuring
-your GUI client below. When entering the hostname, use `localhost` rather than
-`127.0.0.1`.
-
-</TabItem>
-
 </Tabs>
 
 ## MongoDB Compass


### PR DESCRIPTION
https://goteleport.com/docs/connect-your-client/gui-clients/#get-connection-information

Users are confused about whether they must use `tsh proxy db` for Cloud, but in reality they actually can use `tsh proxy db --tunnel` as well. 