### PR TITLE
refactor: [web] update SAML service provider spec and preset types

### DIFF
--- a/web/packages/teleport/src/services/samlidp/types.ts
+++ b/web/packages/teleport/src/services/samlidp/types.ts
@@ -39,7 +39,7 @@ export type SamlIdpServiceProviderSpec = {
   attribute_mapping: AttributeMapping[];
   entity_descriptor: string;
   entity_id: string;
-  preset: string;
+  preset: SamlServiceProviderPreset;
   relay_state: string;
 };
 
@@ -71,7 +71,6 @@ export enum SamlServiceProviderPreset {
  * preserved throughout the flow.
  */
 export type SamlGcpWorkforce = {
-  isAutoConfig: boolean;
   orgId: string;
   poolName: string;
   poolProviderName: string;


### PR DESCRIPTION
- update `SamlIdpServiceProviderSpec.preset` field type from `string` to `SamlServiceProviderPreset`.
- remove `isAutoConfig` field from `SamlGcpWorkforce` type. This field is no longer needed.

Changes required for https://github.com/gravitational/teleport.e/pull/5039