### PR TITLE
Update depguard rules to prevent breaking CGO_ENABLED=0 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -155,6 +155,7 @@ linters-settings:
           - "!$test"
           - '**/tool/tbot/**'
           - '**/lib/client/**'
+          - '**integrations/**'
         deny:
           - pkg: github.com/gravitational/teleport/lib/devicetrust/authn$
             desc: '"devicetrust/authn" requires CGO on darwin'
@@ -178,6 +179,8 @@ linters-settings:
             desc: '"lib/srv/uacc" requires CGO'
           - pkg: github.com/gravitational/teleport/lib/cgroup
             desc: '"lib/cgroup" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/config
+            desc: '"lib/config" requires CGO via "lib/pam" and "lib/backend/lite"'
   errorlint:
     comparison: true
     asserts: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -157,30 +157,32 @@ linters-settings:
           - '**/lib/client/**'
           - '**integrations/**'
         deny:
-          - pkg: github.com/gravitational/teleport/lib/devicetrust/authn$
-            desc: '"devicetrust/authn" requires CGO on darwin'
-          - pkg: github.com/gravitational/teleport/lib/devicetrust/enroll
-            desc: '"devicetrust/enroll" requires CGO on darwin'
-          - pkg: github.com/gravitational/teleport/lib/devicetrust/native
-            desc: '"devicetrust/native" requires CGO on darwin'
           - pkg: github.com/gravitational/teleport/lib/bpf
             desc: '"lib/bpf" requires CGO'
-          - pkg: github.com/gravitational/teleport/lib/vnet/daemon
-            desc: '"vnet/daemon" requires CGO'
-          - pkg: github.com/gravitational/teleport/lib/system/signal
-            desc: '"lib/system/signal" requires CGO'
-          - pkg: github.com/gravitational/teleport/lib/inventory/metadata
-            desc: '"lib/inventory/metadata" requires CGO'
-          - pkg: github.com/gravitational/teleport/lib/desktop/rdp/rdpclient
-            desc: '"lib/desktop/rdp/rdpclient" requires CGO'
-          - pkg: github.com/gravitational/teleport/lib/pam
-            desc: '"lib/pam" requires CGO'
-          - pkg: github.com/gravitational/teleport/lib/srv/uacc
-            desc: '"lib/srv/uacc" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/backend/lite
+            desc: '"lib/backend/lite" requires CGO'
           - pkg: github.com/gravitational/teleport/lib/cgroup
             desc: '"lib/cgroup" requires CGO'
           - pkg: github.com/gravitational/teleport/lib/config
             desc: '"lib/config" requires CGO via "lib/pam" and "lib/backend/lite"'
+          - pkg: github.com/gravitational/teleport/lib/desktop/rdp/rdpclient
+            desc: '"lib/desktop/rdp/rdpclient" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/devicetrust/authn$
+            desc: '"lib/devicetrust/authn" requires CGO on darwin'
+          - pkg: github.com/gravitational/teleport/lib/devicetrust/enroll
+            desc: '"lib/devicetrust/enroll" requires CGO on darwin'
+          - pkg: github.com/gravitational/teleport/lib/devicetrust/native
+            desc: '"lib/devicetrust/native" requires CGO on darwin'
+          - pkg: github.com/gravitational/teleport/lib/inventory/metadata
+            desc: '"lib/inventory/metadata" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/pam
+            desc: '"lib/pam" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/srv/uacc
+            desc: '"lib/srv/uacc" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/system/signal
+            desc: '"lib/system/signal" requires CGO'
+          - pkg: github.com/gravitational/teleport/lib/vnet/daemon
+            desc: '"vnet/daemon" requires CGO'
   errorlint:
     comparison: true
     asserts: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -155,7 +155,8 @@ linters-settings:
           - "!$test"
           - '**/tool/tbot/**'
           - '**/lib/client/**'
-          - '**integrations/**'
+          - '!**/lib/integrations/**'
+          - '**/integrations/**'
         deny:
           - pkg: github.com/gravitational/teleport/lib/bpf
             desc: '"lib/bpf" requires CGO'


### PR DESCRIPTION
The integrations binaries should be able to compile without CGO, however, a recent change introduced a dependency that required CGO(https://github.com/gravitational/teleport/pull/47045). This was fixed in https://github.com/gravitational/teleport/pull/47172, however there were no safety measure put in place to prevent it from happening again in the future.

This updates the existing CGO depguard rules to apply to all files under integrations in addition to denying lib/config which requires CGO by way of lib/pam and lib/backend/lite.