### PR TITLE
[v16] Workload ID: Add tbot support for JWT SVIDs (#47017)

### DIFF
--- a/lib/tbot/config/service_spiffe_svid_test.go
+++ b/lib/tbot/config/service_spiffe_svid_test.go
@@ -40,6 +40,16 @@ func TestSPIFFESVIDOutput_YAML(t *testing.T) {
 					},
 				},
 				IncludeFederatedTrustBundles: true,
+				JWTs: []JWTSVID{
+					{
+						Audience: "example.com",
+						FileName: "foo",
+					},
+					{
+						Audience: "2.example.com",
+						FileName: "bar",
+					},
+				},
 			},
 		},
 		{
@@ -70,8 +80,58 @@ func TestSPIFFESVIDOutput_CheckAndSetDefaults(t *testing.T) {
 							IP:  []string{"10.0.0.1"},
 						},
 					},
+					JWTs: []JWTSVID{
+						{
+							FileName: "foo",
+							Audience: "example.com",
+						},
+					},
 				}
 			},
+		},
+		{
+			name: "missing jwt name",
+			in: func() *SPIFFESVIDOutput {
+				return &SPIFFESVIDOutput{
+					Destination: memoryDestForTest(),
+					SVID: SVIDRequest{
+						Path: "/foo",
+						Hint: "hint",
+						SANS: SVIDRequestSANs{
+							DNS: []string{"example.com"},
+							IP:  []string{"10.0.0.1"},
+						},
+					},
+					JWTs: []JWTSVID{
+						{
+							Audience: "example.com",
+						},
+					},
+				}
+			},
+			wantErr: "name: should not be empty",
+		},
+		{
+			name: "missing jwt audience",
+			in: func() *SPIFFESVIDOutput {
+				return &SPIFFESVIDOutput{
+					Destination: memoryDestForTest(),
+					SVID: SVIDRequest{
+						Path: "/foo",
+						Hint: "hint",
+						SANS: SVIDRequestSANs{
+							DNS: []string{"example.com"},
+							IP:  []string{"10.0.0.1"},
+						},
+					},
+					JWTs: []JWTSVID{
+						{
+							FileName: "foo",
+						},
+					},
+				}
+			},
+			wantErr: "audience: should not be empty",
 		},
 		{
 			name: "missing destination",

--- a/lib/tbot/config/service_spiffe_workload_api.go
+++ b/lib/tbot/config/service_spiffe_workload_api.go
@@ -20,6 +20,7 @@ package config
 
 import (
 	"log/slog"
+	"time"
 
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"
@@ -121,6 +122,10 @@ type SPIFFEWorkloadAPIService struct {
 	SVIDs []SVIDRequestWithRules `yaml:"svids"`
 	// Attestors is the configuration for the workload attestation process.
 	Attestors workloadattest.Config `yaml:"attestors"`
+	// JWTSVIDTTL specifies how long that JWT SVIDs issued by this SPIFFE
+	// Workload API server are valid for. If unspecified, this falls back to
+	// the globally configured default.
+	JWTSVIDTTL time.Duration `yaml:"jwt_svid_ttl,omitempty"`
 }
 
 func (s *SPIFFEWorkloadAPIService) Type() string {

--- a/lib/tbot/config/service_spiffe_workload_api_test.go
+++ b/lib/tbot/config/service_spiffe_workload_api_test.go
@@ -20,6 +20,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gravitational/teleport/lib/tbot/spiffe/workloadattest"
 )
@@ -35,7 +36,8 @@ func TestSPIFFEWorkloadAPIService_YAML(t *testing.T) {
 		{
 			name: "full",
 			in: SPIFFEWorkloadAPIService{
-				Listen: "unix:///var/run/spiffe.sock",
+				Listen:     "unix:///var/run/spiffe.sock",
+				JWTSVIDTTL: time.Minute * 5,
 				Attestors: workloadattest.Config{
 					Kubernetes: workloadattest.KubernetesAttestorConfig{
 						Enabled: true,
@@ -106,7 +108,8 @@ func TestSPIFFEWorkloadAPIService_CheckAndSetDefaults(t *testing.T) {
 			name: "valid",
 			in: func() *SPIFFEWorkloadAPIService {
 				return &SPIFFEWorkloadAPIService{
-					Listen: "unix:///var/run/spiffe.sock",
+					JWTSVIDTTL: time.Minute,
+					Listen:     "unix:///var/run/spiffe.sock",
 					SVIDs: []SVIDRequestWithRules{
 						{
 							SVIDRequest: SVIDRequest{

--- a/lib/tbot/config/testdata/TestSPIFFESVIDOutput_YAML/full.golden
+++ b/lib/tbot/config/testdata/TestSPIFFESVIDOutput_YAML/full.golden
@@ -11,3 +11,8 @@ svid:
       - 10.0.0.1
       - 10.42.0.1
 include_federated_trust_bundles: true
+jwts:
+  - file_name: foo
+    audience: example.com
+  - file_name: bar
+    audience: 2.example.com

--- a/lib/tbot/config/testdata/TestSPIFFEWorkloadAPIService_YAML/full.golden
+++ b/lib/tbot/config/testdata/TestSPIFFEWorkloadAPIService_YAML/full.golden
@@ -30,3 +30,4 @@ attestors:
       ca_path: /path/to/ca.pem
       skip_verify: true
       anonymous: true
+jwt_svid_ttl: 5m0s

--- a/lib/tbot/service_spiffe_svid_output.go
+++ b/lib/tbot/service_spiffe_svid_output.go
@@ -68,7 +68,7 @@ func (s *SPIFFESVIDOutputService) String() string {
 }
 
 func (s *SPIFFESVIDOutputService) OneShot(ctx context.Context) error {
-	res, privateKey, err := s.requestSVID(ctx)
+	res, privateKey, jwtSVIDs, err := s.requestSVID(ctx)
 	if err != nil {
 		return trace.Wrap(err, "requesting SVID")
 	}
@@ -84,7 +84,7 @@ func (s *SPIFFESVIDOutputService) OneShot(ctx context.Context) error {
 		return trace.Wrap(err, "fetching trust bundle set")
 
 	}
-	return s.render(ctx, bundleSet, res, privateKey)
+	return s.render(ctx, bundleSet, res, privateKey, jwtSVIDs)
 }
 
 func (s *SPIFFESVIDOutputService) Run(ctx context.Context) error {
@@ -96,6 +96,7 @@ func (s *SPIFFESVIDOutputService) Run(ctx context.Context) error {
 	jitter := retryutils.NewJitter()
 	var res *machineidv1pb.SignX509SVIDsResponse
 	var privateKey *rsa.PrivateKey
+	var jwtSVIDs map[string]string
 	var failures int
 	firstRun := make(chan struct{}, 1)
 	firstRun <- struct{}{}
@@ -142,14 +143,14 @@ func (s *SPIFFESVIDOutputService) Run(ctx context.Context) error {
 
 		if res == nil || privateKey == nil {
 			var err error
-			res, privateKey, err = s.requestSVID(ctx)
+			res, privateKey, jwtSVIDs, err = s.requestSVID(ctx)
 			if err != nil {
 				s.log.ErrorContext(ctx, "Failed to request SVID", "error", err)
 				failures++
 				continue
 			}
 		}
-		if err := s.render(ctx, bundleSet, res, privateKey); err != nil {
+		if err := s.render(ctx, bundleSet, res, privateKey, jwtSVIDs); err != nil {
 			s.log.ErrorContext(ctx, "Failed to render output", "error", err)
 			failures++
 			continue
@@ -160,7 +161,12 @@ func (s *SPIFFESVIDOutputService) Run(ctx context.Context) error {
 
 func (s *SPIFFESVIDOutputService) requestSVID(
 	ctx context.Context,
-) (*machineidv1pb.SignX509SVIDsResponse, *rsa.PrivateKey, error) {
+) (
+	*machineidv1pb.SignX509SVIDsResponse,
+	*rsa.PrivateKey,
+	map[string]string,
+	error,
+) {
 	ctx, span := tracer.Start(
 		ctx,
 		"SPIFFESVIDOutputService/requestSVID",
@@ -169,7 +175,7 @@ func (s *SPIFFESVIDOutputService) requestSVID(
 
 	roles, err := fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "fetching roles")
+		return nil, nil, nil, trace.Wrap(err, "fetching roles")
 	}
 
 	id, err := generateIdentity(
@@ -181,14 +187,14 @@ func (s *SPIFFESVIDOutputService) requestSVID(
 		nil,
 	)
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "generating identity")
+		return nil, nil, nil, trace.Wrap(err, "generating identity")
 	}
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
 	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
 	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, nil, nil, trace.Wrap(err)
 	}
 	defer impersonatedClient.Close()
 
@@ -199,9 +205,20 @@ func (s *SPIFFESVIDOutputService) requestSVID(
 		s.botCfg.CertificateTTL,
 	)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, nil, nil, trace.Wrap(err, "generating X509 SVID")
 	}
-	return res, privateKey, nil
+
+	jwtSvids, err := generateJWTSVIDs(
+		ctx,
+		impersonatedClient,
+		s.cfg.SVID,
+		s.cfg.JWTs,
+		s.botCfg.CertificateTTL)
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err, "generating JWT SVIDs")
+	}
+
+	return res, privateKey, jwtSvids, nil
 }
 
 func (s *SPIFFESVIDOutputService) render(
@@ -209,6 +226,7 @@ func (s *SPIFFESVIDOutputService) render(
 	bundleSet *spiffe.BundleSet,
 	res *machineidv1pb.SignX509SVIDsResponse,
 	privateKey *rsa.PrivateKey,
+	jwtSVIDs map[string]string,
 ) error {
 	ctx, span := tracer.Start(
 		ctx,
@@ -277,7 +295,63 @@ func (s *SPIFFESVIDOutputService) render(
 		return trace.Wrap(err, "writing svid trust bundle")
 	}
 
+	for fileName, jwt := range jwtSVIDs {
+		if err := s.cfg.Destination.Write(ctx, fileName, []byte(jwt)); err != nil {
+			return trace.Wrap(err, "writing JWT SVID")
+		}
+	}
+
 	return nil
+}
+
+func generateJWTSVIDs(
+	ctx context.Context,
+	clt *authclient.Client,
+	svid config.SVIDRequest,
+	reqs []config.JWTSVID,
+	ttl time.Duration,
+) (map[string]string, error) {
+	ctx, span := tracer.Start(
+		ctx,
+		"generateJWTSVIDs",
+	)
+	defer span.End()
+
+	requestedAudiences := map[string]bool{}
+	for _, jwt := range reqs {
+		requestedAudiences[jwt.Audience] = true
+	}
+
+	jwtReqs := make([]*machineidv1pb.JWTSVIDRequest, 0, len(requestedAudiences))
+	for audience := range requestedAudiences {
+		jwtReqs = append(jwtReqs, &machineidv1pb.JWTSVIDRequest{
+			Audiences:    []string{audience},
+			Ttl:          durationpb.New(ttl),
+			SpiffeIdPath: svid.Path,
+		})
+	}
+
+	if len(jwtReqs) == 0 {
+		return nil, nil
+	}
+
+	jwtRes, err := clt.WorkloadIdentityServiceClient().SignJWTSVIDs(ctx, &machineidv1pb.SignJWTSVIDsRequest{
+		Svids: jwtReqs,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "requesting JWT SVIDs")
+	}
+
+	jwtFiles := map[string]string{}
+	for _, req := range reqs {
+		for _, jwtSVID := range jwtRes.Svids {
+			if len(jwtSVID.Audiences) == 1 && jwtSVID.Audiences[0] == req.Audience {
+				jwtFiles[req.FileName] = jwtSVID.Jwt
+				break
+			}
+		}
+	}
+	return jwtFiles, nil
 }
 
 // generateSVID generates the pre-requisites and makes a SVID generation RPC

--- a/lib/tbot/service_spiffe_workload_api_test.go
+++ b/lib/tbot/service_spiffe_workload_api_test.go
@@ -20,14 +20,25 @@ package tbot
 
 import (
 	"context"
+	"net"
+	"os"
+	"path"
+	"sync"
 	"testing"
+	"time"
 
 	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/spiffe/workloadattest"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
 func ptr[T any](v T) *T {
@@ -422,4 +433,195 @@ func TestSPIFFEWorkloadAPIService_filterSVIDRequests_field(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestBotSPIFFEWorkloadAPI is an end-to-end test of Workload ID's ability to
+// issue a SPIFFE SVID to a workload connecting via the SPIFFE Workload API.
+func TestBotSPIFFEWorkloadAPI(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := utils.NewSlogLoggerForTests()
+
+	// Make a new auth server.
+	process := testenv.MakeTestServer(t, defaultTestServerOpts(t, log))
+	rootClient := testenv.MakeDefaultAuthClient(t, process)
+
+	// Create a role that allows the bot to issue a SPIFFE SVID.
+	role, err := types.NewRole("spiffe-issuer", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			SPIFFE: []*types.SPIFFERoleCondition{
+				{
+					Path: "/*",
+					DNSSANs: []string{
+						"*",
+					},
+					IPSANs: []string{
+						"0.0.0.0/0",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	role, err = rootClient.UpsertRole(ctx, role)
+	require.NoError(t, err)
+
+	pid := os.Getpid()
+
+	tempDir := t.TempDir()
+	socketPath := "unix://" + path.Join(tempDir, "spiffe.sock")
+	onboarding, _ := makeBot(t, rootClient, "test", role.GetName())
+	botConfig := defaultBotConfig(
+		t, process, onboarding, config.ServiceConfigs{
+			&config.SPIFFEWorkloadAPIService{
+				Listen: socketPath,
+				SVIDs: []config.SVIDRequestWithRules{
+					// Intentionally unmatching PID to ensure this SVID
+					// is not issued.
+					{
+						SVIDRequest: config.SVIDRequest{
+							Path: "/bar",
+						},
+						Rules: []config.SVIDRequestRule{
+							{
+								Unix: config.SVIDRequestRuleUnix{
+									PID: ptr(0),
+								},
+							},
+						},
+					},
+					// SVID with rule that matches on PID.
+					{
+						SVIDRequest: config.SVIDRequest{
+							Path: "/foo",
+							Hint: "hint",
+							SANS: config.SVIDRequestSANs{
+								DNS: []string{"example.com"},
+								IP:  []string{"10.0.0.1"},
+							},
+						},
+						Rules: []config.SVIDRequestRule{
+							{
+								Unix: config.SVIDRequestRuleUnix{
+									PID: &pid,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		defaultBotConfigOpts{
+			useAuthServer: true,
+			insecure:      true,
+		},
+	)
+	botConfig.Oneshot = false
+	b := New(botConfig, log)
+
+	// Spin up goroutine for bot to run in
+	botCtx, cancelBot := context.WithCancel(ctx)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := b.Run(botCtx)
+		assert.NoError(t, err, "bot should not exit with error")
+		cancelBot()
+	}()
+	t.Cleanup(func() {
+		// Shut down bot and make sure it exits.
+		cancelBot()
+		wg.Wait()
+	})
+
+	t.Run("X509", func(t *testing.T) {
+		t.Parallel()
+
+		// This has a little flexibility internally in terms of waiting for the
+		// socket to come up, so we don't need a manual sleep/retry here.
+		source, err := workloadapi.NewX509Source(
+			ctx,
+			workloadapi.WithClientOptions(workloadapi.WithAddr(socketPath)),
+		)
+		require.NoError(t, err)
+		defer source.Close()
+
+		svid, err := source.GetX509SVID()
+		require.NoError(t, err)
+
+		// SVID has successfully been issued. We can now assert that it's correct.
+		require.Equal(t, "spiffe://root/foo", svid.ID.String())
+		cert := svid.Certificates[0]
+		require.Equal(t, "spiffe://root/foo", cert.URIs[0].String())
+		require.True(t, net.IPv4(10, 0, 0, 1).Equal(cert.IPAddresses[0]))
+		require.Equal(t, []string{"example.com"}, cert.DNSNames)
+		require.WithinRange(
+			t,
+			cert.NotAfter,
+			cert.NotBefore.Add(time.Hour-time.Minute),
+			cert.NotBefore.Add(time.Hour+time.Minute),
+		)
+	})
+
+	t.Run("JWT", func(t *testing.T) {
+		t.Parallel()
+
+		source, err := workloadapi.NewJWTSource(
+			ctx,
+			workloadapi.WithClientOptions(workloadapi.WithAddr(socketPath)),
+		)
+		require.NoError(t, err)
+		defer source.Close()
+
+		validateSVID := func(
+			t *testing.T,
+			svid *jwtsvid.SVID,
+			wantAudience string,
+		) {
+			t.Helper()
+			// First, check the response fields
+			require.Equal(t, "spiffe://root/foo", svid.ID.String())
+			require.Equal(t, "hint", svid.Hint)
+
+			// Validate "locally" that the SVID is correct.
+			validatedSVID, err := jwtsvid.ParseAndValidate(
+				svid.Marshal(),
+				source,
+				[]string{wantAudience},
+			)
+			require.NoError(t, err)
+			require.Equal(t, svid.Claims, validatedSVID.Claims)
+			require.Equal(t, svid.ID, validatedSVID.ID)
+
+			// Validate "remotely" that the SVID is correct using the Workload
+			// API.
+			validatedSVID, err = workloadapi.ValidateJWTSVID(
+				ctx,
+				svid.Marshal(),
+				wantAudience,
+				workloadapi.WithAddr(socketPath),
+			)
+			require.NoError(t, err)
+			require.Equal(t, svid.Claims, validatedSVID.Claims)
+			require.Equal(t, svid.ID, validatedSVID.ID)
+		}
+
+		svids, err := source.FetchJWTSVIDs(ctx, jwtsvid.Params{
+			Audience:       "example.com",
+			ExtraAudiences: []string{"2.example.com"},
+			Subject:        spiffeid.RequireFromString("spiffe://root/foo"),
+		})
+		require.NoError(t, err)
+		require.Len(t, svids, 1)
+		validateSVID(t, svids[0], "2.example.com")
+
+		// Try again with no specified subject (e.g receive all)
+		svids, err = source.FetchJWTSVIDs(ctx, jwtsvid.Params{
+			Audience: "example.com",
+		})
+		require.NoError(t, err)
+		require.Len(t, svids, 1)
+		validateSVID(t, svids[0], "example.com")
+	})
 }

--- a/lib/tbot/spiffe/trust_bundle_cache.go
+++ b/lib/tbot/spiffe/trust_bundle_cache.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
 	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -118,6 +119,44 @@ func (b *BundleSet) EncodedX509Bundles(includeLocal bool) map[string][]byte {
 		bundles[v.TrustDomain().IDString()] = MarshalX509Bundle(v.X509Bundle())
 	}
 	return bundles
+}
+
+// MarshaledJWKSBundles returns a map of trust domain names to their JWT-SVID
+// signing keys encoded in the RFC 7517 JWKS format. If includeLocal is true,
+// the local trust domain will be included in the output.
+func (b *BundleSet) MarshaledJWKSBundles(includeLocal bool) (map[string][]byte, error) {
+	bundles := make(map[string][]byte)
+	if includeLocal {
+		marshaled, err := b.Local.JWTBundle().Marshal()
+		if err != nil {
+			return nil, trace.Wrap(err, "marshaling local trust bundle")
+		}
+		bundles[b.Local.TrustDomain().IDString()] = marshaled
+	}
+	for _, v := range b.Federated {
+		marshaled, err := v.JWTBundle().Marshal()
+		if err != nil {
+			return nil, trace.Wrap(
+				err,
+				"marshaling federated trust bundle (%s)",
+				v.TrustDomain().Name(),
+			)
+		}
+		bundles[v.TrustDomain().IDString()] = marshaled
+	}
+	return bundles, nil
+}
+
+// GetJWTBundleForTrustDomain returns the JWT bundle for the given trust domain.
+// Implements the jwtbundle.Source interface.
+func (b *BundleSet) GetJWTBundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*jwtbundle.Bundle, error) {
+	if trustDomain.Name() == b.Local.TrustDomain().Name() {
+		return b.Local.JWTBundle(), nil
+	}
+	if bundle, ok := b.Federated[trustDomain.Name()]; ok {
+		return bundle.JWTBundle(), nil
+	}
+	return nil, trace.NotFound("trust domain %q not found", trustDomain.Name())
 }
 
 type eventsWatcher interface {

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"os"
 	"os/user"
+	"path"
 	"path/filepath"
 	"strconv"
 	"sync"

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -27,7 +27,6 @@ import (
 	"net"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -35,7 +34,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgconn"
-	"github.com/spiffe/go-spiffe/v2/workloadapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -718,132 +716,6 @@ func newMockDiscoveredKubeCluster(t *testing.T, name, discoveredName string) *ty
 	)
 	require.NoError(t, err)
 	return kubeCluster
-}
-
-// TestBotSPIFFEWorkloadAPI is an end-to-end test of Workload ID's ability to
-// issue a SPIFFE SVID to a workload connecting via the SPIFFE Workload API.
-func TestBotSPIFFEWorkloadAPI(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
-
-	// Make a new auth server.
-	process := testenv.MakeTestServer(t, defaultTestServerOpts(t, log))
-	rootClient := testenv.MakeDefaultAuthClient(t, process)
-
-	// Create a role that allows the bot to issue a SPIFFE SVID.
-	role, err := types.NewRole("spiffe-issuer", types.RoleSpecV6{
-		Allow: types.RoleConditions{
-			SPIFFE: []*types.SPIFFERoleCondition{
-				{
-					Path: "/*",
-					DNSSANs: []string{
-						"*",
-					},
-					IPSANs: []string{
-						"0.0.0.0/0",
-					},
-				},
-			},
-		},
-	})
-	require.NoError(t, err)
-	role, err = rootClient.UpsertRole(ctx, role)
-	require.NoError(t, err)
-
-	pid := os.Getpid()
-
-	tempDir := t.TempDir()
-	socketPath := "unix://" + path.Join(tempDir, "spiffe.sock")
-	onboarding, _ := makeBot(t, rootClient, "test", role.GetName())
-	botConfig := defaultBotConfig(
-		t, process, onboarding, config.ServiceConfigs{
-			&config.SPIFFEWorkloadAPIService{
-				Listen: socketPath,
-				SVIDs: []config.SVIDRequestWithRules{
-					// Intentionally unmatching PID to ensure this SVID
-					// is not issued.
-					{
-						SVIDRequest: config.SVIDRequest{
-							Path: "/bar",
-						},
-						Rules: []config.SVIDRequestRule{
-							{
-								Unix: config.SVIDRequestRuleUnix{
-									PID: ptr(0),
-								},
-							},
-						},
-					},
-					// SVID with rule that matches on PID.
-					{
-						SVIDRequest: config.SVIDRequest{
-							Path: "/foo",
-							Hint: "hint",
-							SANS: config.SVIDRequestSANs{
-								DNS: []string{"example.com"},
-								IP:  []string{"10.0.0.1"},
-							},
-						},
-						Rules: []config.SVIDRequestRule{
-							{
-								Unix: config.SVIDRequestRuleUnix{
-									PID: &pid,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		defaultBotConfigOpts{
-			useAuthServer: true,
-			insecure:      true,
-		},
-	)
-	botConfig.Oneshot = false
-	b := New(botConfig, log)
-
-	// Spin up goroutine for bot to run in
-	botCtx, cancelBot := context.WithCancel(ctx)
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		err := b.Run(botCtx)
-		assert.NoError(t, err, "bot should not exit with error")
-		cancelBot()
-	}()
-	t.Cleanup(func() {
-		// Shut down bot and make sure it exits.
-		cancelBot()
-		wg.Wait()
-	})
-
-	// This has a little flexibility internally in terms of waiting for the
-	// socket to come up, so we don't need a manual sleep/retry here.
-	source, err := workloadapi.NewX509Source(
-		ctx,
-		workloadapi.WithClientOptions(workloadapi.WithAddr(socketPath)),
-	)
-	require.NoError(t, err)
-	defer source.Close()
-
-	svid, err := source.GetX509SVID()
-	require.NoError(t, err)
-
-	// SVID has successfully been issued. We can now assert that it's correct.
-	require.Equal(t, "spiffe://root/foo", svid.ID.String())
-	cert := svid.Certificates[0]
-	require.Equal(t, "spiffe://root/foo", cert.URIs[0].String())
-	require.True(t, net.IPv4(10, 0, 0, 1).Equal(cert.IPAddresses[0]))
-	require.Equal(t, []string{"example.com"}, cert.DNSNames)
-	require.WithinRange(
-		t,
-		cert.NotAfter,
-		cert.NotBefore.Add(time.Hour-time.Minute),
-		cert.NotBefore.Add(time.Hour+time.Minute),
-	)
 }
 
 func TestBotDatabaseTunnel(t *testing.T) {

--- a/tool/tbot/spiffe.go
+++ b/tool/tbot/spiffe.go
@@ -21,8 +21,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 
 	"github.com/gravitational/teleport/lib/utils"
@@ -42,41 +44,82 @@ func onSPIFFEInspect(ctx context.Context, path string) error {
 	}
 	defer source.Close()
 
-	res, err := source.FetchX509Context(ctx)
+	x509Ctx, err := source.FetchX509Context(ctx)
 	if err != nil {
 		return trace.Wrap(err, "getting x509 context")
 	}
 
-	log.InfoContext(
-		ctx,
-		"Received X.509 SVID context from Workload API",
-		"svids_count", len(res.SVIDs),
-		"bundles_count", res.Bundles.Len(),
-	)
+	audience := "example.com"
+	jwtSVIDs, err := source.FetchJWTSVIDs(ctx, jwtsvid.Params{
+		Audience: audience,
+	})
+	if err != nil {
+		return trace.Wrap(err, "getting JWT SVIDs")
+	}
 
-	if len(res.SVIDs) == 0 {
-		log.ErrorContext(ctx, "No SVIDs received, check your configuration")
-	} else {
-		fmt.Println("SVIDS")
-		for _, svid := range res.SVIDs {
-			fmt.Printf("- %s\n", svid.ID.String())
-			fmt.Printf("  - Hint: %s\n", svid.Hint)
-			fmt.Printf("  - Expiry: %s\n", svid.Certificates[0].NotAfter)
-			for _, san := range svid.Certificates[0].DNSNames {
-				fmt.Printf("  - DNS SAN: %s\n", san)
-			}
-			for _, san := range svid.Certificates[0].IPAddresses {
-				fmt.Printf("  - IP SAN: %s\n", san)
-			}
+	jwtBundles, err := source.FetchJWTBundles(ctx)
+	if err != nil {
+		return trace.Wrap(err, "getting JWT bundles")
+	}
+
+	fmt.Println("# X509 SVIDs")
+	if len(x509Ctx.SVIDs) == 0 {
+		fmt.Println("No X509 SVIDs received, check your configuration")
+	}
+	for _, svid := range x509Ctx.SVIDs {
+		fmt.Printf("- %s\n", svid.ID.String())
+		fmt.Printf("  - Hint: %s\n", svid.Hint)
+		fmt.Printf(
+			"  - Expiry: %s (%s)\n",
+			svid.Certificates[0].NotAfter,
+			time.Until(svid.Certificates[0].NotAfter),
+		)
+		for _, san := range svid.Certificates[0].DNSNames {
+			fmt.Printf("  - DNS SAN: %s\n", san)
+		}
+		for _, san := range svid.Certificates[0].IPAddresses {
+			fmt.Printf("  - IP SAN: %s\n", san)
 		}
 	}
 
-	if res.Bundles.Len() == 0 {
-		log.ErrorContext(ctx, "No trust bundles received, check your configuration")
-	} else {
-		fmt.Println("Trust Bundles")
-		for _, bundle := range res.Bundles.Bundles() {
-			fmt.Printf("- %s\n", bundle.TrustDomain())
+	fmt.Println("# X509 Trust Bundles")
+	if x509Ctx.Bundles.Len() == 0 {
+		fmt.Println("No X509 trust bundles received, check your configuration")
+	}
+	for _, bundle := range x509Ctx.Bundles.Bundles() {
+		fmt.Printf("- %s (#CAs: %d)\n", bundle.TrustDomain(), len(bundle.X509Authorities()))
+	}
+
+	fmt.Println("# JWT SVIDs")
+	if jwtBundles.Len() == 0 {
+		fmt.Println("No JWT SVIDs received, check your configuration")
+	}
+	for _, jwtSVID := range jwtSVIDs {
+		fmt.Printf("- %s\n", jwtSVID.ID)
+		fmt.Printf("  - Expiry: %s (%s)\n", jwtSVID.Expiry, time.Until(jwtSVID.Expiry))
+		fmt.Printf("  - Audiences: %v\n", jwtSVID.Audience)
+		fmt.Printf("  - Hint: %s\n", jwtSVID.Hint)
+		fmt.Printf("  - Value: %s\n", jwtSVID.Marshal())
+
+		// Validate the produced JWT against the Workload API to validate that
+		// ValidateJWTSVID is working as expected, and that the produced JWT is
+		// valid.
+		_, err := source.ValidateJWTSVID(ctx, jwtSVID.Marshal(), audience)
+		if err != nil {
+			fmt.Printf("  - Validation: FAIL - %v\n", err)
+		} else {
+			fmt.Printf("  - Validation: PASS\n")
+		}
+	}
+
+	fmt.Println("# JWT Bundles")
+	if jwtBundles.Len() == 0 {
+		fmt.Println("No JWT trust bundles received, check your configuration")
+	}
+	for _, jwtBundle := range jwtBundles.Bundles() {
+		fmt.Printf("- %s (#Keys: %d)\n", jwtBundle.TrustDomain(), len(jwtBundle.JWTAuthorities()))
+		for keyID := range jwtBundle.JWTAuthorities() {
+			fmt.Printf("  - Key ID: %s\n", keyID)
 		}
 	}
 


### PR DESCRIPTION
Backports #47017 

changelog: Teleport Workload ID now supports issuing JWT SVIDs via the Workload API.