### PR TITLE
propagate proxy upgrade channel config to aws oidc updater

### DIFF
--- a/lib/automaticupgrades/channel.go
+++ b/lib/automaticupgrades/channel.go
@@ -99,6 +99,15 @@ func (c Channels) DefaultVersion(ctx context.Context) (string, error) {
 	return targetVersion, trace.Wrap(err)
 }
 
+// DefaultChannel returns the default upgrade channel.
+func (c Channels) DefaultChannel() (*Channel, error) {
+	defaultChannel, ok := c[DefaultChannelName]
+	if ok && defaultChannel != nil {
+		return defaultChannel, nil
+	}
+	return NewDefaultChannel()
+}
+
 // Channel describes an automatic update channel configuration.
 // It can be configured to serve a static version, or forward version requests
 // to an upstream version server. Forwarded results are cached for 1 minute.

--- a/lib/automaticupgrades/channel_test.go
+++ b/lib/automaticupgrades/channel_test.go
@@ -115,6 +115,46 @@ func Test_Channels_CheckAndSetDefaults(t *testing.T) {
 	})
 }
 
+func Test_Channels_DefaultChannel(t *testing.T) {
+	channels := make(Channels)
+	require.NoError(t, channels.CheckAndSetDefaults())
+
+	defaultChannel, err := NewDefaultChannel()
+	require.NoError(t, err)
+
+	customDefaultChannel := &Channel{ForwardURL: "asdf"}
+	tests := []struct {
+		desc     string
+		channels Channels
+		want     *Channel
+	}{
+		{
+			desc: "nil channels",
+			want: defaultChannel,
+		},
+		{
+			desc:     "default channels",
+			channels: channels,
+			want:     defaultChannel,
+		},
+		{
+			desc: "configured channels",
+			channels: Channels{
+				DefaultChannelName: customDefaultChannel,
+			},
+			want: customDefaultChannel,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			got, err := test.channels.DefaultChannel()
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
 func Test_Channel_CheckAndSetDefaults(t *testing.T) {
 
 	tests := []struct {

--- a/lib/integrations/awsoidc/deployservice_update.go
+++ b/lib/integrations/awsoidc/deployservice_update.go
@@ -105,6 +105,7 @@ func updateServiceContainerImage(ctx context.Context, clt DeployServiceClient, l
 	// There is no need to update the ecs service if the ecs service is already
 	// running the latest stable version of teleport.
 	if currentTeleportImage == teleportImage {
+		log.InfoContext(ctx, "ECS service version already matches, not updating")
 		return nil
 	}
 

--- a/lib/service/awsoidc.go
+++ b/lib/service/awsoidc.go
@@ -48,7 +48,7 @@ const (
 	maxConcurrentUpdates = 3
 )
 
-func (process *TeleportProcess) initAWSOIDCDeployServiceUpdater() error {
+func (process *TeleportProcess) initAWSOIDCDeployServiceUpdater(channels automaticupgrades.Channels) error {
 	// start process only after teleport process has started
 	if _, err := process.WaitForEvent(process.GracefulExitContext(), TeleportReadyEvent); err != nil {
 		return trace.Wrap(err)
@@ -68,11 +68,7 @@ func (process *TeleportProcess) initAWSOIDCDeployServiceUpdater() error {
 		return nil
 	}
 
-	// TODO: use the proxy channel if available?
-	// This would require to pass the proxy configuration there, but would avoid
-	// future inconsistencies: if the proxy is manually configured to serve a
-	// static version, it will not be picked up by the AWS OIDC deploy updater.
-	upgradeChannel, err := automaticupgrades.NewDefaultChannel()
+	upgradeChannel, err := channels.DefaultChannel()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -126,6 +122,10 @@ func (cfg *AWSOIDCDeployServiceUpdaterConfig) CheckAndSetDefaults() error {
 
 	if cfg.TeleportClusterVersion == "" {
 		return trace.BadParameter("teleport cluster version required")
+	}
+
+	if cfg.UpgradeChannel == nil {
+		return trace.BadParameter("automatic upgrades channel required")
 	}
 
 	if cfg.Log == nil {
@@ -307,7 +307,11 @@ func (updater *AWSOIDCDeployServiceUpdater) updateAWSOIDCDeployService(ctx conte
 		}
 	}()
 
-	updater.Log.DebugContext(ctx, "Updating AWS OIDC Deploy Service", "integration", integration.GetName(), "region", awsRegion)
+	updater.Log.DebugContext(ctx, "Updating AWS OIDC Deploy Service",
+		"integration", integration.GetName(),
+		"region", awsRegion,
+		"new_version", teleportVersion,
+	)
 	if err := awsoidc.UpdateDeployService(ctx, awsOIDCDeployServiceClient, updater.Log, awsoidc.UpdateServiceRequest{
 		TeleportClusterName: updater.TeleportClusterName,
 		TeleportVersionTag:  teleportVersion,


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/46625
- https://github.com/gravitational/teleport/issues/46625

This PR passes the proxy's automatic upgrade channel config into the aws oidc service deployment updater so that it selects the same version as a new AWS OIDC deployment would.
Otherwise, the updater may upgrade an agent deployed in AWS ECS only for a (re)-deployment of the agent to downgrade it.

See the linked issue for full context.