### PR TITLE
[v14] Replace EOL Debian Buster with Bullseye in `Dockerfile-node`

### DIFF
--- a/build.assets/Dockerfile-node
+++ b/build.assets/Dockerfile-node
@@ -4,17 +4,18 @@
 # to build the Teleport Connect. It can also be used to build the
 # web assets for the Teleport UI.
 #
-# This image is base on the node image, which is based on Debian Buster.
-# Using it as a image allows us to link agains the same version of
-# glibc as Node.js.
+# This image is base on the node image, which is based on Debian Bullseye.
+# Using it as an image allows us to link against the oldest version of glibc
+# supported by Node.js Docker images.
 #
 # Check the README to learn how to safely introduce changes to Dockerfiles.
 
 ## BUILDBOX-NODE ###################################################################
 
-# Pin the tag to Debian Buster to make sure the Glibc compatibility.
+# Pin the tag to Debian Bullseye to make sure the glibc compatibility
+# (glibc version of Bullseye is 2.31).
 ARG NODE_VERSION
-FROM node:${NODE_VERSION}-buster AS buildbox
+FROM node:${NODE_VERSION}-bullseye AS buildbox
 
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -6,7 +6,7 @@
 GOLANG_VERSION ?= go1.22.8
 GOLANGCI_LINT_VERSION ?= v1.61.0
 
-NODE_VERSION ?= 20.14.0
+NODE_VERSION ?= 20.17.0
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.77.0


### PR DESCRIPTION
Backport #47204 to branch/v14

changelog: Teleport Connect for Linux now requires glibc 2.31 or later
