### PR TITLE
Adding reference for `create_host_user_default_shell` role option

### DIFF
--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -101,10 +101,14 @@ spec:
        mode: extension
        name: login@github.com
        value: '{{ external.github_login }}'
-    # Controls whether this role supports auto provisioning of SSH users.
+    # Controls whether this role supports auto-provisioning of SSH users.
     # Options: keep (keep users at session end), insecure-drop (remove user on session end),
     #          and off (disable host user creation)
     create_host_user_mode: keep
+    # Sets the default shell for auto-provisioned SSH users. An absolute path to a shell or a name
+    # reachable through the system PATH are both valid values. Only applies when
+    # create_host_user_mode is not set to off.
+    create_host_user_default_shell: bash
     # Controls whether this role requires automatic database user provisioning.
     # Options: off (disable database user auto-provisioning), keep (disables the
     # user at session end, removing the roles and locking it), and


### PR DESCRIPTION
Documentation for #46539

Adding a reference for `create_host_user_default_shell` to the role spec.
