### PR TITLE
Set min macOS version to 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,9 +316,8 @@ endif
 
 ifeq ("$(OS)","darwin")
 # Set the minimum version for macOS builds for Go, Rust and Xcode builds.
-# Note the minimum version for Apple silicon (ARM64) is 11.0 and will be automatically
-# clamped to the value for builds of that architecture
-MINIMUM_SUPPORTED_MACOS_VERSION = 10.15
+# (as of Go 1.23 we require macOS 11)
+MINIMUM_SUPPORTED_MACOS_VERSION = 11.0
 MACOSX_VERSION_MIN_FLAG = -mmacosx-version-min=$(MINIMUM_SUPPORTED_MACOS_VERSION)
 
 # Go

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -11,7 +11,7 @@
 # Written mainly for macOS builders.
 set -eu
 
-readonly MACOS_VERSION_MIN=10.15
+readonly MACOS_VERSION_MIN=11.0
 
 # Cross-architecture building
 # Set C_ARCH to $(uname -m) if unset, and validate supported architecture

--- a/build.assets/macos/tctl/tctl.app/Contents/Info.plist
+++ b/build.assets/macos/tctl/tctl.app/Contents/Info.plist
@@ -43,7 +43,7 @@
 		<key>DTXcodeBuild</key>
 		<string>13C100</string>
 		<key>LSMinimumSystemVersion</key>
-		<string>10.15.0</string>
+		<string>11.0.0</string>
 		<key>NSHumanReadableCopyright</key>
 		<string/>
 		<key>NSMainStoryboardFile</key>

--- a/build.assets/macos/tctldev/tctl.app/Contents/Info.plist
+++ b/build.assets/macos/tctldev/tctl.app/Contents/Info.plist
@@ -41,7 +41,7 @@
 		<key>DTXcodeBuild</key>
 		<string>13C100</string>
 		<key>LSMinimumSystemVersion</key>
-		<string>10.15.0</string>
+		<string>11.0.0</string>
 		<key>NSHumanReadableCopyright</key>
 		<string/>
 		<key>NSMainStoryboardFile</key>

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -43,7 +43,7 @@
 		<key>DTXcodeBuild</key>
 		<string>13C100</string>
 		<key>LSMinimumSystemVersion</key>
-		<string>10.15.0</string>
+		<string>11.0.0</string>
 		<key>NSHumanReadableCopyright</key>
 		<string/>
 		<key>NSMainStoryboardFile</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -41,7 +41,7 @@
 		<key>DTXcodeBuild</key>
 		<string>13C100</string>
 		<key>LSMinimumSystemVersion</key>
-		<string>10.15.0</string>
+		<string>11.0.0</string>
 		<key>NSHumanReadableCopyright</key>
 		<string/>
 		<key>NSMainStoryboardFile</key>

--- a/docs/pages/admin-guides/access-controls/guides/passwordless.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/passwordless.mdx
@@ -224,8 +224,7 @@ necessary udev rules.
 If you are having trouble with Touch ID, make sure that you are using the latest
 standalone version of `tsh`. [Download the macOS tsh installer](../../../installation.mdx).
 
-Touch ID support requires Macs with a Touch ID sensor and Secure Enclave. It also
-requires macOS >= 10.15 (macOS Catalina).
+Touch ID support requires Macs with a Touch ID sensor and Secure Enclave.
 
 You can run the `tsh touchid diag` command to verify requirements. A capable
 device and `tsh` binary should show an output similar to the one below:

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -34,7 +34,7 @@ running Teleport on UNIX variants other than Linux \[1].
 | Operating System | `teleport` Daemon | `tctl` Admin Tool | `tsh` and Teleport Connect User Clients [2] | Web UI (via the browser) | `tbot` Daemon |
 | - | - | - | - | - | - |
 | Linux v2.6.23+ (RHEL/CentOS 7+, Amazon Linux 2+, Amazon Linux 2023+, Ubuntu 16.04+, Debian 9+, SLES 12 SP 5+, and SLES 15 SP 5+) \[3] | yes | yes | yes | yes | yes |
-| macOS v10.15+  (Catalina)| yes | yes | yes | yes | yes |
+| macOS 11+  (Big Sur)| yes | yes | yes | yes | yes |
 | Windows 10+ (rev. 1607) \[4] | no | yes | yes | yes | no |
 
 \[1] *Teleport is written in Go and many of these system requirements are due to the requirements
@@ -854,4 +854,3 @@ infrastructure. Get started with:
 - [Application Access](enroll-resources/application-access/introduction.mdx)
 - [Desktop Access](enroll-resources/desktop-access/introduction.mdx)
 - [Machine ID](enroll-resources/machine-id/introduction.mdx)
-

--- a/lib/auth/touchid/api_darwin.go
+++ b/lib/auth/touchid/api_darwin.go
@@ -21,7 +21,7 @@
 
 package touchid
 
-// #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=10.15
+// #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=11.0
 // #cgo LDFLAGS: -framework CoreFoundation -framework Foundation -framework LocalAuthentication -framework Security
 // #include <stdlib.h>
 // #include "authenticate.h"

--- a/lib/devicetrust/native/device_darwin.go
+++ b/lib/devicetrust/native/device_darwin.go
@@ -18,7 +18,7 @@
 
 package native
 
-// #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=10.15
+// #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=11.0
 // #cgo LDFLAGS: -framework CoreFoundation -framework Foundation -framework IOKit -framework Security
 // #include <stdint.h>
 // #include <stdlib.h>

--- a/lib/vnet/daemon/common_darwin.go
+++ b/lib/vnet/daemon/common_darwin.go
@@ -19,7 +19,7 @@
 
 package daemon
 
-// #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=10.15
+// #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=11.0
 // #cgo LDFLAGS: -framework Foundation -framework ServiceManagement
 // #include "common_darwin.h"
 import "C"

--- a/lib/web/scripts/node-join/README.md
+++ b/lib/web/scripts/node-join/README.md
@@ -45,7 +45,7 @@ Things it doesn't do (yet):
   - Architectures
     - x86_64
     - aarch64
-  - MacOS 10.15+
+  - macOS 11.0+
     - uses `.tar.gz` tarball package
 
 ## Arguments


### PR DESCRIPTION
Go 1.23 has a hard requirement of of macOS11 Big Sur or later.

No backport (for now) as we're only on Go 1.23 on master.

changelog: Teleport requires macOS 11 (Big Sur) or later.