### PR TITLE
Fix spelling in TF docs and related protos

### DIFF
--- a/api/proto/teleport/access_graph/v1/authorized_key.proto
+++ b/api/proto/teleport/access_graph/v1/authorized_key.proto
@@ -27,7 +27,7 @@ message AuthorizedKey {
   teleport.header.v1.Metadata metadata = 1;
   // kind is a resource kind.
   string kind = 2;
-  // sub_kind is an optional resource sub kind, used in some resources.
+  // an optional resource sub kind, used in some resources.
   string sub_kind = 3;
   // version is version.
   string version = 4;

--- a/api/proto/teleport/access_graph/v1/private_key.proto
+++ b/api/proto/teleport/access_graph/v1/private_key.proto
@@ -29,7 +29,7 @@ message PrivateKey {
   teleport.header.v1.Metadata metadata = 1;
   // kind is a resource kind.
   string kind = 2;
-  // sub_kind is an optional resource sub kind, used in some resources.
+  // an optional resource sub kind, used in some resources.
   string sub_kind = 3;
   // version is version.
   string version = 4;

--- a/api/proto/teleport/accesslist/v1/accesslist.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist.proto
@@ -51,16 +51,14 @@ message AccessListSpec {
   // audit describes the frequency that this access list must be audited.
   AccessListAudit audit = 3;
 
-  // membership_requires describes the requirements for a user to be a member of
-  // the access list. For a membership to an access list to be effective, the
-  // user must meet the requirements of Membership_requires and must be in the
-  // members list.
+  // describes the requirements for a user to be a member of the access list.
+  // For a membership to an access list to be effective, the user must meet the
+  // requirements of `membership_requires` and must be in the members list.
   AccessListRequires membership_requires = 4;
 
-  // ownership_requires describes the requirements for a user to be an owner of
-  // the access list. For ownership of an access list to be effective, the user
-  // must meet the requirements of ownership_requires and must be in the owners
-  // list.
+  // describes the requirements for a user to be an owner of the access list.
+  // For ownership of an access list to be effective, the user must meet the
+  // requirements of `ownership_requires` and must be in the owners list.
   AccessListRequires ownership_requires = 5;
 
   // grants describes the access granted by membership to this access list.
@@ -69,7 +67,7 @@ message AccessListSpec {
   // title is a plaintext short description of the access list.
   string title = 8;
 
-  // owner_grants describes the access granted by owners to this access list.
+  // describes the access granted by owners to this access list.
   AccessListGrants owner_grants = 11;
 }
 
@@ -126,7 +124,7 @@ message Recurrence {
   // Supported values are 0, 1, 3, 6, and 12.
   ReviewFrequency frequency = 1;
 
-  // day_of_month is the day of month that reviews will be scheduled on.
+  // the day of month that reviews will be scheduled on.
   // Supported values are 0, 1, 15, and 31.
   ReviewDayOfMonth day_of_month = 2;
 }

--- a/api/proto/teleport/accessmonitoringrules/v1/access_monitoring_rules.proto
+++ b/api/proto/teleport/accessmonitoringrules/v1/access_monitoring_rules.proto
@@ -22,11 +22,11 @@ option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport
 
 // AccessMonitoringRule represents an access monitoring rule resources.
 message AccessMonitoringRule {
-  // metadata is the rules's metadata.
+  // metadata is the rule's metadata.
   teleport.header.v1.Metadata metadata = 1;
   // kind is a resource kind
   string kind = 2;
-  // sub_kind is an optional resource sub kind, used in some resources
+  // optional resource sub kind, used in some resources
   string sub_kind = 3;
   // version is version
   string version = 4;

--- a/api/proto/teleport/header/v1/resourceheader.proto
+++ b/api/proto/teleport/header/v1/resourceheader.proto
@@ -24,7 +24,7 @@ option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport
 message ResourceHeader {
   // kind is a resource kind.
   string kind = 1;
-  // sub_kind is an optional resource sub kind, used in some resources.
+  // an optional resource sub kind, used in some resources.
   string sub_kind = 2;
   // Version is the API version used to create the resource. It must be
   // specified. Based on this version, Teleport will apply different defaults on

--- a/api/proto/teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto
+++ b/api/proto/teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto
@@ -25,7 +25,7 @@ option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport
 message KubernetesWaitingContainer {
   // kind is a resource kind
   string kind = 1;
-  // sub_kind is an optional resource sub kind, used in some resources
+  // an optional resource sub kind, used in some resources
   string sub_kind = 2;
   // version is the resource version. It must be specified.
   // Supported values are: `v1`.

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -102,7 +102,7 @@ message Rotation {
   option (gogoproto.goproto_stringer) = false;
   option (gogoproto.stringer) = false;
 
-  // State could be one of "init" or "in_progress".
+  // State could be one of `init` or `in_progress`.
   string State = 1 [(gogoproto.jsontag) = "state,omitempty"];
   // Phase is the current rotation phase.
   string Phase = 2 [(gogoproto.jsontag) = "phase,omitempty"];
@@ -112,7 +112,7 @@ message Rotation {
   // to differentiate between rotation attempts.
   string CurrentID = 4 [(gogoproto.jsontag) = "current_id"];
   // Started is set to the time when rotation has been started
-  // in case if the state of the rotation is "in_progress".
+  // in case if the state of the rotation is `in_progress`.
   google.protobuf.Timestamp Started = 5 [
     (gogoproto.nullable) = false,
     (gogoproto.stdtime) = true,
@@ -274,7 +274,7 @@ message DatabaseV3 {
 
 // DatabaseSpecV3 is the database spec.
 message DatabaseSpecV3 {
-  // Protocol is the database protocol: postgres, mysql, mongodb, etc.
+  // Protocol is the database protocol: `postgres`, `mysql`, `mongodb`, etc.
   string Protocol = 1 [(gogoproto.jsontag) = "protocol"];
   // URI is the database connection endpoint.
   string URI = 2 [(gogoproto.jsontag) = "uri"];
@@ -640,7 +640,7 @@ message DatabaseTLS {
   // TrustSystemCertPool allows Teleport to trust certificate authorities
   // available on the host system. If not set (by default), Teleport only
   // trusts self-signed databases with TLS certificates signed by Teleport's
-  // Database Server CA or the ca_cert specified in this TLS setting. For
+  // Database Server CA or the `ca_cert` specified in this TLS setting. For
   // cloud-hosted databases, Teleport downloads the corresponding required CAs
   // for validation.
   bool TrustSystemCertPool = 4 [(gogoproto.jsontag) = "trust_system_cert_pool,omitempty"];
@@ -947,17 +947,17 @@ message AppV3 {
 
 // CORSPolicy defines the CORS policy for AppSpecV3
 message CORSPolicy {
-  // allowed_origins specifies which origins are allowed to access the app.
+  // `allowed_origins` specifies which origins are allowed to access the app.
   repeated string allowed_origins = 1 [(gogoproto.jsontag) = "allowed_origins,omitempty"];
-  // allowed_methods specifies which methods are allowed when accessing the app.
+  // `allowed_methods` specifies which methods are allowed when accessing the app.
   repeated string allowed_methods = 2 [(gogoproto.jsontag) = "allowed_methods,omitempty"];
-  // allowed_headers specifies which headers can be used when accessing the app.
+  // `allowed_headers` specifies which headers can be used when accessing the app.
   repeated string allowed_headers = 3 [(gogoproto.jsontag) = "allowed_headers,omitempty"];
-  // allow_credentials indicates whether credentials are allowed.
+  // `allow_credentials` indicates whether credentials are allowed.
   bool allow_credentials = 4 [(gogoproto.jsontag) = "allow_credentials,omitempty"];
-  // max_age indicates how long (in seconds) the results of a preflight request can be cached.
+  // `max_age` indicates how long (in seconds) the results of a preflight request can be cached.
   uint32 max_age = 5 [(gogoproto.jsontag) = "max_age,omitempty"];
-  // exposed_headers indicates which headers are made available to scripts via the browser.
+  // `exposed_headers` indicates which headers are made available to scripts via the browser.
   repeated string exposed_headers = 6 [(gogoproto.jsontag) = "exposed_headers,omitempty"];
 }
 
@@ -1026,9 +1026,9 @@ message Rewrite {
 
 // Header represents a single http header passed over to the proxied application.
 message Header {
-  // Name is the http header name.
+  // Name is the HTTP header name.
   string Name = 1 [(gogoproto.jsontag) = "name"];
-  // Value is the http header value.
+  // Value is the HTTP header value.
   string Value = 2 [(gogoproto.jsontag) = "value"];
 }
 
@@ -1277,7 +1277,8 @@ message ProvisionTokenSpecV2 {
     (gogoproto.casttype) = "Duration"
   ];
   // JoinMethod is the joining method required in order to use this token.
-  // Supported joining methods include: azure, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm
+  // Supported joining methods include: `azure`, `circleci`, `ec2`, `gcp`,
+  // `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`
   string JoinMethod = 4 [
     (gogoproto.jsontag) = "join_method",
     (gogoproto.casttype) = "JoinMethod"
@@ -1292,9 +1293,9 @@ message ProvisionTokenSpecV2 {
     (gogoproto.jsontag) = "suggested_labels,omitempty",
     (gogoproto.customtype) = "Labels"
   ];
-  // GitHub allows the configuration of options specific to the "github" join method.
+  // GitHub allows the configuration of options specific to the `github` join method.
   ProvisionTokenSpecV2GitHub GitHub = 7 [(gogoproto.jsontag) = "github,omitempty"];
-  // CircleCI allows the configuration of options specific to the "circleci" join method.
+  // CircleCI allows the configuration of options specific to the `circleci` join method.
   ProvisionTokenSpecV2CircleCI CircleCI = 8 [(gogoproto.jsontag) = "circleci,omitempty"];
   // SuggestedAgentMatcherLabels is a set of labels to be used by agents to match on resources.
   // When an agent uses this token, the agent should monitor resources that match those labels.
@@ -1305,19 +1306,19 @@ message ProvisionTokenSpecV2 {
     (gogoproto.jsontag) = "suggested_agent_matcher_labels,omitempty",
     (gogoproto.customtype) = "Labels"
   ];
-  // Kubernetes allows the configuration of options specific to the "kubernetes" join method.
+  // Kubernetes allows the configuration of options specific to the `kubernetes` join method.
   ProvisionTokenSpecV2Kubernetes Kubernetes = 10 [(gogoproto.jsontag) = "kubernetes,omitempty"];
-  // Azure allows the configuration of options specific to the "azure" join method.
+  // Azure allows the configuration of options specific to the `azure` join method.
   ProvisionTokenSpecV2Azure Azure = 11 [(gogoproto.jsontag) = "azure,omitempty"];
-  // GitLab allows the configuration of options specific to the "gitlab" join method.
+  // GitLab allows the configuration of options specific to the `gitlab` join method.
   ProvisionTokenSpecV2GitLab GitLab = 12 [(gogoproto.jsontag) = "gitlab,omitempty"];
-  // GCP allows the configuration of options specific to the "gcp" join method.
+  // GCP allows the configuration of options specific to the `gcp` join method.
   ProvisionTokenSpecV2GCP GCP = 13 [(gogoproto.jsontag) = "gcp,omitempty"];
-  // Spacelift allows the configuration of options specific to the "spacelift" join method.
+  // Spacelift allows the configuration of options specific to the `spacelift` join method.
   ProvisionTokenSpecV2Spacelift Spacelift = 14 [(gogoproto.jsontag) = "spacelift,omitempty"];
-  // TPM allows the configuration of options specific to the "tpm" join method.
+  // TPM allows the configuration of options specific to the `tpm` join method.
   ProvisionTokenSpecV2TPM TPM = 15 [(gogoproto.jsontag) = "tpm,omitempty"];
-  // TerraformCloud allows the configuration of options specific to the "terraform_cloud" join method.
+  // TerraformCloud allows the configuration of options specific to the `terraform_cloud` join method.
   ProvisionTokenSpecV2TerraformCloud TerraformCloud = 16 [(gogoproto.jsontag) = "terraform_cloud,omitempty"];
 }
 
@@ -1368,7 +1369,7 @@ message ProvisionTokenSpecV2GitHub {
   message Rule {
     // Sub also known as Subject is a string that roughly uniquely identifies
     // the workload. The format of this varies depending on the type of
-    // github action run.
+    // GitHub Actions run.
     string Sub = 1 [(gogoproto.jsontag) = "sub,omitempty"];
     // The repository from where the workflow is running.
     // This includes the name of the owner e.g `gravitational/teleport`
@@ -1424,7 +1425,7 @@ message ProvisionTokenSpecV2GitLab {
     // - Use '?' to match any single character.
     string Sub = 1 [(gogoproto.jsontag) = "sub,omitempty"];
     // Ref allows access to be limited to jobs triggered by a specific git ref.
-    // Ensure this is used in combination with ref_type.
+    // Ensure this is used in combination with `ref_type`.
     //
     // This field supports simple "glob-style" matching:
     // - Use '*' to match zero or more characters.
@@ -1476,7 +1477,7 @@ message ProvisionTokenSpecV2GitLab {
       (gogoproto.jsontag) = "environment_protected,omitempty",
       (gogoproto.customtype) = "BoolOption"
     ];
-    // CIConfigSHA is the git commit SHA for the ci_config_ref_uri.
+    // CIConfigSHA is the git commit SHA for the `ci_config_ref_uri`.
     string CIConfigSHA = 13 [(gogoproto.jsontag) = "ci_config_sha,omitempty"];
     // CIConfigRefURI is the ref path to the top-level pipeline definition, for example,
     // gitlab.example.com/my-group/my-project//.gitlab-ci.yml@refs/heads/main.
@@ -1516,11 +1517,11 @@ message ProvisionTokenSpecV2Spacelift {
     // SpaceID is the ID of the space in which the run that owns the token was
     // executed.
     string SpaceID = 1 [(gogoproto.jsontag) = "space_id,omitempty"];
-    // CallerID is the ID of the caller, ie. the stack or module that generated
+    // CallerID is the ID of the caller, i.e., the stack or module that generated
     // the run.
     string CallerID = 2 [(gogoproto.jsontag) = "caller_id,omitempty"];
-    // CallerType is the type of the caller, ie. the entity that owns the run -
-    // either `stack` or `module`.
+    // CallerType is the type of the caller, i.e., the entity that owns the run
+    // - either `stack` or `module`.
     string CallerType = 3 [(gogoproto.jsontag) = "caller_type,omitempty"];
     // Scope is the scope of the token - either `read` or `write`.
     // See https://docs.spacelift.io/integrations/cloud-providers/oidc/#about-scopes
@@ -1868,7 +1869,7 @@ message ClusterNetworkingConfigSpecV2 {
   ProxyListenerMode ProxyListenerMode = 7 [(gogoproto.jsontag) = "proxy_listener_mode,omitempty"];
 
   // RoutingStrategy determines the strategy used to route to nodes.
-  // 0 is "unambiguous_match"; 1 is "most_recent".
+  // 0 is `unambiguous_match`; 1 is `most_recent`.
   RoutingStrategy RoutingStrategy = 8 [(gogoproto.jsontag) = "routing_strategy,omitempty"];
 
   // TunnelStrategyV1 determines the tunnel strategy used in the cluster.
@@ -2205,7 +2206,7 @@ message HardwareKeySerialNumberValidation {
   bool Enabled = 1 [(gogoproto.jsontag) = "enabled,omitempty"];
 
   // SerialNumberTraitName is an optional custom user trait name for hardware key
-  // serial numbers to replace the default: "hardware_key_serial_numbers".
+  // serial numbers to replace the default: `hardware_key_serial_numbers`.
   //
   // Note: Values for this user trait should be a comma-separated list of serial numbers,
   // or a list of comm-separated lists. e.g ["123", "345,678"]
@@ -2903,8 +2904,8 @@ message RoleOptions {
   reserved 13; // RequireSessionMFA replaced by RequireMFAType
   reserved "RequireSessionMFA";
 
-  // Lock specifies the locking mode (strict|best_effort) to be applied with
-  // the role.
+  // Lock specifies the locking mode (`strict` or `best_effort`) to be applied
+  // with the role.
   string Lock = 14 [
     (gogoproto.jsontag) = "lock,omitempty",
     (gogoproto.casttype) = "github.com/gravitational/teleport/api/constants.LockingMode"
@@ -2996,7 +2997,7 @@ message RoleOptions {
 
   // CreateDatabaseUserMode allows users to be automatically created on a
   // database when not set to off.
-  // 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop".
+  // 0 is `unspecified`, 1 is `off`, 2 is `keep`, 3 is `best_effort_drop`.
   CreateDatabaseUserMode CreateDatabaseUserMode = 29 [(gogoproto.jsontag) = "create_db_user_mode,omitempty"];
 
   // MFAVerificationInterval optionally defines the maximum duration that can elapse
@@ -3093,12 +3094,12 @@ message RoleConditions {
     (gogoproto.jsontag) = "rules,omitempty"
   ];
 
-  // KubeGroups is a list of kubernetes groups
+  // KubeGroups is a list of Kubernetes groups
   repeated string KubeGroups = 5 [(gogoproto.jsontag) = "kubernetes_groups,omitempty"];
 
   AccessRequestConditions Request = 6 [(gogoproto.jsontag) = "request,omitempty"];
 
-  // KubeUsers is an optional kubernetes users to impersonate
+  // KubeUsers indicates optional Kubernetes users to impersonate
   repeated string KubeUsers = 7 [(gogoproto.jsontag) = "kubernetes_users,omitempty"];
 
   // AppLabels is a map of labels used as part of the RBAC system.
@@ -3208,7 +3209,7 @@ message RoleConditions {
   // to remote Teleport clusters.
   string ClusterLabelsExpression = 32 [(gogoproto.jsontag) = "cluster_labels_expression,omitempty"];
   // KubernetesLabelsExpression is a predicate expression used to allow/deny
-  // access to kubernetes clusters.
+  // access to Kubernetes clusters.
   string KubernetesLabelsExpression = 33 [(gogoproto.jsontag) = "kubernetes_labels_expression,omitempty"];
   // DatabaseLabelsExpression is a predicate expression used to allow/deny
   // access to Databases.
@@ -3475,8 +3476,8 @@ message ImpersonateConditions {
   string Where = 3 [(gogoproto.jsontag) = "where,omitempty"];
 }
 
-// BoolValue is a wrapper around bool, used in cases
-// whenever bool value can have different default value when missing
+// BoolValue is a wrapper around `bool`, used in cases whenever a `bool` value
+// can have different default value when missing
 message BoolValue {
   bool Value = 1;
 }
@@ -3517,7 +3518,7 @@ message UserV2 {
 
 // UserStatusV2 is a dynamic state of UserV2.
 message UserStatusV2 {
-  // password_state reflects what the system knows about the user's password.
+  // PasswordState reflects what the system knows about the user's password.
   // Note that this is a "best effort" property, in that it can be UNSPECIFIED
   // for users who were created before this property was introduced and didn't
   // perform any password-related activity since then. See RFD 0159 for
@@ -3551,7 +3552,7 @@ message UserSpecV2 {
     (gogoproto.jsontag) = "saml_identities,omitempty"
   ];
 
-  // GithubIdentities list associated Github OAuth2 identities
+  // GithubIdentities list associated GitHub OAuth2 identities
   // that let user log in using externally verified identity
   repeated ExternalIdentity GithubIdentities = 3 [
     (gogoproto.nullable) = false,
@@ -4202,7 +4203,7 @@ message RemoteClusterStatusV3 {
   ];
 }
 
-// KubernetesCluster is a named kubernetes API endpoint handled by a Server.
+// KubernetesCluster is a named Kubernetes API endpoint handled by a Server.
 //
 // TODO: deprecate and convert all usage to KubernetesClusterV3
 message KubernetesCluster {
@@ -4220,7 +4221,7 @@ message KubernetesCluster {
   ];
 }
 
-// KubernetesClusterV3 represents a named kubernetes API endpoint.
+// KubernetesClusterV3 represents a named Kubernetes API endpoint.
 message KubernetesClusterV3 {
   option (gogoproto.goproto_stringer) = false;
   option (gogoproto.stringer) = false;
@@ -4302,7 +4303,7 @@ message KubeGCP {
   string Name = 3 [(gogoproto.jsontag) = "name,omitempty"];
 }
 
-// KubernetesClusterV3List represents a list of kubernetes clusters.
+// KubernetesClusterV3List represents a list of Kubernetes clusters.
 message KubernetesClusterV3List {
   // KubernetesClusters is a list of kubernetes clusters resources.
   repeated KubernetesClusterV3 KubernetesClusters = 1;
@@ -4499,18 +4500,18 @@ message OIDCConnectorSpecV3 {
   // Scope specifies additional scopes set by provider.
   repeated string Scope = 8 [(gogoproto.jsontag) = "scope,omitempty"];
   // Prompt is an optional OIDC prompt. An empty string omits prompt.
-  // If not specified, it defaults to select_account for backwards compatibility.
+  // If not specified, it defaults to `select_account` for backwards compatibility.
   string Prompt = 9 [(gogoproto.jsontag) = "prompt,omitempty"];
   // ClaimsToRoles specifies a dynamic mapping from claims to roles.
   repeated ClaimMapping ClaimsToRoles = 10 [
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "claims_to_roles,omitempty"
   ];
-  // GoogleServiceAccountURI is a path to a google service account uri.
+  // GoogleServiceAccountURI is a path to a Google service account URI.
   string GoogleServiceAccountURI = 11 [(gogoproto.jsontag) = "google_service_account_uri,omitempty"];
-  // GoogleServiceAccount is a string containing google service account credentials.
+  // GoogleServiceAccount is a string containing Google service account credentials.
   string GoogleServiceAccount = 12 [(gogoproto.jsontag) = "google_service_account,omitempty"];
-  // GoogleAdminEmail is the email of a google admin to impersonate.
+  // GoogleAdminEmail is the email of a Google admin to impersonate.
   string GoogleAdminEmail = 13 [(gogoproto.jsontag) = "google_admin_email,omitempty"];
   // RedirectURLs is a list of callback URLs which the identity provider can use
   // to redirect the client back to the Teleport Proxy to complete authentication.
@@ -4550,7 +4551,7 @@ message MaxAge {
 // SSOClientRedirectSettings contains settings to define which additional client
 // redirect URLs should be allowed for non-browser SSO logins.
 message SSOClientRedirectSettings {
-  // a list of hostnames allowed for https client redirect URLs
+  // a list of hostnames allowed for HTTPS client redirect URLs
   repeated string allowed_https_hostnames = 1;
   // a list of CIDRs allowed for HTTP or HTTPS client redirect URLs
   repeated string insecure_allowed_cidr_ranges = 2;
@@ -4847,7 +4848,7 @@ message GithubConnectorV3 {
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "metadata"
   ];
-  // Spec is an Github connector specification.
+  // Spec is a GitHub connector specification.
   GithubConnectorSpecV3 Spec = 5 [
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "spec"
@@ -4860,15 +4861,15 @@ message GithubConnectorV3List {
   repeated GithubConnectorV3 GithubConnectors = 1;
 }
 
-// GithubConnectorSpecV3 is a Github connector specification.
+// GithubConnectorSpecV3 is a GitHub connector specification.
 message GithubConnectorSpecV3 {
-  // ClientID is the Github OAuth app client ID.
+  // ClientID is the GitHub OAuth app client ID.
   string ClientID = 1 [(gogoproto.jsontag) = "client_id"];
-  // ClientSecret is the Github OAuth app client secret.
+  // ClientSecret is the GitHub OAuth app client secret.
   string ClientSecret = 2 [(gogoproto.jsontag) = "client_secret"];
   // RedirectURL is the authorization callback URL.
   string RedirectURL = 3 [(gogoproto.jsontag) = "redirect_url"];
-  // TeamsToLogins maps Github team memberships onto allowed logins/roles.
+  // TeamsToLogins maps GitHub team memberships onto allowed logins/roles.
   //
   // DELETE IN 11.0.0
   // Deprecated: use GithubTeamsToRoles instead.
@@ -4878,14 +4879,14 @@ message GithubConnectorSpecV3 {
   ];
   // Display is the connector display name.
   string Display = 5 [(gogoproto.jsontag) = "display"];
-  // TeamsToRoles maps Github team memberships onto allowed roles.
+  // TeamsToRoles maps GitHub team memberships onto allowed roles.
   repeated TeamRolesMapping TeamsToRoles = 6 [
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "teams_to_roles"
   ];
   // EndpointURL is the URL of the GitHub instance this connector is for.
   string EndpointURL = 7 [(gogoproto.jsontag) = "endpoint_url"];
-  // APIEndpointURL is the URL of the API endpoint of the Github instance
+  // APIEndpointURL is the URL of the API endpoint of the GitHub instance
   // this connector is for.
   string APIEndpointURL = 8 [(gogoproto.jsontag) = "api_endpoint_url"];
   // ClientRedirectSettings defines which client redirect URLs are allowed for
@@ -5137,21 +5138,21 @@ message GithubClaims {
 //
 // DELETE IN 11.0.0
 message TeamMapping {
-  // Organization is a Github organization a user belongs to.
+  // Organization is a GitHub organization a user belongs to.
   string Organization = 1 [(gogoproto.jsontag) = "organization"];
   // Team is a team within the organization a user belongs to.
   string Team = 2 [(gogoproto.jsontag) = "team"];
   // Logins is a list of allowed logins for this org/team.
   repeated string Logins = 3 [(gogoproto.jsontag) = "logins,omitempty"];
-  // KubeGroups is a list of allowed kubernetes groups for this org/team.
+  // KubeGroups is a list of allowed Kubernetes groups for this org/team.
   repeated string KubeGroups = 4 [(gogoproto.jsontag) = "kubernetes_groups,omitempty"];
-  // KubeUsers is a list of allowed kubernetes users to impersonate for this org/team.
+  // KubeUsers is a list of allowed Kubernetes users to impersonate for this org/team.
   repeated string KubeUsers = 5 [(gogoproto.jsontag) = "kubernetes_users,omitempty"];
 }
 
 // TeamRolesMapping represents a single team membership mapping.
 message TeamRolesMapping {
-  // Organization is a Github organization a user belongs to.
+  // Organization is a GitHub organization a user belongs to.
   string Organization = 1 [(gogoproto.jsontag) = "organization"];
   // Team is a team within the organization a user belongs to.
   string Team = 2 [(gogoproto.jsontag) = "team"];
@@ -5189,9 +5190,9 @@ message TrustedClusterV2List {
 
 // TrustedClusterSpecV2 is a Trusted Cluster specification.
 message TrustedClusterSpecV2 {
-  // Enabled is a bool that indicates if the TrustedCluster is enabled or disabled.
-  // Setting Enabled to false has a side effect of deleting the user and host certificate
-  // authority (CA).
+  // Enabled indicates if the TrustedCluster is enabled or disabled.  Setting
+  // Enabled to false has a side effect of deleting the user and host
+  // certificate authority (CA).
   bool Enabled = 1 [(gogoproto.jsontag) = "enabled"];
   // Roles is a list of roles that users will be assuming when connecting to this cluster.
   repeated string Roles = 2 [(gogoproto.jsontag) = "roles,omitempty"];
@@ -6040,9 +6041,9 @@ enum SignatureAlgorithmSuite {
 
 // Plugin describes a single instance of a Teleport Plugin
 message PluginV1 {
-  // kind is the plugin resource kind.
+  // plugin resource kind.
   string kind = 1;
-  // sub_kind is an optional resource subkind.
+  // optional resource subkind.
   string sub_kind = 2;
   // version is the resource version.
   string version = 3;

--- a/api/proto/teleport/userprovisioning/v2/statichostuser.proto
+++ b/api/proto/teleport/userprovisioning/v2/statichostuser.proto
@@ -26,7 +26,7 @@ option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport
 message StaticHostUser {
   // kind is a resource kind.
   string kind = 1;
-  // sub_kind is an optional resource sub kind, used in some resources.
+  // an optional resource sub kind, used in some resources.
   string sub_kind = 2;
   // version is the resource version. It must be specified.
   // Supported values are: `v2`.

--- a/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
@@ -28,7 +28,7 @@ Optional:
 
 - `kind` (String) kind is a resource kind.
 - `metadata` (Attributes) metadata is resource metadata. (see [below for nested schema](#nested-schema-for-headermetadata))
-- `sub_kind` (String) sub_kind is an optional resource sub kind, used in some resources.
+- `sub_kind` (String) an optional resource sub kind, used in some resources.
 
 ### Nested Schema for `header.metadata`
 
@@ -57,9 +57,9 @@ Required:
 Optional:
 
 - `description` (String) description is an optional plaintext description of the access list.
-- `membership_requires` (Attributes) membership_requires describes the requirements for a user to be a member of the access list. For a membership to an access list to be effective, the user must meet the requirements of Membership_requires and must be in the members list. (see [below for nested schema](#nested-schema-for-specmembership_requires))
-- `owner_grants` (Attributes) owner_grants describes the access granted by owners to this access list. (see [below for nested schema](#nested-schema-for-specowner_grants))
-- `ownership_requires` (Attributes) ownership_requires describes the requirements for a user to be an owner of the access list. For ownership of an access list to be effective, the user must meet the requirements of ownership_requires and must be in the owners list. (see [below for nested schema](#nested-schema-for-specownership_requires))
+- `membership_requires` (Attributes) describes the requirements for a user to be a member of the access list. For a membership to an access list to be effective, the user must meet the requirements of `membership_requires` and must be in the members list. (see [below for nested schema](#nested-schema-for-specmembership_requires))
+- `owner_grants` (Attributes) describes the access granted by owners to this access list. (see [below for nested schema](#nested-schema-for-specowner_grants))
+- `ownership_requires` (Attributes) describes the requirements for a user to be an owner of the access list. For ownership of an access list to be effective, the user must meet the requirements of `ownership_requires` and must be in the owners list. (see [below for nested schema](#nested-schema-for-specownership_requires))
 - `title` (String) title is a plaintext short description of the access list.
 
 ### Nested Schema for `spec.audit`
@@ -81,7 +81,7 @@ Required:
 
 Optional:
 
-- `day_of_month` (Number) day_of_month is the day of month that reviews will be scheduled on. Supported values are 0, 1, 15, and 31.
+- `day_of_month` (Number) the day of month that reviews will be scheduled on. Supported values are 0, 1, 15, and 31.
 
 
 ### Nested Schema for `spec.audit.notifications`

--- a/docs/pages/reference/terraform-provider/data-sources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/access_monitoring_rule.mdx
@@ -20,8 +20,8 @@ description: This page describes the supported values of the teleport_access_mon
 
 ### Optional
 
-- `metadata` (Attributes) metadata is the rules's metadata. (see [below for nested schema](#nested-schema-for-metadata))
-- `sub_kind` (String) sub_kind is an optional resource sub kind, used in some resources
+- `metadata` (Attributes) metadata is the rule's metadata. (see [below for nested schema](#nested-schema-for-metadata))
+- `sub_kind` (String) optional resource sub kind, used in some resources
 
 ### Nested Schema for `spec`
 

--- a/docs/pages/reference/terraform-provider/data-sources/app.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/app.mdx
@@ -63,12 +63,12 @@ Optional:
 
 Optional:
 
-- `allow_credentials` (Boolean) allow_credentials indicates whether credentials are allowed.
-- `allowed_headers` (List of String) allowed_headers specifies which headers can be used when accessing the app.
-- `allowed_methods` (List of String) allowed_methods specifies which methods are allowed when accessing the app.
-- `allowed_origins` (List of String) allowed_origins specifies which origins are allowed to access the app.
-- `exposed_headers` (List of String) exposed_headers indicates which headers are made available to scripts via the browser.
-- `max_age` (Number) max_age indicates how long (in seconds) the results of a preflight request can be cached.
+- `allow_credentials` (Boolean) `allow_credentials` indicates whether credentials are allowed.
+- `allowed_headers` (List of String) `allowed_headers` specifies which headers can be used when accessing the app.
+- `allowed_methods` (List of String) `allowed_methods` specifies which methods are allowed when accessing the app.
+- `allowed_origins` (List of String) `allowed_origins` specifies which origins are allowed to access the app.
+- `exposed_headers` (List of String) `exposed_headers` indicates which headers are made available to scripts via the browser.
+- `max_age` (Number) `max_age` indicates how long (in seconds) the results of a preflight request can be cached.
 
 
 ### Nested Schema for `spec.dynamic_labels`
@@ -92,6 +92,6 @@ Optional:
 
 Optional:
 
-- `name` (String) Name is the http header name.
-- `value` (String) Value is the http header value.
+- `name` (String) Name is the HTTP header name.
+- `value` (String) Value is the HTTP header value.
 

--- a/docs/pages/reference/terraform-provider/data-sources/auth_preference.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/auth_preference.mdx
@@ -68,7 +68,7 @@ Optional:
 Optional:
 
 - `enabled` (Boolean) Enabled indicates whether hardware key serial number validation is enabled.
-- `serial_number_trait_name` (String) SerialNumberTraitName is an optional custom user trait name for hardware key serial numbers to replace the default: "hardware_key_serial_numbers".  Note: Values for this user trait should be a comma-separated list of serial numbers, or a list of comm-separated lists. e.g ["123", "345,678"]
+- `serial_number_trait_name` (String) SerialNumberTraitName is an optional custom user trait name for hardware key serial numbers to replace the default: `hardware_key_serial_numbers`.  Note: Values for this user trait should be a comma-separated list of serial numbers, or a list of comm-separated lists. e.g ["123", "345,678"]
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/cluster_networking_config.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/cluster_networking_config.mdx
@@ -41,7 +41,7 @@ Optional:
 - `keep_alive_interval` (String) KeepAliveInterval is the interval at which the server sends keep-alive messages to the client.
 - `proxy_listener_mode` (Number) ProxyListenerMode is proxy listener mode used by Teleport Proxies. 0 is "separate"; 1 is "multiplex".
 - `proxy_ping_interval` (String) ProxyPingInterval defines in which interval the TLS routing ping message should be sent. This is applicable only when using ping-wrapped connections, regular TLS routing connections are not affected.
-- `routing_strategy` (Number) RoutingStrategy determines the strategy used to route to nodes. 0 is "unambiguous_match"; 1 is "most_recent".
+- `routing_strategy` (Number) RoutingStrategy determines the strategy used to route to nodes. 0 is `unambiguous_match`; 1 is `most_recent`.
 - `session_control_timeout` (String) SessionControlTimeout is the session control lease expiry and defines the upper limit of how long a node may be out of contact with the auth server before it begins terminating controlled sessions.
 - `ssh_dial_timeout` (String) SSHDialTimeout is a custom dial timeout used when establishing SSH connections. If not set, the default timeout of 30s will be used.
 - `tunnel_strategy` (Attributes) TunnelStrategyV1 determines the tunnel strategy used in the cluster. (see [below for nested schema](#nested-schema-for-spectunnel_strategy))

--- a/docs/pages/reference/terraform-provider/data-sources/database.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/database.mdx
@@ -40,7 +40,7 @@ Optional:
 
 Required:
 
-- `protocol` (String) Protocol is the database protocol: postgres, mysql, mongodb, etc.
+- `protocol` (String) Protocol is the database protocol: `postgres`, `mysql`, `mongodb`, etc.
 - `uri` (String) URI is the database connection endpoint.
 
 Optional:
@@ -243,5 +243,5 @@ Optional:
 - `ca_cert` (String) CACert is an optional user provided CA certificate used for verifying database TLS connection.
 - `mode` (Number) Mode is a TLS connection mode. 0 is "verify-full"; 1 is "verify-ca", 2 is "insecure".
 - `server_name` (String) ServerName allows to provide custom hostname. This value will override the servername/hostname on a certificate during validation.
-- `trust_system_cert_pool` (Boolean) TrustSystemCertPool allows Teleport to trust certificate authorities available on the host system. If not set (by default), Teleport only trusts self-signed databases with TLS certificates signed by Teleport's Database Server CA or the ca_cert specified in this TLS setting. For cloud-hosted databases, Teleport downloads the corresponding required CAs for validation.
+- `trust_system_cert_pool` (Boolean) TrustSystemCertPool allows Teleport to trust certificate authorities available on the host system. If not set (by default), Teleport only trusts self-signed databases with TLS certificates signed by Teleport's Database Server CA or the `ca_cert` specified in this TLS setting. For cloud-hosted databases, Teleport downloads the corresponding required CAs for validation.
 

--- a/docs/pages/reference/terraform-provider/data-sources/github_connector.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/github_connector.mdx
@@ -15,7 +15,7 @@ description: This page describes the supported values of the teleport_github_con
 
 ### Required
 
-- `spec` (Attributes) Spec is an Github connector specification. (see [below for nested schema](#nested-schema-for-spec))
+- `spec` (Attributes) Spec is a GitHub connector specification. (see [below for nested schema](#nested-schema-for-spec))
 - `version` (String) Version is the resource version. It must be specified. Supported values are: `v3`.
 
 ### Optional
@@ -27,24 +27,24 @@ description: This page describes the supported values of the teleport_github_con
 
 Required:
 
-- `client_id` (String) ClientID is the Github OAuth app client ID.
-- `client_secret` (String, Sensitive) ClientSecret is the Github OAuth app client secret.
+- `client_id` (String) ClientID is the GitHub OAuth app client ID.
+- `client_secret` (String, Sensitive) ClientSecret is the GitHub OAuth app client secret.
 
 Optional:
 
-- `api_endpoint_url` (String) APIEndpointURL is the URL of the API endpoint of the Github instance this connector is for.
+- `api_endpoint_url` (String) APIEndpointURL is the URL of the API endpoint of the GitHub instance this connector is for.
 - `client_redirect_settings` (Attributes) ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones. (see [below for nested schema](#nested-schema-for-specclient_redirect_settings))
 - `display` (String) Display is the connector display name.
 - `endpoint_url` (String) EndpointURL is the URL of the GitHub instance this connector is for.
 - `redirect_url` (String) RedirectURL is the authorization callback URL.
-- `teams_to_logins` (Attributes List) TeamsToLogins maps Github team memberships onto allowed logins/roles.  DELETE IN 11.0.0 Deprecated: use GithubTeamsToRoles instead. (see [below for nested schema](#nested-schema-for-specteams_to_logins))
-- `teams_to_roles` (Attributes List) TeamsToRoles maps Github team memberships onto allowed roles. (see [below for nested schema](#nested-schema-for-specteams_to_roles))
+- `teams_to_logins` (Attributes List) TeamsToLogins maps GitHub team memberships onto allowed logins/roles.  DELETE IN 11.0.0 Deprecated: use GithubTeamsToRoles instead. (see [below for nested schema](#nested-schema-for-specteams_to_logins))
+- `teams_to_roles` (Attributes List) TeamsToRoles maps GitHub team memberships onto allowed roles. (see [below for nested schema](#nested-schema-for-specteams_to_roles))
 
 ### Nested Schema for `spec.client_redirect_settings`
 
 Optional:
 
-- `allowed_https_hostnames` (List of String) a list of hostnames allowed for https client redirect URLs
+- `allowed_https_hostnames` (List of String) a list of hostnames allowed for HTTPS client redirect URLs
 - `insecure_allowed_cidr_ranges` (List of String) a list of CIDRs allowed for HTTP or HTTPS client redirect URLs
 
 
@@ -52,10 +52,10 @@ Optional:
 
 Optional:
 
-- `kubernetes_groups` (List of String) KubeGroups is a list of allowed kubernetes groups for this org/team.
-- `kubernetes_users` (List of String) KubeUsers is a list of allowed kubernetes users to impersonate for this org/team.
+- `kubernetes_groups` (List of String) KubeGroups is a list of allowed Kubernetes groups for this org/team.
+- `kubernetes_users` (List of String) KubeUsers is a list of allowed Kubernetes users to impersonate for this org/team.
 - `logins` (List of String) Logins is a list of allowed logins for this org/team.
-- `organization` (String) Organization is a Github organization a user belongs to.
+- `organization` (String) Organization is a GitHub organization a user belongs to.
 - `team` (String) Team is a team within the organization a user belongs to.
 
 
@@ -63,7 +63,7 @@ Optional:
 
 Optional:
 
-- `organization` (String) Organization is a Github organization a user belongs to.
+- `organization` (String) Organization is a GitHub organization a user belongs to.
 - `roles` (List of String) Roles is a list of allowed logins for this org/team.
 - `team` (String) Team is a team within the organization a user belongs to.
 

--- a/docs/pages/reference/terraform-provider/data-sources/oidc_connector.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/oidc_connector.mdx
@@ -34,12 +34,12 @@ Optional:
 - `client_redirect_settings` (Attributes) ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones. (see [below for nested schema](#nested-schema-for-specclient_redirect_settings))
 - `client_secret` (String, Sensitive) ClientSecret is used to authenticate the client.
 - `display` (String) Display is the friendly name for this provider.
-- `google_admin_email` (String) GoogleAdminEmail is the email of a google admin to impersonate.
-- `google_service_account` (String, Sensitive) GoogleServiceAccount is a string containing google service account credentials.
-- `google_service_account_uri` (String) GoogleServiceAccountURI is a path to a google service account uri.
+- `google_admin_email` (String) GoogleAdminEmail is the email of a Google admin to impersonate.
+- `google_service_account` (String, Sensitive) GoogleServiceAccount is a string containing Google service account credentials.
+- `google_service_account_uri` (String) GoogleServiceAccountURI is a path to a Google service account URI.
 - `issuer_url` (String) IssuerURL is the endpoint of the provider, e.g. https://accounts.google.com.
 - `max_age` (String)
-- `prompt` (String) Prompt is an optional OIDC prompt. An empty string omits prompt. If not specified, it defaults to select_account for backwards compatibility.
+- `prompt` (String) Prompt is an optional OIDC prompt. An empty string omits prompt. If not specified, it defaults to `select_account` for backwards compatibility.
 - `provider` (String) Provider is the external identity provider.
 - `redirect_url` (List of String)
 - `scope` (List of String) Scope specifies additional scopes set by provider.
@@ -58,7 +58,7 @@ Optional:
 
 Optional:
 
-- `allowed_https_hostnames` (List of String) a list of hostnames allowed for https client redirect URLs
+- `allowed_https_hostnames` (List of String) a list of hostnames allowed for HTTPS client redirect URLs
 - `insecure_allowed_cidr_ranges` (List of String) a list of CIDRs allowed for HTTP or HTTPS client redirect URLs
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/provision_token.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/provision_token.mdx
@@ -33,19 +33,19 @@ Optional:
 
 - `allow` (Attributes List) Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token. (see [below for nested schema](#nested-schema-for-specallow))
 - `aws_iid_ttl` (String) AWSIIDTTL is the TTL to use for AWS EC2 Instance Identity Documents used to join the cluster with this token.
-- `azure` (Attributes) Azure allows the configuration of options specific to the "azure" join method. (see [below for nested schema](#nested-schema-for-specazure))
+- `azure` (Attributes) Azure allows the configuration of options specific to the `azure` join method. (see [below for nested schema](#nested-schema-for-specazure))
 - `bot_name` (String) BotName is the name of the bot this token grants access to, if any
-- `circleci` (Attributes) CircleCI allows the configuration of options specific to the "circleci" join method. (see [below for nested schema](#nested-schema-for-speccircleci))
-- `gcp` (Attributes) GCP allows the configuration of options specific to the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
-- `github` (Attributes) GitHub allows the configuration of options specific to the "github" join method. (see [below for nested schema](#nested-schema-for-specgithub))
-- `gitlab` (Attributes) GitLab allows the configuration of options specific to the "gitlab" join method. (see [below for nested schema](#nested-schema-for-specgitlab))
-- `join_method` (String) JoinMethod is the joining method required in order to use this token. Supported joining methods include: azure, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm
-- `kubernetes` (Attributes) Kubernetes allows the configuration of options specific to the "kubernetes" join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
-- `spacelift` (Attributes) Spacelift allows the configuration of options specific to the "spacelift" join method. (see [below for nested schema](#nested-schema-for-specspacelift))
+- `circleci` (Attributes) CircleCI allows the configuration of options specific to the `circleci` join method. (see [below for nested schema](#nested-schema-for-speccircleci))
+- `gcp` (Attributes) GCP allows the configuration of options specific to the `gcp` join method. (see [below for nested schema](#nested-schema-for-specgcp))
+- `github` (Attributes) GitHub allows the configuration of options specific to the `github` join method. (see [below for nested schema](#nested-schema-for-specgithub))
+- `gitlab` (Attributes) GitLab allows the configuration of options specific to the `gitlab` join method. (see [below for nested schema](#nested-schema-for-specgitlab))
+- `join_method` (String) JoinMethod is the joining method required in order to use this token. Supported joining methods include: `azure`, `circleci`, `ec2`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`
+- `kubernetes` (Attributes) Kubernetes allows the configuration of options specific to the `kubernetes` join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
+- `spacelift` (Attributes) Spacelift allows the configuration of options specific to the `spacelift` join method. (see [below for nested schema](#nested-schema-for-specspacelift))
 - `suggested_agent_matcher_labels` (Map of List of String)
 - `suggested_labels` (Map of List of String)
-- `terraform_cloud` (Attributes) TerraformCloud allows the configuration of options specific to the "terraform_cloud" join method. (see [below for nested schema](#nested-schema-for-specterraform_cloud))
-- `tpm` (Attributes) TPM allows the configuration of options specific to the "tpm" join method. (see [below for nested schema](#nested-schema-for-spectpm))
+- `terraform_cloud` (Attributes) TerraformCloud allows the configuration of options specific to the `terraform_cloud` join method. (see [below for nested schema](#nested-schema-for-specterraform_cloud))
+- `tpm` (Attributes) TPM allows the configuration of options specific to the `tpm` join method. (see [below for nested schema](#nested-schema-for-spectpm))
 
 ### Nested Schema for `spec.allow`
 
@@ -122,7 +122,7 @@ Optional:
 - `ref_type` (String) The type of ref, for example: "branch".
 - `repository` (String) The repository from where the workflow is running. This includes the name of the owner e.g `gravitational/teleport`
 - `repository_owner` (String) The name of the organization in which the repository is stored.
-- `sub` (String) Sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of github action run.
+- `sub` (String) Sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of GitHub Actions run.
 - `workflow` (String) The name of the workflow.
 
 
@@ -139,7 +139,7 @@ Optional:
 Optional:
 
 - `ci_config_ref_uri` (String) CIConfigRefURI is the ref path to the top-level pipeline definition, for example, gitlab.example.com/my-group/my-project//.gitlab-ci.yml@refs/heads/main.
-- `ci_config_sha` (String) CIConfigSHA is the git commit SHA for the ci_config_ref_uri.
+- `ci_config_sha` (String) CIConfigSHA is the git commit SHA for the `ci_config_ref_uri`.
 - `deployment_tier` (String) DeploymentTier is the deployment tier of the environment the job specifies
 - `environment` (String) Environment limits access by the environment the job deploys to (if one is associated)
 - `environment_protected` (Boolean)
@@ -147,7 +147,7 @@ Optional:
 - `pipeline_source` (String) PipelineSource limits access by the job pipeline source type. https://docs.gitlab.com/ee/ci/jobs/job_control.html#common-if-clauses-for-rules Example: `web`
 - `project_path` (String) ProjectPath is used to limit access to jobs belonging to an individual project. Example: `mygroup/myproject`  This field supports simple "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
 - `project_visibility` (String) ProjectVisibility is the visibility of the project where the pipeline is running. Can be internal, private, or public.
-- `ref` (String) Ref allows access to be limited to jobs triggered by a specific git ref. Ensure this is used in combination with ref_type.  This field supports simple "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `ref` (String) Ref allows access to be limited to jobs triggered by a specific git ref. Ensure this is used in combination with `ref_type`.  This field supports simple "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
 - `ref_protected` (Boolean)
 - `ref_type` (String) RefType allows access to be limited to jobs triggered by a specific git ref type. Example: `branch` or `tag`
 - `sub` (String) Sub roughly uniquely identifies the workload. Example: `project_path:mygroup/my-project:ref_type:branch:ref:main` project_path:GROUP/PROJECT:ref_type:TYPE:ref:BRANCH_NAME  This field supports simple "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
@@ -191,8 +191,8 @@ Optional:
 
 Optional:
 
-- `caller_id` (String) CallerID is the ID of the caller, ie. the stack or module that generated the run.
-- `caller_type` (String) CallerType is the type of the caller, ie. the entity that owns the run - either `stack` or `module`.
+- `caller_id` (String) CallerID is the ID of the caller, i.e., the stack or module that generated the run.
+- `caller_type` (String) CallerType is the type of the caller, i.e., the entity that owns the run - either `stack` or `module`.
 - `scope` (String) Scope is the scope of the token - either `read` or `write`. See https://docs.spacelift.io/integrations/cloud-providers/oidc/#about-scopes
 - `space_id` (String) SpaceID is the ID of the space in which the run that owns the token was executed.
 

--- a/docs/pages/reference/terraform-provider/data-sources/role.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/role.mdx
@@ -70,11 +70,11 @@ Optional:
 - `host_sudoers` (List of String) HostSudoers is a list of entries to include in a users sudoer file
 - `impersonate` (Attributes) Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means. (see [below for nested schema](#nested-schema-for-specallowimpersonate))
 - `join_sessions` (Attributes List) JoinSessions specifies policies to allow users to join other sessions. (see [below for nested schema](#nested-schema-for-specallowjoin_sessions))
-- `kubernetes_groups` (List of String) KubeGroups is a list of kubernetes groups
+- `kubernetes_groups` (List of String) KubeGroups is a list of Kubernetes groups
 - `kubernetes_labels` (Map of List of String)
-- `kubernetes_labels_expression` (String) KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.
+- `kubernetes_labels_expression` (String) KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.
 - `kubernetes_resources` (Attributes List) KubernetesResources is the Kubernetes Resources this Role grants access to. (see [below for nested schema](#nested-schema-for-specallowkubernetes_resources))
-- `kubernetes_users` (List of String) KubeUsers is an optional kubernetes users to impersonate
+- `kubernetes_users` (List of String) KubeUsers indicates optional Kubernetes users to impersonate
 - `logins` (List of String) Logins is a list of *nix system logins.
 - `node_labels` (Map of List of String)
 - `node_labels_expression` (String) NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.
@@ -233,11 +233,11 @@ Optional:
 - `host_sudoers` (List of String) HostSudoers is a list of entries to include in a users sudoer file
 - `impersonate` (Attributes) Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means. (see [below for nested schema](#nested-schema-for-specdenyimpersonate))
 - `join_sessions` (Attributes List) JoinSessions specifies policies to allow users to join other sessions. (see [below for nested schema](#nested-schema-for-specdenyjoin_sessions))
-- `kubernetes_groups` (List of String) KubeGroups is a list of kubernetes groups
+- `kubernetes_groups` (List of String) KubeGroups is a list of Kubernetes groups
 - `kubernetes_labels` (Map of List of String)
-- `kubernetes_labels_expression` (String) KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.
+- `kubernetes_labels_expression` (String) KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.
 - `kubernetes_resources` (Attributes List) KubernetesResources is the Kubernetes Resources this Role grants access to. (see [below for nested schema](#nested-schema-for-specdenykubernetes_resources))
-- `kubernetes_users` (List of String) KubeUsers is an optional kubernetes users to impersonate
+- `kubernetes_users` (List of String) KubeUsers indicates optional Kubernetes users to impersonate
 - `logins` (List of String) Logins is a list of *nix system logins.
 - `node_labels` (Map of List of String)
 - `node_labels_expression` (String) NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.
@@ -378,7 +378,7 @@ Optional:
 - `cert_format` (String) CertificateFormat defines the format of the user certificate to allow compatibility with older versions of OpenSSH.
 - `client_idle_timeout` (String) ClientIdleTimeout sets disconnect clients on idle timeout behavior, if set to 0 means do not disconnect, otherwise is set to the idle duration.
 - `create_db_user` (Boolean)
-- `create_db_user_mode` (Number) CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop".
+- `create_db_user_mode` (Number) CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is `unspecified`, 1 is `off`, 2 is `keep`, 3 is `best_effort_drop`.
 - `create_desktop_user` (Boolean)
 - `create_host_user` (Boolean)
 - `create_host_user_default_shell` (String) CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.
@@ -390,7 +390,7 @@ Optional:
 - `enhanced_recording` (List of String) BPF defines what events to record for the BPF-based session recorder.
 - `forward_agent` (Boolean) ForwardAgent is SSH agent forwarding.
 - `idp` (Attributes) IDP is a set of options related to accessing IdPs within Teleport. Requires Teleport Enterprise. (see [below for nested schema](#nested-schema-for-specoptionsidp))
-- `lock` (String) Lock specifies the locking mode (strict|best_effort) to be applied with the role.
+- `lock` (String) Lock specifies the locking mode (`strict` or `best_effort`) to be applied with the role.
 - `max_connections` (Number) MaxConnections defines the maximum number of concurrent connections a user may hold.
 - `max_kubernetes_connections` (Number) MaxKubernetesConnections defines the maximum number of concurrent Kubernetes sessions a user may hold.
 - `max_session_ttl` (String) MaxSessionTTL defines how long a SSH session can last for.

--- a/docs/pages/reference/terraform-provider/data-sources/saml_connector.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/saml_connector.mdx
@@ -68,7 +68,7 @@ Optional:
 
 Optional:
 
-- `allowed_https_hostnames` (List of String) a list of hostnames allowed for https client redirect URLs
+- `allowed_https_hostnames` (List of String) a list of hostnames allowed for HTTPS client redirect URLs
 - `insecure_allowed_cidr_ranges` (List of String) a list of CIDRs allowed for HTTP or HTTPS client redirect URLs
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/trusted_cluster.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/trusted_cluster.mdx
@@ -27,7 +27,7 @@ description: This page describes the supported values of the teleport_trusted_cl
 
 Optional:
 
-- `enabled` (Boolean) Enabled is a bool that indicates if the TrustedCluster is enabled or disabled. Setting Enabled to false has a side effect of deleting the user and host certificate authority (CA).
+- `enabled` (Boolean) Enabled indicates if the TrustedCluster is enabled or disabled.  Setting Enabled to false has a side effect of deleting the user and host certificate authority (CA).
 - `role_map` (Attributes List) RoleMap specifies role mappings to remote roles. (see [below for nested schema](#nested-schema-for-specrole_map))
 - `roles` (List of String) Roles is a list of roles that users will be assuming when connecting to this cluster.
 - `token` (String, Sensitive) Token is the authorization token provided by another cluster needed by this cluster to join.

--- a/docs/pages/reference/terraform-provider/data-sources/user.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/user.mdx
@@ -41,7 +41,7 @@ Optional:
 
 Optional:
 
-- `github_identities` (Attributes List) GithubIdentities list associated Github OAuth2 identities that let user log in using externally verified identity (see [below for nested schema](#nested-schema-for-specgithub_identities))
+- `github_identities` (Attributes List) GithubIdentities list associated GitHub OAuth2 identities that let user log in using externally verified identity (see [below for nested schema](#nested-schema-for-specgithub_identities))
 - `oidc_identities` (Attributes List) OIDCIdentities lists associated OpenID Connect identities that let user log in using externally verified identity (see [below for nested schema](#nested-schema-for-specoidc_identities))
 - `roles` (List of String) Roles is a list of roles assigned to user
 - `saml_identities` (Attributes List) SAMLIdentities lists associated SAML identities that let user log in using externally verified identity (see [below for nested schema](#nested-schema-for-specsaml_identities))
@@ -80,5 +80,5 @@ Optional:
 
 Optional:
 
-- `password_state` (Number) password_state reflects what the system knows about the user's password. Note that this is a "best effort" property, in that it can be UNSPECIFIED for users who were created before this property was introduced and didn't perform any password-related activity since then. See RFD 0159 for details. Do NOT use this value for authentication purposes!
+- `password_state` (Number) PasswordState reflects what the system knows about the user's password. Note that this is a "best effort" property, in that it can be UNSPECIFIED for users who were created before this property was introduced and didn't perform any password-related activity since then. See RFD 0159 for details. Do NOT use this value for authentication purposes!
 

--- a/docs/pages/reference/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/resources/access_list.mdx
@@ -70,7 +70,7 @@ Optional:
 
 - `kind` (String) kind is a resource kind.
 - `metadata` (Attributes) metadata is resource metadata. (see [below for nested schema](#nested-schema-for-headermetadata))
-- `sub_kind` (String) sub_kind is an optional resource sub kind, used in some resources.
+- `sub_kind` (String) an optional resource sub kind, used in some resources.
 
 ### Nested Schema for `header.metadata`
 
@@ -99,9 +99,9 @@ Required:
 Optional:
 
 - `description` (String) description is an optional plaintext description of the access list.
-- `membership_requires` (Attributes) membership_requires describes the requirements for a user to be a member of the access list. For a membership to an access list to be effective, the user must meet the requirements of Membership_requires and must be in the members list. (see [below for nested schema](#nested-schema-for-specmembership_requires))
-- `owner_grants` (Attributes) owner_grants describes the access granted by owners to this access list. (see [below for nested schema](#nested-schema-for-specowner_grants))
-- `ownership_requires` (Attributes) ownership_requires describes the requirements for a user to be an owner of the access list. For ownership of an access list to be effective, the user must meet the requirements of ownership_requires and must be in the owners list. (see [below for nested schema](#nested-schema-for-specownership_requires))
+- `membership_requires` (Attributes) describes the requirements for a user to be a member of the access list. For a membership to an access list to be effective, the user must meet the requirements of `membership_requires` and must be in the members list. (see [below for nested schema](#nested-schema-for-specmembership_requires))
+- `owner_grants` (Attributes) describes the access granted by owners to this access list. (see [below for nested schema](#nested-schema-for-specowner_grants))
+- `ownership_requires` (Attributes) describes the requirements for a user to be an owner of the access list. For ownership of an access list to be effective, the user must meet the requirements of `ownership_requires` and must be in the owners list. (see [below for nested schema](#nested-schema-for-specownership_requires))
 - `title` (String) title is a plaintext short description of the access list.
 
 ### Nested Schema for `spec.audit`
@@ -123,7 +123,7 @@ Required:
 
 Optional:
 
-- `day_of_month` (Number) day_of_month is the day of month that reviews will be scheduled on. Supported values are 0, 1, 15, and 31.
+- `day_of_month` (Number) the day of month that reviews will be scheduled on. Supported values are 0, 1, 15, and 31.
 
 
 ### Nested Schema for `spec.audit.notifications`

--- a/docs/pages/reference/terraform-provider/resources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/terraform-provider/resources/access_monitoring_rule.mdx
@@ -37,8 +37,8 @@ resource "teleport_access_monitoring_rule" "test" {
 
 ### Optional
 
-- `metadata` (Attributes) metadata is the rules's metadata. (see [below for nested schema](#nested-schema-for-metadata))
-- `sub_kind` (String) sub_kind is an optional resource sub kind, used in some resources
+- `metadata` (Attributes) metadata is the rule's metadata. (see [below for nested schema](#nested-schema-for-metadata))
+- `sub_kind` (String) optional resource sub kind, used in some resources
 
 ### Nested Schema for `spec`
 

--- a/docs/pages/reference/terraform-provider/resources/app.mdx
+++ b/docs/pages/reference/terraform-provider/resources/app.mdx
@@ -81,12 +81,12 @@ Optional:
 
 Optional:
 
-- `allow_credentials` (Boolean) allow_credentials indicates whether credentials are allowed.
-- `allowed_headers` (List of String) allowed_headers specifies which headers can be used when accessing the app.
-- `allowed_methods` (List of String) allowed_methods specifies which methods are allowed when accessing the app.
-- `allowed_origins` (List of String) allowed_origins specifies which origins are allowed to access the app.
-- `exposed_headers` (List of String) exposed_headers indicates which headers are made available to scripts via the browser.
-- `max_age` (Number) max_age indicates how long (in seconds) the results of a preflight request can be cached.
+- `allow_credentials` (Boolean) `allow_credentials` indicates whether credentials are allowed.
+- `allowed_headers` (List of String) `allowed_headers` specifies which headers can be used when accessing the app.
+- `allowed_methods` (List of String) `allowed_methods` specifies which methods are allowed when accessing the app.
+- `allowed_origins` (List of String) `allowed_origins` specifies which origins are allowed to access the app.
+- `exposed_headers` (List of String) `exposed_headers` indicates which headers are made available to scripts via the browser.
+- `max_age` (Number) `max_age` indicates how long (in seconds) the results of a preflight request can be cached.
 
 
 ### Nested Schema for `spec.dynamic_labels`
@@ -110,6 +110,6 @@ Optional:
 
 Optional:
 
-- `name` (String) Name is the http header name.
-- `value` (String) Value is the http header value.
+- `name` (String) Name is the HTTP header name.
+- `value` (String) Value is the HTTP header value.
 

--- a/docs/pages/reference/terraform-provider/resources/auth_preference.mdx
+++ b/docs/pages/reference/terraform-provider/resources/auth_preference.mdx
@@ -86,7 +86,7 @@ Optional:
 Optional:
 
 - `enabled` (Boolean) Enabled indicates whether hardware key serial number validation is enabled.
-- `serial_number_trait_name` (String) SerialNumberTraitName is an optional custom user trait name for hardware key serial numbers to replace the default: "hardware_key_serial_numbers".  Note: Values for this user trait should be a comma-separated list of serial numbers, or a list of comm-separated lists. e.g ["123", "345,678"]
+- `serial_number_trait_name` (String) SerialNumberTraitName is an optional custom user trait name for hardware key serial numbers to replace the default: `hardware_key_serial_numbers`.  Note: Values for this user trait should be a comma-separated list of serial numbers, or a list of comm-separated lists. e.g ["123", "345,678"]
 
 
 

--- a/docs/pages/reference/terraform-provider/resources/cluster_networking_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/cluster_networking_config.mdx
@@ -59,7 +59,7 @@ Optional:
 - `keep_alive_interval` (String) KeepAliveInterval is the interval at which the server sends keep-alive messages to the client.
 - `proxy_listener_mode` (Number) ProxyListenerMode is proxy listener mode used by Teleport Proxies. 0 is "separate"; 1 is "multiplex".
 - `proxy_ping_interval` (String) ProxyPingInterval defines in which interval the TLS routing ping message should be sent. This is applicable only when using ping-wrapped connections, regular TLS routing connections are not affected.
-- `routing_strategy` (Number) RoutingStrategy determines the strategy used to route to nodes. 0 is "unambiguous_match"; 1 is "most_recent".
+- `routing_strategy` (Number) RoutingStrategy determines the strategy used to route to nodes. 0 is `unambiguous_match`; 1 is `most_recent`.
 - `session_control_timeout` (String) SessionControlTimeout is the session control lease expiry and defines the upper limit of how long a node may be out of contact with the auth server before it begins terminating controlled sessions.
 - `ssh_dial_timeout` (String) SSHDialTimeout is a custom dial timeout used when establishing SSH connections. If not set, the default timeout of 30s will be used.
 - `tunnel_strategy` (Attributes) TunnelStrategyV1 determines the tunnel strategy used in the cluster. (see [below for nested schema](#nested-schema-for-spectunnel_strategy))

--- a/docs/pages/reference/terraform-provider/resources/database.mdx
+++ b/docs/pages/reference/terraform-provider/resources/database.mdx
@@ -59,7 +59,7 @@ Optional:
 
 Required:
 
-- `protocol` (String) Protocol is the database protocol: postgres, mysql, mongodb, etc.
+- `protocol` (String) Protocol is the database protocol: `postgres`, `mysql`, `mongodb`, etc.
 - `uri` (String) URI is the database connection endpoint.
 
 Optional:
@@ -262,5 +262,5 @@ Optional:
 - `ca_cert` (String) CACert is an optional user provided CA certificate used for verifying database TLS connection.
 - `mode` (Number) Mode is a TLS connection mode. 0 is "verify-full"; 1 is "verify-ca", 2 is "insecure".
 - `server_name` (String) ServerName allows to provide custom hostname. This value will override the servername/hostname on a certificate during validation.
-- `trust_system_cert_pool` (Boolean) TrustSystemCertPool allows Teleport to trust certificate authorities available on the host system. If not set (by default), Teleport only trusts self-signed databases with TLS certificates signed by Teleport's Database Server CA or the ca_cert specified in this TLS setting. For cloud-hosted databases, Teleport downloads the corresponding required CAs for validation.
+- `trust_system_cert_pool` (Boolean) TrustSystemCertPool allows Teleport to trust certificate authorities available on the host system. If not set (by default), Teleport only trusts self-signed databases with TLS certificates signed by Teleport's Database Server CA or the `ca_cert` specified in this TLS setting. For cloud-hosted databases, Teleport downloads the corresponding required CAs for validation.
 

--- a/docs/pages/reference/terraform-provider/resources/github_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/github_connector.mdx
@@ -46,7 +46,7 @@ resource "teleport_github_connector" "github" {
 
 ### Required
 
-- `spec` (Attributes) Spec is an Github connector specification. (see [below for nested schema](#nested-schema-for-spec))
+- `spec` (Attributes) Spec is a GitHub connector specification. (see [below for nested schema](#nested-schema-for-spec))
 - `version` (String) Version is the resource version. It must be specified. Supported values are: `v3`.
 
 ### Optional
@@ -58,24 +58,24 @@ resource "teleport_github_connector" "github" {
 
 Required:
 
-- `client_id` (String) ClientID is the Github OAuth app client ID.
-- `client_secret` (String, Sensitive) ClientSecret is the Github OAuth app client secret.
+- `client_id` (String) ClientID is the GitHub OAuth app client ID.
+- `client_secret` (String, Sensitive) ClientSecret is the GitHub OAuth app client secret.
 
 Optional:
 
-- `api_endpoint_url` (String) APIEndpointURL is the URL of the API endpoint of the Github instance this connector is for.
+- `api_endpoint_url` (String) APIEndpointURL is the URL of the API endpoint of the GitHub instance this connector is for.
 - `client_redirect_settings` (Attributes) ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones. (see [below for nested schema](#nested-schema-for-specclient_redirect_settings))
 - `display` (String) Display is the connector display name.
 - `endpoint_url` (String) EndpointURL is the URL of the GitHub instance this connector is for.
 - `redirect_url` (String) RedirectURL is the authorization callback URL.
-- `teams_to_logins` (Attributes List) TeamsToLogins maps Github team memberships onto allowed logins/roles.  DELETE IN 11.0.0 Deprecated: use GithubTeamsToRoles instead. (see [below for nested schema](#nested-schema-for-specteams_to_logins))
-- `teams_to_roles` (Attributes List) TeamsToRoles maps Github team memberships onto allowed roles. (see [below for nested schema](#nested-schema-for-specteams_to_roles))
+- `teams_to_logins` (Attributes List) TeamsToLogins maps GitHub team memberships onto allowed logins/roles.  DELETE IN 11.0.0 Deprecated: use GithubTeamsToRoles instead. (see [below for nested schema](#nested-schema-for-specteams_to_logins))
+- `teams_to_roles` (Attributes List) TeamsToRoles maps GitHub team memberships onto allowed roles. (see [below for nested schema](#nested-schema-for-specteams_to_roles))
 
 ### Nested Schema for `spec.client_redirect_settings`
 
 Optional:
 
-- `allowed_https_hostnames` (List of String) a list of hostnames allowed for https client redirect URLs
+- `allowed_https_hostnames` (List of String) a list of hostnames allowed for HTTPS client redirect URLs
 - `insecure_allowed_cidr_ranges` (List of String) a list of CIDRs allowed for HTTP or HTTPS client redirect URLs
 
 
@@ -83,10 +83,10 @@ Optional:
 
 Optional:
 
-- `kubernetes_groups` (List of String) KubeGroups is a list of allowed kubernetes groups for this org/team.
-- `kubernetes_users` (List of String) KubeUsers is a list of allowed kubernetes users to impersonate for this org/team.
+- `kubernetes_groups` (List of String) KubeGroups is a list of allowed Kubernetes groups for this org/team.
+- `kubernetes_users` (List of String) KubeUsers is a list of allowed Kubernetes users to impersonate for this org/team.
 - `logins` (List of String) Logins is a list of allowed logins for this org/team.
-- `organization` (String) Organization is a Github organization a user belongs to.
+- `organization` (String) Organization is a GitHub organization a user belongs to.
 - `team` (String) Team is a team within the organization a user belongs to.
 
 
@@ -94,7 +94,7 @@ Optional:
 
 Optional:
 
-- `organization` (String) Organization is a Github organization a user belongs to.
+- `organization` (String) Organization is a GitHub organization a user belongs to.
 - `roles` (List of String) Roles is a list of allowed logins for this org/team.
 - `team` (String) Team is a team within the organization a user belongs to.
 

--- a/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
@@ -63,12 +63,12 @@ Optional:
 - `client_redirect_settings` (Attributes) ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones. (see [below for nested schema](#nested-schema-for-specclient_redirect_settings))
 - `client_secret` (String, Sensitive) ClientSecret is used to authenticate the client.
 - `display` (String) Display is the friendly name for this provider.
-- `google_admin_email` (String) GoogleAdminEmail is the email of a google admin to impersonate.
-- `google_service_account` (String, Sensitive) GoogleServiceAccount is a string containing google service account credentials.
-- `google_service_account_uri` (String) GoogleServiceAccountURI is a path to a google service account uri.
+- `google_admin_email` (String) GoogleAdminEmail is the email of a Google admin to impersonate.
+- `google_service_account` (String, Sensitive) GoogleServiceAccount is a string containing Google service account credentials.
+- `google_service_account_uri` (String) GoogleServiceAccountURI is a path to a Google service account URI.
 - `issuer_url` (String) IssuerURL is the endpoint of the provider, e.g. https://accounts.google.com.
 - `max_age` (String)
-- `prompt` (String) Prompt is an optional OIDC prompt. An empty string omits prompt. If not specified, it defaults to select_account for backwards compatibility.
+- `prompt` (String) Prompt is an optional OIDC prompt. An empty string omits prompt. If not specified, it defaults to `select_account` for backwards compatibility.
 - `provider` (String) Provider is the external identity provider.
 - `redirect_url` (List of String)
 - `scope` (List of String) Scope specifies additional scopes set by provider.
@@ -87,7 +87,7 @@ Optional:
 
 Optional:
 
-- `allowed_https_hostnames` (List of String) a list of hostnames allowed for https client redirect URLs
+- `allowed_https_hostnames` (List of String) a list of hostnames allowed for HTTPS client redirect URLs
 - `insecure_allowed_cidr_ranges` (List of String) a list of CIDRs allowed for HTTP or HTTPS client redirect URLs
 
 

--- a/docs/pages/reference/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/terraform-provider/resources/provision_token.mdx
@@ -67,19 +67,19 @@ Optional:
 
 - `allow` (Attributes List) Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token. (see [below for nested schema](#nested-schema-for-specallow))
 - `aws_iid_ttl` (String) AWSIIDTTL is the TTL to use for AWS EC2 Instance Identity Documents used to join the cluster with this token.
-- `azure` (Attributes) Azure allows the configuration of options specific to the "azure" join method. (see [below for nested schema](#nested-schema-for-specazure))
+- `azure` (Attributes) Azure allows the configuration of options specific to the `azure` join method. (see [below for nested schema](#nested-schema-for-specazure))
 - `bot_name` (String) BotName is the name of the bot this token grants access to, if any
-- `circleci` (Attributes) CircleCI allows the configuration of options specific to the "circleci" join method. (see [below for nested schema](#nested-schema-for-speccircleci))
-- `gcp` (Attributes) GCP allows the configuration of options specific to the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
-- `github` (Attributes) GitHub allows the configuration of options specific to the "github" join method. (see [below for nested schema](#nested-schema-for-specgithub))
-- `gitlab` (Attributes) GitLab allows the configuration of options specific to the "gitlab" join method. (see [below for nested schema](#nested-schema-for-specgitlab))
-- `join_method` (String) JoinMethod is the joining method required in order to use this token. Supported joining methods include: azure, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm
-- `kubernetes` (Attributes) Kubernetes allows the configuration of options specific to the "kubernetes" join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
-- `spacelift` (Attributes) Spacelift allows the configuration of options specific to the "spacelift" join method. (see [below for nested schema](#nested-schema-for-specspacelift))
+- `circleci` (Attributes) CircleCI allows the configuration of options specific to the `circleci` join method. (see [below for nested schema](#nested-schema-for-speccircleci))
+- `gcp` (Attributes) GCP allows the configuration of options specific to the `gcp` join method. (see [below for nested schema](#nested-schema-for-specgcp))
+- `github` (Attributes) GitHub allows the configuration of options specific to the `github` join method. (see [below for nested schema](#nested-schema-for-specgithub))
+- `gitlab` (Attributes) GitLab allows the configuration of options specific to the `gitlab` join method. (see [below for nested schema](#nested-schema-for-specgitlab))
+- `join_method` (String) JoinMethod is the joining method required in order to use this token. Supported joining methods include: `azure`, `circleci`, `ec2`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`
+- `kubernetes` (Attributes) Kubernetes allows the configuration of options specific to the `kubernetes` join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
+- `spacelift` (Attributes) Spacelift allows the configuration of options specific to the `spacelift` join method. (see [below for nested schema](#nested-schema-for-specspacelift))
 - `suggested_agent_matcher_labels` (Map of List of String)
 - `suggested_labels` (Map of List of String)
-- `terraform_cloud` (Attributes) TerraformCloud allows the configuration of options specific to the "terraform_cloud" join method. (see [below for nested schema](#nested-schema-for-specterraform_cloud))
-- `tpm` (Attributes) TPM allows the configuration of options specific to the "tpm" join method. (see [below for nested schema](#nested-schema-for-spectpm))
+- `terraform_cloud` (Attributes) TerraformCloud allows the configuration of options specific to the `terraform_cloud` join method. (see [below for nested schema](#nested-schema-for-specterraform_cloud))
+- `tpm` (Attributes) TPM allows the configuration of options specific to the `tpm` join method. (see [below for nested schema](#nested-schema-for-spectpm))
 
 ### Nested Schema for `spec.allow`
 
@@ -156,7 +156,7 @@ Optional:
 - `ref_type` (String) The type of ref, for example: "branch".
 - `repository` (String) The repository from where the workflow is running. This includes the name of the owner e.g `gravitational/teleport`
 - `repository_owner` (String) The name of the organization in which the repository is stored.
-- `sub` (String) Sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of github action run.
+- `sub` (String) Sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of GitHub Actions run.
 - `workflow` (String) The name of the workflow.
 
 
@@ -173,7 +173,7 @@ Optional:
 Optional:
 
 - `ci_config_ref_uri` (String) CIConfigRefURI is the ref path to the top-level pipeline definition, for example, gitlab.example.com/my-group/my-project//.gitlab-ci.yml@refs/heads/main.
-- `ci_config_sha` (String) CIConfigSHA is the git commit SHA for the ci_config_ref_uri.
+- `ci_config_sha` (String) CIConfigSHA is the git commit SHA for the `ci_config_ref_uri`.
 - `deployment_tier` (String) DeploymentTier is the deployment tier of the environment the job specifies
 - `environment` (String) Environment limits access by the environment the job deploys to (if one is associated)
 - `environment_protected` (Boolean)
@@ -181,7 +181,7 @@ Optional:
 - `pipeline_source` (String) PipelineSource limits access by the job pipeline source type. https://docs.gitlab.com/ee/ci/jobs/job_control.html#common-if-clauses-for-rules Example: `web`
 - `project_path` (String) ProjectPath is used to limit access to jobs belonging to an individual project. Example: `mygroup/myproject`  This field supports simple "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
 - `project_visibility` (String) ProjectVisibility is the visibility of the project where the pipeline is running. Can be internal, private, or public.
-- `ref` (String) Ref allows access to be limited to jobs triggered by a specific git ref. Ensure this is used in combination with ref_type.  This field supports simple "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `ref` (String) Ref allows access to be limited to jobs triggered by a specific git ref. Ensure this is used in combination with `ref_type`.  This field supports simple "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
 - `ref_protected` (Boolean)
 - `ref_type` (String) RefType allows access to be limited to jobs triggered by a specific git ref type. Example: `branch` or `tag`
 - `sub` (String) Sub roughly uniquely identifies the workload. Example: `project_path:mygroup/my-project:ref_type:branch:ref:main` project_path:GROUP/PROJECT:ref_type:TYPE:ref:BRANCH_NAME  This field supports simple "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
@@ -225,8 +225,8 @@ Optional:
 
 Optional:
 
-- `caller_id` (String) CallerID is the ID of the caller, ie. the stack or module that generated the run.
-- `caller_type` (String) CallerType is the type of the caller, ie. the entity that owns the run - either `stack` or `module`.
+- `caller_id` (String) CallerID is the ID of the caller, i.e., the stack or module that generated the run.
+- `caller_type` (String) CallerType is the type of the caller, i.e., the entity that owns the run - either `stack` or `module`.
 - `scope` (String) Scope is the scope of the token - either `read` or `write`. See https://docs.spacelift.io/integrations/cloud-providers/oidc/#about-scopes
 - `space_id` (String) SpaceID is the ID of the space in which the run that owns the token was executed.
 

--- a/docs/pages/reference/terraform-provider/resources/role.mdx
+++ b/docs/pages/reference/terraform-provider/resources/role.mdx
@@ -123,11 +123,11 @@ Optional:
 - `host_sudoers` (List of String) HostSudoers is a list of entries to include in a users sudoer file
 - `impersonate` (Attributes) Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means. (see [below for nested schema](#nested-schema-for-specallowimpersonate))
 - `join_sessions` (Attributes List) JoinSessions specifies policies to allow users to join other sessions. (see [below for nested schema](#nested-schema-for-specallowjoin_sessions))
-- `kubernetes_groups` (List of String) KubeGroups is a list of kubernetes groups
+- `kubernetes_groups` (List of String) KubeGroups is a list of Kubernetes groups
 - `kubernetes_labels` (Map of List of String)
-- `kubernetes_labels_expression` (String) KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.
+- `kubernetes_labels_expression` (String) KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.
 - `kubernetes_resources` (Attributes List) KubernetesResources is the Kubernetes Resources this Role grants access to. (see [below for nested schema](#nested-schema-for-specallowkubernetes_resources))
-- `kubernetes_users` (List of String) KubeUsers is an optional kubernetes users to impersonate
+- `kubernetes_users` (List of String) KubeUsers indicates optional Kubernetes users to impersonate
 - `logins` (List of String) Logins is a list of *nix system logins.
 - `node_labels` (Map of List of String)
 - `node_labels_expression` (String) NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.
@@ -286,11 +286,11 @@ Optional:
 - `host_sudoers` (List of String) HostSudoers is a list of entries to include in a users sudoer file
 - `impersonate` (Attributes) Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means. (see [below for nested schema](#nested-schema-for-specdenyimpersonate))
 - `join_sessions` (Attributes List) JoinSessions specifies policies to allow users to join other sessions. (see [below for nested schema](#nested-schema-for-specdenyjoin_sessions))
-- `kubernetes_groups` (List of String) KubeGroups is a list of kubernetes groups
+- `kubernetes_groups` (List of String) KubeGroups is a list of Kubernetes groups
 - `kubernetes_labels` (Map of List of String)
-- `kubernetes_labels_expression` (String) KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.
+- `kubernetes_labels_expression` (String) KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.
 - `kubernetes_resources` (Attributes List) KubernetesResources is the Kubernetes Resources this Role grants access to. (see [below for nested schema](#nested-schema-for-specdenykubernetes_resources))
-- `kubernetes_users` (List of String) KubeUsers is an optional kubernetes users to impersonate
+- `kubernetes_users` (List of String) KubeUsers indicates optional Kubernetes users to impersonate
 - `logins` (List of String) Logins is a list of *nix system logins.
 - `node_labels` (Map of List of String)
 - `node_labels_expression` (String) NodeLabelsExpression is a predicate expression used to allow/deny access to SSH nodes.
@@ -431,7 +431,7 @@ Optional:
 - `cert_format` (String) CertificateFormat defines the format of the user certificate to allow compatibility with older versions of OpenSSH.
 - `client_idle_timeout` (String) ClientIdleTimeout sets disconnect clients on idle timeout behavior, if set to 0 means do not disconnect, otherwise is set to the idle duration.
 - `create_db_user` (Boolean)
-- `create_db_user_mode` (Number) CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop".
+- `create_db_user_mode` (Number) CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is `unspecified`, 1 is `off`, 2 is `keep`, 3 is `best_effort_drop`.
 - `create_desktop_user` (Boolean)
 - `create_host_user` (Boolean)
 - `create_host_user_default_shell` (String) CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.
@@ -443,7 +443,7 @@ Optional:
 - `enhanced_recording` (List of String) BPF defines what events to record for the BPF-based session recorder.
 - `forward_agent` (Boolean) ForwardAgent is SSH agent forwarding.
 - `idp` (Attributes) IDP is a set of options related to accessing IdPs within Teleport. Requires Teleport Enterprise. (see [below for nested schema](#nested-schema-for-specoptionsidp))
-- `lock` (String) Lock specifies the locking mode (strict|best_effort) to be applied with the role.
+- `lock` (String) Lock specifies the locking mode (`strict` or `best_effort`) to be applied with the role.
 - `max_connections` (Number) MaxConnections defines the maximum number of concurrent connections a user may hold.
 - `max_kubernetes_connections` (Number) MaxKubernetesConnections defines the maximum number of concurrent Kubernetes sessions a user may hold.
 - `max_session_ttl` (String) MaxSessionTTL defines how long a SSH session can last for.

--- a/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
@@ -113,7 +113,7 @@ Optional:
 
 Optional:
 
-- `allowed_https_hostnames` (List of String) a list of hostnames allowed for https client redirect URLs
+- `allowed_https_hostnames` (List of String) a list of hostnames allowed for HTTPS client redirect URLs
 - `insecure_allowed_cidr_ranges` (List of String) a list of CIDRs allowed for HTTP or HTTPS client redirect URLs
 
 

--- a/docs/pages/reference/terraform-provider/resources/server.mdx
+++ b/docs/pages/reference/terraform-provider/resources/server.mdx
@@ -122,8 +122,8 @@ Optional:
 - `mode` (String) Mode sets manual or automatic rotation mode.
 - `phase` (String) Phase is the current rotation phase.
 - `schedule` (Attributes) Schedule is a rotation schedule - used in automatic mode to switch between phases. (see [below for nested schema](#nested-schema-for-specrotationschedule))
-- `started` (String) Started is set to the time when rotation has been started in case if the state of the rotation is "in_progress".
-- `state` (String) State could be one of "init" or "in_progress".
+- `started` (String) Started is set to the time when rotation has been started in case if the state of the rotation is `in_progress`.
+- `state` (String) State could be one of `init` or `in_progress`.
 
 ### Nested Schema for `spec.rotation.schedule`
 

--- a/docs/pages/reference/terraform-provider/resources/trusted_cluster.mdx
+++ b/docs/pages/reference/terraform-provider/resources/trusted_cluster.mdx
@@ -50,7 +50,7 @@ resource "teleport_trusted_cluster" "cluster" {
 
 Optional:
 
-- `enabled` (Boolean) Enabled is a bool that indicates if the TrustedCluster is enabled or disabled. Setting Enabled to false has a side effect of deleting the user and host certificate authority (CA).
+- `enabled` (Boolean) Enabled indicates if the TrustedCluster is enabled or disabled.  Setting Enabled to false has a side effect of deleting the user and host certificate authority (CA).
 - `role_map` (Attributes List) RoleMap specifies role mappings to remote roles. (see [below for nested schema](#nested-schema-for-specrole_map))
 - `roles` (List of String) Roles is a list of roles that users will be assuming when connecting to this cluster.
 - `token` (String, Sensitive) Token is the authorization token provided by another cluster needed by this cluster to join.

--- a/docs/pages/reference/terraform-provider/resources/user.mdx
+++ b/docs/pages/reference/terraform-provider/resources/user.mdx
@@ -87,7 +87,7 @@ Optional:
 
 Optional:
 
-- `github_identities` (Attributes List) GithubIdentities list associated Github OAuth2 identities that let user log in using externally verified identity (see [below for nested schema](#nested-schema-for-specgithub_identities))
+- `github_identities` (Attributes List) GithubIdentities list associated GitHub OAuth2 identities that let user log in using externally verified identity (see [below for nested schema](#nested-schema-for-specgithub_identities))
 - `oidc_identities` (Attributes List) OIDCIdentities lists associated OpenID Connect identities that let user log in using externally verified identity (see [below for nested schema](#nested-schema-for-specoidc_identities))
 - `roles` (List of String) Roles is a list of roles assigned to user
 - `saml_identities` (Attributes List) SAMLIdentities lists associated SAML identities that let user log in using externally verified identity (see [below for nested schema](#nested-schema-for-specsaml_identities))
@@ -126,5 +126,5 @@ Optional:
 
 Optional:
 
-- `password_state` (Number) password_state reflects what the system knows about the user's password. Note that this is a "best effort" property, in that it can be UNSPECIFIED for users who were created before this property was introduced and didn't perform any password-related activity since then. See RFD 0159 for details. Do NOT use this value for authentication purposes!
+- `password_state` (Number) PasswordState reflects what the system knows about the user's password. Note that this is a "best effort" property, in that it can be UNSPECIFIED for users who were created before this property was introduced and didn't perform any password-related activity since then. See RFD 0159 for details. Do NOT use this value for authentication purposes!
 

--- a/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -89,7 +89,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 					Optional:    true,
 				},
 				"sub_kind": {
-					Description: "sub_kind is an optional resource sub kind, used in some resources.",
+					Description: "an optional resource sub kind, used in some resources.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
@@ -122,7 +122,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 						"recurrence": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"day_of_month": {
-									Description: "day_of_month is the day of month that reviews will be scheduled on. Supported values are 0, 1, 15, and 31.",
+									Description: "the day of month that reviews will be scheduled on. Supported values are 0, 1, 15, and 31.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 								},
@@ -195,7 +195,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Optional:    true,
 						},
 					}),
-					Description: "membership_requires describes the requirements for a user to be a member of the access list. For a membership to an access list to be effective, the user must meet the requirements of Membership_requires and must be in the members list.",
+					Description: "describes the requirements for a user to be a member of the access list. For a membership to an access list to be effective, the user must meet the requirements of `membership_requires` and must be in the members list.",
 					Optional:    true,
 				},
 				"owner_grants": {
@@ -222,7 +222,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Optional:    true,
 						},
 					}),
-					Description: "owner_grants describes the access granted by owners to this access list.",
+					Description: "describes the access granted by owners to this access list.",
 					Optional:    true,
 				},
 				"owners": {
@@ -265,7 +265,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Optional:    true,
 						},
 					}),
-					Description: "ownership_requires describes the requirements for a user to be an owner of the access list. For ownership of an access list to be effective, the user must meet the requirements of ownership_requires and must be in the owners list.",
+					Description: "describes the requirements for a user to be an owner of the access list. For ownership of an access list to be effective, the user must meet the requirements of `ownership_requires` and must be in the owners list.",
 					Optional:    true,
 				},
 				"title": {

--- a/integrations/terraform/tfschema/accessmonitoringrules/v1/access_monitoring_rules_terraform.go
+++ b/integrations/terraform/tfschema/accessmonitoringrules/v1/access_monitoring_rules_terraform.go
@@ -88,7 +88,7 @@ func GenSchemaAccessMonitoringRule(ctx context.Context) (github_com_hashicorp_te
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
-			Description: "metadata is the rules's metadata.",
+			Description: "metadata is the rule's metadata.",
 			Optional:    true,
 		},
 		"spec": {
@@ -129,7 +129,7 @@ func GenSchemaAccessMonitoringRule(ctx context.Context) (github_com_hashicorp_te
 			Required:    true,
 		},
 		"sub_kind": {
-			Description: "sub_kind is an optional resource sub kind, used in some resources",
+			Description: "optional resource sub kind, used in some resources",
 			Optional:    true,
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},

--- a/integrations/terraform/tfschema/token/types_terraform.go
+++ b/integrations/terraform/tfschema/token/types_terraform.go
@@ -156,7 +156,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 						Description: "Allow is a list of Rules, nodes using this token must match one allow rule to use this token.",
 						Optional:    true,
 					}}),
-					Description: "Azure allows the configuration of options specific to the \"azure\" join method.",
+					Description: "Azure allows the configuration of options specific to the `azure` join method.",
 					Optional:    true,
 				},
 				"bot_name": {
@@ -188,7 +188,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 					}),
-					Description: "CircleCI allows the configuration of options specific to the \"circleci\" join method.",
+					Description: "CircleCI allows the configuration of options specific to the `circleci` join method.",
 					Optional:    true,
 				},
 				"gcp": {
@@ -213,7 +213,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 						Description: "Allow is a list of Rules, nodes using this token must match one allow rule to use this token.",
 						Optional:    true,
 					}}),
-					Description: "GCP allows the configuration of options specific to the \"gcp\" join method.",
+					Description: "GCP allows the configuration of options specific to the `gcp` join method.",
 					Optional:    true,
 				},
 				"github": {
@@ -251,7 +251,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"sub": {
-									Description: "Sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of github action run.",
+									Description: "Sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of GitHub Actions run.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -275,7 +275,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 					}),
-					Description: "GitHub allows the configuration of options specific to the \"github\" join method.",
+					Description: "GitHub allows the configuration of options specific to the `github` join method.",
 					Optional:    true,
 				},
 				"gitlab": {
@@ -288,7 +288,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"ci_config_sha": {
-									Description: "CIConfigSHA is the git commit SHA for the ci_config_ref_uri.",
+									Description: "CIConfigSHA is the git commit SHA for the `ci_config_ref_uri`.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -324,7 +324,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"ref": {
-									Description: "Ref allows access to be limited to jobs triggered by a specific git ref. Ensure this is used in combination with ref_type.  This field supports simple \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
+									Description: "Ref allows access to be limited to jobs triggered by a specific git ref. Ensure this is used in combination with `ref_type`.  This field supports simple \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -364,11 +364,11 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 					}),
-					Description: "GitLab allows the configuration of options specific to the \"gitlab\" join method.",
+					Description: "GitLab allows the configuration of options specific to the `gitlab` join method.",
 					Optional:    true,
 				},
 				"join_method": {
-					Description: "JoinMethod is the joining method required in order to use this token. Supported joining methods include: azure, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm",
+					Description: "JoinMethod is the joining method required in order to use this token. Supported joining methods include: `azure`, `circleci`, `ec2`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
@@ -398,7 +398,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 					}),
-					Description: "Kubernetes allows the configuration of options specific to the \"kubernetes\" join method.",
+					Description: "Kubernetes allows the configuration of options specific to the `kubernetes` join method.",
 					Optional:    true,
 				},
 				"roles": {
@@ -411,12 +411,12 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 						"allow": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"caller_id": {
-									Description: "CallerID is the ID of the caller, ie. the stack or module that generated the run.",
+									Description: "CallerID is the ID of the caller, i.e., the stack or module that generated the run.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"caller_type": {
-									Description: "CallerType is the type of the caller, ie. the entity that owns the run - either `stack` or `module`.",
+									Description: "CallerType is the type of the caller, i.e., the entity that owns the run - either `stack` or `module`.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -440,7 +440,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 					}),
-					Description: "Spacelift allows the configuration of options specific to the \"spacelift\" join method.",
+					Description: "Spacelift allows the configuration of options specific to the `spacelift` join method.",
 					Optional:    true,
 				},
 				"suggested_agent_matcher_labels": GenSchemaLabels(ctx),
@@ -499,7 +499,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 					}),
-					Description: "TerraformCloud allows the configuration of options specific to the \"terraform_cloud\" join method.",
+					Description: "TerraformCloud allows the configuration of options specific to the `terraform_cloud` join method.",
 					Optional:    true,
 				},
 				"tpm": {
@@ -531,7 +531,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
 					}),
-					Description: "TPM allows the configuration of options specific to the \"tpm\" join method.",
+					Description: "TPM allows the configuration of options specific to the `tpm` join method.",
 					Optional:    true,
 				},
 			}),

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -490,7 +490,7 @@ func GenSchemaDatabaseV3(ctx context.Context) (github_com_hashicorp_terraform_pl
 					Optional:    true,
 				},
 				"protocol": {
-					Description: "Protocol is the database protocol: postgres, mysql, mongodb, etc.",
+					Description: "Protocol is the database protocol: `postgres`, `mysql`, `mongodb`, etc.",
 					Required:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
@@ -512,7 +512,7 @@ func GenSchemaDatabaseV3(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"trust_system_cert_pool": {
-							Description: "TrustSystemCertPool allows Teleport to trust certificate authorities available on the host system. If not set (by default), Teleport only trusts self-signed databases with TLS certificates signed by Teleport's Database Server CA or the ca_cert specified in this TLS setting. For cloud-hosted databases, Teleport downloads the corresponding required CAs for validation.",
+							Description: "TrustSystemCertPool allows Teleport to trust certificate authorities available on the host system. If not set (by default), Teleport only trusts self-signed databases with TLS certificates signed by Teleport's Database Server CA or the `ca_cert` specified in this TLS setting. For cloud-hosted databases, Teleport downloads the corresponding required CAs for validation.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
 						},
@@ -719,12 +719,12 @@ func GenSchemaServerV2(ctx context.Context) (github_com_hashicorp_terraform_plug
 							Optional:    true,
 						},
 						"started": {
-							Description: "Started is set to the time when rotation has been started in case if the state of the rotation is \"in_progress\".",
+							Description: "Started is set to the time when rotation has been started in case if the state of the rotation is `in_progress`.",
 							Optional:    true,
 							Type:        UseRFC3339Time(),
 						},
 						"state": {
-							Description: "State could be one of \"init\" or \"in_progress\".",
+							Description: "State could be one of `init` or `in_progress`.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
@@ -839,32 +839,32 @@ func GenSchemaAppV3(ctx context.Context) (github_com_hashicorp_terraform_plugin_
 				"cors": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						"allow_credentials": {
-							Description: "allow_credentials indicates whether credentials are allowed.",
+							Description: "`allow_credentials` indicates whether credentials are allowed.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
 						},
 						"allowed_headers": {
-							Description: "allowed_headers specifies which headers can be used when accessing the app.",
+							Description: "`allowed_headers` specifies which headers can be used when accessing the app.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
 						"allowed_methods": {
-							Description: "allowed_methods specifies which methods are allowed when accessing the app.",
+							Description: "`allowed_methods` specifies which methods are allowed when accessing the app.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
 						"allowed_origins": {
-							Description: "allowed_origins specifies which origins are allowed to access the app.",
+							Description: "`allowed_origins` specifies which origins are allowed to access the app.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
 						"exposed_headers": {
-							Description: "exposed_headers indicates which headers are made available to scripts via the browser.",
+							Description: "`exposed_headers` indicates which headers are made available to scripts via the browser.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
 						"max_age": {
-							Description: "max_age indicates how long (in seconds) the results of a preflight request can be cached.",
+							Description: "`max_age` indicates how long (in seconds) the results of a preflight request can be cached.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 						},
@@ -918,12 +918,12 @@ func GenSchemaAppV3(ctx context.Context) (github_com_hashicorp_terraform_plugin_
 						"headers": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"name": {
-									Description: "Name is the http header name.",
+									Description: "Name is the HTTP header name.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"value": {
-									Description: "Value is the http header value.",
+									Description: "Value is the HTTP header value.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -1072,7 +1072,7 @@ func GenSchemaClusterNetworkingConfigV2(ctx context.Context) (github_com_hashico
 					Type:        DurationType{},
 				},
 				"routing_strategy": {
-					Description: "RoutingStrategy determines the strategy used to route to nodes. 0 is \"unambiguous_match\"; 1 is \"most_recent\".",
+					Description: "RoutingStrategy determines the strategy used to route to nodes. 0 is `unambiguous_match`; 1 is `most_recent`.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 				},
@@ -1322,7 +1322,7 @@ func GenSchemaAuthPreferenceV2(ctx context.Context) (github_com_hashicorp_terraf
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
 								},
 								"serial_number_trait_name": {
-									Description: "SerialNumberTraitName is an optional custom user trait name for hardware key serial numbers to replace the default: \"hardware_key_serial_numbers\".  Note: Values for this user trait should be a comma-separated list of serial numbers, or a list of comm-separated lists. e.g [\"123\", \"345,678\"]",
+									Description: "SerialNumberTraitName is an optional custom user trait name for hardware key serial numbers to replace the default: `hardware_key_serial_numbers`.  Note: Values for this user trait should be a comma-separated list of serial numbers, or a list of comm-separated lists. e.g [\"123\", \"345,678\"]",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -1649,13 +1649,13 @@ func GenSchemaRoleV6(ctx context.Context) (github_com_hashicorp_terraform_plugin
 							Optional:    true,
 						},
 						"kubernetes_groups": {
-							Description: "KubeGroups is a list of kubernetes groups",
+							Description: "KubeGroups is a list of Kubernetes groups",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
 						"kubernetes_labels": GenSchemaLabels(ctx),
 						"kubernetes_labels_expression": {
-							Description: "KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.",
+							Description: "KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
@@ -1690,7 +1690,7 @@ func GenSchemaRoleV6(ctx context.Context) (github_com_hashicorp_terraform_plugin
 							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 						},
 						"kubernetes_users": {
-							Description: "KubeUsers is an optional kubernetes users to impersonate",
+							Description: "KubeUsers indicates optional Kubernetes users to impersonate",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
@@ -2056,13 +2056,13 @@ func GenSchemaRoleV6(ctx context.Context) (github_com_hashicorp_terraform_plugin
 							Optional:    true,
 						},
 						"kubernetes_groups": {
-							Description: "KubeGroups is a list of kubernetes groups",
+							Description: "KubeGroups is a list of Kubernetes groups",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
 						"kubernetes_labels": GenSchemaLabels(ctx),
 						"kubernetes_labels_expression": {
-							Description: "KubernetesLabelsExpression is a predicate expression used to allow/deny access to kubernetes clusters.",
+							Description: "KubernetesLabelsExpression is a predicate expression used to allow/deny access to Kubernetes clusters.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
@@ -2093,7 +2093,7 @@ func GenSchemaRoleV6(ctx context.Context) (github_com_hashicorp_terraform_plugin
 							Optional:    true,
 						},
 						"kubernetes_users": {
-							Description: "KubeUsers is an optional kubernetes users to impersonate",
+							Description: "KubeUsers indicates optional Kubernetes users to impersonate",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
@@ -2364,7 +2364,7 @@ func GenSchemaRoleV6(ctx context.Context) (github_com_hashicorp_terraform_plugin
 						},
 						"create_db_user": GenSchemaBoolOption(ctx),
 						"create_db_user_mode": {
-							Description: "CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is \"unspecified\", 1 is \"off\", 2 is \"keep\", 3 is \"best_effort_drop\".",
+							Description: "CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is `unspecified`, 1 is `off`, 2 is `keep`, 3 is `best_effort_drop`.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 						},
@@ -2414,7 +2414,7 @@ func GenSchemaRoleV6(ctx context.Context) (github_com_hashicorp_terraform_plugin
 							Optional:    true,
 						},
 						"lock": {
-							Description: "Lock specifies the locking mode (strict|best_effort) to be applied with the role.",
+							Description: "Lock specifies the locking mode (`strict` or `best_effort`) to be applied with the role.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
@@ -2588,7 +2588,7 @@ func GenSchemaUserV2(ctx context.Context) (github_com_hashicorp_terraform_plugin
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 					}),
-					Description: "GithubIdentities list associated Github OAuth2 identities that let user log in using externally verified identity",
+					Description: "GithubIdentities list associated GitHub OAuth2 identities that let user log in using externally verified identity",
 					Optional:    true,
 				},
 				"oidc_identities": {
@@ -2650,7 +2650,7 @@ func GenSchemaUserV2(ctx context.Context) (github_com_hashicorp_terraform_plugin
 		},
 		"status": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"password_state": {
-				Description: "password_state reflects what the system knows about the user's password. Note that this is a \"best effort\" property, in that it can be UNSPECIFIED for users who were created before this property was introduced and didn't perform any password-related activity since then. See RFD 0159 for details. Do NOT use this value for authentication purposes!",
+				Description: "PasswordState reflects what the system knows about the user's password. Note that this is a \"best effort\" property, in that it can be UNSPECIFIED for users who were created before this property was introduced and didn't perform any password-related activity since then. See RFD 0159 for details. Do NOT use this value for authentication purposes!",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 			}}),
@@ -2769,7 +2769,7 @@ func GenSchemaOIDCConnectorV3(ctx context.Context) (github_com_hashicorp_terrafo
 				"client_redirect_settings": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						"allowed_https_hostnames": {
-							Description: "a list of hostnames allowed for https client redirect URLs",
+							Description: "a list of hostnames allowed for HTTPS client redirect URLs",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
@@ -2794,18 +2794,18 @@ func GenSchemaOIDCConnectorV3(ctx context.Context) (github_com_hashicorp_terrafo
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"google_admin_email": {
-					Description: "GoogleAdminEmail is the email of a google admin to impersonate.",
+					Description: "GoogleAdminEmail is the email of a Google admin to impersonate.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"google_service_account": {
-					Description: "GoogleServiceAccount is a string containing google service account credentials.",
+					Description: "GoogleServiceAccount is a string containing Google service account credentials.",
 					Optional:    true,
 					Sensitive:   true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"google_service_account_uri": {
-					Description: "GoogleServiceAccountURI is a path to a google service account uri.",
+					Description: "GoogleServiceAccountURI is a path to a Google service account URI.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
@@ -2820,7 +2820,7 @@ func GenSchemaOIDCConnectorV3(ctx context.Context) (github_com_hashicorp_terrafo
 					Type:        DurationType{},
 				},
 				"prompt": {
-					Description: "Prompt is an optional OIDC prompt. An empty string omits prompt. If not specified, it defaults to select_account for backwards compatibility.",
+					Description: "Prompt is an optional OIDC prompt. An empty string omits prompt. If not specified, it defaults to `select_account` for backwards compatibility.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
@@ -2985,7 +2985,7 @@ func GenSchemaSAMLConnectorV2(ctx context.Context) (github_com_hashicorp_terrafo
 				"client_redirect_settings": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						"allowed_https_hostnames": {
-							Description: "a list of hostnames allowed for https client redirect URLs",
+							Description: "a list of hostnames allowed for HTTPS client redirect URLs",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
@@ -3147,19 +3147,19 @@ func GenSchemaGithubConnectorV3(ctx context.Context) (github_com_hashicorp_terra
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"api_endpoint_url": {
-					Description: "APIEndpointURL is the URL of the API endpoint of the Github instance this connector is for.",
+					Description: "APIEndpointURL is the URL of the API endpoint of the GitHub instance this connector is for.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"client_id": {
-					Description: "ClientID is the Github OAuth app client ID.",
+					Description: "ClientID is the GitHub OAuth app client ID.",
 					Required:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"client_redirect_settings": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						"allowed_https_hostnames": {
-							Description: "a list of hostnames allowed for https client redirect URLs",
+							Description: "a list of hostnames allowed for HTTPS client redirect URLs",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
@@ -3173,7 +3173,7 @@ func GenSchemaGithubConnectorV3(ctx context.Context) (github_com_hashicorp_terra
 					Optional:    true,
 				},
 				"client_secret": {
-					Description: "ClientSecret is the Github OAuth app client secret.",
+					Description: "ClientSecret is the GitHub OAuth app client secret.",
 					Required:    true,
 					Sensitive:   true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
@@ -3196,12 +3196,12 @@ func GenSchemaGithubConnectorV3(ctx context.Context) (github_com_hashicorp_terra
 				"teams_to_logins": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						"kubernetes_groups": {
-							Description: "KubeGroups is a list of allowed kubernetes groups for this org/team.",
+							Description: "KubeGroups is a list of allowed Kubernetes groups for this org/team.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
 						"kubernetes_users": {
-							Description: "KubeUsers is a list of allowed kubernetes users to impersonate for this org/team.",
+							Description: "KubeUsers is a list of allowed Kubernetes users to impersonate for this org/team.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
@@ -3211,7 +3211,7 @@ func GenSchemaGithubConnectorV3(ctx context.Context) (github_com_hashicorp_terra
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
 						"organization": {
-							Description: "Organization is a Github organization a user belongs to.",
+							Description: "Organization is a GitHub organization a user belongs to.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
@@ -3221,13 +3221,13 @@ func GenSchemaGithubConnectorV3(ctx context.Context) (github_com_hashicorp_terra
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 					}),
-					Description: "TeamsToLogins maps Github team memberships onto allowed logins/roles.  DELETE IN 11.0.0 Deprecated: use GithubTeamsToRoles instead.",
+					Description: "TeamsToLogins maps GitHub team memberships onto allowed logins/roles.  DELETE IN 11.0.0 Deprecated: use GithubTeamsToRoles instead.",
 					Optional:    true,
 				},
 				"teams_to_roles": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						"organization": {
-							Description: "Organization is a Github organization a user belongs to.",
+							Description: "Organization is a GitHub organization a user belongs to.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
@@ -3242,11 +3242,11 @@ func GenSchemaGithubConnectorV3(ctx context.Context) (github_com_hashicorp_terra
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 					}),
-					Description: "TeamsToRoles maps Github team memberships onto allowed roles.",
+					Description: "TeamsToRoles maps GitHub team memberships onto allowed roles.",
 					Optional:    true,
 				},
 			}),
-			Description: "Spec is an Github connector specification.",
+			Description: "Spec is a GitHub connector specification.",
 			Required:    true,
 		},
 		"sub_kind": {
@@ -3323,7 +3323,7 @@ func GenSchemaTrustedClusterV2(ctx context.Context) (github_com_hashicorp_terraf
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"enabled": {
-					Description: "Enabled is a bool that indicates if the TrustedCluster is enabled or disabled. Setting Enabled to false has a side effect of deleting the user and host certificate authority (CA).",
+					Description: "Enabled indicates if the TrustedCluster is enabled or disabled.  Setting Enabled to false has a side effect of deleting the user and host certificate authority (CA).",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
 				},


### PR DESCRIPTION
Related to #46191

Help us move to a new, more scalable spell checker based on vale by fixing spelling errors in the Terraform provider resource reference docs. This change fixes the spelling in the protobuf messages that these docs are based on.

Since the vale checker ignores words in backticks, this change wraps field/value names that would otherwise fail the spell checker in backticks.