### PR TITLE
[16.2.2] Bump cloud docs

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -128,7 +128,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "16.2.0",
+      "version": "16.2.2",
       "major_version": "16",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Bumps doc version after platform upgrade to 16.2.2 has completed.