### PR TITLE
all: use package filepath for file paths

### DIFF
--- a/api/client/credentials_test.go
+++ b/api/client/credentials_test.go
@@ -27,7 +27,6 @@ import (
 	"log"
 	"math/big"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 	"time"
@@ -445,7 +444,7 @@ Private-MAC: 8951bbe929e0714a61df01bc8fbc5223e3688f174aee29339931984fb9224c7d`)
 
 func TestDynamicIdentityFileCreds(t *testing.T) {
 	dir := t.TempDir()
-	identityPath := path.Join(dir, "identity")
+	identityPath := filepath.Join(dir, "identity")
 
 	idFile := &identityfile.IdentityFile{
 		PrivateKey: keyPEM,

--- a/build.assets/tooling/cmd/difftest/ast.go
+++ b/build.assets/tooling/cmd/difftest/ast.go
@@ -69,7 +69,7 @@ func findAllSuiteRunners(repoPath string, filename []string) (RunnersMap, error)
 
 	// Find all affected directories
 	for _, f := range filename {
-		dir := path.Join(repoPath, path.Dir(f))
+		dir := filepath.Join(repoPath, path.Dir(f))
 		s[dir] = struct{}{}
 	}
 
@@ -77,7 +77,7 @@ func findAllSuiteRunners(repoPath string, filename []string) (RunnersMap, error)
 
 	// Find all test files in affected directoriees
 	for dir := range s {
-		matches, err := filepath.Glob(path.Join(dir, "*_test.go"))
+		matches, err := filepath.Glob(filepath.Join(dir, "*_test.go"))
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/build.assets/tooling/cmd/difftest/main.go
+++ b/build.assets/tooling/cmd/difftest/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -244,7 +243,7 @@ func inspect(repoPath string, ref string, changedFiles []string, fn func(string,
 			}
 		}
 
-		head, err := parseMethodMap(path.Join(repoPath, filename), nil, runners)
+		head, err := parseMethodMap(filepath.Join(repoPath, filename), nil, runners)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/build.assets/tooling/cmd/notarize-apple-binaries/gon_wrapper.go
+++ b/build.assets/tooling/cmd/notarize-apple-binaries/gon_wrapper.go
@@ -21,7 +21,7 @@ package main
 import (
 	"context"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/go-hclog"
@@ -65,7 +65,7 @@ func (gw *GonWrapper) SignAndNotarizeBinaries() error {
 	if err != nil {
 		return trace.Wrap(err, "failed to zip binaries for notarization")
 	}
-	defer os.RemoveAll(path.Dir(zipPath))
+	defer os.RemoveAll(filepath.Dir(zipPath))
 
 	err = gw.NotarizeBinaries(zipPath)
 	if err != nil {
@@ -99,7 +99,7 @@ func (gw *GonWrapper) ZipBinaries() (string, error) {
 		return "", trace.Wrap(err, "failed to create temporary directory for binary zipping")
 	}
 
-	outputPath := path.Join(tmpDir, zipFileName)
+	outputPath := filepath.Join(tmpDir, zipFileName)
 	gw.logger.Debug("Using binary zip path %q", outputPath)
 
 	err = zip.Zip(gw.ctx, &zip.Options{

--- a/examples/dynamoathenamigration/migration_test.go
+++ b/examples/dynamoathenamigration/migration_test.go
@@ -24,7 +24,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -62,7 +62,7 @@ func TestMigrateProcessDataObjects(t *testing.T) {
 			Logger:          utils.NewLoggerForTests(),
 			NoOfEmitWorkers: 5,
 			bufferSize:      10,
-			CheckpointPath:  path.Join(t.TempDir(), "migration-tests.json"),
+			CheckpointPath:  filepath.Join(t.TempDir(), "migration-tests.json"),
 		},
 	}
 	err := mt.ProcessDataObjects(ctx, &exportInfo{
@@ -133,7 +133,7 @@ func TestLargeEventsParse(t *testing.T) {
 			Logger:          utils.NewLoggerForTests(),
 			NoOfEmitWorkers: 5,
 			bufferSize:      10,
-			CheckpointPath:  path.Join(t.TempDir(), "migration-tests.json"),
+			CheckpointPath:  filepath.Join(t.TempDir(), "migration-tests.json"),
 		},
 	}
 	err := mt.ProcessDataObjects(ctx, &exportInfo{
@@ -223,7 +223,7 @@ func TestMigrationCheckpoint(t *testing.T) {
 		Logger:          utils.NewLoggerForTests(),
 		NoOfEmitWorkers: noOfWorkers,
 		bufferSize:      noOfWorkers * 5,
-		CheckpointPath:  path.Join(t.TempDir(), "migration-tests.json"),
+		CheckpointPath:  filepath.Join(t.TempDir(), "migration-tests.json"),
 	}
 
 	t.Run("no migration checkpoint, emit every event", func(t *testing.T) {

--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"os"
 	"os/user"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -170,8 +170,8 @@ func TestRootUsernameLimit(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	utmpPath := path.Join(dir, "utmp")
-	wtmpPath := path.Join(dir, "wtmp")
+	utmpPath := filepath.Join(dir, "utmp")
+	wtmpPath := filepath.Join(dir, "wtmp")
 
 	err := TouchFile(utmpPath)
 	require.NoError(t, err)
@@ -287,9 +287,9 @@ func newSrvCtx(ctx context.Context, t *testing.T) *SrvCtx {
 	require.NoError(t, err)
 
 	uaccDir := t.TempDir()
-	utmpPath := path.Join(uaccDir, "utmp")
-	wtmpPath := path.Join(uaccDir, "wtmp")
-	btmpPath := path.Join(uaccDir, "btmp")
+	utmpPath := filepath.Join(uaccDir, "utmp")
+	wtmpPath := filepath.Join(uaccDir, "wtmp")
+	btmpPath := filepath.Join(uaccDir, "btmp")
 	require.NoError(t, TouchFile(utmpPath))
 	require.NoError(t, TouchFile(wtmpPath))
 	require.NoError(t, TouchFile(btmpPath))

--- a/integrations/event-handler/cli_test.go
+++ b/integrations/event-handler/cli_test.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -47,13 +47,13 @@ func TestStartCmdConfig(t *testing.T) {
 					FluentdConfig: FluentdConfig{
 						FluentdURL:        "https://localhost:8888/test.log",
 						FluentdSessionURL: "https://localhost:8888/session",
-						FluentdCert:       path.Join(wd, "testdata", "fake-file"),
-						FluentdKey:        path.Join(wd, "testdata", "fake-file"),
-						FluentdCA:         path.Join(wd, "testdata", "fake-file"),
+						FluentdCert:       filepath.Join(wd, "testdata", "fake-file"),
+						FluentdKey:        filepath.Join(wd, "testdata", "fake-file"),
+						FluentdCA:         filepath.Join(wd, "testdata", "fake-file"),
 					},
 					TeleportConfig: TeleportConfig{
 						TeleportAddr:            "localhost:3025",
-						TeleportIdentityFile:    path.Join(wd, "testdata", "fake-file"),
+						TeleportIdentityFile:    filepath.Join(wd, "testdata", "fake-file"),
 						TeleportRefreshEnabled:  true,
 						TeleportRefreshInterval: 2 * time.Minute,
 					},
@@ -85,13 +85,13 @@ func TestStartCmdConfig(t *testing.T) {
 					FluentdConfig: FluentdConfig{
 						FluentdURL:        "https://localhost:8888/test.log",
 						FluentdSessionURL: "https://localhost:8888/session",
-						FluentdCert:       path.Join(wd, "testdata", "fake-file"),
-						FluentdKey:        path.Join(wd, "testdata", "fake-file"),
-						FluentdCA:         path.Join(wd, "testdata", "fake-file"),
+						FluentdCert:       filepath.Join(wd, "testdata", "fake-file"),
+						FluentdKey:        filepath.Join(wd, "testdata", "fake-file"),
+						FluentdCA:         filepath.Join(wd, "testdata", "fake-file"),
 					},
 					TeleportConfig: TeleportConfig{
 						TeleportAddr:            "localhost:3025",
-						TeleportIdentityFile:    path.Join(wd, "testdata", "fake-file"),
+						TeleportIdentityFile:    filepath.Join(wd, "testdata", "fake-file"),
 						TeleportRefreshEnabled:  true,
 						TeleportRefreshInterval: 2 * time.Minute,
 					},
@@ -123,13 +123,13 @@ func TestStartCmdConfig(t *testing.T) {
 					FluentdConfig: FluentdConfig{
 						FluentdURL:        "https://localhost:8888/test.log",
 						FluentdSessionURL: "https://localhost:8888/session",
-						FluentdCert:       path.Join(wd, "testdata", "fake-file"),
-						FluentdKey:        path.Join(wd, "testdata", "fake-file"),
-						FluentdCA:         path.Join(wd, "testdata", "fake-file"),
+						FluentdCert:       filepath.Join(wd, "testdata", "fake-file"),
+						FluentdKey:        filepath.Join(wd, "testdata", "fake-file"),
+						FluentdCA:         filepath.Join(wd, "testdata", "fake-file"),
 					},
 					TeleportConfig: TeleportConfig{
 						TeleportAddr:            "localhost:3025",
-						TeleportIdentityFile:    path.Join(wd, "testdata", "fake-file"),
+						TeleportIdentityFile:    filepath.Join(wd, "testdata", "fake-file"),
 						TeleportRefreshEnabled:  true,
 						TeleportRefreshInterval: 2 * time.Minute,
 					},

--- a/integrations/event-handler/configure_cmd.go
+++ b/integrations/event-handler/configure_cmd.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"math/big"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -119,15 +118,15 @@ const (
 func RunConfigureCmd(cfg *ConfigureCmdConfig) error {
 	c := ConfigureCmd{
 		ConfigureCmdConfig: cfg,
-		caCertPath:         path.Join(cfg.Out, cfg.CAName) + ".crt",
-		caKeyPath:          path.Join(cfg.Out, cfg.CAName) + ".key",
-		serverCertPath:     path.Join(cfg.Out, cfg.ServerName) + ".crt",
-		serverKeyPath:      path.Join(cfg.Out, cfg.ServerName) + ".key",
-		clientCertPath:     path.Join(cfg.Out, cfg.ClientName) + ".crt",
-		clientKeyPath:      path.Join(cfg.Out, cfg.ClientName) + ".key",
-		roleDefPath:        path.Join(cfg.Out, roleDefFileName),
-		fluentdConfPath:    path.Join(cfg.Out, fluentdConfFileName),
-		confPath:           path.Join(cfg.Out, confFileName),
+		caCertPath:         filepath.Join(cfg.Out, cfg.CAName) + ".crt",
+		caKeyPath:          filepath.Join(cfg.Out, cfg.CAName) + ".key",
+		serverCertPath:     filepath.Join(cfg.Out, cfg.ServerName) + ".crt",
+		serverKeyPath:      filepath.Join(cfg.Out, cfg.ServerName) + ".key",
+		clientCertPath:     filepath.Join(cfg.Out, cfg.ClientName) + ".crt",
+		clientKeyPath:      filepath.Join(cfg.Out, cfg.ClientName) + ".key",
+		roleDefPath:        filepath.Join(cfg.Out, roleDefFileName),
+		fluentdConfPath:    filepath.Join(cfg.Out, fluentdConfFileName),
+		confPath:           filepath.Join(cfg.Out, confFileName),
 	}
 
 	g, err := GenerateMTLSCerts(cfg.DNSNames, cfg.IP, cfg.TTL, cfg.Length)
@@ -347,9 +346,9 @@ func (c *ConfigureCmd) writeFluentdConf(pwd string) error {
 		ServerKeyFileName  string
 		Pwd                string
 	}{
-		path.Base(c.caCertPath),
-		path.Base(c.serverCertPath),
-		path.Base(c.serverKeyPath),
+		filepath.Base(c.caCertPath),
+		filepath.Base(c.serverCertPath),
+		filepath.Base(c.serverKeyPath),
 		pwd,
 	}
 

--- a/integrations/event-handler/fake_fluentd_test.go
+++ b/integrations/event-handler/fake_fluentd_test.go
@@ -25,7 +25,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -73,12 +73,12 @@ func (f *FakeFluentd) writeCerts() error {
 		return trace.Wrap(err)
 	}
 
-	f.caCertPath = path.Join(f.keyTmpDir, "ca.crt")
-	f.caKeyPath = path.Join(f.keyTmpDir, "ca.key")
-	f.serverCertPath = path.Join(f.keyTmpDir, "server.crt")
-	f.serverKeyPath = path.Join(f.keyTmpDir, "server.key")
-	f.clientCertPath = path.Join(f.keyTmpDir, "client.crt")
-	f.clientKeyPath = path.Join(f.keyTmpDir, "client.key")
+	f.caCertPath = filepath.Join(f.keyTmpDir, "ca.crt")
+	f.caKeyPath = filepath.Join(f.keyTmpDir, "ca.key")
+	f.serverCertPath = filepath.Join(f.keyTmpDir, "server.crt")
+	f.serverKeyPath = filepath.Join(f.keyTmpDir, "server.key")
+	f.clientCertPath = filepath.Join(f.keyTmpDir, "client.crt")
+	f.clientKeyPath = filepath.Join(f.keyTmpDir, "client.key")
 
 	err = g.CACert.WriteFile(f.caCertPath, f.caKeyPath, "")
 	if err != nil {

--- a/integrations/event-handler/mtls_certs_test.go
+++ b/integrations/event-handler/mtls_certs_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/pem"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -60,9 +60,9 @@ func TestGenerateClientCertFile(t *testing.T) {
 	require.Equal(t, "localhost", certs.serverCert.DNSNames[0])
 
 	// Write the cert to the tempdir
-	err = certs.ClientCert.WriteFile(path.Join(td, cp), path.Join(td, kp), ".")
+	err = certs.ClientCert.WriteFile(filepath.Join(td, cp), filepath.Join(td, kp), ".")
 	require.NoError(t, err)
-	f, err := os.Open(path.Join(td, cp))
+	f, err := os.Open(filepath.Join(td, cp))
 	require.NoError(t, err)
 	b, err := io.ReadAll(f)
 	require.NoError(t, err)

--- a/integrations/event-handler/state.go
+++ b/integrations/event-handler/state.go
@@ -23,7 +23,7 @@ import (
 	"io/fs"
 	"net"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -110,10 +110,10 @@ func createStorageDir(c *StartCmdConfig) (string, error) {
 			return "", trace.Wrap(err)
 		}
 
-		dir = path.Join(dir, "dry_run", rs)
+		dir = filepath.Join(dir, "dry_run", rs)
 	}
 
-	dir = path.Join(c.StorageDir, dir)
+	dir = filepath.Join(c.StorageDir, dir)
 
 	_, err = os.Stat(dir)
 	if os.IsNotExist(err) {

--- a/integrations/lib/tar/extract.go
+++ b/integrations/lib/tar/extract.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -116,10 +115,10 @@ func Extract(reader io.Reader, options ExtractOptions) error {
 			if strip > len(parts)-1 {
 				strip = len(parts) - 1
 			}
-			outFileName = path.Join(parts[strip:]...)
+			outFileName = filepath.Join(parts[strip:]...)
 		}
 
-		outFilePath := path.Join(outDir, outFileName)
+		outFilePath := filepath.Join(outDir, outFileName)
 		outFilePerm := os.FileMode(header.Mode).Perm()
 
 		// fail if the outFilePath is outside outDir, see the "zip slip" vulnerability

--- a/lib/backend/pgbk/common/gcp_test.go
+++ b/lib/backend/pgbk/common/gcp_test.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -79,7 +79,7 @@ func Test_makeGCPCloudSQLAuthOptionsForServiceAccount(t *testing.T) {
 func mustSetGoogleApplicationCredentialsEnv(t *testing.T) {
 	t.Helper()
 
-	file := path.Join(t.TempDir(), uuid.New().String())
+	file := filepath.Join(t.TempDir(), uuid.New().String())
 	err := os.WriteFile(file, []byte(fakeServiceAccountCredentialsJSON), 0644)
 	require.NoError(t, err)
 

--- a/lib/cgroup/cgroup_test.go
+++ b/lib/cgroup/cgroup_test.go
@@ -23,7 +23,7 @@ package cgroup
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
@@ -62,7 +62,7 @@ func TestRootCreate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Make sure that it exists.
-	cgroupPath := path.Join(service.teleportRoot, sessionID)
+	cgroupPath := filepath.Join(service.teleportRoot, sessionID)
 	require.DirExists(t, cgroupPath)
 
 	// Remove cgroup.
@@ -112,7 +112,7 @@ func TestRootCreateCustomRootPath(t *testing.T) {
 			err = service.Create(sessionID)
 			require.NoError(t, err)
 
-			cgroupPath := path.Join(service.teleportRoot, sessionID)
+			cgroupPath := filepath.Join(service.teleportRoot, sessionID)
 			require.DirExists(t, cgroupPath)
 			require.Contains(t, cgroupPath, rootPath)
 
@@ -159,7 +159,7 @@ func TestRootCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// Make sure the cgroup no longer exists.
-	cgroupPath := path.Join(service.teleportRoot, sessionID)
+	cgroupPath := filepath.Join(service.teleportRoot, sessionID)
 	require.NoDirExists(t, cgroupPath)
 }
 
@@ -181,7 +181,7 @@ func TestRootSkipUnmount(t *testing.T) {
 	require.NoError(t, err)
 
 	sessionID := uuid.NewString()
-	sessionPath := path.Join(service.teleportRoot, sessionID)
+	sessionPath := filepath.Join(service.teleportRoot, sessionID)
 	require.NoError(t, service.Create(sessionID))
 
 	require.DirExists(t, sessionPath)
@@ -190,7 +190,7 @@ func TestRootSkipUnmount(t *testing.T) {
 	require.NoError(t, service.Close(skipUnmount))
 
 	require.DirExists(t, service.teleportRoot)
-	require.NoDirExists(t, path.Join(service.teleportRoot, sessionID))
+	require.NoDirExists(t, filepath.Join(service.teleportRoot, sessionID))
 
 	require.NoError(t, service.unmount())
 

--- a/lib/client/db/dbcmd/dbcmd.go
+++ b/lib/client/db/dbcmd/dbcmd.go
@@ -24,7 +24,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -697,7 +697,7 @@ func (c *CLICommandBuilder) getOpenSearchCLICommand() (*exec.Cmd, error) {
 			c.profile.DatabaseKeyPathForCluster(c.tc.SiteName, c.db.ServiceName))
 	}
 
-	baseDir := path.Join(c.profile.Dir, c.profile.Cluster, c.db.ServiceName)
+	baseDir := filepath.Join(c.profile.Dir, c.profile.Cluster, c.db.ServiceName)
 	tempCfg, err := opensearch.WriteConfig(baseDir, cfg)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/db/opensearch/profile.go
+++ b/lib/client/db/opensearch/profile.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
@@ -104,14 +104,14 @@ func WriteConfig(baseDir string, cfg Config) (string, error) {
 	hash := h.Sum32()
 
 	// create config directory if it doesn't exist
-	configDir := path.Join(baseDir, "opensearch-cli")
+	configDir := filepath.Join(baseDir, "opensearch-cli")
 	err = os.MkdirAll(configDir, 0700)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
 
 	// write config to file
-	fn := path.Join(configDir, fmt.Sprintf("%x.yml", hash))
+	fn := filepath.Join(configDir, fmt.Sprintf("%x.yml", hash))
 	err = os.WriteFile(fn, bytes, 0600)
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/lib/client/db/opensearch/profile_test.go
+++ b/lib/client/db/opensearch/profile_test.go
@@ -20,7 +20,7 @@ package opensearch
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -67,7 +67,7 @@ func TestWriteConfig(t *testing.T) {
 	tmp := t.TempDir()
 	fn, err := WriteConfig(tmp, ConfigNoTLS("host.example.com", 8080))
 	require.NoError(t, err)
-	require.Equal(t, path.Join(tmp, "opensearch-cli", "150502df.yml"), fn)
+	require.Equal(t, filepath.Join(tmp, "opensearch-cli", "150502df.yml"), fn)
 	bytes, err := os.ReadFile(fn)
 	require.NoError(t, err)
 	require.Equal(t, `profiles:

--- a/lib/client/tshconfig_test.go
+++ b/lib/client/tshconfig_test.go
@@ -20,7 +20,7 @@ package client
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
@@ -55,7 +55,7 @@ func TestLoadAllConfigs(t *testing.T) {
 	t.Parallel()
 
 	writeConf := func(fn string, config TSHConfig) {
-		dir, _ := path.Split(fn)
+		dir, _ := filepath.Split(fn)
 		err := os.MkdirAll(dir, 0777)
 		require.NoError(t, err)
 		out, err := yaml.Marshal(config)
@@ -66,7 +66,7 @@ func TestLoadAllConfigs(t *testing.T) {
 
 	tmp := t.TempDir()
 
-	globalPath := path.Join(tmp, "etc", "tsh_global.yaml")
+	globalPath := filepath.Join(tmp, "etc", "tsh_global.yaml")
 	globalConf := TSHConfig{
 		ExtraHeaders: []ExtraProxyHeaders{{
 			Proxy:   "global",
@@ -74,8 +74,8 @@ func TestLoadAllConfigs(t *testing.T) {
 		}},
 	}
 
-	homeDir := path.Join(tmp, "home", "myuser", ".tsh")
-	userPath := path.Join(homeDir, "config", "config.yaml")
+	homeDir := filepath.Join(tmp, "home", "myuser", ".tsh")
+	userPath := filepath.Join(homeDir, "config", "config.yaml")
 	userConf := TSHConfig{
 		ExtraHeaders: []ExtraProxyHeaders{{
 			Proxy:   "user",

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -2998,7 +2997,7 @@ func TestDatabaseCLIFlags(t *testing.T) {
 
 func TestTLSCert(t *testing.T) {
 	tmpDir := t.TempDir()
-	tmpCA := path.Join(tmpDir, "ca.pem")
+	tmpCA := filepath.Join(tmpDir, "ca.pem")
 
 	err := os.WriteFile(tmpCA, fixtures.LocalhostCert, 0o644)
 	require.NoError(t, err)

--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -28,7 +28,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -538,8 +538,8 @@ func fetchNodeAutoDiscoverLabels(ctx context.Context, imdsClient imds.Client) (m
 }
 
 // buildAbsoluteFilePath creates the absolute file path
-func (ani *AutoDiscoverNodeInstaller) buildAbsoluteFilePath(filepath string) string {
-	return path.Join(ani.fsRootPrefix, filepath)
+func (ani *AutoDiscoverNodeInstaller) buildAbsoluteFilePath(path string) string {
+	return filepath.Join(ani.fsRootPrefix, path)
 }
 
 // linuxDistribution reads the current file system to detect the Linux Distro and Version of the current system.

--- a/lib/srv/server/installer/autodiscover_test.go
+++ b/lib/srv/server/installer/autodiscover_test.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -71,20 +71,20 @@ func buildMockBins(t *testing.T) (map[string]*bintest.Mock, packagemanager.Binar
 }
 
 func setupDirsForTest(t *testing.T, testTempDir string, distroConfig map[string]string) {
-	require.NoError(t, os.MkdirAll(path.Join(testTempDir, "/etc"), fs.ModePerm))
-	require.NoError(t, os.MkdirAll(path.Join(testTempDir, "/usr/local/bin"), fs.ModePerm))
-	require.NoError(t, os.MkdirAll(path.Join(testTempDir, "/usr/share"), fs.ModePerm))
-	require.NoError(t, os.MkdirAll(path.Join(testTempDir, "/var/lock"), fs.ModePerm))
+	require.NoError(t, os.MkdirAll(filepath.Join(testTempDir, "etc"), fs.ModePerm))
+	require.NoError(t, os.MkdirAll(filepath.Join(testTempDir, "usr/local/bin"), fs.ModePerm))
+	require.NoError(t, os.MkdirAll(filepath.Join(testTempDir, "usr/share"), fs.ModePerm))
+	require.NoError(t, os.MkdirAll(filepath.Join(testTempDir, "var/lock"), fs.ModePerm))
 
 	for fileName, contents := range distroConfig {
 		isDir := strings.HasSuffix(fileName, "/")
 		if isDir {
 			require.Empty(t, contents, "expected no contents for directory %q", fileName)
-			require.NoError(t, os.MkdirAll(path.Join(testTempDir, fileName), fs.ModePerm))
+			require.NoError(t, os.MkdirAll(filepath.Join(testTempDir, fileName), fs.ModePerm))
 		} else {
-			filePathWithoutParent := path.Base(fileName)
-			require.NoError(t, os.MkdirAll(path.Join(testTempDir, filePathWithoutParent), fs.ModePerm))
-			require.NoError(t, os.WriteFile(path.Join(testTempDir, fileName), []byte(contents), fs.ModePerm))
+			filePathWithoutParent := filepath.Base(fileName)
+			require.NoError(t, os.MkdirAll(filepath.Join(testTempDir, filePathWithoutParent), fs.ModePerm))
+			require.NoError(t, os.WriteFile(filepath.Join(testTempDir, fileName), []byte(contents), fs.ModePerm))
 		}
 	}
 }

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -27,7 +27,7 @@ import (
 	"io"
 	"os"
 	"os/user"
-	"path"
+	"path/filepath"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -1747,8 +1747,8 @@ func (s *session) newFileTransferRequest(params *rsession.FileTransferRequestPar
 }
 
 func (s *session) expandFileTransferRequestPath(p string) (string, error) {
-	expanded := path.Clean(p)
-	dir := path.Dir(expanded)
+	expanded := filepath.Clean(p)
+	dir := filepath.Dir(expanded)
 
 	var tildePrefixed bool
 	var noBaseDir bool
@@ -1775,11 +1775,11 @@ func (s *session) expandFileTransferRequestPath(p string) (string, error) {
 
 		if tildePrefixed {
 			// expand home dir to make an absolute path
-			expanded = path.Join(homeDir, expanded[2:])
+			expanded = filepath.Join(homeDir, expanded[2:])
 		} else {
 			// if no directories are specified SFTP will assume the file
 			// to be in the user's home dir
-			expanded = path.Join(homeDir, expanded)
+			expanded = filepath.Join(homeDir, expanded)
 		}
 	}
 

--- a/lib/tbot/output_utils.go
+++ b/lib/tbot/output_utils.go
@@ -24,7 +24,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
-	"path"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -75,9 +75,9 @@ type BotConfigWriter struct {
 // WriteFile writes the file to the Destination. Only the basename of the path
 // is used. Specified permissions are ignored.
 func (b *BotConfigWriter) WriteFile(name string, data []byte, _ os.FileMode) error {
-	p := path.Base(name)
+	p := filepath.Base(name)
 	if b.subpath != "" {
-		p = path.Join(b.subpath, p)
+		p = filepath.Join(b.subpath, p)
 	}
 
 	return trace.Wrap(b.dest.Write(b.ctx, p, data))

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -971,8 +971,8 @@ func TestBotSSHMultiplexer(t *testing.T) {
 	currentUser, err := user.Current()
 	require.NoError(t, err)
 
-	// 104 length limit on UDS on MacOS forces us to use a custom tmpdir.
-	tmpDir := path.Join(os.TempDir(), t.Name())
+	// 104 length limit on UDS on macOS forces us to use a custom tmpdir.
+	tmpDir := filepath.Join(os.TempDir(), t.Name())
 	require.NoError(t, os.RemoveAll(tmpDir))
 	require.NoError(t, os.Mkdir(tmpDir, 0777))
 	t.Cleanup(func() {

--- a/lib/utils/packagemanager/apt.go
+++ b/lib/utils/packagemanager/apt.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -125,8 +125,8 @@ func (pm *APT) AddTeleportRepository(ctx context.Context, linuxInfo *linux.OSRel
 		return trace.Wrap(err)
 	}
 
-	aptTeleportSourceListFile := path.Join(pm.fsRootPrefix, aptTeleportSourceListFileRelative)
-	aptTeleportPublicKeyFile := path.Join(pm.fsRootPrefix, aptTeleportPublicKeyFileRelative)
+	aptTeleportSourceListFile := filepath.Join(pm.fsRootPrefix, aptTeleportSourceListFileRelative)
+	aptTeleportPublicKeyFile := filepath.Join(pm.fsRootPrefix, aptTeleportPublicKeyFileRelative)
 	// Format for teleport repo entry should look like this:
 	// deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} $RepoChannel"
 	teleportRepoMetadata := fmt.Sprintf("deb [signed-by=%s] %s%s %s %s", aptTeleportPublicKeyFile, aptRepoEndpoint, linuxInfo.ID, linuxInfo.VersionCodename, repoChannel)

--- a/tool/tbot/systemd_test.go
+++ b/tool/tbot/systemd_test.go
@@ -24,7 +24,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -40,7 +40,7 @@ func TestInstallSystemdCmd(t *testing.T) {
 
 	// Create pre-existing file to test --force
 	preExistingDir := t.TempDir()
-	err := os.WriteFile(path.Join(preExistingDir, "tbot.service"), []byte("pre-existing"), 0644)
+	err := os.WriteFile(filepath.Join(preExistingDir, "tbot.service"), []byte("pre-existing"), 0644)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -128,14 +128,14 @@ func TestInstallSystemdCmd(t *testing.T) {
 			if tt.wantStdout {
 				// Ensure that in dry run, no actual output is written!
 				_, err = os.ReadFile(
-					path.Join(dirPath, fmt.Sprintf("%s.service", cmp.Or(tt.wantUnitName, "tbot"))),
+					filepath.Join(dirPath, fmt.Sprintf("%s.service", cmp.Or(tt.wantUnitName, "tbot"))),
 				)
 				require.ErrorIs(t, err, os.ErrNotExist)
 				data = stdout.Bytes()
 				data = bytes.ReplaceAll(data, []byte(dirPath), []byte("/test/dir"))
 			} else {
 				data, err = os.ReadFile(
-					path.Join(dirPath, fmt.Sprintf("%s.service", cmp.Or(tt.wantUnitName, "tbot"))),
+					filepath.Join(dirPath, fmt.Sprintf("%s.service", cmp.Or(tt.wantUnitName, "tbot"))),
 				)
 				require.NoError(t, err)
 			}

--- a/tool/tctl/sso/configure/flags/file_reader_test.go
+++ b/tool/tctl/sso/configure/flags/file_reader_test.go
@@ -19,7 +19,7 @@ package flags
 import (
 	"math/rand"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -34,13 +34,13 @@ func TestFileReader(t *testing.T) {
 	tmp := t.TempDir()
 
 	// running against non-existing file returns error, does not change the stored value
-	fn := path.Join(tmp, "does-not-exist.txt")
+	fn := filepath.Join(tmp, "does-not-exist.txt")
 	err := reader.Set(fn)
 	require.Error(t, err)
 	require.Equal(t, "initial", out)
 
 	// lots of ones...
-	fn = path.Join(tmp, "ones.txt")
+	fn = filepath.Join(tmp, "ones.txt")
 	ones := strings.Repeat("1", 1024*1024)
 	err = os.WriteFile(fn, []byte(ones), 0777)
 	require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestFileReader(t *testing.T) {
 	require.Equal(t, ones, out)
 
 	// random string
-	fn = path.Join(tmp, "random.txt")
+	fn = filepath.Join(tmp, "random.txt")
 	src := rand.NewSource(time.Now().UnixNano())
 	buf := make([]byte, 1024*1024)
 	for ix := range buf {

--- a/tool/tctl/sso/configure/saml_test.go
+++ b/tool/tctl/sso/configure/saml_test.go
@@ -19,7 +19,7 @@ package configure
 import (
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -50,10 +50,10 @@ V115UGOwvjOOxmOFbYBn865SHgMndFtr</ds:X509Certificate></ds:X509Data></ds:KeyInfo>
 
 	dir := t.TempDir()
 
-	edBadFile := path.Join(dir, "entity_descriptor_bad.xml")
+	edBadFile := filepath.Join(dir, "entity_descriptor_bad.xml")
 	require.NoError(t, os.WriteFile(edBadFile, []byte("foo bar baz"), 0777))
 
-	edGoodFile := path.Join(dir, "entity_descriptor_good.xml")
+	edGoodFile := filepath.Join(dir, "entity_descriptor_good.xml")
 	require.NoError(t, os.WriteFile(edGoodFile, []byte(edOk), 0777))
 
 	tests := []struct {

--- a/tool/tsh/common/app_azure.go
+++ b/tool/tsh/common/app_azure.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -155,7 +155,7 @@ func (a *azureApp) GetEnvVars() (map[string]string, error) {
 		// 1. `tsh az login` in one console
 		// 2. `az ...` in another console
 		// without custom config dir the second invocation will hang, attempting to connect to (inaccessible without configuration) MSI.
-		"AZURE_CONFIG_DIR": path.Join(profile.FullProfilePath(a.cf.HomePath), "azure", a.appInfo.RouteToApp.ClusterName, a.appInfo.RouteToApp.Name),
+		"AZURE_CONFIG_DIR": filepath.Join(profile.FullProfilePath(a.cf.HomePath), "azure", a.appInfo.RouteToApp.ClusterName, a.appInfo.RouteToApp.Name),
 		// setting MSI_ENDPOINT instructs Azure CLI to make managed identity calls on this address.
 		// the requests will be handled by tsh proxy.
 		"MSI_ENDPOINT": "https://" + types.TeleportAzureMSIEndpoint + "/" + a.msiSecret,

--- a/tool/tsh/common/app_azure_test.go
+++ b/tool/tsh/common/app_azure_test.go
@@ -27,7 +27,7 @@ import (
 	"net/http"
 	"net/url"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -161,9 +161,9 @@ func TestAzure(t *testing.T) {
 				return ""
 			}
 
-			require.Equal(t, path.Join(tmpHomePath, "azure/localhost/azure-api"), getEnvValue("AZURE_CONFIG_DIR"))
+			require.Equal(t, filepath.Join(tmpHomePath, "azure/localhost/azure-api"), getEnvValue("AZURE_CONFIG_DIR"))
 			require.Equal(t, "https://azure-msi.teleport.dev/very-secret", getEnvValue("MSI_ENDPOINT"))
-			require.Equal(t, path.Join(tmpHomePath, "keys/127.0.0.1/alice@example.com-app/localhost/azure-api-localca.pem"), getEnvValue("REQUESTS_CA_BUNDLE"))
+			require.Equal(t, filepath.Join(tmpHomePath, "keys/127.0.0.1/alice@example.com-app/localhost/azure-api-localca.pem"), getEnvValue("REQUESTS_CA_BUNDLE"))
 			require.True(t, strings.HasPrefix(getEnvValue("HTTPS_PROXY"), "http://127.0.0.1:"))
 
 			// Validate MSI endpoint can be reached

--- a/tool/tsh/common/app_gcp.go
+++ b/tool/tsh/common/app_gcp.go
@@ -24,7 +24,7 @@ import (
 	"hash/fnv"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -162,7 +162,7 @@ func (a *gcpApp) Close() error {
 }
 
 func (a *gcpApp) getGcloudConfigPath() string {
-	return path.Join(profile.FullProfilePath(a.cf.HomePath), "gcp", a.appInfo.RouteToApp.ClusterName, a.appInfo.RouteToApp.Name, "gcloud")
+	return filepath.Join(profile.FullProfilePath(a.cf.HomePath), "gcp", a.appInfo.RouteToApp.ClusterName, a.appInfo.RouteToApp.Name, "gcloud")
 }
 
 // removeBotoConfig removes config files written by WriteBotoConfig.
@@ -175,15 +175,15 @@ func (a *gcpApp) removeBotoConfig() []error {
 }
 
 func (a *gcpApp) getBotoConfigDir() string {
-	return path.Join(profile.FullProfilePath(a.cf.HomePath), "gcp", a.appInfo.RouteToApp.ClusterName, a.appInfo.RouteToApp.Name)
+	return filepath.Join(profile.FullProfilePath(a.cf.HomePath), "gcp", a.appInfo.RouteToApp.ClusterName, a.appInfo.RouteToApp.Name)
 }
 
 func (a *gcpApp) getBotoConfigPath() string {
-	return path.Join(a.getBotoConfigDir(), a.prefix+"_boto.cfg")
+	return filepath.Join(a.getBotoConfigDir(), a.prefix+"_boto.cfg")
 }
 
 func (a *gcpApp) getExternalAccountFilePath() string {
-	return path.Join(a.getBotoConfigDir(), a.prefix+"_external.json")
+	return filepath.Join(a.getBotoConfigDir(), a.prefix+"_external.json")
 }
 
 // getBotoConfig returns minimal boto configuration, referencing an external account file.

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -27,7 +27,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"text/template"
 	"time"
 
@@ -369,7 +369,7 @@ func makeKubeLocalProxy(cf *CLIConf, tc *client.TeleportClient, clusters kubecon
 		kubeProxy.kubeConfigPath = os.Getenv(proxyKubeConfigEnvVar)
 		if kubeProxy.kubeConfigPath == "" {
 			_, port, _ := net.SplitHostPort(kubeProxy.forwardProxy.GetAddr())
-			kubeProxy.kubeConfigPath = path.Join(profile.KubeConfigPath(fmt.Sprintf("localproxy-%v", port)))
+			kubeProxy.kubeConfigPath = filepath.Join(profile.KubeConfigPath(fmt.Sprintf("localproxy-%v", port)))
 		}
 	}
 

--- a/tool/tsh/common/kube_proxy_test.go
+++ b/tool/tsh/common/kube_proxy_test.go
@@ -27,7 +27,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -50,7 +50,7 @@ import (
 
 func (p *kubeTestPack) testProxyKube(t *testing.T) {
 	// Set default kubeconfig to a non-exist file to avoid loading other things.
-	t.Setenv("KUBECONFIG", path.Join(os.Getenv(types.HomeEnvVar), uuid.NewString()))
+	t.Setenv("KUBECONFIG", filepath.Join(os.Getenv(types.HomeEnvVar), uuid.NewString()))
 
 	// Test "tsh proxy kube root-cluster1".
 	t.Run("with kube cluster arg", func(t *testing.T) {

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
-	"path"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -76,7 +75,7 @@ func TestKubeLogin(t *testing.T) {
 
 	testKubeLogin := func(t *testing.T, kubeCluster string, expectedAddr string) {
 		// Set default kubeconfig to a non-exist file to avoid loading other things.
-		t.Setenv("KUBECONFIG", path.Join(os.Getenv(types.HomeEnvVar), uuid.NewString()))
+		t.Setenv("KUBECONFIG", filepath.Join(os.Getenv(types.HomeEnvVar), uuid.NewString()))
 
 		// Test "tsh proxy kube root-cluster1".
 
@@ -554,7 +553,7 @@ func TestKubeSelection(t *testing.T) {
 				// clients work in the same profile dir.
 				tshHome, _ := mustLogin(t, s)
 				// Set kubeconfig to a non-exist file to avoid loading other things.
-				kubeConfigPath := path.Join(tshHome, "kube-config")
+				kubeConfigPath := filepath.Join(tshHome, "kube-config")
 				var cmdRunner func(*exec.Cmd) error
 				if len(test.wantProxied) > 0 {
 					cmdRunner = func(cmd *exec.Cmd) error {

--- a/tool/tsh/common/kubectl_test.go
+++ b/tool/tsh/common/kubectl_test.go
@@ -19,7 +19,7 @@
 package common
 
 import (
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
@@ -113,7 +113,7 @@ func Test_maybeStartKubeLocalProxy(t *testing.T) {
 
 			var localProxyCreated bool
 			var loadedKubeClusters kubeconfig.LocalProxyClusters
-			wantLocalProxyKubeConfigLocation := path.Join(tshHome, uuid.NewString())
+			wantLocalProxyKubeConfigLocation := filepath.Join(tshHome, uuid.NewString())
 
 			closeFn, actualKubeConfigLocation, err := maybeStartKubeLocalProxy(cf,
 				withKubectlArgs(test.inputArgs),
@@ -266,7 +266,7 @@ func Test_overwriteKubeconfigFlagInEnv(t *testing.T) {
 }
 
 func mustSetupKubeconfig(t *testing.T, tshHome, kubeCluster string) string {
-	kubeconfigLocation := path.Join(tshHome, "kubeconfig")
+	kubeconfigLocation := filepath.Join(tshHome, "kubeconfig")
 	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
 	require.NoError(t, err)
 	priv, err := keys.NewSoftwarePrivateKey(key)

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -36,7 +36,6 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
-	"path"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -85,8 +84,8 @@ func TestSSH(t *testing.T) {
 	lib.SetInsecureDevMode(false)
 
 	d := t.TempDir()
-	webCertPath := path.Join(d, "cert.pem")
-	webKeyPath := path.Join(d, "key.pem")
+	webCertPath := filepath.Join(d, "cert.pem")
+	webKeyPath := filepath.Join(d, "key.pem")
 	generateWebPKICert(t, webCertPath, webKeyPath)
 
 	s := newTestSuite(t,
@@ -1028,7 +1027,7 @@ func mustLoginSetEnv(t *testing.T, s *suite, args ...string) (tshHome, kubeConfi
 }
 
 func mustLoginIdentity(t *testing.T, s *suite) string {
-	identityFile := path.Join(t.TempDir(), "identity.pem")
+	identityFile := filepath.Join(t.TempDir(), "identity.pem")
 	mustLogin(t, s, "--out", identityFile)
 	return identityFile
 }

--- a/tool/tsh/common/recording_export_test.go
+++ b/tool/tsh/common/recording_export_test.go
@@ -23,7 +23,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -129,13 +129,13 @@ func TestWriteMovieWritesManyFrames(t *testing.T) {
 	require.Equal(t, framesPerSecond, frames)
 }
 
-// Calls writeMovie, and tells the test state to cleanup the created files upon completion.
+// writeMovieWrapper calls writeMovie, and tells the test state to cleanup the created files upon completion.
 // Returns the writeMovie call results, as well as the path-qualified prefix to the created file.
 func writeMovieWrapper(t *testing.T, ctx context.Context, ss events.SessionStreamer, sid session.ID, prefix string,
 	write func(format string, args ...any) (int, error)) (int, string, error) {
 
 	tempDir := t.TempDir()
-	prefix = path.Join(tempDir, prefix)
+	prefix = filepath.Join(tempDir, prefix)
 	frames, err := writeMovie(ctx, ss, sid, prefix, write, "")
 	return frames, prefix, err
 }

--- a/tool/tsh/common/workload_identity.go
+++ b/tool/tsh/common/workload_identity.go
@@ -24,7 +24,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -152,7 +152,7 @@ func (c *svidIssueCommand) run(cf *CLIConf) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		keyPath := path.Join(c.outputDirectory, svidKeyPEMPath)
+		keyPath := filepath.Join(c.outputDirectory, svidKeyPEMPath)
 		err = os.WriteFile(
 			keyPath,
 			pem.EncodeToMemory(&pem.Block{
@@ -166,7 +166,7 @@ func (c *svidIssueCommand) run(cf *CLIConf) error {
 		}
 
 		// Write SVID
-		svidPath := path.Join(c.outputDirectory, svidPEMPath)
+		svidPath := filepath.Join(c.outputDirectory, svidPEMPath)
 		err = os.WriteFile(
 			svidPath,
 			pem.EncodeToMemory(&pem.Block{
@@ -195,7 +195,7 @@ func (c *svidIssueCommand) run(cf *CLIConf) error {
 				}
 			}
 		}
-		trustBundlePath := path.Join(c.outputDirectory, svidTrustBundlePEMPath)
+		trustBundlePath := filepath.Join(c.outputDirectory, svidTrustBundlePEMPath)
 		err = os.WriteFile(
 			trustBundlePath,
 			trustBundleBytes.Bytes(),

--- a/tool/tsh/common/workload_identity_test.go
+++ b/tool/tsh/common/workload_identity_test.go
@@ -26,7 +26,7 @@ import (
 	"encoding/pem"
 	"net"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -81,7 +81,7 @@ func TestWorkloadIdentityIssue(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	certPEM, err := os.ReadFile(path.Join(temp, "svid.pem"))
+	certPEM, err := os.ReadFile(filepath.Join(temp, "svid.pem"))
 	require.NoError(t, err)
 	certBlock, _ := pem.Decode(certPEM)
 	cert, err := x509.ParseCertificate(certBlock.Bytes)
@@ -95,7 +95,7 @@ func TestWorkloadIdentityIssue(t *testing.T) {
 	// balanced-v1 algorithm suite).
 	require.IsType(t, &ecdsa.PublicKey{}, cert.PublicKey)
 
-	keyPEM, err := os.ReadFile(path.Join(temp, "svid_key.pem"))
+	keyPEM, err := os.ReadFile(filepath.Join(temp, "svid_key.pem"))
 	require.NoError(t, err)
 	keyBlock, _ := pem.Decode(keyPEM)
 	privateKey, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
@@ -104,7 +104,7 @@ func TestWorkloadIdentityIssue(t *testing.T) {
 	require.Implements(t, (*crypto.Signer)(nil), privateKey)
 	require.Equal(t, cert.PublicKey, privateKey.(crypto.Signer).Public())
 
-	bundlePEM, err := os.ReadFile(path.Join(temp, "svid_bundle.pem"))
+	bundlePEM, err := os.ReadFile(filepath.Join(temp, "svid_bundle.pem"))
 	require.NoError(t, err)
 	bundleBlock, _ := pem.Decode(bundlePEM)
 	_, err = x509.ParseCertificate(bundleBlock.Bytes)


### PR DESCRIPTION
Some day Teleport will run on systems that don't use / as a path separator.