### PR TITLE
docs: update cloud networking on proxy service

### DIFF
--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -36,21 +36,21 @@ following use cases:
 </TabItem>
 <TabItem scope={["cloud", "team"]} label="Cloud-Hosted">
 
-All Teleport services (e.g., the Application Service and Database Service) have
-an optional `public_addr` property that you can modify in each service's
-configuration file. The public address can take an IP or a DNS name. It can also
-be a list of values:
+For Teleport Enterprise Cloud all Teleport services (e.g. Kubernetes Service, 
+SSH Service,...) connect via reverse tunnels through the Teleport Proxy Service.
+The Teleport Proxy Service and Auth Service are provided so no specification
+is required for those. This makes the usage of `public_addr` limited to the Application Service.
+
+In the case of web applications the public address must be a subdomain of the tenant
+since the domain and TLS certificates are maintained by Teleport.
 
 ```yaml
-public_addr: ["service-one.example.com", "service-two.example.com"]
+public_addr: "myapp.example.teleport.sh"
 ```
 
-Specifying a public address for a Teleport agent may be useful in the
-following use cases:
+For TCP applications you can specify a fqdn outside of `teleport.sh` in combination
+with [VNet](../enroll-resources/application-access/guides/vnet.mdx) since that domain is served via your machine's local network.
 
-- You have multiple identical services behind a load balancer.
-- You want Teleport to issue an SSH certificate for the service with additional
-  principals, e.g., host names.
 </TabItem>
 </Tabs>
 

--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -36,21 +36,8 @@ following use cases:
 </TabItem>
 <TabItem scope={["cloud", "team"]} label="Cloud-Hosted">
 
-On Teleport Enterprise (Cloud), you can choose the sub-domain of
-the domain `teleport.sh` for your account. That fully qualified domain name
-(e.g., `example.teleport.sh`) is managed by Teleport for your account 
-along with any sub-domains assigned to Teleport-protected applications (e.g., `grafana.example.teleport.sh`).
-
-The public address (`public_addr`) for an application in the Teleport Application Service is configurable.
-In the case of web applications, the public address must be a subdomain of the Teleport account URL
-since the domain and TLS certificates are maintained by Teleport.
-
-```yaml
-public_addr: "myapp.example.teleport.sh"
-```
-
-For TCP applications you can specify a fully qualified domain name outside of `teleport.sh` in combination
-with [VNet](../enroll-resources/application-access/guides/vnet.mdx) since that domain is served via your machine's local network.
+On Teleport Enterprise (Cloud) the Teleport agent services always
+connect using reverse tunnels so there is no need to set a public address for a agent.
 
 </TabItem>
 </Tabs>

--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -41,14 +41,14 @@ SSH Service,...) connect via reverse tunnels through the Teleport Proxy Service.
 The Teleport Proxy Service and Auth Service are provided so no specification
 is required for those. This makes the usage of `public_addr` limited to the Application Service.
 
-In the case of web applications the public address must be a subdomain of the tenant
+In the case of web applications the public address must be a subdomain of the Teleport account URL
 since the domain and TLS certificates are maintained by Teleport.
 
 ```yaml
 public_addr: "myapp.example.teleport.sh"
 ```
 
-For TCP applications you can specify a fqdn outside of `teleport.sh` in combination
+For TCP applications you can specify a fully qualified domain name outside of `teleport.sh` in combination
 with [VNet](../enroll-resources/application-access/guides/vnet.mdx) since that domain is served via your machine's local network.
 
 </TabItem>

--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -41,7 +41,8 @@ the domain `teleport.sh` for your account. That fully qualified domain name
 (e.g., `example.teleport.sh`) is managed by Teleport for your account 
 along with any sub-domains assigned to Teleport-protected applications (e.g., `grafana.example.teleport.sh`).
 
-The public address (`public_addr`) for the Teleport Application Service is configurable. In the case of web applications, the public address must be a subdomain of the Teleport account URL
+The public address (`public_addr`) for an application in the Teleport Application Service is configurable.
+In the case of web applications, the public address must be a subdomain of the Teleport account URL
 since the domain and TLS certificates are maintained by Teleport.
 
 ```yaml

--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -36,13 +36,12 @@ following use cases:
 </TabItem>
 <TabItem scope={["cloud", "team"]} label="Cloud-Hosted">
 
-For Teleport Enterprise (managed) you choose the sub-domain of
+On Teleport Enterprise (Cloud), you can choose the sub-domain of
 the domain `teleport.sh` for your account. That fully qualified domain name
-(ex: `example.teleport.sh`) are managed by Teleport for your account 
-along with any sub-domains of it for Teleport Application Service. The public
-address (`public_addr`) for the Teleport Application Service is configurable.
+(e.g., `example.teleport.sh`) is managed by Teleport for your account 
+along with any sub-domains assigned to Teleport-protected applications (e.g., `grafana.example.teleport.sh`).
 
-In the case of web applications the public address must be a subdomain of the Teleport account URL
+The public address (`public_addr`) for the Teleport Application Service is configurable. In the case of web applications, the public address must be a subdomain of the Teleport account URL
 since the domain and TLS certificates are maintained by Teleport.
 
 ```yaml

--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -36,9 +36,11 @@ following use cases:
 </TabItem>
 <TabItem scope={["cloud", "team"]} label="Cloud-Hosted">
 
-For Teleport Enterprise (managed) the domain name and sub-domains
-are managed by Teleport for your account. The public address (`public_addr`)
-for the Teleport Application services are configurable.
+For Teleport Enterprise (managed) you choose the sub-domain of
+the domain `teleport.sh` for your account. That fully qualified domain name
+(ex: `example.teleport.sh`) are managed by Teleport for your account 
+along with any sub-domains of it for Teleport Application Service. The public
+address (`public_addr`) for the Teleport Application Service is configurable.
 
 In the case of web applications the public address must be a subdomain of the Teleport account URL
 since the domain and TLS certificates are maintained by Teleport.

--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -36,10 +36,9 @@ following use cases:
 </TabItem>
 <TabItem scope={["cloud", "team"]} label="Cloud-Hosted">
 
-For Teleport Enterprise Cloud all Teleport services (e.g. Kubernetes Service, 
-SSH Service,...) connect via reverse tunnels through the Teleport Proxy Service.
-The Teleport Proxy Service and Auth Service are provided so no specification
-is required for those. This makes the usage of `public_addr` limited to the Application Service.
+For Teleport Enterprise (managed) the domain name and sub-domains
+are managed by Teleport for your account. The public address (`public_addr`)
+for the Teleport Application services are configurable.
 
 In the case of web applications the public address must be a subdomain of the Teleport account URL
 since the domain and TLS certificates are maintained by Teleport.


### PR DESCRIPTION
This presented as if you could expose public addresses for Teleport services with in Ent Cloud.  Since you can only do reverse tunnel that isn't accurate. 