### PR TITLE
Add session recording access usage event

### DIFF
--- a/lib/usagereporter/teleport/audit.go
+++ b/lib/usagereporter/teleport/audit.go
@@ -299,6 +299,12 @@ func ConvertAuditEvent(event apievents.AuditEvent) Anonymizable {
 		}
 	case *apievents.CrownJewelCreate:
 		return &AccessGraphCrownJewelCreateEvent{}
+	case *apievents.SessionRecordingAccess:
+		return &SessionRecordingAccessEvent{
+			SessionType: e.SessionType,
+			UserName:    e.User,
+			Format:      e.Format,
+		}
 	}
 
 	return nil

--- a/lib/usagereporter/teleport/audit_test.go
+++ b/lib/usagereporter/teleport/audit_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	prehogv1a "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	"github.com/gravitational/teleport/lib/utils"
@@ -209,6 +211,30 @@ func TestConvertAuditEvent(t *testing.T) {
 			expectedAnonymized: &prehogv1a.SubmitEventRequest{
 				Event: &prehogv1a.SubmitEventRequest_AccessGraphCrownJewelCreate{
 					AccessGraphCrownJewelCreate: &prehogv1a.AccessGraphCrownJewelCreateEvent{},
+				},
+			},
+		},
+		{
+			desc: "SessionRecordingAccess",
+			event: &apievents.SessionRecordingAccess{
+				UserMetadata: apievents.UserMetadata{
+					User: "some-user",
+				},
+				SessionType: string(types.SSHSessionKind),
+				Format:      teleport.PTY,
+			},
+			expected: &SessionRecordingAccessEvent{
+				SessionType: string(types.SSHSessionKind),
+				UserName:    "some-user",
+				Format:      teleport.PTY,
+			},
+			expectedAnonymized: &prehogv1a.SubmitEventRequest{
+				Event: &prehogv1a.SubmitEventRequest_SessionRecordingAccess{
+					SessionRecordingAccess: &prehogv1a.SessionRecordingAccessEvent{
+						SessionType: string(types.SSHSessionKind),
+						UserName:    anonymizer.AnonymizeString("some-user"),
+						Format:      teleport.PTY,
+					},
 				},
 			},
 		},

--- a/lib/usagereporter/teleport/types.go
+++ b/lib/usagereporter/teleport/types.go
@@ -1272,6 +1272,22 @@ func (u *UserTaskStateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEvent
 	}
 }
 
+// SessionRecordingAccessEvent is an event that is emitted after an user access
+// a session recording.
+type SessionRecordingAccessEvent prehogv1a.SessionRecordingAccessEvent
+
+func (s *SessionRecordingAccessEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
+	return prehogv1a.SubmitEventRequest{
+		Event: &prehogv1a.SubmitEventRequest_SessionRecordingAccess{
+			SessionRecordingAccess: &prehogv1a.SessionRecordingAccessEvent{
+				SessionType: s.SessionType,
+				UserName:    a.AnonymizeString(s.UserName),
+				Format:      s.Format,
+			},
+		},
+	}
+}
+
 // ConvertUsageEvent converts a usage event from an API object into an
 // anonymizable event. All events that can be submitted externally via the Auth
 // API need to be defined here.


### PR DESCRIPTION
Adds new prehog event to report session recording (playback) access.

Corresponding Cloud PR: [#10625](https://github.com/gravitational/cloud/pull/10625)

Note: prehog protobuf was already updated.