### PR TITLE
Display user friendly name of resources with preview_as_roles

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -4122,6 +4122,7 @@ func GetResourcesWithFilters(ctx context.Context, clt ListResourcesClient, req p
 			SearchKeywords:      req.SearchKeywords,
 			PredicateExpression: req.PredicateExpression,
 			UseSearchAsRoles:    req.UseSearchAsRoles,
+			UsePreviewAsRoles:   req.UsePreviewAsRoles,
 		})
 		if err != nil {
 			if trace.IsLimitExceeded(err) {


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/42424

This configures the `UsePreviewAsRoles` option when requesting a list of resources. Without this option, the client does not request user friendly names of resources in access requests.

changelog: fixes an issue preventing access requests from displaying user friendly resource names.