### PR TITLE
Mention terraform values for `create_host_user_mode` in guide

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -2937,7 +2937,7 @@ message RoleOptions {
     (gogoproto.customtype) = "BoolOption"
   ];
 
-  // CreateHostUser allows users to be automatically created on a host
+  // Deprecated: use CreateHostUserMode instead.
   BoolValue CreateHostUser = 20 [
     (gogoproto.nullable) = true,
     (gogoproto.jsontag) = "create_host_user,omitempty",

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -7833,7 +7833,7 @@ type RoleOptions struct {
 	// workstation and the remote desktop. It defaults to false unless explicitly set to
 	// true.
 	DesktopDirectorySharing *BoolOption `protobuf:"bytes,19,opt,name=DesktopDirectorySharing,proto3,customtype=BoolOption" json:"desktop_directory_sharing"`
-	// CreateHostUser allows users to be automatically created on a host
+	// Deprecated: use CreateHostUserMode instead.
 	CreateHostUser *BoolOption `protobuf:"bytes,20,opt,name=CreateHostUser,proto3,customtype=BoolOption" json:"create_host_user,omitempty"`
 	// PinSourceIP forces the same client IP for certificate generation and usage
 	PinSourceIP Bool `protobuf:"varint,21,opt,name=PinSourceIP,proto3,casttype=Bool" json:"pin_source_ip"`

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -847,6 +847,7 @@
     "snowsql",
     "spacectl",
     "spacelift",
+    "specoptions",
     "spfile",
     "spiffe",
     "splunkd",

--- a/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
@@ -438,3 +438,5 @@ on the hosts.
 
 - Configure automatic user provisioning for [Database Access](../../database-access/auto-user-provisioning.mdx).
 - Configure automatic user provisioning for [desktop access](../../../reference/agent-services/desktop-access-reference/user-creation.mdx).
+- Configure automatic user provisioning with [Terraform](../../../reference/terraform-provider/resources/role.mdx).
+Note when using the terraform provider that some values may be different than described in this guide.

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_roles.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_roles.mdx
@@ -340,7 +340,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |create_db_user|boolean|CreateDatabaseUser enabled automatic database user creation.|
 |create_db_user_mode|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop". Can be either the string or the integer representation of each option.|
 |create_desktop_user|boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
-|create_host_user|boolean|CreateHostUser allows users to be automatically created on a host|
+|create_host_user|boolean|Deprecated: use CreateHostUserMode instead.|
 |create_host_user_default_shell|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
 |create_host_user_mode|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop". Can be either the string or the integer representation of each option.|
 |desktop_clipboard|boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|
@@ -723,7 +723,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |create_db_user|boolean|CreateDatabaseUser enabled automatic database user creation.|
 |create_db_user_mode|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop". Can be either the string or the integer representation of each option.|
 |create_desktop_user|boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
-|create_host_user|boolean|CreateHostUser allows users to be automatically created on a host|
+|create_host_user|boolean|Deprecated: use CreateHostUserMode instead.|
 |create_host_user_default_shell|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
 |create_host_user_mode|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop". Can be either the string or the integer representation of each option.|
 |desktop_clipboard|boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_rolesv6.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_rolesv6.mdx
@@ -340,7 +340,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |create_db_user|boolean|CreateDatabaseUser enabled automatic database user creation.|
 |create_db_user_mode|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop". Can be either the string or the integer representation of each option.|
 |create_desktop_user|boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
-|create_host_user|boolean|CreateHostUser allows users to be automatically created on a host|
+|create_host_user|boolean|Deprecated: use CreateHostUserMode instead.|
 |create_host_user_default_shell|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
 |create_host_user_mode|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop". Can be either the string or the integer representation of each option.|
 |desktop_clipboard|boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|

--- a/docs/pages/reference/operator-resources/resources.teleport.dev_rolesv7.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_rolesv7.mdx
@@ -340,7 +340,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |create_db_user|boolean|CreateDatabaseUser enabled automatic database user creation.|
 |create_db_user_mode|string or integer|CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop". Can be either the string or the integer representation of each option.|
 |create_desktop_user|boolean|CreateDesktopUser allows users to be automatically created on a Windows desktop|
-|create_host_user|boolean|CreateHostUser allows users to be automatically created on a host|
+|create_host_user|boolean|Deprecated: use CreateHostUserMode instead.|
 |create_host_user_default_shell|string|CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.|
 |create_host_user_mode|string or integer|CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop". Can be either the string or the integer representation of each option.|
 |desktop_clipboard|boolean|DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.|

--- a/docs/pages/reference/terraform-provider/data-sources/role.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/role.mdx
@@ -380,7 +380,7 @@ Optional:
 - `create_db_user` (Boolean) CreateDatabaseUser enabled automatic database user creation.
 - `create_db_user_mode` (Number) CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop".
 - `create_desktop_user` (Boolean) CreateDesktopUser allows users to be automatically created on a Windows desktop
-- `create_host_user` (Boolean) CreateHostUser allows users to be automatically created on a host
+- `create_host_user` (Boolean) Deprecated: use CreateHostUserMode instead.
 - `create_host_user_default_shell` (String) CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.
 - `create_host_user_mode` (Number) CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop".
 - `desktop_clipboard` (Boolean) DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.

--- a/docs/pages/reference/terraform-provider/resources/role.mdx
+++ b/docs/pages/reference/terraform-provider/resources/role.mdx
@@ -433,7 +433,7 @@ Optional:
 - `create_db_user` (Boolean) CreateDatabaseUser enabled automatic database user creation.
 - `create_db_user_mode` (Number) CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop".
 - `create_desktop_user` (Boolean) CreateDesktopUser allows users to be automatically created on a Windows desktop
-- `create_host_user` (Boolean) CreateHostUser allows users to be automatically created on a host
+- `create_host_user` (Boolean) Deprecated: use CreateHostUserMode instead.
 - `create_host_user_default_shell` (String) CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.
 - `create_host_user_mode` (Number) CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep"; 4 is "insecure-drop".
 - `desktop_clipboard` (Boolean) DesktopClipboard indicates whether clipboard sharing is allowed between the user's workstation and the remote desktop. It defaults to true unless explicitly set to false.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_roles.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_roles.yaml
@@ -1133,8 +1133,7 @@ spec:
                       created on a Windows desktop
                     type: boolean
                   create_host_user:
-                    description: CreateHostUser allows users to be automatically created
-                      on a host
+                    description: 'Deprecated: use CreateHostUserMode instead.'
                     type: boolean
                   create_host_user_default_shell:
                     description: CreateHostUserDefaultShell is used to configure the
@@ -2465,8 +2464,7 @@ spec:
                       created on a Windows desktop
                     type: boolean
                   create_host_user:
-                    description: CreateHostUser allows users to be automatically created
-                      on a host
+                    description: 'Deprecated: use CreateHostUserMode instead.'
                     type: boolean
                   create_host_user_default_shell:
                     description: CreateHostUserDefaultShell is used to configure the

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv6.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv6.yaml
@@ -1136,8 +1136,7 @@ spec:
                       created on a Windows desktop
                     type: boolean
                   create_host_user:
-                    description: CreateHostUser allows users to be automatically created
-                      on a host
+                    description: 'Deprecated: use CreateHostUserMode instead.'
                     type: boolean
                   create_host_user_default_shell:
                     description: CreateHostUserDefaultShell is used to configure the

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv7.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv7.yaml
@@ -1136,8 +1136,7 @@ spec:
                       created on a Windows desktop
                     type: boolean
                   create_host_user:
-                    description: CreateHostUser allows users to be automatically created
-                      on a host
+                    description: 'Deprecated: use CreateHostUserMode instead.'
                     type: boolean
                   create_host_user_default_shell:
                     description: CreateHostUserDefaultShell is used to configure the

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
@@ -1133,8 +1133,7 @@ spec:
                       created on a Windows desktop
                     type: boolean
                   create_host_user:
-                    description: CreateHostUser allows users to be automatically created
-                      on a host
+                    description: 'Deprecated: use CreateHostUserMode instead.'
                     type: boolean
                   create_host_user_default_shell:
                     description: CreateHostUserDefaultShell is used to configure the
@@ -2465,8 +2464,7 @@ spec:
                       created on a Windows desktop
                     type: boolean
                   create_host_user:
-                    description: CreateHostUser allows users to be automatically created
-                      on a host
+                    description: 'Deprecated: use CreateHostUserMode instead.'
                     type: boolean
                   create_host_user_default_shell:
                     description: CreateHostUserDefaultShell is used to configure the

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv6.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv6.yaml
@@ -1136,8 +1136,7 @@ spec:
                       created on a Windows desktop
                     type: boolean
                   create_host_user:
-                    description: CreateHostUser allows users to be automatically created
-                      on a host
+                    description: 'Deprecated: use CreateHostUserMode instead.'
                     type: boolean
                   create_host_user_default_shell:
                     description: CreateHostUserDefaultShell is used to configure the

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv7.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv7.yaml
@@ -1136,8 +1136,7 @@ spec:
                       created on a Windows desktop
                     type: boolean
                   create_host_user:
-                    description: CreateHostUser allows users to be automatically created
-                      on a host
+                    description: 'Deprecated: use CreateHostUserMode instead.'
                     type: boolean
                   create_host_user_default_shell:
                     description: CreateHostUserDefaultShell is used to configure the

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -2454,7 +2454,7 @@ func GenSchemaRoleV6(ctx context.Context) (github_com_hashicorp_terraform_plugin
 							Optional:    true,
 						}),
 						"create_host_user": GenSchemaBoolOption(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-							Description: "CreateHostUser allows users to be automatically created on a host",
+							Description: "Deprecated: use CreateHostUserMode instead.",
 							Optional:    true,
 						}),
 						"create_host_user_default_shell": {

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -1035,6 +1035,7 @@ func (a *accessChecker) HostUsers(s types.Server) (*HostUsersInfo, error) {
 		}
 
 		createHostUserMode := role.GetOptions().CreateHostUserMode
+		//nolint:staticcheck // this field is preserved for existing deployments, but shouldn't be used going forward
 		createHostUser := role.GetOptions().CreateHostUser
 		if createHostUserMode == types.CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED {
 			createHostUserMode = types.CreateHostUserMode_HOST_USER_MODE_OFF

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2828,6 +2828,7 @@ func newUpack(testSvr *auth.TestServer, username string, allowedLogins []string,
 	role.SetRules(types.Allow, rules)
 	opts := role.GetOptions()
 	opts.PermitX11Forwarding = types.NewBool(true)
+	//nolint:staticcheck // this field is preserved for existing deployments, but shouldn't be used going forward
 	opts.CreateHostUser = types.NewBoolOption(true)
 	role.SetOptions(opts)
 	role.SetLogins(types.Allow, allowedLogins)


### PR DESCRIPTION
This PR adds a quick note about `create_host_user_mode` values when using the terraform provider and also links out to the role reference documentation.
