### PR TITLE
Fix example token in the Terraform Cloud joining docs

### DIFF
--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
@@ -97,7 +97,7 @@ self-hosted Terraform Enterprise:
     roles: [Bot]
     join_method: terraform_cloud
     bot_name: terraform
-    terraform:
+    terraform_cloud:
       allow:
         - organization_name: ExampleOrganization
           project_name: example-project
@@ -121,7 +121,7 @@ self-hosted Terraform Enterprise:
     roles: [Bot]
     join_method: terraform_cloud
     bot_name: terraform
-    terraform:
+    terraform_cloud:
       hostname: terraform.example.com
       allow:
         - organization_name: ExampleOrganization


### PR DESCRIPTION
The `terraform` provision token field was renamed to `terraform_cloud` and this change was not reflected in the docs.