### PR TITLE
buildbox: Update centos7-assets buildbox for EOL

### DIFF
--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -16,17 +16,37 @@ gpgcheck=0
 enabled=1
 EOF
 
+# mirrorlist is no longer available since CentOS 7 EOL. The software collection
+# stuff for arm64 (aarch64) is in /altarch not /centos on vault.centos.org.
+# Make the fixup a script as it needs to be run multiple times as installing
+# and updating centos-release-scl-rh leaves the old unavailable URLs.
+# https://serverfault.com/a/1161847
+RUN cat <<EOF > /tmp/fix-yum-repo-list.sh
+#!/bin/sh
+sed -e 's/mirror.centos.org/vault.centos.org/g' \
+    -e 's/^#.*baseurl=http/baseurl=http/g' \
+    -e 's/^mirrorlist=http/#mirrorlist=http/g' \
+    -i /etc/yum.repos.d/*.repo
+if [ "$(uname -m)" = 'aarch64' ]; then
+    sed 's|centos/7/sclo|altarch/7/sclo|' -i /etc/yum.repos.d/*.repo
+fi
+EOF
+RUN chmod 755 /tmp/fix-yum-repo-list.sh && \
+    /tmp/fix-yum-repo-list.sh
+
 # Install required dependencies.
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
-    yum update -y && \
     yum install -y centos-release-scl-rh && \
+    /tmp/fix-yum-repo-list.sh \
+    yum update -y && \
     yum install -y \
     centos-release-scl \
     cmake3 \
     git \
     scl-utils && \
-    yum clean all
+    yum clean all && \
+    /tmp/fix-yum-repo-list.sh
 
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \


### PR DESCRIPTION

Update the centos7-assets buildbox to build with `vault.centos.org`
instead of `mirror.centos.org` as the latter has gone away now centos7
is EOL. This same change was made to the centos7 buildbox back in July
but was not done to the assets buildbox which rarely needs to be
rebuilt. However a v15 clang change that needs to be applied has shown
this change was missed.

This was done to the centos7 buildbox in #43785 (0f4eadd8d0a3).

---

This won't last very long before switching over to the new buildbox, but as
mentioned, v15 needs a backport before I can do that and that will cause the
assets image to be rebuilt, so this fix is needed first.