### PR TITLE
fix signature_algorithm_suite checks for HSM and Cloud

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -602,7 +602,9 @@ func (c *AuthPreferenceV2) SetDefaultSignatureAlgorithmSuite(params SignatureAlg
 	switch {
 	case params.FIPS:
 		c.SetSignatureAlgorithmSuite(SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_FIPS_V1)
-	case params.UsingHSMOrKMS:
+	case params.UsingHSMOrKMS || params.Cloud:
+		// Cloud may eventually migrate existing CA keys to a KMS, to keep
+		// this option open we default to hsm-v1 suite.
 		c.SetSignatureAlgorithmSuite(SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_HSM_V1)
 	default:
 		c.SetSignatureAlgorithmSuite(SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1)

--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -591,6 +591,8 @@ type SignatureAlgorithmSuiteParams struct {
 	// UsingHSMOrKMS should be true if the auth server is configured to
 	// use an HSM or KMS.
 	UsingHSMOrKMS bool
+	// Cloud should be true when running in Teleport Cloud.
+	Cloud bool
 }
 
 // SetDefaultSignatureAlgorithmSuite sets default signature algorithm suite
@@ -608,8 +610,9 @@ func (c *AuthPreferenceV2) SetDefaultSignatureAlgorithmSuite(params SignatureAlg
 }
 
 var (
-	errNonFIPSSignatureAlgorithmSuite = &trace.BadParameterError{Message: `non-FIPS compliant authentication setting: "signature_algorithm_suite" must be "fips-v1" or "legacy"`}
-	errNonHSMSignatureAlgorithmSuite  = &trace.BadParameterError{Message: `configured "signature_algorithm_suite" is unsupported when "ca_key_params" configures an HSM or KMS, supported values: ["hsm-v1", "fips-v1", "legacy"]`}
+	errNonFIPSSignatureAlgorithmSuite  = &trace.BadParameterError{Message: `non-FIPS compliant authentication setting: "signature_algorithm_suite" must be "fips-v1" or "legacy"`}
+	errNonHSMSignatureAlgorithmSuite   = &trace.BadParameterError{Message: `configured "signature_algorithm_suite" is unsupported when "ca_key_params" configures an HSM or KMS, supported values: ["hsm-v1", "fips-v1", "legacy"]`}
+	errNonCloudSignatureAlgorithmSuite = &trace.BadParameterError{Message: `configured "signature_algorithm_suite" is unsupported in Teleport Cloud, supported values: ["hsm-v1", "fips-v1", "legacy"]`}
 )
 
 // CheckSignatureAlgorithmSuite returns an error if the current signature
@@ -629,7 +632,12 @@ func (c *AuthPreferenceV2) CheckSignatureAlgorithmSuite(params SignatureAlgorith
 			return trace.Wrap(errNonFIPSSignatureAlgorithmSuite)
 		}
 		if params.UsingHSMOrKMS {
+			// Cloud may eventually migrate existing CA keys to a KMS, to keep
+			// this option open we prevent the balanced-v1 suite.
 			return trace.Wrap(errNonHSMSignatureAlgorithmSuite)
+		}
+		if params.Cloud {
+			return trace.Wrap(errNonCloudSignatureAlgorithmSuite)
 		}
 	default:
 		return trace.Errorf("unhandled signature_algorithm_suite %q: this is a bug", c.GetSignatureAlgorithmSuite())

--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -634,11 +634,11 @@ func (c *AuthPreferenceV2) CheckSignatureAlgorithmSuite(params SignatureAlgorith
 			return trace.Wrap(errNonFIPSSignatureAlgorithmSuite)
 		}
 		if params.UsingHSMOrKMS {
-			// Cloud may eventually migrate existing CA keys to a KMS, to keep
-			// this option open we prevent the balanced-v1 suite.
 			return trace.Wrap(errNonHSMSignatureAlgorithmSuite)
 		}
 		if params.Cloud {
+			// Cloud may eventually migrate existing CA keys to a KMS, to keep
+			// this option open we prevent the balanced-v1 suite.
 			return trace.Wrap(errNonCloudSignatureAlgorithmSuite)
 		}
 	default:

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4670,6 +4670,7 @@ func (a *ServerWithRoles) SetAuthPreference(ctx context.Context, newAuthPref typ
 	if err := newAuthPref.CheckSignatureAlgorithmSuite(types.SignatureAlgorithmSuiteParams{
 		FIPS:          a.authServer.fips,
 		UsingHSMOrKMS: a.authServer.keyStore.UsingHSMOrKMS(),
+		Cloud:         modules.GetModules().Features().Cloud,
 	}); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -104,6 +104,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/joinserver"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -5363,6 +5364,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		SignatureAlgorithmSuiteParams: types.SignatureAlgorithmSuiteParams{
 			FIPS:          cfg.AuthServer.fips,
 			UsingHSMOrKMS: cfg.AuthServer.keyStore.UsingHSMOrKMS(),
+			Cloud:         modules.GetModules().Features().Cloud,
 		},
 	})
 	if err != nil {

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -790,6 +790,7 @@ func initializeAuthPreference(ctx context.Context, asrv *Server, newAuthPref typ
 				newAuthPref.SetDefaultSignatureAlgorithmSuite(types.SignatureAlgorithmSuiteParams{
 					FIPS:          asrv.fips,
 					UsingHSMOrKMS: asrv.keyStore.UsingHSMOrKMS(),
+					Cloud:         modules.GetModules().Features().Cloud,
 				})
 			}
 

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -197,6 +197,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 	testCases := map[string]struct {
 		fips                  bool
 		hsm                   bool
+		cloud                 bool
 		expectDefaultSuite    types.SignatureAlgorithmSuite
 		expectUnallowedSuites []types.SignatureAlgorithmSuite
 	}{
@@ -227,15 +228,31 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 				types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_HSM_V1,
 			},
 		},
+		"cloud": {
+			cloud:              true,
+			expectDefaultSuite: types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_HSM_V1,
+			expectUnallowedSuites: []types.SignatureAlgorithmSuite{
+				types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1,
+			},
+		},
 	}
 
 	// Test the behavior of auth server init. A default signature algorithm
 	// suite should never overwrite a persisted signature algorithm suite for an
 	// existing cluster, even if that was also a default.
 	t.Run("init", func(t *testing.T) {
-		t.Parallel()
 		for desc, tc := range testCases {
 			t.Run(desc, func(t *testing.T) {
+				if tc.cloud {
+					modules.SetTestModules(t, &modules.TestModules{
+						TestFeatures: modules.Features{
+							Cloud: true,
+							Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+								entitlements.HSM: {Enabled: true},
+							},
+						},
+					})
+				}
 				// Assert that a fresh cluster gets expected default suite.
 				cfg := setupInitConfig(t, tc.fips, tc.hsm)
 				authServer, err := Init(ctx, cfg)
@@ -294,13 +311,28 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 	// Test that the auth preference cannot be upserted with a signature
 	// algorithm suite incompatible with the cluster FIPS and HSM settings.
 	t.Run("upsert", func(t *testing.T) {
-		t.Parallel()
 		for desc, tc := range testCases {
 			t.Run(desc, func(t *testing.T) {
-				t.Parallel()
+				if tc.cloud {
+					modules.SetTestModules(t, &modules.TestModules{
+						TestFeatures: modules.Features{
+							Cloud: true,
+							Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+								entitlements.HSM: {Enabled: true},
+							},
+						},
+					})
+				}
 				cfg := TestAuthServerConfig{
 					Dir:  t.TempDir(),
 					FIPS: tc.fips,
+					AuthPreferenceSpec: &types.AuthPreferenceSpecV2{
+						// Cloud requires second factor enabled.
+						SecondFactor: constants.SecondFactorOn,
+						Webauthn: &types.Webauthn{
+							RPID: "teleport.example.com",
+						},
+					},
 				}
 				if tc.hsm {
 					cfg.KeystoreConfig = keystore.HSMTestConfig(t)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -62,6 +62,7 @@ import (
 	"github.com/gravitational/teleport/lib/integrations/externalauditstorage/easconfig"
 	"github.com/gravitational/teleport/lib/integrations/samlidp/samlidpconfig"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/pam"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -2552,11 +2553,18 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 		}
 	}
 
-	if err := cfg.Auth.Preference.CheckSignatureAlgorithmSuite(types.SignatureAlgorithmSuiteParams{
-		FIPS:          clf.FIPS,
-		UsingHSMOrKMS: cfg.Auth.KeyStore != (servicecfg.KeystoreConfig{}),
-	}); err != nil {
-		return trace.Wrap(err)
+	if cfg.Auth.Preference.Origin() != types.OriginDefaults {
+		// Only check the signature algorithm suite if the auth preference was
+		// actually set in the config file. If it wasn't set and the default is
+		// used, the algorithm suite will be overwritten in initializeAuthPreference
+		// based on the FIPS and HSM settings, and any already persisted auth preference.
+		if err := cfg.Auth.Preference.CheckSignatureAlgorithmSuite(types.SignatureAlgorithmSuiteParams{
+			FIPS:          clf.FIPS,
+			UsingHSMOrKMS: cfg.Auth.KeyStore != (servicecfg.KeystoreConfig{}),
+			Cloud:         modules.GetModules().Features().Cloud,
+		}); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	// apply --skip-version-check flag.


### PR DESCRIPTION
This PR does two things:
- prevents the balanced-v1 suite from being used in a Cloud cluster
- allows starting an auth server with an HSM or KMS configured and an empty auth preference (this was previously prevented, which I'm considering a bug)

We want to prevent balanced-v1 in cloud so that we won't get any Ed25519 keys in a CA, so that Cloud has the option to migrate existing keys into AWS KMS.