### PR TITLE
Fallback to root when user's home directory is not accessible

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -536,6 +536,10 @@ const (
 	// HomeDirNotFound is returned when a the "teleport checkhomedir" command cannot
 	// find the user's home directory.
 	HomeDirNotFound = 254
+	// HomeDirNotAccessible is returned when a the "teleport checkhomedir" command has
+	// found the user's home directory, but the user does NOT have permissions to
+	// access it.
+	HomeDirNotAccessible = 253
 )
 
 // MaxEnvironmentFileLines is the maximum number of lines in a environment file.

--- a/lib/srv/exec_linux_test.go
+++ b/lib/srv/exec_linux_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"testing"
@@ -33,20 +34,48 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/host"
 )
 
 func TestOSCommandPrep(t *testing.T) {
+	utils.RequireRoot(t)
+
 	srv := newMockServer(t)
 	scx := newExecServerContext(t, srv)
 
-	usr, err := user.Current()
+	// because CheckHomeDir now inspects access to the home directory as the actual user after a rexec,
+	// we need to setup a real, non-root user with a valid home directory in order for this test to
+	// exercise the correct paths
+	tempHome := t.TempDir()
+	require.NoError(t, os.Chmod(filepath.Dir(tempHome), 0777))
+
+	username := "test-os-command-prep"
+	scx.Identity.Login = username
+	_, err := host.UserAdd(username, nil, host.UserOpts{
+		Home: tempHome,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// change homedir back so user deletion doesn't fail
+		changeHomeDir(t, username, tempHome)
+		_, err := host.UserDel(username)
+		require.NoError(t, err)
+	})
+
+	usr, err := user.Lookup(username)
 	require.NoError(t, err)
 
+	uid, err := strconv.Atoi(usr.Uid)
+	require.NoError(t, err)
+
+	require.NoError(t, os.Chown(tempHome, uid, -1))
 	expectedEnv := []string{
 		"LANG=en_US.UTF-8",
-		getDefaultEnvPath(strconv.Itoa(os.Geteuid()), defaultLoginDefsPath),
+		getDefaultEnvPath(usr.Uid, defaultLoginDefsPath),
 		fmt.Sprintf("HOME=%s", usr.HomeDir),
-		fmt.Sprintf("USER=%s", usr.Username),
+		fmt.Sprintf("USER=%s", username),
 		"SHELL=/bin/sh",
 		"SSH_CLIENT=10.0.0.5 4817 3022",
 		"SSH_CONNECTION=10.0.0.5 4817 127.0.0.1 3022",
@@ -99,12 +128,9 @@ func TestOSCommandPrep(t *testing.T) {
 	require.Equal(t, []string{"/bin/sh", "-c", "top"}, cmd.Args)
 	require.Equal(t, syscall.SIGKILL, cmd.SysProcAttr.Pdeathsig)
 
-	if os.Geteuid() != 0 {
-		t.Skip("skipping portion of test which must run as root")
-	}
-
 	// Missing home directory - HOME should still be set to the given
 	// home dir, but the command should set it's CWD to root instead.
+	changeHomeDir(t, username, "/wrong/place")
 	usr.HomeDir = "/wrong/place"
 	root := string(os.PathSeparator)
 	expectedEnv[2] = "HOME=/wrong/place"

--- a/lib/srv/reexec_test.go
+++ b/lib/srv/reexec_test.go
@@ -36,6 +36,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh/agent"
 
@@ -409,4 +410,73 @@ func testX11Forward(ctx context.Context, t *testing.T, proc *networking.Process,
 	readXauthEntry, err := xauthCmd.ReadEntry(display)
 	require.NoError(t, err)
 	require.Equal(t, fakeXauthEntry, readXauthEntry)
+}
+
+func TestRootCheckHomeDir(t *testing.T) {
+	utils.RequireRoot(t)
+
+	tmp := t.TempDir()
+	require.NoError(t, os.Chmod(filepath.Dir(tmp), 0777))
+	require.NoError(t, os.Chmod(tmp, 0777))
+
+	home := filepath.Join(tmp, "home")
+	noAccess := filepath.Join(tmp, "no_access")
+	file := filepath.Join(tmp, "file")
+	notFound := filepath.Join(tmp, "not_found")
+
+	require.NoError(t, os.Mkdir(home, 0700))
+	require.NoError(t, os.Mkdir(noAccess, 0700))
+	_, err := os.Create(file)
+	require.NoError(t, err)
+
+	login := utils.GenerateLocalUsername(t)
+	_, err = host.UserAdd(login, nil, host.UserOpts{Home: home})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// change back to accessible home so deletion works
+		changeHomeDir(t, login, home)
+		_, err := host.UserDel(login)
+		require.NoError(t, err)
+	})
+
+	testUser, err := user.Lookup(login)
+	require.NoError(t, err)
+
+	uid, err := strconv.Atoi(testUser.Uid)
+	require.NoError(t, err)
+
+	gid, err := strconv.Atoi(testUser.Gid)
+	require.NoError(t, err)
+
+	require.NoError(t, os.Chown(home, uid, gid))
+	require.NoError(t, os.Chown(file, uid, gid))
+
+	hasAccess, err := CheckHomeDir(testUser)
+	require.NoError(t, err)
+	require.True(t, hasAccess)
+
+	changeHomeDir(t, login, file)
+	hasAccess, err = CheckHomeDir(testUser)
+	require.NoError(t, err)
+	require.False(t, hasAccess)
+
+	changeHomeDir(t, login, notFound)
+	hasAccess, err = CheckHomeDir(testUser)
+	require.NoError(t, err)
+	require.False(t, hasAccess)
+
+	changeHomeDir(t, login, noAccess)
+	hasAccess, err = CheckHomeDir(testUser)
+	require.NoError(t, err)
+	require.False(t, hasAccess)
+}
+
+func changeHomeDir(t *testing.T, username, home string) {
+	usermodBin, err := exec.LookPath("usermod")
+	assert.NoError(t, err, "usermod binary must be present")
+
+	cmd := exec.Command(usermodBin, "--home", home, username)
+	_, err = cmd.CombinedOutput()
+	assert.NoError(t, err, "changing home should not error")
+	assert.Equal(t, 0, cmd.ProcessState.ExitCode(), "changing home should exit 0")
 }

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1266,7 +1266,7 @@ func (s *Server) HandleNewConn(ctx context.Context, ccx *sshutils.ConnectionCont
 	// Create host user.
 	created, userCloser, err := s.termHandlers.SessionRegistry.UpsertHostUser(identityContext)
 	if err != nil {
-		log.Infof("error while creating host users: %s", err)
+		log.Warnf("error while creating host users: %s", err)
 	}
 
 	// Indicate that the user was created by Teleport.


### PR DESCRIPTION
This PR adds an additional check to `CheckHomeDir` to see if the login user has access to their configured home directory. If not, we fall back to logging them in under the root directory which is the current behavior when their home directory doesn't exist.

changelog: Fixed an issue preventing connections with users whose configured home directories were inaccessible.