### PR TITLE
[v16] display all security group rules for a port range

### DIFF
--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/SingleEnrollment.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/SingleEnrollment.tsx
@@ -201,7 +201,7 @@ export function SingleEnrollment({
     <>
       {showTable && (
         <>
-          <Text mt={3}>Select an RDS to enroll:</Text>
+          <Text mt={3}>Select an RDS database to enroll:</Text>
           <DatabaseList
             wantAutoDiscover={false}
             items={tableData?.items || []}

--- a/web/packages/teleport/src/Discover/Shared/SecurityGroupPicker/SecurityGroupRulesDialog.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SecurityGroupPicker/SecurityGroupRulesDialog.tsx
@@ -32,8 +32,7 @@ export function SecurityGroupRulesDialog({
   viewRulesSelection: ViewRulesSelection;
   onClose: () => void;
 }) {
-  const { ruleType, sg } = viewRulesSelection;
-  const data = ruleType === 'inbound' ? sg.inboundRules : sg.outboundRules;
+  const { name, rules, ruleType } = viewRulesSelection;
 
   return (
     <Dialog disableEscapeKeyDown={false} open={true}>
@@ -44,11 +43,10 @@ export function SecurityGroupRulesDialog({
         textAlign="center"
       >
         <Text mb={4} typography="h4">
-          {ruleType === 'inbound' ? 'Inbound' : 'Outbound'} Rules for [{sg.name}
-          ]
+          {ruleType === 'inbound' ? 'Inbound' : 'Outbound'} Rules for [{name}]
         </Text>
         <StyledTable
-          data={data}
+          data={rules}
           columns={[
             {
               key: 'ipProtocol',
@@ -67,12 +65,9 @@ export function SecurityGroupRulesDialog({
             {
               altKey: 'source',
               headerText: 'Source',
-              render: ({ cidrs }) => {
-                // The AWS API returns an array, however it appears it's not actually possible to have multiple CIDR's for a single rule.
-                // As a fallback we just display the first one.
-                const cidr = cidrs[0];
-                if (cidr) {
-                  return <Cell>{cidr.cidr}</Cell>;
+              render: ({ source }) => {
+                if (source) {
+                  return <Cell>{source}</Cell>;
                 }
                 return null;
               },
@@ -80,10 +75,9 @@ export function SecurityGroupRulesDialog({
             {
               altKey: 'description',
               headerText: 'Description',
-              render: ({ cidrs }) => {
-                const cidr = cidrs[0];
-                if (cidr) {
-                  return <Cell>{cidr.description}</Cell>;
+              render: ({ description }) => {
+                if (description) {
+                  return <Cell>{description}</Cell>;
                 }
                 return null;
               },

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -321,7 +321,7 @@ const cfg = {
     awsRdsDbRequiredVpcsPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/requireddatabasesvpcs',
     awsDatabaseVpcsPath:
-      '/webapi/sites/:clusterId/integrations/aws-oidc/:name/databasevpcs',
+      '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/databasevpcs',
     awsRdsDbListPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/databases',
     awsDeployTeleportServicePath:


### PR DESCRIPTION
Changelog: Fixed a bug where only one IP CIDR block security group rule for a port range was displayed in the web UI RDS enrollment wizard when viewing a security group.

Backport #47009 to branch/v16.

there was a straightforward merge conflict with a `<Text>` on v16 vs `<H2>` in master - I kept the content of the html tag the same as the backported PR but left it as a `<Text>`. Relevant snippet was:

```
        <Text mb={4} typography="h4">
          {ruleType === 'inbound' ? 'Inbound' : 'Outbound'} Rules for [{name}]
        </Text>
```