### PR TITLE
fix: use matching signing region for IAM join method

### DIFF
--- a/lib/auth/join/iam/endpoints.go
+++ b/lib/auth/join/iam/endpoints.go
@@ -75,7 +75,7 @@ var (
 	// FIPSSTSEndpoints returns the set of known valid FIPS AWS STS endpoints.
 	FIPSSTSEndpoints = sync.OnceValue(func() []string {
 		return []string{
-			fipsSTSEndpointUSEast1,
+			"sts-fips.us-east-1.amazonaws.com",
 			"sts-fips.us-east-2.amazonaws.com",
 			"sts-fips.us-west-1.amazonaws.com",
 			"sts-fips.us-west-2.amazonaws.com",
@@ -83,6 +83,16 @@ var (
 			"sts.us-gov-west-1.amazonaws.com",
 		}
 	})
-)
 
-const fipsSTSEndpointUSEast1 = "sts-fips.us-east-1.amazonaws.com"
+	// FIPSSTSRegions returns the set of known AWS regions with FIPS STS endpoints.
+	FIPSSTSRegions = sync.OnceValue(func() []string {
+		return []string{
+			"us-east-1",
+			"us-east-2",
+			"us-west-1",
+			"us-west-2",
+			"us-gov-east-1",
+			"us-gov-west-1",
+		}
+	})
+)


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/47044 was flawed and overrides the target STS endpoint without overriding the signing region used when signing the request. This causes IAM joining to fail with errors like the following whenever the region is set from the IMDSv2 or overridden in a non-FIPS region

```
aws sts api returned status: \"403 Forbidden\" body: \"{\\\"Error\\\":{\\\"Code\\\":\\\"SignatureDoesNotMatch\\\",\\\"Message\\\":\\\"Credential should be scoped to a valid region. \\\",\\\"Type\\\":\\\"Sender\\\"},\\\"RequestId\\\":\\\"5a4361b5-dee0-4a6e-bfbf-35db72ed301c\\\"}
```

This PR fixes the issue by setting the region on the base aws.Config instead of handling region logic in the custom endpoint resolver. The custom endpoint resolver lives on only because it is the simplest way to set the challenge header and the Accept: application/json header, it doesn't actually override the target endpoint.