### PR TITLE
operator: Add secretlookup library

### DIFF
--- a/integrations/operator/controllers/resources/secretlookup/secretlookup.go
+++ b/integrations/operator/controllers/resources/secretlookup/secretlookup.go
@@ -93,9 +93,6 @@ func Try(ctx context.Context, clt kclient.Client, name, namespace, uri string) (
 // explicitly allow the resource, or allow any resource ("*").
 func isInclusionAllowed(secret *corev1.Secret, name string) error {
 	secretName := secret.Name
-	if secret.Annotations == nil {
-		return trace.BadParameter("secret %q has no annotation", secretName)
-	}
 	annotation, ok := secret.Annotations[AllowInclusionAnnotation]
 	if !ok {
 		return trace.BadParameter("secret %q doesn't have the %q annotation", secretName, AllowInclusionAnnotation)

--- a/integrations/operator/controllers/resources/secretlookup/secretlookup.go
+++ b/integrations/operator/controllers/resources/secretlookup/secretlookup.go
@@ -1,0 +1,95 @@
+package secretlookup
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/gravitational/trace"
+	corev1 "k8s.io/api/core/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+const (
+	// secretScheme is the URI scheme for Kubernetes Secret Lookup
+	secretScheme = "secret"
+	secretPrefix = secretScheme + "://"
+
+	// AllowInclusionAnnotation is the annotation a secret must wear for the operator to allow looking up its content
+	// when reconciling a resource. Its value is either a comma-separated list of allowed resources, or a '*'.
+	AllowInclusionAnnotation = "resources.teleport.dev/allow-inclusion-from-cr"
+)
+
+// IsNeeded checks if a string starts with "secret://" and needs a secret lookup.
+func IsNeeded(value string) bool {
+	return strings.HasPrefix(value, secretPrefix)
+}
+
+// Try takes a URI such as "secret://secret-name/secret-key" and returns the data from the secret key.
+// To protect against someone abusing this to read from arbitrary secrets, the secret must be annotated with the
+// names of the CRs allowed to include it (or a wildcard).
+func Try(ctx context.Context, clt kclient.Client, name, namespace, uri string) (string, error) {
+	// Parse and check the URI
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	if u.Scheme != secretScheme {
+		return "", trace.BadParameter("invalid secret scheme %q", u.Scheme)
+	}
+
+	if u.Host == "" {
+		return "", trace.BadParameter("missing secret name")
+	}
+
+	if u.Path == "" {
+		return "", trace.BadParameter("missing secret key")
+	}
+	key := strings.TrimPrefix(u.Path, "/")
+
+	// Lookup the secret
+	secret := &corev1.Secret{}
+	if err := clt.Get(ctx, kclient.ObjectKey{Namespace: namespace, Name: u.Host}, secret); err != nil {
+		return "", trace.Wrap(err, "failed to lookup secret")
+	}
+
+	// Checking permission
+	if err := isInclusionAllowed(secret, name); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	secretData, ok := secret.Data[key]
+	if !ok {
+		return "", trace.BadParameter("secret %q is missing key %q", u.Host, key)
+	}
+
+	// Apparently we don't need to b64 decode ¯\_(ツ)_/¯
+	return string(secretData), nil
+}
+
+// isInclusionAllowed checks if the secret allows inclusion from the CR.
+// The secret must wear the AllowInclusionAnnotation and the annotation must either
+// explicitly allow the resource, or allow any resource ("*").
+func isInclusionAllowed(secret *corev1.Secret, name string) error {
+	secretName := secret.Name
+	if secret.Annotations == nil {
+		return trace.BadParameter("secret %q has no annotation", secretName)
+	}
+	annotation, ok := secret.Annotations[AllowInclusionAnnotation]
+	if !ok {
+		return trace.BadParameter("secret %q doesn't have the %q annotation", secretName, AllowInclusionAnnotation)
+	}
+	if annotation == types.Wildcard {
+		return nil
+	}
+	allowedCRs := strings.Split(annotation, ",")
+	for _, allowedCR := range allowedCRs {
+		if strings.TrimSpace(allowedCR) == name {
+			return nil
+		}
+	}
+	return trace.AccessDenied("secret %q have the annotation %q but it does not contain %q", secretName, AllowInclusionAnnotation, name)
+}

--- a/integrations/operator/controllers/resources/secretlookup/secretlookup.go
+++ b/integrations/operator/controllers/resources/secretlookup/secretlookup.go
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package secretlookup
 
 import (

--- a/integrations/operator/controllers/resources/secretlookup/secretlookup_test.go
+++ b/integrations/operator/controllers/resources/secretlookup/secretlookup_test.go
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package secretlookup
 
 import (

--- a/integrations/operator/controllers/resources/secretlookup/secretlookup_test.go
+++ b/integrations/operator/controllers/resources/secretlookup/secretlookup_test.go
@@ -20,7 +20,6 @@ package secretlookup
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"strings"
 	"testing"
@@ -39,8 +38,6 @@ func TestLookupSecret(t *testing.T) {
 	secretName := "test-secret"
 	keyName := "test-key-name"
 	keyValue := "test-key-value"
-	b64KeyValue := make([]byte, base64.StdEncoding.EncodedLen(len(keyValue)))
-	base64.StdEncoding.Encode(b64KeyValue, []byte(keyValue))
 
 	secretWithAnnotations := func(annotations map[string]string) v1.Secret {
 		return v1.Secret{
@@ -50,7 +47,7 @@ func TestLookupSecret(t *testing.T) {
 				Annotations: annotations,
 			},
 			Data: map[string][]byte{
-				keyName: b64KeyValue,
+				keyName: []byte(keyValue),
 			},
 			StringData: nil,
 			Type:       v1.SecretTypeOpaque,
@@ -104,7 +101,7 @@ func TestLookupSecret(t *testing.T) {
 			input:   fmt.Sprintf("secret://%s/%s", secretName, keyName),
 			secrets: v1.SecretList{Items: []v1.Secret{secretWithAnnotations(nil)}},
 			assertErr: func(t require.TestingT, err error, i ...interface{}) {
-				require.ErrorContains(t, err, "no annotation")
+				require.ErrorContains(t, err, "annotation")
 			},
 		},
 		{
@@ -127,7 +124,7 @@ func TestLookupSecret(t *testing.T) {
 							Annotations: okAnnotations,
 						},
 						Data: map[string][]byte{
-							"wrong-key-name": b64KeyValue,
+							"wrong-key-name": []byte(keyValue),
 						},
 						StringData: nil,
 						Type:       v1.SecretTypeOpaque,

--- a/integrations/operator/controllers/resources/secretlookup/secretlookup_test.go
+++ b/integrations/operator/controllers/resources/secretlookup/secretlookup_test.go
@@ -1,0 +1,237 @@
+package secretlookup
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestLookupSecret(t *testing.T) {
+	// Test setup: crafting fixtures
+	ctx := context.Background()
+	namespace := "foo"
+	crName := "test-cr-name"
+	secretName := "test-secret"
+	keyName := "test-key-name"
+	keyValue := "test-key-value"
+	b64KeyValue := make([]byte, base64.StdEncoding.EncodedLen(len(keyValue)))
+	base64.StdEncoding.Encode(b64KeyValue, []byte(keyValue))
+
+	secretWithAnnotations := func(annotations map[string]string) v1.Secret {
+		return v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        secretName,
+				Namespace:   namespace,
+				Annotations: annotations,
+			},
+			Data: map[string][]byte{
+				keyName: b64KeyValue,
+			},
+			StringData: nil,
+			Type:       v1.SecretTypeOpaque,
+		}
+	}
+	okAnnotations := map[string]string{AllowInclusionAnnotation: strings.Join([]string{"other-cr-name", crName}, ", ")}
+	okSecret := secretWithAnnotations(okAnnotations)
+
+	// Test setup: defining test cases
+	tests := []struct {
+		name      string
+		input     string
+		secrets   v1.SecretList
+		expect    string
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name:    "not an uri",
+			input:   "secret://How do you do, fellow kids?",
+			secrets: v1.SecretList{Items: []v1.Secret{okSecret}},
+			assertErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "parse")
+			},
+		},
+		{
+			name:    "uri does not contain secret name",
+			input:   fmt.Sprintf("secret:///%s", keyName),
+			secrets: v1.SecretList{Items: []v1.Secret{okSecret}},
+			assertErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "missing secret name")
+			},
+		},
+		{
+			name:    "uri does not contain secret key",
+			input:   fmt.Sprintf("secret://%s", secretName),
+			secrets: v1.SecretList{Items: []v1.Secret{okSecret}},
+			assertErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "missing secret key")
+			},
+		},
+		{
+			name:    "secret does not exist",
+			input:   fmt.Sprintf("secret://%s/%s", secretName, keyName),
+			secrets: v1.SecretList{Items: []v1.Secret{}},
+			assertErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "not found")
+			},
+		},
+		{
+			name:    "secret has no annotation",
+			input:   fmt.Sprintf("secret://%s/%s", secretName, keyName),
+			secrets: v1.SecretList{Items: []v1.Secret{secretWithAnnotations(nil)}},
+			assertErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "no annotation")
+			},
+		},
+		{
+			name:    "secret annotations don't allow inclusion",
+			input:   fmt.Sprintf("secret://%s/%s", secretName, keyName),
+			secrets: v1.SecretList{Items: []v1.Secret{secretWithAnnotations(map[string]string{AllowInclusionAnnotation: "not-the-right-cr"})}},
+			assertErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "does not contain")
+			},
+		},
+		{
+			name:  "secret is missing the key",
+			input: fmt.Sprintf("secret://%s/%s", secretName, keyName),
+			secrets: v1.SecretList{
+				Items: []v1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        secretName,
+							Namespace:   namespace,
+							Annotations: okAnnotations,
+						},
+						Data: map[string][]byte{
+							"wrong-key-name": b64KeyValue,
+						},
+						StringData: nil,
+						Type:       v1.SecretTypeOpaque,
+					},
+				},
+			},
+			assertErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "is missing key")
+			},
+		},
+		{
+			name:      "successful lookup",
+			input:     fmt.Sprintf("secret://%s/%s", secretName, keyName),
+			secrets:   v1.SecretList{Items: []v1.Secret{okSecret}},
+			expect:    keyValue,
+			assertErr: require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test setup: creating a mock with the fixtures
+			clientBuilder := fake.NewClientBuilder()
+			clientBuilder.WithLists(&tt.secrets)
+			fakeClient := clientBuilder.Build()
+
+			// Test execution
+			result, err := Try(ctx, fakeClient, crName, namespace, tt.input)
+			t.Log(err)
+			tt.assertErr(t, err)
+			require.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func Test_isInclusionAllowed(t *testing.T) {
+	crName := "test-cr-name"
+	tests := []struct {
+		name      string
+		secret    v1.Secret
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "No annotation",
+			secret: v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+			},
+			assertErr: require.Error,
+		},
+		{
+			name: "Missing inclusion annotation",
+			secret: v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+			assertErr: require.Error,
+		},
+		{
+			name: "Empty inclusion annotation",
+			secret: v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AllowInclusionAnnotation: "",
+					},
+				},
+			},
+			assertErr: require.Error,
+		},
+		{
+			name: "Not matching inclusion annotation",
+			secret: v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AllowInclusionAnnotation: "foo, bar",
+					},
+				},
+			},
+			assertErr: require.Error,
+		},
+		{
+			name: "Single-item matching annotation",
+			secret: v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AllowInclusionAnnotation: crName,
+					},
+				},
+			},
+			assertErr: require.NoError,
+		},
+		{
+			name: "Multi-item matching annotation",
+			secret: v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AllowInclusionAnnotation: strings.Join([]string{"foo", "bar", crName}, ", "),
+					},
+				},
+			},
+			assertErr: require.NoError,
+		},
+		{
+			name: "Wildcard annotation",
+			secret: v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AllowInclusionAnnotation: "*",
+					},
+				},
+			},
+			assertErr: require.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isInclusionAllowed(&tt.secret, crName)
+			tt.assertErr(t, result)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a library allowing the operator controllers to safely lookup values from Kubernetes secrets.

Coupled with https://github.com/gravitational/teleport/pull/46566 this will allow us to address https://github.com/gravitational/teleport/issues/6815.

## Security concerns

The operator will need the ability to read secrets from its namespace. As the operator might be deployed next to `teleport-cluster` or in administrative namespaces, this poses a security risk. Someone with rights to create CRs could ask the operator to exfiltrate the content of Kubernetes secrets living in its namespace.

To mitigate this, the operator will allow inclusion only if the secret explicitly allows it. The included secret must wear the `resources.teleport.dev/allow-inclusion-from-cr` annotation. This annotation contains the comma-separated list of the CRs allowed to read from this secret. A special value `*` allows to make the secret available to every CR.