### PR TITLE
Hopefully fix TestSPIFFEFederationSyncer flakiness

### DIFF
--- a/lib/auth/machineid/machineidv1/spiffe_federation_syncer_test.go
+++ b/lib/auth/machineid/machineidv1/spiffe_federation_syncer_test.go
@@ -152,7 +152,7 @@ func TestSPIFFEFederationSyncer(t *testing.T) {
 			return
 		}
 		assert.Equal(t, string(marshaledBundle1), got.Status.CurrentBundle)
-	}, time.Second*5, time.Millisecond*100)
+	}, time.Second*10, time.Millisecond*200)
 
 	// Create a second SPIFFEFederation and wait for it to be synced
 	created2, err := store.CreateSPIFFEFederation(ctx, &machineidv1pb.SPIFFEFederation{
@@ -184,7 +184,7 @@ func TestSPIFFEFederationSyncer(t *testing.T) {
 			return
 		}
 		assert.Equal(t, string(marshaledBundle2), got.Status.CurrentBundle)
-	}, time.Second*5, time.Millisecond*100)
+	}, time.Second*10, time.Millisecond*200)
 
 	cancel()
 	select {


### PR DESCRIPTION
Taking a look at the failed runs, it looks like in most cases, the desired state is reached not too long after the timeout is hit under the conditions of load on the CI run. I'm hoping that pushing this up a little should resolve the flakes.

Closes https://github.com/gravitational/teleport/issues/47398