### PR TITLE
Add ability to List/Get AMRs to `tctl`

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/constants"
+	accessmonitoringrulesv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
 	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
@@ -1861,6 +1862,35 @@ func (c *autoUpdateVersionCollection) writeText(w io.Writer, verbose bool) error
 		c.version.GetMetadata().GetName(),
 		fmt.Sprintf("%v", c.version.GetSpec().GetToolsVersion()),
 	})
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+type accessMonitoringRuleCollection struct {
+	items []*accessmonitoringrulesv1pb.AccessMonitoringRule
+}
+
+func (c *accessMonitoringRuleCollection) resources() []types.Resource {
+	r := make([]types.Resource, 0, len(c.items))
+	for _, resource := range c.items {
+		r = append(r, types.Resource153ToLegacy(resource))
+	}
+	return r
+}
+
+// writeText formats the user tasks into a table and writes them into w.
+// If verbose is disabled, labels column can be truncated to fit into the console.
+func (c *accessMonitoringRuleCollection) writeText(w io.Writer, verbose bool) error {
+	var rows [][]string
+	for _, item := range c.items {
+		labels := common.FormatLabels(item.GetMetadata().GetLabels(), verbose)
+		rows = append(rows, []string{item.Metadata.GetName(), labels})
+	}
+	headers := []string{"Name", "Labels"}
+	t := asciitable.MakeTable(headers, rows...)
+
+	// stable sort by name.
+	t.SortRowsBy([]int{0}, true)
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)
 }


### PR DESCRIPTION
I noticed a customer support ticket where we said we didn't support Listing/Getting AMRs via `tctl` - this seemed a little odd. I took a look and for some reason, you could create, update and delete AMRs via `tctl` but the functionality for getting/listing was missing.

Related:  https://github.com/gravitational/teleport/pull/40218

changelog: Added ability to list/get AccessMonitoringRule resources with `tctl`

