### PR TITLE
docs: add dedicated account dashboard mention

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/deploy-a-cluster.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deploy-a-cluster.mdx
@@ -6,10 +6,12 @@ description: "Guides to running a self-hosted Teleport cluster in production."
 These guides show you how to run a self-hosted Teleport Enterprise cluster in
 production.
 
-## Dedicated account dashboard
+# Dedicated account dashboard
 
 Teleport Enterprise subscriptions include a dedicated account dashboard with their preferred
 subdomain of [teleport.sh](https://teleport.sh). The dedicated account dashboard provides
 subscription administrators access to the license file, support links and Teleport Enterprise binary downloads.
+
+# Guides to self-hosting Teleport 
 
 (!toc!)

--- a/docs/pages/admin-guides/deploy-a-cluster/deploy-a-cluster.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deploy-a-cluster.mdx
@@ -6,4 +6,10 @@ description: "Guides to running a self-hosted Teleport cluster in production."
 These guides show you how to run a self-hosted Teleport Enterprise cluster in
 production.
 
+## Dedicated account dashboard
+
+Teleport Enterprise subscriptions include a dedicated account dashboard with their preferred
+subdomain of [teleport.sh](https://teleport.sh). The dedicated account dashboard provides
+subscription administrators access to the license file, support links and Teleport Enterprise binary downloads.
+
 (!toc!)

--- a/docs/pages/admin-guides/deploy-a-cluster/deploy-a-cluster.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deploy-a-cluster.mdx
@@ -6,12 +6,12 @@ description: "Guides to running a self-hosted Teleport cluster in production."
 These guides show you how to run a self-hosted Teleport Enterprise cluster in
 production.
 
-# Dedicated account dashboard
+## Dedicated account dashboard
 
 Teleport Enterprise subscriptions include a dedicated account dashboard with their preferred
 subdomain of [teleport.sh](https://teleport.sh). The dedicated account dashboard provides
 subscription administrators access to the license file, support links and Teleport Enterprise binary downloads.
 
-# Guides to self-hosting Teleport 
+## Guides to self-hosting Teleport 
 
 (!toc!)


### PR DESCRIPTION
Self-hosted help and support pages link to https://goteleport.com/docs/admin-guides/deploy-a-cluster/deploy-a-cluster/?scope=enterprise#dedicated-account-dashboard but there's no info on downloads. Adding back in.

![image](https://github.com/user-attachments/assets/69ad2c6d-890b-4703-941c-b7c601eebe1b)
