### PR TITLE
Updating docs for unify mac changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -1367,6 +1367,8 @@ rev. 1607, which is the exact minimum Windows version that we support.
 - [ ] `teleport` runs on the minimum supported macOS version
 - [ ] `tbot` runs on the minimum supported macOS version
 - [ ] Teleport Connect runs on the minimum supported macOS version
+- [ ] `tsh touchid diag` shows positive results for all requirements
+- [ ] `tctl touchid diag` shows positive results for all requirements
 
 ### Linux
 

--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -1368,7 +1368,7 @@ rev. 1607, which is the exact minimum Windows version that we support.
 - [ ] `tbot` runs on the minimum supported macOS version
 - [ ] Teleport Connect runs on the minimum supported macOS version
 - [ ] `tsh touchid diag` shows positive results for all requirements
-- [ ] `tctl touchid diag` shows positive results for all requirements
+- [ ] `tctl touchid diag` shows positive results for all requirements (tctl requires you to be authenticated to run)
 
 ### Linux
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### macOS Package Changes
 
-To support a more consistent user experience, Mac packages have been restructured so that all packages will provide a 
+To support a more consistent user experience, the macOS packages have been restructured so that all packages will provide a 
 `tsh` and `tctl` capable of utilizing TouchID.
 
 All Mac packages now include `tsh.app` and `tctl.app` bundles and the standalone binaries for `tsh` and `tctl` have been removed. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 To support a more consistent user experience, the macOS packages have been restructured so that all packages will provide a 
 `tsh` and `tctl` capable of utilizing TouchID.
 
-All Mac packages now include `tsh.app` and `tctl.app` bundles and the standalone binaries for `tsh` and `tctl` have been removed. 
+The standalone `tsh` and `tctl` binaries have been removed from these packages and
+replaced with `tsh.app` and `tctl.app` bundles.
 The standalone `tsh.pkg` that installs a `tsh.app` bundle has also been removed as part of these changes since it is now included 
 by default in all packages.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-#### Mac Package Changes
+#### macOS Package Changes
 
 To support a more consistent user experience, Mac packages have been restructured so that all packages will provide a 
 `tsh` and `tctl` capable of utilizing TouchID.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Mac Package Changes
 
 To support a more consistent user experience, Mac packages have been restructured so that all packages will provide a 
-`tsh` and `tctl` capable of utilizing TouchID
+`tsh` and `tctl` capable of utilizing TouchID.
 
 All Mac packages now include `tsh.app` and `tctl.app` bundles and the standalone binaries for `tsh` and `tctl` have been removed. 
 The standalone `tsh.pkg` that installs a `tsh.app` bundle has also been removed as part of these changes since it is now included 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,19 @@
 
 ## 17.0.0 (11/xx/2024)
 
-### ** Not yet released **
+### Breaking changes
 
+#### Mac Package Changes
+
+To support a more consistent user experience, Mac packages have been restructured so that all packages will provide a 
+`tsh` and `tctl` capable of utilizing TouchID
+
+All Mac packages now include `tsh.app` and `tctl.app` bundles and the standalone binaries for `tsh` and `tctl` have been removed. 
+The standalone `tsh.pkg` that installs a `tsh.app` bundle has also been removed as part of these changes since it is now included 
+by default in all packages.
+
+`/usr/local/bin/tsh` will now be a symbolic link to `/Applications/tsh.app/Contents/MacOS/tsh`
+`/usr/local/bin/tctl` will now be a symbolic link to `/Applications/tsh.app/Contents/MacOS/tctl`
 
 ## 16.4.6 (10/22/2024)
 


### PR DESCRIPTION
## Overview

The unify mac changes introduced some breaking changes. This is adding those breaking changes to the CHANGELOG.