### PR TITLE
Stop leveraging product type

### DIFF
--- a/lib/httplib/httplib_test.go
+++ b/lib/httplib/httplib_test.go
@@ -296,7 +296,7 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 		},
 		{
 			name:     "for cloud based usage, EUB product (no wasm)",
-			features: proto.Features{Cloud: true, IsUsageBased: true, ProductType: proto.ProductType_PRODUCT_TYPE_EUB},
+			features: proto.Features{Cloud: true, IsUsageBased: true, IsStripeManaged: false},
 			urlPath:  "/web/index.js",
 			expectedCspVals: map[string]string{
 				"default-src":     "'self'",

--- a/lib/services/useracl.go
+++ b/lib/services/useracl.go
@@ -170,7 +170,7 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 	isUsageBased := features.IsUsageBased
 	isStripeManaged := features.IsStripeManaged
 
-	if features.Cloud || (isDashboard && (isUsageBased && !isStripeManaged)) {
+	if features.Cloud || (isDashboard && isUsageBased && !isStripeManaged) {
 		billingAccess = newAccess(userRoles, ctx, types.KindBilling)
 	}
 

--- a/lib/services/useracl.go
+++ b/lib/services/useracl.go
@@ -163,12 +163,14 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 		activeSessionAccess.Read = true
 	}
 
-	// The billing dashboards are available in cloud clusters or for
-	// self-hosted dashboards for usage-based subscriptions.
+	// The billing dashboards are available in: cloud clusters &
+	// usage-based self-hosted non-stripe dashboards.
 	var billingAccess ResourceAccess
 	isDashboard := IsDashboard(features)
-	isUsageBasedEnterprise := features.GetProductType() == proto.ProductType_PRODUCT_TYPE_EUB
-	if features.Cloud || (isDashboard && isUsageBasedEnterprise) {
+	isUsageBased := features.IsUsageBased
+	isStripeManaged := features.IsStripeManaged
+
+	if features.Cloud || (isDashboard && (isUsageBased && !isStripeManaged)) {
 		billingAccess = newAccess(userRoles, ctx, types.KindBilling)
 	}
 


### PR DESCRIPTION
`ProductType_PRODUCT_TYPE_EUB` is the equivalent of `IsUsageBased` && `!IsStripeManaged`; these fields are accessible in the `GRV_CONFIG` (helpful for debugging) and we should use them instead of deprecated product type checks.

related to: https://github.com/gravitational/teleport.e/pull/5020