### PR TITLE
docs: correct user ca rotation command

### DIFF
--- a/docs/pages/admin-guides/management/security/revoking-access.mdx
+++ b/docs/pages/admin-guides/management/security/revoking-access.mdx
@@ -12,7 +12,7 @@ There are two options available for revoking access: CA rotations and Teleport l
 ## CA rotations
 
 To generate a new certificate authority and invalidate user certificates issued
-by the current CA, run `tctl auth rotate --type-user`. This process will require
+by the current CA, run `tctl auth rotate --type=user`. This process will require
 that the newly generated CA certificate is uploaded to your entire fleet of
 OpenSSH servers. This can be a disruptive change, especially in environments
 that lack automation, so proceed with caution.


### PR DESCRIPTION
Command had a `-` instead of `=`.