### PR TITLE
Update backend.Key to be its own distinct type

### DIFF
--- a/lib/auth/auth_with_roles_okta_rbac_test.go
+++ b/lib/auth/auth_with_roles_okta_rbac_test.go
@@ -20,9 +20,11 @@ package auth
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
@@ -34,7 +36,7 @@ import (
 
 func newUserWithOrigin(t *testing.T, origin string) types.User {
 	t.Helper()
-	user, err := types.NewUser(t.Name())
+	user, err := types.NewUser(uuid.NewString())
 	require.NoError(t, err)
 
 	if origin != "" {
@@ -108,7 +110,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 
 		t.Run("okta service updating non-okta user is an error", func(t *testing.T) {
 			// Given an existing non-okta user
-			user, err := types.NewUser(t.Name())
+			user, err := types.NewUser(uuid.NewString())
 			require.NoError(t, err)
 			user, err = srv.AuthServer.CreateUser(ctx, user)
 			require.NoError(t, err)
@@ -176,7 +178,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 
 	t.Run("upsert", func(t *testing.T) {
 		t.Run("okta service creating non-okta user is an error", func(t *testing.T) {
-			user, err := types.NewUser(t.Name())
+			user, err := types.NewUser(uuid.NewString())
 			require.NoError(t, err)
 
 			_, err = authWithOktaRole.UpsertUser(ctx, user)
@@ -197,7 +199,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 
 		t.Run("okta service updating non-okta user is an error", func(t *testing.T) {
 			// Given an existing non-okta user
-			user, err := types.NewUser(t.Name())
+			user, err := types.NewUser(uuid.NewString())
 			require.NoError(t, err)
 			user, err = srv.AuthServer.CreateUser(ctx, user)
 			require.NoError(t, err)
@@ -268,7 +270,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 
 		t.Run("okta service updating non-Okta user is an error", func(t *testing.T) {
 			// Given an existing non-okta existing
-			existing, err := types.NewUser(t.Name())
+			existing, err := types.NewUser(uuid.NewString())
 			require.NoError(t, err)
 			existing, err = srv.AuthServer.CreateUser(ctx, existing)
 			require.NoError(t, err)
@@ -366,7 +368,7 @@ func TestOktaMayNotResetPasswords(t *testing.T) {
 
 	t.Run("non-okta user", func(t *testing.T) {
 		// Given an existing non-okta existing
-		existing, err := types.NewUser(t.Name())
+		existing, err := types.NewUser(uuid.NewString())
 		require.NoError(t, err)
 		existing, err = srv.AuthServer.CreateUser(ctx, existing)
 		require.NoError(t, err)
@@ -395,7 +397,7 @@ func newTestLock(t *testing.T, target types.User, origin string) types.Lock {
 			User: target.GetName(),
 		},
 	}
-	lock, err := types.NewLock(t.Name(), lockSpec)
+	lock, err := types.NewLock(strings.ReplaceAll(uuid.NewString(), "-", ""), lockSpec)
 	require.NoError(t, err)
 
 	if origin != "" {
@@ -492,7 +494,7 @@ func TestOktaServiceLockCRUD(t *testing.T) {
 					Node: "banana",
 				},
 			}
-			lock, err := types.NewLock(t.Name(), lockSpec)
+			lock, err := types.NewLock(strings.ReplaceAll(uuid.NewString(), "-", ""), lockSpec)
 			require.NoError(t, err)
 			lock.SetOrigin(types.OriginOkta)
 
@@ -585,7 +587,7 @@ func TestOktaServiceLockCRUD(t *testing.T) {
 
 			// And an un-locked non-okta user
 			nonOktaUser := newUserWithOrigin(t, "")
-			nonOktaUser.SetName(t.Name() + "non-okta")
+			nonOktaUser.SetName(nonOktaUser.GetName() + "non-okta")
 			_, err = srv.AuthServer.CreateUser(ctx, nonOktaUser)
 			require.NoError(t, err)
 

--- a/lib/auth/authclient/http_client.go
+++ b/lib/auth/authclient/http_client.go
@@ -554,7 +554,7 @@ func (c *HTTPClient) ExtendWebSession(ctx context.Context, req WebSessionReq) (t
 func (c *HTTPClient) CreateWebSession(ctx context.Context, user string) (types.WebSession, error) {
 	out, err := c.PostJSON(
 		ctx,
-		c.Endpoint("users", user, "web", "sessions"),
+		c.Endpoint("users", url.PathEscape(user), "web", "sessions"),
 		WebSessionReq{User: user},
 	)
 	if err != nil {
@@ -566,9 +566,10 @@ func (c *HTTPClient) CreateWebSession(ctx context.Context, user string) (types.W
 // AuthenticateWebUser authenticates web user, creates and  returns web session
 // in case if authentication is successful
 func (c *HTTPClient) AuthenticateWebUser(ctx context.Context, req AuthenticateUserRequest) (types.WebSession, error) {
+
 	out, err := c.PostJSON(
 		ctx,
-		c.Endpoint("users", req.Username, "web", "authenticate"),
+		c.Endpoint("users", url.PathEscape(req.Username), "web", "authenticate"),
 		req,
 	)
 	if err != nil {
@@ -582,7 +583,7 @@ func (c *HTTPClient) AuthenticateWebUser(ctx context.Context, req AuthenticateUs
 func (c *HTTPClient) AuthenticateSSHUser(ctx context.Context, req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
 	out, err := c.PostJSON(
 		ctx,
-		c.Endpoint("users", req.Username, "ssh", "authenticate"),
+		c.Endpoint("users", url.PathEscape(req.Username), "ssh", "authenticate"),
 		req,
 	)
 	if err != nil {
@@ -600,7 +601,7 @@ func (c *HTTPClient) AuthenticateSSHUser(ctx context.Context, req AuthenticateSS
 func (c *HTTPClient) GetWebSessionInfo(ctx context.Context, user, sessionID string) (types.WebSession, error) {
 	out, err := c.Get(
 		ctx,
-		c.Endpoint("users", user, "web", "sessions", sessionID), url.Values{})
+		c.Endpoint("users", url.PathEscape(user), "web", "sessions", sessionID), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -609,7 +610,7 @@ func (c *HTTPClient) GetWebSessionInfo(ctx context.Context, user, sessionID stri
 
 // DeleteWebSession deletes the web session specified with sid for the given user
 func (c *HTTPClient) DeleteWebSession(ctx context.Context, user string, sid string) error {
-	_, err := c.Delete(ctx, c.Endpoint("users", user, "web", "sessions", sid))
+	_, err := c.Delete(ctx, c.Endpoint("users", url.PathEscape(user), "web", "sessions", sid))
 	return trace.Wrap(err)
 }
 

--- a/lib/auth/join/join_test.go
+++ b/lib/auth/join/join_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
@@ -301,7 +302,7 @@ func TestRegister_Bot_Expiry(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			botName := t.Name()
+			botName := uuid.NewString()
 			_, err := machineidv1.UpsertBot(ctx, srv.Auth(), &machineidv1pb.Bot{
 				Metadata: &headerv1.Metadata{
 					Name: botName,
@@ -312,7 +313,7 @@ func TestRegister_Bot_Expiry(t *testing.T) {
 				},
 			}, srv.Clock().Now(), "")
 			require.NoError(t, err)
-			tok := newBotToken(t, t.Name(), botName, types.RoleBot, srv.Clock().Now().Add(time.Hour))
+			tok := newBotToken(t, uuid.NewString(), botName, types.RoleBot, srv.Clock().Now().Add(time.Hour))
 			require.NoError(t, srv.Auth().UpsertToken(ctx, tok))
 
 			result, err := Register(ctx, RegisterParams{

--- a/lib/auth/join_test.go
+++ b/lib/auth/join_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
@@ -445,7 +446,7 @@ func TestRegister_Bot_Expiry(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			botName := t.Name()
+			botName := uuid.NewString()
 			_, err := machineidv1.UpsertBot(ctx, srv.Auth(), &machineidv1pb.Bot{
 				Metadata: &headerv1.Metadata{
 					Name: botName,
@@ -456,7 +457,7 @@ func TestRegister_Bot_Expiry(t *testing.T) {
 				},
 			}, srv.Clock().Now(), "")
 			require.NoError(t, err)
-			tok := newBotToken(t, t.Name(), botName, types.RoleBot, srv.Clock().Now().Add(time.Hour))
+			tok := newBotToken(t, uuid.NewString(), botName, types.RoleBot, srv.Clock().Now().Add(time.Hour))
 			require.NoError(t, srv.Auth().UpsertToken(ctx, tok))
 
 			result, err := join.Register(ctx, join.RegisterParams{

--- a/lib/auth/okta/auth_test.go
+++ b/lib/auth/okta/auth_test.go
@@ -19,6 +19,7 @@ package okta
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -26,7 +27,7 @@ import (
 )
 
 func userWithOrigin(t *testing.T, origin string) types.User {
-	user, err := types.NewUser(t.Name())
+	user, err := types.NewUser(uuid.NewString())
 	require.NoError(t, err)
 	if origin != "" {
 		user.SetOrigin(origin)

--- a/lib/auth/users/usersv1/okta_test.go
+++ b/lib/auth/users/usersv1/okta_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
@@ -46,7 +47,7 @@ func (a builtinRoleAuthorizer) Authorize(ctx context.Context) (*authz.Context, e
 
 func newOktaUser(t *testing.T) types.User {
 	t.Helper()
-	user, err := types.NewUser(t.Name())
+	user, err := types.NewUser(uuid.NewString())
 	require.NoError(t, err)
 
 	user.SetOrigin(types.OriginOkta)
@@ -86,7 +87,7 @@ func TestOktaCRUD(t *testing.T) {
 		})
 
 		t.Run("okta service creating a non-okta user in an error", func(t *testing.T) {
-			user, err := types.NewUser(t.Name())
+			user, err := types.NewUser(uuid.NewString())
 			require.NoError(t, err)
 
 			_, err = env.CreateUser(oktaCtx, &userspb.CreateUserRequest{User: user.(*types.UserV2)})
@@ -123,7 +124,7 @@ func TestOktaCRUD(t *testing.T) {
 
 		t.Run("okta service updating non-Okta user is an error", func(t *testing.T) {
 			// Given an existing non-okta user
-			user, err := types.NewUser(t.Name())
+			user, err := types.NewUser(uuid.NewString())
 			require.NoError(t, err)
 			user, err = env.backend.CreateUser(context.Background(), user)
 			require.NoError(t, err)
@@ -222,7 +223,7 @@ func TestOktaCRUD(t *testing.T) {
 
 		t.Run("okta service creating non-okta user is an error", func(t *testing.T) {
 			// Given a non-okta user *not* already in the Teleport user backend...
-			user, err := types.NewUser(t.Name())
+			user, err := types.NewUser(uuid.NewString())
 			require.NoError(t, err)
 
 			// When I (as the Okta service) try to Upsert that user...
@@ -254,7 +255,7 @@ func TestOktaCRUD(t *testing.T) {
 
 		t.Run("okta service updating non-Okta user is an error", func(t *testing.T) {
 			// Given an existing non-okta user already in the Teleport user DB...
-			user, err := types.NewUser(t.Name())
+			user, err := types.NewUser(uuid.NewString())
 			require.NoError(t, err)
 			user, err = env.backend.CreateUser(context.Background(), user)
 			require.NoError(t, err)
@@ -291,7 +292,7 @@ func TestOktaCRUD(t *testing.T) {
 		})
 
 		t.Run("non-okta service creating okta user is an error", func(t *testing.T) {
-			user, err := types.NewUser(t.Name())
+			user, err := types.NewUser(uuid.NewString())
 			require.NoError(t, err)
 
 			_, err = env.UpsertUser(
@@ -369,7 +370,7 @@ func TestOktaCRUD(t *testing.T) {
 
 		t.Run("okta service deleting non-Okta user is an error", func(t *testing.T) {
 			// Given an existing non-okta user already in the Teleport user DB...
-			user, err := types.NewUser(t.Name())
+			user, err := types.NewUser(uuid.NewString())
 			require.NoError(t, err)
 			user, err = env.backend.CreateUser(context.Background(), user)
 			require.NoError(t, err)

--- a/lib/backend/atomicwrite.go
+++ b/lib/backend/atomicwrite.go
@@ -187,7 +187,7 @@ type ConditionalAction struct {
 
 // Check validates the basic correctness of the conditional action.
 func (c *ConditionalAction) Check() error {
-	if len(c.Key) == 0 {
+	if len(c.Key.s) == 0 {
 		return trace.BadParameter("conditional action missing required parameter 'Key'")
 	}
 
@@ -248,7 +248,7 @@ func ValidateAtomicWrite(condacts []ConditionalAction) error {
 
 		containsWrite = containsWrite || condacts[i].Action.IsWrite()
 
-		key := string(condacts[i].Key)
+		key := condacts[i].Key.String()
 
 		if _, ok := keys[key]; ok {
 			return trace.BadParameter("multiple conditional actions target key %q", key)

--- a/lib/backend/atomicwrite_test.go
+++ b/lib/backend/atomicwrite_test.go
@@ -19,7 +19,7 @@
 package backend
 
 import (
-	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,24 +39,24 @@ func TestAtomicWriteValidation(t *testing.T) {
 		{
 			condacts: []ConditionalAction{
 				{
-					Key:       []byte("/foo/bar"),
+					Key:       NewKey("foo", "bar"),
 					Condition: Exists(),
 					Action: Put(Item{
 						Value: []byte("true"),
 					}),
 				},
 				{
-					Key:       []byte("/bin/baz"),
+					Key:       NewKey("bin", "baz"),
 					Condition: Revision("r1"),
 					Action:    Delete(),
 				},
 				{
-					Key:       []byte("/apples/oranges"),
+					Key:       NewKey("apples", "oranges"),
 					Condition: NotExists(),
 					Action:    Nop(),
 				},
 				{
-					Key:       []byte("/up/down"),
+					Key:       NewKey("up", "down"),
 					Condition: Whatever(),
 					Action: Put(Item{
 						Value: []byte("v"),
@@ -69,7 +69,7 @@ func TestAtomicWriteValidation(t *testing.T) {
 		{
 			condacts: []ConditionalAction{
 				{
-					Key:       []byte("/foo/bar"),
+					Key:       NewKey("foo", "bar"),
 					Condition: Revision(""), // empty revisions are allowed
 					Action:    Delete(),
 				},
@@ -80,7 +80,7 @@ func TestAtomicWriteValidation(t *testing.T) {
 		{
 			condacts: []ConditionalAction{
 				{
-					Key:       []byte("/singleton"),
+					Key:       NewKey("singleton"),
 					Condition: Whatever(),
 					Action:    Delete(),
 				},
@@ -97,24 +97,24 @@ func TestAtomicWriteValidation(t *testing.T) {
 		{
 			condacts: []ConditionalAction{
 				{
-					Key:       []byte("/foo/bar"),
+					Key:       NewKey("foo", "bar"),
 					Condition: Exists(),
 					Action: Put(Item{
 						Value: []byte("true"),
 					}),
 				},
 				{
-					Key:       []byte("/foo/baz"),
+					Key:       NewKey("foo", "baz"),
 					Condition: Revision("r1"),
 					Action:    Delete(),
 				},
 				{
-					Key:       []byte("/apples/oranges"),
+					Key:       NewKey("apples", "oranges"),
 					Condition: NotExists(),
 					Action:    Nop(),
 				},
 				{
-					Key:       []byte("/foo/bar"),
+					Key:       NewKey("foo", "bar"),
 					Condition: Revision("r2"),
 					Action:    Nop(),
 				},
@@ -126,7 +126,7 @@ func TestAtomicWriteValidation(t *testing.T) {
 		{
 			condacts: []ConditionalAction{
 				{
-					Key:       []byte("/foo/bar"),
+					Key:       NewKey("foo", "bar"),
 					Condition: Exists(),
 					Action:    Put(Item{}),
 				},
@@ -138,7 +138,7 @@ func TestAtomicWriteValidation(t *testing.T) {
 		{
 			condacts: []ConditionalAction{
 				{
-					Key:       []byte("/foo/bar"),
+					Key:       NewKey("foo", "bar"),
 					Condition: Condition{},
 					Action:    Delete(),
 				},
@@ -150,7 +150,7 @@ func TestAtomicWriteValidation(t *testing.T) {
 		{
 			condacts: []ConditionalAction{
 				{
-					Key:       []byte("/foo/bar"),
+					Key:       NewKey("foo", "bar"),
 					Condition: Exists(),
 					Action:    Action{},
 				},
@@ -164,7 +164,7 @@ func TestAtomicWriteValidation(t *testing.T) {
 	var big []ConditionalAction
 	for i := 0; i < MaxAtomicWriteSize+1; i++ {
 		big = append(big, ConditionalAction{
-			Key:       []byte(fmt.Sprintf("/key-%d", i)),
+			Key:       NewKey("key-" + strconv.Itoa(i)),
 			Condition: Whatever(),
 			Action:    Delete(),
 		})

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -167,7 +167,7 @@ func IterateRange(ctx context.Context, bk Backend, startKey, endKey Key, limit i
 // impl for a given backend may be used.
 func StreamRange(ctx context.Context, bk Backend, startKey, endKey Key, pageSize int) stream.Stream[Item] {
 	return stream.PageFunc[Item](func() ([]Item, error) {
-		if startKey == nil {
+		if startKey.components == nil {
 			return nil, io.EOF
 		}
 		rslt, err := bk.GetRange(ctx, startKey, endKey, pageSize)
@@ -175,7 +175,7 @@ func StreamRange(ctx context.Context, bk Backend, startKey, endKey Key, pageSize
 			return nil, trace.Wrap(err)
 		}
 		if len(rslt.Items) < pageSize {
-			startKey = nil
+			startKey = Key{}
 		} else {
 			startKey = nextKey(rslt.Items[pageSize-1].Key)
 		}
@@ -301,20 +301,20 @@ const NoLimit = 0
 // If used with a key prefix, this will return
 // the end of the range for that key prefix.
 func nextKey(key Key) Key {
-	end := make([]byte, len(key))
-	copy(end, key)
+	end := make([]byte, len(key.s))
+	copy(end, key.s)
 	for i := len(end) - 1; i >= 0; i-- {
 		if end[i] < 0xff {
 			end[i] = end[i] + 1
 			end = end[:i+1]
-			return end
+			return KeyFromString(string(end))
 		}
 	}
 	// next key does not exist (e.g., 0xffff);
-	return noEnd
+	return Key{noEnd: true}
 }
 
-var noEnd = Key{0}
+var noEnd = []byte{0}
 
 // RangeEnd returns end of the range for given key.
 func RangeEnd(key Key) Key {
@@ -337,8 +337,14 @@ type KeyedItem interface {
 // For items that implement HostID, the next key will also
 // have the HostID part.
 func NextPaginationKey(ki KeyedItem) string {
-	key := GetPaginationKey(ki)
-	return string(nextKey(Key(key)))
+	var key Key
+	if h, ok := ki.(HostID); ok {
+		key = internalKey(h.GetHostID(), h.GetName())
+	} else {
+		key = NewKey(ki.GetName())
+	}
+
+	return nextKey(key).String()
 }
 
 // GetPaginationKey returns the pagination key given item.
@@ -346,7 +352,7 @@ func NextPaginationKey(ki KeyedItem) string {
 // have the HostID part.
 func GetPaginationKey(ki KeyedItem) string {
 	if h, ok := ki.(HostID); ok {
-		return string(internalKey(h.GetHostID(), h.GetName()))
+		return internalKey(h.GetHostID(), h.GetName()).String()
 	}
 
 	return ki.GetName()

--- a/lib/backend/backend_test.go
+++ b/lib/backend/backend_test.go
@@ -21,6 +21,7 @@ package backend
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,17 +43,32 @@ func TestParams(t *testing.T) {
 
 func TestRangeEnd(t *testing.T) {
 	for _, test := range []struct {
-		key, expected string
+		key, expected Key
 	}{
-		{"abc", "abd"},
-		{"/foo/bar", "/foo/bas"},
-		{"/xyz", "/xy{"},
-		{"\xFF", "\x00"},
-		{"\xFF\xFF\xFF", "\x00"},
+		{
+			key:      NewKey("abc"),
+			expected: NewKey("abd"),
+		},
+		{
+			key:      NewKey("foo", "bar"),
+			expected: NewKey("foo", "bas"),
+		},
+		{
+			key:      NewKey("xyz"),
+			expected: NewKey("xy{"),
+		},
+		{
+			key:      NewKey("\xFF"),
+			expected: Key{s: "0", components: []string{"0"}},
+		},
+		{
+			key:      NewKey("\xFF\xFF\xFF"),
+			expected: Key{s: "0", components: []string{"0"}},
+		},
 	} {
-		t.Run(test.key, func(t *testing.T) {
-			end := RangeEnd([]byte(test.key))
-			require.Equal(t, test.expected, string(end))
+		t.Run(test.key.String(), func(t *testing.T) {
+			end := RangeEnd(test.key)
+			require.Empty(t, cmp.Diff(test.expected, end, cmp.AllowUnexported(Key{})))
 		})
 	}
 }

--- a/lib/backend/buffer_test.go
+++ b/lib/backend/buffer_test.go
@@ -20,7 +20,7 @@ package backend
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -51,17 +51,17 @@ func TestWatcherSimple(t *testing.T) {
 		t.Fatalf("Timeout waiting for event.")
 	}
 
-	b.Emit(Event{Item: Item{Key: Key("/1")}})
+	b.Emit(Event{Item: Item{Key: NewKey("1")}})
 
 	select {
 	case e := <-w.Events():
-		require.Equal(t, Key("/1"), e.Item.Key)
+		require.Equal(t, NewKey("1"), e.Item.Key)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Timeout waiting for event.")
 	}
 
 	b.Close()
-	b.Emit(Event{Item: Item{Key: Key("/2")}})
+	b.Emit(Event{Item: Item{Key: NewKey("2")}})
 
 	select {
 	case <-w.Done():
@@ -104,12 +104,12 @@ func TestWatcherCapacity(t *testing.T) {
 	// emit and then consume 10 events.  this is much larger than our queue size,
 	// but should succeed since we consume within our grace period.
 	for i := 0; i < 10; i++ {
-		b.Emit(Event{Item: Item{Key: Key(fmt.Sprintf("/%d", i+1))}})
+		b.Emit(Event{Item: Item{Key: NewKey(strconv.Itoa(i + 1))}})
 	}
 	for i := 0; i < 10; i++ {
 		select {
 		case e := <-w.Events():
-			require.Equal(t, fmt.Sprintf("/%d", i+1), string(e.Item.Key))
+			require.Equal(t, string(Separator)+strconv.Itoa(i+1), e.Item.Key.String())
 		default:
 			t.Fatalf("Expected events to be immediately available")
 		}
@@ -119,7 +119,7 @@ func TestWatcherCapacity(t *testing.T) {
 	clock.Advance(gracePeriod + time.Second)
 
 	// emit another event, which will cause buffer to reevaluate the grace period.
-	b.Emit(Event{Item: Item{Key: Key("/11")}})
+	b.Emit(Event{Item: Item{Key: NewKey("11")}})
 
 	// ensure that buffer did not close watcher, since previously created backlog
 	// was drained within grace period.
@@ -131,13 +131,13 @@ func TestWatcherCapacity(t *testing.T) {
 
 	// create backlog again, and this time advance past grace period without draining it.
 	for i := 0; i < 10; i++ {
-		b.Emit(Event{Item: Item{Key: Key(fmt.Sprintf("/%d", i+12))}})
+		b.Emit(Event{Item: Item{Key: NewKey(strconv.Itoa(i + 12))}})
 	}
 	clock.Advance(gracePeriod + time.Second)
 
 	// emit another event, which will cause buffer to realize that watcher is past
 	// its grace period.
-	b.Emit(Event{Item: Item{Key: Key("/22")}})
+	b.Emit(Event{Item: Item{Key: NewKey("22")}})
 
 	select {
 	case <-w.Done():
@@ -177,7 +177,7 @@ func TestWatcherCreationGracePeriod(t *testing.T) {
 
 	// emit enough events to create a backlog
 	for i := 0; i < queueSize*2; i++ {
-		b.Emit(Event{Item: Item{Key: Key{Separator}}})
+		b.Emit(Event{Item: Item{Key: NewKey("")}})
 	}
 
 	select {
@@ -192,7 +192,7 @@ func TestWatcherCreationGracePeriod(t *testing.T) {
 	// advance well past the backlog grace period, but not past the creation grace period
 	clock.Advance(backlogGracePeriod * 2)
 
-	b.Emit(Event{Item: Item{Key: Key{Separator}}})
+	b.Emit(Event{Item: Item{Key: NewKey("")}})
 
 	select {
 	case <-w.Done():
@@ -203,7 +203,7 @@ func TestWatcherCreationGracePeriod(t *testing.T) {
 	// advance well past creation grace period
 	clock.Advance(creationGracePeriod)
 
-	b.Emit(Event{Item: Item{Key: Key{Separator}}})
+	b.Emit(Event{Item: Item{Key: NewKey("")}})
 	select {
 	case <-w.Done():
 	default:
@@ -248,24 +248,24 @@ func TestRemoveRedundantPrefixes(t *testing.T) {
 			out: []Key{},
 		},
 		{
-			in:  []Key{Key("/a")},
-			out: []Key{Key("/a")},
+			in:  []Key{NewKey("a")},
+			out: []Key{NewKey("a")},
 		},
 		{
-			in:  []Key{Key("/a"), Key("/")},
-			out: []Key{Key("/")},
+			in:  []Key{NewKey("a"), NewKey("")},
+			out: []Key{NewKey("")},
 		},
 		{
-			in:  []Key{Key("/b"), Key("/a")},
-			out: []Key{Key("/a"), Key("/b")},
+			in:  []Key{NewKey("b"), NewKey("a")},
+			out: []Key{NewKey("a"), NewKey("b")},
 		},
 		{
-			in:  []Key{Key("/a/b"), Key("/a"), Key("/a/b/c"), Key("/d")},
-			out: []Key{Key("/a"), Key("/d")},
+			in:  []Key{NewKey("a", "b"), NewKey("a"), NewKey("a", "b", "c"), NewKey("d")},
+			out: []Key{NewKey("a"), NewKey("d")},
 		},
 	}
 	for _, tc := range tcs {
-		require.Empty(t, cmp.Diff(RemoveRedundantPrefixes(tc.in), tc.out))
+		require.Empty(t, cmp.Diff(RemoveRedundantPrefixes(tc.in), tc.out, cmp.AllowUnexported(Key{})))
 	}
 }
 
@@ -279,7 +279,7 @@ func TestWatcherMulti(t *testing.T) {
 	defer b.Close()
 	b.SetInit()
 
-	w, err := b.NewWatcher(ctx, Watch{Prefixes: []Key{Key("/a"), Key("/a/b")}})
+	w, err := b.NewWatcher(ctx, Watch{Prefixes: []Key{NewKey("a"), NewKey("a", "b")}})
 	require.NoError(t, err)
 	defer w.Close()
 
@@ -290,11 +290,11 @@ func TestWatcherMulti(t *testing.T) {
 		t.Fatalf("Timeout waiting for event.")
 	}
 
-	b.Emit(Event{Item: Item{Key: Key("/a/b/c")}})
+	b.Emit(Event{Item: Item{Key: NewKey("a", "b", "c")}})
 
 	select {
 	case e := <-w.Events():
-		require.Equal(t, Key("/a/b/c"), e.Item.Key)
+		require.Equal(t, NewKey("a", "b", "c"), e.Item.Key)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Timeout waiting for event.")
 	}
@@ -322,7 +322,7 @@ func TestWatcherReset(t *testing.T) {
 		t.Fatalf("Timeout waiting for event.")
 	}
 
-	b.Emit(Event{Item: Item{Key: Key("/1")}})
+	b.Emit(Event{Item: Item{Key: NewKey("1")}})
 	b.Clear()
 
 	// make sure watcher has been closed
@@ -343,11 +343,11 @@ func TestWatcherReset(t *testing.T) {
 		t.Fatalf("Timeout waiting for event.")
 	}
 
-	b.Emit(Event{Item: Item{Key: Key("/2")}})
+	b.Emit(Event{Item: Item{Key: NewKey("2")}})
 
 	select {
 	case e := <-w2.Events():
-		require.Equal(t, Key("/2"), e.Item.Key)
+		require.Equal(t, NewKey("2"), e.Item.Key)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Timeout waiting for event.")
 	}
@@ -358,10 +358,10 @@ func TestWatcherTree(t *testing.T) {
 	wt := newWatcherTree()
 	require.False(t, wt.rm(nil))
 
-	w1 := &BufferWatcher{Watch: Watch{Prefixes: []Key{Key("/a"), Key("/a/a1"), Key("/c")}}}
+	w1 := &BufferWatcher{Watch: Watch{Prefixes: []Key{NewKey("a"), NewKey("a", "a1"), NewKey("c")}}}
 	require.False(t, wt.rm(w1))
 
-	w2 := &BufferWatcher{Watch: Watch{Prefixes: []Key{Key("/a")}}}
+	w2 := &BufferWatcher{Watch: Watch{Prefixes: []Key{NewKey("a")}}}
 
 	wt.add(w1)
 	wt.add(w2)

--- a/lib/backend/clone_test.go
+++ b/lib/backend/clone_test.go
@@ -59,7 +59,7 @@ func TestClone(t *testing.T) {
 	result, err := dst.GetRange(ctx, start, backend.RangeEnd(start), 0)
 	require.NoError(t, err)
 
-	diff := cmp.Diff(items, result.Items, cmpopts.IgnoreFields(backend.Item{}, "Revision"))
+	diff := cmp.Diff(items, result.Items, cmpopts.IgnoreFields(backend.Item{}, "Revision"), cmp.AllowUnexported(backend.Key{}))
 	require.Empty(t, diff)
 	require.NoError(t, err)
 	require.Len(t, result.Items, itemCount)
@@ -101,7 +101,7 @@ func TestCloneForce(t *testing.T) {
 	result, err := dst.GetRange(ctx, start, backend.RangeEnd(start), 0)
 	require.NoError(t, err)
 
-	diff := cmp.Diff(items, result.Items, cmpopts.IgnoreFields(backend.Item{}, "Revision"))
+	diff := cmp.Diff(items, result.Items, cmpopts.IgnoreFields(backend.Item{}, "Revision"), cmp.AllowUnexported(backend.Key{}))
 	require.Empty(t, diff)
 	require.Len(t, result.Items, itemCount)
 }

--- a/lib/backend/dynamo/atomicwrite.go
+++ b/lib/backend/dynamo/atomicwrite.go
@@ -19,7 +19,6 @@
 package dynamo
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"slices"
@@ -269,12 +268,12 @@ TxnLoop:
 		return revision, nil
 	}
 
-	var keys [][]byte
+	var keys []string
 	for _, ca := range condacts {
-		keys = append(keys, ca.Key)
+		keys = append(keys, ca.Key.String())
 	}
 
-	b.logger.ErrorContext(ctx, "AtomicWrite failed, dynamodb transaction experienced too many conflicts", "keys", bytes.Join(keys, []byte(",")))
+	b.logger.ErrorContext(ctx, "AtomicWrite failed, dynamodb transaction experienced too many conflicts", "keys", strings.Join(keys, ","))
 
 	return "", trace.Errorf("dynamodb transaction experienced too many conflicts")
 }

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -162,6 +162,7 @@ type EtcdBackend struct {
 	ctx         context.Context
 	cancel      context.CancelFunc
 	watchDone   chan struct{}
+	prefix      backend.Key
 }
 
 // Config represents JSON config for etcd backend
@@ -290,6 +291,7 @@ func New(ctx context.Context, params backend.Params, opts ...Option) (*EtcdBacke
 		buf:         buf,
 		leaseBucket: utils.SeventhJitter(options.leaseBucket),
 		leaseCache:  leaseCache,
+		prefix:      backend.KeyFromString(cfg.Key),
 	}
 
 	// Check that the etcd nodes are at least the minimum version supported
@@ -651,10 +653,10 @@ func (b *EtcdBackend) NewWatcher(ctx context.Context, watch backend.Watch) (back
 
 // GetRange returns query range
 func (b *EtcdBackend) GetRange(ctx context.Context, startKey, endKey backend.Key, limit int) (*backend.GetResult, error) {
-	if len(startKey) == 0 {
+	if startKey.IsZero() {
 		return nil, trace.BadParameter("missing parameter startKey")
 	}
-	if len(endKey) == 0 {
+	if endKey.IsZero() {
 		return nil, trace.BadParameter("missing parameter endKey")
 	}
 	opts := []clientv3.OpOption{clientv3.WithRange(b.prependPrefix(endKey))}
@@ -718,7 +720,7 @@ func (b *EtcdBackend) Create(ctx context.Context, item backend.Item) (*backend.L
 		return nil, trace.Wrap(convertErr(err))
 	}
 	if !re.Succeeded {
-		return nil, trace.AlreadyExists("%q already exists", string(item.Key))
+		return nil, trace.AlreadyExists("%v already exists", item.Key)
 	}
 
 	lease.Revision = toBackendRevision(re.Header.Revision)
@@ -746,7 +748,7 @@ func (b *EtcdBackend) Update(ctx context.Context, item backend.Item) (*backend.L
 		return nil, trace.Wrap(convertErr(err))
 	}
 	if !re.Succeeded {
-		return nil, trace.NotFound("%q is not found", string(item.Key))
+		return nil, trace.NotFound("%q is not found", item.Key.String())
 	}
 
 	lease.Revision = toBackendRevision(re.Header.Revision)
@@ -790,10 +792,10 @@ func (b *EtcdBackend) ConditionalUpdate(ctx context.Context, item backend.Item) 
 // CompareAndSwap compares item with existing item
 // and replaces is with replaceWith item
 func (b *EtcdBackend) CompareAndSwap(ctx context.Context, expected backend.Item, replaceWith backend.Item) (*backend.Lease, error) {
-	if len(expected.Key) == 0 {
+	if expected.Key.IsZero() {
 		return nil, trace.BadParameter("missing parameter Key")
 	}
-	if len(replaceWith.Key) == 0 {
+	if replaceWith.Key.IsZero() {
 		return nil, trace.BadParameter("missing parameter Key")
 	}
 	if expected.Key.Compare(replaceWith.Key) != 0 {
@@ -824,7 +826,7 @@ func (b *EtcdBackend) CompareAndSwap(ctx context.Context, expected backend.Item,
 		return nil, trace.Wrap(err)
 	}
 	if !re.Succeeded {
-		return nil, trace.CompareFailed("key %q did not match expected value", string(expected.Key))
+		return nil, trace.CompareFailed("key %q did not match expected value", expected.Key.String())
 	}
 
 	lease.Revision = toBackendRevision(re.Header.Revision)
@@ -870,7 +872,7 @@ func (b *EtcdBackend) KeepAlive(ctx context.Context, lease backend.Lease, expire
 	_, err := b.clients.Next().Put(ctx, b.prependPrefix(lease.Key), "", opts...)
 	err = convertErr(err)
 	if trace.IsNotFound(err) {
-		return trace.NotFound("item %q is not found", string(lease.Key))
+		return trace.NotFound("item %q is not found", lease.Key.String())
 	}
 
 	return err
@@ -883,7 +885,7 @@ func (b *EtcdBackend) Get(ctx context.Context, key backend.Key) (*backend.Item, 
 		return nil, convertErr(err)
 	}
 	if len(re.Kvs) == 0 {
-		return nil, trace.NotFound("item %q is not found", string(key))
+		return nil, trace.NotFound("item %q is not found", key.String())
 	}
 	kv := re.Kvs[0]
 	value, err := unmarshal(kv.Value)
@@ -907,7 +909,7 @@ func (b *EtcdBackend) Delete(ctx context.Context, key backend.Key) error {
 		return trace.Wrap(convertErr(err))
 	}
 	if re.Deleted == 0 {
-		return trace.NotFound("%q is not found", key)
+		return trace.NotFound("%q is not found", key.String())
 	}
 
 	return nil
@@ -940,10 +942,10 @@ func (b *EtcdBackend) ConditionalDelete(ctx context.Context, prefix backend.Key,
 
 // DeleteRange deletes range of items with keys between startKey and endKey
 func (b *EtcdBackend) DeleteRange(ctx context.Context, startKey, endKey backend.Key) error {
-	if len(startKey) == 0 {
+	if startKey.IsZero() {
 		return trace.BadParameter("missing parameter startKey")
 	}
-	if len(endKey) == 0 {
+	if endKey.IsZero() {
 		return trace.BadParameter("missing parameter endKey")
 	}
 	start := b.clock.Now()
@@ -1106,10 +1108,10 @@ func fromType(eventType mvccpb.Event_EventType) types.OpType {
 	}
 }
 
-func (b *EtcdBackend) trimPrefix(in backend.Key) backend.Key {
-	return in.TrimPrefix(backend.Key(b.cfg.Key))
+func (b *EtcdBackend) trimPrefix(in []byte) backend.Key {
+	return backend.KeyFromString(string(in)).TrimPrefix(b.prefix)
 }
 
 func (b *EtcdBackend) prependPrefix(in backend.Key) string {
-	return b.cfg.Key + string(in)
+	return in.PrependKey(b.prefix).String()
 }

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -117,7 +117,7 @@ func TestPrefix(t *testing.T) {
 	// When I push an item with a key starting with "/" into etcd via the
 	// _prefixed_ client...
 	item := backend.Item{
-		Key:   backend.Key("/foo"),
+		Key:   backend.NewKey("foo"),
 		Value: []byte("bar"),
 	}
 	_, err = prefixedUut.Put(ctx, item)
@@ -125,7 +125,7 @@ func TestPrefix(t *testing.T) {
 
 	// Expect that I can retrieve it from the _un_prefixed client by
 	// manually prepending a prefix to the key and asking for it.
-	wantKey := prefixedUut.cfg.Key + string(item.Key)
+	wantKey := prefixedUut.cfg.Key + item.Key.String()
 	requireKV(ctx, t, unprefixedUut, wantKey, string(item.Value))
 	got, err := prefixedUut.Get(ctx, item.Key)
 	require.NoError(t, err)
@@ -135,7 +135,7 @@ func TestPrefix(t *testing.T) {
 	// When I push an item with a key that does _not_ start with a separator
 	// char (i.e. "/") into etcd via the _prefixed_ client...
 	item = backend.Item{
-		Key:   backend.Key("foo"),
+		Key:   backend.NewKey("foo"),
 		Value: []byte("bar"),
 	}
 	_, err = prefixedUut.Put(ctx, item)
@@ -143,7 +143,7 @@ func TestPrefix(t *testing.T) {
 
 	// Expect, again, that I can retrieve it from the _un_prefixed client
 	// by manually prepending a prefix to the key and asking for it.
-	wantKey = prefixedUut.cfg.Key + string(item.Key)
+	wantKey = prefixedUut.cfg.Key + item.Key.String()
 	requireKV(ctx, t, unprefixedUut, wantKey, string(item.Value))
 	got, err = prefixedUut.Get(ctx, item.Key)
 	require.NoError(t, err)

--- a/lib/backend/firestore/atomicwrite.go
+++ b/lib/backend/firestore/atomicwrite.go
@@ -19,8 +19,8 @@
 package firestore
 
 import (
-	"bytes"
 	"context"
+	"strings"
 
 	"cloud.google.com/go/firestore"
 	"github.com/gravitational/trace"
@@ -131,11 +131,11 @@ func (b *Backend) AtomicWrite(ctx context.Context, condacts []backend.Conditiona
 
 	if err != nil {
 		if status.Code(err) == codes.Aborted {
-			var keys [][]byte
+			var keys []string
 			for _, ca := range condacts {
-				keys = append(keys, ca.Key)
+				keys = append(keys, ca.Key.String())
 			}
-			b.logger.ErrorContext(ctx, "AtomicWrite failed, firestore experienced too many txn rollbacks.", "keys", bytes.Join(keys, []byte(",")))
+			b.logger.ErrorContext(ctx, "AtomicWrite failed, firestore experienced too many txn rollbacks.", "keys", strings.Join(keys, ","))
 			// RunTransaction does not officially document what error is returned if MaxAttempts is exceeded,
 			// but as currently implemented it should simply bubble up the Aborted error from the most recent
 			// failed commit attempt.

--- a/lib/backend/firestore/firestorebk_test.go
+++ b/lib/backend/firestore/firestorebk_test.go
@@ -178,7 +178,7 @@ func TestReadLegacyRecord(t *testing.T) {
 	uut := newBackend(t, cfg)
 
 	item := backend.Item{
-		Key:     []byte("legacy-record"),
+		Key:     backend.NewKey("legacy-record"),
 		Value:   []byte("foo"),
 		Expires: uut.clock.Now().Add(time.Minute).Round(time.Second).UTC(),
 	}
@@ -187,7 +187,7 @@ func TestReadLegacyRecord(t *testing.T) {
 	// version of this backend.
 	ctx := context.Background()
 	rl := legacyRecord{
-		Key:       string(item.Key),
+		Key:       item.Key.String(),
 		Value:     string(item.Value),
 		Expires:   item.Expires.UTC().Unix(),
 		Timestamp: uut.clock.Now().UTC().Unix(),
@@ -237,7 +237,7 @@ func TestReadBrokenRecord(t *testing.T) {
 		Key:   prefix("legacy-record").String(),
 		Value: "sheep",
 	}
-	_, err = uut.svc.Collection(uut.CollectionName).Doc(uut.keyToDocumentID(backend.Key(lr.Key))).Set(ctx, lr)
+	_, err = uut.svc.Collection(uut.CollectionName).Doc(uut.keyToDocumentID(backend.KeyFromString(lr.Key))).Set(ctx, lr)
 	require.NoError(t, err)
 
 	// Create a broken record with a backend.Key key type.
@@ -250,7 +250,7 @@ func TestReadBrokenRecord(t *testing.T) {
 	// Write using broken record format, emulating data written by an older
 	// version of this backend.
 	br := brokenRecord{
-		Key:       brokenItem.Key,
+		Key:       brokenKey(brokenItem.Key.String()),
 		Value:     brokenItem.Value,
 		Expires:   brokenItem.Expires.UTC().Unix(),
 		Timestamp: uut.clock.Now().UTC().Unix(),
@@ -285,7 +285,7 @@ func TestReadBrokenRecord(t *testing.T) {
 		switch r := result.Key.String(); r {
 		case item.Key.String():
 			assert.Equal(t, item.Value, result.Value)
-		case br.Key.String():
+		case string(br.Key):
 			assert.Equal(t, br.Value, result.Value)
 		case lr.Key:
 			assert.Equal(t, lr.Value, string(result.Value))

--- a/lib/backend/firestore/migration.go
+++ b/lib/backend/firestore/migration.go
@@ -135,7 +135,7 @@ func migrateKeyType[T any](ctx context.Context, b *Backend, newKey func([]byte) 
 			// use conditional update to ensure that the document has not been updated since the read
 			jobs[i], err = bulkWriter.Update(
 				b.svc.Collection(b.CollectionName).
-					Doc(b.keyToDocumentID(newDoc.Key)),
+					Doc(b.keyToDocumentID(newDoc.backendItem().Key)),
 				newDoc.updates(),
 				firestore.LastUpdateTime(dbDoc.UpdateTime),
 			)

--- a/lib/backend/key.go
+++ b/lib/backend/key.go
@@ -19,81 +19,172 @@ package backend
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"strings"
 )
 
 // Key is the unique identifier for an [Item].
-type Key []byte
-
-// Separator is used as a separator between key parts
-const Separator = '/'
-
-// NewKey joins parts into path separated by Separator,
-// makes sure path always starts with Separator ("/")
-func NewKey(parts ...string) Key {
-	return internalKey("", parts...)
+type Key struct {
+	s          string
+	components []string
+	exactKey   bool
+	noEnd      bool
 }
 
-// ExactKey is like Key, except a Separator is appended to the result
-// path of Key. This is to ensure range matching of a path will only
+const (
+	// Separator is used as a separator between key parts.
+	Separator = '/'
+	// SeparatorString is string representation of Separator.
+	SeparatorString = string(Separator)
+)
+
+// NewKey joins parts into path separated by [Separator],
+// makes sure path always starts with [Separator].
+func NewKey(components ...string) Key {
+	k := internalKey("", components...)
+	k.exactKey = k.s != "" && k.s[len(k.s)-1] == Separator
+	return k
+}
+
+// ExactKey is like [NewKey], except a [Separator] is appended to the
+// result path of [Key]. This is to ensure range matching of a path will only
 // math child paths and not other paths that have the resulting path
 // as a prefix.
-func ExactKey(parts ...string) Key {
-	return append(NewKey(parts...), Separator)
+func ExactKey(components ...string) Key {
+	k := NewKey(append(components, "")...)
+	k.exactKey = true
+	return k
 }
 
-func internalKey(internalPrefix string, parts ...string) Key {
-	return Key(strings.Join(append([]string{internalPrefix}, parts...), string(Separator)))
+// KeyFromString creates a [Key] from a textual representation
+// of the [Key]. No leading or trailing [Separator] are added
+// like with [NewKey] or [ExactKey].
+func KeyFromString(s string) Key {
+	components := strings.Split(s, SeparatorString)
+	if components[0] == "" && len(components) > 1 {
+		components = components[1:]
+	}
+
+	return Key{
+		components: components,
+		s:          s,
+		exactKey:   s == SeparatorString || (s != "" && s[len(s)-1] == Separator),
+		noEnd:      s == string(noEnd),
+	}
+}
+
+func (k Key) IsZero() bool {
+	return len(k.components) == 0 && k.s == ""
+}
+
+func internalKey(internalPrefix string, components ...string) Key {
+	return Key{
+		components: components,
+		s:          strings.Join(append([]string{internalPrefix}, components...), SeparatorString),
+	}
+}
+
+// ExactKey appends a [Separator] to the key, if one does not already
+// exist. This is to ensure range matching of a path will only
+// math child paths and not other paths that have the resulting path
+// as a prefix.
+func (k Key) ExactKey() Key {
+	if k.exactKey {
+		return k
+	}
+
+	return ExactKey(k.components...)
 }
 
 // String returns the textual representation of the key with
 // each component concatenated together via the [Separator].
 func (k Key) String() string {
-	return string(k)
-}
+	if k.noEnd {
+		return string(noEnd)
+	}
 
-// IsZero reports whether k represents the zero key.
-func (k Key) IsZero() bool {
-	return len(k) == 0
+	return k.s
 }
 
 // HasPrefix reports whether the key begins with prefix.
 func (k Key) HasPrefix(prefix Key) bool {
-	return bytes.HasPrefix(k, prefix)
+	return strings.HasPrefix(k.s, prefix.s)
 }
 
 // TrimPrefix returns the key without the provided leading prefix string.
 // If the key doesn't start with prefix, it is returned unchanged.
 func (k Key) TrimPrefix(prefix Key) Key {
-	return bytes.TrimPrefix(k, prefix)
+	key := strings.TrimPrefix(k.s, prefix.s)
+	if key == "" {
+		return Key{}
+	}
+
+	return KeyFromString(key)
 }
 
-func (k Key) PrependPrefix(p Key) Key {
-	return append(p, k...)
+// PrependKey returns a new [Key] that joins p and k
+// with the components of p followed by the components from k.
+func (k Key) PrependKey(p Key) Key {
+	if p.IsZero() {
+		return k
+	}
+
+	newKey := Key{
+		components: append(slices.Clone(p.components), k.components...),
+	}
+	if strings.HasPrefix(p.s, SeparatorString) {
+		newKey.s = strings.Join(append([]string{""}, newKey.components...), SeparatorString)
+	} else {
+		newKey.s = strings.Join(newKey.components, SeparatorString)
+	}
+
+	return newKey
+}
+
+// AppendKey returns a new [Key] that joins p and k
+// with the components of k followed by the components from p.
+func (k Key) AppendKey(p Key) Key {
+	if k.IsZero() {
+		return p
+	}
+
+	newKey := Key{
+		components: append(k.components, slices.Clone(p.components)...),
+	}
+	if strings.HasPrefix(k.s, SeparatorString) {
+		newKey.s = strings.Join(append([]string{""}, newKey.components...), SeparatorString)
+	} else {
+		newKey.s = strings.Join(newKey.components, SeparatorString)
+	}
+
+	return newKey
 }
 
 // HasSuffix reports whether the key ends with suffix.
 func (k Key) HasSuffix(suffix Key) bool {
-	return bytes.HasSuffix(k, suffix)
+	return strings.HasSuffix(k.s, suffix.s)
 }
 
 // TrimSuffix returns the key without the provided trailing suffix string.
 // If the key doesn't end with suffix, it is returned unchanged.
 func (k Key) TrimSuffix(suffix Key) Key {
-	return bytes.TrimSuffix(k, suffix)
-}
-
-func (k Key) Components() [][]byte {
-	if len(k) == 0 {
-		return nil
+	key := strings.TrimSuffix(k.s, suffix.s)
+	if key == "" {
+		return Key{}
 	}
 
-	sep := []byte{Separator}
-	return bytes.Split(bytes.TrimPrefix(k, sep), sep)
+	return KeyFromString(key)
 }
 
+// Components returns the individual components that make up the [Key].
+func (k Key) Components() []string {
+	return slices.Clone(k.components)
+}
+
+// Compare returns an integer comparing two [Key]s lexicographically.
+// The result will be 0 if a == b, -1 if a < b, and +1 if a > b.
 func (k Key) Compare(o Key) int {
-	return bytes.Compare(k, o)
+	return strings.Compare(k.s, o.s)
 }
 
 // Scan implement sql.Scanner, allowing a [Key] to
@@ -102,9 +193,16 @@ func (k Key) Compare(o Key) int {
 func (k *Key) Scan(scan any) error {
 	switch key := scan.(type) {
 	case []byte:
-		*k = bytes.Clone(key)
+		if len(key) == 0 {
+			return nil
+		}
+		*k = KeyFromString(string(bytes.Clone(key)))
 	case string:
-		*k = []byte(strings.Clone(key))
+		if key == "" {
+			return nil
+		}
+
+		*k = KeyFromString(key)
 	default:
 		return fmt.Errorf("invalid Key type %T", scan)
 	}

--- a/lib/backend/kubernetes/kubernetes.go
+++ b/lib/backend/kubernetes/kubernetes.go
@@ -268,7 +268,7 @@ func (b *Backend) readSecretData(ctx context.Context, key backend.Key) (*backend
 
 	data, ok := secret.Data[backendKeyToSecret(key)]
 	if !ok || len(data) == 0 {
-		return nil, trace.NotFound("key [%s] not found in secret %s", string(key), b.SecretName)
+		return nil, trace.NotFound("key [%s] not found in secret %s", key.String(), b.SecretName)
 	}
 
 	return &backend.Item{
@@ -353,7 +353,7 @@ func generateSecretAnnotations(namespace, releaseNameEnv string) map[string]stri
 // backendKeyToSecret replaces the "/" with "."
 // "/" chars are not allowed in Kubernetes Secret keys.
 func backendKeyToSecret(k backend.Key) string {
-	return strings.ReplaceAll(string(k), "/", ".")
+	return strings.ReplaceAll(k.String(), string(backend.Separator), ".")
 }
 
 func updateDataMap(data map[string][]byte, items ...backend.Item) {

--- a/lib/backend/kubernetes/kubernetes_test.go
+++ b/lib/backend/kubernetes/kubernetes_test.go
@@ -142,7 +142,7 @@ func TestBackend_Get(t *testing.T) {
 	}
 
 	type args struct {
-		key []byte
+		key backend.Key
 	}
 
 	tests := []struct {

--- a/lib/backend/lite/periodic.go
+++ b/lib/backend/lite/periodic.go
@@ -85,7 +85,7 @@ func (l *Backend) removeExpiredKeys() error {
 		defer rows.Close()
 		var keys []backend.Key
 		for rows.Next() {
-			var key []byte
+			var key backend.Key
 			if err := rows.Scan(&key); err != nil {
 				return trace.Wrap(err)
 			}

--- a/lib/backend/pgbk/pgbk.go
+++ b/lib/backend/pgbk/pgbk.go
@@ -452,7 +452,8 @@ func (b *Backend) GetRange(ctx context.Context, startKey, endKey backend.Key, li
 		).Query(func(rows pgx.Rows) error {
 			var err error
 			items, err = pgx.CollectRows(rows, func(row pgx.CollectableRow) (backend.Item, error) {
-				var key, value []byte
+				var key backend.Key
+				var value []byte
 				var expires time.Time
 				var revision revision
 				if err := row.Scan(&key, &value, (*zeronull.Timestamptz)(&expires), &revision); err != nil {

--- a/lib/backend/pgbk/utils.go
+++ b/lib/backend/pgbk/utils.go
@@ -50,7 +50,7 @@ func revisionFromString(s string) (r revision, ok bool) {
 
 // nonNilKey replaces an empty key with a non-nil one.
 func nonNilKey(b backend.Key) []byte {
-	if b == nil {
+	if b.IsZero() {
 		return []byte{}
 	}
 

--- a/lib/backend/pgbk/wal2json.go
+++ b/lib/backend/pgbk/wal2json.go
@@ -139,7 +139,7 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 		return []backend.Event{{
 			Type: types.OpPut,
 			Item: backend.Item{
-				Key:      key,
+				Key:      backend.KeyFromString(string(key)),
 				Value:    value,
 				Expires:  expires.UTC(),
 				Revision: revisionToString(revision),
@@ -154,7 +154,7 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 		return []backend.Event{{
 			Type: types.OpDelete,
 			Item: backend.Item{
-				Key: key,
+				Key: backend.KeyFromString(string(key)),
 			},
 		}}, nil
 
@@ -196,12 +196,12 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 			return []backend.Event{{
 				Type: types.OpDelete,
 				Item: backend.Item{
-					Key: oldKey,
+					Key: backend.KeyFromString(string(oldKey)),
 				},
 			}, {
 				Type: types.OpPut,
 				Item: backend.Item{
-					Key:      key,
+					Key:      backend.KeyFromString(string(key)),
 					Value:    value,
 					Expires:  expires.UTC(),
 					Revision: revisionToString(revision),
@@ -212,7 +212,7 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 		return []backend.Event{{
 			Type: types.OpPut,
 			Item: backend.Item{
-				Key:      key,
+				Key:      backend.KeyFromString(string(key)),
 				Value:    value,
 				Expires:  expires.UTC(),
 				Revision: revisionToString(revision),

--- a/lib/backend/pgbk/wal2json_test.go
+++ b/lib/backend/pgbk/wal2json_test.go
@@ -157,11 +157,11 @@ func TestMessage(t *testing.T) {
 	require.Empty(t, cmp.Diff(evs[0], backend.Event{
 		Type: types.OpPut,
 		Item: backend.Item{
-			Key:      backend.Key("foo"),
+			Key:      backend.KeyFromString("foo"),
 			Value:    []byte(""),
 			Revision: revisionToString(rev),
 		},
-	}))
+	}, cmp.AllowUnexported(backend.Key{})))
 
 	m = &wal2jsonMessage{
 		Action: "U",
@@ -181,11 +181,11 @@ func TestMessage(t *testing.T) {
 	require.Empty(t, cmp.Diff(evs[0], backend.Event{
 		Type: types.OpPut,
 		Item: backend.Item{
-			Key:      backend.Key("foo"),
+			Key:      backend.KeyFromString("foo"),
 			Value:    []byte("foo2"),
 			Revision: revisionToString(rev),
 		},
-	}))
+	}, cmp.AllowUnexported(backend.Key{})))
 
 	m = &wal2jsonMessage{
 		Action: "U",
@@ -209,18 +209,18 @@ func TestMessage(t *testing.T) {
 	require.Empty(t, cmp.Diff(evs[0], backend.Event{
 		Type: types.OpDelete,
 		Item: backend.Item{
-			Key: backend.Key("foo"),
+			Key: backend.KeyFromString("foo"),
 		},
-	}))
+	}, cmp.AllowUnexported(backend.Key{})))
 	require.Empty(t, cmp.Diff(evs[1], backend.Event{
 		Type: types.OpPut,
 		Item: backend.Item{
-			Key:      backend.Key("foo2"),
+			Key:      backend.KeyFromString("foo2"),
 			Value:    []byte("foo2"),
 			Expires:  time.Date(2023, 9, 5, 15, 57, 1, 340426000, time.UTC),
 			Revision: revisionToString(rev),
 		},
-	}))
+	}, cmp.AllowUnexported(backend.Key{})))
 
 	m = &wal2jsonMessage{
 		Action: "U",
@@ -252,7 +252,7 @@ func TestMessage(t *testing.T) {
 	require.Empty(t, cmp.Diff(evs[0], backend.Event{
 		Type: types.OpDelete,
 		Item: backend.Item{
-			Key: backend.Key("foo"),
+			Key: backend.KeyFromString("foo"),
 		},
-	}))
+	}, cmp.AllowUnexported(backend.Key{})))
 }

--- a/lib/backend/report_test.go
+++ b/lib/backend/report_test.go
@@ -61,7 +61,7 @@ func TestReporterTopRequestsLimit(t *testing.T) {
 
 	// Run through 1000 unique keys.
 	for i := 0; i < 1000; i++ {
-		r.trackRequest(context.Background(), types.OpGet, []byte(strconv.Itoa(i)), nil)
+		r.trackRequest(context.Background(), types.OpGet, NewKey(strconv.Itoa(i)), Key{})
 	}
 
 	// Now the metric should have only 10 of the keys above.

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -20,7 +20,6 @@ package backend
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -30,94 +29,94 @@ import (
 
 func TestSanitize(t *testing.T) {
 	tests := []struct {
-		inKey  []byte
+		inKey  Key
 		assert require.ErrorAssertionFunc
 	}{
 		{
-			inKey:  []byte("a-b/c:d/.e_f/01"),
+			inKey:  NewKey("a-b", "c:d", ".e_f", "01"),
 			assert: require.NoError,
 		},
 		{
-			inKey:  []byte("/namespaces//params"),
+			inKey:  NewKey("namespaces", "", "params"),
 			assert: require.Error,
 		},
 		{
-			inKey:  []byte("/namespaces/.."),
+			inKey:  NewKey("namespaces", ".."),
 			assert: require.Error,
 		},
 		{
-			inKey:  []byte("/namespaces/../params"),
+			inKey:  NewKey("namespaces", "..", "params"),
 			assert: require.Error,
 		},
 		{
-			inKey:  []byte("/namespaces/..params"),
+			inKey:  NewKey("namespaces", "..params"),
 			assert: require.NoError,
 		},
 		{
-			inKey:  []byte("/namespaces/."),
+			inKey:  NewKey("namespaces", "."),
 			assert: require.Error,
 		},
 		{
-			inKey:  []byte("/namespaces/./params"),
+			inKey:  NewKey("namespaces", ".", "params"),
 			assert: require.Error,
 		},
 		{
-			inKey:  []byte("/namespaces/.params"),
+			inKey:  NewKey("namespaces", ".params"),
 			assert: require.NoError,
 		},
 		{
-			inKey:  []byte(".."),
+			inKey:  NewKey(".."),
 			assert: require.Error,
 		},
 		{
-			inKey:  []byte("..params"),
+			inKey:  NewKey("..params"),
 			assert: require.NoError,
 		},
 		{
-			inKey:  []byte("../params"),
+			inKey:  NewKey("..", "params"),
 			assert: require.Error,
 		},
 		{
-			inKey:  []byte("."),
+			inKey:  NewKey("."),
 			assert: require.Error,
 		},
 		{
-			inKey:  []byte(".params"),
+			inKey:  NewKey(".params"),
 			assert: require.NoError,
 		},
 		{
-			inKey:  []byte("./params"),
+			inKey:  NewKey(".", "params"),
 			assert: require.Error,
 		},
 		{
-			inKey:  RangeEnd([]byte("a-b/c:d/.e_f/01")),
+			inKey:  RangeEnd(NewKey("a-b", "c:d", ".e_f", "01")),
 			assert: require.NoError,
 		},
 		{
-			inKey:  RangeEnd([]byte("/")),
+			inKey:  RangeEnd(NewKey("")),
 			assert: require.NoError,
 		},
 		{
-			inKey:  RangeEnd([]byte("Malformed \xf0\x90\x28\xbc UTF8")),
+			inKey:  RangeEnd(NewKey("Malformed \xf0\x90\x28\xbc UTF8")),
 			assert: require.Error,
 		},
 		{
-			inKey:  []byte("test+subaddr@example.com"),
+			inKey:  NewKey("test+subaddr@example.com"),
 			assert: require.NoError,
 		},
 		{
-			inKey:  []byte("xyz"),
+			inKey:  NewKey("xyz"),
 			assert: require.NoError,
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("%v", string(tt.inKey)), func(t *testing.T) {
+		t.Run(tt.inKey.String(), func(t *testing.T) {
 			ctx := context.Background()
 			safeBackend := NewSanitizer(&nopBackend{})
 
 			_, err := safeBackend.Get(ctx, tt.inKey)
-			tt.assert(t, err)
+			require.NoError(t, err)
 
 			_, err = safeBackend.Create(ctx, Item{Key: tt.inKey})
 			tt.assert(t, err)
@@ -132,10 +131,10 @@ func TestSanitize(t *testing.T) {
 			tt.assert(t, err)
 
 			err = safeBackend.Delete(ctx, tt.inKey)
-			tt.assert(t, err)
+			require.NoError(t, err)
 
 			err = safeBackend.DeleteRange(ctx, tt.inKey, tt.inKey)
-			tt.assert(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -152,7 +151,7 @@ func (n *nopBackend) Get(_ context.Context, _ Key) (*Item, error) {
 
 func (n *nopBackend) GetRange(_ context.Context, startKey, endKey Key, limit int) (*GetResult, error) {
 	return &GetResult{Items: []Item{
-		{Key: []byte("foo"), Value: []byte("bar")},
+		{Key: NewKey("foo"), Value: []byte("bar")},
 	}}, nil
 }
 

--- a/lib/backend/test/atomicwrite.go
+++ b/lib/backend/test/atomicwrite.go
@@ -21,7 +21,6 @@ package test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -285,8 +284,8 @@ func testAtomicWriteMax(t *testing.T, newBackend Constructor) {
 
 	prefix := MakePrefix()
 
-	keyOf := func(i int) []byte {
-		return prefix(fmt.Sprintf("/key-%d", i))
+	keyOf := func(i int) backend.Key {
+		return prefix("key-" + strconv.Itoa(i))
 	}
 
 	var condacts []backend.ConditionalAction
@@ -468,10 +467,10 @@ func testAtomicWriteNonConflicting(t *testing.T, newBackend Constructor) {
 
 	results := make(chan error, workers)
 
-	commonKey := prefix("/common")
+	commonKey := prefix("common")
 
-	itemKey := func(i int) []byte {
-		return prefix(fmt.Sprintf("/item-%d", i))
+	itemKey := func(i int) backend.Key {
+		return prefix("item-" + strconv.Itoa(i))
 	}
 
 	_, err = bk.Put(ctx, backend.Item{
@@ -531,7 +530,7 @@ func testAtomicWriteOther(t *testing.T, newBackend Constructor) {
 
 	prefix := MakePrefix()
 
-	fooKey, barKey, badKey := prefix("/foo"), prefix("/bar"), prefix("/bad")
+	fooKey, barKey, badKey := prefix("foo"), prefix("bar"), prefix("bad")
 
 	fooVal, barVal := []byte("foo"), []byte("bar")
 

--- a/lib/backend/test/atomicwrite_shim.go
+++ b/lib/backend/test/atomicwrite_shim.go
@@ -44,7 +44,7 @@ func RunBackendComplianceSuiteWithAtomicWriteShim(t *testing.T, newBackend Const
 
 		return AtomicWriteShim{
 			Backend:  bk,
-			sentinel: []byte(uuid.New().String()),
+			sentinel: backend.NewKey(uuid.New().String()),
 		}, clock, nil
 	})
 }
@@ -52,7 +52,7 @@ func RunBackendComplianceSuiteWithAtomicWriteShim(t *testing.T, newBackend Const
 // AtomicWriteShim reimplements all single-write backend methods as calls to AtomicWrite.
 type AtomicWriteShim struct {
 	backend.Backend
-	sentinel []byte
+	sentinel backend.Key
 }
 
 // sca builds a sentinel conditional action to be added to calls to AtomicWrite to force them to

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -213,7 +214,7 @@ func testCRUD(t *testing.T, newBackend Constructor) {
 	ctx := context.Background()
 	prefix := MakePrefix()
 
-	item := backend.Item{Key: prefix("/hello"), Value: []byte("world")}
+	item := backend.Item{Key: prefix("hello"), Value: []byte("world")}
 
 	// update will fail on non-existent item
 	_, err = uut.Update(ctx, item)
@@ -241,7 +242,7 @@ func testCRUD(t *testing.T, newBackend Constructor) {
 	RequireItems(t, []backend.Item{item}, res.Items)
 
 	// update succeeds
-	updated := backend.Item{Key: prefix("/hello"), Value: []byte("world 2")}
+	updated := backend.Item{Key: prefix("hello"), Value: []byte("world 2")}
 	lease, err = uut.Update(ctx, updated)
 	require.NoError(t, err)
 
@@ -260,7 +261,7 @@ func testCRUD(t *testing.T, newBackend Constructor) {
 	require.True(t, trace.IsNotFound(err))
 
 	// put new item succeeds
-	item = backend.Item{Key: prefix("/put"), Value: []byte("world")}
+	item = backend.Item{Key: prefix("put"), Value: []byte("world")}
 	lease, err = uut.Put(ctx, item)
 	require.NoError(t, err)
 
@@ -302,11 +303,11 @@ func testQueryRange(t *testing.T, newBackend Constructor) {
 	ctx := context.Background()
 	prefix := MakePrefix()
 
-	outOfScope := backend.Item{Key: prefix("/a"), Value: []byte("should not show up")}
-	a := backend.Item{Key: prefix("/prefix/a"), Value: []byte("val a")}
-	b := backend.Item{Key: prefix("/prefix/b"), Value: []byte("val b")}
-	c1 := backend.Item{Key: prefix("/prefix/c/c1"), Value: []byte("val c1")}
-	c2 := backend.Item{Key: prefix("/prefix/c/c2"), Value: []byte("val c2")}
+	outOfScope := backend.Item{Key: prefix("a"), Value: []byte("should not show up")}
+	a := backend.Item{Key: prefix("prefix", "a"), Value: []byte("val a")}
+	b := backend.Item{Key: prefix("prefix", "b"), Value: []byte("val b")}
+	c1 := backend.Item{Key: prefix("prefix", "c", "c1"), Value: []byte("val c1")}
+	c2 := backend.Item{Key: prefix("prefix", "c", "c2"), Value: []byte("val c2")}
 
 	// create items and set the revisions received from the lease
 	for _, item := range []*backend.Item{&outOfScope, &a, &b, &c1, &c2} {
@@ -316,36 +317,36 @@ func testQueryRange(t *testing.T, newBackend Constructor) {
 	}
 
 	// prefix range fetch
-	result, err := uut.GetRange(ctx, prefix("/prefix"), backend.RangeEnd(prefix("/prefix")), backend.NoLimit)
+	result, err := uut.GetRange(ctx, prefix("prefix"), backend.RangeEnd(prefix("prefix")), backend.NoLimit)
 	require.NoError(t, err)
 	RequireItems(t, []backend.Item{a, b, c1, c2}, result.Items)
 
 	// sub prefix range fetch
-	result, err = uut.GetRange(ctx, prefix("/prefix/c"), backend.RangeEnd(prefix("/prefix/c")), backend.NoLimit)
+	result, err = uut.GetRange(ctx, prefix("prefix", "c"), backend.RangeEnd(prefix("prefix", "c")), backend.NoLimit)
 	require.NoError(t, err)
 	RequireItems(t, []backend.Item{c1, c2}, result.Items)
 
 	// range match
-	result, err = uut.GetRange(ctx, prefix("/prefix/c/c1"), backend.RangeEnd(prefix("/prefix/c/cz")), backend.NoLimit)
+	result, err = uut.GetRange(ctx, prefix("prefix", "c", "c1"), backend.RangeEnd(prefix("prefix", "c", "cz")), backend.NoLimit)
 	require.NoError(t, err)
 	RequireItems(t, []backend.Item{c1, c2}, result.Items)
 
 	// pagination
-	result, err = uut.GetRange(ctx, prefix("/prefix"), backend.RangeEnd(prefix("/prefix")), 2)
+	result, err = uut.GetRange(ctx, prefix("prefix"), backend.RangeEnd(prefix("prefix")), 2)
 	require.NoError(t, err)
 
 	// expect two first records
 	RequireItems(t, []backend.Item{a, b}, result.Items)
 
 	// fetch next two items
-	result, err = uut.GetRange(ctx, backend.RangeEnd(prefix("/prefix/b")), backend.RangeEnd(prefix("/prefix")), 2)
+	result, err = uut.GetRange(ctx, backend.RangeEnd(prefix("prefix", "b")), backend.RangeEnd(prefix("prefix")), 2)
 	require.NoError(t, err)
 
 	// expect two last records
 	RequireItems(t, []backend.Item{c1, c2}, result.Items)
 
 	// next fetch is empty
-	result, err = uut.GetRange(ctx, backend.RangeEnd(prefix("/prefix/c/c2")), backend.RangeEnd(prefix("/prefix")), 2)
+	result, err = uut.GetRange(ctx, backend.RangeEnd(prefix("prefix", "c", "c2")), backend.RangeEnd(prefix("prefix")), 2)
 	require.NoError(t, err)
 	require.Empty(t, result.Items)
 }
@@ -359,10 +360,10 @@ func testDeleteRange(t *testing.T, newBackend Constructor) {
 	ctx := context.Background()
 	prefix := MakePrefix()
 
-	a := backend.Item{Key: prefix("/prefix/a"), Value: []byte("val a")}
-	b := backend.Item{Key: prefix("/prefix/b"), Value: []byte("val b")}
-	c1 := backend.Item{Key: prefix("/prefix/c/c1"), Value: []byte("val c1")}
-	c2 := backend.Item{Key: prefix("/prefix/c/c2"), Value: []byte("val c2")}
+	a := backend.Item{Key: prefix("prefix", "a"), Value: []byte("val a")}
+	b := backend.Item{Key: prefix("prefix", "b"), Value: []byte("val b")}
+	c1 := backend.Item{Key: prefix("prefix", "c", "c1"), Value: []byte("val c1")}
+	c2 := backend.Item{Key: prefix("prefix", "c", "c2"), Value: []byte("val c2")}
 
 	for _, item := range []*backend.Item{&a, &b, &c1, &c2} {
 		lease, err := uut.Create(ctx, *item)
@@ -374,17 +375,17 @@ func testDeleteRange(t *testing.T, newBackend Constructor) {
 	// be deleted in a single operation. This test is designed to be run with
 	// a backend that has a limit of 25 items per delete operation.
 	for i := 0; i < 100; i++ {
-		item := &backend.Item{Key: prefix(fmt.Sprintf("/prefix/c/cn%d", i)), Value: []byte(fmt.Sprintf("val cn%d", i))}
+		item := &backend.Item{Key: prefix("prefix", "c", "cn", strconv.Itoa(i)), Value: []byte(fmt.Sprintf("val cn%d", i))}
 		lease, err := uut.Create(ctx, *item)
 		require.NoError(t, err, "Failed creating value: %q => %q", item.Key, item.Value)
 		item.Revision = lease.Revision
 	}
 
-	err = uut.DeleteRange(ctx, prefix("/prefix/c"), backend.RangeEnd(prefix("/prefix/c")))
+	err = uut.DeleteRange(ctx, prefix("prefix", "c"), backend.RangeEnd(prefix("prefix", "c")))
 	require.NoError(t, err)
 
 	// make sure items with "/prefix/c" are gone
-	result, err := uut.GetRange(ctx, prefix("/prefix"), backend.RangeEnd(prefix("/prefix")), backend.NoLimit)
+	result, err := uut.GetRange(ctx, prefix("prefix"), backend.RangeEnd(prefix("prefix")), backend.NoLimit)
 	require.NoError(t, err)
 	RequireItems(t, []backend.Item{a, b}, result.Items)
 }
@@ -517,7 +518,7 @@ func testKeepAlive(t *testing.T, newBackend Constructor) {
 
 	// ...expect that the event channel contains the original `init` message
 	// sent when the Firestore client was set up.
-	requireEvent(t, watcher, types.OpInit, nil, eventTimeout)
+	requireEvent(t, watcher, types.OpInit, backend.Key{}, eventTimeout)
 
 	// Make sure that nothing breaks even if the value we are KeepAlive-ing is
 	// somewhat big; PostgreSQL starts optimizing values if their compressed
@@ -586,7 +587,7 @@ func testEvents(t *testing.T, newBackend Constructor) {
 	defer func() { require.NoError(t, watcher.Close()) }()
 
 	// Make sure INIT event is emitted.
-	requireEvent(t, watcher, types.OpInit, nil, eventTimeout)
+	requireEvent(t, watcher, types.OpInit, backend.Key{}, eventTimeout)
 
 	// Add item to backend.
 	item := &backend.Item{Key: prefix("b"), Value: []byte("val"), Expires: clock.Now().UTC().Add(time.Hour)}
@@ -657,12 +658,12 @@ func testFetchLimit(t *testing.T, newBackend Constructor) {
 	itemsCount := 20
 	// Fill the backend with events that total size is greater than 1MB (65KB * 20 > 1MB).
 	for i := 0; i < itemsCount; i++ {
-		item := &backend.Item{Key: prefix(fmt.Sprintf("/db/database%d", i)), Value: buff}
+		item := &backend.Item{Key: prefix("db", "database", strconv.Itoa(i)), Value: buff}
 		_, err = uut.Put(ctx, *item)
 		require.NoError(t, err)
 	}
 
-	result, err := uut.GetRange(ctx, prefix("/db"), backend.RangeEnd(prefix("/db")), backend.NoLimit)
+	result, err := uut.GetRange(ctx, prefix("db"), backend.RangeEnd(prefix("db")), backend.NoLimit)
 	require.NoError(t, err)
 	require.Len(t, result.Items, itemsCount)
 }
@@ -678,7 +679,7 @@ func testLimit(t *testing.T, newBackend Constructor) {
 	defer cancel()
 
 	item := &backend.Item{
-		Key:     prefix("/db/database_tail_item"),
+		Key:     prefix("db", "database_tail_item"),
 		Value:   []byte("data"),
 		Expires: clock.Now().Add(10 * time.Minute),
 	}
@@ -686,7 +687,7 @@ func testLimit(t *testing.T, newBackend Constructor) {
 	require.NoError(t, err)
 	for i := 0; i < 10; i++ {
 		item := &backend.Item{
-			Key:     prefix(fmt.Sprintf("/db/database%d", i)),
+			Key:     prefix("db", "database", strconv.Itoa(i)),
 			Value:   []byte("data"),
 			Expires: clock.Now().Add(time.Second * 3),
 		}
@@ -696,14 +697,14 @@ func testLimit(t *testing.T, newBackend Constructor) {
 	clock.Advance(time.Second * 5)
 
 	item = &backend.Item{
-		Key:     prefix("/db/database_head_item"),
+		Key:     prefix("db", "database_head_item"),
 		Value:   []byte("data"),
 		Expires: clock.Now().Add(10 * time.Minute),
 	}
 	_, err = uut.Put(ctx, *item)
 	require.NoError(t, err)
 
-	result, err := uut.GetRange(ctx, prefix("/db"), backend.RangeEnd(prefix("/db")), 2)
+	result, err := uut.GetRange(ctx, prefix("db"), backend.RangeEnd(prefix("db")), 2)
 	require.NoError(t, err)
 	require.Len(t, result.Items, 2)
 }
@@ -1036,7 +1037,7 @@ func testMirror(t *testing.T, newBackend Constructor) {
 	defer func() { require.NoError(t, watcher.Close()) }()
 
 	// Make sure INIT event is emitted.
-	requireEvent(t, watcher, types.OpInit, nil, eventTimeout)
+	requireEvent(t, watcher, types.OpInit, backend.Key{}, eventTimeout)
 
 	// Add item to backend with a 1 second TTL.
 	item := &backend.Item{
@@ -1105,7 +1106,7 @@ func testConditionalDelete(t *testing.T, newBackend Constructor) {
 	ctx := context.Background()
 	prefix := MakePrefix()
 
-	item := backend.Item{Key: prefix("/hello"), Value: []byte("world")}
+	item := backend.Item{Key: prefix("hello"), Value: []byte("world")}
 	lease, err := uut.Create(ctx, item)
 	require.NoError(t, err)
 	require.NotEmpty(t, lease.Revision)
@@ -1145,7 +1146,7 @@ func testConditionalUpdate(t *testing.T, newBackend Constructor) {
 	ctx := context.Background()
 	prefix := MakePrefix()
 
-	item := backend.Item{Key: prefix("/hello"), Value: []byte("world")}
+	item := backend.Item{Key: prefix("hello"), Value: []byte("world")}
 
 	// Create the item.
 	lease, err := uut.Create(ctx, item)
@@ -1219,9 +1220,9 @@ func requireWaitGroupToFinish(ctx context.Context, t *testing.T, waitGroup *sync
 
 // MakePrefix returns function that appends unique prefix
 // to any key, used to make test suite concurrent-run proof
-func MakePrefix() func(k string) backend.Key {
-	id := "/" + uuid.New().String()
-	return func(k string) backend.Key {
-		return backend.Key(id + k)
+func MakePrefix() func(components ...string) backend.Key {
+	id := uuid.New().String()
+	return func(components ...string) backend.Key {
+		return backend.NewKey(append([]string{id}, components...)...)
 	}
 }

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1073,7 +1073,7 @@ func Test_readOrGenerateHostID(t *testing.T) {
 			},
 		},
 		{
-			name: "Kube Backend is available but key is missing. Load from local storage and store in lube",
+			name: "Kube Backend is available but key is missing. Load from local storage and store in kube",
 			args: args{
 				kubeBackend: &fakeKubeBackend{
 					getData: nil,
@@ -1086,9 +1086,9 @@ func Test_readOrGenerateHostID(t *testing.T) {
 			},
 			wantKubeItemFunc: func(i *backend.Item) bool {
 				return cmp.Diff(&backend.Item{
-					Key:   []byte(hostUUIDKey),
+					Key:   backend.KeyFromString(hostUUIDKey),
 					Value: []byte(id),
-				}, i) == ""
+				}, i, cmp.AllowUnexported(backend.Key{})) == ""
 			},
 		},
 		{
@@ -1096,7 +1096,7 @@ func Test_readOrGenerateHostID(t *testing.T) {
 			args: args{
 				kubeBackend: &fakeKubeBackend{
 					getData: &backend.Item{
-						Key:   []byte(hostUUIDKey),
+						Key:   backend.KeyFromString(hostUUIDKey),
 						Value: []byte(id),
 					},
 					getErr: nil,
@@ -1123,7 +1123,7 @@ func Test_readOrGenerateHostID(t *testing.T) {
 			},
 			wantKubeItemFunc: func(i *backend.Item) bool {
 				_, err := uuid.Parse(string(i.Value))
-				return err == nil && string(i.Key) == hostUUIDKey
+				return err == nil && i.Key.String() == hostUUIDKey
 			},
 		},
 		{
@@ -1158,7 +1158,7 @@ func Test_readOrGenerateHostID(t *testing.T) {
 			},
 			wantKubeItemFunc: func(i *backend.Item) bool {
 				_, err := uuid.Parse(string(i.Value))
-				return err == nil && string(i.Key) == hostUUIDKey
+				return err == nil && i.Key.String() == hostUUIDKey
 			},
 		},
 	}

--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -112,7 +112,7 @@ func (s *AccessService) ListRoles(ctx context.Context, req *proto.ListRolesReque
 				return true, nil
 			}
 
-			if !item.Key.HasSuffix(backend.Key(paramsPrefix)) {
+			if !item.Key.HasSuffix(backend.NewKey(paramsPrefix)) {
 				// Item represents a different resource type in the
 				// same namespace.
 				continue
@@ -373,8 +373,12 @@ func (s *AccessService) ReplaceRemoteLocks(ctx context.Context, clusterName stri
 
 		newRemoteLocksToStore := make(map[string]backend.Item, len(newRemoteLocks))
 		for _, lock := range newRemoteLocks {
+			key := backend.NewKey(locksPrefix)
 			if !strings.HasPrefix(lock.GetName(), clusterName) {
+				key = key.AppendKey(backend.NewKey(clusterName, lock.GetName()))
 				lock.SetName(clusterName + "/" + lock.GetName())
+			} else {
+				key = key.AppendKey(backend.NewKey(lock.GetName()))
 			}
 			rev := lock.GetRevision()
 			value, err := services.MarshalLock(lock)
@@ -382,7 +386,7 @@ func (s *AccessService) ReplaceRemoteLocks(ctx context.Context, clusterName stri
 				return trace.Wrap(err)
 			}
 			item := backend.Item{
-				Key:      backend.NewKey(locksPrefix, lock.GetName()),
+				Key:      key,
 				Value:    value,
 				Expires:  lock.Expiry(),
 				Revision: rev,

--- a/lib/services/local/access_graph.go
+++ b/lib/services/local/access_graph.go
@@ -46,12 +46,12 @@ type AccessGraphSecretsService struct {
 // This service in Teleport is used to keep track of secrets found in Teleport
 // Nodes and on enrolled devices. Currently, it only stores secrets related with
 // SSH Keys. Future implementations might extend them.
-func NewAccessGraphSecretsService(backend backend.Backend) (*AccessGraphSecretsService, error) {
+func NewAccessGraphSecretsService(b backend.Backend) (*AccessGraphSecretsService, error) {
 	authorizedKeysSvc, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*accessgraphsecretspb.AuthorizedKey]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindAccessGraphSecretAuthorizedKey,
-			BackendPrefix: authorizedKeysPrefix,
+			BackendPrefix: backend.NewKey(authorizedKeysPrefix),
 			MarshalFunc:   services.MarshalAccessGraphAuthorizedKey,
 			UnmarshalFunc: services.UnmarshalAccessGraphAuthorizedKey,
 		})
@@ -61,9 +61,9 @@ func NewAccessGraphSecretsService(backend backend.Backend) (*AccessGraphSecretsS
 
 	privateKeysSvc, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*accessgraphsecretspb.PrivateKey]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindAccessGraphSecretPrivateKey,
-			BackendPrefix: privateKeysPrefix,
+			BackendPrefix: backend.NewKey(privateKeysPrefix),
 			MarshalFunc:   services.MarshalAccessGraphPrivateKey,
 			UnmarshalFunc: services.UnmarshalAccessGraphPrivateKey,
 		})

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -79,16 +79,16 @@ type AccessListService struct {
 var _ services.AccessLists = (*AccessListService)(nil)
 
 // NewAccessListService creates a new AccessListService.
-func NewAccessListService(backend backend.Backend, clock clockwork.Clock, opts ...ServiceOption) (*AccessListService, error) {
+func NewAccessListService(b backend.Backend, clock clockwork.Clock, opts ...ServiceOption) (*AccessListService, error) {
 	var opt serviceOptions
 	for _, o := range opts {
 		o(&opt)
 	}
 	service, err := generic.NewService(&generic.ServiceConfig[*accesslist.AccessList]{
-		Backend:                     backend,
+		Backend:                     b,
 		PageLimit:                   accessListMaxPageSize,
 		ResourceKind:                types.KindAccessList,
-		BackendPrefix:               accessListPrefix,
+		BackendPrefix:               backend.NewKey(accessListPrefix),
 		MarshalFunc:                 services.MarshalAccessList,
 		UnmarshalFunc:               services.UnmarshalAccessList,
 		RunWhileLockedRetryInterval: opt.runWhileLockedRetryInterval,
@@ -98,10 +98,10 @@ func NewAccessListService(backend backend.Backend, clock clockwork.Clock, opts .
 	}
 
 	memberService, err := generic.NewService(&generic.ServiceConfig[*accesslist.AccessListMember]{
-		Backend:                     backend,
+		Backend:                     b,
 		PageLimit:                   accessListMemberMaxPageSize,
 		ResourceKind:                types.KindAccessListMember,
-		BackendPrefix:               accessListMemberPrefix,
+		BackendPrefix:               backend.NewKey(accessListMemberPrefix),
 		MarshalFunc:                 services.MarshalAccessListMember,
 		UnmarshalFunc:               services.UnmarshalAccessListMember,
 		RunWhileLockedRetryInterval: opt.runWhileLockedRetryInterval,
@@ -111,10 +111,10 @@ func NewAccessListService(backend backend.Backend, clock clockwork.Clock, opts .
 	}
 
 	reviewService, err := generic.NewService(&generic.ServiceConfig[*accesslist.Review]{
-		Backend:                     backend,
+		Backend:                     b,
 		PageLimit:                   accessListReviewMaxPageSize,
 		ResourceKind:                types.KindAccessListReview,
-		BackendPrefix:               accessListReviewPrefix,
+		BackendPrefix:               backend.NewKey(accessListReviewPrefix),
 		MarshalFunc:                 services.MarshalAccessListReview,
 		UnmarshalFunc:               services.UnmarshalAccessListReview,
 		RunWhileLockedRetryInterval: opt.runWhileLockedRetryInterval,
@@ -651,7 +651,7 @@ func (a *AccessListService) DeleteAllAccessListReviews(ctx context.Context) erro
 }
 
 func lockName(accessListName string) []string {
-	return []string{"access_list", accessListName}
+	return []string{accessListPrefix, accessListName}
 }
 
 // VerifyAccessListCreateLimit ensures creating access list is limited to no more than 1 (updating is allowed).

--- a/lib/services/local/access_monitoring_rules.go
+++ b/lib/services/local/access_monitoring_rules.go
@@ -39,12 +39,12 @@ type AccessMonitoringRulesService struct {
 }
 
 // NewAccessMonitoringRulesService creates a new AccessMonitoringRulesService.
-func NewAccessMonitoringRulesService(backend backend.Backend) (*AccessMonitoringRulesService, error) {
+func NewAccessMonitoringRulesService(b backend.Backend) (*AccessMonitoringRulesService, error) {
 	service, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*accessmonitoringrulesv1.AccessMonitoringRule]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindAccessMonitoringRule,
-			BackendPrefix: accessMonitoringRulesPrefix,
+			BackendPrefix: backend.NewKey(accessMonitoringRulesPrefix),
 			MarshalFunc:   services.MarshalAccessMonitoringRule,
 			UnmarshalFunc: services.UnmarshalAccessMonitoringRule,
 			ValidateFunc:  services.ValidateAccessMonitoringRule,

--- a/lib/services/local/autoupdate.go
+++ b/lib/services/local/autoupdate.go
@@ -43,12 +43,12 @@ type AutoUpdateService struct {
 }
 
 // NewAutoUpdateService returns a new AutoUpdateService.
-func NewAutoUpdateService(backend backend.Backend) (*AutoUpdateService, error) {
+func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 	config, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*autoupdate.AutoUpdateConfig]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindAutoUpdateConfig,
-			BackendPrefix: autoUpdateConfigPrefix,
+			BackendPrefix: backend.NewKey(autoUpdateConfigPrefix),
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateConfig],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateConfig],
 			ValidateFunc:  update.ValidateAutoUpdateConfig,
@@ -61,9 +61,9 @@ func NewAutoUpdateService(backend backend.Backend) (*AutoUpdateService, error) {
 	}
 	version, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*autoupdate.AutoUpdateVersion]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindAutoUpdateVersion,
-			BackendPrefix: autoUpdateVersionPrefix,
+			BackendPrefix: backend.NewKey(autoUpdateVersionPrefix),
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateVersion],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateVersion],
 			ValidateFunc:  update.ValidateAutoUpdateVersion,

--- a/lib/services/local/bot_instance.go
+++ b/lib/services/local/bot_instance.go
@@ -43,12 +43,12 @@ type BotInstanceService struct {
 }
 
 // NewBotInstanceService creates a new BotInstanceService with the given backend.
-func NewBotInstanceService(backend backend.Backend, clock clockwork.Clock) (*BotInstanceService, error) {
+func NewBotInstanceService(b backend.Backend, clock clockwork.Clock) (*BotInstanceService, error) {
 	service, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*machineidv1.BotInstance]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindBotInstance,
-			BackendPrefix: botInstancePrefix,
+			BackendPrefix: backend.NewKey(botInstancePrefix),
 			MarshalFunc:   services.MarshalBotInstance,
 			UnmarshalFunc: services.UnmarshalBotInstance,
 			ValidateFunc:  services.ValidateBotInstance,

--- a/lib/services/local/crown_jewels.go
+++ b/lib/services/local/crown_jewels.go
@@ -37,12 +37,12 @@ type CrownJewelsService struct {
 const crownJewelsKey = "crown_jewels"
 
 // NewCrownJewelsService creates a new CrownJewelsService.
-func NewCrownJewelsService(backend backend.Backend) (*CrownJewelsService, error) {
+func NewCrownJewelsService(b backend.Backend) (*CrownJewelsService, error) {
 	service, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*crownjewelv1.CrownJewel]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindCrownJewel,
-			BackendPrefix: crownJewelsKey,
+			BackendPrefix: backend.NewKey(crownJewelsKey),
 			MarshalFunc:   services.MarshalCrownJewel,
 			UnmarshalFunc: services.UnmarshalCrownJewel,
 		})

--- a/lib/services/local/databaseobject.go
+++ b/lib/services/local/databaseobject.go
@@ -72,12 +72,12 @@ const (
 	databaseObjectPrefix = "databaseObjectPrefix"
 )
 
-func NewDatabaseObjectService(backend backend.Backend) (*DatabaseObjectService, error) {
+func NewDatabaseObjectService(b backend.Backend) (*DatabaseObjectService, error) {
 	service, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*dbobjectv1.DatabaseObject]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindDatabaseObject,
-			BackendPrefix: databaseObjectPrefix,
+			BackendPrefix: backend.NewKey(databaseObjectPrefix),
 			//nolint:staticcheck // SA1019. Using this marshaler for json compatibility.
 			MarshalFunc: services.FastMarshalProtoResourceDeprecated[*dbobjectv1.DatabaseObject],
 			//nolint:staticcheck // SA1019. Using this unmarshaler for json compatibility.

--- a/lib/services/local/databaseobjectimportrule.go
+++ b/lib/services/local/databaseobjectimportrule.go
@@ -70,12 +70,12 @@ const (
 	databaseObjectImportRulePrefix = "databaseObjectImportRulePrefix"
 )
 
-func NewDatabaseObjectImportRuleService(backend backend.Backend) (services.DatabaseObjectImportRules, error) {
+func NewDatabaseObjectImportRuleService(b backend.Backend) (services.DatabaseObjectImportRules, error) {
 	service, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*databaseobjectimportrulev1.DatabaseObjectImportRule]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindDatabaseObjectImportRule,
-			BackendPrefix: databaseObjectImportRulePrefix,
+			BackendPrefix: backend.NewKey(databaseObjectImportRulePrefix),
 			//nolint:staticcheck // SA1019. Using this marshaler for json compatibility.
 			MarshalFunc: services.FastMarshalProtoResourceDeprecated[*databaseobjectimportrulev1.DatabaseObjectImportRule],
 			//nolint:staticcheck // SA1019. Using this unmarshaler for json compatibility.

--- a/lib/services/local/discoveryconfig.go
+++ b/lib/services/local/discoveryconfig.go
@@ -41,12 +41,12 @@ type DiscoveryConfigService struct {
 }
 
 // NewDiscoveryConfigService creates a new DiscoveryConfigService.
-func NewDiscoveryConfigService(backend backend.Backend) (*DiscoveryConfigService, error) {
+func NewDiscoveryConfigService(b backend.Backend) (*DiscoveryConfigService, error) {
 	svc, err := generic.NewService(&generic.ServiceConfig[*discoveryconfig.DiscoveryConfig]{
-		Backend:       backend,
+		Backend:       b,
 		PageLimit:     defaults.MaxIterationLimit,
 		ResourceKind:  types.KindDiscoveryConfig,
-		BackendPrefix: discoveryConfigPrefix,
+		BackendPrefix: backend.NewKey(discoveryConfigPrefix),
 		MarshalFunc:   services.MarshalDiscoveryConfig,
 		UnmarshalFunc: services.UnmarshalDiscoveryConfig,
 	})

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -260,7 +260,7 @@ func (s *DynamicAccessService) GetAccessRequests(ctx context.Context, filter typ
 	}
 	var requests []types.AccessRequest
 	for _, item := range result.Items {
-		if !item.Key.HasSuffix(backend.Key(paramsPrefix)) {
+		if !item.Key.HasSuffix(backend.NewKey(paramsPrefix)) {
 			// Item represents a different resource type in the
 			// same namespace.
 			continue
@@ -340,7 +340,7 @@ func (s *DynamicAccessService) ListAccessRequests(ctx context.Context, req *prot
 				return true, nil
 			}
 
-			if !item.Key.HasSuffix(backend.Key(paramsPrefix)) {
+			if !item.Key.HasSuffix(backend.NewKey(paramsPrefix)) {
 				// Item represents a different resource type in the
 				// same namespace.
 				continue

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -413,16 +414,17 @@ type certAuthorityParser struct {
 func (p *certAuthorityParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		caType, name, err := baseTwoKeys(event.Item.Key)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		components := event.Item.Key.Components()
+		if len(components) != 3 {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
+
 		return &types.ResourceHeader{
 			Kind:    types.KindCertAuthority,
-			SubKind: caType,
+			SubKind: components[1],
 			Version: types.V2,
 			Metadata: types.Metadata{
-				Name:      name,
+				Name:      components[2],
 				Namespace: apidefaults.Namespace,
 			},
 		}, nil
@@ -457,7 +459,20 @@ type provisionTokenParser struct {
 func (p *provisionTokenParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindToken, types.V2, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(tokensPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindToken,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
+
 	case types.OpPut:
 		token, err := services.UnmarshalProvisionToken(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -485,12 +500,14 @@ type staticTokensParser struct {
 func (p *staticTokensParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		h, err := resourceHeader(event, types.KindStaticTokens, types.V2, 0)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		h.SetName(types.MetaNameStaticTokens)
-		return h, nil
+		return &types.ResourceHeader{
+			Kind:    types.KindStaticTokens,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      types.MetaNameStaticTokens,
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		tokens, err := services.UnmarshalStaticTokens(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -518,12 +535,14 @@ type clusterAuditConfigParser struct {
 func (p *clusterAuditConfigParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		h, err := resourceHeader(event, types.KindClusterAuditConfig, types.V2, 0)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		h.SetName(types.MetaNameClusterAuditConfig)
-		return h, nil
+		return &types.ResourceHeader{
+			Kind:    types.KindClusterAuditConfig,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      types.MetaNameClusterAuditConfig,
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		clusterAuditConfig, err := services.UnmarshalClusterAuditConfig(
 			event.Item.Value,
@@ -552,12 +571,14 @@ type clusterNetworkingConfigParser struct {
 func (p *clusterNetworkingConfigParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		h, err := resourceHeader(event, types.KindClusterNetworkingConfig, types.V2, 0)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		h.SetName(types.MetaNameClusterNetworkingConfig)
-		return h, nil
+		return &types.ResourceHeader{
+			Kind:    types.KindClusterNetworkingConfig,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      types.MetaNameClusterNetworkingConfig,
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		clusterNetworkingConfig, err := services.UnmarshalClusterNetworkingConfig(
 			event.Item.Value,
@@ -586,12 +607,14 @@ type authPreferenceParser struct {
 func (p *authPreferenceParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		h, err := resourceHeader(event, types.KindClusterAuthPreference, types.V2, 0)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		h.SetName(types.MetaNameClusterAuthPreference)
-		return h, nil
+		return &types.ResourceHeader{
+			Kind:    types.KindClusterAuthPreference,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      types.MetaNameClusterAuthPreference,
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		ap, err := services.UnmarshalAuthPreference(
 			event.Item.Value,
@@ -620,12 +643,14 @@ type uiConfigParser struct {
 func (p *uiConfigParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		h, err := resourceHeader(event, types.KindUIConfig, types.V1, 0)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		h.SetName(types.MetaNameUIConfig)
-		return h, nil
+		return &types.ResourceHeader{
+			Kind:    types.KindUIConfig,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      types.MetaNameUIConfig,
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		ap, err := services.UnmarshalUIConfig(
 			event.Item.Value,
@@ -654,12 +679,14 @@ type sessionRecordingConfigParser struct {
 func (p *sessionRecordingConfigParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		h, err := resourceHeader(event, types.KindSessionRecordingConfig, types.V2, 0)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		h.SetName(types.MetaNameSessionRecordingConfig)
-		return h, nil
+		return &types.ResourceHeader{
+			Kind:    types.KindSessionRecordingConfig,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      types.MetaNameSessionRecordingConfig,
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		ap, err := services.UnmarshalSessionRecordingConfig(
 			event.Item.Value,
@@ -688,12 +715,14 @@ type clusterNameParser struct {
 func (p *clusterNameParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		h, err := resourceHeader(event, types.KindClusterName, types.V2, 0)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		h.SetName(types.MetaNameClusterName)
-		return h, nil
+		return &types.ResourceHeader{
+			Kind:    types.KindClusterName,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      types.MetaNameClusterName,
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		clusterName, err := services.UnmarshalClusterName(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -721,12 +750,14 @@ type autoUpdateConfigParser struct {
 func (p *autoUpdateConfigParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		h, err := resourceHeader(event, types.KindAutoUpdateConfig, types.V1, 0)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		h.SetName(types.MetaNameAutoUpdateConfig)
-		return h, nil
+		return &types.ResourceHeader{
+			Kind:    types.KindAutoUpdateConfig,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      types.MetaNameAutoUpdateConfig,
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		autoUpdateConfig, err := services.UnmarshalProtoResource[*autoupdate.AutoUpdateConfig](event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -754,12 +785,14 @@ type autoUpdateVersionParser struct {
 func (p *autoUpdateVersionParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		h, err := resourceHeader(event, types.KindAutoUpdateVersion, types.V1, 0)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		h.SetName(types.MetaNameAutoUpdateVersion)
-		return h, nil
+		return &types.ResourceHeader{
+			Kind:    types.KindAutoUpdateVersion,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      types.MetaNameAutoUpdateVersion,
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		autoUpdateVersion, err := services.UnmarshalProtoResource[*autoupdate.AutoUpdateVersion](event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -792,14 +825,26 @@ func (p *namespaceParser) match(key backend.Key) bool {
 	// namespaces are stored under key '/namespaces/<namespace-name>/params'
 	// and this code matches similar pattern
 	return p.baseParser.match(key) &&
-		key.HasSuffix(backend.Key(paramsPrefix)) &&
-		len(key.Components()) == 3
+		key.HasSuffix(backend.NewKey(paramsPrefix)) &&
+		len(key.Components()) > 2
 }
 
 func (p *namespaceParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindNamespace, types.V2, 1)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(namespacesPrefix)).TrimSuffix(backend.NewKey(paramsPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindNamespace,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		namespace, err := services.UnmarshalNamespace(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -827,7 +872,19 @@ type roleParser struct {
 func (p *roleParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindRole, types.V7, 1)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(rolesPrefix)).TrimSuffix(backend.NewKey(paramsPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindRole,
+			Version: types.V7,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		resource, err := services.UnmarshalRole(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -877,7 +934,19 @@ func (p *accessRequestParser) match(key backend.Key) bool {
 func (p *accessRequestParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindAccessRequest, types.V3, 1)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(accessRequestsPrefix)).TrimSuffix(backend.NewKey(paramsPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindAccessRequest,
+			Version: types.V3,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		req, err := itemToAccessRequest(event.Item)
 		if err != nil {
@@ -906,14 +975,26 @@ func (p *userParser) match(key backend.Key) bool {
 	// users are stored under key '/web/users/<username>/params'
 	// and this code matches similar pattern
 	return p.baseParser.match(key) &&
-		key.HasSuffix(backend.Key(paramsPrefix)) &&
-		len(key.Components()) == 4
+		key.HasSuffix(backend.NewKey(paramsPrefix)) &&
+		len(key.Components()) >= 4
 }
 
 func (p *userParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindUser, types.V2, 1)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(webPrefix, usersPrefix)).TrimSuffix(backend.NewKey(paramsPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindUser,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		resource, err := services.UnmarshalUser(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -939,7 +1020,34 @@ type nodeParser struct {
 }
 
 func (p *nodeParser) parse(event backend.Event) (types.Resource, error) {
-	return parseServer(event, types.KindNode)
+	switch event.Type {
+	case types.OpDelete:
+		name := event.Item.Key.TrimPrefix(backend.NewKey(nodesPrefix, apidefaults.Namespace)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindNode,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
+	case types.OpPut:
+		resource, err := services.UnmarshalServer(event.Item.Value,
+			types.KindNode,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return resource, nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
 }
 
 func newProxyParser() *proxyParser {
@@ -953,7 +1061,34 @@ type proxyParser struct {
 }
 
 func (p *proxyParser) parse(event backend.Event) (types.Resource, error) {
-	return parseServer(event, types.KindProxy)
+	switch event.Type {
+	case types.OpDelete:
+		name := event.Item.Key.TrimPrefix(backend.NewKey(proxiesPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindProxy,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
+	case types.OpPut:
+		resource, err := services.UnmarshalServer(event.Item.Value,
+			types.KindProxy,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return resource, nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
 }
 
 func newAuthServerParser() *authServerParser {
@@ -967,7 +1102,34 @@ type authServerParser struct {
 }
 
 func (p *authServerParser) parse(event backend.Event) (types.Resource, error) {
-	return parseServer(event, types.KindAuthServer)
+	switch event.Type {
+	case types.OpDelete:
+		name := event.Item.Key.TrimPrefix(backend.NewKey(authServersPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindAuthServer,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
+	case types.OpPut:
+		resource, err := services.UnmarshalServer(event.Item.Value,
+			types.KindAuthServer,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return resource, nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
 }
 
 func newTunnelConnectionParser() *tunnelConnectionParser {
@@ -983,16 +1145,17 @@ type tunnelConnectionParser struct {
 func (p *tunnelConnectionParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		clusterName, name, err := baseTwoKeys(event.Item.Key)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		components := event.Item.Key.Components()
+		if len(components) != 3 {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
+
 		return &types.ResourceHeader{
 			Kind:    types.KindTunnelConnection,
-			SubKind: clusterName,
+			SubKind: components[1],
 			Version: types.V2,
 			Metadata: types.Metadata{
-				Name:      name,
+				Name:      components[2],
 				Namespace: apidefaults.Namespace,
 			},
 		}, nil
@@ -1023,7 +1186,19 @@ type reverseTunnelParser struct {
 func (p *reverseTunnelParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindReverseTunnel, types.V2, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(reverseTunnelsPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindReverseTunnel,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		resource, err := services.UnmarshalReverseTunnel(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1051,17 +1226,18 @@ type appServerV3Parser struct {
 func (p *appServerV3Parser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		hostID, name, err := baseTwoKeys(event.Item.Key)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		components := event.Item.Key.TrimPrefix(backend.NewKey(appServersPrefix, apidefaults.Namespace)).Components()
+		if len(components) != 2 {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
-		return &types.AppServerV3{
+
+		return &types.ResourceHeader{
 			Kind:    types.KindAppServer,
 			Version: types.V3,
 			Metadata: types.Metadata{
-				Name:        name,
+				Name:        components[1],
 				Namespace:   apidefaults.Namespace,
-				Description: hostID, // Pass host ID via description field for the cache.
+				Description: components[0],
 			},
 		}, nil
 	case types.OpPut:
@@ -1131,7 +1307,20 @@ type webSessionParser struct {
 func (p *webSessionParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeaderWithTemplate(event, p.hdr, 0)
+		components := event.Item.Key.Components()
+		if len(components) != 3 {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    p.hdr.Kind,
+			SubKind: p.hdr.SubKind,
+			Version: p.hdr.Version,
+			Metadata: types.Metadata{
+				Name:      components[2],
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		resource, err := services.UnmarshalWebSession(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1162,7 +1351,19 @@ type webTokenParser struct {
 func (p *webTokenParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindWebToken, types.V1, 0)
+		components := event.Item.Key.Components()
+		if len(components) != 3 {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindWebToken,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      components[2],
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		resource, err := services.UnmarshalWebToken(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1190,17 +1391,18 @@ type kubeServerParser struct {
 func (p *kubeServerParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		hostID, name, err := baseTwoKeys(event.Item.Key)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		components := event.Item.Key.Components()
+		if len(components) != 3 {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
-		return &types.KubernetesServerV3{
+
+		return &types.ResourceHeader{
 			Kind:    types.KindKubeServer,
 			Version: types.V3,
 			Metadata: types.Metadata{
-				Name:        name,
+				Name:        components[2],
 				Namespace:   apidefaults.Namespace,
-				Description: hostID, // Pass host ID via description field for the cache.
+				Description: components[1],
 			},
 		}, nil
 	case types.OpPut:
@@ -1227,17 +1429,18 @@ type databaseServerParser struct {
 func (p *databaseServerParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		hostID, name, err := baseTwoKeys(event.Item.Key)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		components := event.Item.Key.TrimPrefix(backend.NewKey(dbServersPrefix, apidefaults.Namespace)).Components()
+		if len(components) != 2 {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
-		return &types.DatabaseServerV3{
+
+		return &types.ResourceHeader{
 			Kind:    types.KindDatabaseServer,
 			Version: types.V3,
 			Metadata: types.Metadata{
-				Name:        name,
+				Name:        components[1],
 				Namespace:   apidefaults.Namespace,
-				Description: hostID, // Pass host ID via description field for the cache.
+				Description: components[0],
 			},
 		}, nil
 	case types.OpPut:
@@ -1264,7 +1467,18 @@ type databaseServiceParser struct {
 func (p *databaseServiceParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindDatabaseService, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(databaseServicePrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+		return &types.ResourceHeader{
+			Kind:    types.KindDatabaseService,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalDatabaseService(
 			event.Item.Value,
@@ -1289,7 +1503,18 @@ type kubeClusterParser struct {
 func (p *kubeClusterParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindKubernetesCluster, types.V3, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(kubernetesPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+		return &types.ResourceHeader{
+			Kind:    types.KindKubernetesCluster,
+			Version: types.V3,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalKubeCluster(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1313,7 +1538,19 @@ type crownJewelParser struct {
 func (p *crownJewelParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindCrownJewel, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(crownJewelsKey)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindCrownJewel,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		r, err := services.UnmarshalCrownJewel(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1341,7 +1578,19 @@ type appParser struct {
 func (p *appParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindApp, types.V3, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(appPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindApp,
+			Version: types.V3,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalApp(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1365,7 +1614,19 @@ type databaseParser struct {
 func (p *databaseParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindDatabase, types.V3, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(databasesPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindDatabase,
+			Version: types.V3,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalDatabase(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1389,7 +1650,19 @@ type databaseObjectParser struct {
 func (p *databaseObjectParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindDatabaseObject, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(databaseObjectPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindDatabaseObject,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		//nolint:staticcheck // SA1019. Using this unmarshaler for json compatibility.
 		resource, err := services.FastUnmarshalProtoResourceDeprecated[*dbobjectv1.DatabaseObject](event.Item.Value,
@@ -1400,25 +1673,6 @@ func (p *databaseObjectParser) parse(event backend.Event) (types.Resource, error
 			return nil, trace.Wrap(err)
 		}
 		return types.Resource153ToLegacy(resource), nil
-	default:
-		return nil, trace.BadParameter("event %v is not supported", event.Type)
-	}
-}
-
-func parseServer(event backend.Event, kind string) (types.Resource, error) {
-	switch event.Type {
-	case types.OpDelete:
-		return resourceHeader(event, kind, types.V2, 0)
-	case types.OpPut:
-		resource, err := services.UnmarshalServer(event.Item.Value,
-			kind,
-			services.WithExpires(event.Item.Expires),
-			services.WithRevision(event.Item.Revision),
-		)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return resource, nil
 	default:
 		return nil, trace.BadParameter("event %v is not supported", event.Type)
 	}
@@ -1445,7 +1699,19 @@ func (p *remoteClusterParser) match(key backend.Key) bool {
 func (p *remoteClusterParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindRemoteCluster, types.V3, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(remoteClustersPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindRemoteCluster,
+			Version: types.V3,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		resource, err := services.UnmarshalRemoteCluster(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1473,7 +1739,19 @@ type lockParser struct {
 func (p *lockParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindLock, types.V2, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(locksPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindLock,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalLock(
 			event.Item.Value,
@@ -1506,7 +1784,19 @@ func (p *networkRestrictionsParser) match(key backend.Key) bool {
 func (p *networkRestrictionsParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindNetworkRestrictions, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(restrictionsPrefix, network)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindNetworkRestrictions,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		resource, err := services.UnmarshalNetworkRestrictions(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1534,7 +1824,19 @@ type windowsDesktopServicesParser struct {
 func (p *windowsDesktopServicesParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindWindowsDesktopService, types.V3, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(windowsDesktopServicesPrefix, "")).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindWindowsDesktopService,
+			Version: types.V3,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalWindowsDesktopService(
 			event.Item.Value,
@@ -1559,17 +1861,19 @@ type windowsDesktopsParser struct {
 func (p *windowsDesktopsParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		hostID, name, err := baseTwoKeys(event.Item.Key)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		key := event.Item.Key.TrimPrefix(backend.NewKey(windowsDesktopsPrefix))
+		if len(key.Components()) < 2 {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
+		hostID := key.Components()[0]
+
 		return &types.ResourceHeader{
 			Kind:    types.KindWindowsDesktop,
 			Version: types.V3,
 			Metadata: types.Metadata{
-				Name:        name,
+				Name:        strings.TrimPrefix(key.TrimPrefix(backend.NewKey(hostID)).String(), backend.SeparatorString),
 				Namespace:   apidefaults.Namespace,
-				Description: hostID, // pass ID via description field for the cache
+				Description: hostID,
 			},
 		}, nil
 	case types.OpPut:
@@ -1596,11 +1900,19 @@ func newInstallerParser() *installerParser {
 func (p *installerParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		h, err := resourceHeader(event, types.KindInstaller, types.V1, 0)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(clusterConfigPrefix, scriptsPrefix, installerPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
-		return h, nil
+
+		return &types.ResourceHeader{
+			Kind:    types.KindInstaller,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		inst, err := services.UnmarshalInstaller(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1630,11 +1942,19 @@ func newPluginParser(loadSecrets bool) *pluginParser {
 func (p *pluginParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		h, err := resourceHeader(event, types.KindPlugin, types.V1, 0)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(pluginsPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
-		return h, nil
+
+		return &types.ResourceHeader{
+			Kind:    types.KindPlugin,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		plugin, err := services.UnmarshalPlugin(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1662,7 +1982,19 @@ type samlIDPServiceProviderParser struct {
 func (p *samlIDPServiceProviderParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindSAMLIdPServiceProvider, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(samlIDPServiceProviderPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindSAMLIdPServiceProvider,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalSAMLIdPServiceProvider(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1686,7 +2018,19 @@ type userGroupParser struct {
 func (p *userGroupParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindUserGroup, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(userGroupPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindUserGroup,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalUserGroup(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1710,7 +2054,19 @@ type oktaImportRuleParser struct {
 func (p *oktaImportRuleParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindOktaImportRule, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(oktaImportRulePrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindOktaImportRule,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalOktaImportRule(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1734,7 +2090,19 @@ type oktaAssignmentParser struct {
 func (p *oktaAssignmentParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindOktaAssignment, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(oktaAssignmentPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindOktaAssignment,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalOktaAssignment(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1758,7 +2126,19 @@ type integrationParser struct {
 func (p *integrationParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindIntegration, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(integrationsPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindIntegration,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalIntegration(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1782,7 +2162,19 @@ type userTaskParser struct {
 func (p *userTaskParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindUserTask, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(userTasksKey)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindUserTask,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		r, err := services.UnmarshalUserTask(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1810,7 +2202,19 @@ type discoveryConfigParser struct {
 func (p *discoveryConfigParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindDiscoveryConfig, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(discoveryConfigPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindDiscoveryConfig,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalDiscoveryConfig(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1841,7 +2245,19 @@ type headlessAuthenticationParser struct {
 func (p *headlessAuthenticationParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindHeadlessAuthentication, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(headlessAuthenticationPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindHeadlessAuthentication,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		ha, err := unmarshalHeadlessAuthentication(event.Item.Value)
 		if err != nil {
@@ -1869,7 +2285,19 @@ type accessListParser struct {
 func (p *accessListParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindAccessList, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(accessListPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindAccessList,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalAccessList(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1882,7 +2310,7 @@ func (p *accessListParser) parse(event backend.Event) (types.Resource, error) {
 
 func newAuditQueryParser() *auditQueryParser {
 	return &auditQueryParser{
-		baseParser: newBaseParser(backend.NewKey(AuditQueryPrefix)),
+		baseParser: newBaseParser(AuditQueryPrefix),
 	}
 }
 
@@ -1893,7 +2321,19 @@ type auditQueryParser struct {
 func (p *auditQueryParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindAuditQuery, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(AuditQueryPrefix).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindAuditQuery,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalAuditQuery(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1905,7 +2345,7 @@ func (p *auditQueryParser) parse(event backend.Event) (types.Resource, error) {
 
 func newSecurityReportParser() *securityReportParser {
 	return &securityReportParser{
-		baseParser: newBaseParser(backend.NewKey(SecurityReportPrefix)),
+		baseParser: newBaseParser(SecurityReportPrefix),
 	}
 }
 
@@ -1916,7 +2356,19 @@ type securityReportParser struct {
 func (p *securityReportParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindSecurityReport, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(SecurityReportPrefix).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindSecurityReport,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalSecurityReport(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1928,7 +2380,7 @@ func (p *securityReportParser) parse(event backend.Event) (types.Resource, error
 
 func newSecurityReportStateParser() *securityReportStateParser {
 	return &securityReportStateParser{
-		baseParser: newBaseParser(backend.NewKey(SecurityReportStatePrefix)),
+		baseParser: newBaseParser(SecurityReportStatePrefix),
 	}
 }
 
@@ -1939,7 +2391,19 @@ type securityReportStateParser struct {
 func (p *securityReportStateParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindSecurityReportState, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(SecurityReportStatePrefix).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindSecurityReportState,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalSecurityReportState(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1962,7 +2426,19 @@ type userLoginStateParser struct {
 func (p *userLoginStateParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindUserLoginState, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(userLoginStatePrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindUserLoginState,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		return services.UnmarshalUserLoginState(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -1986,17 +2462,19 @@ type accessListMemberParser struct {
 func (p *accessListMemberParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		accessList, name, err := baseTwoKeys(event.Item.Key)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		key := event.Item.Key.TrimPrefix(backend.NewKey(accessListMemberPrefix))
+		if len(key.Components()) < 2 {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
+		accessList := key.Components()[0]
+
 		return &types.ResourceHeader{
 			Kind:    types.KindAccessListMember,
 			Version: types.V1,
 			Metadata: types.Metadata{
-				Name:        name,
+				Name:        strings.TrimPrefix(key.TrimPrefix(backend.NewKey(accessList)).String(), backend.SeparatorString),
 				Namespace:   apidefaults.Namespace,
-				Description: accessList, // pass access list description field for the cache
+				Description: accessList,
 			},
 		}, nil
 	case types.OpPut:
@@ -2022,17 +2500,19 @@ type accessListReviewParser struct {
 func (p *accessListReviewParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		accessList, name, err := baseTwoKeys(event.Item.Key)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		key := event.Item.Key.TrimPrefix(backend.NewKey(accessListReviewPrefix))
+		if len(key.Components()) < 2 {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
+		accessList := key.Components()[0]
+
 		return &types.ResourceHeader{
 			Kind:    types.KindAccessListReview,
 			Version: types.V1,
 			Metadata: types.Metadata{
-				Name:        name,
+				Name:        strings.TrimPrefix(backend.NewKey(key.Components()[1:]...).String(), backend.SeparatorString),
 				Namespace:   apidefaults.Namespace,
-				Description: accessList, // pass access list description field for the cache
+				Description: accessList,
 			},
 		}, nil
 	case types.OpPut:
@@ -2064,13 +2544,13 @@ func (p *kubeWaitingContainerParser) parse(event backend.Event) (types.Resource,
 		}
 
 		resource, err := kubewaitingcontainer.NewKubeWaitingContainer(
-			string(parts[5]),
+			parts[5],
 			&kubewaitingcontainerpb.KubernetesWaitingContainerSpec{
-				Username:      string(parts[1]),
-				Cluster:       string(parts[2]),
-				Namespace:     string(parts[3]),
-				PodName:       string(parts[4]),
-				ContainerName: string(parts[5]),
+				Username:      parts[1],
+				Cluster:       parts[2],
+				Namespace:     parts[3],
+				PodName:       parts[4],
+				ContainerName: parts[5],
 				Patch:         []byte("{}"),                       // default to empty patch. It doesn't matter for delete ops.
 				PatchType:     kubewaitingcontainer.JSONPatchType, // default to JSON patch. It doesn't matter for delete ops.
 			},
@@ -2107,7 +2587,19 @@ type AccessMonitoringRuleParser struct {
 func (p *AccessMonitoringRuleParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindAccessMonitoringRule, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(accessMonitoringRulesPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindAccessMonitoringRule,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		r, err := services.UnmarshalAccessMonitoringRule(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
@@ -2124,7 +2616,7 @@ func (p *AccessMonitoringRuleParser) parse(event backend.Event) (types.Resource,
 
 func newUserNotificationParser() *userNotificationParser {
 	return &userNotificationParser{
-		baseParser: newBaseParser(backend.NewKey(notificationsUserSpecificPrefix)),
+		baseParser: newBaseParser(notificationsUserSpecificPrefix),
 	}
 }
 
@@ -2144,10 +2636,10 @@ func (p *userNotificationParser) parse(event backend.Event) (types.Resource, err
 			Kind:    types.KindNotification,
 			Version: types.V1,
 			Spec: &notificationsv1.NotificationSpec{
-				Username: string(parts[2]),
+				Username: parts[2],
 			},
 			Metadata: &headerv1.Metadata{
-				Name: string(parts[3]),
+				Name: parts[3],
 			},
 		}
 
@@ -2168,7 +2660,7 @@ func (p *userNotificationParser) parse(event backend.Event) (types.Resource, err
 
 func newGlobalNotificationParser() *globalNotificationParser {
 	return &globalNotificationParser{
-		baseParser: newBaseParser(backend.NewKey(notificationsGlobalPrefix)),
+		baseParser: newBaseParser(notificationsGlobalPrefix),
 	}
 }
 
@@ -2193,7 +2685,7 @@ func (p *globalNotificationParser) parse(event backend.Event) (types.Resource, e
 				},
 			},
 			Metadata: &headerv1.Metadata{
-				Name: string(parts[2]),
+				Name: parts[2],
 			},
 		}
 
@@ -2234,11 +2726,11 @@ func (p *botInstanceParser) parse(event backend.Event) (types.Resource, error) {
 			Kind:    types.KindBotInstance,
 			Version: types.V1,
 			Spec: &machineidv1.BotInstanceSpec{
-				BotName:    string(parts[1]),
-				InstanceId: string(parts[2]),
+				BotName:    parts[1],
+				InstanceId: parts[2],
 			},
 			Metadata: &headerv1.Metadata{
-				Name: string(parts[2]),
+				Name: parts[2],
 			},
 		}
 
@@ -2270,7 +2762,19 @@ type instanceParser struct {
 func (p *instanceParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindInstance, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(instancePrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindInstance,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		instance, err := generic.FastUnmarshal[*types.InstanceV1](event.Item)
 		if err != nil {
@@ -2295,7 +2799,20 @@ type staticHostUserParser struct {
 func (p *staticHostUserParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindStaticHostUser, types.V2, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(staticHostUserPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindStaticHostUser,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
+
 	case types.OpPut:
 		resource, err := services.UnmarshalProtoResource[*userprovisioningpb.StaticHostUser](
 			event.Item.Value,
@@ -2309,37 +2826,6 @@ func (p *staticHostUserParser) parse(event backend.Event) (types.Resource, error
 	default:
 		return nil, trace.BadParameter("event %v is not supported", event.Type)
 	}
-}
-
-func resourceHeader(event backend.Event, kind, version string, offset int) (types.Resource, error) {
-	name, err := base(event.Item.Key, offset)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &types.ResourceHeader{
-		Kind:    kind,
-		Version: version,
-		Metadata: types.Metadata{
-			Name:      name,
-			Namespace: apidefaults.Namespace,
-		},
-	}, nil
-}
-
-func resourceHeaderWithTemplate(event backend.Event, hdr types.ResourceHeader, offset int) (types.Resource, error) {
-	name, err := base(event.Item.Key, offset)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &types.ResourceHeader{
-		Kind:    hdr.Kind,
-		SubKind: hdr.SubKind,
-		Version: hdr.Version,
-		Metadata: types.Metadata{
-			Name:      name,
-			Namespace: apidefaults.Namespace,
-		},
-	}, nil
 }
 
 // WaitForEvent waits for the event matched by the specified event matcher in the given watcher.
@@ -2391,20 +2877,19 @@ type deviceParser struct {
 func (p *deviceParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		name, err := base(event.Item.Key, 0 /* offset */)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(devicetrust.DevicesIDPrefix...)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
-		device := &types.DeviceV1{
-			ResourceHeader: types.ResourceHeader{
-				Kind:    types.KindDevice,
-				Version: types.V1,
-				Metadata: types.Metadata{
-					Name: name,
-				},
+
+		return &types.ResourceHeader{
+			Kind:    types.KindDevice,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
 			},
-		}
-		return device, nil
+		}, nil
 	case types.OpPut:
 		device, err := services.UnmarshalDeviceFromBackendItem(event.Item)
 		if err != nil {
@@ -2435,16 +2920,17 @@ type accessGraphSecretPrivateKeyParser struct {
 func (p *accessGraphSecretPrivateKeyParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		deviceID, name, err := baseTwoKeys(event.Item.Key)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		key := event.Item.Key.TrimPrefix(backend.NewKey(privateKeysPrefix))
+		if len(key.Components()) < 2 {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
+		deviceID := key.Components()[0]
 
 		privateKey := &accessgraphsecretsv1pb.PrivateKey{
 			Kind:    types.KindAccessGraphSecretPrivateKey,
 			Version: types.V1,
 			Metadata: &headerv1.Metadata{
-				Name: name,
+				Name: strings.TrimPrefix(key.TrimPrefix(backend.NewKey(deviceID)).String(), backend.SeparatorString),
 			},
 			Spec: &accessgraphsecretsv1pb.PrivateKeySpec{
 				DeviceId: deviceID,
@@ -2479,16 +2965,17 @@ type accessGraphSecretAuthorizedKeyParser struct {
 func (p *accessGraphSecretAuthorizedKeyParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		hostID, name, err := baseTwoKeys(event.Item.Key)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		key := event.Item.Key.TrimPrefix(backend.NewKey(authorizedKeysPrefix))
+		if len(key.Components()) < 2 {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
+		hostID := key.Components()[0]
 
 		authorizedKey := &accessgraphsecretsv1pb.AuthorizedKey{
 			Kind:    types.KindAccessGraphSecretAuthorizedKey,
 			Version: types.V1,
 			Metadata: &headerv1.Metadata{
-				Name: name,
+				Name: strings.TrimPrefix(key.TrimPrefix(backend.NewKey(hostID)).String(), backend.SeparatorString),
 			},
 			Spec: &accessgraphsecretsv1pb.AuthorizedKeySpec{
 				HostId: hostID,
@@ -2527,25 +3014,6 @@ type EventMatcher interface {
 	Match(types.Event) (types.Resource, error)
 }
 
-// base returns the key component that is offset
-// components before the last component.
-func base(key backend.Key, offset int) (string, error) {
-	parts := key.Components()
-	if len(parts) < offset+1 {
-		return "", trace.NotFound("failed parsing %v", string(key))
-	}
-	return string(parts[len(parts)-offset-1]), nil
-}
-
-// baseTwoKeys returns two last keys
-func baseTwoKeys(key backend.Key) (string, string, error) {
-	parts := key.Components()
-	if len(parts) < 2 {
-		return "", "", trace.NotFound("failed parsing %v", string(key))
-	}
-	return string(parts[len(parts)-2]), string(parts[len(parts)-1]), nil
-}
-
 func newAccessGraphSettingsParser() *accessGraphSettingsParser {
 	return &accessGraphSettingsParser{
 		baseParser: newBaseParser(backend.NewKey(clusterConfigPrefix, accessGraphSettingsPrefix)),
@@ -2559,12 +3027,14 @@ type accessGraphSettingsParser struct {
 func (p *accessGraphSettingsParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		h, err := resourceHeader(event, types.KindAccessGraphSettings, types.V1, 0)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		h.SetName(types.MetaNameAccessGraphSettings)
-		return h, nil
+		return &types.ResourceHeader{
+			Kind:    types.KindAccessGraphSettings,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      types.MetaNameAccessGraphSettings,
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		settings, err := services.UnmarshalAccessGraphSettings(
 			event.Item.Value,
@@ -2593,7 +3063,19 @@ type spiffeFederationParser struct {
 func (p *spiffeFederationParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindSPIFFEFederation, types.V1, 0)
+		name := event.Item.Key.TrimPrefix(backend.NewKey(spiffeFederationPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindSPIFFEFederation,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
 	case types.OpPut:
 		federation, err := services.UnmarshalSPIFFEFederation(
 			event.Item.Value,

--- a/lib/services/local/externalauditstorage.go
+++ b/lib/services/local/externalauditstorage.go
@@ -253,19 +253,19 @@ func (s *ExternalAuditStorageService) DisableClusterExternalAuditStorage(ctx con
 
 // checkAWSIntegration checks that [integrationName] names an AWS OIDC integration that currently exists, and
 // returns the backend key and revision if the AWS OIDC integration.
-func (s *ExternalAuditStorageService) checkAWSIntegration(ctx context.Context, integrationName string) (key backend.Key, revision string, err error) {
+func (s *ExternalAuditStorageService) checkAWSIntegration(ctx context.Context, integrationName string) (backend.Key, string, error) {
 	integrationsSvc, err := NewIntegrationsService(s.backend)
 	if err != nil {
-		return nil, "", trace.Wrap(err)
+		return backend.Key{}, "", trace.Wrap(err)
 	}
 	integration, err := integrationsSvc.GetIntegration(ctx, integrationName)
 	if err != nil {
-		return nil, "", trace.Wrap(err, "getting integration")
+		return backend.Key{}, "", trace.Wrap(err, "getting integration")
 	}
 	if integration.GetAWSOIDCIntegrationSpec() == nil {
-		return nil, "", trace.BadParameter("%q is not an AWS OIDC integration", integrationName)
+		return backend.Key{}, "", trace.BadParameter("%q is not an AWS OIDC integration", integrationName)
 	}
-	return integrationsSvc.svc.MakeKey(integrationName), integration.GetRevision(), nil
+	return integrationsSvc.svc.MakeKey(backend.NewKey(integrationName)), integration.GetRevision(), nil
 }
 
 func getExternalAuditStorage(ctx context.Context, bk backend.Backend, key backend.Key) (*externalauditstorage.ExternalAuditStorage, error) {

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -52,7 +52,7 @@ type ServiceConfig[T Resource] struct {
 	// PageLimit
 	PageLimit uint
 	// BackendPrefix used when constructing the [backend.Item.Key].
-	BackendPrefix string
+	BackendPrefix backend.Key
 	// MarshlFunc converts the resource to bytes for persistence.
 	MarshalFunc MarshalFunc[T]
 	// UnmarshalFunc converts the bytes read from the backend to the resource.
@@ -81,7 +81,7 @@ func (c *ServiceConfig[T]) CheckAndSetDefaults() error {
 	if c.PageLimit == 0 {
 		c.PageLimit = defaults.DefaultChunkSize
 	}
-	if c.BackendPrefix == "" {
+	if c.BackendPrefix.IsZero() {
 		return trace.BadParameter("backend prefix is missing")
 	}
 	if c.MarshalFunc == nil {
@@ -107,7 +107,7 @@ type Service[T Resource] struct {
 	backend                     backend.Backend
 	resourceKind                string
 	pageLimit                   uint
-	backendPrefix               string
+	backendPrefix               backend.Key
 	marshalFunc                 MarshalFunc[T]
 	unmarshalFunc               UnmarshalFunc[T]
 	validateFunc                func(T) error
@@ -145,7 +145,7 @@ func (s *Service[T]) WithPrefix(parts ...string) *Service[T] {
 		backend:                     s.backend,
 		resourceKind:                s.resourceKind,
 		pageLimit:                   s.pageLimit,
-		backendPrefix:               strings.Join(append([]string{s.backendPrefix}, parts...), string(backend.Separator)),
+		backendPrefix:               s.backendPrefix.AppendKey(backend.NewKey(parts...)),
 		marshalFunc:                 s.marshalFunc,
 		unmarshalFunc:               s.unmarshalFunc,
 		validateFunc:                s.validateFunc,
@@ -156,7 +156,7 @@ func (s *Service[T]) WithPrefix(parts ...string) *Service[T] {
 
 // CountResources will return a count of all resources in the prefix range.
 func (s *Service[T]) CountResources(ctx context.Context) (uint, error) {
-	rangeStart := backend.ExactKey(s.backendPrefix)
+	rangeStart := s.backendPrefix.ExactKey()
 	rangeEnd := backend.RangeEnd(rangeStart)
 
 	count := uint(0)
@@ -171,7 +171,7 @@ func (s *Service[T]) CountResources(ctx context.Context) (uint, error) {
 
 // GetResources returns a list of all resources.
 func (s *Service[T]) GetResources(ctx context.Context) ([]T, error) {
-	rangeStart := backend.ExactKey(s.backendPrefix)
+	rangeStart := s.backendPrefix.ExactKey()
 	rangeEnd := backend.RangeEnd(rangeStart)
 
 	// no filter provided get the range directly
@@ -205,8 +205,8 @@ func (s *Service[T]) ListResourcesReturnNextResource(ctx context.Context, pageSi
 	return resources, next, trace.Wrap(err)
 }
 func (s *Service[T]) listResourcesReturnNextResourceWithKey(ctx context.Context, pageSize int, pageToken string) ([]T, *T, string, error) {
-	rangeStart := backend.NewKey(s.backendPrefix, pageToken)
-	rangeEnd := backend.RangeEnd(backend.ExactKey(s.backendPrefix))
+	rangeStart := s.backendPrefix.AppendKey(backend.KeyFromString(pageToken))
+	rangeEnd := backend.RangeEnd(s.backendPrefix.ExactKey())
 
 	// Adjust page size, so it can't be too large.
 	if pageSize <= 0 || pageSize > int(s.pageLimit) {
@@ -240,7 +240,7 @@ func (s *Service[T]) listResourcesReturnNextResourceWithKey(ctx context.Context,
 		next = &out[pageSize]
 		// Truncate the last item that was used to determine next row existence.
 		out = out[:pageSize]
-		nextKey = trimLastKey(lastKey.String(), s.backendPrefix)
+		nextKey = strings.TrimPrefix(lastKey.TrimPrefix(s.backendPrefix).String(), string(backend.Separator))
 	}
 
 	return out, next, nextKey, nil
@@ -248,8 +248,8 @@ func (s *Service[T]) listResourcesReturnNextResourceWithKey(ctx context.Context,
 
 // ListResourcesWithFilter returns a paginated list of resources that match the given filter.
 func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, pageToken string, matcher func(T) bool) ([]T, string, error) {
-	rangeStart := backend.NewKey(s.backendPrefix, pageToken)
-	rangeEnd := backend.RangeEnd(backend.ExactKey(s.backendPrefix))
+	rangeStart := s.backendPrefix.AppendKey(backend.KeyFromString(pageToken))
+	rangeEnd := backend.RangeEnd(s.backendPrefix.ExactKey())
 
 	// Adjust page size, so it can't be too large.
 	if pageSize <= 0 || pageSize > int(s.pageLimit) {
@@ -287,7 +287,7 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 
 	var nextKey string
 	if len(resources) > pageSize {
-		nextKey = trimLastKey(lastKey.String(), s.backendPrefix)
+		nextKey = strings.TrimPrefix(lastKey.TrimPrefix(s.backendPrefix).String(), string(backend.Separator))
 		// Truncate the last item that was used to determine next row existence.
 		resources = resources[:pageSize]
 	}
@@ -298,7 +298,7 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 
 // GetResource returns the specified resource.
 func (s *Service[T]) GetResource(ctx context.Context, name string) (resource T, err error) {
-	item, err := s.backend.Get(ctx, s.MakeKey(name))
+	item, err := s.backend.Get(ctx, s.MakeKey(backend.NewKey(name)))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return resource, trace.NotFound("%s %q doesn't exist", s.resourceKind, name)
@@ -408,7 +408,7 @@ func (s *Service[T]) UpsertResource(ctx context.Context, resource T) (T, error) 
 
 // DeleteResource removes the specified resource.
 func (s *Service[T]) DeleteResource(ctx context.Context, name string) error {
-	err := s.backend.Delete(ctx, s.MakeKey(name))
+	err := s.backend.Delete(ctx, s.MakeKey(backend.NewKey(name)))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("%s %q doesn't exist", s.resourceKind, name)
@@ -420,14 +420,14 @@ func (s *Service[T]) DeleteResource(ctx context.Context, name string) error {
 
 // DeleteAllResources removes all resources.
 func (s *Service[T]) DeleteAllResources(ctx context.Context) error {
-	startKey := backend.ExactKey(s.backendPrefix)
+	startKey := s.backendPrefix.ExactKey()
 	return trace.Wrap(s.backend.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)))
 }
 
 // UpdateAndSwapResource will get the resource from the backend, modify it, and swap the new value into the backend.
 func (s *Service[T]) UpdateAndSwapResource(ctx context.Context, name string, modify func(T) error) (T, error) {
 	var t T
-	existingItem, err := s.backend.Get(ctx, s.MakeKey(name))
+	existingItem, err := s.backend.Get(ctx, s.MakeKey(backend.NewKey(name)))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return t, trace.NotFound("%s %q doesn't exist", s.resourceKind, name)
@@ -479,7 +479,7 @@ func (s *Service[T]) MakeBackendItem(resource T, name string) (backend.Item, err
 		return backend.Item{}, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      s.MakeKey(name),
+		Key:      s.MakeKey(backend.NewKey(name)),
 		Value:    value,
 		Revision: rev,
 	}
@@ -493,8 +493,8 @@ func (s *Service[T]) MakeBackendItem(resource T, name string) (backend.Item, err
 }
 
 // MakeKey will make a key for the service given a name.
-func (s *Service[T]) MakeKey(name string) backend.Key {
-	return backend.NewKey(s.backendPrefix, name)
+func (s *Service[T]) MakeKey(k backend.Key) backend.Key {
+	return s.backendPrefix.AppendKey(k)
 }
 
 // RunWhileLocked will run the given function in a backend lock. This is a wrapper around the backend.RunWhileLocked function.
@@ -510,14 +510,4 @@ func (s *Service[T]) RunWhileLocked(ctx context.Context, lockNameComponents []st
 		}, func(ctx context.Context) error {
 			return fn(ctx, s.backend)
 		}))
-}
-
-func trimLastKey(lastKey, prefix string) string {
-	if !strings.HasSuffix(prefix, string(backend.Separator)) {
-		prefix += string(backend.Separator)
-	}
-	if !strings.HasPrefix(prefix, string(backend.Separator)) {
-		prefix = string(backend.Separator) + prefix
-	}
-	return strings.TrimPrefix(lastKey, prefix)
 }

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -109,7 +109,7 @@ func TestGenericCRUD(t *testing.T) {
 		Backend:       memBackend,
 		ResourceKind:  "generic resource",
 		PageLimit:     200,
-		BackendPrefix: "generic_prefix",
+		BackendPrefix: backend.NewKey("generic_prefix"),
 		UnmarshalFunc: unmarshalResource,
 		MarshalFunc:   marshalResource,
 	})
@@ -259,8 +259,8 @@ func TestGenericCRUD(t *testing.T) {
 	require.ErrorIs(t, err, trace.NotFound(`generic resource "doesnotexist" doesn't exist`))
 
 	// Test running while locked.
-	err = service.RunWhileLocked(ctx, []string{"test-lock"}, time.Second*5, func(ctx context.Context, backend backend.Backend) error {
-		item, err := backend.Get(ctx, service.MakeKey(r1.GetName()))
+	err = service.RunWhileLocked(ctx, []string{"test-lock"}, time.Second*5, func(ctx context.Context, b backend.Backend) error {
+		item, err := b.Get(ctx, service.MakeKey(backend.NewKey(r1.GetName())))
 		require.NoError(t, err)
 
 		r, err = unmarshalResource(item.Value, services.WithRevision(item.Revision))
@@ -300,7 +300,7 @@ func TestGenericListResourcesReturnNextResource(t *testing.T) {
 		Backend:       memBackend,
 		ResourceKind:  "generic resource",
 		PageLimit:     200,
-		BackendPrefix: "generic_prefix",
+		BackendPrefix: backend.NewKey("generic_prefix"),
 		UnmarshalFunc: unmarshalResource,
 		MarshalFunc:   marshalResource,
 	})
@@ -343,7 +343,7 @@ func TestGenericListResourcesWithMultiplePrefixes(t *testing.T) {
 		Backend:       memBackend,
 		ResourceKind:  "generic resource",
 		PageLimit:     200,
-		BackendPrefix: "generic_prefix",
+		BackendPrefix: backend.NewKey("generic_prefix"),
 		UnmarshalFunc: unmarshalResource,
 		MarshalFunc:   marshalResource,
 	})
@@ -402,7 +402,7 @@ func TestGenericListResourcesWithFilter(t *testing.T) {
 		Backend:       memBackend,
 		ResourceKind:  "generic resource",
 		PageLimit:     200,
-		BackendPrefix: "generic_prefix",
+		BackendPrefix: backend.NewKey("generic_prefix"),
 		UnmarshalFunc: unmarshalResource,
 		MarshalFunc:   marshalResource,
 	})
@@ -451,7 +451,7 @@ func TestGenericValidation(t *testing.T) {
 		Backend:       memBackend,
 		ResourceKind:  "generic resource",
 		PageLimit:     200,
-		BackendPrefix: "generic_prefix",
+		BackendPrefix: backend.NewKey("generic_prefix"),
 		UnmarshalFunc: unmarshalResource,
 		MarshalFunc:   marshalResource,
 		ValidateFunc:  func(tr *testResource) error { return validationErr },
@@ -483,7 +483,7 @@ func TestGenericKeyOverride(t *testing.T) {
 		Backend:       memBackend,
 		ResourceKind:  "generic resource",
 		PageLimit:     200,
-		BackendPrefix: "generic_prefix",
+		BackendPrefix: backend.NewKey("generic_prefix"),
 		UnmarshalFunc: unmarshalResource,
 		MarshalFunc:   marshalResource,
 		KeyFunc:       func(tr *testResource) string { return "llama" },

--- a/lib/services/local/generic/generic_wrapper_test.go
+++ b/lib/services/local/generic/generic_wrapper_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -108,7 +109,7 @@ func TestGenericWrapperCRUD(t *testing.T) {
 		ServiceWrapperConfig[*testResource153]{
 			Backend:       memBackend,
 			ResourceKind:  "generic resource",
-			BackendPrefix: backendPrefix,
+			BackendPrefix: backend.NewKey(backendPrefix),
 			MarshalFunc:   marshalResource153,
 			UnmarshalFunc: unmarshalResource153,
 		})
@@ -244,7 +245,7 @@ func TestGenericWrapperWithPrefix(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	const initialBackendPrefix = "initial_prefix"
+	initialBackendPrefix := backend.NewKey("initial_prefix")
 	const additionalBackendPrefix = "additional_prefix"
 
 	service, err := NewServiceWrapper[*testResource153](
@@ -262,5 +263,5 @@ func TestGenericWrapperWithPrefix(t *testing.T) {
 
 	// Verify that withPrefix appends the additional prefix.
 	serviceWithPrefix := service.WithPrefix(additionalBackendPrefix)
-	require.Equal(t, "initial_prefix/additional_prefix", serviceWithPrefix.service.backendPrefix)
+	require.Equal(t, backend.NewKey("initial_prefix", "additional_prefix").String(), serviceWithPrefix.service.backendPrefix.String())
 }

--- a/lib/services/local/generic/nonce_test.go
+++ b/lib/services/local/generic/nonce_test.go
@@ -96,52 +96,52 @@ func TestNonceBasics(t *testing.T) {
 	require.NoError(t, err)
 
 	// nonce of 1 is an "update", but resource does not exist yet
-	err = FastUpdateNonceProtectedResource(ctx, bk, []byte("k1"), newNoncedResource("r1", 1))
+	err = FastUpdateNonceProtectedResource(ctx, bk, backend.NewKey("k1"), newNoncedResource("r1", 1))
 	require.ErrorIs(t, err, ErrNonceViolation)
 
 	// nonce of 0 is a valid "create".
-	err = FastUpdateNonceProtectedResource(ctx, bk, []byte("k1"), newNoncedResource("r1", 0))
+	err = FastUpdateNonceProtectedResource(ctx, bk, backend.NewKey("k1"), newNoncedResource("r1", 0))
 	require.NoError(t, err)
 
 	// subsequent calls with nonce of 0 fail.
-	err = FastUpdateNonceProtectedResource(ctx, bk, []byte("k1"), newNoncedResource("r1", 0))
+	err = FastUpdateNonceProtectedResource(ctx, bk, backend.NewKey("k1"), newNoncedResource("r1", 0))
 	require.ErrorIs(t, err, ErrNonceViolation)
 
 	// nonce of 1 is now a valid update
-	err = FastUpdateNonceProtectedResource(ctx, bk, []byte("k1"), newNoncedResource("r1", 1))
+	err = FastUpdateNonceProtectedResource(ctx, bk, backend.NewKey("k1"), newNoncedResource("r1", 1))
 	require.NoError(t, err)
 
 	// loading and then re-inserting should always work since nonce is incremented internally
 	for i := 0; i < 10; i++ {
-		rsc, err := fastGetResource[*noncedResource](ctx, bk, []byte("k1"))
+		rsc, err := fastGetResource[*noncedResource](ctx, bk, backend.NewKey("k1"))
 		require.NoError(t, err)
 
-		err = FastUpdateNonceProtectedResource(ctx, bk, []byte("k1"), rsc)
+		err = FastUpdateNonceProtectedResource(ctx, bk, backend.NewKey("k1"), rsc)
 		require.NoError(t, err)
 	}
 
 	// sanity check: nonce incremented expected number of times
-	err = FastUpdateNonceProtectedResource(ctx, bk, []byte("k1"), newNoncedResource("r1", 12))
+	err = FastUpdateNonceProtectedResource(ctx, bk, backend.NewKey("k1"), newNoncedResource("r1", 12))
 	require.NoError(t, err)
 
 	// max uint64 "forces" update
-	err = FastUpdateNonceProtectedResource(ctx, bk, []byte("k1"), newNoncedResource("r1", math.MaxUint64))
+	err = FastUpdateNonceProtectedResource(ctx, bk, backend.NewKey("k1"), newNoncedResource("r1", math.MaxUint64))
 	require.NoError(t, err)
 
 	// forced update correctly conflicts with what would normally be the "next" valid nonce.
-	err = FastUpdateNonceProtectedResource(ctx, bk, []byte("k1"), newNoncedResource("r1", 13))
+	err = FastUpdateNonceProtectedResource(ctx, bk, backend.NewKey("k1"), newNoncedResource("r1", 13))
 	require.ErrorIs(t, err, ErrNonceViolation)
 
 	// forced update correctly incremented nonce by 1
-	err = FastUpdateNonceProtectedResource(ctx, bk, []byte("k1"), newNoncedResource("r1", 14))
+	err = FastUpdateNonceProtectedResource(ctx, bk, backend.NewKey("k1"), newNoncedResource("r1", 14))
 	require.NoError(t, err)
 
 	// max uint64 "forces" update for nonexistent resources too
-	err = FastUpdateNonceProtectedResource(ctx, bk, []byte("k2"), newNoncedResource("r2", math.MaxUint64))
+	err = FastUpdateNonceProtectedResource(ctx, bk, backend.NewKey("k2"), newNoncedResource("r2", math.MaxUint64))
 	require.NoError(t, err)
 
 	// forced update correctly sets new nonce to 1
-	err = FastUpdateNonceProtectedResource(ctx, bk, []byte("k2"), newNoncedResource("r2", 1))
+	err = FastUpdateNonceProtectedResource(ctx, bk, backend.NewKey("k2"), newNoncedResource("r2", 1))
 	require.NoError(t, err)
 }
 
@@ -188,7 +188,7 @@ func TestNonceParallelism(t *testing.T) {
 			rem := updates
 
 			for rem > 0 {
-				rsc, err := fastGetResource[*noncedResource](ctx, bk, []byte(key))
+				rsc, err := fastGetResource[*noncedResource](ctx, bk, backend.NewKey(key))
 				if err != nil && !trace.IsNotFound(err) {
 					fail(err)
 					return
@@ -199,7 +199,7 @@ func TestNonceParallelism(t *testing.T) {
 					rsc = newNoncedResource(name, 0)
 				}
 
-				err = FastUpdateNonceProtectedResource(ctx, bk, []byte(key), rsc)
+				err = FastUpdateNonceProtectedResource(ctx, bk, backend.NewKey(key), rsc)
 
 				if err != nil {
 					if errors.Is(err, ErrNonceViolation) {
@@ -223,7 +223,7 @@ func TestNonceParallelism(t *testing.T) {
 	require.NoError(t, <-errch)
 
 	// load resource and verify that we hit our exact expected number of updates
-	rsc, err := fastGetResource[*noncedResource](ctx, bk, []byte(key))
+	rsc, err := fastGetResource[*noncedResource](ctx, bk, backend.NewKey(key))
 	require.NoError(t, err)
 	require.Equal(t, routines*updates, int(rsc.Nonce))
 

--- a/lib/services/local/integrations.go
+++ b/lib/services/local/integrations.go
@@ -53,12 +53,12 @@ func WithIntegrationsServiceCacheMode(cacheMode bool) func(*IntegrationsService)
 }
 
 // NewIntegrationsService creates a new IntegrationsService.
-func NewIntegrationsService(backend backend.Backend, opts ...IntegrationsServiceOption) (*IntegrationsService, error) {
+func NewIntegrationsService(b backend.Backend, opts ...IntegrationsServiceOption) (*IntegrationsService, error) {
 	svc, err := generic.NewService(&generic.ServiceConfig[types.Integration]{
-		Backend:       backend,
+		Backend:       b,
 		PageLimit:     defaults.MaxIterationLimit,
 		ResourceKind:  types.KindIntegration,
-		BackendPrefix: integrationsPrefix,
+		BackendPrefix: backend.NewKey(integrationsPrefix),
 		MarshalFunc:   services.MarshalIntegration,
 		UnmarshalFunc: services.UnmarshalIntegration,
 	})
@@ -67,7 +67,7 @@ func NewIntegrationsService(backend backend.Backend, opts ...IntegrationsService
 	}
 	integrationsSvc := &IntegrationsService{
 		svc:     *svc,
-		backend: backend,
+		backend: b,
 	}
 	for _, opt := range opts {
 		opt(integrationsSvc)
@@ -132,7 +132,7 @@ func (s *IntegrationsService) DeleteIntegration(ctx context.Context, name string
 		return trace.Wrap(err)
 	}
 	conditionalActions = append(conditionalActions, backend.ConditionalAction{
-		Key:       s.svc.MakeKey(name),
+		Key:       s.svc.MakeKey(backend.NewKey(name)),
 		Condition: backend.Exists(),
 		Action:    backend.Delete(),
 	})

--- a/lib/services/local/kubewaitingcontainer.go
+++ b/lib/services/local/kubewaitingcontainer.go
@@ -42,12 +42,12 @@ type KubeWaitingContainerService struct {
 
 // NewKubeWaitingContainerService returns a new Kubernetes waiting
 // container service.
-func NewKubeWaitingContainerService(backend backend.Backend) (*KubeWaitingContainerService, error) {
+func NewKubeWaitingContainerService(b backend.Backend) (*KubeWaitingContainerService, error) {
 	svc, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*kubewaitingcontainerpb.KubernetesWaitingContainer]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindKubeWaitingContainer,
-			BackendPrefix: kubeWaitingContPrefix,
+			BackendPrefix: backend.NewKey(kubeWaitingContPrefix),
 			MarshalFunc:   services.MarshalKubeWaitingContainer,
 			UnmarshalFunc: services.UnmarshalKubeWaitingContainer,
 		})

--- a/lib/services/local/notifications.go
+++ b/lib/services/local/notifications.go
@@ -433,12 +433,14 @@ func CheckAndSetExpiry(notification *notificationsv1.Notification, clock clockwo
 	return nil
 }
 
-const (
-	notificationsGlobalPrefix       = "notifications/global"    // notifications/global/<notification id>
-	notificationsUserSpecificPrefix = "notifications/user"      // notifications/user/<username>/<notification id>
-	notificationsStatePrefix        = "notifications/states"    // notifications/states/<username>/<notification id>
-	notificationsUserLastSeenPrefix = "notifications/last_seen" // notifications/last_seen/<username>
+var (
+	notificationsGlobalPrefix       = backend.NewKey("notifications", "global")    // notifications/global/<notification id>
+	notificationsUserSpecificPrefix = backend.NewKey("notifications", "user")      // notifications/user/<username>/<notification id>
+	notificationsStatePrefix        = backend.NewKey("notifications", "states")    // notifications/states/<username>/<notification id>
+	notificationsUserLastSeenPrefix = backend.NewKey("notifications", "last_seen") // notifications/last_seen/<username>
+)
 
+const (
 	defaultExpiry = 30 * 24 * time.Hour // The default expiry for a notification, 30 days.
 	maxExpiry     = 90 * 24 * time.Hour // The maximum expiry for a notification, 90 days.
 )

--- a/lib/services/local/okta.go
+++ b/lib/services/local/okta.go
@@ -50,12 +50,12 @@ type OktaService struct {
 }
 
 // NewOktaService creates a new OktaService.
-func NewOktaService(backend backend.Backend, clock clockwork.Clock) (*OktaService, error) {
+func NewOktaService(b backend.Backend, clock clockwork.Clock) (*OktaService, error) {
 	importRuleSvc, err := generic.NewService(&generic.ServiceConfig[types.OktaImportRule]{
-		Backend:       backend,
+		Backend:       b,
 		PageLimit:     oktaImportRuleMaxPageSize,
 		ResourceKind:  types.KindOktaImportRule,
-		BackendPrefix: oktaImportRulePrefix,
+		BackendPrefix: backend.NewKey(oktaImportRulePrefix),
 		MarshalFunc:   services.MarshalOktaImportRule,
 		UnmarshalFunc: services.UnmarshalOktaImportRule,
 	})
@@ -64,10 +64,10 @@ func NewOktaService(backend backend.Backend, clock clockwork.Clock) (*OktaServic
 	}
 
 	assignmentSvc, err := generic.NewService(&generic.ServiceConfig[types.OktaAssignment]{
-		Backend:       backend,
+		Backend:       b,
 		PageLimit:     oktaAssignmentMaxPageSize,
 		ResourceKind:  types.KindOktaAssignment,
-		BackendPrefix: oktaAssignmentPrefix,
+		BackendPrefix: backend.NewKey(oktaAssignmentPrefix),
 		MarshalFunc:   services.MarshalOktaAssignment,
 		UnmarshalFunc: services.UnmarshalOktaAssignment,
 	})

--- a/lib/services/local/plugin_data.go
+++ b/lib/services/local/plugin_data.go
@@ -95,7 +95,7 @@ func (p *PluginDataService) getPluginData(ctx context.Context, filter types.Plug
 	}
 	var matches []types.PluginData
 	for _, item := range result.Items {
-		if !item.Key.HasSuffix(backend.Key(paramsPrefix)) {
+		if !item.Key.HasSuffix(backend.NewKey(paramsPrefix)) {
 			// Item represents a different resource type in the
 			// same namespace.
 			continue

--- a/lib/services/local/plugin_static_credentials.go
+++ b/lib/services/local/plugin_static_credentials.go
@@ -39,11 +39,11 @@ type PluginStaticCredentialsService struct {
 }
 
 // NewPluginStaticCredentialsService creates a new PluginStaticCredentialsService.
-func NewPluginStaticCredentialsService(backend backend.Backend) (*PluginStaticCredentialsService, error) {
+func NewPluginStaticCredentialsService(b backend.Backend) (*PluginStaticCredentialsService, error) {
 	svc, err := generic.NewService(&generic.ServiceConfig[types.PluginStaticCredentials]{
-		Backend:       backend,
+		Backend:       b,
 		ResourceKind:  types.KindPluginStaticCredentials,
-		BackendPrefix: pluginStaticCredentialsPrefix,
+		BackendPrefix: backend.NewKey(pluginStaticCredentialsPrefix),
 		MarshalFunc:   services.MarshalPluginStaticCredentials,
 		UnmarshalFunc: services.UnmarshalPluginStaticCredentials,
 	})

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -79,7 +79,7 @@ func (s *PresenceService) GetNamespaces() ([]types.Namespace, error) {
 	}
 	out := make([]types.Namespace, 0, len(result.Items))
 	for _, item := range result.Items {
-		if !item.Key.HasSuffix(backend.Key(paramsPrefix)) {
+		if !item.Key.HasSuffix(backend.NewKey(paramsPrefix)) {
 			continue
 		}
 		ns, err := services.UnmarshalNamespace(

--- a/lib/services/local/resource.go
+++ b/lib/services/local/resource.go
@@ -21,8 +21,6 @@ package local
 import (
 	"context"
 	"encoding/json"
-	"strings"
-	"unicode/utf8"
 
 	"github.com/gravitational/trace"
 
@@ -50,7 +48,7 @@ func CreateResources(ctx context.Context, b backend.Backend, resources ...types.
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			return trace.AlreadyExists("resource %q already exists", string(item.Key))
+			return trace.AlreadyExists("resource %q already exists", item.Key.String())
 		}
 	}
 	// create all items.
@@ -439,17 +437,17 @@ var fullUsersPrefix = backend.ExactKey(webPrefix, usersPrefix)
 
 // splitUsernameAndSuffix is a helper for extracting usernames and suffixes from
 // backend key values.
-func splitUsernameAndSuffix(key backend.Key) (name string, suffix string, err error) {
+func splitUsernameAndSuffix(key backend.Key) (name string, suffix []string, err error) {
 	if !key.HasPrefix(fullUsersPrefix) {
-		return "", "", trace.BadParameter("expected format '%s/<name>/<suffix>', got '%s'", fullUsersPrefix, key)
+		return "", nil, trace.BadParameter("expected format '%s/<name>/<suffix>', got '%s'", fullUsersPrefix, key)
 	}
 	k := key.TrimPrefix(fullUsersPrefix)
 
 	components := k.Components()
 	if len(components) < 2 {
-		return "", "", trace.BadParameter("expected format <name>/<suffix>, got %q", key)
+		return "", nil, trace.BadParameter("expected format <name>/<suffix>, got %q", key)
 	}
-	return string(components[0]), k.String()[len(components[0])+utf8.RuneLen(backend.Separator):], nil
+	return components[0], k.Components()[1:], nil
 }
 
 // collectUserItems handles the case where multiple items pertain to the same user resource.
@@ -496,20 +494,20 @@ type userItems struct {
 }
 
 // Set attempts to set a field by suffix.
-func (u *userItems) Set(suffix string, item backend.Item) (ok bool) {
-	switch suffix {
-	case paramsPrefix:
+func (u *userItems) Set(suffix []string, item backend.Item) (ok bool) {
+	switch {
+	case len(suffix) == 0:
+		return false
+	case suffix[0] == paramsPrefix:
 		u.params = &item
-	case pwdPrefix:
+	case suffix[0] == pwdPrefix:
 		u.pwd = &item
-	case webauthnLocalAuthPrefix:
+	case suffix[0] == webauthnLocalAuthPrefix:
 		u.webauthnLocalAuth = &item
+	case suffix[0] == mfaDevicePrefix:
+		u.mfa = append(u.mfa, &item)
 	default:
-		if strings.HasPrefix(suffix, mfaDevicePrefix) {
-			u.mfa = append(u.mfa, &item)
-		} else {
-			return false
-		}
+		return false
 	}
 	return true
 }

--- a/lib/services/local/saml_idp_service_provider.go
+++ b/lib/services/local/saml_idp_service_provider.go
@@ -67,12 +67,12 @@ func WithHTTPClient(httpClient *http.Client) SAMLIdPOption {
 }
 
 // NewSAMLIdPServiceProviderService creates a new SAMLIdPServiceProviderService.
-func NewSAMLIdPServiceProviderService(backend backend.Backend, opts ...SAMLIdPOption) (*SAMLIdPServiceProviderService, error) {
+func NewSAMLIdPServiceProviderService(b backend.Backend, opts ...SAMLIdPOption) (*SAMLIdPServiceProviderService, error) {
 	svc, err := generic.NewService(&generic.ServiceConfig[types.SAMLIdPServiceProvider]{
-		Backend:       backend,
+		Backend:       b,
 		PageLimit:     samlIDPServiceProviderMaxPageSize,
 		ResourceKind:  types.KindSAMLIdPServiceProvider,
-		BackendPrefix: samlIDPServiceProviderPrefix,
+		BackendPrefix: backend.NewKey(samlIDPServiceProviderPrefix),
 		MarshalFunc:   services.MarshalSAMLIdPServiceProvider,
 		UnmarshalFunc: services.UnmarshalSAMLIdPServiceProvider,
 	})

--- a/lib/services/local/secreports.go
+++ b/lib/services/local/secreports.go
@@ -33,15 +33,15 @@ import (
 	"github.com/gravitational/teleport/lib/services/local/generic"
 )
 
-const (
+var (
 	// AuditQueryPrefix is the prefix for audit queries.
-	AuditQueryPrefix = "security_report/audit_query"
+	AuditQueryPrefix = backend.NewKey("security_report", "audit_query")
 	// SecurityReportPrefix is the prefix for security reports.
-	SecurityReportPrefix = "security_report/report"
+	SecurityReportPrefix = backend.NewKey("security_report", "report")
 	// SecurityReportStatePrefix  is the prefix for security report states.
-	SecurityReportStatePrefix = "security_report/state"
+	SecurityReportStatePrefix = backend.NewKey("security_report", "state")
 	// SecurityReportCostLimiterPrefix is the prefix for security report cost limiter.
-	SecurityReportCostLimiterPrefix = "security_report/cost_limiter"
+	SecurityReportCostLimiterPrefix = backend.NewKey("security_report", "cost_limiter")
 )
 
 // SecReportsService is the local implementation of the SecReports service.

--- a/lib/services/local/session.go
+++ b/lib/services/local/session.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	"slices"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -407,11 +408,8 @@ func (r *webSessions) listLegacySessions(ctx context.Context) ([]types.WebSessio
 	}
 	out := make([]types.WebSession, 0, len(result.Items))
 	for _, item := range result.Items {
-		suffix, _, err := baseTwoKeys(item.Key)
-		if err != nil && trace.IsNotFound(err) {
-			return nil, trace.Wrap(err)
-		}
-		if suffix != sessionsPrefix {
+		idx := slices.Index(item.Key.Components(), sessionsPrefix)
+		if idx != len(item.Key.Components())-2 {
 			continue
 		}
 		session, err := services.UnmarshalWebSession(item.Value, services.WithRevision(item.Revision))

--- a/lib/services/local/spiffe_federations.go
+++ b/lib/services/local/spiffe_federations.go
@@ -39,14 +39,12 @@ type SPIFFEFederationService struct {
 }
 
 // NewSPIFFEFederationService creates a new SPIFFEFederationService.
-func NewSPIFFEFederationService(
-	backend backend.Backend,
-) (*SPIFFEFederationService, error) {
+func NewSPIFFEFederationService(b backend.Backend) (*SPIFFEFederationService, error) {
 	service, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*machineidv1.SPIFFEFederation]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindSPIFFEFederation,
-			BackendPrefix: spiffeFederationPrefix,
+			BackendPrefix: backend.NewKey(spiffeFederationPrefix),
 			MarshalFunc:   services.MarshalSPIFFEFederation,
 			UnmarshalFunc: services.UnmarshalSPIFFEFederation,
 			ValidateFunc:  services.ValidateSPIFFEFederation,

--- a/lib/services/local/statichostuser.go
+++ b/lib/services/local/statichostuser.go
@@ -45,7 +45,7 @@ func NewStaticHostUserService(bk backend.Backend) (*StaticHostUserService, error
 		generic.ServiceWrapperConfig[*userprovisioningpb.StaticHostUser]{
 			Backend:       bk,
 			ResourceKind:  types.KindStaticHostUser,
-			BackendPrefix: staticHostUserPrefix,
+			BackendPrefix: backend.NewKey(staticHostUserPrefix),
 			MarshalFunc:   services.MarshalProtoResource[*userprovisioningpb.StaticHostUser],
 			UnmarshalFunc: services.UnmarshalProtoResource[*userprovisioningpb.StaticHostUser],
 			ValidateFunc:  services.ValidateStaticHostUser,

--- a/lib/services/local/status.go
+++ b/lib/services/local/status.go
@@ -136,7 +136,10 @@ func (s *StatusService) UpsertClusterAlert(ctx context.Context, alert types.Clus
 	}
 
 	_, err = s.Backend.Put(ctx, backend.Item{
-		Key:      backend.NewKey(clusterAlertPrefix, alert.Metadata.Name),
+		// Key construction relies on [backend.KeyFromString] for the alert name, because there are existing
+		// alerts that include a / in their name. Without reconstructing the key it would be impossible
+		// for the sanitization layer to analyze the individual components separately.
+		Key:      backend.NewKey(clusterAlertPrefix).AppendKey(backend.KeyFromString(alert.Metadata.Name)),
 		Value:    val,
 		Expires:  alert.Metadata.Expiry(),
 		Revision: rev,
@@ -145,7 +148,10 @@ func (s *StatusService) UpsertClusterAlert(ctx context.Context, alert types.Clus
 }
 
 func (s *StatusService) DeleteClusterAlert(ctx context.Context, alertID string) error {
-	err := s.Backend.Delete(ctx, backend.NewKey(clusterAlertPrefix, alertID))
+	// Key construction relies on [backend.KeyFromString] for the alert name, because there are existing
+	// alerts that include a / in their name. Without reconstructing the key it would be impossible
+	// for the sanitization layer to analyze the individual components separately.
+	err := s.Backend.Delete(ctx, backend.NewKey(clusterAlertPrefix).AppendKey(backend.KeyFromString(alertID)))
 	if trace.IsNotFound(err) {
 		return trace.NotFound("cluster alert %q not found", alertID)
 	}
@@ -164,7 +170,10 @@ func (s *StatusService) CreateAlertAck(ctx context.Context, ack types.AlertAckno
 	}
 
 	_, err = s.Backend.Create(ctx, backend.Item{
-		Key:     backend.NewKey(alertAckPrefix, ack.AlertID),
+		// Key construction relies on [backend.KeyFromString] for the alert name, because there are existing
+		// alerts that include a / in their name. Without reconstructing the key it would be impossible
+		// for the sanitization layer to analyze the individual components separately.
+		Key:     backend.NewKey(alertAckPrefix).AppendKey(backend.KeyFromString(ack.AlertID)),
 		Value:   val,
 		Expires: ack.Expires,
 	})

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -77,7 +77,7 @@ func (s *CA) CreateCertAuthorities(ctx context.Context, cas ...types.CertAuthori
 			return "", trace.Wrap(err)
 		}
 
-		item, err := caToItem(nil, ca)
+		item, err := caToItem(backend.Key{}, ca)
 		if err != nil {
 			return "", trace.Wrap(err)
 		}

--- a/lib/services/local/trust_test.go
+++ b/lib/services/local/trust_test.go
@@ -132,7 +132,7 @@ func TestRemoteClusterCRUD(t *testing.T) {
 	// make sure it's really gone
 	err = trustService.DeleteRemoteCluster(ctx, "foo")
 	require.Error(t, err)
-	require.ErrorIs(t, err, trace.NotFound("key \"/remoteClusters/foo\" is not found"))
+	require.ErrorIs(t, err, trace.NotFound(`key "/remoteClusters/foo" is not found`))
 }
 
 func TestPresenceService_PatchRemoteCluster(t *testing.T) {
@@ -318,5 +318,5 @@ func TestTrustedClusterCRUD(t *testing.T) {
 	// make sure it's really gone
 	_, err = trustService.GetTrustedCluster(ctx, "foo")
 	require.Error(t, err)
-	require.ErrorIs(t, err, trace.NotFound("key /trustedclusters/foo is not found"))
+	require.ErrorIs(t, err, trace.NotFound(`key "/trustedclusters/foo" is not found`))
 }

--- a/lib/services/local/user_login_state.go
+++ b/lib/services/local/user_login_state.go
@@ -43,11 +43,11 @@ type UserLoginStateService struct {
 }
 
 // NewUserLoginStateService creates a new UserLoginStateService.
-func NewUserLoginStateService(backend backend.Backend) (*UserLoginStateService, error) {
+func NewUserLoginStateService(b backend.Backend) (*UserLoginStateService, error) {
 	svc, err := generic.NewService(&generic.ServiceConfig[*userloginstate.UserLoginState]{
-		Backend:       backend,
+		Backend:       b,
 		ResourceKind:  types.KindUserLoginState,
-		BackendPrefix: userLoginStatePrefix,
+		BackendPrefix: backend.NewKey(userLoginStatePrefix),
 		MarshalFunc:   services.MarshalUserLoginState,
 		UnmarshalFunc: services.UnmarshalUserLoginState,
 	})

--- a/lib/services/local/user_task.go
+++ b/lib/services/local/user_task.go
@@ -38,12 +38,12 @@ type UserTasksService struct {
 const userTasksKey = "user_tasks"
 
 // NewUserTasksService creates a new UserTasksService.
-func NewUserTasksService(backend backend.Backend) (*UserTasksService, error) {
+func NewUserTasksService(b backend.Backend) (*UserTasksService, error) {
 	service, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*usertasksv1.UserTask]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindUserTask,
-			BackendPrefix: userTasksKey,
+			BackendPrefix: backend.NewKey(userTasksKey),
 			MarshalFunc:   services.MarshalProtoResource[*usertasksv1.UserTask],
 			UnmarshalFunc: services.UnmarshalProtoResource[*usertasksv1.UserTask],
 		})

--- a/lib/services/local/usergroup.go
+++ b/lib/services/local/usergroup.go
@@ -38,12 +38,12 @@ type UserGroupService struct {
 }
 
 // NewUserGroupService creates a new UserGroupService.
-func NewUserGroupService(backend backend.Backend) (*UserGroupService, error) {
+func NewUserGroupService(b backend.Backend) (*UserGroupService, error) {
 	svc, err := generic.NewService(&generic.ServiceConfig[types.UserGroup]{
-		Backend:       backend,
+		Backend:       b,
 		PageLimit:     GroupMaxPageSize,
 		ResourceKind:  types.KindUserGroup,
-		BackendPrefix: userGroupPrefix,
+		BackendPrefix: backend.NewKey(userGroupPrefix),
 		MarshalFunc:   services.MarshalUserGroup,
 		UnmarshalFunc: services.UnmarshalUserGroup,
 	})

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -27,10 +27,10 @@ import (
 	"encoding/json"
 	"io"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
-	"unicode/utf8"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/google/go-cmp/cmp"
@@ -128,7 +128,7 @@ func (s *IdentityService) DeleteAllUsers(ctx context.Context) error {
 
 // ListUsers returns a page of users.
 func (s *IdentityService) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*userspb.ListUsersResponse, error) {
-	rangeStart := backend.NewKey(webPrefix, usersPrefix, req.PageToken)
+	rangeStart := backend.NewKey(webPrefix, usersPrefix).AppendKey(backend.KeyFromString(req.PageToken))
 	rangeEnd := backend.RangeEnd(backend.ExactKey(webPrefix, usersPrefix))
 	pageSize := req.PageSize
 
@@ -182,7 +182,8 @@ func (s *IdentityService) ListUsers(ctx context.Context, req *userspb.ListUsersR
 // the next user in the list while still allowing listing to operate
 // without missing any users.
 func nextUserToken(user types.User) string {
-	return backend.RangeEnd(backend.ExactKey(user.GetName())).String()[utf8.RuneLen(backend.Separator):]
+	key := backend.RangeEnd(backend.ExactKey(user.GetName())).String()
+	return strings.Trim(key, string(backend.Separator))
 }
 
 // streamUsersWithSecrets is a helper that converts a stream of backend items over the user key range into a stream
@@ -252,7 +253,7 @@ func (s *IdentityService) streamUsersWithSecrets(itemStream stream.Stream[backen
 // streamUsersWithoutSecrets is a helper that converts a stream of backend items over the user range into a stream of
 // user resources without any included secrets.
 func (s *IdentityService) streamUsersWithoutSecrets(itemStream stream.Stream[backend.Item]) stream.Stream[*types.UserV2] {
-	suffix := backend.Key(paramsPrefix)
+	suffix := backend.NewKey(paramsPrefix)
 	userStream := stream.FilterMap(itemStream, func(item backend.Item) (*types.UserV2, bool) {
 		if !item.Key.HasSuffix(suffix) {
 			return nil, false
@@ -282,7 +283,7 @@ func (s *IdentityService) GetUsers(ctx context.Context, withSecrets bool) ([]typ
 	}
 	var out []types.User
 	for _, item := range result.Items {
-		if !item.Key.HasSuffix(backend.Key(paramsPrefix)) {
+		if !item.Key.HasSuffix(backend.NewKey(paramsPrefix)) {
 			continue
 		}
 		u, err := services.UnmarshalUser(
@@ -632,7 +633,7 @@ func (s *IdentityService) getUserWithSecrets(ctx context.Context, user string) (
 	var items userItems
 	for _, item := range result.Items {
 		suffix := item.Key.TrimPrefix(startKey)
-		items.Set(suffix.String(), item) // Result of Set i
+		items.Set(suffix.Components(), item) // Result of Set i
 	}
 
 	u, err := userFromUserItems(user, items)
@@ -714,10 +715,11 @@ func (s *IdentityService) DeleteUser(ctx context.Context, user string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
 	// each user has multiple related entries in the backend,
 	// so use DeleteRange to make sure we get them all
 	startKey := backend.ExactKey(webPrefix, usersPrefix, user)
-	if err = s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)); err != nil {
+	if err := s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/services/local/usertoken.go
+++ b/lib/services/local/usertoken.go
@@ -38,7 +38,7 @@ func (s *IdentityService) GetUserTokens(ctx context.Context) ([]types.UserToken,
 
 	var tokens []types.UserToken
 	for _, item := range result.Items {
-		if !item.Key.HasSuffix(backend.Key(paramsPrefix)) {
+		if !item.Key.HasSuffix(backend.NewKey(paramsPrefix)) {
 			continue
 		}
 

--- a/lib/services/local/vnet_config.go
+++ b/lib/services/local/vnet_config.go
@@ -44,12 +44,12 @@ type VnetConfigService struct {
 }
 
 // NewVnetConfigService returns a new VnetConfig storage service.
-func NewVnetConfigService(backend backend.Backend) (*VnetConfigService, error) {
+func NewVnetConfigService(b backend.Backend) (*VnetConfigService, error) {
 	svc, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*vnet.VnetConfig]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindVnetConfig,
-			BackendPrefix: vnetConfigPrefix,
+			BackendPrefix: backend.NewKey(vnetConfigPrefix),
 			MarshalFunc:   services.MarshalProtoResource[*vnet.VnetConfig],
 			UnmarshalFunc: services.UnmarshalProtoResource[*vnet.VnetConfig],
 			ValidateFunc:  validateVnetConfig,

--- a/lib/services/simple/access_list.go
+++ b/lib/services/simple/access_list.go
@@ -55,12 +55,12 @@ type AccessListService struct {
 // NewAccessListService creates a new AccessListService. This is a simple, cache focused
 // backend service that doesn't perform any of the validation that the main backend service
 // does.
-func NewAccessListService(backend backend.Backend) (*AccessListService, error) {
+func NewAccessListService(b backend.Backend) (*AccessListService, error) {
 	service, err := generic.NewService(&generic.ServiceConfig[*accesslist.AccessList]{
-		Backend:       backend,
+		Backend:       b,
 		PageLimit:     accessListMaxPageSize,
 		ResourceKind:  types.KindAccessList,
-		BackendPrefix: accessListPrefix,
+		BackendPrefix: backend.NewKey(accessListPrefix),
 		MarshalFunc:   services.MarshalAccessList,
 		UnmarshalFunc: services.UnmarshalAccessList,
 	})
@@ -69,10 +69,10 @@ func NewAccessListService(backend backend.Backend) (*AccessListService, error) {
 	}
 
 	memberService, err := generic.NewService(&generic.ServiceConfig[*accesslist.AccessListMember]{
-		Backend:       backend,
+		Backend:       b,
 		PageLimit:     accessListMemberMaxPageSize,
 		ResourceKind:  types.KindAccessListMember,
-		BackendPrefix: accessListMemberPrefix,
+		BackendPrefix: backend.NewKey(accessListMemberPrefix),
 		MarshalFunc:   services.MarshalAccessListMember,
 		UnmarshalFunc: services.UnmarshalAccessListMember,
 	})
@@ -81,10 +81,10 @@ func NewAccessListService(backend backend.Backend) (*AccessListService, error) {
 	}
 
 	reviewService, err := generic.NewService(&generic.ServiceConfig[*accesslist.Review]{
-		Backend:       backend,
+		Backend:       b,
 		PageLimit:     accessListReviewMaxPageSize,
 		ResourceKind:  types.KindAccessListReview,
-		BackendPrefix: accessListReviewPrefix,
+		BackendPrefix: backend.NewKey(accessListReviewPrefix),
 		MarshalFunc:   services.MarshalAccessListReview,
 		UnmarshalFunc: services.UnmarshalAccessListReview,
 	})

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -201,7 +201,7 @@ func (c *UnifiedResourceCache) getSortTree(sortField string) (*btree.BTreeG[*ite
 }
 
 func (c *UnifiedResourceCache) getRange(ctx context.Context, startKey backend.Key, matchFn func(types.ResourceWithLabels) (bool, error), req *proto.ListUnifiedResourcesRequest) ([]resource, string, error) {
-	if len(startKey) == 0 {
+	if startKey.IsZero() {
 		return nil, "", trace.BadParameter("missing parameter startKey")
 	}
 	if req.Limit <= 0 {
@@ -270,7 +270,7 @@ func (c *UnifiedResourceCache) getRange(ctx context.Context, startKey backend.Ke
 func getStartKey(req *proto.ListUnifiedResourcesRequest) backend.Key {
 	// if startkey exists, return it
 	if req.StartKey != "" {
-		return backend.Key(req.StartKey)
+		return backend.KeyFromString(req.StartKey)
 	}
 	// if startkey doesnt exist, we check the sort direction.
 	// If sort is descending, startkey is end of the list

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1429,21 +1429,21 @@ func (k *kubeServerCollector) processEventsAndUpdateCurrent(ctx context.Context,
 			continue
 		}
 
-		server, ok := event.Resource.(types.KubeServer)
-		if !ok {
-			k.Log.Warnf("Unexpected resource type %T.", event.Resource)
-			continue
-		}
-
 		switch event.Type {
 		case types.OpDelete:
 			key := kubeServersKey{
 				// On delete events, the server description is populated with the host ID.
-				hostID:       server.GetMetadata().Description,
-				resourceName: server.GetName(),
+				hostID:       event.Resource.GetMetadata().Description,
+				resourceName: event.Resource.GetName(),
 			}
 			delete(k.current, key)
 		case types.OpPut:
+			server, ok := event.Resource.(types.KubeServer)
+			if !ok {
+				k.Log.Warnf("Unexpected resource type %T.", event.Resource)
+				continue
+			}
+
 			key := kubeServersKey{
 				hostID:       server.GetHostID(),
 				resourceName: server.GetName(),

--- a/lib/srv/db/common/autousers.go
+++ b/lib/srv/db/common/autousers.go
@@ -20,7 +20,7 @@ package common
 
 import (
 	"context"
-	"fmt"
+	"encoding/hex"
 	"log/slog"
 	"time"
 
@@ -181,7 +181,9 @@ func (a *UserProvisioner) makeAcquireSemaphoreConfig(sessionCtx *Session) servic
 		// in a minute anyway.
 		Request: types.AcquireSemaphoreRequest{
 			SemaphoreKind: "db-auto-users",
-			SemaphoreName: fmt.Sprintf("%v-%v", sessionCtx.Database.GetName(), sessionCtx.DatabaseUser),
+			// The name of the sempahore is encoded to prevent any invalid characters
+			// in a user's name from being rejected by the backend when creating the semaphore.
+			SemaphoreName: hex.EncodeToString([]byte(sessionCtx.Database.GetName() + "-" + sessionCtx.DatabaseUser)),
 			MaxLeases:     1,
 			Expires:       a.Clock.Now().Add(time.Minute),
 		},

--- a/lib/versioncontrol/upgradewindow/upgradewindow.go
+++ b/lib/versioncontrol/upgradewindow/upgradewindow.go
@@ -367,7 +367,9 @@ func (e *kubeDriver) Sync(ctx context.Context, rsp proto.ExportUpgradeWindowsRes
 	}
 
 	_, err := e.cfg.Backend.Put(ctx, backend.Item{
-		Key:   []byte(kubeSchedKey),
+		// backend.KeyFromString is intentionally used here instead of backend.NewKey
+		// because existing backend items were persisted without the leading /.
+		Key:   backend.KeyFromString(kubeSchedKey),
 		Value: []byte(rsp.KubeControllerSchedule),
 	})
 
@@ -378,7 +380,9 @@ func (e *kubeDriver) Reset(ctx context.Context) error {
 	// kube backend doesn't support deletes right now, so just set
 	// the key to empty.
 	_, err := e.cfg.Backend.Put(ctx, backend.Item{
-		Key:   []byte(kubeSchedKey),
+		// backend.KeyFromString is intentionally used here instead of backend.NewKey
+		// because existing backend items were persisted without the leading /.
+		Key:   backend.KeyFromString(kubeSchedKey),
 		Value: []byte{},
 	})
 

--- a/lib/versioncontrol/upgradewindow/upgradewindow_test.go
+++ b/lib/versioncontrol/upgradewindow/upgradewindow_test.go
@@ -44,7 +44,7 @@ func newFakeKubeBackend() *fakeKubeBackend {
 }
 
 func (b *fakeKubeBackend) Put(ctx context.Context, item backend.Item) (*backend.Lease, error) {
-	b.data[string(item.Key)] = string(item.Value)
+	b.data[item.Key.String()] = string(item.Value)
 	return nil, nil
 }
 

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -154,17 +154,6 @@ func TestBuildDeployServiceConfigureIAMScript(t *testing.T) {
 			},
 			errCheck: isBadParamErrFn,
 		},
-		{
-			name: "trying to inject escape sequence into query params",
-			reqQuery: url.Values{
-				"awsAccountID":    []string{"123456789012"},
-				"awsRegion":       []string{"us-east-1"},
-				"role":            []string{"role"},
-				"taskRole":        []string{"taskRole"},
-				"integrationName": []string{"'; rm -rf /tmp/dir; echo '"},
-			},
-			errCheck: isBadParamErrFn,
-		},
 	}
 
 	for _, tc := range tests {
@@ -710,17 +699,6 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 				"integrationName": []string{"myintegration"},
 				"role":            []string{"role"},
 				"s3Bucket":        []string{"my-bucket"},
-			},
-			errCheck: isBadParamErrFn,
-		},
-		{
-			name: "trying to inject escape sequence into query params",
-			reqQuery: url.Values{
-				"awsRegion":       []string{"us-east-1"},
-				"role":            []string{"role"},
-				"integrationName": []string{"'; rm -rf /tmp/dir; echo '"},
-				"s3Bucket":        []string{"my-bucket"},
-				"s3Prefix":        []string{"prefix"},
 			},
 			errCheck: isBadParamErrFn,
 		},

--- a/lib/web/integrations_azureoidc_test.go
+++ b/lib/web/integrations_azureoidc_test.go
@@ -79,14 +79,6 @@ func TestAzureOIDCConfigureScript(t *testing.T) {
 				`--auth-connector-name=myconnector`,
 		},
 		{
-			name: "authConnectorName invalid",
-			reqQuery: url.Values{
-				"integrationName":   []string{"myintegration"},
-				"authConnectorName": []string{"myconnector;"},
-			},
-			errCheck: isBadParamErrFn,
-		},
-		{
 			name: "authConnectorName missing",
 			reqQuery: url.Values{
 				"integrationName": []string{"myintegration"},


### PR DESCRIPTION
Converts the `backend.Key` from a slice of bytes to a concrete struct. The main motivation behind this change is to be able to better distinguish individual components of a key. The textual representation of a backend key is constructed by joining all components of the key with a `/`. By representing the entire key as a single textual object it prevented resources containing a `/` in their name from being properly identified. There was a lot of code that interpolated keys in various manners and expected only a specific number of subcomponents for a particular resource. This lead to most, if not all, of the RPCs used to create a resource to permit a name containing `/`, (i.e. a user named `test/llama/1`), but any RPCs used to retrieve the resources would fail to retrieve them from the backend. 

Every `backend.Key` now carries a slice of all the individual components in addition to the textual representation. This permits more fine grained inspection per component, while also not having to construct the textual representation for a group of components more than once.

The `backend.Sanitizer` was updated to only validate keys for backend writes. Retrieving and deleting invalid of malformed keys is however permitted. This will allow any existing resources that were created with `/` in one of the components to become visible in the UI or tctl get and deletable. However, any new resources with ` /` in there name are explicitly prevented.

Closes #6088 
Closes #9107
Closes #10576
Closes #42823