### PR TITLE
[v16] docs: include fdpass-teleport for macos pkg install list

### DIFF
--- a/docs/pages/includes/cloud/install-macos.mdx
+++ b/docs/pages/includes/cloud/install-macos.mdx
@@ -2,7 +2,7 @@
 
   | Link                                                                                                      | Binaries                                   |
   |-----------------------------------------------------------------------------------------------------------|--------------------------------------------|
-  | [`teleport-ent-(=cloud.version=).pkg`](https://cdn.teleport.dev/teleport-ent-(=cloud.version=).pkg) | `teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot` |
+  | [`teleport-ent-(=cloud.version=).pkg`](https://cdn.teleport.dev/teleport-ent-(=cloud.version=).pkg) | `teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`<br/>`fdpass-teleport` |
   | [`tsh-(=cloud.version=).pkg`](https://cdn.teleport.dev/tsh-(=cloud.version=).pkg)                   | `tsh`                                      |
 
   You can also fetch an installer from the command line:

--- a/docs/pages/includes/enterprise/install-macos.mdx
+++ b/docs/pages/includes/enterprise/install-macos.mdx
@@ -2,7 +2,7 @@
 
   | Link                                                                                                      | Binaries                                   |
   |-----------------------------------------------------------------------------------------------------------|--------------------------------------------|
-  | [`teleport-ent-(=teleport.version=).pkg`](https://cdn.teleport.dev/teleport-ent-(=teleport.version=).pkg) | `teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot` |
+  | [`teleport-ent-(=teleport.version=).pkg`](https://cdn.teleport.dev/teleport-ent-(=teleport.version=).pkg) | `teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`<br/>`fdpass-teleport`|
   | [`tsh-(=teleport.version=).pkg`](https://cdn.teleport.dev/tsh-(=teleport.version=).pkg)                   | `tsh`                                      |
 
   You can also fetch an installer from the command line:

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -779,7 +779,7 @@ You can download one of the following .pkg installers for macOS:
 
   |Link|Binaries|
   |-|-|
-  |[`teleport-(=teleport.version=).pkg`](https://cdn.teleport.dev/teleport-(=teleport.version=).pkg)|`teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`|
+  |[`teleport-(=teleport.version=).pkg`](https://cdn.teleport.dev/teleport-(=teleport.version=).pkg)|`teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`<br/>`fdpass-teleport`|
   |[`tsh-(=teleport.version=).pkg`](https://cdn.teleport.dev/tsh-(=teleport.version=).pkg)|`tsh`|
 
   You can also fetch an installer via the command line:


### PR DESCRIPTION
Backport #46954 to branch/v16