### PR TITLE
Emit UsageEvent for UserTask State changes

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -110,6 +110,7 @@ import (
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/server/installer"
+	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -5189,6 +5190,9 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		Authorizer: cfg.Authorizer,
 		Backend:    cfg.AuthServer.Services,
 		Cache:      cfg.AuthServer.Cache,
+		// This must be a function because cfg.AuthServer.UsageReporter is changed after `NewGRPCServer` is called.
+		// It starts as a DiscardUsageReporter, but when running in Cloud, gets replaced by a real reporter.
+		UsageReporter: func() usagereporter.UsageReporter { return cfg.AuthServer.UsageReporter },
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
This PR changes the UserTask Service to start emitting usage events every time the state of a UserTask changes.

UserTasks are created automatically by the DiscoveryService and can be resolved by the user.
Tracking this usage is very useful to understand if there are a lot of problems and if users are able to fix them.

Demo:
![image](https://github.com/user-attachments/assets/41f0ce2a-7b16-4291-aea1-dc27fa04bc58)
