### PR TITLE
validate node hostnames when they are being created or updated

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -62,6 +62,7 @@ import (
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // ServerWithRoles is a wrapper around auth service
@@ -975,6 +976,14 @@ func (a *ServerWithRoles) ClearAlertAcks(ctx context.Context, req proto.ClearAle
 func (a *ServerWithRoles) UpsertNode(ctx context.Context, s types.Server) (*types.KeepAlive, error) {
 	if err := a.action(s.GetNamespace(), types.KindNode, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
+	}
+	if hostname := s.GetHostname(); hostname != "" {
+		// Allow uppercase node hostnames, they aren't valid hostnames
+		// but there's no reason to reject them here. The goal here is
+		// to disallow most special characters.
+		if !utils.IsValidHostname(strings.ToLower(hostname)) {
+			return nil, trace.BadParameter("invalid hostname %q", hostname)
+		}
 	}
 	return a.authServer.UpsertNode(ctx, s)
 }

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -978,11 +978,8 @@ func (a *ServerWithRoles) UpsertNode(ctx context.Context, s types.Server) (*type
 		return nil, trace.Wrap(err)
 	}
 	if hostname := s.GetHostname(); hostname != "" {
-		// Allow uppercase node hostnames, they aren't valid hostnames
-		// but there's no reason to reject them here. The goal here is
-		// to disallow most special characters.
-		if !utils.IsValidHostname(strings.ToLower(hostname)) {
-			return nil, trace.BadParameter("invalid hostname %q", hostname)
+		if err := utils.ValidateNodeHostname(hostname); err != nil {
+			return nil, trace.Wrap(err)
 		}
 	}
 	return a.authServer.UpsertNode(ctx, s)

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -601,11 +601,8 @@ func (c *Controller) handleSSHServerHB(handle *upstreamHandle, sshServer *types.
 		return trace.AccessDenied("incorrect ssh server ID (expected %q, got %q)", handle.Hello().ServerID, sshServer.GetName())
 	}
 	if hostname := sshServer.GetHostname(); hostname != "" {
-		// Allow uppercase node hostnames, they aren't valid hostnames
-		// but there's no reason to reject them here. The goal here is
-		// to disallow most special characters.
-		if !utils.IsValidHostname(strings.ToLower(hostname)) {
-			return trace.BadParameter("invalid ssh server hostname %q in heartbeat", hostname)
+		if err := utils.ValidateNodeHostname(hostname); err != nil {
+			return trace.Wrap(err)
 		}
 	}
 

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -600,6 +600,14 @@ func (c *Controller) handleSSHServerHB(handle *upstreamHandle, sshServer *types.
 	if sshServer.GetName() != handle.Hello().ServerID {
 		return trace.AccessDenied("incorrect ssh server ID (expected %q, got %q)", handle.Hello().ServerID, sshServer.GetName())
 	}
+	if hostname := sshServer.GetHostname(); hostname != "" {
+		// Allow uppercase node hostnames, they aren't valid hostnames
+		// but there's no reason to reject them here. The goal here is
+		// to disallow most special characters.
+		if !utils.IsValidHostname(strings.ToLower(hostname)) {
+			return trace.BadParameter("invalid ssh server hostname %q in heartbeat", hostname)
+		}
+	}
 
 	// if a peer address is available in the context, use it to override zero-value addresses from
 	// the server heartbeat.

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -600,11 +600,6 @@ func (c *Controller) handleSSHServerHB(handle *upstreamHandle, sshServer *types.
 	if sshServer.GetName() != handle.Hello().ServerID {
 		return trace.AccessDenied("incorrect ssh server ID (expected %q, got %q)", handle.Hello().ServerID, sshServer.GetName())
 	}
-	if hostname := sshServer.GetHostname(); hostname != "" {
-		if err := utils.ValidateNodeHostname(hostname); err != nil {
-			return trace.Wrap(err)
-		}
-	}
 
 	// if a peer address is available in the context, use it to override zero-value addresses from
 	// the server heartbeat.

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -348,6 +348,7 @@ func (s *PresenceService) UpsertNode(ctx context.Context, server types.Server) (
 	if n := server.GetNamespace(); n != apidefaults.Namespace {
 		return nil, trace.BadParameter("cannot place node in namespace %q, custom namespaces are deprecated", n)
 	}
+
 	rev := server.GetRevision()
 	value, err := services.MarshalServer(server)
 	if err != nil {

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -350,7 +350,7 @@ func (s *PresenceService) UpsertNode(ctx context.Context, server types.Server) (
 	}
 	if err := utils.ValidateNodeHostname(server.GetHostname()); err != nil {
 		s.log.Warnf(
-			`Node %q is configured with an invalid hostname. Future versions of Teleport will evict nodes with invalid hostnames.
+			`Node %q is configured with an invalid hostname. Future versions of Teleport will change the hostname of nodes with invalid hostnames.
 Please update this hostname to a hostname only consisting of alphanumeric characters and the symbols '.' and '-'.`,
 			server.GetHostname(),
 		)

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -348,6 +348,13 @@ func (s *PresenceService) UpsertNode(ctx context.Context, server types.Server) (
 	if n := server.GetNamespace(); n != apidefaults.Namespace {
 		return nil, trace.BadParameter("cannot place node in namespace %q, custom namespaces are deprecated", n)
 	}
+	if err := utils.ValidateNodeHostname(server.GetHostname()); err != nil {
+		s.log.Warnf(
+			`Node %q is configured with an invalid hostname. Future versions of Teleport will evict nodes with invalid hostnames.
+Please update this hostname to a hostname only consisting of alphanumeric characters and the symbols '.' and '-'.`,
+			server.GetHostname(),
+		)
+	}
 
 	rev := server.GetRevision()
 	value, err := services.MarshalServer(server)

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -946,7 +946,7 @@ func (s *Server) heartbeatEICEInstance(instances *server.EC2Instances) {
 
 			continue
 		}
-		// Only validate the hostname of new nodes to ensure existing EICE nodes that existed
+		// Only validate the hostname of new nodes to ensure existing nodes that existed
 		// before hostname validation was checked are unaffected
 		if len(existingNodes) == 0 {
 			err := utils.ValidateNodeHostname(eiceNode.GetHostname())

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -29,6 +29,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -321,6 +322,30 @@ func IsValidHostname(hostname string) bool {
 		}
 	}
 	return true
+}
+
+const (
+	nodeHostnameMaxLen       = 256
+	nodeHostnameRegexPattern = `^[a-zA-Z0-9]([\.-]?[a-zA-Z0-9]+)*$`
+)
+
+var nodeHostnameRegex = regexp.MustCompile(nodeHostnameRegexPattern)
+
+// ValidateNodeHostname returns an error if the node hostname does not entirely
+// consist of alphanumeric characters as well as '-' and '.'. A valid hostname also
+// cannot begin with a symbol, and a symbol cannot be followed immediately by another symbol.
+func ValidateNodeHostname(hostname string) error {
+	if len(hostname) > nodeHostnameMaxLen {
+		return trace.Errorf("Invalid hostname %q. Valid node hostnames must be under %d characters.", hostname, nodeHostnameMaxLen)
+	}
+	if !nodeHostnameRegex.MatchString(hostname) {
+		return trace.Errorf(
+			`Invalid hostname %q. Valid node hostnames consist of alphanumeric characters as well as the symbols '-' and '.'
+The hostname cannot begin with a symbol, and a symbol cannot be followed immediately by another symbol.`,
+			hostname,
+		)
+	}
+	return nil
 }
 
 // IsValidUnixUser checks if a string represents a valid

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -400,6 +400,11 @@ func TestValidateNodeHostname(t *testing.T) {
 			hostname: "9b61981f-d5c3-491d-8e58-be500db71d54",
 			assert:   require.NoError,
 		},
+		{
+			name:     "uuid with domain name",
+			hostname: "9b61981f-d5c3-491d-8e58-be500db71d54.example.com",
+			assert:   require.NoError,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -358,6 +358,56 @@ func TestIsValidHostname(t *testing.T) {
 	}
 }
 
+func TestValidateNodeHostname(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		hostname string
+		assert   require.ErrorAssertionFunc
+	}{
+		{
+			name:     "normal hostname",
+			hostname: "some-host-1.example.com",
+			assert:   require.NoError,
+		},
+		{
+			name:     "one component",
+			hostname: "example",
+			assert:   require.NoError,
+		},
+		{
+			name:     "empty",
+			hostname: "",
+			assert:   require.Error,
+		},
+		{
+			name:     "invalid characters",
+			hostname: "some spaces.example.com",
+			assert:   require.Error,
+		},
+		{
+			name:     "empty label",
+			hostname: "somewhere..example.com",
+			assert:   require.Error,
+		},
+		{
+			name:     "hostname too long",
+			hostname: strings.Repeat("x.", nodeHostnameMaxLen) + ".example.com",
+			assert:   require.Error,
+		},
+		{
+			name:     "uuid",
+			hostname: "9b61981f-d5c3-491d-8e58-be500db71d54",
+			assert:   require.NoError,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.assert(t, ValidateNodeHostname(tc.hostname))
+		})
+	}
+}
+
 // TestReplaceRegexp tests regexp-style replacement of values
 func TestReplaceRegexp(t *testing.T) {
 	t.Parallel()

--- a/lib/web/ui/perf_test.go
+++ b/lib/web/ui/perf_test.go
@@ -126,8 +126,9 @@ func insertServers(ctx context.Context, b *testing.B, svc services.Presence, kin
 				Labels:    labels,
 			},
 			Spec: types.ServerSpecV2{
-				Addr:    addr,
-				Version: teleport.Version,
+				Addr:     addr,
+				Hostname: name,
+				Version:  teleport.Version,
 			},
 		}
 		var err error


### PR DESCRIPTION
See https://github.com/gravitational/teleport/pull/46892#issuecomment-2448300046 on why the validation logic was changed from previously using `utils.IsValidHostname`.

Updates https://github.com/gravitational/teleport-private/issues/1676.

changelog: validate node hostnames when they are being created or updated