### PR TITLE
[v15] Fix Workload Attestation failure regression

### DIFF
--- a/lib/tbot/service_spiffe_workload_api.go
+++ b/lib/tbot/service_spiffe_workload_api.go
@@ -506,6 +506,10 @@ func (s *SPIFFEWorkloadAPIService) authenticateClient(
 		//
 		// This can also occur if the caller is calling from another process
 		// namespace.
+		//
+		// TODO(noah): We should probably consider skipping all of this code
+		// if we know that the listener is TCP and not UDS, so we can make this
+		// a bit noisier.
 		log.DebugContext(ctx, "Did not detect UDS credentials, will not complete workload attestation")
 		return log, workloadattest.Attestation{}, nil
 	}

--- a/lib/tbot/spiffe/workloadattest/attest.go
+++ b/lib/tbot/spiffe/workloadattest/attest.go
@@ -27,6 +27,9 @@ import (
 
 // Attestation holds the results of the attestation process carried out on a
 // PID by the attestor.
+//
+// The zero value of this type indicates that no attestation was performed or
+// was successful.
 type Attestation struct {
 	Unix       UnixAttestation
 	Kubernetes KubernetesAttestation
@@ -82,10 +85,12 @@ func NewAttestor(log *slog.Logger, cfg Config) (*Attestor, error) {
 
 func (a *Attestor) Attest(ctx context.Context, pid int) (Attestation, error) {
 	a.log.DebugContext(ctx, "Starting workload attestation", "pid", pid)
-	defer a.log.DebugContext(ctx, "Finished workload attestation complete", "pid", pid)
+	defer a.log.DebugContext(ctx, "Finished workload attestation", "pid", pid)
 
-	att := Attestation{}
-	var err error
+	var (
+		att Attestation
+		err error
+	)
 
 	// We always perform the unix attestation first
 	att.Unix, err = a.unix.Attest(ctx, pid)


### PR DESCRIPTION
Backport #47261 to branch/v15

changelog: Fixed error in Workload ID in cases where the process ID cannot be resolved.
