### PR TITLE
Update go-ora/v2 to `teleport-v2.8.21` tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -560,6 +560,6 @@ replace (
 	github.com/keys-pub/go-libfido2 => github.com/gravitational/go-libfido2 v1.5.3-teleport.1
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v0.11.1-0.20230331180905-0f76f1751cd3
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.0.2-teleport.2
-	github.com/sijms/go-ora/v2 => github.com/gravitational/go-ora/v2 v2.0.0-20230821114616-e2a9f1131a46
+	github.com/sijms/go-ora/v2 => github.com/gravitational/go-ora/v2 v2.8.22-0.20241004133430-d1e026bb9cc1
 	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1520,8 +1520,8 @@ github.com/gravitational/go-mysql v1.5.0-teleport.1 h1:EyFryeiTYyP6KslLVp0Q5QTKw
 github.com/gravitational/go-mysql v1.5.0-teleport.1/go.mod h1:GX0clmylJLdZEYAojPCDTCvwZxbTBrke93dV55715u0=
 github.com/gravitational/go-oidc v0.1.1 h1:T5nZxwkrfqfDMW4VPomCiG50Ae5ToaL9NFxEJHKURXc=
 github.com/gravitational/go-oidc v0.1.1/go.mod h1:A/IrBuKme/aPiJ9RIctJnSfPKUAzSQ4zaacIXDCQGx4=
-github.com/gravitational/go-ora/v2 v2.0.0-20230821114616-e2a9f1131a46 h1:k/tkK7NDSH7gjNbA5pdUfAalJXyIVazycM0RW7ZboxM=
-github.com/gravitational/go-ora/v2 v2.0.0-20230821114616-e2a9f1131a46/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
+github.com/gravitational/go-ora/v2 v2.8.22-0.20241004133430-d1e026bb9cc1 h1:m3cqVy2uU47x8KHxDA9obtrQ4lcJ2t1Ie/JkLAlIvfk=
+github.com/gravitational/go-ora/v2 v2.8.22-0.20241004133430-d1e026bb9cc1/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5 h1:qg8FcGwRACSHortU1UxCSo9nF0t34rPWjk9Nef3j2Ic=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/gravitational/kingpin/v2 v2.1.11-0.20230515143221-4ec6b70ecd33 h1:VFER/+0TfRypJhc9XeuggTtEZzhhe75DSVqMv/avHEU=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -344,7 +344,7 @@ replace (
 	// otherwise tests fail with a data race detection.
 	github.com/moby/spdystream => github.com/gravitational/spdystream v0.0.0-20230512133543-4e46862ca9bf
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.0.2-teleport.2
-	github.com/sijms/go-ora/v2 => github.com/gravitational/go-ora/v2 v2.0.0-20230821114616-e2a9f1131a46
+	github.com/sijms/go-ora/v2 => github.com/gravitational/go-ora/v2 v2.8.22-0.20241004133430-d1e026bb9cc1
 	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.1
 	// replace module sigs.k8s.io/kustomize/api until https://github.com/kubernetes-sigs/kustomize/issues/5524 is resolved,
 	// otherwise we get significant increase in size of the "teleport" binary.

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -1159,8 +1159,8 @@ github.com/gravitational/go-libfido2 v1.5.3-teleport.1 h1:nPfxiTH2Sr3J6zan280fbH
 github.com/gravitational/go-libfido2 v1.5.3-teleport.1/go.mod h1:92J9LtSBl0UyUWljElJpTbMMNhC6VeY8dshsu40qjjo=
 github.com/gravitational/go-oidc v0.1.1 h1:T5nZxwkrfqfDMW4VPomCiG50Ae5ToaL9NFxEJHKURXc=
 github.com/gravitational/go-oidc v0.1.1/go.mod h1:A/IrBuKme/aPiJ9RIctJnSfPKUAzSQ4zaacIXDCQGx4=
-github.com/gravitational/go-ora/v2 v2.0.0-20230821114616-e2a9f1131a46 h1:k/tkK7NDSH7gjNbA5pdUfAalJXyIVazycM0RW7ZboxM=
-github.com/gravitational/go-ora/v2 v2.0.0-20230821114616-e2a9f1131a46/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
+github.com/gravitational/go-ora/v2 v2.8.22-0.20241004133430-d1e026bb9cc1 h1:m3cqVy2uU47x8KHxDA9obtrQ4lcJ2t1Ie/JkLAlIvfk=
+github.com/gravitational/go-ora/v2 v2.8.22-0.20241004133430-d1e026bb9cc1/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5 h1:qg8FcGwRACSHortU1UxCSo9nF0t34rPWjk9Nef3j2Ic=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/gravitational/kingpin/v2 v2.1.11-0.20230515143221-4ec6b70ecd33 h1:VFER/+0TfRypJhc9XeuggTtEZzhhe75DSVqMv/avHEU=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -401,7 +401,7 @@ replace (
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v0.11.1-0.20230331180905-0f76f1751cd3
 	github.com/moby/spdystream => github.com/gravitational/spdystream v0.0.0-20230512133543-4e46862ca9bf
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.0.2-teleport.2
-	github.com/sijms/go-ora/v2 => github.com/gravitational/go-ora/v2 v2.0.0-20230821114616-e2a9f1131a46
+	github.com/sijms/go-ora/v2 => github.com/gravitational/go-ora/v2 v2.8.22-0.20241004133430-d1e026bb9cc1
 	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.1
 	sigs.k8s.io/kustomize/api => github.com/gravitational/kustomize/api v0.16.0-teleport.1
 )

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -1304,8 +1304,8 @@ github.com/gravitational/go-mysql v1.5.0-teleport.1 h1:EyFryeiTYyP6KslLVp0Q5QTKw
 github.com/gravitational/go-mysql v1.5.0-teleport.1/go.mod h1:GX0clmylJLdZEYAojPCDTCvwZxbTBrke93dV55715u0=
 github.com/gravitational/go-oidc v0.1.1 h1:T5nZxwkrfqfDMW4VPomCiG50Ae5ToaL9NFxEJHKURXc=
 github.com/gravitational/go-oidc v0.1.1/go.mod h1:A/IrBuKme/aPiJ9RIctJnSfPKUAzSQ4zaacIXDCQGx4=
-github.com/gravitational/go-ora/v2 v2.0.0-20230821114616-e2a9f1131a46 h1:k/tkK7NDSH7gjNbA5pdUfAalJXyIVazycM0RW7ZboxM=
-github.com/gravitational/go-ora/v2 v2.0.0-20230821114616-e2a9f1131a46/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
+github.com/gravitational/go-ora/v2 v2.8.22-0.20241004133430-d1e026bb9cc1 h1:m3cqVy2uU47x8KHxDA9obtrQ4lcJ2t1Ie/JkLAlIvfk=
+github.com/gravitational/go-ora/v2 v2.8.22-0.20241004133430-d1e026bb9cc1/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5 h1:qg8FcGwRACSHortU1UxCSo9nF0t34rPWjk9Nef3j2Ic=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/gravitational/kingpin/v2 v2.1.11-0.20230515143221-4ec6b70ecd33 h1:VFER/+0TfRypJhc9XeuggTtEZzhhe75DSVqMv/avHEU=


### PR DESCRIPTION
Updates https://github.com/gravitational/teleport/issues/43544.

New version: https://github.com/gravitational/go-ora/compare/v2.8.21...v2.8.21+teleport