### PR TITLE
docs: Include version requirement for setting users default shell

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
@@ -104,9 +104,9 @@ The `create_host_user_mode` field enables host user creation when the value is
 the `app:nginx` label, the Teleport SSH Service creates a host user, adds it to
 the groups listed in `host_groups`, and gives it the sudoer permissions
 specified in the `host_sudoers` field. In this case, the new user receives
-permission to restart the Nginx service as root. The default shell for a created
-user can be configured with `create_host_user_default_shell`. Otherwise the
-host's default shell will be used.
+permission to restart the Nginx service as root. In Teleport 16.4.0 and later,
+the default shell for a created user can be configured with `create_host_user_default_shell`. 
+Otherwise the host's default shell will be used.
 
 {/*TODO (ptgott): We should move the information below into a reference guide*/}
 <Details title="Customizing host user creation">

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_rolesv6.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_rolesv6.mdx
@@ -341,7 +341,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |create_db_user_mode|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop". Can be either the string or the integer representation of each option.|
 |create_desktop_user|boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
 |create_host_user|boolean|CreateHostUser allows users to be automatically created on a host|
-|create_host_user_default_shell|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
+|create_host_user_default_shell|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users. Availible in version 16.4.0 and later.|
 |create_host_user_mode|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop". Can be either the string or the integer representation of each option.|
 |desktop_clipboard|boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|
 |desktop_directory_sharing|boolean|DesktopDirectorySharing indicates whether directory sharing is allowed between the user's workstation and the remote desktop. It defaults to false unless explicitly set to true.|


### PR DESCRIPTION
Suggest making the version required for setting a users' shell in host user creation explicit. This is not obvious and customers on slightly older versions may not see this.