### PR TITLE
eliminate hardcoded RSA from lib/teleterm

### DIFF
--- a/lib/teleterm/gateway/kube.go
+++ b/lib/teleterm/gateway/kube.go
@@ -20,6 +20,10 @@ package gateway
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"crypto/tls"
 	"encoding/pem"
 
@@ -28,8 +32,8 @@ import (
 
 	"github.com/gravitational/teleport/api/utils/keypaths"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/utils"
@@ -61,7 +65,7 @@ func makeKubeGateway(cfg Config) (Kube, error) {
 
 	// Generate a new private key for the proxy. The client's existing private key may be
 	// a hardware-backed private key, which cannot be added to the local proxy kube config.
-	key, err := native.GeneratePrivateKey()
+	key, err := newKubeCAKey(cfg.Cert)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -83,6 +87,31 @@ func makeKubeGateway(cfg Config) (Kube, error) {
 		return nil, trace.NewAggregate(err, k.Close())
 	}
 	return k, nil
+}
+
+func newKubeCAKey(kubeCert tls.Certificate) (*keys.PrivateKey, error) {
+	// Use the same key algorithm as the existing kubeCert instead of re-finding
+	// the current signature algorithm suite here.
+	var alg cryptosuites.Algorithm
+	switch kubeCert.PrivateKey.(crypto.Signer).Public().(type) {
+	case *rsa.PublicKey:
+		alg = cryptosuites.RSA2048
+	case *ecdsa.PublicKey:
+		alg = cryptosuites.ECDSAP256
+	case ed25519.PublicKey:
+		alg = cryptosuites.Ed25519
+	default:
+		return nil, trace.BadParameter("unsupported key type in k8s cert: %T", kubeCert.PrivateKey)
+	}
+	signer, err := cryptosuites.GenerateKeyWithAlgorithm(alg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	privateKey, err := keys.NewSoftwarePrivateKey(signer)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return privateKey, nil
 }
 
 func (k *kube) makeALPNLocalProxyForKube(cas map[string]tls.Certificate) error {

--- a/lib/teleterm/gateway/kube_test.go
+++ b/lib/teleterm/gateway/kube_test.go
@@ -21,6 +21,7 @@ package gateway
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -142,9 +143,19 @@ func kubeClientForLocalProxy(t *testing.T, kubeconfigPath, teleportCluster, kube
 	proxyURL, err := url.Parse(config.Clusters[contextName].ProxyURL)
 	require.NoError(t, err)
 
+	// Sanity check the CA and client cert both use ECDSA keys.
+	kubeCAPEM := config.Clusters[contextName].CertificateAuthorityData
+	kubeCA, err := tlsca.ParseCertificatePEM(kubeCAPEM)
+	require.NoError(t, err)
+	require.IsType(t, (*ecdsa.PublicKey)(nil), kubeCA.PublicKey)
+	clientCertPEM := config.AuthInfos[contextName].ClientCertificateData
+	clientCert, err := tlsca.ParseCertificatePEM(clientCertPEM)
+	require.NoError(t, err)
+	require.IsType(t, (*ecdsa.PublicKey)(nil), clientCert.PublicKey)
+
 	tlsClientConfig := rest.TLSClientConfig{
-		CAData:     config.Clusters[contextName].CertificateAuthorityData,
-		CertData:   config.AuthInfos[contextName].ClientCertificateData,
+		CAData:     kubeCAPEM,
+		CertData:   clientCertPEM,
 		KeyData:    config.AuthInfos[contextName].ClientKeyData,
 		ServerName: common.KubeLocalProxySNI(teleportCluster, kubeCluster),
 	}


### PR DESCRIPTION
Part of [RFD 136](https://github.com/gravitational/teleport/blob/master/rfd/0136-modern-signature-algorithms.md).