### PR TITLE
[v16] Fix docs issues that break Docusaurus builds

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -224,11 +224,6 @@
       "permanent": true
     },
     {
-      "source": "/machine-id/deployment/circleci/",
-      "destination": "/enroll-resources/machine-id/deployment/circleci/",
-      "permanent": true
-    },
-    {
       "source": "/machine-id/deployment/gitlab/",
       "destination": "/enroll-resources/machine-id/deployment/gitlab/",
       "permanent": true
@@ -239,18 +234,8 @@
       "permanent": true
     },
     {
-      "source": "/machine-id/access-guides/ansible/",
-      "destination": "/enroll-resources/machine-id/access-guides/ansible/",
-      "permanent": true
-    },
-    {
       "source": "/machine-id/deployment/spacelift/",
       "destination": "/admin-guides/infrastructure-as-code/terraform-provider/spacelift/",
-      "permanent": true
-    },
-    {
-      "source": "/machine-id/access-guides/terraform/",
-      "destination": "/admin-guides/infrastructure-as-code/terraform-provider/dedicated-server/",
       "permanent": true
     },
     {
@@ -264,23 +249,8 @@
       "permanent": true
     },
     {
-      "source": "/machine-id/deployment/gcp/",
-      "destination": "/enroll-resources/machine-id/deployment/gcp/",
-      "permanent": true
-    },
-    {
-      "source": "/machine-id/deployment/azure/",
-      "destination": "/enroll-resources/machine-id/deployment/azure/",
-      "permanent": true
-    },
-    {
       "source": "/machine-id/deployment/kubernetes/",
       "destination": "/enroll-resources/machine-id/deployment/kubernetes/",
-      "permanent": true
-    },
-    {
-      "source": "/machine-id/getting-started/",
-      "destination": "/enroll-resources/machine-id/getting-started/",
       "permanent": true
     },
     {
@@ -296,21 +266,6 @@
     {
       "source": "/database-access/guides/",
       "destination": "/enroll-resources/database-access/guides/",
-      "permanent": true
-    },
-    {
-      "source": "/desktop-access/active-directory/",
-      "destination": "/enroll-resources/desktop-access/active-directory/",
-      "permanent": true
-    },
-    {
-      "source": "/desktop-access/getting-started/",
-      "destination": "/enroll-resources/desktop-access/getting-started/",
-      "permanent": true
-    },
-    {
-      "source": "/server-access/getting-started/",
-      "destination": "/enroll-resources/server-access/getting-started/",
       "permanent": true
     },
     {
@@ -461,11 +416,6 @@
     {
       "source": "/application-access/guides/vnet/",
       "destination": "/enroll-resources/application-access/guides/vnet/",
-      "permanent": true
-    },
-    {
-      "source": "/application-access/introduction/",
-      "destination": "/enroll-resources/application-access/introduction/",
       "permanent": true
     },
     {
@@ -819,16 +769,6 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/",
-      "destination": "/enroll-resources/database-access/guides/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/dynamic-registration/",
-      "destination": "/enroll-resources/database-access/guides/dynamic-registration/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/ha/",
       "destination": "/enroll-resources/database-access/guides/ha/",
       "permanent": true
@@ -1044,11 +984,6 @@
       "permanent": true
     },
     {
-      "source": "/machine-id/deployment/aws/",
-      "destination": "/enroll-resources/machine-id/deployment/aws/",
-      "permanent": true
-    },
-    {
       "source": "/machine-id/deployment/azure/",
       "destination": "/enroll-resources/machine-id/deployment/azure/",
       "permanent": true
@@ -1069,21 +1004,6 @@
       "permanent": true
     },
     {
-      "source": "/machine-id/deployment/gitlab/",
-      "destination": "/enroll-resources/machine-id/deployment/gitlab/",
-      "permanent": true
-    },
-    {
-      "source": "/machine-id/deployment/jenkins/",
-      "destination": "/enroll-resources/machine-id/deployment/jenkins/",
-      "permanent": true
-    },
-    {
-      "source": "/machine-id/deployment/kubernetes/",
-      "destination": "/enroll-resources/machine-id/deployment/kubernetes/",
-      "permanent": true
-    },
-    {
       "source": "/machine-id/deployment/linux-tpm/",
       "destination": "/enroll-resources/machine-id/deployment/linux-tpm/",
       "permanent": true
@@ -1091,11 +1011,6 @@
     {
       "source": "/machine-id/deployment/linux/",
       "destination": "/enroll-resources/machine-id/deployment/linux/",
-      "permanent": true
-    },
-    {
-      "source": "/machine-id/deployment/spacelift/",
-      "destination": "/admin-guides/infrastructure-as-code/terraform-provider/spacelift/",
       "permanent": true
     },
     {
@@ -1274,28 +1189,13 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/rds-proxy-sqlserver/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/rds-proxy-mysql/",
       "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-mysql/",
       "permanent": true
     },
     {
-      "source": "/database-access/guides/ha/",
-      "destination": "/enroll-resources/database-access/guides/ha/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/dynamic-registration/",
       "destination": "/enroll-resources/database-access/guides/dynamic-registration/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/aws-dynamodb/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
       "permanent": true
     },
     {
@@ -1309,23 +1209,8 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/postgres-redshift/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/postgres-redshift/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/redshift-serverless/",
       "destination": "/enroll-resources/database-access/enroll-aws-databases/redshift-serverless/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/azure-redis/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/azure-postgres-mysql/",
-      "destination": "/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql/",
       "permanent": true
     },
     {
@@ -1339,11 +1224,6 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/sql-server-ad/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/sql-server-ad/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/mysql-cloudsql/",
       "destination": "/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql/",
       "permanent": true
@@ -1351,11 +1231,6 @@
     {
       "source": "/database-access/guides/postgres-cloudsql/",
       "destination": "/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/mongodb-atlas/",
-      "destination": "/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas/",
       "permanent": true
     },
     {
@@ -1369,23 +1244,8 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/elastic/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/elastic/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/mongodb-self-hosted/",
       "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/redis/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/redis/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/snowflake/",
-      "destination": "/enroll-resources/database-access/enroll-managed-databases/snowflake/",
       "permanent": true
     },
     {
@@ -1396,11 +1256,6 @@
     {
       "source": "/getting-started/",
       "destination": "/get-started/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/snowflake/",
-      "destination": "/enroll-resources/database-access/enroll-managed-databases/snowflake/",
       "permanent": true
     },
     {
@@ -1456,11 +1311,6 @@
     {
       "source": "/connect-your-client/putty/",
       "destination": "/connect-your-client/putty-winscp/",
-      "permanent": true
-    },
-    {
-      "source": "/machine-id/guides/jenkins/",
-      "destination": "/enroll-resources/machine-id/deployment/jenkins/",
       "permanent": true
     },
     {
@@ -1534,38 +1384,8 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/rds-proxy-sqlserver/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/rds-proxy-mysql/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-mysql/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/ha/",
-      "destination": "/enroll-resources/database-access/guides/ha/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/dynamic-registration/",
-      "destination": "/enroll-resources/database-access/guides/dynamic-registration/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/aws-dynamodb/",
       "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/redis-aws/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/redis-aws/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/aws-cassandra-keyspaces/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/aws-cassandra-keyspaces/",
       "permanent": true
     },
     {
@@ -1574,28 +1394,8 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/redshift-serverless/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/redshift-serverless/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/azure-redis/",
       "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/azure-postgres-mysql/",
-      "destination": "/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/azure-postgres-mysql/",
-      "destination": "/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/azure-sql-server-ad/",
-      "destination": "/enroll-resources/database-access/enroll-azure-databases/azure-sql-server-ad/",
       "permanent": true
     },
     {
@@ -1604,28 +1404,8 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/mysql-cloudsql/",
-      "destination": "/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/postgres-cloudsql/",
-      "destination": "/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/mongodb-atlas/",
       "destination": "/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/cassandra-self-hosted/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/cassandra-self-hosted/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/cockroachdb-self-hosted/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted/",
       "permanent": true
     },
     {
@@ -1634,18 +1414,8 @@
       "permanent": true
     },
     {
-      "source": "/database-access/guides/mongodb-self-hosted/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/guides/redis/",
       "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/redis/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/redis-cluster/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/redis-cluster/",
       "permanent": true
     },
     {

--- a/docs/pages/admin-guides/admin-guides.mdx
+++ b/docs/pages/admin-guides/admin-guides.mdx
@@ -1,0 +1,6 @@
+---
+title: Teleport Admin Guides
+description: Provides step-by-step instructions for completing administrative tasks in Teleport.
+---
+
+(!toc!)

--- a/docs/pages/connect-your-client/connect-your-client.mdx
+++ b/docs/pages/connect-your-client/connect-your-client.mdx
@@ -1,0 +1,6 @@
+---
+title: Teleport User Guides
+description: Provides instructions to help users connect to infrastructure resources with Teleport.
+---
+
+(!toc!)

--- a/docs/pages/enroll-resources/enroll-resources.mdx
+++ b/docs/pages/enroll-resources/enroll-resources.mdx
@@ -1,0 +1,6 @@
+---
+title: Enrolling Teleport Resources
+description: Provides step-by-step instructions for enrolling servers, databases, and other infrastructure resources with your Teleport cluster.
+---
+
+(!toc!)

--- a/docs/pages/reference/reference.mdx
+++ b/docs/pages/reference/reference.mdx
@@ -1,0 +1,6 @@
+---
+title: Teleport Reference Guides
+description: Provides comprehensive information on configuration fields, Teleport commands, and other ways of interacting with Teleport.
+---
+
+(!toc!)


### PR DESCRIPTION
Backports #47471

- Add index pages to top-level docs sections. These pages do not appear in the sidebar of the current docs engine, but are required for the Docusaurus site to render properly. We can build them into fully developed introductory pages in subsequent changes.
- Remove duplicate redirects.
- Remove redirect that points away from an existing page.