### PR TITLE
[v15] docs: bump cloud to 16.2.2

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -130,7 +130,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "16.1.7",
+      "version": "16.2.2",
       "major_version": "16",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Backport for https://github.com/gravitational/teleport/pull/46542