### PR TITLE
Adding docs for nightly releases related to releases

### DIFF
--- a/docs/postrelease.md
+++ b/docs/postrelease.md
@@ -22,3 +22,6 @@ The AWS AMI ID PR can be merged right away.
 - [ ] Update `e/.github/workflows/build-buildboxes-cron.yaml` to bump the
   branches on each job (two per job) and to comment out the final job that only
   exists for the pre-release, and bump the versions for the next release.
+- [ ] Update `e/.github/workflows/nightly-releases.yaml` to bump the branches
+  in the strategy matrix, comment out the final branch that only exists for the
+  pre-release, and bump the version for the next release.

--- a/docs/postrelease.md
+++ b/docs/postrelease.md
@@ -22,6 +22,6 @@ The AWS AMI ID PR can be merged right away.
 - [ ] Update `e/.github/workflows/build-buildboxes-cron.yaml` to bump the
   branches on each job (two per job) and to comment out the final job that only
   exists for the pre-release, and bump the versions for the next release.
-- [ ] Update `e/.github/workflows/nightly-releases.yaml` to bump the branches
-  in the strategy matrix, comment out the final branch that only exists for the
-  pre-release, and bump the version for the next release.
+- [ ] Update `e/.github/workflows/nightly-releases.yaml` on master to bump the 
+  branches in the strategy matrix, comment out the final branch that only 
+  exists for the pre-release, and bump the version for the next release.

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -14,5 +14,7 @@ This checklist is to be run prior to cutting the release branch.
   - [ ] Update the `BUILDBOX_VERSION` in `build.assets/images.mk`. Commit and merge.
   - [ ] Update `e/.github/workflows/build-buildboxes-cron.yaml` to uncomment final pre-release
     job and ensure it has the correct branch names (two places). Commit and merge.
-- [ ] Update `e/.github/workflows/nightly-releases.yaml` to uncomment pre-release branch to enable
-  nightly builds for the upcoming release.
+- [ ] Update `e/.github/workflows/nightly-releases.yaml` on master branch to uncomment pre-release 
+  branch to enable nightly builds for the upcoming release.
+- [ ] Ensure that `e/.github/workflows/nightly-release.yaml` is removed from the release branch 
+  since it is not necessary for non-default branches.

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -14,3 +14,5 @@ This checklist is to be run prior to cutting the release branch.
   - [ ] Update the `BUILDBOX_VERSION` in `build.assets/images.mk`. Commit and merge.
   - [ ] Update `e/.github/workflows/build-buildboxes-cron.yaml` to uncomment final pre-release
     job and ensure it has the correct branch names (two places). Commit and merge.
+- [ ] Update `e/.github/workflows/nightly-releases.yaml` to uncomment pre-release branch to enable
+  nightly builds for the upcoming release.


### PR DESCRIPTION
With the introduction of nightly releases we now have to update some of the configuration referencing release branches during the preflight and postrelease process. To enable nightly releases for the alpha, beta, rc version of the next release docs have been added to the preflight documentation. To clean up and disable the no longer supported release branch docs have been added to the postrelease documentation.