### PR TITLE
Teleterm: add support for access requesting kube namespaces

### DIFF
--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/KubeNamespaceSelector.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/KubeNamespaceSelector.tsx
@@ -129,12 +129,16 @@ export function KubeNamespaceSelector({
   };
 
   async function handleLoadOptions(input: string) {
-    const options = await fetchKubeNamespaces({
+    const namespaces = await fetchKubeNamespaces({
       kubeCluster: kubeClusterItem.id,
       search: input,
     });
 
-    return options;
+    return namespaces.map(namespace => ({
+      kind: 'namespace',
+      value: namespace,
+      label: namespace,
+    }));
   }
 
   return (

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/index.ts
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/index.ts
@@ -17,7 +17,11 @@
  */
 
 export { RequestCheckoutWithSlider, RequestCheckout } from './RequestCheckout';
-export type { RequestCheckoutProps, PendingListItem } from './RequestCheckout';
+export type {
+  RequestCheckoutProps,
+  PendingListItem,
+  PendingKubeResourceItem,
+} from './RequestCheckout';
 
 export * from './utils';
 export type { ReviewerOption } from './types';

--- a/web/packages/shared/components/AccessRequests/NewRequest/index.ts
+++ b/web/packages/shared/components/AccessRequests/NewRequest/index.ts
@@ -20,3 +20,5 @@ export * from './RequestCheckout';
 export * from './ResourceList';
 export type { ResourceMap, RequestableResourceKind } from './resource';
 export { getEmptyResourceState } from './resource';
+export type { KubeNamespaceRequest } from './kube';
+export { isKubeClusterWithNamespaces } from './kube';

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
@@ -32,6 +32,7 @@ import * as Icon from 'design/Icon';
 import { pluralize } from 'shared/utils/text';
 
 import { RequestCheckoutWithSlider } from 'shared/components/AccessRequests/NewRequest';
+import { isKubeClusterWithNamespaces } from 'shared/components/AccessRequests/NewRequest/kube';
 
 import useAccessRequestCheckout from './useAccessRequestCheckout';
 import { AssumedRolesBar } from './AssumedRolesBar';
@@ -102,6 +103,8 @@ export function AccessRequestCheckout() {
     pendingRequestTtlOptions,
     startTime,
     onStartTimeChange,
+    fetchKubeNamespaces,
+    bulkToggleKubeResources,
   } = useAccessRequestCheckout();
 
   const isRoleRequest = pendingAccessRequests[0]?.kind === 'role';
@@ -111,116 +114,126 @@ export function AccessRequestCheckout() {
     setShowCheckout(false);
   }
 
+  const pendingAccessRequestsWithoutParentResource =
+    pendingAccessRequests.filter(
+      d => !isKubeClusterWithNamespaces(d, pendingAccessRequests)
+    );
+
+  const numAddedResources = pendingAccessRequestsWithoutParentResource.length;
+
   // We should rather detect how much space we have,
   // but for simplicity we only count items.
   const moreToShow = Math.max(
-    pendingAccessRequests.length - MAX_RESOURCES_IN_BAR_TO_SHOW,
+    pendingAccessRequestsWithoutParentResource.length -
+      MAX_RESOURCES_IN_BAR_TO_SHOW,
     0
   );
-  const numPendingAccessRequests = pendingAccessRequests.length;
-
   return (
     <>
-      {pendingAccessRequests.length > 0 && !isCollapsed() && (
-        <Box
-          px={3}
-          py={2}
-          css={`
-            border-top: 1px solid
-              ${props => props.theme.colors.spotBackground[1]};
-          `}
-        >
-          <Flex
-            justifyContent="space-between"
-            alignItems="center"
+      {pendingAccessRequestsWithoutParentResource.length > 0 &&
+        !isCollapsed() && (
+          <Box
+            px={3}
+            py={2}
             css={`
-              gap: ${props => props.theme.space[1]}px;
+              border-top: 1px solid
+                ${props => props.theme.colors.spotBackground[1]};
             `}
           >
-            <Flex flexDirection="column" minWidth={0}>
-              <Text mb={1}>
-                {numPendingAccessRequests}{' '}
-                {pluralize(
-                  numPendingAccessRequests,
-                  isRoleRequest ? 'role' : 'resource'
-                )}{' '}
-                added to access request:
-              </Text>
-              <Flex gap={1} flexWrap="wrap">
-                {pendingAccessRequests
-                  .slice(0, MAX_RESOURCES_IN_BAR_TO_SHOW)
-                  .map(c => {
-                    let resource = {
-                      name: c.name,
-                      key: `${c.clusterName}-${c.kind}-${c.id}`,
-                      Icon: undefined,
-                    };
-                    switch (c.kind) {
-                      case 'app':
-                      case 'saml_idp_service_provider':
-                        resource.Icon = Icon.Application;
-                        break;
-                      case 'node':
-                        resource.Icon = Icon.Server;
-                        break;
-                      case 'db':
-                        resource.Icon = Icon.Database;
-                        break;
-                      case 'kube_cluster':
-                        resource.Icon = Icon.Kubernetes;
-                        break;
-                      case 'role':
-                        break;
-                      default:
-                        c satisfies never;
-                    }
-                    return resource;
-                  })
-                  .map(c => (
-                    <Label
-                      kind="secondary"
-                      key={c.key}
-                      css={`
-                        display: flex;
-                        align-items: center;
-                        min-width: 0;
-                        gap: ${props => props.theme.space[1]}px;
-                      `}
-                    >
-                      {c.Icon && <c.Icon size={15} />}
-                      <span
+            <Flex
+              justifyContent="space-between"
+              alignItems="center"
+              css={`
+                gap: ${props => props.theme.space[1]}px;
+              `}
+            >
+              <Flex flexDirection="column" minWidth={0}>
+                <Text mb={1}>
+                  {numAddedResources}{' '}
+                  {pluralize(
+                    numAddedResources,
+                    isRoleRequest ? 'role' : 'resource'
+                  )}{' '}
+                  added to access request:
+                </Text>
+                <Flex gap={1} flexWrap="wrap">
+                  {pendingAccessRequestsWithoutParentResource
+                    .slice(0, MAX_RESOURCES_IN_BAR_TO_SHOW)
+                    .map(c => {
+                      let resource = {
+                        name: c.subResourceName
+                          ? `${c.id}/${c.subResourceName}`
+                          : c.name,
+                        key: `${c.clusterName}-${c.kind}-${c.id}-${c.subResourceName}`,
+                        Icon: undefined,
+                      };
+                      switch (c.kind) {
+                        case 'app':
+                        case 'saml_idp_service_provider':
+                          resource.Icon = Icon.Application;
+                          break;
+                        case 'node':
+                          resource.Icon = Icon.Server;
+                          break;
+                        case 'db':
+                          resource.Icon = Icon.Database;
+                          break;
+                        case 'kube_cluster':
+                        case 'namespace':
+                          resource.Icon = Icon.Kubernetes;
+                          break;
+                        case 'role':
+                          break;
+                        default:
+                          c satisfies never;
+                      }
+                      return resource;
+                    })
+                    .map(c => (
+                      <Label
+                        kind="secondary"
+                        key={c.key}
                         css={`
-                          text-overflow: ellipsis;
-                          white-space: nowrap;
-                          overflow: hidden;
+                          display: flex;
+                          align-items: center;
+                          min-width: 0;
+                          gap: ${props => props.theme.space[1]}px;
                         `}
                       >
-                        {c.name}
-                      </span>
-                    </Label>
-                  ))}
-                {!!moreToShow && (
-                  <Label kind="secondary">+ {moreToShow} more</Label>
-                )}
+                        {c.Icon && <c.Icon size={15} />}
+                        <span
+                          css={`
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                            overflow: hidden;
+                          `}
+                        >
+                          {c.name}
+                        </span>
+                      </Label>
+                    ))}
+                  {!!moreToShow && (
+                    <Label kind="secondary">+ {moreToShow} more</Label>
+                  )}
+                </Flex>
+              </Flex>
+              <Flex gap={3}>
+                <ButtonPrimary
+                  onClick={() => setShowCheckout(!showCheckout)}
+                  textTransform="none"
+                  css={`
+                    white-space: nowrap;
+                  `}
+                >
+                  Proceed to request
+                </ButtonPrimary>
+                <ButtonIcon onClick={collapseBar}>
+                  <Icon.ChevronDown size="medium" />
+                </ButtonIcon>
               </Flex>
             </Flex>
-            <Flex gap={3}>
-              <ButtonPrimary
-                onClick={() => setShowCheckout(!showCheckout)}
-                textTransform="none"
-                css={`
-                  white-space: nowrap;
-                `}
-              >
-                Proceed to request
-              </ButtonPrimary>
-              <ButtonIcon onClick={collapseBar}>
-                <Icon.ChevronDown size="medium" />
-              </ButtonIcon>
-            </Flex>
-          </Flex>
-        </Box>
-      )}
+          </Box>
+        )}
       {assumedRequests.map(request => (
         <AssumedRolesBar key={request.id} assumedRolesRequest={request} />
       ))}
@@ -270,11 +283,8 @@ export function AccessRequestCheckout() {
             setPendingRequestTtl={setPendingRequestTtl}
             startTime={startTime}
             onStartTimeChange={onStartTimeChange}
-            // TODO: these are placeholders to satisy linters.
-            // There is a split PR that handles teleterm support
-            // that will be merged right after this one (once both are approved)
-            bulkToggleKubeResources={() => null}
-            fetchKubeNamespaces={() => null}
+            fetchKubeNamespaces={fetchKubeNamespaces}
+            bulkToggleKubeResources={bulkToggleKubeResources}
           />
         )}
       </Transition>

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.test.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.test.tsx
@@ -21,10 +21,13 @@ import { renderHook, waitFor } from '@testing-library/react';
 import {
   makeRootCluster,
   makeServer,
+  makeKube,
   rootClusterUri,
 } from 'teleterm/services/tshd/testHelpers';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+
+import { mapRequestToKubeNamespaceUri } from '../services/workspacesService/accessRequestsService';
 
 import useAccessRequestCheckout from './useAccessRequestCheckout';
 
@@ -58,6 +61,123 @@ test('fetching requestable roles for servers uses UUID, not hostname', async () 
           clusterName: 'teleport-local',
           kind: 'node',
           name: '1234abcd-1234-abcd-1234-abcd1234abcd',
+          subResourceName: '',
+        },
+      ],
+    })
+  );
+});
+
+test('fetching requestable roles for a kube_cluster resource without specifying a namespace', async () => {
+  const kube = makeKube();
+  const cluster = makeRootCluster();
+  const appContext = new MockAppContext();
+  appContext.clustersService.setState(draftState => {
+    draftState.clusters.set(rootClusterUri, cluster);
+  });
+  await appContext.workspacesService.setActiveWorkspace(rootClusterUri);
+  await appContext.workspacesService
+    .getWorkspaceAccessRequestsService(rootClusterUri)
+    .addOrRemoveResource({
+      kind: 'kube',
+      resource: kube,
+    });
+
+  jest.spyOn(appContext.tshd, 'getRequestableRoles');
+
+  const wrapper = ({ children }) => (
+    <MockAppContextProvider appContext={appContext}>
+      {children}
+    </MockAppContextProvider>
+  );
+
+  renderHook(useAccessRequestCheckout, { wrapper });
+
+  await waitFor(() =>
+    expect(appContext.tshd.getRequestableRoles).toHaveBeenCalledWith({
+      clusterUri: rootClusterUri,
+      resourceIds: [
+        {
+          clusterName: 'teleport-local',
+          kind: 'kube_cluster',
+          name: kube.name,
+          subResourceName: '',
+        },
+      ],
+    })
+  );
+});
+
+test(`fetching requestable roles for a kube cluster's namespaces only creates resource IDs for its namespaces`, async () => {
+  const kube1 = makeKube();
+  const kube2 = makeKube({
+    name: 'kube2',
+    uri: `${rootClusterUri}/kubes/kube2`,
+  });
+  const cluster = makeRootCluster();
+  const appContext = new MockAppContext();
+  appContext.clustersService.setState(draftState => {
+    draftState.clusters.set(rootClusterUri, cluster);
+  });
+  await appContext.workspacesService.setActiveWorkspace(rootClusterUri);
+  await appContext.workspacesService
+    .getWorkspaceAccessRequestsService(rootClusterUri)
+    .addOrRemoveResource({
+      kind: 'kube',
+      resource: kube1,
+    });
+  await appContext.workspacesService
+    .getWorkspaceAccessRequestsService(rootClusterUri)
+    .addOrRemoveResource({
+      kind: 'kube',
+      resource: kube2,
+    });
+
+  await appContext.workspacesService
+    .getWorkspaceAccessRequestsService(rootClusterUri)
+    .addOrRemoveKubeNamespaces([
+      mapRequestToKubeNamespaceUri({
+        clusterUri: rootClusterUri,
+        id: kube1.name,
+        name: 'namespace1',
+      }),
+      mapRequestToKubeNamespaceUri({
+        clusterUri: rootClusterUri,
+        id: kube1.name,
+        name: 'namespace2',
+      }),
+    ]);
+
+  jest.spyOn(appContext.tshd, 'getRequestableRoles');
+
+  const wrapper = ({ children }) => (
+    <MockAppContextProvider appContext={appContext}>
+      {children}
+    </MockAppContextProvider>
+  );
+
+  renderHook(useAccessRequestCheckout, { wrapper });
+
+  await waitFor(() =>
+    expect(appContext.tshd.getRequestableRoles).toHaveBeenCalledWith({
+      clusterUri: rootClusterUri,
+      resourceIds: [
+        {
+          clusterName: 'teleport-local',
+          kind: 'namespace',
+          name: kube1.name,
+          subResourceName: 'namespace1',
+        },
+        {
+          clusterName: 'teleport-local',
+          kind: 'namespace',
+          name: kube1.name,
+          subResourceName: 'namespace2',
+        },
+        {
+          clusterName: 'teleport-local',
+          kind: 'kube_cluster',
+          name: kube2.name,
           subResourceName: '',
         },
       ],

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
@@ -24,6 +24,9 @@ import useAttempt from 'shared/hooks/useAttemptNext';
 import {
   getDryRunMaxDuration,
   PendingListItem,
+  PendingKubeResourceItem,
+  isKubeClusterWithNamespaces,
+  KubeNamespaceRequest,
 } from 'shared/components/AccessRequests/NewRequest';
 import { useSpecifiableFields } from 'shared/components/AccessRequests/NewRequest/useSpecifiableFields';
 
@@ -34,6 +37,8 @@ import {
   PendingAccessRequest,
   extractResourceRequestProperties,
   ResourceRequest,
+  mapRequestToKubeNamespaceUri,
+  mapKubeNamespaceUriToRequest,
 } from 'teleterm/ui/services/workspacesService/accessRequestsService';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 import {
@@ -87,8 +92,17 @@ export default function useAccessRequestCheckout() {
   const workspaceAccessRequest =
     ctx.workspacesService.getActiveWorkspaceAccessRequestsService();
   const docService = ctx.workspacesService.getActiveWorkspaceDocumentService();
-  const pendingAccessRequest =
+  const pendingAccessRequestRequest =
     workspaceAccessRequest?.getPendingAccessRequest();
+
+  const pendingAccessRequests = getPendingAccessRequestsPerResource(
+    pendingAccessRequestRequest
+  );
+
+  const pendingAccessRequestsWithoutParentResource =
+    pendingAccessRequests.filter(
+      p => !isKubeClusterWithNamespaces(p, pendingAccessRequests)
+    );
 
   useEffect(() => {
     // Do a new dry run per changes to pending access requests
@@ -99,20 +113,18 @@ export default function useAccessRequestCheckout() {
     if (showCheckout && requestedCount == 0) {
       performDryRun();
     }
-  }, [showCheckout, pendingAccessRequest]);
+  }, [showCheckout, pendingAccessRequestRequest]);
 
   useEffect(() => {
-    if (!pendingAccessRequest || requestedCount > 0) {
+    if (!pendingAccessRequestRequest || requestedCount > 0) {
       return;
     }
 
-    const pendingAccessRequests =
-      getPendingAccessRequestsPerResource(pendingAccessRequest);
     runFetchResourceRoles(() =>
       retryWithRelogin(ctx, clusterUri, async () => {
         const { response } = await ctx.tshd.getRequestableRoles({
           clusterUri: rootClusterUri,
-          resourceIds: pendingAccessRequests
+          resourceIds: pendingAccessRequestsWithoutParentResource
             .filter(d => d.kind !== 'role')
             .map(d => ({
               // We have to use id, not name.
@@ -121,14 +133,14 @@ export default function useAccessRequestCheckout() {
               name: d.id,
               kind: d.kind,
               clusterName: d.clusterName,
-              subResourceName: '',
+              subResourceName: d.subResourceName || '',
             })),
         });
         setResourceRequestRoles(response.applicableRoles);
         setSelectedResourceRequestRoles(response.applicableRoles);
       })
     );
-  }, [pendingAccessRequest]);
+  }, [pendingAccessRequestRequest]);
 
   useEffect(() => {
     clearCreateAttempt();
@@ -146,6 +158,9 @@ export default function useAccessRequestCheckout() {
     }
   }, [showCheckout, hasExited, createRequestAttempt.status]);
 
+  /**
+   * @param pendingRequest holds a list or map of resources to process
+   */
   function getPendingAccessRequestsPerResource(
     pendingRequest: PendingAccessRequest
   ): PendingListItemWithOriginalItem[] {
@@ -170,9 +185,34 @@ export default function useAccessRequestCheckout() {
       }
       case 'resource': {
         pendingRequest.resources.forEach(resourceRequest => {
+          // If this request is a kube cluster and has namespaces
+          // extract each as own request.
+          if (
+            resourceRequest.kind === 'kube' &&
+            resourceRequest.resource.namespaces?.size > 0
+          ) {
+            // Process each namespace.
+            resourceRequest.resource.namespaces.forEach(namespaceRequestUri => {
+              const { kind, id, name } =
+                mapKubeNamespaceUriToRequest(namespaceRequestUri);
+
+              const item = {
+                kind,
+                id,
+                name,
+                subResourceName: name,
+                originalItem: resourceRequest,
+                clusterName:
+                  ctx.clustersService.findClusterByResource(namespaceRequestUri)
+                    ?.name,
+              };
+              pendingAccessRequests.push(item);
+            });
+          }
+
           const { kind, id, name } =
             extractResourceRequestProperties(resourceRequest);
-          pendingAccessRequests.push({
+          const item: PendingListItemWithOriginalItem = {
             kind,
             id,
             name,
@@ -180,7 +220,8 @@ export default function useAccessRequestCheckout() {
             clusterName: ctx.clustersService.findClusterByResource(
               resourceRequest.resource.uri
             )?.name,
-          });
+          };
+          pendingAccessRequests.push(item);
         });
       }
     }
@@ -207,6 +248,21 @@ export default function useAccessRequestCheckout() {
     );
   }
 
+  async function bulkToggleKubeResources(
+    items: PendingKubeResourceItem[],
+    kubeCluster: PendingListKubeClusterWithOriginalItem
+  ) {
+    await workspaceAccessRequest.addOrRemoveKubeNamespaces(
+      items.map(item =>
+        mapRequestToKubeNamespaceUri({
+          id: item.id,
+          name: item.subResourceName,
+          clusterUri: kubeCluster.originalItem.resource.uri,
+        })
+      )
+    );
+  }
+
   function getAssumedRequests() {
     if (!clusterUri) {
       return [];
@@ -222,28 +278,33 @@ export default function useAccessRequestCheckout() {
    * Shared logic used both during dry runs and regular access request creation.
    */
   function prepareAndCreateRequest(req: CreateRequest) {
-    const pendingAccessRequests =
-      getPendingAccessRequestsPerResource(pendingAccessRequest);
     const params: CreateAccessRequestRequest = {
       rootClusterUri,
       reason: req.reason,
       suggestedReviewers: req.suggestedReviewers || [],
       dryRun: req.dryRun,
-      resourceIds: pendingAccessRequests
+      resourceIds: pendingAccessRequestsWithoutParentResource
         .filter(d => d.kind !== 'role')
-        .map(d => ({
-          name: d.id,
-          clusterName: d.clusterName,
-          kind: d.kind,
-          subResourceName: '',
-        })),
-      roles: pendingAccessRequests
+        .map(d => {
+          return {
+            name: d.id,
+            clusterName: d.clusterName,
+            kind: d.kind,
+            subResourceName: d.subResourceName || '',
+          };
+        }),
+      roles: pendingAccessRequestsWithoutParentResource
         .filter(d => d.kind === 'role')
         .map(d => d.name),
       assumeStartTime: req.start && Timestamp.fromDate(req.start),
       maxDuration: req.maxDuration && Timestamp.fromDate(req.maxDuration),
       requestTtl: req.requestTTL && Timestamp.fromDate(req.requestTTL),
     };
+
+    // Don't attempt creating anything if there are no resources selected.
+    if (!params.resourceIds.length && !params.roles.length) {
+      return;
+    }
 
     // if we have a resource access request, we pass along the selected roles from the checkout
     if (params.resourceIds.length > 0) {
@@ -256,7 +317,8 @@ export default function useAccessRequestCheckout() {
       ctx.clustersService.createAccessRequest(params).then(({ response }) => {
         return {
           accessRequest: response.request,
-          requestedCount: pendingAccessRequests.length,
+          requestedCount:
+            pendingAccessRequestsWithoutParentResource.filter.length,
         };
       })
     ).catch(e => {
@@ -275,9 +337,9 @@ export default function useAccessRequestCheckout() {
       });
       teletermAccessRequest = accessRequest;
     } catch {
+      setCreateRequestAttempt({ status: '' });
       return;
     }
-
     setCreateRequestAttempt({ status: '' });
 
     const accessRequest = makeUiAccessRequest(teletermAccessRequest);
@@ -333,9 +395,27 @@ export default function useAccessRequestCheckout() {
     }
   }
 
+  async function fetchKubeNamespaces({
+    kubeCluster,
+    search,
+  }: KubeNamespaceRequest): Promise<string[]> {
+    const { response } = await ctx.tshd.listKubernetesResources({
+      searchKeywords: search,
+      limit: 50,
+      useSearchAsRoles: true,
+      nextKey: '',
+      resourceType: 'namespace',
+      clusterUri,
+      predicateExpression: '',
+      kubernetesCluster: kubeCluster,
+      kubernetesNamespace: '',
+    });
+    return response.resources.map(i => i.name);
+  }
+
   const shouldShowClusterNameColumn =
-    pendingAccessRequest?.kind === 'resource' &&
-    Array.from(pendingAccessRequest.resources.values()).some(a =>
+    pendingAccessRequestRequest?.kind === 'resource' &&
+    Array.from(pendingAccessRequestRequest.resources.values()).some(a =>
       routing.isLeafCluster(a.resource.uri)
     );
 
@@ -344,8 +424,7 @@ export default function useAccessRequestCheckout() {
     isCollapsed,
     assumedRequests: getAssumedRequests(),
     toggleResource,
-    pendingAccessRequests:
-      getPendingAccessRequestsPerResource(pendingAccessRequest),
+    pendingAccessRequests,
     shouldShowClusterNameColumn,
     createRequest,
     reset,
@@ -373,6 +452,8 @@ export default function useAccessRequestCheckout() {
     pendingRequestTtlOptions,
     startTime,
     onStartTimeChange,
+    fetchKubeNamespaces,
+    bulkToggleKubeResources,
   };
 }
 
@@ -386,3 +467,8 @@ type PendingListItemWithOriginalItem = Omit<PendingListItem, 'kind'> &
         kind: 'role';
       }
   );
+
+type PendingListKubeClusterWithOriginalItem = Omit<PendingListItem, 'kind'> & {
+  kind: Extract<ResourceKind, 'kube_cluster'>;
+  originalItem: Extract<ResourceRequest, { kind: 'kube' }>;
+};

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/NewRequest/useNewRequest.ts
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/NewRequest/useNewRequest.ts
@@ -22,6 +22,7 @@ import { FetchStatus, SortType } from 'design/DataTable/types';
 
 import useAttempt from 'shared/hooks/useAttemptNext';
 import { makeAdvancedSearchQueryForLabel } from 'shared/utils/advancedSearchLabelQuery';
+import { RequestableResourceKind } from 'shared/components/AccessRequests/NewRequest/resource';
 
 import {
   ShowResources,
@@ -49,7 +50,6 @@ import type {
   ResourceLabel,
   ResourceFilter as WeakAgentFilter,
   ResourcesResponse,
-  ResourceIdKind,
   UnifiedResource,
 } from 'teleport/services/agents';
 import type * as teleportApps from 'teleport/services/apps';
@@ -211,6 +211,17 @@ export default function useNewRequest(rootCluster: Cluster) {
       return;
     }
 
+    /**
+     * This should never happen but just a safeguard.
+     * This function is used in the "unified resources" view,
+     * where a user can click on a "request access" button.
+     * Selecting kube_cluster's namespace is not available in this view
+     * (instead it is rendered in the "request checkout" view).
+     */
+    if (kind === 'namespace') {
+      return;
+    }
+
     accessRequestsService.addOrRemoveResource(
       toResourceRequest({
         kind,
@@ -348,8 +359,13 @@ function getDefaultSort(kind: ResourceKind): SortType {
 
 export type ResourceKind =
   | Extract<
-      ResourceIdKind,
-      'node' | 'app' | 'db' | 'kube_cluster' | 'saml_idp_service_provider'
+      RequestableResourceKind,
+      | 'node'
+      | 'app'
+      | 'db'
+      | 'kube_cluster'
+      | 'saml_idp_service_provider'
+      | 'namespace'
     >
   | 'role';
 

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -223,7 +223,7 @@ export function UnifiedResources(props: {
 
   const bulkAddResources = useCallback(
     (resources: UnifiedResourceResponse[]) => {
-      accessRequestsService.addOrRemoveResources(resources);
+      accessRequestsService.addAllOrRemoveAllResources(resources);
     },
     [accessRequestsService]
   );

--- a/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.test.ts
@@ -124,7 +124,7 @@ test('getAddedItemsCount() returns added resource count for pending request', ()
   expect(service.getAddedItemsCount()).toBe(0);
 });
 
-test('addOrRemoveResources() adds all resources to pending request', async () => {
+test('addAllOrRemoveAllResources() adds all resources to pending request', async () => {
   const { accessRequestsService: service } = getTestSetup(
     getMockPendingResourceAccessRequest()
   );
@@ -138,7 +138,9 @@ test('addOrRemoveResources() adds all resources to pending request', async () =>
   });
 
   // add a single resource that isn't added should add to the request
-  await service.addOrRemoveResources([{ kind: 'server', resource: server }]);
+  await service.addAllOrRemoveAllResources([
+    { kind: 'server', resource: server },
+  ]);
   let pendingAccessRequest = service.getPendingAccessRequest();
   expect(
     pendingAccessRequest.kind === 'resource' &&
@@ -149,7 +151,7 @@ test('addOrRemoveResources() adds all resources to pending request', async () =>
   });
 
   // padding an array that contains some resources already added and some that aren't should add them all
-  await service.addOrRemoveResources([
+  await service.addAllOrRemoveAllResources([
     { kind: 'server', resource: server },
     { kind: 'server', resource: server2 },
   ]);
@@ -170,7 +172,7 @@ test('addOrRemoveResources() adds all resources to pending request', async () =>
   });
 
   // passing an array of resources that are all already added should remove all the passed resources
-  await service.addOrRemoveResources([
+  await service.addAllOrRemoveAllResources([
     { kind: 'server', resource: server },
     { kind: 'server', resource: server2 },
   ]);


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/46742

requires:
- [ ] https://github.com/gravitational/teleport/pull/47173
- [ ] https://github.com/gravitational/teleport/pull/47345
- [ ] https://github.com/gravitational/teleport/pull/46753

if you want to test connect, i have a staging cluster that i can invite you to (dm me) then:

1. OS: check out this branch
2. build tsh, and then pnpm start-term and login to my cluster

screenshots and demo similar as: https://github.com/gravitational/teleport/pull/47345


changelog: Add Connect support for selecting Kubernetes namespaces during access requests

