### PR TITLE
Web: fix dom validation error on test

### DIFF
--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.tsx
@@ -21,7 +21,6 @@ import { Link as InternalRouteLink } from 'react-router-dom';
 import { useLocation } from 'react-router';
 import styled from 'styled-components';
 import { Box, ButtonSecondary, Text, Link, Flex, ButtonPrimary } from 'design';
-import { P } from 'design/Text/Text';
 import * as Icons from 'design/Icon';
 import FieldInput from 'shared/components/FieldInput';
 import { requiredIamRoleName } from 'shared/components/Validation/rules';
@@ -152,7 +151,7 @@ export function AwsOidc() {
           AWS RDS
         </RouteLink>{' '}
         instances during resource enrollment.
-        <P>
+        <Box mt={3}>
           AWS Resources created by the integration are tagged so that you can
           search and export them using the{' '}
           <Link target="_blank" href={AWS_RESOURCE_GROUPS_TAG_EDITOR_LINK}>
@@ -173,7 +172,7 @@ export function AwsOidc() {
               },
             ]}
           />
-        </P>
+        </Box>
       </Box>
 
       <Validation>


### PR DESCRIPTION
`IntegrationPick.test.tsx` was failing because of dom validation error something about you can't have a `<p>` wrapping around a `<pre>` element (the `pre` came from `TextMultiSelect` component)