### PR TITLE
docs: update migrating plan

### DIFF
--- a/docs/pages/admin-guides/migrate-plans.mdx
+++ b/docs/pages/admin-guides/migrate-plans.mdx
@@ -237,7 +237,7 @@ To migrate Teleport agents:
 1. If you are using the community version of Teleport uninstall `teleport`
    and install the enterprise version. You can confirm if the `teleport` binary
    is enterprise by running `teleport version`. The output will contain the words
-   `Teleport Enerprise`. The enterprise version of the `teleport`
+   `Teleport Enterprise`. The enterprise version of the `teleport`
    binary should be used when connecting to Teleport Enterprise (cloud) or
    Teleport Enterprise self-hosted.
 

--- a/docs/pages/admin-guides/migrate-plans.mdx
+++ b/docs/pages/admin-guides/migrate-plans.mdx
@@ -235,12 +235,13 @@ To migrate Teleport agents:
    upgrades the `stable/rolling` channel has all released versions.
 
 
-1. If you are using the Teleport Community Edition, [uninstall Teleport](./management/admin/uninstall-teleport.mdx)
-   and install the enterprise version. You can confirm if the `teleport` binary
-   is enterprise by running `teleport version`. The output will contain the words
-   `Teleport Enterprise`. The enterprise version of the `teleport`
+1. If you are using Teleport Community Edition, [uninstall Teleport](./management/admin/uninstall-teleport.mdx)
+   and install the enterprise edition of the `teleport` binary. You can confirm if the binary
+   is correct by running `teleport version`. The output will contain the words
+   `Teleport Enterprise`. The enterprise edition of the `teleport`
    binary should be used when connecting to Teleport Enterprise (Cloud) or
    Teleport Enterprise (Self-Hosted).
+
 
 
 1. Update the `proxy_server` or `auth_servers` field in each Agent configuration

--- a/docs/pages/admin-guides/migrate-plans.mdx
+++ b/docs/pages/admin-guides/migrate-plans.mdx
@@ -84,10 +84,10 @@ migrating from Teleport Enterprise to Teleport Community Edition.
    $ tctl inventory ls --newer-than=<version>
    ```
 
-1. Both the self-hosted and Teleport Enterprise (Cloud) support automatic upgrading
-   that is recommended to maintain a healthy set of agents. See how to 
+1. We recommend that Teleport Enterprise (Self-Hosted) customers set up automatic updates to maintain a healthy set of Agents, and require this in Teleport Enterprise (Cloud). See how to 
    [Set up Automatic Agent Updates](../upgrading/automatic-agent-updates.mdx) to
    incorporate this into your migration.
+
 
 Validate connectivity to both the new Teleport Enterprise cluster and your
 original Teleport Enterprise cluster. You should be able to connect to both
@@ -230,16 +230,20 @@ To migrate Teleport agents:
 
 1. If you are using Teleport repositories to install on Linux
    update the repository channel to `stable/cloud` for Teleport
-   Enterprise (cloud). For self-hosted you can use the major version
-   `stable/v(=teleport.major_version=)` or if you are using the automatic
-   upgrades the `stable/rolling` has all released versions.
+   Enterprise (Cloud). For self-hosted Teleport Enterprise you can use the major version
+   `stable/v(=teleport.major_version=)` or if you are using automatic
 
-1. If you are using the community version of Teleport uninstall `teleport`
+   upgrades the `stable/rolling` channel has all released versions.
+
+
+1. If you are using the Teleport Community Edition, uninstall `teleport`
+
    and install the enterprise version. You can confirm if the `teleport` binary
    is enterprise by running `teleport version`. The output will contain the words
    `Teleport Enterprise`. The enterprise version of the `teleport`
-   binary should be used when connecting to Teleport Enterprise (cloud) or
-   Teleport Enterprise self-hosted.
+   binary should be used when connecting to Teleport Enterprise (Cloud) or
+   Teleport Enterprise (Self-Hosted).
+
 
 1. Update the `proxy_server` or `auth_servers` field in each Agent configuration
    file to point to the address of your new Teleport Enterprise cluster. By
@@ -291,7 +295,8 @@ To migrate Teleport agents:
    # delete the state secret
    kubectl -n <namespace> delete secret <release-name>-0-state
    ```
-   The settings for the new Teleport Kubernetes agent should have the 
+   The settings for the new Teleport Kubernetes Agent should have the 
+
    `enterprise` value set to true.
 
 ### Migrate Machine ID Bots

--- a/docs/pages/admin-guides/migrate-plans.mdx
+++ b/docs/pages/admin-guides/migrate-plans.mdx
@@ -72,13 +72,22 @@ migrating from Teleport Enterprise to Teleport Community Edition.
    Teleport](deploy-a-cluster/deploy-a-cluster.mdx).
 
 1. Ensure you are running Teleport Enterprise agents with versions that are
-   lower than the new Teleport Enterprise account version. To check the
-   versions of your Teleport Enterprise agents, you can use the `tctl` command
+   the same major or just one major version lower than the new Teleport
+   Enterprise account version. To check the  versions of your Teleport 
+   Enterprise agents, you can use the `tctl` command
    to list the inventory of connected agents and their version:
 
    ```code  
+   # check for older versions
    $ tctl inventory ls --older-than=<version>
+   # check for newer versions
+   $ tctl inventory ls --newer-than=<version>
    ```
+
+1. Both the self-hosted and Teleport Enterprise (Cloud) support automatic upgrading
+   that is recommended to maintain a healthy set of agents. See how to 
+   [Set up Automatic Agent Updates](../upgrading/automatic-agent-updates.mdx) to
+   incorporate this into your migration.
 
 Validate connectivity to both the new Teleport Enterprise cluster and your
 original Teleport Enterprise cluster. You should be able to connect to both
@@ -219,6 +228,19 @@ To migrate Teleport agents:
 
 1. Stop Teleport services on each Agent (if applicable).
 
+1. If you are using Teleport repositories to install on Linux
+   update the repository channel to `stable/cloud` for Teleport
+   Enterprise (cloud). For self-hosted you can use the major version
+   `stable/v(=teleport.major_version=)` or if you are using the automatic
+   upgrades the `stable/rolling` has all released versions.
+
+1. If you are using the community version of Teleport uninstall `teleport`
+   and install the enterprise version. You can confirm if the `teleport` binary
+   is enterprise by running `teleport version`. The output will contain the words
+   `Teleport Enerprise`. The enterprise version of the `teleport`
+   binary should be used when connecting to Teleport Enterprise (cloud) or
+   Teleport Enterprise self-hosted.
+
 1. Update the `proxy_server` or `auth_servers` field in each Agent configuration
    file to point to the address of your new Teleport Enterprise cluster. By
    default, on Linux servers, the configuration is located in the
@@ -269,6 +291,8 @@ To migrate Teleport agents:
    # delete the state secret
    kubectl -n <namespace> delete secret <release-name>-0-state
    ```
+   The settings for the new Teleport Kubernetes agent should have the 
+   `enterprise` value set to true.
 
 ### Migrate Machine ID Bots
 

--- a/docs/pages/admin-guides/migrate-plans.mdx
+++ b/docs/pages/admin-guides/migrate-plans.mdx
@@ -232,12 +232,10 @@ To migrate Teleport agents:
    update the repository channel to `stable/cloud` for Teleport
    Enterprise (Cloud). For self-hosted Teleport Enterprise you can use the major version
    `stable/v(=teleport.major_version=)` or if you are using automatic
-
    upgrades the `stable/rolling` channel has all released versions.
 
 
-1. If you are using the Teleport Community Edition, uninstall `teleport`
-
+1. If you are using the Teleport Community Edition, [uninstall Teleport](./management/admin/uninstall-teleport.mdx)
    and install the enterprise version. You can confirm if the `teleport` binary
    is enterprise by running `teleport version`. The output will contain the words
    `Teleport Enterprise`. The enterprise version of the `teleport`
@@ -296,7 +294,6 @@ To migrate Teleport agents:
    kubectl -n <namespace> delete secret <release-name>-0-state
    ```
    The settings for the new Teleport Kubernetes Agent should have the 
-
    `enterprise` value set to true.
 
 ### Migrate Machine ID Bots


### PR DESCRIPTION
Updates:
- mention auto upgrading as something that can be incorporated
- mention to update repo channels and install enterprise version
- update to lower or same version for Teleport Enterprise.