### PR TITLE
Add optional pagerPosition prop to device table

### DIFF
--- a/web/packages/teleport/src/DeviceTrust/types.ts
+++ b/web/packages/teleport/src/DeviceTrust/types.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { PagerPosition } from 'design/DataTable/types';
+
 export type TrustedDevice = {
   id: string;
   assetTag: string;
@@ -33,6 +35,7 @@ export type TrustedDeviceResponse = {
 export type DeviceListProps = {
   items: TrustedDeviceResponse['items'];
   pageSize?: number;
+  pagerPosition?: PagerPosition;
   fetchStatus?: 'loading' | 'disabled' | '';
   fetchData?: () => void;
 };


### PR DESCRIPTION
This adds an optional prop that is required for the new empty state tables (coming in an `e` PR)