### PR TITLE
docs: expand troubleshooting section on clock drift

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -911,6 +911,7 @@
     "thisisunsafe",
     "thred",
     "timechart",
+    "timedatectl",
     "timekey",
     "tlscacerts",
     "tlscert",

--- a/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
@@ -354,12 +354,18 @@ connections.
 Make sure that you [configure a certificate for RDP
 connections](./active-directory.mdx#step-47-configure-a-certificate-for-rdp-connections).
 
-### Expired smartcard certificate
+### Errors stemming from system clock drift
 
-The login screen displays an error of the form:
+Expired smartcard certificate - The login screen displays an error of the form:
 
-```
+```text
 The smartcard certificate used for authentication has expired. Please contact your system administrator.
+```
+
+Or if this error is displayed in the Web UI before a remote session is opened to your desktop of choice:
+
+```text
+Remote error tls expired certificate
 ```
 
 **Solution:** Check the system clock
@@ -368,6 +374,28 @@ Teleport's smartcard certificates are only valid for a short period of time
 (roughly 5 minutes). If the system clock on the Teleport auth server and the
 target Windows host disagree about the current time, the system may reject the
 authentication attempt.
+
+After addressing the system clock synchronization on Windows, this should be checked on the Auth
+Service instance. On Linux systems running systemd, this can be checked with the following command:
+
+```code
+$ timedatectl
+```
+
+Which should produce the following output:
+
+```
+               Local time: Wed 2024-09-11 13:45:17 UTC
+           Universal time: Wed 2024-09-11 13:45:17 UTC
+                 RTC time: Wed 2024-09-11 13:45:17
+                Time zone: Etc/UTC (UTC, +0000)
+System clock synchronized: yes
+              NTP service: active
+          RTC in local TZ: no
+```
+
+If `System clock synchronized` is `no`, this would need to be resolved.
+This should also be checked on your Teleport proxies and Teleport agents to get ahead of other issues which relate to system clock drift.
 
 ### Enhanced RDP security with CredSSP required
 

--- a/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
@@ -395,7 +395,7 @@ System clock synchronized: yes
 ```
 
 If `System clock synchronized` is `no`, this would need to be resolved.
-This should also be checked on your Teleport proxies and Teleport agents to get ahead of other issues which relate to system clock drift.
+This should also be checked on your Teleport Proxy Service instances and Teleport Agents to get ahead of other issues which relate to system clock drift.
 
 ### Enhanced RDP security with CredSSP required
 

--- a/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
@@ -5,6 +5,63 @@ description: Common issues and resolutions for Teleport's desktop access
 
 Common issues and resolution steps.
 
+## Certificate expired or not yet valid
+
+In order for remote desktop access to work correctly, certificates issued by
+Teleport must be validated by several different components. If these components
+do not agree what the current time is, then you will likely encounter
+certificate validation errors which prevent Teleport from working correctly.
+
+These errors can manifest in several different ways depending on which system(s)
+have an incorrect system clock.
+
+For example, you may see that Teleport starts a remote desktop session, but that
+the login screen on the remote desktop shows an error similar to:
+
+```text
+The smartcard certificate used for authentication has expired. Please contact your system administrator.
+```
+
+Alternatively, you may see an error in the Teleport web UI before the remote desktop connection
+is established:
+
+```text
+Remote error tls expired certificate
+```
+
+**Solution:** Check the system clock on all systems
+
+In order to fix these issues, it is important for the system clocks on the
+following components to be synchronized:
+- the Teleport Auth Service
+- the Teleport Proxy Service
+- the Teleport Windows Desktop Service
+- the target Windows hosts
+
+We recommend using NTP on these systems to ensure that the system clock remains
+accurate. On Linux systems running systemd, you can verify the system clock
+settings with the following command:
+
+```code
+$ timedatectl
+```
+
+The following is an example of a correctly configured system:
+
+```
+               Local time: Wed 2024-09-11 13:45:17 UTC
+           Universal time: Wed 2024-09-11 13:45:17 UTC
+                 RTC time: Wed 2024-09-11 13:45:17
+                Time zone: Etc/UTC (UTC, +0000)
+System clock synchronized: yes
+              NTP service: active
+          RTC in local TZ: no
+```
+
+In this example, you can see that NTP service is marked active and that the
+system clock is synchronized. If your output differs from the above then your
+clock settings may need to be reconfigured.
+
 ## Auto-login does not work
 
 ### Smart card service not running
@@ -353,49 +410,6 @@ connections.
 
 Make sure that you [configure a certificate for RDP
 connections](./active-directory.mdx#step-47-configure-a-certificate-for-rdp-connections).
-
-### Errors stemming from system clock drift
-
-Expired smartcard certificate - The login screen displays an error of the form:
-
-```text
-The smartcard certificate used for authentication has expired. Please contact your system administrator.
-```
-
-Or if this error is displayed in the Web UI before a remote session is opened to your desktop of choice:
-
-```text
-Remote error tls expired certificate
-```
-
-**Solution:** Check the system clock
-
-Teleport's smartcard certificates are only valid for a short period of time
-(roughly 5 minutes). If the system clock on the Teleport auth server and the
-target Windows host disagree about the current time, the system may reject the
-authentication attempt.
-
-After addressing the system clock synchronization on Windows, this should be checked on the Auth
-Service instance. On Linux systems running systemd, this can be checked with the following command:
-
-```code
-$ timedatectl
-```
-
-Which should produce the following output:
-
-```
-               Local time: Wed 2024-09-11 13:45:17 UTC
-           Universal time: Wed 2024-09-11 13:45:17 UTC
-                 RTC time: Wed 2024-09-11 13:45:17
-                Time zone: Etc/UTC (UTC, +0000)
-System clock synchronized: yes
-              NTP service: active
-          RTC in local TZ: no
-```
-
-If `System clock synchronized` is `no`, this would need to be resolved.
-This should also be checked on your Teleport Proxy Service instances and Teleport Agents to get ahead of other issues which relate to system clock drift.
 
 ### Enhanced RDP security with CredSSP required
 

--- a/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
@@ -22,7 +22,7 @@ the login screen on the remote desktop shows an error similar to:
 The smartcard certificate used for authentication has expired. Please contact your system administrator.
 ```
 
-Alternatively, you may see an error in the Teleport web UI before the remote desktop connection
+Alternatively, you may see an error in the Teleport Web UI before the remote desktop connection
 is established:
 
 ```text


### PR DESCRIPTION
Duplicate/alternative-to #46487 

We have another case of system-clock related issue which happens if the auth server instance is out of sync.
@zmb3 suggested we bundle the previous Windows system clock issue together with this one.