### PR TITLE
Remove access-graph path resolution, proxy `/enterprise` requests

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,6 @@
       "e-teleport/*": ["e/web/teleport/src/*"],
       "gen-proto-js/*": ["gen/proto/js/*"],
       "gen-proto-ts/*": ["gen/proto/ts/*"],
-      "access-graph": ["e/web/teleport/src/AccessGraph/Loader.tsx"],
     }
   },
   "include": [

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -162,6 +162,11 @@ export function createViteConfig(
           changeOrigin: true,
           secure: false,
         },
+        '/enterprise': {
+          target: `https://${target}`,
+          changeOrigin: true,
+          secure: false,
+        },
       };
       if (process.env.VITE_HTTPS_KEY && process.env.VITE_HTTPS_CERT) {
         config.server.https = {


### PR DESCRIPTION
This removes the `access-graph` module from `tsconfig.json` (not needed anymore - https://github.com/gravitational/teleport.e/pull/5016)

Also changes Vite to proxy `/enterprise` requests to the proxy