### PR TITLE
lib/limiter: remove the Oxy rate limiter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1303,6 +1303,7 @@ ADDLICENSE_COMMON_ARGS := -c 'Gravitational, Inc.' \
 		-ignore 'version.go' \
 		-ignore 'web/packages/design/src/assets/icomoon/style.css' \
 		-ignore 'web/packages/teleport/src/ironrdp/**' \
+		-ignore 'lib/limiter/internal/ratelimit/**' \
 		-ignore 'webassets/**' \
 		-ignore 'ignoreme'
 ADDLICENSE_AGPL3_ARGS := $(ADDLICENSE_COMMON_ARGS) \

--- a/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
@@ -88,7 +88,7 @@ teleport:
 
 <Admonition type="warning" title="Table Names">
 Be careful to ensure that `Example_FIRESTORE_CLUSTER_STATE` and `Example_FIRESTORE_AUDIT_LOGS`
-refer to *different* Firestore collections. The schema is different for each, and using the same 
+refer to *different* Firestore collections. The schema is different for each, and using the same
 collection for both types of data will result in errors.
 </Admonition>
 
@@ -232,9 +232,6 @@ teleport:
   nodename: teleport-auth-server
   data_dir: /var/lib/teleport
   pid_file: /run/teleport.pid
-  connection_limits:
-    max_connections: 15000
-    max_users: 250
   log:
     output: stderr
     severity: DEBUG
@@ -270,9 +267,6 @@ teleport:
   nodename: teleport-auth-server
   data_dir: /var/lib/teleport
   pid_file: /run/teleport.pid
-  connection_limits:
-    max_connections: 15000
-    max_users: 250
   log:
     output: stderr
     severity: DEBUG
@@ -338,8 +332,8 @@ Save the following configuration file as `/etc/teleport.yaml` on the Node:
 version: v3
 teleport:
   auth_token: (= presets.tokens.second =)
-  # Teleport agents can be joined to the cluster via the Proxy Service's 
-  # public address. This will establish a reverse tunnel between the Proxy 
+  # Teleport agents can be joined to the cluster via the Proxy Service's
+  # public address. This will establish a reverse tunnel between the Proxy
   # Service and the agent that is used for all traffic.
   proxy_server: teleport.example.com:443
 # enable the SSH Service and disable the Auth and Proxy Services

--- a/docs/pages/admin-guides/management/operations/scaling.mdx
+++ b/docs/pages/admin-guides/management/operations/scaling.mdx
@@ -32,7 +32,6 @@ to `65000`.
 teleport:
   connection_limits:
     max_connections: 65000
-    max_users: 1000
 ```
 
 ## Agent configuration

--- a/docs/pages/includes/config-reference/instance-wide.yaml
+++ b/docs/pages/includes/config-reference/instance-wide.yaml
@@ -96,11 +96,11 @@ teleport:
     #  # The cache is enabled by default, it can be disabled with this flag
     #  enabled: true
 
-    # Teleport throttles all connections to avoid abuse. These settings allow
-    # you to adjust the default limits
+    # Teleport can limit the number of connections coming from each client
+    # IP address to avoid abuse. Note that these limits are enforced separately
+    # for each service (SSH, Kubernetes, etc.)
     connection_limits:
         max_connections: 1000
-        max_users: 250
 
     # Logging configuration. Possible output values to disk via
     # '/var/lib/teleport/teleport.log',

--- a/go.mod
+++ b/go.mod
@@ -143,8 +143,6 @@ require (
 	github.com/keys-pub/go-libfido2 v1.5.3-0.20220306005615-8ab03fb1ec27 // replaced
 	github.com/lib/pq v1.10.9
 	github.com/mailgun/mailgun-go/v4 v4.16.0
-	github.com/mailgun/timetools v0.0.0-20170619190023-f3a7b8ffff47
-	github.com/mailgun/ttlmap v0.0.0-20170619185759-c1c17f74874f
 	github.com/mattn/go-sqlite3 v1.14.23
 	github.com/mdlayher/netlink v1.7.2
 	github.com/microsoft/go-mssqldb v1.7.2 // replaced
@@ -424,6 +422,8 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailgun/errors v0.3.0 // indirect
+	github.com/mailgun/timetools v0.0.0-20170619190023-f3a7b8ffff47 // indirect
+	github.com/mailgun/ttlmap v0.0.0-20170619185759-c1c17f74874f // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -883,8 +883,7 @@ func (cfg *TestTLSServerConfig) CheckAndSetDefaults() error {
 	// use very permissive limiter configuration by default
 	if cfg.Limiter == nil {
 		cfg.Limiter = &limiter.Config{
-			MaxConnections:   1000,
-			MaxNumberOfUsers: 1000,
+			MaxConnections: 1000,
 		}
 	}
 	return nil

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	"github.com/coreos/go-semver/semver"
-	"github.com/gravitational/oxy/ratelimit"
 	"github.com/gravitational/trace"
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
@@ -361,7 +360,7 @@ func (a *Middleware) Wrap(h http.Handler) {
 	a.Handler = h
 }
 
-func getCustomRate(endpoint string) *ratelimit.RateSet {
+func getCustomRate(endpoint string) *limiter.RateSet {
 	switch endpoint {
 	// Account recovery RPCs.
 	case
@@ -370,7 +369,7 @@ func getCustomRate(endpoint string) *ratelimit.RateSet {
 		"/proto.AuthService/GetAccountRecoveryToken",
 		"/proto.AuthService/StartAccountRecovery",
 		"/proto.AuthService/VerifyAccountRecovery":
-		rates := ratelimit.NewRateSet()
+		rates := limiter.NewRateSet()
 		// This limit means: 1 request per minute with bursts up to 10 requests.
 		if err := rates.Add(time.Minute, 1, 10); err != nil {
 			log.WithError(err).Debugf("Failed to define a custom rate for rpc method %q, using default rate", endpoint)
@@ -382,7 +381,7 @@ func getCustomRate(endpoint string) *ratelimit.RateSet {
 		const period = defaults.LimiterPeriod
 		const average = defaults.LimiterAverage
 		const burst = defaults.LimiterBurst
-		rates := ratelimit.NewRateSet()
+		rates := limiter.NewRateSet()
 		if err := rates.Add(period, average, burst); err != nil {
 			log.WithError(err).Debugf("Failed to define a custom rate for rpc method %q, using default rate", endpoint)
 			return nil

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -633,9 +633,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		if fc.Limits.MaxConnections > 0 {
 			l.MaxConnections = fc.Limits.MaxConnections
 		}
-		if fc.Limits.MaxUsers > 0 {
-			l.MaxNumberOfUsers = fc.Limits.MaxUsers
-		}
+
 		for _, rate := range fc.Limits.Rates {
 			l.Rates = append(l.Rates, limiter.Rate{
 				Period:  rate.Period,

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -1827,8 +1827,7 @@ func TestSetDefaultListenerAddresses(t *testing.T) {
 					Enabled: false,
 				},
 				Limiter: limiter.Config{
-					MaxConnections:   defaults.LimiterMaxConnections,
-					MaxNumberOfUsers: 250,
+					MaxConnections: defaults.LimiterMaxConnections,
 				},
 				IdP: servicecfg.IdP{
 					SAMLIdP: servicecfg.SAMLIdP{
@@ -1855,8 +1854,7 @@ func TestSetDefaultListenerAddresses(t *testing.T) {
 					Enabled: true,
 				},
 				Limiter: limiter.Config{
-					MaxConnections:   defaults.LimiterMaxConnections,
-					MaxNumberOfUsers: 250,
+					MaxConnections: defaults.LimiterMaxConnections,
 				},
 				IdP: servicecfg.IdP{
 					SAMLIdP: servicecfg.SAMLIdP{
@@ -2177,8 +2175,7 @@ func TestProxyConfigurationVersion(t *testing.T) {
 					Enabled: true,
 				},
 				Limiter: limiter.Config{
-					MaxConnections:   defaults.LimiterMaxConnections,
-					MaxNumberOfUsers: 250,
+					MaxConnections: defaults.LimiterMaxConnections,
 				},
 				IdP: servicecfg.IdP{
 					SAMLIdP: servicecfg.SAMLIdP{
@@ -2206,8 +2203,7 @@ func TestProxyConfigurationVersion(t *testing.T) {
 					Enabled: true,
 				},
 				Limiter: limiter.Config{
-					MaxConnections:   defaults.LimiterMaxConnections,
-					MaxNumberOfUsers: 250,
+					MaxConnections: defaults.LimiterMaxConnections,
 				},
 				IdP: servicecfg.IdP{
 					SAMLIdP: servicecfg.SAMLIdP{
@@ -4119,8 +4115,7 @@ func TestApplyKubeConfig(t *testing.T) {
 					},
 				},
 				Limiter: limiter.Config{
-					MaxConnections:   defaults.LimiterMaxConnections,
-					MaxNumberOfUsers: 250,
+					MaxConnections: defaults.LimiterMaxConnections,
 				},
 			},
 		},
@@ -4167,8 +4162,7 @@ func TestApplyKubeConfig(t *testing.T) {
 					},
 				},
 				Limiter: limiter.Config{
-					MaxConnections:   defaults.LimiterMaxConnections,
-					MaxNumberOfUsers: 250,
+					MaxConnections: defaults.LimiterMaxConnections,
 				},
 			},
 		},

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -512,8 +512,10 @@ type ConnectionRate struct {
 // ConnectionLimits sets up connection limiter
 type ConnectionLimits struct {
 	MaxConnections int64            `yaml:"max_connections"`
-	MaxUsers       int              `yaml:"max_users"`
 	Rates          []ConnectionRate `yaml:"rates,omitempty"`
+
+	// Deprecated: MaxUsers has no effect.
+	MaxUsers int `yaml:"max_users"`
 }
 
 // LegacyLog contains the old format of the 'format' field

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -371,9 +371,6 @@ const (
 	// LimiterMaxConnections Number of max. simultaneous connections to a service
 	LimiterMaxConnections = 15000
 
-	// LimiterMaxConcurrentUsers Number of max. simultaneous connected users/logins
-	LimiterMaxConcurrentUsers = 250
-
 	// LimiterMaxConcurrentSignatures limits maximum number of concurrently
 	// generated signatures by the auth server
 	LimiterMaxConcurrentSignatures = 10
@@ -626,7 +623,6 @@ const (
 // ConfigureLimiter assigns the default parameters to a connection throttler (AKA limiter)
 func ConfigureLimiter(lc *limiter.Config) {
 	lc.MaxConnections = LimiterMaxConnections
-	lc.MaxNumberOfUsers = LimiterMaxConcurrentUsers
 }
 
 // AuthListenAddr returns the default listening address for the Auth service

--- a/lib/kube/proxy/utils_testing.go
+++ b/lib/kube/proxy/utils_testing.go
@@ -142,8 +142,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		// this issue.
 		auth.WithLimiterConfig(
 			&limiter.Config{
-				MaxConnections:   100000,
-				MaxNumberOfUsers: 1000,
+				MaxConnections: 100000,
 			},
 		),
 	)
@@ -273,8 +272,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		TLS:           kubeServiceTLSConfig.Clone(),
 		AccessPoint:   client,
 		LimiterConfig: limiter.Config{
-			MaxConnections:   1000,
-			MaxNumberOfUsers: 1000,
+			MaxConnections: 1000,
 		},
 		// each time heartbeat is called we insert data into the channel.
 		// this is used to make sure that heartbeat started and the clusters
@@ -357,8 +355,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		AccessPoint:              client,
 		KubernetesServersWatcher: kubeServersWatcher,
 		LimiterConfig: limiter.Config{
-			MaxConnections:   1000,
-			MaxNumberOfUsers: 1000,
+			MaxConnections: 1000,
 		},
 		Log:             log,
 		InventoryHandle: inventoryHandle,

--- a/lib/limiter/internal/ratelimit/README.md
+++ b/lib/limiter/internal/ratelimit/README.md
@@ -1,0 +1,4 @@
+# ratelimit
+
+The code in this directory is derived from https://github.com/gravitational/oxy
+and is available under an Apache 2.0 license.

--- a/lib/limiter/internal/ratelimit/http.go
+++ b/lib/limiter/internal/ratelimit/http.go
@@ -1,0 +1,60 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimit
+
+import (
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+func ServeHTTPError(w http.ResponseWriter, r *http.Request, err error) {
+	var le *limitExceededError
+	if errors.As(err, &le) {
+		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After#delay-seconds
+		w.Header().Set("Retry-After", strconv.Itoa(int(le.delay.Seconds())+1))
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	status := http.StatusInternalServerError
+	var netError net.Error
+
+	if errors.Is(err, io.EOF) {
+		status = http.StatusBadGateway
+	} else if errors.As(err, &netError) {
+		if netError.Timeout() {
+			status = http.StatusGatewayTimeout
+		} else {
+			status = http.StatusBadGateway
+		}
+	}
+
+	http.Error(w, http.StatusText(status), status)
+}
+
+func ExtractClientIP(r *http.Request) (string, error) {
+	// TODO: use net.SplitHostPort to be compatible with IPv6
+	token, _, _ := strings.Cut(r.RemoteAddr, ":")
+	if token == "" {
+		return "", errors.New("failed to extract source IP")
+	}
+
+	return token, nil
+}

--- a/lib/limiter/internal/ratelimit/ratelimit.go
+++ b/lib/limiter/internal/ratelimit/ratelimit.go
@@ -1,0 +1,197 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// TokenLimiter implements rate limiting middleware.
+type TokenLimiter struct {
+	clock clockwork.Clock
+	log   *slog.Logger
+
+	defaultRates *RateSet
+
+	mutex      sync.Mutex
+	bucketSets *utils.FnCache
+	next       http.Handler
+}
+
+type TokenLimiterConfig struct {
+	Rates *RateSet
+	Clock clockwork.Clock
+}
+
+func (t *TokenLimiterConfig) CheckAndSetDefaults() error {
+	if len(t.Rates.m) == 0 {
+		return trace.BadParameter("missing required rates")
+	}
+
+	if t.Clock == nil {
+		t.Clock = clockwork.NewRealClock()
+	}
+
+	return nil
+}
+
+// New constructs a rate limiter.
+func New(config TokenLimiterConfig) (*TokenLimiter, error) {
+	if err := config.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tl := &TokenLimiter{
+		defaultRates: config.Rates,
+		clock:        config.Clock,
+
+		log: slog.With(teleport.ComponentKey, "ratelimiter"),
+	}
+
+	bucketSets, err := utils.NewFnCache(utils.FnCacheConfig{
+		// The default TTL here is not super important because we set the
+		// TTL explicitly for each entry we insert.
+		TTL:   10 * time.Second,
+		Clock: config.Clock,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tl.bucketSets = bucketSets
+	return tl, nil
+}
+
+func (tl *TokenLimiter) Wrap(next http.Handler) {
+	tl.next = next
+}
+
+func (tl *TokenLimiter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	clientIP, err := ExtractClientIP(req)
+	if err != nil {
+		ServeHTTPError(w, req, err)
+		return
+	}
+
+	if err := tl.consumeRates(clientIP, 1 /* amount */); err != nil {
+		tl.log.InfoContext(context.Background(), "limiting request",
+			"method", req.Method, "url", req.URL.String(), "error", err)
+		ServeHTTPError(w, req, err)
+		return
+	}
+
+	tl.next.ServeHTTP(w, req)
+}
+
+func (tl *TokenLimiter) consumeRates(source string, amount int64) error {
+	tl.mutex.Lock()
+	defer tl.mutex.Unlock()
+
+	// We set the TTL as 10 times the rate period. E.g. if rate is 100 requests/second
+	// per client IP, the counters for this IP will expire after 10 seconds of inactivity.
+	ttl := tl.defaultRates.MaxPeriod()*10 + 1
+	bucketSet, err := utils.FnCacheGetWithTTL(context.TODO(), tl.bucketSets, source, ttl,
+		func(ctx context.Context) (*TokenBucketSet, error) {
+			return NewTokenBucketSet(tl.defaultRates, tl.clock), nil
+		},
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	bucketSet.Update(tl.defaultRates)
+
+	delay, err := bucketSet.Consume(amount)
+	if err != nil {
+		return err
+	}
+	if delay > 0 {
+		return &limitExceededError{delay: delay}
+	}
+	return nil
+}
+
+// RateSet maintains a set of rates. It can contain only one rate per period at a time.
+type RateSet struct {
+	m map[time.Duration]*rate
+}
+
+// rate defines token bucket parameters.
+type rate struct {
+	period  time.Duration
+	average int64
+	burst   int64
+}
+
+// NewRateSet crates an empty rate set.
+func NewRateSet() *RateSet {
+	return &RateSet{m: make(map[time.Duration]*rate)}
+}
+
+// Add adds a rate to the set. If there is a rate with the same period in the
+// set then the new rate overrides the old one.
+func (rs *RateSet) Add(period time.Duration, average int64, burst int64) error {
+	if period <= 0 {
+		return trace.BadParameter("Invalid period: %v", period)
+	}
+	if average <= 0 {
+		return trace.BadParameter("Invalid average: %v", average)
+	}
+	if burst <= 0 {
+		return trace.BadParameter("Invalid burst: %v", burst)
+	}
+	rs.m[period] = &rate{period, average, burst}
+	return nil
+}
+
+// MaxPeriod returns the maximum period in the rate set.
+func (rs *RateSet) MaxPeriod() time.Duration {
+	var result time.Duration
+	for _, rate := range rs.m {
+		result = max(result, rate.period)
+	}
+	return result
+}
+
+type limitExceededError struct {
+	delay time.Duration
+}
+
+func (l *limitExceededError) Error() string {
+	return fmt.Sprintf("rate limit exceeded, try again in %v", l.delay)
+}
+
+func (l *limitExceededError) As(e any) bool {
+	switch err := e.(type) {
+	case **trace.LimitExceededError:
+		*err = &trace.LimitExceededError{
+			Message: l.Error(),
+		}
+		return true
+	default:
+		return false
+	}
+}

--- a/lib/limiter/internal/ratelimit/ratelimit_test.go
+++ b/lib/limiter/internal/ratelimit/ratelimit_test.go
@@ -1,0 +1,33 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitExceededError(t *testing.T) {
+	err := &limitExceededError{delay: 3 * time.Second}
+
+	require.True(t, trace.IsLimitExceeded(err))
+
+	var le *trace.LimitExceededError
+	require.ErrorAs(t, err, &le)
+	require.Equal(t, err.Error(), le.Message)
+}

--- a/lib/limiter/internal/ratelimit/tokenbucket.go
+++ b/lib/limiter/internal/ratelimit/tokenbucket.go
@@ -1,0 +1,211 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimit
+
+import (
+	"cmp"
+	"fmt"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+)
+
+// TokenBucketSet represents a set of buckets covering different time periods.
+type TokenBucketSet struct {
+	buckets   map[time.Duration]*tokenBucket
+	maxPeriod time.Duration
+	clock     clockwork.Clock
+}
+
+// NewTokenBucketSet creates a bucket set from the specified rates.
+func NewTokenBucketSet(rates *RateSet, clock clockwork.Clock) *TokenBucketSet {
+	tbs := &TokenBucketSet{
+		// In the majority of cases we will have only one bucket.
+		buckets: make(map[time.Duration]*tokenBucket, len(rates.m)),
+		clock:   clock,
+	}
+
+	for _, rate := range rates.m {
+		newBucket := newTokenBucket(rate, clock)
+		tbs.buckets[rate.period] = newBucket
+		tbs.maxPeriod = max(tbs.maxPeriod, rate.period)
+	}
+	return tbs
+}
+
+// Update brings the buckets in the set in accordance with the provided rates.
+func (tbs *TokenBucketSet) Update(rates *RateSet) {
+	// Update existing buckets and delete those that have no corresponding spec.
+	for _, bucket := range tbs.buckets {
+		if rate, ok := rates.m[bucket.period]; ok {
+			bucket.update(rate)
+		} else {
+			delete(tbs.buckets, bucket.period)
+		}
+	}
+	// Add missing buckets.
+	for _, rate := range rates.m {
+		if _, ok := tbs.buckets[rate.period]; !ok {
+			newBucket := newTokenBucket(rate, tbs.clock)
+			tbs.buckets[rate.period] = newBucket
+		}
+	}
+	// Identify the maximum period in the set
+	tbs.maxPeriod = 0
+	for _, bucket := range tbs.buckets {
+		tbs.maxPeriod = max(tbs.maxPeriod, bucket.period)
+	}
+}
+
+// Consume makes an attempt to consume the specified number of tokens from the
+// bucket. If there are enough tokens available then (0, nil) is returned.
+// If tokens to consume is larger than the burst size, then an error is returned
+// along with [UndefinedDelay]; otherwise return a non-zero delay that indicates
+// how much time the caller needs to wait until the desired number of tokens
+// will become available for consumption.
+func (tbs *TokenBucketSet) Consume(tokens int64) (time.Duration, error) {
+	var maxDelay time.Duration = UndefinedDelay
+	var firstErr error = nil
+	for _, tokenBucket := range tbs.buckets {
+		// We keep calling Consume even after a error is returned for one of
+		// buckets because that allows us to simplify the rollback procedure,
+		// that is to just call Rollback for all buckets.
+		delay, err := tokenBucket.consume(tokens)
+		if firstErr == nil {
+			if err != nil {
+				firstErr = err
+			} else {
+				maxDelay = max(maxDelay, delay)
+			}
+		}
+	}
+	// If we could not make ALL buckets consume tokens for whatever reason,
+	// then rollback consumption for all of them.
+	if firstErr != nil || maxDelay > 0 {
+		for _, tokenBucket := range tbs.buckets {
+			tokenBucket.rollback()
+		}
+	}
+	return maxDelay, firstErr
+}
+
+func (tbs *TokenBucketSet) GetMaxPeriod() time.Duration {
+	return tbs.maxPeriod
+}
+
+// tokenBucket implements the token bucket algorithm.
+type tokenBucket struct {
+	// The time period controlled by the bucket.
+	period time.Duration
+	// The amount of time that it takes to add one more token to the total
+	// number of available tokens. It effectively caches the value that could
+	// have been otherwise deduced from refillRate.
+	timePerToken time.Duration
+	// The maximum number of tokens that can be accumulate in the bucket.
+	burst int64
+	// The number of tokens available for consumption at the moment. It can
+	// never be larger than burst.
+	availableTokens int64
+
+	clock        clockwork.Clock
+	lastRefresh  time.Time
+	lastConsumed int64
+}
+
+// newTokenBucket crates a tokenBucket instance for the specified rate.
+func newTokenBucket(rate *rate, clock clockwork.Clock) *tokenBucket {
+	period := cmp.Or(rate.period, time.Nanosecond)
+	return &tokenBucket{
+		period:          period,
+		timePerToken:    time.Duration(int64(period) / rate.average),
+		burst:           rate.burst,
+		clock:           clock,
+		lastRefresh:     clock.Now().UTC(),
+		availableTokens: rate.burst,
+	}
+}
+
+const UndefinedDelay = -1
+
+func (tb *tokenBucket) consume(tokens int64) (time.Duration, error) {
+	tb.updateAvailableTokens()
+	tb.lastConsumed = 0
+	if tokens > tb.burst {
+		return UndefinedDelay, fmt.Errorf("Requested tokens larger than max tokens")
+	}
+	if tb.availableTokens < tokens {
+		return tb.timeUntilAvailable(tokens), nil
+	}
+	tb.availableTokens -= tokens
+	tb.lastConsumed = tokens
+	return 0, nil
+}
+
+// rollback reverts effect of the most recent consumption. If the most recent
+// consume resulted in an error or a burst overflow, and therefore did not
+// modify the number of available tokens, then rollback won't do that either.
+// It is safe to call this method multiple times, for the second and all
+// following calls have no effect.
+func (tb *tokenBucket) rollback() {
+	tb.availableTokens += tb.lastConsumed
+	tb.lastConsumed = 0
+}
+
+// Update modifies average and burst fields of the token bucket according
+// to the provided rate.
+func (tb *tokenBucket) update(rate *rate) error {
+	if rate.period != tb.period {
+		return trace.BadParameter("Period mismatch: %v != %v", tb.period, rate.period)
+	}
+	tb.timePerToken = time.Duration(int64(tb.period) / rate.average)
+	tb.burst = rate.burst
+	if tb.availableTokens > rate.burst {
+		tb.availableTokens = rate.burst
+	}
+	return nil
+}
+
+// timeUntilAvailable returns the amount of time that we need to
+// wait until the specified number of tokens becomes available for consumption.
+func (tb *tokenBucket) timeUntilAvailable(tokens int64) time.Duration {
+	missingTokens := tokens - tb.availableTokens
+	return time.Duration(missingTokens) * tb.timePerToken
+}
+
+// updateAvailableTokens updates the number of tokens available for consumption.
+// It is calculated based on the refill rate, the time passed since last refresh,
+// and is limited by the bucket capacity.
+func (tb *tokenBucket) updateAvailableTokens() {
+	if tb.timePerToken == 0 {
+		return
+	}
+
+	now := tb.clock.Now().UTC()
+	timePassed := now.Sub(tb.lastRefresh)
+
+	tokens := tb.availableTokens + int64(timePassed/tb.timePerToken)
+
+	// If we haven't added any tokens that means that not enough time has passed,
+	// in this case do not adjust last refill checkpoint, otherwise it will be
+	// always moving in time in case of frequent requests that exceed the rate
+	if tokens != tb.availableTokens {
+		tb.lastRefresh = now
+		tb.availableTokens = tokens
+	}
+	if tb.availableTokens > tb.burst {
+		tb.availableTokens = tb.burst
+	}
+}

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -87,20 +87,17 @@ func TestDefaultConfig(t *testing.T) {
 	auth := config.Auth
 	require.Equal(t, localAuthAddr, auth.ListenAddr)
 	require.Equal(t, int64(defaults.LimiterMaxConnections), auth.Limiter.MaxConnections)
-	require.Equal(t, defaults.LimiterMaxConcurrentUsers, auth.Limiter.MaxNumberOfUsers)
 	require.Equal(t, lite.GetName(), config.Auth.StorageConfig.Type)
 	require.Equal(t, filepath.Join(config.DataDir, defaults.BackendDir), auth.StorageConfig.Params[defaults.BackendPath])
 
 	// SSH section
 	ssh := config.SSH
 	require.Equal(t, int64(defaults.LimiterMaxConnections), ssh.Limiter.MaxConnections)
-	require.Equal(t, defaults.LimiterMaxConcurrentUsers, ssh.Limiter.MaxNumberOfUsers)
 	require.True(t, ssh.AllowTCPForwarding)
 
 	// proxy section
 	proxy := config.Proxy
 	require.Equal(t, int64(defaults.LimiterMaxConnections), proxy.Limiter.MaxConnections)
-	require.Equal(t, defaults.LimiterMaxConcurrentUsers, proxy.Limiter.MaxNumberOfUsers)
 
 	// Misc levers and dials
 	require.Equal(t, defaults.HighResPollingPeriod, config.RotationConnectionInterval)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -45,7 +45,6 @@ import (
 	"github.com/google/safetext/shsprintf"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
-	"github.com/gravitational/oxy/ratelimit"
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -516,8 +515,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 				Burst:   defaults.LimiterBurst,
 			},
 		},
-		MaxConnections:   defaults.LimiterMaxConnections,
-		MaxNumberOfUsers: defaults.LimiterMaxConcurrentUsers,
+		MaxConnections: defaults.LimiterMaxConnections,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -531,8 +529,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 				Burst:   defaults.LimiterHighBurst,
 			},
 		},
-		MaxConnections:   defaults.LimiterMaxConnections,
-		MaxNumberOfUsers: defaults.LimiterMaxConcurrentUsers,
+		MaxConnections: defaults.LimiterMaxConnections,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -4711,13 +4708,7 @@ func rateLimitRequest(r *http.Request, limiter *limiter.RateLimiter) error {
 		return trace.Wrap(err)
 	}
 
-	err = limiter.RegisterRequest(remote, nil /* customRate */)
-	// MaxRateError doesn't play well with errors.Is, hence the type assertion.
-	var maxRateError *ratelimit.MaxRateError
-	if errors.As(err, &maxRateError) {
-		return trace.LimitExceeded(err.Error())
-	}
-	return trace.Wrap(err)
+	return trace.Wrap(limiter.RegisterRequest(remote, nil /* customRate */))
 }
 
 func (h *Handler) validateCookie(w http.ResponseWriter, r *http.Request) (*SessionContext, error) {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -57,7 +57,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/julienschmidt/httprouter"
-	"github.com/mailgun/timetools"
 	"github.com/pquerna/otp/totp"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -8936,9 +8935,7 @@ func TestWithLimiterHandlerFunc(t *testing.T) {
 				Burst:   burst,
 			},
 		},
-		Clock: &timetools.FreezedTime{
-			CurrentTime: time.Date(2016, 6, 5, 4, 3, 2, 1, time.UTC),
-		},
+		Clock: clockwork.NewFakeClock(),
 	})
 	require.NoError(t, err)
 	h := &Handler{limiter: limiter}
@@ -9127,8 +9124,7 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 		AccessPoint:   client,
 		DynamicLabels: nil,
 		LimiterConfig: limiter.Config{
-			MaxConnections:   1000,
-			MaxNumberOfUsers: 1000,
+			MaxConnections: 1000,
 		},
 		// each time heartbeat is called we insert data into the channel.
 		// this is used to make sure that heartbeat started and the clusters


### PR DESCRIPTION
I've vendored in parts of gravitational/oxy under the lib/limiter/internal/ratelimit package, taking the opportunity to convert to slog and replace mailgun dependencies (ttlmap, timetools) with Teleport equivalents.

After this, there are a few spots in teleport.e that use the oxy rate limiter - that will be the last step before we can remove the oxy dependency completely.