### PR TITLE
Fix docs issues that break Docusaurus builds

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -216,23 +216,8 @@
       "permanent": true
     },
     {
-      "source": "/machine-id/deployment/gcp/",
-      "destination": "/enroll-resources/machine-id/deployment/gcp/",
-      "permanent": true
-    },
-    {
-      "source": "/machine-id/deployment/azure/",
-      "destination": "/enroll-resources/machine-id/deployment/azure/",
-      "permanent": true
-    },
-    {
       "source": "/machine-id/deployment/kubernetes/",
       "destination": "/enroll-resources/machine-id/deployment/kubernetes/",
-      "permanent": true
-    },
-    {
-      "source": "/machine-id/getting-started/",
-      "destination": "/enroll-resources/machine-id/getting-started/",
       "permanent": true
     },
     {
@@ -248,21 +233,6 @@
     {
       "source": "/database-access/guides/",
       "destination": "/enroll-resources/database-access/guides/",
-      "permanent": true
-    },
-    {
-      "source": "/desktop-access/active-directory/",
-      "destination": "/enroll-resources/desktop-access/active-directory/",
-      "permanent": true
-    },
-    {
-      "source": "/desktop-access/getting-started/",
-      "destination": "/enroll-resources/desktop-access/getting-started/",
-      "permanent": true
-    },
-    {
-      "source": "/server-access/getting-started/",
-      "destination": "/enroll-resources/server-access/getting-started/",
       "permanent": true
     },
     {
@@ -771,16 +741,6 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/",
-      "destination": "/enroll-resources/database-access/guides/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/dynamic-registration/",
-      "destination": "/enroll-resources/database-access/guides/dynamic-registration/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/ha/",
       "destination": "/enroll-resources/database-access/guides/ha/",
       "permanent": true
@@ -996,11 +956,6 @@
       "permanent": true
     },
     {
-      "source": "/machine-id/deployment/aws/",
-      "destination": "/enroll-resources/machine-id/deployment/aws/",
-      "permanent": true
-    },
-    {
       "source": "/machine-id/deployment/azure/",
       "destination": "/enroll-resources/machine-id/deployment/azure/",
       "permanent": true
@@ -1028,11 +983,6 @@
     {
       "source": "/machine-id/deployment/jenkins/",
       "destination": "/enroll-resources/machine-id/deployment/jenkins/",
-      "permanent": true
-    },
-    {
-      "source": "/machine-id/deployment/kubernetes/",
-      "destination": "/enroll-resources/machine-id/deployment/kubernetes/",
       "permanent": true
     },
     {
@@ -1226,28 +1176,13 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/rds-proxy-sqlserver/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/rds-proxy-mysql/",
       "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-mysql/",
       "permanent": true
     },
     {
-      "source": "/database-access/guides/ha/",
-      "destination": "/enroll-resources/database-access/guides/ha/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/dynamic-registration/",
       "destination": "/enroll-resources/database-access/guides/dynamic-registration/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/aws-dynamodb/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
       "permanent": true
     },
     {
@@ -1261,23 +1196,8 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/postgres-redshift/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/postgres-redshift/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/redshift-serverless/",
       "destination": "/enroll-resources/database-access/enroll-aws-databases/redshift-serverless/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/azure-redis/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/azure-postgres-mysql/",
-      "destination": "/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql/",
       "permanent": true
     },
     {
@@ -1291,11 +1211,6 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/sql-server-ad/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/sql-server-ad/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/mysql-cloudsql/",
       "destination": "/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql/",
       "permanent": true
@@ -1303,11 +1218,6 @@
     {
       "source": "/database-access/guides/postgres-cloudsql/",
       "destination": "/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/mongodb-atlas/",
-      "destination": "/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas/",
       "permanent": true
     },
     {
@@ -1321,18 +1231,8 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/elastic/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/elastic/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/mongodb-self-hosted/",
       "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/redis/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/redis/",
       "permanent": true
     },
     {
@@ -1341,18 +1241,8 @@
       "permanent": true
     },
     {
-      "source": "/get-started/",
-      "destination": "/admin-guides/deploy-a-cluster/linux-demo/",
-      "permanent": true
-    },
-    {
       "source": "/getting-started/",
-      "destination": "/admin-guides/deploy-a-cluster/linux-demo/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/snowflake/",
-      "destination": "/enroll-resources/database-access/enroll-managed-databases/snowflake/",
+      "destination": "/get-started/",
       "permanent": true
     },
     {
@@ -1486,38 +1376,8 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/rds-proxy-sqlserver/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/rds-proxy-mysql/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-mysql/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/ha/",
-      "destination": "/enroll-resources/database-access/guides/ha/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/dynamic-registration/",
-      "destination": "/enroll-resources/database-access/guides/dynamic-registration/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/aws-dynamodb/",
       "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/redis-aws/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/redis-aws/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/aws-cassandra-keyspaces/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/aws-cassandra-keyspaces/",
       "permanent": true
     },
     {
@@ -1526,28 +1386,8 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/redshift-serverless/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/redshift-serverless/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/azure-redis/",
       "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/azure-postgres-mysql/",
-      "destination": "/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/azure-postgres-mysql/",
-      "destination": "/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/azure-sql-server-ad/",
-      "destination": "/enroll-resources/database-access/enroll-azure-databases/azure-sql-server-ad/",
       "permanent": true
     },
     {
@@ -1556,28 +1396,8 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/mysql-cloudsql/",
-      "destination": "/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/postgres-cloudsql/",
-      "destination": "/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/mongodb-atlas/",
       "destination": "/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/cassandra-self-hosted/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/cassandra-self-hosted/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/cockroachdb-self-hosted/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted/",
       "permanent": true
     },
     {
@@ -1586,18 +1406,8 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/mongodb-self-hosted/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/redis/",
       "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/redis/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/redis-cluster/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/redis-cluster/",
       "permanent": true
     },
     {

--- a/docs/pages/admin-guides/admin-guides.mdx
+++ b/docs/pages/admin-guides/admin-guides.mdx
@@ -1,0 +1,6 @@
+---
+title: Teleport Admin Guides
+description: Provides step-by-step instructions for completing administrative tasks in Teleport.
+---
+
+(!toc!)

--- a/docs/pages/connect-your-client/connect-your-client.mdx
+++ b/docs/pages/connect-your-client/connect-your-client.mdx
@@ -1,0 +1,6 @@
+---
+title: Teleport User Guides
+description: Provides instructions to help users connect to infrastructure resources with Teleport.
+---
+
+(!toc!)

--- a/docs/pages/enroll-resources/enroll-resources.mdx
+++ b/docs/pages/enroll-resources/enroll-resources.mdx
@@ -1,0 +1,6 @@
+---
+title: Enrolling Teleport Resources
+description: Provides step-by-step instructions for enrolling servers, databases, and other infrastructure resources with your Teleport cluster.
+---
+
+(!toc!)

--- a/docs/pages/reference/reference.mdx
+++ b/docs/pages/reference/reference.mdx
@@ -1,0 +1,6 @@
+---
+title: Teleport Reference Guides
+description: Provides comprehensive information on configuration fields, Teleport commands, and other ways of interacting with Teleport.
+---
+
+(!toc!)


### PR DESCRIPTION
- Add index pages to top-level docs sections. These pages do not appear in the sidebar of the current docs engine, but are required for the Docusaurus site to render properly. We can build them into fully developed introductory pages in subsequent changes.
- Remove duplicate redirects.
- Remove redirect that points away from an existing page.