### PR TITLE
Simplify `IsBoringCrypto`

### DIFF
--- a/lib/auth/native/boring.go
+++ b/lib/auth/native/boring.go
@@ -1,0 +1,16 @@
+//go:build boringcrypto
+
+package native
+
+import "crypto/boring"
+
+// IsBoringBinary checks if the binary was compiled with BoringCrypto.
+//
+// It's possible to enable the boringcrypto GOEXPERIMENT (which will enable the
+// boringcrypto build tag) even on platforms that don't support the boringcrypto
+// module, which results in crypto packages being available and working, but not
+// actually using a certified cryptographic module, so we have to check
+// [boring.Enabled] even if this is compiled in.
+func IsBoringBinary() bool {
+	return boring.Enabled()
+}

--- a/lib/auth/native/boring.go
+++ b/lib/auth/native/boring.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 //go:build boringcrypto
 
 package native

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -22,10 +22,8 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -47,15 +45,6 @@ var precomputedKeys = make(chan *rsa.PrivateKey, 25)
 
 // startPrecomputeOnce is used to start the background task that precomputes key pairs.
 var startPrecomputeOnce sync.Once
-
-// IsBoringBinary checks if the binary was compiled with BoringCrypto.
-func IsBoringBinary() bool {
-	// Check the package name for one of the boring primitives, if the package
-	// path is from BoringCrypto, we know this binary was compiled against the
-	// dev.boringcrypto branch of Go.
-	hash := sha256.New()
-	return reflect.TypeOf(hash).Elem().PkgPath() == "crypto/internal/boring"
-}
 
 // GenerateKeyPair generates a new RSA key pair.
 func GenerateKeyPair() ([]byte, []byte, error) {

--- a/lib/auth/native/notboring.go
+++ b/lib/auth/native/notboring.go
@@ -1,0 +1,11 @@
+//go:build !boringcrypto
+
+package native
+
+// IsBoringBinary checks if the binary was compiled with BoringCrypto.
+//
+// The boringcrypto GOEXPERIMENT always sets the boringcrypto build tag, so if
+// this is compiled in, we're not using BoringCrypto.
+func IsBoringBinary() bool {
+	return false
+}

--- a/lib/auth/native/notboring.go
+++ b/lib/auth/native/notboring.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 //go:build !boringcrypto
 
 package native


### PR DESCRIPTION
This PR changes the implementation of `IsBoringCrypto` to call `crypto/boring.Enabled()` if available (which, in turn, just returns a constant value at least in the current implementation) instead of doing a pretty gnarly runtime check every time.