### PR TITLE
Increase feature slider height for smallest screens

### DIFF
--- a/web/packages/shared/components/EmptyState/EmptyState.tsx
+++ b/web/packages/shared/components/EmptyState/EmptyState.tsx
@@ -55,7 +55,7 @@ export const FeatureContainer = styled(Flex)`
   @media (max-width: 1302px) {
     --feature-slider-width: 372px;
     --feature-width: 372px;
-    --feature-height: 112px;
+    --feature-height: 120px;
     --feature-preview-scale: scale(0.7);
     --feature-text-display: inline;
   }


### PR DESCRIPTION
In our empty state pages, we have this neat purple frame that slides over each feature. This gets very slightly wonky if the feature text is a bit too long. This just bumps up the height for the smallest screens to give a bit more breathing room to the text.

Before 
![Screenshot 2024-10-01 at 2 22 41 PM](https://github.com/user-attachments/assets/18e07a9a-b803-46a3-b3fe-5bd1695cd0de)

After
![Screenshot 2024-10-01 at 2 22 50 PM](https://github.com/user-attachments/assets/b940181a-00c1-4f30-b423-11f2c21a6dc1)
