### PR TITLE
Display more user friendly error for invalid os logins in Web UI

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -7803,6 +7803,10 @@ type authProviderMock struct {
 	server types.ServerV2
 }
 
+func (mock authProviderMock) ListUnifiedResources(ctx context.Context, req *authproto.ListUnifiedResourcesRequest) (*authproto.ListUnifiedResourcesResponse, error) {
+	return nil, nil
+}
+
 func (mock authProviderMock) GetNode(ctx context.Context, namespace, name string) (types.Server, error) {
 	return &mock.server, nil
 }


### PR DESCRIPTION
Host resolution no longer happens prior to connections in the Web UI and all dial attempts are by UUID. When an invalid login is attempted the error message constructed only contained the info provided to the dial request: a login and a Host UUID. To make this error more user friendly access denied errors are now augmented with the hostname if the user has permissions to that host and the error occurs only due to an invalid login.

Closes https://github.com/gravitational/teleport/issues/23719

changelog: Include host name instead of host uuid in error messages when SSH connections are prevented due to an invalid login