### PR TITLE
Release 16.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 16.3.0 (09/11/2024)
+
+### Out-of-band user creation
+
+Cluster administrators are now able to configure Teleport's `ssh_service` to
+ensure that certain host users exist on the machine without the need to start
+an SSH session. [#46498](https://github.com/gravitational/teleport/pull/46498)
+
+### Other improvements and fixes
+
+* Allow the cluster wide ssh dial timeout to be set via `auth_service.ssh_dial_timeout` in the Teleport config file. [#46507](https://github.com/gravitational/teleport/pull/46507)
+* Fixed an issue preventing session joining while host user creation was in use. [#46501](https://github.com/gravitational/teleport/pull/46501)
+* Added tbot Helm chart for deploying a Machine ID Bot into a Teleport cluster. [#46373](https://github.com/gravitational/teleport/pull/46373)
+
 ## 16.2.2 (09/10/24)
 
 * Fixed an issue that prevented the Firestore backend from reading existing data. [#46433](https://github.com/gravitational/teleport/issues/46433)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=16.2.2
+VERSION=16.3.0
 
 DOCKER_IMAGE ?= teleport
 

--- a/api/version.go
+++ b/api/version.go
@@ -3,6 +3,6 @@ package api
 
 import "github.com/coreos/go-semver/semver"
 
-const Version = "16.2.2"
+const Version = "16.3.0"
 
 var SemVersion = semver.New(Version)

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -19,13 +19,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>16.2.2</string>
+		<string>16.3.0</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>16.2.2</string>
+		<string>16.3.0</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -17,13 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>16.2.2</string>
+		<string>16.3.0</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>16.2.2</string>
+		<string>16.3.0</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/examples/chart/access/discord/Chart.yaml
+++ b/examples/chart/access/discord/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "16.2.2"
+.version: &version "16.3.0"
 
 apiVersion: v2
 name: teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-discord-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-discord-16.3.0
       name: RELEASE-NAME-teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-discord-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-discord-16.3.0
       name: RELEASE-NAME-teleport-plugin-discord
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-discord
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-discord-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-discord-16.3.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/email/Chart.yaml
+++ b/examples/chart/access/email/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "16.2.2"
+.version: &version "16.3.0"
 
 apiVersion: v2
 name: teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,8 +26,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-email-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-email-16.3.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
@@ -59,8 +59,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-email-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-email-16.3.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, no starttls):
   1: |
@@ -92,8 +92,8 @@ should match the snapshot (smtp on, no starttls):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-email-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-email-16.3.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
@@ -125,8 +125,8 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-email-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-email-16.3.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, roleToRecipients set):
   1: |
@@ -161,8 +161,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-email-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-email-16.3.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -194,6 +194,6 @@ should match the snapshot (smtp on, starttls disabled):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-email-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-email-16.3.0
       name: RELEASE-NAME-teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-email-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-email-16.3.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should be possible to override volume name (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-email-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-email-16.3.0
         spec:
           containers:
           - command:
@@ -34,7 +34,7 @@ should be possible to override volume name (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:16.2.2
+            image: public.ecr.aws/gravitational/teleport-plugin-email:16.3.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -75,8 +75,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-email-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-email-16.3.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-email-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-email-16.3.0
         spec:
           containers:
           - command:
@@ -136,8 +136,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-email-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-email-16.3.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -151,8 +151,8 @@ should match the snapshot (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-email-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-email-16.3.0
         spec:
           containers:
           - command:
@@ -163,7 +163,7 @@ should match the snapshot (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:16.2.2
+            image: public.ecr.aws/gravitational/teleport-plugin-email:16.3.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -204,8 +204,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-email-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-email-16.3.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -219,8 +219,8 @@ should match the snapshot (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-email-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-email-16.3.0
         spec:
           containers:
           - command:
@@ -231,7 +231,7 @@ should match the snapshot (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:16.2.2
+            image: public.ecr.aws/gravitational/teleport-plugin-email:16.3.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -272,8 +272,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-email-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-email-16.3.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -287,8 +287,8 @@ should mount external secret (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-email-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-email-16.3.0
         spec:
           containers:
           - command:
@@ -299,7 +299,7 @@ should mount external secret (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:16.2.2
+            image: public.ecr.aws/gravitational/teleport-plugin-email:16.3.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -340,8 +340,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-email-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-email-16.3.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -355,8 +355,8 @@ should mount external secret (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-email-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-email-16.3.0
         spec:
           containers:
           - command:
@@ -367,7 +367,7 @@ should mount external secret (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:16.2.2
+            image: public.ecr.aws/gravitational/teleport-plugin-email:16.3.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/examples/chart/access/jira/Chart.yaml
+++ b/examples/chart/access/jira/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "16.2.2"
+.version: &version "16.3.0"
 
 apiVersion: v2
 name: teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -32,6 +32,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-jira-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-jira-16.3.0
       name: RELEASE-NAME-teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-jira-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-jira-16.3.0
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-jira
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-jira-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-jira-16.3.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/mattermost/Chart.yaml
+++ b/examples/chart/access/mattermost/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "16.2.2"
+.version: &version "16.3.0"
 
 apiVersion: v2
 name: teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -22,6 +22,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-mattermost-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-mattermost-16.3.0
       name: RELEASE-NAME-teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-mattermost-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-mattermost-16.3.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-mattermost-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-mattermost-16.3.0
         spec:
           containers:
           - command:
@@ -75,8 +75,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-mattermost-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-mattermost-16.3.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should mount external secret:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-mattermost-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-mattermost-16.3.0
         spec:
           containers:
           - command:
@@ -102,7 +102,7 @@ should mount external secret:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:16.2.2
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:16.3.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -143,8 +143,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-mattermost-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-mattermost-16.3.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -158,8 +158,8 @@ should override volume name:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-mattermost-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-mattermost-16.3.0
         spec:
           containers:
           - command:
@@ -170,7 +170,7 @@ should override volume name:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:16.2.2
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:16.3.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/examples/chart/access/msteams/Chart.yaml
+++ b/examples/chart/access/msteams/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "16.2.2"
+.version: &version "16.3.0"
 
 apiVersion: v2
 name: teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
@@ -29,6 +29,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-msteams-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-msteams-16.3.0
       name: RELEASE-NAME-teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-msteams-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-msteams-16.3.0
       name: RELEASE-NAME-teleport-plugin-msteams
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-msteams
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-msteams-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-msteams-16.3.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/pagerduty/Chart.yaml
+++ b/examples/chart/access/pagerduty/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "16.2.2"
+.version: &version "16.3.0"
 
 apiVersion: v2
 name: teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -21,6 +21,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-pagerduty-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-pagerduty-16.3.0
       name: RELEASE-NAME-teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-pagerduty-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-pagerduty-16.3.0
       name: RELEASE-NAME-teleport-plugin-pagerduty
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-pagerduty
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-pagerduty-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-pagerduty-16.3.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/slack/Chart.yaml
+++ b/examples/chart/access/slack/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "16.2.2"
+.version: &version "16.3.0"
 
 apiVersion: v2
 name: teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-slack-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-slack-16.3.0
       name: RELEASE-NAME-teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-slack-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-slack-16.3.0
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-plugin-slack-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-plugin-slack-16.3.0
         spec:
           containers:
           - command:

--- a/examples/chart/event-handler/Chart.yaml
+++ b/examples/chart/event-handler/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "16.2.2"
+.version: &version "16.3.0"
 
 apiVersion: v2
 name: teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-event-handler-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-event-handler-16.3.0
       name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-plugin-event-handler-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-plugin-event-handler-16.3.0
       name: RELEASE-NAME-teleport-plugin-event-handler
     spec:
       replicas: 1
@@ -82,7 +82,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:16.2.2
+      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:16.3.0
       imagePullPolicy: IfNotPresent
       name: teleport-plugin-event-handler
       ports:

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "16.2.2"
+.version: &version "16.3.0"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "16.2.2"
+.version: &version "16.3.0"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
@@ -8,8 +8,8 @@ adds operator permissions to ClusterRole:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-cluster-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-cluster-16.3.0
         teleport.dev/majorVersion: "16"
       name: RELEASE-NAME
     rules:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -1848,8 +1848,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-cluster-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-cluster-16.3.0
         teleport.dev/majorVersion: "16"
       name: RELEASE-NAME-auth
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -8,7 +8,7 @@
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -141,7 +141,7 @@ should set nodeSelector when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -238,7 +238,7 @@ should set resources when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -324,7 +324,7 @@ should set securityContext when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -567,8 +567,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-cluster-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-cluster-16.3.0
         teleport.dev/majorVersion: "16"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -11,8 +11,8 @@ sets clusterDomain on Deployment Pods:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 16.2.2
-        helm.sh/chart: teleport-cluster-16.2.2
+        app.kubernetes.io/version: 16.3.0
+        helm.sh/chart: teleport-cluster-16.3.0
         teleport.dev/majorVersion: "16"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE
@@ -26,7 +26,7 @@ sets clusterDomain on Deployment Pods:
       template:
         metadata:
           annotations:
-            checksum/config: 0b2aa0de04ab5ea6b072bad8387188c0f05d89253add6fc5e62b2ccbaad64f83
+            checksum/config: bb453307e8e4c566f71e6b6ca7143e0038c2ec046becf1f57caf60b358d0e8cb
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -34,8 +34,8 @@ sets clusterDomain on Deployment Pods:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-cluster
-            app.kubernetes.io/version: 16.2.2
-            helm.sh/chart: teleport-cluster-16.2.2
+            app.kubernetes.io/version: 16.3.0
+            helm.sh/chart: teleport-cluster-16.3.0
             teleport.dev/majorVersion: "16"
         spec:
           affinity:
@@ -44,7 +44,7 @@ sets clusterDomain on Deployment Pods:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
-            image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+            image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -105,7 +105,7 @@ sets clusterDomain on Deployment Pods:
             - wait
             - no-resolve
             - RELEASE-NAME-auth-v15.NAMESPACE.svc.test.com
-            image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+            image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
             name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
@@ -137,7 +137,7 @@ should provision initContainer correctly when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v15.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       name: wait-auth-update
       resources:
         limits:
@@ -201,7 +201,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -262,7 +262,7 @@ should set nodeSelector when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v15.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       name: wait-auth-update
     nodeSelector:
       environment: security
@@ -313,7 +313,7 @@ should set resources for wait-auth-update initContainer when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -381,7 +381,7 @@ should set resources for wait-auth-update initContainer when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v15.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       name: wait-auth-update
       resources:
         limits:
@@ -421,7 +421,7 @@ should set resources when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -489,7 +489,7 @@ should set resources when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v15.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       name: wait-auth-update
       resources:
         limits:
@@ -529,7 +529,7 @@ should set securityContext for initContainers when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -597,7 +597,7 @@ should set securityContext for initContainers when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v15.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false
@@ -637,7 +637,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -705,7 +705,7 @@ should set securityContext when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v15.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "16.2.2"
+.version: &version "16.3.0"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -32,7 +32,7 @@ sets Deployment annotations when specified if action is Upgrade:
               value: "true"
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+            image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -109,7 +109,7 @@ sets Deployment labels when specified if action is Upgrade:
             value: "true"
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-          image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+          image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -173,7 +173,7 @@ sets Pod annotations when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -237,7 +237,7 @@ sets Pod labels when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -322,7 +322,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -387,7 +387,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -451,7 +451,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -513,7 +513,7 @@ should expose diag port if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -589,7 +589,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -665,7 +665,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -729,7 +729,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -793,7 +793,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -862,7 +862,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf an
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -932,7 +932,7 @@ should mount jamfCredentialsSecret.name when role is jamf and action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1004,7 +1004,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1078,7 +1078,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1148,7 +1148,7 @@ should provision initContainer correctly when set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1270,7 +1270,7 @@ should set affinity when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1334,7 +1334,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1411,7 +1411,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1539,7 +1539,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1603,7 +1603,7 @@ should set nodeSelector if set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1669,7 +1669,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1745,7 +1745,7 @@ should set preferred affinity when more than one replica is used if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1809,7 +1809,7 @@ should set priorityClassName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1874,7 +1874,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1948,7 +1948,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2012,7 +2012,7 @@ should set resources when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2083,7 +2083,7 @@ should set serviceAccountName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2147,7 +2147,7 @@ should set tolerations when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -108,7 +108,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+            image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
             imagePullPolicy: IfNotPresent
             name: post-delete-job
             securityContext:
@@ -138,7 +138,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -168,7 +168,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -18,7 +18,7 @@ sets Pod annotations when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -90,7 +90,7 @@ sets Pod labels when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -186,7 +186,7 @@ sets StatefulSet labels when specified:
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+            image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -290,7 +290,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -362,7 +362,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -454,7 +454,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+            image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -536,7 +536,7 @@ should add volumeMount for data volume when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -608,7 +608,7 @@ should expose diag port:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -680,7 +680,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -766,7 +766,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -850,7 +850,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -922,7 +922,7 @@ should have one replica when replicaCount is not set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -994,7 +994,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1068,7 +1068,7 @@ should mount extraVolumes and extraVolumeMounts:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1145,7 +1145,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1225,7 +1225,7 @@ should mount jamfCredentialsSecret.name when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1307,7 +1307,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1391,7 +1391,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1471,7 +1471,7 @@ should not add emptyDir for data when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1543,7 +1543,7 @@ should provision initContainer correctly when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1673,7 +1673,7 @@ should set affinity when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1745,7 +1745,7 @@ should set default serviceAccountName when not set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1830,7 +1830,7 @@ should set environment when extraEnv set in values:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1974,7 +1974,7 @@ should set imagePullPolicy when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -2046,7 +2046,7 @@ should set nodeSelector if set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2132,7 +2132,7 @@ should set preferred affinity when more than one replica is used:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2204,7 +2204,7 @@ should set probeTimeoutSeconds when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2286,7 +2286,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2358,7 +2358,7 @@ should set resources when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2437,7 +2437,7 @@ should set serviceAccountName when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2509,7 +2509,7 @@ should set storage.requests when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2581,7 +2581,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2653,7 +2653,7 @@ should set tolerations when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.2.2
+      image: public.ecr.aws/gravitational/teleport-distroless:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:16.2.2
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -73,7 +73,7 @@ sets the tolerations:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:16.2.2
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:16.3.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6


### PR DESCRIPTION
## 16.3.0 (09/11/2024)

### Out-of-band user creation

Cluster administrators are now able to configure Teleport's `ssh_service` to
ensure that certain host users exist on the machine without the need to start
an SSH session. [#46498](https://github.com/gravitational/teleport/pull/46498)

### Other improvements and fixes

* Allow the cluster wide ssh dial timeout to be set via `auth_service.ssh_dial_timeout` in the Teleport config file. [#46507](https://github.com/gravitational/teleport/pull/46507)
* Fixed an issue preventing session joining while host user creation was in use. [#46501](https://github.com/gravitational/teleport/pull/46501)
* Added tbot Helm chart for deploying a Machine ID Bot into a Teleport cluster. [#46373](https://github.com/gravitational/teleport/pull/46373)
