### PR TITLE
Log calculated TrustedDeviceRequirement

### DIFF
--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
@@ -368,6 +369,14 @@ func (a *Server) newWebSession(
 			Warn("Failed to calculate trusted device mode for session")
 	} else {
 		sess.SetTrustedDeviceRequirement(tdr)
+
+		if tdr != types.TrustedDeviceRequirement_TRUSTED_DEVICE_REQUIREMENT_UNSPECIFIED {
+			log.WithFields(logrus.Fields{
+				"session":                    sess.GetName(),
+				"user":                       req.User,
+				"trusted_device_requirement": tdr,
+			}).Debug("Calculated trusted device requirement for session")
+		}
 	}
 
 	return sess, checker, nil

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -372,7 +372,6 @@ func (a *Server) newWebSession(
 
 		if tdr != types.TrustedDeviceRequirement_TRUSTED_DEVICE_REQUIREMENT_UNSPECIFIED {
 			log.WithFields(logrus.Fields{
-				"session":                    sess.GetName(),
 				"user":                       req.User,
 				"trusted_device_requirement": tdr,
 			}).Debug("Calculated trusted device requirement for session")


### PR DESCRIPTION
Log calculated trusted device requirements to assist with debugging.

We skip _UNSPECIFIED as that is not interesting, plus it avoids noise on OSS.