### PR TITLE
fix: Always prompt if multiple MFA methods are running

### DIFF
--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/mfa"
-	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
-	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	libmfa "github.com/gravitational/teleport/lib/client/mfa"
 )
 
@@ -51,8 +49,9 @@ func (tc *TeleportClient) createAuthenticateChallenge(ctx context.Context, req *
 	return rootClient.CreateAuthenticateChallenge(ctx, req)
 }
 
-// WebauthnLoginFunc matches the signature of [wancli.Login].
-type WebauthnLoginFunc func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt, opts *wancli.LoginOpts) (*proto.MFAAuthenticateResponse, string, error)
+// WebauthnLoginFunc is a function that performs WebAuthn login.
+// Mimics the signature of [webauthncli.Login].
+type WebauthnLoginFunc = libmfa.WebauthnLoginFunc
 
 // NewMFAPrompt creates a new MFA prompt from client settings.
 func (tc *TeleportClient) NewMFAPrompt(opts ...mfa.PromptOpt) mfa.Prompt {

--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -22,11 +22,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime"
 	"sync"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/utils/prompt"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
@@ -73,6 +75,22 @@ func (c *CLIPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 			<-otpDone
 		}
 
+		dualPrompt := runOpts.PromptTOTP && runOpts.PromptWebauthn
+
+		// Print the prompt message directly here in case of dualPrompt.
+		// This avoids problems with a goroutine failing before any message is
+		// printed.
+		if dualPrompt {
+			var message string
+			if runtime.GOOS == constants.WindowsOS {
+				message = "Follow the OS dialogs for platform authentication, or enter an OTP code here:"
+				webauthnwin.PromptPlatformMessage = ""
+			} else {
+				message = fmt.Sprintf("Tap any %ssecurity key or enter a code from a %sOTP device", c.promptDevicePrefix(), c.promptDevicePrefix())
+			}
+			fmt.Fprintln(c.writer, message)
+		}
+
 		// Fire TOTP goroutine.
 		if runOpts.PromptTOTP {
 			wg.Add(1)
@@ -81,10 +99,8 @@ func (c *CLIPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 				defer otpCancel()
 				defer close(otpDone)
 
-				// Let Webauthn take the prompt below if applicable.
-				quiet := c.cfg.Quiet || runOpts.PromptWebauthn
-
-				resp, err := c.promptTOTP(otpCtx, chal, quiet)
+				quiet := c.cfg.Quiet || dualPrompt
+				resp, err := c.promptTOTP(otpCtx, quiet)
 				respC <- MFAGoroutineResponse{Resp: resp, Err: trace.Wrap(err, "TOTP authentication failed")}
 			}()
 		}
@@ -93,11 +109,15 @@ func (c *CLIPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 		if runOpts.PromptWebauthn {
 			wg.Add(1)
 			go func() {
-				defer wg.Done()
+				defer func() {
+					wg.Done()
+					// Important for dual-prompt, harmless otherwise.
+					webauthnwin.ResetPromptPlatformMessage()
+				}()
 
 				// Get webauthn prompt and wrap with otp context handler.
 				prompt := &webauthnPromptWithOTP{
-					LoginPrompt:      c.getWebauthnPrompt(ctx, runOpts.PromptTOTP),
+					LoginPrompt:      c.getWebauthnPrompt(ctx, dualPrompt),
 					otpCancelAndWait: otpCancelAndWait,
 				}
 
@@ -110,7 +130,7 @@ func (c *CLIPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 	return HandleMFAPromptGoroutines(ctx, spawnGoroutines)
 }
 
-func (c *CLIPrompt) promptTOTP(ctx context.Context, chal *proto.MFAAuthenticateChallenge, quiet bool) (*proto.MFAAuthenticateResponse, error) {
+func (c *CLIPrompt) promptTOTP(ctx context.Context, quiet bool) (*proto.MFAAuthenticateResponse, error) {
 	var msg string
 	if !quiet {
 		msg = fmt.Sprintf("Enter an OTP code from a %sdevice", c.promptDevicePrefix())
@@ -128,7 +148,7 @@ func (c *CLIPrompt) promptTOTP(ctx context.Context, chal *proto.MFAAuthenticateC
 	}, nil
 }
 
-func (c *CLIPrompt) getWebauthnPrompt(ctx context.Context, withTOTP bool) wancli.LoginPrompt {
+func (c *CLIPrompt) getWebauthnPrompt(ctx context.Context, dualPrompt bool) wancli.LoginPrompt {
 	writer := c.writer
 	if c.cfg.Quiet {
 		writer = io.Discard
@@ -138,13 +158,10 @@ func (c *CLIPrompt) getWebauthnPrompt(ctx context.Context, withTOTP bool) wancli
 	prompt.SecondTouchMessage = fmt.Sprintf("Tap your %ssecurity key to complete login", c.promptDevicePrefix())
 	prompt.FirstTouchMessage = fmt.Sprintf("Tap any %ssecurity key", c.promptDevicePrefix())
 
-	if withTOTP {
-		prompt.FirstTouchMessage = fmt.Sprintf("Tap any %ssecurity key or enter a code from a %sOTP device", c.promptDevicePrefix(), c.promptDevicePrefix())
-
-		// Customize Windows prompt directly.
-		// Note that the platform popup is a modal and will only go away if canceled.
-		webauthnwin.PromptPlatformMessage = "Follow the OS dialogs for platform authentication, or enter an OTP code here:"
-		defer webauthnwin.ResetPromptPlatformMessage()
+	// Skip when both OTP and WebAuthn are possible, as the prompt happens
+	// externally.
+	if dualPrompt {
+		prompt.FirstTouchMessage = ""
 	}
 
 	return prompt

--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -76,7 +76,7 @@ func (c *CLIPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 			var message string
 			if runtime.GOOS == constants.WindowsOS {
 				message = "Follow the OS dialogs for platform authentication, or enter an OTP code here:"
-				webauthnwin.PromptPlatformMessage = ""
+				webauthnwin.SetPromptPlatformMessage("")
 			} else {
 				message = fmt.Sprintf("Tap any %ssecurity key or enter a code from a %sOTP device", c.promptDevicePrefix(), c.promptDevicePrefix())
 			}

--- a/lib/client/mfa/cli_test.go
+++ b/lib/client/mfa/cli_test.go
@@ -21,6 +21,7 @@ package mfa_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -39,12 +40,13 @@ func TestCLIPrompt(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tc := range []struct {
-		name         string
-		stdin        string
-		challenge    *proto.MFAAuthenticateChallenge
-		expectErr    error
-		expectStdOut string
-		expectResp   *proto.MFAAuthenticateResponse
+		name                  string
+		stdin                 string
+		challenge             *proto.MFAAuthenticateChallenge
+		expectErr             error
+		expectStdOut          string
+		expectResp            *proto.MFAAuthenticateResponse
+		makeWebauthnLoginFunc func(stdin *prompt.FakeReader) mfa.WebauthnLoginFunc
 	}{
 		{
 			name:         "OK empty challenge",
@@ -126,6 +128,102 @@ func TestCLIPrompt(t *testing.T) {
 			},
 			expectErr: context.DeadlineExceeded,
 		},
+		{
+			name: "OK otp and webauthn with PIN",
+			challenge: &proto.MFAAuthenticateChallenge{
+				TOTP:              &proto.TOTPChallenge{},
+				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
+			},
+			expectStdOut: `Tap any security key or enter a code from a OTP device
+Detected security key tap
+Enter your security key PIN:
+`,
+			expectResp: &proto.MFAAuthenticateResponse{
+				Response: &proto.MFAAuthenticateResponse_Webauthn{
+					Webauthn: &webauthnpb.CredentialAssertionResponse{
+						RawId: []byte{1, 2, 3, 4, 5},
+					},
+				},
+			},
+			makeWebauthnLoginFunc: func(stdin *prompt.FakeReader) mfa.WebauthnLoginFunc {
+				return func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt, opts *wancli.LoginOpts) (*proto.MFAAuthenticateResponse, string, error) {
+					ack, err := prompt.PromptTouch()
+					if err != nil {
+						return nil, "", trace.Wrap(err)
+					}
+
+					// Ack first (so the OTP goroutine stops)...
+					if err := ack(); err != nil {
+						return nil, "", trace.Wrap(err)
+					}
+
+					// ...then send the PIN to stdin...
+					const pin = "1234"
+					stdin.AddString(pin)
+
+					// ...then prompt for the PIN.
+					switch got, err := prompt.PromptPIN(); {
+					case err != nil:
+						return nil, "", trace.Wrap(err)
+					case got != pin:
+						return nil, "", errors.New("invalid PIN")
+					}
+
+					return &proto.MFAAuthenticateResponse{
+						Response: &proto.MFAAuthenticateResponse_Webauthn{
+							Webauthn: &webauthnpb.CredentialAssertionResponse{
+								RawId: []byte{1, 2, 3, 4, 5},
+							},
+						},
+					}, "", nil
+				}
+			},
+		},
+		{
+			name: "OK webauthn with PIN",
+			challenge: &proto.MFAAuthenticateChallenge{
+				TOTP:              nil, // no TOTP challenge
+				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
+			},
+			stdin: "1234",
+			expectStdOut: `Tap any security key
+Detected security key tap
+Enter your security key PIN:
+`,
+			expectResp: &proto.MFAAuthenticateResponse{
+				Response: &proto.MFAAuthenticateResponse_Webauthn{
+					Webauthn: &webauthnpb.CredentialAssertionResponse{
+						RawId: []byte{1, 2, 3, 4, 5},
+					},
+				},
+			},
+			makeWebauthnLoginFunc: func(_ *prompt.FakeReader) mfa.WebauthnLoginFunc {
+				return func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt, opts *wancli.LoginOpts) (*proto.MFAAuthenticateResponse, string, error) {
+					ack, err := prompt.PromptTouch()
+					if err != nil {
+						return nil, "", trace.Wrap(err)
+					}
+					if err := ack(); err != nil {
+						return nil, "", trace.Wrap(err)
+					}
+
+					switch got, err := prompt.PromptPIN(); {
+					case err != nil:
+						return nil, "", trace.Wrap(err)
+					case got != "1234":
+						return nil, "", errors.New("invalid PIN")
+					}
+
+					return &proto.MFAAuthenticateResponse{
+						Response: &proto.MFAAuthenticateResponse_Webauthn{
+							Webauthn: &webauthnpb.CredentialAssertionResponse{
+								RawId: []byte{1, 2, 3, 4, 5},
+							},
+						},
+					}, "", nil
+				}
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
@@ -143,17 +241,21 @@ func TestCLIPrompt(t *testing.T) {
 			cfg := mfa.NewPromptConfig("proxy.example.com")
 			cfg.AllowStdinHijack = true
 			cfg.WebauthnSupported = true
-			cfg.WebauthnLoginFunc = func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt, opts *wancli.LoginOpts) (*proto.MFAAuthenticateResponse, string, error) {
-				if _, err := prompt.PromptTouch(); err != nil {
-					return nil, "", trace.Wrap(err)
-				}
+			if tc.makeWebauthnLoginFunc != nil {
+				cfg.WebauthnLoginFunc = tc.makeWebauthnLoginFunc(stdin)
+			} else {
+				cfg.WebauthnLoginFunc = func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt, opts *wancli.LoginOpts) (*proto.MFAAuthenticateResponse, string, error) {
+					if _, err := prompt.PromptTouch(); err != nil {
+						return nil, "", trace.Wrap(err)
+					}
 
-				if tc.expectResp.GetWebauthn() == nil {
-					<-ctx.Done()
-					return nil, "", trace.Wrap(ctx.Err())
-				}
+					if tc.expectResp.GetWebauthn() == nil {
+						<-ctx.Done()
+						return nil, "", trace.Wrap(ctx.Err())
+					}
 
-				return tc.expectResp, "", nil
+					return tc.expectResp, "", nil
+				}
 			}
 
 			buffer := make([]byte, 0, 100)

--- a/lib/client/mfa/prompt.go
+++ b/lib/client/mfa/prompt.go
@@ -33,13 +33,23 @@ import (
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 )
 
+// WebauthnLoginFunc is a function that performs WebAuthn login.
+// Mimics the signature of [wancli.Login].
+type WebauthnLoginFunc func(
+	ctx context.Context,
+	origin string,
+	assertion *wantypes.CredentialAssertion,
+	prompt wancli.LoginPrompt,
+	opts *wancli.LoginOpts,
+) (*proto.MFAAuthenticateResponse, string, error)
+
 // PromptConfig contains common mfa prompt config options.
 type PromptConfig struct {
 	mfa.PromptConfig
 	// ProxyAddress is the address of the authenticating proxy. required.
 	ProxyAddress string
 	// WebauthnLoginFunc performs client-side Webauthn login.
-	WebauthnLoginFunc func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt, opts *wancli.LoginOpts) (*proto.MFAAuthenticateResponse, string, error)
+	WebauthnLoginFunc WebauthnLoginFunc
 	// AllowStdinHijack allows stdin hijack during MFA prompts.
 	// Stdin hijack provides a better login UX, but it can be difficult to reason
 	// about and is often a source of bugs.

--- a/lib/client/mfa/prompt.go
+++ b/lib/client/mfa/prompt.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/mfa"
@@ -147,6 +148,9 @@ func HandleMFAPromptGoroutines(ctx context.Context, startGoroutines func(context
 			// Surface error immediately.
 			return nil, trace.Wrap(resp.Err)
 		case err != nil:
+			log.
+				WithError(err).
+				Debug("MFA goroutine failed, continuing so other goroutines have a chance to succeed")
 			errs = append(errs, err)
 			// Continue to give the other authn goroutine a chance to succeed.
 			// If both have failed, this will exit the loop.

--- a/tool/tsh/common/mfa.go
+++ b/tool/tsh/common/mfa.go
@@ -340,8 +340,8 @@ func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportCli
 		// TODO(Joerger): this should live in lib/client/mfa/cli.go using the prompt device prefix.
 		const registeredMsg = "Using platform authentication for *registered* device, follow the OS dialogs"
 		const newMsg = "Using platform authentication for *new* device, follow the OS dialogs"
+		wanwin.SetPromptPlatformMessage(registeredMsg)
 		defer wanwin.ResetPromptPlatformMessage()
-		wanwin.PromptPlatformMessage = registeredMsg
 
 		mfaResp, err := tc.NewMFACeremony().Run(ctx, &proto.CreateAuthenticateChallengeRequest{
 			ChallengeExtensions: &mfav1.ChallengeExtensions{
@@ -363,7 +363,7 @@ func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportCli
 		}
 
 		// Prompt for registration.
-		wanwin.PromptPlatformMessage = newMsg
+		wanwin.SetPromptPlatformMessage(newMsg)
 		registerResp, registerCallback, err := promptRegisterChallenge(ctx, tc.WebProxyAddr, c.devType, registerChallenge)
 		if err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
Fixes a scenario where the MFA prompt wouldn't show if the user has both OTP and WebAuthn devices, but no WebAuthn device is plugged.

I've moved the prompt for "dual prompt" scenarios (OTP+WebAuthn) outside of `wancli` and directly into `lib/client/mfa`. This prompts earlier, but is overall more resilient to some goroutine failing (which was the case here).

I also fixed a (theoretical?) deadlock on the "WebAuthn with PIN" scenario (`otpDone` is never closed in that branch). I can't quite make it happen with the devices I have today (MFA scenarios don't prompt for PIN and passkeys go to other branches), but that doesn't mean it couldn't happen with some other/future device.

#43072

Changelog: Fix missing tsh MFA prompt in certain OTP+WebAuthn scenarios