### PR TITLE
[v16] [kube] support SPDY over websocket protocol for PortForward

### DIFF
--- a/fixtures/ci-teleport-rbac/ci-teleport.yaml
+++ b/fixtures/ci-teleport-rbac/ci-teleport.yaml
@@ -47,7 +47,7 @@ rules:
   resourceNames: ["test-pod"]
 - apiGroups: [""]
   resources: ["pods/portforward"]
-  verbs: ["create"]
+  verbs: ["create", "get"]
   resourceNames: ["test-pod"]
 - apiGroups: [""]
   resources: ["pods/ephemeralcontainers"]


### PR DESCRIPTION
Backport #46663 to branch/v16

changelog: Add support for Kubernetes SPDY over Websocket Protocols for PortForward.
