### PR TITLE
[v15] Fix docs issues that break Docusaurus builds

### DIFF
--- a/docs/pages/admin-guides/admin-guides.mdx
+++ b/docs/pages/admin-guides/admin-guides.mdx
@@ -1,0 +1,6 @@
+---
+title: Teleport Admin Guides
+description: Provides step-by-step instructions for completing administrative tasks in Teleport.
+---
+
+(!toc!)

--- a/docs/pages/connect-your-client/connect-your-client.mdx
+++ b/docs/pages/connect-your-client/connect-your-client.mdx
@@ -1,0 +1,6 @@
+---
+title: Teleport User Guides
+description: Provides instructions to help users connect to infrastructure resources with Teleport.
+---
+
+(!toc!)

--- a/docs/pages/enroll-resources/enroll-resources.mdx
+++ b/docs/pages/enroll-resources/enroll-resources.mdx
@@ -1,0 +1,6 @@
+---
+title: Enrolling Teleport Resources
+description: Provides step-by-step instructions for enrolling servers, databases, and other infrastructure resources with your Teleport cluster.
+---
+
+(!toc!)

--- a/docs/pages/reference/reference.mdx
+++ b/docs/pages/reference/reference.mdx
@@ -1,0 +1,6 @@
+---
+title: Teleport Reference Guides
+description: Provides comprehensive information on configuration fields, Teleport commands, and other ways of interacting with Teleport.
+---
+
+(!toc!)


### PR DESCRIPTION
Backports #47471

- Add index pages to top-level docs sections. These pages do not appear in the sidebar of the current docs engine, but are required for the Docusaurus site to render properly. We can build them into fully developed introductory pages in subsequent changes.
- Remove duplicate redirects.
- Remove redirect that points away from an existing page.