### PR TITLE
Fix creation of JKS wallet for Oracle.

### DIFF
--- a/api/utils/keys/privatekey.go
+++ b/api/utils/keys/privatekey.go
@@ -421,3 +421,15 @@ func X509Certificate(certPEMBlock []byte) (*x509.Certificate, [][]byte, error) {
 	}
 	return x509Cert, rawCerts, nil
 }
+
+// MarshalSoftwarePrivateKeyPKCS8DER marshals the provided private key as PKCS#8 DER.
+func MarshalSoftwarePrivateKeyPKCS8DER(signer crypto.Signer) ([]byte, error) {
+	switch k := signer.(type) {
+	case *PrivateKey:
+		return MarshalSoftwarePrivateKeyPKCS8DER(k.Signer)
+	case *rsa.PrivateKey, *ecdsa.PrivateKey, ed25519.PrivateKey:
+		return x509.MarshalPKCS8PrivateKey(k)
+	default:
+		return nil, trace.BadParameter("unsupported key type: %T", signer)
+	}
+}

--- a/lib/client/db/oracle/oracle.go
+++ b/lib/client/db/oracle/oracle.go
@@ -21,7 +21,6 @@ package oracle
 import (
 	"bytes"
 	"crypto"
-	"crypto/x509"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -87,12 +86,7 @@ func createClientWallet(signer crypto.Signer, certPem []byte, password string, w
 }
 
 func createJKSWallet(signer crypto.Signer, certPEM, caPEM []byte, password string) ([]byte, error) {
-	// unwrap *keys.PrivateKey if necessary.
-	if pk, ok := signer.(*keys.PrivateKey); ok {
-		signer = pk.Signer
-	}
-
-	privateKey, err := x509.MarshalPKCS8PrivateKey(signer)
+	privateKey, err := keys.MarshalSoftwarePrivateKeyPKCS8DER(signer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/db/oracle/oracle.go
+++ b/lib/client/db/oracle/oracle.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -86,6 +87,11 @@ func createClientWallet(signer crypto.Signer, certPem []byte, password string, w
 }
 
 func createJKSWallet(signer crypto.Signer, certPEM, caPEM []byte, password string) ([]byte, error) {
+	// unwrap *keys.PrivateKey if necessary.
+	if pk, ok := signer.(*keys.PrivateKey); ok {
+		signer = pk.Signer
+	}
+
 	privateKey, err := x509.MarshalPKCS8PrivateKey(signer)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/db/oracle/oracle_test.go
+++ b/lib/client/db/oracle/oracle_test.go
@@ -1,0 +1,56 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package oracle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+)
+
+func TestCreateJksWallet(t *testing.T) {
+	algos := []cryptosuites.Algorithm{
+		cryptosuites.RSA2048,
+		cryptosuites.ECDSAP256,
+		cryptosuites.Ed25519,
+	}
+
+	for _, algo := range algos {
+		t.Run(algo.String(), func(t *testing.T) {
+			signer, err := cryptosuites.GenerateKeyWithAlgorithm(algo)
+			require.NoError(t, err)
+
+			publicPEM, err := keys.MarshalPublicKey(signer.Public())
+			require.NoError(t, err)
+
+			privatePEM, err := keys.MarshalPrivateKey(signer)
+			require.NoError(t, err)
+
+			wrapped, err := keys.NewPrivateKey(signer, privatePEM)
+			require.NoError(t, err)
+
+			_, err = createJKSWallet(signer, publicPEM, publicPEM, "dummy")
+			require.NoError(t, err)
+
+			_, err = createJKSWallet(wrapped, publicPEM, publicPEM, "dummy")
+			require.NoError(t, err)
+		})
+	}
+}

--- a/lib/client/db/oracle/oracle_test.go
+++ b/lib/client/db/oracle/oracle_test.go
@@ -40,10 +40,7 @@ func TestCreateJksWallet(t *testing.T) {
 			publicPEM, err := keys.MarshalPublicKey(signer.Public())
 			require.NoError(t, err)
 
-			privatePEM, err := keys.MarshalPrivateKey(signer)
-			require.NoError(t, err)
-
-			wrapped, err := keys.NewPrivateKey(signer, privatePEM)
+			wrapped, err := keys.NewSoftwarePrivateKey(signer)
 			require.NoError(t, err)
 
 			_, err = createJKSWallet(signer, publicPEM, publicPEM, "dummy")


### PR DESCRIPTION
Unwrap `*keys.PrivateKey` to fetch inner signer that satisfies `x509.MarshalPKCS8PrivateKey` expectations. This change allows passing `keys.PrivateKey` to `createJKSWallet`. The updated function will correctly marshal the private key for Oracle's JKS wallet creation.