### PR TITLE
Prevent deleting last passwordless device with no password

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3888,11 +3888,11 @@ func (a *Server) deleteMFADeviceSafely(ctx context.Context, user, deviceName str
 	// Check whether the device to delete is the last passwordless device,
 	// and whether deleting it would lockout the user from login.
 	//
-	// TODO(Joerger): the user may already be locked out from login if a password
+	// Note: the user may already be locked out from login if a password
 	// is not set and passwordless is disabled. Prevent them from deleting
 	// their last passkey to prevent them from being locked out further,
 	// in the case of passwordless being re-enabled.
-	if isPasskey(deviceToDelete) && remainingPasskeys == 0 && readOnlyAuthPref.GetAllowPasswordless() {
+	if isPasskey(deviceToDelete) && remainingPasskeys == 0 {
 		u, err := a.Services.GetUser(ctx, user, false /* withSecrets */)
 		if err != nil {
 			return nil, trace.Wrap(err)


### PR DESCRIPTION
Prevent users from deleting their last passwordless device if they have no other means of logging in, even if passwordless is currently disabled. This way, if passwordless is re-enabled, the user will be able to log in.

I found this small logic edge case while creating https://github.com/gravitational/teleport/pull/47426 and figured it may as well be covered.

Honestly, after giving this more thought and seeing the change on its merit, this may be a distinction without a difference. In practice the user will probably need to be reset anyways, except for the hard to imagine edge case:
1) admin temporarily disabled passwordless login
2) the user has an active login session
3) the user deletes their passkey in, due to confusion or otherwise
4) admin re-enables passworldess, user is now locked out, which could have been avoided

Changelog: Update logic around deleting last passkey to prevent edge case lockouts.