### PR TITLE
[v16] avoid updating user when `MfaWeakestDevice` doesn't change

### DIFF
--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -1235,6 +1235,10 @@ func (s *IdentityService) upsertUserStatusMFADevice(ctx context.Context, user st
 		user,
 		false, /*withSecrets*/
 		func(u types.User) (bool, error) {
+			// If the user already has the weakest device, don't update.
+			if u.GetWeakestDevice() == mfaState {
+				return false, nil
+			}
 			u.SetWeakestDevice(mfaState)
 			return true, nil
 		})

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -1362,6 +1362,7 @@ func TestWeakestMFADeviceKind(t *testing.T) {
 	got, err = identity.GetUser(ctx, "bob", false)
 	require.NoError(t, err)
 	require.Equal(t, types.MFADeviceKind_MFA_DEVICE_KIND_TOTP, got.GetWeakestDevice())
+	oldRevision := got.GetMetadata().Revision
 
 	u2fDev := &types.MFADevice{
 		Metadata: types.Metadata{
@@ -1382,6 +1383,7 @@ func TestWeakestMFADeviceKind(t *testing.T) {
 	got, err = identity.GetUser(ctx, "bob", false)
 	require.NoError(t, err)
 	require.Equal(t, types.MFADeviceKind_MFA_DEVICE_KIND_TOTP, got.GetWeakestDevice())
+	require.Equal(t, oldRevision, got.GetMetadata().Revision, "revision should not change")
 
 	// Create webauthn device but state should still be MFA_DEVICE_KIND_TOTP
 	// because it shows the weakest state.
@@ -1408,6 +1410,7 @@ func TestWeakestMFADeviceKind(t *testing.T) {
 	got, err = identity.GetUser(ctx, "bob", false)
 	require.NoError(t, err)
 	require.Equal(t, types.MFADeviceKind_MFA_DEVICE_KIND_TOTP, got.GetWeakestDevice())
+	require.Equal(t, oldRevision, got.GetMetadata().Revision, "revision should not change")
 
 	// Delete the TOTP device and the state should be MFA_DEVICE_KIND_WEBAUTHN
 	err = identity.DeleteMFADevice(ctx, "bob", totpDevice.Id)
@@ -1416,6 +1419,7 @@ func TestWeakestMFADeviceKind(t *testing.T) {
 	got, err = identity.GetUser(ctx, "bob", false)
 	require.NoError(t, err)
 	require.Equal(t, types.MFADeviceKind_MFA_DEVICE_KIND_WEBAUTHN, got.GetWeakestDevice())
+	oldRevision = got.GetMetadata().Revision
 
 	// Delete the U2F device and the state should be MFA_DEVICE_KIND_WEBAUTHN
 	err = identity.DeleteMFADevice(ctx, "bob", u2fDev.Id)
@@ -1424,6 +1428,7 @@ func TestWeakestMFADeviceKind(t *testing.T) {
 	got, err = identity.GetUser(ctx, "bob", false)
 	require.NoError(t, err)
 	require.Equal(t, types.MFADeviceKind_MFA_DEVICE_KIND_WEBAUTHN, got.GetWeakestDevice())
+	require.Equal(t, oldRevision, got.GetMetadata().Revision, "revision should not change")
 
 	// Delete the Webauthn device and the state should be MFA_DEVICE_KIND_UNSET
 	err = identity.DeleteMFADevice(ctx, "bob", webauthnDevice.Id)


### PR DESCRIPTION
Backport #47390 to branch/v16