### PR TITLE
docs: remove old version references

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -646,8 +646,8 @@ scp"` and use the familiar syntax:
 $ scp -P 61122 -r files root@node:/path/to/dest
 ```
 
-Starting from Teleport 9 the SCP and SFTP protocols are both supported by Server
-Access. OpenSSH `scp` or `sftp` commands can both be used in place of `tsh scp`
+Teleport supports both the SCP and SFTP protocols with Server Access.
+OpenSSH `scp` or `sftp` commands can both be used in place of `tsh scp`
 if desired.
 
 ## Sharing sessions

--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -646,7 +646,7 @@ scp"` and use the familiar syntax:
 $ scp -P 61122 -r files root@node:/path/to/dest
 ```
 
-Teleport supports both the SCP and SFTP protocols with Server Access.
+Teleport supports both the SCP and SFTP protocols.
 OpenSSH `scp` or `sftp` commands can both be used in place of `tsh scp`
 if desired.
 

--- a/docs/pages/enroll-resources/agents/join-services-to-your-cluster/azure.mdx
+++ b/docs/pages/enroll-resources/agents/join-services-to-your-cluster/azure.mdx
@@ -7,10 +7,9 @@ This guide will explain how to use the **Azure join method** to configure
 Teleport instances to join your Teleport cluster without sharing any secrets
 when they are running in an Azure Virtual Machine.
 
-The Azure join method is available in Teleport 12.1+. It is available to any
-Teleport process running in an Azure Virtual Machine. Support for joining a
-cluster with the Proxy Service behind a layer 7 load balancer or reverse proxy
-is available in Teleport 13.0+.
+The Azure join method is available to any Teleport process running in an
+Azure Virtual Machine. Support for joining a cluster with the Proxy Service
+behind a layer 7 load balancer or reverse proxy is available in Teleport 13.0+.
 
 For other methods of joining a Teleport process to a cluster, see [Joining
 Teleport Services to a Cluster](../join-services-to-your-cluster.mdx).

--- a/docs/pages/enroll-resources/agents/join-services-to-your-cluster/kubernetes.mdx
+++ b/docs/pages/enroll-resources/agents/join-services-to-your-cluster/kubernetes.mdx
@@ -20,7 +20,7 @@ joining service to run in the same Kubernetes cluster as the Auth Service.
 
 </Notice>
 
-The Kubernetes join method is available in self-hosted versions of Teleport 12+.
+The Kubernetes join method is available in self-hosted versions of Teleport.
 It supports joining any Teleport service running in the same Kubernetes cluster
 as the Auth Service.
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
@@ -253,8 +253,6 @@ $ tsh db connect --db-user=alice --db-name dev example-mongo
 <Admonition type="note" title="Supported MongoDB clients">
   Either the `mongosh` or `mongo` command-line clients should be available in `PATH` in order to be
   able to connect. The Database Service attempts to run `mongosh` first and, if `mongosh` is not in `PATH`, runs `mongo`.
-
-  Teleport 9.0 added support for `mongosh` and made it the default Mongo DB client.
 </Admonition>
 
 To log out of the database and remove credentials:

--- a/docs/pages/enroll-resources/machine-id/faq.mdx
+++ b/docs/pages/enroll-resources/machine-id/faq.mdx
@@ -25,7 +25,7 @@ runs.
 
 ## Can Machine ID be used with Trusted Clusters ?
 
-You can use Machine ID for SSH Access in trusted leaf clusters.
+You can use Machine ID for SSH access in trusted leaf clusters.
 
 We currently do not support access to applications, databases, or Kubernetes
 clusters in leaf clusters.

--- a/docs/pages/enroll-resources/machine-id/faq.mdx
+++ b/docs/pages/enroll-resources/machine-id/faq.mdx
@@ -25,7 +25,7 @@ runs.
 
 ## Can Machine ID be used with Trusted Clusters ?
 
-From Teleport 12.2, you can use Machine ID for SSH Access in trusted leaf clusters.
+You can use Machine ID for SSH Access in trusted leaf clusters.
 
 We currently do not support access to applications, databases, or Kubernetes
 clusters in leaf clusters.

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -237,10 +237,10 @@ today, but most new users should start with the latest configuration version.
 
 ### Config `v2`
 
-Configuration version `v2` includes support for Teleport's TLS routing feature.
-With TLS routing, Teleport's proxy listens on a single port and uses ALPN and SNI
-to route incoming traffic to the correct Teleport service rather than listening on
-multiple protocol-specific ports.
+Configuration version `v2` was introduced in Teleport 8 as part of Teleport's
+TLS routing feature. With TLS routing, Teleport's proxy listens on a single port
+and uses ALPN and SNI to route incoming traffic to the correct Teleport service
+rather than listening on multiple protocol-specific ports.
 
 For backwards compatibility, configuration version `v1` always listens on these
 protocol-specific ports. When Teleport is using configuration version `v2`, the
@@ -248,9 +248,10 @@ individual protocol-specific ports are not opened unless explicitly set.
 
 ### Config `v3`
 
-In version 3, the `auth_servers` field is no longer supported, and agents must
-specify one of `auth_server` or `proxy_server` to indicate which endpoint to use
-for joining a Teleport cluster.
+Configuration version `v3` was introduced with Teleport 11. In version 3, the
+`auth_servers` field is no longer supported, and agents must specify one of
+`auth_server` or `proxy_server` to indicate which endpoint to use for joining a
+Teleport cluster.
 
 Previous versions of Teleport allowed for `auth_servers` to point to Auth
 Servers or Proxy Servers. As a result, Teleport would try to connect in multiple

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -237,10 +237,10 @@ today, but most new users should start with the latest configuration version.
 
 ### Config `v2`
 
-Configuration version `v2` was introduced in Teleport 8 as part of Teleport's
-TLS routing feature. With TLS routing, Teleport's proxy listens on a single port
-and uses ALPN and SNI to route incoming traffic to the correct Teleport service
-rather than listening on multiple protocol-specific ports.
+Configuration version `v2` includes support for Teleport's TLS routing feature.
+With TLS routing, Teleport's proxy listens on a single port and uses ALPN and SNI
+to route incoming traffic to the correct Teleport service rather than listening on
+multiple protocol-specific ports.
 
 For backwards compatibility, configuration version `v1` always listens on these
 protocol-specific ports. When Teleport is using configuration version `v2`, the
@@ -248,10 +248,9 @@ individual protocol-specific ports are not opened unless explicitly set.
 
 ### Config `v3`
 
-Configuration version `v3` was introduced with Teleport 11. In version 3, the
-`auth_servers` field is no longer supported, and agents must specify one of
-`auth_server` or `proxy_server` to indicate which endpoint to use for joining a
-Teleport cluster.
+In version 3, the `auth_servers` field is no longer supported, and agents must
+specify one of `auth_server` or `proxy_server` to indicate which endpoint to use
+for joining a Teleport cluster.
 
 Previous versions of Teleport allowed for `auth_servers` to point to Auth
 Servers or Proxy Servers. As a result, Teleport would try to connect in multiple

--- a/docs/pages/reference/join-methods.mdx
+++ b/docs/pages/reference/join-methods.mdx
@@ -265,8 +265,6 @@ The IAM join method is available to any Teleport process running anywhere with a
 such as an EC2 instance with an attached IAM role. No specific permissions or IAM policy is required: an
 IAM role with no attached policies is sufficient. No IAM credentials are required on the Teleport Auth Service.
 
-Support for joining a cluster with the Proxy Service behind a layer 7 load balancer or reverse proxy is available in Teleport 13.0+.
-
 This is the recommended method to join workload running on AWS.
 
 (!docs/pages/includes/provision-token/iam-spec.mdx!)

--- a/docs/pages/reference/join-methods.mdx
+++ b/docs/pages/reference/join-methods.mdx
@@ -302,10 +302,9 @@ method](#aws-iam-role-iam) or [ephemeral secret tokens](#ephemeral-tokens).
 
 ### Azure managed identity: `azure`
 
-The Azure join method is available in Teleport 12.1+. It is available to any
-Teleport process running in an Azure Virtual Machine. Support for joining a
-cluster with the Proxy Service behind a layer 7 load balancer or reverse proxy
-is available in Teleport 13.0+.
+The Azure join method is available to any Teleport process running in an 
+Azure Virtual Machine. Support for joining a cluster with the Proxy Service
+behind a layer 7 load balancer or reverse proxy is available in Teleport 13.0+.
 
 (!docs/pages/includes/provision-token/azure-spec.mdx!)
 
@@ -385,9 +384,6 @@ clusters in Kubernetes.
 
 This method should be preferred when available as tokens are revoked as soon as
 the pod enters the `Terminated` state.
-
-The Kubernetes in-cluster join method is available in self-hosted versions of
-Teleport 12+.
 
 (!docs/pages/includes/provision-token/kubernetes-in-cluster-spec.mdx!)
 


### PR DESCRIPTION
Updated to remove references to versions <=v12