### PR TITLE
[v16] Workload Identity: JWT SVID OIDC compatability (#47079)

### DIFF
--- a/lib/auth/machineid/machineidv1/workload_identity_service.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/oidc"
 )
 
 const (
@@ -73,6 +74,7 @@ type WorkloadIdentityServiceConfig struct {
 type WorkloadIdentityCacher interface {
 	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
+	GetProxies() ([]types.Server, error)
 }
 
 // KeyStorer is an interface that provides methods to retrieve keys and
@@ -377,6 +379,7 @@ func (wis *WorkloadIdentityService) signJWTSVID(
 	ctx context.Context,
 	authCtx *authz.Context,
 	clusterName string,
+	issuer string,
 	key *jwt.Key,
 	req *pb.JWTSVIDRequest,
 ) (res *pb.JWTSVIDResponse, err error) {
@@ -457,6 +460,7 @@ func (wis *WorkloadIdentityService) signJWTSVID(
 		SPIFFEID:  spiffeID,
 		TTL:       ttl,
 		JTI:       jti,
+		Issuer:    issuer,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "signing jwt")
@@ -507,10 +511,17 @@ func (wis *WorkloadIdentityService) SignJWTSVIDs(
 		return nil, trace.Wrap(err, "getting JWT key")
 	}
 
+	// Determine the public address of the proxy for inclusion in the JWT as
+	// the issuer for purposes of OIDC compatibility.
+	issuer, err := oidc.IssuerForCluster(ctx, wis.cache, "/workload-identity")
+	if err != nil {
+		return nil, trace.Wrap(err, "determining issuer")
+	}
+
 	res := &pb.SignJWTSVIDsResponse{}
 	for i, svidReq := range req.Svids {
 		svidRes, err := wis.signJWTSVID(
-			ctx, authCtx, clusterName.GetClusterName(), jwtKey, svidReq,
+			ctx, authCtx, clusterName.GetClusterName(), issuer, jwtKey, svidReq,
 		)
 		if err != nil {
 			return nil, trace.Wrap(err, "signing svid %d", i)

--- a/lib/auth/machineid/machineidv1/workload_identity_service_test.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service_test.go
@@ -289,6 +289,16 @@ func TestWorkloadIdentityService_SignJWTSVIDs(t *testing.T) {
 
 	kid := libjwt.KeyID(jwtSigner.Public().(*rsa.PublicKey))
 
+	// Upsert a fake proxy to ensure we have a public address to use for the
+	// issuer.
+	proxy, err := types.NewServer("proxy", types.KindProxy, types.ServerSpecV2{
+		PublicAddrs: []string{"teleport.example.com"},
+	})
+	require.NoError(t, err)
+	err = srv.Auth().UpsertProxy(ctx, proxy)
+	require.NoError(t, err)
+	wantIssuer := "https://teleport.example.com/workload-identity"
+
 	tests := []struct {
 		name           string
 		user           string
@@ -336,6 +346,7 @@ func TestWorkloadIdentityService_SignJWTSVIDs(t *testing.T) {
 				require.Equal(t, wantSPIFFEID, claims.Subject)
 				require.Equal(t, svid.Jti, claims.ID)
 				require.Equal(t, "example.com", claims.Audience[0])
+				require.Equal(t, wantIssuer, claims.Issuer)
 				require.WithinDuration(t, time.Now().Add(30*time.Minute), claims.Expiry.Time(), 5*time.Second)
 				require.WithinDuration(t, time.Now(), claims.IssuedAt.Time(), 5*time.Second)
 			},

--- a/lib/integrations/awsoidc/idp_thumbprint.go
+++ b/lib/integrations/awsoidc/idp_thumbprint.go
@@ -37,7 +37,7 @@ import (
 // Returns the thumbprint of the top intermediate CA that signed the TLS cert used to serve HTTPS requests.
 // In case of a self signed certificate, then it returns the thumbprint of the TLS cert itself.
 func ThumbprintIdP(ctx context.Context, publicAddress string) (string, error) {
-	issuer, err := oidc.IssuerFromPublicAddress(publicAddress)
+	issuer, err := oidc.IssuerFromPublicAddress(publicAddress, "")
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/integrations/awsoidc/token_generator.go
+++ b/lib/integrations/awsoidc/token_generator.go
@@ -119,7 +119,7 @@ func GenerateAWSOIDCToken(ctx context.Context, cacheClt Cache, keyStoreManager K
 	}
 
 	if issuer == "" {
-		issuer, err = oidc.IssuerForCluster(ctx, cacheClt)
+		issuer, err = oidc.IssuerForCluster(ctx, cacheClt, "")
 		if err != nil {
 			return "", trace.Wrap(err)
 		}

--- a/lib/integrations/azureoidc/token_generator.go
+++ b/lib/integrations/azureoidc/token_generator.go
@@ -70,7 +70,7 @@ func GenerateEntraOIDCToken(ctx context.Context, cache Cache, manager KeyStoreMa
 		return "", trace.Wrap(err)
 	}
 
-	issuer, err := oidc.IssuerForCluster(ctx, cache)
+	issuer, err := oidc.IssuerForCluster(ctx, cache, "")
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/jwt/jwt.go
+++ b/lib/jwt/jwt.go
@@ -258,6 +258,9 @@ type SignParamsJWTSVID struct {
 	Audiences []string
 	// TTL is the time to live for the token.
 	TTL time.Duration
+	// Issuer is the value that should be included in the `iss` claim of the
+	// created token.
+	Issuer string
 }
 
 // SignJWTSVID signs a JWT SVID token.
@@ -283,6 +286,11 @@ func (k *Key) SignJWTSVID(p SignParamsJWTSVID) (string, error) {
 		// > noted that JWT-SVID validators are not required to track jti
 		// > uniqueness.
 		ID: p.JTI,
+		// The SPIFFE specification makes no comment on the inclusion of `iss`,
+		// however, we provide this value so that the issued token can be a
+		// valid OIDC ID token and used with non-SPIFFE aware systems that do
+		// understand OIDC.
+		Issuer: p.Issuer,
 	}
 
 	// > 2.2. Key ID:

--- a/lib/utils/oidc/openidconfig.go
+++ b/lib/utils/oidc/openidconfig.go
@@ -19,14 +19,15 @@
 package oidc
 
 // OpenIDConfiguration is the default OpenID Configuration used by Teleport.
+// Based on https://openid.net/specs/openid-connect-discovery-1_0.html
 type OpenIDConfiguration struct {
 	Issuer                           string   `json:"issuer"`
 	JWKSURI                          string   `json:"jwks_uri"`
 	Claims                           []string `json:"claims"`
 	IdTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
 	ResponseTypesSupported           []string `json:"response_types_supported"`
-	ScopesSupported                  []string `json:"scopes_supported"`
-	SubjectTypesSupported            []string `json:"subject_types_supported"`
+	ScopesSupported                  []string `json:"scopes_supported,omitempty"`
+	SubjectTypesSupported            []string `json:"subject_types_supported,omitempty"`
 }
 
 // OpenIDConfigurationForIssuer returns the OpenID Configuration for

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -997,6 +997,8 @@ func (h *Handler) bindDefaultEndpoints() {
 
 	// SPIFFE Federation Trust Bundle
 	h.GET("/webapi/spiffe/bundle.json", h.WithLimiter(h.getSPIFFEBundle))
+	h.GET("/workload-identity/jwt-jwks.json", h.WithLimiter(h.getSPIFFEJWKS))
+	h.GET("/workload-identity/.well-known/openid-configuration", h.WithLimiter(h.getSPIFFEOIDCDiscoveryDocument))
 
 	// DiscoveryConfig CRUD
 	h.GET("/webapi/sites/:site/discoveryconfig", h.WithClusterAuth(h.discoveryconfigList))
@@ -1887,7 +1889,7 @@ func (h *Handler) getUIConfig(ctx context.Context) webclient.UIConfig {
 
 // jwks returns all public keys used to sign JWT tokens for this cluster.
 func (h *Handler) wellKnownJWKS(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
-	return h.jwks(r.Context(), types.JWTSigner)
+	return h.jwks(r.Context(), types.JWTSigner, true)
 }
 
 func (h *Handler) motd(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -1129,7 +1129,7 @@ func (h *Handler) awsOIDCConfigureIdP(w http.ResponseWriter, r *http.Request, p 
 
 	switch {
 	case s3Bucket == "" && s3Prefix == "":
-		proxyAddr, err := oidc.IssuerFromPublicAddress(h.cfg.PublicProxyAddr)
+		proxyAddr, err := oidc.IssuerFromPublicAddress(h.cfg.PublicProxyAddr, "")
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1144,7 +1144,7 @@ func (h *Handler) awsOIDCConfigureIdP(w http.ResponseWriter, r *http.Request, p 
 		}
 		s3URI := url.URL{Scheme: "s3", Host: s3Bucket, Path: s3Prefix}
 
-		jwksContents, err := h.jwks(r.Context(), types.OIDCIdPCA)
+		jwksContents, err := h.jwks(r.Context(), types.OIDCIdPCA, true)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/web/integrations_azureoidc.go
+++ b/lib/web/integrations_azureoidc.go
@@ -37,7 +37,7 @@ func (h *Handler) azureOIDCConfigure(w http.ResponseWriter, r *http.Request, p h
 	ctx := r.Context()
 	queryParams := r.URL.Query()
 
-	oidcIssuer, err := oidc.IssuerFromPublicAddress(h.cfg.PublicProxyAddr)
+	oidcIssuer, err := oidc.IssuerFromPublicAddress(h.cfg.PublicProxyAddr, "")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/spiffe.go
+++ b/lib/web/spiffe.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils/oidc"
 )
 
 // getSPIFFEBundle returns the SPIFFE-compatible trust bundle which allows other
@@ -110,4 +111,41 @@ func (h *Handler) getSPIFFEBundle(w http.ResponseWriter, r *http.Request, _ http
 		h.logger.DebugContext(h.cfg.Context, "Failed to write SPIFFE bundle response", "error", err)
 	}
 	return nil, nil
+}
+
+// Mounted at /workload-identity/.well-known/openid-configuration
+func (h *Handler) getSPIFFEOIDCDiscoveryDocument(_ http.ResponseWriter, _ *http.Request, _ httprouter.Params) (any, error) {
+	issuer, err := oidc.IssuerFromPublicAddress(h.cfg.PublicProxyAddr, "/workload-identity")
+	if err != nil {
+		return nil, trace.Wrap(err, "determining issuer from public address")
+	}
+
+	return &oidc.OpenIDConfiguration{
+		Issuer:  issuer,
+		JWKSURI: issuer + "/jwt-jwks.json",
+		Claims: []string{
+			"iss",
+			"sub",
+			"jti",
+			"aud",
+			"exp",
+			"iat",
+		},
+		IdTokenSigningAlgValuesSupported: []string{
+			"RS256",
+		},
+		ResponseTypesSupported: []string{
+			"id_token",
+		},
+		// Whilst this field is not required for GCP's Workload Identity
+		// Federation, it is required for AWS's AssumeRoleWithWebIdentity.
+		SubjectTypesSupported: []string{
+			"public",
+		},
+	}, nil
+}
+
+// Mounted at /workload-identity/jwt-jwks.json
+func (h *Handler) getSPIFFEJWKS(_ http.ResponseWriter, r *http.Request, _ httprouter.Params) (interface{}, error) {
+	return h.jwks(r.Context(), types.SPIFFECA, false)
 }

--- a/lib/web/spiffe_test.go
+++ b/lib/web/spiffe_test.go
@@ -153,8 +153,8 @@ func TestSPIFFEJWTPublicEndpoints(t *testing.T) {
 		Keys: []jwksKey{
 			{
 				Use:     "sig",
-				KeyType: "EC",
-				Alg:     "ES256",
+				KeyType: "RSA",
+				Alg:     "RS256",
 				KeyID:   gotKeys.Keys[0].KeyID,
 			},
 		},

--- a/lib/web/spiffe_test.go
+++ b/lib/web/spiffe_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"testing"
 
 	"github.com/gravitational/roundtrip"
@@ -85,4 +86,78 @@ func TestGetSPIFFEBundle(t *testing.T) {
 		require.True(t, ok, "wanted public key not found in bundle")
 		require.True(t, gotPubKey.(interface{ Equal(x crypto.PublicKey) bool }).Equal(wantKey), "public keys do not match")
 	}
+}
+
+// TestSPIFFEJWTPublicEndpoints ensures the public endpoints for the SPIFFE JWT
+// OIDC support function correctly.
+func TestSPIFFEJWTPublicEndpoints(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+
+	// Request OpenID Configuration public endpoint.
+	publicClt := proxy.newClient(t)
+	resp, err := publicClt.Get(ctx, proxy.webURL.String()+"/workload-identity/.well-known/openid-configuration", nil)
+	require.NoError(t, err)
+
+	// Deliberately redefining the structs in this test to assert that the JSON
+	// representation doesn't unintentionally change.
+	type oidcConfiguration struct {
+		Issuer                           string   `json:"issuer"`
+		JWKSURI                          string   `json:"jwks_uri"`
+		Claims                           []string `json:"claims"`
+		IdTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+		ResponseTypesSupported           []string `json:"response_types_supported"`
+	}
+
+	var gotConfiguration oidcConfiguration
+	require.NoError(t, json.Unmarshal(resp.Bytes(), &gotConfiguration))
+
+	expectedConfiguration := oidcConfiguration{
+		Issuer:  proxy.webURL.String() + "/workload-identity",
+		JWKSURI: proxy.webURL.String() + "/workload-identity/jwt-jwks.json",
+		// OIDC IdPs MUST support RSA256 here.
+		IdTokenSigningAlgValuesSupported: []string{"RS256"},
+		Claims: []string{
+			"iss",
+			"sub",
+			"jti",
+			"aud",
+			"exp",
+			"iat",
+		},
+		ResponseTypesSupported: []string{"id_token"},
+	}
+	require.Equal(t, expectedConfiguration, gotConfiguration)
+
+	resp, err = publicClt.Get(ctx, gotConfiguration.JWKSURI, nil)
+	require.NoError(t, err)
+
+	type jwksKey struct {
+		Use     string `json:"use"`
+		KeyID   string `json:"kid"`
+		KeyType string `json:"kty"`
+		Alg     string `json:"alg"`
+	}
+	type jwksKeys struct {
+		Keys []jwksKey `json:"keys"`
+	}
+	gotKeys := jwksKeys{}
+	err = json.Unmarshal(resp.Bytes(), &gotKeys)
+	require.NoError(t, err)
+
+	require.Len(t, gotKeys.Keys, 1)
+	require.NotEmpty(t, gotKeys.Keys[0].KeyID)
+	expectedKeys := jwksKeys{
+		Keys: []jwksKey{
+			{
+				Use:     "sig",
+				KeyType: "EC",
+				Alg:     "ES256",
+				KeyID:   gotKeys.Keys[0].KeyID,
+			},
+		},
+	}
+	require.Equal(t, expectedKeys, gotKeys)
 }


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/47079

changelog: Teleport Workload ID issued JWT SVIDs are now compatible with OIDC federation with a number of platforms.