### PR TITLE
Add auto update agent plan service+cache

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3024,6 +3024,59 @@ func (c *Client) DeleteAutoUpdateVersion(ctx context.Context) error {
 	return trace.Wrap(err)
 }
 
+// CreateAutoUpdateAgentPlan creates AutoUpdateAgentPlan resource.
+func (c *Client) CreateAutoUpdateAgentPlan(ctx context.Context, plan *autoupdatev1pb.AutoUpdateAgentPlan) (*autoupdatev1pb.AutoUpdateAgentPlan, error) {
+	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
+	resp, err := client.CreateAutoUpdateAgentPlan(ctx, &autoupdatev1pb.CreateAutoUpdateAgentPlanRequest{
+		Plan: plan,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// GetAutoUpdateAgentPlan gets AutoUpdateAgentPlan resource.
+func (c *Client) GetAutoUpdateAgentPlan(ctx context.Context) (*autoupdatev1pb.AutoUpdateAgentPlan, error) {
+	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
+	resp, err := client.GetAutoUpdateAgentPlan(ctx, &autoupdatev1pb.GetAutoUpdateAgentPlanRequest{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// UpdateAutoUpdateAgentPlan updates AutoUpdateAgentPlan resource.
+func (c *Client) UpdateAutoUpdateAgentPlan(ctx context.Context, plan *autoupdatev1pb.AutoUpdateAgentPlan) (*autoupdatev1pb.AutoUpdateAgentPlan, error) {
+	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
+	resp, err := client.UpdateAutoUpdateAgentPlan(ctx, &autoupdatev1pb.UpdateAutoUpdateAgentPlanRequest{
+		Plan: plan,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// UpsertAutoUpdateAgentPlan updates or creates AutoUpdateAgentPlan resource.
+func (c *Client) UpsertAutoUpdateAgentPlan(ctx context.Context, plan *autoupdatev1pb.AutoUpdateAgentPlan) (*autoupdatev1pb.AutoUpdateAgentPlan, error) {
+	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
+	resp, err := client.UpsertAutoUpdateAgentPlan(ctx, &autoupdatev1pb.UpsertAutoUpdateAgentPlanRequest{
+		Plan: plan,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// DeleteAutoUpdateAgentPlan deletes AutoUpdateAgentPlan resource.
+func (c *Client) DeleteAutoUpdateAgentPlan(ctx context.Context) error {
+	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
+	_, err := client.DeleteAutoUpdateAgentPlan(ctx, &autoupdatev1pb.DeleteAutoUpdateAgentPlanRequest{})
+	return trace.Wrap(err)
+}
+
 // GetClusterAccessGraphConfig retrieves the Cluster Access Graph configuration from Auth server.
 func (c *Client) GetClusterAccessGraphConfig(ctx context.Context) (*clusterconfigpb.AccessGraphConfig, error) {
 	rsp, err := c.ClusterConfigClient().GetClusterAccessGraphConfig(ctx, &clusterconfigpb.GetClusterAccessGraphConfigRequest{})

--- a/api/client/events.go
+++ b/api/client/events.go
@@ -109,6 +109,10 @@ func EventToGRPC(in types.Event) (*proto.Event, error) {
 			out.Resource = &proto.Event_AutoUpdateVersion{
 				AutoUpdateVersion: r,
 			}
+		case *autoupdate.AutoUpdateAgentPlan:
+			out.Resource = &proto.Event_AutoUpdateAgentPlan{
+				AutoUpdateAgentPlan: r,
+			}
 		case *usertasksv1.UserTask:
 			out.Resource = &proto.Event_UserTask{
 				UserTask: r,

--- a/api/client/events.go
+++ b/api/client/events.go
@@ -566,6 +566,9 @@ func EventFromGRPC(in *proto.Event) (*types.Event, error) {
 	} else if r := in.GetAutoUpdateVersion(); r != nil {
 		out.Resource = types.Resource153ToLegacy(r)
 		return &out, nil
+	} else if r := in.GetAutoUpdateAgentPlan(); r != nil {
+		out.Resource = types.Resource153ToLegacy(r)
+		return &out, nil
 	} else if r := in.GetUserTask(); r != nil {
 		out.Resource = types.Resource153ToLegacy(r)
 		return &out, nil

--- a/api/types/autoupdate/version.go
+++ b/api/types/autoupdate/version.go
@@ -72,7 +72,7 @@ func ValidateAutoUpdateVersion(v *autoupdate.AutoUpdateVersion) error {
 
 // NewAutoUpdateAgentPlan creates a new auto update version resource.
 func NewAutoUpdateAgentPlan(spec *autoupdate.AutoUpdateAgentPlanSpec) (*autoupdate.AutoUpdateAgentPlan, error) {
-	version := &autoupdate.AutoUpdateAgentPlan{
+	plan := &autoupdate.AutoUpdateAgentPlan{
 		Kind:    types.KindAutoUpdateAgentPlan,
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
@@ -80,11 +80,11 @@ func NewAutoUpdateAgentPlan(spec *autoupdate.AutoUpdateAgentPlanSpec) (*autoupda
 		},
 		Spec: spec,
 	}
-	if err := ValidateAutoUpdateAgentPlan(version); err != nil {
+	if err := ValidateAutoUpdateAgentPlan(plan); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return version, nil
+	return plan, nil
 }
 
 // ValidateAutoUpdateAgentPlan checks that required parameters are set

--- a/api/types/autoupdate/version.go
+++ b/api/types/autoupdate/version.go
@@ -69,3 +69,41 @@ func ValidateAutoUpdateVersion(v *autoupdate.AutoUpdateVersion) error {
 
 	return nil
 }
+
+// NewAutoUpdateAgentPlan creates a new auto update version resource.
+func NewAutoUpdateAgentPlan(spec *autoupdate.AutoUpdateAgentPlanSpec) (*autoupdate.AutoUpdateAgentPlan, error) {
+	version := &autoupdate.AutoUpdateAgentPlan{
+		Kind:    types.KindAutoUpdateAgentPlan,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: types.MetaNameAutoUpdateAgentPlan,
+		},
+		Spec: spec,
+	}
+	if err := ValidateAutoUpdateAgentPlan(version); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return version, nil
+}
+
+// ValidateAutoUpdateAgentPlan checks that required parameters are set
+// for the specified AutoUpdateAgentPlan.
+func ValidateAutoUpdateAgentPlan(v *autoupdate.AutoUpdateAgentPlan) error {
+	if v == nil {
+		return trace.BadParameter("AutoUpdateAgentPlan is nil")
+	}
+	if v.Metadata == nil {
+		return trace.BadParameter("Metadata is nil")
+	}
+	if v.Metadata.Name != types.MetaNameAutoUpdateAgentPlan {
+		return trace.BadParameter("Name is not valid")
+	}
+	if v.Spec == nil {
+		return trace.BadParameter("Spec is nil")
+	}
+
+	// TODO(hugoShaka): add more validation logic here
+
+	return nil
+}

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -326,11 +326,17 @@ const (
 	// KindAutoUpdateVersion is the resource with autoupdate versions.
 	KindAutoUpdateVersion = "autoupdate_version"
 
+	// KindAutoUpdateAgentPlan is the resource with autoupdate agent plan.
+	KindAutoUpdateAgentPlan = "autoupdate_agent_plan"
+
 	// MetaNameAutoUpdateConfig is the name of a configuration resource for autoupdate config.
 	MetaNameAutoUpdateConfig = "autoupdate-config"
 
 	// MetaNameAutoUpdateVersion is the name of a resource for autoupdate version.
 	MetaNameAutoUpdateVersion = "autoupdate-version"
+
+	// MetaNameAutoUpdateAgentPlan is the name of a resource for autoupdate agent plan.
+	MetaNameAutoUpdateAgentPlan = "autoupdate-agent-plan"
 
 	// KindClusterAuditConfig is the resource that holds cluster audit configuration.
 	KindClusterAuditConfig = "cluster_audit_config"

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -314,6 +314,9 @@ type ReadProxyAccessPoint interface {
 
 	// GetAutoUpdateVersion gets the AutoUpdateVersion from the backend.
 	GetAutoUpdateVersion(ctx context.Context) (*autoupdate.AutoUpdateVersion, error)
+
+	// GetAutoUpdateAgentPlan gets the AutoUpdateAgentPlan from the backend.
+	GetAutoUpdateAgentPlan(ctx context.Context) (*autoupdate.AutoUpdateAgentPlan, error)
 }
 
 // SnowflakeSessionWatcher is watcher interface used by Snowflake web session watcher.
@@ -1200,6 +1203,9 @@ type Cache interface {
 
 	// GetAutoUpdateVersion gets the AutoUpdateVersion from the backend.
 	GetAutoUpdateVersion(ctx context.Context) (*autoupdate.AutoUpdateVersion, error)
+
+	// GetAutoUpdateAgentPlan gets the AutoUpdateAgentPlan from the backend.
+	GetAutoUpdateAgentPlan(ctx context.Context) (*autoupdate.AutoUpdateAgentPlan, error)
 
 	// GetAccessGraphSettings returns the access graph settings.
 	GetAccessGraphSettings(context.Context) (*clusterconfigpb.AccessGraphSettings, error)

--- a/lib/auth/autoupdate/autoupdatev1/service.go
+++ b/lib/auth/autoupdate/autoupdatev1/service.go
@@ -37,6 +37,9 @@ type Cache interface {
 
 	// GetAutoUpdateVersion gets the AutoUpdateVersion from the backend.
 	GetAutoUpdateVersion(ctx context.Context) (*autoupdate.AutoUpdateVersion, error)
+
+	// GetAutoUpdateAgentPlan gets the AutoUpdateAgentPlan from the backend.
+	GetAutoUpdateAgentPlan(ctx context.Context) (*autoupdate.AutoUpdateAgentPlan, error)
 }
 
 // ServiceConfig holds configuration options for the auto update gRPC service.
@@ -264,6 +267,103 @@ func (s *Service) DeleteAutoUpdateVersion(ctx context.Context, req *autoupdate.D
 	}
 
 	if err := s.backend.DeleteAutoUpdateVersion(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &emptypb.Empty{}, nil
+}
+
+// GetAutoUpdateAgentPlan gets the current AutoUpdateVersion singleton.
+func (s *Service) GetAutoUpdateAgentPlan(ctx context.Context, req *autoupdate.GetAutoUpdateAgentPlanRequest) (*autoupdate.AutoUpdateAgentPlan, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindAutoUpdateAgentPlan, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	plan, err := s.cache.GetAutoUpdateAgentPlan(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return plan, nil
+}
+
+// CreateAutoUpdateAgentPlan creates AutoUpdateAgentPlan singleton.
+func (s *Service) CreateAutoUpdateAgentPlan(ctx context.Context, req *autoupdate.CreateAutoUpdateAgentPlanRequest) (*autoupdate.AutoUpdateAgentPlan, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindAutoUpdateAgentPlan, types.VerbCreate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	autoUpdateAgentPlan, err := s.backend.CreateAutoUpdateAgentPlan(ctx, req.Plan)
+	return autoUpdateAgentPlan, trace.Wrap(err)
+}
+
+// UpdateAutoUpdateAgentPlan updates AutoUpdateAgentPlan singleton.
+func (s *Service) UpdateAutoUpdateAgentPlan(ctx context.Context, req *autoupdate.UpdateAutoUpdateAgentPlanRequest) (*autoupdate.AutoUpdateAgentPlan, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindAutoUpdateAgentPlan, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	autoUpdateAgentPlan, err := s.backend.UpdateAutoUpdateAgentPlan(ctx, req.Plan)
+	return autoUpdateAgentPlan, trace.Wrap(err)
+}
+
+// UpsertAutoUpdateAgentPlan updates or creates AutoUpdateAgentPlan singleton.
+func (s *Service) UpsertAutoUpdateAgentPlan(ctx context.Context, req *autoupdate.UpsertAutoUpdateAgentPlanRequest) (*autoupdate.AutoUpdateAgentPlan, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindAutoUpdateAgentPlan, types.VerbCreate, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	autoUpdateAgentPlan, err := s.backend.UpsertAutoUpdateAgentPlan(ctx, req.Plan)
+	return autoUpdateAgentPlan, trace.Wrap(err)
+}
+
+// DeleteAutoUpdateAgentPlan deletes AutoUpdateAgentPlan singleton.
+func (s *Service) DeleteAutoUpdateAgentPlan(ctx context.Context, req *autoupdate.DeleteAutoUpdateAgentPlanRequest) (*emptypb.Empty, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindAutoUpdateAgentPlan, types.VerbDelete); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.AuthorizeAdminAction(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.backend.DeleteAutoUpdateAgentPlan(ctx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, nil

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -3466,6 +3466,7 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 		types.KindStaticHostUser:          types.Resource153ToLegacy(newStaticHostUser(t, "test")),
 		types.KindAutoUpdateConfig:        types.Resource153ToLegacy(newAutoUpdateConfig(t)),
 		types.KindAutoUpdateVersion:       types.Resource153ToLegacy(newAutoUpdateVersion(t)),
+		types.KindAutoUpdateAgentPlan:     types.Resource153ToLegacy(newAutoUpdateAgentPlan(t)),
 		types.KindUserTask:                types.Resource153ToLegacy(newUserTasks(t)),
 	}
 

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -2792,6 +2792,42 @@ func TestAutoUpdateVersion(t *testing.T) {
 	})
 }
 
+// TestAutoUpdateAgentPlan tests that CRUD operations on AutoUpdateAgentPlan resource are
+// replicated from the backend to the cache.
+func TestAutoUpdateAgentPlan(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs153[*autoupdate.AutoUpdateAgentPlan]{
+		newResource: func(name string) (*autoupdate.AutoUpdateAgentPlan, error) {
+			return newAutoUpdateAgentPlan(t), nil
+		},
+		create: func(ctx context.Context, item *autoupdate.AutoUpdateAgentPlan) error {
+			_, err := p.autoUpdateService.UpsertAutoUpdateAgentPlan(ctx, item)
+			return trace.Wrap(err)
+		},
+		list: func(ctx context.Context) ([]*autoupdate.AutoUpdateAgentPlan, error) {
+			item, err := p.autoUpdateService.GetAutoUpdateAgentPlan(ctx)
+			if trace.IsNotFound(err) {
+				return []*autoupdate.AutoUpdateAgentPlan{}, nil
+			}
+			return []*autoupdate.AutoUpdateAgentPlan{item}, trace.Wrap(err)
+		},
+		cacheList: func(ctx context.Context) ([]*autoupdate.AutoUpdateAgentPlan, error) {
+			item, err := p.cache.GetAutoUpdateAgentPlan(ctx)
+			if trace.IsNotFound(err) {
+				return []*autoupdate.AutoUpdateAgentPlan{}, nil
+			}
+			return []*autoupdate.AutoUpdateAgentPlan{item}, trace.Wrap(err)
+		},
+		deleteAll: func(ctx context.Context) error {
+			return trace.Wrap(p.autoUpdateService.DeleteAutoUpdateAgentPlan(ctx))
+		},
+	})
+}
+
 // TestGlobalNotifications tests that CRUD operations on global notification resources are
 // replicated from the backend to the cache.
 func TestGlobalNotifications(t *testing.T) {
@@ -3992,6 +4028,17 @@ func newAutoUpdateVersion(t *testing.T) *autoupdate.AutoUpdateVersion {
 
 	r, err := update.NewAutoUpdateVersion(&autoupdate.AutoUpdateVersionSpec{
 		ToolsVersion: "1.2.3",
+	})
+	require.NoError(t, err)
+	return r
+}
+
+func newAutoUpdateAgentPlan(t *testing.T) *autoupdate.AutoUpdateAgentPlan {
+	t.Helper()
+
+	r, err := update.NewAutoUpdateAgentPlan(&autoupdate.AutoUpdateAgentPlanSpec{
+		StartVersion:  "1.2.3",
+		TargetVersion: "2.3.4",
 	})
 	require.NoError(t, err)
 	return r

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -810,7 +810,7 @@ func setupCollections(c *Cache, watches []types.WatchKind) (*cacheCollections, e
 				cache: c,
 				watch: watch,
 			}
-			collections.byKind[resourceKind] = collections.autoUpdateVersions
+			collections.byKind[resourceKind] = collections.autoUpdateAgentPlans
 		default:
 			return nil, trace.BadParameter("resource %q is not supported", watch.Kind)
 		}

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -1358,8 +1358,8 @@ var _ executor[*autoupdate.AutoUpdateVersion, autoUpdateVersionGetter] = autoUpd
 type autoUpdateAgentPlanExecutor struct{}
 
 func (autoUpdateAgentPlanExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]*autoupdate.AutoUpdateAgentPlan, error) {
-	version, err := cache.AutoUpdateService.GetAutoUpdateAgentPlan(ctx)
-	return []*autoupdate.AutoUpdateAgentPlan{version}, trace.Wrap(err)
+	plan, err := cache.AutoUpdateService.GetAutoUpdateAgentPlan(ctx)
+	return []*autoupdate.AutoUpdateAgentPlan{plan}, trace.Wrap(err)
 }
 
 func (autoUpdateAgentPlanExecutor) upsert(ctx context.Context, cache *Cache, resource *autoupdate.AutoUpdateAgentPlan) error {

--- a/lib/services/autoupdates.go
+++ b/lib/services/autoupdates.go
@@ -31,6 +31,9 @@ type AutoUpdateServiceGetter interface {
 
 	// GetAutoUpdateVersion gets the AutoUpdateVersion singleton resource.
 	GetAutoUpdateVersion(ctx context.Context) (*autoupdate.AutoUpdateVersion, error)
+
+	// GetAutoUpdateAgentPlan gets the AutoUpdateAgentPlan singleton resource.
+	GetAutoUpdateAgentPlan(ctx context.Context) (*autoupdate.AutoUpdateAgentPlan, error)
 }
 
 // AutoUpdateService stores the autoupdate service.
@@ -60,4 +63,16 @@ type AutoUpdateService interface {
 
 	// DeleteAutoUpdateVersion deletes the AutoUpdateVersion singleton resource.
 	DeleteAutoUpdateVersion(ctx context.Context) error
+
+	// CreateAutoUpdateAgentPlan creates the AutoUpdateAgentPlan singleton resource.
+	CreateAutoUpdateAgentPlan(ctx context.Context, config *autoupdate.AutoUpdateAgentPlan) (*autoupdate.AutoUpdateAgentPlan, error)
+
+	// UpdateAutoUpdateAgentPlan updates the AutoUpdateAgentPlan singleton resource.
+	UpdateAutoUpdateAgentPlan(ctx context.Context, config *autoupdate.AutoUpdateAgentPlan) (*autoupdate.AutoUpdateAgentPlan, error)
+
+	// UpsertAutoUpdateAgentPlan sets the AutoUpdateAgentPlan singleton resource.
+	UpsertAutoUpdateAgentPlan(ctx context.Context, c *autoupdate.AutoUpdateAgentPlan) (*autoupdate.AutoUpdateAgentPlan, error)
+
+	// DeleteAutoUpdateAgentPlan deletes the AutoUpdateAgentPlan singleton resource.
+	DeleteAutoUpdateAgentPlan(ctx context.Context) error
 }

--- a/lib/services/autoupdates.go
+++ b/lib/services/autoupdates.go
@@ -65,13 +65,13 @@ type AutoUpdateService interface {
 	DeleteAutoUpdateVersion(ctx context.Context) error
 
 	// CreateAutoUpdateAgentPlan creates the AutoUpdateAgentPlan singleton resource.
-	CreateAutoUpdateAgentPlan(ctx context.Context, config *autoupdate.AutoUpdateAgentPlan) (*autoupdate.AutoUpdateAgentPlan, error)
+	CreateAutoUpdateAgentPlan(ctx context.Context, plan *autoupdate.AutoUpdateAgentPlan) (*autoupdate.AutoUpdateAgentPlan, error)
 
 	// UpdateAutoUpdateAgentPlan updates the AutoUpdateAgentPlan singleton resource.
-	UpdateAutoUpdateAgentPlan(ctx context.Context, config *autoupdate.AutoUpdateAgentPlan) (*autoupdate.AutoUpdateAgentPlan, error)
+	UpdateAutoUpdateAgentPlan(ctx context.Context, plan *autoupdate.AutoUpdateAgentPlan) (*autoupdate.AutoUpdateAgentPlan, error)
 
 	// UpsertAutoUpdateAgentPlan sets the AutoUpdateAgentPlan singleton resource.
-	UpsertAutoUpdateAgentPlan(ctx context.Context, c *autoupdate.AutoUpdateAgentPlan) (*autoupdate.AutoUpdateAgentPlan, error)
+	UpsertAutoUpdateAgentPlan(ctx context.Context, plan *autoupdate.AutoUpdateAgentPlan) (*autoupdate.AutoUpdateAgentPlan, error)
 
 	// DeleteAutoUpdateAgentPlan deletes the AutoUpdateAgentPlan singleton resource.
 	DeleteAutoUpdateAgentPlan(ctx context.Context) error

--- a/lib/services/local/autoupdate.go
+++ b/lib/services/local/autoupdate.go
@@ -78,9 +78,9 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 	}
 	plan, err := generic.NewServiceWrapper(
 		generic.ServiceWrapperConfig[*autoupdate.AutoUpdateAgentPlan]{
-			Backend:       backend,
+			Backend:       b,
 			ResourceKind:  types.KindAutoUpdateAgentPlan,
-			BackendPrefix: autoUpdateAgentPlanPrefix,
+			BackendPrefix: backend.NewKey(autoUpdateAgentPlanPrefix),
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateAgentPlan],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateAgentPlan],
 			ValidateFunc:  update.ValidateAutoUpdateAgentPlan,

--- a/lib/services/local/autoupdate.go
+++ b/lib/services/local/autoupdate.go
@@ -84,7 +84,7 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateAgentPlan],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateAgentPlan],
 			ValidateFunc:  update.ValidateAutoUpdateAgentPlan,
-			KeyFunc: func(version *autoupdate.AutoUpdateAgentPlan) string {
+			KeyFunc: func(_ *autoupdate.AutoUpdateAgentPlan) string {
 				return types.MetaNameAutoUpdateAgentPlan
 			},
 		})

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -251,6 +251,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindAutoUpdateConfig, nil
 	case types.KindAutoUpdateVersion:
 		return types.KindAutoUpdateVersion, nil
+	case types.KindAutoUpdateAgentPlan:
+		return types.KindAutoUpdateAgentPlan, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }


### PR DESCRIPTION
This PR adds the AutoUpdateAgentPlan resource to the AutoUpdateService.

Part of RFD 0184 https://github.com/gravitational/teleport/pull/47126