### PR TITLE
[v15] [kube] Enhance `tsh proxy kube` output table with kubeconfig context name

### DIFF
--- a/lib/kube/kubeconfig/context_overwrite.go
+++ b/lib/kube/kubeconfig/context_overwrite.go
@@ -105,3 +105,16 @@ func executeKubeContextTemplate(tmpl *template.Template, clusterName, kubeName s
 	err := tmpl.Execute(&buf, contextEntry)
 	return buf.String(), trace.Wrap(err)
 }
+
+// ContextNameFromTemplate generates a kubernetes context name from the given template.
+func ContextNameFromTemplate(temp string, clusterName, kubeName string) (string, error) {
+	tmpl, err := parseContextOverrideTemplate(temp)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	if tmpl == nil {
+		return ContextName(clusterName, kubeName), nil
+	}
+	s, err := executeKubeContextTemplate(tmpl, clusterName, kubeName)
+	return s, trace.Wrap(err)
+}

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -266,7 +266,7 @@ func (c *proxyKubeCommand) printPrepare(cf *CLIConf, title string, clusters kube
 	for _, cluster := range clusters {
 		contextName, err := kubeconfig.ContextNameFromTemplate(c.overrideContextName, cluster.TeleportCluster, cluster.KubeCluster)
 		if err != nil {
-			slog.Default().WarnContext(cf.Context, "Failed to generate context name.", "error", err)
+			slog.WarnContext(cf.Context, "Failed to generate context name.", "error", err)
 			contextName = kubeconfig.ContextName(cluster.TeleportCluster, cluster.KubeCluster)
 		}
 		table.AddRow([]string{cluster.TeleportCluster, cluster.KubeCluster, contextName})

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -24,6 +24,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"os/exec"
@@ -261,9 +262,14 @@ func (c *proxyKubeCommand) prepare(cf *CLIConf, tc *client.TeleportClient) (*cli
 
 func (c *proxyKubeCommand) printPrepare(cf *CLIConf, title string, clusters kubeconfig.LocalProxyClusters) {
 	fmt.Fprintln(cf.Stdout(), title)
-	table := asciitable.MakeTable([]string{"Teleport Cluster Name", "Kube Cluster Name"})
+	table := asciitable.MakeTable([]string{"Teleport Cluster Name", "Kube Cluster Name", "Context Name"})
 	for _, cluster := range clusters {
-		table.AddRow([]string{cluster.TeleportCluster, cluster.KubeCluster})
+		contextName, err := kubeconfig.ContextNameFromTemplate(c.overrideContextName, cluster.TeleportCluster, cluster.KubeCluster)
+		if err != nil {
+			slog.Default().WarnContext(cf.Context, "Failed to generate context name.", "error", err)
+			contextName = kubeconfig.ContextName(cluster.TeleportCluster, cluster.KubeCluster)
+		}
+		table.AddRow([]string{cluster.TeleportCluster, cluster.KubeCluster, contextName})
 	}
 	fmt.Fprintln(cf.Stdout(), table.AsBuffer().String())
 }


### PR DESCRIPTION
Backport #47343 to branch/v15

changelog: Added kubeconfig context name to the output table of `tsh proxy kube` command for enhanced clarity.
