### PR TITLE
WebAPI: list User Tasks and mark as resolved

### DIFF
--- a/api/types/usertasks/object.go
+++ b/api/types/usertasks/object.go
@@ -90,19 +90,6 @@ const (
 // This value is used to populate the UserTasks.Spec.IssueType for Discover EC2 tasks.
 // The Web UI will then use those identifiers to show detailed instructions on how to fix the issue.
 const (
-	// AutoDiscoverEC2IssueEICEFailedToCreateNode is used when the EICE flow fails to create a node.
-	// This can happen when the Node does not have a valid PrivateIPAddress.
-	// This is very unlikely and should only happen if the AWS API returns an unexpected response.
-	AutoDiscoverEC2IssueEICEFailedToCreateNode = "ec2-eice-create-node"
-
-	// AutoDiscoverEC2IssueEICEFailedToUpsertNode is used when the EICE flow fails to upsert a node into the cluster.
-	// This is very unlikely and should only happen
-	// - if the Discovery system role was changed
-	// - if the Node resource validation was changed on the Auth and not on the DiscoveryService
-	// - if Teleport backend is offline or in failing mode
-	// - or because of a network error
-	AutoDiscoverEC2IssueEICEFailedToUpsertNode = "ec2-eice-upsert-node"
-
 	// AutoDiscoverEC2IssueScriptInstanceNotRegistered is used to identify instances that failed to auto-enroll
 	// because they are not present in Amazon Systems Manager.
 	// This usually means that the Instance does not have the SSM Agent running,
@@ -132,8 +119,6 @@ const (
 
 // discoverEC2IssueTypes is a list of issue types that can occur when trying to auto enroll EC2 instances.
 var discoverEC2IssueTypes = []string{
-	AutoDiscoverEC2IssueEICEFailedToCreateNode,
-	AutoDiscoverEC2IssueEICEFailedToUpsertNode,
 	AutoDiscoverEC2IssueScriptInstanceNotRegistered,
 	AutoDiscoverEC2IssueScriptInstanceConnectionLost,
 	AutoDiscoverEC2IssueScriptInstanceUnsupportedOS,

--- a/api/types/usertasks/object_test.go
+++ b/api/types/usertasks/object_test.go
@@ -39,7 +39,7 @@ func TestValidateUserTask(t *testing.T) {
 		userTask, err := usertasks.NewDiscoverEC2UserTask(&usertasksv1.UserTaskSpec{
 			Integration: "my-integration",
 			TaskType:    "discover-ec2",
-			IssueType:   "ec2-eice-create-node",
+			IssueType:   "ec2-ssm-invocation-failure",
 			State:       "OPEN",
 			DiscoverEc2: &usertasksv1.DiscoverEC2{
 				AccountId: "123456789012",
@@ -221,7 +221,7 @@ func TestNewDiscoverEC2UserTask(t *testing.T) {
 	baseEC2DiscoverTaskSpec := &usertasksv1.UserTaskSpec{
 		Integration: "my-integration",
 		TaskType:    "discover-ec2",
-		IssueType:   "ec2-eice-create-node",
+		IssueType:   "ec2-ssm-invocation-failure",
 		State:       "OPEN",
 		DiscoverEc2: &usertasksv1.DiscoverEC2{
 			AccountId: "123456789012",
@@ -250,7 +250,7 @@ func TestNewDiscoverEC2UserTask(t *testing.T) {
 				Kind:    "user_task",
 				Version: "v1",
 				Metadata: &headerv1.Metadata{
-					Name:    "bd1e9ec3-33d3-52f8-a674-c8145e739559",
+					Name:    "154e1429-da26-5ce2-add2-b0e77a27dd96",
 					Expires: userTaskExpirationTimestamp,
 				},
 				Spec: baseEC2DiscoverTaskSpec,

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1004,6 +1004,12 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.PUT("/webapi/sites/:site/discoveryconfig/:name", h.WithClusterAuth(h.discoveryconfigUpdate))
 	h.DELETE("/webapi/sites/:site/discoveryconfig/:name", h.WithClusterAuth(h.discoveryconfigDelete))
 
+	// User Tasks CRUD
+	// Listing Tasks by Integration: GET /webapi/sites/:site/usertask?integration=<integration-name>
+	h.GET("/webapi/sites/:site/usertask", h.WithClusterAuth(h.userTaskListByIntegration))
+	h.GET("/webapi/sites/:site/usertask/:name", h.WithClusterAuth(h.userTaskGet))
+	h.PUT("/webapi/sites/:site/usertask/:name/state", h.WithClusterAuth(h.userTaskStateUpdate))
+
 	// Connection upgrades.
 	h.GET("/webapi/connectionupgrade", httplib.MakeHandler(h.connectionUpgrade))
 

--- a/lib/web/ui/usertask.go
+++ b/lib/web/ui/usertask.go
@@ -1,0 +1,103 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ui
+
+import (
+	"github.com/gravitational/trace"
+
+	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+)
+
+// UserTask describes UserTask fields.
+// Used for listing User Tasks without receiving all the details.
+type UserTask struct {
+	// Name is the UserTask name.
+	Name string `json:"name"`
+	// TaskType identifies this task's type.
+	TaskType string `json:"taskType"`
+	// State is the state for the User Task.
+	State string `json:"state,omitempty"`
+	// IssueType identifies this task's issue type.
+	IssueType string `json:"issueType,omitempty"`
+	// Integration is the Integration Name this User Task refers to.
+	Integration string `json:"integration,omitempty"`
+}
+
+// UserTaskDetail contains all the details for a User Task.
+type UserTaskDetail struct {
+	// UserTask has the basic fields that all taks include.
+	UserTask
+	// DiscoverEC2 contains the task details for the DiscoverEC2 tasks.
+	DiscoverEC2 *usertasksv1.DiscoverEC2 `json:"discoverEc2,omitempty"`
+}
+
+// UpdateUserTaskStateRequest is a request to update a UserTask
+type UpdateUserTaskStateRequest struct {
+	// State is the new state for the User Task.
+	State string `json:"state,omitempty"`
+}
+
+// CheckAndSetDefaults checks if the provided values are valid.
+func (r *UpdateUserTaskStateRequest) CheckAndSetDefaults() error {
+	if r.State == "" {
+		return trace.BadParameter("missing state")
+	}
+
+	return nil
+}
+
+// UserTasksListResponse contains a list of UserTasks.
+// In case of exceeding the pagination limit (either via query param `limit` or the default 1000)
+// a `nextToken` is provided and should be used to obtain the next page (as a query param `startKey`)
+type UserTasksListResponse struct {
+	// Items is a list of resources retrieved.
+	Items []UserTask `json:"items"`
+	// NextKey is the position to resume listing events.
+	NextKey string `json:"nextKey"`
+}
+
+// MakeUserTasks creates a UI list of UserTasks.
+func MakeUserTasks(uts []*usertasksv1.UserTask) []UserTask {
+	uiList := make([]UserTask, 0, len(uts))
+
+	for _, ut := range uts {
+		uiList = append(uiList, MakeUserTask(ut))
+	}
+
+	return uiList
+}
+
+// MakeDetailedUserTask creates a UI UserTask representation containing all the details.
+func MakeDetailedUserTask(ut *usertasksv1.UserTask) UserTaskDetail {
+	return UserTaskDetail{
+		UserTask:    MakeUserTask(ut),
+		DiscoverEC2: ut.GetSpec().GetDiscoverEc2(),
+	}
+}
+
+// MakeUserTask creates a UI UserTask representation.
+func MakeUserTask(ut *usertasksv1.UserTask) UserTask {
+	return UserTask{
+		Name:        ut.GetMetadata().GetName(),
+		TaskType:    ut.GetSpec().GetTaskType(),
+		State:       ut.GetSpec().GetState(),
+		IssueType:   ut.GetSpec().GetIssueType(),
+		Integration: ut.GetSpec().GetIntegration(),
+	}
+}

--- a/lib/web/usertasks.go
+++ b/lib/web/usertasks.go
@@ -53,13 +53,13 @@ func (h *Handler) userTaskStateUpdate(w http.ResponseWriter, r *http.Request, p 
 
 	userTask, err := clt.UserTasksServiceClient().GetUserTask(r.Context(), userTaskName)
 	if err != nil {
-		return nil, trace.Wrap(err, "NOT HERE")
+		return nil, trace.Wrap(err)
 	}
 	userTask.Spec.State = req.State
 
 	newUserTask, err := clt.UserTasksServiceClient().UpsertUserTask(r.Context(), userTask)
 	if err != nil {
-		return nil, trace.Wrap(err, "HERE")
+		return nil, trace.Wrap(err)
 	}
 
 	return ui.MakeUserTask(newUserTask), nil
@@ -113,7 +113,6 @@ func (h *Handler) userTaskListByIntegration(w http.ResponseWriter, r *http.Reque
 		return nil, trace.BadParameter("integration query param is required")
 	}
 
-	//userTasks, nextKey, err := clt.UserTasksServiceClient().ListUserTasks(r.Context(), int64(limit), startKey)
 	userTasks, nextKey, err := clt.UserTasksServiceClient().ListUserTasksByIntegration(r.Context(), int64(limit), startKey, integrationName)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/usertasks.go
+++ b/lib/web/usertasks.go
@@ -1,0 +1,131 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import (
+	"net/http"
+
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/web/ui"
+)
+
+// userTaskStateUpdate updates the state of a User Task.
+func (h *Handler) userTaskStateUpdate(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
+	userTaskName := p.ByName("name")
+	if userTaskName == "" {
+		return nil, trace.BadParameter("a user task name is required")
+	}
+
+	var req *ui.UpdateUserTaskStateRequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	userTask, err := clt.UserTasksServiceClient().GetUserTask(r.Context(), userTaskName)
+	if err != nil {
+		return nil, trace.Wrap(err, "NOT HERE")
+	}
+	userTask.Spec.State = req.State
+
+	newUserTask, err := clt.UserTasksServiceClient().UpsertUserTask(r.Context(), userTask)
+	if err != nil {
+		return nil, trace.Wrap(err, "HERE")
+	}
+
+	return ui.MakeUserTask(newUserTask), nil
+}
+
+// userTaskGet returns a User Task based on its name
+func (h *Handler) userTaskGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
+	userTaskName := p.ByName("name")
+	if userTaskName == "" {
+		return nil, trace.BadParameter("a user task name is required")
+	}
+
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ut, err := clt.UserTasksServiceClient().GetUserTask(r.Context(), userTaskName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.MakeDetailedUserTask(ut), nil
+}
+
+// userTaskListByIntegration returns a page of User Tasks.
+// It requires a query param to filter by integration
+//
+// The following query params are optional:
+// - limit: max number of items
+// - startKey: used to iterate over pages
+//
+// It returns a list of user tasks with the base attributes (common among all user tasks).
+// To get a detailed UserTask use the single resource endpoint, ie, usertask/<resource's name>.
+func (h *Handler) userTaskListByIntegration(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	values := r.URL.Query()
+	limit, err := QueryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	startKey := values.Get("startKey")
+
+	integrationName := values.Get("integration")
+	if integrationName == "" {
+		return nil, trace.BadParameter("integration query param is required")
+	}
+
+	//userTasks, nextKey, err := clt.UserTasksServiceClient().ListUserTasks(r.Context(), int64(limit), startKey)
+	userTasks, nextKey, err := clt.UserTasksServiceClient().ListUserTasksByIntegration(r.Context(), int64(limit), startKey, integrationName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	items := make([]ui.UserTask, 0, len(userTasks))
+	for _, userTask := range userTasks {
+		items = append(items, ui.MakeUserTask(userTask))
+	}
+
+	return ui.UserTasksListResponse{
+		Items:   items,
+		NextKey: nextKey,
+	}, nil
+}

--- a/lib/web/usertasks_test.go
+++ b/lib/web/usertasks_test.go
@@ -63,8 +63,6 @@ func TestUserTask(t *testing.T) {
 	}
 
 	issueTypes := []string{
-		usertasks.AutoDiscoverEC2IssueEICEFailedToCreateNode,
-		usertasks.AutoDiscoverEC2IssueEICEFailedToUpsertNode,
 		usertasks.AutoDiscoverEC2IssueInvocationFailure,
 		usertasks.AutoDiscoverEC2IssueScriptFailure,
 		usertasks.AutoDiscoverEC2IssueScriptInstanceConnectionLost,

--- a/lib/web/usertasks_test.go
+++ b/lib/web/usertasks_test.go
@@ -1,0 +1,159 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/usertasks"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/web/ui"
+)
+
+func TestUserTask(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	env := newWebPack(t, 1)
+	clusterName := env.server.ClusterName()
+
+	userWithRW := uuid.NewString()
+	roleRWUserTask, err := types.NewRole(
+		services.RoleNameForUser(userWithRW), types.RoleSpecV6{
+			Allow: types.RoleConditions{Rules: []types.Rule{{
+				Resources: []string{types.KindUserTask},
+				Verbs:     services.RW(),
+			}}},
+		})
+	require.NoError(t, err)
+	pack := env.proxies[0].authPack(t, userWithRW, []types.Role{roleRWUserTask})
+
+	getAllEndpoint := pack.clt.Endpoint("webapi", "sites", clusterName, "usertask")
+	singleItemEndpoint := func(name string) string {
+		return pack.clt.Endpoint("webapi", "sites", clusterName, "usertask", name)
+	}
+	updateStateEndpoint := func(name string) string {
+		return pack.clt.Endpoint("webapi", "sites", clusterName, "usertask", name, "state")
+	}
+
+	issueTypes := []string{
+		usertasks.AutoDiscoverEC2IssueEICEFailedToCreateNode,
+		usertasks.AutoDiscoverEC2IssueEICEFailedToUpsertNode,
+		usertasks.AutoDiscoverEC2IssueInvocationFailure,
+		usertasks.AutoDiscoverEC2IssueScriptFailure,
+		usertasks.AutoDiscoverEC2IssueScriptInstanceConnectionLost,
+		usertasks.AutoDiscoverEC2IssueScriptInstanceNotRegistered,
+		usertasks.AutoDiscoverEC2IssueScriptInstanceUnsupportedOS,
+	}
+	var userTaskForTest *usertasksv1.UserTask
+	for _, issueType := range issueTypes {
+		userTask, err := usertasks.NewDiscoverEC2UserTask(&usertasksv1.UserTaskSpec{
+			Integration: "my-integration",
+			TaskType:    usertasks.TaskTypeDiscoverEC2,
+			IssueType:   issueType,
+			State:       usertasks.TaskStateOpen,
+			DiscoverEc2: &usertasksv1.DiscoverEC2{
+				AccountId: "123456789012",
+				Region:    "us-east-1",
+				Instances: map[string]*usertasksv1.DiscoverEC2Instance{
+					"i-123": {
+						InstanceId:      "i-123",
+						DiscoveryConfig: "dc01",
+						DiscoveryGroup:  "dg01",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = env.proxies[0].auth.Auth().CreateUserTask(ctx, userTask)
+		require.NoError(t, err)
+		userTaskForTest = userTask
+	}
+
+	t.Run("Get One must return not found when it doesn't exist", func(t *testing.T) {
+		resp, err := pack.clt.Get(ctx, singleItemEndpoint("invalid"), nil)
+		require.ErrorContains(t, err, "doesn't exist")
+		require.Equal(t, http.StatusNotFound, resp.Code())
+	})
+
+	t.Run("List by integration", func(t *testing.T) {
+		startKey := ""
+		var listedTasks []ui.UserTask
+		for {
+			// Add a small limit page to test iteration.
+			resp, err := pack.clt.Get(ctx, getAllEndpoint, url.Values{
+				"startKey":    []string{startKey},
+				"integration": []string{"my-integration"},
+			})
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.Code())
+
+			var listResponse ui.UserTasksListResponse
+			err = json.Unmarshal(resp.Bytes(), &listResponse)
+			require.NoError(t, err)
+			require.NotEmpty(t, listResponse.Items)
+			listedTasks = append(listedTasks, listResponse.Items...)
+
+			if listResponse.NextKey == "" {
+				break
+			}
+
+			startKey = listResponse.NextKey
+		}
+		require.Len(t, listedTasks, len(issueTypes))
+	})
+
+	t.Run("task state moves from OPEN to RESOLVED", func(t *testing.T) {
+		userTaskName := userTaskForTest.GetMetadata().GetName()
+
+		// Task starts in OPEN state.
+		resp, err := pack.clt.Get(ctx, singleItemEndpoint(userTaskName), nil)
+		require.NoError(t, err)
+		var userTaskDetailResp ui.UserTaskDetail
+		err = json.Unmarshal(resp.Bytes(), &userTaskDetailResp)
+		require.NoError(t, err)
+		require.Equal(t, "OPEN", userTaskDetailResp.State)
+		require.NotEmpty(t, userTaskDetailResp.DiscoverEC2)
+
+		// Mark it as resolved.
+		_, err = pack.clt.PutJSON(ctx, updateStateEndpoint(userTaskName), ui.UpdateUserTaskStateRequest{
+			State: "RESOLVED",
+		})
+		require.NoError(t, err)
+
+		// Fetch the task again.
+		resp, err = pack.clt.Get(ctx, singleItemEndpoint(userTaskName), nil)
+		require.NoError(t, err)
+		err = json.Unmarshal(resp.Bytes(), &userTaskDetailResp)
+		require.NoError(t, err)
+		require.NotEmpty(t, userTaskDetailResp.DiscoverEC2)
+		require.Equal(t, "RESOLVED", userTaskDetailResp.State)
+	})
+}


### PR DESCRIPTION
This PR adds new endpoints for the WebAPI related to UserTasks:
- list by integration
- get user task detail
- mark user task as resolved