### PR TITLE
Better debug logging for host user creation

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -199,6 +199,9 @@ const (
 	// ComponentSession is an active session.
 	ComponentSession = "session"
 
+	// ComponentHostUsers represents host user management.
+	ComponentHostUsers = "hostusers"
+
 	// ComponentDynamoDB represents dynamodb clients
 	ComponentDynamoDB = "dynamodb"
 

--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -200,7 +200,7 @@ func TestRootHostUsersBackend(t *testing.T) {
 		t.Cleanup(func() {
 			os.RemoveAll(testHome)
 		})
-		require.NoError(t, err)
+		require.ErrorIs(t, err, os.ErrExist)
 		require.NoFileExists(t, "/tmp/ignoreme")
 	})
 }

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/user"
 	"path"
@@ -103,8 +104,11 @@ func MsgParticipantCtrls(w io.Writer, m types.SessionParticipantMode) error {
 type SessionRegistry struct {
 	SessionRegistryConfig
 
-	// log holds the structured logger
+	// deprecated: log holds the legacy logrus structured logger
 	log *log.Entry
+
+	// logger holds the structured logger
+	logger *slog.Logger
 
 	// sessions holds a map between session ID and the session object. Used to
 	// find active sessions as well as close all sessions when the registry
@@ -185,6 +189,7 @@ func NewSessionRegistry(cfg SessionRegistryConfig) (*SessionRegistry, error) {
 		log: log.WithFields(log.Fields{
 			teleport.ComponentKey: teleport.Component(teleport.ComponentSession, cfg.Srv.Component()),
 		}),
+		logger:   slog.With(teleport.ComponentKey, teleport.Component(teleport.ComponentSession, cfg.Srv.Component())),
 		sessions: make(map[rsession.ID]*session),
 		users:    cfg.Srv.GetHostUsers(),
 		sudoers:  cfg.Srv.GetHostSudoers(),
@@ -289,15 +294,19 @@ func (s *SessionRegistry) WriteSudoersFile(identityContext IdentityContext) (io.
 // If the returned closer is not nil, it must be called at the end of the session to
 // clean up the local user.
 func (s *SessionRegistry) UpsertHostUser(identityContext IdentityContext) (bool, io.Closer, error) {
+	ctx := s.Srv.Context()
+	log := s.logger.With("host_username", identityContext.Login)
+
 	if identityContext.Login == teleport.SSHSessionJoinPrincipal {
 		return false, nil, nil
 	}
 
 	if !s.Srv.GetCreateHostUser() || s.users == nil {
-		s.log.Debug("Not creating host user: node has disabled host user creation.")
+		log.DebugContext(ctx, "Not creating host user: node has disabled host user creation.")
 		return false, nil, nil // not an error to not be able to create host users
 	}
 
+	log.DebugContext(ctx, "Attempting to upsert host user")
 	ui, accessErr := identityContext.AccessChecker.HostUsers(s.Srv.GetInfo())
 	if trace.IsAccessDenied(accessErr) {
 		existsErr := s.users.UserExists(identityContext.Login)
@@ -316,16 +325,17 @@ func (s *SessionRegistry) UpsertHostUser(identityContext IdentityContext) (bool,
 
 	userCloser, err := s.users.UpsertUser(identityContext.Login, *ui)
 	if err != nil {
-		log.Debugf("Error creating user %s: %s", identityContext.Login, err)
+		log.DebugContext(ctx, "Error creating user", "error", err)
 
 		if errors.Is(err, unmanagedUserErr) {
-			log.Warnf("User %q is not managed by teleport. Either manually delete the user from this machine or update the host_groups defined in their role to include %q. https://goteleport.com/docs/enroll-resources/server-access/guides/host-user-creation/#migrating-unmanaged-users", identityContext.Login, types.TeleportKeepGroup)
+			log.WarnContext(ctx, "User is not managed by teleport. Either manually delete the user from this machine or update the host_groups defined in their role to include 'teleport-keep'. https://goteleport.com/docs/enroll-resources/server-access/guides/host-user-creation/#migrating-unmanaged-users")
 			return false, nil, nil
 		}
 
 		if !trace.IsAlreadyExists(err) {
 			return false, nil, trace.Wrap(err)
 		}
+		log.DebugContext(ctx, "Host user already exists")
 	}
 
 	return true, userCloser, nil

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -259,6 +259,7 @@ func TestSession_newRecorder(t *testing.T) {
 				id:  "test",
 				log: logger,
 				registry: &SessionRegistry{
+					logger: utils.NewSlogLoggerForTests(),
 					SessionRegistryConfig: SessionRegistryConfig{
 						Srv: &mockServer{
 							component: teleport.ComponentNode,
@@ -279,6 +280,7 @@ func TestSession_newRecorder(t *testing.T) {
 				id:  "test",
 				log: logger,
 				registry: &SessionRegistry{
+					logger: utils.NewSlogLoggerForTests(),
 					SessionRegistryConfig: SessionRegistryConfig{
 						Srv: &mockServer{
 							component: teleport.ComponentNode,
@@ -299,6 +301,7 @@ func TestSession_newRecorder(t *testing.T) {
 				id:  "test",
 				log: logger,
 				registry: &SessionRegistry{
+					logger: utils.NewSlogLoggerForTests(),
 					SessionRegistryConfig: SessionRegistryConfig{
 						Srv: &mockServer{
 							component: teleport.ComponentNode,
@@ -338,6 +341,7 @@ func TestSession_newRecorder(t *testing.T) {
 				id:  "test",
 				log: logger,
 				registry: &SessionRegistry{
+					logger: utils.NewSlogLoggerForTests(),
 					SessionRegistryConfig: SessionRegistryConfig{
 						Srv: &mockServer{
 							component: teleport.ComponentNode,
@@ -384,6 +388,7 @@ func TestSession_newRecorder(t *testing.T) {
 				id:  "test",
 				log: logger,
 				registry: &SessionRegistry{
+					logger: utils.NewSlogLoggerForTests(),
 					SessionRegistryConfig: SessionRegistryConfig{
 						Srv: &mockServer{
 							component: teleport.ComponentNode,
@@ -1122,6 +1127,7 @@ func TestTrackingSession(t *testing.T) {
 				id:  rsession.NewID(),
 				log: utils.NewLoggerForTests().WithField(teleport.ComponentKey, "test-session"),
 				registry: &SessionRegistry{
+					logger: utils.NewSlogLoggerForTests(),
 					SessionRegistryConfig: SessionRegistryConfig{
 						Srv:                   srv,
 						SessionTrackerService: trackingService,
@@ -1527,6 +1533,7 @@ func TestUpsertHostUser(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			registry := SessionRegistry{
+				logger: utils.NewSlogLoggerForTests(),
 				SessionRegistryConfig: SessionRegistryConfig{
 					Srv: &fakeServer{createHostUser: c.createHostUser},
 				},
@@ -1600,6 +1607,7 @@ func TestWriteSudoersFile(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			registry := SessionRegistry{
+				logger: utils.NewSlogLoggerForTests(),
 				SessionRegistryConfig: SessionRegistryConfig{
 					Srv: &fakeServer{hostSudoers: c.hostSudoers},
 				},
@@ -1648,6 +1656,10 @@ func (f *fakeServer) GetHostSudoers() HostSudoers {
 
 func (f *fakeServer) GetInfo() types.Server {
 	return nil
+}
+
+func (f *fakeServer) Context() context.Context {
+	return context.Background()
 }
 
 type fakeAccessChecker struct {

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"os"
 	"os/user"
 	"regexp"
 	"slices"
@@ -33,8 +34,8 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/services"
@@ -47,14 +48,15 @@ func NewHostUsers(ctx context.Context, storage services.PresenceInternal, uuid s
 	backend, err := newHostUsersBackend()
 	switch {
 	case trace.IsNotImplemented(err), trace.IsNotFound(err):
-		log.Debugf("Skipping host user management: %v", err)
+		slog.DebugContext(ctx, "Skipping host user management", "error", err)
 		return nil
 	case err != nil: //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
-		log.Warnf("Error making new HostUsersBackend: %s", err)
+		slog.WarnContext(ctx, "Error making new HostUsersBackend", "error", err)
 		return nil
 	}
 	cancelCtx, cancelFunc := context.WithCancel(ctx)
 	return &HostUserManagement{
+		log:       slog.With(teleport.ComponentKey, teleport.Component(teleport.ComponentHostUsers)),
 		backend:   backend,
 		ctx:       cancelCtx,
 		cancel:    cancelFunc,
@@ -68,10 +70,10 @@ func NewHostSudoers(uuid string) HostSudoers {
 	backend, err := newHostSudoersBackend(uuid)
 	switch {
 	case trace.IsNotImplemented(err):
-		log.Debugf("Skipping host sudoers management: %v", err)
+		slog.DebugContext(context.Background(), "Skipping host sudoers management", "error", err)
 		return nil
 	case err != nil: //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
-		log.Warnf("Error making new HostSudoersBackend: %s", err)
+		slog.DebugContext(context.Background(), "Error making new HostSudoersBackend", "error", err)
 		return nil
 	}
 	return &HostSudoersManagement{
@@ -178,6 +180,8 @@ type HostUsers interface {
 }
 
 type HostUserManagement struct {
+	log *slog.Logger
+
 	backend HostUsersBackend
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -232,6 +236,15 @@ func (u *HostSudoersManagement) RemoveSudoers(name string) error {
 var unmanagedUserErr = errors.New("user not managed by teleport")
 
 func (u *HostUserManagement) updateUser(name string, ui services.HostUsersInfo) (io.Closer, error) {
+	ctx := u.ctx
+	log := u.log.With(
+		"host_username", name,
+		"mode", ui.Mode,
+		"uid", ui.UID,
+		"gid", ui.GID,
+	)
+
+	log.DebugContext(ctx, "Attempting to update host user")
 	existingUser, err := u.backend.Lookup(name)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -269,7 +282,7 @@ func (u *HostUserManagement) updateUser(name string, ui services.HostUsersInfo) 
 	isStaticMode := ui.Mode == services.HostUserModeStatic
 	managedStaticConversion := isManagedUser && (hasStaticGroup != isStaticMode)
 	if managedStaticConversion {
-		slog.DebugContext(context.Background(),
+		slog.DebugContext(ctx,
 			"Aborting host user creation, can't convert between auto-provisioned and static host users.",
 			"login", name)
 		return nil, nil
@@ -293,7 +306,9 @@ func (u *HostUserManagement) updateUser(name string, ui services.HostUsersInfo) 
 				return nil, trace.Wrap(err)
 			}
 
-			if err := u.backend.CreateHomeDirectory(home, existingUser.Uid, existingUser.Gid); err != nil {
+			log.DebugContext(ctx, "Creating home directory", "home_path", home)
+			err = u.backend.CreateHomeDirectory(home, existingUser.Uid, existingUser.Gid)
+			if err != nil && !os.IsExist(err) {
 				return nil, trace.Wrap(err)
 			}
 		}
@@ -316,6 +331,23 @@ func (u *HostUserManagement) updateUser(name string, ui services.HostUsersInfo) 
 	finalGroups[primaryGroup.Name] = struct{}{}
 
 	if !maps.Equal(currentGroups, finalGroups) {
+		// no need to do these allocations unless we're actually going to log them
+		if log.Enabled(ctx, slog.LevelDebug) {
+			current := make([]string, 0, len(currentGroups))
+			for group := range currentGroups {
+				current = append(current, group)
+			}
+
+			final := make([]string, 0, len(finalGroups))
+			for group := range finalGroups {
+				final = append(final, group)
+			}
+
+			slices.Sort(current)
+			slices.Sort(final)
+			log.DebugContext(ctx, "Setting user groups", "before", current, "after", final)
+		}
+
 		if err := u.doWithUserLock(func(_ types.SemaphoreLease) error {
 			return trace.Wrap(u.backend.SetUserGroups(name, ui.Groups))
 		}); err != nil {
@@ -323,6 +355,7 @@ func (u *HostUserManagement) updateUser(name string, ui services.HostUsersInfo) 
 		}
 	}
 
+	log.DebugContext(ctx, "Successfully updated existing host user")
 	return closer, nil
 }
 
@@ -353,6 +386,13 @@ func (u *HostUserManagement) resolveGID(username string, groups []string, gid st
 }
 
 func (u *HostUserManagement) createUser(name string, ui services.HostUsersInfo) (io.Closer, error) {
+	log := u.log.With(
+		"host_username", name,
+		"mode", ui.Mode,
+		"uid", ui.UID,
+	)
+
+	log.DebugContext(u.ctx, "Attempting to create host user", "gid", ui.GID)
 	var err error
 	userOpts := host.UserOpts{
 		UID:   ui.UID,
@@ -393,6 +433,7 @@ func (u *HostUserManagement) createUser(name string, ui services.HostUsersInfo) 
 			return trace.Wrap(err)
 		}
 
+		log.InfoContext(u.ctx, "Creating host user", "gid", userOpts.GID)
 		err = u.backend.CreateUser(name, ui.Groups, userOpts)
 		if err != nil && !trace.IsAlreadyExists(err) {
 			return trace.WrapWithMessage(err, "error while creating user")
@@ -404,16 +445,24 @@ func (u *HostUserManagement) createUser(name string, ui services.HostUsersInfo) 
 		}
 
 		if userOpts.Home != "" {
+			log.InfoContext(u.ctx, "Attempting to create home directory", "home", userOpts.Home, "gid", userOpts.GID)
 			if err := u.backend.CreateHomeDirectory(userOpts.Home, user.Uid, user.Gid); err != nil {
-				return trace.Wrap(err)
+				if !os.IsExist(err) {
+					return trace.Wrap(err)
+				}
+				log.InfoContext(u.ctx, "Home directory already exists", "home", userOpts.Home, "gid", userOpts.GID)
+			} else {
+				log.InfoContext(u.ctx, "Created home directory", "home", userOpts.Home, "gid", userOpts.GID)
 			}
 		}
 
 		return nil
 	})
+
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	return closer, nil
 }
 
@@ -431,13 +480,17 @@ func (u *HostUserManagement) ensureGroupsExist(groups ...string) error {
 
 // UpsertUser creates a temporary Teleport user in the TeleportDropGroup
 func (u *HostUserManagement) UpsertUser(name string, ui services.HostUsersInfo) (io.Closer, error) {
+	log := u.log.With("host_username", name)
+
 	// allow for explicit assignment of teleport-keep group in order to facilitate migrating KEEP users that existed before we added
 	// the teleport-keep group
 	hasKeepGroup := slices.Contains(ui.Groups, types.TeleportKeepGroup)
 	migrateKeepUser := hasKeepGroup && ui.Mode == services.HostUserModeKeep
 
+	log.DebugContext(u.ctx, "Attempting to upsert host user", "migrate_keep_user", migrateKeepUser)
+
 	if hasKeepGroup && !migrateKeepUser {
-		log.Warnf("explicit assignment of %q group is not possible in 'insecure-drop' mode", types.TeleportKeepGroup)
+		log.WarnContext(u.ctx, "Explicit assignment of group is not possible in 'insecure-drop' mode", "group", types.TeleportKeepGroup)
 	}
 
 	groupSet := make(map[string]struct{}, len(ui.Groups))
@@ -460,10 +513,12 @@ func (u *HostUserManagement) UpsertUser(name string, ui services.HostUsersInfo) 
 	}
 	ui.Groups = groups
 
+	log.DebugContext(u.ctx, "Ensuring teleport host groups exist")
 	if err := u.ensureGroupsExist(types.TeleportDropGroup, types.TeleportKeepGroup, types.TeleportStaticGroup); err != nil {
 		return nil, trace.WrapWithMessage(err, "creating teleport system groups")
 	}
 
+	log.DebugContext(u.ctx, "Ensuring configured host groups exist", "groups", groups)
 	if err := u.ensureGroupsExist(groups...); err != nil {
 		return nil, trace.WrapWithMessage(err, "creating configured groups")
 	}
@@ -515,7 +570,12 @@ func (u *HostUserManagement) createGroupIfNotExist(group string) error {
 		return nil
 	}
 
-	return trace.Wrap(err, "%q", group)
+	if err != nil {
+		return trace.Wrap(err, "%q", group)
+	}
+
+	u.log.DebugContext(u.ctx, "Created host group", "group", group)
+	return nil
 }
 
 // isUnknownGroupError returns whether the error from LookupGroup is an unknown group error.
@@ -533,6 +593,7 @@ func isUnknownGroupError(err error, groupName string) bool {
 
 // DeleteAllUsers deletes all host users in the teleport service group.
 func (u *HostUserManagement) DeleteAllUsers() error {
+	u.log.InfoContext(u.ctx, "Attempting to delete all temporary host users")
 	users, err := u.backend.GetAllUsers()
 	if err != nil {
 		return trace.Wrap(err)
@@ -540,7 +601,7 @@ func (u *HostUserManagement) DeleteAllUsers() error {
 	teleportGroup, err := u.backend.LookupGroup(types.TeleportDropGroup)
 	if err != nil {
 		if isUnknownGroupError(err, types.TeleportDropGroup) {
-			log.Debugf("%q group not found, not deleting users", types.TeleportDropGroup)
+			u.log.DebugContext(u.ctx, "Target group not found, not deleting users", "group", types.TeleportDropGroup)
 			return nil
 		}
 		return trace.Wrap(err)
@@ -549,7 +610,7 @@ func (u *HostUserManagement) DeleteAllUsers() error {
 	for _, name := range users {
 		lt, err := u.storage.GetHostUserInteractionTime(u.ctx, name)
 		if err != nil {
-			log.Debugf("Failed to find user %q login time: %s", name, err)
+			u.log.DebugContext(u.ctx, "Failed to find user login time", "host_username", name, "error", err)
 			continue
 		}
 		u.doWithUserLock(func(l types.SemaphoreLease) error {
@@ -572,6 +633,9 @@ func (u *HostUserManagement) DeleteAllUsers() error {
 // DeleteUser deletes the specified user only if they are
 // present in the specified group.
 func (u *HostUserManagement) DeleteUser(username string, gid string) error {
+	log := u.log.With("host_username", username, "gid", gid)
+
+	log.DebugContext(u.ctx, "Attempting to delete host user")
 	tempUser, err := u.backend.Lookup(username)
 	if err != nil {
 		return trace.Wrap(err)
@@ -585,7 +649,7 @@ func (u *HostUserManagement) DeleteUser(username string, gid string) error {
 			err := u.backend.DeleteUser(username)
 			if err != nil {
 				if errors.Is(err, ErrUserLoggedIn) {
-					log.Debugf("Not deleting user %q, user has another session, or running process", username)
+					u.log.DebugContext(u.ctx, "Not deleting user because user has another session or running process")
 					return nil
 				}
 				return trace.Wrap(err)
@@ -594,7 +658,7 @@ func (u *HostUserManagement) DeleteUser(username string, gid string) error {
 			return nil
 		}
 	}
-	log.Debugf("User %q not deleted: not a temporary user", username)
+	u.log.DebugContext(u.ctx, "User not deleted: not a temporary user")
 	return nil
 }
 
@@ -607,10 +671,10 @@ func (u *HostUserManagement) UserCleanup() {
 		err := u.DeleteAllUsers()
 		switch {
 		case trace.IsNotFound(err):
-			log.Debugf("Error during temporary user cleanup: %s, stopping cleanup job", err)
+			u.log.DebugContext(u.ctx, "Error during temporary user cleanup, stopping cleanup job", "error", err)
 			return
 		case err != nil:
-			log.Error("Error during temporary user cleanup: ", err)
+			u.log.ErrorContext(u.ctx, "Error during temporary user cleanup", "error", err)
 		}
 
 		select {
@@ -623,6 +687,7 @@ func (u *HostUserManagement) UserCleanup() {
 
 // Shutdown cancels the UserCleanup loop
 func (u *HostUserManagement) Shutdown() {
+	u.log.DebugContext(u.ctx, "shutting down host user cleanup")
 	u.cancel()
 }
 

--- a/lib/srv/usermgmt_linux.go
+++ b/lib/srv/usermgmt_linux.go
@@ -249,9 +249,6 @@ func (u *HostUsersProvisioningBackend) CreateHomeDirectory(userHome, uidS, gidS 
 
 	err = os.Mkdir(userHome, 0o700)
 	if err != nil {
-		if os.IsExist(err) {
-			return nil
-		}
 		return trace.Wrap(err)
 	}
 

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/host"
 )
 
@@ -253,6 +254,7 @@ func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 	users := HostUserManagement{
 		backend: backend,
 		storage: pres,
+		log:     utils.NewSlogLoggerForTests(),
 	}
 	sudoers := HostSudoersManagement{
 		backend: backend,
@@ -278,6 +280,7 @@ func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 		users := HostUserManagement{
 			backend: backend,
 			storage: pres,
+			log:     utils.NewSlogLoggerForTests(),
 		}
 		// test user already exists but teleport-service group has not yet
 		// been created
@@ -318,6 +321,7 @@ func TestUserMgmt_DeleteAllTeleportSystemUsers(t *testing.T) {
 	users := HostUserManagement{
 		backend:   mgmt,
 		storage:   pres,
+		log:       utils.NewSlogLoggerForTests(),
 		userGrace: 0,
 	}
 
@@ -343,6 +347,7 @@ func TestUserMgmt_DeleteAllTeleportSystemUsers(t *testing.T) {
 	users = HostUserManagement{
 		backend: newTestUserMgmt(),
 		storage: pres,
+		log:     utils.NewSlogLoggerForTests(),
 	}
 	// teleport-system group doesnt exist, DeleteAllUsers will return nil, instead of erroring
 	require.NoError(t, users.DeleteAllUsers())
@@ -702,6 +707,7 @@ func initBackend(t *testing.T, groups []string) (HostUserManagement, *testHostUs
 	users := HostUserManagement{
 		backend: backend,
 		storage: pres,
+		log:     utils.NewSlogLoggerForTests(),
 	}
 
 	for _, group := range groups {
@@ -719,6 +725,7 @@ func TestCreateUserWithExistingPrimaryGroup(t *testing.T) {
 	users := HostUserManagement{
 		backend: backend,
 		storage: pres,
+		log:     utils.NewSlogLoggerForTests(),
 	}
 
 	existingGroups := []string{"alice", "simon"}


### PR DESCRIPTION
Host user creation doesn't produce many useful logs, even in debug mode. This PR adds some new logs and updates some existing ones to help make more sense of what's happening at runtime.
