### PR TITLE
[v16] [gcp] support project discovery

### DIFF
--- a/api/types/matchers_gcp.go
+++ b/api/types/matchers_gcp.go
@@ -102,8 +102,8 @@ func (m *GCPMatcher) CheckAndSetDefaults() error {
 		m.Locations = []string{Wildcard}
 	}
 
-	if slices.Contains(m.ProjectIDs, Wildcard) {
-		return trace.BadParameter("GCP discovery service project_ids does not support wildcards; please specify at least one value in project_ids.")
+	if slices.Contains(m.ProjectIDs, Wildcard) && len(m.ProjectIDs) > 1 {
+		return trace.BadParameter("GCP discovery service either supports wildcard project_ids or multiple values, but not both.")
 	}
 	if len(m.ProjectIDs) == 0 {
 		return trace.BadParameter("GCP discovery service project_ids does cannot be empty; please specify at least one value in project_ids.")

--- a/api/types/matchers_gcp_test.go
+++ b/api/types/matchers_gcp_test.go
@@ -92,12 +92,12 @@ func TestGCPMatcherCheckAndSetDefaults(t *testing.T) {
 			errCheck: isBadParameterErr,
 		},
 		{
-			name: "wildcard is invalid for project ids",
+			name: "wildcard is valid for project ids",
 			in: &GCPMatcher{
 				Types:      []string{"gce"},
 				ProjectIDs: []string{"*"},
 			},
-			errCheck: isBadParameterErr,
+			errCheck: require.NoError,
 		},
 		{
 			name: "invalid type",

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
@@ -454,8 +454,18 @@ value, `gke`.
 #### `discovery_service.gcp[0].project_ids`
 
 In your matcher, replace `myproject` with the ID of your Google Cloud project.
-The `project_ids` field must include at least one value, and it must not be the
-wildcard character (`*`).
+
+Ensure that the `project_ids` field follows these rules:
+- It must include at least one value.
+- It must not combine the wildcard character (`*`) with other values.
+
+##### Examples of valid configurations
+- `["p1", "p2"]`
+- `["*"]`
+- `["p1"]`
+
+##### Example of an invalid configuration
+- `["p1", "*"]`
 
 #### `discovery_service.gcp[0].locations`
 

--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -107,6 +107,8 @@ type GCPClients interface {
 	GetGCPSQLAdminClient(context.Context) (gcp.SQLAdminClient, error)
 	// GetGCPGKEClient returns GKE client.
 	GetGCPGKEClient(context.Context) (gcp.GKEClient, error)
+	// GetGCPProjectsClient returns Projects client.
+	GetGCPProjectsClient(context.Context) (gcp.ProjectsClient, error)
 	// GetGCPInstancesClient returns instances client.
 	GetGCPInstancesClient(context.Context) (gcp.InstancesClient, error)
 }
@@ -266,6 +268,7 @@ func NewClients(opts ...ClientsOption) (Clients, error) {
 		gcpClients: gcpClients{
 			gcpSQLAdmin:  newClientCache[gcp.SQLAdminClient](gcp.NewSQLAdminClient),
 			gcpGKE:       newClientCache[gcp.GKEClient](gcp.NewGKEClient),
+			gcpProjects:  newClientCache[gcp.ProjectsClient](gcp.NewProjectsClient),
 			gcpInstances: newClientCache[gcp.InstancesClient](gcp.NewInstancesClient),
 		},
 		azureClients: azClients,
@@ -324,6 +327,8 @@ type gcpClients struct {
 	gcpSQLAdmin *clientCache[gcp.SQLAdminClient]
 	// gcpGKE is the cached GCP Cloud GKE client.
 	gcpGKE *clientCache[gcp.GKEClient]
+	// gcpProjects is the cached GCP Cloud Projects client.
+	gcpProjects *clientCache[gcp.ProjectsClient]
 	// gcpInstances is the cached GCP instances client.
 	gcpInstances *clientCache[gcp.InstancesClient]
 }
@@ -657,6 +662,11 @@ func (c *cloudClients) GetInstanceMetadataClient(ctx context.Context) (imds.Clie
 // GetGCPGKEClient returns GKE client.
 func (c *cloudClients) GetGCPGKEClient(ctx context.Context) (gcp.GKEClient, error) {
 	return c.gcpGKE.GetClient(ctx)
+}
+
+// GetGCPProjectsClient returns Project client.
+func (c *cloudClients) GetGCPProjectsClient(ctx context.Context) (gcp.ProjectsClient, error) {
+	return c.gcpProjects.GetClient(ctx)
 }
 
 // GetGCPInstancesClient returns instances client.
@@ -1022,6 +1032,7 @@ type TestCloudClients struct {
 	STS                     stsiface.STSAPI
 	GCPSQL                  gcp.SQLAdminClient
 	GCPGKE                  gcp.GKEClient
+	GCPProjects             gcp.ProjectsClient
 	GCPInstances            gcp.InstancesClient
 	EC2                     ec2iface.EC2API
 	SSM                     ssmiface.SSMAPI
@@ -1232,6 +1243,11 @@ func (c *TestCloudClients) GetInstanceMetadataClient(ctx context.Context) (imds.
 // GetGCPGKEClient returns GKE client.
 func (c *TestCloudClients) GetGCPGKEClient(ctx context.Context) (gcp.GKEClient, error) {
 	return c.GCPGKE, nil
+}
+
+// GetGCPGKEClient returns GKE client.
+func (c *TestCloudClients) GetGCPProjectsClient(ctx context.Context) (gcp.ProjectsClient, error) {
+	return c.GCPProjects, nil
 }
 
 // GetGCPInstancesClient returns instances client.

--- a/lib/cloud/gcp/projects.go
+++ b/lib/cloud/gcp/projects.go
@@ -1,0 +1,105 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package gcp
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+// Project is a GCP project.
+type Project struct {
+	// ID is the project ID.
+	ID string
+	// Name is the project name.
+	Name string
+}
+
+// ProjectsClient is an interface to interact with GCP Projects API.
+type ProjectsClient interface {
+	// ListProjects lists the GCP projects that the authenticated user has access to.
+	ListProjects(ctx context.Context) ([]Project, error)
+}
+
+// ProjectsClientConfig is the client configuration for ProjectsClient.
+type ProjectsClientConfig struct {
+	// Client is the GCP client for resourcemanager service.
+	Client *cloudresourcemanager.Service
+}
+
+// CheckAndSetDefaults check and set defaults for ProjectsClientConfig.
+func (c *ProjectsClientConfig) CheckAndSetDefaults(ctx context.Context) (err error) {
+	if c.Client == nil {
+		c.Client, err = cloudresourcemanager.NewService(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// NewProjectsClient returns a ProjectsClient interface wrapping resourcemanager.ProjectsClient
+// for interacting with GCP Projects API.
+func NewProjectsClient(ctx context.Context) (ProjectsClient, error) {
+	var cfg ProjectsClientConfig
+	client, err := NewProjectsClientWithConfig(ctx, cfg)
+	return client, trace.Wrap(err)
+}
+
+// NewProjectsClientWithConfig returns a ProjectsClient interface wrapping resourcemanager.ProjectsClient
+// for interacting with GCP Projects API.
+func NewProjectsClientWithConfig(ctx context.Context, cfg ProjectsClientConfig) (ProjectsClient, error) {
+	if err := cfg.CheckAndSetDefaults(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &projectsClient{cfg}, nil
+}
+
+type projectsClient struct {
+	ProjectsClientConfig
+}
+
+// ListProjects lists the GCP Projects that the authenticated user has access to.
+func (g *projectsClient) ListProjects(ctx context.Context) ([]Project, error) {
+
+	var pageToken string
+	var projects []Project
+	for {
+		projectsCall, err := g.Client.Projects.List().PageToken(pageToken).Do()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		for _, project := range projectsCall.Projects {
+			projects = append(projects,
+				Project{
+					ID:   project.ProjectId,
+					Name: project.Name,
+				},
+			)
+		}
+		if projectsCall.NextPageToken == "" {
+			break
+		}
+		pageToken = projectsCall.NextPageToken
+	}
+
+	return projects, nil
+}

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -4348,6 +4348,53 @@ func TestDiscoveryConfig(t *testing.T) {
 			}},
 		},
 		{
+			desc:          "GCP section is filled with wildcard project ids",
+			expectError:   require.NoError,
+			expectEnabled: require.True,
+			mutate: func(cfg cfgMap) {
+				cfg["discovery_service"].(cfgMap)["enabled"] = "yes"
+				cfg["discovery_service"].(cfgMap)["gcp"] = []cfgMap{
+					{
+						"types":     []string{"gke"},
+						"locations": []string{"eucentral1"},
+						"tags": cfgMap{
+							"discover_teleport": "yes",
+						},
+						"project_ids": []string{"*"},
+					},
+				}
+			},
+			expectedGCPMatchers: []types.GCPMatcher{{
+				Types:     []string{"gke"},
+				Locations: []string{"eucentral1"},
+				Labels: map[string]apiutils.Strings{
+					"discover_teleport": []string{"yes"},
+				},
+				Tags: map[string]apiutils.Strings{
+					"discover_teleport": []string{"yes"},
+				},
+				ProjectIDs: []string{"*"},
+			}},
+		},
+		{
+			desc:          "GCP section mixes wildcard and specific project ids",
+			expectError:   require.Error,
+			expectEnabled: require.True,
+			mutate: func(cfg cfgMap) {
+				cfg["discovery_service"].(cfgMap)["enabled"] = "yes"
+				cfg["discovery_service"].(cfgMap)["gcp"] = []cfgMap{
+					{
+						"types":     []string{"gke"},
+						"locations": []string{"eucentral1"},
+						"tags": cfgMap{
+							"discover_teleport": "yes",
+						},
+						"project_ids": []string{"p1", "*"},
+					},
+				}
+			},
+		},
+		{
 			desc:          "GCP section is filled with installer",
 			expectError:   require.NoError,
 			expectEnabled: require.True,

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1160,6 +1160,24 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 			},
 			wantEvents: 2,
 		},
+		{
+			name:                 "no clusters in auth server, import 3 prod clusters from GKE across multiple projects",
+			existingKubeClusters: []types.KubeCluster{},
+			gcpMatchers: []types.GCPMatcher{
+				{
+					Types:      []string{"gke"},
+					Locations:  []string{"*"},
+					ProjectIDs: []string{"*"},
+					Tags:       map[string]utils.Strings{"env": {"prod"}},
+				},
+			},
+			expectedClustersToExistInAuth: []types.KubeCluster{
+				mustConvertGKEToKubeCluster(t, gkeMockClusters[0], mainDiscoveryGroup),
+				mustConvertGKEToKubeCluster(t, gkeMockClusters[1], mainDiscoveryGroup),
+				mustConvertGKEToKubeCluster(t, gkeMockClusters[4], mainDiscoveryGroup),
+			},
+			wantEvents: 3,
+		},
 	}
 
 	for _, tc := range tcs {
@@ -1173,6 +1191,7 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 				AzureAKSClient: newPopulatedAKSMock(),
 				EKS:            newPopulatedEKSMock(),
 				GCPGKE:         newPopulatedGCPMock(),
+				GCPProjects:    newPopulatedGCPProjectsMock(),
 			}
 
 			ctx := context.Background()
@@ -1650,6 +1669,28 @@ var gkeMockClusters = []gcp.GKECluster{
 		Location:    "central-1",
 		Description: "desc1",
 	},
+	{
+		Name:   "cluster5",
+		Status: containerpb.Cluster_RUNNING,
+		Labels: map[string]string{
+			"env":      "prod",
+			"location": "central-1",
+		},
+		ProjectID:   "p2",
+		Location:    "central-1",
+		Description: "desc1",
+	},
+	{
+		Name:   "cluster6",
+		Status: containerpb.Cluster_RUNNING,
+		Labels: map[string]string{
+			"env":      "stg",
+			"location": "central-1",
+		},
+		ProjectID:   "p2",
+		Location:    "central-1",
+		Description: "desc1",
+	},
 }
 
 func mustConvertGKEToKubeCluster(t *testing.T, gkeCluster gcp.GKECluster, discoveryGroup string) types.KubeCluster {
@@ -1667,7 +1708,15 @@ type mockGKEAPI struct {
 }
 
 func (m *mockGKEAPI) ListClusters(ctx context.Context, projectID string, location string) ([]gcp.GKECluster, error) {
-	return m.clusters, nil
+	var clusters []gcp.GKECluster
+	for _, cluster := range m.clusters {
+		if cluster.ProjectID != projectID {
+			continue
+		}
+		clusters = append(clusters, cluster)
+	}
+
+	return clusters, nil
 }
 
 func TestDiscoveryDatabase(t *testing.T) {
@@ -2565,12 +2614,21 @@ type mockGCPClient struct {
 	vms []*gcpimds.Instance
 }
 
-func (m *mockGCPClient) ListInstances(_ context.Context, _, _ string) ([]*gcpimds.Instance, error) {
-	return m.vms, nil
+func (m *mockGCPClient) getVMSForProject(projectID string) []*gcpimds.Instance {
+	var vms []*gcpimds.Instance
+	for _, vm := range m.vms {
+		if vm.ProjectID == projectID {
+			vms = append(vms, vm)
+		}
+	}
+	return vms
+}
+func (m *mockGCPClient) ListInstances(_ context.Context, projectID, _ string) ([]*gcpimds.Instance, error) {
+	return m.getVMSForProject(projectID), nil
 }
 
-func (m *mockGCPClient) StreamInstances(_ context.Context, _, _ string) stream.Stream[*gcpimds.Instance] {
-	return stream.Slice(m.vms)
+func (m *mockGCPClient) StreamInstances(_ context.Context, projectID, _ string) stream.Stream[*gcpimds.Instance] {
+	return stream.Slice(m.getVMSForProject(projectID))
 }
 
 func (m *mockGCPClient) GetInstance(_ context.Context, _ *gcpimds.InstanceRequest) (*gcpimds.Instance, error) {
@@ -2664,6 +2722,37 @@ func TestGCPVMDiscovery(t *testing.T) {
 			wantInstalledInstances: []string{"myinstance"},
 		},
 		{
+			name:       "no nodes present, 2 found for different projects",
+			presentVMs: []types.Server{},
+			foundGCPVMs: []*gcpimds.Instance{
+				{
+					ProjectID: "p1",
+					Zone:      "myzone",
+					Name:      "myinstance1",
+					Labels: map[string]string{
+						"teleport": "yes",
+					},
+				},
+				{
+					ProjectID: "p2",
+					Zone:      "myzone",
+					Name:      "myinstance2",
+					Labels: map[string]string{
+						"teleport": "yes",
+					},
+				},
+			},
+			staticMatchers: Matchers{
+				GCP: []types.GCPMatcher{{
+					Types:      []string{"gce"},
+					ProjectIDs: []string{"*"},
+					Locations:  []string{"myzone"},
+					Labels:     types.Labels{"teleport": {"yes"}},
+				}},
+			},
+			wantInstalledInstances: []string{"myinstance1", "myinstance2"},
+		},
+		{
 			name: "nodes present, instance filtered",
 			presentVMs: []types.Server{
 				&types.ServerV2{
@@ -2748,6 +2837,7 @@ func TestGCPVMDiscovery(t *testing.T) {
 				GCPInstances: &mockGCPClient{
 					vms: tc.foundGCPVMs,
 				},
+				GCPProjects: newPopulatedGCPProjectsMock(),
 			}
 
 			ctx := context.Background()
@@ -3147,4 +3237,28 @@ func (m fakeWatcher) Close() error {
 
 func (m fakeWatcher) Error() error {
 	return nil
+}
+
+type mockProjectsAPI struct {
+	gcp.ProjectsClient
+	projects []gcp.Project
+}
+
+func (m *mockProjectsAPI) ListProjects(ctx context.Context) ([]gcp.Project, error) {
+	return m.projects, nil
+}
+
+func newPopulatedGCPProjectsMock() *mockProjectsAPI {
+	return &mockProjectsAPI{
+		projects: []gcp.Project{
+			{
+				ID:   "p1",
+				Name: "project1",
+			},
+			{
+				ID:   "p2",
+				Name: "project2",
+			},
+		},
+	}
 }

--- a/lib/srv/discovery/fetchers/gke_test.go
+++ b/lib/srv/discovery/fetchers/gke_test.go
@@ -35,6 +35,7 @@ func TestGKEFetcher(t *testing.T) {
 	type args struct {
 		location     string
 		filterLabels types.Labels
+		projectID    string
 	}
 	tests := []struct {
 		name string
@@ -48,8 +49,9 @@ func TestGKEFetcher(t *testing.T) {
 				filterLabels: types.Labels{
 					types.Wildcard: []string{types.Wildcard},
 				},
+				projectID: "p1",
 			},
-			want: gkeClustersToResources(t, gkeMockClusters...),
+			want: gkeClustersToResources(t, gkeMockClusters[:4]...),
 		},
 		{
 			name: "list prod clusters",
@@ -58,6 +60,7 @@ func TestGKEFetcher(t *testing.T) {
 				filterLabels: types.Labels{
 					"env": []string{"prod"},
 				},
+				projectID: "p1",
 			},
 			want: gkeClustersToResources(t, gkeMockClusters[:2]...),
 		},
@@ -69,8 +72,9 @@ func TestGKEFetcher(t *testing.T) {
 					"env":      []string{"stg"},
 					"location": []string{"central-1"},
 				},
+				projectID: "p1",
 			},
-			want: gkeClustersToResources(t, gkeMockClusters[2:]...),
+			want: gkeClustersToResources(t, gkeMockClusters[2:4]...),
 		},
 		{
 			name: "filter not found",
@@ -79,6 +83,7 @@ func TestGKEFetcher(t *testing.T) {
 				filterLabels: types.Labels{
 					"env": []string{"none"},
 				},
+				projectID: "p1",
 			},
 			want: gkeClustersToResources(t),
 		},
@@ -90,6 +95,18 @@ func TestGKEFetcher(t *testing.T) {
 				filterLabels: types.Labels{
 					"env": []string{"prod", "stg"},
 				},
+				projectID: "p1",
+			},
+			want: gkeClustersToResources(t, gkeMockClusters[:4]...),
+		},
+		{
+			name: "list everything with wildcard project",
+			args: args{
+				location: "uswest2",
+				filterLabels: types.Labels{
+					"env": []string{"prod", "stg"},
+				},
+				projectID: "*",
 			},
 			want: gkeClustersToResources(t, gkeMockClusters...),
 		},
@@ -97,12 +114,14 @@ func TestGKEFetcher(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := GKEFetcherConfig{
-				Client:       newPopulatedGCPMock(),
-				FilterLabels: tt.args.filterLabels,
-				Location:     tt.args.location,
-				Log:          logrus.New(),
+				GKEClient:     newPopulatedGCPMock(),
+				ProjectClient: newPopulatedGCPProjectsMock(),
+				FilterLabels:  tt.args.filterLabels,
+				Location:      tt.args.location,
+				ProjectID:     tt.args.projectID,
+				Log:           logrus.New(),
 			}
-			fetcher, err := NewGKEFetcher(cfg)
+			fetcher, err := NewGKEFetcher(context.Background(), cfg)
 			require.NoError(t, err)
 			resources, err := fetcher.Get(context.Background())
 			require.NoError(t, err)
@@ -118,7 +137,15 @@ type mockGKEAPI struct {
 }
 
 func (m *mockGKEAPI) ListClusters(ctx context.Context, projectID string, location string) ([]gcp.GKECluster, error) {
-	return m.clusters, nil
+	var clusters []gcp.GKECluster
+	for _, cluster := range m.clusters {
+		if cluster.ProjectID != projectID {
+			continue
+		}
+		clusters = append(clusters, cluster)
+	}
+
+	return clusters, nil
 }
 
 func newPopulatedGCPMock() *mockGKEAPI {
@@ -172,6 +199,28 @@ var gkeMockClusters = []gcp.GKECluster{
 		Location:    "central-1",
 		Description: "desc1",
 	},
+	{
+		Name:   "cluster5",
+		Status: containerpb.Cluster_RUNNING,
+		Labels: map[string]string{
+			"env":      "stg",
+			"location": "central-1",
+		},
+		ProjectID:   "p2",
+		Location:    "central-1",
+		Description: "desc1",
+	},
+	{
+		Name:   "cluster6",
+		Status: containerpb.Cluster_RUNNING,
+		Labels: map[string]string{
+			"env":      "stg",
+			"location": "central-1",
+		},
+		ProjectID:   "p2",
+		Location:    "central-1",
+		Description: "desc1",
+	},
 }
 
 func gkeClustersToResources(t *testing.T, clusters ...gcp.GKECluster) types.ResourcesWithLabels {
@@ -184,4 +233,28 @@ func gkeClustersToResources(t *testing.T, clusters ...gcp.GKECluster) types.Reso
 		kubeClusters = append(kubeClusters, kubeCluster)
 	}
 	return kubeClusters.AsResources()
+}
+
+type mockProjectsAPI struct {
+	gcp.ProjectsClient
+	projects []gcp.Project
+}
+
+func (m *mockProjectsAPI) ListProjects(ctx context.Context) ([]gcp.Project, error) {
+	return m.projects, nil
+}
+
+func newPopulatedGCPProjectsMock() *mockProjectsAPI {
+	return &mockProjectsAPI{
+		projects: []gcp.Project{
+			{
+				ID:   "p1",
+				Name: "project1",
+			},
+			{
+				ID:   "p2",
+				Name: "project2",
+			},
+		},
+	}
 }


### PR DESCRIPTION
Backport of #47434 to branch/v16

Changelog: Extended Teleport Discovery Service to support resource discovery across all projects accessible by the service account.