### PR TITLE
eliminate hardcoded RSA from lib/cloud/gcp

### DIFF
--- a/lib/cloud/gcp/vm_test.go
+++ b/lib/cloud/gcp/vm_test.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	gcpimds "github.com/gravitational/teleport/lib/cloud/imds/gcp"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -224,7 +225,7 @@ func TestRunCommand(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
 
-	signer, publicKey, err := generateKeyPair()
+	signer, err := generateKeyPair(cryptosuites.ECDSAP256)
 	require.NoError(t, err)
 	clientConn, serverConn, err := utils.DualPipeNetConn(
 		&utils.NetAddr{Addr: "server", AddrNetwork: "tcp"},
@@ -234,7 +235,7 @@ func TestRunCommand(t *testing.T) {
 	mock := newMockInstance(t, signer, &mockListener{Conn: serverConn, ctx: ctx})
 	require.NoError(t, mock.Start())
 	t.Cleanup(mock.Stop)
-	mock.hostKeys = []ssh.PublicKey{publicKey}
+	mock.hostKeys = []ssh.PublicKey{signer.PublicKey()}
 
 	inst := &gcpimds.Instance{
 		Name:              "my-instance",
@@ -257,6 +258,7 @@ func TestRunCommand(t *testing.T) {
 		dialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return clientConn, nil
 		},
+		SSHKeyAlgo: cryptosuites.ECDSAP256,
 	}))
 	require.Equal(t, 1, mock.execCount)
 }

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cloud"
 	gcpimds "github.com/gravitational/teleport/lib/cloud/imds/gcp"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
@@ -1218,6 +1219,10 @@ func (s *Server) handleGCPInstances(instances *server.GCPInstances) error {
 	s.Log.Debugf("Running Teleport installation on these virtual machines: ProjectID: %s, VMs: %s",
 		instances.ProjectID, genGCPInstancesLogStr(instances.Instances),
 	)
+	sshKeyAlgo, err := cryptosuites.AlgorithmForKey(s.ctx, cryptosuites.GetCurrentSuiteFromPing(s.AccessPoint), cryptosuites.UserSSH)
+	if err != nil {
+		return trace.Wrap(err, "finding algorithm for SSH key from ping response")
+	}
 	req := server.GCPRunRequest{
 		Client:          client,
 		Instances:       instances.Instances,
@@ -1226,6 +1231,7 @@ func (s *Server) handleGCPInstances(instances *server.GCPInstances) error {
 		Params:          instances.Parameters,
 		ScriptName:      instances.ScriptName,
 		PublicProxyAddr: instances.PublicProxyAddr,
+		SSHKeyAlgo:      sshKeyAlgo,
 	}
 	if err := s.gcpInstaller.Run(s.ctx, req); err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/server/gcp_installer.go
+++ b/lib/srv/server/gcp_installer.go
@@ -29,6 +29,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
 	gcpimds "github.com/gravitational/teleport/lib/cloud/imds/gcp"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 )
 
 // GCPInstaller handles running commands that install Teleport on GCP
@@ -47,6 +48,7 @@ type GCPRunRequest struct {
 	ProjectID       string
 	ScriptName      string
 	PublicProxyAddr string
+	SSHKeyAlgo      cryptosuites.Algorithm
 }
 
 // Run runs a command on a set of virtual machines and then blocks until the
@@ -72,6 +74,7 @@ func (gi *GCPInstaller) Run(ctx context.Context, req GCPRunRequest) error {
 					req.PublicProxyAddr,
 					req.Params,
 				),
+				SSHKeyAlgo: req.SSHKeyAlgo,
 			}
 			return trace.Wrap(gcp.RunCommand(ctx, &runRequest))
 		})


### PR DESCRIPTION
This PR eliminates the hardcoded RSA key generation used for GCP VM autodiscovery. I manually tested that default GCP VMs support ECDSA and Ed25519 SSH keys added via metadata.