### PR TITLE
Fix interface check for clusterNameExecutor

### DIFF
--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -1306,6 +1306,8 @@ type clusterNameGetter interface {
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
 }
 
+var _ executor[types.ClusterName, clusterNameGetter] = clusterNameExecutor{}
+
 type autoUpdateConfigExecutor struct{}
 
 func (autoUpdateConfigExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]*autoupdate.AutoUpdateConfig, error) {


### PR DESCRIPTION
In https://github.com/gravitational/teleport/pull/46661 PR interface check for clusterNameExecutor was replaced by mistake