### PR TITLE
Change `clusterFeatures` visibility on web handler

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -158,8 +158,8 @@ type Handler struct {
 	// userConns tracks amount of current active connections with user certificates.
 	userConns atomic.Int32
 
-	// ClusterFeatures contain flags for supported and unsupported features.
-	ClusterFeatures proto.Features
+	// clusterFeatures contain flags for supported and unsupported features.
+	clusterFeatures proto.Features
 
 	// nodeWatcher is a services.NodeWatcher used by Assist to lookup nodes from
 	// the proxy's cache and get nodes in real time.
@@ -462,7 +462,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		log:                  newPackageLogger(),
 		logger:               slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
 		clock:                clockwork.NewRealClock(),
-		ClusterFeatures:      cfg.ClusterFeatures,
+		clusterFeatures:      cfg.ClusterFeatures,
 		healthCheckAppServer: cfg.HealthCheckAppServer,
 		tracer:               cfg.TracerProvider.Tracer(teleport.ComponentWeb),
 		wsIODeadline:         wsIODeadline,

--- a/lib/web/features.go
+++ b/lib/web/features.go
@@ -29,7 +29,7 @@ func (h *Handler) SetClusterFeatures(features proto.Features) {
 	defer h.Mutex.Unlock()
 
 	entitlements.BackfillFeatures(&features)
-	h.ClusterFeatures = features
+	h.clusterFeatures = features
 }
 
 // GetClusterFeatures returns flags for supported and unsupported features.
@@ -37,7 +37,7 @@ func (h *Handler) GetClusterFeatures() proto.Features {
 	h.Mutex.Lock()
 	defer h.Mutex.Unlock()
 
-	return h.ClusterFeatures
+	return h.clusterFeatures
 }
 
 // startFeatureWatcher periodically pings the auth server and updates `clusterFeatures`.

--- a/lib/web/features_test.go
+++ b/lib/web/features_test.go
@@ -70,7 +70,7 @@ func TestFeaturesWatcher(t *testing.T) {
 			Context:              ctx,
 		},
 		clock:           clock,
-		ClusterFeatures: proto.Features{},
+		clusterFeatures: proto.Features{},
 		log:             newPackageLogger(),
 		logger:          slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
 	}


### PR DESCRIPTION
**This PR targets `branch/v16`.**

I've left out this change in [this backport](https://github.com/gravitational/teleport/pull/47039)  so the teleport.e build wouldn't break (see [this comment](https://github.com/gravitational/teleport/pull/47039#issuecomment-2393799761)).

Now that https://github.com/gravitational/teleport.e/pull/5104 is merged, this field is not used anymore, we can safely merge this.