### PR TITLE
Create DiscoverEC2 User Tasks when Auto Discover fails on EC2 instances

### DIFF
--- a/api/types/usertasks/object.go
+++ b/api/types/usertasks/object.go
@@ -90,40 +90,40 @@ const (
 // This value is used to populate the UserTasks.Spec.IssueType for Discover EC2 tasks.
 // The Web UI will then use those identifiers to show detailed instructions on how to fix the issue.
 const (
-	// AutoDiscoverEC2IssueScriptInstanceNotRegistered is used to identify instances that failed to auto-enroll
+	// AutoDiscoverEC2IssueSSMInstanceNotRegistered is used to identify instances that failed to auto-enroll
 	// because they are not present in Amazon Systems Manager.
 	// This usually means that the Instance does not have the SSM Agent running,
 	// or that the instance's IAM Profile does not allow have the managed IAM Policy AmazonSSMManagedInstanceCore assigned to it.
-	AutoDiscoverEC2IssueScriptInstanceNotRegistered = "ec2-ssm-agent-not-registered"
+	AutoDiscoverEC2IssueSSMInstanceNotRegistered = "ec2-ssm-agent-not-registered"
 
-	// AutoDiscoverEC2IssueScriptInstanceConnectionLost is used to identify instances that failed to auto-enroll
+	// AutoDiscoverEC2IssueSSMInstanceConnectionLost is used to identify instances that failed to auto-enroll
 	// because the agent lost connection to Amazon Systems Manager.
 	// This can happen if the user changed some setting in the instance's network or IAM profile.
-	AutoDiscoverEC2IssueScriptInstanceConnectionLost = "ec2-ssm-agent-connection-lost"
+	AutoDiscoverEC2IssueSSMInstanceConnectionLost = "ec2-ssm-agent-connection-lost"
 
-	// AutoDiscoverEC2IssueScriptInstanceUnsupportedOS is used to identify instances that failed to auto-enroll
+	// AutoDiscoverEC2IssueSSMInstanceUnsupportedOS is used to identify instances that failed to auto-enroll
 	// because its OS is not supported by teleport.
 	// This can happen if the instance is running Windows.
-	AutoDiscoverEC2IssueScriptInstanceUnsupportedOS = "ec2-ssm-unsupported-os"
+	AutoDiscoverEC2IssueSSMInstanceUnsupportedOS = "ec2-ssm-unsupported-os"
 
-	// AutoDiscoverEC2IssueScriptFailure is used to identify instances that failed to auto-enroll
+	// AutoDiscoverEC2IssueSSMScriptFailure is used to identify instances that failed to auto-enroll
 	// because the installation script failed.
 	// The invocation url must be included in the report, so that users can see what was wrong.
-	AutoDiscoverEC2IssueScriptFailure = "ec2-ssm-script-failure"
+	AutoDiscoverEC2IssueSSMScriptFailure = "ec2-ssm-script-failure"
 
-	// AutoDiscoverEC2IssueInvocationFailure is used to identify instances that failed to auto-enroll
+	// AutoDiscoverEC2IssueSSMInvocationFailure is used to identify instances that failed to auto-enroll
 	// because the SSM Script Run (also known as Invocation) failed.
 	// This happens when there's a failure with permissions or an invalid configuration (eg, invalid document name).
-	AutoDiscoverEC2IssueInvocationFailure = "ec2-ssm-invocation-failure"
+	AutoDiscoverEC2IssueSSMInvocationFailure = "ec2-ssm-invocation-failure"
 )
 
 // discoverEC2IssueTypes is a list of issue types that can occur when trying to auto enroll EC2 instances.
 var discoverEC2IssueTypes = []string{
-	AutoDiscoverEC2IssueScriptInstanceNotRegistered,
-	AutoDiscoverEC2IssueScriptInstanceConnectionLost,
-	AutoDiscoverEC2IssueScriptInstanceUnsupportedOS,
-	AutoDiscoverEC2IssueScriptFailure,
-	AutoDiscoverEC2IssueInvocationFailure,
+	AutoDiscoverEC2IssueSSMInstanceNotRegistered,
+	AutoDiscoverEC2IssueSSMInstanceConnectionLost,
+	AutoDiscoverEC2IssueSSMInstanceUnsupportedOS,
+	AutoDiscoverEC2IssueSSMScriptFailure,
+	AutoDiscoverEC2IssueSSMInvocationFailure,
 }
 
 // ValidateUserTask validates the UserTask object without modifying it.

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -755,6 +755,9 @@ type ReadDiscoveryAccessPoint interface {
 
 	// GetProxies returns a list of registered proxies.
 	GetProxies() ([]types.Server, error)
+
+	// GetUserTask gets a single User Task by its name.
+	GetUserTask(ctx context.Context, name string) (*usertasksv1.UserTask, error)
 }
 
 // DiscoveryAccessPoint is an API interface implemented by a certificate authority (CA) to be

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -980,10 +980,10 @@ func (s *Server) handleEC2RemoteInstallation(instances *server.EC2Instances) err
 
 		for _, instance := range req.Instances {
 			s.awsEC2Tasks.addFailedEnrollment(
-				awsEC2FailedEnrollmentTaskKey{
+				awsEC2TaskKey{
 					accountID:   instances.AccountID,
 					integration: instances.Integration,
-					issueType:   usertasks.AutoDiscoverEC2IssueInvocationFailure,
+					issueType:   usertasks.AutoDiscoverEC2IssueSSMInvocationFailure,
 					region:      instances.Region,
 				},
 				&usertasksv1.DiscoverEC2Instance{

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -413,9 +413,9 @@ func (s *Server) acquireSemaphoreForUserTask(userTaskName string) (releaseFn fun
 
 	// Once the lease parent context is canceled, the lease will be released.
 	ctxWithLease, cancel := context.WithCancel(lease)
-	defer cancel()
 
 	releaseFn = func() {
+		cancel()
 		lease.Stop()
 		if err := lease.Wait(); err != nil {
 			s.Log.WithError(err).WithField("semaphore", userTaskName).Warn("error cleaning up UserTask semaphore")

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -25,10 +25,16 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	"github.com/gravitational/teleport/api/types/usertasks"
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	libevents "github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/services"
 	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
 	"github.com/gravitational/teleport/lib/srv/server"
 )
@@ -293,5 +299,207 @@ func (s *Server) ReportEC2SSMInstallationResult(ctx context.Context, result *ser
 
 	s.updateDiscoveryConfigStatus(result.DiscoveryConfig)
 
+	s.awsEC2Tasks.addFailedEnrollment(
+		awsEC2FailedEnrollmentGroup{
+			integration: result.IntegrationName,
+			issueType:   result.IssueType,
+			accountID:   result.SSMRunEvent.AccountID,
+			region:      result.SSMRunEvent.Region,
+		},
+		&usertasksv1.DiscoverEC2Instance{
+			// TODO(marco): add instance name
+			InvocationUrl:   result.SSMRunEvent.InvocationURL,
+			DiscoveryConfig: result.DiscoveryConfig,
+			DiscoveryGroup:  s.DiscoveryGroup,
+			SyncTime:        timestamppb.New(result.SSMRunEvent.Time),
+			InstanceId:      result.SSMRunEvent.InstanceID,
+		},
+	)
+
 	return nil
+}
+
+// awsEC2Tasks contains the Discover EC2 User Tasks that must be reported to the user.
+type awsEC2Tasks struct {
+	mu sync.RWMutex
+	// instancesIssues maps the Discover EC2 User Task grouping parts to a set of instances metadata.
+	instancesIssues map[awsEC2FailedEnrollmentGroup]map[string]*usertasksv1.DiscoverEC2Instance
+	// groupPending is used to register which groups were changed in memory but were not yet sent upstream.
+	// When upserting User Tasks, if the group is not present in groupPending,
+	// then the cluster already has the latest version of this particular group.
+	groupPending map[awsEC2FailedEnrollmentGroup]struct{}
+}
+
+// awsEC2FailedEnrollmentGroup identifies a UserTask group.
+type awsEC2FailedEnrollmentGroup struct {
+	integration string
+	issueType   string
+	accountID   string
+	region      string
+}
+
+// iterationStarted clears out any in memory issues that were recorded.
+// This is used when starting a new Auto Discover EC2 watcher iteration.
+func (d *awsEC2Tasks) iterationStarted() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.instancesIssues = make(map[awsEC2FailedEnrollmentGroup]map[string]*usertasksv1.DiscoverEC2Instance)
+	d.groupPending = make(map[awsEC2FailedEnrollmentGroup]struct{})
+}
+
+// addFailedEnrollment adds a
+func (d *awsEC2Tasks) addFailedEnrollment(g awsEC2FailedEnrollmentGroup, instance *usertasksv1.DiscoverEC2Instance) {
+	// Only failures associated with an Integration are reported.
+	// There's no major blocking for showing non-integration User Tasks, but this keeps scope smaller.
+	if g.integration == "" {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.instancesIssues == nil {
+		d.instancesIssues = make(map[awsEC2FailedEnrollmentGroup]map[string]*usertasksv1.DiscoverEC2Instance)
+	}
+	if _, ok := d.instancesIssues[g]; !ok {
+		d.instancesIssues[g] = make(map[string]*usertasksv1.DiscoverEC2Instance)
+	}
+	d.instancesIssues[g][instance.InstanceId] = instance
+
+	if d.groupPending == nil {
+		d.groupPending = make(map[awsEC2FailedEnrollmentGroup]struct{})
+	}
+	d.groupPending[g] = struct{}{}
+}
+
+// mergeUpsertDiscoverEC2Task takes the current DiscoverEC2 User Task issues stored in memory and
+// merges them against the ones that exist in the cluster.
+//
+// All of this flow is protected by a lock to ensure there's no race between this and other DiscoveryServices.
+func (s *Server) mergeUpsertDiscoverEC2Task(taskGroup awsEC2FailedEnrollmentGroup, failedInstances map[string]*usertasksv1.DiscoverEC2Instance) error {
+	userTaskName := usertasks.TaskNameForDiscoverEC2(usertasks.TaskNameForDiscoverEC2Parts{
+		Integration: taskGroup.integration,
+		IssueType:   taskGroup.issueType,
+		AccountID:   taskGroup.accountID,
+		Region:      taskGroup.region,
+	})
+
+	// Use the deterministic task name as semaphore name.
+	semaphoreName := userTaskName
+	semaphoreExpiration := 5 * time.Second
+
+	// AcquireSemaphoreLock will retry until the semaphore is acquired.
+	// This prevents multiple discovery services to write AWS resources in parallel.
+	// lease must be released to cleanup the resource in auth server.
+	lease, err := services.AcquireSemaphoreLockWithRetry(
+		s.ctx,
+		services.SemaphoreLockConfigWithRetry{
+			SemaphoreLockConfig: services.SemaphoreLockConfig{
+				Service: s.AccessPoint,
+				Params: types.AcquireSemaphoreRequest{
+					SemaphoreKind: types.KindUserTask,
+					SemaphoreName: semaphoreName,
+					MaxLeases:     1,
+					Holder:        s.Config.ServerID,
+				},
+				Expiry: semaphoreExpiration,
+				Clock:  s.clock,
+			},
+			Retry: retryutils.LinearConfig{
+				Clock:  s.clock,
+				First:  time.Second,
+				Step:   semaphoreExpiration / 2,
+				Max:    semaphoreExpiration,
+				Jitter: retryutils.NewJitter(),
+			},
+		},
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Once the lease parent context is canceled, the lease will be released.
+	ctxWithLease, cancel := context.WithCancel(lease)
+	defer cancel()
+
+	defer func() {
+		lease.Stop()
+		if err := lease.Wait(); err != nil {
+			s.Log.WithError(err).WithField("semaphore", userTaskName).Warn("error cleaning up UserTask semaphore")
+		}
+	}()
+
+	// Fetch the current task because it might have instances discovered by another group of DiscoveryServices.
+	currentUserTask, err := s.AccessPoint.GetUserTask(ctxWithLease, userTaskName)
+	switch {
+	case trace.IsNotFound(err):
+	case err != nil:
+		return trace.Wrap(err)
+	default:
+		for existingIntanceID, existingInstance := range currentUserTask.Spec.DiscoverEc2.Instances {
+			// Each DiscoveryService works on all the DiscoveryConfigs assigned to a given DiscoveryGroup.
+			// So, it's safe to say that current DiscoveryService has the last state for a given DiscoveryGroup.
+			// If other instances exist for this DiscoveryGroup, they can be discarded because, as said before, the current DiscoveryService has the last state for a given DiscoveryGroup.
+			if existingInstance.DiscoveryGroup == s.DiscoveryGroup {
+				continue
+			}
+
+			// For existing instances whose sync time is too far in the past, just drop them.
+			// This ensures that if an instance is removed from AWS, it will eventually disappear from the User Tasks' instance list.
+			// It might also be the case that the DiscoveryConfig was changed and the instance is no longer matched (because of labels/regions or other matchers).
+			instanceIssueExpiration := s.clock.Now().Add(-2 * s.PollInterval)
+			if existingInstance.SyncTime.AsTime().Before(instanceIssueExpiration) {
+				continue
+			}
+
+			// Merge existing backend state into in-memory object.
+			failedInstances[existingIntanceID] = existingInstance
+		}
+	}
+
+	// If the DiscoveryService is stopped, or the issue does not happen again
+	// the task is removed to prevent users from working on issues that are no longer happening.
+	taskExpiration := s.clock.Now().Add(2 * s.PollInterval)
+
+	task, err := usertasks.NewDiscoverEC2UserTask(
+		&usertasksv1.UserTaskSpec{
+			Integration: taskGroup.integration,
+			TaskType:    usertasks.TaskTypeDiscoverEC2,
+			IssueType:   taskGroup.issueType,
+			State:       usertasks.TaskStateOpen,
+			DiscoverEc2: &usertasksv1.DiscoverEC2{
+				AccountId: taskGroup.accountID,
+				Region:    taskGroup.region,
+				Instances: failedInstances,
+			},
+		},
+		usertasks.WithExpiration(taskExpiration),
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err := s.AccessPoint.UpsertUserTask(ctxWithLease, task); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func (s *Server) upsertTasksForAWSEC2FailedEnrollments() {
+	s.awsEC2Tasks.mu.Lock()
+	defer s.awsEC2Tasks.mu.Unlock()
+	for g := range s.awsEC2Tasks.groupPending {
+		instancesIssueByID := s.awsEC2Tasks.instancesIssues[g]
+		if len(instancesIssueByID) == 0 {
+			continue
+		}
+
+		if err := s.mergeUpsertDiscoverEC2Task(g, instancesIssueByID); err != nil {
+			s.Log.WithError(err).Warning("failed to create discover ec2 user task")
+			continue
+		}
+
+		delete(s.awsEC2Tasks.groupPending, g)
+	}
 }

--- a/lib/srv/server/ssm_install.go
+++ b/lib/srv/server/ssm_install.go
@@ -220,7 +220,7 @@ func (si *SSMInstaller) emitInvalidInstanceEvents(ctx context.Context, req SSMRu
 	for _, instanceID := range instanceIDsState.missing {
 		installationResult := invalidSSMInstanceInstallationResult(req, instanceID,
 			"EC2 Instance is not registered in SSM. Make sure that the instance has AmazonSSMManagedInstanceCore policy assigned.",
-			usertasks.AutoDiscoverEC2IssueScriptInstanceNotRegistered,
+			usertasks.AutoDiscoverEC2IssueSSMInstanceNotRegistered,
 		)
 		if err := si.ReportSSMInstallationResultFunc(ctx, installationResult); err != nil {
 			errs = append(errs, trace.Wrap(err))
@@ -230,7 +230,7 @@ func (si *SSMInstaller) emitInvalidInstanceEvents(ctx context.Context, req SSMRu
 	for _, instanceID := range instanceIDsState.connectionLost {
 		installationResult := invalidSSMInstanceInstallationResult(req, instanceID,
 			"SSM Agent in EC2 Instance is not connecting to SSM Service. Restart or reinstall the SSM service. See https://docs.aws.amazon.com/systems-manager/latest/userguide/ami-preinstalled-agent.html#verify-ssm-agent-status for more details.",
-			usertasks.AutoDiscoverEC2IssueScriptInstanceConnectionLost,
+			usertasks.AutoDiscoverEC2IssueSSMInstanceConnectionLost,
 		)
 		if err := si.ReportSSMInstallationResultFunc(ctx, installationResult); err != nil {
 			errs = append(errs, trace.Wrap(err))
@@ -240,7 +240,7 @@ func (si *SSMInstaller) emitInvalidInstanceEvents(ctx context.Context, req SSMRu
 	for _, instanceID := range instanceIDsState.unsupportedOS {
 		installationResult := invalidSSMInstanceInstallationResult(req, instanceID,
 			"EC2 instance is running an unsupported Operating System. Only Linux is supported.",
-			usertasks.AutoDiscoverEC2IssueScriptInstanceUnsupportedOS,
+			usertasks.AutoDiscoverEC2IssueSSMInstanceUnsupportedOS,
 		)
 		if err := si.ReportSSMInstallationResultFunc(ctx, installationResult); err != nil {
 			errs = append(errs, trace.Wrap(err))
@@ -358,7 +358,7 @@ func (si *SSMInstaller) checkCommand(ctx context.Context, req SSMRunRequest, com
 					SSMRunEvent:     invocationResultEvent,
 					IntegrationName: req.IntegrationName,
 					DiscoveryConfig: req.DiscoveryConfig,
-					IssueType:       usertasks.AutoDiscoverEC2IssueScriptFailure,
+					IssueType:       usertasks.AutoDiscoverEC2IssueSSMScriptFailure,
 				}))
 			}
 
@@ -372,7 +372,7 @@ func (si *SSMInstaller) checkCommand(ctx context.Context, req SSMRunRequest, com
 				SSMRunEvent:     stepResultEvent,
 				IntegrationName: req.IntegrationName,
 				DiscoveryConfig: req.DiscoveryConfig,
-				IssueType:       usertasks.AutoDiscoverEC2IssueScriptFailure,
+				IssueType:       usertasks.AutoDiscoverEC2IssueSSMScriptFailure,
 			}))
 		}
 	}

--- a/lib/srv/server/ssm_install.go
+++ b/lib/srv/server/ssm_install.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/types/usertasks"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	libevents "github.com/gravitational/teleport/lib/events"
 )
@@ -59,6 +60,9 @@ type SSMInstallationResult struct {
 	// DiscoveryConfig is the DiscoveryConfig name which originated this Run Request.
 	// Empty if using static matchers (coming from the `teleport.yaml`).
 	DiscoveryConfig string
+	// IssueType identifies the type of issue that occurred if the installation failed.
+	// These are well known identifiers that can be found at types.AutoDiscoverEC2Issue*.
+	IssueType string
 }
 
 // SSMInstaller handles running SSM commands that install Teleport on EC2 instances.
@@ -191,7 +195,7 @@ func (si *SSMInstaller) Run(ctx context.Context, req SSMRunRequest) error {
 	return trace.Wrap(g.Wait())
 }
 
-func invalidSSMInstanceInstallationResult(req SSMRunRequest, instanceID, status string) *SSMInstallationResult {
+func invalidSSMInstanceInstallationResult(req SSMRunRequest, instanceID, status, issueType string) *SSMInstallationResult {
 	return &SSMInstallationResult{
 		SSMRunEvent: &apievents.SSMRun{
 			Metadata: apievents.Metadata{
@@ -207,6 +211,7 @@ func invalidSSMInstanceInstallationResult(req SSMRunRequest, instanceID, status 
 		},
 		IntegrationName: req.IntegrationName,
 		DiscoveryConfig: req.DiscoveryConfig,
+		IssueType:       issueType,
 	}
 }
 
@@ -215,6 +220,7 @@ func (si *SSMInstaller) emitInvalidInstanceEvents(ctx context.Context, req SSMRu
 	for _, instanceID := range instanceIDsState.missing {
 		installationResult := invalidSSMInstanceInstallationResult(req, instanceID,
 			"EC2 Instance is not registered in SSM. Make sure that the instance has AmazonSSMManagedInstanceCore policy assigned.",
+			usertasks.AutoDiscoverEC2IssueScriptInstanceNotRegistered,
 		)
 		if err := si.ReportSSMInstallationResultFunc(ctx, installationResult); err != nil {
 			errs = append(errs, trace.Wrap(err))
@@ -224,6 +230,7 @@ func (si *SSMInstaller) emitInvalidInstanceEvents(ctx context.Context, req SSMRu
 	for _, instanceID := range instanceIDsState.connectionLost {
 		installationResult := invalidSSMInstanceInstallationResult(req, instanceID,
 			"SSM Agent in EC2 Instance is not connecting to SSM Service. Restart or reinstall the SSM service. See https://docs.aws.amazon.com/systems-manager/latest/userguide/ami-preinstalled-agent.html#verify-ssm-agent-status for more details.",
+			usertasks.AutoDiscoverEC2IssueScriptInstanceConnectionLost,
 		)
 		if err := si.ReportSSMInstallationResultFunc(ctx, installationResult); err != nil {
 			errs = append(errs, trace.Wrap(err))
@@ -233,6 +240,7 @@ func (si *SSMInstaller) emitInvalidInstanceEvents(ctx context.Context, req SSMRu
 	for _, instanceID := range instanceIDsState.unsupportedOS {
 		installationResult := invalidSSMInstanceInstallationResult(req, instanceID,
 			"EC2 instance is running an unsupported Operating System. Only Linux is supported.",
+			usertasks.AutoDiscoverEC2IssueScriptInstanceUnsupportedOS,
 		)
 		if err := si.ReportSSMInstallationResultFunc(ctx, installationResult); err != nil {
 			errs = append(errs, trace.Wrap(err))
@@ -350,6 +358,7 @@ func (si *SSMInstaller) checkCommand(ctx context.Context, req SSMRunRequest, com
 					SSMRunEvent:     invocationResultEvent,
 					IntegrationName: req.IntegrationName,
 					DiscoveryConfig: req.DiscoveryConfig,
+					IssueType:       usertasks.AutoDiscoverEC2IssueScriptFailure,
 				}))
 			}
 
@@ -363,6 +372,7 @@ func (si *SSMInstaller) checkCommand(ctx context.Context, req SSMRunRequest, com
 				SSMRunEvent:     stepResultEvent,
 				IntegrationName: req.IntegrationName,
 				DiscoveryConfig: req.DiscoveryConfig,
+				IssueType:       usertasks.AutoDiscoverEC2IssueScriptFailure,
 			}))
 		}
 	}

--- a/lib/srv/server/ssm_install_test.go
+++ b/lib/srv/server/ssm_install_test.go
@@ -144,6 +144,7 @@ func TestSSMInstaller(t *testing.T) {
 					Status:        ssm.CommandStatusSuccess,
 					InvocationURL: "https://eu-central-1.console.aws.amazon.com/systems-manager/run-command/command-id-1/instance-id-1",
 				},
+				IssueType: "ec2-ssm-script-failure",
 			}},
 		},
 		{
@@ -188,6 +189,7 @@ func TestSSMInstaller(t *testing.T) {
 					Status:        ssm.CommandStatusSuccess,
 					InvocationURL: "https://eu-central-1.console.aws.amazon.com/systems-manager/run-command/command-id-1/instance-id-1",
 				},
+				IssueType: "ec2-ssm-script-failure",
 			}},
 		},
 		{
@@ -234,6 +236,7 @@ func TestSSMInstaller(t *testing.T) {
 					StandardError:  "timeout error",
 					InvocationURL:  "https://eu-central-1.console.aws.amazon.com/systems-manager/run-command/command-id-1/instance-id-1",
 				},
+				IssueType: "ec2-ssm-script-failure",
 			}},
 		},
 		{
@@ -284,6 +287,7 @@ func TestSSMInstaller(t *testing.T) {
 					StandardError:  "timeout error",
 					InvocationURL:  "https://eu-central-1.console.aws.amazon.com/systems-manager/run-command/command-id-1/instance-id-1",
 				},
+				IssueType: "ec2-ssm-script-failure",
 			}},
 		},
 		{
@@ -351,6 +355,7 @@ func TestSSMInstaller(t *testing.T) {
 						Status:        ssm.CommandStatusSuccess,
 						InvocationURL: "https://eu-central-1.console.aws.amazon.com/systems-manager/run-command/command-id-1/instance-id-1",
 					},
+					IssueType: "ec2-ssm-script-failure",
 				},
 				{
 					SSMRunEvent: &events.SSMRun{
@@ -365,6 +370,7 @@ func TestSSMInstaller(t *testing.T) {
 						ExitCode:   -1,
 						Status:     "SSM Agent in EC2 Instance is not connecting to SSM Service. Restart or reinstall the SSM service. See https://docs.aws.amazon.com/systems-manager/latest/userguide/ami-preinstalled-agent.html#verify-ssm-agent-status for more details.",
 					},
+					IssueType: "ec2-ssm-agent-connection-lost",
 				},
 				{
 					SSMRunEvent: &events.SSMRun{
@@ -379,6 +385,7 @@ func TestSSMInstaller(t *testing.T) {
 						ExitCode:   -1,
 						Status:     "EC2 instance is running an unsupported Operating System. Only Linux is supported.",
 					},
+					IssueType: "ec2-ssm-unsupported-os",
 				},
 				{
 					SSMRunEvent: &events.SSMRun{
@@ -393,6 +400,7 @@ func TestSSMInstaller(t *testing.T) {
 						ExitCode:   -1,
 						Status:     "EC2 Instance is not registered in SSM. Make sure that the instance has AmazonSSMManagedInstanceCore policy assigned.",
 					},
+					IssueType: "ec2-ssm-agent-not-registered",
 				},
 			},
 		},
@@ -448,6 +456,7 @@ func TestSSMInstaller(t *testing.T) {
 					StandardOutput: "custom output",
 					InvocationURL:  "https://eu-central-1.console.aws.amazon.com/systems-manager/run-command/command-id-1/instance-id-1",
 				},
+				IssueType: "ec2-ssm-script-failure",
 			}},
 		},
 		{
@@ -488,6 +497,7 @@ func TestSSMInstaller(t *testing.T) {
 					Status:        ssm.CommandStatusSuccess,
 					InvocationURL: "https://eu-central-1.console.aws.amazon.com/systems-manager/run-command/command-id-1/instance-id-1",
 				},
+				IssueType: "ec2-ssm-script-failure",
 			}},
 		},
 		// todo(amk): test that incomplete commands eventually return

--- a/lib/web/usertasks_test.go
+++ b/lib/web/usertasks_test.go
@@ -63,11 +63,11 @@ func TestUserTask(t *testing.T) {
 	}
 
 	issueTypes := []string{
-		usertasks.AutoDiscoverEC2IssueInvocationFailure,
-		usertasks.AutoDiscoverEC2IssueScriptFailure,
-		usertasks.AutoDiscoverEC2IssueScriptInstanceConnectionLost,
-		usertasks.AutoDiscoverEC2IssueScriptInstanceNotRegistered,
-		usertasks.AutoDiscoverEC2IssueScriptInstanceUnsupportedOS,
+		usertasks.AutoDiscoverEC2IssueSSMInvocationFailure,
+		usertasks.AutoDiscoverEC2IssueSSMScriptFailure,
+		usertasks.AutoDiscoverEC2IssueSSMInstanceConnectionLost,
+		usertasks.AutoDiscoverEC2IssueSSMInstanceNotRegistered,
+		usertasks.AutoDiscoverEC2IssueSSMInstanceUnsupportedOS,
 	}
 	var userTaskForTest *usertasksv1.UserTask
 	for _, issueType := range issueTypes {


### PR DESCRIPTION
This PR changes the DiscoveryService to start creating and updating
Discover EC2 User Tasks.

So, what are Discover EC2 User Tasks?
When users set up Auto Discover for EC2 Instances, they don't have a
good way of checking for issues on their configured matchers.

We created User Tasks as a way to warn Users that something's wrong.
Each User Task should describe an issue that happened and a way to fix
it.
This has potential to be used to report unexpected events trough the
whole system, which are not errors per se, but something the user should
take action in order to improve the situation.
In this case, we are creating a sub type of those tasks: DiscoverEC2.

From now on, when the DiscoveryService fails to auto-enroll an instance,
it will create a DiscoverEC2 User Task grouping all the failed instances
by the following props:
- integration
- issue type
- account id
- region

A follow up PR will also create notifications so that the user can
actually be notified on those User Tasks and take action.

Demo:
```
$ tctl get user_tasks
kind: user_task
metadata:
  expires:
    nanos: 542005000
    seconds: 1727976384
  name: 52c33845-a413-5b2e-bfa3-1afc5d79236a
  revision: 663ed34b-6c65-4976-9052-af5898b295e1
spec:
  discover_ec2:
    account_id: "123456789012"
    instances:
      i-123:
        discovery_config: dc001
        discovery_group: aws-prod
        instance_id: i-123
        invocation_url: https://eu-west-2.console.aws.amazon.com/systems-manager/run-command/5041ad35-deab-4be7-8bfb-cd64f1cc2a24/i-123
        sync_time:
          nanos: 525000000
          seconds: 1727976024
    region: eu-west-2
  integration: teleportdev
  issue_type: ec2-ssm-script-failure
  state: OPEN
  task_type: discover-ec2
version: v1
---
kind: user_task
metadata:
  expires:
    nanos: 540832000
    seconds: 1727976378
  name: 7da201b0-57d1-503b-856e-de8ca5acd1e1
  revision: 9f803bb5-7ef6-4bd6-a2e5-fbbf8119248a
spec:
  discover_ec2:
    account_id: "123456789012"
    instances:
      i-1234:
        discovery_config: dc001
        discovery_group: aws-prod
        instance_id: i-1234
        sync_time:
          nanos: 379000000
          seconds: 1727976018
    region: eu-west-2
  integration: teleportdev
  issue_type: ec2-ssm-unsupported-os
  state: OPEN
  task_type: discover-ec2
version: v1
---
kind: user_task
metadata:
  expires:
    nanos: 782998000
    seconds: 1727976378
  name: b64397ac-764d-5d9d-af09-30d4775f7a78
  revision: 30ac5a71-a314-43de-a190-ee7db6cfa36a
spec:
  discover_ec2:
    account_id: "123456789012"
    instances:
      i-12345:
        discovery_config: dc001
        discovery_group: aws-prod
        instance_id: i-12345
        sync_time:
          nanos: 631000000
          seconds: 1727976018
    region: eu-west-2
  integration: teleportdev
  issue_type: ec2-ssm-agent-connection-lost
  state: OPEN
  task_type: discover-ec2
version: v1
---
kind: user_task
metadata:
  expires:
    nanos: 291505000
    seconds: 1727976378
  name: dcdca1c5-d489-58bd-8f01-6477ad9756d1
  revision: 176e6527-5cf7-43a2-b1b5-39cdff720f96
spec:
  discover_ec2:
    account_id: "123456789012"
    instances:
      i-123456:
        discovery_config: dc001
        discovery_group: aws-prod
        instance_id: i-123456
        sync_time:
          nanos: 887000000
          seconds: 1727976017
      i-1234567:
        discovery_config: dc001
        discovery_group: aws-prod
        instance_id: i-1234567
        sync_time:
          nanos: 134000000
          seconds: 1727976018
    region: eu-west-2
  integration: teleportdev
  issue_type: ec2-ssm-agent-not-registered
  state: OPEN
  task_type: discover-ec2
version: v1
```
