### PR TITLE
[v16] Fix panic in `pagerduty` plugin init phase

### DIFF
--- a/integrations/access/pagerduty/app.go
+++ b/integrations/access/pagerduty/app.go
@@ -78,18 +78,7 @@ func NewApp(conf Config) (*App, error) {
 		teleport:   conf.Client,
 		statusSink: conf.StatusSink,
 	}
-	app.accessMonitoringRules = accessmonitoring.NewRuleHandler(accessmonitoring.RuleHandlerConfig{
-		Client:     conf.Client,
-		PluginType: types.PluginTypePagerDuty,
-		PluginName: pluginName,
-		FetchRecipientCallback: func(_ context.Context, name string) (*common.Recipient, error) {
-			return &common.Recipient{
-				Name: name,
-				ID:   name,
-				Kind: common.RecipientKindSchedule,
-			}, nil
-		},
-	})
+
 	app.mainJob = lib.NewServiceJob(app.run)
 
 	return app, nil
@@ -183,6 +172,19 @@ func (a *App) init(ctx context.Context) error {
 			return trace.Wrap(err)
 		}
 	}
+
+	a.accessMonitoringRules = accessmonitoring.NewRuleHandler(accessmonitoring.RuleHandlerConfig{
+		Client:     a.teleport,
+		PluginType: types.PluginTypePagerDuty,
+		PluginName: pluginName,
+		FetchRecipientCallback: func(_ context.Context, name string) (*common.Recipient, error) {
+			return &common.Recipient{
+				Name: name,
+				ID:   name,
+				Kind: common.RecipientKindSchedule,
+			}, nil
+		},
+	})
 
 	if pong, err = a.checkTeleportVersion(ctx); err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Backport #46924 to branch/v16

changelog: Fixes a panic when using the self-hosted PagerDuty plugin.
