### PR TITLE
[v15] Allow cluster wide ssh dial timeout to be set in config file

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -995,6 +995,7 @@ func applyAuthConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 			ProxyPingInterval:             fc.Auth.ProxyPingInterval,
 			AssistCommandExecutionWorkers: assistCommandExecutionWorkers,
 			CaseInsensitiveRouting:        fc.Auth.CaseInsensitiveRouting,
+			SSHDialTimeout:                fc.Auth.SSHDialTimeout,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -341,6 +341,7 @@ func TestConfigReading(t *testing.T) {
 			WebIdleTimeout:        types.Duration(19 * time.Second),
 			RoutingStrategy:       types.RoutingStrategy_MOST_RECENT,
 			ProxyPingInterval:     types.Duration(10 * time.Second),
+			SSHDialTimeout:        types.Duration(45 * time.Second),
 		},
 		SSH: SSH{
 			Service: Service{
@@ -1495,6 +1496,7 @@ func makeConfigFixture() string {
 	conf.Auth.DisconnectExpiredCert = types.NewBoolOption(true)
 	conf.Auth.RoutingStrategy = types.RoutingStrategy_MOST_RECENT
 	conf.Auth.ProxyPingInterval = types.NewDuration(10 * time.Second)
+	conf.Auth.SSHDialTimeout = types.NewDuration(45 * time.Second)
 
 	// ssh service:
 	conf.SSH.EnabledFlag = "true"

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -804,6 +804,9 @@ type Auth struct {
 	// CaseInsensitiveRouting causes proxies to use case-insensitive hostname matching.
 	CaseInsensitiveRouting bool `yaml:"case_insensitive_routing,omitempty"`
 
+	// SSHDialTimeout is the timeout value that should be used for SSH connections.
+	SSHDialTimeout types.Duration `yaml:"ssh_dial_timeout,omitempty"`
+
 	// LoadAllCAs tells tsh to load the CAs for all clusters when trying
 	// to ssh into a node, instead of just the CA for the current cluster.
 	LoadAllCAs bool `yaml:"load_all_cas,omitempty"`
@@ -858,7 +861,8 @@ func (a *Auth) hasCustomNetworkingConfig() bool {
 		a.RoutingStrategy != empty.RoutingStrategy ||
 		a.TunnelStrategy != empty.TunnelStrategy ||
 		a.ProxyPingInterval != empty.ProxyPingInterval ||
-		(a.Assist != nil && a.Assist.CommandExecutionWorkers != 0)
+		(a.Assist != nil && a.Assist.CommandExecutionWorkers != 0) ||
+		a.SSHDialTimeout != empty.SSHDialTimeout
 }
 
 // hasCustomSessionRecording returns true if any of the session recording


### PR DESCRIPTION
Backport #46458 to branch/v15

Changelog: Allow the cluster wide ssh dial timeout to be set via auth_service.ssh_dial_timeout in the Teleport config file.