### PR TITLE
Migrate lib/backend to slog

### DIFF
--- a/lib/backend/buffer.go
+++ b/lib/backend/buffer.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"sort"
 	"sync"
 	"time"
@@ -29,10 +30,10 @@ import (
 	radix "github.com/armon/go-radix"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 type bufferConfig struct {
@@ -85,7 +86,7 @@ func BufferClock(c clockwork.Clock) BufferOption {
 // of predefined size, that is capable of fan-out of the backend events.
 type CircularBuffer struct {
 	sync.Mutex
-	*log.Entry
+	logger       *slog.Logger
 	cfg          bufferConfig
 	init, closed bool
 	watchers     *watcherTree
@@ -103,9 +104,7 @@ func NewCircularBuffer(opts ...BufferOption) *CircularBuffer {
 		opt(&cfg)
 	}
 	return &CircularBuffer{
-		Entry: log.WithFields(log.Fields{
-			teleport.ComponentKey: teleport.ComponentBuffer,
-		}),
+		logger:   slog.With(teleport.ComponentKey, teleport.ComponentBuffer),
 		cfg:      cfg,
 		watchers: newWatcherTree(),
 	}
@@ -157,7 +156,7 @@ func (c *CircularBuffer) SetInit() {
 	})
 
 	for _, watcher := range watchersToDelete {
-		c.Warningf("Closing %v, failed to send init event.", watcher)
+		c.logger.WarnContext(context.Background(), "Closing watcher, failed to send init event.", "watcher", logutils.StringerAttr(watcher))
 		watcher.closeWatcher()
 		c.watchers.rm(watcher)
 	}
@@ -213,7 +212,7 @@ func (c *CircularBuffer) fanOutEvent(r Event) {
 	})
 
 	for _, watcher := range watchersToDelete {
-		c.Warningf("Closing %v, buffer overflow at %v (backlog=%v).", watcher, len(watcher.eventsC), watcher.backlogLen())
+		c.logger.WarnContext(context.Background(), "Closing watcher, buffer overflow", "watcher", logutils.StringerAttr(watcher), "events", len(watcher.eventsC), "backlog", watcher.backlogLen())
 		watcher.closeWatcher()
 		c.watchers.rm(watcher)
 	}
@@ -275,10 +274,10 @@ func (c *CircularBuffer) NewWatcher(ctx context.Context, watch Watch) (Watcher, 
 		cancel:   cancel,
 		capacity: watch.QueueSize,
 	}
-	c.Debugf("Add %v.", w)
+	c.logger.DebugContext(ctx, "Adding watcher", "watcher", logutils.StringerAttr(w))
 	if c.init {
 		if ok := w.init(); !ok {
-			c.Warningf("Closing %v, failed to send init event.", w)
+			c.logger.WarnContext(ctx, "Closing watcher, failed to send init event.", "watcher", logutils.StringerAttr(w))
 			return nil, trace.BadParameter("failed to send init event")
 		}
 	}
@@ -287,16 +286,17 @@ func (c *CircularBuffer) NewWatcher(ctx context.Context, watch Watch) (Watcher, 
 }
 
 func (c *CircularBuffer) removeWatcherWithLock(watcher *BufferWatcher) {
+	ctx := context.Background()
 	c.Lock()
 	defer c.Unlock()
 	if watcher == nil {
-		c.Warningf("Internal logic error: %v.", trace.DebugReport(trace.BadParameter("empty watcher")))
+		c.logger.WarnContext(ctx, "Internal logic error, empty watcher")
 		return
 	}
-	c.Debugf("Removing watcher %v (%p) via external close.", watcher.Name, watcher)
+	c.logger.DebugContext(ctx, "Removing watcher via external close.", "watcher", logutils.StringerAttr(watcher))
 	found := c.watchers.rm(watcher)
 	if !found {
-		c.Debugf("Could not find watcher %v.", watcher.Name)
+		c.logger.DebugContext(ctx, "Could not find watcher", "watcher", watcher.Name)
 	}
 }
 

--- a/lib/backend/dynamo/atomicwrite.go
+++ b/lib/backend/dynamo/atomicwrite.go
@@ -201,7 +201,7 @@ TxnLoop:
 			var txnErr *types.TransactionCanceledException
 			if !errors.As(err, &txnErr) {
 				if s := err.Error(); strings.Contains(s, "AccessDenied") && strings.Contains(s, "dynamodb:ConditionCheckItem") {
-					b.Warnf("AtomicWrite failed with error that may indicate dynamodb is missing the required dynamodb:ConditionCheckItem permission (this permission is now required for teleport v16 and later). Consider updating your IAM policy to include this permission.  Original error: %v", err)
+					b.logger.WarnContext(ctx, "AtomicWrite failed with error that may indicate dynamodb is missing the required dynamodb:ConditionCheckItem permission (this permission is now required for teleport v16 and later). Consider updating your IAM policy to include this permission.", "error", err)
 					return "", trace.Errorf("teleport is missing required AWS permission dynamodb:ConditionCheckItem, please contact your administrator to update permissions")
 				}
 				return "", trace.Errorf("unexpected error during atomic write: %v", err)
@@ -258,7 +258,7 @@ TxnLoop:
 		if n := i + 1; n > 2 {
 			// if we retried more than once, txn experienced non-trivial conflict and we should warn about it. Infrequent warnings of this kind
 			// are nothing to be concerned about, but high volumes may indicate that an automatic process is creating excessive conflicts.
-			b.Warnf("AtomicWrite retried %d times due to dynamodb transaction conflicts. Some conflict is expected, but persistent conflict warnings may indicate an unhealthy state.", n)
+			b.logger.WarnContext(ctx, "AtomicWrite retried due to dynamodb transaction conflicts. Some conflict is expected, but persistent conflict warnings may indicate an unhealthy state.", "retry_attempts", n)
 		}
 
 		if !includesPut {
@@ -274,7 +274,7 @@ TxnLoop:
 		keys = append(keys, ca.Key)
 	}
 
-	b.Errorf("AtomicWrite failed, dynamodb transaction experienced too many conflicts. keys=%s", bytes.Join(keys, []byte(",")))
+	b.logger.ErrorContext(ctx, "AtomicWrite failed, dynamodb transaction experienced too many conflicts", "keys", bytes.Join(keys, []byte(",")))
 
 	return "", trace.Errorf("dynamodb transaction experienced too many conflicts")
 }

--- a/lib/backend/dynamo/dynamodbbk_test.go
+++ b/lib/backend/dynamo/dynamodbbk_test.go
@@ -21,6 +21,7 @@ package dynamo
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -35,10 +36,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
 	"github.com/gravitational/teleport/lib/utils"
@@ -218,7 +219,7 @@ func TestCreateTable(t *testing.T) {
 				expectedProvisionedthroughput: tc.expectedProvisionedThroughput,
 			}
 			b := &Backend{
-				Entry: log.NewEntry(log.New()),
+				logger: slog.With(teleport.ComponentKey, BackendName),
 				Config: Config{
 					BillingMode:        tc.billingMode,
 					ReadCapacityUnits:  int64(tc.readCapacityUnits),

--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 type shardEvent struct {
@@ -48,7 +49,7 @@ func (b *Backend) asyncPollStreams(ctx context.Context) error {
 		Max:  b.RetryPeriod,
 	})
 	if err != nil {
-		b.Errorf("Bad retry parameters: %v", err)
+		b.logger.ErrorContext(ctx, "Bad retry parameters", "error", err)
 		return trace.Wrap(err)
 	}
 
@@ -61,14 +62,14 @@ func (b *Backend) asyncPollStreams(ctx context.Context) error {
 			if b.isClosed() {
 				return trace.Wrap(err)
 			}
-			b.Errorf("Poll streams returned with error: %v.", err)
+			b.logger.ErrorContext(ctx, "Poll streams returned with error", "error", err)
 		}
-		b.Debugf("Reloading %v.", retry)
+		b.logger.DebugContext(ctx, "Reloading", "retry_duration", retry.Duration())
 		select {
 		case <-retry.After():
 			retry.Inc()
 		case <-ctx.Done():
-			b.Debugf("Closed, returning from asyncPollStreams loop.")
+			b.logger.DebugContext(ctx, "Closed, returning from asyncPollStreams loop.")
 			return nil
 		}
 	}
@@ -82,7 +83,7 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	b.Debugf("Found latest event stream %v.", aws.ToString(streamArn))
+	b.logger.DebugContext(ctx, "Found latest event stream", "stream_arn", aws.ToString(streamArn))
 
 	set := make(map[string]struct{})
 	eventsC := make(chan shardEvent)
@@ -94,7 +95,7 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 			return false
 		}
 		if _, ok := set[aws.ToString(shard.ParentShardId)]; ok {
-			b.Tracef("Skipping child shard: %s, still polling parent %s", sid, aws.ToString(shard.ParentShardId))
+			b.logger.Log(ctx, logutils.TraceLevel, "Skipping child shard, still polling parent", "child_shard_id", sid, "parent_shard_id", aws.ToString(shard.ParentShardId))
 			// still processing parent
 			return false
 		}
@@ -120,7 +121,7 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 				continue
 			}
 			shardID := aws.ToString(shards[i].ShardId)
-			b.Tracef("Adding active shard %v.", shardID)
+			b.logger.Log(ctx, logutils.TraceLevel, "Adding active shard", "shard_id", shardID)
 			set[shardID] = struct{}{}
 			go b.asyncPollShard(ctx, streamArn, shards[i], eventsC, initC)
 			started++
@@ -161,15 +162,15 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 				if event.shardID == "" {
 					// empty shard IDs in err-variant events are programming bugs and will lead to
 					// invalid state.
-					b.WithError(err).Warnf("Forcing watch system reset due to empty shard ID on error (this is a bug)")
+					b.logger.WarnContext(ctx, "Forcing watch system reset due to empty shard ID on error (this is a bug)", "error", err)
 					return trace.BadParameter("empty shard ID")
 				}
 				delete(set, event.shardID)
 				if !errors.Is(event.err, io.EOF) {
-					b.Debugf("Shard ID %v closed with error: %v, resetting buffers.", event.shardID, event.err)
+					b.logger.DebugContext(ctx, "Shard closed with error, resetting buffers.", "shard_id", event.shardID, "error", event.err)
 					return trace.Wrap(event.err)
 				}
-				b.Tracef("Shard ID %v exited gracefully.", event.shardID)
+				b.logger.Log(ctx, logutils.TraceLevel, "Shard exited gracefully.", "shard_id", event.shardID)
 			} else {
 				b.buf.Emit(event.events...)
 			}
@@ -178,7 +179,7 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 				return trace.Wrap(err)
 			}
 		case <-ctx.Done():
-			b.Tracef("Context is closing, returning.")
+			b.logger.Log(ctx, logutils.TraceLevel, "Context is closing, returning.")
 			return nil
 		}
 	}
@@ -231,18 +232,18 @@ func (b *Backend) pollShard(ctx context.Context, streamArn *string, shard stream
 				return convertError(err)
 			}
 			if len(out.Records) > 0 {
-				b.Tracef("Got %v new stream shard records.", len(out.Records))
+				b.logger.Log(ctx, logutils.TraceLevel, "Got new stream shard records.", "num_records", len(out.Records))
 			}
 			if len(out.Records) == 0 {
 				if out.NextShardIterator == nil {
-					b.Tracef("Shard is closed: %v.", aws.ToString(shard.ShardId))
+					b.logger.Log(ctx, logutils.TraceLevel, "Shard is closed", "shard_id", aws.ToString(shard.ShardId))
 					return io.EOF
 				}
 				iterator = out.NextShardIterator
 				continue
 			}
 			if out.NextShardIterator == nil {
-				b.Tracef("Shard is closed: %v.", aws.ToString(shard.ShardId))
+				b.logger.Log(ctx, logutils.TraceLevel, "Shard is closed", "shard_id", aws.ToString(shard.ShardId))
 				return io.EOF
 			}
 			events := make([]backend.Event, 0, len(out.Records))
@@ -354,7 +355,7 @@ func (b *Backend) asyncPollShard(ctx context.Context, streamArn *string, shard s
 		select {
 		case eventsC <- shardEvent{err: err, shardID: shardID}:
 		case <-ctx.Done():
-			b.Debugf("Context is closing, returning")
+			b.logger.DebugContext(ctx, "Context is closing, returning")
 			return
 		}
 	}()

--- a/lib/backend/firestore/firestorebk_test.go
+++ b/lib/backend/firestore/firestorebk_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"reflect"
@@ -36,7 +37,6 @@ import (
 	"cloud.google.com/go/firestore/apiv1/firestorepb"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/option"
@@ -421,7 +421,7 @@ func TestDeleteDocuments(t *testing.T) {
 
 			b := &Backend{
 				svc:           client,
-				Entry:         utils.NewLoggerForTests().WithFields(logrus.Fields{teleport.ComponentKey: BackendName}),
+				logger:        slog.With(teleport.ComponentKey, BackendName),
 				clock:         clockwork.NewFakeClock(),
 				clientContext: ctx,
 				clientCancel:  cancel,

--- a/lib/backend/helpers.go
+++ b/lib/backend/helpers.go
@@ -21,11 +21,13 @@ package backend
 import (
 	"bytes"
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
+
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 const (
@@ -209,7 +211,7 @@ func RunWhileLocked(ctx context.Context, cfg RunWhileLockedConfig, fn func(conte
 			case <-cfg.Backend.Clock().After(refreshAfter):
 				if err := lock.resetTTL(ctx, cfg.Backend); err != nil {
 					cancelFunction()
-					log.Errorf("%v", err)
+					slog.ErrorContext(ctx, "failed to reset lock ttl", "error", err, "lock", logutils.StringerAttr(lock.key))
 					return
 				}
 			case <-stopRefresh:

--- a/lib/backend/kubernetes/kubernetes.go
+++ b/lib/backend/kubernetes/kubernetes.go
@@ -21,12 +21,12 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"sync"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -172,7 +172,7 @@ func NewSharedWithClient(restClient kubernetes.Interface) (*Backend, error) {
 	ident := os.Getenv(ReleaseNameEnv)
 	if ident == "" {
 		ident = "teleport"
-		log.Warnf("Var %q is not set, falling back to default identifier %q for shared store.", ReleaseNameEnv, ident)
+		slog.WarnContext(context.Background(), "Var RELEASE_NAME is not set, falling back to default identifier teleport for shared store.")
 	}
 
 	return NewWithConfig(

--- a/lib/backend/lite/periodic.go
+++ b/lib/backend/lite/periodic.go
@@ -39,7 +39,7 @@ func (l *Backend) runPeriodicOperations() {
 		select {
 		case <-l.ctx.Done():
 			if err := l.closeDatabase(); err != nil {
-				l.Warningf("Error closing database: %v", err)
+				l.logger.WarnContext(l.ctx, "Error closing database", "error", err)
 			}
 			return
 		case <-t.C:
@@ -49,19 +49,19 @@ func (l *Backend) runPeriodicOperations() {
 				// or is closing, downgrade the log to debug
 				// to avoid polluting logs in production
 				if trace.IsConnectionProblem(err) {
-					l.Debugf("Failed to run remove expired keys: %v", err)
+					l.logger.DebugContext(l.ctx, "Failed to run remove expired keys", "error", err)
 				} else {
-					l.Warningf("Failed to run remove expired keys: %v", err)
+					l.logger.DebugContext(l.ctx, "Failed to run remove expired keys", "error", err)
 				}
 			}
 			if !l.EventsOff {
 				err = l.removeOldEvents()
 				if err != nil {
-					l.Warningf("Failed to run remove old events: %v", err)
+					l.logger.WarnContext(l.ctx, "Failed to run remove old events", "error", err)
 				}
 				rowid, err = l.pollEvents(rowid)
 				if err != nil {
-					l.Warningf("Failed to run poll events: %v", err)
+					l.logger.WarnContext(l.ctx, "Failed to run poll events", "error", err)
 				}
 			}
 		}
@@ -149,7 +149,7 @@ func (l *Backend) pollEvents(rowid int64) (int64, error) {
 		if err != nil {
 			return rowid, trace.Wrap(err)
 		}
-		l.Debugf("Initialized event ID iterator to %v", rowid)
+		l.logger.DebugContext(l.ctx, "Initialized event ID iterator", "event_id", rowid)
 		l.buf.SetInit()
 	}
 

--- a/lib/backend/report_test.go
+++ b/lib/backend/report_test.go
@@ -19,6 +19,7 @@
 package backend
 
 import (
+	"context"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -60,7 +61,7 @@ func TestReporterTopRequestsLimit(t *testing.T) {
 
 	// Run through 1000 unique keys.
 	for i := 0; i < 1000; i++ {
-		r.trackRequest(types.OpGet, []byte(strconv.Itoa(i)), nil)
+		r.trackRequest(context.Background(), types.OpGet, []byte(strconv.Itoa(i)), nil)
 	}
 
 	// Now the metric should have only 10 of the keys above.


### PR DESCRIPTION
Converts all cluster state backend logging from logrus to slog. Additionally, the Firestore events backend was also migrated because it imports backend/firestore and some of the changes would've broken the build otherwise.