### PR TITLE
Add Okta CA

### DIFF
--- a/api/types/trust.go
+++ b/api/types/trust.go
@@ -60,6 +60,9 @@ const (
 	// SPIFFECA identifies the certificate authority that will be used by the
 	// SPIFFE Workload Identity provider functionality.
 	SPIFFECA CertAuthType = "spiffe"
+	// OktaCA identifies the certificate authority that will be used by the
+	// integration with Okta.
+	OktaCA CertAuthType = "okta"
 )
 
 // CertAuthTypes lists all certificate authority types.
@@ -72,6 +75,7 @@ var CertAuthTypes = []CertAuthType{HostCA,
 	SAMLIDPCA,
 	OIDCIdPCA,
 	SPIFFECA,
+	OktaCA,
 }
 
 // NewlyAdded should return true for CA types that were added in the current
@@ -92,6 +96,8 @@ func (c CertAuthType) addedInMajorVer() int64 {
 		return 15
 	case SPIFFECA:
 		return 15
+	case OktaCA:
+		return 16
 	default:
 		// We don't care about other CAs added before v4.0.0
 		return 4

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -6913,7 +6913,7 @@ func newKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertA
 
 	// Add JWT keys if necessary.
 	switch caID.Type {
-	case types.JWTSigner, types.OIDCIdPCA, types.SPIFFECA:
+	case types.JWTSigner, types.OIDCIdPCA, types.SPIFFECA, types.OktaCA:
 		jwtKeyPair, err := keyStore.NewJWTKeyPair(ctx, jwtCAKeyPurpose(caID.Type))
 		if err != nil {
 			return keySet, trace.Wrap(err)
@@ -6962,6 +6962,8 @@ func jwtCAKeyPurpose(caType types.CertAuthType) cryptosuites.KeyPurpose {
 		return cryptosuites.OIDCIdPCAJWT
 	case types.SPIFFECA:
 		return cryptosuites.SPIFFECAJWT
+	case types.OktaCA:
+		return cryptosuites.OktaCAJWT
 	}
 	return cryptosuites.KeyPurposeUnspecified
 }

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1156,7 +1156,7 @@ func checkResourceConsistency(ctx context.Context, keyStore *keystore.Manager, c
 				_, signerErr = keyStore.GetSSHSigner(ctx, r)
 			case types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA, types.SPIFFECA:
 				_, _, signerErr = keyStore.GetTLSCertAndSigner(ctx, r)
-			case types.JWTSigner, types.OIDCIdPCA:
+			case types.JWTSigner, types.OIDCIdPCA, types.OktaCA:
 				_, signerErr = keyStore.GetJWTSigner(ctx, r)
 			default:
 				return trace.BadParameter("unexpected cert_authority type %s for cluster %v", r.GetType(), clusterName)

--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -107,6 +107,9 @@ const (
 	// keyPurposeMax is 1 greater than the last valid key purpose, used to test that all values less than this
 	// are valid for each suite.
 	keyPurposeMax
+
+	// OktaCAJWT represents the JWT key for the Okta CA.
+	OktaCAJWT
 )
 
 // Algorithm represents a cryptographic signature algorithm.
@@ -172,6 +175,7 @@ var (
 		ProxyToDatabaseAgent: RSA2048,
 		ProxyKubeClient:      RSA2048,
 		// TODO(nklaassen): define remaining key purposes.
+		OktaCAJWT: RSA2048,
 	}
 
 	// balancedV1 strikes a balance between security, compatibility, and
@@ -200,6 +204,7 @@ var (
 		ProxyToDatabaseAgent:    ECDSAP256,
 		ProxyKubeClient:         ECDSAP256,
 		// TODO(nklaassen): define remaining key purposes.
+		OktaCAJWT: ECDSAP256,
 	}
 
 	// fipsv1 is an algorithm suite tailored for FIPS compliance. It is based on
@@ -227,6 +232,7 @@ var (
 		BotSVID:                 ECDSAP256,
 		ProxyToDatabaseAgent:    ECDSAP256,
 		ProxyKubeClient:         ECDSAP256,
+		OktaCAJWT:               ECDSAP256,
 		// TODO(nklaassen): define remaining key purposes.
 	}
 
@@ -257,6 +263,7 @@ var (
 		BotSVID:                 ECDSAP256,
 		ProxyToDatabaseAgent:    ECDSAP256,
 		ProxyKubeClient:         ECDSAP256,
+		OktaCAJWT:               ECDSAP256,
 		// TODO(nklaassen): define remaining key purposes.
 	}
 

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -73,7 +73,7 @@ func ValidateCertAuthority(ca types.CertAuthority) (err error) {
 		err = checkDatabaseCA(ca)
 	case types.OpenSSHCA:
 		err = checkOpenSSHCA(ca)
-	case types.JWTSigner, types.OIDCIdPCA:
+	case types.JWTSigner, types.OIDCIdPCA, types.OktaCA:
 		err = checkJWTKeys(ca)
 	case types.SAMLIDPCA:
 		err = checkSAMLIDPCA(ca)

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -167,7 +167,7 @@ func NewTestCAWithConfig(config TestCAConfig) *types.CertAuthorityV2 {
 
 	// Add JWT keys if necessary.
 	switch config.Type {
-	case types.JWTSigner, types.OIDCIdPCA, types.SPIFFECA:
+	case types.JWTSigner, types.OIDCIdPCA, types.SPIFFECA, types.OktaCA:
 		pubKeyPEM, err := keys.MarshalPublicKey(key.Public())
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
### What


Add  `OktaCA` Authority Type  type that will used in Okta Oauth2.0 JWKS auth flow: 

https://github.com/gravitational/teleport.e/issues/4586

changelog: Add a new OktaCA (Teleport Okta Certificate Authority)
