### PR TITLE
Disable agent forwarding by default in Connect

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -478,7 +478,7 @@ Below is the list of the supported config properties.
 | `keymap.openSearchBar`        | `Command+K` on macOS<br/>`Ctrl+Shift+K` on Windows/Linux                                                             | Shortcut to open the search bar.                                                                           |
 | `headless.skipConfirm`        | false                                                                                                                | Skips the confirmation prompt for Headless WebAuthn approval and instead prompts for WebAuthn immediately. |
 | `ssh.noResume`                | false                                                                                                                | Disables SSH connection resumption.                                                                        |
-| `ssh.forwardAgent`            | true                                                                                                                 | Enables agent forwarding.                                                                                  |
+| `ssh.forwardAgent`            | false                                                                                                                | Enables agent forwarding.                                                                                  |
 
 <Admonition
   type="note"

--- a/web/packages/teleterm/src/services/config/appConfigSchema.ts
+++ b/web/packages/teleterm/src/services/config/appConfigSchema.ts
@@ -190,7 +190,7 @@ export const createAppConfigSchema = (settings: RuntimeSettings) => {
       .describe('Disables SSH connection resumption.'),
     'ssh.forwardAgent': z
       .boolean()
-      .default(true)
+      .default(false)
       .describe(
         "Enables agent forwarding when connecting to SSH nodes. It's the equivalent of the forward-agent flag in tsh ssh."
       ),


### PR DESCRIPTION
Building on #46798, this PR disables agent forwarding by default for reasons described in its parent PR.

changelog: Disabled SSH agent forwarding in Teleport Connect by default; use the `ssh.forwardAgent` config option to bring back previous behavior