### PR TITLE
[v16] Fix static host user audit events

### DIFF
--- a/api/types/events/oneof.go
+++ b/api/types/events/oneof.go
@@ -724,6 +724,18 @@ func ToOneOf(in AuditEvent) (*OneOf, error) {
 		out.Event = &OneOf_PluginDelete{
 			PluginDelete: e,
 		}
+	case *StaticHostUserCreate:
+		out.Event = &OneOf_StaticHostUserCreate{
+			StaticHostUserCreate: e,
+		}
+	case *StaticHostUserUpdate:
+		out.Event = &OneOf_StaticHostUserUpdate{
+			StaticHostUserUpdate: e,
+		}
+	case *StaticHostUserDelete:
+		out.Event = &OneOf_StaticHostUserDelete{
+			StaticHostUserDelete: e,
+		}
 	default:
 		slog.ErrorContext(context.Background(), "Attempted to convert dynamic event of unknown type into protobuf event.", "event_type", in.GetType())
 		unknown := &Unknown{}


### PR DESCRIPTION
This change fixes static host user events not being recognized by the audit log.

Fixes #46673.

Changelog: Fixed audit log not recognizing static host user events