### PR TITLE
Notify users about open user tasks associated with Integrations

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1162,6 +1162,12 @@ const (
 	// NotificationUserCreatedWarningSubKind is the subkind for a user-created warning notification.
 	NotificationUserCreatedWarningSubKind = "user-created-warning"
 
+	// NotificationPendingUserTaskIntegrationSubKind is the subkind for a notification that warns the user about pending User Tasks for a given integration.
+	NotificationPendingUserTaskIntegrationSubKind = "pending-user-task-for-integration"
+	// NotificationIntegrationLabel is the label which contains the name of the integration.
+	// To be used with NotificationPendingUserTaskIntegrationSubKind.
+	NotificationIntegrationLabel = "integration-name"
+
 	// NotificationAccessRequestPendingSubKind is the subkind for a notification for an access request pending review.
 	NotificationAccessRequestPendingSubKind = "access-request-pending"
 	// NotificationAccessRequestApprovedSubKind is the subkind for a notification for a user's access request being approved.

--- a/api/types/notifications/notifications.go
+++ b/api/types/notifications/notifications.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notifications
+
+import (
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// NewPendingUserTasksIntegrationNotification creates a new GlobalNotification for warning the users about pending UserTasks related to an integration.
+func NewPendingUserTasksIntegrationNotification(integrationName string, expires time.Time) *notificationsv1.GlobalNotification {
+	return &notificationsv1.GlobalNotification{
+		Spec: &notificationsv1.GlobalNotificationSpec{
+			Matcher: &notificationsv1.GlobalNotificationSpec_ByPermissions{
+				ByPermissions: &notificationsv1.ByPermissions{
+					RoleConditions: []*types.RoleConditions{{
+						Rules: []types.Rule{{
+							Resources: []string{types.KindIntegration},
+							Verbs:     []string{types.VerbList, types.VerbRead},
+						}},
+					}},
+				},
+			},
+			Notification: &notificationsv1.Notification{
+				Spec:    &notificationsv1.NotificationSpec{},
+				SubKind: types.NotificationPendingUserTaskIntegrationSubKind,
+				Metadata: &headerv1.Metadata{
+					Labels: map[string]string{
+						types.NotificationTitleLabel:       "Your integration needs attention.",
+						types.NotificationIntegrationLabel: integrationName,
+					},
+					Expires: timestamppb.New(expires),
+				},
+			},
+		},
+	}
+}

--- a/api/types/semaphore.go
+++ b/api/types/semaphore.go
@@ -55,6 +55,11 @@ const SemaphoreKindUploadCompleter = "upload_completer"
 // the periodic check which creates access list reminder notifications.
 const SemaphoreKindAccessListReminderLimiter = "access_list_reminder_limiter"
 
+// SemaphoreKindOpenUserTasksForIntegrationNotificationLimiter is the semaphore kind used by
+// the periodic check which creates open UserTasks notifications for a given integration.
+// See [github.com/gravitational/teleport/lib/auth.Server.CreateOpenUserTasksForIntegrationNotifications]
+const SemaphoreKindOpenUserTasksForIntegrationNotificationLimiter = "open_usertasks_integration_notification_limiter"
+
 // Semaphore represents distributed semaphore concept
 type Semaphore interface {
 	// Resource contains common resource values


### PR DESCRIPTION
User Tasks is a new resource that contains issues about an integration.
For now, User Tasks are only created to register issues related to auto
enrolling EC2 instances, RDS databases and EKS clusters.
Other types of issues will be registered in the future.

Users must proactively list User Tasks in order to understand existing
issues.
For now, this can only be done using `tctl get user_task`.

An UI for this new resource will be created, but users still need to
navigate to that UI to see what issues exist.

This PR creates a new Notification type which is used to explicitly
notify the user that the Integration has pending User Tasks.

When are users notified about pending User Tasks?
There's a process running in Auth every 10 minutes that creates notifications as needed.

Before merging:
- [ ] (WebUI) Create User Tasks UI
- [ ] (WebUI) Create Pending User Tasks Integration in Notifications Factory in UI