### PR TITLE
feat: update `tctl status` to show key algorithms and storage

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -72,7 +72,7 @@ const (
 	Github = "github"
 
 	// HumanDateFormatSeconds is a human readable date formatting with seconds
-	HumanDateFormatSeconds = "Jan _2 2006 15:04:05 UTC"
+	HumanDateFormatSeconds = "Jan 2 2006 15:04:05 UTC"
 
 	// MaxLeases serves as an identifying error string indicating that the
 	// semaphore system is rejecting an acquisition attempt due to max

--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -463,16 +463,20 @@ func (r *Rotation) String() string {
 	switch r.State {
 	case "", RotationStateStandby:
 		if r.LastRotated.IsZero() {
-			return "never updated"
+			return "standby (never rotated)"
 		}
-		return fmt.Sprintf("rotated %v", r.LastRotated.Format(constants.HumanDateFormatSeconds))
+		return fmt.Sprintf("standby (last rotated: %v)", r.LastRotated.Format(constants.HumanDateFormatSeconds))
 	case RotationStateInProgress:
-		return fmt.Sprintf("%v (mode: %v, started: %v, ending: %v)",
-			r.PhaseDescription(),
-			r.Mode,
-			r.Started.Format(constants.HumanDateFormatSeconds),
-			r.Started.Add(r.GracePeriod.Duration()).Format(constants.HumanDateFormatSeconds),
-		)
+		switch r.Mode {
+		case RotationModeManual:
+			return fmt.Sprintf("in progress (mode: manual, phase: %s)", r.Phase)
+		default:
+			return fmt.Sprintf("in progress (mode: automatic, phase: %s, started: %v, ending: %v)",
+				r.Phase,
+				r.Started.Format(constants.HumanDateFormatSeconds),
+				r.Started.Add(r.GracePeriod.Duration()).Format(constants.HumanDateFormatSeconds),
+			)
+		}
 	default:
 		return "unknown"
 	}

--- a/constants.go
+++ b/constants.go
@@ -402,12 +402,6 @@ const (
 	// Syslog is a mode for syslog logging
 	Syslog = "syslog"
 
-	// HumanDateFormat is a human readable date formatting
-	HumanDateFormat = "Jan _2 15:04 UTC"
-
-	// HumanDateFormatMilli is a human readable date formatting with milliseconds
-	HumanDateFormatMilli = "Jan _2 15:04:05.000 UTC"
-
 	// DebugLevel is a debug logging level name
 	DebugLevel = "debug"
 

--- a/docs/pages/admin-guides/deploy-a-cluster/aws-kms.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/aws-kms.mdx
@@ -168,6 +168,10 @@ KMS keys, read on to
 After starting up your Auth Service with the `aws_kms` configuration, you can
 confirm that Teleport has generated AWS KMS keys in your account by viewing them
 in the AWS Console.
+
+`tctl status` should also show `AWS KMS` as the `storage` method for all
+Certificate Authority keys.
+
 You can also run the following `tctl` commands to find the ARN of each key.
 
 ```code

--- a/docs/pages/admin-guides/deploy-a-cluster/gcp-kms.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/gcp-kms.mdx
@@ -231,6 +231,9 @@ $ gcloud kms keys list --keyring "<Var name="teleport-keyring"/>" --location <Va
 Try logging in to the cluster with a Teleport user to make sure that new
 certificates can be signed without error.
 
+`tctl status` should also show `GCP KMS` as the `storage` method for all
+Certificate Authority keys.
+
 ## Migrating an existing cluster
 
 If you have an existing Teleport cluster it will have already created software

--- a/docs/pages/admin-guides/deploy-a-cluster/hsm.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/hsm.mdx
@@ -333,6 +333,10 @@ All CAs listed in the output of `tctl status` must be rotated.
 
 ## Step 5/5. Confirm that Teleport is using your HSM
 
-You are all set! Check the teleport logs for `Creating new HSM key pair` to
-confirm that the feature is working. You can also check that keys were created
-in your HSM using your HSM's admin tool.
+You are all set! You can confirm that HSM keys are being used a few different
+ways:
+
+1. `tctl status` will show `PKCS#11 HSM` as the `storage` method for all
+   Certificate Authority keys.
+1. Teleport Auth service logs will contain `Creating new HSM key pair`.
+1. Your HSM's admin tool should show the newly created keys.

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -779,7 +779,7 @@ $ tctl inventory list [<flags>]
 | `--older-than` | none | string | Filter for older teleport versions |
 | `--exact-version` | none | string | Filter output by teleport version |
 | `--services` | none | string | Filter output by service (node,kube,proxy,etc) |
-| `--upgrader` | none | `none`, `kube`, or `unit` | Filter output by upgrader (kube,unit,none) |   
+| `--upgrader` | none | `none`, `kube`, or `unit` | Filter output by upgrader (kube,unit,none) |
 
 ### Global flags
 
@@ -791,7 +791,7 @@ These flags are available for all commands `--debug, --config` . Run
 List inventory
 
 ```code
-$ tctl inventory ls 
+$ tctl inventory ls
 Server ID                            Hostname                        Services                   Agent Version Upgrader Upgrader Version
 ------------------------------------ ------------------------------- -------------------------- ------------- -------- ----------------
 00c3a1f7-5f24-47f9-b866-14401fbb5685 teleport-proxy-77df88c69        Proxy                      (=teleport.version=)       none     none
@@ -825,8 +825,8 @@ $ tctl inventory status [<flags>]
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
 | `--format` | `text` | `yaml, json` or `text` | Output format |
-| `--[no-]connected` | `--no-connected` | none | Show locally connected instances summary |  
-        
+| `--[no-]connected` | `--no-connected` | none | Show locally connected instances summary |
+
 ### Global flags
 
 These are available for all commands `--debug, --config` . Run
@@ -863,10 +863,10 @@ allows seeing connected instances on a specific Auth service.
 
 ```code
 $ tctl inventory status --connected
-Server ID                            Services               Version Upgrader 
------------------------------------- ---------------------- ------- -------- 
-b48e6e81-63e0-498f-834b-1a8adea09d95 Auth                   (=teleport.version=)  none     
-178d9301-2873-4020-895a-014edf067204 Node                   (=teleport.version=)  unit     
+Server ID                            Services               Version Upgrader
+------------------------------------ ---------------------- ------- --------
+b48e6e81-63e0-498f-834b-1a8adea09d95 Auth                   (=teleport.version=)  none
+178d9301-2873-4020-895a-014edf067204 Node                   (=teleport.version=)  unit
 ```
 
  </TabItem>
@@ -1422,7 +1422,7 @@ $ tctl get saml/your-connector-name --with-secrets | tctl sso test
 
 ## tctl status
 
-Report cluster status:
+Report cluster and Certificate Authority status:
 
 ```code
 $ tctl status
@@ -1432,9 +1432,26 @@ $ tctl status
 
 ```code
 # Checks status of cluster.
-$ tctl status Cluster  grav-00 User CA  never updated Host CA  never updated CA
-# pin   sha256:1146cdd2b887772dcc2e879232c8f60012a839f7958724ce5744005474b15b9d
-# Checks remote auth status using exported identity.
+$ tctl status
+Cluster: example.teleport.sh
+Version: 17.0.0
+CA pins: sha256:a5322b9f89cb94fff13da4bc9c7b2e633626e35161a75f7662a179a01be84ccc
+
+authority rotation                                        protocol status algorithm   storage
+--------- ----------------------------------------------- -------- ------ ----------- --------
+host      standby (never rotated)                         SSH      active Ed25519     software
+                                                          TLS      active ECDSA P-256 software
+user      standby (last rotated: Oct 3 2024 22:12:09 UTC) SSH      active ECDSA P-256 AWS KMS
+                                                          TLS      active ECDSA P-256 AWS KMS
+db        standby (never rotated)                         TLS      active RSA 2048    software
+db_client standby (never rotated)                         TLS      active RSA 2048    software
+openssh   standby (never rotated)                         SSH      active Ed25519     software
+jwt       standby (never rotated)                         JWT      active ECDSA P-256 software
+saml_idp  standby (never rotated)                         TLS      active RSA 2048    software
+oidc_idp  standby (never rotated)                         JWT      active RSA 2048    software
+spiffe    standby (never rotated)                         JWT      active ECDSA P-256 software
+                                                          TLS      active ECDSA P-256 software
+okta      standby (never rotated)                         JWT      active ECDSA P-256 software
 $ tctl status \
     --auth-server=192.168.99.102:3025 \
     --identity=identity.pem

--- a/tool/tctl/common/status_command.go
+++ b/tool/tctl/common/status_command.go
@@ -19,18 +19,30 @@
 package common
 
 import (
+	"cmp"
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"slices"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
 
-	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // StatusCommand implements `tctl token` group of commands.
@@ -58,110 +70,249 @@ func (c *StatusCommand) TryRun(ctx context.Context, cmd string, client *authclie
 	return true, trace.Wrap(err)
 }
 
-type caFetchError struct {
-	caType  types.CertAuthType
-	message string
-}
-
 // Status is called to execute "status" CLI command.
 func (c *StatusCommand) Status(ctx context.Context, client *authclient.Client) error {
 	pingRsp, err := client.Ping(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	serverVersion := pingRsp.ServerVersion
-	clusterName := pingRsp.ClusterName
 
-	var (
-		authorities     []types.CertAuthority
-		authFetchErrors []caFetchError
-	)
-
+	var authorities []types.CertAuthority
 	for _, caType := range types.CertAuthTypes {
-		ca, err := client.GetCertAuthorities(ctx, caType, false)
+		cas, err := client.GetCertAuthorities(ctx, caType, false)
 		if err != nil {
-			// Collect all errors, so they can be displayed to the user.
-			fetchError := caFetchError{
-				caType:  caType,
-				message: err.Error(),
-			}
-			authFetchErrors = append(authFetchErrors, fetchError)
-		} else {
-			authorities = append(authorities, ca...)
+			slog.WarnContext(ctx, "Failed to fetch CA.", "type", caType, "error", err)
+			continue
 		}
+		authorities = append(authorities, cas...)
 	}
 
-	// Calculate the CA pins for this cluster. The CA pins are used by the
-	// client to verify the identity of the Auth Server.
-	localCAResponse, err := client.GetClusterCACert(ctx)
+	status, err := newStatusModel(pingRsp, authorities)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	caPins, err := tlsca.CalculatePins(localCAResponse.TLSCA)
-	if err != nil {
+	if err := status.renderText(os.Stdout, c.config.Debug); err != nil {
 		return trace.Wrap(err)
-	}
-
-	view := func() string {
-		table := asciitable.MakeHeadlessTable(2)
-		table.AddRow([]string{"Cluster", clusterName})
-		table.AddRow([]string{"Version", serverVersion})
-		for _, ca := range authorities {
-			if ca.GetClusterName() != clusterName {
-				continue
-			}
-			info := fmt.Sprintf("%v CA ", string(ca.GetType()))
-			rotation := ca.GetRotation()
-			standbyPhase := rotation.Phase == types.RotationPhaseStandby || rotation.Phase == ""
-			if standbyPhase && len(ca.GetAdditionalTrustedKeys().SSH) > 0 {
-				// There should never be AdditionalTrusted keys present during
-				// the Standby phase unless an auth server has just started up
-				// with a new HSM (or without an HSM and all other auth servers
-				// have HSMs)
-				fmt.Println("WARNING: One or more auth servers has a newly added or removed " +
-					"HSM or KMS configured. You should not route traffic to that server until " +
-					"a CA rotation has been completed.")
-			}
-			if c.config.Debug {
-				table.AddRow([]string{
-					info,
-					fmt.Sprintf("%v, update_servers: %v, complete: %v",
-						rotation.String(),
-						rotation.Schedule.UpdateServers.Format(constants.HumanDateFormatSeconds),
-						rotation.Schedule.Standby.Format(constants.HumanDateFormatSeconds),
-					),
-				})
-			} else {
-				table.AddRow([]string{info, rotation.String()})
-			}
-
-		}
-		for _, ca := range authFetchErrors {
-			info := fmt.Sprintf("%v CA ", string(ca.caType))
-			table.AddRow([]string{info, ca.message})
-		}
-		for _, caPin := range caPins {
-			table.AddRow([]string{"CA pin", caPin})
-		}
-		return table.AsBuffer().String()
-	}
-	fmt.Print(view())
-
-	// in debug mode, output mode of remote certificate authorities
-	if c.config.Debug {
-		view := func() string {
-			table := asciitable.MakeHeadlessTable(2)
-			for _, ca := range authorities {
-				if ca.GetClusterName() == clusterName {
-					continue
-				}
-				info := fmt.Sprintf("Remote %v CA %q", string(ca.GetType()), ca.GetClusterName())
-				rotation := ca.GetRotation()
-				table.AddRow([]string{info, rotation.String()})
-			}
-			return "Remote clusters\n\n" + table.AsBuffer().String()
-		}
-		fmt.Print(view())
 	}
 	return nil
+}
+
+type statusModel struct {
+	cluster     *clusterStatusModel
+	authorities []*authorityStatusModel
+}
+
+func newStatusModel(pingResp proto.PingResponse, authorities []types.CertAuthority) (*statusModel, error) {
+	cluster, err := newClusterStatusModel(pingResp, authorities)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	authorityModels := make([]*authorityStatusModel, 0, len(authorities))
+	for _, authority := range authorities {
+		authorityStatus, err := newAuthorityStatusModel(authority)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		authorityModels = append(authorityModels, authorityStatus)
+	}
+	return &statusModel{
+		cluster:     cluster,
+		authorities: authorityModels,
+	}, nil
+}
+
+func (m *statusModel) renderText(w io.Writer, debug bool) error {
+	summaryTable := asciitable.MakeHeadlessTable(2)
+	summaryTable.AddRow([]string{"Cluster:", m.cluster.name})
+	summaryTable.AddRow([]string{"Version:", m.cluster.version})
+	for i, caPin := range m.cluster.caPins {
+		if i == 0 {
+			summaryTable.AddRow([]string{"CA pins:", caPin})
+		} else {
+			summaryTable.AddRow([]string{"", caPin})
+		}
+	}
+	if _, err := io.Copy(w, summaryTable.AsBuffer()); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Fprintln(w, "")
+
+	keysTable := asciitable.MakeTable([]string{"authority", "rotation", "protocol", "status", "algorithm", "storage"})
+	for _, authority := range m.authorities {
+		if !debug && authority.clusterName != m.cluster.name {
+			// Only print remote authorities in debug mode.
+			continue
+		}
+		rows := make([][]string, 0, len(authority.activeKeys)+len(authority.additionalTrustedKeys))
+		for _, key := range authority.activeKeys {
+			rows = append(rows, []string{"", "", key.protocol, "active", key.algo, key.storage})
+		}
+		for _, key := range authority.additionalTrustedKeys {
+			rows = append(rows, []string{"", "", key.protocol, "trusted", key.algo, key.storage})
+		}
+		sortRows(rows)
+		if len(rows) == 0 {
+			rows = [][]string{[]string{"", "", "", "no keys found for authority", "", ""}}
+		}
+		// Each CA gets a row in the table for each key. Only the first row
+		// contains the CA type and the CA rotation status, to reduce clutter
+		// because it's the same for all keys.
+		rows[0][0] = string(authority.authorityType)
+		rows[0][1] = authority.rotationStatus.String()
+		for _, row := range rows {
+			keysTable.AddRow(row)
+		}
+	}
+	_, err := io.Copy(w, keysTable.AsBuffer())
+	return trace.Wrap(err)
+}
+
+// sortRows sorts the rows by each column left to right.
+func sortRows(rows [][]string) {
+	slices.SortFunc(rows, func(a, b []string) int {
+		for i := range len(a) {
+			if a[i] != b[i] {
+				return cmp.Compare(a[i], b[i])
+			}
+		}
+		return 0
+	})
+}
+
+type clusterStatusModel struct {
+	name    string
+	version string
+	caPins  []string
+}
+
+func newClusterStatusModel(pingResp proto.PingResponse, authorities []types.CertAuthority) (*clusterStatusModel, error) {
+	var pins []string
+	for _, authority := range authorities {
+		if authority.GetType() != types.HostCA || authority.GetClusterName() != pingResp.ClusterName {
+			continue
+		}
+		for _, keyPair := range authority.GetTrustedTLSKeyPairs() {
+			cert, err := tlsca.ParseCertificatePEM(keyPair.Cert)
+			if err != nil {
+				return nil, trace.Wrap(err, "parsing host CA TLS certificate")
+			}
+			pin := utils.CalculateSPKI(cert)
+			pins = append(pins, pin)
+		}
+	}
+	return &clusterStatusModel{
+		name:    pingResp.ClusterName,
+		version: pingResp.ServerVersion,
+		caPins:  pins,
+	}, nil
+}
+
+type authorityStatusModel struct {
+	clusterName           string
+	authorityType         types.CertAuthType
+	rotationStatus        types.Rotation
+	activeKeys            []*authorityKeyModel
+	additionalTrustedKeys []*authorityKeyModel
+}
+
+func newAuthorityStatusModel(authority types.CertAuthority) (*authorityStatusModel, error) {
+	return &authorityStatusModel{
+		clusterName:           authority.GetClusterName(),
+		authorityType:         authority.GetType(),
+		rotationStatus:        authority.GetRotation(),
+		activeKeys:            newAuthorityKeyModels(authority.GetActiveKeys()),
+		additionalTrustedKeys: newAuthorityKeyModels(authority.GetAdditionalTrustedKeys()),
+	}, nil
+}
+
+type authorityKeyModel struct {
+	protocol string
+	algo     string
+	storage  string
+}
+
+func newAuthorityKeyModels(keySet types.CAKeySet) []*authorityKeyModel {
+	var out []*authorityKeyModel
+	for _, sshKey := range keySet.SSH {
+		out = append(out, newSSHKeyModel(sshKey))
+	}
+	for _, tlsKey := range keySet.TLS {
+		out = append(out, newTLSKeyModel(tlsKey))
+	}
+	for _, jwtKey := range keySet.JWT {
+		out = append(out, newJWTKeyModel(jwtKey))
+	}
+	return out
+}
+
+func newSSHKeyModel(sshKey *types.SSHKeyPair) *authorityKeyModel {
+	algo := "unknown"
+	if pub, _, _, _, err := ssh.ParseAuthorizedKey(sshKey.PublicKey); err == nil {
+		algo = publicKeyAlgorithmName(pub)
+	} else {
+		slog.ErrorContext(context.Background(), "parsing SSH CA public key", "error", err)
+	}
+	return &authorityKeyModel{
+		protocol: "SSH",
+		algo:     algo,
+		storage:  storageName(sshKey.PrivateKeyType),
+	}
+}
+
+func newTLSKeyModel(tlsKey *types.TLSKeyPair) *authorityKeyModel {
+	algo := "unknown"
+	if cert, err := tlsca.ParseCertificatePEM(tlsKey.Cert); err == nil {
+		algo = publicKeyAlgorithmName(cert.PublicKey)
+	} else {
+		slog.ErrorContext(context.Background(), "parsing TLS CA public key", "error", err)
+	}
+	return &authorityKeyModel{
+		protocol: "TLS",
+		algo:     algo,
+		storage:  storageName(tlsKey.KeyType),
+	}
+}
+
+func newJWTKeyModel(jwtKey *types.JWTKeyPair) *authorityKeyModel {
+	algo := "unknown"
+	if pubKey, err := keys.ParsePublicKey(jwtKey.PublicKey); err == nil {
+		algo = publicKeyAlgorithmName(pubKey)
+	} else {
+		slog.ErrorContext(context.Background(), "parsing JWT CA public key", "error", err)
+	}
+	return &authorityKeyModel{
+		protocol: "JWT",
+		algo:     algo,
+		storage:  storageName(jwtKey.PrivateKeyType),
+	}
+}
+
+func publicKeyAlgorithmName(pubKey crypto.PublicKey) string {
+	switch k := pubKey.(type) {
+	case *rsa.PublicKey:
+		return fmt.Sprintf("RSA %d", k.Size()*8)
+	case *ecdsa.PublicKey:
+		return fmt.Sprintf("ECDSA %s", k.Params().Name)
+	case ed25519.PublicKey:
+		return "Ed25519"
+	case ssh.CryptoPublicKey:
+		return publicKeyAlgorithmName(k.CryptoPublicKey())
+	default:
+		return "unknown"
+	}
+}
+
+func storageName(privateKeyType types.PrivateKeyType) string {
+	switch privateKeyType {
+	case types.PrivateKeyType_RAW:
+		return "software"
+	case types.PrivateKeyType_PKCS11:
+		return "PKCS#11 HSM"
+	case types.PrivateKeyType_GCP_KMS:
+		return "GCP KMS"
+	case types.PrivateKeyType_AWS_KMS:
+		return "AWS KMS"
+	default:
+		return privateKeyType.String()
+	}
 }


### PR DESCRIPTION
This PR updates `tctl status` to display the key algorithm and storage method (software, HSM, AWS KMS, GCP KMS) of each Certificate Authority key.

`tctl status` currently prints each CA and its rotation phase. CA rotation aren't done very often, they can be fairly disruptive if you have any third-parties trusted a teleport CA (openSSH servers, self-hosted databases, windows desktops, etc). The most likely cases you'll want to do a CA rotation are probably when migrating to an HSM or if you want to take advantage of the new key algorithms described in [RFD 136](https://github.com/gravitational/teleport/blob/master/rfd/0136-modern-signature-algorithms.md). This augmented output should be very helpful to see what's happening in these cases.

Example of the new output:
```sh
$ tctl status
Cluster: one.private
Version: 17.0.0-dev
CA pins: sha256:a5322b9f89cb94fff13da4bc9c7b2e633626e35161a75f7662a179a01be84ccc

authority rotation                                        protocol status algorithm   storage
--------- ----------------------------------------------- -------- ------ ----------- --------
host      standby (never rotated)                         SSH      active Ed25519     software
                                                          TLS      active ECDSA P-256 software
user      standby (last rotated: Oct 3 2024 22:12:09 UTC) SSH      active ECDSA P-256 AWS KMS
                                                          TLS      active ECDSA P-256 AWS KMS
db        standby (never rotated)                         TLS      active RSA 2048    software
db_client standby (never rotated)                         TLS      active RSA 2048    software
openssh   standby (never rotated)                         SSH      active Ed25519     software
jwt       standby (never rotated)                         JWT      active ECDSA P-256 software
saml_idp  standby (never rotated)                         TLS      active RSA 2048    software
oidc_idp  standby (never rotated)                         JWT      active RSA 2048    software
spiffe    standby (never rotated)                         JWT      active ECDSA P-256 software
                                                          TLS      active ECDSA P-256 software
okta      standby (never rotated)                         JWT      active ECDSA P-256 software

```

Another example with the host CA mid-rotation
```sh
$ tctl status
Cluster: one.private
Version: 17.0.0-dev
CA pins: sha256:06d205e736d1a37d7ba4cc3729f468c39758bf6c93f9034bf4b001e84eda33c7
         sha256:a5322b9f89cb94fff13da4bc9c7b2e633626e35161a75f7662a179a01be84ccc

authority rotation                                          protocol status  algorithm   storage
--------- ------------------------------------------------- -------- ------- ----------- --------
host      in progress (mode: manual, phase: update_clients) SSH      active  ECDSA P-256 AWS KMS
                                                            SSH      trusted Ed25519     software
                                                            TLS      active  ECDSA P-256 AWS KMS
                                                            TLS      trusted ECDSA P-256 software
user      standby (last rotated: Oct 3 2024 22:12:09 UTC)   SSH      active  ECDSA P-256 AWS KMS
                                                            TLS      active  ECDSA P-256 AWS KMS
db        standby (never rotated)                           TLS      active  RSA 2048    software
db_client standby (never rotated)                           TLS      active  RSA 2048    software
openssh   standby (never rotated)                           SSH      active  Ed25519     software
jwt       standby (never rotated)                           JWT      active  ECDSA P-256 software
saml_idp  standby (never rotated)                           TLS      active  RSA 2048    software
oidc_idp  standby (never rotated)                           JWT      active  RSA 2048    software
spiffe    standby (never rotated)                           JWT      active  ECDSA P-256 software
                                                            TLS      active  ECDSA P-256 software
okta      standby (never rotated)                           JWT      active  ECDSA P-256 software
```

changelog: updated `tctl status` output