### PR TITLE
Remove findDOMNode and defaultProps from suppressed warnings

### DIFF
--- a/web/packages/build/jest/setupTests.ts
+++ b/web/packages/build/jest/setupTests.ts
@@ -65,12 +65,11 @@ const failOnConsoleIgnoreList = new Set([
   'web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx',
   ...entFailOnConsoleIgnoreList,
 ]);
+
 // A list of allowed messages, for expected messages that shouldn't fail the build (e.g., warnings
 // about deprecated functions from 3rd-party libraries).
-const failOnConsoleAllowedMessages = [
-  'defaultProps will be removed',
-  'findDOMNode is deprecated',
-];
+const failOnConsoleAllowedMessages = [];
+
 failOnConsole({
   skipTest: ({ testPath }) => {
     const relativeTestPath = path.relative(rootDir, testPath);

--- a/web/packages/build/jest/setupTests.ts
+++ b/web/packages/build/jest/setupTests.ts
@@ -53,17 +53,10 @@ const rootDir = path.join(__dirname, '..', '..', '..', '..');
 // If the test is expected to use either of those console functions, follow the advice from the
 // error message.
 const failOnConsoleIgnoreList = new Set([
+  ...entFailOnConsoleIgnoreList,
   'web/packages/design/src/utils/match/matchers.test.ts',
   'web/packages/shared/components/TextEditor/TextEditor.test.tsx',
   'web/packages/teleport/src/components/BannerList/useAlerts.test.tsx',
-  'web/packages/teleport/src/Navigation/NavigationItem.test.tsx',
-  // As of the parent commit (708dac8e0d0), the tests below are flakes.
-  // https://github.com/gravitational/teleport/pull/41252#discussion_r1595036569
-  'web/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx',
-  'web/packages/teleport/src/Recordings/Recordings.story.test.tsx',
-  'web/packages/teleport/src/Audit/Audit.story.test.tsx',
-  'web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx',
-  ...entFailOnConsoleIgnoreList,
 ]);
 
 // A list of allowed messages, for expected messages that shouldn't fail the build (e.g., warnings


### PR DESCRIPTION
Now that #46590 has been merged, we can remove `findDOMNode` from suppressed warnings. This should help with making sure that we don't add new code which uses this deprecated API.

The `defaultProps` doesn't need to be in the suppressed warnings as well. I'm not sure at which point it stopped being needed, but it's likely that we had a function component that was using `defaultProps`. In React 19, function components will no longer be able to use default props, but class components should remain unchanged in that regard. The full message for that warning was:

> Warning: Button: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.