### PR TITLE
Always show the green shield for authenticated devices

### DIFF
--- a/web/packages/teleport/src/TopBar/DeviceTrustStatus.tsx
+++ b/web/packages/teleport/src/TopBar/DeviceTrustStatus.tsx
@@ -47,7 +47,7 @@ function getDeviceTrustStatusKind(
   deviceTrusted: boolean,
   deviceTrustRequired: boolean
 ): DeviceTrustStatusKind {
-  if (deviceTrustRequired && deviceTrusted) {
+  if (deviceTrusted) {
     return 'authorized';
   }
   if (deviceTrustRequired) {

--- a/web/packages/teleport/src/TopBar/TopBar.test.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.test.tsx
@@ -159,6 +159,17 @@ test('authorized icon will show if session is authorized', async () => {
   expect(screen.getAllByTestId('device-trusted-icon')).toHaveLength(2);
 });
 
+test('authorized icon will show regardless of device requirements', async () => {
+  setup();
+  jest.spyOn(session, 'getDeviceTrustRequired').mockImplementation(() => false);
+  jest.spyOn(session, 'getIsDeviceTrusted').mockImplementation(() => true);
+
+  render(getTopBar());
+
+  // the icon will show in the topbar and the usermenunav dropdown
+  expect(screen.getAllByTestId('device-trusted-icon')).toHaveLength(2);
+});
+
 test('icon will not show if device trust is not required', async () => {
   setup();
   jest.spyOn(session, 'getDeviceTrustRequired').mockImplementation(() => false);


### PR DESCRIPTION
Show the green shield if the user performed successful device web authentication, regardless of the device trust requirements.

An authenticated device does affect audit, regardless of cluster requirements. Showing the shield also gives feedback to the user about the extra steps they took.

Changelog: Always show the device trust green shield for authenticated devices
