### PR TITLE
feat: SSO MFA - Add SSO MFA ceremony

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -664,6 +664,9 @@ type Config struct {
 	// MFAPromptConstructor is used to create MFA prompts when needed.
 	// If nil, the client will not prompt for MFA.
 	MFAPromptConstructor mfa.PromptConstructor
+	// SSOMFACeremonyConstructor is used to handle SSO MFA when needed.
+	// If nil, the client will not prompt for MFA.
+	SSOMFACeremonyConstructor mfa.SSOMFACeremonyConstructor
 }
 
 // CheckAndSetDefaults checks and sets default config values.
@@ -728,6 +731,11 @@ func (c *Client) GetConnection() *grpc.ClientConn {
 // SetMFAPromptConstructor sets the MFA prompt constructor for this client.
 func (c *Client) SetMFAPromptConstructor(pc mfa.PromptConstructor) {
 	c.c.MFAPromptConstructor = pc
+}
+
+// SetSSOMFACeremonyConstructor sets the SSO MFA ceremony constructor for this client.
+func (c *Client) SetSSOMFACeremonyConstructor(scc mfa.SSOMFACeremonyConstructor) {
+	c.c.SSOMFACeremonyConstructor = scc
 }
 
 // Close closes the Client connection to the auth server.

--- a/api/client/mfa.go
+++ b/api/client/mfa.go
@@ -30,6 +30,7 @@ func (c *Client) PerformMFACeremony(ctx context.Context, challengeRequest *proto
 	mfaCeremony := &mfa.Ceremony{
 		CreateAuthenticateChallenge: c.CreateAuthenticateChallenge,
 		PromptConstructor:           c.c.MFAPromptConstructor,
+		SSOMFACeremonyConstructor:   c.c.SSOMFACeremonyConstructor,
 	}
 	return mfaCeremony.Run(ctx, challengeRequest, promptOpts...)
 }

--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -32,6 +32,17 @@ type Ceremony struct {
 	CreateAuthenticateChallenge CreateAuthenticateChallengeFunc
 	// PromptConstructor creates a prompt to prompt the user to solve an authentication challenge.
 	PromptConstructor PromptConstructor
+	// SSOMFACeremonyConstructor is an optional SSO MFA ceremony constructor. If provided,
+	// the MFA ceremony will also attempt to retrieve an SSO MFA challenge. The provided
+	// context will be closed once the ceremony is complete.
+	SSOMFACeremonyConstructor func(ctx context.Context) (SSOMFACeremony, error)
+}
+
+// SSOMFACeremony is an SSO MFA ceremony.
+type SSOMFACeremony interface {
+	GetClientCallbackURL() string
+	HandleRedirect(ctx context.Context, redirectURL string) error
+	GetCallbackMFAToken(ctx context.Context) (string, error)
 }
 
 // CreateAuthenticateChallengeFunc is a function that creates an authentication challenge.
@@ -52,6 +63,15 @@ func (c *Ceremony) Run(ctx context.Context, req *proto.CreateAuthenticateChallen
 		return nil, trace.BadParameter("missing challenge extensions")
 	case req.ChallengeExtensions.Scope == mfav1.ChallengeScope_CHALLENGE_SCOPE_UNSPECIFIED:
 		return nil, trace.BadParameter("mfa challenge scope must be specified")
+	}
+
+	if c.SSOMFACeremonyConstructor != nil {
+		ssoMFACeremony, err := c.SSOMFACeremonyConstructor(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err, "failed to handle SSO MFA ceremony")
+		}
+		req.SSOClientRedirectURL = ssoMFACeremony.GetClientCallbackURL()
+		promptOpts = append(promptOpts, withSSOMFACeremony(ssoMFACeremony))
 	}
 
 	chal, err := c.CreateAuthenticateChallenge(ctx, req)

--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -35,7 +35,7 @@ type Ceremony struct {
 	// SSOMFACeremonyConstructor is an optional SSO MFA ceremony constructor. If provided,
 	// the MFA ceremony will also attempt to retrieve an SSO MFA challenge. The provided
 	// context will be closed once the ceremony is complete.
-	SSOMFACeremonyConstructor func(ctx context.Context) (SSOMFACeremony, error)
+	SSOMFACeremonyConstructor SSOMFACeremonyConstructor
 }
 
 // SSOMFACeremony is an SSO MFA ceremony.
@@ -43,6 +43,9 @@ type SSOMFACeremony interface {
 	GetClientCallbackURL() string
 	Run(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error)
 }
+
+// SSOMFACeremonyConstructor constructs a new SSO MFA ceremony.
+type SSOMFACeremonyConstructor func(ctx context.Context) (SSOMFACeremony, error)
 
 // CreateAuthenticateChallengeFunc is a function that creates an authentication challenge.
 type CreateAuthenticateChallengeFunc func(ctx context.Context, req *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error)

--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -53,6 +53,9 @@ type CreateAuthenticateChallengeFunc func(ctx context.Context, req *proto.Create
 // req may be nil if ceremony.CreateAuthenticateChallenge does not require it, e.g. in
 // the moderated session mfa ceremony which uses a custom stream rpc to create challenges.
 func (c *Ceremony) Run(ctx context.Context, req *proto.CreateAuthenticateChallengeRequest, promptOpts ...PromptOpt) (*proto.MFAAuthenticateResponse, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	switch {
 	case c.CreateAuthenticateChallenge == nil:
 		return nil, trace.BadParameter("mfa ceremony must have CreateAuthenticateChallenge set in order to begin")

--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -41,8 +41,7 @@ type Ceremony struct {
 // SSOMFACeremony is an SSO MFA ceremony.
 type SSOMFACeremony interface {
 	GetClientCallbackURL() string
-	HandleRedirect(ctx context.Context, redirectURL string) error
-	GetCallbackMFAToken(ctx context.Context) (string, error)
+	Run(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error)
 }
 
 // CreateAuthenticateChallengeFunc is a function that creates an authentication challenge.
@@ -68,6 +67,8 @@ func (c *Ceremony) Run(ctx context.Context, req *proto.CreateAuthenticateChallen
 		return nil, trace.BadParameter("mfa challenge scope must be specified")
 	}
 
+	// If available, prepare an SSO MFA ceremony and set the client redirect URL in the challenge
+	// request to request an SSO challenge in addition to other challenges.
 	if c.SSOMFACeremonyConstructor != nil {
 		ssoMFACeremony, err := c.SSOMFACeremonyConstructor(ctx)
 		if err != nil {

--- a/api/mfa/ceremony_test.go
+++ b/api/mfa/ceremony_test.go
@@ -23,13 +23,14 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/mfa"
 )
 
-func TestPerformMFACeremony(t *testing.T) {
+func TestMFACeremony(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
@@ -127,4 +128,76 @@ func TestPerformMFACeremony(t *testing.T) {
 			tt.assertCeremonyResponse(t, resp, err)
 		})
 	}
+}
+
+func TestMFACeremony_SSO(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	testMFAChallenge := &proto.MFAAuthenticateChallenge{
+		SSOChallenge: &proto.SSOChallenge{
+			RedirectUrl: "redirect",
+			RequestId:   "request-id",
+		},
+	}
+	testMFAResponse := &proto.MFAAuthenticateResponse{
+		Response: &proto.MFAAuthenticateResponse_SSO{
+			SSO: &proto.SSOResponse{
+				Token:     "token",
+				RequestId: "request-id",
+			},
+		},
+	}
+
+	ssoMFACeremony := &mfa.Ceremony{
+		CreateAuthenticateChallenge: func(ctx context.Context, req *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error) {
+			return testMFAChallenge, nil
+		},
+		PromptConstructor: func(opts ...mfa.PromptOpt) mfa.Prompt {
+			cfg := new(mfa.PromptConfig)
+			for _, opt := range opts {
+				opt(cfg)
+			}
+
+			return mfa.PromptFunc(func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+				if cfg.SSOMFACeremony == nil {
+					return nil, trace.BadParameter("expected sso mfa ceremony")
+				}
+
+				return cfg.SSOMFACeremony.Run(ctx, chal)
+			})
+		},
+		SSOMFACeremonyConstructor: func(ctx context.Context) (mfa.SSOMFACeremony, error) {
+			return &mockSSOMFACeremony{
+				clientCallbackURL: "client-redirect",
+				prompt: func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+					return testMFAResponse, nil
+				},
+			}, nil
+		},
+	}
+
+	resp, err := ssoMFACeremony.Run(ctx, &proto.CreateAuthenticateChallengeRequest{
+		ChallengeExtensions: &mfav1.ChallengeExtensions{
+			Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_ADMIN_ACTION,
+		},
+		MFARequiredCheck: &proto.IsMFARequiredRequest{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, testMFAResponse, resp)
+}
+
+type mockSSOMFACeremony struct {
+	clientCallbackURL string
+	prompt            mfa.PromptFunc
+}
+
+// GetClientCallbackURL returns the client callback URL.
+func (m *mockSSOMFACeremony) GetClientCallbackURL() string {
+	return m.clientCallbackURL
+}
+
+// Run the SSO MFA ceremony.
+func (m *mockSSOMFACeremony) Run(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+	return m.prompt(ctx, chal)
 }

--- a/api/mfa/ceremony_test.go
+++ b/api/mfa/ceremony_test.go
@@ -201,3 +201,5 @@ func (m *mockSSOMFACeremony) GetClientCallbackURL() string {
 func (m *mockSSOMFACeremony) Run(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
 	return m.prompt(ctx, chal)
 }
+
+func (m *mockSSOMFACeremony) Close() {}

--- a/api/mfa/prompt.go
+++ b/api/mfa/prompt.go
@@ -54,6 +54,8 @@ type PromptConfig struct {
 	// Extensions are the challenge extensions used to create the prompt's challenge.
 	// Used to enrich certain prompts.
 	Extensions *mfav1.ChallengeExtensions
+	// SSOMFACeremony is an SSO MFA ceremony.
+	SSOMFACeremony
 }
 
 // DeviceDescriptor is a descriptor for a device, such as "registered".
@@ -115,5 +117,12 @@ func WithPromptDeviceType(deviceType DeviceDescriptor) PromptOpt {
 func WithPromptChallengeExtensions(exts *mfav1.ChallengeExtensions) PromptOpt {
 	return func(cfg *PromptConfig) {
 		cfg.Extensions = exts
+	}
+}
+
+// withSSOMFACeremony sets the SSO MFA ceremony for the MFA prompt.
+func withSSOMFACeremony(ssoMFACeremony SSOMFACeremony) PromptOpt {
+	return func(cfg *PromptConfig) {
+		cfg.SSOMFACeremony = ssoMFACeremony
 	}
 }

--- a/api/mfa/prompt.go
+++ b/api/mfa/prompt.go
@@ -55,7 +55,7 @@ type PromptConfig struct {
 	// Used to enrich certain prompts.
 	Extensions *mfav1.ChallengeExtensions
 	// SSOMFACeremony is an SSO MFA ceremony.
-	SSOMFACeremony
+	SSOMFACeremony SSOMFACeremony
 }
 
 // DeviceDescriptor is a descriptor for a device, such as "registered".

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -360,6 +360,9 @@ type Config struct {
 	// authenticators, such as remote hosts or virtual machines.
 	PreferOTP bool
 
+	// PreferSSO prefers SSO in favor of other MFA methods.
+	PreferSSO bool
+
 	// CheckVersions will check that client version is compatible
 	// with auth server version when connecting.
 	CheckVersions bool

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3046,6 +3046,8 @@ func (tc *TeleportClient) ConnectToCluster(ctx context.Context) (_ *ClusterClien
 		return nil, trace.NewAggregate(err, pclt.Close())
 	}
 	authClientCfg.MFAPromptConstructor = tc.NewMFAPrompt
+	authClientCfg.SSOMFACeremonyConstructor = tc.NewSSOMFACeremony
+
 	authClient, err := authclient.NewClient(authClientCfg)
 	if err != nil {
 		return nil, trace.NewAggregate(err, pclt.Close())
@@ -5065,9 +5067,10 @@ func (tc *TeleportClient) NewKubernetesServiceClient(ctx context.Context, cluste
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},
-		ALPNConnUpgradeRequired:  tc.TLSRoutingConnUpgradeRequired,
-		InsecureAddressDiscovery: tc.InsecureSkipVerify,
-		MFAPromptConstructor:     tc.NewMFAPrompt,
+		ALPNConnUpgradeRequired:   tc.TLSRoutingConnUpgradeRequired,
+		InsecureAddressDiscovery:  tc.InsecureSkipVerify,
+		MFAPromptConstructor:      tc.NewMFAPrompt,
+		SSOMFACeremonyConstructor: tc.NewSSOMFACeremony,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -498,9 +498,6 @@ type Config struct {
 	// If empty, a default CLI prompt is used.
 	CustomHardwareKeyPrompt keys.HardwareKeyPrompt
 
-	// SSOCeremonyConstructor is a custom SSO ceremony constructor to use.
-	SSOCeremonyConstructor func() *sso.Ceremony
-
 	// DisableSSHResumption disables transparent SSH connection resumption.
 	DisableSSHResumption bool
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -495,6 +495,9 @@ type Config struct {
 	// If empty, a default CLI prompt is used.
 	CustomHardwareKeyPrompt keys.HardwareKeyPrompt
 
+	// SSOCeremonyConstructor is a custom SSO ceremony constructor to use.
+	SSOCeremonyConstructor func() *sso.Ceremony
+
 	// DisableSSHResumption disables transparent SSH connection resumption.
 	DisableSSHResumption bool
 

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -361,8 +361,9 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 				tc: &TeleportClient{
 					localAgent: agent,
 					Config: Config{
-						SiteName: "test",
-						Tracer:   tracing.NoopTracer("test"),
+						WebProxyAddr: "proxy.example.com",
+						SiteName:     "test",
+						Tracer:       tracing.NoopTracer("test"),
 						MFAPromptConstructor: func(cfg *libmfa.PromptConfig) mfa.Prompt {
 							return test.prompt
 						},

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -33,6 +33,7 @@ func (tc *TeleportClient) NewMFACeremony() *mfa.Ceremony {
 	return &mfa.Ceremony{
 		CreateAuthenticateChallenge: tc.createAuthenticateChallenge,
 		PromptConstructor:           tc.NewMFAPrompt,
+		SSOMFACeremonyConstructor:   tc.newSSOMFACeremony,
 	}
 }
 

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -46,7 +46,7 @@ func (tc *TeleportClient) NewMFACeremony() *mfa.Ceremony {
 			}
 
 			context.AfterFunc(ctx, rd.Close)
-			return &sso.MFACeremony{Ceremony: sso.NewCLICeremony(rd, nil /*init*/)}, nil
+			return sso.NewCLIMFACeremony(rd), nil
 		},
 	}
 }

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -63,6 +63,7 @@ func (tc *TeleportClient) NewMFAPrompt(opts ...mfa.PromptOpt) mfa.Prompt {
 		PromptConfig:     *cfg,
 		Writer:           tc.Stderr,
 		PreferOTP:        tc.PreferOTP,
+		PreferSSO:        tc.PreferSSO,
 		AllowStdinHijack: tc.AllowStdinHijack,
 		StdinFunc:        tc.StdinFunc,
 	})

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -79,5 +79,6 @@ func (tc *TeleportClient) newPromptConfig(opts ...mfa.PromptOpt) *libmfa.PromptC
 		cfg.WebauthnLoginFunc = tc.WebauthnLogin
 		cfg.WebauthnSupported = true
 	}
+
 	return cfg
 }

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -98,6 +98,5 @@ func (tc *TeleportClient) NewSSOMFACeremony(ctx context.Context) (mfa.SSOMFACere
 		return nil, trace.Wrap(err)
 	}
 
-	context.AfterFunc(ctx, rd.Close)
 	return sso.NewCLIMFACeremony(rd), nil
 }

--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -326,21 +326,6 @@ func (w *webauthnPromptWithOTP) PromptPIN() (string, error) {
 }
 
 func (c *CLIPrompt) promptSSO(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
-	if err := c.cfg.SSOMFACeremony.HandleRedirect(ctx, chal.SSOChallenge.RedirectUrl); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	mfaToken, err := c.cfg.SSOMFACeremony.GetCallbackMFAToken(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return &proto.MFAAuthenticateResponse{
-		Response: &proto.MFAAuthenticateResponse_SSO{
-			SSO: &proto.SSOResponse{
-				RequestId: chal.SSOChallenge.RequestId,
-				Token:     mfaToken,
-			},
-		},
-	}, nil
+	resp, err := c.cfg.SSOMFACeremony.Run(ctx, chal)
+	return resp, trace.Wrap(err)
 }

--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -164,6 +164,10 @@ func (c *CLIPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 		chosenMethods = []string{cliMFATypeOTP}
 		promptWebauthn, promptSSO = false, false
 		userSpecifiedMethod = true
+	case c.cfg.AuthenticatorAttachment != wancli.AttachmentAuto:
+		chosenMethods = []string{cliMFATypeWebauthn}
+		promptSSO, promptOTP = false, false
+		userSpecifiedMethod = true
 	}
 
 	// Use stronger auth methods if hijack is not allowed.
@@ -176,10 +180,7 @@ func (c *CLIPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 	case promptWebauthn:
 		chosenMethods = []string{cliMFATypeWebauthn}
 		promptSSO = false
-
-		// If a specific webauthn attachment was requested, skip OTP.
-		// Otherwise, allow dual prompt with OTP.
-		promptOTP = promptOTP && c.cfg.AuthenticatorAttachment == wancli.AttachmentAuto
+		// Allow dual prompt with OTP.
 		if promptOTP {
 			chosenMethods = append(chosenMethods, cliMFATypeOTP)
 		}

--- a/lib/client/mfa/cli_test.go
+++ b/lib/client/mfa/cli_test.go
@@ -43,6 +43,7 @@ func TestCLIPrompt(t *testing.T) {
 		name                  string
 		stdin                 string
 		challenge             *proto.MFAAuthenticateChallenge
+		modifyPromptConfig    func(cfg *mfa.CLIPromptConfig)
 		expectErr             error
 		expectStdOut          string
 		expectResp            *proto.MFAAuthenticateResponse
@@ -65,7 +66,7 @@ func TestCLIPrompt(t *testing.T) {
 				},
 			},
 		}, {
-			name:         "OK totp",
+			name:         "OK otp",
 			expectStdOut: "Enter an OTP code from a device:\n",
 			stdin:        "123456",
 			challenge: &proto.MFAAuthenticateChallenge{
@@ -79,8 +80,134 @@ func TestCLIPrompt(t *testing.T) {
 				},
 			},
 		}, {
-			name:         "OK webauthn or totp choose webauthn",
-			expectStdOut: "Tap any security key or enter a code from a OTP device\n",
+			name:         "OK sso",
+			expectStdOut: "", // sso stdout is handled internally in the SSO ceremony, which is mocked in this test.
+			challenge: &proto.MFAAuthenticateChallenge{
+				SSOChallenge: &proto.SSOChallenge{},
+			},
+			expectResp: &proto.MFAAuthenticateResponse{
+				Response: &proto.MFAAuthenticateResponse_SSO{
+					SSO: &proto.SSOResponse{
+						RequestId: "request-id",
+						Token:     "mfa-token",
+					},
+				},
+			},
+		}, {
+			name:         "OK prefer otp when specified",
+			expectStdOut: "Enter an OTP code from a device:\n",
+			stdin:        "123456",
+			challenge: &proto.MFAAuthenticateChallenge{
+				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
+				TOTP:              &proto.TOTPChallenge{},
+				SSOChallenge:      &proto.SSOChallenge{},
+			},
+			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
+				cfg.PreferOTP = true
+			},
+			expectResp: &proto.MFAAuthenticateResponse{
+				Response: &proto.MFAAuthenticateResponse_TOTP{
+					TOTP: &proto.TOTPResponse{
+						Code: "123456",
+					},
+				},
+			},
+		}, {
+			name:         "OK prefer sso when specified",
+			expectStdOut: "",
+			challenge: &proto.MFAAuthenticateChallenge{
+				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
+				TOTP:              &proto.TOTPChallenge{},
+				SSOChallenge:      &proto.SSOChallenge{},
+			},
+			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
+				cfg.PreferSSO = true
+			},
+			expectResp: &proto.MFAAuthenticateResponse{
+				Response: &proto.MFAAuthenticateResponse_SSO{
+					SSO: &proto.SSOResponse{
+						RequestId: "request-id",
+						Token:     "mfa-token",
+					},
+				},
+			},
+		}, {
+			name: "OK prefer webauthn with authenticator attachment requested",
+			expectStdOut: "" +
+				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN.\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<sso,otp>.\n\n" +
+				"Tap any security key\n",
+			challenge: &proto.MFAAuthenticateChallenge{
+				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
+				TOTP:              &proto.TOTPChallenge{},
+				SSOChallenge:      &proto.SSOChallenge{},
+			},
+			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
+				cfg.AuthenticatorAttachment = wancli.AttachmentPlatform
+			},
+			expectResp: &proto.MFAAuthenticateResponse{
+				Response: &proto.MFAAuthenticateResponse_Webauthn{
+					Webauthn: &webauthnpb.CredentialAssertionResponse{},
+				},
+			},
+		},
+		{
+			name: "OK prefer webauthn over sso",
+			expectStdOut: "" +
+				"Available MFA methods [WEBAUTHN, SSO]. Continuing with WEBAUTHN.\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<sso,otp>.\n\n" +
+				"Tap any security key\n",
+			challenge: &proto.MFAAuthenticateChallenge{
+				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
+				SSOChallenge:      &proto.SSOChallenge{},
+			},
+			expectResp: &proto.MFAAuthenticateResponse{
+				Response: &proto.MFAAuthenticateResponse_Webauthn{
+					Webauthn: &webauthnpb.CredentialAssertionResponse{},
+				},
+			},
+		}, {
+			name: "OK prefer webauthn+otp over sso",
+			expectStdOut: "" +
+				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN and OTP.\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<sso,otp>.\n\n" +
+				"Tap any security key or enter a code from a OTP device\n",
+			challenge: &proto.MFAAuthenticateChallenge{
+				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
+				TOTP:              &proto.TOTPChallenge{},
+				SSOChallenge:      &proto.SSOChallenge{},
+			},
+			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
+				cfg.AllowStdinHijack = true
+			},
+			expectResp: &proto.MFAAuthenticateResponse{
+				Response: &proto.MFAAuthenticateResponse_Webauthn{
+					Webauthn: &webauthnpb.CredentialAssertionResponse{},
+				},
+			},
+		}, {
+			name: "OK prefer sso over otp",
+			expectStdOut: "" +
+				"Available MFA methods [SSO, OTP]. Continuing with SSO.\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<sso,otp>.\n\n",
+			challenge: &proto.MFAAuthenticateChallenge{
+				TOTP:         &proto.TOTPChallenge{},
+				SSOChallenge: &proto.SSOChallenge{},
+			},
+			expectResp: &proto.MFAAuthenticateResponse{
+				Response: &proto.MFAAuthenticateResponse_SSO{
+					SSO: &proto.SSOResponse{
+						RequestId: "request-id",
+						Token:     "mfa-token",
+					},
+				},
+			},
+		}, {
+			name: "OK prefer webauthn over otp when stdin hijack disallowed",
+			expectStdOut: "" +
+				"Available MFA methods [WEBAUTHN, OTP]. Continuing with WEBAUTHN.\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<sso,otp>.\n\n" +
+				"Tap any security key\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
 				TOTP:              &proto.TOTPChallenge{},
@@ -91,12 +218,38 @@ func TestCLIPrompt(t *testing.T) {
 				},
 			},
 		}, {
-			name:         "OK webauthn or totp choose totp",
-			expectStdOut: "Tap any security key or enter a code from a OTP device\n",
-			stdin:        "123456",
+			name: "OK webauthn or otp with stdin hijack allowed, choose webauthn",
+			expectStdOut: "" +
+				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN and OTP.\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<sso,otp>.\n\n" +
+				"Tap any security key or enter a code from a OTP device\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
 				TOTP:              &proto.TOTPChallenge{},
+				SSOChallenge:      &proto.SSOChallenge{},
+			},
+			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
+				cfg.AllowStdinHijack = true
+			},
+			expectResp: &proto.MFAAuthenticateResponse{
+				Response: &proto.MFAAuthenticateResponse_Webauthn{
+					Webauthn: &webauthnpb.CredentialAssertionResponse{},
+				},
+			},
+		}, {
+			name: "OK webauthn or otp with stdin hijack allowed, choose otp",
+			expectStdOut: "" +
+				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN and OTP.\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<sso,otp>.\n\n" +
+				"Tap any security key or enter a code from a OTP device\n",
+			stdin: "123456",
+			challenge: &proto.MFAAuthenticateChallenge{
+				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
+				TOTP:              &proto.TOTPChallenge{},
+				SSOChallenge:      &proto.SSOChallenge{},
+			},
+			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
+				cfg.AllowStdinHijack = true
 			},
 			expectResp: &proto.MFAAuthenticateResponse{
 				Response: &proto.MFAAuthenticateResponse_TOTP{
@@ -113,18 +266,28 @@ func TestCLIPrompt(t *testing.T) {
 			},
 			expectErr: context.DeadlineExceeded,
 		}, {
-			name:         "NOK no totp response",
+			name:         "NOK no sso response",
+			expectStdOut: "",
+			challenge: &proto.MFAAuthenticateChallenge{
+				SSOChallenge: &proto.SSOChallenge{},
+			},
+			expectErr: context.DeadlineExceeded,
+		}, {
+			name:         "NOK no otp response",
 			expectStdOut: "Enter an OTP code from a device:\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				TOTP: &proto.TOTPChallenge{},
 			},
 			expectErr: context.DeadlineExceeded,
 		}, {
-			name:         "NOK no webauthn or totp response",
+			name:         "NOK no webauthn or otp response",
 			expectStdOut: "Tap any security key or enter a code from a OTP device\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
 				TOTP:              &proto.TOTPChallenge{},
+			},
+			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
+				cfg.AllowStdinHijack = true
 			},
 			expectErr: context.DeadlineExceeded,
 		},
@@ -133,6 +296,9 @@ func TestCLIPrompt(t *testing.T) {
 			challenge: &proto.MFAAuthenticateChallenge{
 				TOTP:              &proto.TOTPChallenge{},
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
+			},
+			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
+				cfg.AllowStdinHijack = true
 			},
 			expectStdOut: `Tap any security key or enter a code from a OTP device
 Detected security key tap
@@ -185,6 +351,9 @@ Enter your security key PIN:
 				TOTP:              nil, // no TOTP challenge
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
 			},
+			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
+				cfg.AllowStdinHijack = true
+			},
 			stdin: "1234",
 			expectStdOut: `Tap any security key
 Detected security key tap
@@ -224,19 +393,27 @@ Enter your security key PIN:
 				}
 			},
 		},
+		{
+			name: "NOK webauthn and SSO not supported",
+			challenge: &proto.MFAAuthenticateChallenge{
+				SSOChallenge:      &proto.SSOChallenge{},
+				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
+			},
+			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
+				cfg.WebauthnSupported = false
+				cfg.SSOMFACeremony = nil
+			},
+			expectErr: trace.BadParameter("client does not support any available MFA methods [WEBAUTHN, SSO], see debug logs for details"),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 			defer cancel()
 
-			oldStdin := prompt.Stdin()
-			t.Cleanup(func() { prompt.SetStdin(oldStdin) })
-
 			stdin := prompt.NewFakeReader()
 			if tc.stdin != "" {
 				stdin.AddString(tc.stdin)
 			}
-			prompt.SetStdin(stdin)
 
 			cfg := mfa.NewPromptConfig("proxy.example.com")
 			cfg.WebauthnSupported = true
@@ -257,16 +434,26 @@ Enter your security key PIN:
 				}
 			}
 
+			cfg.SSOMFACeremony = &mockSSOMFACeremony{
+				mfaResp: tc.expectResp,
+			}
+
 			buffer := make([]byte, 0, 100)
 			out := bytes.NewBuffer(buffer)
 
-			prompt := mfa.NewCLIPromptV2(&mfa.CLIPromptConfig{
-				PromptConfig:     *cfg,
-				Writer:           out,
-				AllowStdinHijack: true,
-			})
-			resp, err := prompt.Run(ctx, tc.challenge)
+			cliPromptConfig := &mfa.CLIPromptConfig{
+				PromptConfig: *cfg,
+				Writer:       out,
+				StdinFunc: func() prompt.StdinReader {
+					return stdin
+				},
+			}
 
+			if tc.modifyPromptConfig != nil {
+				tc.modifyPromptConfig(cliPromptConfig)
+			}
+
+			resp, err := mfa.NewCLIPromptV2(cliPromptConfig).Run(ctx, tc.challenge)
 			if tc.expectErr != nil {
 				require.ErrorIs(t, err, tc.expectErr)
 			} else {
@@ -277,4 +464,23 @@ Enter your security key PIN:
 			require.Equal(t, tc.expectStdOut, out.String())
 		})
 	}
+}
+
+type mockSSOMFACeremony struct {
+	mfaResp *proto.MFAAuthenticateResponse
+}
+
+func (m *mockSSOMFACeremony) GetClientCallbackURL() string {
+	return ""
+}
+
+// Run the SSO MFA ceremony.
+func (m *mockSSOMFACeremony) Run(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+	if m.mfaResp == nil {
+		return nil, context.DeadlineExceeded
+	}
+	if m.mfaResp.GetSSO() == nil {
+		return nil, trace.BadParameter("expected an SSO response but got %T", m.mfaResp.Response)
+	}
+	return m.mfaResp, nil
 }

--- a/lib/client/mfa/cli_test.go
+++ b/lib/client/mfa/cli_test.go
@@ -132,11 +132,8 @@ func TestCLIPrompt(t *testing.T) {
 				},
 			},
 		}, {
-			name: "OK prefer webauthn with authenticator attachment requested",
-			expectStdOut: "" +
-				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN.\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<sso,otp>.\n\n" +
-				"Tap any security key\n",
+			name:         "OK prefer webauthn with authenticator attachment requested",
+			expectStdOut: "Tap any security key\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
 				TOTP:              &proto.TOTPChallenge{},
@@ -350,9 +347,6 @@ Enter your security key PIN:
 			challenge: &proto.MFAAuthenticateChallenge{
 				TOTP:              nil, // no TOTP challenge
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
-			},
-			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
-				cfg.AllowStdinHijack = true
 			},
 			stdin: "1234",
 			expectStdOut: `Tap any security key

--- a/lib/client/mfa/cli_test.go
+++ b/lib/client/mfa/cli_test.go
@@ -478,3 +478,5 @@ func (m *mockSSOMFACeremony) Run(ctx context.Context, chal *proto.MFAAuthenticat
 	}
 	return m.mfaResp, nil
 }
+
+func (m *mockSSOMFACeremony) Close() {}

--- a/lib/client/sso.go
+++ b/lib/client/sso.go
@@ -26,10 +26,26 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/utils/prompt"
 	"github.com/gravitational/teleport/lib/client/sso"
 	"github.com/gravitational/teleport/lib/utils"
 )
+
+func (tc *TeleportClient) newSSOMFACeremony(ctx context.Context) (mfa.SSOMFACeremony, error) {
+	rdConfig, err := tc.ssoRedirectorConfig(ctx, "" /*connectorDisplayName*/)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	rd, err := sso.NewRedirector(rdConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rd.Close()
+
+	return &sso.MFACeremony{Ceremony: sso.NewCLICeremony(rd, nil /*init*/)}, nil
+}
 
 // ssoRedirectorConfig returns a standard configured sso redirector for login.
 // A display name for the SSO connector can optionally be provided for minor UI improvements.

--- a/lib/client/sso.go
+++ b/lib/client/sso.go
@@ -26,26 +26,10 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/utils/prompt"
 	"github.com/gravitational/teleport/lib/client/sso"
 	"github.com/gravitational/teleport/lib/utils"
 )
-
-func (tc *TeleportClient) newSSOMFACeremony(ctx context.Context) (mfa.SSOMFACeremony, error) {
-	rdConfig, err := tc.ssoRedirectorConfig(ctx, "" /*connectorDisplayName*/)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	rd, err := sso.NewRedirector(rdConfig)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rd.Close()
-
-	return &sso.MFACeremony{Ceremony: sso.NewCLICeremony(rd, nil /*init*/)}, nil
-}
 
 // ssoRedirectorConfig returns a standard configured sso redirector for login.
 // A display name for the SSO connector can optionally be provided for minor UI improvements.

--- a/lib/client/sso/ceremony.go
+++ b/lib/client/sso/ceremony.go
@@ -52,6 +52,20 @@ func (c *Ceremony) Run(ctx context.Context) (*authclient.SSHLoginResponse, error
 	return resp, trace.Wrap(err)
 }
 
+// GetCallbackMFAResponse returns an SSO MFA auth response once the callback is complete.
+func (c *Ceremony) GetCallbackMFAToken(ctx context.Context) (string, error) {
+	loginResp, err := c.GetCallbackResponse(ctx)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	if loginResp.MFAToken == "" {
+		return "", trace.BadParameter("login response for SSO MFA flow missing MFA token")
+	}
+
+	return loginResp.MFAToken, nil
+}
+
 // NewCLICeremony creates a new CLI SSO ceremony from the given redirector.
 func NewCLICeremony(rd *Redirector, init CeremonyInit) *Ceremony {
 	return &Ceremony{

--- a/lib/client/sso/ceremony.go
+++ b/lib/client/sso/ceremony.go
@@ -97,6 +97,7 @@ func (m *MFACeremony) Run(ctx context.Context, chal *proto.MFAAuthenticateChalle
 	}, nil
 }
 
+// Close closes resources associated with the SSO MFA ceremony.
 func (m *MFACeremony) Close() {
 	if m.close != nil {
 		m.close()
@@ -104,6 +105,7 @@ func (m *MFACeremony) Close() {
 }
 
 // NewCLIMFACeremony creates a new CLI SSO ceremony from the given redirector.
+// The returned MFACeremony takes ownership of the Redirector.
 func NewCLIMFACeremony(rd *Redirector) *MFACeremony {
 	return &MFACeremony{
 		clientCallbackURL: rd.ClientCallbackURL,

--- a/lib/client/sso/ceremony_test.go
+++ b/lib/client/sso/ceremony_test.go
@@ -26,17 +26,20 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"testing"
-	"text/template"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/lib/client/sso"
 	"github.com/gravitational/teleport/lib/web"
 )
 
 func TestCLICeremony(t *testing.T) {
+	ctx := context.Background()
+
 	mockProxy := newMockProxy(t)
 	username := "alice"
 
@@ -69,7 +72,67 @@ func TestCLICeremony(t *testing.T) {
 		return mockIdPServer.URL, nil
 	})
 
-	template.New("Failed to open a browser window for login: %v\n")
+	// Modify handle redirect to also browse to the clickable URL printed to stderr.
+	baseHandleRedirect := ceremony.HandleRedirect
+	ceremony.HandleRedirect = func(ctx context.Context, redirectURL string) error {
+		if err := baseHandleRedirect(ctx, redirectURL); err != nil {
+			return trace.Wrap(err)
+		}
+
+		// Read the clickable url from stderr and navigate to it
+		// using a simplified regexp for http://127.0.0.1:<port>/<uuid>
+		clickableURLPattern := "http://127.0.0.1:.*/.*[0-9a-f]"
+		clickableURL := regexp.MustCompile(clickableURLPattern).Find(stderr.Bytes())
+
+		resp, err := http.Get(string(clickableURL))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		// User should be redirected to success screen.
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, sso.LoginSuccessRedirectURL, string(body))
+		return nil
+	}
+
+	loginResp, err := ceremony.Run(ctx)
+	require.NoError(t, err)
+	require.Equal(t, username, loginResp.Username)
+}
+
+func TestCLICeremony_MFA(t *testing.T) {
+	const token = "sso-mfa-token"
+	const requestID = "soo-mfa-request-id"
+
+	ctx := context.Background()
+	mockProxy := newMockProxy(t)
+
+	// Capture stderr.
+	stderr := bytes.NewBuffer([]byte{})
+
+	// Create a basic redirector.
+	rd, err := sso.NewRedirector(sso.RedirectorConfig{
+		ProxyAddr: mockProxy.URL,
+		Browser:   teleport.BrowserNone,
+		Stderr:    stderr,
+	})
+	require.NoError(t, err)
+	t.Cleanup(rd.Close)
+
+	// Construct a fake mfa response with the redirector's client callback URL.
+	successResponseURL, err := web.ConstructSSHResponse(web.AuthParams{
+		ClientRedirectURL: rd.ClientCallbackURL,
+		MFAToken:          token,
+	})
+	require.NoError(t, err)
+
+	// Open a mock IdP server which will handle a redirect and result in the expected IdP session payload.
+	mockIdPServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, successResponseURL.String(), http.StatusPermanentRedirect)
+	}))
+	t.Cleanup(mockIdPServer.Close)
+
+	ceremony := sso.NewCLIMFACeremony(rd)
 
 	// Modify handle redirect to also browse to the clickable URL printed to stderr.
 	baseHandleRedirect := ceremony.HandleRedirect
@@ -94,7 +157,14 @@ func TestCLICeremony(t *testing.T) {
 		return nil
 	}
 
-	loginResp, err := ceremony.Run(context.Background())
+	mfaResponse, err := ceremony.Run(ctx, &proto.MFAAuthenticateChallenge{
+		SSOChallenge: &proto.SSOChallenge{
+			RedirectUrl: mockIdPServer.URL,
+			RequestId:   requestID,
+		},
+	})
 	require.NoError(t, err)
-	require.Equal(t, username, loginResp.Username)
+	require.NotNil(t, mfaResponse.GetSSO())
+	assert.Equal(t, token, mfaResponse.GetSSO().Token)
+	assert.Equal(t, requestID, mfaResponse.GetSSO().RequestId)
 }

--- a/lib/client/sso/ceremony_test.go
+++ b/lib/client/sso/ceremony_test.go
@@ -132,6 +132,7 @@ func TestCLICeremony_MFA(t *testing.T) {
 	t.Cleanup(mockIdPServer.Close)
 
 	ceremony := sso.NewCLIMFACeremony(rd)
+	defer rd.Close()
 
 	// Modify handle redirect to also browse to the clickable URL printed to stderr.
 	baseHandleRedirect := ceremony.HandleRedirect

--- a/lib/client/sso/ceremony_test.go
+++ b/lib/client/sso/ceremony_test.go
@@ -44,7 +44,7 @@ func TestCLICeremony(t *testing.T) {
 	username := "alice"
 
 	// Capture stderr.
-	stderr := bytes.NewBuffer([]byte{})
+	stderr := &bytes.Buffer{}
 
 	// Create a basic redirector.
 	rd, err := sso.NewRedirector(sso.RedirectorConfig{
@@ -81,10 +81,9 @@ func TestCLICeremony(t *testing.T) {
 
 		// Read the clickable url from stderr and navigate to it
 		// using a simplified regexp for http://127.0.0.1:<port>/<uuid>
-		clickableURLPattern := "http://127.0.0.1:.*/.*[0-9a-f]"
-		clickableURL := regexp.MustCompile(clickableURLPattern).Find(stderr.Bytes())
-
-		resp, err := http.Get(string(clickableURL))
+		const clickableURLPattern = `^http://127.0.0.1:\d+/[0-9A-Fa-f-]+$`
+		clickableURL := regexp.MustCompile(clickableURLPattern).FindString(stderr.String())
+		resp, err := http.Get(clickableURL)
 		require.NoError(t, err)
 		defer resp.Body.Close()
 

--- a/lib/client/sso/ceremony_test.go
+++ b/lib/client/sso/ceremony_test.go
@@ -116,7 +116,6 @@ func TestCLICeremony_MFA(t *testing.T) {
 		Stderr:    stderr,
 	})
 	require.NoError(t, err)
-	t.Cleanup(rd.Close)
 
 	// Construct a fake mfa response with the redirector's client callback URL.
 	successResponseURL, err := web.ConstructSSHResponse(web.AuthParams{
@@ -132,6 +131,7 @@ func TestCLICeremony_MFA(t *testing.T) {
 	t.Cleanup(mockIdPServer.Close)
 
 	ceremony := sso.NewCLIMFACeremony(rd)
+	t.Cleanup(ceremony.Close)
 
 	// Modify handle redirect to also browse to the clickable URL printed to stderr.
 	baseHandleRedirect := ceremony.HandleRedirect

--- a/lib/client/sso/ceremony_test.go
+++ b/lib/client/sso/ceremony_test.go
@@ -28,8 +28,8 @@ import (
 	"testing"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"

--- a/lib/client/sso/ceremony_test.go
+++ b/lib/client/sso/ceremony_test.go
@@ -81,7 +81,7 @@ func TestCLICeremony(t *testing.T) {
 
 		// Read the clickable url from stderr and navigate to it
 		// using a simplified regexp for http://127.0.0.1:<port>/<uuid>
-		const clickableURLPattern = `^http://127.0.0.1:\d+/[0-9A-Fa-f-]+$`
+		const clickableURLPattern = `http://127.0.0.1:\d+/[0-9A-Fa-f-]+`
 		clickableURL := regexp.MustCompile(clickableURLPattern).FindString(stderr.String())
 		resp, err := http.Get(clickableURL)
 		require.NoError(t, err)
@@ -132,7 +132,6 @@ func TestCLICeremony_MFA(t *testing.T) {
 	t.Cleanup(mockIdPServer.Close)
 
 	ceremony := sso.NewCLIMFACeremony(rd)
-	defer rd.Close()
 
 	// Modify handle redirect to also browse to the clickable URL printed to stderr.
 	baseHandleRedirect := ceremony.HandleRedirect

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -268,7 +268,6 @@ func TryRun(commands []CLICommand, args []string) error {
 			return nil, trace.Wrap(err)
 		}
 
-		context.AfterFunc(ctx, rd.Close)
 		return sso.NewCLIMFACeremony(rd), nil
 	})
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -118,6 +118,8 @@ const (
 	mfaModePlatform = "platform"
 	// mfaModeOTP utilizes only OTP devices.
 	mfaModeOTP = "otp"
+	// mfaModeSSO utilizes only SSO devices.
+	mfaModeSSO = "sso"
 )
 
 const (
@@ -766,7 +768,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	app.Flag("bind-addr", "Override host:port used when opening a browser for cluster logins").Envar(bindAddrEnvVar).StringVar(&cf.BindAddr)
 	app.Flag("callback", "Override the base URL (host:port) of the link shown when opening a browser for cluster logins. Must be used with --bind-addr.").StringVar(&cf.CallbackAddr)
 	app.Flag("browser-login", browserHelp).Hidden().Envar(browserEnvVar).StringVar(&cf.Browser)
-	modes := []string{mfaModeAuto, mfaModeCrossPlatform, mfaModePlatform, mfaModeOTP}
+	modes := []string{mfaModeAuto, mfaModeCrossPlatform, mfaModePlatform, mfaModeOTP, mfaModeSSO}
 	app.Flag("mfa-mode", fmt.Sprintf("Preferred mode for MFA and Passwordless assertions (%v)", strings.Join(modes, ", "))).
 		Default(mfaModeAuto).
 		Envar(mfaModeEnvVar).
@@ -4253,6 +4255,7 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 	}
 	c.AuthenticatorAttachment = mfaOpts.AuthenticatorAttachment
 	c.PreferOTP = mfaOpts.PreferOTP
+	c.PreferSSO = mfaOpts.PreferSSO
 
 	// If agent forwarding was specified on the command line enable it.
 	c.ForwardAgent = options.ForwardAgent
@@ -4434,6 +4437,7 @@ func (c *CLIConf) GetProfile() (*profile.Profile, error) {
 type mfaModeOpts struct {
 	AuthenticatorAttachment wancli.AuthenticatorAttachment
 	PreferOTP               bool
+	PreferSSO               bool
 }
 
 func parseMFAMode(mode string) (*mfaModeOpts, error) {
@@ -4446,6 +4450,8 @@ func parseMFAMode(mode string) (*mfaModeOpts, error) {
 		opts.AuthenticatorAttachment = wancli.AttachmentPlatform
 	case mfaModeOTP:
 		opts.PreferOTP = true
+	case mfaModeSSO:
+		opts.PreferSSO = true
 	default:
 		return nil, fmt.Errorf("invalid MFA mode: %q", mode)
 	}


### PR DESCRIPTION
Part of the implementation of [SSO MFA](https://github.com/gravitational/teleport/pull/44699)

Changelog: Support SSO as a second factor method in CLI clients (`tsh` and `tctl`). This is an opt-in feature.

Changes:
- Add an optional SSO ceremony into the MFA ceremony to enable SSO MFA. 
- Implement SSO CLI prompt with the [UX proposed](https://github.com/gravitational/teleport/blob/fc888eb9e36c875853efa40d3ddffbed2e1e7f65/rfd/0180-sso-mfa.md#tsh) in the RFD.

The Teleport Connect and WebUI implementations of the SSO MFA prompt will be added in follow up PRs.

Depends on https://github.com/gravitational/teleport/pull/47684, https://github.com/gravitational/teleport/pull/47874