### PR TITLE
[v16] Updates self-hosted db discover to use 2190h ttl for certificate

### DIFF
--- a/lib/web/sign.go
+++ b/lib/web/sign.go
@@ -44,7 +44,7 @@ POST /webapi/sites/mycluster/sign/db
 
 	{
 		"hostname": "pg.example.com",
-		"TTL": "2190h"
+		"ttl": "2190h"
 	}
 
 Should be equivalent to running:

--- a/lib/web/sign.go
+++ b/lib/web/sign.go
@@ -44,7 +44,7 @@ POST /webapi/sites/mycluster/sign/db
 
 	{
 		"hostname": "pg.example.com",
-		"ttl": "2190h"
+		"TTL": "2190h"
 	}
 
 Should be equivalent to running:

--- a/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
@@ -157,7 +157,10 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
           ]}
         />
         <Text mt={1}>
-          Restart the database server to apply the configuration.
+          Restart the database server to apply the configuration. The
+          certificate is by default 90 days so this will require installing an
+          updated certificate and restarting the database server before that to
+          continue access.
         </Text>
       </Box>
     );
@@ -248,7 +251,10 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                     ]}
                   />
                   <Text mt={1}>
-                    Restart the database server to apply the configuration.
+                    Restart the database server to apply the configuration. The
+                    certificate is by default 90 days so this will require
+                    installing an updated certificate and restarting the
+                    database server before that to continue access.
                   </Text>
                   <Text mt={2}>
                     See{' '}
@@ -281,7 +287,10 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                     ]}
                   />
                   <Text mt={1}>
-                    Restart the database server to apply the configuration.
+                    Restart the database server to apply the configuration. The
+                    certificate is by default 90 days so this will require
+                    installing an updated certificate and restarting the
+                    database server before that to continue access.
                   </Text>
                   <Text mt={2}>
                     See{' '}

--- a/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
@@ -156,17 +156,7 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
             },
           ]}
         />
-        <Text mt={1}>
-          Restart the database server to apply the configuration. The
-          certificate is valid for 90 days so this will require installing an{' '}
-          <Link
-            href="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted/#step-25-create-a-certificatekey-pair"
-            target="_blank"
-          >
-            updated certificate
-          </Link>{' '}
-          and restarting the database server before that to continue access.
-        </Text>
+        <RestartDatabaseText link="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted/#step-25-create-a-certificatekey-pair" />
       </Box>
     );
   }
@@ -255,19 +245,7 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                       },
                     ]}
                   />
-                  <Text mt={1}>
-                    Restart the database server to apply the configuration. The
-                    certificate is valid for 90 days so this will require
-                    installing an{' '}
-                    <Link
-                      href="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted/#step-24-create-a-certificatekey-pair"
-                      target="_blank"
-                    >
-                      updated certificate
-                    </Link>{' '}
-                    and restarting the database server before that to continue
-                    access.
-                  </Text>
+                  <RestartDatabaseText link="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted/#step-24-create-a-certificatekey-pair" />
                   <Text mt={2}>
                     See{' '}
                     <Link
@@ -298,19 +276,7 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                       },
                     ]}
                   />
-                  <Text mt={1}>
-                    Restart the database server to apply the configuration. The
-                    certificate is valid for 90 days so this will require
-                    installing an{' '}
-                    <Link
-                      href="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted/#step-24-create-a-certificatekey-pair"
-                      target="_blank"
-                    >
-                      updated certificate
-                    </Link>{' '}
-                    and restarting the database server before that to continue
-                    access.
-                  </Text>
+                  <RestartDatabaseText link="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted/#step-24-create-a-certificatekey-pair" />
                   <Text mt={2}>
                     See{' '}
                     <Link
@@ -330,3 +296,14 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
     );
   }
 }
+
+const RestartDatabaseText = ({ link }: { link: string }) => (
+  <Text mt={1}>
+    Restart the database server to apply the configuration. The certificate is
+    valid for 90 days so this will require installing an{' '}
+    <Link href={link} target="_blank">
+      updated certificate
+    </Link>{' '}
+    and restarting the database server before that to continue access.
+  </Text>
+);

--- a/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
@@ -158,9 +158,14 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
         />
         <Text mt={1}>
           Restart the database server to apply the configuration. The
-          certificate is by default 90 days so this will require installing an
-          updated certificate and restarting the database server before that to
-          continue access.
+          certificate is valid for 90 days so this will require installing an{' '}
+          <Link
+            href="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted/#step-25-create-a-certificatekey-pair"
+            target="_blank"
+          >
+            updated certificate
+          </Link>{' '}
+          and restarting the database server before that to continue access.
         </Text>
       </Box>
     );
@@ -252,9 +257,16 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                   />
                   <Text mt={1}>
                     Restart the database server to apply the configuration. The
-                    certificate is by default 90 days so this will require
-                    installing an updated certificate and restarting the
-                    database server before that to continue access.
+                    certificate is valid for 90 days so this will require
+                    installing an{' '}
+                    <Link
+                      href="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted/#step-24-create-a-certificatekey-pair"
+                      target="_blank"
+                    >
+                      updated certificate
+                    </Link>{' '}
+                    and restarting the database server before that to continue
+                    access.
                   </Text>
                   <Text mt={2}>
                     See{' '}
@@ -288,9 +300,16 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                   />
                   <Text mt={1}>
                     Restart the database server to apply the configuration. The
-                    certificate is by default 90 days so this will require
-                    installing an updated certificate and restarting the
-                    database server before that to continue access.
+                    certificate is valid for 90 days so this will require
+                    installing an{' '}
+                    <Link
+                      href="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted/#step-24-create-a-certificatekey-pair"
+                      target="_blank"
+                    >
+                      updated certificate
+                    </Link>{' '}
+                    and restarting the database server before that to continue
+                    access.
                   </Text>
                   <Text mt={2}>
                     See{' '}

--- a/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
@@ -113,8 +113,8 @@ function generateSignCertificateCurlCommand(
   if (!token) return '';
 
   const requestUrl = cfg.getDatabaseSignUrl(clusterId);
-  const TTL = cfg.getDatabaseCertificateTTL();
-  const requestData = JSON.stringify({ hostname, TTL });
+  const ttl = cfg.getDatabaseCertificateTTL();
+  const requestData = JSON.stringify({ hostname, ttl });
 
   // curl flag -OJ  makes curl use the file name
   // defined from the response header.

--- a/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
@@ -113,7 +113,8 @@ function generateSignCertificateCurlCommand(
   if (!token) return '';
 
   const requestUrl = cfg.getDatabaseSignUrl(clusterId);
-  const requestData = JSON.stringify({ hostname });
+  const TTL = cfg.getDatabaseCertificateTTL();
+  const requestData = JSON.stringify({ hostname, TTL });
 
   // curl flag -OJ  makes curl use the file name
   // defined from the response header.

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -131,6 +131,8 @@ const cfg = {
     dateFormat: 'YYYY-MM-DD',
   },
 
+  defaultDatabaseTTL: '2190h',
+
   routes: {
     root: '/web',
     discover: '/web/discover',
@@ -790,6 +792,11 @@ const cfg = {
 
   getDatabaseSignUrl(clusterId: string) {
     return generatePath(cfg.api.dbSign, { clusterId });
+  },
+
+  getDatabaseCertificateTTL() {
+    // the length of the certificate to request for the database
+    return cfg.defaultDatabaseTTL;
   },
 
   getDesktopsUrl(clusterId: string, params: UrlResourcesParams) {


### PR DESCRIPTION
Backport #47081 to branch/v16

changelog: Updates self-hosted db discover flow to generate 2190h TTL certs, not 12h
