### PR TITLE
[v16] [kube] return Kubernetes API errors when using Websocket API

### DIFF
--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -34,6 +34,7 @@ import (
 	"golang.org/x/exp/maps"
 	authzapi "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/rest"
@@ -212,7 +213,11 @@ current-context: foo
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
 					},
-					kubeCluster:        mustCreateKubernetesClusterV3(t, "foo"),
+					kubeCluster: mustCreateKubernetesClusterV3(t, "foo"),
+					kubeClusterVersion: &apimachineryversion.Info{
+						Major: "1",
+						Minor: "20",
+					},
 					rbacSupportedTypes: rbacSupportedTypes,
 				},
 				"bar": {
@@ -221,6 +226,10 @@ current-context: foo
 						transportConfig: &transport.Config{},
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
+					},
+					kubeClusterVersion: &apimachineryversion.Info{
+						Major: "1",
+						Minor: "20",
 					},
 					kubeCluster:        mustCreateKubernetesClusterV3(t, "bar"),
 					rbacSupportedTypes: rbacSupportedTypes,
@@ -231,6 +240,10 @@ current-context: foo
 						transportConfig: &transport.Config{},
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
+					},
+					kubeClusterVersion: &apimachineryversion.Info{
+						Major: "1",
+						Minor: "20",
 					},
 					kubeCluster:        mustCreateKubernetesClusterV3(t, "baz"),
 					rbacSupportedTypes: rbacSupportedTypes,
@@ -257,6 +270,10 @@ current-context: foo
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
 					},
+					kubeClusterVersion: &apimachineryversion.Info{
+						Major: "1",
+						Minor: "20",
+					},
 					kubeCluster:        mustCreateKubernetesClusterV3(t, teleClusterName),
 					rbacSupportedTypes: rbacSupportedTypes,
 				},
@@ -275,6 +292,10 @@ current-context: foo
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
 					},
+					kubeClusterVersion: &apimachineryversion.Info{
+						Major: "1",
+						Minor: "20",
+					},
 					kubeCluster:        mustCreateKubernetesClusterV3(t, "foo"),
 					rbacSupportedTypes: rbacSupportedTypes,
 				},
@@ -285,6 +306,10 @@ current-context: foo
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
 					},
+					kubeClusterVersion: &apimachineryversion.Info{
+						Major: "1",
+						Minor: "20",
+					},
 					kubeCluster:        mustCreateKubernetesClusterV3(t, "bar"),
 					rbacSupportedTypes: rbacSupportedTypes,
 				},
@@ -294,6 +319,10 @@ current-context: foo
 						transportConfig: &transport.Config{},
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
+					},
+					kubeClusterVersion: &apimachineryversion.Info{
+						Major: "1",
+						Minor: "20",
 					},
 					kubeCluster:        mustCreateKubernetesClusterV3(t, "baz"),
 					rbacSupportedTypes: rbacSupportedTypes,

--- a/lib/kube/proxy/roundtrip.go
+++ b/lib/kube/proxy/roundtrip.go
@@ -259,23 +259,7 @@ func (s *SpdyRoundTripper) NewConnection(resp *http.Response) (httpstream.Connec
 	connectionHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderConnection))
 	upgradeHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderUpgrade))
 	if (resp.StatusCode != http.StatusSwitchingProtocols) || !strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) || !strings.Contains(upgradeHeader, strings.ToLower(streamspdy.HeaderSpdy31)) {
-		defer resp.Body.Close()
-		responseError := ""
-		responseErrorBytes, err := io.ReadAll(resp.Body)
-		if err != nil {
-			responseError = "unable to read error from server response"
-		} else {
-			// TODO: I don't belong here, I should be abstracted from this class
-			if obj, _, err := statusCodecs.UniversalDecoder().Decode(responseErrorBytes, nil, &metav1.Status{}); err == nil {
-				if status, ok := obj.(*metav1.Status); ok {
-					return nil, &apierrors.StatusError{ErrStatus: *status}
-				}
-			}
-			responseError = string(responseErrorBytes)
-			responseError = strings.TrimSpace(responseError)
-		}
-
-		return nil, fmt.Errorf("unable to upgrade connection: %s", responseError)
+		return nil, trace.Wrap(extractKubeAPIStatusFromReq(resp))
 	}
 
 	return streamspdy.NewClientConnectionWithPings(s.conn, s.pingPeriod)
@@ -291,4 +275,25 @@ func init() {
 	statusScheme.AddUnversionedTypes(metav1.SchemeGroupVersion,
 		&metav1.Status{},
 	)
+}
+
+// extractKubeAPIStatusFromReq extracts the status from the response body and returns it as an error.
+func extractKubeAPIStatusFromReq(rsp *http.Response) error {
+	defer func() {
+		_ = rsp.Body.Close()
+	}()
+	responseError := ""
+	responseErrorBytes, err := io.ReadAll(rsp.Body)
+	if err != nil {
+		responseError = "unable to read error from server response"
+	} else {
+		if obj, _, err := statusCodecs.UniversalDecoder().Decode(responseErrorBytes, nil, &metav1.Status{}); err == nil {
+			if status, ok := obj.(*metav1.Status); ok {
+				return &apierrors.StatusError{ErrStatus: *status}
+			}
+		}
+		responseError = string(responseErrorBytes)
+		responseError = strings.TrimSpace(responseError)
+	}
+	return fmt.Errorf("unable to upgrade connection: %s", responseError)
 }

--- a/lib/kube/proxy/roundtrip_websocket.go
+++ b/lib/kube/proxy/roundtrip_websocket.go
@@ -103,6 +103,9 @@ func (w *WebsocketRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 
 	wsConn, wsResp, err := wsDialer.DialContext(w.ctx, clone.URL.String(), clone.Header)
 	if err != nil {
+		if wsResp != nil {
+			return nil, trace.Wrap(extractKubeAPIStatusFromReq(wsResp))
+		}
 		return nil, &httpstream.UpgradeFailureError{Cause: err}
 	}
 	w.conn = wsConn


### PR DESCRIPTION
Backport #46796 to branch/v16

changelog: Fixes a regression where Teleport swallowed Kubernetes API errors when using kubectl exec with a Kubernetes cluster newer than v1.30.0.
