### PR TITLE
Install the expected `protoc-gen-terraform` version in `lint.yaml`

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -230,4 +230,5 @@ jobs:
 
       - name: Check if Terraform resources are up to date
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
-        run: git config --global --add safe.directory $(realpath .) && go install github.com/gravitational/protoc-gen-terraform@main && make terraform-resources-up-to-date
+        # The protoc-gen-terraform version must match the version in integrations/terraform/Makefile
+        run: git config --global --add safe.directory $(realpath .) && go install github.com/gravitational/protoc-gen-terraform@08768262d29336b8ae0915ef41bb6d9768518c66 && make terraform-resources-up-to-date

--- a/integrations/terraform/Makefile
+++ b/integrations/terraform/Makefile
@@ -45,6 +45,7 @@ $(BUILDDIR)/terraform-provider-teleport_%: terraform-provider-teleport-v$(VERSIO
 	mv $(BUILDDIR)/$(OS)/$*/terraform-provider-teleport $@
 
 CUSTOM_IMPORTS_TMP_DIR ?= /tmp/protoc-gen-terraform/custom-imports
+# This version must match the version installed by .github/workflows/lint.yaml
 PROTOC_GEN_TERRAFORM_VERSION ?= v2.2.0
 PROTOC_GEN_TERRAFORM_EXISTS := $(shell protoc-gen-terraform version 2>&1 >/dev/null | grep 'protoc-gen-terraform $(PROTOC_GEN_TERRAFORM_VERSION)')
 


### PR DESCRIPTION
The `lint.yaml` workflow installs the tip of the `main` branch from the `gravitational/protoc-gen-terraform` repository, while the `gen-tfschema` target in `integrations/terraform/Makefile` expects a fixed version. Since `protoc-gen-terraform` v3.0.0 seems to have broken codegen at the current time, and the version check prevents merging any PR that touches a proto file or a `go.mod` file, this PR changes the workflow to install the exact version that the `Makefile` expects.

For verification, the commit referenced in `lint.yaml` is gravitational/protoc-gen-terraform@08768262d29336b8ae0915ef41bb6d9768518c66 .