### PR TITLE
[v14] fix: Enforce device trust on OSS processes

### DIFF
--- a/lib/devicetrust/authz/authz_test.go
+++ b/lib/devicetrust/authz/authz_test.go
@@ -170,13 +170,13 @@ func runVerifyUserTest(t *testing.T, method string, verify func(dt *types.Device
 			assertErr: assertNoErr,
 		},
 		{
-			name:      "OSS mode never enforced",
+			name:      "OSS mode=required (Enterprise Auth)",
 			buildType: modules.BuildOSS,
 			dt: &types.DeviceTrust{
-				Mode: constants.DeviceTrustModeRequired, // Invalid for OSS, treated as "off".
+				Mode: constants.DeviceTrustModeRequired,
 			},
 			ext:       userWithoutExtensions,
-			assertErr: assertNoErr,
+			assertErr: assertDeniedErr,
 		},
 		{
 			name:      "Enterprise mode=off",

--- a/lib/devicetrust/config/config.go
+++ b/lib/devicetrust/config/config.go
@@ -38,6 +38,18 @@ func GetEffectiveMode(dt *types.DeviceTrust) string {
 	return dt.Mode
 }
 
+// GetEnforcementMode returns the configured device trust mode, disregarding the
+// provenance of the binary if the mode is set.
+// Used for device enforcement checks. Guarantees that OSS binaries paired with
+// an Enterprise Auth will correctly enforce device trust.
+func GetEnforcementMode(dt *types.DeviceTrust) string {
+	// If absent use the defaults from GetEffectiveMode.
+	if dt == nil || dt.Mode == "" {
+		return GetEffectiveMode(dt)
+	}
+	return dt.Mode
+}
+
 // ValidateConfigAgainstModules verifies the device trust configuration against
 // the current modules.
 // This method exists to provide feedback to users about invalid configurations,

--- a/lib/devicetrust/config/config_test.go
+++ b/lib/devicetrust/config/config_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestValidateConfigAgainstModules(t *testing.T) {
+	// Don't t.Parallel, depends on modules.SetTestModules.
+
 	type testCase struct {
 		name        string
 		buildType   string
@@ -103,6 +105,62 @@ func TestValidateConfigAgainstModules(t *testing.T) {
 			} else {
 				assert.NoError(t, gotErr, "ValidateConfigAgainstModules mismatch")
 			}
+		})
+	}
+}
+
+func TestGetEnforcementMode(t *testing.T) {
+	// Don't t.Parallel, depends on modules.SetTestModules.
+
+	tests := []struct {
+		name      string
+		buildType string
+		dt        *types.DeviceTrust
+		want      string
+	}{
+		{
+			name:      "OSS default",
+			buildType: modules.BuildOSS,
+			want:      constants.DeviceTrustModeOff,
+		},
+		{
+			name:      "Enterprise default",
+			buildType: modules.BuildEnterprise,
+			want:      constants.DeviceTrustModeOptional,
+		},
+		{
+			name:      "dt.Mode empty",
+			buildType: modules.BuildEnterprise,
+			dt: &types.DeviceTrust{
+				Mode: "",
+			},
+			want: constants.DeviceTrustModeOptional,
+		},
+		{
+			name:      "dt.Mode set",
+			buildType: modules.BuildEnterprise,
+			dt: &types.DeviceTrust{
+				Mode: constants.DeviceTrustModeRequired,
+			},
+			want: constants.DeviceTrustModeRequired,
+		},
+		{
+			name:      "OSS node with Ent Auth",
+			buildType: modules.BuildOSS,
+			dt: &types.DeviceTrust{
+				Mode: constants.DeviceTrustModeRequired,
+			},
+			want: constants.DeviceTrustModeRequired,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			modules.SetTestModules(t, &modules.TestModules{
+				TestBuildType: test.buildType,
+			})
+
+			got := dtconfig.GetEnforcementMode(test.dt)
+			assert.Equal(t, test.want, got, "dtconfig.GetEnforcementMode mismatch")
 		})
 	}
 }


### PR DESCRIPTION
Backport #46940 to branch/v14

changelog: Enforce a global "device_trust.mode=required" on OSS processes paired with an Enterprise Auth
