### PR TITLE
display all security group rules for a port range

### DIFF
--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/SingleEnrollment.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/SingleEnrollment.tsx
@@ -201,7 +201,7 @@ export function SingleEnrollment({
     <>
       {showTable && (
         <>
-          <Text mt={3}>Select an RDS to enroll:</Text>
+          <Text mt={3}>Select an RDS database to enroll:</Text>
           <DatabaseList
             wantAutoDiscover={false}
             items={tableData?.items || []}

--- a/web/packages/teleport/src/Discover/Shared/SecurityGroupPicker/SecurityGroupPicker.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SecurityGroupPicker/SecurityGroupPicker.tsx
@@ -27,6 +27,7 @@ import { FetchStatus } from 'design/DataTable/types';
 import { Attempt } from 'shared/hooks/useAttemptNext';
 
 import { SecurityGroup } from 'teleport/services/integrations';
+import { SecurityGroupRule } from 'teleport/services/integrations';
 
 import { SecurityGroupRulesDialog } from './SecurityGroupRulesDialog';
 
@@ -43,7 +44,8 @@ type Props = {
 };
 
 export type ViewRulesSelection = {
-  sg: SecurityGroup;
+  name: string;
+  rules: ExpandedSecurityGroupRule[];
   ruleType: 'inbound' | 'outbound';
 };
 
@@ -102,15 +104,20 @@ export const SecurityGroupPicker = ({
             altKey: 'inboundRules',
             headerText: 'Inbound Rules',
             render: sg => {
+              const rules = expandSecurityGroupRules(sg.inboundRules);
               return (
                 <Cell>
                   <Link
                     style={{ cursor: 'pointer' }}
                     onClick={() =>
-                      setViewRulesSelection({ sg, ruleType: 'inbound' })
+                      setViewRulesSelection({
+                        name: sg.name,
+                        rules: rules,
+                        ruleType: 'inbound',
+                      })
                     }
                   >
-                    View ({sg.inboundRules.length})
+                    View ({rules.length})
                   </Link>
                 </Cell>
               );
@@ -120,15 +127,20 @@ export const SecurityGroupPicker = ({
             altKey: 'outboundRules',
             headerText: 'Outbound Rules',
             render: sg => {
+              const rules = expandSecurityGroupRules(sg.outboundRules);
               return (
                 <Cell>
                   <Link
                     style={{ cursor: 'pointer' }}
                     onClick={() =>
-                      setViewRulesSelection({ sg, ruleType: 'outbound' })
+                      setViewRulesSelection({
+                        name: sg.name,
+                        rules: rules,
+                        ruleType: 'outbound',
+                      })
                     }
                   >
-                    View ({sg.outboundRules.length})
+                    View ({rules.length})
                   </Link>
                 </Cell>
               );
@@ -176,4 +188,40 @@ function CheckboxCell({
       </Flex>
     </Cell>
   );
+}
+
+type ExpandedSecurityGroupRule = {
+  // IPProtocol is the protocol used to describe the rule.
+  ipProtocol: string;
+  // FromPort is the inclusive start of the Port range for the Rule.
+  fromPort: string;
+  // ToPort is the inclusive end of the Port range for the Rule.
+  toPort: string;
+  // Source is IP range, security group ID, or prefix list that the rule applies to.
+  source: string;
+  // Description contains a small text describing the source.
+  description: string;
+};
+
+// expandSecurityGroupRule takes a security group rule in the compact form that
+// AWS API returns, wherein rules are grouped by port range, and expands the
+// rule into a list of rules that is not grouped by port range.
+// This is the same display format that the AWS console uses when you view a
+// security group's rules.
+function expandSecurityGroupRule(
+  rule: SecurityGroupRule
+): ExpandedSecurityGroupRule[] {
+  return rule.cidrs.map(source => ({
+    ipProtocol: rule.ipProtocol,
+    fromPort: rule.fromPort,
+    toPort: rule.toPort,
+    source: source.cidr,
+    description: source.description,
+  }));
+}
+
+function expandSecurityGroupRules(
+  rules: SecurityGroupRule[]
+): ExpandedSecurityGroupRule[] {
+  return rules.flatMap(rule => expandSecurityGroupRule(rule));
 }

--- a/web/packages/teleport/src/Discover/Shared/SecurityGroupPicker/SecurityGroupRulesDialog.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SecurityGroupPicker/SecurityGroupRulesDialog.tsx
@@ -32,8 +32,7 @@ export function SecurityGroupRulesDialog({
   viewRulesSelection: ViewRulesSelection;
   onClose: () => void;
 }) {
-  const { ruleType, sg } = viewRulesSelection;
-  const data = ruleType === 'inbound' ? sg.inboundRules : sg.outboundRules;
+  const { name, rules, ruleType } = viewRulesSelection;
 
   return (
     <Dialog disableEscapeKeyDown={false} open={true}>
@@ -44,11 +43,10 @@ export function SecurityGroupRulesDialog({
         textAlign="center"
       >
         <H2 mb={4}>
-          {ruleType === 'inbound' ? 'Inbound' : 'Outbound'} Rules for [{sg.name}
-          ]
+          {ruleType === 'inbound' ? 'Inbound' : 'Outbound'} Rules for [{name}]
         </H2>
         <StyledTable
-          data={data}
+          data={rules}
           columns={[
             {
               key: 'ipProtocol',
@@ -67,12 +65,9 @@ export function SecurityGroupRulesDialog({
             {
               altKey: 'source',
               headerText: 'Source',
-              render: ({ cidrs }) => {
-                // The AWS API returns an array, however it appears it's not actually possible to have multiple CIDR's for a single rule.
-                // As a fallback we just display the first one.
-                const cidr = cidrs[0];
-                if (cidr) {
-                  return <Cell>{cidr.cidr}</Cell>;
+              render: ({ source }) => {
+                if (source) {
+                  return <Cell>{source}</Cell>;
                 }
                 return null;
               },
@@ -80,10 +75,9 @@ export function SecurityGroupRulesDialog({
             {
               altKey: 'description',
               headerText: 'Description',
-              render: ({ cidrs }) => {
-                const cidr = cidrs[0];
-                if (cidr) {
-                  return <Cell>{cidr.description}</Cell>;
+              render: ({ description }) => {
+                if (description) {
+                  return <Cell>{description}</Cell>;
                 }
                 return null;
               },

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -319,7 +319,7 @@ const cfg = {
     awsRdsDbRequiredVpcsPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/requireddatabasesvpcs',
     awsDatabaseVpcsPath:
-      '/webapi/sites/:clusterId/integrations/aws-oidc/:name/databasevpcs',
+      '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/databasevpcs',
     awsRdsDbListPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/databases',
     awsDeployTeleportServicePath:


### PR DESCRIPTION
Changelog: Fixed a bug where only one IP CIDR block security group rule for a port range was displayed in the web UI RDS enrollment wizard when viewing a security group.

Part of:
- #46620

This fixes the web ui to display all of the rules for each port range.
There's another part to that issue that requires a change in the backend code so that we render security group reference rules, but that's for another PR.

## UI Diff

I have an aws security group that has two rules, both of which allow inbound access from an IP address on postgres port 5432.

### Before

![sg-display-before](https://github.com/user-attachments/assets/87e1c05d-58f3-4fef-9e75-331f58963cb6)

### After

![sg-display-after](https://github.com/user-attachments/assets/468179ab-313a-47a5-a0aa-6a102543f246)

