### PR TITLE
Update Terraform Cloud joining minimum version

### DIFF
--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
@@ -19,10 +19,6 @@ dedicated guide:
   Terraform Cloud joining with self-hosted Terraform Enterprise requires
   Teleport Enterprise. Terraform Cloud joining with public HCP Terraform
   (https://app.terraform.io) is supported in Teleport Community Edition.
-
-  Additionally, note that Terraform Enterprise joining is currently in Preview.
-  Please reach out [Teleport support](https://goteleport.com/support) if you
-  encounter issues.
 </Admonition>
 
 When running the Teleport Terraform provider on Terraform Cloud, you can use its

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
@@ -19,6 +19,10 @@ dedicated guide:
   Terraform Cloud joining with self-hosted Terraform Enterprise requires
   Teleport Enterprise. Terraform Cloud joining with public HCP Terraform
   (https://app.terraform.io) is supported in Teleport Community Edition.
+
+  Additionally, note that Terraform Enterprise joining is currently in Preview.
+  Please reach out [Teleport support](https://goteleport.com/support) if you
+  encounter issues.
 </Admonition>
 
 When running the Teleport Terraform provider on Terraform Cloud, you can use its
@@ -55,7 +59,7 @@ provider in these environments.
 - An account and project on either the public Terraform Cloud SaaS or a
   Terraform Enterprise instance
 
-- The Teleport Terraform provider, v16.3.0 or later
+- The Teleport Terraform provider, v16.4.0 or later
 
 ## Step 1/4: Configure Terraform Cloud joining in Teleport
 


### PR DESCRIPTION
This updates the minimum required Teleport version for TF Cloud joining as its release was moved to v16.4