### PR TITLE
fix: Address flakiness and revisit TestTeleportClient_Login_local

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -505,6 +505,10 @@ type Config struct {
 	// StdinFunc allows tests to override prompt.Stdin().
 	// If nil prompt.Stdin() is used.
 	StdinFunc func() prompt.StdinReader
+
+	// HasTouchIDCredentialsFunc allows tests to override touchid.HasCredentials.
+	// If nil touchid.HasCredentials is used.
+	HasTouchIDCredentialsFunc func(rpID, user string) bool
 }
 
 // CachePolicy defines cache policy for local clients
@@ -1265,6 +1269,13 @@ func (tc *TeleportClient) stdin() prompt.StdinReader {
 		return prompt.Stdin()
 	}
 	return tc.StdinFunc()
+}
+
+func (tc *TeleportClient) hasTouchIDCredentials(rpID, user string) bool {
+	if tc.HasTouchIDCredentialsFunc == nil {
+		return touchid.HasCredentials(rpID, user)
+	}
+	return tc.HasTouchIDCredentialsFunc(rpID, user)
 }
 
 func (tc *TeleportClient) ProfileStatus() (*ProfileStatus, error) {
@@ -3693,9 +3704,6 @@ func (tc *TeleportClient) mfaLocalLoginWeb(ctx context.Context, keyRing *KeyRing
 	return clt, session, trace.Wrap(err)
 }
 
-// hasTouchIDCredentials provides indirection for tests.
-var hasTouchIDCredentials = touchid.HasCredentials
-
 // canDefaultToPasswordless checks without user interaction
 // if there is any registered passwordless login.
 func (tc *TeleportClient) canDefaultToPasswordless(pr *webclient.PingResponse) bool {
@@ -3718,7 +3726,7 @@ func (tc *TeleportClient) canDefaultToPasswordless(pr *webclient.PingResponse) b
 		user = tc.Username
 	}
 
-	return hasTouchIDCredentials(pr.Auth.Webauthn.RPID, user)
+	return tc.hasTouchIDCredentials(pr.Auth.Webauthn.RPID, user)
 }
 
 // SSHLoginFunc is a function which carries out authn with an auth server and returns an auth response.

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -89,13 +89,8 @@ func TestTeleportClient_Login_local(t *testing.T) {
 	cfg.InsecureSkipVerify = true
 
 	// Reset functions after tests.
-	oldStdin := prompt.Stdin()
 	oldHasCredentials := *client.HasTouchIDCredentials
-
-	t.Cleanup(func() {
-		prompt.SetStdin(oldStdin)
-		*client.HasTouchIDCredentials = oldHasCredentials
-	})
+	t.Cleanup(func() { *client.HasTouchIDCredentials = oldHasCredentials })
 
 	waitForCancelFn := func(ctx context.Context) (string, error) {
 		<-ctx.Done() // wait for timeout
@@ -264,7 +259,6 @@ func TestTeleportClient_Login_local(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
-			prompt.SetStdin(test.inputReader)
 			*client.HasTouchIDCredentials = func(rpid, user string) bool {
 				return test.hasTouchIDCredentials
 			}
@@ -283,6 +277,7 @@ func TestTeleportClient_Login_local(t *testing.T) {
 			tc.AuthConnector = test.authConnector
 			tc.PreferOTP = test.preferOTP
 			tc.AuthenticatorAttachment = test.authenticatorAttachment
+			tc.StdinFunc = func() prompt.StdinReader { return test.inputReader }
 
 			tc.WebauthnLogin = func(
 				ctx context.Context,

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -137,7 +137,6 @@ func TestTeleportClient_Login_local(t *testing.T) {
 		}
 	}
 
-	ctx := context.Background()
 	tests := []struct {
 		name                    string
 		makeInputReader         func(pass, otpKey string, clock clockwork.Clock) *prompt.FakeReader
@@ -267,9 +266,6 @@ func TestTeleportClient_Login_local(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			defer cancel()
-
 			// Start Teleport.
 			clock := clockwork.NewFakeClockAt(time.Now())
 			sa := newStandaloneTeleport(t, clock)
@@ -315,6 +311,9 @@ func TestTeleportClient_Login_local(t *testing.T) {
 			tc.HasTouchIDCredentialsFunc = func(_, _ string) bool {
 				return test.hasTouchIDCredentials
 			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
 
 			// Test.
 			clock.Advance(30 * time.Second)

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -66,92 +66,82 @@ func TestTeleportClient_Login_local(t *testing.T) {
 
 	silenceLogger(t)
 
-	clock := clockwork.NewFakeClockAt(time.Now())
-	sa := newStandaloneTeleport(t, clock)
-	username := sa.Username
-	password := sa.Password
-	webID := sa.WebAuthnID
-	device := sa.Device
-	otpKey := sa.OTPKey
-
-	// Prepare client config, it won't change throughout the test.
-	cfg := client.MakeDefaultConfig()
-	cfg.Stdout = io.Discard
-	cfg.Stderr = io.Discard
-	cfg.Stdin = &bytes.Buffer{}
-	cfg.Username = username
-	cfg.HostLogin = username
-	cfg.AddKeysToAgent = client.AddKeysToAgentNo
-	// Replace "127.0.0.1" with "localhost". The proxy address becomes the origin
-	// for Webauthn requests, and Webauthn doesn't take IP addresses.
-	cfg.WebProxyAddr = strings.Replace(sa.ProxyWebAddr, "127.0.0.1", "localhost", 1 /* n */)
-	cfg.KeysDir = t.TempDir()
-	cfg.InsecureSkipVerify = true
+	type webauthnFunc func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error)
 
 	waitForCancelFn := func(ctx context.Context) (string, error) {
 		<-ctx.Done() // wait for timeout
 		return "", ctx.Err()
 	}
-	noopWebauthnFn := func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
-		<-ctx.Done() // wait for timeout
-		return nil, ctx.Err()
+	noopWebauthnFn := func(_ *mocku2f.Key, _ []byte) webauthnFunc {
+		return func(ctx context.Context, _ string, _ *wantypes.CredentialAssertion, _ wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
+			<-ctx.Done() // wait for timeout
+			return nil, ctx.Err()
+		}
 	}
 
-	solveOTP := func(ctx context.Context) (string, error) {
-		return totp.GenerateCode(otpKey, clock.Now())
-	}
-	solveWebauthn := func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
-		ackTouch, err := prompt.PromptTouch()
-		if err != nil {
-			return nil, err
+	solveOTP := func(otpKey string, clock clockwork.Clock) func(ctx context.Context) (string, error) {
+		return func(ctx context.Context) (string, error) {
+			return totp.GenerateCode(otpKey, clock.Now())
 		}
+	}
+	solveWebauthn := func(device *mocku2f.Key, _ []byte) webauthnFunc {
+		return func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
+			ackTouch, err := prompt.PromptTouch()
+			if err != nil {
+				return nil, err
+			}
 
-		car, err := device.SignAssertion(origin, assertion)
-		if err != nil {
-			return nil, err
+			car, err := device.SignAssertion(origin, assertion)
+			if err != nil {
+				return nil, err
+			}
+			ackTouch()
+			return &proto.MFAAuthenticateResponse{
+				Response: &proto.MFAAuthenticateResponse_Webauthn{
+					Webauthn: wantypes.CredentialAssertionResponseToProto(car),
+				},
+			}, nil
 		}
-		ackTouch()
-		return &proto.MFAAuthenticateResponse{
-			Response: &proto.MFAAuthenticateResponse_Webauthn{
-				Webauthn: wantypes.CredentialAssertionResponseToProto(car),
-			},
-		}, nil
 	}
-	solvePwdless := func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
-		resp, err := solveWebauthn(ctx, origin, assertion, prompt)
-		if err == nil {
-			resp.GetWebauthn().Response.UserHandle = webID
+	solvePwdless := func(device *mocku2f.Key, webID []byte) webauthnFunc {
+		return func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
+			resp, err := solveWebauthn(device, webID)(ctx, origin, assertion, prompt)
+			if err == nil {
+				resp.GetWebauthn().Response.UserHandle = webID
+			}
+			return resp, err
 		}
-		return resp, err
 	}
 
 	const pin = "pin123"
 	userPINFn := func(ctx context.Context) (string, error) {
 		return pin, nil
 	}
-	solvePIN := func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
-		// Ask and verify the PIN. Usually the authenticator would verify the PIN,
-		// but we are faking it here.
-		got, err := prompt.PromptPIN()
-		switch {
-		case err != nil:
-			return nil, err
-		case got != pin:
-			return nil, errors.New("invalid PIN")
-		}
+	solvePIN := func(device *mocku2f.Key, webID []byte) webauthnFunc {
+		return func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
+			// Ask and verify the PIN. Usually the authenticator would verify the PIN,
+			// but we are faking it here.
+			got, err := prompt.PromptPIN()
+			switch {
+			case err != nil:
+				return nil, err
+			case got != pin:
+				return nil, errors.New("invalid PIN")
+			}
 
-		resp, err := solveWebauthn(ctx, origin, assertion, prompt)
-		if err != nil {
-			return nil, err
+			resp, err := solveWebauthn(device, webID)(ctx, origin, assertion, prompt)
+			if err != nil {
+				return nil, err
+			}
+			return resp, nil
 		}
-		return resp, nil
 	}
 
 	ctx := context.Background()
 	tests := []struct {
 		name                    string
-		inputReader             *prompt.FakeReader
-		solveWebauthn           func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error)
+		makeInputReader         func(pass, otpKey string, clock clockwork.Clock) *prompt.FakeReader
+		makeSolveWebauthn       func(device *mocku2f.Key, webID []byte) webauthnFunc
 		authConnector           string
 		allowStdinHijack        bool
 		preferOTP               bool
@@ -159,81 +149,115 @@ func TestTeleportClient_Login_local(t *testing.T) {
 		authenticatorAttachment wancli.AuthenticatorAttachment
 	}{
 		{
-			name:             "OTP device login with hijack",
-			inputReader:      prompt.NewFakeReader().AddString(password).AddReply(solveOTP),
-			solveWebauthn:    noopWebauthnFn,
-			allowStdinHijack: true,
+			name: "OTP device login with hijack",
+			makeInputReader: func(pass, otpKey string, clock clockwork.Clock) *prompt.FakeReader {
+				return prompt.NewFakeReader().
+					AddString(pass).
+					AddReply(solveOTP(otpKey, clock))
+			},
+			makeSolveWebauthn: noopWebauthnFn,
+			allowStdinHijack:  true,
 		},
 		{
-			name:             "Webauthn device login with hijack",
-			inputReader:      prompt.NewFakeReader().AddString(password).AddReply(waitForCancelFn),
-			solveWebauthn:    solveWebauthn,
-			allowStdinHijack: true,
+			name: "Webauthn device login with hijack",
+			makeInputReader: func(pass, _ string, _ clockwork.Clock) *prompt.FakeReader {
+				return prompt.NewFakeReader().
+					AddString(pass).
+					AddReply(waitForCancelFn)
+			},
+			makeSolveWebauthn: solveWebauthn,
+			allowStdinHijack:  true,
 		},
 		{
-			name:             "Webauthn device with PIN and hijack", // a bit hypothetical, but _could_ happen.
-			inputReader:      prompt.NewFakeReader().AddString(password).AddReply(waitForCancelFn).AddReply(userPINFn),
-			solveWebauthn:    solvePIN,
-			allowStdinHijack: true,
+			name: "Webauthn device with PIN and hijack", // a bit hypothetical, but _could_ happen.
+			makeInputReader: func(pass, _ string, _ clockwork.Clock) *prompt.FakeReader {
+				return prompt.NewFakeReader().
+					AddString(pass).
+					AddReply(waitForCancelFn).
+					AddReply(userPINFn)
+			},
+
+			makeSolveWebauthn: solvePIN,
+			allowStdinHijack:  true,
 		},
 		{
-			name:        "OTP preferred",
-			inputReader: prompt.NewFakeReader().AddString(password).AddReply(solveOTP),
-			solveWebauthn: func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
-				panic("this should not be called")
+			name: "OTP preferred",
+			makeInputReader: func(pass, otpKey string, clock clockwork.Clock) *prompt.FakeReader {
+				return prompt.NewFakeReader().
+					AddString(pass).
+					AddReply(solveOTP(otpKey, clock))
+			},
+			makeSolveWebauthn: func(_ *mocku2f.Key, _ []byte) webauthnFunc {
+				return func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
+					panic("this should not be called")
+				}
 			},
 			preferOTP: true,
 		},
 		{
 			name: "Webauthn device login",
-			inputReader: prompt.NewFakeReader().
-				AddString(password).
-				AddReply(func(ctx context.Context) (string, error) {
-					panic("this should not be called")
-				}),
-			solveWebauthn: solveWebauthn,
+			makeInputReader: func(pass, _ string, _ clockwork.Clock) *prompt.FakeReader {
+				return prompt.NewFakeReader().
+					AddString(pass).
+					AddReply(func(ctx context.Context) (string, error) {
+						panic("this should not be called")
+					})
+			},
+			makeSolveWebauthn: solveWebauthn,
 		},
 		{
-			name:          "passwordless login",
-			inputReader:   prompt.NewFakeReader(), // no inputs
-			solveWebauthn: solvePwdless,
-			authConnector: constants.PasswordlessConnector,
+			name: "passwordless login",
+			makeInputReader: func(_, _ string, _ clockwork.Clock) *prompt.FakeReader {
+				return prompt.NewFakeReader() // no inputs
+			},
+			makeSolveWebauthn: solvePwdless,
+			authConnector:     constants.PasswordlessConnector,
 		},
 		{
-			name:                  "default to passwordless if registered",
-			inputReader:           prompt.NewFakeReader(), // no inputs
-			solveWebauthn:         solvePwdless,
+			name: "default to passwordless if registered",
+			makeInputReader: func(_, _ string, _ clockwork.Clock) *prompt.FakeReader {
+				return prompt.NewFakeReader() // no inputs
+			},
+			makeSolveWebauthn:     solvePwdless,
 			hasTouchIDCredentials: true,
 		},
 		{
 			name: "cross-platform attachment doesn't default to passwordless",
-			inputReader: prompt.NewFakeReader().
-				AddString(password).
-				AddReply(func(ctx context.Context) (string, error) {
-					panic("this should not be called")
-				}),
-			solveWebauthn:           solveWebauthn,
+			makeInputReader: func(pass, _ string, _ clockwork.Clock) *prompt.FakeReader {
+				return prompt.NewFakeReader().
+					AddString(pass).
+					AddReply(func(ctx context.Context) (string, error) {
+						panic("this should not be called")
+					})
+			},
+			makeSolveWebauthn:       solveWebauthn,
 			hasTouchIDCredentials:   true,
 			authenticatorAttachment: wancli.AttachmentCrossPlatform,
 		},
 		{
 			name: "local connector doesn't default to passwordless",
-			inputReader: prompt.NewFakeReader().
-				AddString(password).
-				AddReply(func(ctx context.Context) (string, error) {
-					panic("this should not be called")
-				}),
-			solveWebauthn:         solveWebauthn,
+			makeInputReader: func(pass, _ string, _ clockwork.Clock) *prompt.FakeReader {
+				return prompt.NewFakeReader().
+					AddString(pass).
+					AddReply(func(ctx context.Context) (string, error) {
+						panic("this should not be called")
+					})
+			},
+			makeSolveWebauthn:     solveWebauthn,
 			authConnector:         constants.LocalConnector,
 			hasTouchIDCredentials: true,
 		},
 		{
 			name: "OTP preferred doesn't default to passwordless",
-			inputReader: prompt.NewFakeReader().
-				AddString(password).
-				AddReply(solveOTP),
-			solveWebauthn: func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
-				panic("this should not be called")
+			makeInputReader: func(pass, otpKey string, clock clockwork.Clock) *prompt.FakeReader {
+				return prompt.NewFakeReader().
+					AddString(pass).
+					AddReply(solveOTP(otpKey, clock))
+			},
+			makeSolveWebauthn: func(_ *mocku2f.Key, _ []byte) webauthnFunc {
+				return func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
+					panic("this should not be called")
+				}
 			},
 			preferOTP:             true,
 			hasTouchIDCredentials: true,
@@ -241,22 +265,50 @@ func TestTeleportClient_Login_local(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
+			// Start Teleport.
+			clock := clockwork.NewFakeClockAt(time.Now())
+			sa := newStandaloneTeleport(t, clock)
+			username := sa.Username
+			password := sa.Password
+			webID := sa.WebAuthnID
+			device := sa.Device
+			otpKey := sa.OTPKey
+
+			// Prepare client config.
+			cfg := client.MakeDefaultConfig()
+			cfg.Stdout = io.Discard
+			cfg.Stderr = io.Discard
+			cfg.Stdin = &bytes.Buffer{}
+			cfg.Username = username
+			cfg.HostLogin = username
+			cfg.AddKeysToAgent = client.AddKeysToAgentNo
+			// Replace "127.0.0.1" with "localhost". The proxy address becomes the origin
+			// for Webauthn requests, and Webauthn doesn't take IP addresses.
+			cfg.WebProxyAddr = strings.Replace(sa.ProxyWebAddr, "127.0.0.1", "localhost", 1 /* n */)
+			cfg.KeysDir = t.TempDir()
+			cfg.InsecureSkipVerify = true
+
+			// Prepare the client proper.
 			tc, err := client.NewClient(cfg)
 			require.NoError(t, err)
 			tc.AllowStdinHijack = test.allowStdinHijack
 			tc.AuthConnector = test.authConnector
 			tc.PreferOTP = test.preferOTP
 			tc.AuthenticatorAttachment = test.authenticatorAttachment
-			tc.StdinFunc = func() prompt.StdinReader { return test.inputReader }
+			inputReader := test.makeInputReader(password, otpKey, clock)
+			tc.StdinFunc = func() prompt.StdinReader { return inputReader }
 
+			solveWebauthn := test.makeSolveWebauthn(device, webID)
 			tc.WebauthnLogin = func(
 				ctx context.Context,
 				origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt, _ *wancli.LoginOpts,
 			) (*proto.MFAAuthenticateResponse, string, error) {
-				resp, err := test.solveWebauthn(ctx, origin, assertion, prompt)
+				resp, err := solveWebauthn(ctx, origin, assertion, prompt)
 				return resp, "", err
 			}
 
@@ -264,6 +316,7 @@ func TestTeleportClient_Login_local(t *testing.T) {
 				return test.hasTouchIDCredentials
 			}
 
+			// Test.
 			clock.Advance(30 * time.Second)
 			_, err = tc.Login(ctx)
 			require.NoError(t, err)

--- a/lib/client/export_test.go
+++ b/lib/client/export_test.go
@@ -18,8 +18,6 @@
 
 package client
 
-var HasTouchIDCredentials = &hasTouchIDCredentials
-
 func (tc *TeleportClient) SetDTAttemptLoginIgnorePing(val bool) {
 	tc.dtAttemptLoginIgnorePing = val
 }

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -70,6 +70,7 @@ func (tc *TeleportClient) newPromptConfig(opts ...mfa.PromptOpt) *libmfa.PromptC
 	cfg.AuthenticatorAttachment = tc.AuthenticatorAttachment
 	cfg.PreferOTP = tc.PreferOTP
 	cfg.AllowStdinHijack = tc.AllowStdinHijack
+	cfg.StdinFunc = tc.StdinFunc
 
 	if tc.WebauthnLogin != nil {
 		cfg.WebauthnLoginFunc = tc.WebauthnLogin

--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -49,6 +49,13 @@ func NewCLIPrompt(cfg *PromptConfig, writer io.Writer) *CLIPrompt {
 	}
 }
 
+func (c *CLIPrompt) stdin() prompt.StdinReader {
+	if c.cfg.StdinFunc == nil {
+		return prompt.Stdin()
+	}
+	return c.cfg.StdinFunc()
+}
+
 // Run prompts the user to complete an MFA authentication challenge.
 func (c *CLIPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
 	if c.cfg.PromptReason != "" {
@@ -138,7 +145,7 @@ func (c *CLIPrompt) promptTOTP(ctx context.Context, quiet bool) (*proto.MFAAuthe
 		msg = fmt.Sprintf("Enter an OTP code from a %sdevice", c.promptDevicePrefix())
 	}
 
-	otp, err := prompt.Password(ctx, c.writer, prompt.Stdin(), msg)
+	otp, err := prompt.Password(ctx, c.writer, c.stdin(), msg)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -157,6 +164,7 @@ func (c *CLIPrompt) getWebauthnPrompt(ctx context.Context, dualPrompt bool) wanc
 	}
 
 	prompt := wancli.NewDefaultPrompt(ctx, writer)
+	prompt.StdinFunc = c.cfg.StdinFunc
 	prompt.SecondTouchMessage = fmt.Sprintf("Tap your %ssecurity key to complete login", c.promptDevicePrefix())
 	prompt.FirstTouchMessage = fmt.Sprintf("Tap any %ssecurity key", c.promptDevicePrefix())
 

--- a/lib/client/mfa/prompt.go
+++ b/lib/client/mfa/prompt.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/mfa"
+	"github.com/gravitational/teleport/api/utils/prompt"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 )
@@ -63,6 +64,9 @@ type PromptConfig struct {
 	PreferOTP bool
 	// WebauthnSupported indicates whether Webauthn is supported.
 	WebauthnSupported bool
+	// StdinFunc allows tests to override prompt.Stdin().
+	// If nil prompt.Stdin() is used.
+	StdinFunc func() prompt.StdinReader
 }
 
 // NewPromptConfig returns a prompt config that will induce default behavior.


### PR DESCRIPTION
Fix flakiness due to OTP goroutine cancel changes introduced by #47114 and do various improvements to the test.

The OTP cancel was moved from PromptPIN to PromptTouch, assuming well-behaved implementations, but functions inside TestTeleportClient_Login_local deviate from the norm. The cancel at PromptPIN was reintroduced.

Improvements to the test include:

* Removing calls to prompt.SetStdin
* Removing the global client.hasTouchIDCredentials variable
* (The changes above make the test truly parallel)
* Making sub-tests parallel

Closes #18683.