### PR TITLE
[v14] Updates self-hosted db discover to use 2190h ttl for certificate

### DIFF
--- a/lib/web/sign.go
+++ b/lib/web/sign.go
@@ -42,7 +42,7 @@ POST /webapi/sites/mycluster/sign/db
 
 	{
 		"hostname": "pg.example.com",
-		"TTL": "2190h"
+		"ttl": "2190h"
 	}
 
 Should be equivalent to running:

--- a/lib/web/sign.go
+++ b/lib/web/sign.go
@@ -42,7 +42,7 @@ POST /webapi/sites/mycluster/sign/db
 
 	{
 		"hostname": "pg.example.com",
-		"ttl": "2190h"
+		"TTL": "2190h"
 	}
 
 Should be equivalent to running:

--- a/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
@@ -161,7 +161,10 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
           ]}
         />
         <Text mt={1}>
-          Restart the database server to apply the configuration.
+          Restart the database server to apply the configuration. The
+          certificate is by default 90 days so this will require installing an
+          updated certificate and restarting the database server before that to
+          continue access.
         </Text>
       </Box>
     );
@@ -252,7 +255,10 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                     ]}
                   />
                   <Text mt={1}>
-                    Restart the database server to apply the configuration.
+                    Restart the database server to apply the configuration. The
+                    certificate is by default 90 days so this will require
+                    installing an updated certificate and restarting the
+                    database server before that to continue access.
                   </Text>
                   <Text mt={2}>
                     See{' '}
@@ -285,7 +291,10 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                     ]}
                   />
                   <Text mt={1}>
-                    Restart the database server to apply the configuration.
+                    Restart the database server to apply the configuration. The
+                    certificate is by default 90 days so this will require
+                    installing an updated certificate and restarting the
+                    database server before that to continue access.
                   </Text>
                   <Text mt={2}>
                     See{' '}

--- a/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
@@ -162,9 +162,14 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
         />
         <Text mt={1}>
           Restart the database server to apply the configuration. The
-          certificate is by default 90 days so this will require installing an
-          updated certificate and restarting the database server before that to
-          continue access.
+          certificate is valid for 90 days so this will require installing an{' '}
+          <Link
+            href="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted/#step-25-create-a-certificatekey-pair"
+            target="_blank"
+          >
+            updated certificate
+          </Link>{' '}
+          and restarting the database server before that to continue access.
         </Text>
       </Box>
     );
@@ -256,9 +261,16 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                   />
                   <Text mt={1}>
                     Restart the database server to apply the configuration. The
-                    certificate is by default 90 days so this will require
-                    installing an updated certificate and restarting the
-                    database server before that to continue access.
+                    certificate is valid for 90 days so this will require
+                    installing an{' '}
+                    <Link
+                      href="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted/#step-24-create-a-certificatekey-pair"
+                      target="_blank"
+                    >
+                      updated certificate
+                    </Link>{' '}
+                    and restarting the database server before that to continue
+                    access.
                   </Text>
                   <Text mt={2}>
                     See{' '}
@@ -292,9 +304,16 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                   />
                   <Text mt={1}>
                     Restart the database server to apply the configuration. The
-                    certificate is by default 90 days so this will require
-                    installing an updated certificate and restarting the
-                    database server before that to continue access.
+                    certificate is valid for 90 days so this will require
+                    installing an{' '}
+                    <Link
+                      href="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted/#step-24-create-a-certificatekey-pair"
+                      target="_blank"
+                    >
+                      updated certificate
+                    </Link>{' '}
+                    and restarting the database server before that to continue
+                    access.
                   </Text>
                   <Text mt={2}>
                     See{' '}

--- a/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
@@ -160,17 +160,7 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
             },
           ]}
         />
-        <Text mt={1}>
-          Restart the database server to apply the configuration. The
-          certificate is valid for 90 days so this will require installing an{' '}
-          <Link
-            href="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted/#step-25-create-a-certificatekey-pair"
-            target="_blank"
-          >
-            updated certificate
-          </Link>{' '}
-          and restarting the database server before that to continue access.
-        </Text>
+        <RestartDatabaseText link="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted/#step-25-create-a-certificatekey-pair" />
       </Box>
     );
   }
@@ -259,19 +249,7 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                       },
                     ]}
                   />
-                  <Text mt={1}>
-                    Restart the database server to apply the configuration. The
-                    certificate is valid for 90 days so this will require
-                    installing an{' '}
-                    <Link
-                      href="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted/#step-24-create-a-certificatekey-pair"
-                      target="_blank"
-                    >
-                      updated certificate
-                    </Link>{' '}
-                    and restarting the database server before that to continue
-                    access.
-                  </Text>
+                  <RestartDatabaseText link="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted/#step-24-create-a-certificatekey-pair" />
                   <Text mt={2}>
                     See{' '}
                     <Link
@@ -302,19 +280,7 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
                       },
                     ]}
                   />
-                  <Text mt={1}>
-                    Restart the database server to apply the configuration. The
-                    certificate is valid for 90 days so this will require
-                    installing an{' '}
-                    <Link
-                      href="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted/#step-24-create-a-certificatekey-pair"
-                      target="_blank"
-                    >
-                      updated certificate
-                    </Link>{' '}
-                    and restarting the database server before that to continue
-                    access.
-                  </Text>
+                  <RestartDatabaseText link="https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted/#step-24-create-a-certificatekey-pair" />
                   <Text mt={2}>
                     See{' '}
                     <Link
@@ -334,3 +300,14 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
     );
   }
 }
+
+const RestartDatabaseText = ({ link }: { link: string }) => (
+  <Text mt={1}>
+    Restart the database server to apply the configuration. The certificate is
+    valid for 90 days so this will require installing an{' '}
+    <Link href={link} target="_blank">
+      updated certificate
+    </Link>{' '}
+    and restarting the database server before that to continue access.
+  </Text>
+);

--- a/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
@@ -110,7 +110,8 @@ function generateSignCertificateCurlCommand(
   if (!token) return '';
 
   const requestUrl = cfg.getDatabaseSignUrl(clusterId);
-  const requestData = JSON.stringify({ hostname });
+  const TTL = cfg.getDatabaseCertificateTTL();
+  const requestData = JSON.stringify({ hostname, TTL });
 
   // curl flag -OJ  makes curl use the file name
   // defined from the response header.

--- a/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
@@ -110,8 +110,8 @@ function generateSignCertificateCurlCommand(
   if (!token) return '';
 
   const requestUrl = cfg.getDatabaseSignUrl(clusterId);
-  const TTL = cfg.getDatabaseCertificateTTL();
-  const requestData = JSON.stringify({ hostname, TTL });
+  const ttl = cfg.getDatabaseCertificateTTL();
+  const requestData = JSON.stringify({ hostname, ttl });
 
   // curl flag -OJ  makes curl use the file name
   // defined from the response header.

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -98,6 +98,8 @@ const cfg = {
     dateFormat: 'YYYY-MM-DD',
   },
 
+  defaultDatabaseTTL: '2190h',
+
   routes: {
     root: '/web',
     discover: '/web/discover',
@@ -678,6 +680,11 @@ const cfg = {
 
   getDatabaseSignUrl(clusterId: string) {
     return generatePath(cfg.api.dbSign, { clusterId });
+  },
+
+  getDatabaseCertificateTTL() {
+    // the length of the certificate to request for the database
+    return cfg.defaultDatabaseTTL;
   },
 
   getDesktopsUrl(clusterId: string, params: UrlResourcesParams) {


### PR DESCRIPTION
Backport #47081 to branch/v14

changelog: Updates self-hosted db discover flow to generate 2190h TTL certs, not 12h
