### PR TITLE
Web: Define fetch kube resource web api endpoint

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -863,6 +863,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	// Kube access handlers.
 	h.GET("/webapi/sites/:site/kubernetes", h.WithClusterAuth(h.clusterKubesGet))
 	h.GET("/webapi/sites/:site/pods", h.WithClusterAuth(h.clusterKubePodsGet))
+	h.GET("/webapi/sites/:site/kubernetes/resources", h.WithClusterAuth(h.clusterKubeResourcesGet))
 
 	// Github connector handlers
 	h.GET("/webapi/github/login/web", h.WithRedirect(h.githubLoginWeb))

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -862,7 +862,6 @@ func (h *Handler) bindDefaultEndpoints() {
 
 	// Kube access handlers.
 	h.GET("/webapi/sites/:site/kubernetes", h.WithClusterAuth(h.clusterKubesGet))
-	h.GET("/webapi/sites/:site/pods", h.WithClusterAuth(h.clusterKubePodsGet))
 	h.GET("/webapi/sites/:site/kubernetes/resources", h.WithClusterAuth(h.clusterKubeResourcesGet))
 
 	// Github connector handlers

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -4259,6 +4259,113 @@ func TestClusterKubesGet(t *testing.T) {
 	}
 }
 
+func TestClusterKubeResourcesGet(t *testing.T) {
+	t.Parallel()
+	kubeClusterName := "kube_cluster"
+
+	roleWithFullAccess := func(username string) []types.Role {
+		ret, err := types.NewRole(services.RoleNameForUser(username), types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				Namespaces:       []string{apidefaults.Namespace},
+				KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+				Rules: []types.Rule{
+					types.NewRule(types.KindConnectionDiagnostic, services.RW()),
+				},
+				KubeGroups: []string{"groups"},
+				KubernetesResources: []types.KubernetesResource{
+					{
+						Kind:      types.KindKubePod,
+						Namespace: types.Wildcard,
+						Name:      types.Wildcard,
+					},
+					{
+						Kind: types.KindKubeNamespace,
+						Name: types.Wildcard,
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		return []types.Role{ret}
+	}
+	require.NotNil(t, roleWithFullAccess)
+
+	env := newWebPack(t, 1)
+
+	type testResponse struct {
+		Items      []ui.KubeResource `json:"items"`
+		TotalCount int               `json:"totalCount"`
+	}
+
+	tt := []struct {
+		name             string
+		user             string
+		kind             string
+		expectedResponse []ui.KubeResource
+	}{
+		{
+			name: "get pods from gRPC server",
+			user: "test-user@example.com",
+			kind: types.KindKubePod,
+			expectedResponse: []ui.KubeResource{
+				{
+					Kind:        types.KindKubePod,
+					Name:        "test-pod",
+					Namespace:   "default",
+					Labels:      []ui.Label{{Name: "app", Value: "test"}},
+					KubeCluster: kubeClusterName,
+				},
+				{
+					Kind:        types.KindKubePod,
+					Name:        "test-pod2",
+					Namespace:   "default",
+					Labels:      []ui.Label{{Name: "app", Value: "test2"}},
+					KubeCluster: kubeClusterName,
+				},
+			},
+		},
+		{
+			name: "get namespaces",
+			user: "test-user2@example.com",
+			kind: types.KindKubeNamespace,
+			expectedResponse: []ui.KubeResource{
+				{
+					Kind:        types.KindKubeNamespace,
+					Name:        "default",
+					Namespace:   "",
+					Labels:      []ui.Label{{Name: "app", Value: "test"}},
+					KubeCluster: kubeClusterName,
+				},
+			},
+		},
+	}
+	proxy := env.proxies[0]
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	// Init fake gRPC Kube service.
+	initGRPCServer(t, env, listener)
+	addr := utils.MustParseAddr(listener.Addr().String())
+	proxy.handler.handler.cfg.ProxyWebAddr = *addr
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			pack := proxy.authPack(t, tc.user, roleWithFullAccess(tc.user))
+
+			endpoint := pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "kubernetes", "resources")
+			params := url.Values{}
+			params.Add("kubeCluster", kubeClusterName)
+			params.Add("kind", tc.kind)
+			re, err := pack.clt.Get(context.Background(), endpoint, params)
+			require.NoError(t, err)
+
+			resp := testResponse{}
+			require.NoError(t, json.Unmarshal(re.Bytes(), &resp))
+			require.ElementsMatch(t, tc.expectedResponse, resp.Items)
+		})
+	}
+}
+
 func TestClusterKubePodsGet(t *testing.T) {
 	t.Parallel()
 	kubeClusterName := "kube_cluster"
@@ -9509,35 +9616,59 @@ type fakeKubeService struct {
 }
 
 func (s *fakeKubeService) ListKubernetesResources(ctx context.Context, req *kubeproto.ListKubernetesResourcesRequest) (*kubeproto.ListKubernetesResourcesResponse, error) {
-	return &kubeproto.ListKubernetesResourcesResponse{
-		Resources: []*types.KubernetesResourceV1{
-			{
-				Kind: types.KindKubePod,
-				Metadata: types.Metadata{
-					Name: "test-pod",
-					Labels: map[string]string{
-						"app": "test",
+	switch req.GetResourceType() {
+	case types.KindKubePod:
+		{
+			return &kubeproto.ListKubernetesResourcesResponse{
+				Resources: []*types.KubernetesResourceV1{
+					{
+						Kind: types.KindKubePod,
+						Metadata: types.Metadata{
+							Name: "test-pod",
+							Labels: map[string]string{
+								"app": "test",
+							},
+						},
+						Spec: types.KubernetesResourceSpecV1{
+							Namespace: "default",
+						},
+					},
+					{
+						Kind: types.KindKubePod,
+						Metadata: types.Metadata{
+							Name: "test-pod2",
+							Labels: map[string]string{
+								"app": "test2",
+							},
+						},
+						Spec: types.KubernetesResourceSpecV1{
+							Namespace: "default",
+						},
 					},
 				},
-				Spec: types.KubernetesResourceSpecV1{
-					Namespace: "default",
-				},
-			},
-			{
-				Kind: types.KindKubePod,
-				Metadata: types.Metadata{
-					Name: "test-pod2",
-					Labels: map[string]string{
-						"app": "test2",
+				TotalCount: 2,
+			}, nil
+		}
+	case types.KindKubeNamespace:
+		{
+			return &kubeproto.ListKubernetesResourcesResponse{
+				Resources: []*types.KubernetesResourceV1{
+					{
+						Kind: types.KindNamespace,
+						Metadata: types.Metadata{
+							Name: "default",
+							Labels: map[string]string{
+								"app": "test",
+							},
+						},
 					},
 				},
-				Spec: types.KubernetesResourceSpecV1{
-					Namespace: "default",
-				},
-			},
-		},
-		TotalCount: 2,
-	}, nil
+				TotalCount: 1,
+			}, nil
+		}
+	default:
+		return nil, trace.BadParameter("kubernetes resource kind %q is not mocked", req.GetResourceType())
+	}
 }
 
 func TestWebSocketAuthenticateRequest(t *testing.T) {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -4301,12 +4301,14 @@ func TestClusterKubeResourcesGet(t *testing.T) {
 		name             string
 		user             string
 		kind             string
+		kubeCluster      string
 		expectedResponse []ui.KubeResource
+		wantErr          bool
 	}{
 		{
-			name: "get pods from gRPC server",
-			user: "test-user@example.com",
-			kind: types.KindKubePod,
+			name:        "get pods from gRPC server",
+			kind:        types.KindKubePod,
+			kubeCluster: kubeClusterName,
 			expectedResponse: []ui.KubeResource{
 				{
 					Kind:        types.KindKubePod,
@@ -4325,9 +4327,9 @@ func TestClusterKubeResourcesGet(t *testing.T) {
 			},
 		},
 		{
-			name: "get namespaces",
-			user: "test-user2@example.com",
-			kind: types.KindKubeNamespace,
+			name:        "get namespaces",
+			kind:        types.KindKubeNamespace,
+			kubeCluster: kubeClusterName,
 			expectedResponse: []ui.KubeResource{
 				{
 					Kind:        types.KindKubeNamespace,
@@ -4338,92 +4340,23 @@ func TestClusterKubeResourcesGet(t *testing.T) {
 				},
 			},
 		},
-	}
-	proxy := env.proxies[0]
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	// Init fake gRPC Kube service.
-	initGRPCServer(t, env, listener)
-	addr := utils.MustParseAddr(listener.Addr().String())
-	proxy.handler.handler.cfg.ProxyWebAddr = *addr
-
-	for _, tc := range tt {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			pack := proxy.authPack(t, tc.user, roleWithFullAccess(tc.user))
-
-			endpoint := pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "kubernetes", "resources")
-			params := url.Values{}
-			params.Add("kubeCluster", kubeClusterName)
-			params.Add("kind", tc.kind)
-			re, err := pack.clt.Get(context.Background(), endpoint, params)
-			require.NoError(t, err)
-
-			resp := testResponse{}
-			require.NoError(t, json.Unmarshal(re.Bytes(), &resp))
-			require.ElementsMatch(t, tc.expectedResponse, resp.Items)
-		})
-	}
-}
-
-func TestClusterKubePodsGet(t *testing.T) {
-	t.Parallel()
-	kubeClusterName := "kube_cluster"
-
-	roleWithFullAccess := func(username string) []types.Role {
-		ret, err := types.NewRole(services.RoleNameForUser(username), types.RoleSpecV6{
-			Allow: types.RoleConditions{
-				Namespaces:       []string{apidefaults.Namespace},
-				KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
-				Rules: []types.Rule{
-					types.NewRule(types.KindConnectionDiagnostic, services.RW()),
-				},
-				KubeGroups: []string{"groups"},
-				KubernetesResources: []types.KubernetesResource{
-					{
-						Kind:      types.KindKubePod,
-						Namespace: types.Wildcard,
-						Name:      types.Wildcard,
-					},
-				},
-			},
-		})
-		require.NoError(t, err)
-		return []types.Role{ret}
-	}
-	require.NotNil(t, roleWithFullAccess)
-
-	env := newWebPack(t, 1)
-
-	type testResponse struct {
-		Items      []ui.KubeResource `json:"items"`
-		TotalCount int               `json:"totalCount"`
-	}
-
-	tt := []struct {
-		name             string
-		user             string
-		expectedResponse []ui.KubeResource
-	}{
 		{
-			name: "get pods from gRPC server",
-			user: "test-user@example.com",
-			expectedResponse: []ui.KubeResource{
-				{
-					Kind:        types.KindKubePod,
-					Name:        "test-pod",
-					Namespace:   "default",
-					Labels:      []ui.Label{{Name: "app", Value: "test"}},
-					KubeCluster: kubeClusterName,
-				},
-				{
-					Kind:        types.KindKubePod,
-					Name:        "test-pod2",
-					Namespace:   "default",
-					Labels:      []ui.Label{{Name: "app", Value: "test2"}},
-					KubeCluster: kubeClusterName,
-				},
-			},
+			name:        "missing kind",
+			kind:        "",
+			kubeCluster: kubeClusterName,
+			wantErr:     true,
+		},
+		{
+			name:        "invalid kind",
+			kind:        "invalid-kind",
+			kubeCluster: kubeClusterName,
+			wantErr:     true,
+		},
+		{
+			name:        "missing kube cluster",
+			kind:        types.KindKubeNamespace,
+			kubeCluster: "",
+			wantErr:     true,
 		},
 	}
 	proxy := env.proxies[0]
@@ -4434,22 +4367,27 @@ func TestClusterKubePodsGet(t *testing.T) {
 	addr := utils.MustParseAddr(listener.Addr().String())
 	proxy.handler.handler.cfg.ProxyWebAddr = *addr
 
+	user := "test-user@example.com"
+	pack := proxy.authPack(t, user, roleWithFullAccess(user))
+
 	for _, tc := range tt {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			pack := proxy.authPack(t, tc.user, roleWithFullAccess(tc.user))
-
-			endpoint := pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "pods")
+			endpoint := pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "kubernetes", "resources")
 			params := url.Values{}
-			params.Add("kubeCluster", kubeClusterName)
+			params.Add("kubeCluster", tc.kubeCluster)
+			params.Add("kind", tc.kind)
 			re, err := pack.clt.Get(context.Background(), endpoint, params)
-			require.NoError(t, err)
 
-			resp := testResponse{}
-			require.NoError(t, json.Unmarshal(re.Bytes(), &resp))
-			require.Len(t, resp.Items, 2)
-			require.Equal(t, 2, resp.TotalCount)
-			require.ElementsMatch(t, tc.expectedResponse, resp.Items)
+			if tc.wantErr {
+				require.True(t, trace.IsBadParameter(err))
+			} else {
+				require.NoError(t, err)
+				resp := testResponse{}
+				require.NoError(t, json.Unmarshal(re.Bytes(), &resp))
+				require.ElementsMatch(t, tc.expectedResponse, resp.Items)
+			}
+
 		})
 	}
 }

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -20,6 +20,7 @@ package web
 
 import (
 	"net/http"
+	"slices"
 
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
@@ -61,40 +62,35 @@ func (h *Handler) clusterKubesGet(w http.ResponseWriter, r *http.Request, p http
 	}, nil
 }
 
-// clusterKubePodsGet returns a list of Kubernetes Pods in a form the
-// UI can present.
-func (h *Handler) clusterKubePodsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
-	clt, err := sctx.NewKubernetesServiceClient(r.Context(), h.cfg.ProxyWebAddr.Addr)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	resp, err := listKubeResources(r.Context(), clt, r.URL.Query(), site.GetName(), types.KindKubePod)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return listResourcesGetResponse{
-		Items:      ui.MakeKubeResources(resp.Resources, r.URL.Query().Get("kubeCluster")),
-		StartKey:   resp.NextKey,
-		TotalCount: int(resp.TotalCount),
-	}, nil
-}
-
 // clusterKubeResourcesGet returns supported requested kubernetes subresources eg: pods, namespaces, secrets etc.
 func (h *Handler) clusterKubeResourcesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
+	kind := r.URL.Query().Get("kind")
+	kubeCluster := r.URL.Query().Get("kubeCluster")
+
+	if kubeCluster == "" {
+		return nil, trace.BadParameter("missing param %q", "kubeCluster")
+	}
+
+	if kind == "" {
+		return nil, trace.BadParameter("missing param %q", "kind")
+	}
+
+	if !slices.Contains(types.KubernetesResourcesKinds, kind) {
+		return nil, trace.BadParameter("kind is not valid, valid kinds %v", types.KubernetesResourcesKinds)
+	}
+
 	clt, err := sctx.NewKubernetesServiceClient(r.Context(), h.cfg.ProxyWebAddr.Addr)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := listKubeResources(r.Context(), clt, r.URL.Query(), site.GetName(), r.URL.Query().Get("kind"))
+	resp, err := listKubeResources(r.Context(), clt, r.URL.Query(), site.GetName(), kind)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return listResourcesGetResponse{
-		Items:      ui.MakeKubeResources(resp.Resources, r.URL.Query().Get("kubeCluster")),
+		Items:      ui.MakeKubeResources(resp.Resources, kubeCluster),
 		StartKey:   resp.NextKey,
 		TotalCount: int(resp.TotalCount),
 	}, nil

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -38,6 +38,7 @@ import type { WebauthnAssertionResponse } from './services/auth';
 import type { PluginKind, Regions } from './services/integrations';
 import type { ParticipantMode } from 'teleport/services/session';
 import type { YamlSupportedResourceKind } from './services/yaml/types';
+import type { KubeResourceKind } from './services/kube/types';
 
 const cfg = {
   /** @deprecated Use cfg.edition instead. */
@@ -247,6 +248,8 @@ const cfg = {
 
     kubernetesPath:
       '/v1/webapi/sites/:clusterId/kubernetes?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?',
+    kubernetesResourcesPath:
+      '/v1/webapi/sites/:clusterId/kubernetes/resources?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?&kubeCluster=:kubeCluster?&kubeNamespace=:kubeNamespace?&kind=:kind?',
 
     usersPath: '/v1/webapi/users',
     userWithUsernamePath: '/v1/webapi/users/:username',
@@ -873,6 +876,13 @@ const cfg = {
     });
   },
 
+  getKubernetesResourcesUrl(clusterId: string, params: UrlKubeResourcesParams) {
+    return generateResourcePath(cfg.api.kubernetesResourcesPath, {
+      clusterId,
+      ...params,
+    });
+  },
+
   getAuthnChallengeWithTokenUrl(tokenId: string) {
     return generatePath(cfg.api.mfaAuthnChallengeWithTokenPath, {
       tokenId,
@@ -1223,6 +1233,18 @@ export interface UrlResourcesParams {
   includedResourceMode?: IncludedResourceMode;
   // TODO(bl-nero): Remove this once filters are expressed as advanced search.
   kinds?: string[];
+}
+
+export interface UrlKubeResourcesParams {
+  query?: string;
+  search?: string;
+  sort?: SortType;
+  limit?: number;
+  startKey?: string;
+  searchAsRoles?: 'yes' | '';
+  kubeNamespace?: string;
+  kubeCluster: string;
+  kind: KubeResourceKind;
 }
 
 export interface UrlDeployServiceIamConfigureScriptParams {

--- a/web/packages/teleport/src/generateResourcePath.test.ts
+++ b/web/packages/teleport/src/generateResourcePath.test.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import cfg, { UrlResourcesParams } from './config';
+import cfg, { UrlKubeResourcesParams, UrlResourcesParams } from './config';
 import generateResourcePath from './generateResourcePath';
 
 test('undefined params are set to empty string', () => {
@@ -64,5 +64,21 @@ test('defined params but set to empty values are set to empty string', () => {
     })
   ).toStrictEqual(
     '/v1/webapi/sites/cluster/resources?searchAsRoles=&limit=&startKey=&kinds=&query=&search=&sort=&pinnedOnly=&includedResourceMode='
+  );
+});
+
+test('defined kube related params are set', () => {
+  const params: UrlKubeResourcesParams = {
+    kind: 'namespace',
+    kubeCluster: 'kubecluster',
+    kubeNamespace: 'kubenamespace',
+  };
+  expect(
+    generateResourcePath(cfg.api.kubernetesResourcesPath, {
+      clusterId: 'cluster',
+      ...params,
+    })
+  ).toStrictEqual(
+    '/v1/webapi/sites/cluster/kubernetes/resources?searchAsRoles=&limit=&startKey=&query=&search=&sort=&kubeCluster=kubecluster&kubeNamespace=kubenamespace&kind=namespace'
   );
 });

--- a/web/packages/teleport/src/generateResourcePath.ts
+++ b/web/packages/teleport/src/generateResourcePath.ts
@@ -56,7 +56,10 @@ export default function generateResourcePath(
     .replace(':search?', processedParams.search || '')
     .replace(':searchAsRoles?', processedParams.searchAsRoles || '')
     .replace(':sort?', processedParams.sort || '')
+    .replace(':kind?', processedParams.kind || '')
     .replace(':kinds?', processedParams.kinds || '')
+    .replace(':kubeCluster?', processedParams.kubeCluster || '')
+    .replace(':kubeNamespace?', processedParams.kubeNamespace || '')
     .replace(':pinnedOnly?', processedParams.pinnedOnly || '')
     .replace(
       ':includedResourceMode?',

--- a/web/packages/teleport/src/services/kube/kube.ts
+++ b/web/packages/teleport/src/services/kube/kube.ts
@@ -17,11 +17,14 @@
  */
 
 import api from 'teleport/services/api';
-import cfg, { UrlResourcesParams } from 'teleport/config';
+import cfg, {
+  UrlKubeResourcesParams,
+  UrlResourcesParams,
+} from 'teleport/config';
 import { ResourcesResponse } from 'teleport/services/agents';
 
-import { Kube } from './types';
-import makeKube from './makeKube';
+import { Kube, KubeResourceResponse } from './types';
+import { makeKube, makeKubeResource } from './makeKube';
 
 class KubeService {
   fetchKubernetes(
@@ -36,6 +39,24 @@ class KubeService {
 
         return {
           agents: items.map(makeKube),
+          startKey: json?.startKey,
+          totalCount: json?.totalCount,
+        };
+      });
+  }
+
+  fetchKubernetesResources(
+    clusterId,
+    params: UrlKubeResourcesParams,
+    signal?: AbortSignal
+  ): Promise<KubeResourceResponse> {
+    return api
+      .get(cfg.getKubernetesResourcesUrl(clusterId, params), signal)
+      .then(json => {
+        const items = json?.items || [];
+
+        return {
+          items: items.map(makeKubeResource),
           startKey: json?.startKey,
           totalCount: json?.totalCount,
         };

--- a/web/packages/teleport/src/services/kube/makeKube.ts
+++ b/web/packages/teleport/src/services/kube/makeKube.ts
@@ -16,9 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Kube } from './types';
+import { Kube, KubeResource } from './types';
 
-export default function makeKube(json): Kube {
+export function makeKube(json): Kube {
   const { name, requiresRequest } = json;
   const labels = json.labels || [];
 
@@ -29,5 +29,18 @@ export default function makeKube(json): Kube {
     users: json.kubernetes_users || [],
     groups: json.kubernetes_groups || [],
     requiresRequest,
+  };
+}
+
+export function makeKubeResource(json): KubeResource {
+  const { kind, name, namespace, cluster } = json;
+  const labels = json.labels || [];
+
+  return {
+    kind,
+    name,
+    namespace,
+    labels,
+    cluster,
   };
 }

--- a/web/packages/teleport/src/services/kube/types.ts
+++ b/web/packages/teleport/src/services/kube/types.ts
@@ -25,3 +25,33 @@ export interface Kube {
   groups?: string[];
   requiresRequest?: boolean;
 }
+
+/**
+ * Add kind consts as we go.
+ * Supported kube subresources:
+ * https://github.com/gravitational/teleport/blob/c86f46db17fe149240e30fa0748621239e36c72a/api/types/constants.go#L1233
+ */
+export type KubeResourceKind = 'namespace';
+
+/**
+ * Refers to kube_cluster's subresources like namespaces, pods, etc
+ */
+export type KubeResource = {
+  kind: KubeResourceKind;
+  name: string;
+  /**
+   * namespace will be left blank, if the field `kind` is `namespace`
+   */
+  namespace?: string;
+  labels: ResourceLabel[];
+  /**
+   * the kube cluster where this subresource belongs to
+   */
+  cluster: string;
+};
+
+export interface KubeResourceResponse {
+  items: KubeResource[];
+  startKey?: string;
+  totalCount?: number;
+}

--- a/web/packages/teleport/src/services/resources/makeUnifiedResource.ts
+++ b/web/packages/teleport/src/services/resources/makeUnifiedResource.ts
@@ -20,7 +20,7 @@ import { UnifiedResource, UnifiedResourceKind } from '../agents';
 import makeApp from '../apps/makeApps';
 import { makeDatabase } from '../databases/makeDatabase';
 import { makeDesktop } from '../desktops/makeDesktop';
-import makeKube from '../kube/makeKube';
+import { makeKube } from '../kube/makeKube';
 import makeNode from '../nodes/makeNode';
 
 export function makeUnifiedResource(json: any): UnifiedResource {


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/46742

Opens a new web api endpoint where we can fetch kube sub resources such as namespaces, pods, secrets, etc (we are currently only utilizing `namespace` for now though)

Added all the boilerplate code like adding types etc.
