### PR TITLE
[v14] increase redshift e2e test timeout

### DIFF
--- a/e2e/aws/databases_test.go
+++ b/e2e/aws/databases_test.go
@@ -112,7 +112,7 @@ func awsDBDiscoveryUnmatched(t *testing.T) {
 }
 
 const (
-	waitForConnTimeout = 60 * time.Second
+	waitForConnTimeout = 90 * time.Second
 	connRetryTick      = 10 * time.Second
 )
 


### PR DESCRIPTION
Looks like we at some point changed the way procedures are created on v16+, so the retries added in #47305 were already present on v14, so this just backports the timeout increase for the test.
- #47305