### PR TITLE
Fix the issue with filters dropdown position

### DIFF
--- a/web/packages/design/src/Menu/MenuList.jsx
+++ b/web/packages/design/src/Menu/MenuList.jsx
@@ -22,9 +22,9 @@ import styled from 'styled-components';
 
 class MenuList extends React.Component {
   render() {
-    const { children, ...other } = this.props;
+    const { children, innerRef, ...other } = this.props;
     return (
-      <StyledMenuList role="menu" {...other}>
+      <StyledMenuList ref={innerRef} role="menu" {...other}>
         {children}
       </StyledMenuList>
     );
@@ -55,4 +55,6 @@ MenuList.propTypes = {
   menuListCss: PropTypes.func,
 };
 
-export default MenuList;
+export default React.forwardRef((props, ref) => (
+  <MenuList innerRef={ref} {...props} />
+));


### PR DESCRIPTION
PR #46589 got rid of the `findDOMNode` call, but because we were dealing with untyped JavaScript, we didn't notice that `menuListRef` is now getting a ref to a React component instead of its child DOM node. This change fixes it.

Before:
![Screenshot 2024-10-09 at 19 06 06](https://github.com/user-attachments/assets/d995af9b-2047-49e8-96e0-0541bdf1a3bc)

After:
![Screenshot 2024-10-09 at 19 05 39](https://github.com/user-attachments/assets/4477d916-03bf-4394-b09e-4a16b6c6116a)
