### PR TITLE
[v15] Fix `ListResourcesWithFilter` generic method (only used in Access Monitoring Rules).

### DIFF
--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -256,8 +256,6 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 		pageSize = int(s.pageLimit)
 	}
 
-	limit := pageSize + 1
-
 	var resources []T
 	var lastKey backend.Key
 	if err := backend.IterateRange(
@@ -265,7 +263,7 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 		s.backend,
 		rangeStart,
 		rangeEnd,
-		limit,
+		pageSize+1,
 		func(items []backend.Item) (stop bool, err error) {
 			for _, item := range items {
 				resource, err := s.unmarshalFunc(item.Value, services.WithRevision(item.Revision), services.WithRevision(item.Revision))
@@ -275,12 +273,12 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 				if matcher(resource) {
 					lastKey = item.Key
 					resources = append(resources, resource)
-					if len(resources) == pageSize+1 {
+					if len(resources) >= pageSize+1 {
 						return true, nil
 					}
 				}
 			}
-			return limit == len(resources), nil
+			return false, nil
 		}); err != nil {
 		return nil, "", trace.Wrap(err)
 	}

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -275,9 +275,9 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 				if matcher(resource) {
 					lastKey = item.Key
 					resources = append(resources, resource)
-				}
-				if len(resources) == pageSize {
-					break
+					if len(resources) == pageSize+1 {
+						return true, nil
+					}
 				}
 			}
 			return limit == len(resources), nil

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -508,7 +508,7 @@ func TestGenericListResourcesWithFilterForScale(t *testing.T) {
 
 	pageSizes := []int{1, 2, 3, 5, 7, 100_000}
 	for _, pageSize := range pageSizes {
-		testingProp := strconv.Itoa(r.IntN(totalProps - 1))
+		testingProp := strconv.Itoa(r.IntN(totalProps))
 		t.Run(fmt.Sprintf("pageSize=%d,prop=%s", pageSize, testingProp), func(t *testing.T) {
 			var startingKey string
 			var foundResourcesPropAEquals []*testResource

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -480,7 +480,7 @@ func TestGenericListResourcesWithFilterForScale(t *testing.T) {
 		Backend:       memBackend,
 		ResourceKind:  "generic resource",
 		PageLimit:     200,
-		BackendPrefix: backend.NewKey("my-prefix"),
+		BackendPrefix: "my-prefix",
 		UnmarshalFunc: unmarshalResource,
 		MarshalFunc:   marshalResource,
 	})


### PR DESCRIPTION
Backport #47326 to branch/v15

changelog: Fix possibly missing rules when using large amount of Access Monitoring Rules.
