### PR TITLE
Create a clean autoupdate client

### DIFF
--- a/api/client/autoupdate/autoupdate.go
+++ b/api/client/autoupdate/autoupdate.go
@@ -1,0 +1,118 @@
+package autoupdate
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	autoupdatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+)
+
+// Client is an access list client that conforms to the following lib/services interfaces:
+// * services.AutoUpdates
+type Client struct {
+	grpcClient autoupdatev1.AutoUpdateServiceClient
+}
+
+// NewClient creates a new Access List client.
+func NewClient(grpcClient autoupdatev1.AutoUpdateServiceClient) *Client {
+	return &Client{
+		grpcClient: grpcClient,
+	}
+}
+
+// CreateAutoUpdateConfig creates AutoUpdateConfig resource.
+func (c *Client) CreateAutoUpdateConfig(ctx context.Context, config *autoupdatev1.AutoUpdateConfig) (*autoupdatev1.AutoUpdateConfig, error) {
+	resp, err := c.grpcClient.CreateAutoUpdateConfig(ctx, &autoupdatev1.CreateAutoUpdateConfigRequest{
+		Config: config,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// GetAutoUpdateConfig gets AutoUpdateConfig resource.
+func (c *Client) GetAutoUpdateConfig(ctx context.Context) (*autoupdatev1.AutoUpdateConfig, error) {
+	resp, err := c.grpcClient.GetAutoUpdateConfig(ctx, &autoupdatev1.GetAutoUpdateConfigRequest{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// UpdateAutoUpdateConfig updates AutoUpdateConfig resource.
+func (c *Client) UpdateAutoUpdateConfig(ctx context.Context, config *autoupdatev1.AutoUpdateConfig) (*autoupdatev1.AutoUpdateConfig, error) {
+	resp, err := c.grpcClient.UpdateAutoUpdateConfig(ctx, &autoupdatev1.UpdateAutoUpdateConfigRequest{
+		Config: config,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// UpsertAutoUpdateConfig updates or creates AutoUpdateConfig resource.
+func (c *Client) UpsertAutoUpdateConfig(ctx context.Context, config *autoupdatev1.AutoUpdateConfig) (*autoupdatev1.AutoUpdateConfig, error) {
+	resp, err := c.grpcClient.UpsertAutoUpdateConfig(ctx, &autoupdatev1.UpsertAutoUpdateConfigRequest{
+		Config: config,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// DeleteAutoUpdateConfig deletes AutoUpdateConfig resource.
+func (c *Client) DeleteAutoUpdateConfig(ctx context.Context) error {
+	_, err := c.grpcClient.DeleteAutoUpdateConfig(ctx, &autoupdatev1.DeleteAutoUpdateConfigRequest{})
+	return trace.Wrap(err)
+}
+
+// CreateAutoUpdateVersion creates AutoUpdateVersion resource.
+func (c *Client) CreateAutoUpdateVersion(ctx context.Context, version *autoupdatev1.AutoUpdateVersion) (*autoupdatev1.AutoUpdateVersion, error) {
+	resp, err := c.grpcClient.CreateAutoUpdateVersion(ctx, &autoupdatev1.CreateAutoUpdateVersionRequest{
+		Version: version,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// GetAutoUpdateVersion gets AutoUpdateVersion resource.
+func (c *Client) GetAutoUpdateVersion(ctx context.Context) (*autoupdatev1.AutoUpdateVersion, error) {
+	resp, err := c.grpcClient.GetAutoUpdateVersion(ctx, &autoupdatev1.GetAutoUpdateVersionRequest{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// UpdateAutoUpdateVersion updates AutoUpdateVersion resource.
+func (c *Client) UpdateAutoUpdateVersion(ctx context.Context, version *autoupdatev1.AutoUpdateVersion) (*autoupdatev1.AutoUpdateVersion, error) {
+	resp, err := c.grpcClient.UpdateAutoUpdateVersion(ctx, &autoupdatev1.UpdateAutoUpdateVersionRequest{
+		Version: version,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// UpsertAutoUpdateVersion updates or creates AutoUpdateVersion resource.
+func (c *Client) UpsertAutoUpdateVersion(ctx context.Context, version *autoupdatev1.AutoUpdateVersion) (*autoupdatev1.AutoUpdateVersion, error) {
+	resp, err := c.grpcClient.UpsertAutoUpdateVersion(ctx, &autoupdatev1.UpsertAutoUpdateVersionRequest{
+		Version: version,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// DeleteAutoUpdateVersion deletes AutoUpdateVersion resource.
+func (c *Client) DeleteAutoUpdateVersion(ctx context.Context) error {
+	_, err := c.grpcClient.DeleteAutoUpdateVersion(ctx, &autoupdatev1.DeleteAutoUpdateVersionRequest{})
+	return trace.Wrap(err)
+}

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/client/accesslist"
 	"github.com/gravitational/teleport/api/client/accessmonitoringrules"
+	"github.com/gravitational/teleport/api/client/autoupdate"
 	crownjewelapi "github.com/gravitational/teleport/api/client/crownjewel"
 	"github.com/gravitational/teleport/api/client/discoveryconfig"
 	"github.com/gravitational/teleport/api/client/externalauditstorage"
@@ -67,7 +68,7 @@ import (
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	accessmonitoringrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
-	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	autoupdatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
 	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
@@ -2918,112 +2919,6 @@ func (c *Client) GetClusterAuditConfig(ctx context.Context) (types.ClusterAuditC
 	return resp, nil
 }
 
-// CreateAutoUpdateConfig creates AutoUpdateConfig resource.
-func (c *Client) CreateAutoUpdateConfig(ctx context.Context, config *autoupdatev1pb.AutoUpdateConfig) (*autoupdatev1pb.AutoUpdateConfig, error) {
-	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
-	resp, err := client.CreateAutoUpdateConfig(ctx, &autoupdatev1pb.CreateAutoUpdateConfigRequest{
-		Config: config,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return resp, nil
-}
-
-// GetAutoUpdateConfig gets AutoUpdateConfig resource.
-func (c *Client) GetAutoUpdateConfig(ctx context.Context) (*autoupdatev1pb.AutoUpdateConfig, error) {
-	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
-	resp, err := client.GetAutoUpdateConfig(ctx, &autoupdatev1pb.GetAutoUpdateConfigRequest{})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return resp, nil
-}
-
-// UpdateAutoUpdateConfig updates AutoUpdateConfig resource.
-func (c *Client) UpdateAutoUpdateConfig(ctx context.Context, config *autoupdatev1pb.AutoUpdateConfig) (*autoupdatev1pb.AutoUpdateConfig, error) {
-	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
-	resp, err := client.UpdateAutoUpdateConfig(ctx, &autoupdatev1pb.UpdateAutoUpdateConfigRequest{
-		Config: config,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return resp, nil
-}
-
-// UpsertAutoUpdateConfig updates or creates AutoUpdateConfig resource.
-func (c *Client) UpsertAutoUpdateConfig(ctx context.Context, config *autoupdatev1pb.AutoUpdateConfig) (*autoupdatev1pb.AutoUpdateConfig, error) {
-	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
-	resp, err := client.UpsertAutoUpdateConfig(ctx, &autoupdatev1pb.UpsertAutoUpdateConfigRequest{
-		Config: config,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return resp, nil
-}
-
-// DeleteAutoUpdateConfig deletes AutoUpdateConfig resource.
-func (c *Client) DeleteAutoUpdateConfig(ctx context.Context) error {
-	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
-	_, err := client.DeleteAutoUpdateConfig(ctx, &autoupdatev1pb.DeleteAutoUpdateConfigRequest{})
-	return trace.Wrap(err)
-}
-
-// CreateAutoUpdateVersion creates AutoUpdateVersion resource.
-func (c *Client) CreateAutoUpdateVersion(ctx context.Context, version *autoupdatev1pb.AutoUpdateVersion) (*autoupdatev1pb.AutoUpdateVersion, error) {
-	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
-	resp, err := client.CreateAutoUpdateVersion(ctx, &autoupdatev1pb.CreateAutoUpdateVersionRequest{
-		Version: version,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return resp, nil
-}
-
-// GetAutoUpdateVersion gets AutoUpdateVersion resource.
-func (c *Client) GetAutoUpdateVersion(ctx context.Context) (*autoupdatev1pb.AutoUpdateVersion, error) {
-	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
-	resp, err := client.GetAutoUpdateVersion(ctx, &autoupdatev1pb.GetAutoUpdateVersionRequest{})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return resp, nil
-}
-
-// UpdateAutoUpdateVersion updates AutoUpdateVersion resource.
-func (c *Client) UpdateAutoUpdateVersion(ctx context.Context, version *autoupdatev1pb.AutoUpdateVersion) (*autoupdatev1pb.AutoUpdateVersion, error) {
-	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
-	resp, err := client.UpdateAutoUpdateVersion(ctx, &autoupdatev1pb.UpdateAutoUpdateVersionRequest{
-		Version: version,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return resp, nil
-}
-
-// UpsertAutoUpdateVersion updates or creates AutoUpdateVersion resource.
-func (c *Client) UpsertAutoUpdateVersion(ctx context.Context, version *autoupdatev1pb.AutoUpdateVersion) (*autoupdatev1pb.AutoUpdateVersion, error) {
-	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
-	resp, err := client.UpsertAutoUpdateVersion(ctx, &autoupdatev1pb.UpsertAutoUpdateVersionRequest{
-		Version: version,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return resp, nil
-}
-
-// DeleteAutoUpdateVersion deletes AutoUpdateVersion resource.
-func (c *Client) DeleteAutoUpdateVersion(ctx context.Context) error {
-	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
-	_, err := client.DeleteAutoUpdateVersion(ctx, &autoupdatev1pb.DeleteAutoUpdateVersionRequest{})
-	return trace.Wrap(err)
-}
-
 // GetClusterAccessGraphConfig retrieves the Cluster Access Graph configuration from Auth server.
 func (c *Client) GetClusterAccessGraphConfig(ctx context.Context) (*clusterconfigpb.AccessGraphConfig, error) {
 	rsp, err := c.ClusterConfigClient().GetClusterAccessGraphConfig(ctx, &clusterconfigpb.GetClusterAccessGraphConfigRequest{})
@@ -4819,6 +4714,14 @@ func (c *Client) DiscoveryConfigClient() *discoveryconfig.Client {
 // (as per the default gRPC behavior).
 func (c *Client) CrownJewelServiceClient() *crownjewelapi.Client {
 	return crownjewelapi.NewClient(crownjewelv1.NewCrownJewelServiceClient(c.conn))
+}
+
+// AutoUpdateClient returns an auto update client.
+// Clients connecting to older Teleport versions, still get an auto update client
+// when calling this method, but all RPCs will return "not implemented" errors
+// (as per the default gRPC behavior).
+func (c *Client) AutoUpdateClient() *autoupdate.Client {
+	return autoupdate.NewClient(autoupdatev1.NewAutoUpdateServiceClient(c.conn))
 }
 
 // UserLoginStateClient returns a user login state client.

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -308,12 +308,6 @@ type ReadProxyAccessPoint interface {
 
 	// GetUserGroup returns the specified user group resources.
 	GetUserGroup(ctx context.Context, name string) (types.UserGroup, error)
-
-	// GetAutoUpdateConfig gets the AutoUpdateConfig from the backend.
-	GetAutoUpdateConfig(ctx context.Context) (*autoupdate.AutoUpdateConfig, error)
-
-	// GetAutoUpdateVersion gets the AutoUpdateVersion from the backend.
-	GetAutoUpdateVersion(ctx context.Context) (*autoupdate.AutoUpdateVersion, error)
 }
 
 // SnowflakeSessionWatcher is watcher interface used by Snowflake web session watcher.

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -643,6 +643,10 @@ func (c *Client) AccessMonitoringRuleClient() services.AccessMonitoringRules {
 	return c.APIClient.AccessMonitoringRulesClient()
 }
 
+func (c *Client) AutoUpdateClient() services.AutoUpdateService {
+	return c.APIClient.AutoUpdateClient()
+}
+
 func (c *Client) ExternalAuditStorageClient() *externalauditstorage.Client {
 	return c.APIClient.ExternalAuditStorageClient()
 }
@@ -1581,7 +1585,6 @@ type ClientI interface {
 	WebService
 	services.Status
 	services.ClusterConfiguration
-	services.AutoUpdateServiceGetter
 	services.SessionTrackerService
 	services.ConnectionsDiagnostic
 	services.SAMLIdPSession
@@ -1756,6 +1759,12 @@ type ClientI interface {
 	// when calling this method, but all RPCs will return "not implemented" errors
 	// (as per the default gRPC behavior).
 	AccessMonitoringRuleClient() services.AccessMonitoringRules
+
+	// AutoUpdateClient returns an auto update client.
+	// Clients connecting to older Teleport versions, still get an auto update client
+	// when calling this method, but all RPCs will return "not implemented" errors
+	// (as per the default gRPC behavior).
+	AutoUpdateClient() services.AutoUpdateService
 
 	// DatabaseObjectImportRuleClient returns a database object import rule client.
 	DatabaseObjectImportRuleClient() dbobjectimportrulev1.DatabaseObjectImportRuleServiceClient

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -500,7 +500,7 @@ type Cache struct {
 
 	trustCache                   services.Trust
 	clusterConfigCache           services.ClusterConfiguration
-	autoUpdateCache              *local.AutoUpdateService
+	autoUpdateCache              services.AutoUpdateService
 	provisionerCache             services.Provisioner
 	usersCache                   services.UsersService
 	accessCache                  services.Access

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2577,7 +2577,7 @@ func (process *TeleportProcess) newAccessCacheForClient(cfg accesspoint.Config, 
 	cfg.WebSession = client.WebSessions()
 	cfg.WebToken = client.WebTokens()
 	cfg.WindowsDesktops = client
-	cfg.AutoUpdateService = client
+	cfg.AutoUpdateService = client.AutoUpdateClient()
 
 	return accesspoint.NewCache(cfg)
 }

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -580,7 +580,7 @@ func testEditAutoUpdateConfig(t *testing.T, clt *authclient.Client) {
 	_, err = runEditCommand(t, clt, []string{"edit", "autoupdate_config"}, withEditor(editor))
 	require.NoError(t, err, "expected editing autoupdate config to succeed")
 
-	actual, err := clt.GetAutoUpdateConfig(ctx)
+	actual, err := clt.AutoUpdateClient().GetAutoUpdateConfig(ctx)
 	require.NoError(t, err, "failed to get autoupdate config after edit")
 	assert.NotEqual(t, initial.GetSpec().GetToolsAutoupdate(), actual.GetSpec().GetToolsAutoupdate(),
 		"tools_autoupdate should have been modified by edit")
@@ -614,7 +614,7 @@ func testEditAutoUpdateVersion(t *testing.T, clt *authclient.Client) {
 	_, err = runEditCommand(t, clt, []string{"edit", "autoupdate_version"}, withEditor(editor))
 	require.NoError(t, err, "expected editing autoupdate version to succeed")
 
-	actual, err := clt.GetAutoUpdateVersion(ctx)
+	actual, err := clt.AutoUpdateClient().GetAutoUpdateVersion(ctx)
 	require.NoError(t, err, "failed to get autoupdate version after edit")
 	assert.NotEqual(t, initial.GetSpec().GetToolsVersion(), actual.GetSpec().GetToolsVersion(),
 		"tools_autoupdate should have been modified by edit")

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -3069,13 +3069,13 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &staticHostUserCollection{items: hostUsers}, nil
 	case types.KindAutoUpdateConfig:
-		config, err := client.GetAutoUpdateConfig(ctx)
+		config, err := client.AutoUpdateClient().GetAutoUpdateConfig(ctx)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &autoUpdateConfigCollection{config}, nil
 	case types.KindAutoUpdateVersion:
-		version, err := client.GetAutoUpdateVersion(ctx)
+		version, err := client.AutoUpdateClient().GetAutoUpdateVersion(ctx)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -3433,9 +3433,9 @@ func (rc *ResourceCommand) createAutoUpdateConfig(ctx context.Context, client *a
 	}
 
 	if rc.IsForced() {
-		_, err = client.UpsertAutoUpdateConfig(ctx, config)
+		_, err = client.AutoUpdateClient().UpsertAutoUpdateConfig(ctx, config)
 	} else {
-		_, err = client.CreateAutoUpdateConfig(ctx, config)
+		_, err = client.AutoUpdateClient().CreateAutoUpdateConfig(ctx, config)
 	}
 	if err != nil {
 		return trace.Wrap(err)
@@ -3450,7 +3450,7 @@ func (rc *ResourceCommand) updateAutoUpdateConfig(ctx context.Context, client *a
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if _, err := client.UpdateAutoUpdateConfig(ctx, config); err != nil {
+	if _, err := client.AutoUpdateClient().UpdateAutoUpdateConfig(ctx, config); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Println("autoupdate_config has been updated")
@@ -3464,9 +3464,9 @@ func (rc *ResourceCommand) createAutoUpdateVersion(ctx context.Context, client *
 	}
 
 	if rc.IsForced() {
-		_, err = client.UpsertAutoUpdateVersion(ctx, version)
+		_, err = client.AutoUpdateClient().UpsertAutoUpdateVersion(ctx, version)
 	} else {
-		_, err = client.CreateAutoUpdateVersion(ctx, version)
+		_, err = client.AutoUpdateClient().CreateAutoUpdateVersion(ctx, version)
 	}
 	if err != nil {
 		return trace.Wrap(err)
@@ -3481,7 +3481,7 @@ func (rc *ResourceCommand) updateAutoUpdateVersion(ctx context.Context, client *
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if _, err := client.UpdateAutoUpdateVersion(ctx, version); err != nil {
+	if _, err := client.AutoUpdateClient().UpdateAutoUpdateVersion(ctx, version); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Println("autoupdate_version has been updated")


### PR DESCRIPTION
We made a mistake when implementing autoupdate resources: we put them directly in the main client.
Before we start to sue there everywhere, I'd like to move the autoupdate client methods to a dedeicated sub-client as recommended in the RFD 153:
> For users to interact with the new Foo RPC service the client in the `api`
> module needs to be updated to provide the functionality. To do so a new method
> should be added to `client.Client` that exposes the gRPC client for the service
> as shown below.
> 
> ```go
> func (c *Client) FooClient() foopb.FooServiceClient {
>  	return foopb.NewFooServiceClient(c.conn)
> }
> ```
