### PR TITLE
add retries for postgres auto user proc creation

### DIFF
--- a/e2e/aws/databases_test.go
+++ b/e2e/aws/databases_test.go
@@ -113,7 +113,7 @@ func awsDBDiscoveryUnmatched(t *testing.T) {
 }
 
 const (
-	waitForConnTimeout = 60 * time.Second
+	waitForConnTimeout = 90 * time.Second
 	connRetryTick      = 10 * time.Second
 )
 


### PR DESCRIPTION
- https://github.com/gravitational/teleport/issues/46245
- https://github.com/gravitational/teleport/issues/46348

Hopefully this helps with the recent redshift cluster flakiness.
I noticed that if i run many tests in parallel the proc creation itself fails.

I also upped the connection timeout which will give the tests more retries. I was unable to reproduce flaky test failures however.