### PR TITLE
update links for helm charts, tctl, teleport

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2589,6 +2589,11 @@
       "source": "/enroll-resources/machine-id/deployment/spacelift/",
       "destination": "/admin-guides/infrastructure-as-code/terraform-provider/spacelift/",
       "permanent": true
+    },
+    {
+      "source": "/kubernetes-access/helm/guides/",
+      "destination": "/admin-guides/deploy-a-cluster/helm-deployments/",
+      "permanent": true
     }
   ]
 }

--- a/docs/config.json
+++ b/docs/config.json
@@ -2594,6 +2594,16 @@
       "source": "/kubernetes-access/helm/guides/",
       "destination": "/admin-guides/deploy-a-cluster/helm-deployments/",
       "permanent": true
+    },
+    {
+      "source": "/desktop-access/",
+      "destination": "/enroll-resources/desktop-access/introduction/",
+      "permanent": true
+    },
+    {
+      "source": "/kubernetes-access/",
+      "destination": "/enroll-resources/kubernetes-access/introduction/",
+      "permanent": true
     }
   ]
 }

--- a/examples/chart/teleport-cluster/README.md
+++ b/examples/chart/teleport-cluster/README.md
@@ -37,9 +37,10 @@ or by installing [cert-manager](https://cert-manager.io/docs/) and setting the `
 
 ### Replicated setup guides
 
-- [Running an HA Teleport cluster in Kubernetes using an AWS EKS Cluster](https://goteleport.com/docs/deploy-a-cluster/helm-deployments/aws/)
-- [Running an HA Teleport cluster in Kubernetes using a Google Cloud GKE cluster](https://goteleport.com/docs/deploy-a-cluster/helm-deployments/gcp/)
-- [Running a Teleport cluster in Kubernetes with a custom Teleport config](https://goteleport.com/docs/deploy-a-cluster/helm-deployments/custom/)
+- [Running an HA Teleport cluster in Kubernetes using an AWS EKS Cluster](https://goteleport.com/docs/admin-guides/deploy-a-cluster/helm-deployments/aws/)
+- [Running an HA Teleport cluster in Kubernetes using an Google Cloud GKE cluster](https://goteleport.com/docs/admin-guides/deploy-a-cluster/helm-deployments/gcp/)
+- [Running an HA Teleport cluster in Kubernetes using an Azure AKS cluster](https://goteleport.com/docs/admin-guides/deploy-a-cluster/helm-deployments/azure/)
+- [Running a Teleport cluster in Kubernetes with a custom Teleport config](https://goteleport.com/docs/admin-guides/deploy-a-cluster/helm-deployments/custom/)
 
 ### Creating first user
 
@@ -59,7 +60,7 @@ helm uninstall --namespace teleport-cluster teleport-cluster
 
 ## Documentation
 
-See https://goteleport.com/docs/kubernetes-access/helm/guides/ for guides on setting up HA Teleport clusters
+See https://goteleport.com/docs/admin-guides/deploy-a-cluster/helm-deployments/ for guides on setting up HA Teleport clusters
 in EKS or GKE, plus a comprehensive chart reference.
 
 ## Contributing to the chart

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -49,7 +49,7 @@ teleportVersionOverride: ""
 # connection, but will accept it if present. This mode is considered insecure
 # and should only be used for testing purposes.
 #
-# See https://goteleport.com/docs/ver/14.x/management/security/proxy-protocol/
+# See https://goteleport.com/docs/admin-guides/management/security/proxy-protocol/
 # for more information.
 #
 # proxyProtocol: on


### PR DESCRIPTION
- fixes helm cluster link that was a 404
- updates links to current ones and add Azure AKS
- update v14 link to avoid losing link
- add redirects docs links for `tctl`, `teleport` used for k8s and desktop