### PR TITLE
Root home fallback for `keep` users

### DIFF
--- a/lib/srv/usermgmt_linux.go
+++ b/lib/srv/usermgmt_linux.go
@@ -283,3 +283,13 @@ func (u *HostUsersProvisioningBackend) CreateHomeDirectory(userHome, uidS, gidS 
 
 	return nil
 }
+
+// SetHomeDirectory sets the home directory path for an existing user.
+func (u *HostUsersProvisioningBackend) SetHomeDirectory(username, home string) error {
+	if home == "" {
+		home = string(os.PathSeparator)
+	}
+
+	_, err := host.SetUserHome(username, home)
+	return trace.Wrap(err)
+}

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -166,8 +166,12 @@ func (tm *testHostUserBackend) CreateHomeDirectory(user, uid, gid string) error 
 	return nil
 }
 
+func (tm *testHostUserBackend) SetHomeDirectory(username, home string) error {
+	return nil
+}
+
 func (tm *testHostUserBackend) GetDefaultHomeDirectory(user string) (string, error) {
-	return "", nil
+	return fmt.Sprintf("/home/%s", user), nil
 }
 
 // RemoveSudoersFile implements HostUsersBackend

--- a/lib/utils/host/hostusers.go
+++ b/lib/utils/host/hostusers.go
@@ -213,3 +213,16 @@ func CheckSudoers(contents []byte) error {
 	}
 	return trace.Wrap(err)
 }
+
+func SetUserHome(username, home string) (exitCode int, err error) {
+	usermodBin, err := exec.LookPath("usermod")
+	if err != nil {
+		return -1, trace.Wrap(err, "cant find usermod binary")
+	}
+
+	// usermod -G (replace groups) (username)
+	cmd := exec.Command(usermodBin, "--home", home, username)
+	output, err := cmd.CombinedOutput()
+	log.Debugf("%s output: %s", cmd.Path, string(output))
+	return cmd.ProcessState.ExitCode(), trace.Wrap(err)
+}


### PR DESCRIPTION
This PR falls back to using the root file path as a user's home directory in the case that their expected home directory already exists. This should prevent situations where a user that gets deleted and reprovisioned with a different UID/GID combo is unable to be used as a login for the host.

changelog: Fixed an issue preventing connections when using a newly provisioned host user whose home directory already existed.