### PR TITLE
Add `ssh.forwardAgent` setting to Connect

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -478,6 +478,7 @@ Below is the list of the supported config properties.
 | `keymap.openSearchBar`        | `Command+K` on macOS<br/>`Ctrl+Shift+K` on Windows/Linux                                                             | Shortcut to open the search bar.                                                                           |
 | `headless.skipConfirm`        | false                                                                                                                | Skips the confirmation prompt for Headless WebAuthn approval and instead prompts for WebAuthn immediately. |
 | `ssh.noResume`                | false                                                                                                                | Disables SSH connection resumption.                                                                        |
+| `ssh.forwardAgent`            | true                                                                                                                 | Enables agent forwarding.                                                                                  |
 
 <Admonition
   type="note"

--- a/web/packages/teleterm/src/services/config/appConfigSchema.ts
+++ b/web/packages/teleterm/src/services/config/appConfigSchema.ts
@@ -188,6 +188,12 @@ export const createAppConfigSchema = (settings: RuntimeSettings) => {
       .boolean()
       .default(false)
       .describe('Disables SSH connection resumption.'),
+    'ssh.forwardAgent': z
+      .boolean()
+      .default(true)
+      .describe(
+        "Enables agent forwarding when connecting to SSH nodes. It's the equivalent of the forward-agent flag in tsh ssh."
+      ),
   });
 };
 

--- a/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -212,7 +212,7 @@ export function getPtyProcessOptions({
         `--proxy=${cmd.rootClusterId}`,
         'ssh',
         ...(options.ssh.noResume ? ['--no-resume'] : []),
-        '--forward-agent',
+        ...(options.ssh.forwardAgent ? ['--forward-agent'] : []),
         loginHost,
       ];
 

--- a/web/packages/teleterm/src/services/pty/ptyService.ts
+++ b/web/packages/teleterm/src/services/pty/ptyService.ts
@@ -43,7 +43,10 @@ export function createPtyService(
       const { processOptions, creationStatus, shell } = await buildPtyOptions({
         settings: runtimeSettings,
         options: {
-          ssh: { noResume: configService.get('ssh.noResume').value },
+          ssh: {
+            noResume: configService.get('ssh.noResume').value,
+            forwardAgent: configService.get('ssh.forwardAgent').value,
+          },
           customShellPath: configService.get('terminal.customShell').value,
           windowsPty,
         },

--- a/web/packages/teleterm/src/services/pty/types.ts
+++ b/web/packages/teleterm/src/services/pty/types.ts
@@ -123,6 +123,10 @@ export type SshOptions = {
    * (by adding the `--no-resume` option).
    */
   noResume: boolean;
+  /**
+   * Enables agent forwarding when running `tsh ssh` by adding the --forward-agent option.
+   */
+  forwardAgent: boolean;
 };
 
 export type TerminalOptions = {


### PR DESCRIPTION
In https://github.com/gravitational/webapps/pull/1366, we made it so that Connect always passes `--forward-agent` to fix https://github.com/gravitational/teleport/issues/18320 – before that it was impossible to use agent forwarding in Connect.

When [investigating an issue with gpg-agent](https://gravitational.slack.com/archives/C03FJA391M3/p1726760340261459?thread_ts=1726748067.808069&cid=C03FJA391M3), after [a short discussion](https://gravitational.slack.com/archives/C0DF0TPMY/p1726760991710189) we decided to turn it into an opt-in config option instead.

However, technically it'd be a breaking change, so this is split into two PRs. The first one is going to add `ssh.forwardAgent` that defaults to true (to keep backwards compatibility) and is going to be backported to v15 and v16. The next PR (https://github.com/gravitational/teleport/pull/46799) is going to change the default to false and it will be released in v17.0.0.

Fortunately thanks to the already existing `ssh.noResume` we have an established pattern for selecting flags to pass to `tsh ssh` based on the config of Connect. v14 doesn't have that config option, so I'm not backporting to v14.

changelog: Added a new config option in Teleport Connect to control SSH agent forwarding (`ssh.forwardAgent`); starting in Teleport Connect v17, this option will be disabled by default