### PR TITLE
Workload ID: Expose local SPIFFE CA's JWT keypairs in SPIFFE trust bundles

### DIFF
--- a/lib/tbot/spiffe/trust_bundle_cache_test.go
+++ b/lib/tbot/spiffe/trust_bundle_cache_test.go
@@ -20,6 +20,7 @@ package spiffe
 
 import (
 	"context"
+	"crypto"
 	"crypto/x509/pkix"
 	"testing"
 	"time"
@@ -35,6 +36,9 @@ import (
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	trustv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -176,6 +180,12 @@ func TestTrustBundleCache_Run(t *testing.T) {
 	require.NoError(t, err)
 	caCert, err := tlsca.ParseCertificatePEM(caCertPEM)
 	require.NoError(t, err)
+	jwtCAPublic, jwtCAPrivate, err := testauthority.New().GenerateJWT()
+	require.NoError(t, err)
+	jwtCA, err := keys.ParsePublicKey(jwtCAPublic)
+	require.NoError(t, err)
+	jwtCAKID, err := jwt.KeyID(jwtCA)
+	require.NoError(t, err)
 	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
 		Type:        types.SPIFFECA,
 		ClusterName: "example.com",
@@ -184,6 +194,12 @@ func TestTrustBundleCache_Run(t *testing.T) {
 				{
 					Cert: caCertPEM,
 					Key:  caKey,
+				},
+			},
+			JWT: []*types.JWTKeyPair{
+				{
+					PublicKey:  jwtCAPublic,
+					PrivateKey: jwtCAPrivate,
 				},
 			},
 		},
@@ -233,6 +249,10 @@ func TestTrustBundleCache_Run(t *testing.T) {
 	require.Equal(t, "example.com", gotBundleSet.Local.TrustDomain().Name())
 	require.Len(t, gotBundleSet.Local.X509Authorities(), 1)
 	require.True(t, gotBundleSet.Local.X509Authorities()[0].Equal(caCert))
+	require.Len(t, gotBundleSet.Local.JWTAuthorities(), 1)
+	gotBundleJWTKey, ok := gotBundleSet.Local.FindJWTAuthority(jwtCAKID)
+	require.True(t, ok, "public key not found in bundle")
+	require.True(t, gotBundleJWTKey.(interface{ Equal(x crypto.PublicKey) bool }).Equal(jwtCA), "public keys do not match")
 	// Check the federated bundle
 	gotFederatedBundle, ok := gotBundleSet.Federated["pre-init-federated.example.com"]
 	require.True(t, ok)

--- a/lib/web/spiffe.go
+++ b/lib/web/spiffe.go
@@ -26,6 +26,8 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -71,12 +73,28 @@ func (h *Handler) getSPIFFEBundle(w http.ResponseWriter, r *http.Request, _ http
 		return nil, trace.Wrap(err, "fetching SPIFFE CA")
 	}
 
+	// Add X509 authorities to the trust bundle.
 	for _, certPEM := range services.GetTLSCerts(spiffeCA) {
 		cert, err := tlsca.ParseCertificatePEM(certPEM)
 		if err != nil {
 			return nil, trace.Wrap(err, "parsing certificate")
 		}
 		bundle.AddX509Authority(cert)
+	}
+
+	// Add JWT authorities to the trust bundle.
+	for _, keyPair := range spiffeCA.GetTrustedJWTKeyPairs() {
+		pubKey, err := keys.ParsePublicKey(keyPair.PublicKey)
+		if err != nil {
+			return nil, trace.Wrap(err, "parsing public key")
+		}
+		kid, err := jwt.KeyID(pubKey)
+		if err != nil {
+			return nil, trace.Wrap(err, "generating key ID")
+		}
+		if err := bundle.AddJWTAuthority(kid, pubKey); err != nil {
+			return nil, trace.Wrap(err, "adding JWT authority to bundle")
+		}
 	}
 
 	bundleBytes, err := bundle.Marshal()

--- a/lib/web/spiffe_test.go
+++ b/lib/web/spiffe_test.go
@@ -20,6 +20,7 @@ package web
 
 import (
 	"context"
+	"crypto"
 	"crypto/x509"
 	"testing"
 
@@ -29,7 +30,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -67,5 +70,16 @@ func TestGetSPIFFEBundle(t *testing.T) {
 	require.Len(t, gotBundle.X509Authorities(), len(wantCACerts))
 	for _, caCert := range wantCACerts {
 		require.True(t, gotBundle.HasX509Authority(caCert), "certificate not found in bundle")
+	}
+
+	require.Len(t, gotBundle.JWTAuthorities(), len(ca.GetTrustedJWTKeyPairs()))
+	for _, jwtKeyPair := range ca.GetTrustedJWTKeyPairs() {
+		wantKey, err := keys.ParsePublicKey(jwtKeyPair.PublicKey)
+		require.NoError(t, err)
+		wantKeyID, err := jwt.KeyID(wantKey)
+		require.NoError(t, err)
+		gotPubKey, ok := gotBundle.JWTBundle().FindJWTAuthority(wantKeyID)
+		require.True(t, ok, "wanted public key not found in bundle")
+		require.True(t, gotPubKey.(interface{ Equal(x crypto.PublicKey) bool }).Equal(wantKey), "public keys do not match")
 	}
 }


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/38930

Ensures we convert the JWT keypairs within the SPIFFE CA into JWT authorities within trust bundles. This will later be used by the JWT SVID issuance support in Workload ID.