### PR TITLE
Enforce MFA for Admin Actions when OTP is disabled

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -372,10 +372,10 @@ func (c *AuthPreferenceV2) IsSecondFactorWebauthnAllowed() bool {
 		c.Spec.SecondFactor == constants.SecondFactorOn
 }
 
-// IsAdminActionMFAEnforced checks if admin action MFA is enforced. Currently, the only
-// prerequisite for admin action MFA enforcement is whether Webauthn is enforced.
+// IsAdminActionMFAEnforced checks if admin action MFA is enforced.
 func (c *AuthPreferenceV2) IsAdminActionMFAEnforced() bool {
-	return c.Spec.SecondFactor == constants.SecondFactorWebauthn
+	// OTP is not supported for Admin MFA.
+	return c.IsSecondFactorEnforced() && !c.IsSecondFactorTOTPAllowed()
 }
 
 // GetConnectorName gets the name of the OIDC or SAML connector to use. If


### PR DESCRIPTION
Follow up to https://github.com/gravitational/teleport/pull/37136 to enforce MFA for Admin Actions when MFA is required and OTP is disabled. Functionally this extends enforcement from `second_factor: webauthn` to `second_factor: on` w/ webauthn configured.

Changelog: Enforce MFA for Admin Actions when OTP is disabled.