### PR TITLE
docs: simplify machine-id getting started

### DIFF
--- a/docs/pages/enroll-resources/machine-id/getting-started.mdx
+++ b/docs/pages/enroll-resources/machine-id/getting-started.mdx
@@ -49,17 +49,8 @@ Before you create a bot user, you need to determine which role(s) you want to
 assign to it. You can use the `tctl` command below to examine what roles exist
 on your system.
 
-<Tabs>
-<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 On your client machine, log in to Teleport using `tsh`, then use `tctl` to examine
 what roles exist on your system.
-</TabItem>
-<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
-Connect to the Teleport Auth Server and use `tctl` to examine what roles exist on
-your system.
-</TabItem>
-
-</Tabs>
 
 ```code
 $ tctl get roles --format=text
@@ -179,29 +170,10 @@ this by omitting this.
 
 Replace the following fields with values from your own cluster.
 
-<Tabs>
-<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
-
 - `token` is the token output by the `tctl bots add` command or the name of your IAM method token.
 - `destination-dir` is where Machine ID writes user certificates that can be used by applications and tools.
 - `data-dir` is where Machine ID writes its private data, including its own short-lived renewable certificates. These should not be used by applications and tools.
-- `auth-server` is the address of your Teleport Cloud Proxy Server, for example `example.teleport.sh:443`.
-
-</TabItem>
-<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
-
-- `token` is the token output by the `tctl bots add` command or the name of your IAM method token.
-- `ca-pin` is the CA Pin for your Teleport cluster, and is output by the `tctl bots add` command.
-- `destination-dir` is where Machine ID writes user certificates that can be used by applications and tools.
-- `data-dir` is where Machine ID writes its private data, including its own short-lived renewable certificates. These should not be used by applications and tools.
-- `auth-server` is typically the address of your Teleport Proxy Server
-   (`teleport.example.com:443`), but can also be the address of the
-   Auth Server is direct connectivity is available.
-  `teleport.example.com:443`.
-
-</TabItem>
-
-</Tabs>
+- `proxy-server` is the address of your Teleport Proxy service, for example `example.teleport.sh:443`.
 
 Now that Machine ID has successfully started, let's investigate the
 `/opt/machine-id` directory to see what was written to disk.
@@ -257,19 +229,9 @@ $ ssh -F /opt/machine-id/ssh_config root@node-name.example.com
 In addition to the `ssh` client you can use `tsh`. Replace the `--proxy` parameter
 with your proxy address. 
 
-<Tabs>
-<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
-```code
-$ tsh ssh --proxy=teleport.example.com -i /opt/machine-id/identity root@node-name
-```
-</TabItem>
-<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ```code
 $ tsh ssh --proxy=mytenant.teleport.sh -i /opt/machine-id/identity root@node-name
 ```
-</TabItem>
-
-</Tabs>
 
 <Admonition type="note" title="Roles must have logins defined">
   The below error can occur when the bot does not have permission to log in to

--- a/docs/pages/enroll-resources/machine-id/getting-started.mdx
+++ b/docs/pages/enroll-resources/machine-id/getting-started.mdx
@@ -74,9 +74,7 @@ database. For full details on how traits work in Teleport roles, see the
 [Teleport Access Controls
 Reference](../../reference/access-controls/roles.mdx).
 
-Machine ID can join with a token and multiple other join methods including the [IAM Method](../agents/join-services-to-your-cluster/aws-iam.mdx) on AWS.
-Using the IAM Method and other non-token join methods allows for re-joining if Machine-ID certificates expire. Certificates expire by default
-after an hour so a non-token method could be a better choice for machines that are shut down for long periods.
+Machine ID can join with a token or the [IAM Method](../agents/join-services-to-your-cluster/aws-iam.mdx) on AWS.
 
 Assuming that you are using the default `access` role, ensure that you use the 
 `--logins` flag when adding your bot to specify the SSH logins that you wish to 

--- a/docs/pages/enroll-resources/machine-id/getting-started.mdx
+++ b/docs/pages/enroll-resources/machine-id/getting-started.mdx
@@ -74,7 +74,9 @@ database. For full details on how traits work in Teleport roles, see the
 [Teleport Access Controls
 Reference](../../reference/access-controls/roles.mdx).
 
-Machine ID can join with a token or the [IAM Method](../agents/join-services-to-your-cluster/aws-iam.mdx) on AWS.
+Machine ID can join with a token and multiple other join methods including the [IAM Method](../agents/join-services-to-your-cluster/aws-iam.mdx) on AWS.
+Using the IAM Method and other non-token join methods allows for re-joining if Machine-ID certificates expire. Certificates expire by default
+after an hour so a non-token method could be a better choice for machines that are shut down for long periods.
 
 Assuming that you are using the default `access` role, ensure that you use the 
 `--logins` flag when adding your bot to specify the SSH logins that you wish to 


### PR DESCRIPTION
Removed separation of cloud vs self-hosted.  As a getting started wasn't much value or diff.  This was referring to parameters like `--auth-server` that weren't used that can cause confusion getting started.
