### PR TITLE
[v16] trigger instance refresh on launch_template change

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -350,6 +350,49 @@ The default is `local`.
 
 See the [Teleport authentication reference](../../../reference/access-controls/authentication.mdx) for more information.
 
+### default_tags
+
+```code
+$ export TF_VAR_default_tags='{"key":"value", "env":"dev"}'
+```
+
+This value can be used to control the default tags applied to all resources,
+including resources created dynamically by the AWS Auto Scaling Groups (ASG).
+The default is no tags.
+
+### enable\_auth\_asg\_instance\_refresh
+
+```code
+$ export TF_VAR_enable_auth_asg_instance_refresh="false"
+```
+
+This variable can be used to enable automatic instance refresh on the Teleport
+**auth server** AWS Autoscaling Group (ASG) - the refresh is triggered by
+changes to the launch template or configuration.
+Enable the auth ASG instance refresh with caution - upgrading the version of
+Teleport will trigger an instance refresh and **auth servers must be scaled down
+to only one instance** before upgrading your Teleport cluster.
+
+### enable\_proxy\_asg\_instance\_refresh
+
+```code
+$ export TF_VAR_enable_proxy_asg_instance_refresh="false"
+```
+
+This variable can be used to enable automatic instance refresh on the Teleport
+**proxy server** AWS Autoscaling Group (ASG) - the refresh is triggered by
+changes to the launch template or configuration.
+
+### enable\_node\_asg\_instance\_refresh
+
+```code
+$ export TF_VAR_enable_node_asg_instance_refresh="false"
+```
+
+This variable can be used to enable automatic instance refresh on the Teleport
+**node server** AWS Autoscaling Group (ASG) - the refresh is triggered by
+changes to the launch template or configuration.
+
 ## Reference deployment defaults
 
 ### Instances

--- a/examples/aws/terraform/ha-autoscale-cluster/Makefile
+++ b/examples/aws/terraform/ha-autoscale-cluster/Makefile
@@ -72,7 +72,7 @@ TF_VAR_use_tls_routing ?= false
 TF_VAR_teleport_auth_type ?= "local"
 
 # (optional) AWS tags applied to all resources.
-TF_VAR_default_tags ?=
+TF_VAR_default_tags ?= {}
 
 # (optional) Whether to trigger instance refresh rollout for Teleport Auth
 # servers when the launch template or configuration changes.

--- a/examples/aws/terraform/ha-autoscale-cluster/Makefile
+++ b/examples/aws/terraform/ha-autoscale-cluster/Makefile
@@ -71,6 +71,24 @@ TF_VAR_use_tls_routing ?= false
 # Teleport Enterprise FIPS deployments have local authentication disabled, so should use "github", "oidc", or "saml"
 TF_VAR_teleport_auth_type ?= "local"
 
+# (optional) AWS tags applied to all resources.
+TF_VAR_default_tags ?=
+
+# (optional) Whether to trigger instance refresh rollout for Teleport Auth
+# servers when the launch template or configuration changes.
+# Enable this with caution - upgrading Teleport version will trigger an
+# instance refresh and auth servers must be scaled down to only one instance
+# before upgrading your Teleport cluster.
+TF_VAR_enable_auth_asg_instance_refresh ?= false
+
+# (optional) Whether to trigger instance refresh rollout for Teleport Proxy
+# servers when the launch template or configuration changes.
+TF_VAR_enable_proxy_asg_instance_refresh ?= false
+
+# (optional) Whether to trigger instance refresh rollout for Teleport Node
+# servers when the launch template or configuration changes.
+TF_VAR_enable_node_asg_instance_refresh ?= false
+
 export
 
 # Plan launches terraform plan

--- a/examples/aws/terraform/ha-autoscale-cluster/auth_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/auth_asg.tf
@@ -14,7 +14,7 @@ resource "aws_autoscaling_group" "auth" {
 
   launch_template {
     name    = aws_launch_template.auth.name
-    version = "$Latest"
+    version = aws_launch_template.auth.latest_version
   }
 
   // These are target groups of the auth server network load balancer

--- a/examples/aws/terraform/ha-autoscale-cluster/auth_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/auth_asg.tf
@@ -42,6 +42,17 @@ resource "aws_autoscaling_group" "auth" {
     }
   }
 
+  dynamic "instance_refresh" {
+    for_each = var.enable_auth_asg_instance_refresh ? [1] : []
+    content {
+      strategy = "Rolling"
+      preferences {
+        auto_rollback          = true
+        min_healthy_percentage = 50
+      }
+    }
+  }
+
   // external autoscale algos can modify these values,
   // so ignore changes to them
   lifecycle {

--- a/examples/aws/terraform/ha-autoscale-cluster/auth_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/auth_asg.tf
@@ -33,6 +33,15 @@ resource "aws_autoscaling_group" "auth" {
     propagate_at_launch = true
   }
 
+  dynamic "tag" {
+    for_each = data.aws_default_tags.this.tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+
   // external autoscale algos can modify these values,
   // so ignore changes to them
   lifecycle {
@@ -98,5 +107,13 @@ resource "aws_launch_template" "auth" {
 
   iam_instance_profile {
     name = aws_iam_instance_profile.auth.name
+  }
+
+  dynamic "tag_specifications" {
+    for_each = ["instance", "volume", "network-interface"]
+    content {
+      resource_type = tag_specifications.value
+      tags          = data.aws_default_tags.this.tags
+    }
   }
 }

--- a/examples/aws/terraform/ha-autoscale-cluster/auth_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/auth_asg.tf
@@ -47,8 +47,8 @@ resource "aws_autoscaling_group" "auth" {
     content {
       strategy = "Rolling"
       preferences {
-        auto_rollback          = true
-        min_healthy_percentage = 50
+        auto_rollback          = false
+        min_healthy_percentage = 0
       }
     }
   }

--- a/examples/aws/terraform/ha-autoscale-cluster/data.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/data.tf
@@ -33,3 +33,5 @@ locals {
 data "aws_kms_alias" "ssm" {
   name = var.kms_alias_name
 }
+
+data "aws_default_tags" "this" {}

--- a/examples/aws/terraform/ha-autoscale-cluster/node_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/node_asg.tf
@@ -28,6 +28,15 @@ resource "aws_autoscaling_group" "node" {
     propagate_at_launch = true
   }
 
+  dynamic "tag" {
+    for_each = data.aws_default_tags.this.tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+
   // external autoscale algos can modify these values,
   // so ignore changes to them
   lifecycle {
@@ -82,5 +91,13 @@ resource "aws_launch_template" "node" {
 
   iam_instance_profile {
     name = aws_iam_instance_profile.node.name
+  }
+
+  dynamic "tag_specifications" {
+    for_each = ["instance", "volume", "network-interface"]
+    content {
+      resource_type = tag_specifications.value
+      tags          = data.aws_default_tags.this.tags
+    }
   }
 }

--- a/examples/aws/terraform/ha-autoscale-cluster/node_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/node_asg.tf
@@ -37,6 +37,17 @@ resource "aws_autoscaling_group" "node" {
     }
   }
 
+  dynamic "instance_refresh" {
+    for_each = var.enable_node_asg_instance_refresh ? [1] : []
+    content {
+      strategy = "Rolling"
+      preferences {
+        auto_rollback          = true
+        min_healthy_percentage = 50
+      }
+    }
+  }
+
   // external autoscale algos can modify these values,
   // so ignore changes to them
   lifecycle {

--- a/examples/aws/terraform/ha-autoscale-cluster/node_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/node_asg.tf
@@ -13,7 +13,7 @@ resource "aws_autoscaling_group" "node" {
 
   launch_template {
     id      = aws_launch_template.node.id
-    version = "$Latest"
+    version = aws_launch_template.node.latest_version
   }
 
   tag {

--- a/examples/aws/terraform/ha-autoscale-cluster/provider.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/provider.tf
@@ -10,4 +10,8 @@ terraform {
 
 provider "aws" {
   region = var.region
+
+  default_tags {
+    tags = var.default_tags
+  }
 }

--- a/examples/aws/terraform/ha-autoscale-cluster/proxy_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/proxy_asg.tf
@@ -53,6 +53,17 @@ resource "aws_autoscaling_group" "proxy" {
     }
   }
 
+  dynamic "instance_refresh" {
+    for_each = var.enable_proxy_asg_instance_refresh ? [1] : []
+    content {
+      strategy = "Rolling"
+      preferences {
+        auto_rollback          = true
+        min_healthy_percentage = 50
+      }
+    }
+  }
+
   // external autoscale algos can modify these values,
   // so ignore changes to them
   lifecycle {
@@ -112,6 +123,17 @@ resource "aws_autoscaling_group" "proxy_acm" {
       key                 = tag.key
       value               = tag.value
       propagate_at_launch = true
+    }
+  }
+
+  dynamic "instance_refresh" {
+    for_each = var.enable_proxy_asg_instance_refresh ? [1] : []
+    content {
+      strategy = "Rolling"
+      preferences {
+        auto_rollback          = true
+        min_healthy_percentage = 50
+      }
     }
   }
 

--- a/examples/aws/terraform/ha-autoscale-cluster/proxy_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/proxy_asg.tf
@@ -15,7 +15,7 @@ resource "aws_autoscaling_group" "proxy" {
 
   launch_template {
     name    = aws_launch_template.proxy.name
-    version = "$Latest"
+    version = aws_launch_template.proxy.latest_version
   }
 
   // Auto scaling group is associated with load balancer
@@ -68,7 +68,7 @@ resource "aws_autoscaling_group" "proxy_acm" {
 
   launch_template {
     name    = aws_launch_template.proxy.name
-    version = "$Latest"
+    version = aws_launch_template.proxy.latest_version
   }
 
   // Auto scaling group is associated with load balancer

--- a/examples/aws/terraform/ha-autoscale-cluster/proxy_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/proxy_asg.tf
@@ -44,6 +44,15 @@ resource "aws_autoscaling_group" "proxy" {
     propagate_at_launch = true
   }
 
+  dynamic "tag" {
+    for_each = data.aws_default_tags.this.tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+
   // external autoscale algos can modify these values,
   // so ignore changes to them
   lifecycle {
@@ -95,6 +104,15 @@ resource "aws_autoscaling_group" "proxy_acm" {
     key                 = "TeleportRole"
     value               = "proxy"
     propagate_at_launch = true
+  }
+
+  dynamic "tag" {
+    for_each = data.aws_default_tags.this.tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
   }
 
   // external autoscale algos can modify these values,
@@ -163,5 +181,13 @@ resource "aws_launch_template" "proxy" {
 
   iam_instance_profile {
     name = aws_iam_instance_profile.proxy.id
+  }
+
+  dynamic "tag_specifications" {
+    for_each = ["instance", "volume", "network-interface"]
+    content {
+      resource_type = tag_specifications.value
+      tags          = data.aws_default_tags.this.tags
+    }
   }
 }

--- a/examples/aws/terraform/ha-autoscale-cluster/vars.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/vars.tf
@@ -246,3 +246,24 @@ variable "default_tags" {
   type    = map(string)
   default = {}
 }
+
+// Whether to trigger instance refresh rollout for Teleport Auth servers when
+// the launch template or resource tags change.
+variable "enable_auth_asg_instance_refresh" {
+  type    = bool
+  default = true
+}
+
+// Whether to trigger instance refresh rollout for Teleport Proxy servers when
+// the launch template or resource tags change.
+variable "enable_proxy_asg_instance_refresh" {
+  type    = bool
+  default = true
+}
+
+// Whether to trigger instance refresh rollout for Teleport Node servers when
+// the launch template or resource tags change.
+variable "enable_node_asg_instance_refresh" {
+  type    = bool
+  default = true
+}

--- a/examples/aws/terraform/ha-autoscale-cluster/vars.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/vars.tf
@@ -248,21 +248,24 @@ variable "default_tags" {
 }
 
 // Whether to trigger instance refresh rollout for Teleport Auth servers when
-// the launch template or resource tags change.
+// servers when the launch template or configuration changes.
+// Enable this with caution - upgrading Teleport version will trigger an
+// instance refresh and auth servers must be scaled down to only one instance
+// before upgrading your Teleport cluster.
 variable "enable_auth_asg_instance_refresh" {
   type    = bool
   default = false
 }
 
 // Whether to trigger instance refresh rollout for Teleport Proxy servers when
-// the launch template or resource tags change.
+// servers when the launch template or configuration changes.
 variable "enable_proxy_asg_instance_refresh" {
   type    = bool
   default = false
 }
 
 // Whether to trigger instance refresh rollout for Teleport Node servers when
-// the launch template or resource tags change.
+// servers when the launch template or configuration changes.
 variable "enable_node_asg_instance_refresh" {
   type    = bool
   default = false

--- a/examples/aws/terraform/ha-autoscale-cluster/vars.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/vars.tf
@@ -251,7 +251,7 @@ variable "default_tags" {
 // the launch template or resource tags change.
 variable "enable_auth_asg_instance_refresh" {
   type    = bool
-  default = true
+  default = false
 }
 
 // Whether to trigger instance refresh rollout for Teleport Proxy servers when

--- a/examples/aws/terraform/ha-autoscale-cluster/vars.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/vars.tf
@@ -258,7 +258,7 @@ variable "enable_auth_asg_instance_refresh" {
 // the launch template or resource tags change.
 variable "enable_proxy_asg_instance_refresh" {
   type    = bool
-  default = true
+  default = false
 }
 
 // Whether to trigger instance refresh rollout for Teleport Node servers when

--- a/examples/aws/terraform/ha-autoscale-cluster/vars.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/vars.tf
@@ -265,5 +265,5 @@ variable "enable_proxy_asg_instance_refresh" {
 // the launch template or resource tags change.
 variable "enable_node_asg_instance_refresh" {
   type    = bool
-  default = true
+  default = false
 }

--- a/examples/aws/terraform/ha-autoscale-cluster/vars.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/vars.tf
@@ -240,3 +240,9 @@ variable "teleport_auth_type" {
   type    = string
   default = "local"
 }
+
+// (optional) Change the default tags applied to all resources.
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+}


### PR DESCRIPTION
Backport #46324 to branch/v16

changelog: The "ha-autoscale-cluster" terraform module now support default AWS resource tags and ASG instance refresh on configuration or launch template changes.
