### PR TITLE
Use input as filter for ssh and desktop connect menus

### DIFF
--- a/web/packages/shared/components/MenuLogin/MenuLogin.test.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.test.tsx
@@ -20,6 +20,43 @@ import React from 'react';
 import { render, fireEvent, screen, waitFor } from 'design/utils/testing';
 
 import { MenuLogin } from './MenuLogin';
+import { MenuInputType } from './types';
+
+test('filters options and selects first item when inputType is FILTER', async () => {
+  const loginItems = [
+    { url: '', login: 'user1' },
+    { url: '', login: 'user2' },
+    { url: '', login: 'admin' },
+  ];
+  const onSelect = jest.fn();
+
+  render(
+    <MenuLogin
+      required={false}
+      getLoginItems={() => loginItems}
+      onSelect={onSelect}
+      inputType={MenuInputType.FILTER}
+    />
+  );
+
+  fireEvent.click(await screen.findByText(/connect/i));
+
+  // Type 'user' into the input to filter
+  const input = await screen.findByPlaceholderText('Search logins…');
+  fireEvent.change(input, { target: { value: 'user' } });
+
+  fireEvent.keyPress(input, {
+    key: 'Enter',
+    keyCode: 13,
+  });
+
+  await waitFor(() => {
+    expect(onSelect).toHaveBeenCalledWith(expect.anything(), 'user1');
+  });
+
+  // Verify that 'admin' is not visible in the filtered list
+  expect(screen.queryByText('admin')).not.toBeInTheDocument();
+});
 
 test('does not accept an empty value when required is set to true', async () => {
   const onSelect = jest.fn();

--- a/web/packages/shared/components/MenuLogin/types.ts
+++ b/web/packages/shared/components/MenuLogin/types.ts
@@ -21,10 +21,21 @@ export type LoginItem = {
   login: string;
 };
 
+// MenuInputType determines how the input present in the MenuLogin
+// will function. Default is Input, which allows freeform input and
+// will call the `onSelect` function with whatever value is entered.
+// FILTER will only filter the options present in the list and will
+// pass the 0th item in the filtered list to `onSelect` instead.
+export enum MenuInputType {
+  INPUT,
+  FILTER,
+}
+
 export type MenuLoginProps = {
   getLoginItems: () => LoginItem[] | Promise<LoginItem[]>;
   onSelect: (e: React.SyntheticEvent, login: string) => void;
   anchorOrigin?: any;
+  inputType?: MenuInputType;
   alignButtonWidthToMenu?: boolean;
   transformOrigin?: any;
   textTransform?: string;

--- a/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
@@ -18,7 +18,11 @@
 
 import React, { useState } from 'react';
 import { ButtonBorder, ButtonWithMenu, MenuItem } from 'design';
-import { LoginItem, MenuLogin } from 'shared/components/MenuLogin';
+import {
+  LoginItem,
+  MenuInputType,
+  MenuLogin,
+} from 'shared/components/MenuLogin';
 import { AwsLaunchButton } from 'shared/components/AwsLaunchButton';
 
 import { UnifiedResource } from 'teleport/services/agents';
@@ -84,6 +88,7 @@ const NodeConnect = ({ node }: { node: Node }) => {
   return (
     <MenuLogin
       width="123px"
+      inputType={MenuInputType.FILTER}
       textTransform={'none'}
       alignButtonWidthToMenu
       getLoginItems={handleOnOpen}
@@ -124,6 +129,7 @@ const DesktopConnect = ({ desktop }: { desktop: Desktop }) => {
   return (
     <MenuLogin
       width="123px"
+      inputType={MenuInputType.FILTER}
       textTransform="none"
       alignButtonWidthToMenu
       getLoginItems={handleOnOpen}

--- a/web/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/web/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -19,7 +19,11 @@
 import React from 'react';
 import Table, { Cell, ClickableLabelCell } from 'design/DataTable';
 import { FetchStatus, SortType } from 'design/DataTable/types';
-import { LoginItem, MenuLogin } from 'shared/components/MenuLogin';
+import {
+  LoginItem,
+  MenuInputType,
+  MenuLogin,
+} from 'shared/components/MenuLogin';
 
 import { Node } from 'teleport/services/nodes';
 import { ResourceLabel, ResourceFilter } from 'teleport/services/agents';
@@ -119,6 +123,7 @@ const renderLoginCell = (
   return (
     <Cell align="right">
       <MenuLogin
+        inputType={MenuInputType.FILTER}
         getLoginItems={handleOnOpen}
         onSelect={handleOnSelect}
         transformOrigin={{

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -17,7 +17,11 @@
  */
 
 import React from 'react';
-import { MenuLogin, MenuLoginProps } from 'shared/components/MenuLogin';
+import {
+  MenuInputType,
+  MenuLogin,
+  MenuLoginProps,
+} from 'shared/components/MenuLogin';
 import { AwsLaunchButton } from 'shared/components/AwsLaunchButton';
 import { ButtonBorder, ButtonWithMenu, MenuItem, ButtonPrimary } from 'design';
 
@@ -73,6 +77,7 @@ export function ConnectServerActionButton(props: {
 
   return (
     <MenuLogin
+      inputType={MenuInputType.FILTER}
       textTransform="none"
       getLoginItems={() => getSshLogins().map(login => ({ login, url: '' }))}
       onSelect={(e, login) => connect(login)}


### PR DESCRIPTION
Closes: https://github.com/gravitational/teleport/issues/41123

This will add an optional prop to denote a MenuLogin as "filter" instead of a freeform input. If set to filter type, the input will only filter the available logins and hitting "Enter" will now select the first item in the filtered list. If there are no items, enter does nothing and no longer allows any freeform entry.

Databases still allow freeform entry.

The other solution to this issue was to remove the input all together, however I think have a filter input is better just in case a lot of logins exist and customers are used to just typing in the login they want from the list.


https://github.com/user-attachments/assets/5601c833-4606-42ad-a045-34eab5930933

changelog: The web UI no longer allows freeform input for SSH and Windows Desktop logins.

