### PR TITLE
EAS: use default retry attempts for STS client

### DIFF
--- a/lib/integrations/externalauditstorage/configurator.go
+++ b/lib/integrations/externalauditstorage/configurator.go
@@ -108,7 +108,6 @@ func (o *Options) setDefaults(ctx context.Context, region string) error {
 			ctx,
 			config.WithRegion(region),
 			config.WithUseFIPSEndpoint(useFips),
-			config.WithRetryMaxAttempts(10),
 		)
 		if err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
Replaces #47405 

This PR configures the AWS STS client used by the External Audit Storage integration to use the default number of retry attempts. 

Many error types returned by `AssumeRoleWithWebIdentity` are considered retry-able since they can be caused by ephemeral connectivity issues. 

When we had 10 retry attempts, AWS API errors were being masked by context timeouts and client-side rate limiting. Failures to obtain credentials were difficult to troubleshoot. 

Reducing the retry attempts will allow errors to be returned before the 30s context expires.

Example error log entries:
  - Before (both errors relate to client-side conditions):
    - `Failed to retrieve new credentials: failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, failed to get rate limit token, retry quota exceeded, 0 available, 5 requested`
    - `Failed to retrieve new credentials: failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, request canceled, context canceled`
  - After (error contains context from AWS API):
    - `Failed to retrieve new credentials: failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, exceeded maximum number of attempts, 3, https response error StatusCode: 400, RequestID: <GUID>, InvalidIdentityToken: Incorrect token audience`