### PR TITLE
Web: add a tooltip summary for aws oidc configure step

### DIFF
--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.tsx
@@ -37,6 +37,7 @@ import { AwsOidcPolicyPreset } from 'teleport/services/integrations';
 
 import { FinishDialog } from './FinishDialog';
 import { useAwsOidcIntegration } from './useAwsOidcIntegration';
+import { ConfigureAwsOidcSummary } from './ConfigureAwsOidcSummary';
 
 export function AwsOidc() {
   const {
@@ -161,7 +162,13 @@ export function AwsOidc() {
             {scriptUrl && (
               <>
                 <Container mb={5} width={800}>
-                  <Text bold>Step 2</Text>
+                  <Flex gap={1} alignItems="center">
+                    <Text bold>Step 2</Text>
+                    <ConfigureAwsOidcSummary
+                      roleName={integrationConfig.roleName}
+                      integrationName={integrationConfig.name}
+                    />
+                  </Flex>
                   <ShowConfigurationScript scriptUrl={scriptUrl} />
                 </Container>
                 <Container mb={5} width={800}>

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/ConfigureAwsOidcSummary.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/ConfigureAwsOidcSummary.tsx
@@ -1,0 +1,87 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { Flex, Box, H3, Text } from 'design';
+import TextEditor from 'shared/components/TextEditor';
+import { ToolTipInfo } from 'shared/components/ToolTip';
+
+import useStickyClusterId from 'teleport/useStickyClusterId';
+
+export function ConfigureAwsOidcSummary({
+  roleName,
+  integrationName,
+}: {
+  roleName: string;
+  integrationName: string;
+}) {
+  const { clusterId } = useStickyClusterId();
+
+  const json = `{
+    "name": ${roleName},
+    "description": "Used by Teleport to provide access to AWS resources.",
+    "trust_policy": {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "sts:AssumeRoleWithWebIdentity",
+                "Principal": {
+                    "Federated": "<YOUR_ACCOUNT_ID>":oidc-provider/${roleName}",
+                },
+                "Condition": {
+                    "StringEquals": {
+                        "${clusterId}:aud": "discover.teleport",
+                    }
+                }
+            }
+        ]
+    },
+    "tags": {
+        "teleport.dev/cluster": "${clusterId}",
+        "teleport.dev/integration": "${integrationName}",
+        "teleport.dev/origin": "integration_awsoidc"
+    }
+}`;
+
+  return (
+    <ToolTipInfo sticky={true} maxWidth={800}>
+      <H3 mb={2}>Running the command in AWS CloudShell does the following:</H3>
+      <Text>1. Configures an AWS IAM OIDC Identity Provider (IdP)</Text>
+      <Text>
+        2. Configures an IAM role named "{roleName}" to trust the IdP:
+      </Text>
+      <Box mb={2}>
+        <EditorWrapper>
+          <TextEditor
+            readOnly={true}
+            data={[{ content: json, type: 'json' }]}
+            bg="levels.deep"
+          />
+        </EditorWrapper>
+      </Box>
+    </ToolTipInfo>
+  );
+}
+
+const EditorWrapper = styled(Flex)`
+  height: 300px;
+  margin-top: ${p => p.theme.space[3]}px;
+  width: 700px;
+`;


### PR DESCRIPTION
this is for enrolling aws oidc integration flow

checkout story: https://localhost:9003/?path=/story/teleport-integrations-enroll-awsoidc--flow

<img width="748" alt="image" src="https://github.com/user-attachments/assets/2e2b88c6-9e0c-4e6e-8995-ec7dfd7ed377">



