### PR TITLE
[v15] fix: Enforce device trust on OSS processes

### DIFF
--- a/lib/devicetrust/authz/authz.go
+++ b/lib/devicetrust/authz/authz.go
@@ -19,8 +19,6 @@
 package authz
 
 import (
-	"sync"
-
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
@@ -28,7 +26,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/devicetrust/config"
+	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -73,9 +71,7 @@ func VerifySSHUser(dt *types.DeviceTrust, cert *ssh.Certificate) error {
 }
 
 func verifyDeviceExtensions(dt *types.DeviceTrust, username string, verified bool) error {
-	mode := config.GetEffectiveMode(dt)
-	maybeLogModeMismatch(mode, dt)
-
+	mode := dtconfig.GetEnforcementMode(dt)
 	switch {
 	case mode != constants.DeviceTrustModeRequired:
 		return nil // OK, extensions not enforced.
@@ -87,16 +83,4 @@ func verifyDeviceExtensions(dt *types.DeviceTrust, username string, verified boo
 	default:
 		return nil
 	}
-}
-
-var logModeOnce sync.Once
-
-func maybeLogModeMismatch(effective string, dt *types.DeviceTrust) {
-	if dt == nil || dt.Mode == "" || effective == dt.Mode {
-		return
-	}
-
-	logModeOnce.Do(func() {
-		log.Warnf("Device Trust: mode %q requires Teleport Enterprise. Using effective mode %q.", dt.Mode, effective)
-	})
 }

--- a/lib/devicetrust/authz/authz_test.go
+++ b/lib/devicetrust/authz/authz_test.go
@@ -174,13 +174,13 @@ func runVerifyUserTest(t *testing.T, method string, verify func(dt *types.Device
 			assertErr: assertNoErr,
 		},
 		{
-			name:      "OSS mode never enforced",
+			name:      "OSS mode=required (Enterprise Auth)",
 			buildType: modules.BuildOSS,
 			dt: &types.DeviceTrust{
-				Mode: constants.DeviceTrustModeRequired, // Invalid for OSS, treated as "off".
+				Mode: constants.DeviceTrustModeRequired,
 			},
 			ext:       userWithoutExtensions,
-			assertErr: assertNoErr,
+			assertErr: assertDeniedErr,
 		},
 		{
 			name:      "Enterprise mode=off",

--- a/lib/devicetrust/config/config.go
+++ b/lib/devicetrust/config/config.go
@@ -42,6 +42,18 @@ func GetEffectiveMode(dt *types.DeviceTrust) string {
 	return dt.Mode
 }
 
+// GetEnforcementMode returns the configured device trust mode, disregarding the
+// provenance of the binary if the mode is set.
+// Used for device enforcement checks. Guarantees that OSS binaries paired with
+// an Enterprise Auth will correctly enforce device trust.
+func GetEnforcementMode(dt *types.DeviceTrust) string {
+	// If absent use the defaults from GetEffectiveMode.
+	if dt == nil || dt.Mode == "" {
+		return GetEffectiveMode(dt)
+	}
+	return dt.Mode
+}
+
 // ValidateConfigAgainstModules verifies the device trust configuration against
 // the current modules.
 // This method exists to provide feedback to users about invalid configurations,

--- a/lib/srv/session_control_test.go
+++ b/lib/srv/session_control_test.go
@@ -163,6 +163,10 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 		}
 		return idCtx
 	}
+	assertTrustedDeviceRequired := func(t *testing.T, _ context.Context, err error, _ *eventstest.MockRecorderEmitter) {
+		assert.ErrorContains(t, err, "device", "AcquireSessionContext returned an unexpected error")
+		assert.True(t, trace.IsAccessDenied(err), "AcquireSessionContext returned an error other than trace.AccessDeniedError: %T", err)
+	}
 
 	cases := []struct {
 		name      string
@@ -451,22 +455,17 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 			},
 		},
 		{
-			name:     "device extensions not enforced for OSS",
-			cfg:      cfgWithDeviceMode(constants.DeviceTrustModeRequired),
-			identity: minimalIdentity,
-			assertion: func(t *testing.T, _ context.Context, err error, _ *eventstest.MockRecorderEmitter) {
-				assert.NoError(t, err, "AcquireSessionContext returned an unexpected error")
-			},
+			name:      "device extensions enforced for OSS",
+			cfg:       cfgWithDeviceMode(constants.DeviceTrustModeRequired),
+			identity:  minimalIdentity,
+			assertion: assertTrustedDeviceRequired,
 		},
 		{
 			name:      "device extensions enforced for Enterprise",
 			buildType: modules.BuildEnterprise,
 			cfg:       cfgWithDeviceMode(constants.DeviceTrustModeRequired),
 			identity:  minimalIdentity,
-			assertion: func(t *testing.T, _ context.Context, err error, _ *eventstest.MockRecorderEmitter) {
-				assert.ErrorContains(t, err, "device", "AcquireSessionContext returned an unexpected error")
-				assert.True(t, trace.IsAccessDenied(err), "AcquireSessionContext returned an error other than trace.AccessDeniedError: %T", err)
-			},
+			assertion: assertTrustedDeviceRequired,
 		},
 		{
 			name:      "device extensions valid for Enterprise",


### PR DESCRIPTION
Backport #46940 to branch/v15

changelog: Enforce a global "device_trust.mode=required" on OSS processes paired with an Enterprise Auth
