### PR TITLE
docs: include fdpass-teleport in machine-id getting started

### DIFF
--- a/docs/pages/enroll-resources/machine-id/getting-started.mdx
+++ b/docs/pages/enroll-resources/machine-id/getting-started.mdx
@@ -31,12 +31,13 @@ In this step, you will be downloading and installing Teleport binaries onto the
 machine you wish to assign an identity to.
 
 Each Teleport package hosted on our downloads page ships with several useful
-binaries, including `teleport`, `tctl`, `tsh`, and `tbot`:
+binaries, including `teleport`, `tctl`, `tsh`,`tbot`, and `fdpass-teleport`:
 
 - `teleport` is the daemon used to initialize a Teleport cluster; this binary is not used in this guide
 - `tctl` is the administrative tool you will use to create the bot user (step 1/4)
 - `tsh` is the client tool you will use to log in to the Teleport Cluster (steps 2/4 and 4/4)
 - `tbot` is the Machine ID tool you will use to associate a bot user with a machine (step 3/4)
+- `fdpass-teleport` is used to integrate Machine ID with OpenSSH to enable higher performance and reduced resource consumption when establishing SSH connections; this binary is not used in this guide
 
 Download the appropriate Teleport package for your platform: 
 


### PR DESCRIPTION
`fdpass-teleport` was not included with the other binaries that are installed.