### PR TITLE
[v16] Remove docs URLs from code fence comments

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -1110,9 +1110,6 @@ proxy_templates:
   #
   # Query by predicate expression similar to tsh ls --query.
   # Has priority over search but will be ignored if a host is provided.
-  #
-  # See https://goteleport.com/docs/reference/predicate-language/#resource-filtering for
-  # predicate expression examples.
   query: "labels.env == $1"
 
   # Optional fuzzy search terms to resolve the target host with.
@@ -1125,6 +1122,12 @@ proxy_templates:
 # match takes effect.
 - template: ...
 ```
+
+In the configuration above, `query` accepts an predicate expression.  This has
+priority over search but will be ignored if a host is provided.  See the
+[predicate language
+documentation](../reference/predicate-language.mdx#resource-filtering for
+predicate expression examples.
 
 `tsh -J {{proxy}} ssh` and `tsh -J {{proxy}} proxy ssh` will attempt to match the
 host server address `%h:%p` with the configured templates. For each replace rule set,

--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -2,9 +2,6 @@ teleport:
 
     # Configuration for the storage back-end used for the cluster state and the
     # audit log. Several back-end types are supported.
-    # See the "Storage backends" (https://goteleport.com/docs/setup/reference/backends)
-    # section of the documentation to learn how to configure
-    # DynamoDB, S3, etcd, and other highly available back-ends.
     storage:
         # By default teleport uses a SQLite database in the `data_dir`
         # directory on a local filesystem
@@ -26,8 +23,6 @@ teleport:
 
         # Use this setting to configure teleport to store the recorded sessions
         # in an AWS S3 bucket or use GCP Storage with 'gs://'.
-        # See the S3 section on "Storage backends" for more information
-        # (https://goteleport.com/docs/setup/reference/backends/#s3).
         audit_sessions_uri: 's3://example.com/path/to/bucket?region=us-east-1'
 
         # SQLite-specific section:
@@ -155,7 +150,6 @@ auth_service:
 
         # Sets whether local auth is enabled alongside any other authentication
         # type. Default is true. local_auth must be 'false' for FedRAMP / FIPS.
-        # (https://goteleport.com/docs/enterprise/ssh-kubernetes-fedramp/)
         #local_auth: true
 
         # Enforce per-session MFA or PIV-hardware key restrictions on user login sessions.
@@ -181,10 +175,8 @@ auth_service:
         # Sets the default authentication connector for the cluster:
         # - 'local' for local authentication (password, WebAuthn, etc.)
         # - 'passwordless' for passwordless authentication
-        #   (http://goteleport.com/docs/access-controls/guides/passwordless/#optional-enable-passwordless-by-default)
         # - 'headless' for headless authentication
-        #   (http://goteleport.com/docs/access-controls/guides/headless-login/#optional-enable-passwordless-by-default)
-        # - A specific SSO connector name - see https://goteleport.com/docs/access-controls/sso/ for details.
+        # - A specific SSO connector name
         # Defaults to "local".
         #connector_name: local
 
@@ -245,14 +237,11 @@ auth_service:
 
         # Locking mode determines how to apply lock views locally available to
         # a Teleport component; can be strict or best_effort.
-        # See the "Locking mode" section for more details
-        # (https://goteleport.com/docs/access-controls/guides/locking/#locking-mode).
         locking_mode: best_effort
 
         # Device Trust configures Teleport's behavior in regards to trusted
         # devices.
         # Device Trust is a Teleport Enterprise feature.
-        # (https://goteleport.com/docs/access-controls/guides/device-trust/)
         device_trust:
           # 'mode' is the cluster-wide device trust mode.
           # The following values are supported:
@@ -308,9 +297,7 @@ auth_service:
 
     # This setting determines if a Teleport proxy performs strict host key
     # checks.
-    # Only applicable if session_recording=proxy, see "Recording Proxy Mode"
-    # for details
-    # (https://goteleport.com/docs/architecture/proxy/#recording-proxy-mode).
+    # Only applicable if session_recording=proxy
     proxy_checks_host_keys: yes
 
     # Determines if sessions to cluster resources are forcefully terminated after

--- a/docs/pages/includes/config-reference/database-config.yaml
+++ b/docs/pages/includes/config-reference/database-config.yaml
@@ -5,8 +5,6 @@ db_service:
   # Matchers for database resources created with "tctl create" command or by the
   # discovery service.
   resources:
-    # See "Database labels reference" (https://goteleport.com/docs/database-access/reference/labels/)
-    # to learn more on database labels.
   - labels:
       "*": "*"
     # Optional AWS role that the Database Service will assume to access the

--- a/docs/pages/includes/config-reference/desktop-config.yaml
+++ b/docs/pages/includes/config-reference/desktop-config.yaml
@@ -112,10 +112,6 @@ windows_desktop_service:
   # Rules for applying labels to Windows hosts based on regular expressions
   # matched against the host name. If multiple rules match, the desktop will
   # get the union of all matching labels.
-  #
-  # The rules for matching static hosts and discovered hosts
-  # are slightly different. See https://goteleport.com/docs/desktop-access/rbac/
-  # for details.
   host_labels:
   - match: '^.*\.dev\.example\.com'
     labels:

--- a/docs/pages/includes/config-reference/instance-wide.yaml
+++ b/docs/pages/includes/config-reference/instance-wide.yaml
@@ -11,8 +11,6 @@ teleport:
     nodename: graviton
 
     # Data directory where Teleport daemon keeps its data.
-    # See "Storage backends" for more details
-    # (https://goteleport.com/docs/setup/reference/backends/).
     data_dir: /var/lib/teleport
 
     # PID file for Teleport process
@@ -32,11 +30,6 @@ teleport:
 
     # join_params are parameters to set when joining a cluster via
     # EC2, IAM or a token.
-    #
-    # EC2 join method documentation:
-    # https://goteleport.com/docs/setup/guides/joining-nodes-aws-ec2/
-    # IAM join method documentation:
-    # https://goteleport.com/docs/setup/guides/joining-nodes-aws-iam/
     join_params:
         # When `method` is set to "token", it is the equivalent to using `auth_token` above.
         # You should only use either auth_token or join_params.
@@ -67,9 +60,6 @@ teleport:
     # ca_pin:
     #   - /var/lib/teleport/pin1
     #   - /var/lib/teleport/pin2
-    #
-    # See the documentation on using CA pins:
-    # https://goteleport.com/docs/management/join-services-to-your-cluster/join-token/#connecting-directly-to-the-auth-service.
     ca_pin:
       "sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"
 
@@ -81,8 +71,6 @@ teleport:
 
     # Teleport provides HTTP endpoints for monitoring purposes. They are
     # disabled by default but you can enable them using the diagnosis address.
-    # See the Teleport metrics reference:
-    # https://goteleport.com/docs/management/diagnostics/metrics/
     diag_addr: "127.0.0.1:3000"
 
     # Only use one of auth_server or proxy_server.

--- a/docs/pages/includes/config-reference/proxy-service.yaml
+++ b/docs/pages/includes/config-reference/proxy-service.yaml
@@ -55,10 +55,8 @@ proxy_service:
     # proxies behind a load balancer, this name must point to the load balancer
     # If application access is enabled, public_addr is used to write correct
     # redirects
-    # (https://goteleport.com/docs/application-access/guides/connecting-apps/#start-authproxy-service).
     # If database access is enabled, Database clients will connect to the Proxy
     # over this hostname
-    # (https://goteleport.com/docs/database-access/architecture/#database-client-to-proxy).
     public_addr: proxy.example.com:3080
 
     # The DNS name of the proxy SSH endpoint as accessible by cluster clients.

--- a/docs/pages/includes/config-reference/ssh-service.yaml
+++ b/docs/pages/includes/config-reference/ssh-service.yaml
@@ -10,16 +10,12 @@ ssh_service:
     # bypassing a Teleport proxy.
     public_addr: node.example.com:3022
 
-    # See the explanation of labels in the "Labels" page
-    # (https://goteleport.com/docs/setup/admin/labels).
     labels:
         role: leader
         type: postgres
 
     # List of the commands to periodically execute. Their output will be used
     # as node labels.
-    # See the "Labels" page for more information and more examples
-    # (https://goteleport.com/docs/setup/admin/labels).
     commands:
     # this command will add a label 'arch=x86_64' to a node
     - name: arch
@@ -35,7 +31,6 @@ ssh_service:
     disable_create_host_user: true
 
     # Enhanced Session Recording
-    # see https://goteleport.com/docs/features/enhanced-session-recording/
     enhanced_recording:
        # Enable or disable enhanced auditing for this node. Default value:
        # false.
@@ -58,8 +53,7 @@ ssh_service:
        # cgroups will be placed. Default value: /teleport
        root_path: /teleport
 
-    # Configures PAM integration. See our PAM guide for more details
-    # (https://goteleport.com/docs/features/ssh-pam/).
+    # Configures the PAM integration.
     pam:
         # "no" by default
         enabled: yes

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -97,6 +97,16 @@ These settings apply to any `teleport` instance:
 (!docs/pages/includes/config-reference/instance-wide.yaml!)
 ```
 
+Further reading:
+- [Joining Services to a
+  Cluster](../enroll-resources/agents/join-services-to-your-cluster.mdx):
+  Available join methods to help you configure `join_params`.
+- [Using a CA
+  Pin](../enroll-resources/agents/join-services-to-your-cluster/join-token.mdx):
+  When to assign a value to `ca_pin`.
+- [Teleport Metrics Reference](monitoring/monitoring.mdx): Data to collect using
+  `diag_addr`.
+
 ### Proxy Service
 
 These settings apply to the Teleport Proxy Service:
@@ -123,6 +133,23 @@ to specify these configuration settings.
 (!docs/pages/includes/config-reference/auth-service.yaml!)
 ```
 
+Further reading:
+- [Storage Backends](backends.mdx) reference: instructions on configuring DynamoDB, S3, etcd, and other highly available
+  backends.
+- [Passwordless](../admin-guides/access-controls/guides/passwordless.mdx): More
+  information about the `passwordless` authentication option.
+- [Headless
+  WebAuthn](../admin-guides/access-controls/guides/headless.mdx): The
+  `headless` authentication option.
+- [Single Sign-On](../admin-guides/access-controls/sso.mdx): Configuring SSO
+  so you can configure Teleport to use a specific SSO authentication connector.
+- [Locking](../admin-guides/access-controls/guides/locking.mdx): Configuring the
+  `locking_mode` option.
+- [Device Trust](../admin-guides/access-controls/device-trust.mdx): Configuring
+  the `device_trust` section.
+- [Recording Proxy Mode](architecture/session-recording.mdx): If you configure
+  Recording Proxy Mode, consider enabling `proxy_checks_host_keys`.
+
 ### SSH Service
 
 These settings apply to the Teleport SSH Service:
@@ -130,6 +157,13 @@ These settings apply to the Teleport SSH Service:
 ```yaml
 (!docs/pages/includes/config-reference/ssh-service.yaml!)
 ```
+
+Further reading:
+- [Enhanced Session
+  Recording](../enroll-resources/server-access/guides/bpf-session-recording.mdx):
+  Configuring `enhanced_recording`.
+- [PAM Integration](../enroll-resources/server-access/guides/ssh-pam.mdx):
+  Configuring the `pam` section.
 
 ### Kubernetes Service
 

--- a/docs/pages/reference/terraform-provider/resources/installer.mdx
+++ b/docs/pages/reference/terraform-provider/resources/installer.mdx
@@ -24,8 +24,9 @@ resource "teleport_installer" "example" {
   }
 
   spec = {
-    # This is the default installer script. For more details about the installer script
-    # see https://goteleport.com/docs/enroll-resources/auto-discovery/servers/ec2-discovery/#step-67-optional-customize-the-default-installer-script
+    # This is the default installer script. Edit it to customize the commands
+    # that the Teleport Discovery Service configures virtual machines to run to
+    # install Teleport on startup.
     script = <<EOF
 #!/usr/bin/env sh
 set -eu

--- a/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
@@ -13,8 +13,7 @@ description: This page describes the supported values of the teleport_oidc_conne
 ```hcl
 # Teleport OIDC connector
 # 
-# Please note that OIDC connector will work in Enterprise version only. Check the setup docs:
-# https://goteleport.com/docs/enterprise/sso/oidc/
+# Please note that the OIDC connector will work in Teleport Enterprise only.
 
 variable "oidc_secret" {}
 

--- a/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
@@ -13,8 +13,7 @@ description: This page describes the supported values of the teleport_saml_conne
 ```hcl
 # Teleport SAML connector
 # 
-# Please note that SAML connector will work in Enterprise version only. Check the setup docs:
-# https://goteleport.com/docs/enterprise/sso/okta/
+# Please note that the SAML connector will work in Teleport Enterprise only.
 
 resource "teleport_saml_connector" "example" {
   # This block will tell Terraform to never update private key from our side if a keys are managed 

--- a/docs/pages/reference/terraform-provider/resources/trusted_cluster.mdx
+++ b/docs/pages/reference/terraform-provider/resources/trusted_cluster.mdx
@@ -12,8 +12,6 @@ description: This page describes the supported values of the teleport_trusted_cl
 
 ```hcl
 # Teleport trusted cluster
-#
-# https://goteleport.com/docs/setup/admin/trustedclusters/
 
 resource "teleport_trusted_cluster" "cluster" {
   metadata = {

--- a/integrations/terraform/examples/resources/teleport_installer/resource.tf
+++ b/integrations/terraform/examples/resources/teleport_installer/resource.tf
@@ -11,8 +11,9 @@ resource "teleport_installer" "example" {
   }
 
   spec = {
-    # This is the default installer script. For more details about the installer script
-    # see https://goteleport.com/docs/enroll-resources/auto-discovery/servers/ec2-discovery/#step-67-optional-customize-the-default-installer-script
+    # This is the default installer script. Edit it to customize the commands
+    # that the Teleport Discovery Service configures virtual machines to run to
+    # install Teleport on startup.
     script = <<EOF
 #!/usr/bin/env sh
 set -eu

--- a/integrations/terraform/examples/resources/teleport_oidc_connector/resource.tf
+++ b/integrations/terraform/examples/resources/teleport_oidc_connector/resource.tf
@@ -1,7 +1,6 @@
 # Teleport OIDC connector
 # 
-# Please note that OIDC connector will work in Enterprise version only. Check the setup docs:
-# https://goteleport.com/docs/enterprise/sso/oidc/
+# Please note that the OIDC connector will work in Teleport Enterprise only.
 
 variable "oidc_secret" {}
 

--- a/integrations/terraform/examples/resources/teleport_saml_connector/resource.tf
+++ b/integrations/terraform/examples/resources/teleport_saml_connector/resource.tf
@@ -1,7 +1,6 @@
 # Teleport SAML connector
 # 
-# Please note that SAML connector will work in Enterprise version only. Check the setup docs:
-# https://goteleport.com/docs/enterprise/sso/okta/
+# Please note that the SAML connector will work in Teleport Enterprise only.
 
 resource "teleport_saml_connector" "example" {
   # This block will tell Terraform to never update private key from our side if a keys are managed 

--- a/integrations/terraform/examples/resources/teleport_trusted_cluster/resource.tf
+++ b/integrations/terraform/examples/resources/teleport_trusted_cluster/resource.tf
@@ -1,6 +1,4 @@
 # Teleport trusted cluster
-#
-# https://goteleport.com/docs/setup/admin/trustedclusters/
 
 resource "teleport_trusted_cluster" "cluster" {
   metadata = {


### PR DESCRIPTION
Backports #46363

* Remove docs URLs from code fence comments

Some example configurations include docs URLs in comments. Since the docs linter does not check whether these correspond to actual docs pages, they can easily go out of date when we reorganize the documentation.

Further, since these docs URLs are absolute, the docs engine does not rewrite them to include version-specific URL paths, so they always link to the default version of the docs.

Some of the changes modify example Terraform resources since we generate the Terraform provider reference.

* Respond to ravicious feedback

- Add context to comment re: the default installer script
- Add context to the configuration reference in places where we removed in-comment docs URLs