### PR TITLE
Use the new -diff flag for the go mod tidy check

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,8 +2,9 @@ name: Lint (Go)
 run-name: Lint (Go and Rust)
 on:
   pull_request:
-
   merge_group:
+env:
+  GOFLAGS: '-buildvcs=false'
 
 jobs:
   changes:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -85,15 +85,12 @@ jobs:
       - name: Check for untidy go modules
         shell: bash
         run: |
-          find . -path ./e -prune -o -name go.mod -print | while read f; do 
+          find . -path ./e -prune -o -name go.mod -print | while read f; do
             echo "checking $f"
-            pushd $(dirname "$f") > /dev/null; 
-            go mod tidy;
+            pushd $(dirname "$f") > /dev/null;
+            go mod tidy -diff;
             popd > /dev/null;
           done
-
-          # We have to add the current directory as a safe directory or else git commands will not work as expected.
-          git config --global --add safe.directory $( realpath . ) && git diff --exit-code;
 
       - name: Set linter versions
         run: |


### PR DESCRIPTION
Go 1.23 introduces a `go mod tidy -diff` option that prints the diff and exits with a non-zero status code if updates are needed, which eliminates the need for us to check the git state to determine if the modules needed tidying.

Note to reviewers: the downside of this change is the check will fail at the first untidy module rather then checking all modules and reporting the results. I'm open to suggestions if we prefer the original behavior.