### PR TITLE
Edit the Agent service reference intro

### DIFF
--- a/docs/pages/reference/agent-services/agent-services.mdx
+++ b/docs/pages/reference/agent-services/agent-services.mdx
@@ -4,7 +4,9 @@ h1: Agent Service References
 description: Includes guides to use while using the SSH Service, Database Service, and other Teleport Agent services.
 ---
 
-Use these reference guides to configure and run the SSH Service, Database
-Service, and other Teleport Agent services.
+Use these reference guides to configure and run Teleport Agent services. For a
+comprehensive list of options you can configure when running the `teleport`
+binary, including all options for Agent services, consult the [Teleport
+Configuration Reference](../config.mdx).
 
 (!toc!)


### PR DESCRIPTION
Closes #47256

Avoid the impression that there is a dedicated Teleport SSH Service reference guide by editing the introduction to the Agent Service Reference section.

Service-specific references are not very popular and date from a time when Teleport users would focus on an "Access" product for a specific type of resource. Rather than add an SSH Service reference, point users to the general Teleport configuration reference.

The remaining service-specific reference guides are legacy documentation. While there is a case to be made for merging them into more popular documentation pages, that is outside the scope of this change.