### PR TITLE
Fix flaky terminal tests

### DIFF
--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.test.tsx
@@ -90,7 +90,6 @@ test.each([
 test("mouse right click opens context menu when 'terminal.rightClick: menu' is configured", async () => {
   const appContext = new MockAppContext();
   const user = userEvent.setup();
-  jest.spyOn(appContext.mainProcessClient, 'openTerminalContextMenu');
   appContext.configService.set('terminal.rightClick', 'menu');
   const openContextMenu = jest.fn();
 

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.test.tsx
@@ -33,10 +33,6 @@ beforeAll(() => {
   Logger.init(new NullService());
 });
 
-beforeEach(() => {
-  userEvent.setup();
-});
-
 // TODO(gzdunek): Add tests for copying text.
 // Unfortunately, simulating text selection with a single right click or
 // mouseMove doesn't work.
@@ -45,11 +41,12 @@ beforeEach(() => {
 
 test('keyboard shortcut pastes text', async () => {
   const appContext = new MockAppContext({ platform: 'win32' });
+  const user = userEvent.setup();
 
   render(<ConfiguredTerminal appContext={appContext} />);
 
   await navigator.clipboard.writeText('some-command');
-  await userEvent.keyboard('{Control>}{Shift>}V'); // Ctrl+Shift+V
+  await user.keyboard('{Control>}{Shift>}V'); // Ctrl+Shift+V
 
   await waitFor(() => {
     expect(screen.getByText('some-command')).toBeInTheDocument();
@@ -75,14 +72,15 @@ test.each([
   },
 ])(`$name`, async testCase => {
   const appContext = testCase.getAppContext();
+  const user = userEvent.setup();
 
   render(<ConfiguredTerminal appContext={appContext} />);
 
-  await userEvent.keyboard('some-command');
+  await user.keyboard('some-command');
   const terminalContent = await screen.findByText('some-command');
 
   await navigator.clipboard.writeText(' --flag=test');
-  await userEvent.pointer({ keys: '[MouseRight]', target: terminalContent });
+  await user.pointer({ keys: '[MouseRight]', target: terminalContent });
 
   await waitFor(() => {
     expect(screen.getByText('some-command --flag=test')).toBeInTheDocument();
@@ -91,6 +89,7 @@ test.each([
 
 test("mouse right click opens context menu when 'terminal.rightClick: menu' is configured", async () => {
   const appContext = new MockAppContext();
+  const user = userEvent.setup();
   jest.spyOn(appContext.mainProcessClient, 'openTerminalContextMenu');
   appContext.configService.set('terminal.rightClick', 'menu');
   const openContextMenu = jest.fn();
@@ -102,10 +101,10 @@ test("mouse right click opens context menu when 'terminal.rightClick: menu' is c
     />
   );
 
-  await userEvent.keyboard('some-command');
+  await user.keyboard('some-command');
   const terminalContent = await screen.findByText('some-command');
 
-  await userEvent.pointer({ keys: '[MouseRight]', target: terminalContent });
+  await user.pointer({ keys: '[MouseRight]', target: terminalContent });
 
   await waitFor(() => {
     expect(openContextMenu).toHaveBeenCalledTimes(1);

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.test.tsx
@@ -78,10 +78,10 @@ test.each([
 
   render(<ConfiguredTerminal appContext={appContext} />);
 
-  await userEvent.keyboard('some-command ');
+  await userEvent.keyboard('some-command');
   const terminalContent = await screen.findByText('some-command');
 
-  await navigator.clipboard.writeText('--flag=test');
+  await navigator.clipboard.writeText(' --flag=test');
   await userEvent.pointer({ keys: '[MouseRight]', target: terminalContent });
 
   await waitFor(() => {
@@ -102,10 +102,9 @@ test("mouse right click opens context menu when 'terminal.rightClick: menu' is c
     />
   );
 
-  await userEvent.keyboard('some-command ');
+  await userEvent.keyboard('some-command');
   const terminalContent = await screen.findByText('some-command');
 
-  await navigator.clipboard.writeText('--flag=test');
   await userEvent.pointer({ keys: '[MouseRight]', target: terminalContent });
 
   await waitFor(() => {


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/46474

After two hours of frustrating debugging, I think I’ve finally found the fix! 😅

I couldn't reproduce the issue on my local machine, but I managed to replicate it on a Windows VM. 
The problem seems to be a race condition caused by not fully processing the user's input (`user.keyboard('some-command '`)) before simulating a right-click. This happened because the command included a trailing space (`some-command `), but I was waiting for the text without the space in `screen.findByText` (I think I added the space to separate the command from the argument which I sent later, but it's better to prepend the space to it instead).

Since `userEvent.keyboard` sends input as individual keystrokes, `xterm.js` was still rendering the input when the right-click was triggered. I guess that `xterm` called `.stopPropagation()` on the mouse event, leading to the test failure.

I fixed the test by removing the problematic space. I also added a few other changes (which probably don't have any effect, but clean up the code slightly).