### PR TITLE
Fixing default shell assignment

### DIFF
--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -19,6 +19,7 @@
 package services
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"net"
@@ -1059,11 +1060,8 @@ func (a *accessChecker) HostUsers(s types.Server) (*HostUsersInfo, error) {
 		}
 
 		hostUserShell := role.GetOptions().CreateHostUserDefaultShell
+		shell = cmp.Or(shell, hostUserShell)
 		if hostUserShell != "" {
-			if shell != "" {
-				shell = hostUserShell
-			}
-
 			shellToRoles[hostUserShell] = append(shellToRoles[hostUserShell], role.GetName())
 		}
 


### PR DESCRIPTION
Fixes #47283

This fixes a bug preventing role-defined default shell assignment from propagating to host users.

Changelog: Fixed an issue preventing default shell assignment for host users