### PR TITLE
Fix operator docs reference generator bug

### DIFF
--- a/docs/pages/reference/operator-resources/resources.teleport.dev_oktaimportrules.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_oktaimportrules.mdx
@@ -33,8 +33,8 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
-|add_labels|[object](#specmappings itemsadd_labels)|AddLabels specifies which labels to add if any of the previous matches match.|
-|match|[][object](#specmappings itemsmatch-items)|Match is a set of matching rules for this mapping. If any of these match, then the mapping will be applied.|
+|add_labels|[object](#specmappings-itemsadd_labels)|AddLabels specifies which labels to add if any of the previous matches match.|
+|match|[][object](#specmappings-itemsmatch-items)|Match is a set of matching rules for this mapping. If any of these match, then the mapping will be applied.|
 
 ### spec.mappings items.add_labels
 

--- a/integrations/operator/crdgen/handlerequest_test.go
+++ b/integrations/operator/crdgen/handlerequest_test.go
@@ -517,6 +517,73 @@ state of this API Resource.\n---\nThis struct is intended for direct use as an a
 				},
 			},
 		},
+		{
+			description: "array of objects with object field",
+			input: apiextv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]apiextv1.JSONSchemaProps{
+					"mappings": apiextv1.JSONSchemaProps{
+						Type:        "array",
+						Description: "Mappings is a list of matches that will map match conditions to labels.",
+						Items: &apiextv1.JSONSchemaPropsOrArray{
+							Schema: &apiextv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiextv1.JSONSchemaProps{
+									"add_labels": apiextv1.JSONSchemaProps{
+										Type:        "object",
+										Description: "AddLabels specifies which labels to add if any of the previous matches match.",
+										Nullable:    true,
+										Properties: map[string]apiextv1.JSONSchemaProps{
+											"key": apiextv1.JSONSchemaProps{
+												Type: "string",
+											},
+											"value": apiextv1.JSONSchemaProps{
+												Type: "string",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []PropertyTable{
+				{
+					Name: "",
+					Fields: []PropertyTableField{
+						{
+							Name:        "mappings",
+							Type:        "[][object](#mappings-items)",
+							Description: "Mappings is a list of matches that will map match conditions to labels.",
+						},
+					},
+				},
+				{
+					Name: "mappings items",
+					Fields: []PropertyTableField{
+						{
+							Name:        "add_labels",
+							Type:        "[object](#mappings-itemsadd_labels)",
+							Description: "AddLabels specifies which labels to add if any of the previous matches match.",
+						},
+					},
+				},
+				{
+					Name: "mappings items.add_labels",
+					Fields: []PropertyTableField{
+						{
+							Name: "key",
+							Type: "string",
+						},
+						{
+							Name: "value",
+							Type: "string",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
In the reference page for one Kubernetes operator resource, some Markdown links are malformed.

The issue is that some fields of custom resource definitions used by the operator consist of arrays of anonymous objects with fields that are also objects. When creating docs based on these fields, the operator resource docs generator creates a malformed link reference.

This change modifies the generator to replace any spaces with hyphens before outputting link references, causing the resulting internal links to work correctly.

This change also does some light refactoring to remove an unnecessary `switch` statement.