### PR TITLE
[access_graph] propagate s3 permission errors

### DIFF
--- a/lib/srv/discovery/fetchers/aws-sync/s3.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3.go
@@ -155,7 +155,7 @@ func (a *awsFetcher) fetchS3Buckets(ctx context.Context) ([]*accessgraphv1alpha.
 	// always discard the error
 	_ = eG.Wait()
 
-	return s3s, trace.Wrap(err)
+	return s3s, trace.NewAggregate(errs...)
 }
 
 func awsS3Bucket(name string,

--- a/lib/srv/discovery/fetchers/aws-sync/s3_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3_test.go
@@ -49,12 +49,13 @@ func TestPollAWSS3(t *testing.T) {
 		accountID       = "12345678"
 		bucketName      = "bucket1"
 		otherBucketName = "bucket2"
+		missingBucket   = "missing_perm_bucket"
 	)
 	var (
 		regions       = []string{"eu-west-1"}
 		mockedClients = &cloud.TestCloudClients{
 			S3: &mocks.S3Mock{
-				Buckets: s3Buckets(bucketName, otherBucketName),
+				Buckets: s3Buckets(bucketName, otherBucketName, missingBucket),
 				BucketPolicy: map[string]string{
 					bucketName:      "policy",
 					otherBucketName: "otherPolicy",
@@ -139,6 +140,10 @@ func TestPollAWSS3(t *testing.T) {
 							},
 						},
 					},
+					{
+						Name:      missingBucket,
+						AccountId: accountID,
+					},
 				},
 			},
 		},
@@ -168,7 +173,7 @@ func TestPollAWSS3(t *testing.T) {
 			result := &Resources{}
 			execFunc := a.pollAWSS3Buckets(context.Background(), result, collectErr)
 			require.NoError(t, execFunc())
-			require.NoError(t, trace.NewAggregate(errs...))
+			require.Error(t, trace.NewAggregate(errs...))
 
 			sortSlice(tt.want.S3Buckets)
 			sortSlice(result.S3Buckets)


### PR DESCRIPTION
This PR fixes a typo where S3 permission errors weren't correctly propagated