### PR TITLE
Increase login length limit to 128 characters

### DIFF
--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -333,7 +333,7 @@ func IsValidUnixUser(u string) bool {
 	// '\t', etc.). Note that using a slash ('/') may break the default algorithm for the
 	// definition of the user's home directory.
 
-	const maxUsernameLen = 32
+	const maxUsernameLen = 128
 	if len(u) > maxUsernameLen || len(u) == 0 || u[0] == '-' {
 		return false
 	}


### PR DESCRIPTION
Traditionally POSIX systems imposed a maximum of 32 characters for the length of any particular username. Teleport was following this limit. However, many modern systems follow higher limits like 255.

This change increases the maximum to 128 characters. I believe the full 255 characters are unlikely to be used in practice and likely a result of an error. 

Changelog: maximum length for individual UNIX login was increased to 128 characters from previous 32.