### PR TITLE
[v16] Reword errors shown in GUIs when attempting to download a folder

### DIFF
--- a/lib/sshutils/sftp/sftp.go
+++ b/lib/sshutils/sftp/sftp.go
@@ -410,10 +410,9 @@ func (c *Config) transfer(ctx context.Context) error {
 				return trace.Wrap(err, "could not access %s path %q", c.srcFS.Type(), match)
 			}
 			if fi.IsDir() && !c.opts.Recursive {
-				// Note: using any other error constructor than BadParameter
-				// might lead to relogin attempt and a completely obscure
-				// error message
-				return trace.BadParameter("%q is a directory, but the recursive option was not passed", match)
+				// Note: Using an error constructor included in lib/client.IsErrorResolvableWithRelogin,
+				// e.g. BadParameter, will lead to relogin attempt and a completely obscure error message.
+				return trace.Errorf("%q is a directory, but the recursive option was not passed", match)
 			}
 			fileInfos = append(fileInfos, fi)
 		}

--- a/lib/sshutils/sftp/sftp_test.go
+++ b/lib/sshutils/sftp/sftp_test.go
@@ -321,6 +321,7 @@ func TestUpload(t *testing.T) {
 			},
 			errCheck: func(t require.TestingT, err error, i ...interface{}) {
 				require.EqualError(t, err, fmt.Sprintf(`"%s/src" is a directory, but the recursive option was not passed`, i[0]))
+				require.ErrorAs(t, err, new(*NonRecursiveDirectoryTransferError))
 			},
 		},
 		{

--- a/lib/teleterm/clusters/cluster_file_transfer.go
+++ b/lib/teleterm/clusters/cluster_file_transfer.go
@@ -20,6 +20,7 @@ package clusters
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"sync"
@@ -54,6 +55,9 @@ func (c *Cluster) TransferFile(ctx context.Context, request *api.FileTransferReq
 
 	err = AddMetadataToRetryableError(ctx, func() error {
 		err := c.clusterClient.TransferFiles(ctx, request.GetLogin(), serverUUID+":0", config)
+		if errors.As(err, new(*sftp.NonRecursiveDirectoryTransferError)) {
+			return trace.Errorf("transferring directories through Teleport Connect is not supported at the moment, please use tsh scp -r")
+		}
 		return trace.Wrap(err)
 	})
 	return trace.Wrap(err)

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -21,6 +21,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
@@ -147,6 +148,9 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 
 	err = tc.TransferFiles(ctx, req.login, req.serverID+":0", cfg)
 	if err != nil {
+		if errors.As(err, new(*sftp.NonRecursiveDirectoryTransferError)) {
+			return nil, trace.Errorf("transferring directories through the Web UI is not supported at the moment, please use tsh scp -r")
+		}
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Backport #46595 to branch/v16

changelog: Fixed tsh scp showing a login prompt when attempting to transfer a folder without the recursive option