### PR TITLE
Clarify the wording on the device trust authorization dialog

### DIFF
--- a/web/packages/teleterm/src/ui/ModalsHost/modals/AuthenticateWebDevice/AuthenticateWebDevice.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/AuthenticateWebDevice/AuthenticateWebDevice.tsx
@@ -49,28 +49,28 @@ export const AuthenticateWebDevice = ({
 
   return (
     <Dialog open={true}>
-      {/* 360px was used as a way to do our best to get clusterName as the first item on the second line */}
-      <DialogContent maxWidth="360px">
+      {/* 400px was used as a way to do our best to get clusterName as the first item on the second line */}
+      <DialogContent maxWidth="400px">
         <Text>
-          Would you like to launch an authorized web session for{' '}
+          Would you like to authorize a device trust web session for{' '}
           <b>{clusterName}</b>?
         </Text>
       </DialogContent>
       {attempt.status === 'error' && <Alert>{attempt.statusText}</Alert>}
-      <Flex>
+      <Flex flexDirection="column">
         <ButtonPrimary
           disabled={attempt.status === 'processing'}
           block={true}
           onClick={run}
-          mr={3}
+          mb={3}
         >
-          Launch Web Session
+          Authorize session
         </ButtonPrimary>
         <ButtonSecondary
           disabled={attempt.status === 'processing'}
           onClick={onCancel}
         >
-          Cancel
+          Continue without device trust
         </ButtonSecondary>
       </Flex>
     </Dialog>


### PR DESCRIPTION
"Cancel" was a bad name for the secondary button, because most users expect cancel will close the modal and do nothing else. The actual behavior is that the web session is launched either way, and the user is only choosing whether or not to allow it to be authorized for device trust.

<img width="647" alt="image" src="https://github.com/user-attachments/assets/d108f9bd-2c41-499b-a2c1-5f1417bc94a3">

Closes #45478