### PR TITLE
docs: include amazon linux 2023 in supported enhanced logging

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
@@ -88,7 +88,7 @@ Teleport supports enhanced session recording with BPF on `amd64` and `arm64` arc
 | Fedora                  | 33             | 5.8+           |
 | Arch Linux              | 2020.09.01     | 5.8.5+         |
 | Flatcar                 | 2765.2.2       | 5.10.25+       |
-| Amazon Linux            | 2              | 5.10+          |
+| Amazon Linux            | 2 and 2023     | 5.10+          |
 
 - (!docs/pages/includes/tctl.mdx!)
 


### PR DESCRIPTION
Amazon Linux 2023 is supported for enhanced logging. Including as done for install support for linux flavors.