### PR TITLE
Replace more Logrus usage with Slog

### DIFF
--- a/integration/tctl_terraform_env_test.go
+++ b/integration/tctl_terraform_env_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -235,7 +236,7 @@ func getAuthClientForProxy(t *testing.T, tc *helpers.TeleInstance, username stri
 		TLS:                  tlsConfig,
 		SSH:                  sshConfig,
 		AuthServers:          []utils.NetAddr{*authAddr},
-		Log:                  utils.NewLoggerForTests(),
+		Log:                  utils.NewSlogLoggerForTests(),
 		CircuitBreakerConfig: breaker.Config{},
 		DialTimeout:          0,
 		DialOpts:             nil,
@@ -258,7 +259,7 @@ func getAuthClientForProxy(t *testing.T, tc *helpers.TeleInstance, username stri
 	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
 		Resolver:              resolver,
 		ClientConfig:          clientConfig.SSH,
-		Log:                   clientConfig.Log,
+		Log:                   slog.Default(),
 		InsecureSkipTLSVerify: clientConfig.Insecure,
 		GetClusterCAs:         client.ClusterCAsFromCertPool(clientConfig.TLS.RootCAs),
 	})
@@ -288,7 +289,7 @@ func getAuthClientForAuth(t *testing.T, tc *helpers.TeleInstance, username strin
 	clientConfig := &authclient.Config{
 		TLS:                  tlsConfig,
 		AuthServers:          []utils.NetAddr{*authAddr},
-		Log:                  utils.NewLoggerForTests(),
+		Log:                  utils.NewSlogLoggerForTests(),
 		CircuitBreakerConfig: breaker.Config{},
 		DialTimeout:          0,
 		DialOpts:             nil,

--- a/lib/auth/access.go
+++ b/lib/auth/access.go
@@ -51,7 +51,7 @@ func (a *Server) CreateRole(ctx context.Context, role types.Role) (types.Role, e
 		},
 		ConnectionMetadata: authz.ConnectionMetadata(ctx),
 	}); err != nil {
-		log.WithError(err).Warnf("Failed to emit role create event.")
+		a.logger.WarnContext(ctx, "Failed to emit role create event.", "error", err)
 	}
 	return created, nil
 }
@@ -74,7 +74,7 @@ func (a *Server) UpdateRole(ctx context.Context, role types.Role) (types.Role, e
 		},
 		ConnectionMetadata: authz.ConnectionMetadata(ctx),
 	}); err != nil {
-		log.WithError(err).Warnf("Failed to emit role create event.")
+		a.logger.WarnContext(ctx, "Failed to emit role update event.", "error", err)
 	}
 	return created, nil
 }
@@ -97,7 +97,7 @@ func (a *Server) UpsertRole(ctx context.Context, role types.Role) (types.Role, e
 		},
 		ConnectionMetadata: authz.ConnectionMetadata(ctx),
 	}); err != nil {
-		log.WithError(err).Warnf("Failed to emit role create event.")
+		a.logger.WarnContext(ctx, "Failed to emit role create event.", "error", err)
 	}
 	return upserted, nil
 }
@@ -119,7 +119,10 @@ func (a *Server) DeleteRole(ctx context.Context, name string) error {
 		if slices.Contains(u.GetRoles(), name) {
 			// Mask the actual error here as it could be used to enumerate users
 			// within the system.
-			log.Warnf("Failed to delete role: role %v is used by user %v.", name, u.GetName())
+			a.logger.WarnContext(
+				ctx, "Failed to delete role: role is still in use by a user",
+				"role", name, "user", u.GetName(),
+			)
 			return trace.Wrap(errDeleteRoleUser)
 		}
 	}
@@ -129,11 +132,14 @@ func (a *Server) DeleteRole(ctx context.Context, name string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	for _, a := range cas {
-		if slices.Contains(a.GetRoles(), name) {
+	for _, ca := range cas {
+		if slices.Contains(ca.GetRoles(), name) {
 			// Mask the actual error here as it could be used to enumerate users
 			// within the system.
-			log.Warnf("Failed to delete role: role %v is used by user cert authority %v", name, a.GetClusterName())
+			a.logger.WarnContext(
+				ctx, "Failed to delete role: role is still in use by a user cert authority",
+				"role", name, "ca", ca.GetClusterName(),
+			)
 			return trace.Wrap(errDeleteRoleCA)
 		}
 	}
@@ -149,17 +155,27 @@ func (a *Server) DeleteRole(ctx context.Context, name string) error {
 
 		for _, accessList := range accessLists {
 			if slices.Contains(accessList.Spec.Grants.Roles, name) {
-				log.Warnf("Failed to delete role: role %v is granted by access list %s", name, accessList.GetName())
+				a.logger.WarnContext(
+					ctx, "Failed to delete role: role is granted by access list",
+					"role", name, "access_list", accessList.GetName(),
+				)
 				return trace.Wrap(errDeleteRoleAccessList)
 			}
 
 			if slices.Contains(accessList.Spec.MembershipRequires.Roles, name) {
-				log.Warnf("Failed to delete role: role %v is required by members of access list %s", name, accessList.GetName())
+				a.logger.WarnContext(
+					ctx, "Failed to delete role: role is required by members of access list",
+					"role", name, "access_list", accessList.GetName(),
+				)
 				return trace.Wrap(errDeleteRoleAccessList)
 			}
 
 			if slices.Contains(accessList.Spec.OwnershipRequires.Roles, name) {
-				log.Warnf("Failed to delete role: role %v is required by owners of access list %s", name, accessList.GetName())
+				a.logger.WarnContext(
+					ctx,
+					"Failed to delete role: role is required by owners of access list",
+					"role", name, "access_list", accessList.GetName(),
+				)
 				return trace.Wrap(errDeleteRoleAccessList)
 			}
 		}
@@ -184,7 +200,7 @@ func (a *Server) DeleteRole(ctx context.Context, name string) error {
 		},
 		ConnectionMetadata: authz.ConnectionMetadata(ctx),
 	}); err != nil {
-		log.WithError(err).Warnf("Failed to emit role delete event.")
+		a.logger.WarnContext(ctx, "Failed to emit role delete event", "error", err)
 	}
 	return nil
 }
@@ -217,7 +233,7 @@ func (a *Server) UpsertLock(ctx context.Context, lock types.Lock) error {
 			Target: lock.Target(),
 		},
 	}); err != nil {
-		log.WithError(err).Warning("Failed to emit lock create event.")
+		a.logger.WarnContext(ctx, "Failed to emit lock create event.", "error", err)
 	}
 	return nil
 }
@@ -245,7 +261,7 @@ func (a *Server) DeleteLock(ctx context.Context, lockName string) error {
 			Target: lock.Target(),
 		},
 	}); err != nil {
-		log.WithError(err).Warning("Failed to emit lock delete event.")
+		a.logger.WarnContext(ctx, "Failed to emit lock delete event.", "error", err)
 	}
 	return nil
 }

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -728,7 +728,13 @@ func (s *APIServer) getSessionChunk(auth *ServerWithRoles, w http.ResponseWriter
 	if err != nil || offsetBytes < 0 {
 		offsetBytes = 0
 	}
-	log.Debugf("apiserver.GetSessionChunk(%v, %v, offset=%d)", namespace, *sid, offsetBytes)
+	s.AuthServer.logger.DebugContext(
+		r.Context(), "apiserver.GetSessionChunk called",
+		"namespace", namespace,
+		"sid", sid,
+		"offset", offsetBytes,
+	)
+
 	w.Header().Set("Content-Type", "text/plain")
 
 	buffer, err := auth.GetSessionChunk(namespace, *sid, offsetBytes, max)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -354,6 +354,9 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 			return nil, trace.Wrap(err, "creating SPIFFEFederation service")
 		}
 	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.With(teleport.ComponentKey, teleport.ComponentAuth)
+	}
 
 	limiter, err := limiter.NewConnectionsLimiter(limiter.Config{
 		MaxConnections: defaults.LimiterMaxConcurrentSignatures,
@@ -1018,6 +1021,9 @@ type Server struct {
 	// GithubUserAndTeamsOverride overrides the user and teams that would
 	// normally be fetched from the GitHub API. Used for testing.
 	GithubUserAndTeamsOverride func() (*GithubUserResponse, []GithubTeamResponse, error)
+
+	// logger is the logger used by the auth server.
+	logger *slog.Logger
 }
 
 // SetSAMLService registers svc as the SAMLService that provides the SAML

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -474,6 +474,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		loadAllCAs:              cfg.LoadAllCAs,
 		httpClientForAWSSTS:     cfg.HTTPClientForAWSSTS,
 		accessMonitoringEnabled: cfg.AccessMonitoringEnabled,
+		logger:                  cfg.Logger,
 	}
 	as.inventory = inventory.NewController(&as, services,
 		inventory.WithAuthServerID(cfg.HostUUID),

--- a/lib/auth/authclient/authclient.go
+++ b/lib/auth/authclient/authclient.go
@@ -23,10 +23,10 @@ package authclient
 import (
 	"context"
 	"crypto/tls"
+	"log/slog"
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc"
 
@@ -44,7 +44,7 @@ type Config struct {
 	// AuthServers is a list of possible auth or proxy server addresses.
 	AuthServers []utils.NetAddr
 	// Log sets the logger for the client to use.
-	Log logrus.FieldLogger
+	Log *slog.Logger
 	// CircuitBreakerConfig is the configuration for the auth client circuit breaker.
 	CircuitBreakerConfig breaker.Config
 	// DialTimeout determines how long to wait for dialing to succeed before aborting.
@@ -60,7 +60,7 @@ type Config struct {
 // Connect creates a valid client connection to the auth service.  It may
 // connect directly to the auth server, or tunnel through the proxy.
 func Connect(ctx context.Context, cfg *Config) (*Client, error) {
-	cfg.Log.Debugf("Connecting to: %v.", cfg.AuthServers)
+	cfg.Log.DebugContext(ctx, "Auth client connecting", "auth_servers", cfg.AuthServers)
 
 	directClient, err := connectViaAuthDirect(ctx, cfg)
 	if err == nil {

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc"
@@ -670,10 +669,11 @@ func authClientForRegisterResult(t *testing.T, ctx context.Context, addr *utils.
 		nil /* clock */)
 	require.NoError(t, err)
 
+	log := utils.NewSlogLoggerForTests()
 	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
 		Resolver:              resolver,
 		ClientConfig:          sshConfig,
-		Log:                   logrus.StandardLogger(),
+		Log:                   log,
 		InsecureSkipTLSVerify: true,
 		GetClusterCAs:         apiclient.ClusterCAsFromCertPool(tlsConfig.RootCAs),
 	})
@@ -683,7 +683,7 @@ func authClientForRegisterResult(t *testing.T, ctx context.Context, addr *utils.
 		TLS:         tlsConfig,
 		SSH:         sshConfig,
 		AuthServers: []utils.NetAddr{*addr},
-		Log:         logrus.StandardLogger(),
+		Log:         log,
 		Insecure:    true,
 		ProxyDialer: dialer,
 		DialOpts: []grpc.DialOption{

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 	"os"
 	"strconv"
@@ -5172,7 +5171,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		Reporter:   cfg.AuthServer.Services.UsageReporter,
 		Emitter:    cfg.Emitter,
 		Clock:      cfg.AuthServer.GetClock(),
-		Logger:     slog.With(teleport.ComponentKey, "bot.service"),
+		Logger:     cfg.AuthServer.logger.With(teleport.ComponentKey, "bot.service"),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating bot service")
@@ -5196,7 +5195,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		Emitter:    cfg.Emitter,
 		Clock:      cfg.AuthServer.GetClock(),
 		KeyStore:   cfg.AuthServer.keyStore,
-		Logger:     slog.With(teleport.ComponentKey, "workload-identity.service"),
+		Logger:     cfg.AuthServer.logger.With(teleport.ComponentKey, "workload-identity.service"),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating workload identity service")

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"strconv"
@@ -5171,6 +5172,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		Reporter:   cfg.AuthServer.Services.UsageReporter,
 		Emitter:    cfg.Emitter,
 		Clock:      cfg.AuthServer.GetClock(),
+		Logger:     slog.With(teleport.ComponentKey, "bot.service"),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating bot service")
@@ -5194,6 +5196,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		Emitter:    cfg.Emitter,
 		Clock:      cfg.AuthServer.GetClock(),
 		KeyStore:   cfg.AuthServer.keyStore,
+		Logger:     slog.With(teleport.ComponentKey, "workload-identity.service"),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating workload identity service")

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -25,6 +25,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"slices"
 	"strings"
@@ -318,6 +319,9 @@ type InitConfig struct {
 	// StaticHostUsers is a service that manages host users that should be
 	// created on SSH nodes.
 	StaticHostUsers services.StaticHostUser
+
+	// Logger is the logger instance for the auth service to use.
+	Logger *slog.Logger
 }
 
 // Init instantiates and configures an instance of AuthServer

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1277,7 +1277,7 @@ func (process *TeleportProcess) newClientThroughTunnel(tlsConfig *tls.Config, ss
 	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
 		Resolver:              process.resolver,
 		ClientConfig:          sshConfig,
-		Log:                   process.log,
+		Log:                   process.logger,
 		InsecureSkipTLSVerify: lib.IsInsecureDevMode(),
 		GetClusterCAs:         apiclient.ClusterCAsFromCertPool(tlsConfig.RootCAs),
 	})

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2043,6 +2043,8 @@ func (process *TeleportProcess) initAuthService() error {
 		return trace.Wrap(err)
 	}
 
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentAuth, process.id))
+
 	// first, create the AuthServer
 	authServer, err := auth.Init(
 		process.ExitContext(),
@@ -2088,6 +2090,7 @@ func (process *TeleportProcess) initAuthService() error {
 			HTTPClientForAWSSTS:     cfg.Auth.HTTPClientForAWSSTS,
 			Tracer:                  process.TracingProvider.Tracer(teleport.ComponentAuth),
 			CloudClients:            cloudClients,
+			Logger:                  logger,
 		}, func(as *auth.Server) error {
 			if !process.Config.CachePolicy.Enabled {
 				return nil
@@ -2109,8 +2112,6 @@ func (process *TeleportProcess) initAuthService() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentAuth, process.id))
 
 	lockWatcher, err := services.NewLockWatcher(process.ExitContext(), services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/singleflight"
@@ -642,7 +641,7 @@ func clientForFacade(
 	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
 		Resolver:              resolver,
 		ClientConfig:          sshConfig,
-		Log:                   logrus.StandardLogger(),
+		Log:                   log,
 		InsecureSkipTLSVerify: cfg.Insecure,
 		GetClusterCAs:         client.ClusterCAsFromCertPool(tlsConfig.RootCAs),
 	})
@@ -656,7 +655,7 @@ func clientForFacade(
 		// TODO(noah): It'd be ideal to distinguish the proxy addr and auth addr
 		// here to avoid pointlessly hitting the address as an auth server.
 		AuthServers: []utils.NetAddr{*parsedAddr},
-		Log:         logrus.StandardLogger(),
+		Log:         log,
 		Insecure:    cfg.Insecure,
 		ProxyDialer: dialer,
 		DialOpts: []grpc.DialOption{

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -1086,7 +1086,7 @@ func newAdminActionTestSuite(t *testing.T) *adminActionTestSuite {
 	localAdminClient, err := authclient.Connect(ctx, &authclient.Config{
 		TLS:         localAdminTLS,
 		AuthServers: []utils.NetAddr{*authAddr},
-		Log:         utils.NewLoggerForTests(),
+		Log:         utils.NewSlogLoggerForTests(),
 	})
 	require.NoError(t, err)
 

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -223,7 +223,7 @@ func TryRun(commands []CLICommand, args []string) error {
 	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
 		Resolver:              resolver,
 		ClientConfig:          clientConfig.SSH,
-		Log:                   clientConfig.Log,
+		Log:                   cfg.Logger,
 		InsecureSkipTLSVerify: clientConfig.Insecure,
 		GetClusterCAs:         apiclient.ClusterCAsFromCertPool(clientConfig.TLS.RootCAs),
 	})
@@ -291,6 +291,7 @@ func ApplyConfig(ccf *GlobalCLIFlags, cfg *servicecfg.Config) (*authclient.Confi
 		log.Debugf("Debug logging has been enabled.")
 	}
 	cfg.Log = log.StandardLogger()
+	cfg.Logger = slog.Default()
 
 	if cfg.Version == "" {
 		cfg.Version = defaults.TeleportConfigVersionV1
@@ -408,7 +409,7 @@ func ApplyConfig(ccf *GlobalCLIFlags, cfg *servicecfg.Config) (*authclient.Confi
 	authConfig.TLS.InsecureSkipVerify = ccf.Insecure
 	authConfig.Insecure = ccf.Insecure
 	authConfig.AuthServers = cfg.AuthServerAddresses()
-	authConfig.Log = cfg.Log
+	authConfig.Log = cfg.Logger
 	authConfig.DialOpts = append(authConfig.DialOpts, metadata.WithUserAgentFromTeleportComponent(teleport.ComponentTCTL))
 
 	return authConfig, nil
@@ -481,7 +482,7 @@ func LoadConfigFromProfile(ccf *GlobalCLIFlags, cfg *servicecfg.Config) (*authcl
 		cfg.SetAuthServerAddress(*webProxyAddr)
 	}
 	authConfig.AuthServers = cfg.AuthServerAddresses()
-	authConfig.Log = cfg.Log
+	authConfig.Log = cfg.Logger
 	authConfig.DialOpts = append(authConfig.DialOpts, metadata.WithUserAgentFromTeleportComponent(teleport.ComponentTCTL))
 
 	if c.TLSRoutingEnabled {

--- a/tool/teleport/testenv/test_server.go
+++ b/tool/teleport/testenv/test_server.go
@@ -673,7 +673,7 @@ func MakeDefaultAuthClient(t *testing.T, process *service.TeleportProcess) *auth
 	require.NoError(t, err)
 
 	authConfig.AuthServers = cfg.AuthServerAddresses()
-	authConfig.Log = utils.NewLogger()
+	authConfig.Log = cfg.Logger
 
 	client, err := authclient.Connect(context.Background(), authConfig)
 	require.NoError(t, err)


### PR DESCRIPTION
I think the most "notable" bit here is that I've wired a `*slog.Logger` through as a field on `auth.Server` - this should make it easier for future conversions of Logrus -> Slog in the `lib/auth` package.