### PR TITLE
docs: update proxy service ports networking example

### DIFF
--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -185,11 +185,11 @@ In those cases, they can set up separate listeners in the config file.
 
 Cloud-hosted Teleport deployments allocate a different set of ports to each
 tenant's Proxy Service. To see which ports are available for your Teleport
-tenant, run a command similar to the following, replacing `mytenant.teleport.sh`
+tenant, run a command similar to the following, replacing `example.teleport.sh`
 with your tenant domain:
 
 ```code
-$ curl https://mytenant.teleport.sh/webapi/ping | jq '.proxy'
+$ curl https://example.teleport.sh/webapi/ping | jq '.proxy'
 ```
 
 The output should resemble the following, including the unique ports assigned to
@@ -199,20 +199,18 @@ your tenant:
 {
   "kube": {
     "enabled": true,
-    "public_addr": "mytenant.teleport.sh:11107",
-    "listen_addr": "0.0.0.0:3026"
+    "listen_addr": "0.0.0.0:3080"
   },
   "ssh": {
-    "listen_addr": "[::]:3023",
-    "tunnel_listen_addr": "0.0.0.0:3024",
-    "public_addr": "mytenant.teleport.sh:443",
-    "ssh_public_addr": "mytenant.teleport.sh:11105",
-    "ssh_tunnel_public_addr": "mytenant.teleport.sh:11106"
+    "listen_addr": "0.0.0.0:3080",
+    "tunnel_listen_addr": "0.0.0.0:3080",
+    "web_listen_addr": "0.0.0.0:3080",
+    "public_addr": "example.teleport.sh:443",
+    "dial_timeout": 30000000000
   },
   "db": {
-    "postgres_public_addr": "mytenant.teleport.sh:11109",
-    "mysql_listen_addr": "0.0.0.0:3036",
-    "mysql_public_addr": "mytenant.teleport.sh:11108"
+    "postgres_listen_addr": "0.0.0.0:3080",
+    "mysql_listen_addr": "0.0.0.0:3080"
   },
   "tls_routing_enabled": true
 }


### PR DESCRIPTION
The networking shown was a non TLS routing example when TLS routing was enabled.  Updated to the current TLS routing example.