### PR TITLE
AWS Terraform fixes for license and update output of web address.

### DIFF
--- a/examples/aws/terraform/ha-autoscale-cluster/outputs.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/outputs.tf
@@ -38,7 +38,7 @@ output "cluster_name" {
 
 output "cluster_web_address" {
   description = "Web address to access the Teleport cluster"
-  value       = "https://${var.use_acm ? aws_route53_record.proxy_acm[0].name : aws_route53_record.proxy[0].name}"
+  value       = "https://${var.use_acm ? aws_route53_record.proxy_acm[0].name : aws_route53_record.proxy[0].fqdn}"
 }
 
 output "key_name" {

--- a/examples/aws/terraform/ha-autoscale-cluster/ssm.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/ssm.tf
@@ -8,5 +8,5 @@ resource "aws_ssm_parameter" "license" {
   type      = "SecureString"
   value     = file(var.license_path)
   overwrite = true
-  tier      = "Advanced"
+  tier      = "Intelligent-Tiering"
 }

--- a/examples/aws/terraform/ha-autoscale-cluster/ssm.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/ssm.tf
@@ -8,4 +8,5 @@ resource "aws_ssm_parameter" "license" {
   type      = "SecureString"
   value     = file(var.license_path)
   overwrite = true
+  tier      = "Advanced"
 }

--- a/examples/aws/terraform/starter-cluster/outputs.tf
+++ b/examples/aws/terraform/starter-cluster/outputs.tf
@@ -10,7 +10,7 @@ output "cluster_name" {
 
 output "cluster_web_address" {
   description = "Web address to access the Teleport cluster"
-  value       = "https://${var.use_acm ? aws_route53_record.cluster_acm[0].name : aws_route53_record.cluster[0].name}"
+  value       = "https://${var.use_acm ? aws_route53_record.cluster_acm[0].name : aws_route53_record.cluster[0].fqdn}"
 }
 
 output "key_name" {

--- a/examples/aws/terraform/starter-cluster/ssm.tf
+++ b/examples/aws/terraform/starter-cluster/ssm.tf
@@ -5,5 +5,5 @@ resource "aws_ssm_parameter" "license" {
   type      = "SecureString"
   value     = file(var.license_path)
   overwrite = true
-  tier      = "Advanced"
+  tier      = "Intelligent-Tiering"
 }

--- a/examples/aws/terraform/starter-cluster/ssm.tf
+++ b/examples/aws/terraform/starter-cluster/ssm.tf
@@ -5,4 +5,5 @@ resource "aws_ssm_parameter" "license" {
   type      = "SecureString"
   value     = file(var.license_path)
   overwrite = true
+  tier      = "Advanced"
 }


### PR DESCRIPTION
changelog: Fix the example Terraform code to support the new larger Teleport Enterprise licenses and updates output of web address to use fqdn when ACM is disabled.