### PR TITLE
Scaffolding for QUIC proxy peering

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1028,6 +1028,11 @@ const (
 	// group they should attempt to be connected to.
 	ProxyGroupGenerationLabel = TeleportInternalLabelPrefix + "proxygroup-gen"
 
+	// ProxyPeerQUICLabel is the internal-user label for proxy heartbeats that's
+	// used to signal that the proxy supports receiving proxy peering
+	// connections over QUIC.
+	ProxyPeerQUICLabel = TeleportInternalLabelPrefix + "proxy-peer-quic"
+
 	// OktaAppNameLabel is the individual app name label.
 	OktaAppNameLabel = TeleportInternalLabelPrefix + "okta-app-name"
 

--- a/go.mod
+++ b/go.mod
@@ -164,6 +164,7 @@ require (
 	github.com/prometheus/client_golang v1.20.4
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.55.0
+	github.com/quic-go/quic-go v0.47.0
 	github.com/redis/go-redis/v9 v9.5.1 // replaced
 	github.com/russellhaering/gosaml2 v0.9.1
 	github.com/russellhaering/goxmldsig v1.4.0
@@ -351,6 +352,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
+	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-webauthn/x v0.1.14 // indirect
 	github.com/gobuffalo/flect v1.0.2 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
@@ -370,6 +372,7 @@ require (
 	github.com/google/go-configfs-tsm v0.2.2 // indirect
 	github.com/google/go-tspi v0.3.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af // indirect
 	github.com/google/s2a-go v0.1.8 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect
@@ -450,6 +453,7 @@ require (
 	github.com/nsf/termbox-go v1.1.1 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/onsi/ginkgo/v2 v2.19.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pascaldekloe/name v1.0.1 // indirect
@@ -527,6 +531,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.29.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	go.uber.org/mock v0.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/tools v0.24.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240716161551-93cc26a95ae9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1276,7 +1276,6 @@ github.com/go-resty/resty/v2 v2.15.3/go.mod h1:0fHAoK7JoBy/Ch36N8VFeMsK7xQOHhvWa
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
@@ -2000,6 +1999,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20231025115547-084445ff1adf h1:014O62zIzQwvoD7Ekj3ePDF5bv9Xxy0w6AZk0qYbjUk=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20231025115547-084445ff1adf/go.mod h1:jgxiZysxFPM+iWKwQwPR+y+Jvo54ARd4EisXxKYpB5c=
+github.com/quic-go/quic-go v0.47.0 h1:yXs3v7r2bm1wmPTYNLKAAJTHMYkPEsfYJmTazXrCZ7Y=
+github.com/quic-go/quic-go v0.47.0/go.mod h1:3bCapYsJvXGZcipOHuu7plYtaV6tnF+z7wIFsU0WK9E=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
@@ -2309,6 +2310,8 @@ go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
+go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -1419,6 +1419,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/quic-go/quic-go v0.47.0 h1:yXs3v7r2bm1wmPTYNLKAAJTHMYkPEsfYJmTazXrCZ7Y=
+github.com/quic-go/quic-go v0.47.0/go.mod h1:3bCapYsJvXGZcipOHuu7plYtaV6tnF+z7wIFsU0WK9E=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
@@ -1580,6 +1582,8 @@ go.starlark.net v0.0.0-20230525235612-a134d8f9ddca h1:VdD38733bfYv5tUZwEIskMM93V
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
+go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -162,6 +162,7 @@ require (
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-piv/piv-go v1.11.0 // indirect
+	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-webauthn/webauthn v0.11.2 // indirect
 	github.com/go-webauthn/x v0.1.14 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
@@ -182,6 +183,7 @@ require (
 	github.com/google/go-tpm-tools v0.4.4 // indirect
 	github.com/google/go-tspi v0.3.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af // indirect
 	github.com/google/s2a-go v0.1.8 // indirect
 	github.com/google/safetext v0.0.0-20240104143208-7a7d9b3d812f // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
@@ -271,6 +273,7 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/okta/okta-sdk-golang/v2 v2.20.0 // indirect
+	github.com/onsi/ginkgo/v2 v2.19.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 // indirect
@@ -290,6 +293,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/quic-go/quic-go v0.47.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/rubenv/sql-migrate v1.7.0 // indirect
@@ -342,6 +346,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.30.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
+	go.uber.org/mock v0.4.0 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.21.0 // indirect
@@ -352,6 +357,7 @@ require (
 	golang.org/x/term v0.24.0 // indirect
 	golang.org/x/text v0.18.0 // indirect
 	golang.org/x/time v0.6.0 // indirect
+	golang.org/x/tools v0.24.0 // indirect
 	google.golang.org/api v0.197.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240903143218-8af14fe29dc1 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -1738,6 +1738,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/quic-go/quic-go v0.47.0 h1:yXs3v7r2bm1wmPTYNLKAAJTHMYkPEsfYJmTazXrCZ7Y=
+github.com/quic-go/quic-go v0.47.0/go.mod h1:3bCapYsJvXGZcipOHuu7plYtaV6tnF+z7wIFsU0WK9E=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
@@ -1967,6 +1969,8 @@ go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
+go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=

--- a/lib/proxy/peer/client_test.go
+++ b/lib/proxy/peer/client_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	clientapi "github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // TestClientConn checks the client's connection caching capabilities
@@ -46,33 +47,33 @@ func TestClientConn(t *testing.T) {
 	require.Len(t, client.conns, 2)
 
 	// dial first server and send a test data frame
-	stream, cached, err := client.dial([]string{"s1"}, &proto.DialRequest{})
+	stream, cached, err := client.dial([]string{"s1"}, "", &utils.NetAddr{}, &utils.NetAddr{}, "")
 	require.NoError(t, err)
 	require.True(t, cached)
-	require.NotNil(t, stream.stream)
+	require.NotNil(t, stream)
 	stream.Close()
 
 	// dial second server
-	stream, cached, err = client.dial([]string{"s2"}, &proto.DialRequest{})
+	stream, cached, err = client.dial([]string{"s2"}, "", &utils.NetAddr{}, &utils.NetAddr{}, "")
 	require.NoError(t, err)
 	require.True(t, cached)
-	require.NotNil(t, stream.stream)
+	require.NotNil(t, stream)
 	stream.Close()
 
 	// redial second server
-	stream, cached, err = client.dial([]string{"s2"}, &proto.DialRequest{})
+	stream, cached, err = client.dial([]string{"s2"}, "", &utils.NetAddr{}, &utils.NetAddr{}, "")
 	require.NoError(t, err)
 	require.True(t, cached)
-	require.NotNil(t, stream.stream)
+	require.NotNil(t, stream)
 	stream.Close()
 
 	// close second server
 	// and attempt to redial it
 	server2.Shutdown()
-	stream, cached, err = client.dial([]string{"s2"}, &proto.DialRequest{})
+	stream, cached, err = client.dial([]string{"s2"}, "", &utils.NetAddr{}, &utils.NetAddr{}, "")
 	require.Error(t, err)
 	require.True(t, cached)
-	require.Nil(t, stream.stream)
+	require.Nil(t, stream)
 }
 
 // TestClientUpdate checks the client's watcher update behavior
@@ -90,12 +91,12 @@ func TestClientUpdate(t *testing.T) {
 	require.Contains(t, client.conns, "s1")
 	require.Contains(t, client.conns, "s2")
 
-	s1, _, err := client.dial([]string{"s1"}, &proto.DialRequest{})
+	s1, _, err := client.dial([]string{"s1"}, "", &utils.NetAddr{}, &utils.NetAddr{}, "")
 	require.NoError(t, err)
-	require.NotNil(t, s1.stream)
-	s2, _, err := client.dial([]string{"s2"}, &proto.DialRequest{})
+	require.NotNil(t, s1)
+	s2, _, err := client.dial([]string{"s2"}, "", &utils.NetAddr{}, &utils.NetAddr{}, "")
 	require.NoError(t, err)
-	require.NotNil(t, s2.stream)
+	require.NotNil(t, s2)
 
 	// watcher finds one of the two servers
 	err = client.updateConnections([]types.Server{def1})
@@ -114,7 +115,7 @@ func TestClientUpdate(t *testing.T) {
 	require.Len(t, client.conns, 2)
 	require.Contains(t, client.conns, "s1")
 	sendMsg(t, s1) // stream is still going strong
-	_, _, err = client.dial([]string{"s2"}, &proto.DialRequest{})
+	_, _, err = client.dial([]string{"s2"}, "", &utils.NetAddr{}, &utils.NetAddr{}, "")
 	require.Error(t, err) // can't dial server2, obviously
 
 	// peer address change
@@ -124,7 +125,7 @@ func TestClientUpdate(t *testing.T) {
 	require.Len(t, client.conns, 1)
 	require.Contains(t, client.conns, "s1")
 	sendMsg(t, s1) // stream is not forcefully closed. ClientConn waits for a graceful shutdown before it closes.
-	s3, _, err := client.dial([]string{"s1"}, &proto.DialRequest{})
+	s3, _, err := client.dial([]string{"s1"}, "", &utils.NetAddr{}, &utils.NetAddr{}, "")
 	require.NoError(t, err)
 	require.NotNil(t, s3)
 
@@ -145,9 +146,10 @@ func TestCAChange(t *testing.T) {
 	conn, err := client.connect("s1", ts.GetPeerAddr())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
+	require.IsType(t, (*grpcClientConn)(nil), conn)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	stream, err := clientapi.NewProxyServiceClient(conn.ClientConn).DialNode(ctx)
+	stream, err := clientapi.NewProxyServiceClient(conn.(*grpcClientConn).cc).DialNode(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, stream)
 
@@ -162,7 +164,8 @@ func TestCAChange(t *testing.T) {
 	conn, err = client.connect("s1", ts.GetPeerAddr())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	stream, err = clientapi.NewProxyServiceClient(conn.ClientConn).DialNode(ctx)
+	require.IsType(t, (*grpcClientConn)(nil), conn)
+	stream, err = clientapi.NewProxyServiceClient(conn.(*grpcClientConn).cc).DialNode(ctx)
 	require.Error(t, err)
 	require.Nil(t, stream)
 
@@ -173,7 +176,8 @@ func TestCAChange(t *testing.T) {
 	conn, err = client.connect("s1", ts.GetPeerAddr())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	stream, err = clientapi.NewProxyServiceClient(conn.ClientConn).DialNode(ctx)
+	require.IsType(t, (*grpcClientConn)(nil), conn)
+	stream, err = clientapi.NewProxyServiceClient(conn.(*grpcClientConn).cc).DialNode(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, stream)
 }
@@ -196,17 +200,18 @@ func TestBackupClient(t *testing.T) {
 
 	err := client.updateConnections([]types.Server{def1, def2})
 	require.NoError(t, err)
-	waitForConns(t, client.conns, time.Second*2)
+	waitForGRPCConns(t, client.conns, time.Second*2)
 
-	_, _, err = client.dial([]string{def1.GetName(), def2.GetName()}, &proto.DialRequest{})
+	_, _, err = client.dial([]string{def1.GetName(), def2.GetName()}, "", &utils.NetAddr{}, &utils.NetAddr{}, "")
 	require.NoError(t, err)
 	require.True(t, dialCalled)
 }
 
-func waitForConns(t *testing.T, conns map[string]*clientConn, d time.Duration) {
+func waitForGRPCConns(t *testing.T, conns map[string]clientConn, d time.Duration) {
 	require.Eventually(t, func() bool {
 		for _, conn := range conns {
-			if conn.GetState() != connectivity.Ready {
+			// panic if we hit a non-grpc client conn
+			if conn.(*grpcClientConn).cc.GetState() != connectivity.Ready {
 				return false
 			}
 		}

--- a/lib/proxy/peer/client_test.go
+++ b/lib/proxy/peer/client_test.go
@@ -143,7 +143,8 @@ func TestCAChange(t *testing.T) {
 	t.Cleanup(func() { server.Close() })
 
 	// dial server and send a test data frame
-	conn, err := client.connect("s1", ts.GetPeerAddr())
+	const supportsQUICFalse = false
+	conn, err := client.connect("s1", ts.GetPeerAddr(), supportsQUICFalse)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	require.IsType(t, (*grpcClientConn)(nil), conn)
@@ -161,7 +162,7 @@ func TestCAChange(t *testing.T) {
 
 	// new connection should fail because client tls config still references old
 	// RootCAs.
-	conn, err = client.connect("s1", ts.GetPeerAddr())
+	conn, err = client.connect("s1", ts.GetPeerAddr(), supportsQUICFalse)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	require.IsType(t, (*grpcClientConn)(nil), conn)
@@ -173,7 +174,7 @@ func TestCAChange(t *testing.T) {
 	// RootCAs.
 	currentServerCA.Store(newServerCA)
 
-	conn, err = client.connect("s1", ts.GetPeerAddr())
+	conn, err = client.connect("s1", ts.GetPeerAddr(), supportsQUICFalse)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	require.IsType(t, (*grpcClientConn)(nil), conn)

--- a/lib/proxy/peer/credentials.go
+++ b/lib/proxy/peer/credentials.go
@@ -30,45 +30,6 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
-// serverCredentials wraps a [crendentials.TransportCredentials] that
-// extends the ServerHandshake to ensure the credentials contain the proxy system role.
-type serverCredentials struct {
-	credentials.TransportCredentials
-}
-
-// newServerCredentials creates new serverCredentials from the given [crendentials.TransportCredentials].
-func newServerCredentials(creds credentials.TransportCredentials) *serverCredentials {
-	return &serverCredentials{
-		TransportCredentials: creds,
-	}
-}
-
-// ServerHandshake performs the TLS handshake and then verifies that the client
-// attempting to connect is a Proxy.
-func (c *serverCredentials) ServerHandshake(conn net.Conn) (_ net.Conn, _ credentials.AuthInfo, err error) {
-	conn, authInfo, err := c.TransportCredentials.ServerHandshake(conn)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	defer func() {
-		if err != nil {
-			conn.Close()
-		}
-	}()
-
-	identity, err := getIdentity(authInfo)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	if err := checkProxyRole(identity); err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	return conn, authInfo, nil
-}
-
 // clientCredentials wraps a [crendentials.TransportCredentials] that
 // extends the ClientHandshake to ensure the credentials contain the proxy system role
 // and that connections are established to the expected peer.

--- a/lib/proxy/peer/helpers_test.go
+++ b/lib/proxy/peer/helpers_test.go
@@ -258,7 +258,7 @@ func setupServer(t *testing.T, name string, serverCA, clientCA *tlsca.CertAuthor
 	return server, ts
 }
 
-func sendMsg(t *testing.T, stream frameStream) {
-	err := stream.Send([]byte("ping"))
+func sendMsg(t *testing.T, stream net.Conn) {
+	_, err := stream.Write([]byte("ping"))
 	require.NoError(t, err)
 }

--- a/lib/proxy/peer/helpers_test.go
+++ b/lib/proxy/peer/helpers_test.go
@@ -219,22 +219,21 @@ func setupServer(t *testing.T, name string, serverCA, clientCA *tlsca.CertAuthor
 		Username: name + ".test",
 		Groups:   []string{string(role)},
 	})
-	tlsConf := &tls.Config{
-		Certificates: []tls.Certificate{tlsCert},
-	}
-	tlsConf.ClientCAs = x509.NewCertPool()
-	tlsConf.ClientCAs.AddCert(clientCA.Cert)
-
-	listener, err := net.Listen("tcp", "localhost:0")
-	require.NoError(t, err)
+	clientCAs := x509.NewCertPool()
+	clientCAs.AddCert(clientCA.Cert)
 
 	config := ServerConfig{
-		Listener:      listener,
-		TLSConfig:     tlsConf,
 		ClusterDialer: &mockClusterDialer{},
-		service:       &mockProxyService{},
-		ClusterName:   "test",
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return &tlsCert, nil
+		},
+		GetClientCAs: func(*tls.ClientHelloInfo) (*x509.CertPool, error) {
+			return clientCAs, nil
+		},
+
+		service: &mockProxyService{},
 	}
+
 	for _, option := range options {
 		option(&config)
 	}
@@ -242,16 +241,19 @@ func setupServer(t *testing.T, name string, serverCA, clientCA *tlsca.CertAuthor
 	server, err := NewServer(config)
 	require.NoError(t, err)
 
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	go server.Serve(listener)
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+	})
+
 	ts, err := types.NewServer(
 		name, types.KindProxy,
 		types.ServerSpecV2{PeerAddr: listener.Addr().String()},
 	)
 	require.NoError(t, err)
-
-	go server.Serve()
-	t.Cleanup(func() {
-		require.NoError(t, server.Close())
-	})
 
 	return server, ts
 }

--- a/lib/proxy/peer/quicserver.go
+++ b/lib/proxy/peer/quicserver.go
@@ -30,13 +30,28 @@ import (
 	"github.com/gravitational/teleport"
 )
 
+// QUICServerConfig holds the parameters for [NewQUICServer].
 type QUICServerConfig struct {
-	Log           *slog.Logger
+	Log *slog.Logger
+	// ClusterDialer is the dialer used to open connections to agents on behalf
+	// of the peer proxies. Required.
 	ClusterDialer ClusterDialer
 
-	CipherSuites   []uint16
+	// CipherSuites is the set of TLS ciphersuites to be used by the server.
+	//
+	// Note: it won't actually have an effect, since QUIC always uses (the DTLS
+	// equivalent of) TLS 1.3, and TLS 1.3 ciphersuites can't be configured in
+	// crypto/tls, but for consistency's sake this should be passed along from
+	// the agent configuration.
+	CipherSuites []uint16
+	// GetCertificate should return the server certificate at time of use. It
+	// should be a certificate with the Proxy host role. Required.
 	GetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
-	GetClientCAs   func(*tls.ClientHelloInfo) (*x509.CertPool, error)
+	// GetClientCAs should return the certificate pool that should be used to
+	// validate the client certificates of peer proxies; i.e., a pool containing
+	// the trusted signers for the certificate authority of the local cluster.
+	// Required.
+	GetClientCAs func(*tls.ClientHelloInfo) (*x509.CertPool, error)
 }
 
 func (c *QUICServerConfig) checkAndSetDefaults() error {
@@ -65,6 +80,7 @@ func (c *QUICServerConfig) checkAndSetDefaults() error {
 // QUICServer is a proxy peering server that uses the QUIC protocol.
 type QUICServer struct{}
 
+// NewQUICServer returns a [QUICServer] with the given config.
 func NewQUICServer(cfg QUICServerConfig) (*QUICServer, error) {
 	if err := cfg.checkAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
@@ -72,14 +88,21 @@ func NewQUICServer(cfg QUICServerConfig) (*QUICServer, error) {
 	panic("QUIC proxy peering is not implemented")
 }
 
+// Serve opens a listener and serves incoming connection. Returns after calling
+// Close or Shutdown.
 func (s *QUICServer) Serve(t *quic.Transport) error {
 	panic("QUIC proxy peering is not implemented")
 }
 
+// Close stops listening for incoming connections and ungracefully terminates
+// all the existing ones.
 func (s *QUICServer) Close() error {
 	panic("QUIC proxy peering is not implemented")
 }
 
+// Shutdown stops listening for incoming connections and waits until the
+// existing ones are closed or until the context expires. If the context
+// expires, running connections are ungracefully terminated.
 func (s *QUICServer) Shutdown(ctx context.Context) error {
 	panic("QUIC proxy peering is not implemented")
 }

--- a/lib/proxy/peer/quicserver.go
+++ b/lib/proxy/peer/quicserver.go
@@ -1,0 +1,85 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package peer
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+	"github.com/quic-go/quic-go"
+
+	"github.com/gravitational/teleport"
+)
+
+type QUICServerConfig struct {
+	Log           *slog.Logger
+	ClusterDialer ClusterDialer
+
+	CipherSuites   []uint16
+	GetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
+	GetClientCAs   func(*tls.ClientHelloInfo) (*x509.CertPool, error)
+}
+
+func (c *QUICServerConfig) checkAndSetDefaults() error {
+	if c.Log == nil {
+		c.Log = slog.Default()
+	}
+	c.Log = c.Log.With(
+		teleport.ComponentKey,
+		teleport.Component(teleport.ComponentProxy, "qpeer"),
+	)
+
+	if c.ClusterDialer == nil {
+		return trace.BadParameter("missing cluster dialer")
+	}
+
+	if c.GetCertificate == nil {
+		return trace.BadParameter("missing GetCertificate")
+	}
+	if c.GetClientCAs == nil {
+		return trace.BadParameter("missing GetClientCAs")
+	}
+
+	return nil
+}
+
+// QUICServer is a proxy peering server that uses the QUIC protocol.
+type QUICServer struct{}
+
+func NewQUICServer(cfg QUICServerConfig) (*QUICServer, error) {
+	if err := cfg.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	panic("QUIC proxy peering is not implemented")
+}
+
+func (s *QUICServer) Serve(t *quic.Transport) error {
+	panic("QUIC proxy peering is not implemented")
+}
+
+func (s *QUICServer) Close() error {
+	panic("QUIC proxy peering is not implemented")
+}
+
+func (s *QUICServer) Shutdown(ctx context.Context) error {
+	panic("QUIC proxy peering is not implemented")
+}

--- a/lib/proxy/peer/server.go
+++ b/lib/proxy/peer/server.go
@@ -22,13 +22,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"log/slog"
 	"math"
 	"net"
 	"slices"
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
@@ -49,7 +49,7 @@ const (
 
 // ServerConfig configures a Server instance.
 type ServerConfig struct {
-	Log           logrus.FieldLogger
+	Log           *slog.Logger
 	ClusterDialer ClusterDialer
 
 	CipherSuites   []uint16
@@ -64,9 +64,9 @@ type ServerConfig struct {
 // checkAndSetDefaults checks and sets default values
 func (c *ServerConfig) checkAndSetDefaults() error {
 	if c.Log == nil {
-		c.Log = logrus.StandardLogger()
+		c.Log = slog.Default()
 	}
-	c.Log = c.Log.WithField(
+	c.Log = c.Log.With(
 		teleport.ComponentKey,
 		teleport.Component(teleport.ComponentProxy, "peer"),
 	)
@@ -94,7 +94,7 @@ func (c *ServerConfig) checkAndSetDefaults() error {
 
 // Server is a proxy service server using grpc and tls.
 type Server struct {
-	log           logrus.FieldLogger
+	log           *slog.Logger
 	clusterDialer ClusterDialer
 	server        *grpc.Server
 }

--- a/lib/proxy/peer/server.go
+++ b/lib/proxy/peer/server.go
@@ -20,9 +20,11 @@ package peer
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"math"
 	"net"
+	"slices"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -34,7 +36,9 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/metadata"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -45,11 +49,12 @@ const (
 
 // ServerConfig configures a Server instance.
 type ServerConfig struct {
-	Listener      net.Listener
-	TLSConfig     *tls.Config
-	ClusterDialer ClusterDialer
 	Log           logrus.FieldLogger
-	ClusterName   string
+	ClusterDialer ClusterDialer
+
+	CipherSuites   []uint16
+	GetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
+	GetClientCAs   func(*tls.ClientHelloInfo) (*x509.CertPool, error)
 
 	// service is a custom ProxyServiceServer
 	// configurable for testing purposes.
@@ -59,29 +64,23 @@ type ServerConfig struct {
 // checkAndSetDefaults checks and sets default values
 func (c *ServerConfig) checkAndSetDefaults() error {
 	if c.Log == nil {
-		c.Log = logrus.New()
+		c.Log = logrus.StandardLogger()
 	}
 	c.Log = c.Log.WithField(
 		teleport.ComponentKey,
 		teleport.Component(teleport.ComponentProxy, "peer"),
 	)
 
-	if c.Listener == nil {
-		return trace.BadParameter("missing listener")
-	}
-
 	if c.ClusterDialer == nil {
 		return trace.BadParameter("missing cluster dialer server")
 	}
 
-	if c.ClusterName == "" {
-		return trace.BadParameter("missing cluster name")
+	if c.GetCertificate == nil {
+		return trace.BadParameter("missing GetCertificate")
 	}
-
-	if c.TLSConfig == nil {
-		return trace.BadParameter("missing tls config")
+	if c.GetClientCAs == nil {
+		return trace.BadParameter("missing GetClientCAs")
 	}
-	c.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
 
 	if c.service == nil {
 		c.service = &proxyService{
@@ -95,13 +94,14 @@ func (c *ServerConfig) checkAndSetDefaults() error {
 
 // Server is a proxy service server using grpc and tls.
 type Server struct {
-	config ServerConfig
-	server *grpc.Server
+	log           logrus.FieldLogger
+	clusterDialer ClusterDialer
+	server        *grpc.Server
 }
 
 // NewServer creates a new proxy server instance.
-func NewServer(config ServerConfig) (*Server, error) {
-	err := config.checkAndSetDefaults()
+func NewServer(cfg ServerConfig) (*Server, error) {
+	err := cfg.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -113,8 +113,27 @@ func NewServer(config ServerConfig) (*Server, error) {
 
 	reporter := newReporter(metrics)
 
+	tlsConfig := utils.TLSConfig(cfg.CipherSuites)
+	tlsConfig.NextProtos = []string{"h2"}
+	tlsConfig.GetCertificate = cfg.GetCertificate
+	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	tlsConfig.VerifyPeerCertificate = verifyPeerCertificateIsProxy
+
+	getClientCAs := cfg.GetClientCAs
+	tlsConfig.GetConfigForClient = func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+		clientCAs, err := getClientCAs(chi)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		utils.RefreshTLSConfigTickets(tlsConfig)
+		c := tlsConfig.Clone()
+		c.ClientCAs = clientCAs
+		return c, nil
+	}
+
 	server := grpc.NewServer(
-		grpc.Creds(newServerCredentials(credentials.NewTLS(config.TLSConfig))),
+		grpc.Creds(credentials.NewTLS(tlsConfig)),
 		grpc.StatsHandler(newStatsHandler(reporter)),
 		grpc.ChainStreamInterceptor(metadata.StreamServerInterceptor, interceptors.GRPCServerStreamErrorInterceptor),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
@@ -136,17 +155,35 @@ func NewServer(config ServerConfig) (*Server, error) {
 		grpc.MaxConcurrentStreams(math.MaxUint32),
 	)
 
-	proto.RegisterProxyServiceServer(server, config.service)
+	proto.RegisterProxyServiceServer(server, cfg.service)
 
 	return &Server{
-		config: config,
-		server: server,
+		log:           cfg.Log,
+		clusterDialer: cfg.ClusterDialer,
+		server:        server,
 	}, nil
 }
 
+func verifyPeerCertificateIsProxy(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	if len(verifiedChains) < 1 {
+		return trace.AccessDenied("missing client certificate (this is a bug)")
+	}
+
+	clientCert := verifiedChains[0][0]
+	clientIdentity, err := tlsca.FromSubject(clientCert.Subject, clientCert.NotAfter)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if !slices.Contains(clientIdentity.Groups, string(types.RoleProxy)) {
+		return trace.AccessDenied("expected Proxy client credentials")
+	}
+	return nil
+}
+
 // Serve starts the proxy server.
-func (s *Server) Serve() error {
-	if err := s.server.Serve(s.config.Listener); err != nil {
+func (s *Server) Serve(l net.Listener) error {
+	if err := s.server.Serve(l); err != nil {
 		if errors.Is(err, grpc.ErrServerStopped) ||
 			utils.IsUseOfClosedNetworkError(err) {
 			return nil

--- a/lib/proxy/peer/server_test.go
+++ b/lib/proxy/peer/server_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // TestServerTLS ensures that only trusted certificates with the proxy role
@@ -38,7 +38,7 @@ func TestServerTLS(t *testing.T) {
 	_, serverDef1 := setupServer(t, "s1", ca1, ca1, types.RoleProxy)
 	err := client1.updateConnections([]types.Server{serverDef1})
 	require.NoError(t, err)
-	stream, _, err := client1.dial([]string{"s1"}, &proto.DialRequest{})
+	stream, _, err := client1.dial([]string{"s1"}, "", &utils.NetAddr{}, &utils.NetAddr{}, "")
 	require.NoError(t, err)
 	require.NotNil(t, stream)
 	stream.Close()
@@ -48,7 +48,7 @@ func TestServerTLS(t *testing.T) {
 	_, serverDef2 := setupServer(t, "s2", ca1, ca1, types.RoleProxy)
 	err = client2.updateConnections([]types.Server{serverDef2})
 	require.NoError(t, err) // connection succeeds but is in transient failure state
-	_, _, err = client2.dial([]string{"s2"}, &proto.DialRequest{})
+	_, _, err = client2.dial([]string{"s2"}, "", &utils.NetAddr{}, &utils.NetAddr{}, "")
 	require.Error(t, err)
 
 	// certificates with correct role from different CAs
@@ -56,7 +56,7 @@ func TestServerTLS(t *testing.T) {
 	_, serverDef3 := setupServer(t, "s3", ca2, ca1, types.RoleProxy)
 	err = client3.updateConnections([]types.Server{serverDef3})
 	require.NoError(t, err)
-	stream, _, err = client3.dial([]string{"s3"}, &proto.DialRequest{})
+	stream, _, err = client3.dial([]string{"s3"}, "", &utils.NetAddr{}, &utils.NetAddr{}, "")
 	require.NoError(t, err)
 	require.NotNil(t, stream)
 	stream.Close()

--- a/lib/proxy/peer/service_test.go
+++ b/lib/proxy/peer/service_test.go
@@ -20,11 +20,11 @@ package peer
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"testing"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -52,7 +52,7 @@ func setupService(t *testing.T) (*proxyService, proto.ProxyServiceClient) {
 	require.NoError(t, err)
 
 	proxyService := &proxyService{
-		log: logrus.New(),
+		log: slog.Default(),
 	}
 	proto.RegisterProxyServiceServer(server, proxyService)
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4710,7 +4710,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		peerAddrString = peerAddr.String()
 
 		peerServer, err = peer.NewServer(peer.ServerConfig{
-			Log:           process.log,
+			Log:           process.logger,
 			ClusterDialer: clusterdial.NewClusterDialer(tsrv),
 			CipherSuites:  cfg.CipherSuites,
 			GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -55,6 +55,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/quic-go/quic-go"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
@@ -4311,9 +4312,31 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	// from remote teleport nodes
 	var tsrv reversetunnelclient.Server
 	var peerClient *peer.Client
-
+	var peerQUICTransport *quic.Transport
 	if !process.Config.Proxy.DisableReverseTunnel {
 		if listeners.proxyPeer != nil {
+			// TODO(espadolini): allow this when the implementation is merged
+			if false && os.Getenv("TELEPORT_UNSTABLE_QUIC_PROXY_PEERING") == "yes" {
+				// the stateless reset key is important in case there's a crash
+				// so peers can be told to close their side of the connections
+				// instead of having to wait for a timeout; for this reason, we
+				// store it in the datadir, which should persist just as much as
+				// the host ID and the cluster credentials
+				resetKey, err := process.readOrInitPeerStatelessResetKey()
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				pc, err := process.createPacketConn(string(ListenerProxyPeer), listeners.proxyPeer.Addr().String())
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				peerQUICTransport = &quic.Transport{
+					Conn: pc,
+
+					StatelessResetKey: resetKey,
+				}
+			}
+
 			peerClient, err = peer.NewClient(peer.ClientConfig{
 				Context:           process.ExitContext(),
 				ID:                process.Config.HostUUID,
@@ -4325,6 +4348,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				Log:               process.log,
 				Clock:             process.Clock,
 				ClusterName:       clusterName,
+				QUICTransport:     peerQUICTransport,
 			})
 			if err != nil {
 				return trace.Wrap(err)
@@ -4677,6 +4701,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	var peerAddrString string
 	var peerServer *peer.Server
+	var peerQUICServer *peer.QUICServer
 	if !process.Config.Proxy.DisableReverseTunnel && listeners.proxyPeer != nil {
 		peerAddr, err := process.Config.Proxy.PublicPeerAddr()
 		if err != nil {
@@ -4705,11 +4730,11 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 		process.RegisterCriticalFunc("proxy.peer", func() error {
 			if _, err := process.WaitForEvent(process.ExitContext(), ProxyReverseTunnelReady); err != nil {
-				logger.DebugContext(process.ExitContext(), "Process exiting: failed to start peer proxy service waiting for reverse tunnel server")
+				logger.DebugContext(process.ExitContext(), "Process exiting: failed to start peer proxy service waiting for reverse tunnel server.")
 				return nil
 			}
 
-			logger.InfoContext(process.ExitContext(), "Starting peer proxy service", "listen_address", logutils.StringerAttr(listeners.proxyPeer.Addr()))
+			logger.InfoContext(process.ExitContext(), "Starting peer proxy service.", "listen_address", logutils.StringerAttr(listeners.proxyPeer.Addr()))
 			err := peerServer.Serve(listeners.proxyPeer)
 			if err != nil {
 				return trace.Wrap(err)
@@ -4717,9 +4742,45 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 			return nil
 		})
+
+		if peerQUICTransport != nil {
+			peerQUICServer, err := peer.NewQUICServer(peer.QUICServerConfig{
+				Log:           process.logger,
+				ClusterDialer: clusterdial.NewClusterDialer(tsrv),
+				CipherSuites:  cfg.CipherSuites,
+				GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+					return conn.serverGetCertificate()
+				},
+				GetClientCAs: func(chi *tls.ClientHelloInfo) (*x509.CertPool, error) {
+					pool, _, err := authclient.ClientCertPool(chi.Context(), accessPoint, clusterName, types.HostCA)
+					if err != nil {
+						return nil, trace.Wrap(err)
+					}
+					return pool, nil
+				},
+			})
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			process.RegisterCriticalFunc("proxy.peer.quic", func() error {
+				if _, err := process.WaitForEvent(process.ExitContext(), ProxyReverseTunnelReady); err != nil {
+					logger.DebugContext(process.ExitContext(), "Process exiting: failed to start QUIC peer proxy service waiting for reverse tunnel server.")
+					return nil
+				}
+
+				logger.InfoContext(process.ExitContext(), "Starting QUIC peer proxy service.", "local_addr", logutils.StringerAttr(peerQUICTransport.Conn.LocalAddr()))
+				err := peerQUICServer.Serve(peerQUICTransport)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+
+				return nil
+			})
+		}
 	}
 
-	staticLabels := make(map[string]string, 2)
+	staticLabels := make(map[string]string, 3)
 	if cfg.Proxy.ProxyGroupID != "" {
 		staticLabels[types.ProxyGroupIDLabel] = cfg.Proxy.ProxyGroupID
 	}
@@ -4728,6 +4789,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	}
 	if len(staticLabels) > 0 {
 		logger.InfoContext(process.ExitContext(), "Enabling proxy group labels.", "group_id", cfg.Proxy.ProxyGroupID, "generation", cfg.Proxy.ProxyGroupGeneration)
+	}
+	if peerQUICTransport != nil {
+		staticLabels[types.ProxyPeerQUICLabel] = "x"
+		logger.InfoContext(process.ExitContext(), "Advertising proxy peering QUIC support.")
 	}
 
 	sshProxy, err := regular.New(
@@ -5256,6 +5321,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			if peerServer != nil {
 				warnOnErr(process.ExitContext(), peerServer.Close(), logger)
 			}
+			if peerQUICServer != nil {
+				warnOnErr(process.ExitContext(), peerQUICServer.Close(), logger)
+			}
 			if webServer != nil {
 				warnOnErr(process.ExitContext(), webServer.Close(), logger)
 			}
@@ -5307,6 +5375,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			if peerServer != nil {
 				warnOnErr(ctx, peerServer.Shutdown(), logger)
 			}
+			if peerQUICServer != nil {
+				warnOnErr(ctx, peerQUICServer.Shutdown(ctx), logger)
+			}
 			if peerClient != nil {
 				peerClient.Shutdown(ctx)
 			}
@@ -5342,6 +5413,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			if clientTLSConfigGenerator != nil {
 				clientTLSConfigGenerator.Close()
 			}
+		}
+		if peerQUICTransport != nil {
+			_ = peerQUICTransport.Close()
+			_ = peerQUICTransport.Conn.Close()
 		}
 		warnOnErr(process.ExitContext(), asyncEmitter.Close(), logger)
 		warnOnErr(process.ExitContext(), conn.Close(), logger)
@@ -5415,6 +5490,26 @@ func (process *TeleportProcess) initMinimalReverseTunnel(listeners *proxyListene
 	})
 
 	return minimalWebServer, nil
+}
+
+func (process *TeleportProcess) readOrInitPeerStatelessResetKey() (*quic.StatelessResetKey, error) {
+	resetKeyPath := filepath.Join(process.Config.DataDir, "peer_stateless_reset_key")
+	k := new(quic.StatelessResetKey)
+	stored, err := os.ReadFile(resetKeyPath)
+	if err == nil && len(stored) == len(k) {
+		copy(k[:], stored)
+		return k, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		process.logger.WarnContext(process.ExitContext(), "Stateless reset key file unreadable or invalid.", "error", err)
+	}
+	if _, err := rand.Read(k[:]); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	if err := renameio.WriteFile(resetKeyPath, k[:], 0o600); err != nil {
+		process.logger.WarnContext(process.ExitContext(), "Failed to persist stateless reset key.", "error", err)
+	}
+	return k, nil
 }
 
 // kubeDialAddr returns Proxy Kube service address used for dialing local kube service

--- a/lib/service/signals.go
+++ b/lib/service/signals.go
@@ -344,6 +344,34 @@ func (process *TeleportProcess) createListener(typ ListenerType, address string)
 	return listener, nil
 }
 
+// createPacketConn opens a UDP socket with the given address. UDP sockets are
+// never passed on to a different process, so they're not registered anywhere.
+func (process *TeleportProcess) createPacketConn(typ string, address string) (net.PacketConn, error) {
+	listenersClosed := func() bool {
+		process.Lock()
+		defer process.Unlock()
+		return process.listenersClosed
+	}
+
+	if listenersClosed() {
+		process.logger.DebugContext(process.ExitContext(), "Listening is blocked, not opening packet conn.", "type", typ, "address", address)
+		return nil, trace.BadParameter("listening is blocked")
+	}
+
+	pc, err := net.ListenPacket("udp", address)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if listenersClosed() {
+		_ = pc.Close()
+		process.logger.DebugContext(process.ExitContext(), "Listening is blocked, closing newly-created packet conn.", "type", typ, "address", address)
+		return nil, trace.BadParameter("listening is blocked")
+	}
+
+	return pc, nil
+}
+
 // getListenerNeedsLock tries to get an existing listener that matches the type/addr.
 func (process *TeleportProcess) getListenerNeedsLock(typ ListenerType, address string) (listener net.Listener, ok bool) {
 	for _, l := range process.registeredListeners {

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -190,3 +190,10 @@ func DefaultCipherSuites() []uint16 {
 		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 	}
 }
+
+// RefreshTLSConfigTickets should be called right before cloning a [tls.Config]
+// for a one-off use to not break TLS session resumption, as a workaround for
+// https://github.com/golang/go/issues/60506 .
+func RefreshTLSConfigTickets(c *tls.Config) {
+	_, _ = c.DecryptTicket(nil, tls.ConnectionState{})
+}


### PR DESCRIPTION
This PR adds some scaffolding necessary to support QUIC proxy peering:
- the current (gRPC) peering server is tweaked so that the way it handles its TLS config is streamlined and will match what we will do for the QUIC server;
- the client is made generic over the specific per-proxy implementation of the dialing process, with the existing implementation tweaked to fit in the interface;
- the proxy initialization is changed to (pretend to) set up the appropriate PacketConn and a QUIC transport (to be used for both the client and the server) and start/stop/shutdown a mock QUIC peering server.