### PR TITLE
Fix `ListResourcesWithFilter` generic method (only used in Access Monitoring Rules).

### DIFF
--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -256,8 +256,6 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 		pageSize = int(s.pageLimit)
 	}
 
-	limit := pageSize + 1
-
 	var resources []T
 	var lastKey backend.Key
 	if err := backend.IterateRange(
@@ -265,7 +263,7 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 		s.backend,
 		rangeStart,
 		rangeEnd,
-		limit,
+		pageSize+1,
 		func(items []backend.Item) (stop bool, err error) {
 			for _, item := range items {
 				resource, err := s.unmarshalFunc(item.Value, services.WithRevision(item.Revision), services.WithRevision(item.Revision))
@@ -275,12 +273,12 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 				if matcher(resource) {
 					lastKey = item.Key
 					resources = append(resources, resource)
-					if len(resources) == pageSize+1 {
+					if len(resources) >= pageSize+1 {
 						return true, nil
 					}
 				}
 			}
-			return limit == len(resources), nil
+			return false, nil
 		}); err != nil {
 		return nil, "", trace.Wrap(err)
 	}

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -275,9 +275,9 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 				if matcher(resource) {
 					lastKey = item.Key
 					resources = append(resources, resource)
-				}
-				if len(resources) == pageSize {
-					break
+					if len(resources) == pageSize+1 {
+						return true, nil
+					}
 				}
 			}
 			return limit == len(resources), nil

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand/v2"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -43,7 +44,7 @@ import (
 // testResource for testing the generic service.
 type testResource struct {
 	types.ResourceHeader
-	SpecPropA string
+	Spec testResourceSpec
 }
 
 func newTestResource(name string) *testResource {
@@ -61,6 +62,10 @@ func newTestResource(name string) *testResource {
 	return tr
 }
 
+type testResourceSpec struct {
+	PropA string
+}
+
 func newTestResourceWithSpec(name string, specPropA string) *testResource {
 	tr := &testResource{
 		ResourceHeader: types.ResourceHeader{
@@ -70,7 +75,9 @@ func newTestResourceWithSpec(name string, specPropA string) *testResource {
 			Kind:    "test_resource",
 			Version: types.V1,
 		},
-		SpecPropA: specPropA,
+		Spec: testResourceSpec{
+			PropA: specPropA,
+		},
 	}
 
 	tr.CheckAndSetDefaults()
@@ -481,12 +488,13 @@ func TestGenericListResourcesWithFilterForScale(t *testing.T) {
 	var totalResources []*testResource
 	for i := 0; i < totalResourcesPerProp; i++ {
 		for j := 0; j < totalProps; j++ {
-			r := newTestResourceWithSpec(uuid.NewString(), fmt.Sprintf("%d", j))
+			r := newTestResourceWithSpec(uuid.NewString(), strconv.Itoa(j))
 			totalResources = append(totalResources, r)
 		}
 	}
 
-	rand.Shuffle(len(totalResources), func(i, j int) {
+	r := rand.New(rand.NewPCG(uint64(82), uint64(123)))
+	r.Shuffle(len(totalResources), func(i, j int) {
 		totalResources[i], totalResources[j] = totalResources[j], totalResources[i]
 	})
 
@@ -497,14 +505,14 @@ func TestGenericListResourcesWithFilterForScale(t *testing.T) {
 
 	pageSizes := []int{1, 2, 3, 5, 7, 100_000}
 	for _, pageSize := range pageSizes {
-		testingProp := fmt.Sprintf("%d", rand.N(totalProps-1))
+		testingProp := strconv.Itoa(r.IntN(totalProps - 1))
 		t.Run(fmt.Sprintf("pageSize=%d,prop=%s", pageSize, testingProp), func(t *testing.T) {
 			var startingKey string
 			var foundResourcesPropAEquals []*testResource
 			for {
 				var totalMatchedElements atomic.Uint64
 				page, nextKey, err := service.ListResourcesWithFilter(ctx, pageSize, startingKey, func(r *testResource) bool {
-					if r.SpecPropA == testingProp {
+					if r.Spec.PropA == testingProp {
 						totalMatchedElements.Add(1)
 						return true
 					}

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -505,7 +505,7 @@ func TestGenericListResourcesWithFilterForScale(t *testing.T) {
 
 	pageSizes := []int{1, 2, 3, 5, 7, 100_000}
 	for _, pageSize := range pageSizes {
-		testingProp := strconv.Itoa(r.IntN(totalProps - 1))
+		testingProp := strconv.Itoa(r.IntN(totalProps))
 		t.Run(fmt.Sprintf("pageSize=%d,prop=%s", pageSize, testingProp), func(t *testing.T) {
 			var startingKey string
 			var foundResourcesPropAEquals []*testResource

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -20,11 +20,15 @@ package generic
 
 import (
 	"context"
+	"fmt"
+	"math/rand/v2"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
@@ -39,6 +43,7 @@ import (
 // testResource for testing the generic service.
 type testResource struct {
 	types.ResourceHeader
+	SpecPropA string
 }
 
 func newTestResource(name string) *testResource {
@@ -50,6 +55,22 @@ func newTestResource(name string) *testResource {
 			Kind:    "test_resource",
 			Version: types.V1,
 		},
+	}
+
+	tr.CheckAndSetDefaults()
+	return tr
+}
+
+func newTestResourceWithSpec(name string, specPropA string) *testResource {
+	tr := &testResource{
+		ResourceHeader: types.ResourceHeader{
+			Metadata: types.Metadata{
+				Name: name,
+			},
+			Kind:    "test_resource",
+			Version: types.V1,
+		},
+		SpecPropA: specPropA,
 	}
 
 	tr.CheckAndSetDefaults()
@@ -434,6 +455,80 @@ func TestGenericListResourcesWithFilter(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
 	require.Equal(t, "", nextKey)
+}
+
+func TestGenericListResourcesWithFilterForScale(t *testing.T) {
+	ctx := context.Background()
+
+	memBackend, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	service, err := NewService(&ServiceConfig[*testResource]{
+		Backend:       memBackend,
+		ResourceKind:  "generic resource",
+		PageLimit:     200,
+		BackendPrefix: backend.NewKey("my-prefix"),
+		UnmarshalFunc: unmarshalResource,
+		MarshalFunc:   marshalResource,
+	})
+	require.NoError(t, err)
+
+	totalResourcesPerProp := 100
+	totalProps := 100
+	var totalResources []*testResource
+	for i := 0; i < totalResourcesPerProp; i++ {
+		for j := 0; j < totalProps; j++ {
+			r := newTestResourceWithSpec(uuid.NewString(), fmt.Sprintf("%d", j))
+			totalResources = append(totalResources, r)
+		}
+	}
+
+	rand.Shuffle(len(totalResources), func(i, j int) {
+		totalResources[i], totalResources[j] = totalResources[j], totalResources[i]
+	})
+
+	for _, r := range totalResources {
+		_, err = service.UpsertResource(ctx, r)
+		require.NoError(t, err)
+	}
+
+	pageSizes := []int{1, 2, 3, 5, 7, 100_000}
+	for _, pageSize := range pageSizes {
+		testingProp := fmt.Sprintf("%d", rand.N(totalProps-1))
+		t.Run(fmt.Sprintf("pageSize=%d,prop=%s", pageSize, testingProp), func(t *testing.T) {
+			var startingKey string
+			var foundResourcesPropAEquals []*testResource
+			for {
+				var totalMatchedElements atomic.Uint64
+				page, nextKey, err := service.ListResourcesWithFilter(ctx, pageSize, startingKey, func(r *testResource) bool {
+					if r.SpecPropA == testingProp {
+						totalMatchedElements.Add(1)
+						return true
+					}
+
+					return false
+				})
+				require.NoError(t, err)
+				// At most, there's an extra comparison to ensure the next key is valid and there are actually more elements.
+				require.LessOrEqual(t, totalMatchedElements.Load(), uint64(pageSize+1))
+				foundResourcesPropAEquals = append(foundResourcesPropAEquals, page...)
+
+				// A page must never contain more items than the page size limit.
+				require.LessOrEqual(t, len(page), pageSize)
+				if nextKey == "" {
+					// A page can contain 0 elements but only when there's no matching elements.
+					// This is never true for our current test setup.
+					require.NotEmpty(t, page)
+					break
+				}
+				startingKey = nextKey
+			}
+			require.Len(t, foundResourcesPropAEquals, totalResourcesPerProp)
+		})
+	}
 }
 
 func TestGenericValidation(t *testing.T) {


### PR DESCRIPTION
I was using the `ListResourcesWithFilter` for another resource and noticed a strange behaviour when doing tests with thousands of entries.

The bug is better described with an example:
Let's say we have two matching items and `pageSize=1`.
A new iterator is started and it returns both items in the callback function.
When iterating over the items, the first one matches and we immediately break the loop (remember `pageSize == 1` and `len(resources) == 1` because the first element was a match).
Because `len(resources) != limit` (and thus, `stop=false`), we ask for another page.
However, the backend already returned the two elements it had, and so the iterator stops.
At this point we have a single resource.
```go
	var nextKey string
	if len(resources) > pageSize {
		nextKey =
```
Given this condition is never true, it never sets a `nextKey`.
And so, even tho we had two matching items, only one of them is returned with an `nextPageToken`.

Added a couple of tests that exercise the method.
It was not returning a correct next key and clients might receive empty pages or empty next key even tho there were more items in the backend.

changelog: Fix possibly missing rules when using large amount of Access Monitoring Rules.