### PR TITLE
[v14] chore: Bump Go to v1.22.8

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.22.7
+GOLANG_VERSION ?= go1.22.8
 GOLANGCI_LINT_VERSION ?= v1.61.0
 
 NODE_VERSION ?= 20.14.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gravitational/teleport
 
 go 1.21
 
-toolchain go1.22.7
+toolchain go1.22.8
 
 require (
 	cloud.google.com/go/compute v1.25.0


### PR DESCRIPTION
Update Go to the latest patch.

* https://go.dev/doc/devel/release#go1.22.8

Changelog: Updated Go to 1.22.8