### PR TITLE
[v15] Set the key id in JWT (#45350)

### DIFF
--- a/lib/jwt/jwt.go
+++ b/lib/jwt/jwt.go
@@ -205,7 +205,13 @@ func (k *Key) Sign(p SignParams) (string, error) {
 		Traits:   p.Traits,
 	}
 
-	return k.sign(claims, nil)
+	// RFC 7517 requires that `kid` be present in the JWT header if there are multiple keys in the JWKS.
+	// We ignore the error because go-jose omits the kid if it is empty.
+	so := &jose.SignerOptions{}
+	if v, ok := k.config.PublicKey.(*rsa.PublicKey); ok {
+		so.WithHeader("kid", KeyID(v))
+	}
+	return k.sign(claims, so)
 }
 
 // awsOIDCCustomClaims defines the require claims for the JWT token used in AWS OIDC Integration.

--- a/lib/jwt/jwt_test.go
+++ b/lib/jwt/jwt_test.go
@@ -57,6 +57,13 @@ func TestSignAndVerify(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	//decode the signed token
+	decodedToken, err := josejwt.ParseSigned(token)
+	require.NoError(t, err)
+
+	// verify that the kid header is present, and not empty
+	require.NotEmpty(t, decodedToken.Headers[0].KeyID)
+
 	// Verify that the token can be validated and values match expected values.
 	claims, err := key.Verify(VerifyParams{
 		Username: "foo@example.com",


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/45350

changelog: Include JWK header in JWTs issued by Teleport Application Access.