### PR TITLE
Expose client tools auto update for find endpoint

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -334,8 +334,8 @@ type ProxySettings struct {
 type AutoUpdateSettings struct {
 	// ToolsVersion defines the version of {tsh, tctl} for client auto update.
 	ToolsVersion string `json:"tools_version"`
-	// ToolsAutoupdate enables client auto update feature.
-	ToolsAutoupdate bool `json:"tools_autoupdate"`
+	// ToolsAutoUpdate enables client auto update feature.
+	ToolsAutoUpdate bool `json:"tools_auto_update"`
 }
 
 // KubeProxySettings is kubernetes proxy settings

--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -297,6 +297,10 @@ type PingResponse struct {
 	ServerVersion string `json:"server_version"`
 	// MinClientVersion is the minimum client version required by the server.
 	MinClientVersion string `json:"min_client_version"`
+	// ToolsVersion defines the version of {tsh, tctl} for client auto update.
+	ToolsVersion string `json:"tools_version"`
+	// ToolsAutoupdate enables client auto update feature.
+	ToolsAutoupdate bool `json:"tools_autoupdate"`
 	// ClusterName contains the name of the Teleport cluster.
 	ClusterName string `json:"cluster_name"`
 

--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -297,10 +297,8 @@ type PingResponse struct {
 	ServerVersion string `json:"server_version"`
 	// MinClientVersion is the minimum client version required by the server.
 	MinClientVersion string `json:"min_client_version"`
-	// ToolsVersion defines the version of {tsh, tctl} for client auto update.
-	ToolsVersion string `json:"tools_version"`
-	// ToolsAutoupdate enables client auto update feature.
-	ToolsAutoupdate bool `json:"tools_autoupdate"`
+	// AutoUpdateSettings contains the auto update settings.
+	AutoUpdate AutoUpdateSettings `json:"auto_update"`
 	// ClusterName contains the name of the Teleport cluster.
 	ClusterName string `json:"cluster_name"`
 
@@ -330,6 +328,14 @@ type ProxySettings struct {
 	// TLSRoutingEnabled indicates that proxy supports ALPN SNI server where
 	// all proxy services are exposed on a single TLS listener (Proxy Web Listener).
 	TLSRoutingEnabled bool `json:"tls_routing_enabled"`
+}
+
+// AutoUpdateSettings contains information about the auto update requirements.
+type AutoUpdateSettings struct {
+	// ToolsVersion defines the version of {tsh, tctl} for client auto update.
+	ToolsVersion string `json:"tools_version"`
+	// ToolsAutoupdate enables client auto update feature.
+	ToolsAutoupdate bool `json:"tools_autoupdate"`
 }
 
 // KubeProxySettings is kubernetes proxy settings

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1529,15 +1529,15 @@ func (h *Handler) find(w http.ResponseWriter, r *http.Request, p httprouter.Para
 	}
 
 	autoUpdateConfig, err := h.cfg.AccessPoint.GetAutoUpdateConfig(r.Context())
-	// TODO(vapopov) DELETE IN v18.0.0
+	// TODO(vapopov) DELETE IN v18.0.0 check of IsNotImplemented, must be backported to all latest supported versions.
 	if err != nil && !trace.IsNotFound(err) && !trace.IsNotImplemented(err) {
 		h.logger.ErrorContext(r.Context(), "failed to receive AutoUpdateConfig", "error", err)
 	} else if err == nil {
-		response.AutoUpdate.ToolsAutoupdate = autoUpdateConfig.GetSpec().GetToolsAutoupdate()
+		response.AutoUpdate.ToolsAutoUpdate = autoUpdateConfig.GetSpec().GetToolsAutoupdate()
 	}
 
 	autoUpdateVersion, err := h.cfg.AccessPoint.GetAutoUpdateVersion(r.Context())
-	// TODO(vapopov) DELETE IN v18.0.0
+	// TODO(vapopov) DELETE IN v18.0.0 check of IsNotImplemented, must be backported to all latest supported versions.
 	if err != nil && !trace.IsNotFound(err) && !trace.IsNotImplemented(err) {
 		h.logger.ErrorContext(r.Context(), "failed to receive AutoUpdateVersion", "error", err)
 	} else if err == nil {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1528,18 +1528,20 @@ func (h *Handler) find(w http.ResponseWriter, r *http.Request, p httprouter.Para
 		ClusterName:      h.auth.clusterName,
 	}
 
-	autoUpdateConfig, err := h.GetAccessPoint().GetAutoUpdateConfig(r.Context())
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
+	autoUpdateConfig, err := h.cfg.AccessPoint.GetAutoUpdateConfig(r.Context())
+	// TODO(vapopov) DELETE IN v18.0.0
+	if err != nil && !trace.IsNotFound(err) && !trace.IsNotImplemented(err) {
+		h.logger.ErrorContext(r.Context(), "failed to receive AutoUpdateConfig", "error", err)
 	} else if err == nil {
-		response.ToolsAutoupdate = autoUpdateConfig.GetSpec().GetToolsAutoupdate()
+		response.AutoUpdate.ToolsAutoupdate = autoUpdateConfig.GetSpec().GetToolsAutoupdate()
 	}
 
-	autoUpdateVersion, err := h.GetAccessPoint().GetAutoUpdateVersion(r.Context())
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
+	autoUpdateVersion, err := h.cfg.AccessPoint.GetAutoUpdateVersion(r.Context())
+	// TODO(vapopov) DELETE IN v18.0.0
+	if err != nil && !trace.IsNotFound(err) && !trace.IsNotImplemented(err) {
+		h.logger.ErrorContext(r.Context(), "failed to receive AutoUpdateVersion", "error", err)
 	} else if err == nil {
-		response.ToolsVersion = autoUpdateVersion.GetSpec().GetToolsVersion()
+		response.AutoUpdate.ToolsVersion = autoUpdateVersion.GetSpec().GetToolsVersion()
 	}
 
 	return response, nil

--- a/lib/web/apiserver_ping_test.go
+++ b/lib/web/apiserver_ping_test.go
@@ -29,9 +29,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
+	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/autoupdate"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/modules"
 )
@@ -244,5 +247,44 @@ func TestPing_minimalAPI(t *testing.T) {
 			require.NoError(t, resp.Body.Close())
 		})
 	}
+}
 
+// TestPing_autoUpdateResources tests that find endpoint return correct data related to auto updates.
+func TestPing_autoUpdateResources(t *testing.T) {
+	env := newWebPack(t, 1, func(cfg *proxyConfig) {
+		cfg.minimalHandler = true
+	})
+	proxy := env.proxies[0]
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Enable tools auto update.
+	config, err := autoupdate.NewAutoUpdateConfig(&autoupdatev1pb.AutoUpdateConfigSpec{
+		ToolsAutoupdate: true,
+	})
+	require.NoError(t, err)
+	_, err = env.server.Auth().UpsertAutoUpdateConfig(ctx, config)
+	require.NoError(t, err)
+
+	// Set the client tools version.
+	version, err := autoupdate.NewAutoUpdateVersion(&autoupdatev1pb.AutoUpdateVersionSpec{
+		ToolsVersion: teleport.Version,
+	})
+	require.NoError(t, err)
+	_, err = env.server.Auth().UpsertAutoUpdateVersion(ctx, version)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, proxy.newClient(t).Endpoint("webapi", "find"), nil)
+	require.NoError(t, err)
+	req.Host = proxy.handler.handler.cfg.ProxyPublicAddrs[0].Host()
+	resp, err := client.NewInsecureWebClient().Do(req)
+	require.NoError(t, err)
+
+	pr := &webclient.PingResponse{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(pr))
+	require.NoError(t, resp.Body.Close())
+
+	assert.True(t, pr.AutoUpdate.ToolsAutoupdate, "tools_autoupdate must be enabled")
+	assert.Equal(t, teleport.Version, pr.AutoUpdate.ToolsVersion, "tools_version must be equal to current version")
 }


### PR DESCRIPTION
In this PR added exposing client auto update fields (is enabled, and required client tools version for update)

Related: https://github.com/gravitational/teleport/pull/39805/files#diff-8d3c0408dd826f27e9f13cd15f09f4d7e89202862f0b13ce131a2e3072c2a40dR49-R53