### PR TITLE
fix: Silence staticcheck false positive on lib/utils/disk.go

### DIFF
--- a/lib/utils/disk.go
+++ b/lib/utils/disk.go
@@ -53,6 +53,7 @@ func FreeDiskWithReserve(dir string, reservedFreeDisk uint64) (uint64, error) {
 	if err != nil {
 		return 0, trace.Wrap(err)
 	}
+	//nolint:staticcheck // SA4003. False positive on macOS.
 	if stat.Bsize < 0 {
 		return 0, trace.Errorf("invalid size")
 	}


### PR DESCRIPTION
Statfs_t.Bsize is an int64 on Linux, but an [uint32 on macOS][1].

[1]: https://cs.opensource.google/go/go/+/refs/tags/go1.23.2:src/syscall/ztypes_darwin_arm64.go;l=88