### PR TITLE
Propagate redirect_uri during device trust web auth

### DIFF
--- a/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.tsx
+++ b/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.tsx
@@ -20,7 +20,7 @@ import { useEffect } from 'react';
 import styled from 'styled-components';
 import { Box, Flex, ButtonPrimary, Text, ButtonLink } from 'design';
 import { Link } from 'react-router-dom';
-import { useParams } from 'react-router';
+import { useParams, useLocation } from 'react-router';
 
 import cfg from 'teleport/config';
 import useTeleport from 'teleport/useTeleport';
@@ -32,14 +32,18 @@ import {
   DownloadLink,
   getConnectDownloadLinks,
 } from 'shared/components/DownloadConnect/DownloadConnect';
+import { processRedirectUri } from 'shared/redirects';
 import { makeDeepLinkWithSafeInput } from 'shared/deepLinks';
 
 export const PassthroughPage = () => {
   const ctx = useTeleport();
+  const { search } = useLocation();
   const { id, token } = useParams<{
     id: string;
     token: string;
   }>();
+  const redirect_uri = new URLSearchParams(search).get('redirect_uri');
+
   const { cluster, username } = ctx.storeUser.state;
   const deviceTrustAuthorize = makeDeepLinkWithSafeInput({
     proxyHost: cluster?.publicURL,
@@ -48,6 +52,7 @@ export const PassthroughPage = () => {
     searchParams: {
       id,
       token,
+      redirect_uri,
     },
   });
   const platform = getPlatform();
@@ -70,6 +75,7 @@ export const PassthroughPage = () => {
 
   return (
     <DeviceTrustConnectPassthrough
+      redirectUri={redirect_uri}
       downloadLinks={downloadLinks}
       authorizeWebDeviceDeepLink={deviceTrustAuthorize}
     />
@@ -78,9 +84,11 @@ export const PassthroughPage = () => {
 
 export const DeviceTrustConnectPassthrough = ({
   authorizeWebDeviceDeepLink,
+  redirectUri,
   downloadLinks,
 }: {
   authorizeWebDeviceDeepLink: string;
+  redirectUri?: string;
   downloadLinks: Array<DownloadLink>;
 }) => {
   return (
@@ -123,7 +131,7 @@ export const DeviceTrustConnectPassthrough = ({
               css={`
                 text-decoration: none;
               `}
-              to={cfg.routes.root}
+              to={processRedirectUri(redirectUri)}
             >
               continue without device trust{' '}
             </Link>

--- a/web/packages/shared/deepLinks.ts
+++ b/web/packages/shared/deepLinks.ts
@@ -67,7 +67,7 @@ export type ConnectMyComputerDeepURL = BaseDeepURL & {
 
 export type AuthenticateWebDeviceDeepURL = BaseDeepURL & {
   pathname: '/authenticate_web_device';
-  searchParams: { id: string; token: string };
+  searchParams: { id: string; token: string; redirect_uri?: string };
 };
 
 export type DeepURL = ConnectMyComputerDeepURL | AuthenticateWebDeviceDeepURL;
@@ -77,8 +77,7 @@ export const CUSTOM_PROTOCOL = 'teleport' as const;
 /**
  * makeDeepLinkWithSafeInput creates a deep link by interpolating passed arguments.
  *
- * Important: This function does not perform any validation or parsing. It must not be called with
- * user-generated content.
+ * Important: This function does not perform any validation or parsing.
  */
 export function makeDeepLinkWithSafeInput<
   Pathname extends DeepURL['pathname'],
@@ -106,6 +105,8 @@ export function makeDeepLinkWithSafeInput<
     : '';
 
   const searchParamsString = Object.entries(args.searchParams)
+    // filter out params that have no value to prevent a string like "&myparam=null"
+    .filter(kv => kv[1] !== null && kv[1] !== undefined)
     .map(kv => kv.map(encodeURIComponent).join('='))
     .join('&');
 

--- a/web/packages/shared/redirects/index.ts
+++ b/web/packages/shared/redirects/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { processRedirectUri } from './processRedirectUri';
+
+export { processRedirectUri };

--- a/web/packages/shared/redirects/processRedirectUri.test.ts
+++ b/web/packages/shared/redirects/processRedirectUri.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { processRedirectUri } from './processRedirectUri';
+
+describe('processRedirectURI', () => {
+  const tests: Array<{ name: string; input: string | null; expected: string }> =
+    [
+      {
+        name: 'null input',
+        input: null,
+        expected: '/web',
+      },
+      {
+        name: 'empty string',
+        input: '',
+        expected: '/web',
+      },
+      {
+        name: 'valid internal URL',
+        input: 'https://example.com/custom/path',
+        expected: '/web/custom/path',
+      },
+      {
+        name: 'handles URL encoded characters',
+        input: 'https://example.com/path with spaces',
+        expected: '/web/path%20with%20spaces',
+      },
+      {
+        name: 'valid external URL',
+        input: 'https://external.com/path',
+        expected: '/web/path',
+      },
+      {
+        name: 'URL with app access path',
+        input: 'https://example.com/web/launch/myapp.example.com',
+        expected: '/web/launch/myapp.example.com',
+      },
+      {
+        name: 'invalid URL',
+        input: '://invalid',
+        expected: '/web',
+      },
+      {
+        name: 'URL with empty path',
+        input: 'https://example.com',
+        expected: '/web',
+      },
+      {
+        name: 'relative path',
+        input: '/custom/path',
+        expected: '/web/custom/path',
+      },
+      {
+        name: 'path already starting with /web',
+        input: '/web/existing/path',
+        expected: '/web/existing/path',
+      },
+    ];
+
+  test.each(tests)('$name', ({ input, expected }) => {
+    const result = processRedirectUri(input);
+    expect(result).toEqual(expected);
+  });
+});

--- a/web/packages/shared/redirects/processRedirectUri.ts
+++ b/web/packages/shared/redirects/processRedirectUri.ts
@@ -1,0 +1,71 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const BASE_PATH = '/web';
+
+/**
+ * Processes a redirect URI to ensure it's valid and follows the expected format.
+ *
+ * This function handles various cases:
+ * - Null or empty input: Returns the basePath
+ * - Full URLs:
+ *   - External: Uses only the pathname, prepending the basePath if not already present
+ *   - Internal: Prepends the basePath if not already present
+ * - Relative paths: Prepends the basePath if not already present
+ * - Invalid URIs: Returns the basePath
+ *
+ * @param redirectUri - The redirect URI to process. Can be null, a relative path, or a full URL.
+ * @returns A processed URI string that always starts with the basePath, unless it's an invalid input.
+ *
+ * @example
+ * processRedirectURI('/web', null) // returns '/web'
+ * processRedirectURI('/web', 'https://example.com/path') // returns '/web/path'
+ * processRedirectURI('/web', '/custom/path') // returns '/web/custom/path'
+ * processRedirectURI('/web', '/web/existing/path') // returns '/web/existing/path'
+ * processRedirectURI('/web', 'invalid://url') // returns '/web'
+ * processRedirectURI('/app', 'https://example.com/path') // returns '/app/path'
+ */
+export function processRedirectUri(redirectUri: string | null): string {
+  // should be equal to cfg.routes.root
+  if (!redirectUri) {
+    return BASE_PATH;
+  }
+  try {
+    const url = new URL(redirectUri);
+    const path = url.pathname;
+    // If it already starts with basePath, return as is
+    if (path.startsWith(BASE_PATH)) {
+      return path;
+    }
+
+    if (path === '/') {
+      return BASE_PATH;
+    }
+
+    return `${BASE_PATH}${path.startsWith('/') ? '' : '/'}${path}`;
+  } catch (error) {
+    // If it's not a valid URL, it might be a relative path
+    if (redirectUri.startsWith('/')) {
+      return redirectUri.startsWith(BASE_PATH)
+        ? redirectUri
+        : `${BASE_PATH}${redirectUri}`;
+    }
+    // For invalid URIs, return the default
+    return BASE_PATH;
+  }
+}

--- a/web/packages/teleport/src/Login/useLogin.ts
+++ b/web/packages/teleport/src/Login/useLogin.ts
@@ -134,7 +134,12 @@ type LoginResponse = {
 };
 
 function authorizeWithDeviceTrust(token: DeviceWebToken) {
-  const authorize = cfg.getDeviceTrustAuthorizeRoute(token.id, token.token);
+  let redirect = history.getRedirectParam();
+  const authorize = cfg.getDeviceTrustAuthorizeRoute(
+    token.id,
+    token.token,
+    redirect
+  );
   history.push(authorize, true);
 }
 

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -482,8 +482,20 @@ const cfg = {
     return 'sso';
   },
 
-  getDeviceTrustAuthorizeRoute(id: string, token: string) {
-    return generatePath(cfg.routes.deviceTrustAuthorize, { id, token });
+  getDeviceTrustAuthorizeRoute(id: string, token: string, redirect?: string) {
+    const path = generatePath(cfg.routes.deviceTrustAuthorize, {
+      id,
+      token,
+    });
+
+    const searchParams = new URLSearchParams();
+
+    if (redirect) {
+      searchParams.append('redirect_uri', redirect);
+    }
+
+    const searchString = searchParams.toString();
+    return searchString ? `${path}?${searchString}` : path;
   },
 
   getSsoUrl(providerUrl, providerName, redirect) {

--- a/web/packages/teleport/src/services/history/history.ts
+++ b/web/packages/teleport/src/services/history/history.ts
@@ -81,6 +81,7 @@ const history = {
     this._pageRefresh(url);
   },
 
+  // TODO (avatus): make this return a path only if a full URI is present
   getRedirectParam() {
     return getUrlParameter('redirect_uri', this.original().location.search);
   },

--- a/web/packages/teleterm/src/deepLinks.test.ts
+++ b/web/packages/teleterm/src/deepLinks.test.ts
@@ -53,6 +53,23 @@ describe('parseDeepLink', () => {
           searchParams: {
             id: '123',
             token: '234',
+            redirect_uri: null,
+          },
+        },
+      },
+      {
+        input:
+          'teleport://cluster.example.com/authenticate_web_device?id=123&token=234&redirect_uri=http://cluster.example.com/web/users',
+        expectedURL: {
+          host: 'cluster.example.com',
+          hostname: 'cluster.example.com',
+          port: '',
+          pathname: '/authenticate_web_device',
+          username: '',
+          searchParams: {
+            id: '123',
+            token: '234',
+            redirect_uri: 'http://cluster.example.com/web/users',
           },
         },
       },
@@ -191,6 +208,16 @@ describe('makeDeepLinkWithSafeInput followed by parseDeepLink gives the same res
         id: '123',
       },
     },
+    {
+      proxyHost: 'cluster.example.com:1337',
+      path: '/authenticate_web_device',
+      username: 'alice.bobson@example.com',
+      searchParams: {
+        token: '123',
+        id: '123',
+        redirect_uri: 'http://cluster.example.com:1337/web/users',
+      },
+    },
   ];
 
   test.each(inputs)('%j', input => {
@@ -214,6 +241,7 @@ describe('parseDeepLink followed by makeDeepLinkWithSafeInput gives the same res
     'teleport://alice@cluster.example.com/connect_my_computer',
     'teleport://alice.bobson%40example.com@cluster.example.com:1337/connect_my_computer',
     'teleport://alice@cluster.example.com/authenticate_web_device?id=123&token=234',
+    'teleport://alice@cluster.example.com/authenticate_web_device?id=123&token=234&redirect_uri=http%3A%2F%2Fcluster.example.com%2Fweb%2Fusers',
   ];
 
   test.each(inputs)('%s', input => {

--- a/web/packages/teleterm/src/deepLinks.ts
+++ b/web/packages/teleterm/src/deepLinks.ts
@@ -106,6 +106,7 @@ export function parseDeepLink(rawUrl: string): DeepLinkParseResult {
     case '/authenticate_web_device': {
       const id = searchParams.get('id');
       const token = searchParams.get('token');
+      const redirect_uri = searchParams.get('redirect_uri');
       if (!(id && token)) {
         return {
           status: 'error',
@@ -122,6 +123,7 @@ export function parseDeepLink(rawUrl: string): DeepLinkParseResult {
         searchParams: {
           id,
           token,
+          redirect_uri,
         },
       };
       return { status: 'success', url };


### PR DESCRIPTION
In the web UI, if a user tries to access a page but they are unauthenticated, after logging in, they are automatically redirected back to the originally requested page. If the user has to authenticate their session with device trust, this URI got swallowed and the user would always end up at "/web". This PR passes the redirect through to the authentication process.

Fixes: https://github.com/gravitational/teleport/issues/46980