### PR TITLE
Host users take ownership of existing home directories

### DIFF
--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -82,7 +82,8 @@ func getUserShells(path string) (map[string]string, error) {
 func TestRootHostUsersBackend(t *testing.T) {
 	utils.RequireRoot(t)
 	sudoersTestDir := t.TempDir()
-	usersbk := srv.HostUsersProvisioningBackend{}
+	usersbk, err := srv.NewHostUsersBackend(utils.NewSlogLoggerForTests())
+	require.NoError(t, err)
 	sudoersbk := srv.HostSudoersProvisioningBackend{
 		SudoersPath: sudoersTestDir,
 		HostUUID:    "hostuuid",

--- a/lib/srv/hostusers_linux_test.go
+++ b/lib/srv/hostusers_linux_test.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build linux
+// +build linux
 
 /*
  * Teleport
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package utils
+package srv
 
 import (
 	"os"
@@ -93,14 +93,14 @@ func TestRecursiveChown(t *testing.T) {
 	t.Run("notFoundError", func(t *testing.T) {
 		t.Parallel()
 
-		require.Error(t, RecursiveChown("/invalid/path/to/nowhere", 1000, 1000))
+		require.Error(t, recursiveChown("/invalid/path/to/nowhere", 1000, 1000))
 	})
 	t.Run("simpleChown", func(t *testing.T) {
 		t.Parallel()
 		_, _, newUid, newGid, _ := setupRecursiveChownUser(t)
 		dir1Path, dir1FilePath, _, _ := setupRecursiveChownFiles(t)
 
-		require.NoError(t, RecursiveChown(dir1Path, newUid, newGid))
+		require.NoError(t, recursiveChown(dir1Path, newUid, newGid))
 		// validate ownership matches expected ids
 		verifyOwnership(t, dir1Path, newUid, newGid)
 		verifyOwnership(t, dir1FilePath, newUid, newGid)
@@ -114,7 +114,7 @@ func TestRecursiveChown(t *testing.T) {
 		}
 		_, dir1FilePath, dir2Path, dir2SymlinkToFile := setupRecursiveChownFiles(t)
 
-		require.NoError(t, RecursiveChown(dir2Path, newUid, newGid))
+		require.NoError(t, recursiveChown(dir2Path, newUid, newGid))
 		// Validate symlink has changed
 		verifyOwnership(t, dir2SymlinkToFile, newUid, newGid)
 		// Validate pointed file has not changed

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -588,7 +588,7 @@ func (u *HostUserManagement) UserCleanup() {
 		err := u.DeleteAllUsers()
 		switch {
 		case trace.IsNotFound(err):
-			u.log.DebugContext(u.ctx, "Error during temporary user cleanup, stopping cleanup job", "error", err)
+			u.log.Debug("Error during temporary user cleanup, stopping cleanup job", "error", err)
 			return
 		case err != nil:
 			u.log.ErrorContext(u.ctx, "Error during temporary user cleanup", "error", err)

--- a/lib/srv/usermgmt_other.go
+++ b/lib/srv/usermgmt_other.go
@@ -22,11 +22,13 @@
 package srv
 
 import (
+	"log/slog"
+
 	"github.com/gravitational/trace"
 )
 
 //nolint:staticcheck // intended to always return an error for non-linux builds
-func newHostUsersBackend() (HostUsersBackend, error) {
+func NewHostUsersBackend(log *slog.Logger) (HostUsersBackend, error) {
 	return nil, trace.NotImplemented("Host user creation management is only supported on linux")
 }
 

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -393,35 +393,6 @@ func RemoveFileIfExist(filePath string) error {
 	return nil
 }
 
-func RecursiveChown(dir string, uid, gid int) error {
-	// First, walk the directory to gather a list of files and directories to update before we open up to modifications
-	var pathsToUpdate []string
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		pathsToUpdate = append(pathsToUpdate, path)
-		return nil
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	// filepath.WalkDir is documented to walk the paths in lexical order, iterating
-	// in the reverse order ensures that files are always Lchowned before their parent directory
-	for i := len(pathsToUpdate) - 1; i >= 0; i-- {
-		path := pathsToUpdate[i]
-		if err := os.Lchown(path, uid, gid); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				// Unexpected condition where file was removed after discovery.
-				continue
-			}
-			return trace.Wrap(err)
-		}
-	}
-	return nil
-}
-
 func CopyFile(src, dest string, perm os.FileMode) error {
 	srcFile, err := os.Open(src)
 	if err != nil {


### PR DESCRIPTION
This PR updates `CreateHomeDirectory` such that it takes ownership of existing home directories and their contents. I originally thought we were already `chown`ing the directory contents and we were just omitting the directory itself. However, I realized while implementing that this only happened for the files copied from skel so we'll need to figure out if this is something we want to move forward with or not

changelog: Allows host user creation to take ownership of existing home directories on behalf of the newly created user.