### PR TITLE
[v16] update bastion machine type to variable in AWS HA terraform

### DIFF
--- a/examples/aws/terraform/ha-autoscale-cluster/Makefile
+++ b/examples/aws/terraform/ha-autoscale-cluster/Makefile
@@ -22,21 +22,21 @@ TF_VAR_license_path ?=
 TF_VAR_ami_name ?=
 
 
-# Instance types used for authentication servers auto scale group
-# This should match to the AMI instance architecture type, Arm or x86
+# Instance types used for authentication server auto scaling group
+# This should match to the AMI instance architecture type, ARM or x86
 TF_VAR_auth_instance_type ?= m7g.large
 
-# Instance types used for proxy auto scale groups
-# This should match to the AMI instance architecture type, Arm or x86
+# Instance types used for proxy server auto scaling group
+# This should match to the AMI instance architecture type, ARM or x86
 TF_VAR_proxy_instance_type =? m7g.large
 
-# Instance types used for teleport nodes auto scale groups
-# This should match to the AMI instance architecture type, Arm or x86 
+# Instance types used for Teleport node auto scaling group
+# This should match to the AMI instance architecture type, ARM or x86
 TF_VAR_node_instance_type ?= t4g.medium
 
 # Instance type used for bastion server
-# This should match to the AMI instance architecture type, Arm or x86 
-TF_VAR_bastion_instance_type ?=  t4g.medium
+# This should match to the AMI instance architecture type, ARM or x86
+TF_VAR_bastion_instance_type ?= t4g.medium
 
 # Route 53 zone to use, should be the zone registered in AWS, e.g. example.com
 TF_VAR_route53_zone ?=

--- a/examples/aws/terraform/ha-autoscale-cluster/Makefile
+++ b/examples/aws/terraform/ha-autoscale-cluster/Makefile
@@ -28,7 +28,7 @@ TF_VAR_auth_instance_type ?= m7g.large
 
 # Instance types used for proxy server auto scaling group
 # This should match to the AMI instance architecture type, ARM or x86
-TF_VAR_proxy_instance_type =? m7g.large
+TF_VAR_proxy_instance_type ?= m7g.large
 
 # Instance types used for Teleport node auto scaling group
 # This should match to the AMI instance architecture type, ARM or x86

--- a/examples/aws/terraform/ha-autoscale-cluster/Makefile
+++ b/examples/aws/terraform/ha-autoscale-cluster/Makefile
@@ -21,6 +21,23 @@ TF_VAR_license_path ?=
 # FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
 TF_VAR_ami_name ?=
 
+
+# Instance types used for authentication servers auto scale group
+# This should match to the AMI instance architecture type, Arm or x86
+TF_VAR_auth_instance_type ?= m7g.large
+
+# Instance types used for proxy auto scale groups
+# This should match to the AMI instance architecture type, Arm or x86
+TF_VAR_proxy_instance_type =? m7g.large
+
+# Instance types used for teleport nodes auto scale groups
+# This should match to the AMI instance architecture type, Arm or x86 
+TF_VAR_node_instance_type ?= t4g.medium
+
+# Instance type used for bastion server
+# This should match to the AMI instance architecture type, Arm or x86 
+TF_VAR_bastion_instance_type ?=  t4g.medium
+
 # Route 53 zone to use, should be the zone registered in AWS, e.g. example.com
 TF_VAR_route53_zone ?=
 

--- a/examples/aws/terraform/ha-autoscale-cluster/README.md
+++ b/examples/aws/terraform/ha-autoscale-cluster/README.md
@@ -48,21 +48,21 @@ export TF_VAR_cluster_name="teleport.example.com"
 # FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
 export TF_VAR_ami_name="teleport-ent-15.3.7-arm64"
 
-# Instance types used for authentication servers auto scale group
-# This should match to the AMI instance architecture type, Arm or x86
+# Instance types used for authentication server auto scaling group
+# This should match to the AMI instance architecture type, ARM or x86
 TF_VAR_auth_instance_type ?= m7g.large
 
-# Instance types used for proxy auto scale groups
-# This should match to the AMI instance architecture type, Arm or x86
+# Instance types used for proxy auto scaling group
+# This should match to the AMI instance architecture type, ARM or x86
 TF_VAR_proxy_instance_type =? m7g.large
 
-# Instance types used for teleport nodes auto scale groups
-# This should match to the AMI instance architecture type, Arm or x86
+# Instance types used for Teleport node auto scaling group
+# This should match to the AMI instance architecture type, ARM or x86
 TF_VAR_node_instance_type ?= t4g.medium
 
 # Instance type used for bastion server
-# This should match to the AMI instance architecture type, Arm or x86
-TF_VAR_bastion_instance_type ?=  t4g.medium
+# This should match to the AMI instance architecture type, ARM or x86
+TF_VAR_bastion_instance_type ?= t4g.medium
 
 # AWS SSH key name to provision in installed instances, should be available in the region
 export TF_VAR_key_name="example"

--- a/examples/aws/terraform/ha-autoscale-cluster/README.md
+++ b/examples/aws/terraform/ha-autoscale-cluster/README.md
@@ -48,6 +48,22 @@ export TF_VAR_cluster_name="teleport.example.com"
 # FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
 export TF_VAR_ami_name="teleport-ent-15.3.7-arm64"
 
+# Instance types used for authentication servers auto scale group
+# This should match to the AMI instance architecture type, Arm or x86
+TF_VAR_auth_instance_type ?= m7g.large
+
+# Instance types used for proxy auto scale groups
+# This should match to the AMI instance architecture type, Arm or x86
+TF_VAR_proxy_instance_type =? m7g.large
+
+# Instance types used for teleport nodes auto scale groups
+# This should match to the AMI instance architecture type, Arm or x86
+TF_VAR_node_instance_type ?= t4g.medium
+
+# Instance type used for bastion server
+# This should match to the AMI instance architecture type, Arm or x86
+TF_VAR_bastion_instance_type ?=  t4g.medium
+
 # AWS SSH key name to provision in installed instances, should be available in the region
 export TF_VAR_key_name="example"
 

--- a/examples/aws/terraform/ha-autoscale-cluster/README.md
+++ b/examples/aws/terraform/ha-autoscale-cluster/README.md
@@ -54,7 +54,7 @@ TF_VAR_auth_instance_type ?= m7g.large
 
 # Instance types used for proxy auto scaling group
 # This should match to the AMI instance architecture type, ARM or x86
-TF_VAR_proxy_instance_type =? m7g.large
+TF_VAR_proxy_instance_type ?= m7g.large
 
 # Instance types used for Teleport node auto scaling group
 # This should match to the AMI instance architecture type, ARM or x86

--- a/examples/aws/terraform/ha-autoscale-cluster/bastion.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/bastion.tf
@@ -5,7 +5,7 @@
 resource "aws_instance" "bastion" {
   count                       = "1"
   ami                         = data.aws_ami.base.id
-  instance_type               = "t4g.medium"
+  instance_type               = var.bastion_instance_type
   key_name                    = var.key_name
   associate_public_ip_address = true
   source_dest_check           = false

--- a/examples/aws/terraform/ha-autoscale-cluster/vars.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/vars.tf
@@ -38,6 +38,12 @@ variable "node_instance_type" {
   default = "t4g.medium"
 }
 
+// Instance type used for bastion server
+variable "bastion_instance_type" {
+  type    = string
+  default = "t4g.medium"
+}
+
 // SSH key name to provision instances withx
 variable "key_name" {
   type = string


### PR DESCRIPTION
Backport #47297 to branch/v16

changelog: Allow specifying the instance type of AWS HA Terraform bastion instance
