### PR TITLE
Fixed typos in doc

### DIFF
--- a/docs/pages/admin-guides/access-controls/idps/saml-gcp-workforce-identity-federation.mdx
+++ b/docs/pages/admin-guides/access-controls/idps/saml-gcp-workforce-identity-federation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Access GCP Web Console and API with a federated authentication.
+title: Access GCP Web Console and API with federated authentication
 description: Manage Google Cloud Platform (GCP) web console access with Teleport SAML IdP.
 h1: GCP Workforce Identity Federation with Teleport SAML IdP
 ---

--- a/docs/pages/admin-guides/access-controls/idps/saml-gcp-workforce-identity-federation.mdx
+++ b/docs/pages/admin-guides/access-controls/idps/saml-gcp-workforce-identity-federation.mdx
@@ -216,7 +216,7 @@ gcloud iam workforce-pools providers create-saml <pool_provider_name> \
       --workforce-pool=<pool_name> \
       --display-name=<pool_provider_name> \
       --description="Teleport workforce identity provider" \
-      --idp-metadata-path=teleport-samlidp-metadata.xml" \
+      --idp-metadata-path=./teleport-samlidp-metadata.xml \
       --attribute-mapping="google.subject=assertion.subject,google.groups=assertion.attributes.roles" \
       --location=global
 ```

--- a/docs/pages/admin-guides/access-controls/idps/saml-gcp-workforce-identity-federation.mdx
+++ b/docs/pages/admin-guides/access-controls/idps/saml-gcp-workforce-identity-federation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Access GCP Web Console and API with a federated authentication.
-description: Manage Google Cloud Platform (GCP) web console access with Teleport SAMl IdP.
+description: Manage Google Cloud Platform (GCP) web console access with Teleport SAML IdP.
 h1: GCP Workforce Identity Federation with Teleport SAML IdP
 ---
 

--- a/docs/pages/admin-guides/access-controls/idps/saml-gcp-workforce-identity-federation.mdx
+++ b/docs/pages/admin-guides/access-controls/idps/saml-gcp-workforce-identity-federation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Access GCP Web Console and API with a federated authentication.
 description: Manage Google Cloud Platform (GCP) web console access with Teleport SAMl IdP.
-h1: GCP Workforce Identity Federation with Teleport SAML IdP.
+h1: GCP Workforce Identity Federation with Teleport SAML IdP
 ---
 
 GCP Workforce Identity Federation enables provisioning access to GCP web console and APIs
@@ -201,7 +201,8 @@ First, create a workforce pool.
 gcloud iam workforce-pools create <pool_name> \
       --display-name=<pool_name> \
       --organization=<gcp_organization_id> \
-      --description="Teleport workforce pool"
+      --description="Teleport workforce pool" \
+      --location=global
 ```
 
 Next, download Teleport SAML IdP metadata file.


### PR DESCRIPTION
Fixed typos in doc:
- removed fullstop from title.
- added location flag to `gcloud iam workforce-pools create` command.