### PR TITLE
eliminate GenerateRSAKeyRing

### DIFF
--- a/lib/client/conntest/kube.go
+++ b/lib/client/conntest/kube.go
@@ -157,8 +157,9 @@ func (s *KubeConnectionTester) TestConnection(ctx context.Context, req TestConne
 // genKubeRestTLSClientConfig creates the Teleport user credentials to access
 // the given Kubernetes cluster name.
 func (s KubeConnectionTester) genKubeRestTLSClientConfig(ctx context.Context, mfaResponse *proto.MFAAuthenticateResponse, connectionDiagnosticID, clusterName, userName string) (rest.TLSClientConfig, error) {
-	// TODO(nklaassen): support configurable key algorithms.
-	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.RSA2048)
+	key, err := cryptosuites.GenerateKey(ctx,
+		cryptosuites.GetCurrentSuiteFromAuthPreference(s.cfg.UserClient),
+		cryptosuites.UserTLS)
 	if err != nil {
 		return rest.TLSClientConfig{}, trace.Wrap(err)
 	}

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -41,7 +41,6 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -159,17 +158,6 @@ func (k *KeyRing) generateSubjectTLSKey(ctx context.Context, tc *TeleportClient,
 		return nil, trace.Wrap(err)
 	}
 	return priv, nil
-}
-
-// GenerateRSAKeyRing generates a new unsigned RSA key ring.
-//
-// TODO(nklaassen): get away from hardcoding RSA here.
-func GenerateRSAKeyRing() (*KeyRing, error) {
-	priv, err := native.GeneratePrivateKey()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return NewKeyRing(priv, priv), nil
 }
 
 // NewKeyRing creates a new KeyRing for the given private keys.

--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/native"
 )
@@ -89,6 +90,8 @@ const (
 
 	// DatabaseClient represents a key used for a database client.
 	DatabaseClient
+	// DatabaseServer represents a key used for a database server.
+	DatabaseServer
 
 	// HostSSH represents a host SSH key.
 	HostSSH
@@ -166,6 +169,7 @@ var (
 		UserSSH:                 RSA2048,
 		UserTLS:                 RSA2048,
 		DatabaseClient:          RSA2048,
+		DatabaseServer:          RSA2048,
 		HostSSH:                 RSA2048,
 		HostIdentity:            RSA2048,
 		BotImpersonatedIdentity: RSA2048,
@@ -198,6 +202,7 @@ var (
 		UserSSH:                 Ed25519,
 		UserTLS:                 ECDSAP256,
 		DatabaseClient:          RSA2048,
+		DatabaseServer:          RSA2048,
 		HostSSH:                 Ed25519,
 		HostIdentity:            ECDSAP256,
 		BotImpersonatedIdentity: ECDSAP256,
@@ -227,6 +232,7 @@ var (
 		UserSSH:                 ECDSAP256,
 		UserTLS:                 ECDSAP256,
 		DatabaseClient:          RSA2048,
+		DatabaseServer:          RSA2048,
 		HostSSH:                 ECDSAP256,
 		HostIdentity:            ECDSAP256,
 		BotImpersonatedIdentity: ECDSAP256,
@@ -258,6 +264,7 @@ var (
 		UserSSH:                 Ed25519,
 		UserTLS:                 ECDSAP256,
 		DatabaseClient:          RSA2048,
+		DatabaseServer:          RSA2048,
 		HostSSH:                 Ed25519,
 		HostIdentity:            ECDSAP256,
 		BotImpersonatedIdentity: ECDSAP256,
@@ -291,6 +298,25 @@ func GetCurrentSuiteFromAuthPreference(authPrefGetter AuthPreferenceGetter) GetS
 			return types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_UNSPECIFIED, trace.Wrap(err)
 		}
 		return authPref.GetSignatureAlgorithmSuite(), nil
+	})
+}
+
+// Pinger is an interface for pinging the auth server.
+type Pinger interface {
+	// Ping returns a Ping response containing the current signature algorithm
+	// suite.
+	Ping(context.Context) (proto.PingResponse, error)
+}
+
+// GetCurrentSuiteFromPing returns a [GetSuiteFunc] that fetches the signature
+// algorithm suite currently configured in the cluster via the ping endpoint.
+func GetCurrentSuiteFromPing(pinger Pinger) GetSuiteFunc {
+	return GetSuiteFunc(func(ctx context.Context) (types.SignatureAlgorithmSuite, error) {
+		pingResp, err := pinger.Ping(ctx)
+		if err != nil {
+			return types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_UNSPECIFIED, trace.Wrap(err)
+		}
+		return pingResp.SignatureAlgorithmSuite, nil
 	})
 }
 

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -244,7 +244,9 @@ func (a *AuthCommand) ExportAuthorities(ctx context.Context, clt *authclient.Cli
 
 // GenerateKeys generates a new keypair
 func (a *AuthCommand) GenerateKeys(ctx context.Context, clusterAPI certificateSigner) error {
-	signer, err := cryptosuites.GenerateKey(ctx, getCurrentSuiteFromPing(clusterAPI), cryptosuites.UserSSH)
+	signer, err := cryptosuites.GenerateKey(ctx,
+		cryptosuites.GetCurrentSuiteFromPing(clusterAPI),
+		cryptosuites.UserSSH)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -502,7 +504,9 @@ func (a *AuthCommand) generateHostKeys(ctx context.Context, clusterAPI certifica
 	principals := strings.Split(a.genHost, ",")
 
 	// Generate an SSH key.
-	signer, err := cryptosuites.GenerateKey(ctx, getCurrentSuiteFromPing(clusterAPI), cryptosuites.HostSSH)
+	signer, err := cryptosuites.GenerateKey(ctx,
+		cryptosuites.GetCurrentSuiteFromPing(clusterAPI),
+		cryptosuites.HostSSH)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -853,16 +857,6 @@ client_encryption_options:
 `))
 )
 
-func getCurrentSuiteFromPing(clusterAPI certificateSigner) cryptosuites.GetSuiteFunc {
-	return func(ctx context.Context) (types.SignatureAlgorithmSuite, error) {
-		pr, err := clusterAPI.Ping(ctx)
-		if err != nil {
-			return types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_UNSPECIFIED, trace.Wrap(err)
-		}
-		return pr.SignatureAlgorithmSuite, nil
-	}
-}
-
 // generateKeyRing generates and returns a keyring using a key algorithm
 // determined by the current cluster signature algorithm suite and [purpose].
 // The returned KeyRing always uses a single private key for both SSH and TLS,
@@ -870,7 +864,9 @@ func getCurrentSuiteFromPing(clusterAPI certificateSigner) cryptosuites.GetSuite
 // single protocol anyway, or writes to an identity file which only supports a
 // single private key.
 func generateKeyRing(ctx context.Context, clusterAPI certificateSigner, purpose cryptosuites.KeyPurpose) (*client.KeyRing, error) {
-	signer, err := cryptosuites.GenerateKey(ctx, getCurrentSuiteFromPing(clusterAPI), purpose)
+	signer, err := cryptosuites.GenerateKey(ctx,
+		cryptosuites.GetCurrentSuiteFromPing(clusterAPI),
+		purpose)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR eliminates `client.GenerateRSAKeyRing` in favor of generating keys with an algorithm based on the current signature algorithm suite. Part of [RFD 136](https://github.com/gravitational/teleport/blob/master/rfd/0136-modern-signature-algorithms.md).