### PR TITLE
Fix license stringification

### DIFF
--- a/api/types/license.go
+++ b/api/types/license.go
@@ -529,7 +529,7 @@ func (c *LicenseV3) String() string {
 	if c.GetTrial() {
 		features = append(features, "is trial")
 	}
-	if c.GetReportsUsage() {
+	if c.GetSalesCenterReporting() {
 		features = append(features, "reports usage")
 	}
 	if c.GetSupportsKubernetes() {


### PR DESCRIPTION
The "reports usage" flag refers to legacy (Houston) usage reporting, which no longer exists. Update the string method to look at the new "Sales Center reporting" flag.

This change ensures that the auth server startup logs are looking at the correct field to determine if the license has enabled usage reporting.

Note: the old Houston flag sticks around for now because it exists in several repos.