### PR TITLE
Fix `roleToRecipients` descriptions

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-discord.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-discord.mdx
@@ -208,8 +208,7 @@ To determine the numeric ID of a channel for the bot to notify, follow the instr
 </Tabs>
 
 In the `role_to_recipients` map, each key is the name of a Teleport role. Each
-value configures the Discord channel (or channels) to notify. The value can be a
-single string or an array of strings.
+value configures the Discord channel (or channels) to notify.
 
 The `role_to_recipients` map must also include an entry for `"*"`, which the
 plugin looks up if no other entry matches a given role name. In the example
@@ -222,6 +221,10 @@ by adding the following to your `role_to_recipients` config (replace
 
 <Tabs>
 <TabItem label="Executable or Docker">
+
+Here is an example of a `role_to_recipients` map. Each value can be a single
+string or an array of strings:
+
 ```toml
 [role_to_recipients]
 "*" = "YOUR-CHANNEL-ID"
@@ -229,10 +232,15 @@ by adding the following to your `role_to_recipients` config (replace
 ```
 </TabItem>
 <TabItem label="Helm Chart">
+
+In the Helm chart, the `role_to_recipients` field is called `roleToRecipients`
+and uses the following format, where keys are strings and values are arrays of
+strings:
+
 ```yaml
 roleToRecipients:
-  "*": "YOUR-CHANNEL-ID"
-  "editor": "YOUR-CHANNEL-ID"
+  "*": ["YOUR-CHANNEL-ID"]
+  "editor": ["YOUR-CHANNEL-ID"]
 ```
 </TabItem>
 </Tabs>

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-email.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-email.mdx
@@ -202,10 +202,11 @@ recipients that the email plugin will notify when a user requests access to a
 specific role. When the plugin receives an Access Request from the Auth Service,
 it will look up the role being requested and identify the recipients to notify.
 
-Here is an example of a `role_to_recipients` map:
-
 <Tabs>
 <TabItem label="Executable or Docker">
+
+Here is an example of a `role_to_recipients` map. Each value can be a single
+string or an array of strings:
 
 ```toml
 [role_to_recipients]
@@ -217,11 +218,15 @@ Here is an example of a `role_to_recipients` map:
 </TabItem>
 <TabItem label="Helm Chart">
 
+In the Helm chart, the `role_to_recipients` field is called `roleToRecipients`
+and uses the following format, where keys are strings and values are arrays of
+strings:
+
 ```yaml
 roleToRecipients:
   "*": ["security@example.com", "executive-team@example.com"]
-  "dev": "eng@example.com"
-  "dba": "mallory@example.com"
+  "dev": ["eng@example.com"]
+  "dba": ["mallory@example.com"]
 ```
 
 </TabItem>
@@ -229,8 +234,7 @@ roleToRecipients:
 
 In the `role_to_recipients` map, each key is the name of a Teleport role. Each
 value configures the recipients the plugin will email when it receives an Access
-Request for that role. The value can be a single string or an array of strings.
-Each string must be an email address.
+Request for that role.  Each string must be an email address.
 
 The `role_to_recipients` map must also include an entry for `"*"`, which the
 plugin looks up if no other entry matches a given role name. In the example

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-msteams.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-msteams.mdx
@@ -256,16 +256,17 @@ the correct information, which you obtained earlier in this guide.
 
 #### `[role_to_recipients]`
 
-The `role_to_recipients` map (`roleToRecipients` for Helm users) configure the users and channels that the
-Microsoft Teams plugin will notify when a user requests access to a specific role. When
-the Microsoft Teams plugin receives an Access Request from the Auth Service, it will
-look up the role being requested and identify the Microsoft Teams users and channels to
-notify.
+The `role_to_recipients` map (`roleToRecipients` for Helm users) configures the
+users and channels that the Microsoft Teams plugin will notify when a user
+requests access to a specific role. When the Microsoft Teams plugin receives an
+Access Request from the Auth Service, it will look up the role being requested
+and identify the Microsoft Teams users and channels to notify.
 
 <Tabs>
 <TabItem label="Executable or Docker">
 
-Here is an example of a `role_to_recipients` map:
+Here is an example of a `role_to_recipients` map. Each value can be a single
+string or an array of strings:
 
 ```toml
 [role_to_recipients]
@@ -276,7 +277,9 @@ Here is an example of a `role_to_recipients` map:
 </TabItem>
 <TabItem label="Helm Chart">
 
-Here is an example of a `role_to_recipients` map:
+In the Helm chart, the `role_to_recipients` field is called `roleToRecipients`
+and uses the following format, where keys are strings and values are arrays of
+strings:
 
 ```toml
 roleToRecipients:
@@ -288,9 +291,8 @@ roleToRecipients:
 </Tabs>
 
 In the `role_to_recipients` map, each key is the name of a Teleport role. Each
-value configures the Teams user (or users) to notify. The value can be a single
-string or an array of strings. Each string must be either the email address of
-a Microsoft Teams user or a channel URL.
+value configures the Teams user (or users) to notify. Each string must be either
+the email address of a Microsoft Teams user or a channel URL.
 
 You can find the URL of a channel by opening the channel and clicking the button
 "Get link to channel":

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-slack.mdx
@@ -206,7 +206,8 @@ requested and identify the Slack channels to notify.
 
 <Tabs>
 <TabItem label="Executable or Docker">
-Here is an example of a `role_to_recipients` map:
+Here is an example of a `role_to_recipients` map. Each value can be a
+single string or an array of strings:
 
 ```toml
 [role_to_recipients]
@@ -216,26 +217,26 @@ Here is an example of a `role_to_recipients` map:
 ```
 </TabItem>
 <TabItem label="Helm Chart">
-In our Helm chart, the `role_to_recipients` field is called `roleToRecipients`
-and uses the following format:
+In the Helm chart, the `role_to_recipients` field is called `roleToRecipients`
+and uses the following format, where keys are strings and values are arrays of
+strings:
 
 ```yaml
 roleToRecipients:
-  "*": "admin-slack-channel"
+  "*": ["admin-slack-channel"]
   "dev":
     - "dev-slack-channel"
     - "admin-slack-channel"
-  "dba": "alex@gmail.com"
+  "dba": ["alex@gmail.com"]
 ```
 </TabItem>
 </Tabs>
 
 In the `role_to_recipients` map, each key is the name of a Teleport role. Each
-value configures the Slack channel (or channels) to notify. The value can be a
-single string or an array of strings. Each string must be either the name of a
-Slack channel (including a user's direct message channel) or the email address
-of a Slack user. If the recipient is an email address, the Slack plugin will
-use that email address to look up a direct message channel.
+value configures the Slack channel (or channels) to notify. Each string must be
+either the name of a Slack channel (including a user's direct message channel)
+or the email address of a Slack user. If the recipient is an email address, the
+Slack plugin will use that email address to look up a direct message channel.
 
 The `role_to_recipients` map must also include an entry for `"*"`, which the
 plugin looks up if no other entry matches a given role name. In the example


### PR DESCRIPTION
Closes #45287

Access Request plugin guides describe the value of the `roleToRecipients` field in Access Request plugin Helm charts as taking either a single string or an array of strings as the value of each mapping. This change fixes the error in all Access Request plugin guides that include this Helm chart value.