### PR TITLE
Remove LockConfiguration.LockName

### DIFF
--- a/lib/backend/helpers.go
+++ b/lib/backend/helpers.go
@@ -54,9 +54,6 @@ func randomID() ([]byte, error) {
 type LockConfiguration struct {
 	// Backend to create the lock in.
 	Backend Backend
-	// LockName the precomputed lock name.
-	// TODO(tross) DELETE WHEN teleport.e is updated to use LockNameComponents.
-	LockName string
 	// LockNameComponents are subcomponents to be used when constructing
 	// the lock name.
 	LockNameComponents []string
@@ -71,12 +68,8 @@ func (l *LockConfiguration) CheckAndSetDefaults() error {
 	if l.Backend == nil {
 		return trace.BadParameter("missing Backend")
 	}
-	if l.LockName == "" && len(l.LockNameComponents) == 0 {
-		return trace.BadParameter("missing LockName/LockNameComponents")
-	}
-
 	if len(l.LockNameComponents) == 0 {
-		l.LockNameComponents = []string{l.LockName}
+		return trace.BadParameter("missing LockNameComponents")
 	}
 
 	if l.TTL == 0 {

--- a/lib/backend/helpers_test.go
+++ b/lib/backend/helpers_test.go
@@ -72,10 +72,10 @@ func TestLockConfiguration_CheckAndSetDefaults(t *testing.T) {
 			wantErr: "missing Backend",
 		},
 		{
-			name: "missing lock name",
+			name: "missing lock components",
 			in: LockConfiguration{
-				Backend:  mockBackend{},
-				LockName: "",
+				Backend:            mockBackend{},
+				LockNameComponents: nil,
 			},
 			wantErr: "missing LockName",
 		},
@@ -143,7 +143,6 @@ func TestRunWhileLockedConfigCheckAndSetDefaults(t *testing.T) {
 			name: "errors from LockConfiguration is passed",
 			input: func() RunWhileLockedConfig {
 				cfg := minimumValidConfig
-				cfg.LockName = ""
 				cfg.LockNameComponents = nil
 				return cfg
 			},


### PR DESCRIPTION
Cleans up the deprecated config option now that https://github.com/gravitational/teleport.e/pull/5034 has been merged.