### PR TITLE
add mention of MariaDB to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ We have implemented Teleport as a single Go binary that integrates with multiple
 
 * [SSH nodes](https://goteleport.com/docs/enroll-resources/server-access/introduction/).
 * [Kubernetes clusters](https://goteleport.com/docs/enroll-resources/kubernetes-access/introduction/)
-* [PostgreSQL, MongoDB, CockroachDB and MySQL databases](https://goteleport.com/docs/enroll-resources/database-access/database-access/).
+* [PostgreSQL, MongoDB, CockroachDB, MariaDB and MySQL databases](https://goteleport.com/docs/enroll-resources/database-access/database-access/).
 * [Internal Web apps](https://goteleport.com/docs/enroll-resources/application-access/introduction/).
 * [Windows Hosts](https://goteleport.com/docs/enroll-resources/desktop-access/introduction/).
 * [Networked servers](https://goteleport.com/docs/enroll-resources/server-access/introduction/).


### PR DESCRIPTION
Add mention of MariaDB in list of databases in README.md, as asked about in discussion https://github.com/gravitational/teleport/issues/46629 - where it was mentioned that mariadb support is mentioned in docs at https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted/