### PR TITLE
Fix panic in `pagerduty` plugin init phase

### DIFF
--- a/integrations/access/pagerduty/app.go
+++ b/integrations/access/pagerduty/app.go
@@ -78,18 +78,7 @@ func NewApp(conf Config) (*App, error) {
 		teleport:   conf.Client,
 		statusSink: conf.StatusSink,
 	}
-	app.accessMonitoringRules = accessmonitoring.NewRuleHandler(accessmonitoring.RuleHandlerConfig{
-		Client:     conf.Client,
-		PluginType: types.PluginTypePagerDuty,
-		PluginName: pluginName,
-		FetchRecipientCallback: func(_ context.Context, name string) (*common.Recipient, error) {
-			return &common.Recipient{
-				Name: name,
-				ID:   name,
-				Kind: common.RecipientKindSchedule,
-			}, nil
-		},
-	})
+
 	app.mainJob = lib.NewServiceJob(app.run)
 
 	return app, nil
@@ -183,6 +172,19 @@ func (a *App) init(ctx context.Context) error {
 			return trace.Wrap(err)
 		}
 	}
+
+	a.accessMonitoringRules = accessmonitoring.NewRuleHandler(accessmonitoring.RuleHandlerConfig{
+		Client:     a.teleport,
+		PluginType: types.PluginTypePagerDuty,
+		PluginName: pluginName,
+		FetchRecipientCallback: func(_ context.Context, name string) (*common.Recipient, error) {
+			return &common.Recipient{
+				Name: name,
+				ID:   name,
+				Kind: common.RecipientKindSchedule,
+			}, nil
+		},
+	})
 
 	if pong, err = a.checkTeleportVersion(ctx); err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This PR fixes a problem caused by pagerduty not having the Teleport client initialized when starting from the standalone plugin.

This PR fixes the issue by moving the access monitoring rules init function to a place where the teleport client is already initialized.

Changelog: Fixes a panic when using the self-hosted PagerDuty plugin.