### PR TITLE
docs: update api user

### DIFF
--- a/docs/pages/admin-guides/api/getting-started.mdx
+++ b/docs/pages/admin-guides/api/getting-started.mdx
@@ -31,7 +31,6 @@ Here are the steps we'll walkthrough:
 Create a user `api-admin` with the built-in role `editor`:
 
 ```code
-# Add a user and login with that user
 $ tctl users add api-admin --roles=editor
 ```
 

--- a/docs/pages/admin-guides/api/getting-started.mdx
+++ b/docs/pages/admin-guides/api/getting-started.mdx
@@ -31,9 +31,8 @@ Here are the steps we'll walkthrough:
 Create a user `api-admin` with the built-in role `editor`:
 
 ```code
-# Run this directly on your Auth Server unless you are using Teleport Cloud
-# Add a user and login via the Proxy Service
-$ sudo tctl users add api-admin --roles=editor
+# Add a user and login with that user
+$ tctl users add api-admin --roles=editor
 ```
 
 ## Step 2/3. Generate client credentials


### PR DESCRIPTION
Remove `sudo`. Recommend using the remote `tctl` access as default.