### PR TITLE
[v16] Fix v16 redirects

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1389,23 +1389,13 @@
       "permanent": true
     },
     {
-      "source": "/get-started/",
-      "destination": "/admin-guides/deploy-a-cluster/linux-demo/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/redis-cluster/",
       "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/redis-cluster/",
       "permanent": true
     },
     {
-      "source": "/get-started/",
-      "destination": "/admin-guides/deploy-a-cluster/linux-demo/",
-      "permanent": true
-    },
-    {
       "source": "/getting-started/",
-      "destination": "/admin-guides/deploy-a-cluster/linux-demo/",
+      "destination": "/get-started/",
       "permanent": true
     },
     {


### PR DESCRIPTION
While we have a page with the slug `/get-started`, there are multiple redirects that direct this slug to the `linux-demo` guide. This change removes unnecessary redirects. It also redirects the `/getting-started` slug to `/get-started`.