### PR TITLE
Use dynamic base path for favicon images

### DIFF
--- a/web/packages/design/src/ThemeProvider/index.tsx
+++ b/web/packages/design/src/ThemeProvider/index.tsx
@@ -68,14 +68,18 @@ export function getPrefersDark(): boolean {
 }
 
 export function updateFavicon() {
+  let base = '/web/app/';
+  if (import.meta.env.MODE === 'development') {
+    base = '/app/';
+  }
   const darkModePreferred = getPrefersDark();
   const favicon = document.querySelector('link[rel="icon"]');
 
   if (favicon instanceof HTMLLinkElement) {
     if (darkModePreferred) {
-      favicon.href = '/app/favicon-dark.png';
+      favicon.href = base + 'favicon-dark.png';
     } else {
-      favicon.href = '/app/favicon-light.png';
+      favicon.href = base + 'favicon-light.png';
     }
   }
 }


### PR DESCRIPTION
This PR will import relative favicon paths instead of hardcoding to accommodate between dev builds and prod builds. dev uses `/app/` directory and prod build uses `/web/app`)

edit:
Vite complained about importing from outside of `src` (public in this case), so I changed to just check for dev mode and update the path

changelog: Fixed the web favicon not displaying on specific builds.