### PR TITLE
[v16] Restore the previous order of shell arguments in `resolveShellEnv`

### DIFF
--- a/web/packages/teleterm/src/services/pty/ptyHost/resolveShellEnv.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/resolveShellEnv.ts
@@ -98,7 +98,7 @@ async function resolveUnixShellEnv(
     // When bash is run with -c, it is considered a non-interactive shell, and it does not read ~/.bashrc, unless is -i specified.
     // https://unix.stackexchange.com/questions/277312/is-the-shell-created-by-bash-i-c-command-interactive
     const shellArgs =
-      shell === '/bin/tcsh' || shell === '/bin/csh' ? ['-ic'] : ['-cil'];
+      shell === '/bin/tcsh' || shell === '/bin/csh' ? ['-ic'] : ['-ilc'];
 
     logger.info(`Reading shell ${shell} ${shellArgs} ${command}`);
 


### PR DESCRIPTION
Backport #46631 to branch/v16

changelog: Fixed a regression that prevented the fish shell from starting in Teleport Connect
