### PR TITLE
Convert usage reporting to use slog

### DIFF
--- a/lib/events/usageevents/usageevents.go
+++ b/lib/events/usageevents/usageevents.go
@@ -19,6 +19,7 @@
 package usageevents
 
 import (
+	"cmp"
 	"context"
 	"log/slog"
 
@@ -75,16 +76,8 @@ func (u *UsageLogger) EmitAuditEvent(ctx context.Context, event apievents.AuditE
 // New creates a new usage event IAuditLog impl, which wraps another IAuditLog
 // impl and forwards a subset of audit log events to the cluster UsageReporter
 // service.
-// TODO(tross) replace log any with slog.Logger once e is updated
-func New(reporter usagereporter.UsageReporter, log any, inner apievents.Emitter) (*UsageLogger, error) {
-	logger := slog.Default()
-
-	if log != nil {
-		if l, ok := log.(*slog.Logger); ok {
-			logger = l
-		}
-	}
-
+func New(reporter usagereporter.UsageReporter, log *slog.Logger, inner apievents.Emitter) (*UsageLogger, error) {
+	logger := cmp.Or(log, slog.Default())
 	return &UsageLogger{
 		logger:   logger.With(teleport.ComponentKey, teleport.ComponentUsageReporting),
 		reporter: reporter,

--- a/lib/usagereporter/teleport/aggregating/reporter_test.go
+++ b/lib/usagereporter/teleport/aggregating/reporter_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -70,7 +69,6 @@ func TestReporter(t *testing.T) {
 
 	r, err := NewReporter(ctx, ReporterConfig{
 		Backend:          bk,
-		Log:              logrus.StandardLogger(),
 		Clock:            clk,
 		ClusterName:      clusterName,
 		HostID:           uuid.NewString(),

--- a/lib/usagereporter/teleport/aggregating/submitter.go
+++ b/lib/usagereporter/teleport/aggregating/submitter.go
@@ -21,6 +21,7 @@ package aggregating
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -68,8 +69,11 @@ var alertMessage = fmt.Sprintf("Teleport has failed to contact the usage reporti
 type SubmitterConfig struct {
 	// Backend is the backend to use to read reports and apply locks. Required.
 	Backend backend.Backend
-	// Log is the [logrus.FieldLogger] used for logging. Required.
+	// Log is the [logrus.FieldLogger] used for logging.
+	// TODO(tross): remove once e has been converted
 	Log logrus.FieldLogger
+	// Logger is the used for emitting log messages.
+	Logger *slog.Logger
 	// Status is used to create or clear cluster alerts on a failure. Required.
 	Status services.StatusInternal
 	// Submitter is used to submit usage reports. Required.
@@ -87,14 +91,14 @@ func (cfg *SubmitterConfig) CheckAndSetDefaults() error {
 	if cfg.Backend == nil {
 		return trace.BadParameter("missing Backend")
 	}
-	if cfg.Log == nil {
-		return trace.BadParameter("missing Log")
-	}
 	if cfg.Status == nil {
 		return trace.BadParameter("missing Status")
 	}
 	if cfg.Submitter == nil {
 		return trace.BadParameter("missing Submitter")
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
 	}
 	return nil
 }
@@ -127,7 +131,7 @@ func submitOnce(ctx context.Context, c SubmitterConfig) {
 
 	userActivityReports, err := svc.listUserActivityReports(ctx, submitBatchSize)
 	if err != nil {
-		c.Log.WithError(err).Error("Failed to load usage reports for submission.")
+		c.Logger.ErrorContext(ctx, "Failed to load usage reports for submission.", "error", err)
 		return
 	}
 
@@ -136,7 +140,7 @@ func submitOnce(ctx context.Context, c SubmitterConfig) {
 	if freeBatchSize > 0 {
 		resourcePresenceReports, err = svc.listResourcePresenceReports(ctx, freeBatchSize)
 		if err != nil {
-			c.Log.WithError(err).Error("Failed to load resource counts reports for submission.")
+			c.Logger.ErrorContext(ctx, "Failed to load resource counts reports for submission.", "error", err)
 			return
 		}
 	}
@@ -146,9 +150,9 @@ func submitOnce(ctx context.Context, c SubmitterConfig) {
 	if totalReportCount < 1 {
 		err := ClearAlert(ctx, c.Status)
 		if err == nil {
-			c.Log.Infof("Deleted cluster alert %v after successfully clearing usage report backlog.", alertName)
+			c.Logger.InfoContext(ctx, "Deleted cluster alert after successfully clearing usage report backlog.", "alert", alertName)
 		} else if !trace.IsNotFound(err) {
-			c.Log.WithError(err).Errorf("Failed to delete cluster alert %v.", alertName)
+			c.Logger.ErrorContext(ctx, "Failed to delete cluster alert", "alert", alertName, "error", err)
 		}
 		return
 	}
@@ -175,9 +179,9 @@ func submitOnce(ctx context.Context, c SubmitterConfig) {
 	debugPayload := fmt.Sprintf("%v %q", time.Now().Round(0), c.HostID)
 	if err := svc.createUserActivityReportsLock(ctx, submitLockDuration, []byte(debugPayload)); err != nil {
 		if trace.IsAlreadyExists(err) {
-			c.Log.Debugf("Failed to acquire lock %v, already held.", userActivityReportsLock)
+			c.Logger.DebugContext(ctx, "Failed to acquire lock, already held.", "lock", userActivityReportsLock)
 		} else {
-			c.Log.WithError(err).Errorf("Failed to acquire lock %v.", userActivityReportsLock)
+			c.Logger.ErrorContext(ctx, "Failed to acquire lock.", "lock", userActivityReportsLock, "error", err)
 		}
 		return
 	}
@@ -190,11 +194,12 @@ func submitOnce(ctx context.Context, c SubmitterConfig) {
 		ResourcePresence: resourcePresenceReports,
 	})
 	if err != nil {
-		c.Log.WithError(err).WithFields(logrus.Fields{
-			"reports":       totalReportCount,
-			"oldest_report": oldest,
-			"newest_report": newest,
-		}).Error("Failed to send usage reports.")
+		c.Logger.ErrorContext(ctx, "Failed to send usage reports.",
+			"reports", totalReportCount,
+			"oldest_report", oldest,
+			"newest_report", newest,
+			"error", err,
+		)
 
 		if time.Since(oldest) <= alertGraceDuration {
 			return
@@ -208,22 +213,22 @@ func submitOnce(ctx context.Context, c SubmitterConfig) {
 			types.WithAlertLabel(types.AlertLinkText, alertLinkText),
 		)
 		if err != nil {
-			c.Log.WithError(err).Errorf("Failed to create cluster alert %v.", alertName)
+			c.Logger.ErrorContext(ctx, "Failed to create cluster alert", "alert", alertName, "error", err)
 			return
 		}
 		alert.Metadata.Description = debugPayload
 		if err := c.Status.UpsertClusterAlert(ctx, alert); err != nil {
-			c.Log.WithError(err).Errorf("Failed to upsert cluster alert %v.", alertName)
+			c.Logger.ErrorContext(ctx, "Failed to upsert cluster alert", "alert", alertName, "error", err)
 		}
 		return
 	}
 
-	c.Log.WithFields(logrus.Fields{
-		"batch_uuid":    batchUUID,
-		"reports":       totalReportCount,
-		"oldest_report": oldest,
-		"newest_report": newest,
-	}).Info("Successfully sent usage reports.")
+	c.Logger.InfoContext(ctx, "Successfully sent usage reports.",
+		"batch_uuid", batchUUID,
+		"reports", totalReportCount,
+		"oldest_report", oldest,
+		"newest_report", newest,
+	)
 
 	var lastErr error
 	for _, report := range userActivityReports {
@@ -237,7 +242,7 @@ func submitOnce(ctx context.Context, c SubmitterConfig) {
 		}
 	}
 	if lastErr != nil {
-		c.Log.WithField("last_error", lastErr).Warn("Failed to delete some usage reports after successful send.")
+		c.Logger.WarnContext(ctx, "Failed to delete some usage reports after successful send.", "last_error", lastErr)
 	}
 }
 

--- a/lib/usagereporter/teleport/aggregating/submitter_test.go
+++ b/lib/usagereporter/teleport/aggregating/submitter_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -69,7 +68,6 @@ func TestSubmitOnce(t *testing.T) {
 
 	scfg := SubmitterConfig{
 		Backend:   bk,
-		Log:       logrus.StandardLogger(),
 		Status:    local.NewStatusService(bk),
 		Submitter: submitOk,
 	}

--- a/lib/usagereporter/usagereporter.go
+++ b/lib/usagereporter/usagereporter.go
@@ -20,12 +20,12 @@ package usagereporter
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
 )
@@ -94,8 +94,8 @@ type SubmittedEvent[T any] struct {
 }
 
 type UsageReporter[T any] struct {
-	// Entry is a log entry
-	*logrus.Entry
+	// logger  writes log messages
+	logger *slog.Logger
 
 	// clock is the clock used for the main batching goroutine
 	clock clockwork.Clock
@@ -169,7 +169,7 @@ func (r *UsageReporter[T]) runSubmit(ctx context.Context) {
 		t0 := time.Now()
 
 		if failed, err := r.submit(r, batch); err != nil {
-			r.WithField("batch_size", len(batch)).Warnf("failed to submit batch of usage events: %v", err)
+			r.logger.WarnContext(ctx, "failed to submit batch of usage events", "batch_size", len(batch), "error", err)
 			usageBatchesFailed.Inc()
 
 			var resubmit []*SubmittedEvent[T]
@@ -183,7 +183,7 @@ func (r *UsageReporter[T]) runSubmit(ctx context.Context) {
 
 			droppedCount := len(failed) - len(resubmit)
 			if droppedCount > 0 {
-				r.WithField("dropped_count", droppedCount).Warnf("dropping events due to error: %+v", err)
+				r.logger.WarnContext(ctx, "dropping events due to error", "dropped_count", droppedCount, "error", err)
 				usageEventsDropped.Add(float64(droppedCount))
 			}
 
@@ -192,7 +192,7 @@ func (r *UsageReporter[T]) runSubmit(ctx context.Context) {
 		} else {
 			usageBatchesSubmitted.Inc()
 
-			r.WithField("batch_size", len(batch)).Debug("successfully submitted batch of usage events")
+			r.logger.DebugContext(ctx, "successfully submitted batch of usage events", "batch_size", len(batch))
 		}
 
 		usageBatchSubmissionDuration.Observe(time.Since(t0).Seconds())
@@ -259,7 +259,7 @@ func (r *UsageReporter[T]) Run(ctx context.Context) {
 	go r.runSubmit(ctx)
 	defer close(r.submissionQueue)
 
-	r.Debug("usage reporter is ready")
+	r.logger.DebugContext(ctx, "usage reporter is ready")
 
 	for {
 		var subQueue chan []*SubmittedEvent[T]
@@ -272,7 +272,7 @@ func (r *UsageReporter[T]) Run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			if len(r.buf) > 0 {
-				r.WithField("discarded_count", len(r.buf)).Warn("dropped events due to context close")
+				r.logger.WarnContext(ctx, "dropped events due to context close", "discarded_count", len(r.buf))
 			}
 			return
 
@@ -281,11 +281,11 @@ func (r *UsageReporter[T]) Run(ctx context.Context) {
 				subBatch, subRest := splitBuffer()
 				select {
 				case <-ctx.Done():
-					r.WithField("discarded_count", len(r.buf)).Warn("dropped events due to context close during graceful stop")
+					r.logger.WarnContext(ctx, "dropped events due to context close during graceful stop", "discarded_count", len(r.buf))
 					return
 				case r.submissionQueue <- subBatch:
 					usageBatchesTotal.Inc()
-					r.WithField("batch_size", len(subBatch)).Debug("enqueued batch of usage events during graceful stop")
+					r.logger.DebugContext(ctx, "enqueued batch of usage events during graceful stop", "batch_size", len(subBatch))
 					r.buf = subRest
 				}
 			}
@@ -296,7 +296,7 @@ func (r *UsageReporter[T]) Run(ctx context.Context) {
 
 		case subQueue <- subBatch:
 			usageBatchesTotal.Inc()
-			r.WithField("batch_size", len(subBatch)).Debug("enqueued batch of usage events")
+			r.logger.DebugContext(ctx, "enqueued batch of usage events", "batch_size", len(subBatch))
 			r.buf = subRest
 			minBatchSize = r.minBatchSize
 
@@ -317,7 +317,7 @@ func (r *UsageReporter[T]) Run(ctx context.Context) {
 					keep = 0
 				}
 
-				r.WithField("discarded_count", len(events)-keep).Warn("usage event buffer is full, events will be discarded")
+				r.logger.WarnContext(ctx, "usage event buffer is full, events will be discarded", "discarded_count", len(events)-keep)
 				events = events[:keep]
 
 				usageEventsDropped.Add(float64(len(events) - keep))
@@ -376,7 +376,7 @@ func (r *UsageReporter[T]) submitEvents(events []*SubmittedEvent[T]) {
 }
 
 type Options[T any] struct {
-	Log logrus.FieldLogger
+	Logger *slog.Logger
 	// Submit is a func that submits a batch of usage events.
 	Submit SubmitFunc[T]
 	// MinBatchSize determines the size at which a batch is sent
@@ -409,8 +409,8 @@ type Options[T any] struct {
 // NewUsageReporter creates a new usage reporter. `Run()` must be executed to
 // process incoming events.
 func NewUsageReporter[T any](options *Options[T]) *UsageReporter[T] {
-	if options.Log == nil {
-		options.Log = logrus.StandardLogger()
+	if options.Logger == nil {
+		options.Logger = slog.Default()
 	}
 	if options.Clock == nil {
 		options.Clock = clockwork.NewRealClock()
@@ -420,10 +420,7 @@ func NewUsageReporter[T any](options *Options[T]) *UsageReporter[T] {
 	}
 
 	reporter := &UsageReporter[T]{
-		Entry: options.Log.WithField(
-			teleport.ComponentKey,
-			teleport.Component(teleport.ComponentUsageReporting),
-		),
+		logger:          options.Logger.With(teleport.ComponentKey, teleport.ComponentUsageReporting),
 		events:          make(chan []*SubmittedEvent[T], 1),
 		submissionQueue: make(chan []*SubmittedEvent[T], 1),
 		eventsClosed:    make(chan struct{}),


### PR DESCRIPTION
This builds on https://github.com/gravitational/teleport.e/pull/5149 to convert all of the usage reporting logging to slog. After the changes here land there should only need to be one additional follow up in teleport.e before the remaining TODOs can be removed.


> [!IMPORTANT]  
> Do not merge until the e ref is updated to include https://github.com/gravitational/teleport.e/pull/5149.