### PR TITLE
[v15] Add ssh.forwardAgent setting to Connect

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -437,6 +437,7 @@ Below is the list of the supported config properties.
 | `keymap.openSearchBar`        | `Command+K` on macOS<br/>`Ctrl+K` on Windows/Linux                                                                   | Shortcut to open the search bar.                                       |
 | `headless.skipConfirm` | false | Skips the confirmation prompt for Headless WebAuthn approval and instead prompts for WebAuthn immediately. |
 | `ssh.noResume`                | false                                                                                                                | Disables SSH connection resumption.                                                                        |
+| `ssh.forwardAgent`            | true                                                                                                                 | Enables agent forwarding.                                                                                  |
 
 <Admonition
   type="note"

--- a/web/packages/teleterm/src/preload.ts
+++ b/web/packages/teleterm/src/preload.ts
@@ -75,6 +75,8 @@ async function getElectronGlobals(): Promise<ElectronGlobals> {
     {
       ssh: {
         noResume: mainProcessClient.configService.get('ssh.noResume').value,
+        forwardAgent:
+          mainProcessClient.configService.get('ssh.forwardAgent').value,
       },
       terminal: {
         windowsBackend: mainProcessClient.configService.get(

--- a/web/packages/teleterm/src/services/config/appConfigSchema.ts
+++ b/web/packages/teleterm/src/services/config/appConfigSchema.ts
@@ -151,6 +151,12 @@ export const createAppConfigSchema = (platform: Platform) => {
       .boolean()
       .default(false)
       .describe('Disables SSH connection resumption.'),
+    'ssh.forwardAgent': z
+      .boolean()
+      .default(true)
+      .describe(
+        "Enables agent forwarding when connecting to SSH nodes. It's the equivalent of the forward-agent flag in tsh ssh."
+      ),
   });
 };
 

--- a/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -153,7 +153,7 @@ export function getPtyProcessOptions(
         `--proxy=${cmd.rootClusterId}`,
         'ssh',
         ...(options.ssh.noResume ? ['--no-resume'] : []),
-        '--forward-agent',
+        ...(options.ssh.forwardAgent ? ['--forward-agent'] : []),
         loginHost,
       ];
 

--- a/web/packages/teleterm/src/services/pty/types.ts
+++ b/web/packages/teleterm/src/services/pty/types.ts
@@ -118,6 +118,10 @@ export type SshOptions = {
    * (by adding the `--no-resume` option).
    */
   noResume: boolean;
+  /**
+   * Enables agent forwarding when running `tsh ssh` by adding the --forward-agent option.
+   */
+  forwardAgent: boolean;
 };
 
 export type TerminalOptions = {


### PR DESCRIPTION
Backport #46798 to branch/v16

changelog: Added a new config option in Teleport Connect to control SSH agent forwarding (ssh.forwardAgent); starting in Teleport Connect v17, this option will be disabled by default