### PR TITLE
docs: update Teleport uninstall

### DIFF
--- a/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
@@ -3,7 +3,7 @@ title: Uninstall Teleport
 description: How to remove Teleport from your system
 ---
 
-This guide explains how to uninstall Teleport binaries completely.
+This guide explains how to uninstall Teleport installations completely including binaries, configurations and data.
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
@@ -3,7 +3,7 @@ title: Uninstall Teleport
 description: How to remove Teleport from your system
 ---
 
-This guide explains how to uninstall Teleport installations completely including binaries, configurations and data.
+This guide explains how to uninstall Teleport completely including binaries, configurations and data.
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
@@ -167,6 +167,7 @@ Follow the instructions for your Linux distribution:
   $ sudo rm -f /usr/local/bin/tctl
   $ sudo rm -f /usr/local/bin/teleport
   $ sudo rm -f /usr/local/bin/tsh
+  $ sudo rm -f /usr/local/bin/fdpass-teleport
   ```
 
   <Admonition type="notice" title="Uninstall macOS client tools">


### PR DESCRIPTION
Updates:
  - update description to include binaries, configs and data. only said binaries before
  - include fdpass-teleport in uninstall macos
