### PR TITLE
Update the docs release plan

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-plan-docs.md
+++ b/.github/ISSUE_TEMPLATE/test-plan-docs.md
@@ -5,10 +5,15 @@ title: "Teleport X Docs Test Plan"
 labels: testplan
 ---
 
-Perform the following checks on the Teleport documentation whenever we release a
-new major version of Teleport:
+Perform the following checks on the Teleport documentation whenever we roll out
+a new major version of Teleport on Teleport Cloud. Use `/docs/upcoming-releases`
+to determine the rollout date.
 
 ## Is the docs site configuration accurate?
+
+> [!IMPORTANT] 
+> **Do not merge the new docs site configuration** before we roll out a new
+> major version to Teleport Enterprise (Cloud).
 
 - [ ] Verify the latest version in `gravitational/docs/config.json`
 


### PR DESCRIPTION
Indicate that we will update the Teleport version of the docs site when we roll out a new major version of Teleport Enterprise (Cloud).

This way, since we roll out new major versions to Teleport Enterprise (Cloud) a few weeks after we release a new Teleport major version, Teleport Enterprise (Cloud) customers will not be confused when they visit the Teleport docs site when we release a new major version.

With this change, self-hosted Teleport Enterprise customers on the latest Teleport version will see an outdated version of the docs site as the default. However, this is less of a problem than the reverse situation since we do not expect self-hosted customers to update right away.