### PR TITLE
[v15] tsh: Deduplicate the list of request IDs

### DIFF
--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -21,6 +21,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -792,12 +793,14 @@ func TestMaxLength(t *testing.T) {
 	req, err := types.NewAccessRequest("some-id", "dave", "dictator", "never")
 	require.NoError(t, err)
 
-	var s []byte
-	for i := 0; i <= maxAccessRequestReasonSize; i++ {
-		s = append(s, 'a')
-	}
+	req.SetRequestReason(strings.Repeat("a", maxAccessRequestReasonSize))
+	require.Error(t, ValidateAccessRequest(req))
 
-	req.SetRequestReason(string(s))
+	resourceIDs, err := types.ResourceIDsFromString(`["/cluster/node/some-node", "/cluster/node/some-other-node" ]`)
+	require.NoError(t, err)
+
+	req.SetRequestReason("")
+	req.SetRequestedResourceIDs(slices.Repeat(resourceIDs, maxResourcesPerRequest/2+1))
 	require.Error(t, ValidateAccessRequest(req))
 }
 
@@ -2153,6 +2156,70 @@ func (mcg mockClusterGetter) GetRemoteCluster(clusterName string) (types.RemoteC
 		return cluster, nil
 	}
 	return nil, trace.NotFound("remote cluster %q was not found", clusterName)
+}
+
+func TestValidateDuplicateRequestedResources(t *testing.T) {
+	g := &mockGetter{
+		roles:       make(map[string]types.Role),
+		userStates:  make(map[string]*userloginstate.UserLoginState),
+		users:       make(map[string]types.User),
+		nodes:       make(map[string]types.Server),
+		kubeServers: make(map[string]types.KubeServer),
+		dbServers:   make(map[string]types.DatabaseServer),
+		appServers:  make(map[string]types.AppServer),
+		desktops:    make(map[string]types.WindowsDesktop),
+		clusterName: "someCluster",
+	}
+
+	for i := 1; i < 3; i++ {
+		node, err := types.NewServerWithLabels(
+			fmt.Sprintf("resource%d", i),
+			types.KindNode,
+			types.ServerSpecV2{},
+			map[string]string{"foo": "bar"},
+		)
+		require.NoError(t, err)
+		g.nodes[node.GetName()] = node
+	}
+
+	searchAsRole, err := types.NewRole("searchAs", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins:     []string{"root"},
+			NodeLabels: types.Labels{"*": []string{"*"}},
+		},
+	})
+	require.NoError(t, err)
+	g.roles[searchAsRole.GetName()] = searchAsRole
+
+	testRole, err := types.NewRole("testRole", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				SearchAsRoles: []string{searchAsRole.GetName()},
+			},
+		},
+	})
+	require.NoError(t, err)
+	g.roles[testRole.GetName()] = testRole
+
+	user := g.user(t, testRole.GetName())
+
+	clock := clockwork.NewFakeClock()
+	identity := tlsca.Identity{
+		Expires: clock.Now().UTC().Add(8 * time.Hour),
+	}
+
+	req, err := types.NewAccessRequestWithResources("name", user, nil, /* roles */
+		[]types.ResourceID{
+			{ClusterName: "someCluster", Kind: "node", Name: "resource1"},
+			{ClusterName: "someCluster", Kind: "node", Name: "resource1"}, // a  duplicate
+			{ClusterName: "someCluster", Kind: "node", Name: "resource2"}, // not a duplicate
+		})
+	require.NoError(t, err)
+
+	require.NoError(t, ValidateAccessRequestForUser(context.Background(), clock, g, req, identity, ExpandVars(true)))
+	require.Len(t, req.GetRequestedResourceIDs(), 2)
+	require.Equal(t, "/someCluster/node/resource1", types.ResourceIDToString(req.GetRequestedResourceIDs()[0]))
+	require.Equal(t, "/someCluster/node/resource2", types.ResourceIDToString(req.GetRequestedResourceIDs()[1]))
 }
 
 func TestValidateAccessRequestClusterNames(t *testing.T) {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2504,6 +2504,7 @@ func createAccessRequest(cf *CLIConf) (types.AccessRequest, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	req, err := services.NewAccessRequestWithResources(cf.Username, roles, requestedResourceIDs)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -4367,15 +4367,14 @@ func TestSerializeProfilesNoOthers(t *testing.T) {
 	expected := `
 	{
 		"active": {
-      "profile_url": "example.com",
-      "username": "test",
-      "cluster": "main",
-      "kubernetes_enabled": false,
-      "valid_until": "1970-01-01T00:00:00Z"
-    },
+			"profile_url": "example.com",
+			"username": "test",
+			"cluster": "main",
+			"kubernetes_enabled": false,
+			"valid_until": "1970-01-01T00:00:00Z"
+		},
 		"profiles": []
-	}
-	`
+	}`
 	aTime := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
 	p, err := url.Parse("example.com")
 	require.NoError(t, err)
@@ -4462,26 +4461,25 @@ func TestSerializeAccessRequests(t *testing.T) {
 
 	expected := `
 	{
-    "kind": "access_request",
-    "version": "v3",
-    "metadata": {
-      "name": "test"
-    },
-    "spec": {
-      "user": "user",
-      "roles": [
-        "a",
-        "b",
-        "c"
-      ],
-      "state": 1,
-      "created": "0001-01-01T00:00:00Z",
-      "expires": "0001-01-01T00:00:00Z",
-      "max_duration": "0001-01-01T00:00:00Z",
-      "session_ttl": "0001-01-01T00:00:00Z"
-    }
-  }
-	`
+		"kind": "access_request",
+		"version": "v3",
+		"metadata": {
+			"name": "test"
+		},
+		"spec": {
+			"user": "user",
+			"roles": [
+				"a",
+				"b",
+				"c"
+			],
+			"state": 1,
+			"created": "0001-01-01T00:00:00Z",
+			"expires": "0001-01-01T00:00:00Z",
+			"max_duration": "0001-01-01T00:00:00Z",
+			"session_ttl": "0001-01-01T00:00:00Z"
+		}
+	}`
 	req, err := types.NewAccessRequest("test", "user", "a", "b", "c")
 	require.NoError(t, err)
 	testSerialization(t, expected, func(f string) (string, error) {
@@ -4499,68 +4497,67 @@ func TestSerializeKubeSessions(t *testing.T) {
 	aTime := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
 	expected := `
 	[
-  {
-    "kind": "session_tracker",
-    "version": "v1",
-    "metadata": {
-      "name": "id",
-      "expires": "1970-01-01T00:00:00Z"
-    },
-    "spec": {
-      "session_id": "id",
-      "kind": "session-kind",
-      "state": 1,
-      "created": "1970-01-01T00:00:00Z",
-      "expires": "1970-01-01T00:00:00Z",
-      "attached": "arbitrary attached data",
-      "reason": "some reason",
-      "invited": [
-        "a",
-        "b",
-        "c"
-      ],
-      "target_hostname": "example.com",
-      "target_address": "https://example.com",
-      "cluster_name": "cluster",
-      "login": "login",
-      "participants": [
-        {
-          "id": "some-id",
-          "user": "test",
-          "mode": "mode",
-          "last_active": "1970-01-01T00:00:00Z"
-        }
-      ],
-      "kubernetes_cluster": "kc",
-      "host_user": "test",
-      "host_roles": [
-        {
-          "name": "policy",
-          "version": "v1",
-          "require_session_join": [
-            {
-              "name": "policy",
-              "filter": "filter",
-              "kinds": [
-                "x",
-                "y",
-                "z"
-              ],
-              "count": 1,
-              "modes": [
-                "mode",
-                "mode-1",
-                "mode-2"
-              ],
-              "on_leave": "do something"
-            }
-          ]
-        }
-      ]
-    }
-  }
-]
-	`
+		{
+			"kind": "session_tracker",
+			"version": "v1",
+			"metadata": {
+				"name": "id",
+				"expires": "1970-01-01T00:00:00Z"
+			},
+			"spec": {
+				"session_id": "id",
+				"kind": "session-kind",
+				"state": 1,
+				"created": "1970-01-01T00:00:00Z",
+				"expires": "1970-01-01T00:00:00Z",
+				"attached": "arbitrary attached data",
+				"reason": "some reason",
+				"invited": [
+					"a",
+					"b",
+					"c"
+				],
+				"target_hostname": "example.com",
+				"target_address": "https://example.com",
+				"cluster_name": "cluster",
+				"login": "login",
+				"participants": [
+					{
+						"id": "some-id",
+						"user": "test",
+						"mode": "mode",
+						"last_active": "1970-01-01T00:00:00Z"
+					}
+				],
+				"kubernetes_cluster": "kc",
+				"host_user": "test",
+				"host_roles": [
+					{
+						"name": "policy",
+						"version": "v1",
+						"require_session_join": [
+							{
+								"name": "policy",
+								"filter": "filter",
+								"kinds": [
+									"x",
+									"y",
+									"z"
+								],
+								"count": 1,
+								"modes": [
+									"mode",
+									"mode-1",
+									"mode-2"
+								],
+								"on_leave": "do something"
+							}
+						]
+					}
+				]
+			}
+		}
+	]`
 	tracker, err := types.NewSessionTracker(types.SessionTrackerSpecV1{
 		SessionID:    "id",
 		Kind:         "session-kind",
@@ -4664,7 +4661,7 @@ func TestSerializeMFADevices(t *testing.T) {
 	aTime := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
 	expected := `
 	[
-  {"metadata":{"Name":"my device"},"id":"id","addedAt":"1970-01-01T00:00:00Z","lastUsed":"1970-01-01T00:00:00Z"}
+		{"metadata":{"Name":"my device"},"id":"id","addedAt":"1970-01-01T00:00:00Z","lastUsed":"1970-01-01T00:00:00Z"}
 	]
 	`
 	dev := types.NewMFADevice("my device", "id", aTime)
@@ -5183,7 +5180,7 @@ func TestShowSessions(t *testing.T) {
 	var buf bytes.Buffer
 	err := common.ShowSessions(sessions, teleport.JSON, &buf)
 	require.NoError(t, err)
-	require.Equal(t, expected, buf.String())
+	require.JSONEq(t, expected, buf.String())
 }
 
 func TestMakeProfileInfo_NoInternalLogins(t *testing.T) {


### PR DESCRIPTION
It's possible to specify the same request multiple times with tsh request create. The duplicates eventually get resolved before we generate a certificate, but they do exist in the access request resource. This can cause the size of the resource to exceed the limits of a gRPC message and break listing.

Backports #46780 