### PR TITLE
operator: Simpler and more powerful Mutate function

### DIFF
--- a/integrations/operator/controllers/reconcilers/generic.go
+++ b/integrations/operator/controllers/reconcilers/generic.go
@@ -179,7 +179,7 @@ func (r resourceReconciler[T, K]) Upsert(ctx context.Context, obj kclient.Object
 					Type:    ConditionTypeSuccessfullyReconciled,
 					Status:  metav1.ConditionFalse,
 					Reason:  ConditionReasonMutationError,
-					Message: fmt.Sprintf("The reconciliation failed, the operator failed to mutate the resource before creating it in Teleport. Mutatin failed with error: %s", err),
+					Message: fmt.Sprintf("The reconciliation failed, the operator failed to mutate the resource before creating it in Teleport. Mutation failed with error: %s", err),
 				},
 			})
 

--- a/integrations/operator/controllers/reconcilers/generic.go
+++ b/integrations/operator/controllers/reconcilers/generic.go
@@ -62,7 +62,7 @@ type KubernetesCR[T Resource] interface {
 // Implementing this interface allows to be reconciled by the resourceReconciler
 // instead of writing a new specific reconciliation loop.
 // resourceClient implementations can optionally implement the resourceMutator
-// and existingResourceMutator interfaces.
+// and resourceMutator interfaces.
 type resourceClient[T Resource] interface {
 	Get(context.Context, string) (T, error)
 	Create(context.Context, T) error
@@ -70,16 +70,10 @@ type resourceClient[T Resource] interface {
 	Delete(context.Context, string) error
 }
 
-// resourceMutator can be implemented by resourceClients
-// to edit a Resource before its creation/update.
+// resourceMutator can be implemented by TeleportResourceClients
+// to edit a Resource before its creation, or before its update based on the existing one.
 type resourceMutator[T Resource] interface {
-	Mutate(new T)
-}
-
-// existingResourceMutator can be implemented by TeleportResourceClients
-// to edit a Resource before its update based on the existing one.
-type existingResourceMutator[T Resource] interface {
-	MutateExisting(new, existing T)
+	Mutate(ctx context.Context, new, existing T, crKey kclient.ObjectKey) error
 }
 
 // resourceReconciler is a Teleport generic reconciler.
@@ -172,23 +166,35 @@ func (r resourceReconciler[T, K]) Upsert(ctx context.Context, obj kclient.Object
 	r.adapter.SetResourceLabels(teleportResource, teleportLabels)
 	debugLog.Info("Propagating labels from kube resource", "kubeLabels", kubeLabels, "teleportLabels", teleportLabels)
 
+	if mutator, ok := r.resourceClient.(resourceMutator[T]); ok {
+		debugLog.Info("Mutating resource")
+		objKey := kclient.ObjectKeyFromObject(k8sResource)
+		if err := mutator.Mutate(ctx, teleportResource, existingResource, objKey); err != nil {
+			// If an error happens we want to put it in status.conditions before returning.
+			updateErr = updateStatus(updateStatusConfig{
+				ctx:         ctx,
+				client:      r.Client,
+				k8sResource: k8sResource,
+				condition: metav1.Condition{
+					Type:    ConditionTypeSuccessfullyReconciled,
+					Status:  metav1.ConditionFalse,
+					Reason:  ConditionReasonMutationError,
+					Message: fmt.Sprintf("The reconciliation failed, the operator failed to mutate the resource before creating it in Teleport. Mutatin failed with error: %s", err),
+				},
+			})
+
+			return trace.NewAggregate(err, updateErr)
+		}
+	}
+
 	if !exists {
 		// This is a new Resource
-		if mutator, ok := r.resourceClient.(resourceMutator[T]); ok {
-			debugLog.Info("Mutating new resource")
-			mutator.Mutate(teleportResource)
-		}
-
 		err = r.resourceClient.Create(ctx, teleportResource)
 	} else {
 		// This is a Resource update, we must propagate the revision
 		currentRevision := r.adapter.GetResourceRevision(existingResource)
 		r.adapter.SetResourceRevision(teleportResource, currentRevision)
 		debugLog.Info("Propagating revision", "currentRevision", currentRevision)
-		if mutator, ok := r.resourceClient.(existingResourceMutator[T]); ok {
-			debugLog.Info("Mutating existing resource")
-			mutator.MutateExisting(teleportResource, existingResource)
-		}
 
 		err = r.resourceClient.Update(ctx, teleportResource)
 	}

--- a/integrations/operator/controllers/reconcilers/utils.go
+++ b/integrations/operator/controllers/reconcilers/utils.go
@@ -44,6 +44,7 @@ const (
 	ConditionReasonNewResource            = "NewResource"
 	ConditionReasonNoError                = "NoError"
 	ConditionReasonTeleportError          = "TeleportError"
+	ConditionReasonMutationError          = "MutationError"
 	ConditionTypeTeleportResourceOwned    = "TeleportResourceOwned"
 	ConditionTypeSuccessfullyReconciled   = "SuccessfullyReconciled"
 	ConditionTypeValidStructure           = "ValidStructure"

--- a/integrations/operator/controllers/resources/accesslist_controller.go
+++ b/integrations/operator/controllers/resources/accesslist_controller.go
@@ -57,11 +57,15 @@ func (r accessListClient) Delete(ctx context.Context, name string) error {
 	return trace.Wrap(r.teleportClient.AccessListClient().DeleteAccessList(ctx, name))
 }
 
-// MutateExisting propagates fields from the existing AccessList resource
+// Mutate propagates fields from the existing AccessList resource
 // to the one the operator will upsert. This allows propagating fields computed
 // server-side such as the NextAuditDate.
-func (r accessListClient) MutateExisting(new, existing *accesslist.AccessList) {
+func (r accessListClient) Mutate(_ context.Context, new, existing *accesslist.AccessList, crKey kclient.ObjectKey) error {
+	if existing == nil {
+		return nil
+	}
 	new.Spec.Audit.NextAuditDate = existing.Spec.Audit.NextAuditDate
+	return nil
 }
 
 // NewAccessListReconciler instantiates a new Kubernetes controller reconciling access_list resources

--- a/integrations/operator/controllers/resources/accesslist_controller.go
+++ b/integrations/operator/controllers/resources/accesslist_controller.go
@@ -60,7 +60,7 @@ func (r accessListClient) Delete(ctx context.Context, name string) error {
 // Mutate propagates fields from the existing AccessList resource
 // to the one the operator will upsert. This allows propagating fields computed
 // server-side such as the NextAuditDate.
-func (r accessListClient) Mutate(_ context.Context, new, existing *accesslist.AccessList, crKey kclient.ObjectKey) error {
+func (r accessListClient) Mutate(_ context.Context, new, existing *accesslist.AccessList, _ kclient.ObjectKey) error {
 	if existing == nil {
 		return nil
 	}

--- a/integrations/operator/controllers/resources/rolevX_controller.go
+++ b/integrations/operator/controllers/resources/rolevX_controller.go
@@ -34,7 +34,7 @@ import (
 
 // roleClient implements TeleportResourceClient and offers CRUD methods needed to reconcile roles
 // Currently the same client is used by all role versions. If we need to treat
-// them differently at some point, for example by introducing Mutate or MutateExisting
+// them differently at some point, for example by adding a Mutate function
 // functions, we can always split the client into separate clients.
 type roleClient struct {
 	teleportClient *client.Client

--- a/integrations/operator/controllers/resources/user_controller.go
+++ b/integrations/operator/controllers/resources/user_controller.go
@@ -59,11 +59,12 @@ func (r userClient) Delete(ctx context.Context, name string) error {
 	return trace.Wrap(r.teleportClient.DeleteUser(ctx, name))
 }
 
-// MutateExisting ensures the spec.createdBy property is persisted
-func (r userClient) MutateExisting(newUser, existingUser types.User) {
+// Mutate ensures the spec.createdBy property is persisted
+func (r userClient) Mutate(_ context.Context, newUser, existingUser types.User, _ kclient.ObjectKey) error {
 	if existingUser != nil {
 		newUser.SetCreatedBy(existingUser.GetCreatedBy())
 	}
+	return nil
 }
 
 // NewUserReconciler instantiates a new Kubernetes controller reconciling user resources


### PR DESCRIPTION
This PR is changing the operator mutation logic.

Before: we had `Mutate(new T)` (on Create), and `MutateExisting(old, new T)` (on Update).
After: we'll have a single `Mutate(ctx context.Context, old, new T, crKey kclient.ObjectKey)`

This change will allow us to:
- write a single mutator for both create and update (this will be very useful for looking up values from Kubernetes secrets, PR coming soon)
- have access to a context (to use a kube client)
- know the name and the namespace of the reconciled resource in the mutator (required if we want to lookup other kubernetes resources from the same namespace in the mutation hook)
- return Mutation errors and surface them in the resource status

Part of https://github.com/gravitational/teleport/issues/6815