### PR TITLE
Empty `host_groups` as no-op group assignment

### DIFF
--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -381,7 +381,12 @@ func TestRootHostUsers(t *testing.T) {
 				secondGroups: []string{"group1", "group2"},
 			},
 			{
-				name:        "delete groups",
+				name:         "delete groups",
+				firstGroups:  []string{"group1", "group2"},
+				secondGroups: []string{"group1"},
+			},
+			{
+				name:        "stop managing groups",
 				firstGroups: []string{"group1", "group2"},
 			},
 			{
@@ -424,6 +429,11 @@ func TestRootHostUsers(t *testing.T) {
 				// Verify that the appropriate groups form the first set were deleted.
 				userGroups := getUserGroups(t, u)
 				for _, group := range tc.firstGroups {
+					if len(tc.secondGroups) == 0 {
+						require.Contains(t, userGroups, group)
+						continue
+					}
+
 					if !slices.Contains(tc.secondGroups, group) {
 						require.NotContains(t, userGroups, group)
 					}

--- a/lib/utils/host/hostusers.go
+++ b/lib/utils/host/hostusers.go
@@ -117,7 +117,7 @@ func SetUserGroups(username string, groups []string) (exitCode int, err error) {
 	if err != nil {
 		return -1, trace.Wrap(err, "cant find usermod binary")
 	}
-	// usermod -G (replace groups) (username)
+
 	cmd := exec.Command(usermodBin, "-G", strings.Join(groups, ","), username)
 	output, err := cmd.CombinedOutput()
 	log.Debugf("%s output: %s", cmd.Path, string(output))


### PR DESCRIPTION
Fixes #44169

Treats empty `host_groups` configurations as a no-op for host user group assignment. The only groups that will still be modified are teleport groups, such as `teleport-system` and `teleport-keep`. This allows for group management external to teleport without breaking our ability to identify teleport managed host users.

changelog: Fixed an issue where Teleport would remove groups from host users even if `host_groups` was not defined. Teleport can now fit into environments where host user groups are managed external to Teleport.
