### PR TITLE
Move OKTA TF tests to TerraformSuiteEnterprise

### DIFF
--- a/integrations/operator/controllers/resources/okta_import_rule_controller_test.go
+++ b/integrations/operator/controllers/resources/okta_import_rule_controller_test.go
@@ -160,16 +160,19 @@ func (g *oktaImportRuleTestingPrimitives) CompareTeleportAndKubernetesResource(t
 }
 
 func TestOktaImportRuleCreation(t *testing.T) {
+	t.Skip("Skipping test since okta reconsider is not available in OSS")
 	test := &oktaImportRuleTestingPrimitives{}
 	testlib.ResourceCreationTest[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, test)
 }
 
 func TestOktaImportRuleDeletionDrift(t *testing.T) {
+	t.Skip("Skipping test since okta reconsider is not available in OSS")
 	test := &oktaImportRuleTestingPrimitives{}
 	testlib.ResourceDeletionDriftTest[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, test)
 }
 
 func TestOktaImportRuleUpdate(t *testing.T) {
+	t.Skip("Skipping test since okta reconsider is not available in OSS")
 	test := &oktaImportRuleTestingPrimitives{}
 	testlib.ResourceUpdateTest[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, test)
 }

--- a/integrations/operator/controllers/resources/setup.go
+++ b/integrations/operator/controllers/resources/setup.go
@@ -72,11 +72,12 @@ func SetupAllControllers(log logr.Logger, mgr manager.Manager, teleportClient *c
 		log.Info("Login Rules are only available in Teleport Enterprise edition. TeleportLoginRule resources won't be reconciled")
 	}
 
-	// AccessLists are enterprise-only but there is no specific feature-flag for them.
+	// AccessLists, OktaImports are enterprise-only but there is no specific feature-flag for them.
 	if features.GetAdvancedAccessWorkflows() {
 		reconcilers = append(reconcilers, reconcilerFactory{"TeleportAccessList", NewAccessListReconciler})
+		reconcilers = append(reconcilers, reconcilerFactory{"TeleportOktaImportRule", NewOktaImportRuleReconciler})
 	} else {
-		log.Info("The cluster license does not contain advanced workflows. TeleportAccessList resources won't be reconciled")
+		log.Info("The cluster license does not contain advanced workflows. TeleportAccessList, TeleportOktaImportRule  resourcess won't be reconciled")
 	}
 
 	kubeClient := mgr.GetClient()

--- a/integrations/terraform/testlib/okta_import_rule_test.go
+++ b/integrations/terraform/testlib/okta_import_rule_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
-func (s *TerraformSuiteOSS) TestOktaImportRule() {
+func (s *TerraformSuiteEnterprise) TestOktaImportRule() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.T().Cleanup(cancel)
 
@@ -95,7 +95,7 @@ func (s *TerraformSuiteOSS) TestOktaImportRule() {
 	})
 }
 
-func (s *TerraformSuiteOSS) TestImportOktaImportRule() {
+func (s *TerraformSuiteEnterprise) TestImportOktaImportRule() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.T().Cleanup(cancel)
 


### PR DESCRIPTION
### What


Fix missing `TestTerraformOSS` alignment after moving okta service to e package: https://github.com/gravitational/teleport/pull/46149 