### PR TITLE
Fix Auto Discover EC2 test when running in darwin

### DIFF
--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -369,7 +369,7 @@ func (ani *AutoDiscoverNodeInstaller) configureTeleportNode(ctx context.Context,
 }
 
 func checksum(filename string) (string, error) {
-	f, err := utils.OpenFileNoUnsafeLinks(filename)
+	f, err := utils.OpenFileAllowingUnsafeLinks(filename)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR changes the method used for calculating the checksum for the `/etc/teleport.yaml` file.

It was using a method that doesn't allow symlinks and we can't run tests that use it in darwin boxes.

We don't expect any real issues with this, because files are in root-only allowed directories (`/etc/`).

From: https://github.com/gravitational/teleport/pull/44282#discussion_r1746289818