### PR TITLE
Reword errors shown in GUIs when attempting to download a folder

### DIFF
--- a/lib/sshutils/sftp/sftp.go
+++ b/lib/sshutils/sftp/sftp.go
@@ -410,10 +410,9 @@ func (c *Config) transfer(ctx context.Context) error {
 				return trace.Wrap(err, "could not access %s path %q", c.srcFS.Type(), match)
 			}
 			if fi.IsDir() && !c.opts.Recursive {
-				// Note: using any other error constructor than BadParameter
-				// might lead to relogin attempt and a completely obscure
-				// error message
-				return trace.BadParameter("%q is a directory, but the recursive option was not passed", match)
+				// Note: Using an error constructor included in lib/client.IsErrorResolvableWithRelogin,
+				// e.g. BadParameter, will lead to relogin attempt and a completely obscure error message.
+				return trace.Errorf("%q is a directory, but the recursive option was not passed", match)
 			}
 			fileInfos = append(fileInfos, fi)
 		}

--- a/lib/sshutils/sftp/sftp_test.go
+++ b/lib/sshutils/sftp/sftp_test.go
@@ -321,6 +321,7 @@ func TestUpload(t *testing.T) {
 			},
 			errCheck: func(t require.TestingT, err error, i ...interface{}) {
 				require.EqualError(t, err, fmt.Sprintf(`"%s/src" is a directory, but the recursive option was not passed`, i[0]))
+				require.ErrorAs(t, err, new(*NonRecursiveDirectoryTransferError))
 			},
 		},
 		{

--- a/lib/teleterm/clusters/cluster_file_transfer.go
+++ b/lib/teleterm/clusters/cluster_file_transfer.go
@@ -20,6 +20,7 @@ package clusters
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"sync"
@@ -54,6 +55,9 @@ func (c *Cluster) TransferFile(ctx context.Context, request *api.FileTransferReq
 
 	err = AddMetadataToRetryableError(ctx, func() error {
 		err := c.clusterClient.TransferFiles(ctx, request.GetLogin(), serverUUID+":0", config)
+		if errors.As(err, new(*sftp.NonRecursiveDirectoryTransferError)) {
+			return trace.Errorf("transferring directories through Teleport Connect is not supported at the moment, please use tsh scp -r")
+		}
 		return trace.Wrap(err)
 	})
 	return trace.Wrap(err)

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -21,6 +21,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
@@ -148,6 +149,9 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 
 	err = tc.TransferFiles(ctx, req.login, req.serverID+":0", cfg)
 	if err != nil {
+		if errors.As(err, new(*sftp.NonRecursiveDirectoryTransferError)) {
+			return nil, trace.Errorf("transferring directories through the Web UI is not supported at the moment, please use tsh scp -r")
+		}
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/26417.

changelog: Fixed tsh scp showing a login prompt when attempting to transfer a folder without the recursive option

This PR addresses two problems.

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/f6725cad-104c-433b-b0b3-dc77722b4aac) | ![after](https://github.com/user-attachments/assets/904699c6-f3a9-4e9b-a7ee-42956ee7e655) |

## `tsh scp` showing relogin prompt

First, `tsh scp` was showing a relogin prompt when downloading a dir without the `-r` option. This comment was incorrect:

https://github.com/gravitational/teleport/blob/3f906d786dca48df907927833ca128f6a255797d/lib/sshutils/sftp/sftp.go#L412-L416

I believe it originated from a similar comment `lib/sshutils/scp` which predates it and is correct:

https://github.com/gravitational/teleport/blob/3f906d786dca48df907927833ca128f6a255797d/lib/sshutils/scp/scp.go#L277-L281

This is because we infamously show relogin prompt on `trace.BadParameter`, a decision made circa 2016 that is now widely regarded as a bad move.

## Web UI and Connect show error message about recursive option

A lot of error messages in `lib/` is tsh-centric. The error linked to above would float to Web UI and Connect, where the mention of the recursive option doesn't make sense because those UIs don't let you provide this option.

Ideally, I think `lib/sshutils/sftp` should return a "generic", universal message and then each client, be it tsh or Web UI, should enhance it. tsh could point towards the recursive option, Web UI and Connect could point to tsh.

For now I've decided to merely "rethrow" the error in Web UI and Connect with a different message.

Another solution would be to add support for recursive transfers to GUIs. But that's a bigger task and I'm writing this PR during my support shift.