### PR TITLE
[v16] Add `ssh.forwardAgent` setting to Connect

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -478,6 +478,7 @@ Below is the list of the supported config properties.
 | `keymap.openSearchBar`        | `Command+K` on macOS<br/>`Ctrl+Shift+K` on Windows/Linux                                                             | Shortcut to open the search bar.                                                                           |
 | `headless.skipConfirm`        | false                                                                                                                | Skips the confirmation prompt for Headless WebAuthn approval and instead prompts for WebAuthn immediately. |
 | `ssh.noResume`                | false                                                                                                                | Disables SSH connection resumption.                                                                        |
+| `ssh.forwardAgent`            | true                                                                                                                 | Enables agent forwarding.                                                                                  |
 
 <Admonition
   type="note"

--- a/web/packages/teleterm/src/services/config/appConfigSchema.ts
+++ b/web/packages/teleterm/src/services/config/appConfigSchema.ts
@@ -188,6 +188,12 @@ export const createAppConfigSchema = (settings: RuntimeSettings) => {
       .boolean()
       .default(false)
       .describe('Disables SSH connection resumption.'),
+    'ssh.forwardAgent': z
+      .boolean()
+      .default(true)
+      .describe(
+        "Enables agent forwarding when connecting to SSH nodes. It's the equivalent of the forward-agent flag in tsh ssh."
+      ),
   });
 };
 

--- a/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -212,7 +212,7 @@ export function getPtyProcessOptions({
         `--proxy=${cmd.rootClusterId}`,
         'ssh',
         ...(options.ssh.noResume ? ['--no-resume'] : []),
-        '--forward-agent',
+        ...(options.ssh.forwardAgent ? ['--forward-agent'] : []),
         loginHost,
       ];
 

--- a/web/packages/teleterm/src/services/pty/ptyService.ts
+++ b/web/packages/teleterm/src/services/pty/ptyService.ts
@@ -43,7 +43,10 @@ export function createPtyService(
       const { processOptions, creationStatus, shell } = await buildPtyOptions({
         settings: runtimeSettings,
         options: {
-          ssh: { noResume: configService.get('ssh.noResume').value },
+          ssh: {
+            noResume: configService.get('ssh.noResume').value,
+            forwardAgent: configService.get('ssh.forwardAgent').value,
+          },
           customShellPath: configService.get('terminal.customShell').value,
           windowsPty,
         },

--- a/web/packages/teleterm/src/services/pty/types.ts
+++ b/web/packages/teleterm/src/services/pty/types.ts
@@ -123,6 +123,10 @@ export type SshOptions = {
    * (by adding the `--no-resume` option).
    */
   noResume: boolean;
+  /**
+   * Enables agent forwarding when running `tsh ssh` by adding the --forward-agent option.
+   */
+  forwardAgent: boolean;
 };
 
 export type TerminalOptions = {


### PR DESCRIPTION
Backport #46798 to branch/v16

changelog: Added a new config option in Teleport Connect to control SSH agent forwarding (`ssh.forwardAgent`); starting in Teleport Connect v17, this option will be disabled by default
