### PR TITLE
fix security group picker for auto-discover flow

### DIFF
--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.story.tsx
@@ -65,11 +65,13 @@ Init.parameters = {
 };
 
 export const InitWithAutoDiscover = () => {
+  const dbMeta = getDbMeta();
+  dbMeta.selectedAwsRdsDb = undefined; // there is no selection for discovery
   return (
     <TeleportProvider
       resourceKind={ResourceKind.Database}
       agentMeta={{
-        ...getDbMeta(),
+        ...dbMeta,
         autoDiscovery: {
           config: { name: '', discoveryGroup: '', aws: [] },
         },


### PR DESCRIPTION
Fixes a bug introduced in #47245
- #47245

The bug basically was that we tried to recommend security groups for a selected database, but in the auto-discovery variant there is no selected database. I failed to check for undefined selected db, therefore the security group would fail to render with an error like "db.uri undefined".

Now it checks for undefined selected database. There were a couple other lines that looked wrong that I changed as well, which would likely be buggy if there were multiple security group pages fetched (100+).

I updated storybook to test this case and verified that before the fix it showed an error and with the fix it does not.