### PR TITLE
Added TLS time desync to desktop-access troubleshooting

### DIFF
--- a/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
@@ -380,7 +380,7 @@ Remote error tls expired certificate
 **Solution:** Check the system clock on the Teleport Auth Service instance
 
 Related to [Expired smartcard certificate](./troubleshooting.mdx#expired-smartcard-certificate), this error
-most likely stems from time drift on the Auth Service Instance. On Linux systems running systemd, this can be
+most likely stems from time drift on the Auth Service instance. On Linux systems running systemd, this can be
 checked with the following command:
 
 ```code

--- a/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
@@ -369,6 +369,40 @@ Teleport's smartcard certificates are only valid for a short period of time
 target Windows host disagree about the current time, the system may reject the
 authentication attempt.
 
+### Expired TLS certificate
+
+This error will be displayed in the Web UI before a remote session is opened to your desktop of choice:
+
+```text
+Remote error tls expired certificate
+```
+
+**Solution:** Check the system clock on the Teleport auth server
+
+Related to [Expired smartcard certificate](./troubleshooting.mdx#expired-smartcard-certificate), this error
+most likely stems from time drift on the auth server. On Linux systems running systemd, this can be
+checked with the following command:
+
+```code
+$ timedatectl
+```
+
+Which should produce the following output:
+
+```
+               Local time: Wed 2024-09-11 13:45:17 UTC
+           Universal time: Wed 2024-09-11 13:45:17 UTC
+                 RTC time: Wed 2024-09-11 13:45:17
+                Time zone: Etc/UTC (UTC, +0000)
+System clock synchronized: yes
+              NTP service: active
+          RTC in local TZ: no
+```
+
+If `System clock synchronized` is `no`, this would need to be resolved.
+This should also be checked on your Teleport proxies and Teleport agents to get ahead of other issues
+stemming from problems which relate to time desynchronization.
+
 ### Enhanced RDP security with CredSSP required
 
 Attempts to connect to a desktop fail, and the logs show an error similar to:

--- a/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
@@ -377,10 +377,10 @@ This error will be displayed in the Web UI before a remote session is opened to 
 Remote error tls expired certificate
 ```
 
-**Solution:** Check the system clock on the Teleport auth server
+**Solution:** Check the system clock on the Teleport Auth Service instance
 
 Related to [Expired smartcard certificate](./troubleshooting.mdx#expired-smartcard-certificate), this error
-most likely stems from time drift on the auth server. On Linux systems running systemd, this can be
+most likely stems from time drift on the Auth Service Instance. On Linux systems running systemd, this can be
 checked with the following command:
 
 ```code


### PR DESCRIPTION
This PR handles an issue customers experience when using desktop access on a Teleport cluster where the auth service does not have time synchronized