### PR TITLE
Correct postgres retention_period as a fragment instead of a GET param

### DIFF
--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -58,7 +58,7 @@ teleport:
         # consume the retention period via a query parameter in the audit_events_uri. See the examples below
         # for how to configure the retention period for other backends.
         # Firestore: firestore://events_table_name?eventRetentionPeriod=10d
-        # Postgres: postgresql://user_name@database-address/teleport_audit?retention_period=10d
+        # Postgres: postgresql://user_name@database-address/teleport_audit#retention_period=240h
         retention_period: 365d
 
         # minimum/maximum read capacity in units


### PR DESCRIPTION
When trying to use `retention_period` with a GET parameter in `postgresql://` URI, this causes a failure.

`server error (FATAL: unrecognized configuration parameter "retention_period" (SQLSTATE 42704))`

Instead, the `retention_period` should be included as part of the _fragment_ of the URI. Updating doc to show correct syntax.