### PR TITLE
Remove oxy connections limiter

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -372,12 +372,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		cfg.Logger = slog.With(teleport.ComponentKey, teleport.ComponentAuth)
 	}
 
-	limiter, err := limiter.NewConnectionsLimiter(limiter.Config{
-		MaxConnections: defaults.LimiterMaxConcurrentSignatures,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	limiter := limiter.NewConnectionsLimiter(defaults.LimiterMaxConcurrentSignatures)
 
 	keystoreOpts := &keystore.Options{
 		HostUUID:             cfg.HostUUID,

--- a/lib/limiter/connlimiter.go
+++ b/lib/limiter/connlimiter.go
@@ -19,19 +19,23 @@
 package limiter
 
 import (
+	"context"
+	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 
-	"github.com/gravitational/oxy/connlimit"
-	"github.com/gravitational/oxy/utils"
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
 )
 
-// ConnectionsLimiter is a network connection limiter and tracker
+// ConnectionsLimiter is a network connection limiter.
 type ConnectionsLimiter struct {
-	*connlimit.ConnLimiter
 	maxConnections int64
+	log            *slog.Logger
+
+	next http.Handler
 
 	sync.Mutex
 	connections map[string]int64
@@ -39,28 +43,45 @@ type ConnectionsLimiter struct {
 
 // NewConnectionsLimiter returns new connection limiter, in case if connection
 // limits are not set, they won't be tracked
-func NewConnectionsLimiter(config Config) (*ConnectionsLimiter, error) {
-	limiter := ConnectionsLimiter{
-		maxConnections: config.MaxConnections,
+func NewConnectionsLimiter(maxConnections int64) *ConnectionsLimiter {
+	return &ConnectionsLimiter{
+		maxConnections: maxConnections,
+		log:            slog.With(teleport.ComponentKey, "limiter"),
 		connections:    make(map[string]int64),
 	}
-
-	ipExtractor, err := utils.NewExtractor("client.ip")
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	limiter.ConnLimiter, err = connlimit.New(nil, ipExtractor, config.MaxConnections)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return &limiter, nil
 }
 
-// WrapHandle adds connection limiter to the handle
-func (l *ConnectionsLimiter) WrapHandle(h http.Handler) {
-	l.ConnLimiter.Wrap(h)
+// Wrap wraps an HTTP handler.
+func (l *ConnectionsLimiter) Wrap(h http.Handler) {
+	l.next = h
+}
+
+func (l *ConnectionsLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if l.next == nil {
+		sc := http.StatusInternalServerError
+		http.Error(w, http.StatusText(sc), sc)
+		return
+	}
+
+	// TODO: use net.SplitHostPort to be more compatible with IPv6
+	token, _, _ := strings.Cut(r.RemoteAddr, ":")
+	if token == "" {
+		l.log.WarnContext(context.Background(), "failed to extract source IP", "remote_addr", r.RemoteAddr)
+		sc := http.StatusInternalServerError
+		http.Error(w, http.StatusText(sc), sc)
+		return
+	}
+
+	if err := l.AcquireConnection(token); err != nil {
+		l.log.InfoContext(context.Background(), "limiting request", "token", token, "error", err)
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(trace.UserMessage(err)))
+		return
+	}
+
+	defer l.ReleaseConnection(token)
+
+	l.next.ServeHTTP(w, r)
 }
 
 // AcquireConnection acquires connection and bumps counter
@@ -97,7 +118,6 @@ func (l *ConnectionsLimiter) ReleaseConnection(token string) {
 
 	numberOfConnections, exists := l.connections[token]
 	if !exists {
-		log.Errorf("Trying to set negative number of connections")
 		return
 	}
 

--- a/lib/limiter/connlimiter_test.go
+++ b/lib/limiter/connlimiter_test.go
@@ -1,0 +1,70 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package limiter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/limiter"
+)
+
+func TestConnectionsLimiter(t *testing.T) {
+	l := limiter.NewConnectionsLimiter(0)
+
+	for i := 0; i < 10; i++ {
+		require.NoError(t, l.AcquireConnection("token1"))
+	}
+	for i := 0; i < 5; i++ {
+		require.NoError(t, l.AcquireConnection("token2"))
+	}
+
+	for i := 0; i < 10; i++ {
+		l.ReleaseConnection("token1")
+	}
+	for i := 0; i < 5; i++ {
+		l.ReleaseConnection("token2")
+	}
+
+	l = limiter.NewConnectionsLimiter(5)
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, l.AcquireConnection("token1"))
+	}
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, l.AcquireConnection("token2"))
+	}
+	for i := 0; i < 5; i++ {
+		require.Error(t, l.AcquireConnection("token2"))
+	}
+
+	for i := 0; i < 10; i++ {
+		l.ReleaseConnection("token1")
+		require.NoError(t, l.AcquireConnection("token1"))
+	}
+
+	for i := 0; i < 5; i++ {
+		l.ReleaseConnection("token2")
+	}
+	for i := 0; i < 5; i++ {
+		require.NoError(t, l.AcquireConnection("token2"))
+	}
+}

--- a/lib/limiter/limiter.go
+++ b/lib/limiter/limiter.go
@@ -21,7 +21,6 @@ package limiter
 
 import (
 	"context"
-	"encoding/json"
 	"net"
 	"net/http"
 
@@ -34,8 +33,8 @@ import (
 
 // Limiter helps limiting connections and request rates
 type Limiter struct {
-	// ConnectionsLimiter limits simultaneous connection
-	*ConnectionsLimiter
+	// connectionLimiter limits simultaneous connection
+	connectionLimiter *ConnectionsLimiter
 	// rateLimiter limits request rate
 	rateLimiter *RateLimiter
 }
@@ -52,24 +51,10 @@ type Config struct {
 	Clock timetools.TimeProvider
 }
 
-// SetEnv reads LimiterConfig from JSON string
-func (l *Config) SetEnv(v string) error {
-	if err := json.Unmarshal([]byte(v), l); err != nil {
-		return trace.Wrap(err, "expected JSON encoded remote certificate")
-	}
-	return nil
-}
-
 // NewLimiter returns new rate and connection limiter
 func NewLimiter(config Config) (*Limiter, error) {
-	if config.MaxConnections < 0 {
-		config.MaxConnections = 0
-	}
-
-	connectionsLimiter, err := NewConnectionsLimiter(config)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	config.MaxConnections = max(config.MaxConnections, 0)
+	connectionsLimiter := NewConnectionsLimiter(config.MaxConnections)
 
 	rateLimiter, err := NewRateLimiter(config)
 	if err != nil {
@@ -77,9 +62,13 @@ func NewLimiter(config Config) (*Limiter, error) {
 	}
 
 	return &Limiter{
-		ConnectionsLimiter: connectionsLimiter,
-		rateLimiter:        rateLimiter,
+		connectionLimiter: connectionsLimiter,
+		rateLimiter:       rateLimiter,
 	}, nil
+}
+
+func (l *Limiter) GetNumConnection(token string) (int64, error) {
+	return l.connectionLimiter.GetNumConnection(token)
 }
 
 func (l *Limiter) RegisterRequest(token string) error {
@@ -90,10 +79,14 @@ func (l *Limiter) RegisterRequestWithCustomRate(token string, customRate *rateli
 	return l.rateLimiter.RegisterRequest(token, customRate)
 }
 
+func (l *Limiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	l.connectionLimiter.ServeHTTP(w, r)
+}
+
 // WrapHandle adds limiter to the handle
 func (l *Limiter) WrapHandle(h http.Handler) {
 	l.rateLimiter.Wrap(h)
-	l.ConnLimiter.Wrap(l.rateLimiter)
+	l.connectionLimiter.Wrap(l.rateLimiter)
 }
 
 // RegisterRequestAndConnection register a rate and connection limiter for a given token. Close function is returned,
@@ -112,11 +105,11 @@ func (l *Limiter) RegisterRequestAndConnection(token string) (func(), error) {
 	}
 
 	// Apply connection limiting.
-	if err := l.AcquireConnection(token); err != nil {
+	if err := l.connectionLimiter.AcquireConnection(token); err != nil {
 		return func() {}, trace.LimitExceeded("exceeded connection limit for %q", token)
 	}
 
-	return func() { l.ReleaseConnection(token) }, nil
+	return func() { l.connectionLimiter.ReleaseConnection(token) }, nil
 }
 
 // UnaryServerInterceptor returns a gRPC unary interceptor which
@@ -148,10 +141,10 @@ func (l *Limiter) UnaryServerInterceptorWithCustomRate(customRate CustomRateFunc
 		if err := l.RegisterRequestWithCustomRate(clientIP, customRate(info.FullMethod)); err != nil {
 			return nil, trace.LimitExceeded("rate limit exceeded")
 		}
-		if err := l.ConnLimiter.Acquire(clientIP, 1); err != nil {
+		if err := l.connectionLimiter.AcquireConnection(clientIP); err != nil {
 			return nil, trace.LimitExceeded("connection limit exceeded")
 		}
-		defer l.ConnLimiter.Release(clientIP, 1)
+		defer l.connectionLimiter.ReleaseConnection(clientIP)
 		return handler(ctx, req)
 	}
 }
@@ -171,17 +164,17 @@ func (l *Limiter) StreamServerInterceptor(srv interface{}, serverStream grpc.Ser
 	if err := l.RegisterRequest(clientIP); err != nil {
 		return trace.LimitExceeded("rate limit exceeded")
 	}
-	if err := l.ConnLimiter.Acquire(clientIP, 1); err != nil {
+	if err := l.connectionLimiter.AcquireConnection(clientIP); err != nil {
 		return trace.LimitExceeded("connection limit exceeded")
 	}
-	defer l.ConnLimiter.Release(clientIP, 1)
+	defer l.connectionLimiter.ReleaseConnection(clientIP)
 	return handler(srv, serverStream)
 }
 
 // WrapListener returns a [Listener] that wraps the provided listener
 // with one that limits connections
 func (l *Limiter) WrapListener(ln net.Listener) (*Listener, error) {
-	return NewListener(ln, l.ConnectionsLimiter)
+	return NewListener(ln, l.connectionLimiter)
 }
 
 type handlerWrapper interface {

--- a/lib/limiter/limiter_test.go
+++ b/lib/limiter/limiter_test.go
@@ -43,61 +43,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestConnectionsLimiter(t *testing.T) {
-	limiter, err := NewLimiter(
-		Config{
-			MaxConnections: 0,
-		},
-	)
-	require.NoError(t, err)
-
-	for i := 0; i < 10; i++ {
-		require.NoError(t, limiter.AcquireConnection("token1"))
-	}
-	for i := 0; i < 5; i++ {
-		require.NoError(t, limiter.AcquireConnection("token2"))
-	}
-
-	for i := 0; i < 10; i++ {
-		limiter.ReleaseConnection("token1")
-	}
-	for i := 0; i < 5; i++ {
-		limiter.ReleaseConnection("token2")
-	}
-
-	limiter, err = NewLimiter(
-		Config{
-			MaxConnections: 5,
-		},
-	)
-	require.NoError(t, err)
-
-	for i := 0; i < 5; i++ {
-		require.NoError(t, limiter.AcquireConnection("token1"))
-	}
-
-	for i := 0; i < 5; i++ {
-		require.NoError(t, limiter.AcquireConnection("token2"))
-	}
-	for i := 0; i < 5; i++ {
-		require.Error(t, limiter.AcquireConnection("token2"))
-	}
-
-	for i := 0; i < 10; i++ {
-		limiter.ReleaseConnection("token1")
-		require.NoError(t, limiter.AcquireConnection("token1"))
-	}
-
-	for i := 0; i < 5; i++ {
-		limiter.ReleaseConnection("token2")
-	}
-	for i := 0; i < 5; i++ {
-		require.NoError(t, limiter.AcquireConnection("token2"))
-	}
-}
-
 func TestRateLimiter(t *testing.T) {
-	// TODO: this test fails
 	clock := &timetools.FreezedTime{
 		CurrentTime: time.Date(2016, 6, 5, 4, 3, 2, 1, time.UTC),
 	}
@@ -404,8 +350,7 @@ func TestListener(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			limiter, err := NewConnectionsLimiter(test.config)
-			require.NoError(t, err)
+			limiter := NewConnectionsLimiter(test.config.MaxConnections)
 
 			ln, err := NewListener(test.listener, limiter)
 			require.NoError(t, err)

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -194,10 +194,8 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(logger *slog
 		return tlsCopy, nil
 	}
 
-	connLimiter, err := limiter.NewConnectionsLimiter(cfg.WindowsDesktop.ConnLimiter)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	connLimiter := limiter.NewConnectionsLimiter(cfg.WindowsDesktop.ConnLimiter.MaxConnections)
+
 	var publicAddr string
 	switch {
 	case useTunnel:


### PR DESCRIPTION
lib/limiter composes a maximum simultaneous connections limiter as well as a rate limiter. This commit replaces the connections limiter from oxy with built-in code.

Note: this also introduces a bug fix that may change behavior. Prior to this change, the connection limiter kept a separate connection account for HTTP connections than it did for connections managed manually with acquire/release. We no longer maintain separate counts - all connections (HTTP or not) contribute to the number of allowed connections.