### PR TITLE
Add support to Firestore backends for custom databases

### DIFF
--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -1307,6 +1307,10 @@ teleport:
     # Name of the Firestore table.
     collection_name: Example_TELEPORT_FIRESTORE_TABLE_NAME
 
+    # An optional database id to use. If not provided the default
+    # database for the project is used.
+    database_id: Example_TELEPORT_FIRESTORE_DATABASE_ID
+
     credentials_path: /var/lib/teleport/gcs_creds
 
     # This setting configures Teleport to send the audit events to three places:
@@ -1315,7 +1319,7 @@ teleport:
     # database table, so attempting to use the same table for both will result in errors.
     # When using highly available storage like Firestore, you should make sure that the list always specifies
     # the High Availability storage method first, as this is what the Teleport web UI uses as its source of events to display.
-    audit_events_uri:  ['firestore://Example_TELEPORT_FIRESTORE_EVENTS_TABLE_NAME', 'file:///var/lib/teleport/audit/events', 'stdout://']
+    audit_events_uri:  ['firestore://Example_TELEPORT_FIRESTORE_EVENTS_TABLE_NAME?projectID=$PROJECT_ID&credentialsPath=$CREDENTIALS_PATH&databaseID=$DATABASE_ID', 'file:///var/lib/teleport/audit/events', 'stdout://']
 
     # This setting configures Teleport to save the recorded sessions in GCP storage:
     audit_sessions_uri: gs://Example_TELEPORT_GCS_BUCKET/records

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -19,6 +19,7 @@
 package firestoreevents
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -202,6 +203,8 @@ func (cfg *EventsConfig) SetFromURL(url *url.URL) error {
 	}
 	cfg.ProjectID = projectIDParamString
 
+	cfg.DatabaseID = url.Query().Get("databaseID")
+
 	eventRetentionPeriodParamString := url.Query().Get(eventRetentionPeriodPropertyKey)
 	if eventRetentionPeriodParamString == "" {
 		cfg.RetentionPeriod = defaultEventRetentionPeriod
@@ -284,7 +287,7 @@ func New(cfg EventsConfig) (*Log, error) {
 	closeCtx, cancel := context.WithCancel(context.Background())
 	l := slog.With(teleport.ComponentKey, teleport.ComponentFirestore)
 	l.InfoContext(closeCtx, "Initializing event backend.")
-	firestoreAdminClient, firestoreClient, err := firestorebk.CreateFirestoreClients(closeCtx, cfg.ProjectID, cfg.EndPoint, cfg.CredentialsPath)
+	firestoreAdminClient, firestoreClient, err := firestorebk.CreateFirestoreClients(closeCtx, cfg.ProjectID, cfg.DatabaseID, cfg.EndPoint, cfg.CredentialsPath)
 	if err != nil {
 		cancel()
 		return nil, trace.Wrap(err)
@@ -581,7 +584,8 @@ type searchEventsFilter struct {
 }
 
 func (l *Log) getIndexParent() string {
-	return "projects/" + l.ProjectID + "/databases/(default)/collectionGroups/" + l.CollectionName
+	database := cmp.Or(l.Config.DatabaseID, "(default)")
+	return "projects/" + l.ProjectID + "/databases/" + database + "/collectionGroups/" + l.CollectionName
 }
 
 func (l *Log) ensureIndexes(adminSvc *apiv1.FirestoreAdminClient) error {


### PR DESCRIPTION
Firestore has supported multiple databases in a project for a while (see https://cloud.google.com/blog/products/databases/manage-multiple-firestore-databases-in-a-project), however, Teleport only allowed using the default database in the project. The DatabaseID is now exposed in the file config, and if provided both the state and events backends will use the appropriate database.

Closes https://github.com/gravitational/teleport/issues/37227.

Changelog: Allow using a custom database for Firestore backends.