### PR TITLE
[v16] fix: Update operator CRD docs

### DIFF
--- a/docs/pages/reference/operator-resources/resources.teleport.dev_rolesv6.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_rolesv6.mdx
@@ -341,7 +341,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |create_db_user_mode|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop". Can be either the string or the integer representation of each option.|
 |create_desktop_user|boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
 |create_host_user|boolean|CreateHostUser allows users to be automatically created on a host|
-|create_host_user_default_shell|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users. Availible in version 16.4.0 and later.|
+|create_host_user_default_shell|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
 |create_host_user_mode|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop". Can be either the string or the integer representation of each option.|
 |desktop_clipboard|boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|
 |desktop_directory_sharing|boolean|DesktopDirectorySharing indicates whether directory sharing is allowed between the user's workstation and the remote desktop. It defaults to false unless explicitly set to true.|


### PR DESCRIPTION
Done using `make -C integrations/operator crd-docs`.

Backports #46973