### PR TITLE
adding a reference to  to the host user guide

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
@@ -81,6 +81,7 @@ spec:
   options:
     # Allow automatic creation of users.
     create_host_user_mode: keep
+    create_host_user_default_shell: /bin/bash
   allow:
     logins: [ "nginxrestarter" ]
     # List of host groups the created user will be added to. Any that don't already exist are created.
@@ -103,7 +104,9 @@ The `create_host_user_mode` field enables host user creation when the value is
 the `app:nginx` label, the Teleport SSH Service creates a host user, adds it to
 the groups listed in `host_groups`, and gives it the sudoer permissions
 specified in the `host_sudoers` field. In this case, the new user receives
-permission to restart the Nginx service as root.
+permission to restart the Nginx service as root. The default shell for a created
+user can be configured with `create_host_user_default_shell`. Otherwise the
+host's default shell will be used.
 
 {/*TODO (ptgott): We should move the information below into a reference guide*/}
 <Details title="Customizing host user creation">


### PR DESCRIPTION
Adds an example and a note about `create_host_user_default_shell` to the host user creation guide. The static host users portion already references `default_shell` in the example spec, so I've left it alone for now.
