### PR TITLE
Fix content generated from proto

### DIFF
--- a/docs/pages/reference/operator-resources/resources.teleport.dev_samlconnectors.mdx
+++ b/docs/pages/reference/operator-resources/resources.teleport.dev_samlconnectors.mdx
@@ -36,6 +36,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |display|string|Display controls how this connector is displayed.|
 |entity_descriptor|string|EntityDescriptor is XML with descriptor. It can be used to supply configuration parameters in one XML file rather than supplying them in the individual elements.|
 |entity_descriptor_url|string|EntityDescriptorURL is a URL that supplies a configuration XML.|
+|force_authn|string or integer|ForceAuthn specified whether re-authentication should be forced on login. UNSPECIFIED is treated as NO. Can be either the string or the integer representation of each option.|
 |issuer|string|Issuer is the identity provider issuer.|
 |mfa|[object](#specmfa)|MFASettings contains settings to enable SSO MFA checks through this auth connector.|
 |provider|string|Provider is the external identity provider.|
@@ -73,6 +74,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |enabled|boolean|Enabled specified whether this SAML connector supports MFA checks. Defaults to false.|
 |entity_descriptor|string|EntityDescriptor is XML with descriptor. It can be used to supply configuration parameters in one XML file rather than supplying them in the individual elements.|
 |entity_descriptor_url|string|EntityDescriptorUrl is a URL that supplies a configuration XML.|
+|force_authn|string or integer|ForceAuthn specified whether re-authentication should be forced for MFA checks. UNSPECIFIED is treated as YES to always re-authentication for MFA checks. This should only be set to NO if the IdP is setup to perform MFA checks on top of active user sessions. Can be either the string or the integer representation of each option.|
 
 ### spec.signing_key_pair
 

--- a/docs/pages/reference/terraform-provider/data-sources/saml_connector.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/saml_connector.mdx
@@ -40,6 +40,7 @@ Optional:
 - `display` (String) Display controls how this connector is displayed.
 - `entity_descriptor` (String, Sensitive) EntityDescriptor is XML with descriptor. It can be used to supply configuration parameters in one XML file rather than supplying them in the individual elements.
 - `entity_descriptor_url` (String) EntityDescriptorURL is a URL that supplies a configuration XML.
+- `force_authn` (Number) ForceAuthn specified whether re-authentication should be forced on login. UNSPECIFIED is treated as NO.
 - `issuer` (String) Issuer is the identity provider issuer.
 - `mfa` (Attributes) MFASettings contains settings to enable SSO MFA checks through this auth connector. (see [below for nested schema](#nested-schema-for-specmfa))
 - `provider` (String) Provider is the external identity provider.
@@ -80,6 +81,7 @@ Optional:
 - `enabled` (Boolean) Enabled specified whether this SAML connector supports MFA checks. Defaults to false.
 - `entity_descriptor` (String) EntityDescriptor is XML with descriptor. It can be used to supply configuration parameters in one XML file rather than supplying them in the individual elements.
 - `entity_descriptor_url` (String) EntityDescriptorUrl is a URL that supplies a configuration XML.
+- `force_authn` (Number) ForceAuthn specified whether re-authentication should be forced for MFA checks. UNSPECIFIED is treated as YES to always re-authentication for MFA checks. This should only be set to NO if the IdP is setup to perform MFA checks on top of active user sessions.
 
 
 ### Nested Schema for `spec.signing_key_pair`

--- a/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
@@ -85,6 +85,7 @@ Optional:
 - `display` (String) Display controls how this connector is displayed.
 - `entity_descriptor` (String, Sensitive) EntityDescriptor is XML with descriptor. It can be used to supply configuration parameters in one XML file rather than supplying them in the individual elements.
 - `entity_descriptor_url` (String) EntityDescriptorURL is a URL that supplies a configuration XML.
+- `force_authn` (Number) ForceAuthn specified whether re-authentication should be forced on login. UNSPECIFIED is treated as NO.
 - `issuer` (String) Issuer is the identity provider issuer.
 - `mfa` (Attributes) MFASettings contains settings to enable SSO MFA checks through this auth connector. (see [below for nested schema](#nested-schema-for-specmfa))
 - `provider` (String) Provider is the external identity provider.
@@ -125,6 +126,7 @@ Optional:
 - `enabled` (Boolean) Enabled specified whether this SAML connector supports MFA checks. Defaults to false.
 - `entity_descriptor` (String) EntityDescriptor is XML with descriptor. It can be used to supply configuration parameters in one XML file rather than supplying them in the individual elements.
 - `entity_descriptor_url` (String) EntityDescriptorUrl is a URL that supplies a configuration XML.
+- `force_authn` (Number) ForceAuthn specified whether re-authentication should be forced for MFA checks. UNSPECIFIED is treated as YES to always re-authentication for MFA checks. This should only be set to NO if the IdP is setup to perform MFA checks on top of active user sessions.
 
 
 ### Nested Schema for `spec.signing_key_pair`

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_samlconnectors.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_samlconnectors.yaml
@@ -115,6 +115,10 @@ spec:
                 description: EntityDescriptorURL is a URL that supplies a configuration
                   XML.
                 type: string
+              force_authn:
+                description: ForceAuthn specified whether re-authentication should
+                  be forced on login. UNSPECIFIED is treated as NO.
+                x-kubernetes-int-or-string: true
               issuer:
                 description: Issuer is the identity provider issuer.
                 type: string
@@ -136,6 +140,13 @@ spec:
                     description: EntityDescriptorUrl is a URL that supplies a configuration
                       XML.
                     type: string
+                  force_authn:
+                    description: ForceAuthn specified whether re-authentication should
+                      be forced for MFA checks. UNSPECIFIED is treated as YES to always
+                      re-authentication for MFA checks. This should only be set to
+                      NO if the IdP is setup to perform MFA checks on top of active
+                      user sessions.
+                    x-kubernetes-int-or-string: true
                 type: object
               provider:
                 description: Provider is the external identity provider.

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_samlconnectors.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_samlconnectors.yaml
@@ -115,6 +115,10 @@ spec:
                 description: EntityDescriptorURL is a URL that supplies a configuration
                   XML.
                 type: string
+              force_authn:
+                description: ForceAuthn specified whether re-authentication should
+                  be forced on login. UNSPECIFIED is treated as NO.
+                x-kubernetes-int-or-string: true
               issuer:
                 description: Issuer is the identity provider issuer.
                 type: string
@@ -136,6 +140,13 @@ spec:
                     description: EntityDescriptorUrl is a URL that supplies a configuration
                       XML.
                     type: string
+                  force_authn:
+                    description: ForceAuthn specified whether re-authentication should
+                      be forced for MFA checks. UNSPECIFIED is treated as YES to always
+                      re-authentication for MFA checks. This should only be set to
+                      NO if the IdP is setup to perform MFA checks on top of active
+                      user sessions.
+                    x-kubernetes-int-or-string: true
                 type: object
               provider:
                 description: Provider is the external identity provider.

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -3052,6 +3052,11 @@ func GenSchemaSAMLConnectorV2(ctx context.Context) (github_com_hashicorp_terrafo
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
+				"force_authn": {
+					Description: "ForceAuthn specified whether re-authentication should be forced on login. UNSPECIFIED is treated as NO.",
+					Optional:    true,
+					Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
+				},
 				"issuer": {
 					Computed:      true,
 					Description:   "Issuer is the identity provider issuer.",
@@ -3075,6 +3080,11 @@ func GenSchemaSAMLConnectorV2(ctx context.Context) (github_com_hashicorp_terrafo
 							Description: "EntityDescriptorUrl is a URL that supplies a configuration XML.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"force_authn": {
+							Description: "ForceAuthn specified whether re-authentication should be forced for MFA checks. UNSPECIFIED is treated as YES to always re-authentication for MFA checks. This should only be set to NO if the IdP is setup to perform MFA checks on top of active user sessions.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 						},
 					}),
 					Description: "MFASettings contains settings to enable SSO MFA checks through this auth connector.",
@@ -31015,7 +31025,41 @@ func CopySAMLConnectorV2FromTerraform(_ context.Context, tf github_com_hashicorp
 											}
 										}
 									}
+									{
+										a, ok := tf.Attrs["force_authn"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"SAMLConnectorV2.Spec.MFASettings.force_authn"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Int64)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"SAMLConnectorV2.Spec.MFASettings.force_authn", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
+											} else {
+												var t github_com_gravitational_teleport_api_types.SAMLForceAuthn
+												if !v.Null && !v.Unknown {
+													t = github_com_gravitational_teleport_api_types.SAMLForceAuthn(v.Value)
+												}
+												obj.ForceAuthn = t
+											}
+										}
+									}
 								}
+							}
+						}
+					}
+					{
+						a, ok := tf.Attrs["force_authn"]
+						if !ok {
+							diags.Append(attrReadMissingDiag{"SAMLConnectorV2.Spec.ForceAuthn"})
+						} else {
+							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Int64)
+							if !ok {
+								diags.Append(attrReadConversionFailureDiag{"SAMLConnectorV2.Spec.ForceAuthn", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
+							} else {
+								var t github_com_gravitational_teleport_api_types.SAMLForceAuthn
+								if !v.Null && !v.Unknown {
+									t = github_com_gravitational_teleport_api_types.SAMLForceAuthn(v.Value)
+								}
+								obj.ForceAuthn = t
 							}
 						}
 					}
@@ -32118,10 +32162,54 @@ func CopySAMLConnectorV2ToTerraform(ctx context.Context, obj *github_com_gravita
 											tf.Attrs["entity_descriptor_url"] = v
 										}
 									}
+									{
+										t, ok := tf.AttrTypes["force_authn"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"SAMLConnectorV2.Spec.MFASettings.force_authn"})
+										} else {
+											v, ok := tf.Attrs["force_authn"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"SAMLConnectorV2.Spec.MFASettings.force_authn", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Int64)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"SAMLConnectorV2.Spec.MFASettings.force_authn", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
+												}
+												v.Null = int64(obj.ForceAuthn) == 0
+											}
+											v.Value = int64(obj.ForceAuthn)
+											v.Unknown = false
+											tf.Attrs["force_authn"] = v
+										}
+									}
 								}
 								v.Unknown = false
 								tf.Attrs["mfa"] = v
 							}
+						}
+					}
+					{
+						t, ok := tf.AttrTypes["force_authn"]
+						if !ok {
+							diags.Append(attrWriteMissingDiag{"SAMLConnectorV2.Spec.ForceAuthn"})
+						} else {
+							v, ok := tf.Attrs["force_authn"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
+							if !ok {
+								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+								if err != nil {
+									diags.Append(attrWriteGeneralError{"SAMLConnectorV2.Spec.ForceAuthn", err})
+								}
+								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Int64)
+								if !ok {
+									diags.Append(attrWriteConversionFailureDiag{"SAMLConnectorV2.Spec.ForceAuthn", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
+								}
+								v.Null = int64(obj.ForceAuthn) == 0
+							}
+							v.Value = int64(obj.ForceAuthn)
+							v.Unknown = false
+							tf.Attrs["force_authn"] = v
 						}
 					}
 				}


### PR DESCRIPTION
Due to a CI misconfiguration, https://github.com/gravitational/teleport/pull/46703 passed without updating the CRDs, documentation or TF schema.

This PR fixes the drift. @tigrato already fixed the CI enforcement rules, this should not happen again.