### PR TITLE
Use challenge response when adding MFA device

### DIFF
--- a/web/packages/teleport/src/Account/Account.test.tsx
+++ b/web/packages/teleport/src/Account/Account.test.tsx
@@ -244,6 +244,9 @@ test('adding an MFA device', async () => {
   const ctx = createTeleportContext();
   jest.spyOn(ctx.mfaService, 'fetchDevices').mockResolvedValue([testPasskey]);
   jest
+    .spyOn(auth, 'getChallenge')
+    .mockResolvedValue({ webauthnPublicKey: null, totpChallenge: true });
+  jest
     .spyOn(auth, 'createNewWebAuthnDevice')
     .mockResolvedValueOnce(dummyCredential);
   jest
@@ -322,6 +325,9 @@ test('removing an MFA method', async () => {
   const user = userEvent.setup();
   const ctx = createTeleportContext();
   jest.spyOn(ctx.mfaService, 'fetchDevices').mockResolvedValue([testMfaMethod]);
+  jest
+    .spyOn(auth, 'getChallenge')
+    .mockResolvedValue({ webauthnPublicKey: null, totpChallenge: false });
   jest
     .spyOn(auth, 'createPrivilegeTokenWithWebauthn')
     .mockResolvedValueOnce('webauthn-privilege-token');

--- a/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
+++ b/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
@@ -22,7 +22,7 @@ import { ButtonPrimary, ButtonSecondary } from 'design/Button';
 import Dialog from 'design/Dialog';
 import Flex from 'design/Flex';
 import { RadioGroup } from 'design/RadioGroup';
-import { StepComponentProps, StepSlider } from 'design/StepSlider';
+import { StepComponentProps, StepSlider, StepHeader } from 'design/StepSlider';
 import React, { useState } from 'react';
 import FieldInput from 'shared/components/FieldInput';
 import Validation, { Validator } from 'shared/components/Validation';
@@ -35,8 +35,6 @@ import { useAsync } from 'shared/hooks/useAsync';
 import { Auth2faType } from 'shared/services';
 
 import Box from 'design/Box';
-
-import { StepHeader } from 'design/StepSlider';
 
 import { ChangePasswordReq } from 'teleport/services/auth';
 import auth, { MfaChallengeScope } from 'teleport/services/auth/auth';

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -37,8 +37,8 @@ import {
   ChangePasswordReq,
   CreateNewHardwareDeviceRequest,
   DeviceUsage,
+  CreateAuthenticateChallengeRequest,
 } from './types';
-import { CreateAuthenticateChallengeRequest } from './types';
 
 const auth = {
   checkWebauthnSupport() {
@@ -256,6 +256,21 @@ const auth = {
 
   createPrivilegeTokenWithTotp(secondFactorToken: string) {
     return api.post(cfg.api.createPrivilegeTokenPath, { secondFactorToken });
+  },
+
+  async getChallenge(
+    req: CreateAuthenticateChallengeRequest,
+    abortSignal?: AbortSignal
+  ) {
+    return api
+      .post(
+        cfg.api.mfaAuthnChallengePath,
+        {
+          challenge_scope: req.scope,
+        },
+        abortSignal
+      )
+      .then(makeMfaAuthenticateChallenge);
   },
 
   async fetchWebAuthnChallenge(

--- a/web/packages/teleport/src/services/auth/makeMfa.ts
+++ b/web/packages/teleport/src/services/auth/makeMfa.ts
@@ -70,6 +70,7 @@ export function makeMfaAuthenticateChallenge(json): MfaAuthenticateChallenge {
   }
 
   return {
+    totpChallenge: json.totp_challenge,
     webauthnPublicKey: webauthnPublicKey,
   };
 }

--- a/web/packages/teleport/src/services/auth/types.ts
+++ b/web/packages/teleport/src/services/auth/types.ts
@@ -33,6 +33,7 @@ export type AuthnChallengeRequest = {
 };
 
 export type MfaAuthenticateChallenge = {
+  totpChallenge: boolean;
   webauthnPublicKey: PublicKeyCredentialRequestOptions;
 };
 


### PR DESCRIPTION
Part of SSO as MFA

This PR changes the requirement for the "Reauthenticate" step when adding an MFA device. Currently, we rely on the number of devices returned when we fetch the devices. However, in the future with SSOasMFA, these devices won't always be enabled.

This will allow us to check the backend if any of the available devices are "enabled" and if we've received a valid challenge for a device. if not, we forward the user through the privilege token flow instead.

This will be expanded by checking for SSO challenges as well and can now be expanded for any other type of auth.

@Joerger you can determine when/where we will need backports for this and let me know. Thank you!