### PR TITLE
docs: update aws opensearch tokens

### DIFF
--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-opensearch.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-opensearch.mdx
@@ -174,18 +174,7 @@ the correct STS endpoint.
 
 ### Generate a token
 
-<Details title="Alterative methods">
-
-For users with a lot of infrastructure in AWS, or who might create or recreate
-many instances, consider alternative methods for joining new EC2 instances running
-Teleport:
-
-- [Configure Teleport to Automatically Enroll EC2 instances (Preview)](../../auto-discovery/servers/ec2-discovery.mdx)
-- [Joining Nodes via AWS IAM
-  Role](../../agents/join-services-to-your-cluster/aws-iam.mdx)
-- [Joining Nodes via AWS EC2 Identity Document](../../agents/join-services-to-your-cluster/aws-ec2.mdx)
-
-</Details>
+(!docs/pages/includes/database-access/alternative-methods-join.mdx!)
 
 (!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 


### PR DESCRIPTION
Replace section with common include.  This had some incorrect words and old preview titles.