### PR TITLE
support key algorithms for proxy generated k8s certs

### DIFF
--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -78,6 +78,9 @@ const (
 	// ProxyToDatabaseAgent represents keys used by the Proxy to dial the
 	// Database agent over a reverse tunnel.
 	ProxyToDatabaseAgent
+	// ProxyKubeClient represents a key generated on the proxy used as the
+	// subject for a generated kubernetes client cert.
+	ProxyKubeClient
 
 	// UserSSH represents a user SSH key.
 	UserSSH
@@ -146,9 +149,11 @@ var (
 		UserSSH:             RSA2048,
 		UserTLS:             RSA2048,
 		UserDatabase:        RSA2048,
-		// We could consider updating this algorithm even in the legacy suite, only database agents need to
-		// accept these connections and they have never restricted algorithm support.
+		// We could consider updating these algorithms even in the legacy suite,
+		// only teleport agents need to accept these connections and they have
+		// never restricted algorithm support.
 		ProxyToDatabaseAgent: RSA2048,
+		ProxyKubeClient:      RSA2048,
 		// TODO(nklaassen): define remaining key purposes.
 	}
 
@@ -172,6 +177,7 @@ var (
 		UserTLS:              ECDSAP256,
 		UserDatabase:         RSA2048,
 		ProxyToDatabaseAgent: ECDSAP256,
+		ProxyKubeClient:      ECDSAP256,
 		// TODO(nklaassen): define remaining key purposes.
 	}
 
@@ -195,6 +201,7 @@ var (
 		UserTLS:              ECDSAP256,
 		UserDatabase:         RSA2048,
 		ProxyToDatabaseAgent: ECDSAP256,
+		ProxyKubeClient:      ECDSAP256,
 		// TODO(nklaassen): define remaining key purposes.
 	}
 
@@ -220,6 +227,7 @@ var (
 		UserTLS:              ECDSAP256,
 		UserDatabase:         RSA2048,
 		ProxyToDatabaseAgent: ECDSAP256,
+		ProxyKubeClient:      ECDSAP256,
 		// TODO(nklaassen): define remaining key purposes.
 	}
 


### PR DESCRIPTION
This PR adds support for configurable key algorithms for keys generated by the proxy kubernetes gRPC service

Part of [RFD 136](https://github.com/gravitational/teleport/blob/master/rfd/0136-modern-signature-algorithms.md)