### PR TITLE
docs: update server access guides

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/jetbrains-sftp.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/jetbrains-sftp.mdx
@@ -12,7 +12,7 @@ This guide explains how to use Teleport and a JetBrains IDE to access files with
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+(!docs/pages/includes/edition-prereqs-tabs-not-admin.mdx!)
 
 - JetBrains IDE like PyCharm, IntelliJ, GoLand etc. See [Products](https://www.jetbrains.com/products/#type=ide) for a full list of JetBrains IDEs.
 - One or more Teleport SSH Service instances. If you have not yet done this,

--- a/docs/pages/enroll-resources/server-access/guides/vscode.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/vscode.mdx
@@ -8,7 +8,7 @@ This guide explains how to use Teleport and Visual Studio Code's remote SSH exte
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+(!docs/pages/includes/edition-prereqs-tabs-not-admin.mdx!)
 
 - OpenSSH client.
 - Visual Studio Code with the [Remote - SSH extension](https://code.visualstudio.com/docs/remote/ssh#_system-requirements)

--- a/docs/pages/includes/edition-prereqs-tabs-not-admin.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs-not-admin.mdx
@@ -1,0 +1,10 @@
+{{ version="(=teleport.version=)" }}
+
+- A running Teleport cluster version {{ version }} or above. If you want to get started with Teleport, [sign
+  up](https://goteleport.com/signup) for a free trial or [set up a demo
+  environment](../admin-guides/deploy-a-cluster/linux-demo.mdx).
+
+- The `tsh` client tool.
+
+  Visit [Installation](../installation.mdx) for instructions on downloading
+  `tsh`.


### PR DESCRIPTION
Guides specified that `tctl` admin tool was required. But it is never used.