### PR TITLE
[v15] Fix Firestore backend keys

### DIFF
--- a/lib/backend/firestore/firestorebk_test.go
+++ b/lib/backend/firestore/firestorebk_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/option"
 	"google.golang.org/genproto/googleapis/rpc/code"
@@ -213,6 +214,101 @@ func TestReadLegacyRecord(t *testing.T) {
 	require.Equal(t, item.Value, got.Value)
 	require.Equal(t, item.ID, got.ID)
 	require.Equal(t, item.Expires, got.Expires)
+}
+
+func TestReadBrokenRecord(t *testing.T) {
+	cfg := firestoreParams()
+	ensureTestsEnabled(t)
+	ensureEmulatorRunning(t, cfg)
+
+	uut := newBackend(t, cfg)
+
+	ctx := context.Background()
+
+	prefix := test.MakePrefix()
+
+	// Create a valid record with the correct key type.
+	item := backend.Item{
+		Key:   prefix("valid-record"),
+		Value: []byte("llamas"),
+	}
+	_, err := uut.Put(ctx, item)
+	require.NoError(t, err)
+
+	// Create a legacy record with a string key type.
+	lr := legacyRecord{
+		Key:   prefix("legacy-record").String(),
+		Value: "sheep",
+	}
+	_, err = uut.svc.Collection(uut.CollectionName).Doc(uut.keyToDocumentID(backend.Key(lr.Key))).Set(ctx, lr)
+	require.NoError(t, err)
+
+	// Create a broken record with a backend.Key key type.
+	brokenItem := backend.Item{
+		Key:     prefix("broken-record"),
+		Value:   []byte("foo"),
+		Expires: uut.clock.Now().Add(time.Minute).Round(time.Second).UTC(),
+	}
+
+	// Write using broken record format, emulating data written by an older
+	// version of this backend.
+	br := brokenRecord{
+		Key:       brokenItem.Key,
+		Value:     brokenItem.Value,
+		Expires:   brokenItem.Expires.UTC().Unix(),
+		Timestamp: uut.clock.Now().UTC().Unix(),
+	}
+	_, err = uut.svc.Collection(uut.CollectionName).Doc(uut.keyToDocumentID(brokenItem.Key)).Set(ctx, br)
+	require.NoError(t, err)
+
+	// Read the data back and make sure it matches the original item.
+	got, err := uut.Get(ctx, brokenItem.Key)
+	require.NoError(t, err)
+	require.Equal(t, brokenItem.Key, got.Key)
+	require.Equal(t, brokenItem.Value, got.Value)
+	require.Equal(t, brokenItem.Expires, got.Expires)
+
+	// Read the data back using a range query too.
+	gotRange, err := uut.GetRange(ctx, brokenItem.Key, brokenItem.Key, 1)
+	require.NoError(t, err)
+	require.Len(t, gotRange.Items, 1)
+
+	got = &gotRange.Items[0]
+	require.Equal(t, brokenItem.Key, got.Key)
+	require.Equal(t, brokenItem.Value, got.Value)
+	require.Equal(t, brokenItem.Expires, got.Expires)
+
+	// Retrieve the entire key range to validate that there are no duplicate records
+	results, err := uut.GetRange(ctx, prefix(""), backend.RangeEnd(prefix("")), 5)
+	require.NoError(t, err)
+
+	require.Len(t, results.Items, 3)
+
+	for _, result := range results.Items {
+		switch r := result.Key.String(); r {
+		case item.Key.String():
+			assert.Equal(t, item.Value, result.Value)
+		case br.Key.String():
+			assert.Equal(t, br.Value, result.Value)
+		case lr.Key:
+			assert.Equal(t, lr.Value, string(result.Value))
+		default:
+			t.Errorf("GetRange returned unexpected item key %s", r)
+		}
+	}
+
+	// Update the value and ensure that it's set to the correct key value
+	item.Value = []byte("llama")
+	_, err = uut.Update(ctx, item)
+	require.NoError(t, err)
+
+	doc, err := uut.svc.Collection(uut.CollectionName).Doc(uut.keyToDocumentID(item.Key)).Get(ctx)
+	require.NoError(t, err)
+
+	var r record
+	require.NoError(t, doc.DataTo(&r))
+	require.Equal(t, []byte(item.Key.String()), r.Key)
+	require.Equal(t, item.Value, r.Value)
 }
 
 type mockFirestoreServer struct {


### PR DESCRIPTION
Backport #46406 to branch/v15

changelog: Fixed an issue that prevented the Firestore backend from reading existing data.