### PR TITLE
Disable periodic functions that are not required for dashboards

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1367,6 +1367,14 @@ func (a *Server) runPeriodicOperations() {
 		go a.periodicSyncUpgradeWindowStartHour()
 	}
 
+	// disable periodics that are not required for cloud dashboard tenants
+	if services.IsDashboard(*modules.GetModules().Features().ToProto()) {
+		releaseCheck.Stop()
+		localReleaseCheck.Stop()
+		heartbeatCheckTicker.Stop()
+		dynamicLabelsCheck.Stop()
+	}
+
 	for {
 		select {
 		case <-a.closeCtx.Done():
@@ -1512,7 +1520,7 @@ const (
 )
 
 // syncReleaseAlerts calculates alerts related to new teleport releases. When checkRemote
-// is true it pulls the latest release info from github.  Otherwise, it loads the versions used
+// is true it pulls the latest release info from GitHub.  Otherwise, it loads the versions used
 // for the most recent alerts and re-syncs with latest cluster state.
 func (a *Server) syncReleaseAlerts(ctx context.Context, checkRemote bool) {
 	log.Debug("Checking for new teleport releases via github api.")


### PR DESCRIPTION
There's no need for our many dashboard tenants to periodically check for releases on GitHub (we keep these up to date automatically), check for nodes with missing heartbeats (there are no nodes allowed on dashboards), or to check for dynamic labels in deny rules (users don't get to create or edit roles in dashboards).