### PR TITLE
docs: include description as optional field for app config reference

### DIFF
--- a/docs/pages/includes/config-reference/app-service.yaml
+++ b/docs/pages/includes/config-reference/app-service.yaml
@@ -22,6 +22,8 @@ app_service:
       # Optional: For access to cloud provider APIs, specify the cloud
       # provider. Allowed values are "AWS", "Azure", and "GCP".
       cloud: ""
+      # Optional: Free-form description of the application.
+      description: "Kubernetes Dashboard to development cluster"
       # URI of Application. For TCP applications
       # use tcp, ex: tcp://localhost:5432.
       uri: "http://10.0.1.27:8000"


### PR DESCRIPTION
`description` was not included as a optional field for the config reference.