### PR TITLE
Update HeartbeatV2Config.GetResource to be fallible

### DIFF
--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -400,8 +400,10 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	for _, app := range apps {
 		select {
 		case sender := <-inventoryHandle.Sender():
+			appServer, err := s.appServer.getServerInfo(app)
+			require.NoError(t, err)
 			require.NoError(t, sender.Send(s.closeContext, proto.InventoryHeartbeat{
-				AppServer: s.appServer.getServerInfo(app),
+				AppServer: appServer,
 			}))
 		case <-time.After(20 * time.Second):
 			t.Fatal("timed out waiting for inventory handle sender")

--- a/lib/srv/heartbeatv2.go
+++ b/lib/srv/heartbeatv2.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -46,7 +47,7 @@ type HeartbeatV2Config[T any] struct {
 	// InventoryHandle is used to send heartbeats.
 	InventoryHandle inventory.DownstreamHandle
 	// GetResource gets the latest item to heartbeat.
-	GetResource func() T
+	GetResource func(context.Context) (T, error)
 
 	// -- below values are all optional
 
@@ -87,8 +88,11 @@ func NewSSHServerHeartbeat(cfg HeartbeatV2Config[*types.ServerV2]) (*HeartbeatV2
 		getMetadata: metadata.Get,
 		announcer:   cfg.Announcer,
 	}
-	inner.getServer = func(ctx context.Context) *types.ServerV2 {
-		server := cfg.GetResource()
+	inner.getServer = func(ctx context.Context) (*types.ServerV2, error) {
+		server, err := cfg.GetResource(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 
 		doneCtx, cancel := context.WithCancel(ctx)
 		cancel() // not a typo
@@ -98,7 +102,7 @@ func NewSSHServerHeartbeat(cfg HeartbeatV2Config[*types.ServerV2]) (*HeartbeatV2
 			server.SetCloudMetadata(meta.CloudMetadata)
 		}
 
-		return server
+		return server, nil
 	}
 
 	return newHeartbeatV2(cfg.InventoryHandle, inner, heartbeatV2Config{
@@ -117,7 +121,7 @@ func NewAppServerHeartbeat(cfg HeartbeatV2Config[*types.AppServerV3]) (*Heartbea
 	}
 
 	inner := &appServerHeartbeatV2{
-		getServer: func(ctx context.Context) *types.AppServerV3 { return cfg.GetResource() },
+		getServer: cfg.GetResource,
 		announcer: cfg.Announcer,
 	}
 
@@ -137,7 +141,7 @@ func NewDatabaseServerHeartbeat(cfg HeartbeatV2Config[*types.DatabaseServerV3]) 
 	}
 
 	inner := &dbServerHeartbeatV2{
-		getServer: func(ctx context.Context) *types.DatabaseServerV3 { return cfg.GetResource() },
+		getServer: cfg.GetResource,
 		announcer: cfg.Announcer,
 	}
 
@@ -507,7 +511,7 @@ type metadataGetter func(ctx context.Context) (*metadata.Metadata, error)
 
 // sshServerHeartbeatV2 is the heartbeatV2 implementation for ssh servers.
 type sshServerHeartbeatV2 struct {
-	getServer   func(ctx context.Context) *types.ServerV2
+	getServer   func(ctx context.Context) (*types.ServerV2, error)
 	getMetadata metadataGetter
 	announcer   authclient.Announcer
 	prev        *types.ServerV2
@@ -517,7 +521,13 @@ func (h *sshServerHeartbeatV2) Poll(ctx context.Context) (changed bool) {
 	if h.prev == nil {
 		return true
 	}
-	return services.CompareServers(h.getServer(ctx), h.prev) == services.Different
+
+	server, err := h.getServer(ctx)
+	if err != nil {
+		return false
+	}
+
+	return services.CompareServers(server, h.prev) == services.Different
 }
 
 func (h *sshServerHeartbeatV2) SupportsFallback() bool {
@@ -528,22 +538,29 @@ func (h *sshServerHeartbeatV2) FallbackAnnounce(ctx context.Context) (ok bool) {
 	if h.announcer == nil {
 		return false
 	}
-	server := h.getServer(ctx)
-	_, err := h.announcer.UpsertNode(ctx, server)
+	server, err := h.getServer(ctx)
 	if err != nil {
 		log.Warnf("Failed to perform fallback heartbeat for ssh server: %v", err)
 		return false
 	}
+
+	if _, err := h.announcer.UpsertNode(ctx, server); err != nil {
+		log.Warnf("Failed to perform fallback heartbeat for ssh server: %v", err)
+		return false
+	}
+
 	h.prev = server
 	return true
 }
 
 func (h *sshServerHeartbeatV2) Announce(ctx context.Context, sender inventory.DownstreamSender) (ok bool) {
-	server := h.getServer(ctx)
-	err := sender.Send(ctx, proto.InventoryHeartbeat{
-		SSHServer: h.getServer(ctx),
-	})
+	server, err := h.getServer(ctx)
 	if err != nil {
+		log.Warnf("Failed to perform inventory heartbeat for ssh server: %v", err)
+		return false
+	}
+
+	if err := sender.Send(ctx, proto.InventoryHeartbeat{SSHServer: apiutils.CloneProtoMsg(server)}); err != nil {
 		log.Warnf("Failed to perform inventory heartbeat for ssh server: %v", err)
 		return false
 	}
@@ -553,7 +570,7 @@ func (h *sshServerHeartbeatV2) Announce(ctx context.Context, sender inventory.Do
 
 // appServerHeartbeatV2 is the heartbeatV2 implementation for app servers.
 type appServerHeartbeatV2 struct {
-	getServer func(ctx context.Context) *types.AppServerV3
+	getServer func(ctx context.Context) (*types.AppServerV3, error)
 	announcer authclient.Announcer
 	prev      *types.AppServerV3
 }
@@ -562,7 +579,13 @@ func (h *appServerHeartbeatV2) Poll(ctx context.Context) (changed bool) {
 	if h.prev == nil {
 		return true
 	}
-	return services.CompareServers(h.getServer(ctx), h.prev) == services.Different
+
+	server, err := h.getServer(ctx)
+	if err != nil {
+		return false
+	}
+
+	return services.CompareServers(server, h.prev) == services.Different
 }
 
 func (h *appServerHeartbeatV2) SupportsFallback() bool {
@@ -573,9 +596,13 @@ func (h *appServerHeartbeatV2) FallbackAnnounce(ctx context.Context) (ok bool) {
 	if h.announcer == nil {
 		return false
 	}
-	server := h.getServer(ctx)
-	_, err := h.announcer.UpsertApplicationServer(ctx, server)
+	server, err := h.getServer(ctx)
 	if err != nil {
+		log.Warnf("Failed to perform fallback heartbeat for app server: %v", err)
+		return false
+	}
+
+	if _, err := h.announcer.UpsertApplicationServer(ctx, server); err != nil {
 		if !errors.Is(err, context.Canceled) && status.Code(err) != codes.Canceled {
 			log.Warnf("Failed to perform fallback heartbeat for app server: %v", err)
 		}
@@ -597,8 +624,13 @@ func (h *appServerHeartbeatV2) Announce(ctx context.Context, sender inventory.Do
 		return h.FallbackAnnounce(ctx)
 	}
 
-	server := h.getServer(ctx)
-	if err := sender.Send(ctx, proto.InventoryHeartbeat{AppServer: h.getServer(ctx)}); err != nil {
+	server, err := h.getServer(ctx)
+	if err != nil {
+		log.Warnf("Failed to perform inventory heartbeat for app server: %v", err)
+		return false
+	}
+
+	if err := sender.Send(ctx, proto.InventoryHeartbeat{AppServer: apiutils.CloneProtoMsg(server)}); err != nil {
 		if !errors.Is(err, context.Canceled) && status.Code(err) != codes.Canceled {
 			log.Warnf("Failed to perform inventory heartbeat for app server: %v", err)
 		}
@@ -611,7 +643,7 @@ func (h *appServerHeartbeatV2) Announce(ctx context.Context, sender inventory.Do
 
 // dbServerHeartbeatV2 is the heartbeatV2 implementation for db servers.
 type dbServerHeartbeatV2 struct {
-	getServer func(ctx context.Context) *types.DatabaseServerV3
+	getServer func(ctx context.Context) (*types.DatabaseServerV3, error)
 	announcer authclient.Announcer
 	prev      *types.DatabaseServerV3
 }
@@ -620,7 +652,13 @@ func (h *dbServerHeartbeatV2) Poll(ctx context.Context) (changed bool) {
 	if h.prev == nil {
 		return true
 	}
-	return services.CompareServers(h.getServer(ctx), h.prev) == services.Different
+
+	server, err := h.getServer(ctx)
+	if err != nil {
+		return false
+	}
+
+	return services.CompareServers(server, h.prev) == services.Different
 }
 
 func (h *dbServerHeartbeatV2) SupportsFallback() bool {
@@ -631,9 +669,12 @@ func (h *dbServerHeartbeatV2) FallbackAnnounce(ctx context.Context) (ok bool) {
 	if h.announcer == nil {
 		return false
 	}
-	server := h.getServer(ctx)
-	_, err := h.announcer.UpsertDatabaseServer(ctx, server)
+	server, err := h.getServer(ctx)
 	if err != nil {
+		log.Warnf("Failed to perform fallback heartbeat for database server: %v", err)
+		return false
+	}
+	if _, err := h.announcer.UpsertDatabaseServer(ctx, server); err != nil {
 		if !errors.Is(err, context.Canceled) && status.Code(err) != codes.Canceled {
 			log.Warnf("Failed to perform fallback heartbeat for database server: %v", err)
 		}
@@ -655,8 +696,12 @@ func (h *dbServerHeartbeatV2) Announce(ctx context.Context, sender inventory.Dow
 		return h.FallbackAnnounce(ctx)
 	}
 
-	server := h.getServer(ctx)
-	if err := sender.Send(ctx, proto.InventoryHeartbeat{DatabaseServer: h.getServer(ctx)}); err != nil {
+	server, err := h.getServer(ctx)
+	if err != nil {
+		log.Warnf("Failed to perform inventory heartbeat for database server: %v", err)
+		return false
+	}
+	if err := sender.Send(ctx, proto.InventoryHeartbeat{DatabaseServer: apiutils.CloneProtoMsg(server)}); err != nil {
 		if !errors.Is(err, context.Canceled) && status.Code(err) != codes.Canceled {
 			log.Warnf("Failed to perform inventory heartbeat for database server: %v", err)
 		}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1093,7 +1093,7 @@ func (s *Server) getBasicInfo() *types.ServerV2 {
 	return srv
 }
 
-func (s *Server) getServerInfo() *types.ServerV2 {
+func (s *Server) getServerInfo(context.Context) (*types.ServerV2, error) {
 	server := s.getBasicInfo()
 	if s.getRotation != nil {
 		rotation, err := s.getRotation(s.getRole())
@@ -1108,11 +1108,11 @@ func (s *Server) getServerInfo() *types.ServerV2 {
 
 	server.SetExpiry(s.clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL))
 	server.SetPeerAddr(s.peerAddr)
-	return server
+	return server, nil
 }
 
 func (s *Server) getServerResource() (types.Resource, error) {
-	return s.getServerInfo(), nil
+	return s.getServerInfo(s.ctx)
 }
 
 // dialTCPIP dials the given tcpip address through the network process.

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -257,7 +257,9 @@ func newCustomFixture(t testing.TB, mutateCfg func(*auth.TestServerConfig), sshO
 		sshSrv.Wait()
 	})
 
-	_, err = testServer.Auth().UpsertNode(ctx, sshSrv.getServerInfo())
+	server, err := sshSrv.getServerInfo(ctx)
+	require.NoError(t, err)
+	_, err = testServer.Auth().UpsertNode(ctx, server)
 	require.NoError(t, err)
 
 	sshSrvAddress := sshSrv.Addr()


### PR DESCRIPTION
Up until now, the resources converted to srv.HeartbbeatV2 have not been fallible. However, in order to support KubernetesServer resources, which rely on external factors to populate the resource, the GetResource function needs to be updated to return an error.