### PR TITLE
Web/Connect: delete v16 TODOs

### DIFF
--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
@@ -124,16 +124,8 @@ export function useKeyBasedPagination<T>({
         pendingPromise.current = null;
         abortController.current = null;
 
-        // this will handle backward compatibility with access requests.
-        // The old access requests API returns only an array of resources while
-        // the new one sends the paginated object with startKey/requests
-        // If this webclient requests an older proxy, this should allow the
-        // old request to not break the webui
-        // TODO (avatus): DELETE in 17
-        const newResources = res[dataKey] || res;
-
         setState({
-          resources: [...resources, ...newResources],
+          resources: [...resources, ...res[dataKey]],
           startKey: res.startKey,
           finished: !res.startKey,
           attempt: { status: 'success' },
@@ -157,7 +149,15 @@ export function useKeyBasedPagination<T>({
         });
       }
     },
-    [fetchFunc, stateRef, clear, setState, fetchMoreSize, initialFetchSize]
+    [
+      fetchFunc,
+      stateRef,
+      clear,
+      setState,
+      fetchMoreSize,
+      initialFetchSize,
+      dataKey,
+    ]
   );
 
   function updateFetchedResources(modifiedResources: T[]) {

--- a/web/packages/teleport/src/services/resources/resource.ts
+++ b/web/packages/teleport/src/services/resources/resource.ts
@@ -60,20 +60,7 @@ class ResourceService {
     items: RoleResource[];
     startKey: string;
   }> {
-    const response = await api.get(cfg.getListRolesUrl(params));
-
-    // This will handle backward compatibility with roles.
-    // The old roles API returns only an array of resources while
-    // the new one sends the paginated object with startKey/requests
-    // If this webclient requests an older proxy
-    // (this may happen in multi proxy deployments),
-    //  this should allow the old request to not break the Web UI.
-    // TODO (gzdunek): DELETE in 17.0.0
-    if (Array.isArray(response)) {
-      return makeRolesPageLocally(params, response);
-    }
-
-    return response;
+    return await api.get(cfg.getListRolesUrl(params));
   }
 
   fetchPresetRoles() {
@@ -132,31 +119,3 @@ class ResourceService {
 }
 
 export default ResourceService;
-
-// TODO (gzdunek): DELETE in 17.0.0.
-// See the comment where this function is used.
-function makeRolesPageLocally(
-  params: UrlListRolesParams,
-  response: RoleResource[]
-): {
-  items: RoleResource[];
-  startKey: string;
-} {
-  if (params.search) {
-    // A serverside search would also match labels, here we only check the name.
-    response = response.filter(p =>
-      p.name.toLowerCase().includes(params.search.toLowerCase())
-    );
-  }
-
-  if (params.startKey) {
-    const startIndex = response.findIndex(p => p.name === params.startKey);
-    response = response.slice(startIndex);
-  }
-
-  const limit = params.limit || 200;
-  const nextKey = response.at(limit)?.name;
-  response = response.slice(0, limit);
-
-  return { items: response, startKey: nextKey };
-}

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -20,6 +20,7 @@ import {
   makeRootCluster,
   makeAppGateway,
 } from 'teleterm/services/tshd/testHelpers';
+import { getDefaultUnifiedResourcePreferences } from 'teleterm/ui/services/workspacesService';
 
 import { VnetClient, TshdClient } from '../createClient';
 import { MockedUnaryCall } from '../cloneableClient';
@@ -107,7 +108,13 @@ export class MockTshClient implements TshdClient {
     new MockedUnaryCall({ resources: [], nextKey: '' });
   listKubernetesResources = () =>
     new MockedUnaryCall({ resources: [], nextKey: '' });
-  getUserPreferences = () => new MockedUnaryCall({});
+  getUserPreferences = () =>
+    new MockedUnaryCall({
+      userPreferences: {
+        unifiedResourcePreferences: getDefaultUnifiedResourcePreferences(),
+        clusterPreferences: { pinnedResources: { resourceIds: [] } },
+      },
+    });
   updateUserPreferences = () => new MockedUnaryCall({});
   getSuggestedAccessLists = () => new MockedUnaryCall({ accessLists: [] });
   promoteAccessRequest = () => new MockedUnaryCall({});

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/ReviewAccessRequest/useReviewAccessRequest.ts
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/ReviewAccessRequest/useReviewAccessRequest.ts
@@ -31,7 +31,6 @@ import { useAsync } from 'shared/hooks/useAsync';
 import * as tsh from 'teleterm/services/tshd/types';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { useWorkspaceLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
-import { isUnimplementedError } from 'teleterm/services/tshd/errors';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 import { useWorkspaceContext } from 'teleterm/ui/Documents';
 
@@ -110,22 +109,12 @@ export function useReviewAccessRequest({
   const [fetchSuggestedAccessListsAttempt, runFetchSuggestedAccessLists] =
     useAsync(
       useCallback(async () => {
-        try {
-          const { response } = await ctx.tshd.getSuggestedAccessLists({
-            rootClusterUri,
-            accessRequestId: requestId,
-          });
+        const { response } = await ctx.tshd.getSuggestedAccessLists({
+          rootClusterUri,
+          accessRequestId: requestId,
+        });
 
-          return response.accessLists.map(makeUiAccessList);
-        } catch (e) {
-          if (isUnimplementedError(e)) {
-            // TODO(gzdunek): DELETE IN 16.0.0
-            throw new Error(
-              'To approve long-term access via Access List in Teleport Connect, update your cluster to 13.4.13 or 14.3.'
-            );
-          }
-          throw e;
-        }
+        return response.accessLists.map(makeUiAccessList);
       }, [ctx.tshd, requestId, rootClusterUri])
     );
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -263,7 +263,10 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
   getUnifiedResourcePreferences(
     rootClusterUri: RootClusterUri
   ): UnifiedResourcePreferences {
-    return this.state.workspaces[rootClusterUri].unifiedResourcePreferences;
+    return (
+      this.state.workspaces[rootClusterUri].unifiedResourcePreferences ||
+      getDefaultUnifiedResourcePreferences()
+    );
   }
 
   /**
@@ -566,6 +569,7 @@ export function getDefaultUnifiedResourcePreferences(): UnifiedResourcePreferenc
     availableResourceMode: AvailableResourceMode.NONE,
   };
 }
+
 const unifiedResourcePreferencesSchema = z
   .object({
     defaultTab: z


### PR DESCRIPTION
- remove the need for old resource response in keybase pagination
- remove the need for old resource response in roles pagination
- Remove the no longer needed UnimplementedError for approving access lists in Connect
- Remove the need to merge unified resource preferences with defaults. Now we either use what is returned or a default set
