### PR TITLE
Add extraArgs support for teleport-operator

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
             - -ca-pin
             - '{{ join "," .Values.caPins }}'
   {{- end }}
+  {{- if .Values.extraArgs }}
+            {{- toYaml .Values.extraArgs | nindent 12 }}
+  {{- end }}
   {{- if or (.Values.tls.existingCASecretName) (.Values.teleportClusterName) }}
           env:
     {{- if .Values.tls.existingCASecretName }}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -33,6 +33,10 @@ teleportAddress: ""
 # (port `443` or `3080`).
 caPins: []
 
+# extraArgs to pass to '/teleport-operator' startup command
+# command options can be viewed by running '/teleport-operator --help'
+extraArgs: []
+
 # joinMethod(string) -- describes how the Teleport Kubernetes Operator joins the Teleport cluster.
 # The operator does not store its Teleport-issued identity, it must be able to join the
 # cluster again on each pod restart. To achieve this, it needs to use a delegated join


### PR DESCRIPTION
This adds support to pass extraArgs to the operator container to control additional settings like logging.

Fixes https://github.com/gravitational/teleport/issues/46465