### PR TITLE
[v15] chore: Bump golangci-lint to v1.61.0

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.22.7
-GOLANGCI_LINT_VERSION ?= v1.60.3
+GOLANGCI_LINT_VERSION ?= v1.61.0
 
 NODE_VERSION ?= 20.14.0
 


### PR DESCRIPTION
Backport #46400 to branch/v15.