### PR TITLE
Replace EOL Debian Buster with Bullseye in `Dockerfile-node`

### DIFF
--- a/build.assets/Dockerfile-node
+++ b/build.assets/Dockerfile-node
@@ -4,17 +4,18 @@
 # to build the Teleport Connect. It can also be used to build the
 # web assets for the Teleport UI.
 #
-# This image is base on the node image, which is based on Debian Buster.
-# Using it as a image allows us to link agains the same version of
-# glibc as Node.js.
+# This image is base on the node image, which is based on Debian Bullseye.
+# Using it as an image allows us to link against the oldest version of glibc
+# supported by Node.js Docker images.
 #
 # Check the README to learn how to safely introduce changes to Dockerfiles.
 
 ## BUILDBOX-NODE ###################################################################
 
-# Pin the tag to Debian Buster to make sure the Glibc compatibility.
+# Pin the tag to Debian Bullseye to make sure the glibc compatibility
+# (glibc version of Bullseye is 2.31).
 ARG NODE_VERSION
-FROM node:${NODE_VERSION}-buster AS buildbox
+FROM node:${NODE_VERSION}-bullseye AS buildbox
 
 # BUILDARCH is automatically set by DOCKER when building the image with Build Kit (MacOS by deafult).
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -6,7 +6,7 @@
 GOLANG_VERSION ?= go1.23.2
 GOLANGCI_LINT_VERSION ?= v1.61.0
 
-NODE_VERSION ?= 20.14.0
+NODE_VERSION ?= 20.17.0
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.81.0


### PR DESCRIPTION
Electron upgrade to version 32.1.2 [failed because Electron started requiring GCC v10](https://github.com/gravitational/teleport.e/actions/runs/11178176728/job/31075273887):
```
g++: error: unrecognized command line option ‘-std=gnu++20’; did you mean ‘-std=gnu++2a’?
```
While we could probably install it, I noticed that the Buster image we use, went EOL some time ago https://github.com/nodejs/docker-node/pull/2114.
Updating to Bullseye resolves the problem with GCC version.
The only downside is that it increases the glibc requirement, from 2.29 to 2.31. However, this should not have a minimal impact on users, for example, Ubuntu 20.04 LTS has glibc 2.31.

Successful tag build https://github.com/gravitational/teleport.e/actions/runs/11180298411/job/31081783865

changelog: Teleport Connect for Linux now requires glibc 2.31 or later