### PR TITLE
update mfa missing error

### DIFF
--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -79,7 +79,7 @@ var (
 	// ErrNoMFADevices is returned when an MFA ceremony is performed without possible devices to
 	// complete the challenge with.
 	ErrNoMFADevices = &trace.AccessDeniedError{
-		Message: "MFA is required to access this resource but user has no MFA devices; see Account Settings in the Web UI or use 'tsh mfa add' via CLI to register MFA devices",
+		Message: "MFA is required to access this resource but user has no MFA devices; see Account Settings in the Web UI or use 'tsh mfa add' to register MFA devices",
 	}
 	// InvalidUserPassError is the error for when either the provided username or
 	// password is incorrect.

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -79,7 +79,7 @@ var (
 	// ErrNoMFADevices is returned when an MFA ceremony is performed without possible devices to
 	// complete the challenge with.
 	ErrNoMFADevices = &trace.AccessDeniedError{
-		Message: "MFA is required to access this resource but user has no MFA devices; use 'tsh mfa add' to register MFA devices",
+		Message: "MFA is required to access this resource but user has no MFA devices; see Account Settings in the Web UI or use 'tsh mfa add' via CLI to register MFA devices",
 	}
 	// InvalidUserPassError is the error for when either the provided username or
 	// password is incorrect.


### PR DESCRIPTION
Update missing MFA error to provide guidance on using Web UI too for adding mfa devices. This shows in the Web UI and CLI interactions so good to mention both as options.

Current messages:

![image](https://github.com/user-attachments/assets/3c8e95db-89a4-497f-b68e-3c6ed68ed0c2)

update to:

`MFA is required to access this resource but user has no MFA devices; see Account Settings in the Web UI or use 'tsh mfa add' via CLI to register MFA devices`
