### PR TITLE
Simplify how-to guides

### DIFF
--- a/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
@@ -138,11 +138,14 @@ For auto-enrollment to work, the following conditions must be met:
 integration, like the [Jamf Pro integration](./jamf-integration.mdx).
 - Auto-enrollment must be enabled in the cluster setting.
 
-Enable auto-enrollment in your cluster settings:
+Enable auto-enrollment in your cluster settings. To do so, modify the dynamic
+config resource using the following command:
 
-<Tabs dropDownCaption="Teleport Deployment">
-<TabItem label="Dynamic Resources" options="Self-Hosted,Teleport Enterprise Cloud" >
-Modify the dynamic config resource using `tctl edit cluster_auth_preference`:
+```code
+$ tctl edit cluster_auth_preference
+```
+
+Make the following change:
 
 ```diff
 kind: cluster_auth_preference
@@ -156,22 +159,7 @@ spec:
 +   auto_enroll: true
 ```
 
-</TabItem>
-<TabItem label="Static Config" options="Self-Hosted">
-Edit the Auth Server's `teleport.yaml` file:
-
-```diff
-auth_service:
-  authentication:
-    # ...
-    device_trust:
-+     auto_enroll: true
-```
-
-After saving the changes, restart the Teleport service.
-
-</TabItem>
-</Tabs>
+Save and close your editor to apply your changes.
 
 Once enabled, users with their device registered in Teleport will have their
 device enrolled to Teleport in their next login.
@@ -244,18 +232,14 @@ To configure `ekcert_allowed_cas`, you must first obtain the CA certificate in
 PEM format from the manufacturer of the TPM included in your devices. This step
 varies from manufacturer to manufacturer.
 
-After you obtain the CA certificate in PEM format, there are two ways of
-configuring `ekcert_allowed_cas`:
+After you obtain the CA certificate in PEM format, modify the dynamic config
+resource using the following command:
 
-- Statically using the Teleport configuration file. This is the simplest
-  option, but is not possible for Teleport Cloud clusters and not recommended
-  for clusters in a highly available configuration.
-- Dynamically using `cluster_auth_preference` resource. This works with all
-  clusters and is the most flexible.
+```code
+$ tctl edit cluster_auth_preference
+```
 
-<Tabs dropDownCaption="Teleport Deployment">
-<TabItem label="Dynamic Resources" options="Self-Hosted,Teleport Enterprise Cloud" >
-Modify the dynamic config resource using `tctl edit cluster_auth_preference`:
+Make the following change:
 
 ```diff
 kind: cluster_auth_preference
@@ -274,27 +258,7 @@ spec:
 +        -----END CERTIFICATE-----
 ```
 
-</TabItem>
-<TabItem label="Static Config" options="Self-Hosted">
-Edit the Auth Server's `teleport.yaml` file and restart:
-
-```diff
-auth_service:
-  authentication:
-    ...
-    device_trust:
-+      ekcert_allowed_cas:
-+      # The CA can be configured inline within the configuration file:
-+      - |
-+        -----BEGIN CERTIFICATE-----
-+        --snip--
-+        -----END CERTIFICATE-----
-+      # Or, it can be configured in the configuration file using a path:
-+      - /path/to/my/ekcert-ca.pem
-```
-
-</TabItem>
-</Tabs>
+Save and close your editor to apply your changes.
 
 ## Troubleshooting
 

--- a/docs/pages/admin-guides/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/enforcing-device-trust.mdx
@@ -96,10 +96,13 @@ accesses.
 
 To enable device mode `required` update your configuration as follows:
 
-<Tabs dropDownCaption="Teleport Deployment">
-<TabItem label="Dynamic Resources" options="Self-Hosted,Teleport Enterprise Cloud" >
-Create a `cap.yaml` file or get the existing configuration using
-`tctl get cluster_auth_preference`:
+Edit your cluster authentication preference using the following command:
+
+```code
+$ tctl edit cluster_auth_preference
+```
+
+Make the following change:
 
 ```diff
 kind: cluster_auth_preference
@@ -115,39 +118,11 @@ spec:
 +   mode: "required" # add this line
 ```
 
-Update the configuration:
+Save and close your editor to apply your changes.
 
-```code
-$ tctl create -f cap.yaml
-cluster auth preference has been updated
-```
-
-You can also edit this configuration directly:
-
-```code
-$ tctl edit cluster_auth_preference
-```
-
-</TabItem>
-<TabItem label="Static Config" options="Self-Hosted">
-Edit the Auth Server's `teleport.yaml` file and restart all Auth Services:
-
-```diff
-auth_service:
-  authentication:
-    type: local
-    second_factor: "on"
-    webauthn:
-      rp_id: (=clusterDefaults.clusterName=)
-    device_trust:
-+     mode: "required" # add this line
-```
-
-</TabItem>
-</Tabs>
-
-Once the config is updated, SSH, Database and Kubernetes access without a trusted device will be forbidden.
-For example, SSH access without a trusted device fails with the following error:
+Once the config is updated, SSH, Database and Kubernetes access without a
+trusted device will be forbidden.  For example, SSH access without a trusted
+device fails with the following error:
 
 ```code
 $ tsh ssh (=clusterDefaults.nodeIP=)

--- a/docs/pages/admin-guides/access-controls/guides/mfa-for-admin-actions.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/mfa-for-admin-actions.mdx
@@ -56,50 +56,30 @@ WebAuthn is the only form of second factor allowed.
   for a wider range of cluster configurations.
 </Notice>
 
-<Tabs>
-  <TabItem label="Dynamic Resources" scope={["team", "cloud"]}>
+Edit the `cluster_auth_preference` resource:
 
-  Edit the `cluster_auth_preference` resource:
+```code
+$ tctl edit cap
+```
 
-  ```code
-  $ tctl edit cap
-  ```
+Update the `cluster_auth_preference` definition to include the following content:
 
-  Update the `cluster_auth_preference` definition to include the following content:
+```yaml
+kind: cluster_auth_preference
+version: v2
+metadata:
+  name: cluster-auth-preference
+spec:
+  type: local
+  # To make webauthn the only form of second factor allowed, set this field to 'webauthn'.
+  second_factor: "webauthn"
+  webauthn:
+    rp_id: example.com
+```
 
-  ```yaml
-  kind: cluster_auth_preference
-  version: v2
-  metadata:
-    name: cluster-auth-preference
-  spec:
-    type: local
-    # To make webauthn the only form of second factor allowed, set this field to 'webauthn'.
-    second_factor: "webauthn"
-    webauthn:
-      rp_id: example.com
-  ```
+Save and exit the file. `tctl` will update the remote definition:
 
-  Save and exit the file. `tctl` will update the remote definition:
+```text
+cluster auth preference has been updated
+```
 
-  ```text
-  cluster auth preference has been updated
-  ```
-
-  </TabItem>
-  <TabItem label="Static Config" scope={["oss", "enterprise"]}>
-  Edit the Auth Service's `teleport.yaml` file and restart all Auth Service instances:
-
-  ```yaml
-  # snippet from /etc/teleport.yaml:
-  auth_service:
-    authentication:
-      type: local
-      # To make webauthn the only form of second factor allowed, set this field to 'webauthn'.
-      second_factor: "webauthn"
-      webauthn:
-        rp_id: example.com
-  ```
-
-  </TabItem>
-</Tabs>

--- a/docs/pages/admin-guides/access-controls/guides/passwordless.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/passwordless.mdx
@@ -119,54 +119,17 @@ using `tsh login --proxy=example.com --auth=local` in order to get their first
 passwordless registration.
 
 To enable passwordless by default, add `connector_name: passwordless` to your
-cluster configuration:
+cluster configuration.
 
-<Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-<Tabs>
-  <TabItem label="Static Config">
-    Auth Server `teleport.yaml` file:
+Edit your cluster authentication preference configuration using the following
+command:
 
-    ```yaml
-    auth_service:
-      authentication:
-        type: local
-        second_factor: on
-        webauthn:
-          rp_id: example.com
-        connector_name: passwordless # passwordless by default
-    ```
-  </TabItem>
-  <TabItem label="Dynamic resources">
-    Create a `cap.yaml` file or get the existing configuration using
-    `tctl get cluster_auth_preference`:
+```code
+$ tctl edit cluster_auth_preference
+```
 
-    ```yaml
-    kind: cluster_auth_preference
-    version: v2
-    metadata:
-      name: cluster-auth-preference
-    spec:
-      type: local
-      second_factor: "on"
-      webauthn:
-        rp_id: example.com
-      connector_name: passwordless # passwordless by default
-    ```
-
-    Update the configuration:
-
-    ```code
-    $ tctl create -f cap.yaml
-    # cluster auth preference has been updated
-    ```
-  </TabItem>
-</Tabs>
-</TabItem>
-
-<TabItem scope={["cloud"]} label="Teleport Enterprise">
-Create a `cap.yaml` file or get the existing configuration using
-`tctl get cluster_auth_preference`:
+Ensure that the configuration includes the `connector_name` field as shown
+below:
 
 ```yaml
 kind: cluster_auth_preference
@@ -180,16 +143,6 @@ spec:
     rp_id: example.com
   connector_name: passwordless # passwordless by default
 ```
-
-Update the configuration:
-
-```code
-$ tctl create -f cap.yaml
-# cluster auth preference has been updated
-```
-</TabItem>
-
-</Tabs>
 
 ## Troubleshooting
 
@@ -259,55 +212,15 @@ $ tsh webauthnwin diag
 ### Disable passwordless
 
 If you want to forbid passwordless access to your cluster, add `passwordless:
-false` to your configuration:
+false` to your configuration. Edit your cluster authentication preference using
+the following command:
 
-<Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-<Tabs>
-  <TabItem label="Static Config">
-    Auth Server `teleport.yaml` file:
+```code
+$ tctl edit cluster_auth_preference
+```
 
-    ```yaml
-    # snippet from /etc/teleport.yaml:
-    auth_service:
-      authentication:
-        type: local
-        second_factor: on
-        webauthn:
-          rp_id: example.com
-        passwordless: false # disable passwordless
-    ```
-  </TabItem>
-  <TabItem label="Dynamic resources">
-    Create a `cap.yaml` file or get the existing configuration using
-    `tctl get cluster_auth_preference`:
-
-    ```yaml
-    kind: cluster_auth_preference
-    version: v2
-    metadata:
-      name: cluster-auth-preference
-    spec:
-      type: local
-      second_factor: "on"
-      webauthn:
-        rp_id: example.com
-      passwordless: false # disable passwordless
-    ```
-
-    Update the configuration:
-
-    ```code
-    $ tctl create -f cap.yaml
-    # cluster auth preference has been updated
-    ```
-  </TabItem>
-</Tabs>
-</TabItem>
-
-<TabItem scope={["cloud"]} label="Teleport Enterprise">
-Create a `cap.yaml` file or get the existing configuration using
-`tctl get cluster_auth_preference`:
+In your editor, ensure that your `cluster_auth_preference` includes a
+`passwordless` field similar to the following:
 
 ```yaml
 kind: cluster_auth_preference
@@ -322,15 +235,7 @@ spec:
   passwordless: false # disable passwordless
 ```
 
-Update the configuration:
-
-```code
-$ tctl create -f cap.yaml
-# cluster auth preference has been updated
-```
-</TabItem>
-
-</Tabs>
+Save and close your editor to apply your changes.
 
 ### Why did my multi-factor authentication (MFA) device become a passkey?
 

--- a/docs/pages/admin-guides/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/per-session-mfa.mdx
@@ -56,26 +56,8 @@ Per-session MFA can be enforced cluster-wide or only for some specific roles.
 
 ### Cluster-wide
 
-<Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-
 To enforce MFA checks for all roles, edit your cluster authentication
-configuration:
-
-<Tabs>
-<TabItem label="Static configuration">
-
-Update `teleport.yaml` on the Auth Server to include the following content:
-
-```yaml
-auth_service:
-  authentication:
-    # require per-session MFA cluster-wide
-    require_session_mfa: yes
-```
-
-</TabItem>
-<TabItem label="Dynamic resources">
+configuration.
 
 Edit your `cluster_auth_preference` resource:
 
@@ -95,35 +77,6 @@ version: v2
 ```
 
 Apply your changes by saving and closing the file in your editor.
-
-</TabItem>
-</Tabs>
-
-</TabItem>
-<TabItem scope="cloud" label="Teleport Enterprise">
-
-Edit your `cluster_auth_preference` resource:
-
-```code
-$ tctl edit cap
-```
-
-Ensure that the resource contains the following content:
-
-```yaml
-kind: cluster_auth_preference
-metadata:
-  name: cluster-auth-preference
-spec:
-  require_session_mfa: true
-version: v2
-```
-
-Apply your changes by saving and closing the file in your editor.
-
-</TabItem>
-
-</Tabs>
 
 ### Per role
 

--- a/docs/pages/connect-your-client/web-ui.mdx
+++ b/docs/pages/connect-your-client/web-ui.mdx
@@ -40,9 +40,6 @@ interacted with any Web UI browser tab, either through keyboard input or mouse m
 To change the default idle timeout of 10 minutes, ask your cluster admin to adjust the
 `web_idle_timeout` setting in the Auth Service configuration.
 
-<Tabs>
-<TabItem scope={["cloud", "team"]} label="Dynamic Resources (All Editions)">
-
 Use `tctl` to edit the `cluster_networking_config` value:
 
 ```code
@@ -68,15 +65,3 @@ After you save and exit the editor, `tctl` will update the resource:
 cluster networking configuration has been updated
 ```
 
-</TabItem>
-<TabItem label="Static Config (Self-Hosted)" scope={["oss", "enterprise"]}>
-
-Update `/etc/teleport.yaml` in the `auth_service` section and restart the `teleport` daemon.
-
-```yaml
-auth_service:
-  web_idle_timeout: 10m0s
-```
-
-</TabItem>
-</Tabs>

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-opensearch.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-opensearch.mdx
@@ -184,9 +184,6 @@ Use the token provided by the output of this command in the next step.
 
 (!docs/pages/includes/install-linux.mdx!)
 
-<Tabs>
-<TabItem label="Generating a new Teleport Config file">
-
 On the host where you will run the Teleport Database Service, start Teleport
 with the appropriate configuration.
 
@@ -213,59 +210,6 @@ $ sudo teleport db configure create \
 ```
 
 (!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
-
-</TabItem>
-
-<TabItem label="Modifying the existing Database Service Config">
-Modify your Teleport Database Service static configuration file:
-
-```yaml
-db_service:
-  enabled: "yes"
-  databases:
-  - name: example-opensearch
-    aws:
-      account_id: "(=aws.aws_access_key=)"
-    protocol: opensearch
-    uri: <Var name="opensearch-uri" />:443
-    static_labels:
-      env: dev
-```
-
-Restart the Teleport Database Service for the configuration file changes to take
-effect.
-
-</TabItem>
-<TabItem label="Dynamic Config">
-Create a dynamic database resource to dynamically register an AWS database
-in an external account and proxy connections to it.
-
-```yaml
-kind: db
-version: v3
-metadata:
-  name: "example-opensearch"
-  description: "Example dynamic database resource"
-  labels:
-    env: "dev"
-spec:
-  protocol: "opensearch"
-  uri: <Var name="opensearch-uri" />:443
-  aws:
-    account_id: "(=aws.aws_access_key=)"
-```
-
-Save the configuration to a file like `database.yaml` and create it with `tctl`:
-
-```code
-$ tctl create database.yaml
-```
-
-For more information about database registration using dynamic database
-resources, see: [Dynamic Registration](../guides/dynamic-registration.mdx).
-
-</TabItem>
-</Tabs>
 
 ## Step 4/4. Connect
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
@@ -204,10 +204,9 @@ AUDIT ALL STATEMENTS by alice BY access;
 You must enable auditing for each Teleport user that will be used to connect to Oracle.
 Additionally you can create a different audit policy for each user.
 
-Configure the Teleport Database Service to pull audit logs from Oracle Audit Trail:
+Edit the Database Service configuration you created earlier pull audit logs from
+Oracle Audit Trail:
 
-<Tabs>
-<TabItem label="Static config">
 ```yaml
 db_service:
   enabled: "yes"
@@ -218,22 +217,6 @@ db_service:
     oracle:
       audit_user: "teleport"
 ```
-</TabItem>
-<TabItem label="Dynamic resource">
-```yaml
-kind: db
-version: v3
-metadata:
-  name: oracle
-spec:
-  protocol: "oracle"
-  uri: "oracle.example.com:2484"
-  oracle:
-    audit_user: "teleport"
-```
-</TabItem>
-</Tabs>
-
 
 Teleport doesn't clean up audit trail events from Oracle Audit Trail.
 Make sure to configure an Oracle Audit Trail cleanup policy to avoid running out of disk space.

--- a/docs/pages/includes/database-access/auto-user-provisioning/db-definition-default-dbname.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning/db-definition-default-dbname.mdx
@@ -1,23 +1,6 @@
 {{ default="'teleport'" }}
 Next, configure the database admin user in the Teleport database configuration:
 
-<Tabs>
-<TabItem label="Static config">
-```yaml
-db_service:
-  enabled: "yes"
-  databases:
-  - name: "example"
-    protocol: "{{ protocol }}"
-    uri: "{{ uri }}"
-    admin_user:
-      name: "teleport-admin"
-      # Optional default database the admin user logs into. Default is
-      # {{ default }}, if not specified.
-      # default_database: teleport
-```
-</TabItem>
-<TabItem label="Dynamic resource">
 ```yaml
 kind: db
 version: v3
@@ -32,11 +15,12 @@ spec:
     # {{ default }}, if not specified.
     # default_database: teleport
 ```
-</TabItem>
-</Tabs>
 
-<Admonition type="tip" title="Auto-discovered databases">
+This example assumes that you have configured the database as a dynamic
+resource. If you have configured your database using a static Teleport Database
+Service configuration, edit the entry in your `db_service.databases`
+configuration.
+
 For auto-discovered cloud databases, the name of the admin user is taken from
 the `teleport.dev/db-admin` label, and the default database is taken from the
 `teleport.dev/db-admin-default-database` label.
-</Admonition>

--- a/docs/pages/includes/database-access/auto-user-provisioning/db-definition-self-hosted.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning/db-definition-self-hosted.mdx
@@ -1,19 +1,5 @@
 Next, configure the database admin user in the Teleport database configuration:
 
-<Tabs>
-<TabItem label="Static config">
-```yaml
-db_service:
-  enabled: "yes"
-  databases:
-  - name: "example"
-    protocol: "{{ protocol }}"
-    uri: "{{ uri }}"
-    admin_user:
-      name: "teleport-admin"
-```
-</TabItem>
-<TabItem label="Dynamic resource">
 ```yaml
 kind: db
 version: v3
@@ -25,5 +11,8 @@ spec:
   admin_user:
     name: "teleport-admin"
 ```
-</TabItem>
-</Tabs>
+
+This example assumes that you have configured the database as a dynamic
+resource. If you have configured your database using a static Teleport Database
+Service configuration, edit the entry in your `db_service.databases`
+configuration.

--- a/docs/pages/includes/database-access/auto-user-provisioning/db-definition.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning/db-definition.mdx
@@ -1,19 +1,5 @@
 Next, configure the database admin user in the Teleport database configuration:
 
-<Tabs>
-<TabItem label="Static config">
-```yaml
-db_service:
-  enabled: "yes"
-  databases:
-  - name: "example"
-    protocol: "{{ protocol }}"
-    uri: "{{ uri }}"
-    admin_user:
-      name: "teleport-admin"
-```
-</TabItem>
-<TabItem label="Dynamic resource">
 ```yaml
 kind: db
 version: v3
@@ -25,10 +11,11 @@ spec:
   admin_user:
     name: "teleport-admin"
 ```
-</TabItem>
-</Tabs>
 
-<Admonition type="tip" title="Auto-discovered databases">
+This example assumes that you have configured the database as a dynamic
+resource. If you have configured your database using a static Teleport Database
+Service configuration, edit the entry in your `db_service.databases`
+configuration.
+
 For auto-discovered cloud databases, the name of the admin user is taken from
 the `teleport.dev/db-admin` label.
-</Admonition>

--- a/docs/pages/includes/enterprise/oidcauthentication.mdx
+++ b/docs/pages/includes/enterprise/oidcauthentication.mdx
@@ -1,39 +1,19 @@
 Configure Teleport to use OIDC authentication as the default instead of the local
 user database. 
 
-Follow the instructions for your Teleport edition:
+Edit your `cluster_auth_preference` resource:
 
-<Tabs>
-  <TabItem label="Static Config (Self-Hosted)" scope={["oss", "enterprise"]}>
+```code
+$ tctl edit cap
+```
 
- Update `/etc/teleport.yaml` in the `auth_service` section and restart the `teleport` daemon.
+In your editor, ensure that the file contains the following content:
 
-  ```yaml
-  auth_service:
-    authentication:
-      type: oidc
-
-  ```
-
-  </TabItem>
-  <TabItem scope={["cloud"]} label="Dynamic Resources (All Editions)">
-
-  Create a file called `cap.yaml`:
-  
-  ```yaml
-  kind: cluster_auth_preference
-  metadata:
-    name: cluster-auth-preference
-  spec:    
-    type: oidc
-  version: v2
-  ```
-
-  Create a resource:
-
-  ```code
-  $ tctl create -f cap.yaml
-  ```
-  </TabItem>
-</Tabs>
-
+```yaml
+kind: cluster_auth_preference
+metadata:
+  name: cluster-auth-preference
+spec:    
+  type: oidc
+version: v2
+```

--- a/docs/pages/includes/enterprise/samlauthentication.mdx
+++ b/docs/pages/includes/enterprise/samlauthentication.mdx
@@ -3,11 +3,6 @@
 Configure Teleport to use SAML authentication as the default instead of the local
 user database.
 
-Follow the instructions for your Teleport edition:
-
-<Tabs>
-<TabItem scope={["cloud", "team"]} label="Dynamic Resources (All Editions)">
-
 Use `tctl` to edit the `cluster_auth_preference` value:
 
 ```code
@@ -33,20 +28,6 @@ After you save and exit the editor, `tctl` will update the resource:
 ```text
 cluster auth preference has been updated
 ```
-
-</TabItem>
-<TabItem label="Static Config (Self-Hosted)" scope={["oss", "enterprise"]}>
-
-Update `/etc/teleport.yaml` in the `auth_service` section and restart the `teleport` daemon.
-
-```yaml
-auth_service:
-  authentication:
-    type: saml
-```
-
-</TabItem>
-</Tabs>
 
 <Admonition type="tip">
 


### PR DESCRIPTION
Closes #38931

Remove "Static" and "Dynamic" configuration branching. Use the dynamic approach unless the guide already shows readers how to use the static approach elsewhere, e.g., using `teleport db configure create`.

For example, in the AWS OpenSearch guide, creating a Teleport configuration is required for the guide anyway, so this change uses only the static approach.

Ignore edge cases where the branching has some qualities that are unique to a specific guide:

- `application-access/cloud-apis/google-cloud.mdx`: includes branching on authentication preference type.
- `application-access/guides/connecting-apps.mdx` because it explains syntax differences between the static and dynamic approaches.
- `enroll-aws-databases/aws-cross-account.mdx`: branches using three tabs, so editing requires another approach than the one this change applies.

This change edits only how-to guides, not conceptual guides, since the goal of a how-to guide is to get the user to an end state as quickly as possible.