### PR TITLE
docs: update ssh keys scan tctl editing example

### DIFF
--- a/docs/pages/admin-guides/teleport-policy/integrations/ssh-keys-scan.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/ssh-keys-scan.mdx
@@ -84,12 +84,15 @@ from Teleport Auth Service.
 
 To enable SSH Key Scanning, you need to configure the Teleport cluster to scan for SSH Authorized Keys.
 
-To enable the SSH Key Scanning feature, edit the Teleport Access Graph configuration file and set the
-`spec.secrets_scan_config` field to `enabled` as shown below:
+To enable the SSH Key Scanning feature, edit the Teleport Access Graph configuration file: 
 
-```bash
+```code
 $ tctl edit access_graph_settings
+```
 
+Set the `spec.secrets_scan_config` field to `enabled` as shown below:
+
+```yaml
 kind: access_graph_settings
 metadata:
   name: access-graph-settings


### PR DESCRIPTION
This updates `tctl edit` example to similar examples. If we put the contents in the the `code` block that causes issues when trying to copy and paste just the command.