### PR TITLE
[v14] Display user friendly name of resources with preview_as_roles

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3786,6 +3786,7 @@ func GetResourcesWithFilters(ctx context.Context, clt ListResourcesClient, req p
 			SearchKeywords:      req.SearchKeywords,
 			PredicateExpression: req.PredicateExpression,
 			UseSearchAsRoles:    req.UseSearchAsRoles,
+			UsePreviewAsRoles:   req.UsePreviewAsRoles,
 		})
 		if err != nil {
 			if trace.IsLimitExceeded(err) {


### PR DESCRIPTION
Backport #47056 to branch/v14

changelog: fixes an issue preventing access requests from displaying user friendly resource names.
