### PR TITLE
Document AWS Tags used when using the AWS OIDC Integration

### DIFF
--- a/docs/pages/admin-guides/management/guides/awsoidc-integration.mdx
+++ b/docs/pages/admin-guides/management/guides/awsoidc-integration.mdx
@@ -28,6 +28,14 @@ The integration requires no extra configuration or services to run.
 Initially, no policy is added to the IAM role, but users are asked to add them the first time they are trying to use a given feature.
 For example, when setting up [External Audit Storage](../external-audit-storage.mdx), you will be asked to add the required policies to this IAM role.
 
+AWS Resources created by the integration are tagged so that you can search and export them using the [AWS Resource Groups / Tag Editor](https://console.aws.amazon.com/resource-groups/tag-editor/find-resources).
+The following tags are applied:
+```code
+teleport.dev/cluster      <Var name="cluster-name"/>
+teleport.dev/origin       integration_awsoidc
+teleport.dev/integration  <Var name="my-integration"/>
+```
+
 ## Prerequisites
 
 - A running Teleport cluster.

--- a/web/packages/teleport/src/Discover/Shared/const.ts
+++ b/web/packages/teleport/src/Discover/Shared/const.ts
@@ -20,3 +20,6 @@ export const WILD_CARD = '*';
 
 export const AWS_TAG_INFO_LINK =
   'https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags_roles.html#id_tags_roles_procs-console';
+
+export const AWS_RESOURCE_GROUPS_TAG_EDITOR_LINK =
+  'https://console.aws.amazon.com/resource-groups/tag-editor/find-resources';

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.tsx
@@ -21,6 +21,7 @@ import { Link as InternalRouteLink } from 'react-router-dom';
 import { useLocation } from 'react-router';
 import styled from 'styled-components';
 import { Box, ButtonSecondary, Text, Link, Flex, ButtonPrimary } from 'design';
+import { P } from 'design/Text/Text';
 import * as Icons from 'design/Icon';
 import FieldInput from 'shared/components/FieldInput';
 import { requiredIamRoleName } from 'shared/components/Validation/rules';
@@ -34,8 +35,10 @@ import {
   userEventService,
 } from 'teleport/services/userEvent';
 import { Header } from 'teleport/Discover/Shared';
+import { AWS_RESOURCE_GROUPS_TAG_EDITOR_LINK } from 'teleport/Discover/Shared/const';
 import { DiscoverUrlLocationState } from 'teleport/Discover/useDiscover';
 import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
+import useStickyClusterId from 'teleport/useStickyClusterId';
 
 import {
   Integration,
@@ -53,6 +56,8 @@ export function AwsOidc() {
   const [scriptUrl, setScriptUrl] = useState('');
   const [createdIntegration, setCreatedIntegration] = useState<Integration>();
   const { attempt, run } = useAttempt('');
+
+  const { clusterId } = useStickyClusterId();
 
   const location = useLocation<DiscoverUrlLocationState>();
 
@@ -147,6 +152,28 @@ export function AwsOidc() {
           AWS RDS
         </RouteLink>{' '}
         instances during resource enrollment.
+        <P>
+          AWS Resources created by the integration are tagged so that you can
+          search and export them using the{' '}
+          <Link target="_blank" href={AWS_RESOURCE_GROUPS_TAG_EDITOR_LINK}>
+            AWS Resource Groups / Tag Editor
+          </Link>
+          . The following tags are applied:
+          <TextSelectCopyMulti
+            bash={false}
+            lines={[
+              {
+                text:
+                  `teleport.dev/cluster: ` +
+                  clusterId +
+                  `\n` +
+                  `teleport.dev/origin: integration_awsoidc\n` +
+                  `teleport.dev/integration: ` +
+                  integrationName,
+              },
+            ]}
+          />
+        </P>
       </Box>
 
       <Validation>


### PR DESCRIPTION
When the AWS OIDC Integration creates an AWS Resource it adds a couple of tags.
Those can be used to group resources in AWS.
Even tho Teleport was doing it, it was not documented.

This PR adds the documentation to this, in both the Docs and Discover flows.

Demo:
<img width="1125" alt="image" src="https://github.com/user-attachments/assets/4e434f10-6eca-4765-9679-eb3fc854a0a0">

Related: https://github.com/gravitational/teleport/issues/43427
