### PR TITLE
Fix spelling in Operator docs and related protos

### DIFF
--- a/api/proto/teleport/accesslist/v1/accesslist.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist.proto
@@ -51,16 +51,16 @@ message AccessListSpec {
   // audit describes the frequency that this access list must be audited.
   AccessListAudit audit = 3;
 
-  // membership_requires describes the requirements for a user to be a member of
-  // the access list. For a membership to an access list to be effective, the
-  // user must meet the requirements of Membership_requires and must be in the
+  // `membership_requires` describes the requirements for a user to be a member
+  // of the access list. For a membership to an access list to be effective, the
+  // user must meet the requirements of `membership_requires` and must be in the
   // members list.
   AccessListRequires membership_requires = 4;
 
-  // ownership_requires describes the requirements for a user to be an owner of
-  // the access list. For ownership of an access list to be effective, the user
-  // must meet the requirements of ownership_requires and must be in the owners
-  // list.
+  // `ownership_requires` describes the requirements for a user to be an owner
+  // of the access list. For ownership of an access list to be effective, the
+  // user must meet the requirements of `ownership_requires` and must be in the
+  // owners list.
   AccessListRequires ownership_requires = 5;
 
   // grants describes the access granted by membership to this access list.
@@ -69,7 +69,7 @@ message AccessListSpec {
   // title is a plaintext short description of the access list.
   string title = 8;
 
-  // owner_grants describes the access granted by owners to this access list.
+  // `owner_grants` describes the access granted by owners to this access list.
   AccessListGrants owner_grants = 11;
 }
 
@@ -82,8 +82,8 @@ message AccessListOwner {
   // owner.
   string description = 2;
 
-  // ineligible_status describes if this owner is eligible or not
-  // and if not, describes how they're lacking eligibility.
+  // describes if this owner is eligible or not and if not, describes how
+  // they're lacking eligibility.
   IneligibleStatus ineligible_status = 3;
 }
 
@@ -92,7 +92,7 @@ message AccessListAudit {
   reserved 1;
   reserved "frequency";
 
-  // next_audit_date is when the next audit date should be done by.
+  // when the next audit date should be done by.
   google.protobuf.Timestamp next_audit_date = 2;
 
   // recurrence is the recurrence definition
@@ -126,7 +126,7 @@ message Recurrence {
   // Supported values are 0, 1, 3, 6, and 12.
   ReviewFrequency frequency = 1;
 
-  // day_of_month is the day of month that reviews will be scheduled on.
+  // The day of month that reviews will be scheduled on.
   // Supported values are 0, 1, 15, and 31.
   ReviewDayOfMonth day_of_month = 2;
 }
@@ -210,7 +210,7 @@ enum IneligibleStatus {
   INELIGIBLE_STATUS_USER_NOT_EXIST = 2;
   // INELIGIBLE_STATUS_MISSING_REQUIREMENTS means user is missing some
   // requirements defined by AccessListRequires (fields can be either
-  // ownership_requires or membership_requires)
+  // `ownership_requires` or `membership_requires`)
   INELIGIBLE_STATUS_MISSING_REQUIREMENTS = 3;
   // INELIGIBLE_STATUS_EXPIRED means user is expired.
   // Only applicable to members.
@@ -250,8 +250,7 @@ message ReviewChanges {
   reserved 1;
   reserved "frequency_changed";
 
-  // membership_requirements_changed is populated if the requirements were
-  // changed as part of this review.
+  // populated if the requirements were changed as part of this review.
   AccessListRequires membership_requirements_changed = 2;
 
   // removed_members contains the members that were removed as part of this

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -102,7 +102,7 @@ message Rotation {
   option (gogoproto.goproto_stringer) = false;
   option (gogoproto.stringer) = false;
 
-  // State could be one of "init" or "in_progress".
+  // State could be one of `init` or `in_progress`.
   string State = 1 [(gogoproto.jsontag) = "state,omitempty"];
   // Phase is the current rotation phase.
   string Phase = 2 [(gogoproto.jsontag) = "phase,omitempty"];
@@ -112,7 +112,7 @@ message Rotation {
   // to differentiate between rotation attempts.
   string CurrentID = 4 [(gogoproto.jsontag) = "current_id"];
   // Started is set to the time when rotation has been started
-  // in case if the state of the rotation is "in_progress".
+  // in case if the state of the rotation is `in_progress`.
   google.protobuf.Timestamp Started = 5 [
     (gogoproto.nullable) = false,
     (gogoproto.stdtime) = true,
@@ -1277,7 +1277,8 @@ message ProvisionTokenSpecV2 {
     (gogoproto.casttype) = "Duration"
   ];
   // JoinMethod is the joining method required in order to use this token.
-  // Supported joining methods include: azure, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm
+  // Supported joining methods include: `azure`, `circleci`, `ec2`, `gcp`,
+  // `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`
   string JoinMethod = 4 [
     (gogoproto.jsontag) = "join_method",
     (gogoproto.casttype) = "JoinMethod"
@@ -1292,9 +1293,9 @@ message ProvisionTokenSpecV2 {
     (gogoproto.jsontag) = "suggested_labels,omitempty",
     (gogoproto.customtype) = "Labels"
   ];
-  // GitHub allows the configuration of options specific to the "github" join method.
+  // GitHub allows the configuration of options specific to the `github` join method.
   ProvisionTokenSpecV2GitHub GitHub = 7 [(gogoproto.jsontag) = "github,omitempty"];
-  // CircleCI allows the configuration of options specific to the "circleci" join method.
+  // CircleCI allows the configuration of options specific to the `circleci` join method.
   ProvisionTokenSpecV2CircleCI CircleCI = 8 [(gogoproto.jsontag) = "circleci,omitempty"];
   // SuggestedAgentMatcherLabels is a set of labels to be used by agents to match on resources.
   // When an agent uses this token, the agent should monitor resources that match those labels.
@@ -1305,19 +1306,19 @@ message ProvisionTokenSpecV2 {
     (gogoproto.jsontag) = "suggested_agent_matcher_labels,omitempty",
     (gogoproto.customtype) = "Labels"
   ];
-  // Kubernetes allows the configuration of options specific to the "kubernetes" join method.
+  // Kubernetes allows the configuration of options specific to the `kubernetes` join method.
   ProvisionTokenSpecV2Kubernetes Kubernetes = 10 [(gogoproto.jsontag) = "kubernetes,omitempty"];
-  // Azure allows the configuration of options specific to the "azure" join method.
+  // Azure allows the configuration of options specific to the `azure` join method.
   ProvisionTokenSpecV2Azure Azure = 11 [(gogoproto.jsontag) = "azure,omitempty"];
-  // GitLab allows the configuration of options specific to the "gitlab" join method.
+  // GitLab allows the configuration of options specific to the `gitlab` join method.
   ProvisionTokenSpecV2GitLab GitLab = 12 [(gogoproto.jsontag) = "gitlab,omitempty"];
-  // GCP allows the configuration of options specific to the "gcp" join method.
+  // GCP allows the configuration of options specific to the `gcp` join method.
   ProvisionTokenSpecV2GCP GCP = 13 [(gogoproto.jsontag) = "gcp,omitempty"];
-  // Spacelift allows the configuration of options specific to the "spacelift" join method.
+  // Spacelift allows the configuration of options specific to the `spacelift` join method.
   ProvisionTokenSpecV2Spacelift Spacelift = 14 [(gogoproto.jsontag) = "spacelift,omitempty"];
-  // TPM allows the configuration of options specific to the "tpm" join method.
+  // TPM allows the configuration of options specific to the `tpm` join method.
   ProvisionTokenSpecV2TPM TPM = 15 [(gogoproto.jsontag) = "tpm,omitempty"];
-  // TerraformCloud allows the configuration of options specific to the "terraform_cloud" join method.
+  // TerraformCloud allows the configuration of options specific to the `terraform_cloud` join method.
   ProvisionTokenSpecV2TerraformCloud TerraformCloud = 16 [(gogoproto.jsontag) = "terraform_cloud,omitempty"];
 }
 
@@ -1389,10 +1390,10 @@ message ProvisionTokenSpecV2GitHub {
   // Allow is a list of TokenRules, nodes using this token must match one
   // allow rule to use this token.
   repeated Rule Allow = 1 [(gogoproto.jsontag) = "allow,omitempty"];
-  // EnterpriseServerHost allows joining from runners associated with a
-  // GitHub Enterprise Server instance. When unconfigured, tokens will be
-  // validated against github.com, but when configured to the host of a GHES
-  // instance, then the tokens will be validated against host.
+  // EnterpriseServerHost allows joining from runners associated with a GitHub
+  // Enterprise Server instance. When unconfigured, tokens will be validated
+  // against `github.com`, but when configured to the host of a GHES instance,
+  // then the tokens will be validated against host.
   //
   // This value should be the hostname of the GHES instance, and should not
   // include the scheme or a path. The instance must be accessible over HTTPS
@@ -2990,13 +2991,13 @@ message RoleOptions {
 
   // CreateHostUserMode allows users to be automatically created on a
   // host when not set to off.
-  // 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above),
-  // 3 is "keep"; 4 is "insecure-drop".
+  // 0 is `unspecified`; 1 is `off`; 2 is `drop` (removed for v15 and above),
+  // 3 is `keep`; 4 is `insecure-drop`.
   CreateHostUserMode CreateHostUserMode = 28 [(gogoproto.jsontag) = "create_host_user_mode,omitempty"];
 
   // CreateDatabaseUserMode allows users to be automatically created on a
   // database when not set to off.
-  // 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop".
+  // 0 is `unspecified`, 1 is `off`, 2 is `keep`, 3 is `best_effort_drop`.
   CreateDatabaseUserMode CreateDatabaseUserMode = 29 [(gogoproto.jsontag) = "create_db_user_mode,omitempty"];
 
   // MFAVerificationInterval optionally defines the maximum duration that can elapse
@@ -3093,12 +3094,12 @@ message RoleConditions {
     (gogoproto.jsontag) = "rules,omitempty"
   ];
 
-  // KubeGroups is a list of kubernetes groups
+  // KubeGroups is a list of Kubernetes groups
   repeated string KubeGroups = 5 [(gogoproto.jsontag) = "kubernetes_groups,omitempty"];
 
   AccessRequestConditions Request = 6 [(gogoproto.jsontag) = "request,omitempty"];
 
-  // KubeUsers is an optional kubernetes users to impersonate
+  // KubeUsers is an optional Kubernetes users to impersonate
   repeated string KubeUsers = 7 [(gogoproto.jsontag) = "kubernetes_users,omitempty"];
 
   // AppLabels is a map of labels used as part of the RBAC system.
@@ -3116,7 +3117,7 @@ message RoleConditions {
     (gogoproto.customtype) = "Labels"
   ];
 
-  // KubernetesLabels is a map of kubernetes cluster labels used for RBAC.
+  // KubernetesLabels is a map of Kubernetes cluster labels used for RBAC.
   wrappers.LabelValues KubernetesLabels = 10 [
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "kubernetes_labels,omitempty",
@@ -3208,7 +3209,7 @@ message RoleConditions {
   // to remote Teleport clusters.
   string ClusterLabelsExpression = 32 [(gogoproto.jsontag) = "cluster_labels_expression,omitempty"];
   // KubernetesLabelsExpression is a predicate expression used to allow/deny
-  // access to kubernetes clusters.
+  // access to Kubernetes clusters.
   string KubernetesLabelsExpression = 33 [(gogoproto.jsontag) = "kubernetes_labels_expression,omitempty"];
   // DatabaseLabelsExpression is a predicate expression used to allow/deny
   // access to Databases.
@@ -3551,7 +3552,7 @@ message UserSpecV2 {
     (gogoproto.jsontag) = "saml_identities,omitempty"
   ];
 
-  // GithubIdentities list associated Github OAuth2 identities
+  // GithubIdentities list associated GitHub OAuth2 identities
   // that let user log in using externally verified identity
   repeated ExternalIdentity GithubIdentities = 3 [
     (gogoproto.nullable) = false,
@@ -4498,15 +4499,15 @@ message OIDCConnectorSpecV3 {
   string Display = 7 [(gogoproto.jsontag) = "display,omitempty"];
   // Scope specifies additional scopes set by provider.
   repeated string Scope = 8 [(gogoproto.jsontag) = "scope,omitempty"];
-  // Prompt is an optional OIDC prompt. An empty string omits prompt.
-  // If not specified, it defaults to select_account for backwards compatibility.
+  // Prompt is an optional OIDC prompt. An empty string omits prompt.  If not
+  // specified, it defaults to `select_account` for backwards compatibility.
   string Prompt = 9 [(gogoproto.jsontag) = "prompt,omitempty"];
   // ClaimsToRoles specifies a dynamic mapping from claims to roles.
   repeated ClaimMapping ClaimsToRoles = 10 [
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "claims_to_roles,omitempty"
   ];
-  // GoogleServiceAccountURI is a path to a google service account uri.
+  // GoogleServiceAccountURI is a path to a google service account URI.
   string GoogleServiceAccountURI = 11 [(gogoproto.jsontag) = "google_service_account_uri,omitempty"];
   // GoogleServiceAccount is a string containing google service account credentials.
   string GoogleServiceAccount = 12 [(gogoproto.jsontag) = "google_service_account,omitempty"];
@@ -4516,7 +4517,7 @@ message OIDCConnectorSpecV3 {
   // to redirect the client back to the Teleport Proxy to complete authentication.
   // This list should match the URLs on the provider's side. The URL used for a
   // given auth request will be chosen to match the requesting Proxy's public
-  // address. If there is no match, the first url in the list will be used.
+  // address. If there is no match, the first URL in the list will be used.
   wrappers.StringValues RedirectURLs = 14 [
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "redirect_url",
@@ -4550,7 +4551,7 @@ message MaxAge {
 // SSOClientRedirectSettings contains settings to define which additional client
 // redirect URLs should be allowed for non-browser SSO logins.
 message SSOClientRedirectSettings {
-  // a list of hostnames allowed for https client redirect URLs
+  // a list of hostnames allowed for HTTPS client redirect URLs
   repeated string allowed_https_hostnames = 1;
   // a list of CIDRs allowed for HTTP or HTTPS client redirect URLs
   repeated string insecure_allowed_cidr_ranges = 2;
@@ -4862,13 +4863,13 @@ message GithubConnectorV3List {
 
 // GithubConnectorSpecV3 is a Github connector specification.
 message GithubConnectorSpecV3 {
-  // ClientID is the Github OAuth app client ID.
+  // ClientID is the GitHub OAuth app client ID.
   string ClientID = 1 [(gogoproto.jsontag) = "client_id"];
-  // ClientSecret is the Github OAuth app client secret.
+  // ClientSecret is the GitHub OAuth app client secret.
   string ClientSecret = 2 [(gogoproto.jsontag) = "client_secret"];
   // RedirectURL is the authorization callback URL.
   string RedirectURL = 3 [(gogoproto.jsontag) = "redirect_url"];
-  // TeamsToLogins maps Github team memberships onto allowed logins/roles.
+  // TeamsToLogins maps GitHub team memberships onto allowed logins/roles.
   //
   // DELETE IN 11.0.0
   // Deprecated: use GithubTeamsToRoles instead.
@@ -4878,14 +4879,14 @@ message GithubConnectorSpecV3 {
   ];
   // Display is the connector display name.
   string Display = 5 [(gogoproto.jsontag) = "display"];
-  // TeamsToRoles maps Github team memberships onto allowed roles.
+  // TeamsToRoles maps GitHub team memberships onto allowed roles.
   repeated TeamRolesMapping TeamsToRoles = 6 [
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "teams_to_roles"
   ];
   // EndpointURL is the URL of the GitHub instance this connector is for.
   string EndpointURL = 7 [(gogoproto.jsontag) = "endpoint_url"];
-  // APIEndpointURL is the URL of the API endpoint of the Github instance
+  // APIEndpointURL is the URL of the API endpoint of the GitHub instance
   // this connector is for.
   string APIEndpointURL = 8 [(gogoproto.jsontag) = "api_endpoint_url"];
   // ClientRedirectSettings defines which client redirect URLs are allowed for
@@ -5151,7 +5152,7 @@ message TeamMapping {
 
 // TeamRolesMapping represents a single team membership mapping.
 message TeamRolesMapping {
-  // Organization is a Github organization a user belongs to.
+  // Organization is a GitHub organization a user belongs to.
   string Organization = 1 [(gogoproto.jsontag) = "organization"];
   // Team is a team within the organization a user belongs to.
   string Team = 2 [(gogoproto.jsontag) = "team"];

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_accesslists.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_accesslists.mdx
@@ -13,82 +13,82 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 ## resources.teleport.dev/v1
 
-**apiVersion:** resources.teleport.dev/v1
+`apiVersion: resources.teleport.dev/v1`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|AccessList resource definition v1 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|AccessList resource definition v1 from Teleport|
 
-### spec
-
-|Field|Type|Description|
-|---|---|---|
-|audit|[object](#specaudit)|audit describes the frequency that this access list must be audited.|
-|description|string|description is an optional plaintext description of the access list.|
-|grants|[object](#specgrants)|grants describes the access granted by membership to this access list.|
-|membership_requires|[object](#specmembership_requires)|membership_requires describes the requirements for a user to be a member of the access list. For a membership to an access list to be effective, the user must meet the requirements of Membership_requires and must be in the members list.|
-|owner_grants|[object](#specowner_grants)|owner_grants describes the access granted by owners to this access list.|
-|owners|[][object](#specowners-items)|owners is a list of owners of the access list.|
-|ownership_requires|[object](#specownership_requires)|ownership_requires describes the requirements for a user to be an owner of the access list. For ownership of an access list to be effective, the user must meet the requirements of ownership_requires and must be in the owners list.|
-|title|string|title is a plaintext short description of the access list.|
-
-### spec.audit
+### `spec.audit.notifications`
 
 |Field|Type|Description|
 |---|---|---|
-|next_audit_date|string|next_audit_date is when the next audit date should be done by.|
-|notifications|[object](#specauditnotifications)|notifications is the configuration for notifying users.|
-|recurrence|[object](#specauditrecurrence)|recurrence is the recurrence definition|
+|`start`|string|start specifies when to start notifying users that the next audit date is coming up.|
 
-### spec.audit.notifications
+### `spec.audit.recurrence`
 
 |Field|Type|Description|
 |---|---|---|
-|start|string|start specifies when to start notifying users that the next audit date is coming up.|
+|`day_of_month`|string or integer|The day of month that reviews will be scheduled on. Supported values are 0, 1, 15, and 31. Can be either the string or the integer representation of each option.|
+|`frequency`|string or integer|frequency is the frequency of reviews. This represents the period in months between two reviews. Supported values are 0, 1, 3, 6, and 12. Can be either the string or the integer representation of each option.|
 
-### spec.audit.recurrence
-
-|Field|Type|Description|
-|---|---|---|
-|day_of_month|string or integer|day_of_month is the day of month that reviews will be scheduled on. Supported values are 0, 1, 15, and 31. Can be either the string or the integer representation of each option.|
-|frequency|string or integer|frequency is the frequency of reviews. This represents the period in months between two reviews. Supported values are 0, 1, 3, 6, and 12. Can be either the string or the integer representation of each option.|
-
-### spec.grants
+### `spec.audit`
 
 |Field|Type|Description|
 |---|---|---|
-|roles|[]string|roles are the roles that are granted to users who are members of the access list.|
-|traits|object|traits are the traits that are granted to users who are members of the access list.|
+|`next_audit_date`|string|when the next audit date should be done by.|
+|`notifications`|[object](#specauditnotifications)|notifications is the configuration for notifying users.|
+|`recurrence`|[object](#specauditrecurrence)|recurrence is the recurrence definition|
 
-### spec.membership_requires
-
-|Field|Type|Description|
-|---|---|---|
-|roles|[]string|roles are the user roles that must be present for the user to obtain access.|
-|traits|object|traits are the traits that must be present for the user to obtain access.|
-
-### spec.owner_grants
+### `spec.grants`
 
 |Field|Type|Description|
 |---|---|---|
-|roles|[]string|roles are the roles that are granted to users who are members of the access list.|
-|traits|object|traits are the traits that are granted to users who are members of the access list.|
+|`roles`|[]string|roles are the roles that are granted to users who are members of the access list.|
+|`traits`|object|traits are the traits that are granted to users who are members of the access list.|
 
-### spec.owners items
-
-|Field|Type|Description|
-|---|---|---|
-|description|string|description is the plaintext description of the owner and why they are an owner.|
-|ineligible_status|string or integer|ineligible_status describes if this owner is eligible or not and if not, describes how they're lacking eligibility. Can be either the string or the integer representation of each option.|
-|name|string|name is the username of the owner.|
-
-### spec.ownership_requires
+### `spec.membership_requires`
 
 |Field|Type|Description|
 |---|---|---|
-|roles|[]string|roles are the user roles that must be present for the user to obtain access.|
-|traits|object|traits are the traits that must be present for the user to obtain access.|
+|`roles`|[]string|roles are the user roles that must be present for the user to obtain access.|
+|`traits`|object|traits are the traits that must be present for the user to obtain access.|
+
+### `spec.owner_grants`
+
+|Field|Type|Description|
+|---|---|---|
+|`roles`|[]string|roles are the roles that are granted to users who are members of the access list.|
+|`traits`|object|traits are the traits that are granted to users who are members of the access list.|
+
+### `spec.owners` items
+
+|Field|Type|Description|
+|---|---|---|
+|`description`|string|description is the plaintext description of the owner and why they are an owner.|
+|`ineligible_status`|string or integer|describes if this owner is eligible or not and if not, describes how they're lacking eligibility. Can be either the string or the integer representation of each option.|
+|`name`|string|name is the username of the owner.|
+
+### `spec.ownership_requires`
+
+|Field|Type|Description|
+|---|---|---|
+|`roles`|[]string|roles are the user roles that must be present for the user to obtain access.|
+|`traits`|object|traits are the traits that must be present for the user to obtain access.|
+
+### `spec`
+
+|Field|Type|Description|
+|---|---|---|
+|`audit`|[object](#specaudit)|audit describes the frequency that this access list must be audited.|
+|`description`|string|description is an optional plaintext description of the access list.|
+|`grants`|[object](#specgrants)|grants describes the access granted by membership to this access list.|
+|`membership_requires`|[object](#specmembership_requires)|`membership_requires` describes the requirements for a user to be a member of the access list. For a membership to an access list to be effective, the user must meet the requirements of `membership_requires` and must be in the members list.|
+|`owner_grants`|[object](#specowner_grants)|`owner_grants` describes the access granted by owners to this access list.|
+|`owners`|[][object](#specowners-items)|owners is a list of owners of the access list.|
+|`ownership_requires`|[object](#specownership_requires)|`ownership_requires` describes the requirements for a user to be an owner of the access list. For ownership of an access list to be effective, the user must meet the requirements of `ownership_requires` and must be in the owners list.|
+|`title`|string|title is a plaintext short description of the access list.|
 

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_githubconnectors.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_githubconnectors.mdx
@@ -13,40 +13,40 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 ## resources.teleport.dev/v3
 
-**apiVersion:** resources.teleport.dev/v3
+`apiVersion: resources.teleport.dev/v3`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|GithubConnector resource definition v3 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|GithubConnector resource definition v3 from Teleport|
 
-### spec
-
-|Field|Type|Description|
-|---|---|---|
-|api_endpoint_url|string|APIEndpointURL is the URL of the API endpoint of the Github instance this connector is for.|
-|client_id|string|ClientID is the Github OAuth app client ID.|
-|client_redirect_settings|[object](#specclient_redirect_settings)|ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones.|
-|client_secret|string|ClientSecret is the Github OAuth app client secret. This field supports secret lookup. See the operator documentation for more details.|
-|display|string|Display is the connector display name.|
-|endpoint_url|string|EndpointURL is the URL of the GitHub instance this connector is for.|
-|redirect_url|string|RedirectURL is the authorization callback URL.|
-|teams_to_roles|[][object](#specteams_to_roles-items)|TeamsToRoles maps Github team memberships onto allowed roles.|
-
-### spec.client_redirect_settings
+### `spec.client_redirect_settings`
 
 |Field|Type|Description|
 |---|---|---|
-|allowed_https_hostnames|[]string|a list of hostnames allowed for https client redirect URLs|
-|insecure_allowed_cidr_ranges|[]string|a list of CIDRs allowed for HTTP or HTTPS client redirect URLs|
+|`allowed_https_hostnames`|[]string|a list of hostnames allowed for HTTPS client redirect URLs|
+|`insecure_allowed_cidr_ranges`|[]string|a list of CIDRs allowed for HTTP or HTTPS client redirect URLs|
 
-### spec.teams_to_roles items
+### `spec.teams_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|organization|string|Organization is a Github organization a user belongs to.|
-|roles|[]string|Roles is a list of allowed logins for this org/team.|
-|team|string|Team is a team within the organization a user belongs to.|
+|`organization`|string|Organization is a GitHub organization a user belongs to.|
+|`roles`|[]string|Roles is a list of allowed logins for this org/team.|
+|`team`|string|Team is a team within the organization a user belongs to.|
+
+### `spec`
+
+|Field|Type|Description|
+|---|---|---|
+|`api_endpoint_url`|string|APIEndpointURL is the URL of the API endpoint of the GitHub instance this connector is for.|
+|`client_id`|string|ClientID is the GitHub OAuth app client ID.|
+|`client_redirect_settings`|[object](#specclient_redirect_settings)|ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones.|
+|`client_secret`|string|ClientSecret is the GitHub OAuth app client secret. This field supports secret lookup. See the operator documentation for more details.|
+|`display`|string|Display is the connector display name.|
+|`endpoint_url`|string|EndpointURL is the URL of the GitHub instance this connector is for.|
+|`redirect_url`|string|RedirectURL is the authorization callback URL.|
+|`teams_to_roles`|[][object](#specteams_to_roles-items)|TeamsToRoles maps GitHub team memberships onto allowed roles.|
 

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_loginrules.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_loginrules.mdx
@@ -13,20 +13,20 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 ## resources.teleport.dev/v1
 
-**apiVersion:** resources.teleport.dev/v1
+`apiVersion: resources.teleport.dev/v1`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|LoginRule resource definition v1 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|LoginRule resource definition v1 from Teleport|
 
-### spec
+### `spec`
 
 |Field|Type|Description|
 |---|---|---|
-|priority|integer|Priority is the priority of the login rule relative to other login rules in the same cluster. Login rules with a lower numbered priority will be evaluated first.|
-|traits_expression|string|TraitsExpression is a predicate expression which should return the desired traits for the user upon login.|
-|traits_map|object|TraitsMap is a map of trait keys to lists of predicate expressions which should evaluate to the desired values for that trait.|
+|`priority`|integer|Priority is the priority of the login rule relative to other login rules in the same cluster. Login rules with a lower numbered priority will be evaluated first.|
+|`traits_expression`|string|TraitsExpression is a predicate expression which should return the desired traits for the user upon login.|
+|`traits_map`|object|TraitsMap is a map of trait keys to lists of predicate expressions which should evaluate to the desired values for that trait.|
 

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_oidcconnectors.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_oidcconnectors.mdx
@@ -13,49 +13,49 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 ## resources.teleport.dev/v3
 
-**apiVersion:** resources.teleport.dev/v3
+`apiVersion: resources.teleport.dev/v3`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|OIDCConnector resource definition v3 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|OIDCConnector resource definition v3 from Teleport|
 
-### spec
-
-|Field|Type|Description|
-|---|---|---|
-|acr_values|string|ACR is an Authentication Context Class Reference value. The meaning of the ACR value is context-specific and varies for identity providers.|
-|allow_unverified_email|boolean|AllowUnverifiedEmail tells the connector to accept OIDC users with unverified emails.|
-|claims_to_roles|[][object](#specclaims_to_roles-items)|ClaimsToRoles specifies a dynamic mapping from claims to roles.|
-|client_id|string|ClientID is the id of the authentication client (Teleport Auth server).|
-|client_redirect_settings|[object](#specclient_redirect_settings)|ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones.|
-|client_secret|string|ClientSecret is used to authenticate the client. This field supports secret lookup. See the operator documentation for more details.|
-|display|string|Display is the friendly name for this provider.|
-|google_admin_email|string|GoogleAdminEmail is the email of a google admin to impersonate.|
-|google_service_account|string|GoogleServiceAccount is a string containing google service account credentials.|
-|google_service_account_uri|string|GoogleServiceAccountURI is a path to a google service account uri.|
-|issuer_url|string|IssuerURL is the endpoint of the provider, e.g. https://accounts.google.com.|
-|max_age|string|MaxAge is the amount of time that user logins are valid for. If a user logs in, but then does not login again within this time period, they will be forced to re-authenticate.|
-|prompt|string|Prompt is an optional OIDC prompt. An empty string omits prompt. If not specified, it defaults to select_account for backwards compatibility.|
-|provider|string|Provider is the external identity provider.|
-|redirect_url|[]string|RedirectURLs is a list of callback URLs which the identity provider can use to redirect the client back to the Teleport Proxy to complete authentication. This list should match the URLs on the provider's side. The URL used for a given auth request will be chosen to match the requesting Proxy's public address. If there is no match, the first url in the list will be used.|
-|scope|[]string|Scope specifies additional scopes set by provider.|
-|username_claim|string|UsernameClaim specifies the name of the claim from the OIDC connector to be used as the user's username.|
-
-### spec.claims_to_roles items
+### `spec.claims_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
 
-### spec.client_redirect_settings
+### `spec.client_redirect_settings`
 
 |Field|Type|Description|
 |---|---|---|
-|allowed_https_hostnames|[]string|a list of hostnames allowed for https client redirect URLs|
-|insecure_allowed_cidr_ranges|[]string|a list of CIDRs allowed for HTTP or HTTPS client redirect URLs|
+|`allowed_https_hostnames`|[]string|a list of hostnames allowed for HTTPS client redirect URLs|
+|`insecure_allowed_cidr_ranges`|[]string|a list of CIDRs allowed for HTTP or HTTPS client redirect URLs|
+
+### `spec`
+
+|Field|Type|Description|
+|---|---|---|
+|`acr_values`|string|ACR is an Authentication Context Class Reference value. The meaning of the ACR value is context-specific and varies for identity providers.|
+|`allow_unverified_email`|Boolean|AllowUnverifiedEmail tells the connector to accept OIDC users with unverified emails.|
+|`claims_to_roles`|[][object](#specclaims_to_roles-items)|ClaimsToRoles specifies a dynamic mapping from claims to roles.|
+|`client_id`|string|ClientID is the id of the authentication client (Teleport Auth server).|
+|`client_redirect_settings`|[object](#specclient_redirect_settings)|ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones.|
+|`client_secret`|string|ClientSecret is used to authenticate the client. This field supports secret lookup. See the operator documentation for more details.|
+|`display`|string|Display is the friendly name for this provider.|
+|`google_admin_email`|string|GoogleAdminEmail is the email of a google admin to impersonate.|
+|`google_service_account`|string|GoogleServiceAccount is a string containing google service account credentials.|
+|`google_service_account_uri`|string|GoogleServiceAccountURI is a path to a google service account URI.|
+|`issuer_url`|string|IssuerURL is the endpoint of the provider, e.g. https://accounts.google.com.|
+|`max_age`|string|MaxAge is the amount of time that user logins are valid for. If a user logs in, but then does not login again within this time period, they will be forced to re-authenticate.|
+|`prompt`|string|Prompt is an optional OIDC prompt. An empty string omits prompt.  If not specified, it defaults to `select_account` for backwards compatibility.|
+|`provider`|string|Provider is the external identity provider.|
+|`redirect_url`|[]string|RedirectURLs is a list of callback URLs which the identity provider can use to redirect the client back to the Teleport Proxy to complete authentication. This list should match the URLs on the provider's side. The URL used for a given auth request will be chosen to match the requesting Proxy's public address. If there is no match, the first URL in the list will be used.|
+|`scope`|[]string|Scope specifies additional scopes set by provider.|
+|`username_claim`|string|UsernameClaim specifies the name of the claim from the OIDC connector to be used as the user's username.|
 

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_oktaimportrules.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_oktaimportrules.mdx
@@ -13,42 +13,42 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 ## resources.teleport.dev/v1
 
-**apiVersion:** resources.teleport.dev/v1
+`apiVersion: resources.teleport.dev/v1`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|OktaImportRule resource definition v1 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|OktaImportRule resource definition v1 from Teleport|
 
-### spec
-
-|Field|Type|Description|
-|---|---|---|
-|mappings|[][object](#specmappings-items)|Mappings is a list of matches that will map match conditions to labels.|
-|priority|integer|Priority represents the priority of the rule application. Lower numbered rules will be applied first.|
-
-### spec.mappings items
+### `spec.mappings` items
 
 |Field|Type|Description|
 |---|---|---|
-|add_labels|[object](#specmappings-itemsadd_labels)|AddLabels specifies which labels to add if any of the previous matches match.|
-|match|[][object](#specmappings-itemsmatch-items)|Match is a set of matching rules for this mapping. If any of these match, then the mapping will be applied.|
+|`add_labels`|[object](#specmappings-itemsadd_labels)|AddLabels specifies which labels to add if any of the previous matches match.|
+|`match`|[][object](#specmappings-itemsmatch-items)|Match is a set of matching rules for this mapping. If any of these match, then the mapping will be applied.|
 
-### spec.mappings items.add_labels
-
-|Field|Type|Description|
-|---|---|---|
-|key|string||
-|value|string||
-
-### spec.mappings items.match items
+### `spec.mappings` items`.add_labels`
 
 |Field|Type|Description|
 |---|---|---|
-|app_ids|[]string|AppIDs is a list of app IDs to match against.|
-|app_name_regexes|[]string|AppNameRegexes is a list of regexes to match against app names.|
-|group_ids|[]string|GroupIDs is a list of group IDs to match against.|
-|group_name_regexes|[]string|GroupNameRegexes is a list of regexes to match against group names.|
+|`key`|string||
+|`value`|string||
+
+### `spec.mappings` items`.match` items
+
+|Field|Type|Description|
+|---|---|---|
+|`app_ids`|[]string|AppIDs is a list of app IDs to match against.|
+|`app_name_regexes`|[]string|AppNameRegexes is a list of regexes to match against app names.|
+|`group_ids`|[]string|GroupIDs is a list of group IDs to match against.|
+|`group_name_regexes`|[]string|GroupNameRegexes is a list of regexes to match against group names.|
+
+### `spec`
+
+|Field|Type|Description|
+|---|---|---|
+|`mappings`|[][object](#specmappings-items)|Mappings is a list of matches that will map match conditions to labels.|
+|`priority`|integer|Priority represents the priority of the rule application. Lower numbered rules will be applied first.|
 

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_openssheiceserversv2.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_openssheiceserversv2.mdx
@@ -13,64 +13,64 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 ## resources.teleport.dev/v1
 
-**apiVersion:** resources.teleport.dev/v1
+`apiVersion: resources.teleport.dev/v1`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|OpenSSHEICEServer resource definition v2 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|OpenSSHEICEServer resource definition v2 from Teleport|
 
-### spec
-
-|Field|Type|Description|
-|---|---|---|
-|addr|string|Addr is a host:port address where this server can be reached.|
-|cloud_metadata|[object](#speccloud_metadata)|CloudMetadata contains info about the cloud instance the server is running on, if any.|
-|hostname|string|Hostname is server hostname|
-|peer_addr|string|PeerAddr is the address a proxy server is reachable at by its peer proxies.|
-|proxy_ids|[]string|ProxyIDs is a list of proxy IDs this server is expected to be connected to.|
-|public_addrs|[]string|PublicAddrs is a list of public addresses where this server can be reached.|
-|rotation|[object](#specrotation)|Rotation specifies server rotation|
-|use_tunnel|boolean|UseTunnel indicates that connections to this server should occur over a reverse tunnel.|
-|version|string|TeleportVersion is the teleport version that the server is running on|
-
-### spec.cloud_metadata
+### `spec.cloud_metadata.aws`
 
 |Field|Type|Description|
 |---|---|---|
-|aws|[object](#speccloud_metadataaws)|AWSInfo contains attributes to match to an EC2 instance.|
+|`account_id`|string|AccountID is an AWS account ID.|
+|`instance_id`|string|InstanceID is an EC2 instance ID.|
+|`integration`|string|Integration is the integration name that added this Node. When connecting to it, it will use this integration to issue AWS API calls in order to set up the connection. This includes sending an SSH Key and then opening a tunnel (EC2 Instance Connect Endpoint) so Teleport can connect to it.|
+|`region`|string|Region is the AWS EC2 Instance Region.|
+|`subnet_id`|string|SubnetID is the Subnet ID in use by the instance.|
+|`vpc_id`|string|VPCID is the AWS VPC ID where the Instance is running.|
 
-### spec.cloud_metadata.aws
-
-|Field|Type|Description|
-|---|---|---|
-|account_id|string|AccountID is an AWS account ID.|
-|instance_id|string|InstanceID is an EC2 instance ID.|
-|integration|string|Integration is the integration name that added this Node. When connecting to it, it will use this integration to issue AWS API calls in order to set up the connection. This includes sending an SSH Key and then opening a tunnel (EC2 Instance Connect Endpoint) so Teleport can connect to it.|
-|region|string|Region is the AWS EC2 Instance Region.|
-|subnet_id|string|SubnetID is the Subnet ID in use by the instance.|
-|vpc_id|string|VPCID is the AWS VPC ID where the Instance is running.|
-
-### spec.rotation
+### `spec.cloud_metadata`
 
 |Field|Type|Description|
 |---|---|---|
-|current_id|string|CurrentID is the ID of the rotation operation to differentiate between rotation attempts.|
-|grace_period|string|GracePeriod is a period during which old and new CA are valid for checking purposes, but only new CA is issuing certificates.|
-|last_rotated|string|LastRotated specifies the last time of the completed rotation.|
-|mode|string|Mode sets manual or automatic rotation mode.|
-|phase|string|Phase is the current rotation phase.|
-|schedule|[object](#specrotationschedule)|Schedule is a rotation schedule - used in automatic mode to switch between phases.|
-|started|string|Started is set to the time when rotation has been started in case if the state of the rotation is "in_progress".|
-|state|string|State could be one of "init" or "in_progress".|
+|`aws`|[object](#speccloud_metadataaws)|AWSInfo contains attributes to match to an EC2 instance.|
 
-### spec.rotation.schedule
+### `spec.rotation.schedule`
 
 |Field|Type|Description|
 |---|---|---|
-|standby|string|Standby specifies time to switch to the "Standby" phase.|
-|update_clients|string|UpdateClients specifies time to switch to the "Update clients" phase|
-|update_servers|string|UpdateServers specifies time to switch to the "Update servers" phase.|
+|`standby`|string|Standby specifies time to switch to the "Standby" phase.|
+|`update_clients`|string|UpdateClients specifies time to switch to the "Update clients" phase|
+|`update_servers`|string|UpdateServers specifies time to switch to the "Update servers" phase.|
+
+### `spec.rotation`
+
+|Field|Type|Description|
+|---|---|---|
+|`current_id`|string|CurrentID is the ID of the rotation operation to differentiate between rotation attempts.|
+|`grace_period`|string|GracePeriod is a period during which old and new CA are valid for checking purposes, but only new CA is issuing certificates.|
+|`last_rotated`|string|LastRotated specifies the last time of the completed rotation.|
+|`mode`|string|Mode sets manual or automatic rotation mode.|
+|`phase`|string|Phase is the current rotation phase.|
+|`schedule`|[object](#specrotationschedule)|Schedule is a rotation schedule - used in automatic mode to switch between phases.|
+|`started`|string|Started is set to the time when rotation has been started in case if the state of the rotation is `in_progress`.|
+|`state`|string|State could be one of `init` or `in_progress`.|
+
+### `spec`
+
+|Field|Type|Description|
+|---|---|---|
+|`addr`|string|Addr is a host:port address where this server can be reached.|
+|`cloud_metadata`|[object](#speccloud_metadata)|CloudMetadata contains info about the cloud instance the server is running on, if any.|
+|`hostname`|string|Hostname is server hostname|
+|`peer_addr`|string|PeerAddr is the address a proxy server is reachable at by its peer proxies.|
+|`proxy_ids`|[]string|ProxyIDs is a list of proxy IDs this server is expected to be connected to.|
+|`public_addrs`|[]string|PublicAddrs is a list of public addresses where this server can be reached.|
+|`rotation`|[object](#specrotation)|Rotation specifies server rotation|
+|`use_tunnel`|Boolean|UseTunnel indicates that connections to this server should occur over a reverse tunnel.|
+|`version`|string|TeleportVersion is the teleport version that the server is running on|
 

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_opensshserversv2.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_opensshserversv2.mdx
@@ -13,64 +13,64 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 ## resources.teleport.dev/v1
 
-**apiVersion:** resources.teleport.dev/v1
+`apiVersion: resources.teleport.dev/v1`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|OpenSSHServer resource definition v2 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|OpenSSHServer resource definition v2 from Teleport|
 
-### spec
-
-|Field|Type|Description|
-|---|---|---|
-|addr|string|Addr is a host:port address where this server can be reached.|
-|cloud_metadata|[object](#speccloud_metadata)|CloudMetadata contains info about the cloud instance the server is running on, if any.|
-|hostname|string|Hostname is server hostname|
-|peer_addr|string|PeerAddr is the address a proxy server is reachable at by its peer proxies.|
-|proxy_ids|[]string|ProxyIDs is a list of proxy IDs this server is expected to be connected to.|
-|public_addrs|[]string|PublicAddrs is a list of public addresses where this server can be reached.|
-|rotation|[object](#specrotation)|Rotation specifies server rotation|
-|use_tunnel|boolean|UseTunnel indicates that connections to this server should occur over a reverse tunnel.|
-|version|string|TeleportVersion is the teleport version that the server is running on|
-
-### spec.cloud_metadata
+### `spec.cloud_metadata.aws`
 
 |Field|Type|Description|
 |---|---|---|
-|aws|[object](#speccloud_metadataaws)|AWSInfo contains attributes to match to an EC2 instance.|
+|`account_id`|string|AccountID is an AWS account ID.|
+|`instance_id`|string|InstanceID is an EC2 instance ID.|
+|`integration`|string|Integration is the integration name that added this Node. When connecting to it, it will use this integration to issue AWS API calls in order to set up the connection. This includes sending an SSH Key and then opening a tunnel (EC2 Instance Connect Endpoint) so Teleport can connect to it.|
+|`region`|string|Region is the AWS EC2 Instance Region.|
+|`subnet_id`|string|SubnetID is the Subnet ID in use by the instance.|
+|`vpc_id`|string|VPCID is the AWS VPC ID where the Instance is running.|
 
-### spec.cloud_metadata.aws
-
-|Field|Type|Description|
-|---|---|---|
-|account_id|string|AccountID is an AWS account ID.|
-|instance_id|string|InstanceID is an EC2 instance ID.|
-|integration|string|Integration is the integration name that added this Node. When connecting to it, it will use this integration to issue AWS API calls in order to set up the connection. This includes sending an SSH Key and then opening a tunnel (EC2 Instance Connect Endpoint) so Teleport can connect to it.|
-|region|string|Region is the AWS EC2 Instance Region.|
-|subnet_id|string|SubnetID is the Subnet ID in use by the instance.|
-|vpc_id|string|VPCID is the AWS VPC ID where the Instance is running.|
-
-### spec.rotation
+### `spec.cloud_metadata`
 
 |Field|Type|Description|
 |---|---|---|
-|current_id|string|CurrentID is the ID of the rotation operation to differentiate between rotation attempts.|
-|grace_period|string|GracePeriod is a period during which old and new CA are valid for checking purposes, but only new CA is issuing certificates.|
-|last_rotated|string|LastRotated specifies the last time of the completed rotation.|
-|mode|string|Mode sets manual or automatic rotation mode.|
-|phase|string|Phase is the current rotation phase.|
-|schedule|[object](#specrotationschedule)|Schedule is a rotation schedule - used in automatic mode to switch between phases.|
-|started|string|Started is set to the time when rotation has been started in case if the state of the rotation is "in_progress".|
-|state|string|State could be one of "init" or "in_progress".|
+|`aws`|[object](#speccloud_metadataaws)|AWSInfo contains attributes to match to an EC2 instance.|
 
-### spec.rotation.schedule
+### `spec.rotation.schedule`
 
 |Field|Type|Description|
 |---|---|---|
-|standby|string|Standby specifies time to switch to the "Standby" phase.|
-|update_clients|string|UpdateClients specifies time to switch to the "Update clients" phase|
-|update_servers|string|UpdateServers specifies time to switch to the "Update servers" phase.|
+|`standby`|string|Standby specifies time to switch to the "Standby" phase.|
+|`update_clients`|string|UpdateClients specifies time to switch to the "Update clients" phase|
+|`update_servers`|string|UpdateServers specifies time to switch to the "Update servers" phase.|
+
+### `spec.rotation`
+
+|Field|Type|Description|
+|---|---|---|
+|`current_id`|string|CurrentID is the ID of the rotation operation to differentiate between rotation attempts.|
+|`grace_period`|string|GracePeriod is a period during which old and new CA are valid for checking purposes, but only new CA is issuing certificates.|
+|`last_rotated`|string|LastRotated specifies the last time of the completed rotation.|
+|`mode`|string|Mode sets manual or automatic rotation mode.|
+|`phase`|string|Phase is the current rotation phase.|
+|`schedule`|[object](#specrotationschedule)|Schedule is a rotation schedule - used in automatic mode to switch between phases.|
+|`started`|string|Started is set to the time when rotation has been started in case if the state of the rotation is `in_progress`.|
+|`state`|string|State could be one of `init` or `in_progress`.|
+
+### `spec`
+
+|Field|Type|Description|
+|---|---|---|
+|`addr`|string|Addr is a host:port address where this server can be reached.|
+|`cloud_metadata`|[object](#speccloud_metadata)|CloudMetadata contains info about the cloud instance the server is running on, if any.|
+|`hostname`|string|Hostname is server hostname|
+|`peer_addr`|string|PeerAddr is the address a proxy server is reachable at by its peer proxies.|
+|`proxy_ids`|[]string|ProxyIDs is a list of proxy IDs this server is expected to be connected to.|
+|`public_addrs`|[]string|PublicAddrs is a list of public addresses where this server can be reached.|
+|`rotation`|[object](#specrotation)|Rotation specifies server rotation|
+|`use_tunnel`|Boolean|UseTunnel indicates that connections to this server should occur over a reverse tunnel.|
+|`version`|string|TeleportVersion is the teleport version that the server is running on|
 

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_provisiontokens.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_provisiontokens.mdx
@@ -13,203 +13,203 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 ## resources.teleport.dev/v2
 
-**apiVersion:** resources.teleport.dev/v2
+`apiVersion: resources.teleport.dev/v2`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|ProvisionToken resource definition v2 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|ProvisionToken resource definition v2 from Teleport|
 
-### spec
-
-|Field|Type|Description|
-|---|---|---|
-|allow|[][object](#specallow-items)|Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.|
-|aws_iid_ttl|string|AWSIIDTTL is the TTL to use for AWS EC2 Instance Identity Documents used to join the cluster with this token.|
-|azure|[object](#specazure)|Azure allows the configuration of options specific to the "azure" join method.|
-|bot_name|string|BotName is the name of the bot this token grants access to, if any|
-|circleci|[object](#speccircleci)|CircleCI allows the configuration of options specific to the "circleci" join method.|
-|gcp|[object](#specgcp)|GCP allows the configuration of options specific to the "gcp" join method.|
-|github|[object](#specgithub)|GitHub allows the configuration of options specific to the "github" join method.|
-|gitlab|[object](#specgitlab)|GitLab allows the configuration of options specific to the "gitlab" join method.|
-|join_method|string|JoinMethod is the joining method required in order to use this token. Supported joining methods include: azure, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm|
-|kubernetes|[object](#speckubernetes)|Kubernetes allows the configuration of options specific to the "kubernetes" join method.|
-|roles|[]string|Roles is a list of roles associated with the token, that will be converted to metadata in the SSH and X509 certificates issued to the user of the token|
-|spacelift|[object](#specspacelift)|Spacelift allows the configuration of options specific to the "spacelift" join method.|
-|suggested_agent_matcher_labels|object|SuggestedAgentMatcherLabels is a set of labels to be used by agents to match on resources. When an agent uses this token, the agent should monitor resources that match those labels. For databases, this means adding the labels to `db_service.resources.labels`. Currently, only node-join scripts create a configuration according to the suggestion.|
-|suggested_labels|object|SuggestedLabels is a set of labels that resources should set when using this token to enroll themselves in the cluster. Currently, only node-join scripts create a configuration according to the suggestion.|
-|terraform_cloud|[object](#specterraform_cloud)|TerraformCloud allows the configuration of options specific to the "terraform_cloud" join method.|
-|tpm|[object](#spectpm)|TPM allows the configuration of options specific to the "tpm" join method.|
-
-### spec.allow items
+### `spec.allow` items
 
 |Field|Type|Description|
 |---|---|---|
-|aws_account|string|AWSAccount is the AWS account ID.|
-|aws_arn|string|AWSARN is used for the IAM join method, the AWS identity of joining nodes must match this ARN. Supports wildcards "*" and "?".|
-|aws_regions|[]string|AWSRegions is used for the EC2 join method and is a list of AWS regions a node is allowed to join from.|
-|aws_role|string|AWSRole is used for the EC2 join method and is the ARN of the AWS role that the auth server will assume in order to call the ec2 API.|
+|`aws_account`|string|AWSAccount is the AWS account ID.|
+|`aws_arn`|string|AWSARN is used for the IAM join method, the AWS identity of joining nodes must match this ARN. Supports wildcards "*" and "?".|
+|`aws_regions`|[]string|AWSRegions is used for the EC2 join method and is a list of AWS regions a node is allowed to join from.|
+|`aws_role`|string|AWSRole is used for the EC2 join method and is the ARN of the AWS role that the auth server will assume in order to call the ec2 API.|
 
-### spec.azure
-
-|Field|Type|Description|
-|---|---|---|
-|allow|[][object](#specazureallow-items)|Allow is a list of Rules, nodes using this token must match one allow rule to use this token.|
-
-### spec.azure.allow items
+### `spec.azure.allow` items
 
 |Field|Type|Description|
 |---|---|---|
-|resource_groups|[]string||
-|subscription|string||
+|`resource_groups`|[]string||
+|`subscription`|string||
 
-### spec.circleci
-
-|Field|Type|Description|
-|---|---|---|
-|allow|[][object](#speccircleciallow-items)|Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.|
-|organization_id|string||
-
-### spec.circleci.allow items
+### `spec.azure`
 
 |Field|Type|Description|
 |---|---|---|
-|context_id|string||
-|project_id|string||
+|`allow`|[][object](#specazureallow-items)|Allow is a list of Rules, nodes using this token must match one allow rule to use this token.|
 
-### spec.gcp
-
-|Field|Type|Description|
-|---|---|---|
-|allow|[][object](#specgcpallow-items)|Allow is a list of Rules, nodes using this token must match one allow rule to use this token.|
-
-### spec.gcp.allow items
+### `spec.circleci.allow` items
 
 |Field|Type|Description|
 |---|---|---|
-|locations|[]string||
-|project_ids|[]string||
-|service_accounts|[]string||
+|`context_id`|string||
+|`project_id`|string||
 
-### spec.github
-
-|Field|Type|Description|
-|---|---|---|
-|allow|[][object](#specgithuballow-items)|Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.|
-|enterprise_server_host|string|EnterpriseServerHost allows joining from runners associated with a GitHub Enterprise Server instance. When unconfigured, tokens will be validated against github.com, but when configured to the host of a GHES instance, then the tokens will be validated against host.  This value should be the hostname of the GHES instance, and should not include the scheme or a path. The instance must be accessible over HTTPS at this hostname and the certificate must be trusted by the Auth Server.|
-|enterprise_slug|string|EnterpriseSlug allows the slug of a GitHub Enterprise organisation to be included in the expected issuer of the OIDC tokens. This is for compatibility with the `include_enterprise_slug` option in GHE.  This field should be set to the slug of your enterprise if this is enabled. If this is not enabled, then this field must be left empty. This field cannot be specified if `enterprise_server_host` is specified.  See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise for more information about customized issuer values.|
-
-### spec.github.allow items
+### `spec.circleci`
 
 |Field|Type|Description|
 |---|---|---|
-|actor|string||
-|environment|string||
-|ref|string||
-|ref_type|string||
-|repository|string||
-|repository_owner|string||
-|sub|string||
-|workflow|string||
+|`allow`|[][object](#speccircleciallow-items)|Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.|
+|`organization_id`|string||
 
-### spec.gitlab
+### `spec.gcp.allow` items
 
 |Field|Type|Description|
 |---|---|---|
-|allow|[][object](#specgitlaballow-items)|Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.|
-|domain|string|Domain is the domain of your GitLab instance. This will default to `gitlab.com` - but can be set to the domain of your self-hosted GitLab e.g `gitlab.example.com`.|
+|`locations`|[]string||
+|`project_ids`|[]string||
+|`service_accounts`|[]string||
 
-### spec.gitlab.allow items
-
-|Field|Type|Description|
-|---|---|---|
-|ci_config_ref_uri|string||
-|ci_config_sha|string||
-|deployment_tier|string||
-|environment|string||
-|environment_protected|boolean||
-|namespace_path|string||
-|pipeline_source|string||
-|project_path|string||
-|project_visibility|string||
-|ref|string||
-|ref_protected|boolean||
-|ref_type|string||
-|sub|string||
-|user_email|string||
-|user_id|string||
-|user_login|string||
-
-### spec.kubernetes
+### `spec.gcp`
 
 |Field|Type|Description|
 |---|---|---|
-|allow|[][object](#speckubernetesallow-items)|Allow is a list of Rules, nodes using this token must match one allow rule to use this token.|
-|static_jwks|[object](#speckubernetesstatic_jwks)|StaticJWKS is the configuration specific to the `static_jwks` type.|
-|type|string|Type controls which behavior should be used for validating the Kubernetes Service Account token. Support values: - `in_cluster` - `static_jwks` If unset, this defaults to `in_cluster`.|
+|`allow`|[][object](#specgcpallow-items)|Allow is a list of Rules, nodes using this token must match one allow rule to use this token.|
 
-### spec.kubernetes.allow items
+### `spec.github.allow` items
 
 |Field|Type|Description|
 |---|---|---|
-|service_account|string||
+|`actor`|string||
+|`environment`|string||
+|`ref`|string||
+|`ref_type`|string||
+|`repository`|string||
+|`repository_owner`|string||
+|`sub`|string||
+|`workflow`|string||
 
-### spec.kubernetes.static_jwks
-
-|Field|Type|Description|
-|---|---|---|
-|jwks|string||
-
-### spec.spacelift
-
-|Field|Type|Description|
-|---|---|---|
-|allow|[][object](#specspaceliftallow-items)|Allow is a list of Rules, nodes using this token must match one allow rule to use this token.|
-|hostname|string|Hostname is the hostname of the Spacelift tenant that tokens will originate from. E.g `example.app.spacelift.io`|
-
-### spec.spacelift.allow items
+### `spec.github`
 
 |Field|Type|Description|
 |---|---|---|
-|caller_id|string||
-|caller_type|string||
-|scope|string||
-|space_id|string||
+|`allow`|[][object](#specgithuballow-items)|Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.|
+|`enterprise_server_host`|string|EnterpriseServerHost allows joining from runners associated with a GitHub Enterprise Server instance. When unconfigured, tokens will be validated against `github.com`, but when configured to the host of a GHES instance, then the tokens will be validated against host.  This value should be the hostname of the GHES instance, and should not include the scheme or a path. The instance must be accessible over HTTPS at this hostname and the certificate must be trusted by the Auth Server.|
+|`enterprise_slug`|string|EnterpriseSlug allows the slug of a GitHub Enterprise organisation to be included in the expected issuer of the OIDC tokens. This is for compatibility with the `include_enterprise_slug` option in GHE.  This field should be set to the slug of your enterprise if this is enabled. If this is not enabled, then this field must be left empty. This field cannot be specified if `enterprise_server_host` is specified.  See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise for more information about customized issuer values.|
 
-### spec.terraform_cloud
-
-|Field|Type|Description|
-|---|---|---|
-|allow|[][object](#specterraform_cloudallow-items)|Allow is a list of Rules, nodes using this token must match one allow rule to use this token.|
-|audience|string|Audience is the JWT audience as configured in the TFC_WORKLOAD_IDENTITY_AUDIENCE(_$TAG) variable in Terraform Cloud. If unset, defaults to the Teleport cluster name. For example, if `TFC_WORKLOAD_IDENTITY_AUDIENCE_TELEPORT=foo` is set in Terraform Cloud, this value should be `foo`. If the variable is set to match the cluster name, it does not need to be set here.|
-|hostname|string|Hostname is the hostname of the Terraform Enterprise instance expected to issue JWTs allowed by this token. This may be unset for regular Terraform Cloud use, in which case it will be assumed to be `app.terraform.io`. Otherwise, it must both match the `iss` (issuer) field included in JWTs, and provide standard JWKS endpoints.|
-
-### spec.terraform_cloud.allow items
+### `spec.gitlab.allow` items
 
 |Field|Type|Description|
 |---|---|---|
-|organization_id|string||
-|organization_name|string||
-|project_id|string||
-|project_name|string||
-|run_phase|string||
-|workspace_id|string||
-|workspace_name|string||
+|`ci_config_ref_uri`|string||
+|`ci_config_sha`|string||
+|`deployment_tier`|string||
+|`environment`|string||
+|`environment_protected`|Boolean||
+|`namespace_path`|string||
+|`pipeline_source`|string||
+|`project_path`|string||
+|`project_visibility`|string||
+|`ref`|string||
+|`ref_protected`|Boolean||
+|`ref_type`|string||
+|`sub`|string||
+|`user_email`|string||
+|`user_id`|string||
+|`user_login`|string||
 
-### spec.tpm
+### `spec.gitlab`
 
 |Field|Type|Description|
 |---|---|---|
-|allow|[][object](#spectpmallow-items)|Allow is a list of Rules, the presented delegated identity must match one allow rule to permit joining.|
-|ekcert_allowed_cas|[]string|EKCertAllowedCAs is a list of CA certificates that will be used to validate TPM EKCerts. When specified, joining TPMs must present an EKCert signed by one of the specified CAs. TPMs that do not present an EKCert will be not permitted to join. When unspecified, TPMs will be allowed to join with either an EKCert or an EKPubHash.|
+|`allow`|[][object](#specgitlaballow-items)|Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.|
+|`domain`|string|Domain is the domain of your GitLab instance. This will default to `gitlab.com` - but can be set to the domain of your self-hosted GitLab e.g `gitlab.example.com`.|
 
-### spec.tpm.allow items
+### `spec.kubernetes.allow` items
 
 |Field|Type|Description|
 |---|---|---|
-|description|string||
-|ek_certificate_serial|string||
-|ek_public_hash|string||
+|`service_account`|string||
+
+### `spec.kubernetes.static_jwks`
+
+|Field|Type|Description|
+|---|---|---|
+|`jwks`|string||
+
+### `spec.kubernetes`
+
+|Field|Type|Description|
+|---|---|---|
+|`allow`|[][object](#speckubernetesallow-items)|Allow is a list of Rules, nodes using this token must match one allow rule to use this token.|
+|`static_jwks`|[object](#speckubernetesstatic_jwks)|StaticJWKS is the configuration specific to the `static_jwks` type.|
+|`type`|string|Type controls which behavior should be used for validating the Kubernetes Service Account token. Support values: - `in_cluster` - `static_jwks` If unset, this defaults to `in_cluster`.|
+
+### `spec.spacelift.allow` items
+
+|Field|Type|Description|
+|---|---|---|
+|`caller_id`|string||
+|`caller_type`|string||
+|`scope`|string||
+|`space_id`|string||
+
+### `spec.spacelift`
+
+|Field|Type|Description|
+|---|---|---|
+|`allow`|[][object](#specspaceliftallow-items)|Allow is a list of Rules, nodes using this token must match one allow rule to use this token.|
+|`hostname`|string|Hostname is the hostname of the Spacelift tenant that tokens will originate from. E.g `example.app.spacelift.io`|
+
+### `spec.terraform_cloud.allow` items
+
+|Field|Type|Description|
+|---|---|---|
+|`organization_id`|string||
+|`organization_name`|string||
+|`project_id`|string||
+|`project_name`|string||
+|`run_phase`|string||
+|`workspace_id`|string||
+|`workspace_name`|string||
+
+### `spec.terraform_cloud`
+
+|Field|Type|Description|
+|---|---|---|
+|`allow`|[][object](#specterraform_cloudallow-items)|Allow is a list of Rules, nodes using this token must match one allow rule to use this token.|
+|`audience`|string|Audience is the JWT audience as configured in the TFC_WORKLOAD_IDENTITY_AUDIENCE(_$TAG) variable in Terraform Cloud. If unset, defaults to the Teleport cluster name. For example, if `TFC_WORKLOAD_IDENTITY_AUDIENCE_TELEPORT=foo` is set in Terraform Cloud, this value should be `foo`. If the variable is set to match the cluster name, it does not need to be set here.|
+|`hostname`|string|Hostname is the hostname of the Terraform Enterprise instance expected to issue JWTs allowed by this token. This may be unset for regular Terraform Cloud use, in which case it will be assumed to be `app.terraform.io`. Otherwise, it must both match the `iss` (issuer) field included in JWTs, and provide standard JWKS endpoints.|
+
+### `spec.tpm.allow` items
+
+|Field|Type|Description|
+|---|---|---|
+|`description`|string||
+|`ek_certificate_serial`|string||
+|`ek_public_hash`|string||
+
+### `spec.tpm`
+
+|Field|Type|Description|
+|---|---|---|
+|`allow`|[][object](#spectpmallow-items)|Allow is a list of Rules, the presented delegated identity must match one allow rule to permit joining.|
+|`ekcert_allowed_cas`|[]string|EKCertAllowedCAs is a list of CA certificates that will be used to validate TPM EKCerts. When specified, joining TPMs must present an EKCert signed by one of the specified CAs. TPMs that do not present an EKCert will be not permitted to join. When unspecified, TPMs will be allowed to join with either an EKCert or an EKPubHash.|
+
+### `spec`
+
+|Field|Type|Description|
+|---|---|---|
+|`allow`|[][object](#specallow-items)|Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.|
+|`aws_iid_ttl`|string|AWSIIDTTL is the TTL to use for AWS EC2 Instance Identity Documents used to join the cluster with this token.|
+|`azure`|[object](#specazure)|Azure allows the configuration of options specific to the `azure` join method.|
+|`bot_name`|string|BotName is the name of the bot this token grants access to, if any|
+|`circleci`|[object](#speccircleci)|CircleCI allows the configuration of options specific to the `circleci` join method.|
+|`gcp`|[object](#specgcp)|GCP allows the configuration of options specific to the `gcp` join method.|
+|`github`|[object](#specgithub)|GitHub allows the configuration of options specific to the `github` join method.|
+|`gitlab`|[object](#specgitlab)|GitLab allows the configuration of options specific to the `gitlab` join method.|
+|`join_method`|string|JoinMethod is the joining method required in order to use this token. Supported joining methods include: `azure`, `circleci`, `ec2`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`|
+|`kubernetes`|[object](#speckubernetes)|Kubernetes allows the configuration of options specific to the `kubernetes` join method.|
+|`roles`|[]string|Roles is a list of roles associated with the token, that will be converted to metadata in the SSH and X509 certificates issued to the user of the token|
+|`spacelift`|[object](#specspacelift)|Spacelift allows the configuration of options specific to the `spacelift` join method.|
+|`suggested_agent_matcher_labels`|object|SuggestedAgentMatcherLabels is a set of labels to be used by agents to match on resources. When an agent uses this token, the agent should monitor resources that match those labels. For databases, this means adding the labels to `db_service.resources.labels`. Currently, only node-join scripts create a configuration according to the suggestion.|
+|`suggested_labels`|object|SuggestedLabels is a set of labels that resources should set when using this token to enroll themselves in the cluster. Currently, only node-join scripts create a configuration according to the suggestion.|
+|`terraform_cloud`|[object](#specterraform_cloud)|TerraformCloud allows the configuration of options specific to the `terraform_cloud` join method.|
+|`tpm`|[object](#spectpm)|TPM allows the configuration of options specific to the `tpm` join method.|
 

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_roles.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_roles.mdx
@@ -13,767 +13,767 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 ## resources.teleport.dev/v5
 
-**apiVersion:** resources.teleport.dev/v5
+`apiVersion: resources.teleport.dev/v5`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|Role resource definition v5 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|Role resource definition v5 from Teleport|
 
-### spec
-
-|Field|Type|Description|
-|---|---|---|
-|allow|[object](#specallow)|Allow is the set of conditions evaluated to grant access.|
-|deny|[object](#specdeny)|Deny is the set of conditions evaluated to deny access. Deny takes priority over allow.|
-|options|[object](#specoptions)|Options is for OpenSSH options like agent forwarding.|
-
-### spec.allow
+### `spec.allow.db_permissions` items
 
 |Field|Type|Description|
 |---|---|---|
-|app_labels|object|AppLabels is a map of labels used as part of the RBAC system.|
-|app_labels_expression|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
-|aws_role_arns|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
-|azure_identities|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
-|cluster_labels|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
-|cluster_labels_expression|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
-|db_labels|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
-|db_labels_expression|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
-|db_names|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
-|db_permissions|[][object](#specallowdb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
-|db_roles|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
-|db_service_labels|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
-|db_service_labels_expression|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
-|db_users|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
-|desktop_groups|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
-|gcp_service_accounts|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
-|group_labels|object|GroupLabels is a map of labels used as part of the RBAC system.|
-|group_labels_expression|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
-|host_groups|[]string|HostGroups is a list of groups for created users to be added to|
-|host_sudoers|[]string|HostSudoers is a list of entries to include in a users sudoer file|
-|impersonate|[object](#specallowimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
-|join_sessions|[][object](#specallowjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
-|kubernetes_groups|[]string|KubeGroups is a list of kubernetes groups|
-|kubernetes_labels|object|KubernetesLabels is a map of kubernetes cluster labels used for RBAC.|
-|kubernetes_labels_expression|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.|
-|kubernetes_resources|[][object](#specallowkubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
-|kubernetes_users|[]string|KubeUsers is an optional kubernetes users to impersonate|
-|logins|[]string|Logins is a list of *nix system logins.|
-|node_labels|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
-|node_labels_expression|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
-|request|[object](#specallowrequest)||
-|require_session_join|[][object](#specallowrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
-|review_requests|[object](#specallowreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
-|rules|[][object](#specallowrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
-|spiffe|[][object](#specallowspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
-|windows_desktop_labels|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
-|windows_desktop_labels_expression|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
-|windows_desktop_logins|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
+|`match`|object|Match is a list of object labels that must be matched for the permission to be granted.|
+|`permissions`|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
 
-### spec.allow.db_permissions items
+### `spec.allow.impersonate`
 
 |Field|Type|Description|
 |---|---|---|
-|match|object|Match is a list of object labels that must be matched for the permission to be granted.|
-|permissions|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
+|`roles`|[]string|Roles is a list of resources this role is allowed to impersonate|
+|`users`|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
+|`where`|string|Where specifies optional advanced matcher|
 
-### spec.allow.impersonate
-
-|Field|Type|Description|
-|---|---|---|
-|roles|[]string|Roles is a list of resources this role is allowed to impersonate|
-|users|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
-|where|string|Where specifies optional advanced matcher|
-
-### spec.allow.join_sessions items
+### `spec.allow.join_sessions` items
 
 |Field|Type|Description|
 |---|---|---|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is a list of permitted participant modes for this policy.|
-|name|string|Name is the name of the policy.|
-|roles|[]string|Roles is a list of roles that you can join the session of.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is a list of permitted participant modes for this policy.|
+|`name`|string|Name is the name of the policy.|
+|`roles`|[]string|Roles is a list of roles that you can join the session of.|
 
-### spec.allow.kubernetes_resources items
-
-|Field|Type|Description|
-|---|---|---|
-|kind|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
-|name|string|Name is the resource name. It supports wildcards.|
-|namespace|string|Namespace is the resource namespace. It supports wildcards.|
-|verbs|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
-
-### spec.allow.request
+### `spec.allow.kubernetes_resources` items
 
 |Field|Type|Description|
 |---|---|---|
-|annotations|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
-|claims_to_roles|[][object](#specallowrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|max_duration|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
-|roles|[]string|Roles is the name of roles which will match the request rule.|
-|search_as_roles|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
-|suggested_reviewers|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
-|thresholds|[][object](#specallowrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
+|`kind`|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
+|`name`|string|Name is the resource name. It supports wildcards.|
+|`namespace`|string|Namespace is the resource namespace. It supports wildcards.|
+|`verbs`|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
 
-### spec.allow.request.claims_to_roles items
+### `spec.allow.request.claims_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
 
-### spec.allow.request.thresholds items
-
-|Field|Type|Description|
-|---|---|---|
-|approve|integer|Approve is the number of matching approvals needed for state-transition.|
-|deny|integer|Deny is the number of denials needed for state-transition.|
-|filter|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
-|name|string|Name is the optional human-readable name of the threshold.|
-
-### spec.allow.require_session_join items
+### `spec.allow.request.thresholds` items
 
 |Field|Type|Description|
 |---|---|---|
-|count|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
-|filter|string|Filter is a predicate that determines what users count towards this policy.|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is the list of modes that may be used to fulfill this policy.|
-|name|string|Name is the name of the policy.|
-|on_leave|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
+|`approve`|integer|Approve is the number of matching approvals needed for state-transition.|
+|`deny`|integer|Deny is the number of denials needed for state-transition.|
+|`filter`|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
+|`name`|string|Name is the optional human-readable name of the threshold.|
 
-### spec.allow.review_requests
+### `spec.allow.request`
 
 |Field|Type|Description|
 |---|---|---|
-|claims_to_roles|[][object](#specallowreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|preview_as_roles|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
-|roles|[]string|Roles is the name of roles which may be reviewed.|
-|where|string|Where is an optional predicate which further limits which requests are reviewable.|
+|`annotations`|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
+|`claims_to_roles`|[][object](#specallowrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`max_duration`|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
+|`roles`|[]string|Roles is the name of roles which will match the request rule.|
+|`search_as_roles`|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
+|`suggested_reviewers`|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
+|`thresholds`|[][object](#specallowrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
 
-### spec.allow.review_requests.claims_to_roles items
-
-|Field|Type|Description|
-|---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
-
-### spec.allow.rules items
+### `spec.allow.require_session_join` items
 
 |Field|Type|Description|
 |---|---|---|
-|actions|[]string|Actions specifies optional actions taken when this rule matches|
-|resources|[]string|Resources is a list of resources|
-|verbs|[]string|Verbs is a list of verbs|
-|where|string|Where specifies optional advanced matcher|
+|`count`|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
+|`filter`|string|Filter is a predicate that determines what users count towards this policy.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is the list of modes that may be used to fulfill this policy.|
+|`name`|string|Name is the name of the policy.|
+|`on_leave`|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
 
-### spec.allow.spiffe items
-
-|Field|Type|Description|
-|---|---|---|
-|dns_sans|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
-|ip_sans|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
-|path|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
-
-### spec.deny
+### `spec.allow.review_requests.claims_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|app_labels|object|AppLabels is a map of labels used as part of the RBAC system.|
-|app_labels_expression|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
-|aws_role_arns|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
-|azure_identities|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
-|cluster_labels|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
-|cluster_labels_expression|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
-|db_labels|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
-|db_labels_expression|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
-|db_names|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
-|db_permissions|[][object](#specdenydb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
-|db_roles|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
-|db_service_labels|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
-|db_service_labels_expression|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
-|db_users|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
-|desktop_groups|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
-|gcp_service_accounts|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
-|group_labels|object|GroupLabels is a map of labels used as part of the RBAC system.|
-|group_labels_expression|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
-|host_groups|[]string|HostGroups is a list of groups for created users to be added to|
-|host_sudoers|[]string|HostSudoers is a list of entries to include in a users sudoer file|
-|impersonate|[object](#specdenyimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
-|join_sessions|[][object](#specdenyjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
-|kubernetes_groups|[]string|KubeGroups is a list of kubernetes groups|
-|kubernetes_labels|object|KubernetesLabels is a map of kubernetes cluster labels used for RBAC.|
-|kubernetes_labels_expression|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.|
-|kubernetes_resources|[][object](#specdenykubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
-|kubernetes_users|[]string|KubeUsers is an optional kubernetes users to impersonate|
-|logins|[]string|Logins is a list of *nix system logins.|
-|node_labels|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
-|node_labels_expression|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
-|request|[object](#specdenyrequest)||
-|require_session_join|[][object](#specdenyrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
-|review_requests|[object](#specdenyreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
-|rules|[][object](#specdenyrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
-|spiffe|[][object](#specdenyspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
-|windows_desktop_labels|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
-|windows_desktop_labels_expression|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
-|windows_desktop_logins|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
 
-### spec.deny.db_permissions items
+### `spec.allow.review_requests`
 
 |Field|Type|Description|
 |---|---|---|
-|match|object|Match is a list of object labels that must be matched for the permission to be granted.|
-|permissions|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
+|`claims_to_roles`|[][object](#specallowreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`preview_as_roles`|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
+|`roles`|[]string|Roles is the name of roles which may be reviewed.|
+|`where`|string|Where is an optional predicate which further limits which requests are reviewable.|
 
-### spec.deny.impersonate
-
-|Field|Type|Description|
-|---|---|---|
-|roles|[]string|Roles is a list of resources this role is allowed to impersonate|
-|users|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
-|where|string|Where specifies optional advanced matcher|
-
-### spec.deny.join_sessions items
+### `spec.allow.rules` items
 
 |Field|Type|Description|
 |---|---|---|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is a list of permitted participant modes for this policy.|
-|name|string|Name is the name of the policy.|
-|roles|[]string|Roles is a list of roles that you can join the session of.|
+|`actions`|[]string|Actions specifies optional actions taken when this rule matches|
+|`resources`|[]string|Resources is a list of resources|
+|`verbs`|[]string|Verbs is a list of verbs|
+|`where`|string|Where specifies optional advanced matcher|
 
-### spec.deny.kubernetes_resources items
-
-|Field|Type|Description|
-|---|---|---|
-|kind|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
-|name|string|Name is the resource name. It supports wildcards.|
-|namespace|string|Namespace is the resource namespace. It supports wildcards.|
-|verbs|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
-
-### spec.deny.request
+### `spec.allow.spiffe` items
 
 |Field|Type|Description|
 |---|---|---|
-|annotations|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
-|claims_to_roles|[][object](#specdenyrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|max_duration|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
-|roles|[]string|Roles is the name of roles which will match the request rule.|
-|search_as_roles|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
-|suggested_reviewers|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
-|thresholds|[][object](#specdenyrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
+|`dns_sans`|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
+|`ip_sans`|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
+|`path`|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
 
-### spec.deny.request.claims_to_roles items
+### `spec.allow`
 
 |Field|Type|Description|
 |---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
+|`app_labels`|object|AppLabels is a map of labels used as part of the RBAC system.|
+|`app_labels_expression`|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
+|`aws_role_arns`|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
+|`azure_identities`|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
+|`cluster_labels`|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
+|`cluster_labels_expression`|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
+|`db_labels`|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
+|`db_labels_expression`|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
+|`db_names`|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
+|`db_permissions`|[][object](#specallowdb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
+|`db_roles`|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
+|`db_service_labels`|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
+|`db_service_labels_expression`|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
+|`db_users`|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
+|`desktop_groups`|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
+|`gcp_service_accounts`|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
+|`group_labels`|object|GroupLabels is a map of labels used as part of the RBAC system.|
+|`group_labels_expression`|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
+|`host_groups`|[]string|HostGroups is a list of groups for created users to be added to|
+|`host_sudoers`|[]string|HostSudoers is a list of entries to include in a users sudoer file|
+|`impersonate`|[object](#specallowimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
+|`join_sessions`|[][object](#specallowjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
+|`kubernetes_groups`|[]string|KubeGroups is a list of Kubernetes groups|
+|`kubernetes_labels`|object|KubernetesLabels is a map of Kubernetes cluster labels used for RBAC.|
+|`kubernetes_labels_expression`|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.|
+|`kubernetes_resources`|[][object](#specallowkubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
+|`kubernetes_users`|[]string|KubeUsers is an optional Kubernetes users to impersonate|
+|`logins`|[]string|Logins is a list of *nix system logins.|
+|`node_labels`|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
+|`node_labels_expression`|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
+|`request`|[object](#specallowrequest)||
+|`require_session_join`|[][object](#specallowrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
+|`review_requests`|[object](#specallowreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
+|`rules`|[][object](#specallowrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
+|`spiffe`|[][object](#specallowspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
+|`windows_desktop_labels`|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
+|`windows_desktop_labels_expression`|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
+|`windows_desktop_logins`|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
 
-### spec.deny.request.thresholds items
-
-|Field|Type|Description|
-|---|---|---|
-|approve|integer|Approve is the number of matching approvals needed for state-transition.|
-|deny|integer|Deny is the number of denials needed for state-transition.|
-|filter|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
-|name|string|Name is the optional human-readable name of the threshold.|
-
-### spec.deny.require_session_join items
-
-|Field|Type|Description|
-|---|---|---|
-|count|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
-|filter|string|Filter is a predicate that determines what users count towards this policy.|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is the list of modes that may be used to fulfill this policy.|
-|name|string|Name is the name of the policy.|
-|on_leave|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
-
-### spec.deny.review_requests
-
-|Field|Type|Description|
-|---|---|---|
-|claims_to_roles|[][object](#specdenyreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|preview_as_roles|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
-|roles|[]string|Roles is the name of roles which may be reviewed.|
-|where|string|Where is an optional predicate which further limits which requests are reviewable.|
-
-### spec.deny.review_requests.claims_to_roles items
-
-|Field|Type|Description|
-|---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
-
-### spec.deny.rules items
+### `spec.deny.db_permissions` items
 
 |Field|Type|Description|
 |---|---|---|
-|actions|[]string|Actions specifies optional actions taken when this rule matches|
-|resources|[]string|Resources is a list of resources|
-|verbs|[]string|Verbs is a list of verbs|
-|where|string|Where specifies optional advanced matcher|
+|`match`|object|Match is a list of object labels that must be matched for the permission to be granted.|
+|`permissions`|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
 
-### spec.deny.spiffe items
+### `spec.deny.impersonate`
 
 |Field|Type|Description|
 |---|---|---|
-|dns_sans|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
-|ip_sans|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
-|path|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
+|`roles`|[]string|Roles is a list of resources this role is allowed to impersonate|
+|`users`|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
+|`where`|string|Where specifies optional advanced matcher|
 
-### spec.options
-
-|Field|Type|Description|
-|---|---|---|
-|cert_extensions|[][object](#specoptionscert_extensions-items)|CertExtensions specifies the key/values|
-|cert_format|string|CertificateFormat defines the format of the user certificate to allow compatibility with older versions of OpenSSH.|
-|client_idle_timeout|string|ClientIdleTimeout sets disconnect clients on idle timeout behavior, if set to 0 means do not disconnect, otherwise is set to the idle duration.|
-|create_db_user|boolean|CreateDatabaseUser enabled automatic database user creation.|
-|create_db_user_mode|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop". Can be either the string or the integer representation of each option.|
-|create_desktop_user|boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
-|create_host_user|boolean|CreateHostUser allows users to be automatically created on a host|
-|create_host_user_default_shell|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
-|create_host_user_mode|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop". Can be either the string or the integer representation of each option.|
-|desktop_clipboard|boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|
-|desktop_directory_sharing|boolean|DesktopDirectorySharing indicates whether directory sharing is allowed between the user's workstation and the remote desktop. It defaults to false unless explicitly set to true.|
-|device_trust_mode|string|DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode.|
-|disconnect_expired_cert|boolean|DisconnectExpiredCert sets disconnect clients on expired certificates.|
-|enhanced_recording|[]string|BPF defines what events to record for the BPF-based session recorder.|
-|forward_agent|boolean|ForwardAgent is SSH agent forwarding.|
-|idp|[object](#specoptionsidp)|IDP is a set of options related to accessing IdPs within Teleport. Requires Teleport Enterprise.|
-|lock|string|Lock specifies the locking mode (strict|best_effort) to be applied with the role.|
-|max_connections|integer|MaxConnections defines the maximum number of concurrent connections a user may hold.|
-|max_kubernetes_connections|integer|MaxKubernetesConnections defines the maximum number of concurrent Kubernetes sessions a user may hold.|
-|max_session_ttl|string|MaxSessionTTL defines how long a SSH session can last for.|
-|max_sessions|integer|MaxSessions defines the maximum number of concurrent sessions per connection.|
-|mfa_verification_interval|string|MFAVerificationInterval optionally defines the maximum duration that can elapse between successive MFA verifications. This variable is used to ensure that users are periodically prompted to verify their identity, enhancing security by preventing prolonged sessions without re-authentication when using tsh proxy * derivatives. It's only effective if the session requires MFA. If not set, defaults to `max_session_ttl`.|
-|permit_x11_forwarding|boolean|PermitX11Forwarding authorizes use of X11 forwarding.|
-|pin_source_ip|boolean|PinSourceIP forces the same client IP for certificate generation and usage|
-|port_forwarding|boolean|PortForwarding defines if the certificate will have "permit-port-forwarding" in the certificate. PortForwarding is "yes" if not set, that's why this is a pointer|
-|record_session|[object](#specoptionsrecord_session)|RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.|
-|request_access|string|RequestAccess defines the request strategy (optional|note|always) where optional is the default.|
-|request_prompt|string|RequestPrompt is an optional message which tells users what they aught to request.|
-|require_session_mfa|string or integer|RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN". Can be either the string or the integer representation of each option.|
-|ssh_file_copy|boolean|SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.|
-
-### spec.options.cert_extensions items
+### `spec.deny.join_sessions` items
 
 |Field|Type|Description|
 |---|---|---|
-|mode|string or integer|Mode is the type of extension to be used -- currently critical-option is not supported. 0 is "extension". Can be either the string or the integer representation of each option.|
-|name|string|Name specifies the key to be used in the cert extension.|
-|type|string or integer|Type represents the certificate type being extended, only ssh is supported at this time. 0 is "ssh". Can be either the string or the integer representation of each option.|
-|value|string|Value specifies the value to be used in the cert extension.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is a list of permitted participant modes for this policy.|
+|`name`|string|Name is the name of the policy.|
+|`roles`|[]string|Roles is a list of roles that you can join the session of.|
 
-### spec.options.idp
-
-|Field|Type|Description|
-|---|---|---|
-|saml|[object](#specoptionsidpsaml)|SAML are options related to the Teleport SAML IdP.|
-
-### spec.options.idp.saml
+### `spec.deny.kubernetes_resources` items
 
 |Field|Type|Description|
 |---|---|---|
-|enabled|boolean|Enabled is set to true if this option allows access to the Teleport SAML IdP.|
+|`kind`|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
+|`name`|string|Name is the resource name. It supports wildcards.|
+|`namespace`|string|Namespace is the resource namespace. It supports wildcards.|
+|`verbs`|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
 
-### spec.options.record_session
+### `spec.deny.request.claims_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|default|string|Default indicates the default value for the services.|
-|desktop|boolean|Desktop indicates whether desktop sessions should be recorded. It defaults to true unless explicitly set to false.|
-|ssh|string|SSH indicates the session mode used on SSH sessions.|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
+
+### `spec.deny.request.thresholds` items
+
+|Field|Type|Description|
+|---|---|---|
+|`approve`|integer|Approve is the number of matching approvals needed for state-transition.|
+|`deny`|integer|Deny is the number of denials needed for state-transition.|
+|`filter`|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
+|`name`|string|Name is the optional human-readable name of the threshold.|
+
+### `spec.deny.request`
+
+|Field|Type|Description|
+|---|---|---|
+|`annotations`|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
+|`claims_to_roles`|[][object](#specdenyrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`max_duration`|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
+|`roles`|[]string|Roles is the name of roles which will match the request rule.|
+|`search_as_roles`|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
+|`suggested_reviewers`|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
+|`thresholds`|[][object](#specdenyrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
+
+### `spec.deny.require_session_join` items
+
+|Field|Type|Description|
+|---|---|---|
+|`count`|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
+|`filter`|string|Filter is a predicate that determines what users count towards this policy.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is the list of modes that may be used to fulfill this policy.|
+|`name`|string|Name is the name of the policy.|
+|`on_leave`|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
+
+### `spec.deny.review_requests.claims_to_roles` items
+
+|Field|Type|Description|
+|---|---|---|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
+
+### `spec.deny.review_requests`
+
+|Field|Type|Description|
+|---|---|---|
+|`claims_to_roles`|[][object](#specdenyreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`preview_as_roles`|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
+|`roles`|[]string|Roles is the name of roles which may be reviewed.|
+|`where`|string|Where is an optional predicate which further limits which requests are reviewable.|
+
+### `spec.deny.rules` items
+
+|Field|Type|Description|
+|---|---|---|
+|`actions`|[]string|Actions specifies optional actions taken when this rule matches|
+|`resources`|[]string|Resources is a list of resources|
+|`verbs`|[]string|Verbs is a list of verbs|
+|`where`|string|Where specifies optional advanced matcher|
+
+### `spec.deny.spiffe` items
+
+|Field|Type|Description|
+|---|---|---|
+|`dns_sans`|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
+|`ip_sans`|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
+|`path`|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
+
+### `spec.deny`
+
+|Field|Type|Description|
+|---|---|---|
+|`app_labels`|object|AppLabels is a map of labels used as part of the RBAC system.|
+|`app_labels_expression`|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
+|`aws_role_arns`|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
+|`azure_identities`|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
+|`cluster_labels`|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
+|`cluster_labels_expression`|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
+|`db_labels`|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
+|`db_labels_expression`|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
+|`db_names`|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
+|`db_permissions`|[][object](#specdenydb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
+|`db_roles`|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
+|`db_service_labels`|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
+|`db_service_labels_expression`|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
+|`db_users`|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
+|`desktop_groups`|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
+|`gcp_service_accounts`|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
+|`group_labels`|object|GroupLabels is a map of labels used as part of the RBAC system.|
+|`group_labels_expression`|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
+|`host_groups`|[]string|HostGroups is a list of groups for created users to be added to|
+|`host_sudoers`|[]string|HostSudoers is a list of entries to include in a users sudoer file|
+|`impersonate`|[object](#specdenyimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
+|`join_sessions`|[][object](#specdenyjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
+|`kubernetes_groups`|[]string|KubeGroups is a list of Kubernetes groups|
+|`kubernetes_labels`|object|KubernetesLabels is a map of Kubernetes cluster labels used for RBAC.|
+|`kubernetes_labels_expression`|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.|
+|`kubernetes_resources`|[][object](#specdenykubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
+|`kubernetes_users`|[]string|KubeUsers is an optional Kubernetes users to impersonate|
+|`logins`|[]string|Logins is a list of *nix system logins.|
+|`node_labels`|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
+|`node_labels_expression`|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
+|`request`|[object](#specdenyrequest)||
+|`require_session_join`|[][object](#specdenyrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
+|`review_requests`|[object](#specdenyreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
+|`rules`|[][object](#specdenyrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
+|`spiffe`|[][object](#specdenyspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
+|`windows_desktop_labels`|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
+|`windows_desktop_labels_expression`|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
+|`windows_desktop_logins`|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
+
+### `spec.options.cert_extensions` items
+
+|Field|Type|Description|
+|---|---|---|
+|`mode`|string or integer|Mode is the type of extension to be used -- currently critical-option is not supported. 0 is "extension". Can be either the string or the integer representation of each option.|
+|`name`|string|Name specifies the key to be used in the cert extension.|
+|`type`|string or integer|Type represents the certificate type being extended, only ssh is supported at this time. 0 is "ssh". Can be either the string or the integer representation of each option.|
+|`value`|string|Value specifies the value to be used in the cert extension.|
+
+### `spec.options.idp.saml`
+
+|Field|Type|Description|
+|---|---|---|
+|`enabled`|Boolean|Enabled is set to true if this option allows access to the Teleport SAML IdP.|
+
+### `spec.options.idp`
+
+|Field|Type|Description|
+|---|---|---|
+|`saml`|[object](#specoptionsidpsaml)|SAML are options related to the Teleport SAML IdP.|
+
+### `spec.options.record_session`
+
+|Field|Type|Description|
+|---|---|---|
+|`default`|string|Default indicates the default value for the services.|
+|`desktop`|Boolean|Desktop indicates whether desktop sessions should be recorded. It defaults to true unless explicitly set to false.|
+|`ssh`|string|SSH indicates the session mode used on SSH sessions.|
+
+### `spec.options`
+
+|Field|Type|Description|
+|---|---|---|
+|`cert_extensions`|[][object](#specoptionscert_extensions-items)|CertExtensions specifies the key/values|
+|`cert_format`|string|CertificateFormat defines the format of the user certificate to allow compatibility with older versions of OpenSSH.|
+|`client_idle_timeout`|string|ClientIdleTimeout sets disconnect clients on idle timeout behavior, if set to 0 means do not disconnect, otherwise is set to the idle duration.|
+|`create_db_user`|Boolean|CreateDatabaseUser enabled automatic database user creation.|
+|`create_db_user_mode`|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is `unspecified`, 1 is `off`, 2 is `keep`, 3 is `best_effort_drop`. Can be either the string or the integer representation of each option.|
+|`create_desktop_user`|Boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
+|`create_host_user`|Boolean|CreateHostUser allows users to be automatically created on a host|
+|`create_host_user_default_shell`|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
+|`create_host_user_mode`|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is `unspecified`; 1 is `off`; 2 is `drop` (removed for v15 and above), 3 is `keep`; 4 is `insecure-drop`. Can be either the string or the integer representation of each option.|
+|`desktop_clipboard`|Boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|
+|`desktop_directory_sharing`|Boolean|DesktopDirectorySharing indicates whether directory sharing is allowed between the user's workstation and the remote desktop. It defaults to false unless explicitly set to true.|
+|`device_trust_mode`|string|DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode.|
+|`disconnect_expired_cert`|Boolean|DisconnectExpiredCert sets disconnect clients on expired certificates.|
+|`enhanced_recording`|[]string|BPF defines what events to record for the BPF-based session recorder.|
+|`forward_agent`|Boolean|ForwardAgent is SSH agent forwarding.|
+|`idp`|[object](#specoptionsidp)|IDP is a set of options related to accessing IdPs within Teleport. Requires Teleport Enterprise.|
+|`lock`|string|Lock specifies the locking mode (strict|best_effort) to be applied with the role.|
+|`max_connections`|integer|MaxConnections defines the maximum number of concurrent connections a user may hold.|
+|`max_kubernetes_connections`|integer|MaxKubernetesConnections defines the maximum number of concurrent Kubernetes sessions a user may hold.|
+|`max_session_ttl`|string|MaxSessionTTL defines how long a SSH session can last for.|
+|`max_sessions`|integer|MaxSessions defines the maximum number of concurrent sessions per connection.|
+|`mfa_verification_interval`|string|MFAVerificationInterval optionally defines the maximum duration that can elapse between successive MFA verifications. This variable is used to ensure that users are periodically prompted to verify their identity, enhancing security by preventing prolonged sessions without re-authentication when using tsh proxy * derivatives. It's only effective if the session requires MFA. If not set, defaults to `max_session_ttl`.|
+|`permit_x11_forwarding`|Boolean|PermitX11Forwarding authorizes use of X11 forwarding.|
+|`pin_source_ip`|Boolean|PinSourceIP forces the same client IP for certificate generation and usage|
+|`port_forwarding`|Boolean|PortForwarding defines if the certificate will have "permit-port-forwarding" in the certificate. PortForwarding is "yes" if not set, that's why this is a pointer|
+|`record_session`|[object](#specoptionsrecord_session)|RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.|
+|`request_access`|string|RequestAccess defines the request strategy (optional|note|always) where optional is the default.|
+|`request_prompt`|string|RequestPrompt is an optional message which tells users what they aught to request.|
+|`require_session_mfa`|string or integer|RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN". Can be either the string or the integer representation of each option.|
+|`ssh_file_copy`|Boolean|SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.|
+
+### `spec`
+
+|Field|Type|Description|
+|---|---|---|
+|`allow`|[object](#specallow)|Allow is the set of conditions evaluated to grant access.|
+|`deny`|[object](#specdeny)|Deny is the set of conditions evaluated to deny access. Deny takes priority over allow.|
+|`options`|[object](#specoptions)|Options is for OpenSSH options like agent forwarding.|
 
 ## resources.teleport.dev/v6
 
-**apiVersion:** resources.teleport.dev/v6
+`apiVersion: resources.teleport.dev/v6`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|Role resource definition v6 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|Role resource definition v6 from Teleport|
 
-### spec
-
-|Field|Type|Description|
-|---|---|---|
-|allow|[object](#specallow)|Allow is the set of conditions evaluated to grant access.|
-|deny|[object](#specdeny)|Deny is the set of conditions evaluated to deny access. Deny takes priority over allow.|
-|options|[object](#specoptions)|Options is for OpenSSH options like agent forwarding.|
-
-### spec.allow
+### `spec.allow.db_permissions` items
 
 |Field|Type|Description|
 |---|---|---|
-|app_labels|object|AppLabels is a map of labels used as part of the RBAC system.|
-|app_labels_expression|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
-|aws_role_arns|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
-|azure_identities|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
-|cluster_labels|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
-|cluster_labels_expression|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
-|db_labels|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
-|db_labels_expression|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
-|db_names|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
-|db_permissions|[][object](#specallowdb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
-|db_roles|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
-|db_service_labels|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
-|db_service_labels_expression|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
-|db_users|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
-|desktop_groups|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
-|gcp_service_accounts|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
-|group_labels|object|GroupLabels is a map of labels used as part of the RBAC system.|
-|group_labels_expression|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
-|host_groups|[]string|HostGroups is a list of groups for created users to be added to|
-|host_sudoers|[]string|HostSudoers is a list of entries to include in a users sudoer file|
-|impersonate|[object](#specallowimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
-|join_sessions|[][object](#specallowjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
-|kubernetes_groups|[]string|KubeGroups is a list of kubernetes groups|
-|kubernetes_labels|object|KubernetesLabels is a map of kubernetes cluster labels used for RBAC.|
-|kubernetes_labels_expression|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.|
-|kubernetes_resources|[][object](#specallowkubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
-|kubernetes_users|[]string|KubeUsers is an optional kubernetes users to impersonate|
-|logins|[]string|Logins is a list of *nix system logins.|
-|node_labels|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
-|node_labels_expression|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
-|request|[object](#specallowrequest)||
-|require_session_join|[][object](#specallowrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
-|review_requests|[object](#specallowreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
-|rules|[][object](#specallowrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
-|spiffe|[][object](#specallowspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
-|windows_desktop_labels|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
-|windows_desktop_labels_expression|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
-|windows_desktop_logins|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
+|`match`|object|Match is a list of object labels that must be matched for the permission to be granted.|
+|`permissions`|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
 
-### spec.allow.db_permissions items
+### `spec.allow.impersonate`
 
 |Field|Type|Description|
 |---|---|---|
-|match|object|Match is a list of object labels that must be matched for the permission to be granted.|
-|permissions|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
+|`roles`|[]string|Roles is a list of resources this role is allowed to impersonate|
+|`users`|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
+|`where`|string|Where specifies optional advanced matcher|
 
-### spec.allow.impersonate
-
-|Field|Type|Description|
-|---|---|---|
-|roles|[]string|Roles is a list of resources this role is allowed to impersonate|
-|users|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
-|where|string|Where specifies optional advanced matcher|
-
-### spec.allow.join_sessions items
+### `spec.allow.join_sessions` items
 
 |Field|Type|Description|
 |---|---|---|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is a list of permitted participant modes for this policy.|
-|name|string|Name is the name of the policy.|
-|roles|[]string|Roles is a list of roles that you can join the session of.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is a list of permitted participant modes for this policy.|
+|`name`|string|Name is the name of the policy.|
+|`roles`|[]string|Roles is a list of roles that you can join the session of.|
 
-### spec.allow.kubernetes_resources items
-
-|Field|Type|Description|
-|---|---|---|
-|kind|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
-|name|string|Name is the resource name. It supports wildcards.|
-|namespace|string|Namespace is the resource namespace. It supports wildcards.|
-|verbs|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
-
-### spec.allow.request
+### `spec.allow.kubernetes_resources` items
 
 |Field|Type|Description|
 |---|---|---|
-|annotations|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
-|claims_to_roles|[][object](#specallowrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|max_duration|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
-|roles|[]string|Roles is the name of roles which will match the request rule.|
-|search_as_roles|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
-|suggested_reviewers|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
-|thresholds|[][object](#specallowrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
+|`kind`|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
+|`name`|string|Name is the resource name. It supports wildcards.|
+|`namespace`|string|Namespace is the resource namespace. It supports wildcards.|
+|`verbs`|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
 
-### spec.allow.request.claims_to_roles items
+### `spec.allow.request.claims_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
 
-### spec.allow.request.thresholds items
-
-|Field|Type|Description|
-|---|---|---|
-|approve|integer|Approve is the number of matching approvals needed for state-transition.|
-|deny|integer|Deny is the number of denials needed for state-transition.|
-|filter|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
-|name|string|Name is the optional human-readable name of the threshold.|
-
-### spec.allow.require_session_join items
+### `spec.allow.request.thresholds` items
 
 |Field|Type|Description|
 |---|---|---|
-|count|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
-|filter|string|Filter is a predicate that determines what users count towards this policy.|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is the list of modes that may be used to fulfill this policy.|
-|name|string|Name is the name of the policy.|
-|on_leave|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
+|`approve`|integer|Approve is the number of matching approvals needed for state-transition.|
+|`deny`|integer|Deny is the number of denials needed for state-transition.|
+|`filter`|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
+|`name`|string|Name is the optional human-readable name of the threshold.|
 
-### spec.allow.review_requests
+### `spec.allow.request`
 
 |Field|Type|Description|
 |---|---|---|
-|claims_to_roles|[][object](#specallowreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|preview_as_roles|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
-|roles|[]string|Roles is the name of roles which may be reviewed.|
-|where|string|Where is an optional predicate which further limits which requests are reviewable.|
+|`annotations`|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
+|`claims_to_roles`|[][object](#specallowrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`max_duration`|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
+|`roles`|[]string|Roles is the name of roles which will match the request rule.|
+|`search_as_roles`|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
+|`suggested_reviewers`|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
+|`thresholds`|[][object](#specallowrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
 
-### spec.allow.review_requests.claims_to_roles items
-
-|Field|Type|Description|
-|---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
-
-### spec.allow.rules items
+### `spec.allow.require_session_join` items
 
 |Field|Type|Description|
 |---|---|---|
-|actions|[]string|Actions specifies optional actions taken when this rule matches|
-|resources|[]string|Resources is a list of resources|
-|verbs|[]string|Verbs is a list of verbs|
-|where|string|Where specifies optional advanced matcher|
+|`count`|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
+|`filter`|string|Filter is a predicate that determines what users count towards this policy.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is the list of modes that may be used to fulfill this policy.|
+|`name`|string|Name is the name of the policy.|
+|`on_leave`|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
 
-### spec.allow.spiffe items
-
-|Field|Type|Description|
-|---|---|---|
-|dns_sans|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
-|ip_sans|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
-|path|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
-
-### spec.deny
+### `spec.allow.review_requests.claims_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|app_labels|object|AppLabels is a map of labels used as part of the RBAC system.|
-|app_labels_expression|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
-|aws_role_arns|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
-|azure_identities|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
-|cluster_labels|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
-|cluster_labels_expression|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
-|db_labels|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
-|db_labels_expression|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
-|db_names|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
-|db_permissions|[][object](#specdenydb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
-|db_roles|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
-|db_service_labels|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
-|db_service_labels_expression|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
-|db_users|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
-|desktop_groups|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
-|gcp_service_accounts|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
-|group_labels|object|GroupLabels is a map of labels used as part of the RBAC system.|
-|group_labels_expression|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
-|host_groups|[]string|HostGroups is a list of groups for created users to be added to|
-|host_sudoers|[]string|HostSudoers is a list of entries to include in a users sudoer file|
-|impersonate|[object](#specdenyimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
-|join_sessions|[][object](#specdenyjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
-|kubernetes_groups|[]string|KubeGroups is a list of kubernetes groups|
-|kubernetes_labels|object|KubernetesLabels is a map of kubernetes cluster labels used for RBAC.|
-|kubernetes_labels_expression|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.|
-|kubernetes_resources|[][object](#specdenykubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
-|kubernetes_users|[]string|KubeUsers is an optional kubernetes users to impersonate|
-|logins|[]string|Logins is a list of *nix system logins.|
-|node_labels|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
-|node_labels_expression|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
-|request|[object](#specdenyrequest)||
-|require_session_join|[][object](#specdenyrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
-|review_requests|[object](#specdenyreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
-|rules|[][object](#specdenyrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
-|spiffe|[][object](#specdenyspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
-|windows_desktop_labels|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
-|windows_desktop_labels_expression|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
-|windows_desktop_logins|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
 
-### spec.deny.db_permissions items
+### `spec.allow.review_requests`
 
 |Field|Type|Description|
 |---|---|---|
-|match|object|Match is a list of object labels that must be matched for the permission to be granted.|
-|permissions|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
+|`claims_to_roles`|[][object](#specallowreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`preview_as_roles`|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
+|`roles`|[]string|Roles is the name of roles which may be reviewed.|
+|`where`|string|Where is an optional predicate which further limits which requests are reviewable.|
 
-### spec.deny.impersonate
-
-|Field|Type|Description|
-|---|---|---|
-|roles|[]string|Roles is a list of resources this role is allowed to impersonate|
-|users|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
-|where|string|Where specifies optional advanced matcher|
-
-### spec.deny.join_sessions items
+### `spec.allow.rules` items
 
 |Field|Type|Description|
 |---|---|---|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is a list of permitted participant modes for this policy.|
-|name|string|Name is the name of the policy.|
-|roles|[]string|Roles is a list of roles that you can join the session of.|
+|`actions`|[]string|Actions specifies optional actions taken when this rule matches|
+|`resources`|[]string|Resources is a list of resources|
+|`verbs`|[]string|Verbs is a list of verbs|
+|`where`|string|Where specifies optional advanced matcher|
 
-### spec.deny.kubernetes_resources items
-
-|Field|Type|Description|
-|---|---|---|
-|kind|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
-|name|string|Name is the resource name. It supports wildcards.|
-|namespace|string|Namespace is the resource namespace. It supports wildcards.|
-|verbs|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
-
-### spec.deny.request
+### `spec.allow.spiffe` items
 
 |Field|Type|Description|
 |---|---|---|
-|annotations|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
-|claims_to_roles|[][object](#specdenyrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|max_duration|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
-|roles|[]string|Roles is the name of roles which will match the request rule.|
-|search_as_roles|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
-|suggested_reviewers|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
-|thresholds|[][object](#specdenyrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
+|`dns_sans`|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
+|`ip_sans`|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
+|`path`|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
 
-### spec.deny.request.claims_to_roles items
+### `spec.allow`
 
 |Field|Type|Description|
 |---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
+|`app_labels`|object|AppLabels is a map of labels used as part of the RBAC system.|
+|`app_labels_expression`|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
+|`aws_role_arns`|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
+|`azure_identities`|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
+|`cluster_labels`|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
+|`cluster_labels_expression`|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
+|`db_labels`|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
+|`db_labels_expression`|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
+|`db_names`|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
+|`db_permissions`|[][object](#specallowdb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
+|`db_roles`|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
+|`db_service_labels`|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
+|`db_service_labels_expression`|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
+|`db_users`|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
+|`desktop_groups`|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
+|`gcp_service_accounts`|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
+|`group_labels`|object|GroupLabels is a map of labels used as part of the RBAC system.|
+|`group_labels_expression`|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
+|`host_groups`|[]string|HostGroups is a list of groups for created users to be added to|
+|`host_sudoers`|[]string|HostSudoers is a list of entries to include in a users sudoer file|
+|`impersonate`|[object](#specallowimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
+|`join_sessions`|[][object](#specallowjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
+|`kubernetes_groups`|[]string|KubeGroups is a list of Kubernetes groups|
+|`kubernetes_labels`|object|KubernetesLabels is a map of Kubernetes cluster labels used for RBAC.|
+|`kubernetes_labels_expression`|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.|
+|`kubernetes_resources`|[][object](#specallowkubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
+|`kubernetes_users`|[]string|KubeUsers is an optional Kubernetes users to impersonate|
+|`logins`|[]string|Logins is a list of *nix system logins.|
+|`node_labels`|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
+|`node_labels_expression`|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
+|`request`|[object](#specallowrequest)||
+|`require_session_join`|[][object](#specallowrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
+|`review_requests`|[object](#specallowreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
+|`rules`|[][object](#specallowrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
+|`spiffe`|[][object](#specallowspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
+|`windows_desktop_labels`|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
+|`windows_desktop_labels_expression`|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
+|`windows_desktop_logins`|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
 
-### spec.deny.request.thresholds items
-
-|Field|Type|Description|
-|---|---|---|
-|approve|integer|Approve is the number of matching approvals needed for state-transition.|
-|deny|integer|Deny is the number of denials needed for state-transition.|
-|filter|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
-|name|string|Name is the optional human-readable name of the threshold.|
-
-### spec.deny.require_session_join items
-
-|Field|Type|Description|
-|---|---|---|
-|count|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
-|filter|string|Filter is a predicate that determines what users count towards this policy.|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is the list of modes that may be used to fulfill this policy.|
-|name|string|Name is the name of the policy.|
-|on_leave|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
-
-### spec.deny.review_requests
-
-|Field|Type|Description|
-|---|---|---|
-|claims_to_roles|[][object](#specdenyreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|preview_as_roles|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
-|roles|[]string|Roles is the name of roles which may be reviewed.|
-|where|string|Where is an optional predicate which further limits which requests are reviewable.|
-
-### spec.deny.review_requests.claims_to_roles items
-
-|Field|Type|Description|
-|---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
-
-### spec.deny.rules items
+### `spec.deny.db_permissions` items
 
 |Field|Type|Description|
 |---|---|---|
-|actions|[]string|Actions specifies optional actions taken when this rule matches|
-|resources|[]string|Resources is a list of resources|
-|verbs|[]string|Verbs is a list of verbs|
-|where|string|Where specifies optional advanced matcher|
+|`match`|object|Match is a list of object labels that must be matched for the permission to be granted.|
+|`permissions`|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
 
-### spec.deny.spiffe items
+### `spec.deny.impersonate`
 
 |Field|Type|Description|
 |---|---|---|
-|dns_sans|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
-|ip_sans|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
-|path|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
+|`roles`|[]string|Roles is a list of resources this role is allowed to impersonate|
+|`users`|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
+|`where`|string|Where specifies optional advanced matcher|
 
-### spec.options
-
-|Field|Type|Description|
-|---|---|---|
-|cert_extensions|[][object](#specoptionscert_extensions-items)|CertExtensions specifies the key/values|
-|cert_format|string|CertificateFormat defines the format of the user certificate to allow compatibility with older versions of OpenSSH.|
-|client_idle_timeout|string|ClientIdleTimeout sets disconnect clients on idle timeout behavior, if set to 0 means do not disconnect, otherwise is set to the idle duration.|
-|create_db_user|boolean|CreateDatabaseUser enabled automatic database user creation.|
-|create_db_user_mode|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop". Can be either the string or the integer representation of each option.|
-|create_desktop_user|boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
-|create_host_user|boolean|CreateHostUser allows users to be automatically created on a host|
-|create_host_user_default_shell|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
-|create_host_user_mode|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop". Can be either the string or the integer representation of each option.|
-|desktop_clipboard|boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|
-|desktop_directory_sharing|boolean|DesktopDirectorySharing indicates whether directory sharing is allowed between the user's workstation and the remote desktop. It defaults to false unless explicitly set to true.|
-|device_trust_mode|string|DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode.|
-|disconnect_expired_cert|boolean|DisconnectExpiredCert sets disconnect clients on expired certificates.|
-|enhanced_recording|[]string|BPF defines what events to record for the BPF-based session recorder.|
-|forward_agent|boolean|ForwardAgent is SSH agent forwarding.|
-|idp|[object](#specoptionsidp)|IDP is a set of options related to accessing IdPs within Teleport. Requires Teleport Enterprise.|
-|lock|string|Lock specifies the locking mode (strict|best_effort) to be applied with the role.|
-|max_connections|integer|MaxConnections defines the maximum number of concurrent connections a user may hold.|
-|max_kubernetes_connections|integer|MaxKubernetesConnections defines the maximum number of concurrent Kubernetes sessions a user may hold.|
-|max_session_ttl|string|MaxSessionTTL defines how long a SSH session can last for.|
-|max_sessions|integer|MaxSessions defines the maximum number of concurrent sessions per connection.|
-|mfa_verification_interval|string|MFAVerificationInterval optionally defines the maximum duration that can elapse between successive MFA verifications. This variable is used to ensure that users are periodically prompted to verify their identity, enhancing security by preventing prolonged sessions without re-authentication when using tsh proxy * derivatives. It's only effective if the session requires MFA. If not set, defaults to `max_session_ttl`.|
-|permit_x11_forwarding|boolean|PermitX11Forwarding authorizes use of X11 forwarding.|
-|pin_source_ip|boolean|PinSourceIP forces the same client IP for certificate generation and usage|
-|port_forwarding|boolean|PortForwarding defines if the certificate will have "permit-port-forwarding" in the certificate. PortForwarding is "yes" if not set, that's why this is a pointer|
-|record_session|[object](#specoptionsrecord_session)|RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.|
-|request_access|string|RequestAccess defines the request strategy (optional|note|always) where optional is the default.|
-|request_prompt|string|RequestPrompt is an optional message which tells users what they aught to request.|
-|require_session_mfa|string or integer|RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN". Can be either the string or the integer representation of each option.|
-|ssh_file_copy|boolean|SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.|
-
-### spec.options.cert_extensions items
+### `spec.deny.join_sessions` items
 
 |Field|Type|Description|
 |---|---|---|
-|mode|string or integer|Mode is the type of extension to be used -- currently critical-option is not supported. 0 is "extension". Can be either the string or the integer representation of each option.|
-|name|string|Name specifies the key to be used in the cert extension.|
-|type|string or integer|Type represents the certificate type being extended, only ssh is supported at this time. 0 is "ssh". Can be either the string or the integer representation of each option.|
-|value|string|Value specifies the value to be used in the cert extension.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is a list of permitted participant modes for this policy.|
+|`name`|string|Name is the name of the policy.|
+|`roles`|[]string|Roles is a list of roles that you can join the session of.|
 
-### spec.options.idp
-
-|Field|Type|Description|
-|---|---|---|
-|saml|[object](#specoptionsidpsaml)|SAML are options related to the Teleport SAML IdP.|
-
-### spec.options.idp.saml
+### `spec.deny.kubernetes_resources` items
 
 |Field|Type|Description|
 |---|---|---|
-|enabled|boolean|Enabled is set to true if this option allows access to the Teleport SAML IdP.|
+|`kind`|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
+|`name`|string|Name is the resource name. It supports wildcards.|
+|`namespace`|string|Namespace is the resource namespace. It supports wildcards.|
+|`verbs`|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
 
-### spec.options.record_session
+### `spec.deny.request.claims_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|default|string|Default indicates the default value for the services.|
-|desktop|boolean|Desktop indicates whether desktop sessions should be recorded. It defaults to true unless explicitly set to false.|
-|ssh|string|SSH indicates the session mode used on SSH sessions.|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
+
+### `spec.deny.request.thresholds` items
+
+|Field|Type|Description|
+|---|---|---|
+|`approve`|integer|Approve is the number of matching approvals needed for state-transition.|
+|`deny`|integer|Deny is the number of denials needed for state-transition.|
+|`filter`|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
+|`name`|string|Name is the optional human-readable name of the threshold.|
+
+### `spec.deny.request`
+
+|Field|Type|Description|
+|---|---|---|
+|`annotations`|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
+|`claims_to_roles`|[][object](#specdenyrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`max_duration`|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
+|`roles`|[]string|Roles is the name of roles which will match the request rule.|
+|`search_as_roles`|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
+|`suggested_reviewers`|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
+|`thresholds`|[][object](#specdenyrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
+
+### `spec.deny.require_session_join` items
+
+|Field|Type|Description|
+|---|---|---|
+|`count`|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
+|`filter`|string|Filter is a predicate that determines what users count towards this policy.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is the list of modes that may be used to fulfill this policy.|
+|`name`|string|Name is the name of the policy.|
+|`on_leave`|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
+
+### `spec.deny.review_requests.claims_to_roles` items
+
+|Field|Type|Description|
+|---|---|---|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
+
+### `spec.deny.review_requests`
+
+|Field|Type|Description|
+|---|---|---|
+|`claims_to_roles`|[][object](#specdenyreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`preview_as_roles`|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
+|`roles`|[]string|Roles is the name of roles which may be reviewed.|
+|`where`|string|Where is an optional predicate which further limits which requests are reviewable.|
+
+### `spec.deny.rules` items
+
+|Field|Type|Description|
+|---|---|---|
+|`actions`|[]string|Actions specifies optional actions taken when this rule matches|
+|`resources`|[]string|Resources is a list of resources|
+|`verbs`|[]string|Verbs is a list of verbs|
+|`where`|string|Where specifies optional advanced matcher|
+
+### `spec.deny.spiffe` items
+
+|Field|Type|Description|
+|---|---|---|
+|`dns_sans`|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
+|`ip_sans`|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
+|`path`|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
+
+### `spec.deny`
+
+|Field|Type|Description|
+|---|---|---|
+|`app_labels`|object|AppLabels is a map of labels used as part of the RBAC system.|
+|`app_labels_expression`|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
+|`aws_role_arns`|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
+|`azure_identities`|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
+|`cluster_labels`|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
+|`cluster_labels_expression`|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
+|`db_labels`|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
+|`db_labels_expression`|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
+|`db_names`|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
+|`db_permissions`|[][object](#specdenydb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
+|`db_roles`|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
+|`db_service_labels`|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
+|`db_service_labels_expression`|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
+|`db_users`|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
+|`desktop_groups`|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
+|`gcp_service_accounts`|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
+|`group_labels`|object|GroupLabels is a map of labels used as part of the RBAC system.|
+|`group_labels_expression`|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
+|`host_groups`|[]string|HostGroups is a list of groups for created users to be added to|
+|`host_sudoers`|[]string|HostSudoers is a list of entries to include in a users sudoer file|
+|`impersonate`|[object](#specdenyimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
+|`join_sessions`|[][object](#specdenyjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
+|`kubernetes_groups`|[]string|KubeGroups is a list of Kubernetes groups|
+|`kubernetes_labels`|object|KubernetesLabels is a map of Kubernetes cluster labels used for RBAC.|
+|`kubernetes_labels_expression`|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.|
+|`kubernetes_resources`|[][object](#specdenykubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
+|`kubernetes_users`|[]string|KubeUsers is an optional Kubernetes users to impersonate|
+|`logins`|[]string|Logins is a list of *nix system logins.|
+|`node_labels`|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
+|`node_labels_expression`|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
+|`request`|[object](#specdenyrequest)||
+|`require_session_join`|[][object](#specdenyrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
+|`review_requests`|[object](#specdenyreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
+|`rules`|[][object](#specdenyrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
+|`spiffe`|[][object](#specdenyspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
+|`windows_desktop_labels`|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
+|`windows_desktop_labels_expression`|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
+|`windows_desktop_logins`|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
+
+### `spec.options.cert_extensions` items
+
+|Field|Type|Description|
+|---|---|---|
+|`mode`|string or integer|Mode is the type of extension to be used -- currently critical-option is not supported. 0 is "extension". Can be either the string or the integer representation of each option.|
+|`name`|string|Name specifies the key to be used in the cert extension.|
+|`type`|string or integer|Type represents the certificate type being extended, only ssh is supported at this time. 0 is "ssh". Can be either the string or the integer representation of each option.|
+|`value`|string|Value specifies the value to be used in the cert extension.|
+
+### `spec.options.idp.saml`
+
+|Field|Type|Description|
+|---|---|---|
+|`enabled`|Boolean|Enabled is set to true if this option allows access to the Teleport SAML IdP.|
+
+### `spec.options.idp`
+
+|Field|Type|Description|
+|---|---|---|
+|`saml`|[object](#specoptionsidpsaml)|SAML are options related to the Teleport SAML IdP.|
+
+### `spec.options.record_session`
+
+|Field|Type|Description|
+|---|---|---|
+|`default`|string|Default indicates the default value for the services.|
+|`desktop`|Boolean|Desktop indicates whether desktop sessions should be recorded. It defaults to true unless explicitly set to false.|
+|`ssh`|string|SSH indicates the session mode used on SSH sessions.|
+
+### `spec.options`
+
+|Field|Type|Description|
+|---|---|---|
+|`cert_extensions`|[][object](#specoptionscert_extensions-items)|CertExtensions specifies the key/values|
+|`cert_format`|string|CertificateFormat defines the format of the user certificate to allow compatibility with older versions of OpenSSH.|
+|`client_idle_timeout`|string|ClientIdleTimeout sets disconnect clients on idle timeout behavior, if set to 0 means do not disconnect, otherwise is set to the idle duration.|
+|`create_db_user`|Boolean|CreateDatabaseUser enabled automatic database user creation.|
+|`create_db_user_mode`|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is `unspecified`, 1 is `off`, 2 is `keep`, 3 is `best_effort_drop`. Can be either the string or the integer representation of each option.|
+|`create_desktop_user`|Boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
+|`create_host_user`|Boolean|CreateHostUser allows users to be automatically created on a host|
+|`create_host_user_default_shell`|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
+|`create_host_user_mode`|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is `unspecified`; 1 is `off`; 2 is `drop` (removed for v15 and above), 3 is `keep`; 4 is `insecure-drop`. Can be either the string or the integer representation of each option.|
+|`desktop_clipboard`|Boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|
+|`desktop_directory_sharing`|Boolean|DesktopDirectorySharing indicates whether directory sharing is allowed between the user's workstation and the remote desktop. It defaults to false unless explicitly set to true.|
+|`device_trust_mode`|string|DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode.|
+|`disconnect_expired_cert`|Boolean|DisconnectExpiredCert sets disconnect clients on expired certificates.|
+|`enhanced_recording`|[]string|BPF defines what events to record for the BPF-based session recorder.|
+|`forward_agent`|Boolean|ForwardAgent is SSH agent forwarding.|
+|`idp`|[object](#specoptionsidp)|IDP is a set of options related to accessing IdPs within Teleport. Requires Teleport Enterprise.|
+|`lock`|string|Lock specifies the locking mode (strict|best_effort) to be applied with the role.|
+|`max_connections`|integer|MaxConnections defines the maximum number of concurrent connections a user may hold.|
+|`max_kubernetes_connections`|integer|MaxKubernetesConnections defines the maximum number of concurrent Kubernetes sessions a user may hold.|
+|`max_session_ttl`|string|MaxSessionTTL defines how long a SSH session can last for.|
+|`max_sessions`|integer|MaxSessions defines the maximum number of concurrent sessions per connection.|
+|`mfa_verification_interval`|string|MFAVerificationInterval optionally defines the maximum duration that can elapse between successive MFA verifications. This variable is used to ensure that users are periodically prompted to verify their identity, enhancing security by preventing prolonged sessions without re-authentication when using tsh proxy * derivatives. It's only effective if the session requires MFA. If not set, defaults to `max_session_ttl`.|
+|`permit_x11_forwarding`|Boolean|PermitX11Forwarding authorizes use of X11 forwarding.|
+|`pin_source_ip`|Boolean|PinSourceIP forces the same client IP for certificate generation and usage|
+|`port_forwarding`|Boolean|PortForwarding defines if the certificate will have "permit-port-forwarding" in the certificate. PortForwarding is "yes" if not set, that's why this is a pointer|
+|`record_session`|[object](#specoptionsrecord_session)|RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.|
+|`request_access`|string|RequestAccess defines the request strategy (optional|note|always) where optional is the default.|
+|`request_prompt`|string|RequestPrompt is an optional message which tells users what they aught to request.|
+|`require_session_mfa`|string or integer|RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN". Can be either the string or the integer representation of each option.|
+|`ssh_file_copy`|Boolean|SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.|
+
+### `spec`
+
+|Field|Type|Description|
+|---|---|---|
+|`allow`|[object](#specallow)|Allow is the set of conditions evaluated to grant access.|
+|`deny`|[object](#specdeny)|Deny is the set of conditions evaluated to deny access. Deny takes priority over allow.|
+|`options`|[object](#specoptions)|Options is for OpenSSH options like agent forwarding.|
 

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_rolesv6.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_rolesv6.mdx
@@ -13,384 +13,384 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 ## resources.teleport.dev/v1
 
-**apiVersion:** resources.teleport.dev/v1
+`apiVersion: resources.teleport.dev/v1`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|Role resource definition v6 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|Role resource definition v6 from Teleport|
 
-### spec
-
-|Field|Type|Description|
-|---|---|---|
-|allow|[object](#specallow)|Allow is the set of conditions evaluated to grant access.|
-|deny|[object](#specdeny)|Deny is the set of conditions evaluated to deny access. Deny takes priority over allow.|
-|options|[object](#specoptions)|Options is for OpenSSH options like agent forwarding.|
-
-### spec.allow
+### `spec.allow.db_permissions` items
 
 |Field|Type|Description|
 |---|---|---|
-|app_labels|object|AppLabels is a map of labels used as part of the RBAC system.|
-|app_labels_expression|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
-|aws_role_arns|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
-|azure_identities|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
-|cluster_labels|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
-|cluster_labels_expression|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
-|db_labels|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
-|db_labels_expression|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
-|db_names|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
-|db_permissions|[][object](#specallowdb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
-|db_roles|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
-|db_service_labels|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
-|db_service_labels_expression|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
-|db_users|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
-|desktop_groups|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
-|gcp_service_accounts|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
-|group_labels|object|GroupLabels is a map of labels used as part of the RBAC system.|
-|group_labels_expression|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
-|host_groups|[]string|HostGroups is a list of groups for created users to be added to|
-|host_sudoers|[]string|HostSudoers is a list of entries to include in a users sudoer file|
-|impersonate|[object](#specallowimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
-|join_sessions|[][object](#specallowjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
-|kubernetes_groups|[]string|KubeGroups is a list of kubernetes groups|
-|kubernetes_labels|object|KubernetesLabels is a map of kubernetes cluster labels used for RBAC.|
-|kubernetes_labels_expression|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.|
-|kubernetes_resources|[][object](#specallowkubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
-|kubernetes_users|[]string|KubeUsers is an optional kubernetes users to impersonate|
-|logins|[]string|Logins is a list of *nix system logins.|
-|node_labels|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
-|node_labels_expression|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
-|request|[object](#specallowrequest)||
-|require_session_join|[][object](#specallowrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
-|review_requests|[object](#specallowreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
-|rules|[][object](#specallowrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
-|spiffe|[][object](#specallowspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
-|windows_desktop_labels|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
-|windows_desktop_labels_expression|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
-|windows_desktop_logins|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
+|`match`|object|Match is a list of object labels that must be matched for the permission to be granted.|
+|`permissions`|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
 
-### spec.allow.db_permissions items
+### `spec.allow.impersonate`
 
 |Field|Type|Description|
 |---|---|---|
-|match|object|Match is a list of object labels that must be matched for the permission to be granted.|
-|permissions|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
+|`roles`|[]string|Roles is a list of resources this role is allowed to impersonate|
+|`users`|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
+|`where`|string|Where specifies optional advanced matcher|
 
-### spec.allow.impersonate
-
-|Field|Type|Description|
-|---|---|---|
-|roles|[]string|Roles is a list of resources this role is allowed to impersonate|
-|users|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
-|where|string|Where specifies optional advanced matcher|
-
-### spec.allow.join_sessions items
+### `spec.allow.join_sessions` items
 
 |Field|Type|Description|
 |---|---|---|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is a list of permitted participant modes for this policy.|
-|name|string|Name is the name of the policy.|
-|roles|[]string|Roles is a list of roles that you can join the session of.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is a list of permitted participant modes for this policy.|
+|`name`|string|Name is the name of the policy.|
+|`roles`|[]string|Roles is a list of roles that you can join the session of.|
 
-### spec.allow.kubernetes_resources items
-
-|Field|Type|Description|
-|---|---|---|
-|kind|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
-|name|string|Name is the resource name. It supports wildcards.|
-|namespace|string|Namespace is the resource namespace. It supports wildcards.|
-|verbs|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
-
-### spec.allow.request
+### `spec.allow.kubernetes_resources` items
 
 |Field|Type|Description|
 |---|---|---|
-|annotations|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
-|claims_to_roles|[][object](#specallowrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|max_duration|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
-|roles|[]string|Roles is the name of roles which will match the request rule.|
-|search_as_roles|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
-|suggested_reviewers|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
-|thresholds|[][object](#specallowrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
+|`kind`|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
+|`name`|string|Name is the resource name. It supports wildcards.|
+|`namespace`|string|Namespace is the resource namespace. It supports wildcards.|
+|`verbs`|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
 
-### spec.allow.request.claims_to_roles items
+### `spec.allow.request.claims_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
 
-### spec.allow.request.thresholds items
-
-|Field|Type|Description|
-|---|---|---|
-|approve|integer|Approve is the number of matching approvals needed for state-transition.|
-|deny|integer|Deny is the number of denials needed for state-transition.|
-|filter|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
-|name|string|Name is the optional human-readable name of the threshold.|
-
-### spec.allow.require_session_join items
+### `spec.allow.request.thresholds` items
 
 |Field|Type|Description|
 |---|---|---|
-|count|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
-|filter|string|Filter is a predicate that determines what users count towards this policy.|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is the list of modes that may be used to fulfill this policy.|
-|name|string|Name is the name of the policy.|
-|on_leave|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
+|`approve`|integer|Approve is the number of matching approvals needed for state-transition.|
+|`deny`|integer|Deny is the number of denials needed for state-transition.|
+|`filter`|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
+|`name`|string|Name is the optional human-readable name of the threshold.|
 
-### spec.allow.review_requests
+### `spec.allow.request`
 
 |Field|Type|Description|
 |---|---|---|
-|claims_to_roles|[][object](#specallowreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|preview_as_roles|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
-|roles|[]string|Roles is the name of roles which may be reviewed.|
-|where|string|Where is an optional predicate which further limits which requests are reviewable.|
+|`annotations`|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
+|`claims_to_roles`|[][object](#specallowrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`max_duration`|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
+|`roles`|[]string|Roles is the name of roles which will match the request rule.|
+|`search_as_roles`|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
+|`suggested_reviewers`|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
+|`thresholds`|[][object](#specallowrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
 
-### spec.allow.review_requests.claims_to_roles items
-
-|Field|Type|Description|
-|---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
-
-### spec.allow.rules items
+### `spec.allow.require_session_join` items
 
 |Field|Type|Description|
 |---|---|---|
-|actions|[]string|Actions specifies optional actions taken when this rule matches|
-|resources|[]string|Resources is a list of resources|
-|verbs|[]string|Verbs is a list of verbs|
-|where|string|Where specifies optional advanced matcher|
+|`count`|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
+|`filter`|string|Filter is a predicate that determines what users count towards this policy.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is the list of modes that may be used to fulfill this policy.|
+|`name`|string|Name is the name of the policy.|
+|`on_leave`|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
 
-### spec.allow.spiffe items
-
-|Field|Type|Description|
-|---|---|---|
-|dns_sans|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
-|ip_sans|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
-|path|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
-
-### spec.deny
+### `spec.allow.review_requests.claims_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|app_labels|object|AppLabels is a map of labels used as part of the RBAC system.|
-|app_labels_expression|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
-|aws_role_arns|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
-|azure_identities|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
-|cluster_labels|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
-|cluster_labels_expression|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
-|db_labels|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
-|db_labels_expression|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
-|db_names|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
-|db_permissions|[][object](#specdenydb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
-|db_roles|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
-|db_service_labels|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
-|db_service_labels_expression|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
-|db_users|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
-|desktop_groups|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
-|gcp_service_accounts|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
-|group_labels|object|GroupLabels is a map of labels used as part of the RBAC system.|
-|group_labels_expression|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
-|host_groups|[]string|HostGroups is a list of groups for created users to be added to|
-|host_sudoers|[]string|HostSudoers is a list of entries to include in a users sudoer file|
-|impersonate|[object](#specdenyimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
-|join_sessions|[][object](#specdenyjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
-|kubernetes_groups|[]string|KubeGroups is a list of kubernetes groups|
-|kubernetes_labels|object|KubernetesLabels is a map of kubernetes cluster labels used for RBAC.|
-|kubernetes_labels_expression|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.|
-|kubernetes_resources|[][object](#specdenykubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
-|kubernetes_users|[]string|KubeUsers is an optional kubernetes users to impersonate|
-|logins|[]string|Logins is a list of *nix system logins.|
-|node_labels|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
-|node_labels_expression|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
-|request|[object](#specdenyrequest)||
-|require_session_join|[][object](#specdenyrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
-|review_requests|[object](#specdenyreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
-|rules|[][object](#specdenyrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
-|spiffe|[][object](#specdenyspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
-|windows_desktop_labels|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
-|windows_desktop_labels_expression|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
-|windows_desktop_logins|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
 
-### spec.deny.db_permissions items
+### `spec.allow.review_requests`
 
 |Field|Type|Description|
 |---|---|---|
-|match|object|Match is a list of object labels that must be matched for the permission to be granted.|
-|permissions|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
+|`claims_to_roles`|[][object](#specallowreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`preview_as_roles`|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
+|`roles`|[]string|Roles is the name of roles which may be reviewed.|
+|`where`|string|Where is an optional predicate which further limits which requests are reviewable.|
 
-### spec.deny.impersonate
-
-|Field|Type|Description|
-|---|---|---|
-|roles|[]string|Roles is a list of resources this role is allowed to impersonate|
-|users|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
-|where|string|Where specifies optional advanced matcher|
-
-### spec.deny.join_sessions items
+### `spec.allow.rules` items
 
 |Field|Type|Description|
 |---|---|---|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is a list of permitted participant modes for this policy.|
-|name|string|Name is the name of the policy.|
-|roles|[]string|Roles is a list of roles that you can join the session of.|
+|`actions`|[]string|Actions specifies optional actions taken when this rule matches|
+|`resources`|[]string|Resources is a list of resources|
+|`verbs`|[]string|Verbs is a list of verbs|
+|`where`|string|Where specifies optional advanced matcher|
 
-### spec.deny.kubernetes_resources items
-
-|Field|Type|Description|
-|---|---|---|
-|kind|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
-|name|string|Name is the resource name. It supports wildcards.|
-|namespace|string|Namespace is the resource namespace. It supports wildcards.|
-|verbs|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
-
-### spec.deny.request
+### `spec.allow.spiffe` items
 
 |Field|Type|Description|
 |---|---|---|
-|annotations|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
-|claims_to_roles|[][object](#specdenyrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|max_duration|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
-|roles|[]string|Roles is the name of roles which will match the request rule.|
-|search_as_roles|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
-|suggested_reviewers|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
-|thresholds|[][object](#specdenyrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
+|`dns_sans`|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
+|`ip_sans`|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
+|`path`|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
 
-### spec.deny.request.claims_to_roles items
+### `spec.allow`
 
 |Field|Type|Description|
 |---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
+|`app_labels`|object|AppLabels is a map of labels used as part of the RBAC system.|
+|`app_labels_expression`|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
+|`aws_role_arns`|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
+|`azure_identities`|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
+|`cluster_labels`|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
+|`cluster_labels_expression`|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
+|`db_labels`|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
+|`db_labels_expression`|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
+|`db_names`|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
+|`db_permissions`|[][object](#specallowdb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
+|`db_roles`|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
+|`db_service_labels`|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
+|`db_service_labels_expression`|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
+|`db_users`|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
+|`desktop_groups`|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
+|`gcp_service_accounts`|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
+|`group_labels`|object|GroupLabels is a map of labels used as part of the RBAC system.|
+|`group_labels_expression`|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
+|`host_groups`|[]string|HostGroups is a list of groups for created users to be added to|
+|`host_sudoers`|[]string|HostSudoers is a list of entries to include in a users sudoer file|
+|`impersonate`|[object](#specallowimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
+|`join_sessions`|[][object](#specallowjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
+|`kubernetes_groups`|[]string|KubeGroups is a list of Kubernetes groups|
+|`kubernetes_labels`|object|KubernetesLabels is a map of Kubernetes cluster labels used for RBAC.|
+|`kubernetes_labels_expression`|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.|
+|`kubernetes_resources`|[][object](#specallowkubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
+|`kubernetes_users`|[]string|KubeUsers is an optional Kubernetes users to impersonate|
+|`logins`|[]string|Logins is a list of *nix system logins.|
+|`node_labels`|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
+|`node_labels_expression`|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
+|`request`|[object](#specallowrequest)||
+|`require_session_join`|[][object](#specallowrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
+|`review_requests`|[object](#specallowreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
+|`rules`|[][object](#specallowrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
+|`spiffe`|[][object](#specallowspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
+|`windows_desktop_labels`|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
+|`windows_desktop_labels_expression`|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
+|`windows_desktop_logins`|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
 
-### spec.deny.request.thresholds items
-
-|Field|Type|Description|
-|---|---|---|
-|approve|integer|Approve is the number of matching approvals needed for state-transition.|
-|deny|integer|Deny is the number of denials needed for state-transition.|
-|filter|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
-|name|string|Name is the optional human-readable name of the threshold.|
-
-### spec.deny.require_session_join items
-
-|Field|Type|Description|
-|---|---|---|
-|count|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
-|filter|string|Filter is a predicate that determines what users count towards this policy.|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is the list of modes that may be used to fulfill this policy.|
-|name|string|Name is the name of the policy.|
-|on_leave|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
-
-### spec.deny.review_requests
-
-|Field|Type|Description|
-|---|---|---|
-|claims_to_roles|[][object](#specdenyreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|preview_as_roles|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
-|roles|[]string|Roles is the name of roles which may be reviewed.|
-|where|string|Where is an optional predicate which further limits which requests are reviewable.|
-
-### spec.deny.review_requests.claims_to_roles items
-
-|Field|Type|Description|
-|---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
-
-### spec.deny.rules items
+### `spec.deny.db_permissions` items
 
 |Field|Type|Description|
 |---|---|---|
-|actions|[]string|Actions specifies optional actions taken when this rule matches|
-|resources|[]string|Resources is a list of resources|
-|verbs|[]string|Verbs is a list of verbs|
-|where|string|Where specifies optional advanced matcher|
+|`match`|object|Match is a list of object labels that must be matched for the permission to be granted.|
+|`permissions`|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
 
-### spec.deny.spiffe items
+### `spec.deny.impersonate`
 
 |Field|Type|Description|
 |---|---|---|
-|dns_sans|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
-|ip_sans|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
-|path|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
+|`roles`|[]string|Roles is a list of resources this role is allowed to impersonate|
+|`users`|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
+|`where`|string|Where specifies optional advanced matcher|
 
-### spec.options
-
-|Field|Type|Description|
-|---|---|---|
-|cert_extensions|[][object](#specoptionscert_extensions-items)|CertExtensions specifies the key/values|
-|cert_format|string|CertificateFormat defines the format of the user certificate to allow compatibility with older versions of OpenSSH.|
-|client_idle_timeout|string|ClientIdleTimeout sets disconnect clients on idle timeout behavior, if set to 0 means do not disconnect, otherwise is set to the idle duration.|
-|create_db_user|boolean|CreateDatabaseUser enabled automatic database user creation.|
-|create_db_user_mode|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop". Can be either the string or the integer representation of each option.|
-|create_desktop_user|boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
-|create_host_user|boolean|CreateHostUser allows users to be automatically created on a host|
-|create_host_user_default_shell|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
-|create_host_user_mode|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop". Can be either the string or the integer representation of each option.|
-|desktop_clipboard|boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|
-|desktop_directory_sharing|boolean|DesktopDirectorySharing indicates whether directory sharing is allowed between the user's workstation and the remote desktop. It defaults to false unless explicitly set to true.|
-|device_trust_mode|string|DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode.|
-|disconnect_expired_cert|boolean|DisconnectExpiredCert sets disconnect clients on expired certificates.|
-|enhanced_recording|[]string|BPF defines what events to record for the BPF-based session recorder.|
-|forward_agent|boolean|ForwardAgent is SSH agent forwarding.|
-|idp|[object](#specoptionsidp)|IDP is a set of options related to accessing IdPs within Teleport. Requires Teleport Enterprise.|
-|lock|string|Lock specifies the locking mode (strict|best_effort) to be applied with the role.|
-|max_connections|integer|MaxConnections defines the maximum number of concurrent connections a user may hold.|
-|max_kubernetes_connections|integer|MaxKubernetesConnections defines the maximum number of concurrent Kubernetes sessions a user may hold.|
-|max_session_ttl|string|MaxSessionTTL defines how long a SSH session can last for.|
-|max_sessions|integer|MaxSessions defines the maximum number of concurrent sessions per connection.|
-|mfa_verification_interval|string|MFAVerificationInterval optionally defines the maximum duration that can elapse between successive MFA verifications. This variable is used to ensure that users are periodically prompted to verify their identity, enhancing security by preventing prolonged sessions without re-authentication when using tsh proxy * derivatives. It's only effective if the session requires MFA. If not set, defaults to `max_session_ttl`.|
-|permit_x11_forwarding|boolean|PermitX11Forwarding authorizes use of X11 forwarding.|
-|pin_source_ip|boolean|PinSourceIP forces the same client IP for certificate generation and usage|
-|port_forwarding|boolean|PortForwarding defines if the certificate will have "permit-port-forwarding" in the certificate. PortForwarding is "yes" if not set, that's why this is a pointer|
-|record_session|[object](#specoptionsrecord_session)|RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.|
-|request_access|string|RequestAccess defines the request strategy (optional|note|always) where optional is the default.|
-|request_prompt|string|RequestPrompt is an optional message which tells users what they aught to request.|
-|require_session_mfa|string or integer|RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN". Can be either the string or the integer representation of each option.|
-|ssh_file_copy|boolean|SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.|
-
-### spec.options.cert_extensions items
+### `spec.deny.join_sessions` items
 
 |Field|Type|Description|
 |---|---|---|
-|mode|string or integer|Mode is the type of extension to be used -- currently critical-option is not supported. 0 is "extension". Can be either the string or the integer representation of each option.|
-|name|string|Name specifies the key to be used in the cert extension.|
-|type|string or integer|Type represents the certificate type being extended, only ssh is supported at this time. 0 is "ssh". Can be either the string or the integer representation of each option.|
-|value|string|Value specifies the value to be used in the cert extension.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is a list of permitted participant modes for this policy.|
+|`name`|string|Name is the name of the policy.|
+|`roles`|[]string|Roles is a list of roles that you can join the session of.|
 
-### spec.options.idp
-
-|Field|Type|Description|
-|---|---|---|
-|saml|[object](#specoptionsidpsaml)|SAML are options related to the Teleport SAML IdP.|
-
-### spec.options.idp.saml
+### `spec.deny.kubernetes_resources` items
 
 |Field|Type|Description|
 |---|---|---|
-|enabled|boolean|Enabled is set to true if this option allows access to the Teleport SAML IdP.|
+|`kind`|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
+|`name`|string|Name is the resource name. It supports wildcards.|
+|`namespace`|string|Namespace is the resource namespace. It supports wildcards.|
+|`verbs`|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
 
-### spec.options.record_session
+### `spec.deny.request.claims_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|default|string|Default indicates the default value for the services.|
-|desktop|boolean|Desktop indicates whether desktop sessions should be recorded. It defaults to true unless explicitly set to false.|
-|ssh|string|SSH indicates the session mode used on SSH sessions.|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
+
+### `spec.deny.request.thresholds` items
+
+|Field|Type|Description|
+|---|---|---|
+|`approve`|integer|Approve is the number of matching approvals needed for state-transition.|
+|`deny`|integer|Deny is the number of denials needed for state-transition.|
+|`filter`|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
+|`name`|string|Name is the optional human-readable name of the threshold.|
+
+### `spec.deny.request`
+
+|Field|Type|Description|
+|---|---|---|
+|`annotations`|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
+|`claims_to_roles`|[][object](#specdenyrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`max_duration`|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
+|`roles`|[]string|Roles is the name of roles which will match the request rule.|
+|`search_as_roles`|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
+|`suggested_reviewers`|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
+|`thresholds`|[][object](#specdenyrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
+
+### `spec.deny.require_session_join` items
+
+|Field|Type|Description|
+|---|---|---|
+|`count`|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
+|`filter`|string|Filter is a predicate that determines what users count towards this policy.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is the list of modes that may be used to fulfill this policy.|
+|`name`|string|Name is the name of the policy.|
+|`on_leave`|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
+
+### `spec.deny.review_requests.claims_to_roles` items
+
+|Field|Type|Description|
+|---|---|---|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
+
+### `spec.deny.review_requests`
+
+|Field|Type|Description|
+|---|---|---|
+|`claims_to_roles`|[][object](#specdenyreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`preview_as_roles`|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
+|`roles`|[]string|Roles is the name of roles which may be reviewed.|
+|`where`|string|Where is an optional predicate which further limits which requests are reviewable.|
+
+### `spec.deny.rules` items
+
+|Field|Type|Description|
+|---|---|---|
+|`actions`|[]string|Actions specifies optional actions taken when this rule matches|
+|`resources`|[]string|Resources is a list of resources|
+|`verbs`|[]string|Verbs is a list of verbs|
+|`where`|string|Where specifies optional advanced matcher|
+
+### `spec.deny.spiffe` items
+
+|Field|Type|Description|
+|---|---|---|
+|`dns_sans`|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
+|`ip_sans`|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
+|`path`|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
+
+### `spec.deny`
+
+|Field|Type|Description|
+|---|---|---|
+|`app_labels`|object|AppLabels is a map of labels used as part of the RBAC system.|
+|`app_labels_expression`|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
+|`aws_role_arns`|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
+|`azure_identities`|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
+|`cluster_labels`|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
+|`cluster_labels_expression`|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
+|`db_labels`|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
+|`db_labels_expression`|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
+|`db_names`|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
+|`db_permissions`|[][object](#specdenydb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
+|`db_roles`|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
+|`db_service_labels`|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
+|`db_service_labels_expression`|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
+|`db_users`|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
+|`desktop_groups`|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
+|`gcp_service_accounts`|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
+|`group_labels`|object|GroupLabels is a map of labels used as part of the RBAC system.|
+|`group_labels_expression`|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
+|`host_groups`|[]string|HostGroups is a list of groups for created users to be added to|
+|`host_sudoers`|[]string|HostSudoers is a list of entries to include in a users sudoer file|
+|`impersonate`|[object](#specdenyimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
+|`join_sessions`|[][object](#specdenyjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
+|`kubernetes_groups`|[]string|KubeGroups is a list of Kubernetes groups|
+|`kubernetes_labels`|object|KubernetesLabels is a map of Kubernetes cluster labels used for RBAC.|
+|`kubernetes_labels_expression`|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.|
+|`kubernetes_resources`|[][object](#specdenykubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
+|`kubernetes_users`|[]string|KubeUsers is an optional Kubernetes users to impersonate|
+|`logins`|[]string|Logins is a list of *nix system logins.|
+|`node_labels`|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
+|`node_labels_expression`|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
+|`request`|[object](#specdenyrequest)||
+|`require_session_join`|[][object](#specdenyrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
+|`review_requests`|[object](#specdenyreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
+|`rules`|[][object](#specdenyrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
+|`spiffe`|[][object](#specdenyspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
+|`windows_desktop_labels`|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
+|`windows_desktop_labels_expression`|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
+|`windows_desktop_logins`|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
+
+### `spec.options.cert_extensions` items
+
+|Field|Type|Description|
+|---|---|---|
+|`mode`|string or integer|Mode is the type of extension to be used -- currently critical-option is not supported. 0 is "extension". Can be either the string or the integer representation of each option.|
+|`name`|string|Name specifies the key to be used in the cert extension.|
+|`type`|string or integer|Type represents the certificate type being extended, only ssh is supported at this time. 0 is "ssh". Can be either the string or the integer representation of each option.|
+|`value`|string|Value specifies the value to be used in the cert extension.|
+
+### `spec.options.idp.saml`
+
+|Field|Type|Description|
+|---|---|---|
+|`enabled`|Boolean|Enabled is set to true if this option allows access to the Teleport SAML IdP.|
+
+### `spec.options.idp`
+
+|Field|Type|Description|
+|---|---|---|
+|`saml`|[object](#specoptionsidpsaml)|SAML are options related to the Teleport SAML IdP.|
+
+### `spec.options.record_session`
+
+|Field|Type|Description|
+|---|---|---|
+|`default`|string|Default indicates the default value for the services.|
+|`desktop`|Boolean|Desktop indicates whether desktop sessions should be recorded. It defaults to true unless explicitly set to false.|
+|`ssh`|string|SSH indicates the session mode used on SSH sessions.|
+
+### `spec.options`
+
+|Field|Type|Description|
+|---|---|---|
+|`cert_extensions`|[][object](#specoptionscert_extensions-items)|CertExtensions specifies the key/values|
+|`cert_format`|string|CertificateFormat defines the format of the user certificate to allow compatibility with older versions of OpenSSH.|
+|`client_idle_timeout`|string|ClientIdleTimeout sets disconnect clients on idle timeout behavior, if set to 0 means do not disconnect, otherwise is set to the idle duration.|
+|`create_db_user`|Boolean|CreateDatabaseUser enabled automatic database user creation.|
+|`create_db_user_mode`|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is `unspecified`, 1 is `off`, 2 is `keep`, 3 is `best_effort_drop`. Can be either the string or the integer representation of each option.|
+|`create_desktop_user`|Boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
+|`create_host_user`|Boolean|CreateHostUser allows users to be automatically created on a host|
+|`create_host_user_default_shell`|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
+|`create_host_user_mode`|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is `unspecified`; 1 is `off`; 2 is `drop` (removed for v15 and above), 3 is `keep`; 4 is `insecure-drop`. Can be either the string or the integer representation of each option.|
+|`desktop_clipboard`|Boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|
+|`desktop_directory_sharing`|Boolean|DesktopDirectorySharing indicates whether directory sharing is allowed between the user's workstation and the remote desktop. It defaults to false unless explicitly set to true.|
+|`device_trust_mode`|string|DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode.|
+|`disconnect_expired_cert`|Boolean|DisconnectExpiredCert sets disconnect clients on expired certificates.|
+|`enhanced_recording`|[]string|BPF defines what events to record for the BPF-based session recorder.|
+|`forward_agent`|Boolean|ForwardAgent is SSH agent forwarding.|
+|`idp`|[object](#specoptionsidp)|IDP is a set of options related to accessing IdPs within Teleport. Requires Teleport Enterprise.|
+|`lock`|string|Lock specifies the locking mode (strict|best_effort) to be applied with the role.|
+|`max_connections`|integer|MaxConnections defines the maximum number of concurrent connections a user may hold.|
+|`max_kubernetes_connections`|integer|MaxKubernetesConnections defines the maximum number of concurrent Kubernetes sessions a user may hold.|
+|`max_session_ttl`|string|MaxSessionTTL defines how long a SSH session can last for.|
+|`max_sessions`|integer|MaxSessions defines the maximum number of concurrent sessions per connection.|
+|`mfa_verification_interval`|string|MFAVerificationInterval optionally defines the maximum duration that can elapse between successive MFA verifications. This variable is used to ensure that users are periodically prompted to verify their identity, enhancing security by preventing prolonged sessions without re-authentication when using tsh proxy * derivatives. It's only effective if the session requires MFA. If not set, defaults to `max_session_ttl`.|
+|`permit_x11_forwarding`|Boolean|PermitX11Forwarding authorizes use of X11 forwarding.|
+|`pin_source_ip`|Boolean|PinSourceIP forces the same client IP for certificate generation and usage|
+|`port_forwarding`|Boolean|PortForwarding defines if the certificate will have "permit-port-forwarding" in the certificate. PortForwarding is "yes" if not set, that's why this is a pointer|
+|`record_session`|[object](#specoptionsrecord_session)|RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.|
+|`request_access`|string|RequestAccess defines the request strategy (optional|note|always) where optional is the default.|
+|`request_prompt`|string|RequestPrompt is an optional message which tells users what they aught to request.|
+|`require_session_mfa`|string or integer|RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN". Can be either the string or the integer representation of each option.|
+|`ssh_file_copy`|Boolean|SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.|
+
+### `spec`
+
+|Field|Type|Description|
+|---|---|---|
+|`allow`|[object](#specallow)|Allow is the set of conditions evaluated to grant access.|
+|`deny`|[object](#specdeny)|Deny is the set of conditions evaluated to deny access. Deny takes priority over allow.|
+|`options`|[object](#specoptions)|Options is for OpenSSH options like agent forwarding.|
 

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_rolesv7.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_rolesv7.mdx
@@ -13,384 +13,384 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 ## resources.teleport.dev/v1
 
-**apiVersion:** resources.teleport.dev/v1
+`apiVersion: resources.teleport.dev/v1`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|Role resource definition v7 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|Role resource definition v7 from Teleport|
 
-### spec
-
-|Field|Type|Description|
-|---|---|---|
-|allow|[object](#specallow)|Allow is the set of conditions evaluated to grant access.|
-|deny|[object](#specdeny)|Deny is the set of conditions evaluated to deny access. Deny takes priority over allow.|
-|options|[object](#specoptions)|Options is for OpenSSH options like agent forwarding.|
-
-### spec.allow
+### `spec.allow.db_permissions` items
 
 |Field|Type|Description|
 |---|---|---|
-|app_labels|object|AppLabels is a map of labels used as part of the RBAC system.|
-|app_labels_expression|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
-|aws_role_arns|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
-|azure_identities|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
-|cluster_labels|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
-|cluster_labels_expression|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
-|db_labels|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
-|db_labels_expression|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
-|db_names|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
-|db_permissions|[][object](#specallowdb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
-|db_roles|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
-|db_service_labels|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
-|db_service_labels_expression|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
-|db_users|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
-|desktop_groups|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
-|gcp_service_accounts|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
-|group_labels|object|GroupLabels is a map of labels used as part of the RBAC system.|
-|group_labels_expression|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
-|host_groups|[]string|HostGroups is a list of groups for created users to be added to|
-|host_sudoers|[]string|HostSudoers is a list of entries to include in a users sudoer file|
-|impersonate|[object](#specallowimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
-|join_sessions|[][object](#specallowjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
-|kubernetes_groups|[]string|KubeGroups is a list of kubernetes groups|
-|kubernetes_labels|object|KubernetesLabels is a map of kubernetes cluster labels used for RBAC.|
-|kubernetes_labels_expression|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.|
-|kubernetes_resources|[][object](#specallowkubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
-|kubernetes_users|[]string|KubeUsers is an optional kubernetes users to impersonate|
-|logins|[]string|Logins is a list of *nix system logins.|
-|node_labels|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
-|node_labels_expression|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
-|request|[object](#specallowrequest)||
-|require_session_join|[][object](#specallowrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
-|review_requests|[object](#specallowreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
-|rules|[][object](#specallowrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
-|spiffe|[][object](#specallowspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
-|windows_desktop_labels|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
-|windows_desktop_labels_expression|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
-|windows_desktop_logins|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
+|`match`|object|Match is a list of object labels that must be matched for the permission to be granted.|
+|`permissions`|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
 
-### spec.allow.db_permissions items
+### `spec.allow.impersonate`
 
 |Field|Type|Description|
 |---|---|---|
-|match|object|Match is a list of object labels that must be matched for the permission to be granted.|
-|permissions|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
+|`roles`|[]string|Roles is a list of resources this role is allowed to impersonate|
+|`users`|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
+|`where`|string|Where specifies optional advanced matcher|
 
-### spec.allow.impersonate
-
-|Field|Type|Description|
-|---|---|---|
-|roles|[]string|Roles is a list of resources this role is allowed to impersonate|
-|users|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
-|where|string|Where specifies optional advanced matcher|
-
-### spec.allow.join_sessions items
+### `spec.allow.join_sessions` items
 
 |Field|Type|Description|
 |---|---|---|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is a list of permitted participant modes for this policy.|
-|name|string|Name is the name of the policy.|
-|roles|[]string|Roles is a list of roles that you can join the session of.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is a list of permitted participant modes for this policy.|
+|`name`|string|Name is the name of the policy.|
+|`roles`|[]string|Roles is a list of roles that you can join the session of.|
 
-### spec.allow.kubernetes_resources items
-
-|Field|Type|Description|
-|---|---|---|
-|kind|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
-|name|string|Name is the resource name. It supports wildcards.|
-|namespace|string|Namespace is the resource namespace. It supports wildcards.|
-|verbs|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
-
-### spec.allow.request
+### `spec.allow.kubernetes_resources` items
 
 |Field|Type|Description|
 |---|---|---|
-|annotations|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
-|claims_to_roles|[][object](#specallowrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|max_duration|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
-|roles|[]string|Roles is the name of roles which will match the request rule.|
-|search_as_roles|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
-|suggested_reviewers|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
-|thresholds|[][object](#specallowrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
+|`kind`|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
+|`name`|string|Name is the resource name. It supports wildcards.|
+|`namespace`|string|Namespace is the resource namespace. It supports wildcards.|
+|`verbs`|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
 
-### spec.allow.request.claims_to_roles items
+### `spec.allow.request.claims_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
 
-### spec.allow.request.thresholds items
-
-|Field|Type|Description|
-|---|---|---|
-|approve|integer|Approve is the number of matching approvals needed for state-transition.|
-|deny|integer|Deny is the number of denials needed for state-transition.|
-|filter|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
-|name|string|Name is the optional human-readable name of the threshold.|
-
-### spec.allow.require_session_join items
+### `spec.allow.request.thresholds` items
 
 |Field|Type|Description|
 |---|---|---|
-|count|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
-|filter|string|Filter is a predicate that determines what users count towards this policy.|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is the list of modes that may be used to fulfill this policy.|
-|name|string|Name is the name of the policy.|
-|on_leave|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
+|`approve`|integer|Approve is the number of matching approvals needed for state-transition.|
+|`deny`|integer|Deny is the number of denials needed for state-transition.|
+|`filter`|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
+|`name`|string|Name is the optional human-readable name of the threshold.|
 
-### spec.allow.review_requests
+### `spec.allow.request`
 
 |Field|Type|Description|
 |---|---|---|
-|claims_to_roles|[][object](#specallowreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|preview_as_roles|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
-|roles|[]string|Roles is the name of roles which may be reviewed.|
-|where|string|Where is an optional predicate which further limits which requests are reviewable.|
+|`annotations`|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
+|`claims_to_roles`|[][object](#specallowrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`max_duration`|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
+|`roles`|[]string|Roles is the name of roles which will match the request rule.|
+|`search_as_roles`|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
+|`suggested_reviewers`|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
+|`thresholds`|[][object](#specallowrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
 
-### spec.allow.review_requests.claims_to_roles items
-
-|Field|Type|Description|
-|---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
-
-### spec.allow.rules items
+### `spec.allow.require_session_join` items
 
 |Field|Type|Description|
 |---|---|---|
-|actions|[]string|Actions specifies optional actions taken when this rule matches|
-|resources|[]string|Resources is a list of resources|
-|verbs|[]string|Verbs is a list of verbs|
-|where|string|Where specifies optional advanced matcher|
+|`count`|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
+|`filter`|string|Filter is a predicate that determines what users count towards this policy.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is the list of modes that may be used to fulfill this policy.|
+|`name`|string|Name is the name of the policy.|
+|`on_leave`|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
 
-### spec.allow.spiffe items
-
-|Field|Type|Description|
-|---|---|---|
-|dns_sans|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
-|ip_sans|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
-|path|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
-
-### spec.deny
+### `spec.allow.review_requests.claims_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|app_labels|object|AppLabels is a map of labels used as part of the RBAC system.|
-|app_labels_expression|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
-|aws_role_arns|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
-|azure_identities|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
-|cluster_labels|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
-|cluster_labels_expression|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
-|db_labels|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
-|db_labels_expression|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
-|db_names|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
-|db_permissions|[][object](#specdenydb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
-|db_roles|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
-|db_service_labels|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
-|db_service_labels_expression|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
-|db_users|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
-|desktop_groups|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
-|gcp_service_accounts|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
-|group_labels|object|GroupLabels is a map of labels used as part of the RBAC system.|
-|group_labels_expression|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
-|host_groups|[]string|HostGroups is a list of groups for created users to be added to|
-|host_sudoers|[]string|HostSudoers is a list of entries to include in a users sudoer file|
-|impersonate|[object](#specdenyimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
-|join_sessions|[][object](#specdenyjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
-|kubernetes_groups|[]string|KubeGroups is a list of kubernetes groups|
-|kubernetes_labels|object|KubernetesLabels is a map of kubernetes cluster labels used for RBAC.|
-|kubernetes_labels_expression|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.|
-|kubernetes_resources|[][object](#specdenykubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
-|kubernetes_users|[]string|KubeUsers is an optional kubernetes users to impersonate|
-|logins|[]string|Logins is a list of *nix system logins.|
-|node_labels|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
-|node_labels_expression|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
-|request|[object](#specdenyrequest)||
-|require_session_join|[][object](#specdenyrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
-|review_requests|[object](#specdenyreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
-|rules|[][object](#specdenyrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
-|spiffe|[][object](#specdenyspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
-|windows_desktop_labels|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
-|windows_desktop_labels_expression|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
-|windows_desktop_logins|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
 
-### spec.deny.db_permissions items
+### `spec.allow.review_requests`
 
 |Field|Type|Description|
 |---|---|---|
-|match|object|Match is a list of object labels that must be matched for the permission to be granted.|
-|permissions|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
+|`claims_to_roles`|[][object](#specallowreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`preview_as_roles`|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
+|`roles`|[]string|Roles is the name of roles which may be reviewed.|
+|`where`|string|Where is an optional predicate which further limits which requests are reviewable.|
 
-### spec.deny.impersonate
-
-|Field|Type|Description|
-|---|---|---|
-|roles|[]string|Roles is a list of resources this role is allowed to impersonate|
-|users|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
-|where|string|Where specifies optional advanced matcher|
-
-### spec.deny.join_sessions items
+### `spec.allow.rules` items
 
 |Field|Type|Description|
 |---|---|---|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is a list of permitted participant modes for this policy.|
-|name|string|Name is the name of the policy.|
-|roles|[]string|Roles is a list of roles that you can join the session of.|
+|`actions`|[]string|Actions specifies optional actions taken when this rule matches|
+|`resources`|[]string|Resources is a list of resources|
+|`verbs`|[]string|Verbs is a list of verbs|
+|`where`|string|Where specifies optional advanced matcher|
 
-### spec.deny.kubernetes_resources items
-
-|Field|Type|Description|
-|---|---|---|
-|kind|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
-|name|string|Name is the resource name. It supports wildcards.|
-|namespace|string|Namespace is the resource namespace. It supports wildcards.|
-|verbs|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
-
-### spec.deny.request
+### `spec.allow.spiffe` items
 
 |Field|Type|Description|
 |---|---|---|
-|annotations|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
-|claims_to_roles|[][object](#specdenyrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|max_duration|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
-|roles|[]string|Roles is the name of roles which will match the request rule.|
-|search_as_roles|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
-|suggested_reviewers|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
-|thresholds|[][object](#specdenyrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
+|`dns_sans`|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
+|`ip_sans`|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
+|`path`|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
 
-### spec.deny.request.claims_to_roles items
+### `spec.allow`
 
 |Field|Type|Description|
 |---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
+|`app_labels`|object|AppLabels is a map of labels used as part of the RBAC system.|
+|`app_labels_expression`|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
+|`aws_role_arns`|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
+|`azure_identities`|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
+|`cluster_labels`|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
+|`cluster_labels_expression`|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
+|`db_labels`|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
+|`db_labels_expression`|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
+|`db_names`|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
+|`db_permissions`|[][object](#specallowdb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
+|`db_roles`|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
+|`db_service_labels`|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
+|`db_service_labels_expression`|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
+|`db_users`|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
+|`desktop_groups`|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
+|`gcp_service_accounts`|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
+|`group_labels`|object|GroupLabels is a map of labels used as part of the RBAC system.|
+|`group_labels_expression`|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
+|`host_groups`|[]string|HostGroups is a list of groups for created users to be added to|
+|`host_sudoers`|[]string|HostSudoers is a list of entries to include in a users sudoer file|
+|`impersonate`|[object](#specallowimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
+|`join_sessions`|[][object](#specallowjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
+|`kubernetes_groups`|[]string|KubeGroups is a list of Kubernetes groups|
+|`kubernetes_labels`|object|KubernetesLabels is a map of Kubernetes cluster labels used for RBAC.|
+|`kubernetes_labels_expression`|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.|
+|`kubernetes_resources`|[][object](#specallowkubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
+|`kubernetes_users`|[]string|KubeUsers is an optional Kubernetes users to impersonate|
+|`logins`|[]string|Logins is a list of *nix system logins.|
+|`node_labels`|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
+|`node_labels_expression`|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
+|`request`|[object](#specallowrequest)||
+|`require_session_join`|[][object](#specallowrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
+|`review_requests`|[object](#specallowreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
+|`rules`|[][object](#specallowrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
+|`spiffe`|[][object](#specallowspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
+|`windows_desktop_labels`|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
+|`windows_desktop_labels_expression`|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
+|`windows_desktop_logins`|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
 
-### spec.deny.request.thresholds items
-
-|Field|Type|Description|
-|---|---|---|
-|approve|integer|Approve is the number of matching approvals needed for state-transition.|
-|deny|integer|Deny is the number of denials needed for state-transition.|
-|filter|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
-|name|string|Name is the optional human-readable name of the threshold.|
-
-### spec.deny.require_session_join items
-
-|Field|Type|Description|
-|---|---|---|
-|count|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
-|filter|string|Filter is a predicate that determines what users count towards this policy.|
-|kinds|[]string|Kinds are the session kinds this policy applies to.|
-|modes|[]string|Modes is the list of modes that may be used to fulfill this policy.|
-|name|string|Name is the name of the policy.|
-|on_leave|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
-
-### spec.deny.review_requests
-
-|Field|Type|Description|
-|---|---|---|
-|claims_to_roles|[][object](#specdenyreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
-|preview_as_roles|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
-|roles|[]string|Roles is the name of roles which may be reviewed.|
-|where|string|Where is an optional predicate which further limits which requests are reviewable.|
-
-### spec.deny.review_requests.claims_to_roles items
-
-|Field|Type|Description|
-|---|---|---|
-|claim|string|Claim is a claim name.|
-|roles|[]string|Roles is a list of static teleport roles to match.|
-|value|string|Value is a claim value to match.|
-
-### spec.deny.rules items
+### `spec.deny.db_permissions` items
 
 |Field|Type|Description|
 |---|---|---|
-|actions|[]string|Actions specifies optional actions taken when this rule matches|
-|resources|[]string|Resources is a list of resources|
-|verbs|[]string|Verbs is a list of verbs|
-|where|string|Where specifies optional advanced matcher|
+|`match`|object|Match is a list of object labels that must be matched for the permission to be granted.|
+|`permissions`|[]string|Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...|
 
-### spec.deny.spiffe items
+### `spec.deny.impersonate`
 
 |Field|Type|Description|
 |---|---|---|
-|dns_sans|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
-|ip_sans|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
-|path|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
+|`roles`|[]string|Roles is a list of resources this role is allowed to impersonate|
+|`users`|[]string|Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern|
+|`where`|string|Where specifies optional advanced matcher|
 
-### spec.options
-
-|Field|Type|Description|
-|---|---|---|
-|cert_extensions|[][object](#specoptionscert_extensions-items)|CertExtensions specifies the key/values|
-|cert_format|string|CertificateFormat defines the format of the user certificate to allow compatibility with older versions of OpenSSH.|
-|client_idle_timeout|string|ClientIdleTimeout sets disconnect clients on idle timeout behavior, if set to 0 means do not disconnect, otherwise is set to the idle duration.|
-|create_db_user|boolean|CreateDatabaseUser enabled automatic database user creation.|
-|create_db_user_mode|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop". Can be either the string or the integer representation of each option.|
-|create_desktop_user|boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
-|create_host_user|boolean|CreateHostUser allows users to be automatically created on a host|
-|create_host_user_default_shell|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
-|create_host_user_mode|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop". Can be either the string or the integer representation of each option.|
-|desktop_clipboard|boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|
-|desktop_directory_sharing|boolean|DesktopDirectorySharing indicates whether directory sharing is allowed between the user's workstation and the remote desktop. It defaults to false unless explicitly set to true.|
-|device_trust_mode|string|DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode.|
-|disconnect_expired_cert|boolean|DisconnectExpiredCert sets disconnect clients on expired certificates.|
-|enhanced_recording|[]string|BPF defines what events to record for the BPF-based session recorder.|
-|forward_agent|boolean|ForwardAgent is SSH agent forwarding.|
-|idp|[object](#specoptionsidp)|IDP is a set of options related to accessing IdPs within Teleport. Requires Teleport Enterprise.|
-|lock|string|Lock specifies the locking mode (strict|best_effort) to be applied with the role.|
-|max_connections|integer|MaxConnections defines the maximum number of concurrent connections a user may hold.|
-|max_kubernetes_connections|integer|MaxKubernetesConnections defines the maximum number of concurrent Kubernetes sessions a user may hold.|
-|max_session_ttl|string|MaxSessionTTL defines how long a SSH session can last for.|
-|max_sessions|integer|MaxSessions defines the maximum number of concurrent sessions per connection.|
-|mfa_verification_interval|string|MFAVerificationInterval optionally defines the maximum duration that can elapse between successive MFA verifications. This variable is used to ensure that users are periodically prompted to verify their identity, enhancing security by preventing prolonged sessions without re-authentication when using tsh proxy * derivatives. It's only effective if the session requires MFA. If not set, defaults to `max_session_ttl`.|
-|permit_x11_forwarding|boolean|PermitX11Forwarding authorizes use of X11 forwarding.|
-|pin_source_ip|boolean|PinSourceIP forces the same client IP for certificate generation and usage|
-|port_forwarding|boolean|PortForwarding defines if the certificate will have "permit-port-forwarding" in the certificate. PortForwarding is "yes" if not set, that's why this is a pointer|
-|record_session|[object](#specoptionsrecord_session)|RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.|
-|request_access|string|RequestAccess defines the request strategy (optional|note|always) where optional is the default.|
-|request_prompt|string|RequestPrompt is an optional message which tells users what they aught to request.|
-|require_session_mfa|string or integer|RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN". Can be either the string or the integer representation of each option.|
-|ssh_file_copy|boolean|SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.|
-
-### spec.options.cert_extensions items
+### `spec.deny.join_sessions` items
 
 |Field|Type|Description|
 |---|---|---|
-|mode|string or integer|Mode is the type of extension to be used -- currently critical-option is not supported. 0 is "extension". Can be either the string or the integer representation of each option.|
-|name|string|Name specifies the key to be used in the cert extension.|
-|type|string or integer|Type represents the certificate type being extended, only ssh is supported at this time. 0 is "ssh". Can be either the string or the integer representation of each option.|
-|value|string|Value specifies the value to be used in the cert extension.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is a list of permitted participant modes for this policy.|
+|`name`|string|Name is the name of the policy.|
+|`roles`|[]string|Roles is a list of roles that you can join the session of.|
 
-### spec.options.idp
-
-|Field|Type|Description|
-|---|---|---|
-|saml|[object](#specoptionsidpsaml)|SAML are options related to the Teleport SAML IdP.|
-
-### spec.options.idp.saml
+### `spec.deny.kubernetes_resources` items
 
 |Field|Type|Description|
 |---|---|---|
-|enabled|boolean|Enabled is set to true if this option allows access to the Teleport SAML IdP.|
+|`kind`|string|Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported.|
+|`name`|string|Name is the resource name. It supports wildcards.|
+|`namespace`|string|Namespace is the resource namespace. It supports wildcards.|
+|`verbs`|[]string|Verbs are the allowed Kubernetes verbs for the following resource.|
 
-### spec.options.record_session
+### `spec.deny.request.claims_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|default|string|Default indicates the default value for the services.|
-|desktop|boolean|Desktop indicates whether desktop sessions should be recorded. It defaults to true unless explicitly set to false.|
-|ssh|string|SSH indicates the session mode used on SSH sessions.|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
+
+### `spec.deny.request.thresholds` items
+
+|Field|Type|Description|
+|---|---|---|
+|`approve`|integer|Approve is the number of matching approvals needed for state-transition.|
+|`deny`|integer|Deny is the number of denials needed for state-transition.|
+|`filter`|string|Filter is an optional predicate used to determine which reviews count toward this threshold.|
+|`name`|string|Name is the optional human-readable name of the threshold.|
+
+### `spec.deny.request`
+
+|Field|Type|Description|
+|---|---|---|
+|`annotations`|object|Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.|
+|`claims_to_roles`|[][object](#specdenyrequestclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`max_duration`|string|MaxDuration is the amount of time the access will be granted for. If this is zero, the default duration is used.|
+|`roles`|[]string|Roles is the name of roles which will match the request rule.|
+|`search_as_roles`|[]string|SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request.|
+|`suggested_reviewers`|[]string|SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.|
+|`thresholds`|[][object](#specdenyrequestthresholds-items)|Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.|
+
+### `spec.deny.require_session_join` items
+
+|Field|Type|Description|
+|---|---|---|
+|`count`|integer|Count is the amount of people that need to be matched for this policy to be fulfilled.|
+|`filter`|string|Filter is a predicate that determines what users count towards this policy.|
+|`kinds`|[]string|Kinds are the session kinds this policy applies to.|
+|`modes`|[]string|Modes is the list of modes that may be used to fulfill this policy.|
+|`name`|string|Name is the name of the policy.|
+|`on_leave`|string|OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session.|
+
+### `spec.deny.review_requests.claims_to_roles` items
+
+|Field|Type|Description|
+|---|---|---|
+|`claim`|string|Claim is a claim name.|
+|`roles`|[]string|Roles is a list of static teleport roles to match.|
+|`value`|string|Value is a claim value to match.|
+
+### `spec.deny.review_requests`
+
+|Field|Type|Description|
+|---|---|---|
+|`claims_to_roles`|[][object](#specdenyreview_requestsclaims_to_roles-items)|ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.|
+|`preview_as_roles`|[]string|PreviewAsRoles is a list of extra roles which should apply to a reviewer while they are viewing a Resource Access Request for the purposes of viewing details such as the hostname and labels of requested resources.|
+|`roles`|[]string|Roles is the name of roles which may be reviewed.|
+|`where`|string|Where is an optional predicate which further limits which requests are reviewable.|
+
+### `spec.deny.rules` items
+
+|Field|Type|Description|
+|---|---|---|
+|`actions`|[]string|Actions specifies optional actions taken when this rule matches|
+|`resources`|[]string|Resources is a list of resources|
+|`verbs`|[]string|Verbs is a list of verbs|
+|`where`|string|Where specifies optional advanced matcher|
+
+### `spec.deny.spiffe` items
+
+|Field|Type|Description|
+|---|---|---|
+|`dns_sans`|[]string|DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com|
+|`ip_sans`|[]string|IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42|
+|`path`|string|Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\/svc\/foo\/.*\/bar$ would match /svc/foo/baz/bar|
+
+### `spec.deny`
+
+|Field|Type|Description|
+|---|---|---|
+|`app_labels`|object|AppLabels is a map of labels used as part of the RBAC system.|
+|`app_labels_expression`|string|AppLabelsExpression is a predicate expression used to allow/deny access to Apps.|
+|`aws_role_arns`|[]string|AWSRoleARNs is a list of AWS role ARNs this role is allowed to assume.|
+|`azure_identities`|[]string|AzureIdentities is a list of Azure identities this role is allowed to assume.|
+|`cluster_labels`|object|ClusterLabels is a map of node labels (used to dynamically grant access to clusters).|
+|`cluster_labels_expression`|string|ClusterLabelsExpression is a predicate expression used to allow/deny access to remote Teleport clusters.|
+|`db_labels`|object|DatabaseLabels are used in RBAC system to allow/deny access to databases.|
+|`db_labels_expression`|string|DatabaseLabelsExpression is a predicate expression used to allow/deny access to Databases.|
+|`db_names`|[]string|DatabaseNames is a list of database names this role is allowed to connect to.|
+|`db_permissions`|[][object](#specdenydb_permissions-items)|DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.|
+|`db_roles`|[]string|DatabaseRoles is a list of databases roles for automatic user creation.|
+|`db_service_labels`|object|DatabaseServiceLabels are used in RBAC system to allow/deny access to Database Services.|
+|`db_service_labels_expression`|string|DatabaseServiceLabelsExpression is a predicate expression used to allow/deny access to Database Services.|
+|`db_users`|[]string|DatabaseUsers is a list of databases users this role is allowed to connect as.|
+|`desktop_groups`|[]string|DesktopGroups is a list of groups for created desktop users to be added to|
+|`gcp_service_accounts`|[]string|GCPServiceAccounts is a list of GCP service accounts this role is allowed to assume.|
+|`group_labels`|object|GroupLabels is a map of labels used as part of the RBAC system.|
+|`group_labels_expression`|string|GroupLabelsExpression is a predicate expression used to allow/deny access to user groups.|
+|`host_groups`|[]string|HostGroups is a list of groups for created users to be added to|
+|`host_sudoers`|[]string|HostSudoers is a list of entries to include in a users sudoer file|
+|`impersonate`|[object](#specdenyimpersonate)|Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.|
+|`join_sessions`|[][object](#specdenyjoin_sessions-items)|JoinSessions specifies policies to allow users to join other sessions.|
+|`kubernetes_groups`|[]string|KubeGroups is a list of Kubernetes groups|
+|`kubernetes_labels`|object|KubernetesLabels is a map of Kubernetes cluster labels used for RBAC.|
+|`kubernetes_labels_expression`|string|KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.|
+|`kubernetes_resources`|[][object](#specdenykubernetes_resources-items)|KubernetesResources is the Kubernetes Resources this Role grants access to.|
+|`kubernetes_users`|[]string|KubeUsers is an optional Kubernetes users to impersonate|
+|`logins`|[]string|Logins is a list of *nix system logins.|
+|`node_labels`|object|NodeLabels is a map of node labels (used to dynamically grant access to nodes).|
+|`node_labels_expression`|string|NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.|
+|`request`|[object](#specdenyrequest)||
+|`require_session_join`|[][object](#specdenyrequire_session_join-items)|RequireSessionJoin specifies policies for required users to start a session.|
+|`review_requests`|[object](#specdenyreview_requests)|ReviewRequests defines conditions for submitting access reviews.|
+|`rules`|[][object](#specdenyrules-items)|Rules is a list of rules and their access levels. Rules are a high level construct used for access control.|
+|`spiffe`|[][object](#specdenyspiffe-items)|SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.|
+|`windows_desktop_labels`|object|WindowsDesktopLabels are used in the RBAC system to allow/deny access to Windows desktops.|
+|`windows_desktop_labels_expression`|string|WindowsDesktopLabelsExpression is a predicate expression used to allow/deny access to Windows desktops.|
+|`windows_desktop_logins`|[]string|WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.|
+
+### `spec.options.cert_extensions` items
+
+|Field|Type|Description|
+|---|---|---|
+|`mode`|string or integer|Mode is the type of extension to be used -- currently critical-option is not supported. 0 is "extension". Can be either the string or the integer representation of each option.|
+|`name`|string|Name specifies the key to be used in the cert extension.|
+|`type`|string or integer|Type represents the certificate type being extended, only ssh is supported at this time. 0 is "ssh". Can be either the string or the integer representation of each option.|
+|`value`|string|Value specifies the value to be used in the cert extension.|
+
+### `spec.options.idp.saml`
+
+|Field|Type|Description|
+|---|---|---|
+|`enabled`|Boolean|Enabled is set to true if this option allows access to the Teleport SAML IdP.|
+
+### `spec.options.idp`
+
+|Field|Type|Description|
+|---|---|---|
+|`saml`|[object](#specoptionsidpsaml)|SAML are options related to the Teleport SAML IdP.|
+
+### `spec.options.record_session`
+
+|Field|Type|Description|
+|---|---|---|
+|`default`|string|Default indicates the default value for the services.|
+|`desktop`|Boolean|Desktop indicates whether desktop sessions should be recorded. It defaults to true unless explicitly set to false.|
+|`ssh`|string|SSH indicates the session mode used on SSH sessions.|
+
+### `spec.options`
+
+|Field|Type|Description|
+|---|---|---|
+|`cert_extensions`|[][object](#specoptionscert_extensions-items)|CertExtensions specifies the key/values|
+|`cert_format`|string|CertificateFormat defines the format of the user certificate to allow compatibility with older versions of OpenSSH.|
+|`client_idle_timeout`|string|ClientIdleTimeout sets disconnect clients on idle timeout behavior, if set to 0 means do not disconnect, otherwise is set to the idle duration.|
+|`create_db_user`|Boolean|CreateDatabaseUser enabled automatic database user creation.|
+|`create_db_user_mode`|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is `unspecified`, 1 is `off`, 2 is `keep`, 3 is `best_effort_drop`. Can be either the string or the integer representation of each option.|
+|`create_desktop_user`|Boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
+|`create_host_user`|Boolean|CreateHostUser allows users to be automatically created on a host|
+|`create_host_user_default_shell`|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
+|`create_host_user_mode`|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is `unspecified`; 1 is `off`; 2 is `drop` (removed for v15 and above), 3 is `keep`; 4 is `insecure-drop`. Can be either the string or the integer representation of each option.|
+|`desktop_clipboard`|Boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|
+|`desktop_directory_sharing`|Boolean|DesktopDirectorySharing indicates whether directory sharing is allowed between the user's workstation and the remote desktop. It defaults to false unless explicitly set to true.|
+|`device_trust_mode`|string|DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode.|
+|`disconnect_expired_cert`|Boolean|DisconnectExpiredCert sets disconnect clients on expired certificates.|
+|`enhanced_recording`|[]string|BPF defines what events to record for the BPF-based session recorder.|
+|`forward_agent`|Boolean|ForwardAgent is SSH agent forwarding.|
+|`idp`|[object](#specoptionsidp)|IDP is a set of options related to accessing IdPs within Teleport. Requires Teleport Enterprise.|
+|`lock`|string|Lock specifies the locking mode (strict|best_effort) to be applied with the role.|
+|`max_connections`|integer|MaxConnections defines the maximum number of concurrent connections a user may hold.|
+|`max_kubernetes_connections`|integer|MaxKubernetesConnections defines the maximum number of concurrent Kubernetes sessions a user may hold.|
+|`max_session_ttl`|string|MaxSessionTTL defines how long a SSH session can last for.|
+|`max_sessions`|integer|MaxSessions defines the maximum number of concurrent sessions per connection.|
+|`mfa_verification_interval`|string|MFAVerificationInterval optionally defines the maximum duration that can elapse between successive MFA verifications. This variable is used to ensure that users are periodically prompted to verify their identity, enhancing security by preventing prolonged sessions without re-authentication when using tsh proxy * derivatives. It's only effective if the session requires MFA. If not set, defaults to `max_session_ttl`.|
+|`permit_x11_forwarding`|Boolean|PermitX11Forwarding authorizes use of X11 forwarding.|
+|`pin_source_ip`|Boolean|PinSourceIP forces the same client IP for certificate generation and usage|
+|`port_forwarding`|Boolean|PortForwarding defines if the certificate will have "permit-port-forwarding" in the certificate. PortForwarding is "yes" if not set, that's why this is a pointer|
+|`record_session`|[object](#specoptionsrecord_session)|RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.|
+|`request_access`|string|RequestAccess defines the request strategy (optional|note|always) where optional is the default.|
+|`request_prompt`|string|RequestPrompt is an optional message which tells users what they aught to request.|
+|`require_session_mfa`|string or integer|RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN". Can be either the string or the integer representation of each option.|
+|`ssh_file_copy`|Boolean|SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.|
+
+### `spec`
+
+|Field|Type|Description|
+|---|---|---|
+|`allow`|[object](#specallow)|Allow is the set of conditions evaluated to grant access.|
+|`deny`|[object](#specdeny)|Deny is the set of conditions evaluated to deny access. Deny takes priority over allow.|
+|`options`|[object](#specoptions)|Options is for OpenSSH options like agent forwarding.|
 

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_samlconnectors.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_samlconnectors.mdx
@@ -13,62 +13,62 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 ## resources.teleport.dev/v2
 
-**apiVersion:** resources.teleport.dev/v2
+`apiVersion: resources.teleport.dev/v2`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|SAMLConnector resource definition v2 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|SAMLConnector resource definition v2 from Teleport|
 
-### spec
-
-|Field|Type|Description|
-|---|---|---|
-|acs|string|AssertionConsumerService is a URL for assertion consumer service on the service provider (Teleport's side).|
-|allow_idp_initiated|boolean|AllowIDPInitiated is a flag that indicates if the connector can be used for IdP-initiated logins.|
-|assertion_key_pair|[object](#specassertion_key_pair)|EncryptionKeyPair is a key pair used for decrypting SAML assertions.|
-|attributes_to_roles|[][object](#specattributes_to_roles-items)|AttributesToRoles is a list of mappings of attribute statements to roles.|
-|audience|string|Audience uniquely identifies our service provider.|
-|cert|string|Cert is the identity provider certificate PEM. IDP signs `<Response>` responses using this certificate.|
-|client_redirect_settings|[object](#specclient_redirect_settings)|ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones.|
-|display|string|Display controls how this connector is displayed.|
-|entity_descriptor|string|EntityDescriptor is XML with descriptor. It can be used to supply configuration parameters in one XML file rather than supplying them in the individual elements.|
-|entity_descriptor_url|string|EntityDescriptorURL is a URL that supplies a configuration XML.|
-|issuer|string|Issuer is the identity provider issuer.|
-|provider|string|Provider is the external identity provider.|
-|service_provider_issuer|string|ServiceProviderIssuer is the issuer of the service provider (Teleport).|
-|signing_key_pair|[object](#specsigning_key_pair)|SigningKeyPair is an x509 key pair used to sign AuthnRequest.|
-|single_logout_url|string|SingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out). If this is not provided, SLO is disabled.|
-|sso|string|SSO is the URL of the identity provider's SSO service.|
-
-### spec.assertion_key_pair
+### `spec.assertion_key_pair`
 
 |Field|Type|Description|
 |---|---|---|
-|cert|string|Cert is a PEM-encoded x509 certificate.|
-|private_key|string|PrivateKey is a PEM encoded x509 private key.|
+|`cert`|string|Cert is a PEM-encoded x509 certificate.|
+|`private_key`|string|PrivateKey is a PEM encoded x509 private key.|
 
-### spec.attributes_to_roles items
-
-|Field|Type|Description|
-|---|---|---|
-|name|string|Name is an attribute statement name.|
-|roles|[]string|Roles is a list of static teleport roles to map to.|
-|value|string|Value is an attribute statement value to match.|
-
-### spec.client_redirect_settings
+### `spec.attributes_to_roles` items
 
 |Field|Type|Description|
 |---|---|---|
-|allowed_https_hostnames|[]string|a list of hostnames allowed for https client redirect URLs|
-|insecure_allowed_cidr_ranges|[]string|a list of CIDRs allowed for HTTP or HTTPS client redirect URLs|
+|`name`|string|Name is an attribute statement name.|
+|`roles`|[]string|Roles is a list of static teleport roles to map to.|
+|`value`|string|Value is an attribute statement value to match.|
 
-### spec.signing_key_pair
+### `spec.client_redirect_settings`
 
 |Field|Type|Description|
 |---|---|---|
-|cert|string|Cert is a PEM-encoded x509 certificate.|
-|private_key|string|PrivateKey is a PEM encoded x509 private key.|
+|`allowed_https_hostnames`|[]string|a list of hostnames allowed for HTTPS client redirect URLs|
+|`insecure_allowed_cidr_ranges`|[]string|a list of CIDRs allowed for HTTP or HTTPS client redirect URLs|
+
+### `spec.signing_key_pair`
+
+|Field|Type|Description|
+|---|---|---|
+|`cert`|string|Cert is a PEM-encoded x509 certificate.|
+|`private_key`|string|PrivateKey is a PEM encoded x509 private key.|
+
+### `spec`
+
+|Field|Type|Description|
+|---|---|---|
+|`acs`|string|AssertionConsumerService is a URL for assertion consumer service on the service provider (Teleport's side).|
+|`allow_idp_initiated`|Boolean|AllowIDPInitiated is a flag that indicates if the connector can be used for IdP-initiated logins.|
+|`assertion_key_pair`|[object](#specassertion_key_pair)|EncryptionKeyPair is a key pair used for decrypting SAML assertions.|
+|`attributes_to_roles`|[][object](#specattributes_to_roles-items)|AttributesToRoles is a list of mappings of attribute statements to roles.|
+|`audience`|string|Audience uniquely identifies our service provider.|
+|`cert`|string|Cert is the identity provider certificate PEM. IDP signs `<Response>` responses using this certificate.|
+|`client_redirect_settings`|[object](#specclient_redirect_settings)|ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones.|
+|`display`|string|Display controls how this connector is displayed.|
+|`entity_descriptor`|string|EntityDescriptor is XML with descriptor. It can be used to supply configuration parameters in one XML file rather than supplying them in the individual elements.|
+|`entity_descriptor_url`|string|EntityDescriptorURL is a URL that supplies a configuration XML.|
+|`issuer`|string|Issuer is the identity provider issuer.|
+|`provider`|string|Provider is the external identity provider.|
+|`service_provider_issuer`|string|ServiceProviderIssuer is the issuer of the service provider (Teleport).|
+|`signing_key_pair`|[object](#specsigning_key_pair)|SigningKeyPair is an x509 key pair used to sign AuthnRequest.|
+|`single_logout_url`|string|SingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out). If this is not provided, SLO is disabled.|
+|`sso`|string|SSO is the URL of the identity provider's SSO service.|
 

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_users.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_users.mdx
@@ -13,47 +13,47 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 ## resources.teleport.dev/v2
 
-**apiVersion:** resources.teleport.dev/v2
+`apiVersion: resources.teleport.dev/v2`
 
 |Field|Type|Description|
 |---|---|---|
-|apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
-|kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
-|metadata|object||
-|spec|[object](#spec)|User resource definition v2 from Teleport|
+|`apiVersion`|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
+|`kind`|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
+|`metadata`|object||
+|`spec`|[object](#spec)|User resource definition v2 from Teleport|
 
-### spec
-
-|Field|Type|Description|
-|---|---|---|
-|github_identities|[][object](#specgithub_identities-items)|GithubIdentities list associated Github OAuth2 identities that let user log in using externally verified identity|
-|oidc_identities|[][object](#specoidc_identities-items)|OIDCIdentities lists associated OpenID Connect identities that let user log in using externally verified identity|
-|roles|[]string|Roles is a list of roles assigned to user|
-|saml_identities|[][object](#specsaml_identities-items)|SAMLIdentities lists associated SAML identities that let user log in using externally verified identity|
-|traits|object|Traits are key/value pairs received from an identity provider (through OIDC claims or SAML assertions) or from a system administrator for local accounts. Traits are used to populate role variables.|
-|trusted_device_ids|[]string|TrustedDeviceIDs contains the IDs of trusted devices enrolled by the user.  Note that SSO users are transient and thus may contain an empty TrustedDeviceIDs field, even though the user->device association exists under the Device Trust subsystem. Do not rely on this field to determine device associations or ownership, it exists for legacy/informative purposes only.  Managed by the Device Trust subsystem, avoid manual edits.|
-
-### spec.github_identities items
+### `spec.github_identities` items
 
 |Field|Type|Description|
 |---|---|---|
-|connector_id|string|ConnectorID is id of registered OIDC connector, e.g. 'google-example.com'|
-|samlSingleLogoutUrl|string|SAMLSingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out), if applicable.|
-|username|string|Username is username supplied by external identity provider|
+|`connector_id`|string|ConnectorID is id of registered OIDC connector, e.g. 'google-example.com'|
+|`samlSingleLogoutUrl`|string|SAMLSingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out), if applicable.|
+|`username`|string|Username is username supplied by external identity provider|
 
-### spec.oidc_identities items
-
-|Field|Type|Description|
-|---|---|---|
-|connector_id|string|ConnectorID is id of registered OIDC connector, e.g. 'google-example.com'|
-|samlSingleLogoutUrl|string|SAMLSingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out), if applicable.|
-|username|string|Username is username supplied by external identity provider|
-
-### spec.saml_identities items
+### `spec.oidc_identities` items
 
 |Field|Type|Description|
 |---|---|---|
-|connector_id|string|ConnectorID is id of registered OIDC connector, e.g. 'google-example.com'|
-|samlSingleLogoutUrl|string|SAMLSingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out), if applicable.|
-|username|string|Username is username supplied by external identity provider|
+|`connector_id`|string|ConnectorID is id of registered OIDC connector, e.g. 'google-example.com'|
+|`samlSingleLogoutUrl`|string|SAMLSingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out), if applicable.|
+|`username`|string|Username is username supplied by external identity provider|
+
+### `spec.saml_identities` items
+
+|Field|Type|Description|
+|---|---|---|
+|`connector_id`|string|ConnectorID is id of registered OIDC connector, e.g. 'google-example.com'|
+|`samlSingleLogoutUrl`|string|SAMLSingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out), if applicable.|
+|`username`|string|Username is username supplied by external identity provider|
+
+### `spec`
+
+|Field|Type|Description|
+|---|---|---|
+|`github_identities`|[][object](#specgithub_identities-items)|GithubIdentities list associated GitHub OAuth2 identities that let user log in using externally verified identity|
+|`oidc_identities`|[][object](#specoidc_identities-items)|OIDCIdentities lists associated OpenID Connect identities that let user log in using externally verified identity|
+|`roles`|[]string|Roles is a list of roles assigned to user|
+|`saml_identities`|[][object](#specsaml_identities-items)|SAMLIdentities lists associated SAML identities that let user log in using externally verified identity|
+|`traits`|object|Traits are key/value pairs received from an identity provider (through OIDC claims or SAML assertions) or from a system administrator for local accounts. Traits are used to populate role variables.|
+|`trusted_device_ids`|[]string|TrustedDeviceIDs contains the IDs of trusted devices enrolled by the user.  Note that SSO users are transient and thus may contain an empty TrustedDeviceIDs field, even though the user->device association exists under the Device Trust subsystem. Do not rely on this field to determine device associations or ownership, it exists for legacy/informative purposes only.  Managed by the Device Trust subsystem, avoid manual edits.|
 

--- a/integrations/operator/crdgen/handlerequest_test.go
+++ b/integrations/operator/crdgen/handlerequest_test.go
@@ -106,7 +106,7 @@ func Test_propertyTable(t *testing.T) {
 					},
 				},
 				{
-					Name: "port_info",
+					Name: "`port_info`",
 					Fields: []PropertyTableField{
 						{
 							Name:        "port",
@@ -209,7 +209,7 @@ func Test_propertyTable(t *testing.T) {
 					},
 				},
 				{
-					Name: "ports items",
+					Name: "`ports` items",
 					Fields: []PropertyTableField{
 						{
 							Name:        "port",
@@ -309,7 +309,7 @@ func Test_propertyTable(t *testing.T) {
 					},
 				},
 				{
-					Name: "metadata",
+					Name: "`metadata`",
 					Fields: []PropertyTableField{
 						{
 							Name:        "name",
@@ -319,7 +319,7 @@ func Test_propertyTable(t *testing.T) {
 					},
 				},
 				{
-					Name: "datacenter",
+					Name: "`datacenter`",
 					Fields: []PropertyTableField{
 						{
 							Name:        "metadata",
@@ -329,7 +329,7 @@ func Test_propertyTable(t *testing.T) {
 					},
 				},
 				{
-					Name: "datacenter.metadata",
+					Name: "`datacenter.metadata`",
 					Fields: []PropertyTableField{
 						{
 							Name:        "name",
@@ -409,7 +409,7 @@ func Test_propertyTable(t *testing.T) {
 					},
 				},
 				{
-					Name: "circleci",
+					Name: "`circleci`",
 					Fields: []PropertyTableField{
 						{
 							Name:        "allow",
@@ -419,7 +419,7 @@ func Test_propertyTable(t *testing.T) {
 					},
 				},
 				{
-					Name: "circleci.allow items",
+					Name: "`circleci.allow` items",
 					Fields: []PropertyTableField{
 						{
 							Name:        "project_id",
@@ -429,7 +429,7 @@ func Test_propertyTable(t *testing.T) {
 					},
 				},
 				{
-					Name: "gitlab",
+					Name: "`gitlab`",
 					Fields: []PropertyTableField{
 						{
 							Name:        "allow",
@@ -439,7 +439,7 @@ func Test_propertyTable(t *testing.T) {
 					},
 				},
 				{
-					Name: "gitlab.allow items",
+					Name: "`gitlab.allow` items",
 					Fields: []PropertyTableField{
 						{
 							Name:        "project_id",
@@ -560,7 +560,7 @@ state of this API Resource.\n---\nThis struct is intended for direct use as an a
 					},
 				},
 				{
-					Name: "mappings items",
+					Name: "`mappings` items",
 					Fields: []PropertyTableField{
 						{
 							Name:        "add_labels",
@@ -570,7 +570,7 @@ state of this API Resource.\n---\nThis struct is intended for direct use as an a
 					},
 				},
 				{
-					Name: "mappings items.add_labels",
+					Name: "`mappings` items`.add_labels`",
 					Fields: []PropertyTableField{
 						{
 							Name: "key",


### PR DESCRIPTION
Related to #46191

Help us move to a new, more scalable spell checker based on vale by supporting spell checking in the Operator resource reference. While vale cannot ignore specific files (unless we run the CLI on all _but_ those files), it is possible to fine-tune a vale spell-check rule so we can check the Operator resource reference docs:

- Fix specific spelling errors in some of our proto files.
- Use "Boolean" instead of "boolean" in Operator resource reference docs by substituting the incorrect spelling in the docs generator.
- Wrap field type names and headings in backticks to avoid the vale spell checker. The vale spell checker ignores all content in backticks.