### PR TITLE
Add retry button in login dialog to refetch auth preferences

### DIFF
--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
@@ -45,6 +45,7 @@ function makeProps(): ClusterLoginPresentationProps {
       status: '',
       statusText: '',
     } as Attempt<void>,
+    init: () => null,
     initAttempt: {
       status: 'success',
       statusText: '',

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import * as Alerts from 'design/Alert';
-import { ButtonIcon, Text, Indicator, Box, H2 } from 'design';
+import { ButtonIcon, Text, Indicator, Box, H2, ButtonPrimary } from 'design';
 import * as Icons from 'design/Icon';
 import { DialogHeader, DialogContent } from 'design/Dialog';
 import { PrimaryAuthType } from 'shared/services';
@@ -43,6 +43,7 @@ export type ClusterLoginPresentationProps = State & {
 export function ClusterLoginPresentation({
   title,
   initAttempt,
+  init,
   loginAttempt,
   clearLoginAttempt,
   onLoginWithLocal,
@@ -69,10 +70,12 @@ export function ClusterLoginPresentation({
         {reason && <Reason reason={reason} />}
 
         {initAttempt.status === 'error' && (
-          <Alerts.Danger m={4}>
-            Unable to retrieve cluster auth preferences,{' '}
-            {initAttempt.statusText}
-          </Alerts.Danger>
+          <Box m={4}>
+            <Alerts.Danger details={initAttempt.statusText}>
+              Unable to retrieve cluster auth preferences
+            </Alerts.Danger>
+            <ButtonPrimary onClick={init}>Retry</ButtonPrimary>
+          </Box>
         )}
         {initAttempt.status === 'processing' && (
           <Box textAlign="center" m={4}>

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
@@ -184,6 +184,7 @@ export default function useClusterLogin(props: Props) {
     onAbort,
     loginAttempt,
     initAttempt,
+    init,
     clearLoginAttempt,
   };
 }


### PR DESCRIPTION
Currently, the login dialog doesn't offer a way to retry fetching auth preferences when the call fails. The user has to close the dialog and then click 'Connect' again (it happens to me every time I forget to start the cluster first).
<img width="765" alt="image" src="https://github.com/user-attachments/assets/2bdf2dbb-2563-454d-bc1d-1da28833fb24">

This PR adds a 'Retry' button:
<img width="765" alt="image" src="https://github.com/user-attachments/assets/0476e873-ef69-44ec-9ca6-b4776081653a">

I'm not going to backport it because I'm using the `details` property of `Alerts.Danger`, which exists only on master.